### PR TITLE
disable coverage

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -434,9 +434,6 @@ endif
 check-style: plugin-checker vet golangci-lint ## Runs style/lint checks
 
 
-do-cover-file: ## Creates the test coverage report file.
-	@echo "mode: count" > cover.out
-
 go-junit-report:
 	$(GO) install github.com/jstemmer/go-junit-report@v1.0.0
 
@@ -457,7 +454,7 @@ modules-tidy:
 		mv channels/imports/imports.go.orig channels/imports/imports.go; \
 	fi;
 
-test-server-pre: check-prereqs-enterprise start-docker go-junit-report do-cover-file ## Runs tests.
+test-server-pre: check-prereqs-enterprise start-docker go-junit-report ## Runs tests.
 ifeq ($(BUILD_ENTERPRISE_READY),true)
 	@echo Running all tests
 else
@@ -465,9 +462,9 @@ else
 endif
 
 test-server-race: test-server-pre
-	./scripts/test.sh "$(GO)" "-race $(GOFLAGS)" "$(TE_PACKAGES) $(EE_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "90m" "atomic"
-	./scripts/test.sh "$(GO)" "-race $(GOFLAGS)" "$(BOARDS_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "90m" "atomic"
-	./scripts/test.sh "$(GO)" "-race $(GOFLAGS)" "$(PLAYBOOKS_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "90m" "atomic"
+	./scripts/test.sh "$(GO)" "-race $(GOFLAGS)" "$(TE_PACKAGES) $(EE_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "90m"
+	./scripts/test.sh "$(GO)" "-race $(GOFLAGS)" "$(BOARDS_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "90m"
+	./scripts/test.sh "$(GO)" "-race $(GOFLAGS)" "$(PLAYBOOKS_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "90m"
 ifneq ($(IS_CI),true)
   ifneq ($(MM_NO_DOCKER),true)
     ifneq ($(TEMP_DOCKER_SERVICES),)
@@ -478,7 +475,7 @@ ifneq ($(IS_CI),true)
 endif
 
 test-server: test-server-pre
-	./scripts/test.sh "$(GO)" "$(GOFLAGS)" "$(SUITE_PACKAGES) $(EE_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "90m" "count"
+	./scripts/test.sh "$(GO)" "$(GOFLAGS)" "$(SUITE_PACKAGES) $(EE_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "90m"
 ifneq ($(IS_CI),true)
   ifneq ($(MM_NO_DOCKER),true)
     ifneq ($(TEMP_DOCKER_SERVICES),)
@@ -488,9 +485,9 @@ ifneq ($(IS_CI),true)
   endif
 endif
 
-test-server-ee: check-prereqs-enterprise start-docker go-junit-report do-cover-file ## Runs EE tests.
+test-server-ee: check-prereqs-enterprise start-docker go-junit-report ## Runs EE tests.
 	@echo Running only EE tests
-	./scripts/test.sh "$(GO)" "$(GOFLAGS)" "$(EE_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "20m" "count"
+	./scripts/test.sh "$(GO)" "$(GOFLAGS)" "$(EE_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "20m"
 
 test-server-quick: check-prereqs-enterprise ## Runs only quick tests.
 ifeq ($(BUILD_ENTERPRISE_READY),true)

--- a/server/channels/store/storetest/settings.go
+++ b/server/channels/store/storetest/settings.go
@@ -182,7 +182,7 @@ func databaseSettings(driver, dataSource string) *model.SqlSettings {
 	*settings.ConnMaxIdleTimeMilliseconds = 300000
 	*settings.MaxOpenConns = 100
 	*settings.QueryTimeout = 60
-	*settings.MigrationsStatementTimeoutSeconds = 10
+	*settings.MigrationsStatementTimeoutSeconds = 60
 
 	return settings
 }

--- a/server/scripts/test-xprog.sh
+++ b/server/scripts/test-xprog.sh
@@ -2,8 +2,7 @@
 set -e
 [[ $1 =~ (github.com.*)/_test ]] && \
     echo Testing ${BASH_REMATCH[1]}
-coverprofile=`pwd`/cprofile.out
 if [[ $1 == *"/enterprise/"* ]]; then
     cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
 fi
-"$@" -test.coverprofile "$coverprofile"
+"$@"

--- a/server/scripts/test.sh
+++ b/server/scripts/test.sh
@@ -10,7 +10,6 @@ TESTS=$4
 TESTFLAGS=$5
 GOBIN=$6
 TIMEOUT=$7
-COVERMODE=$8
 
 PACKAGES_COMMA=$(echo $PACKAGES | tr ' ' ',')
 export MM_SERVER_PATH=$PWD
@@ -23,15 +22,13 @@ then
 	export GOMAXPROCS=4
 fi
 
-find . -name 'cprofile*.out' -exec sh -c 'rm "{}"' \;
 find . -type d -name data -not -path './data' | xargs rm -rf
 
-$GO test $GOFLAGS -run=$TESTS $TESTFLAGS -v -timeout=$TIMEOUT -covermode=$COVERMODE -coverpkg=$PACKAGES_COMMA -exec $DIR/test-xprog.sh $PACKAGES 2>&1 > >( tee output )
+$GO test $GOFLAGS -run=$TESTS $TESTFLAGS -v -timeout=$TIMEOUT -exec $DIR/test-xprog.sh $PACKAGES 2>&1 > >( tee output )
 EXIT_STATUS=$?
 
 cat output | $GOBIN/go-junit-report > report.xml
 rm output
-find . -name 'cprofile*.out' -exec sh -c 'tail -n +2 "{}" >> cover.out ; rm "{}"' \;
 rm -f config/*.crt
 rm -f config/*.key
 


### PR DESCRIPTION
#### Summary
In the course of preparing https://github.com/mattermost/mattermost/pull/22826, I realized my server-side tests were running 3x faster. Thinking something was perhaps wrong, I narrowed it down to my ripping out the already unused coverage. 

To prove the effect, I pulled out those changes into this PR, turning off the collection of coverage data when running the Go server tests, and reducing the runtime of the test suite from ~30m to ~10m. That's ~60m of `ubuntu-latest-8-cores` usage per build!!

As part of this, bump the `settings.MigrationsStatementTimeoutSeconds` from `10s` to `60s` only when running tests to work around performance issues with the CI runners, e.g.:
```
driver: mysql, message: failed when applying migration, command: apply_migration, originalError: context deadline exceeded, query: 
```

Before:

![CleanShot 2023-06-08 at 20 30 09@2x](https://github.com/mattermost/mattermost/assets/1023171/074a5573-7fc9-4d17-9d68-b34dc982be75)

After:

![CleanShot 2023-06-08 at 20 34 30@2x](https://github.com/mattermost/mattermost/assets/1023171/2868b479-e01e-4fba-b086-d1ff6cfc9bff)

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```