### PR TITLE
MM-45055 Change "Enable Authentication Transfer" to be configurable in Cloud by the System Admin

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -353,7 +353,7 @@ type ServiceSettings struct {
 	EnableUserTypingMessages                          *bool   `access:"experimental_features,write_restrictable,cloud_restrictable"`
 	EnableChannelViewedMessages                       *bool   `access:"experimental_features,write_restrictable,cloud_restrictable"`
 	EnableUserStatuses                                *bool   `access:"write_restrictable,cloud_restrictable"`
-	ExperimentalEnableAuthenticationTransfer          *bool   `access:"experimental_features,write_restrictable,cloud_restrictable"`
+	ExperimentalEnableAuthenticationTransfer          *bool   `access:"experimental_features"`
 	ClusterLogTimeoutMilliseconds                     *int    `access:"write_restrictable,cloud_restrictable"`
 	EnablePreviewFeatures                             *bool   `access:"experimental_features"`
 	EnableTutorial                                    *bool   `access:"experimental_features"`


### PR DESCRIPTION
#### Summary
Change "Enable Authentication Transfer" to be configurable in Cloud by the System Admin

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45055

```release-note
Change "Enable Authentication Transfer" to be configurable in Cloud by the System Admin
```