### PR TITLE
MM-52881: Fix date picker selected day

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/custom_status/custom_status_expiry/custom_status_expiry_4_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/custom_status/custom_status_expiry/custom_status_expiry_4_spec.ts
@@ -142,4 +142,33 @@ describe('MM-T4066 Setting manual status clear time more than 7 days away', () =
         // * Correct clear time should be displayed in the status dropdown
         cy.get('.status-dropdown-menu .custom_status__expiry time').should('have.text', dateToBeSelected.format('MMM DD'));
     });
+
+    it('MM-52881 should show the selected date when reopening the date picker', () => {
+        // # clear the status
+        cy.get('.input-clear-x').click();
+
+        // # open the status modal
+        cy.get('.custom_status__row').click();
+
+        // # select the first option
+        cy.get('.statusSuggestion__row').first().click();
+
+        // # open the date picker
+        cy.get('.dateTime__calendar-icon').click();
+
+        // * Verify that DayPicker overlay is visible
+        cy.get('.date-picker__popper').should('be.visible');
+
+        // # Click on the date which is dateToBeSelected
+        for (let i = 0; i < months; i++) {
+            cy.get('.fa-angle-right').click();
+        }
+        cy.get('.date-picker__popper').find(`.rdp-month button[aria-label="${dateToBeSelected.format('Do MMMM (dddd)')}"]`).click();
+
+        // # reopen the date picker
+        cy.get('.dateTime__calendar-icon').click();
+
+        // * Verify that date selected is still selected
+        cy.get('.date-picker__popper').find(`.rdp-month button[aria-label="${dateToBeSelected.format('Do MMMM (dddd)')}"]`).should('have.class', 'rdp-day_selected');
+    });
 });

--- a/webapp/channels/src/components/custom_status/date_time_input.tsx
+++ b/webapp/channels/src/components/custom_status/date_time_input.tsx
@@ -146,6 +146,7 @@ const DateTimeInputContainer: React.FC<Props> = (props: Props) => {
         initialFocus: isPopperOpen,
         mode: 'single',
         selected: time.toDate(),
+        defaultMonth: time.toDate(),
         onDayClick: handleDayChange,
         disabled: [{
             before: currentTime,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Hi, I noticed the displayed selected day in the date picker is not correct. It is always set to the current date, even if you change it. 

The date picker is used in the custom status and post reminder modal.

For example, here we can see I selected the 17th but the 15 (date of the day I took the screenshot) is still selected.
![Screenshot 2023-05-15 at 17 01 30](https://github.com/mattermost/mattermost-server/assets/81326532/d9e1555a-e72e-4f98-879b-f95281fb60ec)
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-52881

#### Screenshots
|  before  |  after  |
|----|----|
| ![Screenshot 2023-05-15 at 16 40 38](https://github.com/mattermost/mattermost-server/assets/81326532/25087a05-f62f-44aa-bfca-2302b0d895a8) | ![Screenshot 2023-05-15 at 16 41 39](https://github.com/mattermost/mattermost-server/assets/81326532/65472856-2c78-4160-842b-011739761fed)|
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.


-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
