### PR TITLE
[MM-52867] feat: add advisor warn log for Elasticsearch

### DIFF
--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -1243,7 +1243,7 @@ func runConfigCleanupJob(s *Server) {
 
 func runElasticsearchWorkspaceOptimizationJob(s *Server) {
 	// Schedule startup job
-	model.CreateRecurringTaskFromNextIntervalTime("Elasticsearch workspace optimization check (startup)", func() {
+	model.CreateTask("Elasticsearch workspace optimization check (startup)", func() {
 		doElasticsearchWorkspaceOptimizationCheck(s)
 	}, time.Minute*10)
 

--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -1245,8 +1245,7 @@ func runElasticsearchWorkspaceOptimizationJob(s *Server) {
 	doElasticsearchWorkspaceOptimizationCheck(s)
 	model.CreateRecurringTask("Elasticsearch workspace optimization check", func() {
 		doElasticsearchWorkspaceOptimizationCheck(s)
-		// }, time.Hour*24)
-	}, time.Minute*1)
+	}, time.Hour*24)
 }
 
 func (s *Server) runLicenseExpirationCheckJob() {

--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -1342,7 +1342,7 @@ func doElasticsearchWorkspaceOptimizationCheck(s *Server) {
 
 	postCount, err := s.Store().Post().AnalyticsPostCount(&model.PostCountOptions{})
 	if err != nil {
-		s.Log().Error("error getting post count to display warning", mlog.Err(err))
+		s.Log().Error("error getting post count to do a search engine display", mlog.Err(err))
 		return
 	}
 

--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -1242,7 +1242,12 @@ func runConfigCleanupJob(s *Server) {
 }
 
 func runElasticsearchWorkspaceOptimizationJob(s *Server) {
-	doElasticsearchWorkspaceOptimizationCheck(s)
+	// Schedule startup job
+	model.CreateRecurringTaskFromNextIntervalTime("Elasticsearch workspace optimization check (startup)", func() {
+		doElasticsearchWorkspaceOptimizationCheck(s)
+	}, time.Minute*10)
+
+	// Schedule recurring job
 	model.CreateRecurringTask("Elasticsearch workspace optimization check", func() {
 		doElasticsearchWorkspaceOptimizationCheck(s)
 	}, time.Hour*24)

--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -1347,7 +1347,7 @@ func doElasticsearchWorkspaceOptimizationCheck(s *Server) {
 
 	userCount, err := s.Store().User().Count(model.UserCountOptions{})
 	if err != nil {
-		s.Log().Error("error getting user count to display warning", mlog.Err(err))
+		s.Log().Error("error getting user count to do a search engine display", mlog.Err(err))
 		return
 	}
 

--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -1821,3 +1821,49 @@ func (s *Server) Log() *mlog.Logger {
 func (s *Server) NotificationsLog() *mlog.Logger {
 	return s.platform.NotificationsLogger()
 }
+
+// StartConsoleWarnings starts a goroutine that periodically checks and displays warnings in the console.
+func (s *Server) StartConsoleWarnings() error {
+	// Check license and license feature
+	if s.License() == nil || s.License().Features.Elasticsearch == nil || !*s.License().Features.Elasticsearch {
+		return nil
+	}
+
+	// Check if elasticsearch is enabled
+	if !(s.Config().ElasticsearchSettings.EnableIndexing != nil && *s.Config().ElasticsearchSettings.EnableIndexing &&
+		s.Config().ElasticsearchSettings.EnableSearching != nil && *s.Config().ElasticsearchSettings.EnableSearching) {
+		return nil
+	}
+
+	checkElasticsearch := func() {
+		postCount, err := s.Store().Post().AnalyticsPostCount(&model.PostCountOptions{})
+		if err != nil {
+			s.Log().Error("error getting post count to display warning", mlog.Err(err))
+			return
+		}
+
+		userCount, err := s.Store().User().Count(model.UserCountOptions{})
+		if err != nil {
+			s.Log().Error("error getting user count to display warning", mlog.Err(err))
+			return
+		}
+
+		if postCount > 2000000 && userCount > 500 {
+			s.Log().Warn("Your system exceeds 2,000,000 messages. We highly recommend deploying Elasticsearch to optimize search performance in your system. Learn more at https://mattermost.com/pl/setup-elasticsearch")
+		}
+	}
+
+	go func() {
+		ticker := time.NewTicker(24 * time.Hour)
+		defer ticker.Stop()
+
+		// Ensure it runs before the ticker
+		checkElasticsearch()
+
+		for range ticker.C {
+			checkElasticsearch()
+		}
+	}()
+
+	return nil
+}

--- a/server/cmd/mattermost/commands/server.go
+++ b/server/cmd/mattermost/commands/server.go
@@ -78,10 +78,6 @@ func runServer(configStore *config.Store, interruptChan chan os.Signal) error {
 	}
 	defer server.Shutdown()
 
-	if err = server.StartConsoleWarnings(); err != nil {
-		mlog.Error(err.Error())
-	}
-
 	// We add this after shutdown so that it can be called
 	// before server shutdown happens as it can close
 	// the advanced logger and prevent the mlog call from working properly.

--- a/server/cmd/mattermost/commands/server.go
+++ b/server/cmd/mattermost/commands/server.go
@@ -77,6 +77,11 @@ func runServer(configStore *config.Store, interruptChan chan os.Signal) error {
 		return err
 	}
 	defer server.Shutdown()
+
+	if err = server.StartConsoleWarnings(); err != nil {
+		mlog.Error(err.Error())
+	}
+
 	// We add this after shutdown so that it can be called
 	// before server shutdown happens as it can close
 	// the advanced logger and prevent the mlog call from working properly.


### PR DESCRIPTION
#### Summary

This commit addresses the addition of a new warning log line for server admins that advise the usage of Elasticsearch when the post count is too big and Elastic is not enabled.

#### Notes 

This is merely a draft, requesting some feedback since this is my first contribution to the suite:
- Made a single method for the logic since the codebase is pretty big and I wasn't sure where this should land. Suggestions appreciated.
- Initially I used `app.GetAnalytics()`, but that performs more queries that I needed and I didn't wan't to modify that method (at least not without confirming that I should). Maybe we could cache the analytics?
- This will add two `COUNT` queries daily. It shouldn't be much in terms of performance, and since the requirements are pretty specific it shouldn't pose an issue. If you have any concerns please let me know.
- I tried to replicate the same conditions used in [the webapp](https://github.com/mattermost/mattermost/blob/master/webapp/channels/src/components/admin_console/workspace-optimization/dashboard_checks/performance.ts#L11-L59). Please let me know if that's appropriate or if I should get the data from somewhere else.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-52867

#### Release Note
```release-note
feat: advise admins of elasticsearch usage in console periodically
```
