### PR TITLE
ci: remove image push to the official image repository and use the test instead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -477,8 +477,7 @@ jobs:
             export DOCKER_CLI_EXPERIMENTAL=enabled
             echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
             export MM_PACKAGE=https://pr-builds.mattermost.com/mattermost-server/commit/${CIRCLE_SHA1}/mattermost-team-linux-amd64.tar.gz
-            # Pushing the images to two places to not break anything, but the `mattermost/mattermost-team-edition` will be removed soon.
-            docker buildx build --push --build-arg MM_PACKAGE=$MM_PACKAGE -t mattermost/mattermost-team-edition:${TAG} -t mattermost/mm-te-test:${TAG} build
+            docker buildx build --push --build-arg MM_PACKAGE=$MM_PACKAGE -t mattermost/mm-te-test:${TAG} build
 
 workflows:
   version: 2


### PR DESCRIPTION
#### Summary
the change made here https://github.com/mattermost/mattermost-server/pull/18488 is now completed and the test servers are using the test repository instead of the official 

this PR removes the image push to `mattermost/mattermost-team-edition`/`mattermost/mattermost-enterprise-edition`

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/DOPS-632

#### Related Pull Requests

webapp: https://github.com/mattermost/mattermost-webapp/pull/9170
enterprise: https://github.com/mattermost/enterprise/pull/1083

#### Release Note

```release-note
NONE
```
