### PR TITLE
[MM-32576] Text copied from Microsoft OneNote pastes as an image

### DIFF
--- a/webapp/channels/src/components/advanced_create_post/advanced_create_post.tsx
+++ b/webapp/channels/src/components/advanced_create_post/advanced_create_post.tsx
@@ -925,7 +925,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
         const hasLinks = hasHtmlLink(clipboardData);
         let table = getTable(clipboardData);
 
-        if (!table && !hasLinks && !shouldApplyLinkMarkdown) {
+        if (!table && !hasLinks && !shouldApplyLinkMarkdown && !clipboardText) {
             return;
         }
 
@@ -954,8 +954,17 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             return;
         }
 
+        let formattedMessage;
+
+        if (table || hasLinks) {
+            formattedMessage = formatMarkdownMessage(clipboardData, message.trim(), this.state.caretPosition);
+        } else if (clipboardText) {
+            formattedMessage = clipboardText;
+        } else {
+            return;
+        }
+
         const originalSize = message.length;
-        const formattedMessage = formatMarkdownMessage(clipboardData, message.trim(), this.state.caretPosition);
         const newCaretPosition = formattedMessage.length - (originalSize - this.state.caretPosition);
         this.setMessageAndCaretPostion(formattedMessage, newCaretPosition);
         this.handlePostPasteDraft(formattedMessage);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Added ability to paste plain text while copy-pasting from MS Office products on Mac, not only picture.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/16858
https://mattermost.atlassian.net/browse/MM-32576

#### Screenshots
![image](https://github.com/mattermost/mattermost-server/assets/1384262/e9d89c80-962c-4b57-b309-6f10c586a8a7)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
