### PR TITLE
Feature/mm 21565 audit add context and logging

### DIFF
--- a/api4/system.go
+++ b/api4/system.go
@@ -264,7 +264,7 @@ func getAudits(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	audits, appErr := c.App.GetAuditsPage("", c.Params.Page, c.Params.PerPage)
+	audits, appErr := c.App.GetAuditsPage(c.AppContext, "", c.Params.Page, c.Params.PerPage)
 	if appErr != nil {
 		c.Err = appErr
 		return

--- a/api4/user.go
+++ b/api4/user.go
@@ -2174,7 +2174,7 @@ func getUserAudits(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	audits, err := c.App.GetAuditsPage(c.Params.UserId, c.Params.Page, c.Params.PerPage)
+	audits, err := c.App.GetAuditsPage(c.AppContext, c.Params.UserId, c.Params.Page, c.Params.PerPage)
 	if err != nil {
 		c.Err = err
 		return

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -246,11 +246,11 @@ type AppIface interface {
 	// InstallPlugin unpacks and installs a plugin but does not enable or activate it.
 	InstallPlugin(pluginFile io.ReadSeeker, replace bool) (*model.Manifest, *model.AppError)
 	// LogAuditRec logs an audit record using default LvlAuditCLI.
-	LogAuditRec(rec *audit.Record, err error)
+	LogAuditRec(c request.CTX, rec *audit.Record, err error)
 	// LogAuditRecWithLevel logs an audit record using specified Level.
-	LogAuditRecWithLevel(rec *audit.Record, level mlog.Level, err error)
+	LogAuditRecWithLevel(c request.CTX, rec *audit.Record, level mlog.Level, err error)
 	// MakeAuditRecord creates a audit record pre-populated with defaults.
-	MakeAuditRecord(event string, initialStatus string) *audit.Record
+	MakeAuditRecord(c request.CTX, event string, initialStatus string) *audit.Record
 	// MarkChanelAsUnreadFromPost will take a post and set the channel as unread from that one.
 	MarkChannelAsUnreadFromPost(c request.CTX, postID string, userID string, collapsedThreadsSupported bool) (*model.ChannelUnreadAt, *model.AppError)
 	// MentionsToPublicChannels returns all the mentions to public channels,
@@ -583,8 +583,8 @@ type AppIface interface {
 	GetAllTeamsPageWithCount(offset int, limit int, opts *model.TeamSearch) (*model.TeamsWithCount, *model.AppError)
 	GetAnalytics(name string, teamID string) (model.AnalyticsRows, *model.AppError)
 	GetAppliedSchemaMigrations() ([]model.AppliedMigration, *model.AppError)
-	GetAudits(userID string, limit int) (model.Audits, *model.AppError)
-	GetAuditsPage(userID string, page int, perPage int) (model.Audits, *model.AppError)
+	GetAudits(c request.CTX, userID string, limit int) (model.Audits, *model.AppError)
+	GetAuditsPage(c request.CTX, userID string, page int, perPage int) (model.Audits, *model.AppError)
 	GetAuthorizationCode(w http.ResponseWriter, r *http.Request, service string, props map[string]string, loginHint string) (string, *model.AppError)
 	GetAuthorizedAppsForUser(userID string, page, perPage int) ([]*model.OAuthApp, *model.AppError)
 	GetBrandImage() ([]byte, *model.AppError)

--- a/app/audit_test.go
+++ b/app/audit_test.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/v6/app/request"
+	"github.com/mattermost/mattermost-server/v6/audit"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/services/imageproxy"
+	"github.com/mattermost/mattermost-server/v6/store/storetest/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAudits(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+	s := th.Server
+
+	ch := &Channels{
+		srv:           s,
+		imageProxy:    imageproxy.MakeImageProxy(s.platform, s.httpService, s.Log()),
+		uploadLockMap: map[string]bool{},
+	}
+
+	a := &App{
+		ch: ch,
+	}
+	mockAuditStore := mocks.AuditStore{}
+
+	mockAuditStore.On("Get", mock.Anything).Return(mockAuditStore.TestData(), nil)
+	t.Run("GetAudits", func(t *testing.T) {
+		got, err := a.GetAudits(th.Context, th.BasicUser.Id, 0)
+		require.Nil(t, err)
+		require.Nil(t, got)
+	})
+
+}
+
+func TestMakeAuditRecord(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+	s := th.Server
+	type fields struct {
+		ch *Channels
+	}
+	type args struct {
+		c             request.CTX
+		event         string
+		initialStatus string
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		Expected *audit.Record
+	}{
+		{
+			"create audit record",
+			fields{ch: &Channels{
+				srv:           s,
+				imageProxy:    imageproxy.MakeImageProxy(s.platform, s.httpService, s.Log()),
+				uploadLockMap: map[string]bool{},
+			}},
+			args{th.Context, "testImport", audit.Success},
+			&audit.Record{
+				EventName: "testImport",
+				Status:    "",
+				EventData: audit.EventData{},
+				Actor:     audit.EventActor{},
+				Meta:      map[string]interface{}{},
+				Error:     audit.EventError{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &App{
+				ch: tt.fields.ch,
+			}
+
+			if got := a.MakeAuditRecord(tt.args.c, tt.args.event, tt.args.initialStatus); !reflect.DeepEqual(got.EventName, tt.Expected.EventName) {
+				t.Errorf("App.MakeAuditRecord() = %v, want %v", got, tt.Expected)
+			}
+		})
+	}
+}
+
+func TestGetAuditsPage(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+	s := th.Server
+	type fields struct {
+		ch *Channels
+	}
+	type args struct {
+		c       request.CTX
+		userID  string
+		page    int
+		perPage int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   model.Audits
+		want1  *model.AppError
+	}{
+		{
+			"get audits page",
+			fields{ch: &Channels{
+				srv:           s,
+				imageProxy:    imageproxy.MakeImageProxy(s.platform, s.httpService, s.Log()),
+				uploadLockMap: map[string]bool{},
+			}},
+			args{th.Context, "testUserId", 0, 1},
+			nil,
+			&model.AppError{
+				Id:            "",
+				Message:       "",
+				DetailedError: "",
+				RequestId:     "",
+				StatusCode:    0,
+				Where:         "",
+				IsOAuth:       false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &App{
+				ch: tt.fields.ch,
+			}
+			mockStore := mocks.Store{}
+			mockStore.On("Audit").Return(th.App.Srv().Store().Audit())
+
+			mockAuditStore := mocks.AuditStore{}
+			mockAuditStore.On("Get", mock.Anything).Return(mockAuditStore.TestData(), nil)
+
+			got, got1 := a.GetAuditsPage(tt.args.c, tt.args.userID, tt.args.page, tt.args.perPage)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("App.GetAuditsPage() got = %v, want %v", got, tt.want)
+			}
+			require.Nil(t, got1)
+		})
+	}
+}
+
+func TestLogAuditRec(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+	s := th.Server
+
+	type fields struct {
+		ch *Channels
+	}
+	type args struct {
+		c   request.CTX
+		rec *audit.Record
+		err error
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			"log audit rec",
+			fields{ch: &Channels{
+				srv:           s,
+				imageProxy:    imageproxy.MakeImageProxy(s.platform, s.httpService, s.Log()),
+				uploadLockMap: map[string]bool{},
+			}},
+			args{th.Context, &audit.Record{
+				EventName: "testImport",
+				Status:    "",
+				EventData: audit.EventData{},
+				Actor:     audit.EventActor{},
+				Meta:      map[string]interface{}{},
+				Error:     audit.EventError{},
+			}, nil},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &App{
+				ch: tt.fields.ch,
+			}
+
+			a.LogAuditRec(tt.args.c, tt.args.rec, tt.args.err)
+
+		})
+	}
+}

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -4719,7 +4719,7 @@ func (a *OpenTracingAppLayer) GetAppliedSchemaMigrations() ([]model.AppliedMigra
 	return resultVar0, resultVar1
 }
 
-func (a *OpenTracingAppLayer) GetAudits(userID string, limit int) (model.Audits, *model.AppError) {
+func (a *OpenTracingAppLayer) GetAudits(c request.CTX, userID string, limit int) (model.Audits, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetAudits")
 
@@ -4731,7 +4731,7 @@ func (a *OpenTracingAppLayer) GetAudits(userID string, limit int) (model.Audits,
 	}()
 
 	defer span.Finish()
-	resultVar0, resultVar1 := a.app.GetAudits(userID, limit)
+	resultVar0, resultVar1 := a.app.GetAudits(c, userID, limit)
 
 	if resultVar1 != nil {
 		span.LogFields(spanlog.Error(resultVar1))
@@ -4741,7 +4741,7 @@ func (a *OpenTracingAppLayer) GetAudits(userID string, limit int) (model.Audits,
 	return resultVar0, resultVar1
 }
 
-func (a *OpenTracingAppLayer) GetAuditsPage(userID string, page int, perPage int) (model.Audits, *model.AppError) {
+func (a *OpenTracingAppLayer) GetAuditsPage(c request.CTX, userID string, page int, perPage int) (model.Audits, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetAuditsPage")
 
@@ -4753,7 +4753,7 @@ func (a *OpenTracingAppLayer) GetAuditsPage(userID string, page int, perPage int
 	}()
 
 	defer span.Finish()
-	resultVar0, resultVar1 := a.app.GetAuditsPage(userID, page, perPage)
+	resultVar0, resultVar1 := a.app.GetAuditsPage(c, userID, page, perPage)
 
 	if resultVar1 != nil {
 		span.LogFields(spanlog.Error(resultVar1))
@@ -12082,7 +12082,7 @@ func (a *OpenTracingAppLayer) ListTeamCommands(teamID string) ([]*model.Command,
 	return resultVar0, resultVar1
 }
 
-func (a *OpenTracingAppLayer) LogAuditRec(rec *audit.Record, err error) {
+func (a *OpenTracingAppLayer) LogAuditRec(c request.CTX, rec *audit.Record, err error) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.LogAuditRec")
 
@@ -12094,10 +12094,10 @@ func (a *OpenTracingAppLayer) LogAuditRec(rec *audit.Record, err error) {
 	}()
 
 	defer span.Finish()
-	a.app.LogAuditRec(rec, err)
+	a.app.LogAuditRec(c,rec, err)
 }
 
-func (a *OpenTracingAppLayer) LogAuditRecWithLevel(rec *audit.Record, level mlog.Level, err error) {
+func (a *OpenTracingAppLayer) LogAuditRecWithLevel(c request.CTX, rec *audit.Record, level mlog.Level, err error) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.LogAuditRecWithLevel")
 
@@ -12109,7 +12109,7 @@ func (a *OpenTracingAppLayer) LogAuditRecWithLevel(rec *audit.Record, level mlog
 	}()
 
 	defer span.Finish()
-	a.app.LogAuditRecWithLevel(rec, level, err)
+	a.app.LogAuditRecWithLevel(c, rec, level, err)
 }
 
 func (a *OpenTracingAppLayer) LoginByOAuth(c *request.Context, service string, userData io.Reader, teamID string, tokenUser *model.User) (*model.User, *model.AppError) {
@@ -12134,7 +12134,7 @@ func (a *OpenTracingAppLayer) LoginByOAuth(c *request.Context, service string, u
 	return resultVar0, resultVar1
 }
 
-func (a *OpenTracingAppLayer) MakeAuditRecord(event string, initialStatus string) *audit.Record {
+func (a *OpenTracingAppLayer) MakeAuditRecord(c request.CTX,event string, initialStatus string) *audit.Record {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.MakeAuditRecord")
 
@@ -12146,7 +12146,7 @@ func (a *OpenTracingAppLayer) MakeAuditRecord(event string, initialStatus string
 	}()
 
 	defer span.Finish()
-	resultVar0 := a.app.MakeAuditRecord(event, initialStatus)
+	resultVar0 := a.app.MakeAuditRecord(c,event, initialStatus)
 
 	return resultVar0
 }

--- a/app/session.go
+++ b/app/session.go
@@ -11,6 +11,7 @@ import (
 	"os"
 
 	"github.com/mattermost/mattermost-server/v6/app/platform"
+	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/app/users"
 	"github.com/mattermost/mattermost-server/v6/audit"
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -281,9 +282,9 @@ func (a *App) ExtendSessionExpiryIfNeeded(session *model.Session) bool {
 	if elapsed < threshold {
 		return false
 	}
-
-	auditRec := a.MakeAuditRecord("extendSessionExpiry", audit.Fail)
-	defer a.LogAuditRec(auditRec, nil)
+	ctx := request.EmptyContext(a.Log())
+	auditRec := a.MakeAuditRecord(ctx, "extendSessionExpiry", audit.Fail)
+	defer a.LogAuditRec(ctx, auditRec, nil)
 	auditRec.AddMeta("session", session)
 
 	newExpiry := now + sessionLength

--- a/cmd/mattermost/commands/db.go
+++ b/cmd/mattermost/commands/db.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/audit"
 	"github.com/mattermost/mattermost-server/v6/config"
 	"github.com/mattermost/mattermost-server/v6/store/sqlstore"
@@ -124,9 +125,9 @@ func resetCmdF(command *cobra.Command, args []string) error {
 
 	a.Srv().Store().DropAllTables()
 	CommandPrettyPrintln("Database successfully reset")
-
-	auditRec := a.MakeAuditRecord("reset", audit.Success)
-	a.LogAuditRec(auditRec, nil)
+	ctx := request.EmptyContext(a.Log())
+	auditRec := a.MakeAuditRecord(ctx, "reset", audit.Success)
+	a.LogAuditRec(ctx, auditRec, nil)
 
 	return nil
 }

--- a/cmd/mattermost/commands/export.go
+++ b/cmd/mattermost/commands/export.go
@@ -141,11 +141,11 @@ func scheduleExportCmdF(command *cobra.Command, args []string) error {
 			CommandPrintErrorln("ERROR: Message export job failed. Please check the server logs")
 		} else {
 			CommandPrettyPrintln("SUCCESS: Message export job complete")
-
-			auditRec := a.MakeAuditRecord("scheduleExport", audit.Success)
+			ctx := request.EmptyContext(a.Log())
+			auditRec := a.MakeAuditRecord(ctx, "scheduleExport", audit.Success)
 			auditRec.AddMeta("format", format)
 			auditRec.AddMeta("start", startTime)
-			a.LogAuditRec(auditRec, nil)
+			a.LogAuditRec(ctx, auditRec, nil)
 		}
 	}
 	return nil
@@ -190,11 +190,11 @@ func buildExportCmdF(format string) func(command *cobra.Command, args []string) 
 				CommandPrettyPrintln(fmt.Sprintf("WARNING: %d warnings encountered, see warning.txt for details.", warningsCount))
 			}
 		}
-
-		auditRec := a.MakeAuditRecord("buildExport", audit.Success)
+		ctx := request.EmptyContext(a.Log())
+		auditRec := a.MakeAuditRecord(ctx, "buildExport", audit.Success)
 		auditRec.AddMeta("format", format)
 		auditRec.AddMeta("start", startTime)
-		a.LogAuditRec(auditRec, nil)
+		a.LogAuditRec(ctx, auditRec, nil)
 
 		return nil
 	}
@@ -239,15 +239,16 @@ func bulkExportCmdF(command *cobra.Command, args []string) error {
 	var opts model.BulkExportOpts
 	opts.IncludeAttachments = attachments
 	opts.CreateArchive = archive
-	if err := a.BulkExport(request.EmptyContext(a.Log()), fileWriter, filepath.Dir(outPath), opts); err != nil {
+	ctx := request.EmptyContext(a.Log())
+	if err := a.BulkExport(ctx, fileWriter, filepath.Dir(outPath), opts); err != nil {
 		CommandPrintErrorln(err.Error())
 		return err
 	}
 
-	auditRec := a.MakeAuditRecord("bulkExport", audit.Success)
+	auditRec := a.MakeAuditRecord(ctx, "bulkExport", audit.Success)
 	auditRec.AddMeta("all_teams", allTeams)
 	auditRec.AddMeta("file", args[0])
-	a.LogAuditRec(auditRec, nil)
+	a.LogAuditRec(ctx, auditRec, nil)
 
 	return nil
 }

--- a/cmd/mattermost/commands/import.go
+++ b/cmd/mattermost/commands/import.go
@@ -91,11 +91,11 @@ func slackImportCmdF(command *cobra.Command, args []string) error {
 
 	CommandPrettyPrintln("Finished Slack Import.")
 	CommandPrettyPrintln("")
-
-	auditRec := a.MakeAuditRecord("slackImport", audit.Success)
+	ctx := request.EmptyContext(a.Log())
+	auditRec := a.MakeAuditRecord(ctx, "slackImport", audit.Success)
 	auditRec.AddMeta("team", team)
 	auditRec.AddMeta("file", args[1])
-	a.LogAuditRec(auditRec, nil)
+	a.LogAuditRec(ctx, auditRec, nil)
 
 	return nil
 }
@@ -162,9 +162,10 @@ func bulkImportCmdF(command *cobra.Command, args []string) error {
 
 	if apply {
 		CommandPrettyPrintln("Finished Bulk Import.")
-		auditRec := a.MakeAuditRecord("bulkImport", audit.Success)
+		ctx := request.EmptyContext(a.Log())
+		auditRec := a.MakeAuditRecord(ctx, "bulkImport", audit.Success)
 		auditRec.AddMeta("file", args[0])
-		a.LogAuditRec(auditRec, nil)
+		a.LogAuditRec(ctx, auditRec, nil)
 	} else {
 		CommandPrettyPrintln("Validation complete. You can now perform the import by rerunning this command with the --apply flag.")
 	}

--- a/cmd/mattermost/commands/jobserver.go
+++ b/cmd/mattermost/commands/jobserver.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/audit"
 	"github.com/mattermost/mattermost-server/v6/config"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
@@ -56,8 +57,9 @@ func jobserverCmdF(command *cobra.Command, args []string) error {
 	}
 
 	if !noJobs || !noSchedule {
-		auditRec := a.MakeAuditRecord("jobServer", audit.Success)
-		a.LogAuditRec(auditRec, nil)
+		ctx := request.EmptyContext(a.Log())
+		auditRec := a.MakeAuditRecord(ctx, "jobServer", audit.Success)
+		a.LogAuditRec(ctx, auditRec, nil)
 	}
 
 	signalChan := make(chan os.Signal, 1)


### PR DESCRIPTION
-  Change all public methods in app/auto_responder.go to receive c request.CTX as the first argument.
- Change all methods in app/auto_responder.go (even private ones) that use the mlog logger to use receive the context as well. - no methods were found
- Make sure all functions calling the changed methods pass along the context.
- Update the generated interfaces with make generated.
- Update the tests.

#### Summary
I have update all the public function in the app/audit.go .others like func (s *Server) ... should be skipped.
There was no audit_test.go so I have create one.
I have run all the test in order to be sure I have not break something.
I have use the request.EmptyContext(a.Log()) where was not possible to add the context 

_

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/21565

```release-note
NONE
```
