### PR TITLE
Fix store cache invalidation for reactions

### DIFF
--- a/store/local_cache_supplier_reactions.go
+++ b/store/local_cache_supplier_reactions.go
@@ -23,7 +23,7 @@ func (s *LocalCacheSupplier) ReactionSave(ctx context.Context, reaction *model.R
 }
 
 func (s *LocalCacheSupplier) ReactionDelete(ctx context.Context, reaction *model.Reaction, hints ...LayeredStoreHint) *LayeredStoreSupplierResult {
-	s.doInvalidateCacheCluster(s.reactionCache, reaction.PostId)
+	defer s.doInvalidateCacheCluster(s.reactionCache, reaction.PostId)
 	return s.Next().ReactionDelete(ctx, reaction, hints...)
 }
 
@@ -42,7 +42,7 @@ func (s *LocalCacheSupplier) ReactionGetForPost(ctx context.Context, postId stri
 func (s *LocalCacheSupplier) ReactionDeleteAllWithEmojiName(ctx context.Context, emojiName string, hints ...LayeredStoreHint) *LayeredStoreSupplierResult {
 	// This could be improved. Right now we just clear the whole
 	// cache because we don't have a way find what post Ids have this emoji name.
-	s.doClearCacheCluster(s.reactionCache)
+	defer s.doClearCacheCluster(s.reactionCache)
 	return s.Next().ReactionDeleteAllWithEmojiName(ctx, emojiName, hints...)
 }
 


### PR DESCRIPTION
Follow up for https://github.com/mattermost/mattermost-server/pull/9211 since I accidentally removed the part of the cache that I actually wanted to fix