### PR TITLE
[MM-52919] Remove all uses of window.desktop.version from webapp

### DIFF
--- a/webapp/channels/src/actions/notification_actions.jsx
+++ b/webapp/channels/src/actions/notification_actions.jsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import semver from 'semver';
-
 import {logError} from 'mattermost-redux/actions/errors';
 import {getProfilesByIds} from 'mattermost-redux/actions/users';
 import {getCurrentChannel, getMyChannelMember, makeGetChannel} from 'mattermost-redux/selectors/entities/channels';
@@ -197,8 +195,8 @@ export function sendDesktopNotification(post, msgProps) {
 }
 
 const notifyMe = (title, body, channel, teamId, silent, soundName, url) => (dispatch) => {
-    // handle notifications in desktop app >= 4.3.0
-    if (isDesktopApp() && window.desktop && semver.gte(window.desktop.version, '4.3.0')) {
+    // handle notifications in desktop app
+    if (isDesktopApp()) {
         const msg = {
             title,
             body,
@@ -206,16 +204,8 @@ const notifyMe = (title, body, channel, teamId, silent, soundName, url) => (disp
             teamId,
             silent,
         };
-
-        if (isDesktopApp() && window.desktop) {
-            if (semver.gte(window.desktop.version, '4.6.0')) {
-                msg.data = {soundName};
-            }
-
-            if (semver.gte(window.desktop.version, '4.7.2')) {
-                msg.url = url;
-            }
-        }
+        msg.data = {soundName};
+        msg.url = url;
 
         // get the desktop app to trigger the notification
         window.postMessage(

--- a/webapp/channels/src/components/logged_in/logged_in.tsx
+++ b/webapp/channels/src/components/logged_in/logged_in.tsx
@@ -164,6 +164,7 @@ export default class LoggedIn extends React.PureComponent<Props> {
     }
 
     // listen for messages from the desktop app
+    // TODO: This needs to be deprecated in favour of a more solid Desktop App API.
     private onDesktopMessageListener = (desktopMessage: DesktopMessage) => {
         if (!this.props.currentUser) {
             return;
@@ -174,6 +175,7 @@ export default class LoggedIn extends React.PureComponent<Props> {
 
         switch (desktopMessage.data.type) {
         case 'register-desktop': {
+            // Currently used by calls
             const {version} = desktopMessage.data.message;
             if (!window.desktop) {
                 window.desktop = {};

--- a/webapp/channels/src/components/user_settings/notifications/desktop_notification_setting/desktop_notification_settings.tsx
+++ b/webapp/channels/src/components/user_settings/notifications/desktop_notification_setting/desktop_notification_settings.tsx
@@ -5,13 +5,10 @@ import React, {ChangeEvent, RefObject} from 'react';
 import ReactSelect, {ValueType} from 'react-select';
 import {FormattedMessage} from 'react-intl';
 
-import semver from 'semver';
-
 import {NotificationLevels} from 'utils/constants';
 import * as NotificationSounds from 'utils/notification_sounds';
 import * as Utils from 'utils/utils';
 import {t} from 'utils/i18n';
-import {isDesktopApp} from 'utils/user_agent';
 
 import SettingItemMin from 'components/setting_item_min';
 import SettingItemMax from 'components/setting_item_max';
@@ -129,20 +126,18 @@ export default class DesktopNotificationSettings extends React.PureComponent<Pro
                     return {value: sound, label: sound};
                 });
 
-                if (!isDesktopApp() || (window.desktop && semver.gte(window.desktop.version || '', '4.6.0'))) {
-                    notificationSelection = (<div className='pt-2'>
-                        <ReactSelect
-                            className='react-select notification-sound-dropdown'
-                            classNamePrefix='react-select'
-                            id='displaySoundNotification'
-                            options={options}
-                            clearable={false}
-                            onChange={this.setDesktopNotificationSound}
-                            value={this.state.selectedOption}
-                            isSearchable={false}
-                            ref={this.dropdownSoundRef}
-                        /></div>);
-                }
+                notificationSelection = (<div className='pt-2'>
+                    <ReactSelect
+                        className='react-select notification-sound-dropdown'
+                        classNamePrefix='react-select'
+                        id='displaySoundNotification'
+                        options={options}
+                        clearable={false}
+                        onChange={this.setDesktopNotificationSound}
+                        value={this.state.selectedOption}
+                        isSearchable={false}
+                        ref={this.dropdownSoundRef}
+                    /></div>);
             }
 
             if (NotificationSounds.hasSoundOptions()) {

--- a/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.tsx
+++ b/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.tsx
@@ -6,13 +6,10 @@
 import React, {ChangeEvent, RefObject} from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import semver from 'semver';
-
 import {ActionResult} from 'mattermost-redux/types/actions';
 
 import Constants, {NotificationLevels} from 'utils/constants';
 import {a11yFocus, localizeMessage, moveCursorToEnd} from 'utils/utils';
-import {isDesktopApp} from 'utils/user_agent';
 import {t} from 'utils/i18n';
 
 import SettingItem from 'components/setting_item';
@@ -200,9 +197,7 @@ export default class NotificationsTab extends React.PureComponent<Props, State> 
         const data: UserNotifyProps = {} as UserNotifyProps;
         data.email = this.state.enableEmail;
         data.desktop_sound = this.state.desktopSound;
-        if (!isDesktopApp() || (window.desktop && semver.gte(window.desktop.version || '', '4.6.0'))) {
-            data.desktop_notification_sound = this.state.desktopNotificationSound;
-        }
+        data.desktop_notification_sound = this.state.desktopNotificationSound;
         data.desktop = this.state.desktopActivity;
         data.desktop_threads = this.state.desktopThreads;
         data.email_threads = this.state.emailThreads;


### PR DESCRIPTION
#### Summary
This PR cleans up the use of `window.desktop.version`, which was used for versions of the Desktop App before v5 to check for the version to turn functionality on or off.

As it stands, there's nothing that has used this since v5, and since v4.7 and before is no longer supported, removing this makes sense.

Going forward, we're going to implement a new Desktop API in the Web App to check to see if certain features are enabled or not.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52919

```release-note
NONE
```
