### PR TITLE
Pre-fill CreateAt to let link previews work.

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -267,7 +267,9 @@ func (a *App) CreatePost(c *request.Context, post *model.Post, channel *model.Ch
 	}
 
 	// Pre-fill the CreateAt field for link previews to get the correct timestamp.
-	post.CreateAt = model.GetMillis()
+	if post.CreateAt == 0 {
+		post.CreateAt = model.GetMillis()
+	}
 
 	post = a.getEmbedsAndImages(post, true)
 	previewPost := post.GetPreviewPost()


### PR DESCRIPTION
Because of the fact that getEmbedsAndImages has been now
refactored to work _before_ a post is saved. So the CreateAt
field of a post was absent.

This led to link previews being failed to save in the DB
because the timestamp wasn't there. So we just pre-fill
the field for it to work.

At the store layer, if the timestamp is present, it will just
reuse that.

https://community-daily.mattermost.com/boards/workspace/zyoahc9uapdn3xdptac6jb69ic/285b80a3-257d-41f6-8cf4-ed80ca9d92e5/495cdb4d-c13a-4992-8eb9-80cfee2819a4?c=305651ab-a96f-40d3-8bcf-8391c0d3e306

```release-note
NONE
```
