### PR TITLE
[MM-39448] Implement auditUserPatch

### DIFF
--- a/model/auditconv.go
+++ b/model/auditconv.go
@@ -25,6 +25,10 @@ func AuditModelTypeConv(val interface{}) (newVal interface{}, converted bool) {
 		return newAuditUser(v), true
 	case User:
 		return newAuditUser(&v), true
+	case *UserPatch:
+		return newAuditUserPatch(v), true
+	case UserPatch:
+		return newAuditUserPatch(&v), true
 	case *Command:
 		return newAuditCommand(v), true
 	case Command:
@@ -166,6 +170,21 @@ func newAuditUser(u *User) auditUser {
 		user.Roles = u.Roles
 	}
 	return user
+}
+
+type auditUserPatch struct {
+	Name string
+}
+
+// newAuditUserPatch creates a simplified representation of UserPatch for output to audit log.
+func newAuditUserPatch(up *UserPatch) auditUserPatch {
+	var userPatch auditUserPatch
+	if up != nil {
+		if up.Username != nil {
+			userPatch.Name = *up.Username
+		}
+	}
+	return userPatch
 }
 
 func (u auditUser) MarshalJSONObject(enc *gojay.Encoder) {

--- a/model/auditconv_test.go
+++ b/model/auditconv_test.go
@@ -20,6 +20,7 @@ func TestAuditModelTypeConv(t *testing.T) {
 	sampleArr := []*Sample{sample, sample2}
 
 	user := &User{}
+	userPatch := &UserPatch{}
 
 	type args struct {
 		val interface{}
@@ -38,7 +39,9 @@ func TestAuditModelTypeConv(t *testing.T) {
 		{name: "struct pointer value", args: args{val: sample}, wantConverted: false, wantNewVal: sample},
 		{name: "struct pointer array", args: args{val: sampleArr}, wantConverted: false, wantNewVal: sampleArr},
 		{name: "model user pointer", args: args{val: user}, wantConverted: true, wantNewVal: "XXX"},
-		{name: "model user value", args: args{val: *user}, wantConverted: true, wantNewVal: "XXX"},
+		{name: "model user pointer", args: args{val: user}, wantConverted: true, wantNewVal: "XXX"},
+		{name: "user patch pointer", args: args{val: userPatch}, wantConverted: true, wantNewVal: "XXX"},
+		{name: "user patch value", args: args{val: *userPatch}, wantConverted: true, wantNewVal: "XXX"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#### Summary

Adding conversion for `model.UserPatch` as well that was completely missing.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-39448

#### Release Note

```release-note
NONE
```
