### PR TITLE
 [MM-21901] Set trigger timeout for Interactive Dialogue dynamically using config instead of const value

### DIFF
--- a/app/integration_action.go
+++ b/app/integration_action.go
@@ -585,7 +585,7 @@ func (a *App) DoLocalRequest(c *request.Context, rawURL string, body []byte) (*h
 }
 
 func (a *App) OpenInteractiveDialog(request model.OpenDialogRequest) *model.AppError {
-	clientTriggerId, userID, appErr := request.DecodeAndVerifyTriggerId(a.AsymmetricSigningKey())
+	clientTriggerId, userID, appErr := request.DecodeAndVerifyTriggerId(a.AsymmetricSigningKey(), *a.ch.srv.platform.Config().ServiceSettings.InteractiveDialogTriggerTimeout)
 	if appErr != nil {
 		return appErr
 	}

--- a/model/config.go
+++ b/model/config.go
@@ -104,6 +104,7 @@ const (
 	ServiceSettingsDefaultTLSKeyFile       = ""
 	ServiceSettingsDefaultReadTimeout      = 300
 	ServiceSettingsDefaultWriteTimeout     = 300
+	ServiceSettingsDefaultInteractiveDialogTriggerTimeout = 5000
 	ServiceSettingsDefaultIdleTimeout      = 60
 	ServiceSettingsDefaultMaxLoginAttempts = 10
 	ServiceSettingsDefaultAllowCorsFrom    = ""
@@ -299,6 +300,8 @@ type ServiceSettings struct {
 	TrustedProxyIPHeader                []string `access:"write_restrictable,cloud_restrictable"` // telemetry: none
 	ReadTimeout                         *int     `access:"environment_web_server,write_restrictable,cloud_restrictable"`
 	WriteTimeout                        *int     `access:"environment_web_server,write_restrictable,cloud_restrictable"`
+	// In milliseconds
+	InteractiveDialogTriggerTimeout     *int  `access:"experimental_features,write_restrictable,cloud_restrictable"`
 	IdleTimeout                         *int     `access:"write_restrictable,cloud_restrictable"`
 	MaximumLoginAttempts                *int     `access:"authentication_password,write_restrictable,cloud_restrictable"`
 	GoroutineHealthThreshold            *int     `access:"write_restrictable,cloud_restrictable"` // telemetry: none
@@ -541,6 +544,10 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 
 	if s.WriteTimeout == nil {
 		s.WriteTimeout = NewInt(ServiceSettingsDefaultWriteTimeout)
+	}
+
+	if s.InteractiveDialogTriggerTimeout == nil {
+		s.InteractiveDialogTriggerTimeout = NewInt(ServiceSettingsDefaultInteractiveDialogTriggerTimeout)
 	}
 
 	if s.IdleTimeout == nil {

--- a/model/integration_action.go
+++ b/model/integration_action.go
@@ -279,7 +279,7 @@ func (r *PostActionIntegrationRequest) GenerateTriggerId(s crypto.Signer) (strin
 	return clientTriggerId, triggerId, nil
 }
 
-func DecodeAndVerifyTriggerId(triggerId string, s *ecdsa.PrivateKey, InteractiveDialogTriggerTimeout int) (string, string, *AppError) {
+func DecodeAndVerifyTriggerId(triggerId string, s *ecdsa.PrivateKey, interactiveDialogTriggerTimeout int) (string, string, *AppError) {
 	triggerIdBytes, err := base64.StdEncoding.DecodeString(triggerId)
 	if err != nil {
 		return "", "", NewAppError("DecodeAndVerifyTriggerId", "interactive_message.decode_trigger_id.base64_decode_failed", nil, "", http.StatusBadRequest).Wrap(err)
@@ -296,8 +296,8 @@ func DecodeAndVerifyTriggerId(triggerId string, s *ecdsa.PrivateKey, Interactive
 	timestamp, _ := strconv.ParseInt(timestampStr, 10, 64)
 
 	now := GetMillis()
-	if now-timestamp > int64(InteractiveDialogTriggerTimeout) {
-		return "", "", NewAppError("DecodeAndVerifyTriggerId", "interactive_message.decode_trigger_id.expired", map[string]any{"Seconds": InteractiveDialogTriggerTimeout / 1000}, "", http.StatusBadRequest)
+	if now-timestamp > int64(interactiveDialogTriggerTimeout) {
+		return "", "", NewAppError("DecodeAndVerifyTriggerId", "interactive_message.decode_trigger_id.expired", map[string]any{"Seconds": interactiveDialogTriggerTimeout / 1000}, "", http.StatusBadRequest)
 	}
 
 	signature, err := base64.StdEncoding.DecodeString(split[3])
@@ -326,8 +326,8 @@ func DecodeAndVerifyTriggerId(triggerId string, s *ecdsa.PrivateKey, Interactive
 	return clientTriggerId, userId, nil
 }
 
-func (r *OpenDialogRequest) DecodeAndVerifyTriggerId(s *ecdsa.PrivateKey, InteractiveDialogTriggerTimeout int) (string, string, *AppError) {
-	return DecodeAndVerifyTriggerId(r.TriggerId, s, InteractiveDialogTriggerTimeout)
+func (r *OpenDialogRequest) DecodeAndVerifyTriggerId(s *ecdsa.PrivateKey, interactiveDialogTriggerTimeout int) (string, string, *AppError) {
+	return DecodeAndVerifyTriggerId(r.TriggerId, s, interactiveDialogTriggerTimeout)
 }
 
 func (o *Post) StripActionIntegrations() {

--- a/model/integration_action.go
+++ b/model/integration_action.go
@@ -24,7 +24,6 @@ import (
 const (
 	PostActionTypeButton                        = "button"
 	PostActionTypeSelect                        = "select"
-	InteractiveDialogTriggerTimeoutMilliseconds = 3000
 )
 
 var PostActionRetainPropKeys = []string{"from_webhook", "override_username", "override_icon_url"}

--- a/model/integration_action.go
+++ b/model/integration_action.go
@@ -280,7 +280,7 @@ func (r *PostActionIntegrationRequest) GenerateTriggerId(s crypto.Signer) (strin
 	return clientTriggerId, triggerId, nil
 }
 
-func DecodeAndVerifyTriggerId(triggerId string, s *ecdsa.PrivateKey) (string, string, *AppError) {
+func DecodeAndVerifyTriggerId(triggerId string, s *ecdsa.PrivateKey, InteractiveDialogTriggerTimeout int) (string, string, *AppError) {
 	triggerIdBytes, err := base64.StdEncoding.DecodeString(triggerId)
 	if err != nil {
 		return "", "", NewAppError("DecodeAndVerifyTriggerId", "interactive_message.decode_trigger_id.base64_decode_failed", nil, "", http.StatusBadRequest).Wrap(err)
@@ -297,8 +297,8 @@ func DecodeAndVerifyTriggerId(triggerId string, s *ecdsa.PrivateKey) (string, st
 	timestamp, _ := strconv.ParseInt(timestampStr, 10, 64)
 
 	now := GetMillis()
-	if now-timestamp > InteractiveDialogTriggerTimeoutMilliseconds {
-		return "", "", NewAppError("DecodeAndVerifyTriggerId", "interactive_message.decode_trigger_id.expired", map[string]any{"Seconds": InteractiveDialogTriggerTimeoutMilliseconds / 1000}, "", http.StatusBadRequest)
+	if now-timestamp > int64(InteractiveDialogTriggerTimeout) {
+		return "", "", NewAppError("DecodeAndVerifyTriggerId", "interactive_message.decode_trigger_id.expired", map[string]any{"Seconds": InteractiveDialogTriggerTimeout / 1000}, "", http.StatusBadRequest)
 	}
 
 	signature, err := base64.StdEncoding.DecodeString(split[3])
@@ -327,8 +327,8 @@ func DecodeAndVerifyTriggerId(triggerId string, s *ecdsa.PrivateKey) (string, st
 	return clientTriggerId, userId, nil
 }
 
-func (r *OpenDialogRequest) DecodeAndVerifyTriggerId(s *ecdsa.PrivateKey) (string, string, *AppError) {
-	return DecodeAndVerifyTriggerId(r.TriggerId, s)
+func (r *OpenDialogRequest) DecodeAndVerifyTriggerId(s *ecdsa.PrivateKey, InteractiveDialogTriggerTimeout int) (string, string, *AppError) {
+	return DecodeAndVerifyTriggerId(r.TriggerId, s, InteractiveDialogTriggerTimeout)
 }
 
 func (o *Post) StripActionIntegrations() {

--- a/model/integration_action_test.go
+++ b/model/integration_action_test.go
@@ -36,7 +36,7 @@ func TestTriggerIdDecodeAndVerification(t *testing.T) {
 		clientTriggerId, triggerId, appErr := actionReq.GenerateTriggerId(key)
 		require.Nil(t, appErr)
 		dialogReq := &OpenDialogRequest{TriggerId: triggerId}
-		decodedClientTriggerId, decodedUserId, appErr := dialogReq.DecodeAndVerifyTriggerId(key)
+		decodedClientTriggerId, decodedUserId, appErr := dialogReq.DecodeAndVerifyTriggerId(key, interactiveDialogTriggerTimeout)
 		assert.Nil(t, appErr)
 		assert.Equal(t, clientTriggerId, decodedClientTriggerId)
 		assert.Equal(t, actionReq.UserId, decodedUserId)

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -413,6 +413,7 @@ func (ts *TelemetryService) trackConfig() {
 		"isdefault_tls_key_file":                                  isDefault(*cfg.ServiceSettings.TLSKeyFile, model.ServiceSettingsDefaultTLSKeyFile),
 		"isdefault_read_timeout":                                  isDefault(*cfg.ServiceSettings.ReadTimeout, model.ServiceSettingsDefaultReadTimeout),
 		"isdefault_write_timeout":                                 isDefault(*cfg.ServiceSettings.WriteTimeout, model.ServiceSettingsDefaultWriteTimeout),
+		"isdefault_write_timeout":                                 isDefault(*cfg.ServiceSettings.InteractiveDialogTriggerTimeout, model.ServiceSettingsDefaultInteractiveDialogTriggerTimeout),
 		"isdefault_idle_timeout":                                  isDefault(*cfg.ServiceSettings.IdleTimeout, model.ServiceSettingsDefaultIdleTimeout),
 		"isdefault_google_developer_key":                          isDefault(cfg.ServiceSettings.GoogleDeveloperKey, ""),
 		"isdefault_allow_cors_from":                               isDefault(*cfg.ServiceSettings.AllowCorsFrom, model.ServiceSettingsDefaultAllowCorsFrom),

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -413,7 +413,7 @@ func (ts *TelemetryService) trackConfig() {
 		"isdefault_tls_key_file":                                  isDefault(*cfg.ServiceSettings.TLSKeyFile, model.ServiceSettingsDefaultTLSKeyFile),
 		"isdefault_read_timeout":                                  isDefault(*cfg.ServiceSettings.ReadTimeout, model.ServiceSettingsDefaultReadTimeout),
 		"isdefault_write_timeout":                                 isDefault(*cfg.ServiceSettings.WriteTimeout, model.ServiceSettingsDefaultWriteTimeout),
-		"isdefault_write_timeout":                                 isDefault(*cfg.ServiceSettings.InteractiveDialogTriggerTimeout, model.ServiceSettingsDefaultInteractiveDialogTriggerTimeout),
+		"isdefault_interactive_dialog_trigger_timeout":            isDefault(*cfg.ServiceSettings.InteractiveDialogTriggerTimeout, model.ServiceSettingsDefaultInteractiveDialogTriggerTimeout),
 		"isdefault_idle_timeout":                                  isDefault(*cfg.ServiceSettings.IdleTimeout, model.ServiceSettingsDefaultIdleTimeout),
 		"isdefault_google_developer_key":                          isDefault(cfg.ServiceSettings.GoogleDeveloperKey, ""),
 		"isdefault_allow_cors_from":                               isDefault(*cfg.ServiceSettings.AllowCorsFrom, model.ServiceSettingsDefaultAllowCorsFrom),


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
 Set trigger timeout for Interactive Dialogue dynamically using config instead of const value to allow the client/user to decide the dialogue timeout issue instead of using a constant timeout value

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/21901
#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has client changes ([[MM-21901] : Add Interactive Dialog Trigger Timeout config option in Integration Management setting](https://github.com/mattermost/mattermost-webapp/pull/12356))

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
 Set trigger timeout for Interactive Dialogue dynamically using config instead of const value
```



[MM-21901]: https://mattermost.atlassian.net/browse/MM-21901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ