### PR TITLE
[MM-39205] Check that emails match during sign-up

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -72,6 +72,11 @@ func (a *App) CreateUserWithToken(c *request.Context, user *model.User, token *m
 		return nil, model.NewAppError("CreateUserWithToken", "app.channel.get_channels_by_ids.app_error", nil, nErr.Error(), http.StatusInternalServerError)
 	}
 
+	emailFromToken := tokenData["email"]
+	if emailFromToken != user.Email {
+		return nil, model.NewAppError("CreateUserWithToken", "api.user.create_user.bad_token_email_data.app_error", nil, "", http.StatusBadRequest)
+	}
+
 	user.Email = tokenData["email"]
 	user.EmailVerified = true
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3872,6 +3872,10 @@
     "translation": "The email you provided does not belong to an accepted domain. Please contact your administrator or sign up with a different email."
   },
   {
+    "id": "api.user.create_user.bad_token_email_data.app_error",
+    "translation": "The email address in the token does not match the one in the user data."
+  },
+  {
     "id": "api.user.create_user.disabled.app_error",
     "translation": "User creation is disabled."
   },


### PR DESCRIPTION
#### Summary
This PR adds a check to the sign-up flow to make sure the user email matches the expected one

#### Ticket Link
[MM-39205](https://mattermost.atlassian.net/browse/MM-39205)

#### Release Note

```release-note
NONE

```
