### PR TITLE
MM-52995: Fix opening DM/GM thread from thread footer

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/collapsed_reply_threads/open_thread_dm_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/collapsed_reply_threads/open_thread_dm_spec.js
@@ -1,0 +1,70 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @channels @collapsed_reply_threads
+
+describe('Collapsed Reply Threads', () => {
+    let testTeam;
+    let testUser;
+    let otherUser;
+
+    before(() => {
+        cy.apiUpdateConfig({
+            ServiceSettings: {
+                ThreadAutoFollow: true,
+                CollapsedThreads: 'default_off',
+                EnableTutorial: false,
+            },
+        });
+
+        // # Create new channel and other user, and add other user to channel
+        cy.apiInitSetup({loginAfter: true, promoteNewUserAsAdmin: true}).then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
+
+            cy.apiSaveCRTPreference(testUser.id, 'on');
+            cy.apiCreateUser({prefix: 'other'}).then(({user: user1}) => {
+                otherUser = user1;
+
+                cy.apiAddUserToTeam(testTeam.id, otherUser.id);
+            });
+        });
+    });
+
+    beforeEach(() => {
+        // # Visit the channel
+        cy.visit(`/${testTeam.name}/messages/@${otherUser.username}`);
+    });
+
+    it('should open thread when thread footer reply button is clicked in a DM/GM channel', () => {
+        // # Post a message
+        const msg = 'Root post';
+        cy.postMessage(msg);
+
+        cy.getLastPostId().then((rootId) => {
+            // # Thread with replies
+            cy.clickPostCommentIcon(rootId);
+            cy.uiGetReplyTextBox().type('reply{enter}');
+            cy.uiGetReplyTextBox().type('reply2{enter}');
+            cy.uiCloseRHS();
+
+            // * Check that the RHS is closed
+            cy.get('#rhsContainer').should('not.exist');
+
+            // # Get thread footer of last post and find reply button
+            cy.uiGetPostThreadFooter(rootId).find('button.ReplyButton').click();
+
+            // * Thread should be visible in RHS
+            cy.get(`#rhsPost_${rootId}`).within(() => {
+                cy.get(`#rhsPostMessageText_${rootId}`).should('be.visible').and('have.text', msg);
+            });
+        });
+    });
+});

--- a/webapp/channels/src/components/post/post_component.tsx
+++ b/webapp/channels/src/components/post/post_component.tsx
@@ -395,7 +395,7 @@ const PostComponent = (props: Props): JSX.Element => {
         } else {
             handleJumpClick(e);
         }
-    }, [handleCommentClick, handleJumpClick]);
+    }, [handleCommentClick, handleJumpClick, props.currentTeam.id, teamId]);
 
     const postClass = classNames('post__body', {'post--edited': PostUtils.isEdited(post), 'search-item-snippet': isSearchResultItem});
 

--- a/webapp/channels/src/components/post/post_component.tsx
+++ b/webapp/channels/src/components/post/post_component.tsx
@@ -390,7 +390,7 @@ const PostComponent = (props: Props): JSX.Element => {
     }, [post, props.actions, props.actions.selectPostFromRightHandSideSearch]);
 
     const handleThreadClick = useCallback((e: React.MouseEvent) => {
-        if (props.currentTeam.id === props.team?.id) {
+        if (props.currentTeam.id === teamId) {
             handleCommentClick(e);
         } else {
             handleJumpClick(e);


### PR DESCRIPTION
#### Summary
Fixes an issue when opening a thread in a DM/GM channel from the reply button in thread footer (CRT=ON) where the root post would be highlighted instead of the thread opening in RHS.

#### Ticket Link
- Fixes https://mattermost.atlassian.net/browse/MM-52995

#### Screenshots

Before:
https://github.com/mattermost/mattermost/assets/11724372/26382992-59ef-4903-84a8-67af1645e949

After:
https://github.com/mattermost/mattermost/assets/11724372/a8d10557-9124-4753-83e6-73586c958108



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
