### PR TITLE
Display tableName and columnName for jsonb schema failures

### DIFF
--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -873,10 +873,15 @@ func (ss *SqlStore) AlterColumnTypeIfExists(tableName string, columnName string,
 
 	if err != nil {
 		msg := "Failed to alter column type."
+		fields := []mlog.Field{mlog.Err(err)}
 		if mySqlColType == "JSON" && postgresColType == "jsonb" {
 			msg += " It is likely you have invalid JSON values in the column. Please fix the values manually and run the migration again."
+			fields = append(fields,
+				mlog.String("tableName", tableName),
+				mlog.String("columnName", columnName),
+			)
 		}
-		mlog.Fatal(msg, mlog.Err(err))
+		mlog.Fatal(msg, fields...)
 	}
 
 	return true


### PR DESCRIPTION
These are incredibly helpful during failures and should be there.

```release-note
NONE
```
