### PR TITLE
[MM-45601] Add support for custom groups to invite slash command

### DIFF
--- a/app/slashcommands/command_invite.go
+++ b/app/slashcommands/command_invite.go
@@ -138,24 +138,22 @@ func (i *InviteProvider) parseMessage(a *app.App, c request.CTX, args *model.Com
 }
 
 func (i *InviteProvider) getUsersFromMention(a *app.App, username string) []*model.User {
-	users := make([]*model.User, 0, 1)
-
 	userProfile, err := a.Srv().Store().User().GetByUsername(username)
 	if err == nil && userProfile.DeleteAt == 0 {
-		users = append(users, userProfile)
+		return []*model.User{userProfile}
 	}
 
 	group, appErr := a.GetGroupByName(username, model.GroupSearchOpts{})
 	if appErr != nil || group == nil {
-		return users
+		return nil
 	}
 
 	members, appErr := a.GetGroupMemberUsers(group.Id)
 	if appErr != nil {
-		return users
+		return nil
 	}
 
-	return append(users, members...)
+	return members
 }
 
 func (i *InviteProvider) checkPermissions(a *app.App, c request.CTX, args *model.CommandArgs, resps *[]string, targetUser *model.User, targetChannels []*model.Channel) []*model.Channel {

--- a/app/slashcommands/command_invite.go
+++ b/app/slashcommands/command_invite.go
@@ -93,11 +93,11 @@ func (i *InviteProvider) parseMessage(a *app.App, c request.CTX, args *model.Com
 		}
 
 		if msg[0] == '@' || (msg[0] != '~' && j == 0) {
-			targetUsername := strings.TrimPrefix(msg, "@")
-			users := i.getUsersFromMention(a, targetUsername)
+			targetMentionName := strings.TrimPrefix(msg, "@")
+			users := i.getUsersFromMentionName(a, targetMentionName)
 			if len(users) == 0 {
 				*resps = append(*resps, args.T("api.command_invite.missing_user.app_error", map[string]any{
-					"User": targetUsername,
+					"User": targetMentionName,
 				}))
 				continue
 			}
@@ -137,13 +137,13 @@ func (i *InviteProvider) parseMessage(a *app.App, c request.CTX, args *model.Com
 	return targetUsers, targetChannels, ""
 }
 
-func (i *InviteProvider) getUsersFromMention(a *app.App, username string) []*model.User {
-	userProfile, err := a.Srv().Store().User().GetByUsername(username)
+func (i *InviteProvider) getUsersFromMentionName(a *app.App, mentionName string) []*model.User {
+	userProfile, err := a.Srv().Store().User().GetByUsername(mentionName)
 	if err == nil && userProfile.DeleteAt == 0 {
 		return []*model.User{userProfile}
 	}
 
-	group, appErr := a.GetGroupByName(username, model.GroupSearchOpts{})
+	group, appErr := a.GetGroupByName(mentionName, model.GroupSearchOpts{})
 	if appErr != nil || group == nil {
 		return nil
 	}

--- a/app/slashcommands/command_invite_test.go
+++ b/app/slashcommands/command_invite_test.go
@@ -246,6 +246,25 @@ func TestInviteProvider(t *testing.T) {
 		checkIsMember(channel.Id, user2.Id)
 		checkIsMember(channel.Id, user3.Id)
 	})
+
+	t.Run("add users both using group and users in the another channel", func(t *testing.T) {
+		channel := th.createChannel(th.BasicTeam, model.ChannelTypeOpen)
+		group := th.createGroup()
+		user1 := th.createUser()
+		user2 := th.createUser()
+		user3 := th.createUser()
+		th.linkUserToTeam(user1, th.BasicTeam)
+		th.linkUserToTeam(user2, th.BasicTeam)
+		th.linkUserToTeam(user3, th.BasicTeam)
+		th.addUserToGroup(user1, group)
+		th.addUserToGroup(user2, group)
+
+		msg := "@" + *group.Name + " @" + user3.Username + " ~" + channel.Name
+		runCmd(msg, "api.command_invite.success\napi.command_invite.success\napi.command_invite.success")
+		checkIsMember(channel.Id, user1.Id)
+		checkIsMember(channel.Id, user2.Id)
+		checkIsMember(channel.Id, user3.Id)
+	})
 }
 
 func TestInviteGroup(t *testing.T) {

--- a/app/slashcommands/command_invite_test.go
+++ b/app/slashcommands/command_invite_test.go
@@ -207,6 +207,45 @@ func TestInviteProvider(t *testing.T) {
 		runCmd(msg, "api.command_invite.user_not_in_team.app_error")
 		checkIsNotMember(th.BasicChannel.Id, bot.UserId)
 	})
+
+	t.Run("add users using a group in the current channel", func(t *testing.T) {
+		group := th.createGroup()
+		user1 := th.createUser()
+		user2 := th.createUser()
+		user3 := th.createUser()
+		th.linkUserToTeam(user1, th.BasicTeam)
+		th.linkUserToTeam(user2, th.BasicTeam)
+		th.linkUserToTeam(user3, th.BasicTeam)
+		th.addUserToGroup(user1, group)
+		th.addUserToGroup(user2, group)
+		th.addUserToGroup(user3, group)
+
+		msg := "@" + *group.Name
+		runCmd(msg, "")
+		checkIsMember(th.BasicChannel.Id, user1.Id)
+		checkIsMember(th.BasicChannel.Id, user2.Id)
+		checkIsMember(th.BasicChannel.Id, user3.Id)
+	})
+
+	t.Run("add users using a group in the another channel", func(t *testing.T) {
+		channel := th.createChannel(th.BasicTeam, model.ChannelTypeOpen)
+		group := th.createGroup()
+		user1 := th.createUser()
+		user2 := th.createUser()
+		user3 := th.createUser()
+		th.linkUserToTeam(user1, th.BasicTeam)
+		th.linkUserToTeam(user2, th.BasicTeam)
+		th.linkUserToTeam(user3, th.BasicTeam)
+		th.addUserToGroup(user1, group)
+		th.addUserToGroup(user2, group)
+		th.addUserToGroup(user3, group)
+
+		msg := "@" + *group.Name + " ~" + channel.Name
+		runCmd(msg, "api.command_invite.success\napi.command_invite.success\napi.command_invite.success")
+		checkIsMember(channel.Id, user1.Id)
+		checkIsMember(channel.Id, user2.Id)
+		checkIsMember(channel.Id, user3.Id)
+	})
 }
 
 func TestInviteGroup(t *testing.T) {

--- a/app/slashcommands/helper_test.go
+++ b/app/slashcommands/helper_test.go
@@ -325,6 +325,21 @@ func (th *TestHelper) createGroupChannel(user1 *model.User, user2 *model.User) *
 	return channel
 }
 
+func (th *TestHelper) createGroup() *model.Group {
+	id := model.NewId()
+	g, appErr := th.App.CreateGroup(&model.Group{
+		DisplayName: "dn_" + id,
+		Name:        model.NewString("name" + id),
+		Source:      model.GroupSourceLdap,
+		Description: "description_" + id,
+		RemoteId:    model.NewString(model.NewId()),
+	})
+	if appErr != nil {
+		panic(appErr)
+	}
+	return g
+}
+
 func (th *TestHelper) createPost(channel *model.Channel) *model.Post {
 	id := model.NewId()
 
@@ -353,6 +368,14 @@ func (th *TestHelper) addUserToChannel(user *model.User, channel *model.Channel)
 	member, err := th.App.AddUserToChannel(th.Context, user, channel, false)
 	if err != nil {
 		panic(err)
+	}
+	return member
+}
+
+func (th *TestHelper) addUserToGroup(user *model.User, group *model.Group) *model.GroupMember {
+	member, appErr := th.App.UpsertGroupMember(group.Id, user.Id)
+	if appErr != nil {
+		panic(appErr)
 	}
 	return member
 }


### PR DESCRIPTION
#### Summary
As a continuation of https://github.com/mattermost/mattermost-server/pull/21726, this PR adds support for custom groups to slash command.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45601

#### Release Note
```release-note
Adds support for custom groups to invite slash command.
```
