### PR TITLE
CLD-5770 - Upgrade docker CI image to 23.0.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,8 +13,8 @@ include:
 variables:
   BUILD: "yes"
   IMAGE_BUILD_SERVER: $CI_REGISTRY/mattermost/ci/images/mattermost-build-server:20230118_golang-1.19.5
-  IMAGE_BUILD_DOCKER: $CI_REGISTRY/mattermost/ci/images/mattermost-build-docker:19.03.14-1
-  IMAGE_DIND: $CI_REGISTRY/mattermost/ci/images/docker-dind:19.03.14-1
+  IMAGE_BUILD_DOCKER: $CI_REGISTRY/mattermost/ci/devops-images/mattermost-build-docker:23.0.1-0
+  IMAGE_DIND: $CI_REGISTRY/mattermost/ci/devops-images/docker-dind:23.0.1-0
 
 empty:
   stage: create-vars


### PR DESCRIPTION
#### Summary

The docker CI image upgrade was already submitted [in this MR](https://git.internal.mattermost.com/ci/bundle/-/merge_requests/65), but actually the `IMAGE_BUILD_DOCKER` in this repo overrides the variables of the same name in any downstream multi-project pipelines (eventually leading to [this issue](https://git.internal.mattermost.com/ci/bundle/-/jobs/1567540)), bringing docker back to `19.03.14` despite the above MR.

This PR should finally bring the change we need to the release pipeline.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-5770

#### Release Note
```release-note
NONE
```
