### PR TITLE
Adding Permissions check and reactions function to plugins API

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -311,6 +311,18 @@ func (api *PluginAPI) PublishWebSocketEvent(event string, payload map[string]int
 	})
 }
 
+func (api *PluginAPI) HasPermissionTo(userId string, permission *model.Permission) bool {
+	return api.app.HasPermissionTo(userId, permission)
+}
+
+func (api *PluginAPI) HasPermissionToTeam(userId, teamId string, permission *model.Permission) bool {
+	return api.app.HasPermissionToTeam(userId, teamId, permission)
+}
+
+func (api *PluginAPI) HasPermissionToChannel(userId, channelId string, permission *model.Permission) bool {
+	return api.app.HasPermissionToChannel(userId, channelId, permission)
+}
+
 func (api *PluginAPI) LogDebug(msg string, keyValuePairs ...interface{}) {
 	api.logger.Debug(msg, keyValuePairs...)
 }

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -186,6 +186,15 @@ type API interface {
 	// broadcast determines to which users to send the event
 	PublishWebSocketEvent(event string, payload map[string]interface{}, broadcast *model.WebsocketBroadcast)
 
+	// HasPermissionTo check if the user has the permission at system scope.
+	HasPermissionTo(userId string, permission *model.Permission) bool
+
+	// HasPermissionToTeam check if the user has the permission at team scope.
+	HasPermissionToTeam(userId, teamId string, permission *model.Permission) bool
+
+	// HasPermissionToChannel check if the user has the permission at channel scope.
+	HasPermissionToChannel(userId, channelId string, permission *model.Permission) bool
+
 	// LogDebug writes a log message to the Mattermost server log file.
 	// Appropriate context such as the plugin name will already be added as fields so plugins
 	// do not need to add that info.

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -2051,6 +2051,95 @@ func (s *apiRPCServer) PublishWebSocketEvent(args *Z_PublishWebSocketEventArgs, 
 	return nil
 }
 
+type Z_HasPermissionToArgs struct {
+	A string
+	B *model.Permission
+}
+
+type Z_HasPermissionToReturns struct {
+	A bool
+}
+
+func (g *apiRPCClient) HasPermissionTo(userId string, permission *model.Permission) bool {
+	_args := &Z_HasPermissionToArgs{userId, permission}
+	_returns := &Z_HasPermissionToReturns{}
+	if err := g.client.Call("Plugin.HasPermissionTo", _args, _returns); err != nil {
+		log.Printf("RPC call to HasPermissionTo API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) HasPermissionTo(args *Z_HasPermissionToArgs, returns *Z_HasPermissionToReturns) error {
+	if hook, ok := s.impl.(interface {
+		HasPermissionTo(userId string, permission *model.Permission) bool
+	}); ok {
+		returns.A = hook.HasPermissionTo(args.A, args.B)
+	} else {
+		return fmt.Errorf("API HasPermissionTo called but not implemented.")
+	}
+	return nil
+}
+
+type Z_HasPermissionToTeamArgs struct {
+	A string
+	B string
+	C *model.Permission
+}
+
+type Z_HasPermissionToTeamReturns struct {
+	A bool
+}
+
+func (g *apiRPCClient) HasPermissionToTeam(userId, teamId string, permission *model.Permission) bool {
+	_args := &Z_HasPermissionToTeamArgs{userId, teamId, permission}
+	_returns := &Z_HasPermissionToTeamReturns{}
+	if err := g.client.Call("Plugin.HasPermissionToTeam", _args, _returns); err != nil {
+		log.Printf("RPC call to HasPermissionToTeam API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) HasPermissionToTeam(args *Z_HasPermissionToTeamArgs, returns *Z_HasPermissionToTeamReturns) error {
+	if hook, ok := s.impl.(interface {
+		HasPermissionToTeam(userId, teamId string, permission *model.Permission) bool
+	}); ok {
+		returns.A = hook.HasPermissionToTeam(args.A, args.B, args.C)
+	} else {
+		return fmt.Errorf("API HasPermissionToTeam called but not implemented.")
+	}
+	return nil
+}
+
+type Z_HasPermissionToChannelArgs struct {
+	A string
+	B string
+	C *model.Permission
+}
+
+type Z_HasPermissionToChannelReturns struct {
+	A bool
+}
+
+func (g *apiRPCClient) HasPermissionToChannel(userId, channelId string, permission *model.Permission) bool {
+	_args := &Z_HasPermissionToChannelArgs{userId, channelId, permission}
+	_returns := &Z_HasPermissionToChannelReturns{}
+	if err := g.client.Call("Plugin.HasPermissionToChannel", _args, _returns); err != nil {
+		log.Printf("RPC call to HasPermissionToChannel API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) HasPermissionToChannel(args *Z_HasPermissionToChannelArgs, returns *Z_HasPermissionToChannelReturns) error {
+	if hook, ok := s.impl.(interface {
+		HasPermissionToChannel(userId, channelId string, permission *model.Permission) bool
+	}); ok {
+		returns.A = hook.HasPermissionToChannel(args.A, args.B, args.C)
+	} else {
+		return fmt.Errorf("API HasPermissionToChannel called but not implemented.")
+	}
+	return nil
+}
+
 type Z_LogDebugArgs struct {
 	A string
 	B []interface{}

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -849,6 +849,48 @@ func (_m *API) GetUserStatusesByIds(userIds []string) ([]*model.Status, *model.A
 	return r0, r1
 }
 
+// HasPermissionTo provides a mock function with given fields: userId, permission
+func (_m *API) HasPermissionTo(userId string, permission *model.Permission) bool {
+	ret := _m.Called(userId, permission)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, *model.Permission) bool); ok {
+		r0 = rf(userId, permission)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// HasPermissionToChannel provides a mock function with given fields: userId, channelId, permission
+func (_m *API) HasPermissionToChannel(userId string, channelId string, permission *model.Permission) bool {
+	ret := _m.Called(userId, channelId, permission)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, string, *model.Permission) bool); ok {
+		r0 = rf(userId, channelId, permission)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// HasPermissionToTeam provides a mock function with given fields: userId, teamId, permission
+func (_m *API) HasPermissionToTeam(userId string, teamId string, permission *model.Permission) bool {
+	ret := _m.Called(userId, teamId, permission)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, string, *model.Permission) bool); ok {
+		r0 = rf(userId, teamId, permission)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // KVDelete provides a mock function with given fields: key
 func (_m *API) KVDelete(key string) *model.AppError {
 	ret := _m.Called(key)


### PR DESCRIPTION
#### Summary
To be able to create plugins aware about permissions is important to
have the permissions checking functions exposed in the API.

Besides I added the hability to react to a post from the plugins API
too.