### PR TITLE
CLD-5698 - Add e2e smoketests

### DIFF
--- a/.github/workflows/docker-push-mirrored.yml
+++ b/.github/workflows/docker-push-mirrored.yml
@@ -1,5 +1,4 @@
 ---
-# TODO before merge: do a first manual upload run, and adapt the image references in the docker-compose files
 name: Push mirrored docker images
 on:
   push:

--- a/.github/workflows/docker-push-mirrored.yml
+++ b/.github/workflows/docker-push-mirrored.yml
@@ -1,0 +1,25 @@
+---
+# TODO before merge: do a first manual upload run, and adapt the image references in the docker-compose files
+name: Push mirrored docker images
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - server/scripts/mirror-docker-images.*
+
+jobs:
+  build-docker:
+    name: cd/Push mirrored docker images
+    runs-on: ubuntu-22.04
+    steps:
+      - name: cd/Login to Docker Hub
+        uses: docker/login-action@3da7dc6e2b31f99ef2cb9fb4c50fb0971e0d0139 # v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_DEV_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_DEV_TOKEN }}
+      - name: cd/Run image upload script
+        env:
+          IMAGES_FILE: server/scripts/mirror-docker-images.json
+          DRY_RUN: no
+        run: ./server/scripts/mirror-docker-images.sh

--- a/.github/workflows/e2e-tests-ci.yml
+++ b/.github/workflows/e2e-tests-ci.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          ref: ${{ inputs.commit_sha || github.sha }}
       - name: ci/setup-node
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         id: setup_node
@@ -60,6 +62,8 @@ jobs:
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          ref: ${{ inputs.commit_sha || github.sha }}
       - name: ci/setup-node
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         id: setup_node
@@ -90,6 +94,8 @@ jobs:
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          ref: ${{ inputs.commit_sha || github.sha }}
       - name: ci/e2e-smoketests
         run: |
           make

--- a/.github/workflows/e2e-tests-ci.yml
+++ b/.github/workflows/e2e-tests-ci.yml
@@ -1,17 +1,35 @@
-name: mattermost-e2e-tests
+name: E2E Tests
 on:
-  pull_request:
-  push:
-    branches:
-      - master
-      - mono-repo*
+  # For PRs, this workflow gets triggered from the Argo Events platform.
+  # Check the following repo for details: https://github.com/mattermost/delivery-platform
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        type: string
+        required: false
 
 defaults:
   run:
     shell: bash
+
 jobs:
+  update-initial-status:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: mattermost/actions/delivery/update-commit-status@main
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          repository_full_name: ${{ github.repository }}
+          commit_sha: ${{ inputs.commit_sha || github.sha }}
+          context: ci/e2e-tests
+          description: E2E tests for mattermost server app
+          status: pending
+
   cypress-check:
     runs-on: ubuntu-22.04
+    needs:
+      - update-initial-status
     defaults:
       run:
         working-directory: e2e-tests/cypress
@@ -24,15 +42,18 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: npm
-          cache-dependency-path: 'e2e-tests/cypress/package-lock.json'
+          cache-dependency-path: "e2e-tests/cypress/package-lock.json"
       - name: ci/cypress/npm-install
         run: |
           npm ci
       - name: ci/cypress/npm-check
         run: |
           npm run check
+
   playwright-check:
     runs-on: ubuntu-22.04
+    needs:
+      - update-initial-status
     defaults:
       run:
         working-directory: e2e-tests/playwright
@@ -45,7 +66,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: npm
-          cache-dependency-path: 'e2e-tests/playwright/package-lock.json'
+          cache-dependency-path: "e2e-tests/playwright/package-lock.json"
       - name: ci/get-webapp-node-modules
         working-directory: webapp
         # requires build of client and types
@@ -57,3 +78,38 @@ jobs:
       - name: ci/playwright/npm-check
         run: |
           npm run check
+
+  smoketests:
+    runs-on: ubuntu-22.04
+    needs:
+      - cypress-check
+      - playwright-check
+    defaults:
+      run:
+        working-directory: e2e-tests
+    steps:
+      - name: ci/checkout-repo
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: ci/e2e-smoketests
+        run: |
+          make
+          # Assert that the run contained 0 failures
+          CYPRESS_FAILURES=$(find cypress/results -name '*.json' | xargs -l jq -r '.stats.failures' | jq -s add)
+          echo "Cypress run completed with $CYPRESS_FAILURES failures"
+          [ "$CYPRESS_FAILURES" = "0" ]
+
+  update-final-status:
+    runs-on: ubuntu-22.04
+    if: always()
+    needs:
+      - smoketests
+    steps:
+      - uses: mattermost/actions/delivery/update-commit-status@main
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          repository_full_name: ${{ github.repository }}
+          commit_sha: ${{ inputs.commit_sha || github.sha }}
+          context: ci/e2e-tests
+          description: E2E tests for mattermost server app
+          status: ${{ job.status }}

--- a/e2e-tests/.ci/.e2erc
+++ b/e2e-tests/.ci/.e2erc
@@ -65,6 +65,12 @@ mme2e_wait_image () {
   RETRIES_INTERVAL=${3:-10}
   mme2e_wait_command_success "docker pull $IMAGE_NAME" "Waiting for docker image ${IMAGE_NAME} to be available" "$RETRIES_LEFT" "$RETRIES_INTERVAL"
 }
+mme2e_legacy_setup () {
+  # These functions are needed until every pipeline depending on the `server/build/gitlab-dc.*.yml` files is adapted to not use external docker networking anymore
+  # After that is fixed, this function and the external network in the docker-compose files may be removed
+  export COMPOSE_PROJECT_NAME=mmserver
+  docker network inspect ${COMPOSE_PROJECT_NAME} >/dev/null 2>&1 || docker network create ${COMPOSE_PROJECT_NAME}
+}
 
 # Utility alias, for interactive shell usage. Can be reversed with 'unalias docker-compose' in your shell
 # NB: this won't work in the script
@@ -73,3 +79,4 @@ alias docker-compose-mmdashboard="${MME2E_DC_DASHBOARD}"
 
 # Call prerequisite utility functions
 mme2e_load_env_file
+mme2e_legacy_setup # Temporary

--- a/e2e-tests/.ci/.e2erc
+++ b/e2e-tests/.ci/.e2erc
@@ -68,7 +68,7 @@ mme2e_wait_image () {
 mme2e_legacy_setup () {
   # These functions are needed until every pipeline depending on the `server/build/gitlab-dc.*.yml` files is adapted to not use external docker networking anymore
   # After that is fixed, this function and the external network in the docker-compose files may be removed
-  export COMPOSE_PROJECT_NAME=mmserver
+  export COMPOSE_PROJECT_NAME=mmserver_legacy
   docker network inspect ${COMPOSE_PROJECT_NAME} >/dev/null 2>&1 || docker network create ${COMPOSE_PROJECT_NAME}
 }
 

--- a/e2e-tests/.ci/.e2erc
+++ b/e2e-tests/.ci/.e2erc
@@ -1,0 +1,75 @@
+# Utility variables
+# NB: these assume you `source` them from the directory this file is in
+export MME2E_DC_SERVER="docker-compose -p mmserver -f $(readlink -e ../../server/build/gitlab-dc.postgres.yml) -f $(readlink -e ./server.override.yml)"
+export MME2E_DC_DASHBOARD="docker-compose -p mmdashboard -f $(readlink -e ./dashboard/docker/docker-compose.yml) -f $(readlink -e ./dashboard.override.yml)"
+export MME2E_UID=$(id -u)
+
+# Default the optional variables that are used in the docker-compose file
+export SERVER_IMAGE_DEFAULT="mattermostdevelopment/mm-ee-test:$(git rev-parse --short=7 HEAD)"
+export SERVER_IMAGE=${SERVER_IMAGE:-$SERVER_IMAGE_DEFAULT}
+
+# Function definitions
+mme2e_log () { echo "[$(date -Is)]" "$@"; }
+mme2e_get_current_shopt_arg () {
+  # This function lets you get the current value of shell options, e.g. pipefail or allexport, in the form
+  # of arguments to pass to the 'set' shell function, in order to restore its value later
+  SHOPT_ARG=${1:?}
+  case $(set -o | sed -n -E "s/^${SHOPT_ARG}[[:space:]]+(o..?)$/\1/p") in
+    on) echo -n "-o ${SHOPT_ARG}";;
+    off) echo -n "+o ${SHOPT_ARG}";;
+    *) exit 1;;
+  esac
+}
+mme2e_load_env_file () {
+  # This loads the ./env file. Variables are automatically exported
+  [ -f ./env ] || return 0
+  MME2E_PREVIOUS_ALLEXPORT=$(mme2e_get_current_shopt_arg allexport)
+  set -o allexport
+  mme2e_log "Loading env file"
+  . ./env
+  set ${MME2E_PREVIOUS_ALLEXPORT}
+}
+mme2e_generate_envfile_from_var_names () {
+  # Read var names from stdin, one per line
+  while read VARIABLE; do
+    [ -z "${!VARIABLE:-}" ] || echo "${VARIABLE}=${!VARIABLE}";
+  done
+}
+mme2e_wait_command_success () {
+  COMMAND=${1?}
+  RETRY_MESSAGE=${2?}
+  RETRIES_LEFT=${3:-1}
+  RETRIES_INTERVAL=${4:-10}
+  MME2E_PREVIOUS_PIPEFAIL=$(mme2e_get_current_shopt_arg pipefail)
+  set -o pipefail
+  until bash -c "${COMMAND}"; do
+    RETRIES_LEFT=$((RETRIES_LEFT - 1))
+    [ "$RETRIES_LEFT" -le "0" ] && break
+    mme2e_log "${RETRY_MESSAGE} ($RETRIES_LEFT retries left, sleeping $RETRIES_INTERVAL seconds)"
+    sleep $RETRIES_INTERVAL
+  done
+  set ${MME2E_PREVIOUS_PIPEFAIL}
+  if [ "$RETRIES_LEFT" = "0" ]; then
+    exit 1
+  fi
+}
+mme2e_wait_service_healthy () {
+  SERVICE_NAME=${1?}
+  RETRIES_LEFT=${2:-1}
+  RETRIES_INTERVAL=${3:-10}
+  mme2e_wait_command_success "${MME2E_DC_SERVER} ps ${SERVICE_NAME} | grep -q '\(healthy\)'" "Waiting for ${SERVICE_NAME} container to be healthy" "$RETRIES_LEFT" "$RETRIES_INTERVAL"
+}
+mme2e_wait_image () {
+  IMAGE_NAME=${1?}
+  RETRIES_LEFT=${2:-1}
+  RETRIES_INTERVAL=${3:-10}
+  mme2e_wait_command_success "docker pull $IMAGE_NAME" "Waiting for docker image ${IMAGE_NAME} to be available" "$RETRIES_LEFT" "$RETRIES_INTERVAL"
+}
+
+# Utility alias, for interactive shell usage. Can be reversed with 'unalias docker-compose' in your shell
+# NB: this won't work in the script
+alias docker-compose-mmserver="${MME2E_DC_SERVER}"
+alias docker-compose-mmdashboard="${MME2E_DC_DASHBOARD}"
+
+# Call prerequisite utility functions
+mme2e_load_env_file

--- a/e2e-tests/.ci/.env.cypress
+++ b/e2e-tests/.ci/.env.cypress
@@ -1,0 +1,1 @@
+# NB: this file is just a placeholder required by docker-compose. It's supposed to be modified by the CI pipeline and should remain empty in git

--- a/e2e-tests/.ci/.env.dashboard
+++ b/e2e-tests/.ci/.env.dashboard
@@ -1,0 +1,1 @@
+# NB: this file is just a placeholder required by docker-compose. It's supposed to be modified by the CI pipeline and should remain empty in git

--- a/e2e-tests/.ci/.env.server
+++ b/e2e-tests/.ci/.env.server
@@ -1,0 +1,1 @@
+# NB: this file is just a placeholder required by docker-compose. It's supposed to be modified by the CI pipeline and should remain empty in git

--- a/e2e-tests/.ci/.gitignore
+++ b/e2e-tests/.ci/.gitignore
@@ -1,0 +1,5 @@
+dashboard
+env
+!.env.cypress
+!.env.server
+!.env.dashboard

--- a/e2e-tests/.ci/dashboard.entrypoint.sh
+++ b/e2e-tests/.ci/dashboard.entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e -u -o pipefail
+
+npm install
+
+# Run migrations. This is also a way to wait for the database to be up
+MIGRATION_ATTEMPTS_LEFT=10
+MIGRATION_ATTEMPTS_INTERVAL=10
+until npm run migrate:latest; do
+	MIGRATION_ATTEMPTS_LEFT=$((MIGRATION_ATTEMPTS_LEFT - 1))
+	[ "$MIGRATION_ATTEMPTS_LEFT" -gt 0 ] || break
+	echo "Migration script failed, sleeping $MIGRATION_ATTEMPTS_INTERVAL"
+	sleep $MIGRATION_ATTEMPTS_INTERVAL
+done
+[ "$MIGRATION_ATTEMPTS_LEFT" -gt 0 ] || {
+	echo "Migration script failed, exhausted attempts. Giving up."
+	exit 1
+}
+
+# Launch the dashboard
+exec npm run dev

--- a/e2e-tests/.ci/dashboard.override.yml
+++ b/e2e-tests/.ci/dashboard.override.yml
@@ -1,0 +1,24 @@
+---
+version: '3.1'
+
+services:
+    dashboard:
+        image: node:16.17.0
+        environment:
+          PG_URI: postgres://mmuser:mostest@db:5432/automation_dashboard_db
+          JWT_SECRET: s8gGBA3ujKRohSw1L8HLOY7Jjnu2ZYv8 # Generated with e.g. `dd if=/dev/urandom count=24 bs=1 2>/dev/null | base64 -w0`
+          JWT_USER: cypress-test
+          JWT_ROLE: integration
+          JWT_ALG: HS256
+          JWT_EXPIRES_IN: 365d
+          ALLOWED_USER: cypress-test
+          ALLOWED_ROLE: integration
+        user: "${MME2E_UID}"
+        volumes:
+          - "../:/app"
+          - "../../dashboard.entrypoint.sh:/usr/local/bin/dashboard.entrypoint.sh:ro"
+          - "../../.env.dashboard:/var/local/.env.dashboard:rw"
+        working_dir: /app
+        entrypoint: /usr/local/bin/dashboard.entrypoint.sh
+        ports:
+            - 4000:4000

--- a/e2e-tests/.ci/dashboard.start.sh
+++ b/e2e-tests/.ci/dashboard.start.sh
@@ -7,7 +7,10 @@ MME2E_DASHBOARD_REF_DEFAULT="origin/main"
 MME2E_DASHBOARD_REF=${MME2E_DASHBOARD_REF:-$MME2E_DASHBOARD_REF_DEFAULT}
 
 mme2e_log "Cloning the automation-dashboard project"
-[ -d dashboard ] || git clone https://github.com/saturninoabril/automation-dashboard.git dashboard
+if [ ! -d dashboard ]; then
+  git clone https://github.com/saturninoabril/automation-dashboard.git dashboard
+  . .e2erc # Must reinitialize some variables that depend on the dashboard repo being checked out
+fi
 git -C dashboard fetch
 git -C dashboard checkout $MME2E_DASHBOARD_REF
 
@@ -20,6 +23,7 @@ MME2E_DC_DASHBOARD_GATEWAY=$(docker network inspect $MME2E_DC_DASHBOARD_NETWORK 
 AUTOMATION_DASHBOARD_URL="http://${MME2E_DC_DASHBOARD_GATEWAY}:4000/api"
 
 mme2e_log "Generating a signed JWT token for accessing the dashboard"
+${MME2E_DC_DASHBOARD} exec -T -u $MME2E_UID dashboard npm i
 AUTOMATION_DASHBOARD_TOKEN=$(${MME2E_DC_DASHBOARD} exec -T -u $MME2E_UID dashboard node script/sign.js | awk '{ print $2; }') # The token secret is specified in the dashboard.override.yml file
 
 mme2e_log "Generating the .env.dashboard file, to point Cypress to the dashboard URL"

--- a/e2e-tests/.ci/dashboard.start.sh
+++ b/e2e-tests/.ci/dashboard.start.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e -u -o pipefail
+cd $(dirname $0)
+. .e2erc
+
+MME2E_DASHBOARD_REF_DEFAULT="origin/main"
+MME2E_DASHBOARD_REF=${MME2E_DASHBOARD_REF:-$MME2E_DASHBOARD_REF_DEFAULT}
+
+mme2e_log "Cloning the automation-dashboard project"
+[ -d dashboard ] || git clone https://github.com/saturninoabril/automation-dashboard.git dashboard
+git -C dashboard fetch
+git -C dashboard checkout $MME2E_DASHBOARD_REF
+
+mme2e_log "Starting the dashboard"
+${MME2E_DC_DASHBOARD} up -d db dashboard
+
+mme2e_log "Generating the dashboard's local URL"
+MME2E_DC_DASHBOARD_NETWORK=$(${MME2E_DC_DASHBOARD} ps -q dashboard | xargs -l docker inspect | jq -r '.[0].NetworkSettings.Networks | (keys|.[0])')
+MME2E_DC_DASHBOARD_GATEWAY=$(docker network inspect $MME2E_DC_DASHBOARD_NETWORK | jq -r '.[0].IPAM.Config[0].Gateway')
+AUTOMATION_DASHBOARD_URL="http://${MME2E_DC_DASHBOARD_GATEWAY}:4000/api"
+
+mme2e_log "Generating a signed JWT token for accessing the dashboard"
+AUTOMATION_DASHBOARD_TOKEN=$(${MME2E_DC_DASHBOARD} exec -T -u $MME2E_UID dashboard node script/sign.js | awk '{ print $2; }') # The token secret is specified in the dashboard.override.yml file
+
+mme2e_log "Generating the .env.dashboard file, to point Cypress to the dashboard URL"
+mme2e_generate_envfile_from_var_names >.env.dashboard <<EOF
+AUTOMATION_DASHBOARD_URL
+AUTOMATION_DASHBOARD_TOKEN
+EOF

--- a/e2e-tests/.ci/dashboard.stop.sh
+++ b/e2e-tests/.ci/dashboard.stop.sh
@@ -3,4 +3,9 @@ set -e -u -o pipefail
 cd $(dirname $0)
 . .e2erc
 
-[ ! -d dashboard ] || ${MME2E_DC_DASHBOARD} down
+if [ -d dashboard ]; then
+  mme2e_log "Stopping the dashboard containers"
+  ${MME2E_DC_DASHBOARD} down
+else
+  mme2e_log "Not stopping the dashboard containers: dashboard repo not checked out locally, skipping"
+fi

--- a/e2e-tests/.ci/dashboard.stop.sh
+++ b/e2e-tests/.ci/dashboard.stop.sh
@@ -3,4 +3,4 @@ set -e -u -o pipefail
 cd $(dirname $0)
 . .e2erc
 
-${MME2E_DC_DASHBOARD} down
+[ ! -d dashboard ] || ${MME2E_DC_DASHBOARD} down

--- a/e2e-tests/.ci/dashboard.stop.sh
+++ b/e2e-tests/.ci/dashboard.stop.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e -u -o pipefail
+cd $(dirname $0)
+. .e2erc
+
+${MME2E_DC_DASHBOARD} down

--- a/e2e-tests/.ci/server.override.yml
+++ b/e2e-tests/.ci/server.override.yml
@@ -1,0 +1,121 @@
+---
+# Image hashes in this file are for amd64 systems
+# NB: paths relative to the `server/build` directory, which contains the original compose file that this yaml is overriding
+version: '2.4'
+services:
+
+  server:
+    image: "${SERVER_IMAGE}"
+    restart: always
+    env_file:
+      - "../../e2e-tests/.ci/.env.server"
+    environment:
+      MM_SERVICESETTINGS_SITEURL: "http://server:8065"
+      MM_SERVICESETTINGS_ENABLELOCALMODE: "true"
+      MM_PLUGINSETTINGS_ENABLED: "true"
+      MM_PLUGINSETTINGS_ENABLEUPLOADS: "true"
+      MM_PLUGINSETTINGS_AUTOMATICPREPACKAGEDPLUGINS: "true"
+      MM_TEAMSETTINGS_ENABLEOPENSERVER: "true"
+      MM_ELASTICSEARCHSETTINGS_CONNECTIONURL: "true"
+      MM_SQLSETTINGS_DATASOURCE: "postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10&binary_parameters=yes"
+      MM_SQLSETTINGS_DRIVERNAME: "postgres"
+      MM_LDAPSETTINGS_LDAPSERVER: "openldap"
+      MM_EMAILSETTINGS_SMTPSERVER: "inbucket"
+      MM_CLUSTERSETTINGS_READONLYCONFIG: "false"
+      MM_FEATUREFLAGS_USECASEONBOARDING: "false"
+      MM_SERVICESETTINGS_ENABLEONBOARDINGFLOW: "false"
+      MM_FEATUREFLAGS_ONBOARDINGTOURTIPS: "false"
+    ports:
+      - "8065:8065"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      inbucket:
+        condition: service_healthy
+      openldap:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+      keycloak:
+        condition: service_healthy
+      dejavu:
+        condition: service_healthy
+      prometheus:
+        condition: service_healthy
+      grafana:
+        condition: service_healthy
+      webhook-interactions:
+        condition: service_healthy
+
+  webhook-interactions:
+    image:  public.ecr.aws/q3m3k0p4/mattermost-build-webapp:20220802_node-16.10.0
+    command: sh -c "npm install -g axios express client-oauth2@larkox/js-client-oauth2#e24e2eb5dfcbbbb3a59d095e831dbe0012b0ac49 && exec node webhook_serve.js"
+    environment:
+      NODE_PATH: /usr/local/lib/node_modules/
+    healthcheck:
+      test: [ "CMD", "curl", "-s", "-o/dev/null", "127.0.0.1:3000" ]
+      interval: 10s
+      timeout: 15s
+      retries: 12
+    working_dir: /cypress
+    volumes:
+      - "../../e2e-tests/cypress/:/cypress:ro"
+    networks:
+      default:
+        aliases:
+          - webhook-interactions
+
+  cypress:
+    image: "public.ecr.aws/mattermostqa/cypress-browsers-public:node16.14.2-slim-chrome100-ff99-edge"
+    entrypoint: [ "/bin/bash", "-c" ]
+    command: [ "until [ -f /var/run/mm_terminate ]; do sleep 5; done" ]
+    env_file:
+      - "../../e2e-tests/.ci/.env.dashboard"
+      - "../../e2e-tests/.ci/.env.cypress"
+    environment:
+      REPO: "mattermost-server"
+      # Cypress configuration
+      BROWSER: "chrome"
+      HEADLESS: "true"
+      CYPRESS_baseUrl: "http://server:8065"
+      CYPRESS_dbConnection: "postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10"
+      CYPRESS_elasticsearchConnectionURL: "http://elasticsearch:9200"
+      CYPRESS_keycloakBaseUrl: "http://keycloak:8484"
+      CYPRESS_ldapServer: "openldap"
+      CYPRESS_minioS3Endpoint: "minio:9000"
+      CYPRESS_smtpUrl: "http://inbucket:9001"
+      CYPRESS_webhookBaseUrl: "http://webhook-interactions:3000"
+      CYPRESS_chromeWebSecurity: "false"
+      CYPRESS_firstTest: "true"
+      CYPRESS_resetBeforeTest: "true"
+      CYPRESS_runLDAPSync: "true"
+      CYPRESS_allowedUntrustedInternalConnections: "localhost webhook-interactions"
+      CYPRESS_serverEdition: E20
+      TM4J_ENABLE: "false"
+      # disable shared memory X11 affecting Cypress v4 and Chrome
+      # https://github.com/cypress-io/cypress-docker-images/issues/270
+      QT_X11_NO_MITSHM: "1"
+      _X11_NO_MITSHM: "1"
+      _MITSHM: "0"
+      # avoid too many progress messages
+      # https://github.com/cypress-io/cypress/issues/1243
+      CI: "1"
+      # Ensure we're independent from the global node environment
+      PATH: /app/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    ulimits:
+      nofile:
+        soft: 8096
+        hard: 1048576
+    working_dir: /app
+    volumes:
+      - "../../e2e-tests/cypress/:/app"
+
+  utils:
+    image: "public.ecr.aws/mattermostqa/mattermost-build-server:20220415_golang-1.18.1"
+    entrypoint: [ "/bin/bash", "-c" ]
+    command: [ "until [ -f /var/run/mm_terminate ]; do sleep 5; done" ]
+    working_dir: "/opt/mattermost-server"
+    volumes:
+    - "../../:/opt/mattermost-server"

--- a/e2e-tests/.ci/server.override.yml
+++ b/e2e-tests/.ci/server.override.yml
@@ -68,7 +68,7 @@ services:
           - webhook-interactions
 
   cypress:
-    image: "public.ecr.aws/mattermostqa/cypress-browsers-public:node16.14.2-slim-chrome100-ff99-edge"
+    image: "mattermostdevelopment/mirrored-cypress-browsers-public:node16.14.2-slim-chrome100-ff99-edge"
     entrypoint: [ "/bin/bash", "-c" ]
     command: [ "until [ -f /var/run/mm_terminate ]; do sleep 5; done" ]
     env_file:
@@ -113,7 +113,7 @@ services:
       - "../../e2e-tests/cypress/:/app"
 
   utils:
-    image: "public.ecr.aws/mattermostqa/mattermost-build-server:20220415_golang-1.18.1"
+    image: "mattermostdevelopment/mirrored-golang:1.19.5"
     entrypoint: [ "/bin/bash", "-c" ]
     command: [ "until [ -f /var/run/mm_terminate ]; do sleep 5; done" ]
     working_dir: "/opt/mattermost-server"

--- a/e2e-tests/.ci/server.override.yml
+++ b/e2e-tests/.ci/server.override.yml
@@ -25,6 +25,7 @@ services:
       MM_FEATUREFLAGS_USECASEONBOARDING: "false"
       MM_SERVICESETTINGS_ENABLEONBOARDINGFLOW: "false"
       MM_FEATUREFLAGS_ONBOARDINGTOURTIPS: "false"
+      MM_SERVICEENVIRONMENT: "test"
     ports:
       - "8065:8065"
     depends_on:

--- a/e2e-tests/.ci/server.override.yml
+++ b/e2e-tests/.ci/server.override.yml
@@ -26,6 +26,8 @@ services:
       MM_SERVICESETTINGS_ENABLEONBOARDINGFLOW: "false"
       MM_FEATUREFLAGS_ONBOARDINGTOURTIPS: "false"
       MM_SERVICEENVIRONMENT: "test"
+    volumes:
+    - "server-config:/mattermost/config"
     ports:
       - "8065:8065"
     depends_on:
@@ -120,3 +122,7 @@ services:
     working_dir: "/opt/mattermost-server"
     volumes:
     - "../../:/opt/mattermost-server"
+    - "server-config:/opt/server-config"
+
+volumes:
+  server-config:

--- a/e2e-tests/.ci/server.prepare.sh
+++ b/e2e-tests/.ci/server.prepare.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -e -u -o pipefail
+cd $(dirname $0)
+. .e2erc
+
+# Install cypress dependencies
+mme2e_log "Prepare Cypress: install dependencies"
+${MME2E_DC_SERVER} exec -T -u 0 -- cypress bash -c "id $MME2E_UID || useradd -u $MME2E_UID -m nodeci" # Works around the node image's assumption that the app files are owned by user 1000
+${MME2E_DC_SERVER} exec -T -u $MME2E_UID -- cypress npm i
+${MME2E_DC_SERVER} exec -T -u $MME2E_UID -- cypress cypress install
+
+# Populate cypress fixtures
+mme2e_log "Prepare Cypress: populating fixtures"
+${MME2E_DC_SERVER} exec -T -- server curl -L --silent https://github.com/mattermost/mattermost-plugin-gitlab/releases/download/v1.3.0/com.github.manland.mattermost-plugin-gitlab-1.3.0.tar.gz | ${MME2E_DC_SERVER} exec -T -u $MME2E_UID -- cypress tee tests/fixtures/com.github.manland.mattermost-plugin-gitlab-1.3.0.tar.gz >/dev/null
+${MME2E_DC_SERVER} exec -T -- server curl -L --silent https://github.com/mattermost/mattermost-plugin-demo/releases/download/v0.9.0/com.mattermost.demo-plugin-0.9.0.tar.gz | ${MME2E_DC_SERVER} exec -T -u $MME2E_UID -- cypress tee tests/fixtures/com.mattermost.demo-plugin-0.9.0.tar.gz >/dev/null
+${MME2E_DC_SERVER} exec -T -- server curl -L --silent https://github.com/mattermost/mattermost-plugin-demo/releases/download/v0.8.0/com.mattermost.demo-plugin-0.8.0.tar.gz | ${MME2E_DC_SERVER} exec -T -u $MME2E_UID -- cypress tee tests/fixtures/com.mattermost.demo-plugin-0.8.0.tar.gz >/dev/null
+${MME2E_DC_SERVER} exec -T -- server curl -L --silent https://github.com/mattermost/mattermost-plugin-demo/releases/download/v0.8.0/com.mattermost.demo-plugin-0.8.0.tar.gz | ${MME2E_DC_SERVER} exec -T -u $MME2E_UID -- cypress tee tests/fixtures/com.mattermost.demo-plugin-0.8.0.tar.gz >/dev/null
+${MME2E_DC_SERVER} exec -T -u $MME2E_UID -- cypress tee tests/fixtures/keycloak.crt >/dev/null <../../server/build/docker/keycloak/keycloak.crt
+
+# Generate the test mattermosts-server config, and restart its container
+mme2e_log "Prepare Server: patching the mattermost-server config"
+${MME2E_DC_SERVER} exec -T -e "OUTPUT_CONFIG=/tmp/config_generated.json" -w /opt/mattermost-server/server -- utils go run scripts/config_generator/main.go
+${MME2E_DC_SERVER} exec -T -- utils bash <<EOF
+jq "
+  .ServiceSettings.SiteURL=\"http://server:8065\"
+| .PluginSettings.Enable=true
+| .PluginSettings.EnableUploads=true
+| .PluginSettings.AutomaticPrepackagedPlugins=true
+| .TeamSettings.EnableOpenServer=true
+| .ElasticsearchSettings.ConnectionURL=\"http://elasticsearch:9200\"
+" </tmp/config_generated.json >/tmp/config_patched.json
+EOF
+# TODO double check: could there be race conditions, if the server tries to write back to the file? Afaiu, nobody touching the UI -> no changes to the config file
+${MME2E_DC_SERVER} exec -T -- utils cat /tmp/config_patched.json | ${MME2E_DC_SERVER} exec -T -- server tee config/config.json >/dev/null
+${MME2E_DC_SERVER} restart server
+if ! mme2e_wait_service_healthy server 60 10; then
+  mme2e_log "Mattermost container not healthy, retry attempts exhausted. Giving up." >&2
+  exit 1
+fi
+mme2e_log "Mattermost container is running and healthy"
+
+# Inject test data, prepare for E2E tests
+mme2e_log "Prepare Server: injecting E2E test data"
+${MME2E_DC_SERVER} exec -T -- server mmctl config set TeamSettings.MaxUsersPerTeam 100 --local
+${MME2E_DC_SERVER} exec -T -- server mmctl sampledata -u 60 --local
+${MME2E_DC_SERVER} exec -T -- openldap bash -c 'ldapadd -x -D "cn=admin,dc=mm,dc=test,dc=com" -w mostest' <../../server/tests/test-data.ldif
+${MME2E_DC_SERVER} exec -T -- minio sh -c 'mkdir -p /data/mattermost-test'
+mme2e_log "Mattermost is running and ready for E2E testing"
+mme2e_log "You can use the test data credentials for logging in (username=sysadmin password=Sys@dmin-sample1)"

--- a/e2e-tests/.ci/server.prepare.sh
+++ b/e2e-tests/.ci/server.prepare.sh
@@ -17,29 +17,6 @@ ${MME2E_DC_SERVER} exec -T -- server curl -L --silent https://github.com/matterm
 ${MME2E_DC_SERVER} exec -T -- server curl -L --silent https://github.com/mattermost/mattermost-plugin-demo/releases/download/v0.8.0/com.mattermost.demo-plugin-0.8.0.tar.gz | ${MME2E_DC_SERVER} exec -T -u $MME2E_UID -- cypress tee tests/fixtures/com.mattermost.demo-plugin-0.8.0.tar.gz >/dev/null
 ${MME2E_DC_SERVER} exec -T -u $MME2E_UID -- cypress tee tests/fixtures/keycloak.crt >/dev/null <../../server/build/docker/keycloak/keycloak.crt
 
-# Generate the test mattermosts-server config, and restart its container
-mme2e_log "Prepare Server: patching the mattermost-server config"
-${MME2E_DC_SERVER} exec -T  -- utils bash -c "apt update && apt install -y jq"
-${MME2E_DC_SERVER} exec -T -e "OUTPUT_CONFIG=/tmp/config_generated.json" -w /opt/mattermost-server/server -- utils go run scripts/config_generator/main.go
-${MME2E_DC_SERVER} exec -T -- utils bash <<EOF
-jq "
-  .ServiceSettings.SiteURL=\"http://server:8065\"
-| .PluginSettings.Enable=true
-| .PluginSettings.EnableUploads=true
-| .PluginSettings.AutomaticPrepackagedPlugins=true
-| .TeamSettings.EnableOpenServer=true
-| .ElasticsearchSettings.ConnectionURL=\"http://elasticsearch:9200\"
-" </tmp/config_generated.json >/tmp/config_patched.json
-EOF
-# TODO double check: could there be race conditions, if the server tries to write back to the file? Afaiu, nobody touching the UI -> no changes to the config file
-${MME2E_DC_SERVER} exec -T -- utils cat /tmp/config_patched.json | ${MME2E_DC_SERVER} exec -T -- server tee config/config.json >/dev/null
-${MME2E_DC_SERVER} restart server
-if ! mme2e_wait_service_healthy server 60 10; then
-  mme2e_log "Mattermost container not healthy, retry attempts exhausted. Giving up." >&2
-  exit 1
-fi
-mme2e_log "Mattermost container is running and healthy"
-
 # Inject test data, prepare for E2E tests
 mme2e_log "Prepare Server: injecting E2E test data"
 ${MME2E_DC_SERVER} exec -T -- server mmctl config set TeamSettings.MaxUsersPerTeam 100 --local

--- a/e2e-tests/.ci/server.prepare.sh
+++ b/e2e-tests/.ci/server.prepare.sh
@@ -19,6 +19,7 @@ ${MME2E_DC_SERVER} exec -T -u $MME2E_UID -- cypress tee tests/fixtures/keycloak.
 
 # Generate the test mattermosts-server config, and restart its container
 mme2e_log "Prepare Server: patching the mattermost-server config"
+${MME2E_DC_SERVER} exec -T  -- utils bash -c "apt update && apt install -y jq"
 ${MME2E_DC_SERVER} exec -T -e "OUTPUT_CONFIG=/tmp/config_generated.json" -w /opt/mattermost-server/server -- utils go run scripts/config_generator/main.go
 ${MME2E_DC_SERVER} exec -T -- utils bash <<EOF
 jq "

--- a/e2e-tests/.ci/server.run_cypress.sh
+++ b/e2e-tests/.ci/server.run_cypress.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e -u -o pipefail
+cd $(dirname $0)
+. .e2erc
+
+# Set required variables
+TEST_FILTER_DEFAULT='--stage=@prod --group=@smoke'
+TEST_FILTER=${TEST_FILTER:-$TEST_FILTER_DEFAULT}
+
+# Print run information
+mme2e_log "Printing Cypress container informations"
+${MME2E_DC_SERVER} exec -T -u $MME2E_UID -- cypress node -p 'module.paths'
+${MME2E_DC_SERVER} exec -T -u $MME2E_UID -- cypress bash <<"EOF"
+cat <<INNEREOF
+node version:    $(node -v)
+npm version:     $(npm -v)
+debian version:  $(cat /etc/debian_version)
+user:            $(whoami)
+chrome:          $(google-chrome --version || true)
+firefox:         $(firefox --version || true)
+INNEREOF
+EOF
+
+# Initialize cypress report directory
+mme2e_log "Prepare Cypress: clean and initialize report and logs directory"
+${MME2E_DC_SERVER} exec -T -u $MME2E_UID -- cypress bash <<EOF
+rm -rf logs results
+mkdir -p logs
+mkdir -p results/junit
+touch results/junit/empty.xml
+echo '<?xml version="1.0" encoding="UTF-8"?>' > results/junit/empty.xml
+EOF
+
+# Run cypress test
+# No need to collect its exit status: if it's nonzero, this script will terminate since we use '-e'
+if ${MME2E_DC_SERVER} exec -T -u $MME2E_UID -- cypress bash -c '[ -n "${AUTOMATION_DASHBOARD_URL}" ]'; then
+	mme2e_log "AUTOMATION_DASHBOARD_URL is set. Using run_test_cycle.js for the cypress run"
+	${MME2E_DC_SERVER} exec -T -u $MME2E_UID -- cypress node --trace-warnings generate_test_cycle.js ${TEST_FILTER}
+	${MME2E_DC_SERVER} exec -T -u $MME2E_UID -- cypress node run_test_cycle.js | tee ../cypress/logs/cypress.log
+else
+	mme2e_log "AUTOMATION_DASHBOARD_URL is unset. Using run_tests.js for the cypress run"
+	${MME2E_DC_SERVER} exec -T -u $MME2E_UID -- cypress node run_tests.js ${TEST_FILTER} | tee ../cypress/logs/cypress.log
+fi
+
+# Collect server logs
+${MME2E_DC_SERVER} exec -T -- server cat /mattermost/logs/mattermost.log >../cypress/logs/mattermost.log

--- a/e2e-tests/.ci/server.start.sh
+++ b/e2e-tests/.ci/server.start.sh
@@ -41,9 +41,9 @@ mme2e_wait_image ${SERVER_IMAGE} 30 60
 mme2e_log "Creating E2E containers and generating server config"
 ${MME2E_DC_SERVER} create
 ${MME2E_DC_SERVER} up -d -- utils
-${MME2E_DC_SERVER} exec -T  -- utils bash -c "apt update && apt install -y jq"
-${MME2E_DC_SERVER} exec -T -e "OUTPUT_CONFIG=/tmp/config_generated.json" -w /opt/mattermost-server/server -- utils go run scripts/config_generator/main.go
-${MME2E_DC_SERVER} exec -T -- utils bash <<EOF
+${MME2E_DC_SERVER} exec -T -w /opt/mattermost-server/server -- utils bash <<EOF
+apt update && apt install -y jq
+OUTPUT_CONFIG=/tmp/config_generated.json go run scripts/config_generator/main.go
 jq "
   .ServiceSettings.SiteURL=\"http://server:8065\"
 | .PluginSettings.Enable=true
@@ -52,6 +52,8 @@ jq "
 | .TeamSettings.EnableOpenServer=true
 | .ElasticsearchSettings.ConnectionURL=\"http://elasticsearch:9200\"
 " </tmp/config_generated.json >/opt/server-config/config.json
+echo "### Generated server config:"
+cat /opt/server-config/config.json
 EOF
 
 # Launch mattermost-server, and wait for it to be healthy

--- a/e2e-tests/.ci/server.start.sh
+++ b/e2e-tests/.ci/server.start.sh
@@ -33,9 +33,28 @@ AUTOMATION_DASHBOARD_URL
 AUTOMATION_DASHBOARD_TOKEN
 EOF
 
-# Launch mattermost-server, and wait for it to be healthy
+# Wait for the required server image
 mme2e_log "Waiting for server image to be available"
 mme2e_wait_image ${SERVER_IMAGE} 30 60
+
+# Create the containers and generate the server config
+mme2e_log "Creating E2E containers and generating server config"
+${MME2E_DC_SERVER} create
+${MME2E_DC_SERVER} up -d -- utils
+${MME2E_DC_SERVER} exec -T  -- utils bash -c "apt update && apt install -y jq"
+${MME2E_DC_SERVER} exec -T -e "OUTPUT_CONFIG=/tmp/config_generated.json" -w /opt/mattermost-server/server -- utils go run scripts/config_generator/main.go
+${MME2E_DC_SERVER} exec -T -- utils bash <<EOF
+jq "
+  .ServiceSettings.SiteURL=\"http://server:8065\"
+| .PluginSettings.Enable=true
+| .PluginSettings.EnableUploads=true
+| .PluginSettings.AutomaticPrepackagedPlugins=true
+| .TeamSettings.EnableOpenServer=true
+| .ElasticsearchSettings.ConnectionURL=\"http://elasticsearch:9200\"
+" </tmp/config_generated.json >/opt/server-config/config.json
+EOF
+
+# Launch mattermost-server, and wait for it to be healthy
 mme2e_log "Starting E2E containers"
 ${MME2E_DC_SERVER} up -d
 if ! mme2e_wait_service_healthy server 60 10; then

--- a/e2e-tests/.ci/server.start.sh
+++ b/e2e-tests/.ci/server.start.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e -u -o pipefail
+cd $(dirname $0)
+. .e2erc
+
+export BRANCH_DEFAULT=$(git branch --show-current)
+export BRANCH=${BRANCH:-$BRANCH_DEFAULT}
+export BUILD_ID_DEFAULT=$(date +%s)
+export BUILD_ID=${BUILD_ID:-$BUILD_ID_DEFAULT}
+export CI_BASE_URL="${CI_BASE_URL:-localhost}"
+
+# Cleanup old containers, if any
+mme2e_log "Stopping leftover E2E containers, if any are running"
+${MME2E_DC_SERVER} down -v
+
+# Generate .env.server
+mme2e_log "Generating .env.server"
+mme2e_generate_envfile_from_var_names >.env.server <<EOF
+MM_LICENSE
+EOF
+envarr=$(echo ${MM_ENV:-} | tr "," "\n")
+for env in $envarr; do
+  echo "$env" >> .env.server
+done
+
+# Generate .env.cypress
+mme2e_log "Generating .env.cypress"
+mme2e_generate_envfile_from_var_names >.env.cypress <<EOF
+BRANCH
+BUILD_ID
+CI_BASE_URL
+AUTOMATION_DASHBOARD_URL
+AUTOMATION_DASHBOARD_TOKEN
+EOF
+
+# Launch mattermost-server, and wait for it to be healthy
+mme2e_log "Waiting for server image to be available"
+mme2e_wait_image ${SERVER_IMAGE} 30 60
+mme2e_log "Starting E2E containers"
+${MME2E_DC_SERVER} up -d
+if ! mme2e_wait_service_healthy server 60 10; then
+  mme2e_log "Mattermost container not healthy, retry attempts exhausted. Giving up." >&2
+  exit 1
+fi
+mme2e_log "Mattermost container is running and healthy"

--- a/e2e-tests/.ci/server.stop.sh
+++ b/e2e-tests/.ci/server.stop.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e -u -o pipefail
+cd $(dirname $0)
+. .e2erc
+
+mme2e_log "Stopping E2E containers"
+${MME2E_DC_SERVER} down -v

--- a/e2e-tests/.gitignore
+++ b/e2e-tests/.gitignore
@@ -6,3 +6,6 @@
 
 # Plugin
 *.tar.gz
+
+# node
+*.lock

--- a/e2e-tests/Makefile
+++ b/e2e-tests/Makefile
@@ -1,0 +1,28 @@
+.PHONY: all run stop
+all: run
+run: start-server prepare-server run-cypress
+stop: stop-server stop-dashboard clean-env-placeholders
+
+.PHONY: start-server prepare-server run-cypress stop-server restart-server
+start-server:
+	./.ci/server.start.sh
+prepare-server:
+	./.ci/server.prepare.sh
+run-cypress:
+	./.ci/server.run_cypress.sh
+stop-server:
+	./.ci/server.stop.sh
+restart-server: stop-server start-server
+
+.PHONY: start-dashboard stop-dashboard
+start-dashboard:
+	./.ci/dashboard.start.sh
+stop-dashboard:
+	./.ci/dashboard.stop.sh
+
+.PHONY: print-env-placeholders clean-env-placeholders
+print-env-placeholders:
+	find .ci -maxdepth 1 -name '.env.*'  | xargs --verbose -l cat
+clean-env-placeholders:
+	git reset .ci/.env.*
+	git checkout .ci/.env.*

--- a/e2e-tests/Makefile
+++ b/e2e-tests/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 .PHONY: all run stop
 all: run
 run: start-server prepare-server run-cypress
@@ -24,5 +26,5 @@ stop-dashboard:
 print-env-placeholders:
 	find .ci -maxdepth 1 -name '.env.*'  | xargs --verbose -l cat
 clean-env-placeholders:
-	git reset .ci/.env.*
-	git checkout .ci/.env.*
+	git reset .ci/.env.{cypress,server,dashboard}
+	git checkout .ci/.env.{cypress,server,dashboard}

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -1,0 +1,33 @@
+# E2E testing for the Mattermost web client
+
+This directory contains the E2E testing code for the Mattermost web client.
+
+### How to run locally
+
+The E2E testing scripts depend on the following tools being installed on your system: `docker`, `docker-compose`, `make`, `git`, `jq`, and some common utilities (`coreutils`, `findutils`, `bash`, `awk`, `sed`, `grep`)
+
+Instructions, tl;dr: create a local branch with your E2E test changes, then open a PR to the `mattermost-server` repo targeting the `master` branch (so that CI will produce the image that docker-compose needs), then run `make` in this directory.
+
+Instructions, detailed:
+1. Create the `.ci/env` file, and populate the variables you need, keeping in mind that:
+  * The following variables will be passed over to the server container: `MM_LICENSE` (no enterprise features will be available if this is unset), and the exploded `MM_ENV` (a comma-separated list of env var specifications)
+  * The following variables will be passed over to the cypress container: `BRANCH`, `BUILD_ID`, `CI_BASE_URL`, `AUTOMATION_DASHBOARD_URL` and `AUTOMATION_DASHBOARD_TOKEN`
+  * The `SERVER_IMAGE` variable can also be set, if you want to select a custom mattermost-server image
+  * The `TEST_FILTER` variable can also be set, to customize which tests you want cypress to run
+  * All variables are optional, and will be set to sane defaults
+2. (optional) `make start-dashboard`: start the automation-dashboard in the background
+  * This also sets the `AUTOMATION_DASHBOARD_URL` and `AUTOMATION_DASHBOARD_TOKEN` variables for the cypress container
+  * Note that if you run the dashboard locally, but also specify other `AUTOMATION_DASHBOARD_*` variables in your env, the latter variables will take precedence
+3. `make`: start and prepare the server, then run the cypress tests
+  * You can track the progress of the run in the `http://localhost:4000/cycles` dashboard, if you launched it locally
+4. `make stop`: tears down the server (and the dashboard, if running), then cleans up the env placeholder files
+
+Notes:
+- Aside from some exceptions (e.g. `TEST_FILTER`), most of the variables in `.ci/env` must be set before the `make start-server` command is run. Modifting that file afterwards has no effect, because the containers' env files are generated in that step.
+- If you restart the dashboard at any point, you must also restart the server containers, so that it picks up the new IP of the dashboard from the newly generated `.env.dashboard` file
+- If you started the dashboard locally in the past, but want to point to another dasbhoard later, you can run `make clean-env-placeholders` to remove references to the local dasbhoard (you'll likely need to restart the server)
+- Dynamically set variables for the server or cypress should be managed within the `.env.*` files, rather than in the docker-compose files, to streamline their management.
+
+##### How to control which tests to run
+
+The `TEST_FILTER` variable will control which test files to run Cypress tests against. Please check the `e2e-tests/cypress/run_tests.js` file for details about its format.

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -23,9 +23,9 @@ Instructions, detailed:
 4. `make stop`: tears down the server (and the dashboard, if running), then cleans up the env placeholder files
 
 Notes:
-- Aside from some exceptions (e.g. `TEST_FILTER`), most of the variables in `.ci/env` must be set before the `make start-server` command is run. Modifting that file afterwards has no effect, because the containers' env files are generated in that step.
+- Aside from some exceptions (e.g. `TEST_FILTER`), most of the variables in `.ci/env` must be set before the `make start-server` command is run. Modifying that file afterwards has no effect, because the containers' env files are generated in that step.
 - If you restart the dashboard at any point, you must also restart the server containers, so that it picks up the new IP of the dashboard from the newly generated `.env.dashboard` file
-- If you started the dashboard locally in the past, but want to point to another dasbhoard later, you can run `make clean-env-placeholders` to remove references to the local dasbhoard (you'll likely need to restart the server)
+- If you started the dashboard locally in the past, but want to point to another dashboard later, you can run `make clean-env-placeholders` to remove references to the local dashboard (you'll likely need to restart the server)
 - Dynamically set variables for the server or cypress should be managed within the `.env.*` files, rather than in the docker-compose files, to streamline their management.
 
 ##### How to control which tests to run

--- a/e2e-tests/cypress/package-lock.json
+++ b/e2e-tests/cypress/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "cypress",
+  "name": "app",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/e2e-tests/cypress/tests/support/index.js
+++ b/e2e-tests/cypress/tests/support/index.js
@@ -217,6 +217,9 @@ function sysadminSetup(user) {
     // # Deactivate test bots if any
     cy.apiDeactivateTestBots();
 
+    // # Disable welcome tours if any
+    cy.apiDisableTutorials(user.id);
+
     // # Check if default team is present; create if not found.
     cy.apiGetTeamsForUser().then(({teams}) => {
         const defaultTeam = teams && teams.length > 0 && teams.find((team) => team.name === DEFAULT_TEAM.name);

--- a/server/build/gitlab-dc.common.yml
+++ b/server/build/gitlab-dc.common.yml
@@ -1,29 +1,44 @@
 version: '2.4'
 services:
   minio:
-    image: ${CI_REGISTRY}/mattermost/ci/images/minio:RELEASE.2019-10-11T00-38-09Z-1
+    image: public.ecr.aws/mattermostqa/minio:RELEASE.2019-10-11T00-38-09Z-1
     command: "server /data"
     environment:
       MINIO_ACCESS_KEY: minioaccesskey
       MINIO_SECRET_KEY: miniosecretkey
       MINIO_SSE_MASTER_KEY: "my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574"
+    healthcheck:
+      test: [ "CMD", "nc", "-z", "-w1", "127.0.0.1", "9000" ]
+      interval: 10s
+      timeout: 15s
+      retries: 12
   inbucket:
-    image: ${CI_REGISTRY}/mattermost/ci/images/inbucket:v3.0.0-rc1-2-gc64e7a6-1
+    image: public.ecr.aws/mattermostqa/inbucket:3.0.0
     restart: always
     environment:
       INBUCKET_WEB_ADDR: "0.0.0.0:9001"
       INBUCKET_POP3_ADDR: "0.0.0.0:10110"
       INBUCKET_SMTP_ADDR: "0.0.0.0:10025"
+    healthcheck:
+      test: [ "CMD", "nc", "-z", "-w1", "127.0.0.1", "10025" ]
+      interval: 10s
+      timeout: 15s
+      retries: 12
   openldap:
-    image: ${CI_REGISTRY}/mattermost/ci/images/openldap:1.4.0-1
+    image: public.ecr.aws/mattermostqa/openldap:1.4.0
     restart: always
     environment:
       LDAP_TLS_VERIFY_CLIENT: "never"
       LDAP_ORGANISATION: "Mattermost Test"
       LDAP_DOMAIN: "mm.test.com"
       LDAP_ADMIN_PASSWORD: "mostest"
+    healthcheck:
+      test: [ "CMD", "bash", "-o", "pipefail", "-c", "ss -ltn 'sport = :636' | grep -qE '^LISTEN'" ]
+      interval: 10s
+      timeout: 15s
+      retries: 12
   elasticsearch:
-    image: ${CI_REGISTRY}/mattermost/ci/images/mattermost-elasticsearch-docker:7.17.3
+    image: mattermost/mattermost-elasticsearch-docker:7.17.3
     environment:
       http.host: "0.0.0.0"
       http.port: 9200
@@ -33,10 +48,20 @@ services:
       http.cors.allow-credentials: "true"
       transport.host: "127.0.0.1"
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+    healthcheck:
+      test: [ "CMD", "bash", "-o", "pipefail", "-c", "curl --silent localhost:9200/_cat/health | awk '{ print $$4 }' | grep -qE '^green$$'" ]
+      interval: 10s
+      timeout: 15s
+      retries: 12
   dejavu:
-    image: ${CI_REGISTRY}/mattermost/ci/images/dejavu:3.4.2-1
+    image: public.ecr.aws/mattermostqa/dejavu:3.4.2
+    healthcheck:
+      test: [ "CMD", "nc", "-z", "-w1", "127.0.0.1", "1358" ]
+      interval: 10s
+      timeout: 15s
+      retries: 12
   keycloak:
-    image: ${CI_REGISTRY}/mattermost/ci/images/keycloak:10.0.2-1
+    image: public.ecr.aws/mattermostqa/keycloak:10.0.2
     restart: always
     environment:
       KEYCLOAK_USER: mmuser
@@ -45,13 +70,29 @@ services:
       KEYCLOAK_IMPORT: /setup/realm.json
     volumes:
      - "./docker/keycloak:/setup"
+    healthcheck:
+      test: [ "CMD", "bash", "-o", "pipefail", "-c", "curl --silent localhost:9990/health | grep -q '\"status\":\"UP\"'" ]
+      interval: 10s
+      timeout: 15s
+      retries: 12
   prometheus:
-    image: ${CI_REGISTRY}/mattermost/ci/images/prometheus:2.27.1-1
+    image: public.ecr.aws/mattermostqa/prometheus:v2.27.1
     volumes:
       - "./docker/prometheus-linux.yml:/etc/prometheus/prometheus.yml"
+    healthcheck:
+      test: [ "CMD", "wget", "-q", "-O-", "127.0.0.1:9090/-/ready" ]
+      interval: 10s
+      timeout: 15s
+      retries: 12
+  # wget -q -O- localhost:3000/healthz | grep -q Ok
   grafana:
-    image: ${CI_REGISTRY}/mattermost/ci/images/grafana:8.0.1-1
+    image: public.ecr.aws/mattermostqa/grafana:8.0.1
     volumes:
      - "./docker/grafana/grafana.ini:/etc/grafana/grafana.ini"
      - "./docker/grafana/provisioning:/etc/grafana/provisioning"
      - "./docker/grafana/dashboards:/var/lib/grafana/dashboards"
+    healthcheck:
+      test: [ "CMD", "bash", "-o", "pipefail", "-c", "wget -q -O- localhost:3000/healthz | grep -q Ok" ]
+      interval: 10s
+      timeout: 15s
+      retries: 12

--- a/server/build/gitlab-dc.common.yml
+++ b/server/build/gitlab-dc.common.yml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   minio:
-    image: public.ecr.aws/mattermostqa/minio:RELEASE.2019-10-11T00-38-09Z-1
+    image: mattermostdevelopment/mirrored-minio:RELEASE.2019-10-11T00-38-09Z-1
     command: "server /data"
     environment:
       MINIO_ACCESS_KEY: minioaccesskey
@@ -13,7 +13,7 @@ services:
       timeout: 15s
       retries: 12
   inbucket:
-    image: public.ecr.aws/mattermostqa/inbucket:3.0.0
+    image: mattermostdevelopment/mirrored-inbucket:3.0.0
     restart: always
     environment:
       INBUCKET_WEB_ADDR: "0.0.0.0:9001"
@@ -25,7 +25,7 @@ services:
       timeout: 15s
       retries: 12
   openldap:
-    image: public.ecr.aws/mattermostqa/openldap:1.4.0
+    image: mattermostdevelopment/mirrored-openldap:1.4.0
     restart: always
     environment:
       LDAP_TLS_VERIFY_CLIENT: "never"
@@ -54,14 +54,14 @@ services:
       timeout: 15s
       retries: 12
   dejavu:
-    image: public.ecr.aws/mattermostqa/dejavu:3.4.2
+    image: mattermostdevelopment/mirrored-dejavu:3.4.2
     healthcheck:
       test: [ "CMD", "nc", "-z", "-w1", "127.0.0.1", "1358" ]
       interval: 10s
       timeout: 15s
       retries: 12
   keycloak:
-    image: public.ecr.aws/mattermostqa/keycloak:10.0.2
+    image: mattermostdevelopment/mirrored-keycloak:10.0.2
     restart: always
     environment:
       KEYCLOAK_USER: mmuser
@@ -76,7 +76,7 @@ services:
       timeout: 15s
       retries: 12
   prometheus:
-    image: public.ecr.aws/mattermostqa/prometheus:v2.27.1
+    image: mattermostdevelopment/mirrored-prometheus:v2.27.1
     volumes:
       - "./docker/prometheus-linux.yml:/etc/prometheus/prometheus.yml"
     healthcheck:
@@ -86,7 +86,7 @@ services:
       retries: 12
   # wget -q -O- localhost:3000/healthz | grep -q Ok
   grafana:
-    image: public.ecr.aws/mattermostqa/grafana:8.0.1
+    image: mattermostdevelopment/mirrored-grafana:8.0.1
     volumes:
      - "./docker/grafana/grafana.ini:/etc/grafana/grafana.ini"
      - "./docker/grafana/provisioning:/etc/grafana/provisioning"

--- a/server/build/gitlab-dc.mysql.yml
+++ b/server/build/gitlab-dc.mysql.yml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   mysql:
-    image: ${CI_REGISTRY}/mattermost/ci/images/mysql:5.7-1
+    image: public.ecr.aws/mattermostqa/mysql:5.7.12
     restart: always
     environment:
       MYSQL_ROOT_HOST: "%"
@@ -83,7 +83,7 @@ services:
           - grafana
 
   start_dependencies:
-    image: ${CI_REGISTRY}/mattermost/ci/images/mattermost-wait-for-dep:latest-1
+    image: mattermost/mattermost-wait-for-dep:latest
     depends_on:
       - mysql
       - minio
@@ -95,8 +95,3 @@ services:
     command: mysql:3306 minio:9000 inbucket:9001 openldap:389 elasticsearch:9200 prometheus:9090 grafana:3000
     networks:
       default:
-
-networks:
-  default:
-    external:
-      name: ${COMPOSE_PROJECT_NAME}

--- a/server/build/gitlab-dc.mysql.yml
+++ b/server/build/gitlab-dc.mysql.yml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   mysql:
-    image: public.ecr.aws/mattermostqa/mysql:5.7.12
+    image: mattermostdevelopment/mirrored-mysql:5.7.12
     restart: always
     environment:
       MYSQL_ROOT_HOST: "%"

--- a/server/build/gitlab-dc.mysql.yml
+++ b/server/build/gitlab-dc.mysql.yml
@@ -95,3 +95,8 @@ services:
     command: mysql:3306 minio:9000 inbucket:9001 openldap:389 elasticsearch:9200 prometheus:9090 grafana:3000
     networks:
       default:
+
+networks:
+  default:
+    external:
+      name: ${COMPOSE_PROJECT_NAME}

--- a/server/build/gitlab-dc.postgres.yml
+++ b/server/build/gitlab-dc.postgres.yml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   postgres:
-    image: ${CI_REGISTRY}/mattermost/ci/images/postgres:10-1
+    image: public.ecr.aws/mattermostqa/postgres:12
     restart: always
     environment:
       POSTGRES_USER: mmuser
@@ -12,9 +12,9 @@ services:
      - "./docker/postgres.conf:/etc/postgresql/postgresql.conf"
     healthcheck:
       test: [ "CMD", "pg_isready", "-h", "localhost" ]
-      interval: 5s
-      timeout: 10s
-      retries: 3
+      interval: 10s
+      timeout: 15s
+      retries: 12
     networks:
       default:
         aliases:
@@ -81,7 +81,7 @@ services:
           - grafana
 
   start_dependencies:
-    image: ${CI_REGISTRY}/mattermost/ci/images/mattermost-wait-for-dep:latest-1
+    image: mattermost/mattermost-wait-for-dep:latest
     depends_on:
       - postgres
       - minio
@@ -93,9 +93,3 @@ services:
     command: postgres:5432 minio:9000 inbucket:9001 openldap:389 elasticsearch:9200 prometheus:9090 grafana:3000
     networks:
       default:
-
-
-networks:
-  default:
-    external:
-      name: ${COMPOSE_PROJECT_NAME}

--- a/server/build/gitlab-dc.postgres.yml
+++ b/server/build/gitlab-dc.postgres.yml
@@ -93,3 +93,8 @@ services:
     command: postgres:5432 minio:9000 inbucket:9001 openldap:389 elasticsearch:9200 prometheus:9090 grafana:3000
     networks:
       default:
+
+networks:
+  default:
+    external:
+      name: ${COMPOSE_PROJECT_NAME}

--- a/server/build/gitlab-dc.postgres.yml
+++ b/server/build/gitlab-dc.postgres.yml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   postgres:
-    image: public.ecr.aws/mattermostqa/postgres:12
+    image: mattermostdevelopment/mirrored-postgres:12
     restart: always
     environment:
       POSTGRES_USER: mmuser

--- a/server/build/gitlab-dc.schemamysql.yml
+++ b/server/build/gitlab-dc.schemamysql.yml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   mysql:
-    image: public.ecr.aws/mattermostqa/mysql:5.7.12
+    image: mattermostdevelopment/mirrored-mysql:5.7.12
     restart: always
     environment:
       MYSQL_ROOT_HOST: "%"

--- a/server/build/gitlab-dc.schemamysql.yml
+++ b/server/build/gitlab-dc.schemamysql.yml
@@ -29,3 +29,8 @@ services:
     command: mysql:3306
     networks:
       default:
+
+networks:
+  default:
+    external:
+      name: ${COMPOSE_PROJECT_NAME}

--- a/server/build/gitlab-dc.schemamysql.yml
+++ b/server/build/gitlab-dc.schemamysql.yml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   mysql:
-    image: ${CI_REGISTRY}/mattermost/ci/images/mysql:5.7-1
+    image: public.ecr.aws/mattermostqa/mysql:5.7.12
     restart: always
     environment:
       MYSQL_ROOT_HOST: "%"
@@ -23,14 +23,9 @@ services:
           - mysql
 
   start_dependencies:
-    image: ${CI_REGISTRY}/mattermost/ci/images/mattermost-wait-for-dep:latest-1
+    image: mattermost/mattermost-wait-for-dep:latest
     depends_on:
       - mysql
     command: mysql:3306
     networks:
       default:
-
-networks:
-  default:
-    external:
-      name: ${COMPOSE_PROJECT_NAME}

--- a/server/build/gitlab-dc.schemapostgres.yml
+++ b/server/build/gitlab-dc.schemapostgres.yml
@@ -27,3 +27,8 @@ services:
     command: postgres:5432
     networks:
       default:
+
+networks:
+  default:
+    external:
+      name: ${COMPOSE_PROJECT_NAME}

--- a/server/build/gitlab-dc.schemapostgres.yml
+++ b/server/build/gitlab-dc.schemapostgres.yml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   postgres:
-    image: ${CI_REGISTRY}/mattermost/ci/images/postgres:10-1
+    image: public.ecr.aws/mattermostqa/postgres:12
     restart: always
     environment:
       POSTGRES_USER: mmuser
@@ -21,14 +21,9 @@ services:
           - postgres
 
   start_dependencies:
-    image: ${CI_REGISTRY}/mattermost/ci/images/mattermost-wait-for-dep:latest-1
+    image: mattermost/mattermost-wait-for-dep:latest
     depends_on:
       - postgres
     command: postgres:5432
     networks:
       default:
-
-networks:
-  default:
-    external:
-      name: ${COMPOSE_PROJECT_NAME}

--- a/server/build/gitlab-dc.schemapostgres.yml
+++ b/server/build/gitlab-dc.schemapostgres.yml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   postgres:
-    image: public.ecr.aws/mattermostqa/postgres:12
+    image: mattermostdevelopment/mirrored-postgres:12
     restart: always
     environment:
       POSTGRES_USER: mmuser

--- a/server/scripts/mirror-docker-images.json
+++ b/server/scripts/mirror-docker-images.json
@@ -29,5 +29,8 @@
   },
   "cypress-browsers-public": {
     "node16.14.2-slim-chrome100-ff99-edge": "cypress/browsers:node16.14.2-slim-chrome100-ff99-edge@sha256:f8459ee677ce356eff64698095fbdf48eb9ab018fc5eb0d30c07ba23884edace"
+  },
+  "golang": {
+    "1.19.5": "golang:1.19.5@sha256:bb9811fad43a7d6fd2173248d8331b2dcf5ac9af20976b1937ecd214c5b8c383"
   }
 }

--- a/server/scripts/mirror-docker-images.json
+++ b/server/scripts/mirror-docker-images.json
@@ -1,0 +1,33 @@
+{
+  "postgres": {
+    "10": "postgres:10@sha256:7a484b11fcabd39596b1bf08780cdb61fa9b0d8bfad0844dbdce3a6922df95d1",
+    "12": "postgres:12@sha256:cc7a021d9aff3aa02788d35c27a5cc32d4790ad92d72232a6be75b76ab7d79db"
+  },
+  "mysql": {
+    "5.7.12": "mysql/mysql-server:5.7.12@sha256:3f0d90736a3298bb04965db697a3a85f1df1480da49eafd256be1ea2b9b5337e"
+  },
+  "minio": {
+    "RELEASE.2019-10-11T00-38-09Z-1": "minio/minio:RELEASE.2019-10-11T00-38-09Z@sha256:0d02f16a1662653f9b961211b21ed7de04bf04492f44c2b7594bacbfcc519eb5"
+  },
+  "inbucket": {
+    "3.0.0": "inbucket/inbucket:3.0.0@sha256:1f10a0efea694592c06799c729aee1d6d71c9a4f72b73031d4a426ef5f26dfc1"
+  },
+  "openldap": {
+    "1.4.0": "osixia/openldap:1.4.0@sha256:d5b2f2b816b25a1b57033b34f5d48c91cc3161a7d041811a9032604030bad9db"
+  },
+  "keycloak": {
+    "10.0.2": "jboss/keycloak:10.0.2@sha256:3720b5ace316b5790a58ce838f46e8cd44cedbdb7e35d3866311ddc5a5e71466"
+  },
+  "dejavu": {
+    "3.4.2": "appbaseio/dejavu:3.4.2@sha256:8f2f4d45565da53c4235495737fff3921d302955daeb2f53a433c7b0e2044951"
+  },
+  "prometheus": {
+    "v2.27.1": "prom/prometheus:v2.27.1@sha256:5accb68b56ba452e449a5e552411acaeabbbe0f087acf19a1157ce3dd10a8bed"
+  },
+  "grafana": {
+    "8.0.1": "grafana/grafana:8.0.1@sha256:1c3e2fc7896adf9e33be5d062c08066087cb556f63b0a95f8aefe92bd37a6f38"
+  },
+  "cypress-browsers-public": {
+    "node16.14.2-slim-chrome100-ff99-edge": "cypress/browsers:node16.14.2-slim-chrome100-ff99-edge@sha256:f8459ee677ce356eff64698095fbdf48eb9ab018fc5eb0d30c07ba23884edace"
+  }
+}

--- a/server/scripts/mirror-docker-images.sh
+++ b/server/scripts/mirror-docker-images.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -eu -o pipefail
+
+# Assert that IMAGE_FILE var is given, and that the file exists
+: ${IMAGES_FILE}
+[ -f ${IMAGES_FILE} ] || {
+  echo "Error: images spec file $IMAGES_FILE does not exist. Aborting." >&2
+  exit 1
+}
+
+DRY_RUN=${DRY_RUN:-yes}
+log () { echo "[$(date -Is)]" $*; }
+get_image_specs_per_line () {
+  jq -c '. as $images | keys[] | . as $image | $images[.] | keys[] | {dst_img_name: $image, dst_img_tag: ., src_img: $images[$image][.]}' <$IMAGES_FILE
+}
+
+log "Pusing images from given spec file: $IMAGES_FILE"
+log "Content of the spec file:"
+cat $IMAGES_FILE
+get_image_specs_per_line | while read IMAGE_SPEC; do
+  DST_IMG_NAME=$(jq -r '.dst_img_name' <<<$IMAGE_SPEC)
+  DST_IMG_TAG=$(jq -r '.dst_img_tag' <<<$IMAGE_SPEC)
+  SOURCE_IMAGE=$(jq -r '.src_img' <<<$IMAGE_SPEC)
+  DESTINATION_IMAGE=mattermostdevelopment/mirrored-${DST_IMG_NAME}:${DST_IMG_TAG}
+  if [ "${DRY_RUN,,}" = "no" ]; then
+    log "Pushing image: $SOURCE_IMAGE ---> $DESTINATION_IMAGE"
+    docker pull $SOURCE_IMAGE
+    docker tag $SOURCE_IMAGE $DESTINATION_IMAGE
+    docker push $DESTINATION_IMAGE
+  else
+    log "Pushing image: $SOURCE_IMAGE ---> $DESTINATION_IMAGE (dry run mode, set the DRY_RUN=no env var to disable)"
+  fi
+done
+log "All images pushed."


### PR DESCRIPTION
#### Summary

This PR reintroduces the Github Actions E2E smoketests originally added by https://github.com/mattermost/mattermost/pull/23301 , but fixes the first PR's problem which prevented the full E2E tests from running.

The root cause was the change to the docker-compose file networking, which was not expected by the currently existing E2E test run scripts. That has been addressed in this PR.

tl;dr of the changes compared to https://github.com/mattermost/mattermost/pull/23301 :
- Fix the root cause of the revert: do not change the docker-compose networking that E2E scripts currently rely on.
- Use Docker Hub as a registry, for the images required by E2E tests
  * Due to parallelism, we incurred in docker's [infrastructural rate limits](https://docs.docker.com/docker-hub/download-rate-limit/#other-limits), but this is avoided through staggered sleep in [this MR](https://git.internal.mattermost.com/qa/cypress-ui-automation/-/merge_requests/69)
- Push the images required by E2E to Docker Hub, in CI
- Fix a bug in the `e2e-tests-ci` workflow: use the `inputs.commit_sha` wherever required
- Fix other minor issues

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-5698
https://mattermost.atlassian.net/browse/CLD-5703

#### Release Note

```release-note
NONE
```
