### PR TITLE
Automated cherry pick of #18784

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -69,8 +69,8 @@ func (f *FeatureFlags) SetDefaults() {
 	f.PermalinkPreviews = true
 	f.GlobalHeader = true
 	f.AddChannelButton = "by_team_name"
-	f.PrewrittenMessages = "none"
-	f.DownloadAppsCTA = "none"
+	f.PrewrittenMessages = "tour_point"
+	f.DownloadAppsCTA = "tips_and_next_steps"
 	f.BoardsUnfurl = true
 	f.CallsMobile = false
 	f.AutoTour = "none"


### PR DESCRIPTION
Cherry pick of #18784 on cloud.

/cc  @neallred

```release-note
NONE
```