### PR TITLE
skip TestExportGMandDMChannels for now

### DIFF
--- a/app/export_test.go
+++ b/app/export_test.go
@@ -314,6 +314,7 @@ func TestExportGMChannel(t *testing.T) {
 }
 
 func TestExportGMandDMChannels(t *testing.T) {
+	t.Skip("Skipping test that fails randomly.")
 	th1 := Setup(t).InitBasic()
 
 	// DM Channel


### PR DESCRIPTION
#### Summary
Disable TestExportGMandDMChannels for now because it is too flaky