### PR TITLE
[MM-32576] Text copied from Microsoft OneNote pastes as an image (v2)

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/files_and_attachments/disabled_file_upload_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/files_and_attachments/disabled_file_upload_spec.js
@@ -140,6 +140,7 @@ describe('Upload Files - Settings', () => {
                     },
                 }],
                 types: [],
+                getData: () => {},
             }});
 
             // * An error should be visible saying 'File attachments are disabled'
@@ -165,6 +166,7 @@ describe('Upload Files - Settings', () => {
                     },
                 }],
                 types: [],
+                getData: () => {},
             }});
 
             // * An error should be visible saying 'File attachments are disabled'

--- a/e2e-tests/cypress/tests/integration/channels/files_and_attachments/paste_image_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/files_and_attachments/paste_image_spec.js
@@ -41,6 +41,7 @@ describe('Paste Image', () => {
                     },
                 }],
                 types: [],
+                getData: () => {},
             }});
 
             cy.uiWaitForFileUploadPreview();

--- a/webapp/channels/src/components/file_upload/file_upload.test.tsx
+++ b/webapp/channels/src/components/file_upload/file_upload.test.tsx
@@ -206,7 +206,7 @@ describe('components/FileUpload', () => {
         event.preventDefault = jest.fn();
         const getAsFile = jest.fn().mockReturnValue(new File(['test'], 'test.png'));
         const file = {getAsFile, kind: 'file', name: 'test.png'};
-        (event as any).clipboardData = {items: [file], types: ['image/png']};
+        (event as any).clipboardData = {items: [file], types: ['image/png'], getData: () => {}};
 
         const wrapper = shallowWithIntl(
             <FileUpload
@@ -229,7 +229,7 @@ describe('components/FileUpload', () => {
         const event = new Event('paste');
         event.preventDefault = jest.fn();
         const getAsString = jest.fn();
-        (event as any).clipboardData = {items: [{getAsString, kind: 'string', type: 'text/plain'}], types: ['text/plain']};
+        (event as any).clipboardData = {items: [{getAsString, kind: 'string', type: 'text/plain'}], types: ['text/plain'], getData: () => {}};
 
         const wrapper = shallowWithIntl(
             <FileUpload

--- a/webapp/channels/src/components/file_upload/file_upload.tsx
+++ b/webapp/channels/src/components/file_upload/file_upload.tsx
@@ -18,7 +18,6 @@ import {
     isIosChrome,
     isMobileApp,
 } from 'utils/user_agent';
-import {getHtmlTable} from 'utils/paste';
 import {
     clearFileInput,
     generateId,
@@ -451,7 +450,7 @@ export class FileUpload extends PureComponent<Props, State> {
     pasteUpload = (e: ClipboardEvent) => {
         const {formatMessage} = this.props.intl;
 
-        if (!e.clipboardData || !e.clipboardData.items || getHtmlTable(e.clipboardData)) {
+        if (!e.clipboardData || !e.clipboardData.items || e.clipboardData.getData('text/html')) {
             return;
         }
 


### PR DESCRIPTION

#### Summary
Added ability to paste plain text while copy-pasting from MS Office products on Mac, **WITHOUT** picture.

This is a second version if this PR: https://github.com/mattermost/mattermost-server/pull/23401
[hmhealey](https://github.com/hmhealey) suggested to drop an image and save only text in this case.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/16858
https://mattermost.atlassian.net/browse/MM-32576

#### Screenshots


#### Release Note
```release-note
NONE
```
