### PR TITLE
Mm 52259 system message ignore colorize

### DIFF
--- a/webapp/channels/src/components/post/user_profile.tsx
+++ b/webapp/channels/src/components/post/user_profile.tsx
@@ -4,7 +4,7 @@
 import React, {ReactNode} from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import Constants, {Locations} from 'utils/constants';
+import {Locations} from 'utils/constants';
 import {fromAutoResponder, isFromWebhook} from 'utils/post_utils';
 
 import Tag from 'components/widgets/tag/tag';
@@ -17,7 +17,6 @@ import {Post} from '@mattermost/types/posts';
 type Props = {
     post: Post;
     compactDisplay?: boolean;
-    currentUserId: string;
     colorizeUsernames?: boolean;
     enablePostUsernameOverride?: boolean;
     isConsecutivePost?: boolean;
@@ -142,7 +141,6 @@ const PostUserProfile = (props: Props): JSX.Element | null => {
                         />
                     }
                     userId={post.user_id}
-                    overwriteImage={Constants.SYSTEM_MESSAGE_PROFILE_IMAGE}
                     disablePopover={true}
                     channelId={post.channel_id}
                     colorize={colorize}

--- a/webapp/channels/src/components/post_view/commented_on/__snapshots__/commented_on.test.tsx.snap
+++ b/webapp/channels/src/components/post_view/commented_on/__snapshots__/commented_on.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`components/post_view/CommentedOn should match snapshot 1`] = `
               hasMention={true}
               hideStatus={false}
               isRHS={false}
-              overwriteImage=""
               overwriteName=""
               userId=""
             />
@@ -60,7 +59,6 @@ exports[`components/post_view/CommentedOn should match snapshot 2`] = `
               hasMention={true}
               hideStatus={false}
               isRHS={false}
-              overwriteImage=""
               overwriteName=""
               userId=""
             />
@@ -99,7 +97,6 @@ exports[`components/post_view/CommentedOn should match snapshot 3`] = `
               hasMention={true}
               hideStatus={false}
               isRHS={false}
-              overwriteImage=""
               overwriteName=""
               userId=""
             />
@@ -140,7 +137,6 @@ exports[`components/post_view/CommentedOn should match snapshots for post with p
               hasMention={true}
               hideStatus={false}
               isRHS={false}
-              overwriteImage=""
               overwriteName=""
               userId=""
             />
@@ -179,7 +175,6 @@ exports[`components/post_view/CommentedOn should match snapshots for post with p
               hasMention={true}
               hideStatus={false}
               isRHS={false}
-              overwriteImage=""
               overwriteName=""
               userId=""
             />
@@ -218,7 +213,6 @@ exports[`components/post_view/CommentedOn should match snapshots for post with p
               hasMention={true}
               hideStatus={false}
               isRHS={false}
-              overwriteImage=""
               overwriteName=""
               userId=""
             />
@@ -257,7 +251,6 @@ exports[`components/post_view/CommentedOn should match snapshots for post with p
               hasMention={true}
               hideStatus={false}
               isRHS={false}
-              overwriteImage=""
               overwriteName=""
               userId=""
             />

--- a/webapp/channels/src/components/user_profile/__snapshots__/user_profile.test.tsx.snap
+++ b/webapp/channels/src/components/user_profile/__snapshots__/user_profile.test.tsx.snap
@@ -147,7 +147,7 @@ exports[`components/UserProfile should match snapshot, with colorization 1`] = `
       className="user-popover style--none"
       style={
         Object {
-          "color": "#000000",
+          "color": "#bbd279",
         }
       }
     >

--- a/webapp/channels/src/components/user_profile/user_profile.test.tsx
+++ b/webapp/channels/src/components/user_profile/user_profile.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import {UserProfile as UserProfileType} from '@mattermost/types/users';
+import {Preferences} from 'mattermost-redux/constants';
 
 import UserProfile from './user_profile';
 
@@ -14,6 +15,7 @@ describe('components/UserProfile', () => {
         isBusy: false,
         user: {username: 'username'} as UserProfileType,
         userId: 'user_id',
+        theme: Preferences.THEMES.onyx,
     };
 
     test('should match snapshot', () => {

--- a/webapp/channels/src/components/user_profile/user_profile.tsx
+++ b/webapp/channels/src/components/user_profile/user_profile.tsx
@@ -35,7 +35,6 @@ export type UserProfileProps = {
     hasMention?: boolean;
     hideStatus?: boolean;
     isRHS?: boolean;
-    overwriteImage?: React.ReactNode;
     channelId?: string;
     theme?: Theme;
 }
@@ -49,7 +48,6 @@ export default class UserProfile extends PureComponent<UserProfileProps> {
         hasMention: false,
         hideStatus: false,
         isRHS: false,
-        overwriteImage: '',
         overwriteName: '',
         colorize: false,
     };
@@ -132,7 +130,7 @@ export default class UserProfile extends PureComponent<UserProfileProps> {
         }
 
         return (
-            <React.Fragment>
+            <>
                 <OverlayTrigger
                     ref={this.setOverlaynRef}
                     trigger={['click']}
@@ -165,7 +163,7 @@ export default class UserProfile extends PureComponent<UserProfileProps> {
                 {sharedIcon}
                 {(user && user.is_bot) && <BotTag/>}
                 {(user && isGuest(user.roles)) && <GuestTag/>}
-            </React.Fragment>
+            </>
         );
     }
 }

--- a/webapp/channels/src/components/user_profile/user_profile.tsx
+++ b/webapp/channels/src/components/user_profile/user_profile.tsx
@@ -92,7 +92,7 @@ export default class UserProfile extends PureComponent<UserProfileProps> {
 
         const ariaName: string = typeof name === 'string' ? name.toLowerCase() : '';
 
-        let userColor = '#000000';
+        let userColor = theme?.centerChannelColor;
         if (user && theme) {
             userColor = generateColor(user.username, theme.centerChannelBg);
         }

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -18,7 +18,6 @@ import pdfIcon from 'images/icons/pdf.svg';
 import pptIcon from 'images/icons/ppt.svg';
 import videoIcon from 'images/icons/video.svg';
 import wordIcon from 'images/icons/word.svg';
-import logoImage from 'images/logo_compact.png';
 import githubIcon from 'images/themes/code_themes/github.png';
 import monokaiIcon from 'images/themes/code_themes/monokai.png';
 import solarizedDarkIcon from 'images/themes/code_themes/solarized-dark.png';
@@ -1508,7 +1507,6 @@ export const Constants = {
     MENTION_NAME_PADDING_LEFT: 2.4,
     AVATAR_WIDTH: 24,
     AUTO_RESPONDER: 'system_auto_responder',
-    SYSTEM_MESSAGE_PROFILE_IMAGE: logoImage,
     RESERVED_TEAM_NAMES: [
         'signup',
         'login',


### PR DESCRIPTION
#### Summary
This PR sets the default value for the username color using the theme provided value replacing the hardcoded values (#000000) which was causing the system messages not displaying correctly in dark themes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52259

#### Screenshots
Before:
*Dark theme:
<img width="1392" alt="Screenshot 2023-06-05 at 16 35 18" src="https://github.com/mattermost/mattermost/assets/10082627/fe17c5e7-cd22-4eca-a55d-1a6c2aa14749">


*Light Theme:
<img width="1401" alt="Screenshot 2023-06-05 at 16 19 15" src="https://github.com/mattermost/mattermost/assets/10082627/ae651d03-379f-4eaf-ae1a-89aa55db10b9">


After:
<img width="759" alt="Screenshot 2023-06-05 at 16 33 08" src="https://github.com/mattermost/mattermost/assets/10082627/c1575874-f627-4b4a-9cb7-164460193bcc">
<img width="783" alt="Screenshot 2023-06-05 at 16 33 52" src="https://github.com/mattermost/mattermost/assets/10082627/057dc265-9108-4cf5-9708-73dd4a9f5525">


#### Release Note
```release-note
NONE
```
