### PR TITLE
Add a sleep in-between retries

### DIFF
--- a/store/layer_generators/retry_layer.go.tmpl
+++ b/store/layer_generators/retry_layer.go.tmpl
@@ -8,7 +8,7 @@ package retrylayer
 
 import (
 	"context"
-	"time"
+	timepkg "time"
 
 	"github.com/lib/pq"
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -75,7 +75,7 @@ func (s *{{$.Name}}{{$substoreName}}Store) {{$index}}({{$element.Params | joinPa
                     {{$element.Results | errorVar}} = errors.Wrap({{$element.Results | errorVar}}, "giving up after 3 consecutive repeatable transaction failures")
                     return {{genResultsVars $element.Results false }}
                 }
-                time.Sleep(100 * time.Millisecond)
+                timepkg.Sleep(100 * timepkg.Millisecond)
             }
         {{else}}
             return s.{{$substoreName}}Store.{{$index}}({{$element.Params | joinParams}})

--- a/store/retrylayer/retrylayer.go
+++ b/store/retrylayer/retrylayer.go
@@ -8,7 +8,7 @@ package retrylayer
 
 import (
 	"context"
-	"time"
+	timepkg "time"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/lib/pq"
@@ -425,7 +425,7 @@ func (s *RetryLayerAuditStore) Get(user_id string, offset int, limit int) (model
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -446,7 +446,7 @@ func (s *RetryLayerAuditStore) PermanentDeleteByUser(userID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -467,7 +467,7 @@ func (s *RetryLayerAuditStore) Save(audit *model.Audit) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -488,7 +488,7 @@ func (s *RetryLayerBotStore) Get(userID string, includeDeleted bool) (*model.Bot
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -509,7 +509,7 @@ func (s *RetryLayerBotStore) GetAll(options *model.BotGetOptions) ([]*model.Bot,
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -530,7 +530,7 @@ func (s *RetryLayerBotStore) PermanentDelete(userID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -551,7 +551,7 @@ func (s *RetryLayerBotStore) Save(bot *model.Bot) (*model.Bot, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -572,7 +572,7 @@ func (s *RetryLayerBotStore) Update(bot *model.Bot) (*model.Bot, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -593,7 +593,7 @@ func (s *RetryLayerChannelStore) AnalyticsDeletedTypeCount(teamID string, channe
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -614,7 +614,7 @@ func (s *RetryLayerChannelStore) AnalyticsTypeCount(teamID string, channelType m
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -635,7 +635,7 @@ func (s *RetryLayerChannelStore) Autocomplete(userID string, term string, includ
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -656,7 +656,7 @@ func (s *RetryLayerChannelStore) AutocompleteInTeam(teamID string, userID string
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -677,7 +677,7 @@ func (s *RetryLayerChannelStore) AutocompleteInTeamForSearch(teamID string, user
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -698,7 +698,7 @@ func (s *RetryLayerChannelStore) ClearAllCustomRoleAssignments() error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -725,7 +725,7 @@ func (s *RetryLayerChannelStore) ClearSidebarOnTeamLeave(userID string, teamID s
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -746,7 +746,7 @@ func (s *RetryLayerChannelStore) CountPostsAfter(channelID string, timestamp int
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, resultVar1, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -767,7 +767,7 @@ func (s *RetryLayerChannelStore) CreateDirectChannel(userID *model.User, otherUs
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -788,7 +788,7 @@ func (s *RetryLayerChannelStore) CreateInitialSidebarCategories(userID string, t
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -809,7 +809,7 @@ func (s *RetryLayerChannelStore) CreateSidebarCategory(userID string, teamID str
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -830,7 +830,7 @@ func (s *RetryLayerChannelStore) Delete(channelID string, time int64) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -851,7 +851,7 @@ func (s *RetryLayerChannelStore) DeleteSidebarCategory(categoryID string) error 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -872,7 +872,7 @@ func (s *RetryLayerChannelStore) DeleteSidebarChannelsByPreferences(preferences 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -893,7 +893,7 @@ func (s *RetryLayerChannelStore) Get(id string, allowFromCache bool) (*model.Cha
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -914,7 +914,7 @@ func (s *RetryLayerChannelStore) GetAll(teamID string) ([]*model.Channel, error)
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -935,7 +935,7 @@ func (s *RetryLayerChannelStore) GetAllChannelMembersById(id string) ([]string, 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -956,7 +956,7 @@ func (s *RetryLayerChannelStore) GetAllChannelMembersForUser(userID string, allo
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -977,7 +977,7 @@ func (s *RetryLayerChannelStore) GetAllChannelMembersNotifyPropsForChannel(chann
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -998,7 +998,7 @@ func (s *RetryLayerChannelStore) GetAllChannels(page int, perPage int, opts stor
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1019,7 +1019,7 @@ func (s *RetryLayerChannelStore) GetAllChannelsCount(opts store.ChannelSearchOpt
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1040,7 +1040,7 @@ func (s *RetryLayerChannelStore) GetAllChannelsForExportAfter(limit int, afterID
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1061,7 +1061,7 @@ func (s *RetryLayerChannelStore) GetAllDirectChannelsForExportAfter(limit int, a
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1082,7 +1082,7 @@ func (s *RetryLayerChannelStore) GetByName(team_id string, name string, allowFro
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1103,7 +1103,7 @@ func (s *RetryLayerChannelStore) GetByNameIncludeDeleted(team_id string, name st
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1124,7 +1124,7 @@ func (s *RetryLayerChannelStore) GetByNames(team_id string, names []string, allo
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1145,7 +1145,7 @@ func (s *RetryLayerChannelStore) GetChannelCounts(teamID string, userID string) 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1166,7 +1166,7 @@ func (s *RetryLayerChannelStore) GetChannelMembersForExport(userID string, teamI
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1187,7 +1187,7 @@ func (s *RetryLayerChannelStore) GetChannelMembersTimezones(channelID string) ([
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1208,7 +1208,7 @@ func (s *RetryLayerChannelStore) GetChannelUnread(channelID string, userID strin
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1229,7 +1229,7 @@ func (s *RetryLayerChannelStore) GetChannels(teamID string, userID string, inclu
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1250,7 +1250,7 @@ func (s *RetryLayerChannelStore) GetChannelsBatchForIndexing(startTime int64, en
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1271,7 +1271,7 @@ func (s *RetryLayerChannelStore) GetChannelsByIds(channelIds []string, includeDe
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1292,7 +1292,7 @@ func (s *RetryLayerChannelStore) GetChannelsByScheme(schemeID string, offset int
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1313,7 +1313,7 @@ func (s *RetryLayerChannelStore) GetChannelsByUser(userID string, includeDeleted
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1334,7 +1334,7 @@ func (s *RetryLayerChannelStore) GetChannelsWithTeamDataByIds(channelIds []strin
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1355,7 +1355,7 @@ func (s *RetryLayerChannelStore) GetDeleted(team_id string, offset int, limit in
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1376,7 +1376,7 @@ func (s *RetryLayerChannelStore) GetDeletedByName(team_id string, name string) (
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1397,7 +1397,7 @@ func (s *RetryLayerChannelStore) GetForPost(postID string) (*model.Channel, erro
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1418,7 +1418,7 @@ func (s *RetryLayerChannelStore) GetFromMaster(id string) (*model.Channel, error
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1439,7 +1439,7 @@ func (s *RetryLayerChannelStore) GetGuestCount(channelID string, allowFromCache 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1460,7 +1460,7 @@ func (s *RetryLayerChannelStore) GetMember(ctx context.Context, channelID string
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1481,7 +1481,7 @@ func (s *RetryLayerChannelStore) GetMemberCount(channelID string, allowFromCache
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1508,7 +1508,7 @@ func (s *RetryLayerChannelStore) GetMemberCountsByGroup(ctx context.Context, cha
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1529,7 +1529,7 @@ func (s *RetryLayerChannelStore) GetMemberForPost(postID string, userID string) 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1550,7 +1550,7 @@ func (s *RetryLayerChannelStore) GetMembers(channelID string, offset int, limit 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1571,7 +1571,7 @@ func (s *RetryLayerChannelStore) GetMembersByChannelIds(channelIds []string, use
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1592,7 +1592,7 @@ func (s *RetryLayerChannelStore) GetMembersByIds(channelID string, userIds []str
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1613,7 +1613,7 @@ func (s *RetryLayerChannelStore) GetMembersForUser(teamID string, userID string)
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1634,7 +1634,7 @@ func (s *RetryLayerChannelStore) GetMembersForUserWithPagination(userID string, 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1655,7 +1655,7 @@ func (s *RetryLayerChannelStore) GetMoreChannels(teamID string, userID string, o
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1676,7 +1676,7 @@ func (s *RetryLayerChannelStore) GetPinnedPostCount(channelID string, allowFromC
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1697,7 +1697,7 @@ func (s *RetryLayerChannelStore) GetPinnedPosts(channelID string) (*model.PostLi
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1718,7 +1718,7 @@ func (s *RetryLayerChannelStore) GetPrivateChannelsForTeam(teamID string, offset
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1739,7 +1739,7 @@ func (s *RetryLayerChannelStore) GetPublicChannelsByIdsForTeam(teamID string, ch
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1760,7 +1760,7 @@ func (s *RetryLayerChannelStore) GetPublicChannelsForTeam(teamID string, offset 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1781,7 +1781,7 @@ func (s *RetryLayerChannelStore) GetSidebarCategories(userID string, teamID stri
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1802,7 +1802,7 @@ func (s *RetryLayerChannelStore) GetSidebarCategory(categoryID string) (*model.S
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1823,7 +1823,7 @@ func (s *RetryLayerChannelStore) GetSidebarCategoryOrder(userID string, teamID s
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1844,7 +1844,7 @@ func (s *RetryLayerChannelStore) GetTeamChannels(teamID string) (model.ChannelLi
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1865,7 +1865,7 @@ func (s *RetryLayerChannelStore) GetTeamForChannel(channelID string) (*model.Tea
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1886,7 +1886,7 @@ func (s *RetryLayerChannelStore) GetTeamMembersForChannel(channelID string) ([]s
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1907,7 +1907,7 @@ func (s *RetryLayerChannelStore) GroupSyncedChannelCount() (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1928,7 +1928,7 @@ func (s *RetryLayerChannelStore) IncrementMentionCount(channelID string, userID 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -1997,7 +1997,7 @@ func (s *RetryLayerChannelStore) MigrateChannelMembers(fromChannelID string, fro
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2018,7 +2018,7 @@ func (s *RetryLayerChannelStore) MigratePublicChannels() error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2039,7 +2039,7 @@ func (s *RetryLayerChannelStore) PermanentDelete(channelID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2060,7 +2060,7 @@ func (s *RetryLayerChannelStore) PermanentDeleteByTeam(teamID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2081,7 +2081,7 @@ func (s *RetryLayerChannelStore) PermanentDeleteMembersByChannel(channelID strin
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2102,7 +2102,7 @@ func (s *RetryLayerChannelStore) PermanentDeleteMembersByUser(userID string) err
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2123,7 +2123,7 @@ func (s *RetryLayerChannelStore) RemoveAllDeactivatedMembers(channelID string) e
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2144,7 +2144,7 @@ func (s *RetryLayerChannelStore) RemoveMember(channelID string, userID string) e
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2165,7 +2165,7 @@ func (s *RetryLayerChannelStore) RemoveMembers(channelID string, userIds []strin
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2186,7 +2186,7 @@ func (s *RetryLayerChannelStore) ResetAllChannelSchemes() error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2207,7 +2207,7 @@ func (s *RetryLayerChannelStore) Restore(channelID string, time int64) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2228,7 +2228,7 @@ func (s *RetryLayerChannelStore) Save(channel *model.Channel, maxChannelsPerTeam
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2249,7 +2249,7 @@ func (s *RetryLayerChannelStore) SaveDirectChannel(channel *model.Channel, membe
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2270,7 +2270,7 @@ func (s *RetryLayerChannelStore) SaveMember(member *model.ChannelMember) (*model
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2291,7 +2291,7 @@ func (s *RetryLayerChannelStore) SaveMultipleMembers(members []*model.ChannelMem
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2312,7 +2312,7 @@ func (s *RetryLayerChannelStore) SearchAllChannels(term string, opts store.Chann
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, resultVar1, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2333,7 +2333,7 @@ func (s *RetryLayerChannelStore) SearchArchivedInTeam(teamID string, term string
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2354,7 +2354,7 @@ func (s *RetryLayerChannelStore) SearchForUserInTeam(userID string, teamID strin
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2375,7 +2375,7 @@ func (s *RetryLayerChannelStore) SearchGroupChannels(userID string, term string)
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2396,7 +2396,7 @@ func (s *RetryLayerChannelStore) SearchInTeam(teamID string, term string, includ
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2417,7 +2417,7 @@ func (s *RetryLayerChannelStore) SearchMore(userID string, teamID string, term s
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2438,7 +2438,7 @@ func (s *RetryLayerChannelStore) SetDeleteAt(channelID string, deleteAt int64, u
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2459,7 +2459,7 @@ func (s *RetryLayerChannelStore) SetShared(channelId string, shared bool) error 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2480,7 +2480,7 @@ func (s *RetryLayerChannelStore) Update(channel *model.Channel) (*model.Channel,
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2501,7 +2501,7 @@ func (s *RetryLayerChannelStore) UpdateLastViewedAt(channelIds []string, userID 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2522,7 +2522,7 @@ func (s *RetryLayerChannelStore) UpdateLastViewedAtPost(unreadPost *model.Post, 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2543,7 +2543,7 @@ func (s *RetryLayerChannelStore) UpdateMember(member *model.ChannelMember) (*mod
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2564,7 +2564,7 @@ func (s *RetryLayerChannelStore) UpdateMemberNotifyProps(channelID string, userI
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2585,7 +2585,7 @@ func (s *RetryLayerChannelStore) UpdateMembersRole(channelID string, userIDs []s
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2606,7 +2606,7 @@ func (s *RetryLayerChannelStore) UpdateMultipleMembers(members []*model.ChannelM
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2627,7 +2627,7 @@ func (s *RetryLayerChannelStore) UpdateSidebarCategories(userID string, teamID s
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, resultVar1, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2648,7 +2648,7 @@ func (s *RetryLayerChannelStore) UpdateSidebarCategoryOrder(userID string, teamI
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2669,7 +2669,7 @@ func (s *RetryLayerChannelStore) UpdateSidebarChannelCategoryOnMove(channel *mod
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2690,7 +2690,7 @@ func (s *RetryLayerChannelStore) UpdateSidebarChannelsByPreferences(preferences 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2711,7 +2711,7 @@ func (s *RetryLayerChannelStore) UserBelongsToChannels(userID string, channelIds
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2732,7 +2732,7 @@ func (s *RetryLayerChannelMemberHistoryStore) DeleteOrphanedRows(limit int) (int
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2753,7 +2753,7 @@ func (s *RetryLayerChannelMemberHistoryStore) GetUsersInChannelDuring(startTime 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2774,7 +2774,7 @@ func (s *RetryLayerChannelMemberHistoryStore) LogJoinEvent(userID string, channe
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2795,7 +2795,7 @@ func (s *RetryLayerChannelMemberHistoryStore) LogLeaveEvent(userID string, chann
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2816,7 +2816,7 @@ func (s *RetryLayerChannelMemberHistoryStore) PermanentDeleteBatch(endTime int64
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2837,7 +2837,7 @@ func (s *RetryLayerChannelMemberHistoryStore) PermanentDeleteBatchForRetentionPo
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, resultVar1, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2858,7 +2858,7 @@ func (s *RetryLayerClusterDiscoveryStore) Cleanup() error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2879,7 +2879,7 @@ func (s *RetryLayerClusterDiscoveryStore) Delete(discovery *model.ClusterDiscove
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2900,7 +2900,7 @@ func (s *RetryLayerClusterDiscoveryStore) Exists(discovery *model.ClusterDiscove
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2921,7 +2921,7 @@ func (s *RetryLayerClusterDiscoveryStore) GetAll(discoveryType string, clusterNa
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2942,7 +2942,7 @@ func (s *RetryLayerClusterDiscoveryStore) Save(discovery *model.ClusterDiscovery
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2963,7 +2963,7 @@ func (s *RetryLayerClusterDiscoveryStore) SetLastPingAt(discovery *model.Cluster
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -2984,7 +2984,7 @@ func (s *RetryLayerCommandStore) AnalyticsCommandCount(teamID string) (int64, er
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3005,7 +3005,7 @@ func (s *RetryLayerCommandStore) Delete(commandID string, time int64) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3026,7 +3026,7 @@ func (s *RetryLayerCommandStore) Get(id string) (*model.Command, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3047,7 +3047,7 @@ func (s *RetryLayerCommandStore) GetByTeam(teamID string) ([]*model.Command, err
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3068,7 +3068,7 @@ func (s *RetryLayerCommandStore) GetByTrigger(teamID string, trigger string) (*m
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3089,7 +3089,7 @@ func (s *RetryLayerCommandStore) PermanentDeleteByTeam(teamID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3110,7 +3110,7 @@ func (s *RetryLayerCommandStore) PermanentDeleteByUser(userID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3131,7 +3131,7 @@ func (s *RetryLayerCommandStore) Save(webhook *model.Command) (*model.Command, e
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3152,7 +3152,7 @@ func (s *RetryLayerCommandStore) Update(hook *model.Command) (*model.Command, er
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3179,7 +3179,7 @@ func (s *RetryLayerCommandWebhookStore) Get(id string) (*model.CommandWebhook, e
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3200,7 +3200,7 @@ func (s *RetryLayerCommandWebhookStore) Save(webhook *model.CommandWebhook) (*mo
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3221,7 +3221,7 @@ func (s *RetryLayerCommandWebhookStore) TryUse(id string, limit int) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3242,7 +3242,7 @@ func (s *RetryLayerComplianceStore) ComplianceExport(compliance *model.Complianc
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, resultVar1, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3263,7 +3263,7 @@ func (s *RetryLayerComplianceStore) Get(id string) (*model.Compliance, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3284,7 +3284,7 @@ func (s *RetryLayerComplianceStore) GetAll(offset int, limit int) (model.Complia
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3305,7 +3305,7 @@ func (s *RetryLayerComplianceStore) MessageExport(cursor model.MessageExportCurs
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, resultVar1, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3326,7 +3326,7 @@ func (s *RetryLayerComplianceStore) Save(compliance *model.Compliance) (*model.C
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3347,7 +3347,7 @@ func (s *RetryLayerComplianceStore) Update(compliance *model.Compliance) (*model
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3368,7 +3368,7 @@ func (s *RetryLayerEmojiStore) Delete(emoji *model.Emoji, time int64) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3389,7 +3389,7 @@ func (s *RetryLayerEmojiStore) Get(ctx context.Context, id string, allowFromCach
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3410,7 +3410,7 @@ func (s *RetryLayerEmojiStore) GetByName(ctx context.Context, name string, allow
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3431,7 +3431,7 @@ func (s *RetryLayerEmojiStore) GetList(offset int, limit int, sort string) ([]*m
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3452,7 +3452,7 @@ func (s *RetryLayerEmojiStore) GetMultipleByName(names []string) ([]*model.Emoji
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3473,7 +3473,7 @@ func (s *RetryLayerEmojiStore) Save(emoji *model.Emoji) (*model.Emoji, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3494,7 +3494,7 @@ func (s *RetryLayerEmojiStore) Search(name string, prefixOnly bool, limit int) (
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3515,7 +3515,7 @@ func (s *RetryLayerFileInfoStore) AttachToPost(fileID string, postID string, cre
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3542,7 +3542,7 @@ func (s *RetryLayerFileInfoStore) CountAll() (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3563,7 +3563,7 @@ func (s *RetryLayerFileInfoStore) DeleteForPost(postID string) (string, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3584,7 +3584,7 @@ func (s *RetryLayerFileInfoStore) Get(id string) (*model.FileInfo, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3605,7 +3605,7 @@ func (s *RetryLayerFileInfoStore) GetByIds(ids []string) ([]*model.FileInfo, err
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3626,7 +3626,7 @@ func (s *RetryLayerFileInfoStore) GetByPath(path string) (*model.FileInfo, error
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3647,7 +3647,7 @@ func (s *RetryLayerFileInfoStore) GetFilesBatchForIndexing(startTime int64, endT
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3668,7 +3668,7 @@ func (s *RetryLayerFileInfoStore) GetForPost(postID string, readFromMaster bool,
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3689,7 +3689,7 @@ func (s *RetryLayerFileInfoStore) GetForUser(userID string) ([]*model.FileInfo, 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3710,7 +3710,7 @@ func (s *RetryLayerFileInfoStore) GetFromMaster(id string) (*model.FileInfo, err
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3731,7 +3731,7 @@ func (s *RetryLayerFileInfoStore) GetWithOptions(page int, perPage int, opt *mod
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3758,7 +3758,7 @@ func (s *RetryLayerFileInfoStore) PermanentDelete(fileID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3779,7 +3779,7 @@ func (s *RetryLayerFileInfoStore) PermanentDeleteBatch(endTime int64, limit int6
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3800,7 +3800,7 @@ func (s *RetryLayerFileInfoStore) PermanentDeleteByUser(userID string) (int64, e
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3821,7 +3821,7 @@ func (s *RetryLayerFileInfoStore) Save(info *model.FileInfo) (*model.FileInfo, e
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3842,7 +3842,7 @@ func (s *RetryLayerFileInfoStore) Search(paramsList []*model.SearchParams, userI
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3863,7 +3863,7 @@ func (s *RetryLayerFileInfoStore) SetContent(fileID string, content string) erro
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3884,7 +3884,7 @@ func (s *RetryLayerFileInfoStore) Upsert(info *model.FileInfo) (*model.FileInfo,
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3905,7 +3905,7 @@ func (s *RetryLayerGroupStore) AdminRoleGroupsForSyncableMember(userID string, s
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3926,7 +3926,7 @@ func (s *RetryLayerGroupStore) ChannelMembersMinusGroupMembers(channelID string,
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3947,7 +3947,7 @@ func (s *RetryLayerGroupStore) ChannelMembersToAdd(since int64, channelID *strin
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3968,7 +3968,7 @@ func (s *RetryLayerGroupStore) ChannelMembersToRemove(channelID *string) ([]*mod
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -3989,7 +3989,7 @@ func (s *RetryLayerGroupStore) CountChannelMembersMinusGroupMembers(channelID st
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4010,7 +4010,7 @@ func (s *RetryLayerGroupStore) CountGroupsByChannel(channelID string, opts model
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4031,7 +4031,7 @@ func (s *RetryLayerGroupStore) CountGroupsByTeam(teamID string, opts model.Group
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4052,7 +4052,7 @@ func (s *RetryLayerGroupStore) CountTeamMembersMinusGroupMembers(teamID string, 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4073,7 +4073,7 @@ func (s *RetryLayerGroupStore) Create(group *model.Group) (*model.Group, error) 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4094,7 +4094,7 @@ func (s *RetryLayerGroupStore) CreateGroupSyncable(groupSyncable *model.GroupSyn
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4115,7 +4115,7 @@ func (s *RetryLayerGroupStore) Delete(groupID string) (*model.Group, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4136,7 +4136,7 @@ func (s *RetryLayerGroupStore) DeleteGroupSyncable(groupID string, syncableID st
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4157,7 +4157,7 @@ func (s *RetryLayerGroupStore) DeleteMember(groupID string, userID string) (*mod
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4178,7 +4178,7 @@ func (s *RetryLayerGroupStore) DistinctGroupMemberCount() (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4199,7 +4199,7 @@ func (s *RetryLayerGroupStore) Get(groupID string) (*model.Group, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4220,7 +4220,7 @@ func (s *RetryLayerGroupStore) GetAllBySource(groupSource model.GroupSource) ([]
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4241,7 +4241,7 @@ func (s *RetryLayerGroupStore) GetAllGroupSyncablesByGroupId(groupID string, syn
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4262,7 +4262,7 @@ func (s *RetryLayerGroupStore) GetByIDs(groupIDs []string) ([]*model.Group, erro
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4283,7 +4283,7 @@ func (s *RetryLayerGroupStore) GetByName(name string, opts model.GroupSearchOpts
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4304,7 +4304,7 @@ func (s *RetryLayerGroupStore) GetByRemoteID(remoteID string, groupSource model.
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4325,7 +4325,7 @@ func (s *RetryLayerGroupStore) GetByUser(userID string) ([]*model.Group, error) 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4346,7 +4346,7 @@ func (s *RetryLayerGroupStore) GetGroupSyncable(groupID string, syncableID strin
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4367,7 +4367,7 @@ func (s *RetryLayerGroupStore) GetGroups(page int, perPage int, opts model.Group
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4388,7 +4388,7 @@ func (s *RetryLayerGroupStore) GetGroupsAssociatedToChannelsByTeam(teamID string
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4409,7 +4409,7 @@ func (s *RetryLayerGroupStore) GetGroupsByChannel(channelID string, opts model.G
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4430,7 +4430,7 @@ func (s *RetryLayerGroupStore) GetGroupsByTeam(teamID string, opts model.GroupSe
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4451,7 +4451,7 @@ func (s *RetryLayerGroupStore) GetMemberCount(groupID string) (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4472,7 +4472,7 @@ func (s *RetryLayerGroupStore) GetMemberUsers(groupID string) ([]*model.User, er
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4493,7 +4493,7 @@ func (s *RetryLayerGroupStore) GetMemberUsersInTeam(groupID string, teamID strin
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4514,7 +4514,7 @@ func (s *RetryLayerGroupStore) GetMemberUsersNotInChannel(groupID string, channe
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4535,7 +4535,7 @@ func (s *RetryLayerGroupStore) GetMemberUsersPage(groupID string, page int, perP
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4556,7 +4556,7 @@ func (s *RetryLayerGroupStore) GroupChannelCount() (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4577,7 +4577,7 @@ func (s *RetryLayerGroupStore) GroupCount() (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4598,7 +4598,7 @@ func (s *RetryLayerGroupStore) GroupCountWithAllowReference() (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4619,7 +4619,7 @@ func (s *RetryLayerGroupStore) GroupMemberCount() (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4640,7 +4640,7 @@ func (s *RetryLayerGroupStore) GroupTeamCount() (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4661,7 +4661,7 @@ func (s *RetryLayerGroupStore) PermanentDeleteMembersByUser(userID string) error
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4682,7 +4682,7 @@ func (s *RetryLayerGroupStore) PermittedSyncableAdmins(syncableID string, syncab
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4703,7 +4703,7 @@ func (s *RetryLayerGroupStore) TeamMembersMinusGroupMembers(teamID string, group
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4724,7 +4724,7 @@ func (s *RetryLayerGroupStore) TeamMembersToAdd(since int64, teamID *string, inc
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4745,7 +4745,7 @@ func (s *RetryLayerGroupStore) TeamMembersToRemove(teamID *string) ([]*model.Tea
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4766,7 +4766,7 @@ func (s *RetryLayerGroupStore) Update(group *model.Group) (*model.Group, error) 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4787,7 +4787,7 @@ func (s *RetryLayerGroupStore) UpdateGroupSyncable(groupSyncable *model.GroupSyn
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4808,7 +4808,7 @@ func (s *RetryLayerGroupStore) UpsertMember(groupID string, userID string) (*mod
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4829,7 +4829,7 @@ func (s *RetryLayerJobStore) Cleanup(expiryTime int64, batchSize int) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4850,7 +4850,7 @@ func (s *RetryLayerJobStore) Delete(id string) (string, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4871,7 +4871,7 @@ func (s *RetryLayerJobStore) Get(id string) (*model.Job, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4892,7 +4892,7 @@ func (s *RetryLayerJobStore) GetAllByStatus(status string) ([]*model.Job, error)
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4913,7 +4913,7 @@ func (s *RetryLayerJobStore) GetAllByType(jobType string) ([]*model.Job, error) 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4934,7 +4934,7 @@ func (s *RetryLayerJobStore) GetAllByTypePage(jobType string, offset int, limit 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4955,7 +4955,7 @@ func (s *RetryLayerJobStore) GetAllByTypesPage(jobTypes []string, offset int, li
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4976,7 +4976,7 @@ func (s *RetryLayerJobStore) GetAllPage(offset int, limit int) ([]*model.Job, er
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -4997,7 +4997,7 @@ func (s *RetryLayerJobStore) GetCountByStatusAndType(status string, jobType stri
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5018,7 +5018,7 @@ func (s *RetryLayerJobStore) GetNewestJobByStatusAndType(status string, jobType 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5039,7 +5039,7 @@ func (s *RetryLayerJobStore) GetNewestJobByStatusesAndType(statuses []string, jo
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5060,7 +5060,7 @@ func (s *RetryLayerJobStore) Save(job *model.Job) (*model.Job, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5081,7 +5081,7 @@ func (s *RetryLayerJobStore) UpdateOptimistically(job *model.Job, currentStatus 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5102,7 +5102,7 @@ func (s *RetryLayerJobStore) UpdateStatus(id string, status string) (*model.Job,
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5123,7 +5123,7 @@ func (s *RetryLayerJobStore) UpdateStatusOptimistically(id string, currentStatus
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5144,7 +5144,7 @@ func (s *RetryLayerLicenseStore) Get(id string) (*model.LicenseRecord, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5165,7 +5165,7 @@ func (s *RetryLayerLicenseStore) GetAll() ([]*model.LicenseRecord, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5186,7 +5186,7 @@ func (s *RetryLayerLicenseStore) Save(license *model.LicenseRecord) (*model.Lice
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5207,7 +5207,7 @@ func (s *RetryLayerLinkMetadataStore) Get(url string, timestamp int64) (*model.L
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5228,7 +5228,7 @@ func (s *RetryLayerLinkMetadataStore) Save(linkMetadata *model.LinkMetadata) (*m
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5249,7 +5249,7 @@ func (s *RetryLayerOAuthStore) DeleteApp(id string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5270,7 +5270,7 @@ func (s *RetryLayerOAuthStore) GetAccessData(token string) (*model.AccessData, e
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5291,7 +5291,7 @@ func (s *RetryLayerOAuthStore) GetAccessDataByRefreshToken(token string) (*model
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5312,7 +5312,7 @@ func (s *RetryLayerOAuthStore) GetAccessDataByUserForApp(userID string, clientId
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5333,7 +5333,7 @@ func (s *RetryLayerOAuthStore) GetApp(id string) (*model.OAuthApp, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5354,7 +5354,7 @@ func (s *RetryLayerOAuthStore) GetAppByUser(userID string, offset int, limit int
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5375,7 +5375,7 @@ func (s *RetryLayerOAuthStore) GetApps(offset int, limit int) ([]*model.OAuthApp
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5396,7 +5396,7 @@ func (s *RetryLayerOAuthStore) GetAuthData(code string) (*model.AuthData, error)
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5417,7 +5417,7 @@ func (s *RetryLayerOAuthStore) GetAuthorizedApps(userID string, offset int, limi
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5438,7 +5438,7 @@ func (s *RetryLayerOAuthStore) GetPreviousAccessData(userID string, clientId str
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5459,7 +5459,7 @@ func (s *RetryLayerOAuthStore) PermanentDeleteAuthDataByUser(userID string) erro
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5480,7 +5480,7 @@ func (s *RetryLayerOAuthStore) RemoveAccessData(token string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5501,7 +5501,7 @@ func (s *RetryLayerOAuthStore) RemoveAllAccessData() error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5522,7 +5522,7 @@ func (s *RetryLayerOAuthStore) RemoveAuthData(code string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5543,7 +5543,7 @@ func (s *RetryLayerOAuthStore) SaveAccessData(accessData *model.AccessData) (*mo
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5564,7 +5564,7 @@ func (s *RetryLayerOAuthStore) SaveApp(app *model.OAuthApp) (*model.OAuthApp, er
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5585,7 +5585,7 @@ func (s *RetryLayerOAuthStore) SaveAuthData(authData *model.AuthData) (*model.Au
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5606,7 +5606,7 @@ func (s *RetryLayerOAuthStore) UpdateAccessData(accessData *model.AccessData) (*
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5627,7 +5627,7 @@ func (s *RetryLayerOAuthStore) UpdateApp(app *model.OAuthApp) (*model.OAuthApp, 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5648,7 +5648,7 @@ func (s *RetryLayerPluginStore) CompareAndDelete(keyVal *model.PluginKeyValue, o
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5669,7 +5669,7 @@ func (s *RetryLayerPluginStore) CompareAndSet(keyVal *model.PluginKeyValue, oldV
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5690,7 +5690,7 @@ func (s *RetryLayerPluginStore) Delete(pluginID string, key string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5711,7 +5711,7 @@ func (s *RetryLayerPluginStore) DeleteAllExpired() error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5732,7 +5732,7 @@ func (s *RetryLayerPluginStore) DeleteAllForPlugin(PluginID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5753,7 +5753,7 @@ func (s *RetryLayerPluginStore) Get(pluginID string, key string) (*model.PluginK
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5774,7 +5774,7 @@ func (s *RetryLayerPluginStore) List(pluginID string, page int, perPage int) ([]
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5795,7 +5795,7 @@ func (s *RetryLayerPluginStore) SaveOrUpdate(keyVal *model.PluginKeyValue) (*mod
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5816,7 +5816,7 @@ func (s *RetryLayerPluginStore) SetWithOptions(pluginID string, key string, valu
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5837,7 +5837,7 @@ func (s *RetryLayerPostStore) AnalyticsPostCount(teamID string, mustHaveFile boo
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5858,7 +5858,7 @@ func (s *RetryLayerPostStore) AnalyticsPostCountsByDay(options *model.AnalyticsP
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5879,7 +5879,7 @@ func (s *RetryLayerPostStore) AnalyticsUserCountsWithPostsByDay(teamID string) (
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5906,7 +5906,7 @@ func (s *RetryLayerPostStore) Delete(postID string, time int64, deleteByID strin
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5927,7 +5927,7 @@ func (s *RetryLayerPostStore) DeleteOrphanedRows(limit int) (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5948,7 +5948,7 @@ func (s *RetryLayerPostStore) Get(ctx context.Context, id string, skipFetchThrea
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5969,7 +5969,7 @@ func (s *RetryLayerPostStore) GetDirectPostParentsForExportAfter(limit int, afte
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -5996,7 +5996,7 @@ func (s *RetryLayerPostStore) GetFlaggedPosts(userID string, offset int, limit i
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6017,7 +6017,7 @@ func (s *RetryLayerPostStore) GetFlaggedPostsForChannel(userID string, channelID
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6038,7 +6038,7 @@ func (s *RetryLayerPostStore) GetFlaggedPostsForTeam(userID string, teamID strin
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6065,7 +6065,7 @@ func (s *RetryLayerPostStore) GetOldest() (*model.Post, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6086,7 +6086,7 @@ func (s *RetryLayerPostStore) GetOldestEntityCreationTime() (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6107,7 +6107,7 @@ func (s *RetryLayerPostStore) GetParentsForExportAfter(limit int, afterID string
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6128,7 +6128,7 @@ func (s *RetryLayerPostStore) GetPostAfterTime(channelID string, time int64, col
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6149,7 +6149,7 @@ func (s *RetryLayerPostStore) GetPostIdAfterTime(channelID string, time int64, c
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6170,7 +6170,7 @@ func (s *RetryLayerPostStore) GetPostIdBeforeTime(channelID string, time int64, 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6191,7 +6191,7 @@ func (s *RetryLayerPostStore) GetPosts(options model.GetPostsOptions, allowFromC
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6212,7 +6212,7 @@ func (s *RetryLayerPostStore) GetPostsAfter(options model.GetPostsOptions) (*mod
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6233,7 +6233,7 @@ func (s *RetryLayerPostStore) GetPostsBatchForIndexing(startTime int64, endTime 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6254,7 +6254,7 @@ func (s *RetryLayerPostStore) GetPostsBefore(options model.GetPostsOptions) (*mo
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6275,7 +6275,7 @@ func (s *RetryLayerPostStore) GetPostsByIds(postIds []string) ([]*model.Post, er
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6296,7 +6296,7 @@ func (s *RetryLayerPostStore) GetPostsCreatedAt(channelID string, time int64) ([
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6317,7 +6317,7 @@ func (s *RetryLayerPostStore) GetPostsSince(options model.GetPostsSinceOptions, 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6338,7 +6338,7 @@ func (s *RetryLayerPostStore) GetPostsSinceForSync(options model.GetPostsSinceFo
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, resultVar1, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6359,7 +6359,7 @@ func (s *RetryLayerPostStore) GetRepliesForExport(parentID string) ([]*model.Rep
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6380,7 +6380,7 @@ func (s *RetryLayerPostStore) GetSingle(id string, inclDeleted bool) (*model.Pos
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6401,7 +6401,7 @@ func (s *RetryLayerPostStore) HasAutoResponsePostByUserSince(options model.GetPo
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6428,7 +6428,7 @@ func (s *RetryLayerPostStore) Overwrite(post *model.Post) (*model.Post, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6449,7 +6449,7 @@ func (s *RetryLayerPostStore) OverwriteMultiple(posts []*model.Post) ([]*model.P
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, resultVar1, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6470,7 +6470,7 @@ func (s *RetryLayerPostStore) PermanentDeleteBatch(endTime int64, limit int64) (
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6491,7 +6491,7 @@ func (s *RetryLayerPostStore) PermanentDeleteBatchForRetentionPolicies(now int64
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, resultVar1, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6512,7 +6512,7 @@ func (s *RetryLayerPostStore) PermanentDeleteByChannel(channelID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6533,7 +6533,7 @@ func (s *RetryLayerPostStore) PermanentDeleteByUser(userID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6554,7 +6554,7 @@ func (s *RetryLayerPostStore) Save(post *model.Post) (*model.Post, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6575,7 +6575,7 @@ func (s *RetryLayerPostStore) SaveMultiple(posts []*model.Post) ([]*model.Post, 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, resultVar1, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6596,7 +6596,7 @@ func (s *RetryLayerPostStore) Search(teamID string, userID string, params *model
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6617,7 +6617,7 @@ func (s *RetryLayerPostStore) SearchPostsForUser(paramsList []*model.SearchParam
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6638,7 +6638,7 @@ func (s *RetryLayerPostStore) Update(newPost *model.Post, oldPost *model.Post) (
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6659,7 +6659,7 @@ func (s *RetryLayerPreferenceStore) CleanupFlagsBatch(limit int64) (int64, error
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6680,7 +6680,7 @@ func (s *RetryLayerPreferenceStore) Delete(userID string, category string, name 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6701,7 +6701,7 @@ func (s *RetryLayerPreferenceStore) DeleteCategory(userID string, category strin
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6722,7 +6722,7 @@ func (s *RetryLayerPreferenceStore) DeleteCategoryAndName(category string, name 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6743,7 +6743,7 @@ func (s *RetryLayerPreferenceStore) DeleteOrphanedRows(limit int) (int64, error)
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6764,7 +6764,7 @@ func (s *RetryLayerPreferenceStore) Get(userID string, category string, name str
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6785,7 +6785,7 @@ func (s *RetryLayerPreferenceStore) GetAll(userID string) (model.Preferences, er
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6806,7 +6806,7 @@ func (s *RetryLayerPreferenceStore) GetCategory(userID string, category string) 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6827,7 +6827,7 @@ func (s *RetryLayerPreferenceStore) PermanentDeleteByUser(userID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6848,7 +6848,7 @@ func (s *RetryLayerPreferenceStore) Save(preferences model.Preferences) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6869,7 +6869,7 @@ func (s *RetryLayerProductNoticesStore) Clear(notices []string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6890,7 +6890,7 @@ func (s *RetryLayerProductNoticesStore) ClearOldNotices(currentNotices model.Pro
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6911,7 +6911,7 @@ func (s *RetryLayerProductNoticesStore) GetViews(userID string) ([]model.Product
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6932,7 +6932,7 @@ func (s *RetryLayerProductNoticesStore) View(userID string, notices []string) er
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6953,7 +6953,7 @@ func (s *RetryLayerReactionStore) BulkGetForPosts(postIds []string) ([]*model.Re
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6974,7 +6974,7 @@ func (s *RetryLayerReactionStore) Delete(reaction *model.Reaction) (*model.React
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -6995,7 +6995,7 @@ func (s *RetryLayerReactionStore) DeleteAllWithEmojiName(emojiName string) error
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7016,7 +7016,7 @@ func (s *RetryLayerReactionStore) DeleteOrphanedRows(limit int) (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7037,7 +7037,7 @@ func (s *RetryLayerReactionStore) GetForPost(postID string, allowFromCache bool)
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7058,7 +7058,7 @@ func (s *RetryLayerReactionStore) GetForPostSince(postId string, since int64, ex
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7079,7 +7079,7 @@ func (s *RetryLayerReactionStore) PermanentDeleteBatch(endTime int64, limit int6
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7100,7 +7100,7 @@ func (s *RetryLayerReactionStore) Save(reaction *model.Reaction) (*model.Reactio
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7121,7 +7121,7 @@ func (s *RetryLayerRemoteClusterStore) Delete(remoteClusterId string) (bool, err
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7142,7 +7142,7 @@ func (s *RetryLayerRemoteClusterStore) Get(remoteClusterId string) (*model.Remot
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7163,7 +7163,7 @@ func (s *RetryLayerRemoteClusterStore) GetAll(filter model.RemoteClusterQueryFil
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7184,7 +7184,7 @@ func (s *RetryLayerRemoteClusterStore) Save(rc *model.RemoteCluster) (*model.Rem
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7205,7 +7205,7 @@ func (s *RetryLayerRemoteClusterStore) SetLastPingAt(remoteClusterId string) err
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7226,7 +7226,7 @@ func (s *RetryLayerRemoteClusterStore) Update(rc *model.RemoteCluster) (*model.R
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7247,7 +7247,7 @@ func (s *RetryLayerRemoteClusterStore) UpdateTopics(remoteClusterId string, topi
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7268,7 +7268,7 @@ func (s *RetryLayerRetentionPolicyStore) AddChannels(policyId string, channelIds
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7289,7 +7289,7 @@ func (s *RetryLayerRetentionPolicyStore) AddTeams(policyId string, teamIds []str
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7310,7 +7310,7 @@ func (s *RetryLayerRetentionPolicyStore) Delete(id string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7331,7 +7331,7 @@ func (s *RetryLayerRetentionPolicyStore) DeleteOrphanedRows(limit int) (int64, e
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7352,7 +7352,7 @@ func (s *RetryLayerRetentionPolicyStore) Get(id string) (*model.RetentionPolicyW
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7373,7 +7373,7 @@ func (s *RetryLayerRetentionPolicyStore) GetAll(offset int, limit int) ([]*model
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7394,7 +7394,7 @@ func (s *RetryLayerRetentionPolicyStore) GetChannelPoliciesCountForUser(userID s
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7415,7 +7415,7 @@ func (s *RetryLayerRetentionPolicyStore) GetChannelPoliciesForUser(userID string
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7436,7 +7436,7 @@ func (s *RetryLayerRetentionPolicyStore) GetChannels(policyId string, offset int
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7457,7 +7457,7 @@ func (s *RetryLayerRetentionPolicyStore) GetChannelsCount(policyId string) (int6
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7478,7 +7478,7 @@ func (s *RetryLayerRetentionPolicyStore) GetCount() (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7499,7 +7499,7 @@ func (s *RetryLayerRetentionPolicyStore) GetTeamPoliciesCountForUser(userID stri
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7520,7 +7520,7 @@ func (s *RetryLayerRetentionPolicyStore) GetTeamPoliciesForUser(userID string, o
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7541,7 +7541,7 @@ func (s *RetryLayerRetentionPolicyStore) GetTeams(policyId string, offset int, l
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7562,7 +7562,7 @@ func (s *RetryLayerRetentionPolicyStore) GetTeamsCount(policyId string) (int64, 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7583,7 +7583,7 @@ func (s *RetryLayerRetentionPolicyStore) Patch(patch *model.RetentionPolicyWithT
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7604,7 +7604,7 @@ func (s *RetryLayerRetentionPolicyStore) RemoveChannels(policyId string, channel
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7625,7 +7625,7 @@ func (s *RetryLayerRetentionPolicyStore) RemoveTeams(policyId string, teamIds []
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7646,7 +7646,7 @@ func (s *RetryLayerRetentionPolicyStore) Save(policy *model.RetentionPolicyWithT
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7667,7 +7667,7 @@ func (s *RetryLayerRoleStore) AllChannelSchemeRoles() ([]*model.Role, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7688,7 +7688,7 @@ func (s *RetryLayerRoleStore) ChannelHigherScopedPermissions(roleNames []string)
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7709,7 +7709,7 @@ func (s *RetryLayerRoleStore) ChannelRolesUnderTeamRole(roleName string) ([]*mod
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7730,7 +7730,7 @@ func (s *RetryLayerRoleStore) Delete(roleID string) (*model.Role, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7751,7 +7751,7 @@ func (s *RetryLayerRoleStore) Get(roleID string) (*model.Role, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7772,7 +7772,7 @@ func (s *RetryLayerRoleStore) GetAll() ([]*model.Role, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7793,7 +7793,7 @@ func (s *RetryLayerRoleStore) GetByName(ctx context.Context, name string) (*mode
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7814,7 +7814,7 @@ func (s *RetryLayerRoleStore) GetByNames(names []string) ([]*model.Role, error) 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7835,7 +7835,7 @@ func (s *RetryLayerRoleStore) PermanentDeleteAll() error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7856,7 +7856,7 @@ func (s *RetryLayerRoleStore) Save(role *model.Role) (*model.Role, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7877,7 +7877,7 @@ func (s *RetryLayerSchemeStore) CountByScope(scope string) (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7898,7 +7898,7 @@ func (s *RetryLayerSchemeStore) CountWithoutPermission(scope string, permissionI
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7919,7 +7919,7 @@ func (s *RetryLayerSchemeStore) Delete(schemeID string) (*model.Scheme, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7940,7 +7940,7 @@ func (s *RetryLayerSchemeStore) Get(schemeID string) (*model.Scheme, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7961,7 +7961,7 @@ func (s *RetryLayerSchemeStore) GetAllPage(scope string, offset int, limit int) 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -7982,7 +7982,7 @@ func (s *RetryLayerSchemeStore) GetByName(schemeName string) (*model.Scheme, err
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8003,7 +8003,7 @@ func (s *RetryLayerSchemeStore) PermanentDeleteAll() error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8024,7 +8024,7 @@ func (s *RetryLayerSchemeStore) Save(scheme *model.Scheme) (*model.Scheme, error
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8045,7 +8045,7 @@ func (s *RetryLayerSessionStore) AnalyticsSessionCount() (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8066,7 +8066,7 @@ func (s *RetryLayerSessionStore) Cleanup(expiryTime int64, batchSize int64) erro
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8087,7 +8087,7 @@ func (s *RetryLayerSessionStore) Get(ctx context.Context, sessionIDOrToken strin
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8108,7 +8108,7 @@ func (s *RetryLayerSessionStore) GetSessions(userID string) ([]*model.Session, e
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8129,7 +8129,7 @@ func (s *RetryLayerSessionStore) GetSessionsExpired(thresholdMillis int64, mobil
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8150,7 +8150,7 @@ func (s *RetryLayerSessionStore) GetSessionsWithActiveDeviceIds(userID string) (
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8171,7 +8171,7 @@ func (s *RetryLayerSessionStore) PermanentDeleteSessionsByUser(teamID string) er
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8192,7 +8192,7 @@ func (s *RetryLayerSessionStore) Remove(sessionIDOrToken string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8213,7 +8213,7 @@ func (s *RetryLayerSessionStore) RemoveAllSessions() error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8234,7 +8234,7 @@ func (s *RetryLayerSessionStore) Save(session *model.Session) (*model.Session, e
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8255,7 +8255,7 @@ func (s *RetryLayerSessionStore) UpdateDeviceId(id string, deviceID string, expi
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8276,7 +8276,7 @@ func (s *RetryLayerSessionStore) UpdateExpiredNotify(sessionid string, notified 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8297,7 +8297,7 @@ func (s *RetryLayerSessionStore) UpdateExpiresAt(sessionID string, time int64) e
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8318,7 +8318,7 @@ func (s *RetryLayerSessionStore) UpdateLastActivityAt(sessionID string, time int
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8339,7 +8339,7 @@ func (s *RetryLayerSessionStore) UpdateProps(session *model.Session) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8360,7 +8360,7 @@ func (s *RetryLayerSessionStore) UpdateRoles(userID string, roles string) (strin
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8381,7 +8381,7 @@ func (s *RetryLayerSharedChannelStore) Delete(channelId string) (bool, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8402,7 +8402,7 @@ func (s *RetryLayerSharedChannelStore) DeleteRemote(remoteId string) (bool, erro
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8423,7 +8423,7 @@ func (s *RetryLayerSharedChannelStore) Get(channelId string) (*model.SharedChann
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8444,7 +8444,7 @@ func (s *RetryLayerSharedChannelStore) GetAll(offset int, limit int, opts model.
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8465,7 +8465,7 @@ func (s *RetryLayerSharedChannelStore) GetAllCount(opts model.SharedChannelFilte
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8486,7 +8486,7 @@ func (s *RetryLayerSharedChannelStore) GetAttachment(fileId string, remoteId str
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8507,7 +8507,7 @@ func (s *RetryLayerSharedChannelStore) GetRemote(id string) (*model.SharedChanne
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8528,7 +8528,7 @@ func (s *RetryLayerSharedChannelStore) GetRemoteByIds(channelId string, remoteId
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8549,7 +8549,7 @@ func (s *RetryLayerSharedChannelStore) GetRemoteForUser(remoteId string, userId 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8570,7 +8570,7 @@ func (s *RetryLayerSharedChannelStore) GetRemotes(opts model.SharedChannelRemote
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8591,7 +8591,7 @@ func (s *RetryLayerSharedChannelStore) GetRemotesStatus(channelId string) ([]*mo
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8612,7 +8612,7 @@ func (s *RetryLayerSharedChannelStore) GetSingleUser(userID string, channelID st
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8633,7 +8633,7 @@ func (s *RetryLayerSharedChannelStore) GetUsersForSync(filter model.GetUsersForS
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8654,7 +8654,7 @@ func (s *RetryLayerSharedChannelStore) GetUsersForUser(userID string) ([]*model.
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8675,7 +8675,7 @@ func (s *RetryLayerSharedChannelStore) HasChannel(channelID string) (bool, error
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8696,7 +8696,7 @@ func (s *RetryLayerSharedChannelStore) HasRemote(channelID string, remoteId stri
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8717,7 +8717,7 @@ func (s *RetryLayerSharedChannelStore) Save(sc *model.SharedChannel) (*model.Sha
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8738,7 +8738,7 @@ func (s *RetryLayerSharedChannelStore) SaveAttachment(remote *model.SharedChanne
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8759,7 +8759,7 @@ func (s *RetryLayerSharedChannelStore) SaveRemote(remote *model.SharedChannelRem
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8780,7 +8780,7 @@ func (s *RetryLayerSharedChannelStore) SaveUser(remote *model.SharedChannelUser)
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8801,7 +8801,7 @@ func (s *RetryLayerSharedChannelStore) Update(sc *model.SharedChannel) (*model.S
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8822,7 +8822,7 @@ func (s *RetryLayerSharedChannelStore) UpdateAttachmentLastSyncAt(id string, syn
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8843,7 +8843,7 @@ func (s *RetryLayerSharedChannelStore) UpdateRemote(remote *model.SharedChannelR
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8864,7 +8864,7 @@ func (s *RetryLayerSharedChannelStore) UpdateRemoteCursor(id string, cursor mode
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8885,7 +8885,7 @@ func (s *RetryLayerSharedChannelStore) UpdateUserLastSyncAt(userID string, chann
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8906,7 +8906,7 @@ func (s *RetryLayerSharedChannelStore) UpsertAttachment(remote *model.SharedChan
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8927,7 +8927,7 @@ func (s *RetryLayerStatusStore) Get(userID string) (*model.Status, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8948,7 +8948,7 @@ func (s *RetryLayerStatusStore) GetByIds(userIds []string) ([]*model.Status, err
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8969,7 +8969,7 @@ func (s *RetryLayerStatusStore) GetTotalActiveUsersCount() (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -8990,7 +8990,7 @@ func (s *RetryLayerStatusStore) ResetAll() error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9011,7 +9011,7 @@ func (s *RetryLayerStatusStore) SaveOrUpdate(status *model.Status) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9032,7 +9032,7 @@ func (s *RetryLayerStatusStore) UpdateExpiredDNDStatuses() ([]*model.Status, err
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9053,7 +9053,7 @@ func (s *RetryLayerStatusStore) UpdateLastActivityAt(userID string, lastActivity
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9074,7 +9074,7 @@ func (s *RetryLayerSystemStore) Get() (model.StringMap, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9095,7 +9095,7 @@ func (s *RetryLayerSystemStore) GetByName(name string) (*model.System, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9116,7 +9116,7 @@ func (s *RetryLayerSystemStore) InsertIfExists(system *model.System) (*model.Sys
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9137,7 +9137,7 @@ func (s *RetryLayerSystemStore) PermanentDeleteByName(name string) (*model.Syste
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9158,7 +9158,7 @@ func (s *RetryLayerSystemStore) Save(system *model.System) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9179,7 +9179,7 @@ func (s *RetryLayerSystemStore) SaveOrUpdate(system *model.System) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9200,7 +9200,7 @@ func (s *RetryLayerSystemStore) SaveOrUpdateWithWarnMetricHandling(system *model
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9221,7 +9221,7 @@ func (s *RetryLayerSystemStore) Update(system *model.System) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9242,7 +9242,7 @@ func (s *RetryLayerTeamStore) AnalyticsGetTeamCountForScheme(schemeID string) (i
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9263,7 +9263,7 @@ func (s *RetryLayerTeamStore) AnalyticsTeamCount(opts *model.TeamSearch) (int64,
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9284,7 +9284,7 @@ func (s *RetryLayerTeamStore) ClearAllCustomRoleAssignments() error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9311,7 +9311,7 @@ func (s *RetryLayerTeamStore) Get(id string) (*model.Team, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9332,7 +9332,7 @@ func (s *RetryLayerTeamStore) GetActiveMemberCount(teamID string, restrictions *
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9353,7 +9353,7 @@ func (s *RetryLayerTeamStore) GetAll() ([]*model.Team, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9374,7 +9374,7 @@ func (s *RetryLayerTeamStore) GetAllForExportAfter(limit int, afterID string) ([
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9395,7 +9395,7 @@ func (s *RetryLayerTeamStore) GetAllPage(offset int, limit int, opts *model.Team
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9416,7 +9416,7 @@ func (s *RetryLayerTeamStore) GetAllPrivateTeamListing() ([]*model.Team, error) 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9437,7 +9437,7 @@ func (s *RetryLayerTeamStore) GetAllTeamListing() ([]*model.Team, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9458,7 +9458,7 @@ func (s *RetryLayerTeamStore) GetByInviteId(inviteID string) (*model.Team, error
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9479,7 +9479,7 @@ func (s *RetryLayerTeamStore) GetByName(name string) (*model.Team, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9500,7 +9500,7 @@ func (s *RetryLayerTeamStore) GetByNames(name []string) ([]*model.Team, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9521,7 +9521,7 @@ func (s *RetryLayerTeamStore) GetChannelUnreadsForAllTeams(excludeTeamID string,
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9542,7 +9542,7 @@ func (s *RetryLayerTeamStore) GetChannelUnreadsForTeam(teamID string, userID str
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9563,7 +9563,7 @@ func (s *RetryLayerTeamStore) GetCommonTeamIDsForTwoUsers(userID string, otherUs
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9584,7 +9584,7 @@ func (s *RetryLayerTeamStore) GetMember(ctx context.Context, teamID string, user
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9605,7 +9605,7 @@ func (s *RetryLayerTeamStore) GetMembers(teamID string, offset int, limit int, t
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9626,7 +9626,7 @@ func (s *RetryLayerTeamStore) GetMembersByIds(teamID string, userIds []string, r
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9647,7 +9647,7 @@ func (s *RetryLayerTeamStore) GetTeamMembersForExport(userID string) ([]*model.T
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9668,7 +9668,7 @@ func (s *RetryLayerTeamStore) GetTeamsByScheme(schemeID string, offset int, limi
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9689,7 +9689,7 @@ func (s *RetryLayerTeamStore) GetTeamsByUserId(userID string) ([]*model.Team, er
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9710,7 +9710,7 @@ func (s *RetryLayerTeamStore) GetTeamsForUser(ctx context.Context, userID string
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9731,7 +9731,7 @@ func (s *RetryLayerTeamStore) GetTeamsForUserWithPagination(userID string, page 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9752,7 +9752,7 @@ func (s *RetryLayerTeamStore) GetTotalMemberCount(teamID string, restrictions *m
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9773,7 +9773,7 @@ func (s *RetryLayerTeamStore) GetUserTeamIds(userID string, allowFromCache bool)
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9794,7 +9794,7 @@ func (s *RetryLayerTeamStore) GroupSyncedTeamCount() (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9821,7 +9821,7 @@ func (s *RetryLayerTeamStore) MigrateTeamMembers(fromTeamID string, fromUserID s
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9842,7 +9842,7 @@ func (s *RetryLayerTeamStore) PermanentDelete(teamID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9863,7 +9863,7 @@ func (s *RetryLayerTeamStore) RemoveAllMembersByTeam(teamID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9884,7 +9884,7 @@ func (s *RetryLayerTeamStore) RemoveAllMembersByUser(userID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9905,7 +9905,7 @@ func (s *RetryLayerTeamStore) RemoveMember(teamID string, userID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9926,7 +9926,7 @@ func (s *RetryLayerTeamStore) RemoveMembers(teamID string, userIds []string) err
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9947,7 +9947,7 @@ func (s *RetryLayerTeamStore) ResetAllTeamSchemes() error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9968,7 +9968,7 @@ func (s *RetryLayerTeamStore) Save(team *model.Team) (*model.Team, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -9989,7 +9989,7 @@ func (s *RetryLayerTeamStore) SaveMember(member *model.TeamMember, maxUsersPerTe
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10010,7 +10010,7 @@ func (s *RetryLayerTeamStore) SaveMultipleMembers(members []*model.TeamMember, m
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10031,7 +10031,7 @@ func (s *RetryLayerTeamStore) SearchAll(opts *model.TeamSearch) ([]*model.Team, 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10052,7 +10052,7 @@ func (s *RetryLayerTeamStore) SearchAllPaged(opts *model.TeamSearch) ([]*model.T
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, resultVar1, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10073,7 +10073,7 @@ func (s *RetryLayerTeamStore) SearchOpen(opts *model.TeamSearch) ([]*model.Team,
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10094,7 +10094,7 @@ func (s *RetryLayerTeamStore) SearchPrivate(opts *model.TeamSearch) ([]*model.Te
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10115,7 +10115,7 @@ func (s *RetryLayerTeamStore) Update(team *model.Team) (*model.Team, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10136,7 +10136,7 @@ func (s *RetryLayerTeamStore) UpdateLastTeamIconUpdate(teamID string, curTime in
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10157,7 +10157,7 @@ func (s *RetryLayerTeamStore) UpdateMember(member *model.TeamMember) (*model.Tea
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10178,7 +10178,7 @@ func (s *RetryLayerTeamStore) UpdateMembersRole(teamID string, userIDs []string)
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10199,7 +10199,7 @@ func (s *RetryLayerTeamStore) UpdateMultipleMembers(members []*model.TeamMember)
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10220,7 +10220,7 @@ func (s *RetryLayerTeamStore) UserBelongsToTeams(userID string, teamIds []string
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10241,7 +10241,7 @@ func (s *RetryLayerTermsOfServiceStore) Get(id string, allowFromCache bool) (*mo
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10262,7 +10262,7 @@ func (s *RetryLayerTermsOfServiceStore) GetLatest(allowFromCache bool) (*model.T
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10283,7 +10283,7 @@ func (s *RetryLayerTermsOfServiceStore) Save(termsOfService *model.TermsOfServic
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10304,7 +10304,7 @@ func (s *RetryLayerThreadStore) CollectThreadsWithNewerReplies(userId string, ch
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10325,7 +10325,7 @@ func (s *RetryLayerThreadStore) Delete(postID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10346,7 +10346,7 @@ func (s *RetryLayerThreadStore) DeleteMembershipForUser(userId string, postID st
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10367,7 +10367,7 @@ func (s *RetryLayerThreadStore) DeleteOrphanedRows(limit int) (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10388,7 +10388,7 @@ func (s *RetryLayerThreadStore) Get(id string) (*model.Thread, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10409,7 +10409,7 @@ func (s *RetryLayerThreadStore) GetMembershipForUser(userId string, postID strin
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10430,7 +10430,7 @@ func (s *RetryLayerThreadStore) GetMembershipsForUser(userId string, teamID stri
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10451,7 +10451,7 @@ func (s *RetryLayerThreadStore) GetPosts(threadID string, since int64) ([]*model
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10472,7 +10472,7 @@ func (s *RetryLayerThreadStore) GetThreadFollowers(threadID string, fetchOnlyAct
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10493,7 +10493,7 @@ func (s *RetryLayerThreadStore) GetThreadForUser(teamID string, threadMembership
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10514,7 +10514,7 @@ func (s *RetryLayerThreadStore) GetThreadsForUser(userId string, teamID string, 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10535,7 +10535,7 @@ func (s *RetryLayerThreadStore) MaintainMembership(userID string, postID string,
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10556,7 +10556,7 @@ func (s *RetryLayerThreadStore) MarkAllAsRead(userID string, teamID string) erro
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10577,7 +10577,7 @@ func (s *RetryLayerThreadStore) MarkAllAsReadInChannels(userID string, channelID
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10598,7 +10598,7 @@ func (s *RetryLayerThreadStore) MarkAsRead(userID string, threadID string, times
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10619,7 +10619,7 @@ func (s *RetryLayerThreadStore) PermanentDeleteBatchForRetentionPolicies(now int
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, resultVar1, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10640,7 +10640,7 @@ func (s *RetryLayerThreadStore) PermanentDeleteBatchThreadMembershipsForRetentio
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, resultVar1, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10661,7 +10661,7 @@ func (s *RetryLayerThreadStore) Save(thread *model.Thread) (*model.Thread, error
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10682,7 +10682,7 @@ func (s *RetryLayerThreadStore) SaveMembership(membership *model.ThreadMembershi
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10703,7 +10703,7 @@ func (s *RetryLayerThreadStore) SaveMultiple(thread []*model.Thread) ([]*model.T
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, resultVar1, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10724,7 +10724,7 @@ func (s *RetryLayerThreadStore) Update(thread *model.Thread) (*model.Thread, err
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10745,7 +10745,7 @@ func (s *RetryLayerThreadStore) UpdateMembership(membership *model.ThreadMembers
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10766,7 +10766,7 @@ func (s *RetryLayerThreadStore) UpdateUnreadsByChannel(userId string, changedThr
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10793,7 +10793,7 @@ func (s *RetryLayerTokenStore) Delete(token string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10814,7 +10814,7 @@ func (s *RetryLayerTokenStore) GetAllTokensByType(tokenType string) ([]*model.To
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10835,7 +10835,7 @@ func (s *RetryLayerTokenStore) GetByToken(token string) (*model.Token, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10856,7 +10856,7 @@ func (s *RetryLayerTokenStore) RemoveAllTokensByType(tokenType string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10877,7 +10877,7 @@ func (s *RetryLayerTokenStore) Save(recovery *model.Token) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10898,7 +10898,7 @@ func (s *RetryLayerUploadSessionStore) Delete(id string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10919,7 +10919,7 @@ func (s *RetryLayerUploadSessionStore) Get(id string) (*model.UploadSession, err
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10940,7 +10940,7 @@ func (s *RetryLayerUploadSessionStore) GetForUser(userID string) ([]*model.Uploa
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10961,7 +10961,7 @@ func (s *RetryLayerUploadSessionStore) Save(session *model.UploadSession) (*mode
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -10982,7 +10982,7 @@ func (s *RetryLayerUploadSessionStore) Update(session *model.UploadSession) erro
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11003,7 +11003,7 @@ func (s *RetryLayerUserStore) AnalyticsActiveCount(time int64, options model.Use
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11024,7 +11024,7 @@ func (s *RetryLayerUserStore) AnalyticsActiveCountForPeriod(startTime int64, end
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11045,7 +11045,7 @@ func (s *RetryLayerUserStore) AnalyticsGetExternalUsers(hostDomain string) (bool
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11066,7 +11066,7 @@ func (s *RetryLayerUserStore) AnalyticsGetGuestCount() (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11087,7 +11087,7 @@ func (s *RetryLayerUserStore) AnalyticsGetInactiveUsersCount() (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11108,7 +11108,7 @@ func (s *RetryLayerUserStore) AnalyticsGetSystemAdminCount() (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11129,7 +11129,7 @@ func (s *RetryLayerUserStore) AutocompleteUsersInChannel(teamID string, channelI
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11150,7 +11150,7 @@ func (s *RetryLayerUserStore) ClearAllCustomRoleAssignments() error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11177,7 +11177,7 @@ func (s *RetryLayerUserStore) Count(options model.UserCountOptions) (int64, erro
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11198,7 +11198,7 @@ func (s *RetryLayerUserStore) DeactivateGuests() ([]string, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11219,7 +11219,7 @@ func (s *RetryLayerUserStore) DemoteUserToGuest(userID string) (*model.User, err
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11240,7 +11240,7 @@ func (s *RetryLayerUserStore) Get(ctx context.Context, id string) (*model.User, 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11261,7 +11261,7 @@ func (s *RetryLayerUserStore) GetAll() ([]*model.User, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11282,7 +11282,7 @@ func (s *RetryLayerUserStore) GetAllAfter(limit int, afterID string) ([]*model.U
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11303,7 +11303,7 @@ func (s *RetryLayerUserStore) GetAllNotInAuthService(authServices []string) ([]*
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11324,7 +11324,7 @@ func (s *RetryLayerUserStore) GetAllProfiles(options *model.UserGetOptions) ([]*
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11345,7 +11345,7 @@ func (s *RetryLayerUserStore) GetAllProfilesInChannel(ctx context.Context, chann
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11366,7 +11366,7 @@ func (s *RetryLayerUserStore) GetAllUsingAuthService(authService string) ([]*mod
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11387,7 +11387,7 @@ func (s *RetryLayerUserStore) GetAnyUnreadPostCountForChannel(userID string, cha
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11408,7 +11408,7 @@ func (s *RetryLayerUserStore) GetByAuth(authData *string, authService string) (*
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11429,7 +11429,7 @@ func (s *RetryLayerUserStore) GetByEmail(email string) (*model.User, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11450,7 +11450,7 @@ func (s *RetryLayerUserStore) GetByUsername(username string) (*model.User, error
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11471,7 +11471,7 @@ func (s *RetryLayerUserStore) GetChannelGroupUsers(channelID string) ([]*model.U
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11510,7 +11510,7 @@ func (s *RetryLayerUserStore) GetForLogin(loginID string, allowSignInWithUsernam
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11531,7 +11531,7 @@ func (s *RetryLayerUserStore) GetKnownUsers(userID string) ([]string, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11552,7 +11552,7 @@ func (s *RetryLayerUserStore) GetMany(ctx context.Context, ids []string) ([]*mod
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11573,7 +11573,7 @@ func (s *RetryLayerUserStore) GetNewUsersForTeam(teamID string, offset int, limi
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11594,7 +11594,7 @@ func (s *RetryLayerUserStore) GetProfileByGroupChannelIdsForUser(userID string, 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11615,7 +11615,7 @@ func (s *RetryLayerUserStore) GetProfileByIds(ctx context.Context, userIds []str
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11636,7 +11636,7 @@ func (s *RetryLayerUserStore) GetProfiles(options *model.UserGetOptions) ([]*mod
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11657,7 +11657,7 @@ func (s *RetryLayerUserStore) GetProfilesByUsernames(usernames []string, viewRes
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11678,7 +11678,7 @@ func (s *RetryLayerUserStore) GetProfilesInChannel(options *model.UserGetOptions
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11699,7 +11699,7 @@ func (s *RetryLayerUserStore) GetProfilesInChannelByStatus(options *model.UserGe
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11720,7 +11720,7 @@ func (s *RetryLayerUserStore) GetProfilesNotInChannel(teamID string, channelId s
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11741,7 +11741,7 @@ func (s *RetryLayerUserStore) GetProfilesNotInTeam(teamID string, groupConstrain
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11762,7 +11762,7 @@ func (s *RetryLayerUserStore) GetProfilesWithoutTeam(options *model.UserGetOptio
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11783,7 +11783,7 @@ func (s *RetryLayerUserStore) GetRecentlyActiveUsersForTeam(teamID string, offse
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11804,7 +11804,7 @@ func (s *RetryLayerUserStore) GetSystemAdminProfiles() (map[string]*model.User, 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11825,7 +11825,7 @@ func (s *RetryLayerUserStore) GetTeamGroupUsers(teamID string) ([]*model.User, e
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11846,7 +11846,7 @@ func (s *RetryLayerUserStore) GetUnreadCount(userID string) (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11867,7 +11867,7 @@ func (s *RetryLayerUserStore) GetUnreadCountForChannel(userID string, channelID 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11888,7 +11888,7 @@ func (s *RetryLayerUserStore) GetUsersBatchForIndexing(startTime int64, endTime 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11909,7 +11909,7 @@ func (s *RetryLayerUserStore) InferSystemInstallDate() (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11948,7 +11948,7 @@ func (s *RetryLayerUserStore) IsEmpty(excludeBots bool) (bool, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11969,7 +11969,7 @@ func (s *RetryLayerUserStore) PermanentDelete(userID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -11990,7 +11990,7 @@ func (s *RetryLayerUserStore) PromoteGuestToUser(userID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12011,7 +12011,7 @@ func (s *RetryLayerUserStore) ResetAuthDataToEmailForUsers(service string, userI
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12032,7 +12032,7 @@ func (s *RetryLayerUserStore) ResetLastPictureUpdate(userID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12053,7 +12053,7 @@ func (s *RetryLayerUserStore) Save(user *model.User) (*model.User, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12074,7 +12074,7 @@ func (s *RetryLayerUserStore) Search(teamID string, term string, options *model.
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12095,7 +12095,7 @@ func (s *RetryLayerUserStore) SearchInChannel(channelID string, term string, opt
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12116,7 +12116,7 @@ func (s *RetryLayerUserStore) SearchInGroup(groupID string, term string, options
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12137,7 +12137,7 @@ func (s *RetryLayerUserStore) SearchNotInChannel(teamID string, channelID string
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12158,7 +12158,7 @@ func (s *RetryLayerUserStore) SearchNotInTeam(notInTeamID string, term string, o
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12179,7 +12179,7 @@ func (s *RetryLayerUserStore) SearchWithoutTeam(term string, options *model.User
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12200,7 +12200,7 @@ func (s *RetryLayerUserStore) Update(user *model.User, allowRoleUpdate bool) (*m
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12221,7 +12221,7 @@ func (s *RetryLayerUserStore) UpdateAuthData(userID string, service string, auth
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12242,7 +12242,7 @@ func (s *RetryLayerUserStore) UpdateFailedPasswordAttempts(userID string, attemp
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12263,7 +12263,7 @@ func (s *RetryLayerUserStore) UpdateLastPictureUpdate(userID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12284,7 +12284,7 @@ func (s *RetryLayerUserStore) UpdateMfaActive(userID string, active bool) error 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12305,7 +12305,7 @@ func (s *RetryLayerUserStore) UpdateMfaSecret(userID string, secret string) erro
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12326,7 +12326,7 @@ func (s *RetryLayerUserStore) UpdateNotifyProps(userID string, props map[string]
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12347,7 +12347,7 @@ func (s *RetryLayerUserStore) UpdatePassword(userID string, newPassword string) 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12368,7 +12368,7 @@ func (s *RetryLayerUserStore) UpdateUpdateAt(userID string) (int64, error) {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12389,7 +12389,7 @@ func (s *RetryLayerUserStore) VerifyEmail(userID string, email string) (string, 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12410,7 +12410,7 @@ func (s *RetryLayerUserAccessTokenStore) Delete(tokenID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12431,7 +12431,7 @@ func (s *RetryLayerUserAccessTokenStore) DeleteAllForUser(userID string) error {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12452,7 +12452,7 @@ func (s *RetryLayerUserAccessTokenStore) Get(tokenID string) (*model.UserAccessT
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12473,7 +12473,7 @@ func (s *RetryLayerUserAccessTokenStore) GetAll(offset int, limit int) ([]*model
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12494,7 +12494,7 @@ func (s *RetryLayerUserAccessTokenStore) GetByToken(tokenString string) (*model.
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12515,7 +12515,7 @@ func (s *RetryLayerUserAccessTokenStore) GetByUser(userID string, page int, perP
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12536,7 +12536,7 @@ func (s *RetryLayerUserAccessTokenStore) Save(token *model.UserAccessToken) (*mo
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12557,7 +12557,7 @@ func (s *RetryLayerUserAccessTokenStore) Search(term string) ([]*model.UserAcces
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12578,7 +12578,7 @@ func (s *RetryLayerUserAccessTokenStore) UpdateTokenDisable(tokenID string) erro
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12599,7 +12599,7 @@ func (s *RetryLayerUserAccessTokenStore) UpdateTokenEnable(tokenID string) error
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12620,7 +12620,7 @@ func (s *RetryLayerUserTermsOfServiceStore) Delete(userID string, termsOfService
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12641,7 +12641,7 @@ func (s *RetryLayerUserTermsOfServiceStore) GetByUser(userID string) (*model.Use
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12662,7 +12662,7 @@ func (s *RetryLayerUserTermsOfServiceStore) Save(userTermsOfService *model.UserT
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12683,7 +12683,7 @@ func (s *RetryLayerWebhookStore) AnalyticsIncomingCount(teamID string) (int64, e
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12704,7 +12704,7 @@ func (s *RetryLayerWebhookStore) AnalyticsOutgoingCount(teamID string) (int64, e
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12731,7 +12731,7 @@ func (s *RetryLayerWebhookStore) DeleteIncoming(webhookID string, time int64) er
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12752,7 +12752,7 @@ func (s *RetryLayerWebhookStore) DeleteOutgoing(webhookID string, time int64) er
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12773,7 +12773,7 @@ func (s *RetryLayerWebhookStore) GetIncoming(id string, allowFromCache bool) (*m
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12794,7 +12794,7 @@ func (s *RetryLayerWebhookStore) GetIncomingByChannel(channelID string) ([]*mode
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12815,7 +12815,7 @@ func (s *RetryLayerWebhookStore) GetIncomingByTeam(teamID string, offset int, li
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12836,7 +12836,7 @@ func (s *RetryLayerWebhookStore) GetIncomingByTeamByUser(teamID string, userID s
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12857,7 +12857,7 @@ func (s *RetryLayerWebhookStore) GetIncomingList(offset int, limit int) ([]*mode
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12878,7 +12878,7 @@ func (s *RetryLayerWebhookStore) GetIncomingListByUser(userID string, offset int
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12899,7 +12899,7 @@ func (s *RetryLayerWebhookStore) GetOutgoing(id string) (*model.OutgoingWebhook,
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12920,7 +12920,7 @@ func (s *RetryLayerWebhookStore) GetOutgoingByChannel(channelID string, offset i
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12941,7 +12941,7 @@ func (s *RetryLayerWebhookStore) GetOutgoingByChannelByUser(channelID string, us
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12962,7 +12962,7 @@ func (s *RetryLayerWebhookStore) GetOutgoingByTeam(teamID string, offset int, li
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -12983,7 +12983,7 @@ func (s *RetryLayerWebhookStore) GetOutgoingByTeamByUser(teamID string, userID s
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -13004,7 +13004,7 @@ func (s *RetryLayerWebhookStore) GetOutgoingList(offset int, limit int) ([]*mode
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -13025,7 +13025,7 @@ func (s *RetryLayerWebhookStore) GetOutgoingListByUser(userID string, offset int
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -13052,7 +13052,7 @@ func (s *RetryLayerWebhookStore) PermanentDeleteIncomingByChannel(channelID stri
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -13073,7 +13073,7 @@ func (s *RetryLayerWebhookStore) PermanentDeleteIncomingByUser(userID string) er
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -13094,7 +13094,7 @@ func (s *RetryLayerWebhookStore) PermanentDeleteOutgoingByChannel(channelID stri
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -13115,7 +13115,7 @@ func (s *RetryLayerWebhookStore) PermanentDeleteOutgoingByUser(userID string) er
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -13136,7 +13136,7 @@ func (s *RetryLayerWebhookStore) SaveIncoming(webhook *model.IncomingWebhook) (*
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -13157,7 +13157,7 @@ func (s *RetryLayerWebhookStore) SaveOutgoing(webhook *model.OutgoingWebhook) (*
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -13178,7 +13178,7 @@ func (s *RetryLayerWebhookStore) UpdateIncoming(webhook *model.IncomingWebhook) 
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
@@ -13199,7 +13199,7 @@ func (s *RetryLayerWebhookStore) UpdateOutgoing(hook *model.OutgoingWebhook) (*m
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
 		}
-		time.Sleep(100 * time.Millisecond)
+		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }


### PR DESCRIPTION
From the logs in production, we have observed that practically
when a deadlock happens, it always fails even after trying 3 times.

Therefore, allowing it some time to recover before trying again.

https://community-daily.mattermost.com/boards/workspace/zyoahc9uapdn3xdptac6jb69ic/285b80a3-257d-41f6-8cf4-ed80ca9d92e5/495cdb4d-c13a-4992-8eb9-80cfee2819a4?c=bf0e73f6-fd69-4d04-88af-53922672b556

```release-note
NONE
```
