### PR TITLE
MM-39603 Re-config logger when config changes

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -452,6 +452,11 @@ func NewServer(options ...Option) (*Server, error) {
 		s.Go(func() {
 			s.Publish(message)
 		})
+
+		if err = s.initLogging(); err != nil {
+			mlog.Error("Error re-configuring logging after config change", mlog.Err(err))
+			return
+		}
 	})
 	s.licenseListenerId = s.AddLicenseListener(func(oldLicense, newLicense *model.License) {
 		s.Channels().regenerateClientConfig()


### PR DESCRIPTION
#### Summary
Hot-reloading of `config.json` was removed for V6.  While implementing this the config listener was removed for logging, thus the logging engine no longer re-configures even if changed via the system console.

This PR ensures logger is reconfigured when the config is changed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39603

#### Release Note
```release-note
Issue fixed where logging was not re-configured when server config is changed via the system console.
```
