### PR TITLE
[GH-21566] Add the request context to all public methods in app/authentication.go

### DIFF
--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -426,7 +426,7 @@ type AppIface interface {
 	AttachCloudSessionCookie(c *request.Context, w http.ResponseWriter, r *http.Request)
 	AttachDeviceId(sessionID string, deviceID string, expiresAt int64) *model.AppError
 	AttachSessionCookies(c *request.Context, w http.ResponseWriter, r *http.Request)
-	AuthenticateUserForLogin(c *request.Context, id, loginId, password, mfaToken, cwsToken string, ldapOnly bool) (user *model.User, err *model.AppError)
+	AuthenticateUserForLogin(c request.CTX, id, loginId, password, mfaToken, cwsToken string, ldapOnly bool) (user *model.User, err *model.AppError)
 	AuthorizeOAuthUser(w http.ResponseWriter, r *http.Request, service, code, state, redirectURI string) (io.ReadCloser, string, map[string]string, *model.User, *model.AppError)
 	AutocompleteChannels(c request.CTX, userID, term string) (model.ChannelListWithTeamData, *model.AppError)
 	AutocompleteChannelsForSearch(c request.CTX, teamID string, userID string, term string) (model.ChannelList, *model.AppError)

--- a/app/authentication.go
+++ b/app/authentication.go
@@ -138,7 +138,7 @@ func (a *App) DoubleCheckPassword(user *model.User, password string) *model.AppE
 	return nil
 }
 
-func (a *App) checkLdapUserPasswordAndAllCriteria(c *request.Context, ldapId *string, password string, mfaToken string) (*model.User, *model.AppError) {
+func (a *App) checkLdapUserPasswordAndAllCriteria(c request.CTX, ldapId *string, password string, mfaToken string) (*model.User, *model.AppError) {
 	if a.Ldap() == nil || ldapId == nil {
 		err := model.NewAppError("doLdapAuthentication", "api.user.login_ldap.not_available.app_error", nil, "", http.StatusNotImplemented)
 		return nil, err
@@ -241,7 +241,7 @@ func checkUserNotBot(user *model.User) *model.AppError {
 	return nil
 }
 
-func (a *App) authenticateUser(c *request.Context, user *model.User, password, mfaToken string) (*model.User, *model.AppError) {
+func (a *App) authenticateUser(c request.CTX, user *model.User, password, mfaToken string) (*model.User, *model.AppError) {
 	license := a.Srv().License()
 	ldapAvailable := *a.Config().LdapSettings.Enable && a.Ldap() != nil && license != nil && *license.Features.LDAP
 
@@ -278,7 +278,7 @@ func (a *App) authenticateUser(c *request.Context, user *model.User, password, m
 	return user, nil
 }
 
-func ParseAuthTokenFromRequest(r *http.Request) (token string, loc TokenLocation) {
+func ParseAuthTokenFromRequest(c request.CTX, r *http.Request) (token string, loc TokenLocation) {
 	defer func() {
 		// Stripping off tokens of large sizes
 		// to prevent logging a large string.

--- a/app/authentication_test.go
+++ b/app/authentication_test.go
@@ -31,6 +31,9 @@ func TestParseAuthTokenFromRequest(t *testing.T) {
 		{"mytoken", "", "", "mytoken", TokenLocationCloudHeader},
 	}
 
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
 	for testnum, tc := range cases {
 		pathname := "/test/here"
 		if tc.query != "" {
@@ -49,7 +52,7 @@ func TestParseAuthTokenFromRequest(t *testing.T) {
 			})
 		}
 
-		token, location := ParseAuthTokenFromRequest(req)
+		token, location := ParseAuthTokenFromRequest(th.Context, req)
 
 		require.Equal(t, tc.expectedToken, token, "Wrong token on test "+strconv.Itoa(testnum))
 		require.Equal(t, tc.expectedLocation, location, "Wrong location on test "+strconv.Itoa(testnum))

--- a/app/login.go
+++ b/app/login.go
@@ -43,7 +43,7 @@ func (a *App) CheckForClientSideCert(r *http.Request) (string, string, string) {
 	return pem, subject, email
 }
 
-func (a *App) AuthenticateUserForLogin(c *request.Context, id, loginId, password, mfaToken, cwsToken string, ldapOnly bool) (user *model.User, err *model.AppError) {
+func (a *App) AuthenticateUserForLogin(c request.CTX, id, loginId, password, mfaToken, cwsToken string, ldapOnly bool) (user *model.User, err *model.AppError) {
 	// Do statistics
 	defer func() {
 		if a.Metrics() != nil {

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -753,7 +753,7 @@ func (a *OpenTracingAppLayer) AttachSessionCookies(c *request.Context, w http.Re
 	a.app.AttachSessionCookies(c, w, r)
 }
 
-func (a *OpenTracingAppLayer) AuthenticateUserForLogin(c *request.Context, id string, loginId string, password string, mfaToken string, cwsToken string, ldapOnly bool) (user *model.User, err *model.AppError) {
+func (a *OpenTracingAppLayer) AuthenticateUserForLogin(c request.CTX, id string, loginId string, password string, mfaToken string, cwsToken string, ldapOnly bool) (user *model.User, err *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.AuthenticateUserForLogin")
 

--- a/app/server.go
+++ b/app/server.go
@@ -936,7 +936,7 @@ func (s *Server) Start() error {
 		}
 
 		s.RateLimiter = rateLimiter
-		handler = rateLimiter.RateLimitHandler(handler)
+		handler = rateLimiter.RateLimitHandler(request.EmptyContext(s.Log()), handler)
 	}
 
 	// Creating a logger for logging errors from http.Server at error level

--- a/einterfaces/ldap.go
+++ b/einterfaces/ldap.go
@@ -9,7 +9,7 @@ import (
 )
 
 type LdapInterface interface {
-	DoLogin(c *request.Context, id string, password string) (*model.User, *model.AppError)
+	DoLogin(c request.CTX, id string, password string) (*model.User, *model.AppError)
 	GetUser(id string) (*model.User, *model.AppError)
 	GetUserAttributes(id string, attributes []string) (map[string]string, *model.AppError)
 	CheckPassword(id string, password string) *model.AppError

--- a/einterfaces/mocks/LdapInterface.go
+++ b/einterfaces/mocks/LdapInterface.go
@@ -62,11 +62,11 @@ func (_m *LdapInterface) CheckProviderAttributes(LS *model.LdapSettings, ouser *
 }
 
 // DoLogin provides a mock function with given fields: c, id, password
-func (_m *LdapInterface) DoLogin(c *request.Context, id string, password string) (*model.User, *model.AppError) {
+func (_m *LdapInterface) DoLogin(c request.CTX, id string, password string) (*model.User, *model.AppError) {
 	ret := _m.Called(c, id, password)
 
 	var r0 *model.User
-	if rf, ok := ret.Get(0).(func(*request.Context, string, string) *model.User); ok {
+	if rf, ok := ret.Get(0).(func(request.CTX, string, string) *model.User); ok {
 		r0 = rf(c, id, password)
 	} else {
 		if ret.Get(0) != nil {
@@ -75,7 +75,7 @@ func (_m *LdapInterface) DoLogin(c *request.Context, id string, password string)
 	}
 
 	var r1 *model.AppError
-	if rf, ok := ret.Get(1).(func(*request.Context, string, string) *model.AppError); ok {
+	if rf, ok := ret.Get(1).(func(request.CTX, string, string) *model.AppError); ok {
 		r1 = rf(c, id, password)
 	} else {
 		if ret.Get(1) != nil {

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -262,7 +262,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	token, tokenLocation := app.ParseAuthTokenFromRequest(r)
+	token, tokenLocation := app.ParseAuthTokenFromRequest(c.AppContext, r)
 
 	if token != "" && tokenLocation != app.TokenLocationCloudHeader && tokenLocation != app.TokenLocationRemoteClusterHeader {
 		session, err := c.App.GetSession(token)


### PR DESCRIPTION
#### Summary

 Add the request context and logger to all public methods in app/authentication.go

#### Tasks
[X]Change all public methods in app/authentication.go to receive c request.CTX as the first argument [1].
[X]Change all methods in app/authentication.go (even private ones) that use the mlog logger to use receive the context as well.
[X]Make sure all functions calling the changed methods pass along the context.
[X]Update the generated interfaces with make generated.
[X]Update the tests.


#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/21566

#### Release note
```release-note
- Replace *request.Context in app/authentication.go file to request.CTX
```
