### PR TITLE
[MM-52986] Add theming support to one of the dropdown input components

### DIFF
--- a/webapp/channels/src/components/dropdown_input.scss
+++ b/webapp/channels/src/components/dropdown_input.scss
@@ -25,6 +25,20 @@ $dropdown_input_index: 999999;
     }
 }
 
+.DropdownInput__controlContainer {
+    .DropDown__control {
+        background-color: var(--center-channel-bg);
+    }
+}
+
+.DropDown__menu {
+    background-color: var(--center-channel-bg) !important;
+}
+
+.DropDown__single-value {
+    color: var(--center-channel-color) !important;
+}
+
 .DropdownInput__indicatorsContainer {
     margin-right: 8px;
 


### PR DESCRIPTION
#### Summary
This dropdown input component wasn't displaying correctly when certain dark mode themes were activated because its default styles were not overridden by the theme variables. 

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
Before:
![image](https://github.com/mattermost/mattermost/assets/12176405/5757deba-a223-4e4b-a605-f47cba09a503)
After:
![image](https://github.com/mattermost/mattermost/assets/12176405/d274774c-5e86-4d53-bb2c-928e60d22976)
 



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
