### PR TITLE
Remove use case onboarding feature flag

### DIFF
--- a/server/channels/app/migrations.go
+++ b/server/channels/app/migrations.go
@@ -473,12 +473,6 @@ func (s *Server) doPlaybooksRolesCreationMigration() {
 const existingInstallationPostsThreshold = 10
 
 func (s *Server) doFirstAdminSetupCompleteMigration() {
-	// Don't run the migration until the flag is turned on.
-
-	if !s.platform.Config().FeatureFlags.UseCaseOnboarding {
-		return
-	}
-
 	// If the migration is already marked as completed, don't do it again.
 	if _, err := s.Store().System().GetByName(FirstAdminSetupCompleteKey); err == nil {
 		return

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -41,9 +41,6 @@ type FeatureFlags struct {
 
 	NormalizeLdapDNs bool
 
-	// Enable special onboarding flow for first admin
-	UseCaseOnboarding bool
-
 	// Enable GraphQL feature
 	GraphQL bool
 
@@ -91,7 +88,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.BoardsFeatureFlags = ""
 	f.BoardsDataRetention = false
 	f.NormalizeLdapDNs = false
-	f.UseCaseOnboarding = true
 	f.GraphQL = false
 	f.InsightsEnabled = true
 	f.CommandPalette = false


### PR DESCRIPTION
#### Summary

Remove use case onboarding feature flag that is no longer used. Currently, the full-screen onboarding is only shown for the first admin the first time they start a new server. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53085

#### Release Note
```release-note
NONE
```
