### PR TITLE
[MM-39297] Drop existing default on Users.Timezone prior to column type change

### DIFF
--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -133,6 +133,7 @@ type SqlStore struct {
 // ColumnInfo holds information about a column.
 type ColumnInfo struct {
 	DataType          string
+	DefaultValue      string
 	CharMaximumLength int
 }
 
@@ -651,7 +652,7 @@ func (ss *SqlStore) GetColumnInfo(tableName, columnName string) (*ColumnInfo, er
 	var columnInfo ColumnInfo
 	if ss.DriverName() == model.DatabaseDriverPostgres {
 		err := ss.GetMaster().SelectOne(&columnInfo,
-			`SELECT data_type as DataType,
+			`SELECT data_type as DataType, COALESCE(column_default, '') as DefaultValue,
 					COALESCE(character_maximum_length, 0) as CharMaximumLength
 			 FROM information_schema.columns
 			 WHERE lower(table_name) = lower($1)
@@ -663,7 +664,7 @@ func (ss *SqlStore) GetColumnInfo(tableName, columnName string) (*ColumnInfo, er
 		return &columnInfo, nil
 	} else if ss.DriverName() == model.DatabaseDriverMysql {
 		err := ss.GetMaster().SelectOne(&columnInfo,
-			`SELECT data_type as DataType,
+			`SELECT data_type as DataType, COALESCE(column_default, '') as DefaultValue,
 					COALESCE(character_maximum_length, 0) as CharMaximumLength
 			 FROM information_schema.columns
 			 WHERE table_schema = DATABASE()


### PR DESCRIPTION
#### Summary

A default for the `Users.Timezone` column was introduced in version 4.9 but never applied on new installations. This caused an error during 6.0 migration for older installations when converting the column type from `text/character varying` to `JSON/jsonb`. To fix this we drop the default prior to the migration. We don't need to add it back given we already set a default from the app side on user creation.

#### Ticket

https://mattermost.atlassian.net/browse/MM-39297

#### Release Note

```release-note
Fixed 6.0 migration for installations where the Users.Timezone column has a default.
```

#### Reported Issue

https://github.com/mattermost/mattermost-server/issues/18663
