### PR TITLE
[MM-51090] - Notify Admin post fails MessageHasBeenPosted plugin hook

### DIFF
--- a/model/post.go
+++ b/model/post.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"regexp"
@@ -777,6 +778,9 @@ func (o *Post) ToNilIfInvalid() *Post {
 func (o *Post) ForPlugin() *Post {
 	p := o.Clone()
 	p.Metadata = nil
+	if p.Type == fmt.Sprintf("%sup_notification", PostCustomTypePrefix) {
+		p.DelProp("requested_features")
+	}
 	return p
 }
 

--- a/model/post_test.go
+++ b/model/post_test.go
@@ -5,6 +5,7 @@ package model
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -905,4 +906,35 @@ func TestPostAttachments(t *testing.T) {
 		assert.Equal(t, attachments[0].Fields[0].Value, ":emoji1:")
 		assert.Equal(t, attachments[0].Fields[1].Value, ":emoji2:")
 	})
+}
+
+func TestPostForPlugin(t *testing.T) {
+	t.Run("post type custom_up_notification for plugin should have no requested features prop", func(t *testing.T) {
+		p := &Post{
+			Type: fmt.Sprintf("%sup_notification", PostCustomTypePrefix),
+		}
+		props := make(StringInterface)
+		props["requested_features"] = "test_requested_features_map"
+		p.SetProps(props)
+
+		require.NotNil(t, p.GetProp("requested_features"))
+
+		pluginPost := p.ForPlugin()
+		require.Nil(t, pluginPost.GetProp("requested_features"))
+	})
+
+	t.Run("non post type custom_up_notification for plugin should have requested features prop", func(t *testing.T) {
+		p := &Post{
+			Type: PostTypeWelcomePost,
+		}
+		props := make(StringInterface)
+		props["requested_features"] = "test_requested_features_map"
+		p.SetProps(props)
+
+		require.NotNil(t, p.GetProp("requested_features"))
+
+		pluginPost := p.ForPlugin()
+		require.NotNil(t, pluginPost.GetProp("requested_features"))
+	})
+
 }


### PR DESCRIPTION
#### Summary

Problem
---
When a NotifyAdmin post is being created, features_requested data that is of the type `map[model.MattermostPaidFeature][]*model.NotifyAdminData` is added to props. For plugins that implement the rpc hook `MessageHasBeenPosted` and other hooks that receive the type `model.Post` in their args, type `map[model.MattermostPaidFeature][]*model.NotifyAdminData` doesn't seem to be gob encodable and therefore fails the rpc connection. 

Solution
---
For now, for post data being sent over rpc to the plugins, we remove `requested_features` data from the props


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51090

#### Release Note

```release-note
NONE
```
