### PR TITLE
[MM-47359] webapp/channels : Avoid passing global state into "user_actions.ts"

### DIFF
--- a/webapp/channels/src/actions/channel_actions.test.ts
+++ b/webapp/channels/src/actions/channel_actions.test.ts
@@ -10,7 +10,6 @@ import {
     openGroupChannelToUserIds,
     loadChannelsForCurrentUser, fetchChannelsAndMembers,
 } from 'actions/channel_actions';
-import {loadProfilesForSidebar} from 'actions/user_actions';
 import {CHANNELS_AND_CHANNEL_MEMBERS_PER_PAGE} from 'actions/channel_queries';
 
 import {Channel} from '@mattermost/types/channels';
@@ -136,7 +135,9 @@ jest.mock('mattermost-redux/actions/channels', () => ({
 jest.mock('actions/user_actions', () => ({
     loadNewDMIfNeeded: jest.fn(),
     loadNewGMIfNeeded: jest.fn(),
-    loadProfilesForSidebar: jest.fn(),
+    loadProfilesForSidebar: () => ({
+        type: 'MOCK_PROFILES_FOR_SIDEBAR',
+    }),
 }));
 
 describe('Actions.Channel', () => {
@@ -146,11 +147,13 @@ describe('Actions.Channel', () => {
         const expectedActions = [{
             type: 'MOCK_FETCH_CHANNELS_AND_MEMBERS',
             args: ['team-id'],
+        }, 
+        {
+            type: 'MOCK_PROFILES_FOR_SIDEBAR',
         }];
 
         await testStore.dispatch(loadChannelsForCurrentUser());
         expect(testStore.getActions()).toEqual(expectedActions);
-        expect(loadProfilesForSidebar).toHaveBeenCalledTimes(1);
     });
 
     test('searchMoreChannels', async () => {

--- a/webapp/channels/src/actions/channel_actions.ts
+++ b/webapp/channels/src/actions/channel_actions.ts
@@ -104,7 +104,7 @@ export function loadChannelsForCurrentUser(): ActionFunc {
             }
         }
 
-        loadProfilesForSidebar();
+        dispatch(loadProfilesForSidebar());
         return {data: true};
     };
 }

--- a/webapp/channels/src/actions/global_actions.tsx
+++ b/webapp/channels/src/actions/global_actions.tsx
@@ -90,7 +90,7 @@ export function emitChannelClickEvent(channel: Channel) {
         }
 
         if (currentChannelId) {
-            loadProfilesForSidebar();
+            dispatch(loadProfilesForSidebar());
         }
 
         dispatch(batchActions([

--- a/webapp/channels/src/actions/user_actions.test.ts
+++ b/webapp/channels/src/actions/user_actions.test.ts
@@ -615,7 +615,7 @@ describe('Actions.User', () => {
         const testStore = mockStore(state);
         store.getState.mockImplementation(testStore.getState);
 
-        await UserActions.loadProfilesForGM();
+        await testStore.dispatch(UserActions.loadProfilesForGM());
         expect(UserActions.queue.onEmpty).toHaveBeenCalled();
         expect(UserActions.queue.add).toHaveBeenCalled();
     });

--- a/webapp/channels/src/actions/user_actions.ts
+++ b/webapp/channels/src/actions/user_actions.ts
@@ -297,7 +297,7 @@ export function loadProfilesForGroupChannels(groupChannels: Channel[]) {
     };
 }
 
-export async function loadProfilesForSidebar() {
+export function loadProfilesForSidebar() {
     return async (dispatch: DispatchFunc) => {
         await Promise.all([dispatch(loadProfilesForDM()), dispatch(loadProfilesForGM())]);
         return { data: true}

--- a/webapp/channels/src/actions/user_actions.ts
+++ b/webapp/channels/src/actions/user_actions.ts
@@ -39,23 +39,23 @@ import {Constants, Preferences, UserStatuses} from 'utils/constants';
 export const queue = new PQueue({concurrency: 4});
 
 export function loadProfilesAndStatusesInChannel(channelId: string, page = 0, perPage: number = General.PROFILE_CHUNK_SIZE, sort = '', options = {}) {
-    return async (doDispatch: DispatchFunc) => {
-        const {data} = await doDispatch(UserActions.getProfilesInChannel(channelId, page, perPage, sort, options));
+    return async (dispatch: DispatchFunc) => {
+        const {data} = await dispatch(UserActions.getProfilesInChannel(channelId, page, perPage, sort, options));
         if (data) {
-            doDispatch(loadStatusesForProfilesList(data));
+            dispatch(loadStatusesForProfilesList(data));
         }
         return {data: true};
     };
 }
 
 export function loadProfilesAndReloadTeamMembers(page: number, perPage: number, teamId: string, options = {}) {
-    return async (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
-        const newTeamId = teamId || getCurrentTeamId(doGetState());
-        const {data} = await doDispatch(UserActions.getProfilesInTeam(newTeamId, page, perPage, '', options));
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const newTeamId = teamId || getCurrentTeamId(getState());
+        const {data} = await dispatch(UserActions.getProfilesInTeam(newTeamId, page, perPage, '', options));
         if (data) {
             await Promise.all([
-                doDispatch(loadTeamMembersForProfilesList(data, newTeamId, true)),
-                doDispatch(loadStatusesForProfilesList(data)),
+                dispatch(loadTeamMembersForProfilesList(data, newTeamId, true)),
+                dispatch(loadStatusesForProfilesList(data)),
             ]);
         }
 
@@ -64,13 +64,13 @@ export function loadProfilesAndReloadTeamMembers(page: number, perPage: number, 
 }
 
 export function loadProfilesAndReloadChannelMembers(page: number, perPage?: number, channelId?: string, sort = '', options = {}) {
-    return async (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
-        const newChannelId = channelId || getCurrentChannelId(doGetState());
-        const {data} = await doDispatch(UserActions.getProfilesInChannel(newChannelId, page, perPage, sort, options));
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const newChannelId = channelId || getCurrentChannelId(getState());
+        const {data} = await dispatch(UserActions.getProfilesInChannel(newChannelId, page, perPage, sort, options));
         if (data) {
             await Promise.all([
-                doDispatch(loadChannelMembersForProfilesList(data, newChannelId, true)),
-                doDispatch(loadStatusesForProfilesList(data)),
+                dispatch(loadChannelMembersForProfilesList(data, newChannelId, true)),
+                dispatch(loadStatusesForProfilesList(data)),
             ]);
         }
 
@@ -79,12 +79,12 @@ export function loadProfilesAndReloadChannelMembers(page: number, perPage?: numb
 }
 
 export function loadProfilesAndTeamMembers(page: number, perPage: number, teamId: string, options?: Record<string, any>) {
-    return async (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
-        const newTeamId = teamId || getCurrentTeamId(doGetState());
-        const {data} = await doDispatch(UserActions.getProfilesInTeam(newTeamId, page, perPage, '', options));
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const newTeamId = teamId || getCurrentTeamId(getState());
+        const {data} = await dispatch(UserActions.getProfilesInTeam(newTeamId, page, perPage, '', options));
         if (data) {
-            doDispatch(loadTeamMembersForProfilesList(data, newTeamId));
-            doDispatch(loadStatusesForProfilesList(data));
+            dispatch(loadTeamMembersForProfilesList(data, newTeamId));
+            dispatch(loadStatusesForProfilesList(data));
         }
 
         return {data: true};
@@ -92,13 +92,13 @@ export function loadProfilesAndTeamMembers(page: number, perPage: number, teamId
 }
 
 export function searchProfilesAndTeamMembers(term = '', options: Record<string, any> = {}) {
-    return async (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
-        const newTeamId = options.team_id || getCurrentTeamId(doGetState());
-        const {data} = await doDispatch(UserActions.searchProfiles(term, options));
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const newTeamId = options.team_id || getCurrentTeamId(getState());
+        const {data} = await dispatch(UserActions.searchProfiles(term, options));
         if (data) {
             await Promise.all([
-                doDispatch(loadTeamMembersForProfilesList(data, newTeamId)),
-                doDispatch(loadStatusesForProfilesList(data)),
+                dispatch(loadTeamMembersForProfilesList(data, newTeamId)),
+                dispatch(loadStatusesForProfilesList(data)),
             ]);
         }
 
@@ -107,13 +107,13 @@ export function searchProfilesAndTeamMembers(term = '', options: Record<string, 
 }
 
 export function searchProfilesAndChannelMembers(term: string, options: Record<string, any> = {}) {
-    return async (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
-        const newChannelId = options.in_channel_id || getCurrentChannelId(doGetState());
-        const {data} = await doDispatch(UserActions.searchProfiles(term, options));
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const newChannelId = options.in_channel_id || getCurrentChannelId(getState());
+        const {data} = await dispatch(UserActions.searchProfiles(term, options));
         if (data) {
             await Promise.all([
-                doDispatch(loadChannelMembersForProfilesList(data, newChannelId)),
-                doDispatch(loadStatusesForProfilesList(data)),
+                dispatch(loadChannelMembersForProfilesList(data, newChannelId)),
+                dispatch(loadStatusesForProfilesList(data)),
             ]);
         }
 
@@ -122,16 +122,16 @@ export function searchProfilesAndChannelMembers(term: string, options: Record<st
 }
 
 export function loadProfilesAndTeamMembersAndChannelMembers(page: number, perPage: number, teamId: string, channelId: string, options?: {active?: boolean}) {
-    return async (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
-        const state = doGetState();
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const state = getState();
         const teamIdParam = teamId || getCurrentTeamId(state);
         const channelIdParam = channelId || getCurrentChannelId(state);
-        const {data} = await doDispatch(UserActions.getProfilesInChannel(channelIdParam, page, perPage, '', options));
+        const {data} = await dispatch(UserActions.getProfilesInChannel(channelIdParam, page, perPage, '', options));
         if (data) {
-            const {data: listData} = await doDispatch(loadTeamMembersForProfilesList(data, teamIdParam));
+            const {data: listData} = await dispatch(loadTeamMembersForProfilesList(data, teamIdParam));
             if (listData) {
-                doDispatch(loadChannelMembersForProfilesList(data, channelIdParam));
-                doDispatch(loadStatusesForProfilesList(data));
+                dispatch(loadChannelMembersForProfilesList(data, channelIdParam));
+                dispatch(loadStatusesForProfilesList(data));
             }
         }
 
@@ -140,8 +140,8 @@ export function loadProfilesAndTeamMembersAndChannelMembers(page: number, perPag
 }
 
 export function loadTeamMembersForProfilesList(profiles: UserProfile[], teamId: string, reloadAllMembers = false) {
-    return async (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
-        const state = doGetState();
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const state = getState();
         const teamIdParam = teamId || getCurrentTeamId(state);
         const membersToLoad: Record<string, true> = {};
         for (let i = 0; i < profiles.length; i++) {
@@ -157,30 +157,30 @@ export function loadTeamMembersForProfilesList(profiles: UserProfile[], teamId: 
             return {data: true};
         }
 
-        await doDispatch(getTeamMembersByIds(teamIdParam, userIdsToLoad));
+        await dispatch(getTeamMembersByIds(teamIdParam, userIdsToLoad));
 
         return {data: true};
     };
 }
 
 export function loadProfilesWithoutTeam(page: number, perPage: number, options?: Record<string, any>) {
-    return async (doDispatch: DispatchFunc) => {
-        const {data} = await doDispatch(UserActions.getProfilesWithoutTeam(page, perPage, options));
+    return async (dispatch: DispatchFunc) => {
+        const {data} = await dispatch(UserActions.getProfilesWithoutTeam(page, perPage, options));
 
-        doDispatch(loadStatusesForProfilesMap(data));
+        dispatch(loadStatusesForProfilesMap(data));
 
         return data;
     };
 }
 
 export function loadTeamMembersAndChannelMembersForProfilesList(profiles: UserProfile[], teamId: string, channelId: string) {
-    return async (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
-        const state = doGetState();
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const state = getState();
         const teamIdParam = teamId || getCurrentTeamId(state);
         const channelIdParam = channelId || getCurrentChannelId(state);
-        const {data} = await doDispatch(loadTeamMembersForProfilesList(profiles, teamIdParam));
+        const {data} = await dispatch(loadTeamMembersForProfilesList(profiles, teamIdParam));
         if (data) {
-            doDispatch(loadChannelMembersForProfilesList(profiles, channelIdParam));
+            dispatch(loadChannelMembersForProfilesList(profiles, channelIdParam));
         }
 
         return {data: true};
@@ -188,8 +188,8 @@ export function loadTeamMembersAndChannelMembersForProfilesList(profiles: UserPr
 }
 
 export function loadChannelMembersForProfilesList(profiles: UserProfile[], channelId: string, reloadAllMembers = false) {
-    return async (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
-        const state = doGetState();
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const state = getState();
         const channelIdParam = channelId || getCurrentChannelId(state);
         const membersToLoad: Record<string, boolean> = {};
         for (let i = 0; i < profiles.length; i++) {
@@ -206,14 +206,14 @@ export function loadChannelMembersForProfilesList(profiles: UserProfile[], chann
             return {data: true};
         }
 
-        await doDispatch(getChannelMembersByIds(channelIdParam, list));
+        await dispatch(getChannelMembersByIds(channelIdParam, list));
         return {data: true};
     };
 }
 
 export function loadNewDMIfNeeded(channelId: string) {
-    return async (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
-        const state = doGetState();
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const state = getState();
         const currentUserId = Selectors.getCurrentUserId(state);
 
         function checkPreference(channel: Channel) {
@@ -229,7 +229,7 @@ export function loadNewDMIfNeeded(channelId: string) {
                 savePreferences(currentUserId, [
                     {user_id: currentUserId, category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, name: userId, value: 'true'},
                     {user_id: currentUserId, category: Preferences.CATEGORY_CHANNEL_OPEN_TIME, name: channelId, value: now.toString()},
-                ])(doDispatch);
+                ])(dispatch);
                 loadProfilesForDM();
                 return {data: true};
             }
@@ -238,11 +238,11 @@ export function loadNewDMIfNeeded(channelId: string) {
 
         let result = {data: false} as ActionResult;
 
-        const channel = getChannel(doGetState(), channelId);
+        const channel = getChannel(getState(), channelId);
         if (channel) {
             result = checkPreference(channel);
         } else {
-            result = await getChannelAndMyMember(channelId)(doDispatch, doGetState) as ActionResult;
+            result = await getChannelAndMyMember(channelId)(dispatch, getState) as ActionResult;
             if (result.data) {
                 result = checkPreference(result.data.channel);
             }
@@ -252,14 +252,14 @@ export function loadNewDMIfNeeded(channelId: string) {
 }
 
 export function loadNewGMIfNeeded(channelId: string) {
-    return async (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
-        const state = doGetState();
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const state = getState();
         const currentUserId = Selectors.getCurrentUserId(state);
 
         function checkPreference() {
             const pref = getBool(state, Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channelId, false);
             if (pref === false) {
-                doDispatch(savePreferences(currentUserId, [{user_id: currentUserId, category: Preferences.CATEGORY_GROUP_CHANNEL_SHOW, name: channelId, value: 'true'}]));
+                dispatch(savePreferences(currentUserId, [{user_id: currentUserId, category: Preferences.CATEGORY_GROUP_CHANNEL_SHOW, name: channelId, value: 'true'}]));
                 loadProfilesForGM();
                 return {data: true};
             }
@@ -268,15 +268,15 @@ export function loadNewGMIfNeeded(channelId: string) {
 
         const channel = getChannel(state, channelId);
         if (!channel) {
-            await getChannelAndMyMember(channelId)(doDispatch, doGetState);
+            await getChannelAndMyMember(channelId)(dispatch, getState);
         }
         return checkPreference();
     };
 }
 
 export function loadProfilesForGroupChannels(groupChannels: Channel[]) {
-    return (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
-        const state = doGetState();
+    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const state = getState();
         const userIdsInChannels = Selectors.getUserIdsInChannels(state);
 
         const groupChannelsToFetch = groupChannels.reduce((acc, {id}) => {
@@ -289,7 +289,7 @@ export function loadProfilesForGroupChannels(groupChannels: Channel[]) {
         }, ([] as string[]));
 
         if (groupChannelsToFetch.length > 0) {
-            doDispatch(UserActions.getProfilesInGroupChannels(groupChannelsToFetch));
+            dispatch(UserActions.getProfilesInGroupChannels(groupChannelsToFetch));
             return {data: true};
         }
 
@@ -312,8 +312,8 @@ export const getGMsForLoading = (state: GlobalState) => {
 };
 
 export async function loadProfilesForGM() {
-    return async (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
-        const state = doGetState();
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const state = getState();
         const newPreferences = [];
         const userIdsInChannels = Selectors.getUserIdsInChannels(state);
         const currentUserId = Selectors.getCurrentUserId(state);
@@ -350,23 +350,23 @@ export async function loadProfilesForGM() {
             }
 
             const getProfilesAction = UserActions.getProfilesInChannel(channel.id, 0, Constants.MAX_USERS_IN_GM);
-            queue.add(() => doDispatch(getProfilesAction));
+            queue.add(() => dispatch(getProfilesAction));
         }
 
         await queue.onEmpty();
 
         if (userIdsForLoadingCustomEmojis.size > 0) {
-            doDispatch(loadCustomEmojisForCustomStatusesByUserIds(userIdsForLoadingCustomEmojis));
+            dispatch(loadCustomEmojisForCustomStatusesByUserIds(userIdsForLoadingCustomEmojis));
         }
         if (newPreferences.length > 0) {
-            doDispatch(savePreferences(currentUserId, newPreferences));
+            dispatch(savePreferences(currentUserId, newPreferences));
         }
     };
 }
 
 export async function loadProfilesForDM() {
-    return async (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
-        const state = doGetState();
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const state = getState();
         const channels = getMyChannels(state);
         const newPreferences = [];
         const profilesToLoad = [];
@@ -408,44 +408,44 @@ export async function loadProfilesForDM() {
         }
 
         if (newPreferences.length > 0) {
-            savePreferences(currentUserId, newPreferences)(doDispatch);
+            savePreferences(currentUserId, newPreferences)(dispatch);
         }
 
         if (profilesToLoad.length > 0) {
-            await UserActions.getProfilesByIds(profilesToLoad)(doDispatch, doGetState);
+            await UserActions.getProfilesByIds(profilesToLoad)(dispatch, getState);
         }
-        await loadCustomEmojisForCustomStatusesByUserIds(profileIds)(doDispatch, doGetState);
+        await loadCustomEmojisForCustomStatusesByUserIds(profileIds)(dispatch, getState);
     };
 }
 
 export function autocompleteUsersInTeam(username: string) {
-    return async (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
-        const currentTeamId = getCurrentTeamId(doGetState());
-        const {data} = await doDispatch(UserActions.autocompleteUsers(username, currentTeamId));
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const currentTeamId = getCurrentTeamId(getState());
+        const {data} = await dispatch(UserActions.autocompleteUsers(username, currentTeamId));
         return data;
     };
 }
 
 export function autocompleteUsers(username: string) {
-    return async (doDispatch: DispatchFunc) => {
-        const {data} = await doDispatch(UserActions.autocompleteUsers(username));
+    return async (dispatch: DispatchFunc) => {
+        const {data} = await dispatch(UserActions.autocompleteUsers(username));
         return data;
     };
 }
 
 export function autoResetStatus() {
-    return async (doDispatch: DispatchFunc, doGetState: GetStateFunc): Promise<{data: UserStatus}> => {
-        const {currentUserId} = doGetState().entities.users;
-        const {data: userStatus} = await (UserActions.getStatus(currentUserId)(doDispatch, doGetState) as Promise<{data: UserStatus}>);
+    return async (dispatch: DispatchFunc, getState: GetStateFunc): Promise<{data: UserStatus}> => {
+        const {currentUserId} = getState().entities.users;
+        const {data: userStatus} = await (UserActions.getStatus(currentUserId)(dispatch, getState) as Promise<{data: UserStatus}>);
 
         if (userStatus.status === UserStatuses.OUT_OF_OFFICE || !userStatus.manual) {
             return {data: userStatus};
         }
 
-        const autoReset = getBool(doGetState(), PreferencesRedux.CATEGORY_AUTO_RESET_MANUAL_STATUS, currentUserId, false);
+        const autoReset = getBool(getState(), PreferencesRedux.CATEGORY_AUTO_RESET_MANUAL_STATUS, currentUserId, false);
 
         if (autoReset) {
-            UserActions.setStatus({user_id: currentUserId, status: 'online'})(doDispatch, doGetState);
+            UserActions.setStatus({user_id: currentUserId, status: 'online'})(dispatch, getState);
             return {data: userStatus};
         }
 

--- a/webapp/channels/src/actions/user_actions.ts
+++ b/webapp/channels/src/actions/user_actions.ts
@@ -313,7 +313,7 @@ export const getGMsForLoading = (state: GlobalState) => {
 
 export async function loadProfilesForGM() {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const state = getState();
+        const state = getState() as GlobalState;
         const newPreferences = [];
         const userIdsInChannels = Selectors.getUserIdsInChannels(state);
         const currentUserId = Selectors.getCurrentUserId(state);

--- a/webapp/channels/src/actions/user_actions.ts
+++ b/webapp/channels/src/actions/user_actions.ts
@@ -230,7 +230,7 @@ export function loadNewDMIfNeeded(channelId: string) {
                     {user_id: currentUserId, category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, name: userId, value: 'true'},
                     {user_id: currentUserId, category: Preferences.CATEGORY_CHANNEL_OPEN_TIME, name: channelId, value: now.toString()},
                 ])(dispatch);
-                loadProfilesForDM();
+                dispatch(loadProfilesForDM());
                 return {data: true};
             }
             return {data: false};
@@ -260,7 +260,7 @@ export function loadNewGMIfNeeded(channelId: string) {
             const pref = getBool(state, Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channelId, false);
             if (pref === false) {
                 dispatch(savePreferences(currentUserId, [{user_id: currentUserId, category: Preferences.CATEGORY_GROUP_CHANNEL_SHOW, name: channelId, value: 'true'}]));
-                loadProfilesForGM();
+                dispatch(loadProfilesForGM());
                 return {data: true};
             }
             return {data: false};
@@ -298,7 +298,10 @@ export function loadProfilesForGroupChannels(groupChannels: Channel[]) {
 }
 
 export async function loadProfilesForSidebar() {
-    await Promise.all([loadProfilesForDM(), loadProfilesForGM()]);
+    return async (dispatch: DispatchFunc) => {
+        await Promise.all([dispatch(loadProfilesForDM()), dispatch(loadProfilesForGM())]);
+        return { data: true}
+    }
 }
 
 export const getGMsForLoading = (state: GlobalState) => {
@@ -311,7 +314,7 @@ export const getGMsForLoading = (state: GlobalState) => {
     return channels;
 };
 
-export async function loadProfilesForGM() {
+export function loadProfilesForGM() {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState() as GlobalState;
         const newPreferences = [];
@@ -361,10 +364,12 @@ export async function loadProfilesForGM() {
         if (newPreferences.length > 0) {
             dispatch(savePreferences(currentUserId, newPreferences));
         }
+    
+        return {data: true};
     };
 }
 
-export async function loadProfilesForDM() {
+export function loadProfilesForDM() {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState();
         const channels = getMyChannels(state);
@@ -415,6 +420,7 @@ export async function loadProfilesForDM() {
             await UserActions.getProfilesByIds(profilesToLoad)(dispatch, getState);
         }
         await loadCustomEmojisForCustomStatusesByUserIds(profileIds)(dispatch, getState);
+        return {data: true};
     };
 }
 

--- a/webapp/channels/src/actions/user_actions.ts
+++ b/webapp/channels/src/actions/user_actions.ts
@@ -33,14 +33,10 @@ import {loadStatusesForProfilesList, loadStatusesForProfilesMap} from 'actions/s
 
 import {getDisplayedChannels} from 'selectors/views/channel_sidebar';
 
-import store from 'stores/redux_store.jsx';
-
 import * as Utils from 'utils/utils';
 import {Constants, Preferences, UserStatuses} from 'utils/constants';
 
 export const queue = new PQueue({concurrency: 4});
-const dispatch = store.dispatch;
-const getState = store.getState;
 
 export function loadProfilesAndStatusesInChannel(channelId: string, page = 0, perPage: number = General.PROFILE_CHUNK_SIZE, sort = '', options = {}) {
     return async (doDispatch: DispatchFunc) => {
@@ -263,7 +259,7 @@ export function loadNewGMIfNeeded(channelId: string) {
         function checkPreference() {
             const pref = getBool(state, Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channelId, false);
             if (pref === false) {
-                dispatch(savePreferences(currentUserId, [{user_id: currentUserId, category: Preferences.CATEGORY_GROUP_CHANNEL_SHOW, name: channelId, value: 'true'}]));
+                doDispatch(savePreferences(currentUserId, [{user_id: currentUserId, category: Preferences.CATEGORY_GROUP_CHANNEL_SHOW, name: channelId, value: 'true'}]));
                 loadProfilesForGM();
                 return {data: true};
             }
@@ -316,106 +312,110 @@ export const getGMsForLoading = (state: GlobalState) => {
 };
 
 export async function loadProfilesForGM() {
-    const state = getState();
-    const newPreferences = [];
-    const userIdsInChannels = Selectors.getUserIdsInChannels(state);
-    const currentUserId = Selectors.getCurrentUserId(state);
-    const collapsedThreads = isCollapsedThreadsEnabled(state);
+    return async (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
+        const state = doGetState();
+        const newPreferences = [];
+        const userIdsInChannels = Selectors.getUserIdsInChannels(state);
+        const currentUserId = Selectors.getCurrentUserId(state);
+        const collapsedThreads = isCollapsedThreadsEnabled(state);
 
-    const userIdsForLoadingCustomEmojis = new Set();
-    for (const channel of getGMsForLoading(state)) {
-        const userIds = userIdsInChannels[channel.id] || new Set();
+        const userIdsForLoadingCustomEmojis = new Set();
+        for (const channel of getGMsForLoading(state)) {
+            const userIds = userIdsInChannels[channel.id] || new Set();
 
-        userIds.forEach((userId) => userIdsForLoadingCustomEmojis.add(userId));
+            userIds.forEach((userId) => userIdsForLoadingCustomEmojis.add(userId));
 
-        if (userIds.size >= Constants.MIN_USERS_IN_GM) {
-            continue;
-        }
-
-        const isVisible = getBool(state, Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channel.id);
-
-        if (!isVisible) {
-            const messageCount = getChannelMessageCount(state, channel.id);
-            const member = getMyChannelMember(state, channel.id);
-
-            const unreadCount = calculateUnreadCount(messageCount, member, collapsedThreads);
-
-            if (!unreadCount.showUnread) {
+            if (userIds.size >= Constants.MIN_USERS_IN_GM) {
                 continue;
             }
 
-            newPreferences.push({
-                user_id: currentUserId,
-                category: Preferences.CATEGORY_GROUP_CHANNEL_SHOW,
-                name: channel.id,
-                value: 'true',
-            });
+            const isVisible = getBool(state, Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channel.id);
+
+            if (!isVisible) {
+                const messageCount = getChannelMessageCount(state, channel.id);
+                const member = getMyChannelMember(state, channel.id);
+
+                const unreadCount = calculateUnreadCount(messageCount, member, collapsedThreads);
+
+                if (!unreadCount.showUnread) {
+                    continue;
+                }
+
+                newPreferences.push({
+                    user_id: currentUserId,
+                    category: Preferences.CATEGORY_GROUP_CHANNEL_SHOW,
+                    name: channel.id,
+                    value: 'true',
+                });
+            }
+
+            const getProfilesAction = UserActions.getProfilesInChannel(channel.id, 0, Constants.MAX_USERS_IN_GM);
+            queue.add(() => doDispatch(getProfilesAction));
         }
 
-        const getProfilesAction = UserActions.getProfilesInChannel(channel.id, 0, Constants.MAX_USERS_IN_GM);
-        queue.add(() => dispatch(getProfilesAction));
-    }
+        await queue.onEmpty();
 
-    await queue.onEmpty();
-
-    if (userIdsForLoadingCustomEmojis.size > 0) {
-        dispatch(loadCustomEmojisForCustomStatusesByUserIds(userIdsForLoadingCustomEmojis));
-    }
-    if (newPreferences.length > 0) {
-        dispatch(savePreferences(currentUserId, newPreferences));
-    }
+        if (userIdsForLoadingCustomEmojis.size > 0) {
+            doDispatch(loadCustomEmojisForCustomStatusesByUserIds(userIdsForLoadingCustomEmojis));
+        }
+        if (newPreferences.length > 0) {
+            doDispatch(savePreferences(currentUserId, newPreferences));
+        }
+    };
 }
 
 export async function loadProfilesForDM() {
-    const state = getState();
-    const channels = getMyChannels(state);
-    const newPreferences = [];
-    const profilesToLoad = [];
-    const profileIds = [];
-    const currentUserId = Selectors.getCurrentUserId(state);
-    const collapsedThreads = isCollapsedThreadsEnabled(state);
+    return async (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
+        const state = doGetState();
+        const channels = getMyChannels(state);
+        const newPreferences = [];
+        const profilesToLoad = [];
+        const profileIds = [];
+        const currentUserId = Selectors.getCurrentUserId(state);
+        const collapsedThreads = isCollapsedThreadsEnabled(state);
 
-    for (let i = 0; i < channels.length; i++) {
-        const channel = channels[i];
-        if (channel.type !== Constants.DM_CHANNEL) {
-            continue;
-        }
-
-        const teammateId = channel.name.replace(currentUserId, '').replace('__', '');
-        const isVisible = getBool(state, Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, teammateId);
-
-        if (!isVisible) {
-            const member = getMyChannelMember(state, channel.id);
-            const messageCount = getChannelMessageCount(state, channel.id);
-
-            const unreadCount = calculateUnreadCount(messageCount, member, collapsedThreads);
-
-            if (!member || !unreadCount.showUnread) {
+        for (let i = 0; i < channels.length; i++) {
+            const channel = channels[i];
+            if (channel.type !== Constants.DM_CHANNEL) {
                 continue;
             }
 
-            newPreferences.push({
-                user_id: currentUserId,
-                category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW,
-                name: teammateId,
-                value: 'true',
-            });
+            const teammateId = channel.name.replace(currentUserId, '').replace('__', '');
+            const isVisible = getBool(state, Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, teammateId);
+
+            if (!isVisible) {
+                const member = getMyChannelMember(state, channel.id);
+                const messageCount = getChannelMessageCount(state, channel.id);
+
+                const unreadCount = calculateUnreadCount(messageCount, member, collapsedThreads);
+
+                if (!member || !unreadCount.showUnread) {
+                    continue;
+                }
+
+                newPreferences.push({
+                    user_id: currentUserId,
+                    category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW,
+                    name: teammateId,
+                    value: 'true',
+                });
+            }
+
+            if (!Selectors.getUser(state, teammateId)) {
+                profilesToLoad.push(teammateId);
+            }
+            profileIds.push(teammateId);
         }
 
-        if (!Selectors.getUser(state, teammateId)) {
-            profilesToLoad.push(teammateId);
+        if (newPreferences.length > 0) {
+            savePreferences(currentUserId, newPreferences)(doDispatch);
         }
-        profileIds.push(teammateId);
-    }
 
-    if (newPreferences.length > 0) {
-        savePreferences(currentUserId, newPreferences)(dispatch);
-    }
-
-    if (profilesToLoad.length > 0) {
-        await UserActions.getProfilesByIds(profilesToLoad)(dispatch, getState);
-    }
-    await loadCustomEmojisForCustomStatusesByUserIds(profileIds)(dispatch, getState);
+        if (profilesToLoad.length > 0) {
+            await UserActions.getProfilesByIds(profilesToLoad)(doDispatch, doGetState);
+        }
+        await loadCustomEmojisForCustomStatusesByUserIds(profileIds)(doDispatch, doGetState);
+    };
 }
 
 export function autocompleteUsersInTeam(username: string) {
@@ -435,14 +435,14 @@ export function autocompleteUsers(username: string) {
 
 export function autoResetStatus() {
     return async (doDispatch: DispatchFunc, doGetState: GetStateFunc): Promise<{data: UserStatus}> => {
-        const {currentUserId} = getState().entities.users;
+        const {currentUserId} = doGetState().entities.users;
         const {data: userStatus} = await (UserActions.getStatus(currentUserId)(doDispatch, doGetState) as Promise<{data: UserStatus}>);
 
         if (userStatus.status === UserStatuses.OUT_OF_OFFICE || !userStatus.manual) {
             return {data: userStatus};
         }
 
-        const autoReset = getBool(getState(), PreferencesRedux.CATEGORY_AUTO_RESET_MANUAL_STATUS, currentUserId, false);
+        const autoReset = getBool(doGetState(), PreferencesRedux.CATEGORY_AUTO_RESET_MANUAL_STATUS, currentUserId, false);
 
         if (autoReset) {
             UserActions.setStatus({user_id: currentUserId, status: 'online'})(doDispatch, doGetState);

--- a/webapp/channels/src/actions/websocket_actions.jsx
+++ b/webapp/channels/src/actions/websocket_actions.jsx
@@ -1219,7 +1219,7 @@ function handlePreferenceChangedEvent(msg) {
     dispatch({type: PreferenceTypes.RECEIVED_PREFERENCES, data: [preference]});
 
     if (addedNewDmUser(preference)) {
-        loadProfilesForSidebar();
+        dispatch(loadProfilesForSidebar());
     }
 }
 
@@ -1228,7 +1228,7 @@ function handlePreferencesChangedEvent(msg) {
     dispatch({type: PreferenceTypes.RECEIVED_PREFERENCES, data: preferences});
 
     if (preferences.findIndex(addedNewDmUser) !== -1) {
-        loadProfilesForSidebar();
+        dispatch(loadProfilesForSidebar());
     }
 }
 

--- a/webapp/channels/src/components/data_prefetch/data_prefetch.test.tsx
+++ b/webapp/channels/src/components/data_prefetch/data_prefetch.test.tsx
@@ -6,8 +6,6 @@ import React from 'react';
 
 import {ChannelType} from '@mattermost/types/channels';
 
-import {loadProfilesForSidebar} from 'actions/user_actions';
-
 import {TestHelper} from 'utils/test_helper';
 
 import DataPrefetch from './data_prefetch';
@@ -20,7 +18,7 @@ jest.mock('p-queue', () => class PQueueMock {
 });
 
 jest.mock('actions/user_actions', () => ({
-    loadProfilesForSidebar: jest.fn(() => Promise.resolve({})),
+    loadProfilesForSidebar: jest.fn(),
 }));
 
 describe('/components/data_prefetch', () => {
@@ -29,6 +27,7 @@ describe('/components/data_prefetch', () => {
         actions: {
             prefetchChannelPosts: jest.fn(() => Promise.resolve({})),
             trackPreloadedChannels: jest.fn(),
+            loadProfilesForSidebar: jest.fn()
         },
         prefetchQueueObj: {
             1: [],
@@ -101,20 +100,19 @@ describe('/components/data_prefetch', () => {
         const wrapper = shallow<DataPrefetch>(
             <DataPrefetch {...props}/>,
         );
-
-        expect(loadProfilesForSidebar).not.toHaveBeenCalled();
+        expect(props.actions.loadProfilesForSidebar).not.toHaveBeenCalled();
 
         // Change channels
         wrapper.setProps({currentChannelId: 'currentChannelId'});
         await Promise.resolve(true);
 
-        expect(loadProfilesForSidebar).toHaveBeenCalledTimes(1);
+        expect(props.actions.loadProfilesForSidebar).toHaveBeenCalledTimes(1);
 
         // Change channels again
         wrapper.setProps({currentChannelId: 'anotherChannelId'});
         await Promise.resolve(true);
 
-        expect(loadProfilesForSidebar).toHaveBeenCalledTimes(1);
+        expect(props.actions.loadProfilesForSidebar).toHaveBeenCalledTimes(1);
     });
 
     test('should fetch channels in priority order', async () => {
@@ -357,7 +355,7 @@ describe('/components/data_prefetch', () => {
         );
         wrapper.setProps({});
 
-        expect(loadProfilesForSidebar).not.toHaveBeenCalled();
+        expect(props.actions.loadProfilesForSidebar).not.toHaveBeenCalled();
 
         // With current channel loaded first
         wrapper = shallow<DataPrefetch>(
@@ -367,13 +365,13 @@ describe('/components/data_prefetch', () => {
             currentChannelId: 'channel',
         });
 
-        expect(loadProfilesForSidebar).not.toHaveBeenCalled();
+        expect(props.actions.loadProfilesForSidebar).not.toHaveBeenCalled();
 
         wrapper.setProps({
             sidebarLoaded: true,
         });
 
-        expect(loadProfilesForSidebar).toHaveBeenCalled();
+        expect(props.actions.loadProfilesForSidebar).toHaveBeenCalled();
 
         jest.clearAllMocks();
 
@@ -385,13 +383,13 @@ describe('/components/data_prefetch', () => {
             sidebarLoaded: true,
         });
 
-        expect(loadProfilesForSidebar).not.toHaveBeenCalled();
+        expect(props.actions.loadProfilesForSidebar).not.toHaveBeenCalled();
 
         wrapper.setProps({
             currentChannelId: 'channel',
         });
 
-        expect(loadProfilesForSidebar).toHaveBeenCalled();
+        expect(props.actions.loadProfilesForSidebar).toHaveBeenCalled();
 
         jest.clearAllMocks();
 
@@ -404,6 +402,6 @@ describe('/components/data_prefetch', () => {
             sidebarLoaded: true,
         });
 
-        expect(loadProfilesForSidebar).toHaveBeenCalled();
+        expect(props.actions.loadProfilesForSidebar).toHaveBeenCalled();
     });
 });

--- a/webapp/channels/src/components/data_prefetch/data_prefetch.tsx
+++ b/webapp/channels/src/components/data_prefetch/data_prefetch.tsx
@@ -7,7 +7,6 @@ import PQueue from 'p-queue';
 import {Channel} from '@mattermost/types/channels';
 
 import {Constants} from 'utils/constants';
-import {loadProfilesForSidebar} from 'actions/user_actions';
 
 const queue = new PQueue({concurrency: 2});
 
@@ -23,6 +22,7 @@ type Props = {
     actions: {
         prefetchChannelPosts: (channelId: string, delay?: number) => Promise<any>;
         trackPreloadedChannels: (prefetchQueueObj: Record<string, string[]>) => void;
+        loadProfilesForSidebar: () => void;
     };
 }
 
@@ -41,7 +41,7 @@ type Props = {
         In order to solve the above conditions the component looks for changes in selector unread channels.
         if there is a change in unreads selector, then component clears existing queue as it can be obselete
         i.e there can be new mentions and we need to prioritise instead of unreads so, contructs a new queue
-        with dispacthes of unreads posts for channels which do not have prefetched requests.
+        with dispatches of unreads posts for channels which do not have prefetched requests.
 
     * other changes:
         Adds current channel posts requests to be dispatched as soon as it is set in redux state instead of dispatching it from actions down the hierarchy. Otherwise couple of prefetching requests are sent before the postlist makes a request for posts.
@@ -54,7 +54,7 @@ export default class DataPrefetch extends React.PureComponent<Props> {
         const {currentChannelId, prefetchQueueObj, sidebarLoaded} = this.props;
         if (currentChannelId && sidebarLoaded && (!prevProps.currentChannelId || !prevProps.sidebarLoaded)) {
             queue.add(async () => this.prefetchPosts(currentChannelId));
-            await loadProfilesForSidebar();
+            this.props.actions.loadProfilesForSidebar();
             this.prefetchData();
         } else if (prevProps.prefetchQueueObj !== prefetchQueueObj) {
             clearTimeout(this.prefetchTimeout);

--- a/webapp/channels/src/components/data_prefetch/index.ts
+++ b/webapp/channels/src/components/data_prefetch/index.ts
@@ -23,11 +23,14 @@ import {GlobalState} from 'types/store';
 import {isCollapsedThreadsEnabled} from '../../packages/mattermost-redux/src/selectors/entities/preferences';
 
 import {trackPreloadedChannels} from './actions';
+import { loadProfilesForSidebar } from 'actions/user_actions';
+
 import DataPrefetch from './data_prefetch';
 
 type Actions = {
     prefetchChannelPosts: (channelId: string, delay?: number) => Promise<{data: PostList}>;
     trackPreloadedChannels: (prefetchQueueObj: Record<string, string[]>) => void;
+    loadProfilesForSidebar: () => void;
 };
 
 enum Priority {
@@ -36,7 +39,7 @@ enum Priority {
     low
 }
 
-// function to return a queue obj with priotiy as key and array of channelIds as values.
+// function to return a queue obj with priority as key and array of channelIds as values.
 // high priority has channels with mentions
 // medium priority has channels with unreads
 const prefetchQueue = memoizeResult((
@@ -99,6 +102,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
         actions: bindActionCreators<ActionCreatorsMapObject, Actions>({
             prefetchChannelPosts,
             trackPreloadedChannels,
+            loadProfilesForSidebar
         }, dispatch),
     };
 }

--- a/webapp/channels/src/components/threading/global_threads/global_threads.tsx
+++ b/webapp/channels/src/components/threading/global_threads/global_threads.tsx
@@ -67,7 +67,7 @@ const GlobalThreads = () => {
         dispatch(suppressRHS);
         dispatch(selectLhsItem(LhsItemType.Page, LhsPage.Threads));
         dispatch(clearLastUnreadChannel);
-        loadProfilesForSidebar();
+        dispatch(loadProfilesForSidebar());
 
         const penultimateType = LocalStorageStore.getPreviousViewedType(currentUserId, currentTeamId);
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR avoids using the imported global store's state and dispatch in functions in `user_actions.ts` by removing references to the imported global store's dispatch() and getState() methods. To achieve this, functions have been refactored to thunk action creators and use the dispatch() and getState() functions passed to thunks. The way the refactored functions are called, passed, and tested have also been updated.

The purpose of removing the global store's state and dispatch in action creators is to make them more predictable and improve their testability by making sure they are always passed to mapDispatchToProps in the connected components. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
This PR addresses Github issue https://github.com/mattermost/mattermost-server/issues/21250 AKA JIRA ticket [#47359](https://mattermost.atlassian.net/browse/MM-47359)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```

```release-note

```
-->
```
NONE
```