### PR TITLE
Temporarily let AdvancedLoggingConfig take precedence over AdvancedLoggingJSON

### DIFF
--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -1345,7 +1345,7 @@ func (s *LogSettings) SetDefaults() {
 		}
 	}
 	// temporarily let AdvancedLoggingConfig take precedence.
-	if s.AdvancedLoggingConfig != nil {
+	if s.AdvancedLoggingConfig == nil {
 		s.AdvancedLoggingConfig = NewString("")
 	}
 	//s.AdvancedLoggingConfig = nil
@@ -1413,17 +1413,23 @@ func (s *ExperimentalAuditSettings) SetDefaults() {
 			s.AdvancedLoggingJSON = []byte("{}")
 		}
 	}
-	s.AdvancedLoggingConfig = nil
+
+	// temporarily let AdvancedLoggingConfig take precedence.
+	if s.AdvancedLoggingConfig == nil {
+		s.AdvancedLoggingConfig = NewString("")
+	}
+	//s.AdvancedLoggingConfig = nil
 }
 
 // GetAdvancedLoggingConfig returns the advanced logging config as a []byte.
 // AdvancedLoggingJSON takes precident over the deprecated AdvancedLoggingConfig.
 func (s *ExperimentalAuditSettings) GetAdvancedLoggingConfig() []byte {
-	if !utils.IsEmptyJSON(s.AdvancedLoggingJSON) {
-		return s.AdvancedLoggingJSON
-	}
+	// temporarily let AdvancedLoggingConfig take precedence.
 	if s.AdvancedLoggingConfig != nil && !utils.IsEmptyJSON([]byte(*s.AdvancedLoggingConfig)) {
 		return []byte(*s.AdvancedLoggingConfig)
+	}
+	if !utils.IsEmptyJSON(s.AdvancedLoggingJSON) {
+		return s.AdvancedLoggingJSON
 	}
 	return []byte("{}")
 }
@@ -1482,17 +1488,22 @@ func (s *NotificationLogSettings) SetDefaults() {
 			s.AdvancedLoggingJSON = []byte("{}")
 		}
 	}
-	s.AdvancedLoggingConfig = nil
+	// temporarily let AdvancedLoggingConfig take precedence.
+	if s.AdvancedLoggingConfig == nil {
+		s.AdvancedLoggingConfig = NewString("")
+	}
+	//s.AdvancedLoggingConfig = nil
 }
 
 // GetAdvancedLoggingConfig returns the advanced logging config as a []byte.
 // AdvancedLoggingJSON takes precident over the deprecated AdvancedLoggingConfig.
 func (s *NotificationLogSettings) GetAdvancedLoggingConfig() []byte {
-	if !utils.IsEmptyJSON(s.AdvancedLoggingJSON) {
-		return s.AdvancedLoggingJSON
-	}
+	// temporarily let AdvancedLoggingConfig take precedence.
 	if s.AdvancedLoggingConfig != nil && !utils.IsEmptyJSON([]byte(*s.AdvancedLoggingConfig)) {
 		return []byte(*s.AdvancedLoggingConfig)
+	}
+	if !utils.IsEmptyJSON(s.AdvancedLoggingJSON) {
+		return s.AdvancedLoggingJSON
 	}
 	return []byte("{}")
 }

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -1344,17 +1344,19 @@ func (s *LogSettings) SetDefaults() {
 			s.AdvancedLoggingJSON = []byte("{}")
 		}
 	}
-	s.AdvancedLoggingConfig = nil
+	// temporarily let AdvancedLoggingConfig take precedence.
+	//s.AdvancedLoggingConfig = nil
 }
 
 // GetAdvancedLoggingConfig returns the advanced logging config as a []byte.
 // AdvancedLoggingJSON takes precident over the deprecated AdvancedLoggingConfig.
 func (s *LogSettings) GetAdvancedLoggingConfig() []byte {
-	if !utils.IsEmptyJSON(s.AdvancedLoggingJSON) {
-		return s.AdvancedLoggingJSON
-	}
+	// temporarily let AdvancedLoggingConfig take precedence.
 	if s.AdvancedLoggingConfig != nil && !utils.IsEmptyJSON([]byte(*s.AdvancedLoggingConfig)) {
 		return []byte(*s.AdvancedLoggingConfig)
+	}
+	if !utils.IsEmptyJSON(s.AdvancedLoggingJSON) {
+		return s.AdvancedLoggingJSON
 	}
 	return []byte("{}")
 }

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -1345,6 +1345,9 @@ func (s *LogSettings) SetDefaults() {
 		}
 	}
 	// temporarily let AdvancedLoggingConfig take precedence.
+	if s.AdvancedLoggingConfig != nil {
+		s.AdvancedLoggingConfig = NewString("")
+	}
 	//s.AdvancedLoggingConfig = nil
 }
 


### PR DESCRIPTION
#### Summary
Temporarily let `AdvancedLoggingConfig` take precedence over `AdvancedLoggingJSON`.  This addresses an issue where environment overrides for `AdvancedLoggingJSON` do not work because the override resolver does not support []byte (json.RawMessage), causing community to not get audit logging.

This will be undone asap via a PR that includes support for []byte in the override resolver.

#### Ticket Link
NONE

#### Screenshots
```release-note
NONE
```
