### PR TITLE
Mobile Web view : I am not able to create a new category

### DIFF
--- a/webapp/channels/src/components/menu/menu.tsx
+++ b/webapp/channels/src/components/menu/menu.tsx
@@ -66,6 +66,7 @@ interface Props {
     menuButtonTooltip?: MenuButtonTooltipProps;
     menu: MenuProps;
     children: ReactNode[];
+    onMenuModalClose: () => void
 }
 
 /**
@@ -98,6 +99,7 @@ export function Menu(props: Props) {
     function handleMenuModalClose(modalId: MenuProps['id']) {
         dispatch(closeModal(modalId));
         setAnchorElement(null);
+        props.onMenuModalClose();
     }
 
     function handleMenuClick() {

--- a/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category_menu/sidebar_category_menu.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category_menu/sidebar_category_menu.tsx
@@ -39,6 +39,7 @@ type Props = OwnProps & PropsFromRedux;
 
 const SidebarCategoryMenu = (props: Props) => {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const [isCloseMenuManually, setIsCloseMenuManually] = useState(false);
 
     const {formatMessage} = useIntl();
 
@@ -217,6 +218,7 @@ const SidebarCategoryMenu = (props: Props) => {
             dialogType: EditCategoryModal,
         });
         trackEvent('ui', 'ui_sidebar_category_menu_createCategory');
+        setIsCloseMenuManually(true);
     }
 
     const createNewCategoryMenuItem = (
@@ -236,6 +238,10 @@ const SidebarCategoryMenu = (props: Props) => {
 
     function handleMenuToggle(isOpen: boolean) {
         setIsMenuOpen(isOpen);
+    }
+
+    function onMenuModalClose() {
+        setIsCloseMenuManually(false);
     }
 
     return (
@@ -265,7 +271,9 @@ const SidebarCategoryMenu = (props: Props) => {
                     id: `SidebarChannelMenu-MenuList-${props.category.id}`,
                     'aria-label': formatMessage({id: 'sidebar_left.sidebar_category_menu.dropdownAriaLabel', defaultMessage: 'Edit category menu'}),
                     onToggle: handleMenuToggle,
+                    closeMenuManually: isCloseMenuManually,
                 }}
+                onMenuModalClose={onMenuModalClose}
             >
                 {muteUnmuteCategoryMenuItem}
                 {renameCategoryMenuItem}


### PR DESCRIPTION


#### Summary
On Mattermost web mobile, I'm not able to create a new category.


#### Ticket Link
[Link](https://github.com/mattermost/mattermost/issues/23603)

#### Screenshots

<img width="518" alt="Screen Shot 2023-06-04 at 11 25 53 PM" src="https://github.com/mattermost/mattermost/assets/65722778/9fb1073d-851c-4695-8de3-c7ac7d74aebe">

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
The user should be able to create a new category.
```
