### PR TITLE
[MM-52006] Fix panic if JSON null value is passed as channel update

### DIFF
--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -125,7 +125,7 @@ func updateChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var channel *model.Channel
 	err := json.NewDecoder(r.Body).Decode(&channel)
-	if err != nil {
+	if err != nil || channel == nil {
 		c.SetInvalidParamWithErr("channel", err)
 		return
 	}

--- a/server/channels/api4/channel_test.go
+++ b/server/channels/api4/channel_test.go
@@ -250,6 +250,15 @@ func TestUpdateChannel(t *testing.T) {
 	_, resp, err = client.UpdateChannel(directChannel)
 	require.Error(t, err)
 	CheckForbiddenStatus(t, resp)
+
+	t.Run("null value", func(t *testing.T) {
+		r, err := client.DoAPIPut(fmt.Sprintf("/channels"+"/%v", channel.Id), "null")
+		resp := model.BuildResponse(r)
+		defer closeBody(r)
+
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+	})
 }
 
 func TestPatchChannel(t *testing.T) {


### PR DESCRIPTION
#### Summary
Heads up that there is an ongoing discussion about if we could also fix other code pieces that are vulnerable to a `null` JSON value.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52006

#### Release Note
```release-note
Fix panic if JSON null value is passed as channel update
```
