### PR TITLE
Cherry-pick MM-53031 Fix typo in index name for idx_teammembers_create_at

### DIFF
--- a/db/migrations/mysql/000092_add_createat_to_teammembers.up.sql
+++ b/db/migrations/mysql/000092_add_createat_to_teammembers.up.sql
@@ -18,7 +18,7 @@ SET @preparedStatement = (SELECT IF(
         SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
         WHERE table_name = 'TeamMembers'
         AND table_schema = DATABASE()
-        AND index_name = 'idx_teammembers_create_at'
+        AND index_name = 'idx_teammembers_createat'
     ) > 0,
     'SELECT 1',
     'CREATE INDEX idx_teammembers_createat ON TeamMembers(CreateAt);'


### PR DESCRIPTION
Manual cherry-pick of https://github.com/mattermost/mattermost/pull/23632

#### Summary
This PR fixes a typo in the migration script `000092_add_createat_to_teammembers.up.sql` that breaks idempotency.  The check for existence of index `idx_teammembers_create_at` is different than the index creation name `idx_teammembers_createat`

This is blocking a customer upgrade.

The fix is to make the names consistent, and the name will be `idx_teammembers_createat` to match the existing created indexes. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53031

#### Screenshots

#### Release Note
```release-note
Fixed typo in database migration scripts that broke idempotency.
```
