### PR TITLE
[MM-44796] Include participants in Recent, Saved and Pinned APIs responses.

### DIFF
--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -3299,7 +3299,7 @@ func (a *App) RemoveUsersFromChannelNotMemberOfTeam(c request.CTX, remover *mode
 }
 
 func (a *App) GetPinnedPosts(c request.CTX, channelID string) (*model.PostList, *model.AppError) {
-	posts, err := a.Srv().Store().Channel().GetPinnedPosts(channelID)
+	posts, err := a.Srv().Store().Channel().GetPinnedPosts(channelID, c.Session().UserId)
 	if err != nil {
 		return nil, model.NewAppError("GetPinnedPosts", "app.channel.pinned_posts.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}

--- a/server/channels/store/opentracinglayer/opentracinglayer.go
+++ b/server/channels/store/opentracinglayer/opentracinglayer.go
@@ -1678,7 +1678,7 @@ func (s *OpenTracingLayerChannelStore) GetPinnedPostCount(channelID string, allo
 	return result, err
 }
 
-func (s *OpenTracingLayerChannelStore) GetPinnedPosts(channelID string) (*model.PostList, error) {
+func (s *OpenTracingLayerChannelStore) GetPinnedPosts(channelID string, userID string) (*model.PostList, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ChannelStore.GetPinnedPosts")
 	s.Root.Store.SetContext(newCtx)
@@ -1687,7 +1687,7 @@ func (s *OpenTracingLayerChannelStore) GetPinnedPosts(channelID string) (*model.
 	}()
 
 	defer span.Finish()
-	result, err := s.ChannelStore.GetPinnedPosts(channelID)
+	result, err := s.ChannelStore.GetPinnedPosts(channelID, userID)
 	if err != nil {
 		span.LogFields(spanlog.Error(err))
 		ext.Error.Set(span, true)

--- a/server/channels/store/opentracinglayer/opentracinglayer.go
+++ b/server/channels/store/opentracinglayer/opentracinglayer.go
@@ -6651,7 +6651,7 @@ func (s *OpenTracingLayerPostStore) PermanentDeleteByUser(userID string) error {
 	return err
 }
 
-func (s *OpenTracingLayerPostStore) PrepareThreadedResponse(posts []*model.PostWithExtra, extended bool, reversed bool, sanitizeOptions map[string]bool) (*model.PostList, error) {
+func (s *OpenTracingLayerPostStore) PrepareThreadedResponse(posts []*model.PostWithCRTMetadata, extended bool, reversed bool, sanitizeOptions map[string]bool) (*model.PostList, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "PostStore.PrepareThreadedResponse")
 	s.Root.Store.SetContext(newCtx)

--- a/server/channels/store/opentracinglayer/opentracinglayer.go
+++ b/server/channels/store/opentracinglayer/opentracinglayer.go
@@ -6651,6 +6651,24 @@ func (s *OpenTracingLayerPostStore) PermanentDeleteByUser(userID string) error {
 	return err
 }
 
+func (s *OpenTracingLayerPostStore) PrepareThreadedResponse(posts []*model.PostWithExtra, extended bool, reversed bool, sanitizeOptions map[string]bool) (*model.PostList, error) {
+	origCtx := s.Root.Store.Context()
+	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "PostStore.PrepareThreadedResponse")
+	s.Root.Store.SetContext(newCtx)
+	defer func() {
+		s.Root.Store.SetContext(origCtx)
+	}()
+
+	defer span.Finish()
+	result, err := s.PostStore.PrepareThreadedResponse(posts, extended, reversed, sanitizeOptions)
+	if err != nil {
+		span.LogFields(spanlog.Error(err))
+		ext.Error.Set(span, true)
+	}
+
+	return result, err
+}
+
 func (s *OpenTracingLayerPostStore) Save(post *model.Post) (*model.Post, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "PostStore.Save")

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -1874,11 +1874,11 @@ func (s *RetryLayerChannelStore) GetPinnedPostCount(channelID string, allowFromC
 
 }
 
-func (s *RetryLayerChannelStore) GetPinnedPosts(channelID string) (*model.PostList, error) {
+func (s *RetryLayerChannelStore) GetPinnedPosts(channelID string, userID string) (*model.PostList, error) {
 
 	tries := 0
 	for {
-		result, err := s.ChannelStore.GetPinnedPosts(channelID)
+		result, err := s.ChannelStore.GetPinnedPosts(channelID, userID)
 		if err == nil {
 			return result, nil
 		}

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -7529,6 +7529,27 @@ func (s *RetryLayerPostStore) PermanentDeleteByUser(userID string) error {
 
 }
 
+func (s *RetryLayerPostStore) PrepareThreadedResponse(posts []*model.PostWithExtra, extended bool, reversed bool, sanitizeOptions map[string]bool) (*model.PostList, error) {
+
+	tries := 0
+	for {
+		result, err := s.PostStore.PrepareThreadedResponse(posts, extended, reversed, sanitizeOptions)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerPostStore) Save(post *model.Post) (*model.Post, error) {
 
 	tries := 0

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -7529,7 +7529,7 @@ func (s *RetryLayerPostStore) PermanentDeleteByUser(userID string) error {
 
 }
 
-func (s *RetryLayerPostStore) PrepareThreadedResponse(posts []*model.PostWithExtra, extended bool, reversed bool, sanitizeOptions map[string]bool) (*model.PostList, error) {
+func (s *RetryLayerPostStore) PrepareThreadedResponse(posts []*model.PostWithCRTMetadata, extended bool, reversed bool, sanitizeOptions map[string]bool) (*model.PostList, error) {
 
 	tries := 0
 	for {

--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -832,14 +832,16 @@ func (s SqlChannelStore) InvalidateChannelByName(teamId, name string) {
 	}
 }
 
-func (s SqlChannelStore) GetPinnedPosts(channelId string) (*model.PostList, error) {
+func (s SqlChannelStore) GetPinnedPosts(channelId string, userID string) (*model.PostList, error) {
 	builder := s.getQueryBuilder().Select(
 		"p.*",
 		"COALESCE(Threads.ReplyCount, 0) as ThreadReplyCount",
 		"COALESCE(Threads.LastReplyAt, 0) as LastReplyAt",
 		"COALESCE(Threads.Participants, '[]') as ThreadParticipants",
+		"ThreadMemberships.Following as IsFollowing",
 	).From("Posts p").
 		LeftJoin("Threads ON Threads.PostId = p.Id").
+		LeftJoin("ThreadMemberships ON ThreadMemberships.PostId = p.Id AND ThreadMemberships.UserId = ?", userID).
 		Where(sq.Eq{
 			"p.IsPinned":  true,
 			"p.ChannelId": channelId,

--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -854,7 +854,7 @@ func (s SqlChannelStore) GetPinnedPosts(channelId string, userID string) (*model
 		return nil, err
 	}
 
-	posts := []*model.PostWithExtra{}
+	posts := []*model.PostWithCRTMetadata{}
 	if err := s.GetReplicaX().Select(&posts, query, queryArgs...); err != nil {
 		return nil, errors.Wrap(err, "failed to find Posts")
 	}

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -409,6 +409,7 @@ type PostStore interface {
 
 	// Insights - top DMs
 	GetTopDMsForUserSince(userID string, since int64, offset int, limit int) (*model.TopDMList, error)
+	PrepareThreadedResponse(posts []*model.PostWithExtra, extended, reversed bool, sanitizeOptions map[string]bool) (*model.PostList, error)
 }
 
 type UserStore interface {

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -404,12 +404,12 @@ type PostStore interface {
 	SetPostReminder(reminder *model.PostReminder) error
 	GetPostReminders(now int64) ([]*model.PostReminder, error)
 	GetPostReminderMetadata(postID string) (*PostReminderMetadata, error)
+	PrepareThreadedResponse(posts []*model.PostWithCRTMetadata, extended, reversed bool, sanitizeOptions map[string]bool) (*model.PostList, error)
 	// GetNthRecentPostTime returns the CreateAt time of the nth most recent post.
 	GetNthRecentPostTime(n int64) (int64, error)
 
 	// Insights - top DMs
 	GetTopDMsForUserSince(userID string, since int64, offset int, limit int) (*model.TopDMList, error)
-	PrepareThreadedResponse(posts []*model.PostWithExtra, extended, reversed bool, sanitizeOptions map[string]bool) (*model.PostList, error)
 }
 
 type UserStore interface {

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -237,7 +237,7 @@ type ChannelStore interface {
 	GetPinnedPostCount(channelID string, allowFromCache bool) (int64, error)
 	InvalidateGuestCount(channelID string)
 	GetGuestCount(channelID string, allowFromCache bool) (int64, error)
-	GetPinnedPosts(channelID string) (*model.PostList, error)
+	GetPinnedPosts(channelID string, userID string) (*model.PostList, error)
 	RemoveMember(channelID string, userID string) error
 	RemoveMembers(channelID string, userIds []string) error
 	PermanentDeleteMembersByUser(userID string) error

--- a/server/channels/store/storetest/channel_store.go
+++ b/server/channels/store/storetest/channel_store.go
@@ -6992,7 +6992,7 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 	require.NoError(t, errGet, errGet)
 	require.Empty(t, pl.Posts, "wasn't supposed to return posts")
 
-	t.Run("with correct ReplyCount", func(t *testing.T) {
+	t.Run("with correct CRT meta data", func(t *testing.T) {
 		teamId := model.NewId()
 		channel, err := ss.Channel().Save(&model.Channel{
 			TeamId:      teamId,
@@ -7004,11 +7004,12 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 
 		user, err := ss.User().Save(&model.User{Email: MakeEmail()})
 		require.NoError(t, err)
-		userId := user.Id
+		user2, err := ss.User().Save(&model.User{Email: MakeEmail()})
+		require.NoError(t, err)
 
 		post1, err := ss.Post().Save(&model.Post{
 			ChannelId: channel.Id,
-			UserId:    userId,
+			UserId:    user.Id,
 			Message:   "message",
 			IsPinned:  true,
 		})
@@ -7017,7 +7018,7 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 
 		post2, err := ss.Post().Save(&model.Post{
 			ChannelId: channel.Id,
-			UserId:    userId,
+			UserId:    model.NewId(),
 			Message:   "message",
 			IsPinned:  true,
 		})
@@ -7026,7 +7027,7 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 
 		post3, err := ss.Post().Save(&model.Post{
 			ChannelId: channel.Id,
-			UserId:    userId,
+			UserId:    user2.Id,
 			RootId:    post1.Id,
 			Message:   "message",
 			IsPinned:  true,
@@ -7034,12 +7035,32 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 		require.NoError(t, err)
 		time.Sleep(time.Millisecond)
 
-		posts, err := ss.Channel().GetPinnedPosts(channel.Id, userId)
+		_, err = ss.Thread().MaintainMembership(post2.UserId, post1.Id, store.ThreadMembershipOpts{
+			Following:       true,
+			UpdateFollowing: true,
+		})
+		require.NoError(t, err)
+
+		posts, err := ss.Channel().GetPinnedPosts(channel.Id, post2.UserId)
 		require.NoError(t, err)
 		require.Len(t, posts.Posts, 3)
+
 		assert.Equal(t, int64(1), posts.Posts[post1.Id].ReplyCount)
 		assert.Equal(t, int64(0), posts.Posts[post2.Id].ReplyCount)
 		assert.Equal(t, int64(0), posts.Posts[post3.Id].ReplyCount)
+
+		assert.Equal(t, posts.Posts[post3.Id].CreateAt, posts.Posts[post1.Id].LastReplyAt)
+		assert.Equal(t, int64(0), posts.Posts[post2.Id].LastReplyAt)
+		assert.Equal(t, int64(0), posts.Posts[post3.Id].LastReplyAt)
+
+		assert.True(t, *posts.Posts[post1.Id].IsFollowing)
+		assert.Nil(t, posts.Posts[post2.Id].IsFollowing)
+		assert.Nil(t, posts.Posts[post3.Id].IsFollowing)
+
+		assert.Empty(t, posts.Posts[post3.Id].Participants)
+		assert.Empty(t, posts.Posts[post2.Id].Participants)
+		require.Len(t, posts.Posts[post1.Id].Participants, 1)
+		assert.Equal(t, post3.UserId, posts.Posts[post1.Id].Participants[0].Id)
 	})
 }
 

--- a/server/channels/store/storetest/channel_store.go
+++ b/server/channels/store/storetest/channel_store.go
@@ -6998,7 +6998,9 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 		}, -1)
 		require.NoError(t, err)
 
-		userId := model.NewId()
+		user, err := ss.User().Save(&model.User{Email: MakeEmail()})
+		require.NoError(t, err)
+		userId := user.Id
 
 		post1, err := ss.Post().Save(&model.Post{
 			ChannelId: channel.Id,
@@ -7031,9 +7033,9 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 		posts, err := ss.Channel().GetPinnedPosts(channel.Id)
 		require.NoError(t, err)
 		require.Len(t, posts.Posts, 3)
-		require.Equal(t, posts.Posts[post1.Id].ReplyCount, int64(1))
-		require.Equal(t, posts.Posts[post2.Id].ReplyCount, int64(0))
-		require.Equal(t, posts.Posts[post3.Id].ReplyCount, int64(1))
+		assert.Equal(t, int64(1), posts.Posts[post1.Id].ReplyCount)
+		assert.Equal(t, int64(0), posts.Posts[post2.Id].ReplyCount)
+		assert.Equal(t, int64(0), posts.Posts[post3.Id].ReplyCount)
 	})
 }
 

--- a/server/channels/store/storetest/channel_store.go
+++ b/server/channels/store/storetest/channel_store.go
@@ -6955,15 +6955,19 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 	o1, nErr := ss.Channel().Save(ch1, -1)
 	require.NoError(t, nErr)
 
+	user, err := ss.User().Save(&model.User{Email: MakeEmail()})
+	require.NoError(t, err)
+	userID := user.Id
+
 	p1, err := ss.Post().Save(&model.Post{
-		UserId:    model.NewId(),
+		UserId:    userID,
 		ChannelId: o1.Id,
 		Message:   "test",
 		IsPinned:  true,
 	})
 	require.NoError(t, err)
 
-	pl, errGet := ss.Channel().GetPinnedPosts(o1.Id)
+	pl, errGet := ss.Channel().GetPinnedPosts(o1.Id, userID)
 	require.NoError(t, errGet, errGet)
 	require.NotNil(t, pl.Posts[p1.Id], "didn't return relevant pinned posts")
 
@@ -6984,7 +6988,7 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 	})
 	require.NoError(t, err)
 
-	pl, errGet = ss.Channel().GetPinnedPosts(o2.Id)
+	pl, errGet = ss.Channel().GetPinnedPosts(o2.Id, userID)
 	require.NoError(t, errGet, errGet)
 	require.Empty(t, pl.Posts, "wasn't supposed to return posts")
 
@@ -7030,7 +7034,7 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 		require.NoError(t, err)
 		time.Sleep(time.Millisecond)
 
-		posts, err := ss.Channel().GetPinnedPosts(channel.Id)
+		posts, err := ss.Channel().GetPinnedPosts(channel.Id, userId)
 		require.NoError(t, err)
 		require.Len(t, posts.Posts, 3)
 		assert.Equal(t, int64(1), posts.Posts[post1.Id].ReplyCount)

--- a/server/channels/store/storetest/mocks/ChannelStore.go
+++ b/server/channels/store/storetest/mocks/ChannelStore.go
@@ -1495,25 +1495,25 @@ func (_m *ChannelStore) GetPinnedPostCount(channelID string, allowFromCache bool
 	return r0, r1
 }
 
-// GetPinnedPosts provides a mock function with given fields: channelID
-func (_m *ChannelStore) GetPinnedPosts(channelID string) (*model.PostList, error) {
-	ret := _m.Called(channelID)
+// GetPinnedPosts provides a mock function with given fields: channelID, userID
+func (_m *ChannelStore) GetPinnedPosts(channelID string, userID string) (*model.PostList, error) {
+	ret := _m.Called(channelID, userID)
 
 	var r0 *model.PostList
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (*model.PostList, error)); ok {
-		return rf(channelID)
+	if rf, ok := ret.Get(0).(func(string, string) (*model.PostList, error)); ok {
+		return rf(channelID, userID)
 	}
-	if rf, ok := ret.Get(0).(func(string) *model.PostList); ok {
-		r0 = rf(channelID)
+	if rf, ok := ret.Get(0).(func(string, string) *model.PostList); ok {
+		r0 = rf(channelID, userID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.PostList)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(channelID)
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(channelID, userID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/storetest/mocks/PostStore.go
+++ b/server/channels/store/storetest/mocks/PostStore.go
@@ -1078,15 +1078,15 @@ func (_m *PostStore) PermanentDeleteByUser(userID string) error {
 }
 
 // PrepareThreadedResponse provides a mock function with given fields: posts, extended, reversed, sanitizeOptions
-func (_m *PostStore) PrepareThreadedResponse(posts []*model.PostWithExtra, extended bool, reversed bool, sanitizeOptions map[string]bool) (*model.PostList, error) {
+func (_m *PostStore) PrepareThreadedResponse(posts []*model.PostWithCRTMetadata, extended bool, reversed bool, sanitizeOptions map[string]bool) (*model.PostList, error) {
 	ret := _m.Called(posts, extended, reversed, sanitizeOptions)
 
 	var r0 *model.PostList
 	var r1 error
-	if rf, ok := ret.Get(0).(func([]*model.PostWithExtra, bool, bool, map[string]bool) (*model.PostList, error)); ok {
+	if rf, ok := ret.Get(0).(func([]*model.PostWithCRTMetadata, bool, bool, map[string]bool) (*model.PostList, error)); ok {
 		return rf(posts, extended, reversed, sanitizeOptions)
 	}
-	if rf, ok := ret.Get(0).(func([]*model.PostWithExtra, bool, bool, map[string]bool) *model.PostList); ok {
+	if rf, ok := ret.Get(0).(func([]*model.PostWithCRTMetadata, bool, bool, map[string]bool) *model.PostList); ok {
 		r0 = rf(posts, extended, reversed, sanitizeOptions)
 	} else {
 		if ret.Get(0) != nil {
@@ -1094,7 +1094,7 @@ func (_m *PostStore) PrepareThreadedResponse(posts []*model.PostWithExtra, exten
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func([]*model.PostWithExtra, bool, bool, map[string]bool) error); ok {
+	if rf, ok := ret.Get(1).(func([]*model.PostWithCRTMetadata, bool, bool, map[string]bool) error); ok {
 		r1 = rf(posts, extended, reversed, sanitizeOptions)
 	} else {
 		r1 = ret.Error(1)

--- a/server/channels/store/storetest/mocks/PostStore.go
+++ b/server/channels/store/storetest/mocks/PostStore.go
@@ -1077,6 +1077,29 @@ func (_m *PostStore) PermanentDeleteByUser(userID string) error {
 	return r0
 }
 
+// PrepareThreadedResponse provides a mock function with given fields: posts, extended, reversed, sanitizeOptions
+func (_m *PostStore) PrepareThreadedResponse(posts []*model.PostWithExtra, extended bool, reversed bool, sanitizeOptions map[string]bool) (*model.PostList, error) {
+	ret := _m.Called(posts, extended, reversed, sanitizeOptions)
+
+	var r0 *model.PostList
+	if rf, ok := ret.Get(0).(func([]*model.PostWithExtra, bool, bool, map[string]bool) *model.PostList); ok {
+		r0 = rf(posts, extended, reversed, sanitizeOptions)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.PostList)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]*model.PostWithExtra, bool, bool, map[string]bool) error); ok {
+		r1 = rf(posts, extended, reversed, sanitizeOptions)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Save provides a mock function with given fields: post
 func (_m *PostStore) Save(post *model.Post) (*model.Post, error) {
 	ret := _m.Called(post)

--- a/server/channels/store/storetest/mocks/PostStore.go
+++ b/server/channels/store/storetest/mocks/PostStore.go
@@ -1082,6 +1082,10 @@ func (_m *PostStore) PrepareThreadedResponse(posts []*model.PostWithExtra, exten
 	ret := _m.Called(posts, extended, reversed, sanitizeOptions)
 
 	var r0 *model.PostList
+	var r1 error
+	if rf, ok := ret.Get(0).(func([]*model.PostWithExtra, bool, bool, map[string]bool) (*model.PostList, error)); ok {
+		return rf(posts, extended, reversed, sanitizeOptions)
+	}
 	if rf, ok := ret.Get(0).(func([]*model.PostWithExtra, bool, bool, map[string]bool) *model.PostList); ok {
 		r0 = rf(posts, extended, reversed, sanitizeOptions)
 	} else {
@@ -1090,7 +1094,6 @@ func (_m *PostStore) PrepareThreadedResponse(posts []*model.PostWithExtra, exten
 		}
 	}
 
-	var r1 error
 	if rf, ok := ret.Get(1).(func([]*model.PostWithExtra, bool, bool, map[string]bool) error); ok {
 		r1 = rf(posts, extended, reversed, sanitizeOptions)
 	} else {

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -6020,7 +6020,7 @@ func (s *TimerLayerPostStore) PermanentDeleteByUser(userID string) error {
 	return err
 }
 
-func (s *TimerLayerPostStore) PrepareThreadedResponse(posts []*model.PostWithExtra, extended bool, reversed bool, sanitizeOptions map[string]bool) (*model.PostList, error) {
+func (s *TimerLayerPostStore) PrepareThreadedResponse(posts []*model.PostWithCRTMetadata, extended bool, reversed bool, sanitizeOptions map[string]bool) (*model.PostList, error) {
 	start := time.Now()
 
 	result, err := s.PostStore.PrepareThreadedResponse(posts, extended, reversed, sanitizeOptions)

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -1552,10 +1552,10 @@ func (s *TimerLayerChannelStore) GetPinnedPostCount(channelID string, allowFromC
 	return result, err
 }
 
-func (s *TimerLayerChannelStore) GetPinnedPosts(channelID string) (*model.PostList, error) {
+func (s *TimerLayerChannelStore) GetPinnedPosts(channelID string, userID string) (*model.PostList, error) {
 	start := time.Now()
 
-	result, err := s.ChannelStore.GetPinnedPosts(channelID)
+	result, err := s.ChannelStore.GetPinnedPosts(channelID, userID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -6020,6 +6020,22 @@ func (s *TimerLayerPostStore) PermanentDeleteByUser(userID string) error {
 	return err
 }
 
+func (s *TimerLayerPostStore) PrepareThreadedResponse(posts []*model.PostWithExtra, extended bool, reversed bool, sanitizeOptions map[string]bool) (*model.PostList, error) {
+	start := time.Now()
+
+	result, err := s.PostStore.PrepareThreadedResponse(posts, extended, reversed, sanitizeOptions)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("PostStore.PrepareThreadedResponse", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerPostStore) Save(post *model.Post) (*model.Post, error) {
 	start := time.Now()
 

--- a/server/public/model/post.go
+++ b/server/public/model/post.go
@@ -148,6 +148,13 @@ type PostEphemeral struct {
 	Post   *Post  `json:"post"`
 }
 
+type PostWithExtra struct {
+	ThreadReplyCount   int64
+	IsFollowing        *bool
+	ThreadParticipants StringArray
+	Post
+}
+
 type PostPatch struct {
 	IsPinned     *bool            `json:"is_pinned"`
 	Message      *string          `json:"message"`

--- a/server/public/model/post.go
+++ b/server/public/model/post.go
@@ -148,7 +148,7 @@ type PostEphemeral struct {
 	Post   *Post  `json:"post"`
 }
 
-type PostWithExtra struct {
+type PostWithCRTMetadata struct {
 	ThreadReplyCount   int64
 	IsFollowing        *bool
 	ThreadParticipants StringArray


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Include participants in Recent, Saved and Pinned APIs responses.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://mattermost.atlassian.net/browse/MM-44796

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
* Fixed the following 3 APIs to populate the "participants" field of the "post" response model.
  * posts/search
  * users/{user_id}/posts/flagged
  * channels/{channel_id}/pinned
```
