### PR TITLE
Fix French typo, missing letter T in word Résultats

### DIFF
--- a/webapp/channels/src/i18n/fr.json
+++ b/webapp/channels/src/i18n/fr.json
@@ -3929,7 +3929,7 @@
   "search_header.channelFiles": "Fichiers",
   "search_header.loading": "Recherche en cours…",
   "search_header.pinnedPosts": "Messages épinglés",
-  "search_header.results": "Résulats de la recherche",
+  "search_header.results": "Résultats de la recherche",
   "search_header.search": "Recherche",
   "search_header.title2": "Mentions récentes",
   "search_header.title3": "Messages enregistrés",


### PR DESCRIPTION
```release-note
L18N French translation fix
```