### PR TITLE
MM-53002: Fix ESR CI

### DIFF
--- a/.github/workflows/esrupgrade-common.yml
+++ b/.github/workflows/esrupgrade-common.yml
@@ -63,7 +63,7 @@ jobs:
             --env MM_SQLSETTINGS_DATASOURCE="mmuser:mostest@tcp(mysql:3306)/mattermost_test?charset=utf8mb4,utf8&multiStatements=true&maxAllowedPacket=4194304" \
             -v ~/work/mattermost:/mm \
             -w /mm \
-            $BUILD_IMAGE&
+            $BUILD_IMAGE &
           # In parallel, wait for the migrations to finish.
           # To verify this, we check that the server has finished the startup job through the log line "Server is listening on"
           until docker logs mmserver | grep "Server is listening on"; do\

--- a/.github/workflows/esrupgrade-common.yml
+++ b/.github/workflows/esrupgrade-common.yml
@@ -139,7 +139,7 @@ jobs:
           name: upgraded-dump-script
           path: ${{ env.DUMP_SCRIPT_NAME }}.gz
   esr-upgrade-diff:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     needs:
       - esr-upgrade-server
       - esr-upgrade-script

--- a/.github/workflows/esrupgrade-common.yml
+++ b/.github/workflows/esrupgrade-common.yml
@@ -61,9 +61,9 @@ jobs:
             --env-file=dotenv/test.env \
             --env MM_SQLSETTINGS_DRIVERNAME="mysql" \
             --env MM_SQLSETTINGS_DATASOURCE="mmuser:mostest@tcp(mysql:3306)/mattermost_test?charset=utf8mb4,utf8&multiStatements=true&maxAllowedPacket=4194304" \
-            -v ~/work/mattermost:/mattermost \
-            -w /mattermost/mattermost \
-            $BUILD_IMAGE &
+            -v ~/work/mattermost:/mm \
+            -w /mm \
+            $BUILD_IMAGE&
           # In parallel, wait for the migrations to finish.
           # To verify this, we check that the server has finished the startup job through the log line "Server is listening on"
           until docker logs mmserver | grep "Server is listening on"; do\


### PR DESCRIPTION
#### Summary
It seems that the `/mattermost` path is the one used [in the image](https://github.com/mattermost/mattermost/blob/master/server/build/Dockerfile), and it somehow conflicted with the running process of the server here. I honestly am not sure why, but using any other path does seem to work.

I also downgraded the machine type in the `esr-upgrade-diff` job, since that's not compute-heavy at all.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53002

#### Screenshots
--

#### Release Note
```release-note
NONE
```
