### PR TITLE
Fix Flaky test UpdateUserEmail

### DIFF
--- a/app/user_test.go
+++ b/app/user_test.go
@@ -522,7 +522,11 @@ func TestUpdateUserEmail(t *testing.T) {
 		require.Eventually(t, func() bool {
 			var err error
 			tokens, err = th.App.Srv().Store.Token().GetAllTokensByType(TokenTypeVerifyEmail)
-			return err == nil && len(tokens) == 1
+			// We verify the same conditions as the earlier function,
+			// but we also need to ensure that this is not the same token
+			// as before, which is possible if the token updation goroutine
+			// hasn't yet run.
+			return err == nil && len(tokens) == 1 && tokens[0].Token != firstToken.Token
 		}, 100*time.Millisecond, 10*time.Millisecond)
 		secondToken := tokens[0]
 


### PR DESCRIPTION
Since the email sending would run in a separate goroutine,
it was possible that during the second th.App.UpdateUser call
the goroutine would run much later.

So the secondToken would be the same as the firstToken,
and the test would fail.

The fix is to ensure that the token received is different
from the firstToken.

https://community-daily.mattermost.com/boards/workspace/zyoahc9uapdn3xdptac6jb69ic/285b80a3-257d-41f6-8cf4-ed80ca9d92e5/495cdb4d-c13a-4992-8eb9-80cfee2819a4?c=254a9782-a59b-4d38-8886-4927f593e715

```release-note
NONE
```
