### PR TITLE
[MM-49571] Browse Channels option missing - mobile web version

### DIFF
--- a/webapp/channels/src/components/menu/menu.tsx
+++ b/webapp/channels/src/components/menu/menu.tsx
@@ -66,6 +66,7 @@ interface Props {
     menuButtonTooltip?: MenuButtonTooltipProps;
     menu: MenuProps;
     children: ReactNode[];
+    onMenuModalClose: () => void
 }
 
 /**
@@ -98,6 +99,7 @@ export function Menu(props: Props) {
     function handleMenuModalClose(modalId: MenuProps['id']) {
         dispatch(closeModal(modalId));
         setAnchorElement(null);
+        props.onMenuModalClose();
     }
 
     function handleMenuClick() {

--- a/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category_menu/index.ts
+++ b/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category_menu/index.ts
@@ -9,13 +9,31 @@ import {openModal} from 'actions/views/modals';
 
 import SidebarCategoryMenu from './sidebar_category_menu';
 
+import {GlobalState} from 'types/store';
+
+import {getIsMobileView} from 'selectors/views/browser';
+
+import {haveICurrentChannelPermission} from 'mattermost-redux/selectors/entities/roles';
+
+import Permissions from 'mattermost-redux/constants/permissions';
+
+function mapStateToProps() {
+
+    return (state: GlobalState) => {
+        return {
+            isMobileView: getIsMobileView(state),
+            canJoinPublicChannel: haveICurrentChannelPermission(state, Permissions.JOIN_PUBLIC_CHANNELS),
+        };
+    };
+}
+
 const mapDispatchToProps = {
     openModal,
     setCategoryMuted,
     setCategorySorting,
 };
 
-const connector = connect(null, mapDispatchToProps);
+const connector = connect(mapStateToProps, mapDispatchToProps);
 
 export type PropsFromRedux = ConnectedProps<typeof connector>;
 


### PR DESCRIPTION
#### Summary
Add Browse Channels option for mobile web version

#### Ticket Link
[Link](https://github.com/mattermost/mattermost/issues/22031)

#### Screenshots

<img width="696" alt="Screen Shot 2023-06-04 at 10 52 40 PM" src="https://github.com/mattermost/mattermost/assets/65722778/57a6208a-9848-4f8e-b0c0-50895b672e53">

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Browse Channels option for mobile web version
```
