### PR TITLE
Cleanup go.tools.mod

### DIFF
--- a/go.tools.mod
+++ b/go.tools.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
-	github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20200814100246-5fc14ed48292 // indirect
+	github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20200821090819-f7569391b4d3 // indirect
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/reflog/struct2interface v0.6.1 // indirect
 	github.com/tinylib/msgp v1.1.2 // indirect

--- a/go.tools.sum
+++ b/go.tools.sum
@@ -54,12 +54,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20200721093743-053c38dcd293 h1:N9FaqZD58xkAIJGFGY5qdKXGlY2aNMaYQ9KkVEXv8xE=
-github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20200721093743-053c38dcd293/go.mod h1:3gKozJI8n2Y/vW37GfnFWAdehGXe5yZlt+HykK6Y3DM=
-github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20200730135456-e2334fe87160 h1:+JXFDXEkbMieBt54Rihj3ppnZ/Pm1kZxkLOD0hrWFzs=
-github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20200730135456-e2334fe87160/go.mod h1:3gKozJI8n2Y/vW37GfnFWAdehGXe5yZlt+HykK6Y3DM=
-github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20200814100246-5fc14ed48292 h1:swpUQyq7HWhc0aStUAgdZI6o0UOD9OzXJxbxUTLo1fo=
-github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20200814100246-5fc14ed48292/go.mod h1:3gKozJI8n2Y/vW37GfnFWAdehGXe5yZlt+HykK6Y3DM=
+github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20200821090819-f7569391b4d3 h1:H2Ir959KhgPrj+/zBP73pW5zxrC32HgICWtcerxCtcc=
+github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20200821090819-f7569391b4d3/go.mod h1:3gKozJI8n2Y/vW37GfnFWAdehGXe5yZlt+HykK6Y3DM=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=


### PR DESCRIPTION
- Update reference to mmgotool in go.tools.mod
This would automatically be bumped while running i18n-extract.
- We also remove some other redundant lines for mmgotool that went in.
This has to be removed manually because go mod tidy would automatically scan the entire
codebase which is not possible with this file.
