### PR TITLE
Fine-tuning the ESR2ESR migration script

### DIFF
--- a/server/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/server/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -869,6 +869,9 @@ BEGIN
 	DECLARE CreateIndexCreateAt BOOLEAN;
 	DECLARE CreateIndexCreateAtQuery TEXT DEFAULT NULL;
 
+	-- Condition to control whether to update the RootId column.
+	DECLARE UpdateRootId BOOLEAN;
+
 	SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
 		WHERE TABLE_NAME = 'Posts'
 		AND table_schema = DATABASE()
@@ -909,7 +912,10 @@ BEGIN
 
 	IF DropParentId THEN
 		SET DropParentIdQuery = 'DROP COLUMN ParentId';
-		UPDATE Posts SET RootId = ParentId WHERE RootId = '' AND RootId != ParentId;
+		SELECT COUNT(*) FROM Posts WHERE RootId != ParentId INTO UpdateRootId;
+		IF UpdateRootId THEN
+			UPDATE Posts SET RootId = ParentId WHERE RootId = '' AND RootId != ParentId;
+		END IF;
 	END IF;
 
 	IF ModifyFileIds THEN


### PR DESCRIPTION
#### Summary
There's a customer that reported that this `UPDATE` was taking ages to finish, even when it was useless, since there was no matching rows to update. According to their report, the SELECT with the same filter was orders of magnitude faster.

We offered this workaround, and they're running it with this patch, so we should merge it into master, or at least have a discussion around it.

As for the impact of this in the script: I was not able to reproduce the behaviour reported by the customer in the first place, but I didn't see any negative impact either, so I don't think it's harmful.

#### Ticket Link
--

#### Screenshots
--

#### Release Note
```release-note
NONE
```
