### PR TITLE
update LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,8 +11,8 @@ You may be licensed to use source code to create compiled versions not produced 
 1. Under the Free Software Foundation’s GNU AGPL v.3.0, subject to the exceptions outlined in this policy; or
 2. Under a commercial license available from Mattermost, Inc. by contacting commercial@mattermost.com
 
-You are licensed to use the source code in Admin Tools and Configuration Files (templates/, config/default.json, i18n/, model/,
-plugin/ and all subdirectories thereof) under the Apache License v2.0.
+You are licensed to use the source code in Admin Tools and Configuration Files (server/templates/, server/i18n/, model/,
+plugin/, server/boards/, server/playbooks/, webapp/ and all subdirectories thereof) under the Apache License v2.0.
 
 We promise that we will not enforce the copyleft provisions in AGPL v3.0 against you if your application (a) does not
 link to the Mattermost Platform directly, but exclusively uses the Mattermost Admin Tools and Configuration Files, and


### PR DESCRIPTION
#### Summary
Update the LICENSE.txt:
* Reflect the updated paths to `server/templates/`, `server/i18n/`
* Apply the Apache License v2.0 to `server/boards/`, `server/playbooks/`, and `webapp/`.
* Remove `config/default.json`, as this file has not existed for a long time.

#### Ticket Link
None, this is mono-repo fallout.

#### Release Note
```release-note
Update LICENSE.txt to reflect merging Webapp, Boards & Playbooks in the monorepo.
```
