### PR TITLE
MM-53115 Fix ridiculous Babel bug by removing unused code 

### DIFF
--- a/webapp/playbooks/.eslintrc.json
+++ b/webapp/playbooks/.eslintrc.json
@@ -649,6 +649,13 @@
         "@typescript-eslint/ban-ts-ignore": 0,
         "@typescript-eslint/ban-types": 1,
         "@typescript-eslint/ban-ts-comment": 0,
+        "@typescript-eslint/no-unused-vars": [
+          2,
+          {
+            "vars": "all",
+            "args": "after-used"
+          }
+        ],
         "@typescript-eslint/no-var-requires": 0,
         "@typescript-eslint/prefer-interface": 0,
         "@typescript-eslint/explicit-function-return-type": 0,

--- a/webapp/playbooks/package.json
+++ b/webapp/playbooks/package.json
@@ -107,6 +107,6 @@
     "report-unused-exports": "ts-prune",
     "start:product": "webpack --mode=development --watch",
     "deploy:product": "node scripts/deploy.js",
-    "clean": "rm -rf node_modules"
+    "clean": "rm -rf dist node_modules .eslintcache"
   }
 }

--- a/webapp/playbooks/src/actions.ts
+++ b/webapp/playbooks/src/actions.ts
@@ -102,10 +102,9 @@ export function startPlaybookRun(teamId: string, postId?: string) {
     };
 }
 
-export function openUpdateRunNameModal(playbookRunId: string, teamId: string, type: PlaybookRunType, onSubmit: (newName: string) => void) {
+export function openUpdateRunNameModal(playbookRunId: string, onSubmit: (newName: string) => void) {
     return modals.openModal(makeUpdateRunNameModalDefinition({
         playbookRunId,
-        teamId,
         onSubmit,
     }));
 }
@@ -352,8 +351,8 @@ export const setChecklistItemsFilter = (key: string, nextState: ChecklistItemsFi
     nextState,
 });
 
-export function openTaskActionsModal(onTaskActionsChange: (newTaskActions: TaskActionType[]) => void, taskActions?: TaskActionType[] | null, playbookRunId?: string) {
-    return modals.openModal(makeTaskActionsModalDefinition(onTaskActionsChange, taskActions, playbookRunId));
+export function openTaskActionsModal(onTaskActionsChange: (newTaskActions: TaskActionType[]) => void, taskActions?: TaskActionType[] | null) {
+    return modals.openModal(makeTaskActionsModalDefinition(onTaskActionsChange, taskActions));
 }
 
 export const closeBackstageRHS = (): CloseBackstageRHS => ({

--- a/webapp/playbooks/src/components/actions_modal_action_children.tsx
+++ b/webapp/playbooks/src/components/actions_modal_action_children.tsx
@@ -4,8 +4,6 @@
 import React from 'react';
 import {useIntl} from 'react-intl';
 
-import {useFloatingPortalNode} from '@floating-ui/react-dom-interactions';
-
 import {usePlaybook, usePlaybooksCrud} from 'src/hooks';
 
 import MarkdownTextbox from 'src/components/markdown_textbox';
@@ -49,7 +47,6 @@ interface OptionType {
 
 export const RunPlaybookChildren = ({playbookId, onUpdate, editable}: RunPlaybookProps) => {
     const {formatMessage} = useIntl();
-    const portalEl = useFloatingPortalNode();
     const [playbook] = usePlaybook(playbookId);
     const {playbooks, params, setSearchTerm} = usePlaybooksCrud({sort: 'title'}, {infinitePaging: false});
 

--- a/webapp/playbooks/src/components/assets/illustrations/bug_search_svg.tsx
+++ b/webapp/playbooks/src/components/assets/illustrations/bug_search_svg.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import Svg from 'src/components/assets/svg';
 
-const BugSearch = (props: {className?: string}) => (
+const BugSearch = () => (
     <Svg
         width='65'
         height='68'

--- a/webapp/playbooks/src/components/assets/illustrations/dumpster_fire_svg.tsx
+++ b/webapp/playbooks/src/components/assets/illustrations/dumpster_fire_svg.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import Svg from 'src/components/assets/svg';
 
-const DumpsterFire = (props: {className?: string}) => (
+const DumpsterFire = () => (
     <Svg
         width='60'
         height='72'

--- a/webapp/playbooks/src/components/assets/illustrations/gears_svg.tsx
+++ b/webapp/playbooks/src/components/assets/illustrations/gears_svg.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import Svg from 'src/components/assets/svg';
 
-const Gears = (props: {className?: string}) => (
+const Gears = () => (
     <Svg
         width='74'
         height='69'

--- a/webapp/playbooks/src/components/assets/illustrations/handshake_svg.tsx
+++ b/webapp/playbooks/src/components/assets/illustrations/handshake_svg.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import Svg from 'src/components/assets/svg';
 
-const Handshake = (props: {className?: string}) => (
+const Handshake = () => (
     <Svg
         width='96'
         height='61'

--- a/webapp/playbooks/src/components/assets/illustrations/light_bulb_svg.tsx
+++ b/webapp/playbooks/src/components/assets/illustrations/light_bulb_svg.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import Svg from 'src/components/assets/svg';
 
-const LightBulb = (props: {className?: string}) => (
+const LightBulb = () => (
     <Svg
         width='48'
         height='72'

--- a/webapp/playbooks/src/components/assets/illustrations/rocket_man_svg.tsx
+++ b/webapp/playbooks/src/components/assets/illustrations/rocket_man_svg.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import Svg from 'src/components/assets/svg';
 
-const RocketMan = (props: {className?: string}) => (
+const RocketMan = () => (
     <Svg
         width='176'
         height='170'

--- a/webapp/playbooks/src/components/assets/illustrations/rocket_svg.tsx
+++ b/webapp/playbooks/src/components/assets/illustrations/rocket_svg.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import Svg from 'src/components/assets/svg';
 
-const Rocket = (props: {className?: string}) => (
+const Rocket = () => (
     <Svg
         width='60'
         height='68'

--- a/webapp/playbooks/src/components/assets/illustrations/search_svg.tsx
+++ b/webapp/playbooks/src/components/assets/illustrations/search_svg.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import Svg from 'src/components/assets/svg';
 
-const Search = (props: {className?: string}) => (
+const Search = () => (
 
     <Svg
         width='180'

--- a/webapp/playbooks/src/components/assets/illustrations/smiley_sunglasses_svg.tsx
+++ b/webapp/playbooks/src/components/assets/illustrations/smiley_sunglasses_svg.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import Svg from 'src/components/assets/svg';
 
-const SmileySunglasses = (props: {className?: string}) => (
+const SmileySunglasses = () => (
     <Svg
         width='62'
         height='60'

--- a/webapp/playbooks/src/components/backstage/file_drag_detection.tsx
+++ b/webapp/playbooks/src/components/backstage/file_drag_detection.tsx
@@ -15,12 +15,12 @@ export const useFileDragDetection = () => {
             setIsDraggingFile(dragDepth > 0);
         };
 
-        const handleDragEnter = (e: DragEvent) => {
+        const handleDragEnter = () => {
             dragDepth++;
             updateIsDraggingFile();
         };
 
-        const handleDragLeave = (e: DragEvent) => {
+        const handleDragLeave = () => {
             dragDepth--;
             updateIsDraggingFile();
         };

--- a/webapp/playbooks/src/components/backstage/playbook_edit/automation/menu_list.tsx
+++ b/webapp/playbooks/src/components/backstage/playbook_edit/automation/menu_list.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useCallback} from 'react';
 
 import styled from 'styled-components';
 import {Scrollbars} from 'react-custom-scrollbars';
@@ -26,11 +26,17 @@ const ThumbVertical = styled.div`
 `;
 
 const MenuList = <T extends OptionTypeBase>(props: MenuListComponentProps<T, false>) => {
+    const renderThumbVertical = useCallback((thumbProps) => {
+        const thumbPropsWithoutStyle = {...thumbProps};
+        Reflect.deleteProperty(thumbPropsWithoutStyle, 'style');
+        return <ThumbVertical {...thumbPropsWithoutStyle}/>;
+    }, []);
+
     return (
         <MenuListWrapper>
             <StyledScrollbars
                 autoHeight={true}
-                renderThumbVertical={({style, ...thumbProps}) => <ThumbVertical {...thumbProps}/>}
+                renderThumbVertical={renderThumbVertical}
             >
                 {props.children}
             </StyledScrollbars>

--- a/webapp/playbooks/src/components/backstage/playbook_editor/outline/section_actions.tsx
+++ b/webapp/playbooks/src/components/backstage/playbook_editor/outline/section_actions.tsx
@@ -154,20 +154,6 @@ const LegacyActionsEdit = ({playbook}: Props) => {
         });
     };
 
-    const handleToggleCategorizePlaybookRun = () => {
-        updatePlaybook({
-            categorizeChannelEnabled: !playbook.categorize_channel_enabled,
-        });
-    };
-
-    const handleCategoryNameChange = (categoryName: string) => {
-        if (playbook.category_name !== categoryName) {
-            updatePlaybook({
-                categoryName,
-            });
-        }
-    };
-
     return (
         <>
             <StyledSection>

--- a/webapp/playbooks/src/components/backstage/runs_list/filters.tsx
+++ b/webapp/playbooks/src/components/backstage/runs_list/filters.tsx
@@ -64,10 +64,6 @@ const OwnerControlComponent = (ownProps: ControlProps<ProfileOption, boolean>) =
     return controlComponent(ownProps, 'owners');
 };
 
-const TeamControlComponent = (ownProps: ControlProps<TeamOption, boolean>) => {
-    return controlComponent(ownProps, 'teams');
-};
-
 const PlaybookControlComponent = (ownProps: ControlProps<PlaybookOption, boolean>) => {
     return controlComponent(ownProps, 'playbooks');
 };
@@ -75,7 +71,6 @@ const PlaybookControlComponent = (ownProps: ControlProps<PlaybookOption, boolean
 const Filters = ({fetchParams, setFetchParams, fixedPlaybook, fixedFinished}: Props) => {
     const {formatMessage} = useIntl();
     const [profileSelectorToggle, setProfileSelectorToggle] = useState(false);
-    const [teamSelectorToggle, setTeamSelectorToggle] = useState(false);
     const [playbookSelectorToggle, setPlaybookSelectorToggle] = useState(false);
     const currentTeamId = useSelector(getCurrentTeamId);
 
@@ -89,12 +84,6 @@ const Filters = ({fetchParams, setFetchParams, fixedPlaybook, fixedFinished}: Pr
     const setOwnerId = (user?: UserProfile) => {
         setFetchParams((oldParams) => {
             return {...oldParams, owner_user_id: user?.id, page: 0};
-        });
-    };
-
-    const setTeamId = (teamId?: string) => {
-        setFetchParams((oldParams) => {
-            return {...oldParams, team_id: teamId, page: 0};
         });
     };
 
@@ -120,11 +109,6 @@ const Filters = ({fetchParams, setFetchParams, fixedPlaybook, fixedFinished}: Pr
     const resetOwner = () => {
         setOwnerId();
         setProfileSelectorToggle(!profileSelectorToggle);
-    };
-
-    const resetTeam = () => {
-        setTeamId();
-        setTeamSelectorToggle(!teamSelectorToggle);
     };
 
     const resetPlaybook = () => {

--- a/webapp/playbooks/src/components/backstage/stats_view.tsx
+++ b/webapp/playbooks/src/components/backstage/stats_view.tsx
@@ -147,7 +147,7 @@ const StatsView = (props: Props) => {
                 <GraphBox>
                     <LineGraph
                         title={formatMessage({defaultMessage: 'TOTAL RUNS started per week over the last 12 weeks'})}
-                        labels={props.stats.runs_started_per_week_times.map(([start, _]) => DateTime.fromMillis(start).toLocaleString(DateTimeFormats.DATE_MED_NO_YEAR))}
+                        labels={props.stats.runs_started_per_week_times.map(([start]) => DateTime.fromMillis(start).toLocaleString(DateTimeFormats.DATE_MED_NO_YEAR))}
                         data={props.stats.runs_started_per_week}
                         tooltipTitleCallback={(date) => formatMessage({defaultMessage: 'Week of {date}'}, {date})}
                         tooltipLabelCallback={(numTotalRuns) => formatMessage({defaultMessage: '{numTotalRuns, plural, =0 {no runs started} =1 {# run started} other {# runs started}}'}, {numTotalRuns})}
@@ -159,7 +159,7 @@ const StatsView = (props: Props) => {
                 <GraphBox>
                     <BarGraph
                         title={formatMessage({defaultMessage: 'ACTIVE RUNS per day over the last 14 days'})}
-                        labels={props.stats.active_runs_per_day_times.map(([start, _]) => DateTime.fromMillis(start).toLocaleString(DateTimeFormats.DATE_MED_NO_YEAR))}
+                        labels={props.stats.active_runs_per_day_times.map(([start]) => DateTime.fromMillis(start).toLocaleString(DateTimeFormats.DATE_MED_NO_YEAR))}
                         data={props.stats.active_runs_per_day}
                         tooltipTitleCallback={(date) => formatMessage({defaultMessage: 'Day: {date}'}, {date})}
                         tooltipLabelCallback={(numActiveRuns) => formatMessage({defaultMessage: '{numActiveRuns, plural, =0 {no active runs} =1 {# active run} other {# active runs}}'}, {numActiveRuns})}
@@ -169,7 +169,7 @@ const StatsView = (props: Props) => {
                 <GraphBox>
                     <BarGraph
                         title={formatMessage({defaultMessage: 'ACTIVE PARTICIPANTS per day over the last 14 days'})}
-                        labels={props.stats.active_participants_per_day_times.map(([start, _]) => DateTime.fromMillis(start).toLocaleString(DateTimeFormats.DATE_MED_NO_YEAR))}
+                        labels={props.stats.active_participants_per_day_times.map(([start]) => DateTime.fromMillis(start).toLocaleString(DateTimeFormats.DATE_MED_NO_YEAR))}
                         data={props.stats.active_participants_per_day}
                         color={'--center-channel-color-40'}
                         tooltipTitleCallback={(date) => formatMessage({defaultMessage: 'Day: {date}'}, {date})}

--- a/webapp/playbooks/src/components/backstage/upgrade_modal.tsx
+++ b/webapp/playbooks/src/components/backstage/upgrade_modal.tsx
@@ -7,7 +7,7 @@ import GenericModal, {DefaultFooterContainer} from 'src/components/widgets/gener
 import {postMessageToAdmins} from 'src/client';
 import UpgradeModalFooter from 'src/components/backstage/upgrade_modal_footer';
 
-import {getAdminAnalytics, isCurrentUserAdmin, isTeamEdition} from 'src/selectors';
+import {isCurrentUserAdmin, isTeamEdition} from 'src/selectors';
 
 import {AdminNotificationType} from 'src/constants';
 import {isCloud} from 'src/license';
@@ -32,9 +32,6 @@ const UpgradeModal = (props: Props) => {
     const openTrialFormModal = useOpenStartTrialFormModal();
 
     const [actionState, setActionState] = useState(ModalActionState.Uninitialized);
-
-    const analytics = useSelector(getAdminAnalytics);
-    const serverTotalUsers = analytics?.TOTAL_USERS || 0;
 
     const requestLicenseSelfHosted = async () => {
         if (actionState === ModalActionState.Loading) {

--- a/webapp/playbooks/src/components/checklist_item/checklist_item.tsx
+++ b/webapp/playbooks/src/components/checklist_item/checklist_item.tsx
@@ -280,7 +280,6 @@ export const ChecklistItem = (props: ChecklistItemProps): React.ReactElement => 
             <TaskActions
                 editable={isEditing || (!props.readOnly && !isSkipped())}
                 taskActions={taskActions}
-                playbookRunId={props.playbookRunId}
                 onTaskActionsChange={onTaskActionsChange}
             />
         );

--- a/webapp/playbooks/src/components/checklist_item/task_actions.tsx
+++ b/webapp/playbooks/src/components/checklist_item/task_actions.tsx
@@ -10,7 +10,6 @@ import {openTaskActionsModal} from 'src/actions';
 interface TaskActionsProps {
     taskActions?: TaskActionType[] | null
     onTaskActionsChange: (newTaskActions: TaskActionType[]) => void;
-    playbookRunId?: string;
     editable: boolean;
 }
 
@@ -33,7 +32,7 @@ const TaskActions = (props: TaskActionsProps) => {
             isPlaceholder={!(lenTasks > 0 && enabledAction)}
             onClick={() => {
                 if (props.editable) {
-                    dispatch(openTaskActionsModal(props.onTaskActionsChange, props.taskActions, props.playbookRunId));
+                    dispatch(openTaskActionsModal(props.onTaskActionsChange, props.taskActions));
                 }
             }}
         >

--- a/webapp/playbooks/src/components/checklist_item/task_actions_modal.tsx
+++ b/webapp/playbooks/src/components/checklist_item/task_actions_modal.tsx
@@ -21,11 +21,10 @@ const MarkItemAsDoneActionType = 'mark_item_as_done';
 export const makeTaskActionsModalDefinition = (
     onTaskActionsChange: (newTaskActions: TaskActionType[]) => void,
     taskActions?: TaskActionType[] | null,
-    playbookRunId?: string,
 ) => ({
     modalId: ID,
     dialogType: TaskActionsModal,
-    dialogProps: {taskActions, onTaskActionsChange, playbookRunId},
+    dialogProps: {taskActions, onTaskActionsChange},
 });
 
 type KeywordsTriggerPayload = {keywords: string[]; user_ids: string[];}
@@ -49,10 +48,9 @@ const markAsDonePayloadFromTaskAction = (taskAction: TaskActionType): MarkAsDone
 type Props = {
     onTaskActionsChange: (newTaskActions: TaskActionType[]) => void,
     taskActions?: TaskActionType[] | null,
-    playbookRunId?: string,
 } & Partial<ComponentProps<typeof GenericModal>>;
 
-const TaskActionsModal = ({onTaskActionsChange, taskActions, playbookRunId, ...modalProps}: Props) => {
+const TaskActionsModal = ({onTaskActionsChange, taskActions, ...modalProps}: Props) => {
     const {formatMessage} = useIntl();
     const emptyTask = {} as TaskActionType;
     const taskAction = (taskActions && (taskActions.length > 0)) ? taskActions[0] : emptyTask;

--- a/webapp/playbooks/src/components/create_playbook_modal.tsx
+++ b/webapp/playbooks/src/components/create_playbook_modal.tsx
@@ -26,7 +26,6 @@ export const makePlaybookCreateModal = (props: PlaybookCreateModalProps) => ({
 
 export type PlaybookCreateModalProps = {
     startingName?: string
-    startingTeamId?: string
     startingTemplate?: string
     startingDescription?: string
     startingPublic?: boolean
@@ -45,7 +44,7 @@ const Body = styled.div`
 	}
 `;
 
-const PlaybookCreateModal = ({startingName, startingTeamId, startingTemplate, startingDescription, startingPublic, ...modalProps}: PlaybookCreateModalProps) => {
+const PlaybookCreateModal = ({startingName, startingTemplate, startingDescription, startingPublic, ...modalProps}: PlaybookCreateModalProps) => {
     const {formatMessage} = useIntl();
     const [name, setName] = useState(startingName);
     const teamId = useSelector(getCurrentTeamId);

--- a/webapp/playbooks/src/components/datetime_parsing.test.ts
+++ b/webapp/playbooks/src/components/datetime_parsing.test.ts
@@ -69,7 +69,7 @@ describe('durationFromQuery', () => {
         Settings.defaultLocale = locale;
 
         const duration = Duration.fromObject(durationObj);
-        const [long, short, narrow] = [...queries].map((query) => durationFromQuery(locale, query));
+        const [long/*, short, narrow*/] = [...queries].map((query) => durationFromQuery(locale, query));
 
         expect(long?.toMillis()).toBe(duration.toMillis());
 

--- a/webapp/playbooks/src/components/formatted_duration.tsx
+++ b/webapp/playbooks/src/components/formatted_duration.tsx
@@ -27,14 +27,6 @@ interface DurationProps {
     truncate?: TruncateBehavior;
 }
 
-const label = (num: number, style: FormatStyle, narrow: string, singular: string, plural: string) => {
-    if (style === 'narrow') {
-        return narrow;
-    }
-
-    return num >= 2 ? plural : singular;
-};
-
 const UNITS: DurationUnit[] = ['years', 'days', 'hours', 'minutes'];
 
 export const formatDuration = (value: Duration, style: FormatStyle = 'narrow', truncate: TruncateBehavior = 'none') => {

--- a/webapp/playbooks/src/components/modals/run_update_channel.tsx
+++ b/webapp/playbooks/src/components/modals/run_update_channel.tsx
@@ -44,15 +44,6 @@ const UpdateRunModal = ({
         }
     }, [run, run?.channel_id]);
 
-    const header = (
-        <Header>
-            {isPlaybookRun ? formatMessage({defaultMessage: 'Link run to a different channel'}) : formatMessage({defaultMessage: 'Link checklist to a different channel'})}
-            <ModalSubheading>
-                {run?.name}
-            </ModalSubheading>
-        </Header>
-    );
-
     return (
         <StyledGenericModal
             cancelButtonText={formatMessage({defaultMessage: 'Cancel'})}

--- a/webapp/playbooks/src/components/modals/run_update_name.tsx
+++ b/webapp/playbooks/src/components/modals/run_update_name.tsx
@@ -14,7 +14,6 @@ const ID = 'playbook_run_update';
 
 type Props = {
     playbookRunId: string;
-    teamId: string;
     onSubmit: (newName: string) => void;
 } & Partial<ComponentProps<typeof GenericModal>>;
 
@@ -26,7 +25,6 @@ export const makeModalDefinition = (props: Props) => ({
 
 const UpdateRunModal = ({
     playbookRunId,
-    teamId,
     onSubmit,
     ...modalProps
 }: Props) => {

--- a/webapp/playbooks/src/components/rhs/rhs_home.tsx
+++ b/webapp/playbooks/src/components/rhs/rhs_home.tsx
@@ -118,7 +118,7 @@ const RHSHome = () => {
             telemetryEventForTemplate(template.title, 'use_template_option');
         }
 
-        dispatch(displayPlaybookCreateModal({startingTemplate: template?.title, startingTeamId: currentTeamId}));
+        dispatch(displayPlaybookCreateModal({startingTemplate: template?.title}));
     };
 
     const headerContent = (

--- a/webapp/playbooks/src/components/rhs/rhs_run_list.tsx
+++ b/webapp/playbooks/src/components/rhs/rhs_run_list.tsx
@@ -808,7 +808,7 @@ const ContextMenu = (props: ContextMenuProps) => {
                 <FormattedMessage defaultMessage='Link run to a different channel'/>
             </StyledDropdownMenuItem>
             <StyledDropdownMenuItem
-                onClick={() => dispatch(openUpdateRunNameModal(props.playbookRunID, props.teamID, PlaybookRunType.Playbook, props.onUpdateName))}
+                onClick={() => dispatch(openUpdateRunNameModal(props.playbookRunID, props.onUpdateName))}
                 disabled={!props.canEditRun}
                 disabledAltText={formatMessage({defaultMessage: 'You do not have permission to edit this run'})}
             >
@@ -871,7 +871,7 @@ const ChannelChecklistContextMenu = (props: ChannelChecklistContextMenuProps) =>
                 <FormattedMessage defaultMessage='Link checklist to a different channel'/>
             </StyledDropdownMenuItem>
             <StyledDropdownMenuItem
-                onClick={() => dispatch(openUpdateRunNameModal(props.playbookRunID, props.teamID, PlaybookRunType.ChannelChecklist, props.onUpdateName))}
+                onClick={() => dispatch(openUpdateRunNameModal(props.playbookRunID, props.onUpdateName))}
                 disabled={!props.canEditRun}
                 disabledAltText={formatMessage({defaultMessage: 'You do not have permission to edit this checklist'})}
             >

--- a/webapp/playbooks/src/components/upgrade_banner.tsx
+++ b/webapp/playbooks/src/components/upgrade_banner.tsx
@@ -11,7 +11,7 @@ import General from 'mattermost-redux/constants/general';
 import {FormattedMessage} from 'react-intl';
 
 import LoadingSpinner from 'src/components/assets/loading_spinner';
-import {getAdminAnalytics, isTeamEdition} from 'src/selectors';
+import {isTeamEdition} from 'src/selectors';
 import StartTrialNotice from 'src/components/backstage/start_trial_notice';
 import ConvertEnterpriseNotice from 'src/components/backstage/convert_enterprise_notice';
 import {postMessageToAdmins} from 'src/client';
@@ -126,9 +126,6 @@ const UpgradeBanner = (props: Props) => {
     const [actionState, setActionState] = useState(ActionState.Uninitialized);
     const isServerTeamEdition = useSelector(isTeamEdition);
     const openTrialFormModal = useOpenStartTrialFormModal();
-
-    const analytics = useSelector(getAdminAnalytics);
-    const serverTotalUsers = analytics?.TOTAL_USERS || 0;
 
     const endUserMainAction = async () => {
         if (actionState === ActionState.Loading) {

--- a/webapp/playbooks/src/graphql/generated/fragment-masking.ts
+++ b/webapp/playbooks/src/graphql/generated/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import {TypedDocumentNode as DocumentNode, ResultOf} from '@graphql-typed-document-node/core';
 
 export type FragmentType<TDocumentType extends DocumentNode<any, any>> = TDocumentType extends DocumentNode<

--- a/webapp/playbooks/src/hooks/general.test.ts
+++ b/webapp/playbooks/src/hooks/general.test.ts
@@ -80,7 +80,7 @@ describe('useEnsureProfile', () => {
         useDispatchSpy.mockReturnValue(mockDispatchFn);
 
         const userId = 'unknown';
-        const {rerender} = renderHook(() => {
+        renderHook(() => {
             useEnsureProfile(userId);
         });
         expect(mockDispatchFn).toHaveBeenCalledTimes(1);
@@ -184,7 +184,7 @@ describe('useEnsureProfiles', () => {
         useDispatchSpy.mockReturnValue(mockDispatchFn);
 
         const userIds = ['user1', 'user2', 'unknown'];
-        const {rerender} = renderHook(() => {
+        renderHook(() => {
             useEnsureProfiles(userIds);
         });
         expect(mockDispatchFn).toHaveBeenCalledTimes(1);

--- a/webapp/playbooks/src/index.tsx
+++ b/webapp/playbooks/src/index.tsx
@@ -6,7 +6,6 @@ import {render, unmountComponentAtNode} from 'react-dom';
 import {Store, Unsubscribe} from 'redux';
 import {Redirect, useLocation, useRouteMatch} from 'react-router-dom';
 import {GlobalState} from '@mattermost/types/store';
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {Client4} from 'mattermost-redux/client';
 import WebsocketEvents from 'mattermost-redux/constants/websocket';
 import {General} from 'mattermost-redux/constants';
@@ -203,7 +202,6 @@ export default class Plugin {
 
         // App Bar icon
         if (registry.registerAppBarComponent) {
-            const siteUrl = getConfig(store.getState())?.SiteURL || '';
             registry.registerAppBarComponent(appIcon, boundToggleRHSAction, ChannelHeaderTooltip);
         }
 

--- a/webapp/playbooks/src/types/playbook_run.ts
+++ b/webapp/playbooks/src/types/playbook_run.ts
@@ -93,10 +93,6 @@ export interface RunMetricData {
     value: number | null;
 }
 
-function isString(arg: any): arg is string {
-    return Boolean(typeof arg === 'string');
-}
-
 export function playbookRunIsActive(playbookRun: PlaybookRun): boolean {
     return playbookRun.current_status === PlaybookRunStatus.InProgress;
 }

--- a/webapp/playbooks/src/types/settings.ts
+++ b/webapp/playbooks/src/types/settings.ts
@@ -20,6 +20,7 @@ export function globalSettingsSetDefaults(globalSettings?: Partial<GlobalSetting
     }
 
     // Strip bad values from partial
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const fixedGlobalSettings = Object.fromEntries(Object.entries(globalSettings).filter(([_, value]) => value !== null));
 
     return {...defaults, ...fixedGlobalSettings};


### PR DESCRIPTION
#### Summary
There's a more thorough explanation of this bug starting from [this post](https://community.mattermost.com/core/pl/my19ijhsciyk5fmr5xnhke937r) in that thread which goes into more detail about the issue, but basically, both `UpgradeModal` and `UpgradeBanner` have the following code
```js
const analytics = useSelector(getAdminAnalytics);
const serverTotalUsers = analytics?.TOTAL_USERS || 0;
```
which they never use the result of. For whatever reason, the updated version of Babel from https://github.com/mattermost/mattermost/pull/23543 rewrites that to call the selector, discards the result of it, and then call `analytics?.TOTAL_USERS` without having ever declared `analytics` which causes an error. After figuring that all out, thankfully, it was easy enough to fix by just removing the code that wasn't actually used.

I also decided to turn on the TS version of `no-unused-vars` in Playbooks to ensure we aren't running into this sort of thing anywhere else.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53115

#### Release Note
```release-note
NONE
```
