### PR TITLE
[MM-27473] Additional slash command responses appear as replies

### DIFF
--- a/app/command.go
+++ b/app/command.go
@@ -544,7 +544,7 @@ func (a *App) HandleCommandResponse(c request.CTX, command *model.Command, args 
 	}
 
 	var lastError *model.AppError
-	_, err := a.HandleCommandResponsePost(c, command, args, response, builtIn)
+	rootCommandPost, err := a.HandleCommandResponsePost(c, command, args, response, builtIn)
 
 	if err != nil {
 		mlog.Debug("Error occurred in handling command response post", mlog.Err(err))
@@ -553,6 +553,7 @@ func (a *App) HandleCommandResponse(c request.CTX, command *model.Command, args 
 
 	if response.ExtraResponses != nil {
 		for _, resp := range response.ExtraResponses {
+			args.RootId = rootCommandPost.Id
 			_, err := a.HandleCommandResponsePost(c, command, args, resp, builtIn)
 
 			if err != nil {


### PR DESCRIPTION
#### Summary
Previously, if the original slash command response is a root post i.e. it's triggered from the center panel, additional responses will not get placed in the same thread but instead open new threads i.e. are root posts themselves. This change presents additional responses as replies to the original response in the same thread.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/15174

#### Release Note
```release-note
Changed additional slash command responses from appearing as new posts to appearing as replies to the first response.
```
