### PR TITLE
[MM-49344] - Improve error message when trying to upload another trial license

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2055,7 +2055,7 @@
   },
   {
     "id": "api.license.request-trial.can-start-trial.not-allowed",
-    "translation": "This trial license key for Mattermost Enterprise Edition has expired and is no longer valid. If you would like to extend your trial period please [contact our sales team](https://mattermost.com/contact-us/)."
+    "translation": "Failed to apply new trial license. You have previously applied a trial license to this Mattermost instance.. If you would like to extend your trial period please [contact our sales team](https://mattermost.com/contact-us/)."
   },
   {
     "id": "api.license.request_renewal_link.app_error",


### PR DESCRIPTION
#### Summary
This PR adds a clearer message when a user tries to upload a second trial license. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49344

#### Release Note

```release-note
NONE
```
