### PR TITLE
Support json.RawMessage in configuration env overrides

### DIFF
--- a/server/config/environment.go
+++ b/server/config/environment.go
@@ -72,7 +72,11 @@ func applyEnvKey(key, value string, rValueSubject reflect.Value) {
 		if err == nil {
 			rFieldValue.Set(reflect.ValueOf(intVal))
 		}
-	case reflect.SliceOf(reflect.TypeOf("")).Kind():
+	case reflect.Slice:
+		if rFieldValue.Type() == reflect.TypeOf(json.RawMessage{}) {
+			rFieldValue.Set(reflect.ValueOf([]byte(value)))
+			break
+		}
 		rFieldValue.Set(reflect.ValueOf(strings.Split(value, " ")))
 	case reflect.Map:
 		target := reflect.New(rFieldValue.Type()).Interface()

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -1344,22 +1344,17 @@ func (s *LogSettings) SetDefaults() {
 			s.AdvancedLoggingJSON = []byte("{}")
 		}
 	}
-	// temporarily let AdvancedLoggingConfig take precedence.
-	if s.AdvancedLoggingConfig == nil {
-		s.AdvancedLoggingConfig = NewString("")
-	}
-	//s.AdvancedLoggingConfig = nil
+	s.AdvancedLoggingConfig = nil
 }
 
 // GetAdvancedLoggingConfig returns the advanced logging config as a []byte.
-// AdvancedLoggingJSON takes precident over the deprecated AdvancedLoggingConfig.
+// AdvancedLoggingJSON takes precedence over the deprecated AdvancedLoggingConfig.
 func (s *LogSettings) GetAdvancedLoggingConfig() []byte {
-	// temporarily let AdvancedLoggingConfig take precedence.
-	if s.AdvancedLoggingConfig != nil && !utils.IsEmptyJSON([]byte(*s.AdvancedLoggingConfig)) {
-		return []byte(*s.AdvancedLoggingConfig)
-	}
 	if !utils.IsEmptyJSON(s.AdvancedLoggingJSON) {
 		return s.AdvancedLoggingJSON
+	}
+	if s.AdvancedLoggingConfig != nil && !utils.IsEmptyJSON([]byte(*s.AdvancedLoggingConfig)) {
+		return []byte(*s.AdvancedLoggingConfig)
 	}
 	return []byte("{}")
 }
@@ -1413,23 +1408,17 @@ func (s *ExperimentalAuditSettings) SetDefaults() {
 			s.AdvancedLoggingJSON = []byte("{}")
 		}
 	}
-
-	// temporarily let AdvancedLoggingConfig take precedence.
-	if s.AdvancedLoggingConfig == nil {
-		s.AdvancedLoggingConfig = NewString("")
-	}
-	//s.AdvancedLoggingConfig = nil
+	s.AdvancedLoggingConfig = nil
 }
 
 // GetAdvancedLoggingConfig returns the advanced logging config as a []byte.
-// AdvancedLoggingJSON takes precident over the deprecated AdvancedLoggingConfig.
+// AdvancedLoggingJSON takes precedence over the deprecated AdvancedLoggingConfig.
 func (s *ExperimentalAuditSettings) GetAdvancedLoggingConfig() []byte {
-	// temporarily let AdvancedLoggingConfig take precedence.
-	if s.AdvancedLoggingConfig != nil && !utils.IsEmptyJSON([]byte(*s.AdvancedLoggingConfig)) {
-		return []byte(*s.AdvancedLoggingConfig)
-	}
 	if !utils.IsEmptyJSON(s.AdvancedLoggingJSON) {
 		return s.AdvancedLoggingJSON
+	}
+	if s.AdvancedLoggingConfig != nil && !utils.IsEmptyJSON([]byte(*s.AdvancedLoggingConfig)) {
+		return []byte(*s.AdvancedLoggingConfig)
 	}
 	return []byte("{}")
 }
@@ -1488,22 +1477,17 @@ func (s *NotificationLogSettings) SetDefaults() {
 			s.AdvancedLoggingJSON = []byte("{}")
 		}
 	}
-	// temporarily let AdvancedLoggingConfig take precedence.
-	if s.AdvancedLoggingConfig == nil {
-		s.AdvancedLoggingConfig = NewString("")
-	}
-	//s.AdvancedLoggingConfig = nil
+	s.AdvancedLoggingConfig = nil
 }
 
 // GetAdvancedLoggingConfig returns the advanced logging config as a []byte.
-// AdvancedLoggingJSON takes precident over the deprecated AdvancedLoggingConfig.
+// AdvancedLoggingJSON takes precedence over the deprecated AdvancedLoggingConfig.
 func (s *NotificationLogSettings) GetAdvancedLoggingConfig() []byte {
-	// temporarily let AdvancedLoggingConfig take precedence.
-	if s.AdvancedLoggingConfig != nil && !utils.IsEmptyJSON([]byte(*s.AdvancedLoggingConfig)) {
-		return []byte(*s.AdvancedLoggingConfig)
-	}
 	if !utils.IsEmptyJSON(s.AdvancedLoggingJSON) {
 		return s.AdvancedLoggingJSON
+	}
+	if s.AdvancedLoggingConfig != nil && !utils.IsEmptyJSON([]byte(*s.AdvancedLoggingConfig)) {
+		return []byte(*s.AdvancedLoggingConfig)
 	}
 	return []byte("{}")
 }


### PR DESCRIPTION
#### Summary
PR [MM-43077 Allow inline JSON in config.json for advanced logging config](https://github.com/mattermost/mattermost/pull/23324)  allowed inline JSON in config.json so that advanced logging config could be done with readable JSON.  This caused in issue in community in that the preexisting handing of env var overrides does not support the json.Message field type needed for inline JSON.

This PR adds support for env overrides of any json.RawMessage fields in config.json. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53009

#### Screenshots

#### Release Note
```release-note
Added support for environment variable overrides of AdvancedLoggingConfigJSON fields.
```
