### PR TITLE
Optimize TotalUnreadMentions

### DIFF
--- a/store/sqlstore/thread_store.go
+++ b/store/sqlstore/thread_store.go
@@ -200,7 +200,7 @@ func (s *SqlThreadStore) GetThreadsForUser(userId, teamId string, opts model.Get
 	}()
 	go func() {
 		mentionsQuery, mentionsQueryArgs, _ := s.getQueryBuilder().
-			Select("SUM(ThreadMemberships.UnreadMentions)").
+			Select("COALESCE(SUM(ThreadMemberships.UnreadMentions), 0)").
 			From("ThreadMemberships, Posts, Channels").
 			Where("Posts.Id = ThreadMemberships.PostId").
 			Where("Posts.ChannelId = Channels.Id").


### PR DESCRIPTION
We avoid joining with the Threads table entirely
as ChannelId is available from Posts table directly.

Also we replace left joins by inner joins.

https://community-daily.mattermost.com/boards/workspace/zyoahc9uapdn3xdptac6jb69ic/285b80a3-257d-41f6-8cf4-ed80ca9d92e5/495cdb4d-c13a-4992-8eb9-80cfee2819a4?c=c9aa17f3-b918-4a78-86aa-01562e418634

Old plan

```
 Finalize Aggregate  (cost=30869.29..30869.30 rows=1 width=32) (actual time=27.216..31.674 rows=1 loops=1)
   ->  Gather  (cost=30869.18..30869.29 rows=1 width=32) (actual time=27.089..31.665 rows=2 loops=1)
         Workers Planned: 1
         Workers Launched: 1
         ->  Partial Aggregate  (cost=29869.18..29869.19 rows=1 width=32) (actual time=18.442..18.445 rows=1 loops=2)
               ->  Nested Loop  (cost=1881.68..29869.11 rows=25 width=8) (actual time=2.052..18.417 rows=72 loops=2)
                     ->  Hash Join  (cost=1881.12..29771.45 rows=25 width=62) (actual time=2.028..17.744 rows=72 loops=2)
                           Hash Cond: ((threads.channelid)::text = (channels.id)::text)
                           ->  Nested Loop  (cost=0.84..27883.40 rows=2963 width=89) (actual time=0.220..15.849 rows=163 loops=2)
                                 ->  Parallel Index Scan using threadmemberships_pkey on threadmemberships  (cost=0.41..7423.65 rows=2963 width=35) (actual time=0.031..3.937 rows=2504 loops=2)
                                       Index Cond: ((userid)::text = 'tc3p1yqw67d8idcp3g98awexqe'::text)
                                       Filter: following
                                 ->  Index Scan using threads_pkey on threads  (cost=0.42..6.91 rows=1 width=54) (actual time=0.004..0.004 rows=0 loops=5007)
                                       Index Cond: ((postid)::text = (threadmemberships.postid)::text)
                           ->  Hash  (cost=1866.60..1866.60 rows=1094 width=27) (actual time=1.763..1.764 rows=1002 loops=2)
                                 Buckets: 2048  Batches: 1  Memory Usage: 74kB
                                 ->  Index Scan using idx_channels_team_id_type on channels  (cost=0.42..1866.60 rows=1094 width=27) (actual time=0.022..1.493 rows=1002 loops=2)
                                       Index Cond: ((teamid)::text = '8ywxyw9ocp8smxrmjzrkqhrdwe'::text)
                     ->  Index Scan using posts_pkey on posts  (cost=0.56..3.91 rows=1 width=27) (actual time=0.009..0.009 rows=1 loops=145)
                           Index Cond: ((id)::text = (threads.postid)::text)
                           Filter: (deleteat = 0)
 Planning Time: 2.415 ms
 Execution Time: 31.798 ms
```

New plan

```
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=34717.01..34717.02 rows=1 width=32) (actual time=42.375..48.143 rows=1 loops=1)
   ->  Gather  (cost=34716.89..34717.00 rows=1 width=32) (actual time=42.249..48.117 rows=2 loops=1)
         Workers Planned: 1
         Workers Launched: 1
         ->  Partial Aggregate  (cost=33716.89..33716.90 rows=1 width=32) (actual time=30.960..30.962 rows=1 loops=2)
               ->  Hash Join  (cost=1881.25..33716.83 rows=25 width=8) (actual time=2.438..30.780 rows=1058 loops=2)
                     Hash Cond: ((posts.channelid)::text = (channels.id)::text)
                     ->  Nested Loop  (cost=0.98..31828.77 rows=2963 width=35) (actual time=0.091..27.374 rows=2504 loops=2)
                           ->  Parallel Index Scan using threadmemberships_pkey on threadmemberships  (cost=0.41..6815.65 rows=2963 width=35) (actual time=0.034..4.674 rows=2504 loops=2)
                                 Index Cond: ((userid)::text = 'tc3p1yqw67d8idcp3g98awexqe'::text)
                                 Filter: following
                           ->  Index Scan using posts_pkey on posts  (cost=0.56..8.44 rows=1 width=54) (actual time=0.008..0.008 rows=1 loops=5007)
                                 Index Cond: ((id)::text = (threadmemberships.postid)::text)
                                 Filter: (deleteat = 0)
                     ->  Hash  (cost=1866.60..1866.60 rows=1094 width=27) (actual time=2.289..2.289 rows=1002 loops=2)
                           Buckets: 2048  Batches: 1  Memory Usage: 74kB
                           ->  Index Scan using idx_channels_team_id_type on channels  (cost=0.42..1866.60 rows=1094 width=27) (actual time=0.028..1.927 rows=1002 loops=2)
                                 Index Cond: ((teamid)::text = '8ywxyw9ocp8smxrmjzrkqhrdwe'::text)
```

```release-note
NONE
```
