### PR TITLE
ci/fix: add ignore_missing flag for creating sentry release likely introduced by repo rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,8 +288,11 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ secrets.MM_SERVER_SENTRY_AUTH_TOKEN }}
       SENTRY_ORG: ${{ secrets.MM_SERVER_SENTRY_ORG }}
       SENTRY_PROJECT: ${{ secrets.MM_SERVER_SENTRY_PROJECT }}
+      SENTRY_LOG_LEVEL: 'debug'
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Create Sentry release
         uses: getsentry/action-release@85e0095193a153d57c458995f99d0afd81b9e5ea # v1.3.0
+        with:
+          ignore_missing: true


### PR DESCRIPTION
#### Summary
Added ignore_missing flag for creating sentry release likely introduced by repo rename

#### Release Note
```release-note
NONE
```
