### PR TITLE
MM-12519: simplify autocomplete team id checking

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -873,9 +873,9 @@ func TestAutocompleteUsers(t *testing.T) {
 		t.Fatal("should not show first/last name")
 	}
 
-	t.Run("team id, if provided, must match channel's team id", func(t *testing.T) {
+	t.Run("user must have access to team id, especially when it does not match channel's team id", func(t *testing.T) {
 		rusers, resp = Client.AutocompleteUsersInChannel("otherTeamId", channelId, username, "")
-		CheckErrorMessage(t, resp, "api.user.autocomplete_users.invalid_team_id")
+		CheckErrorMessage(t, resp, "api.context.permissions.app_error")
 	})
 }
 


### PR DESCRIPTION
#### Summary
This handles clients sending a team id in a direct message or group channel autocomplete, when it necessarily won't match. Just verify that the user has permission for the team in question, whenever it is provided.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12519

#### Checklist
- [x] Added or updated unit tests (required for all new features)