### PR TITLE
Cypress/E2E: Fixed failed e2e tests

### DIFF
--- a/e2e-tests/cypress/tests/fixtures/markdown/markdown_inline_images_6.md
+++ b/e2e-tests/cypress/tests/fixtures/markdown/markdown_inline_images_6.md
@@ -1,3 +1,3 @@
 ### In-line Images
 
-![test image](https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/image-small-height.png)
+![test image](https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/image-small-height.png)

--- a/e2e-tests/cypress/tests/integration/channels/files_and_attachments/image_link_preview_new_window_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/files_and_attachments/image_link_preview_new_window_spec.js
@@ -30,7 +30,7 @@ describe('Image Link Preview', () => {
     });
 
     it('MM-T329 Image link preview', () => {
-        const link = 'https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/image-small-height.png';
+        const link = 'https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/image-small-height.png';
         const baseUrl = Cypress.config('baseUrl');
         const encodedIconUrl = encodeURIComponent(link);
 

--- a/e2e-tests/cypress/tests/integration/channels/files_and_attachments/image_link_preview_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/files_and_attachments/image_link_preview_spec.js
@@ -38,7 +38,7 @@ describe('Image Link Preview', () => {
     });
 
     it('MM-T331 Image link preview - Collapse and expand', () => {
-        const link = 'https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/small-image.png';
+        const link = 'https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/small-image.png';
 
         // # Post a link to an externally hosted image
         cy.postMessage(link);
@@ -178,13 +178,13 @@ describe('Image Link Preview', () => {
             {
                 filename: 'image-1000x40.jpg',
                 originalSize: {width: 1000, height: 40},
-                thumbnailSize: {width: 948, height: 38},
+                thumbnailSize: {width: 899, height: 36},
                 containerSize: {height: 46},
             },
             {
                 filename: 'image-1600x40.jpg',
                 originalSize: {width: 1600, height: 40},
-                thumbnailSize: {width: 948, height: 24},
+                thumbnailSize: {width: 899, height: 23},
                 previewSize: {width: 1204, height: 30},
                 containerSize: {height: 46},
             },

--- a/e2e-tests/cypress/tests/integration/channels/integrations/slash_commands_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/integrations/slash_commands_spec.js
@@ -188,7 +188,7 @@ describe('Integrations', () => {
         cy.getLastPost().should('contain', 'Image links now expand by default').and('contain', 'System');
 
         // # Post message
-        cy.postMessage('https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/png-image-file.png');
+        cy.postMessage('https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/png-image-file.png');
         cy.getLastPostId().as('postID');
 
         cy.get('@postID').then((postID) => {
@@ -208,7 +208,7 @@ describe('Integrations', () => {
         cy.visit(offTopicUrl1);
 
         // # Post message
-        cy.postMessage('https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/png-image-file.png');
+        cy.postMessage('https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/png-image-file.png');
         cy.getLastPostId().as('postID');
 
         // # Open RHS
@@ -244,6 +244,7 @@ describe('Integrations', () => {
     it('MM-T705 Ephemeral message', () => {
         cy.apiAdminLogin();
         cy.visit(offTopicUrl1);
+        cy.postMessage('hello');
 
         // # Navigate to slash commands and create the slash command
         cy.uiOpenProductMenu('Integrations');

--- a/e2e-tests/cypress/tests/integration/channels/markdown/markdown_image_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/markdown/markdown_image_spec.js
@@ -122,7 +122,7 @@ describe('Markdown', () => {
 
     it('channel header is markdown image', () => {
         // # Update channel header
-        cy.updateChannelHeader('![MM Logo](https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/small-image.png)').wait(TIMEOUTS.TWO_SEC);
+        cy.updateChannelHeader('![MM Logo](https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/small-image.png)').wait(TIMEOUTS.TWO_SEC);
 
         // * Verify image in header
         cy.get('#channelHeaderDescription').find('span.markdown__paragraph-inline').as('imageDiv');
@@ -145,7 +145,7 @@ describe('Markdown', () => {
 
     it('channel header is markdown image that is also a link', () => {
         // # Update channel header
-        cy.updateChannelHeader('[![Build Status](https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/small-image.png)](https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/small-image.png)').wait(TIMEOUTS.TWO_SEC);
+        cy.updateChannelHeader('[![Build Status](https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/small-image.png)](https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/small-image.png)').wait(TIMEOUTS.TWO_SEC);
 
         // * Verify image in header
         cy.get('#channelHeaderDescription').find('span.markdown__paragraph-inline').as('imageDiv');

--- a/e2e-tests/cypress/tests/integration/channels/messaging/inline_images_open_preview_window_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/inline_images_open_preview_window_spec.js
@@ -21,7 +21,7 @@ describe('Messaging', () => {
 
     it('MM-T187 Inline markdown images open preview window', () => {
         // # Post the image link to the channel
-        cy.postMessage('Hello ![test image](https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/image-small-height.png)');
+        cy.postMessage('Hello ![test image](https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/image-small-height.png)');
 
         // * Confirm the image container is visible
         cy.uiWaitUntilMessagePostedIncludes('Hello');


### PR DESCRIPTION
#### Summary
Fixed failed e2e tests

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-5824
Found at https://github.com/mattermost/mattermost/pull/23660

#### Screenshots
<img width="925" alt="Screenshot 2023-06-14 at 5 34 15 PM" src="https://github.com/mattermost/mattermost/assets/5334504/08d3b04f-4e15-4d1b-9cc8-97cf602994b0">
<img width="927" alt="Screenshot 2023-06-14 at 5 34 00 PM" src="https://github.com/mattermost/mattermost/assets/5334504/03f91f77-01bd-48c7-954d-3380881cf812">
<img width="929" alt="Screenshot 2023-06-14 at 5 33 44 PM" src="https://github.com/mattermost/mattermost/assets/5334504/ca354b5c-bf8a-4df9-aff3-b2bea35cadfc">
<img width="927" alt="Screenshot 2023-06-14 at 5 33 21 PM" src="https://github.com/mattermost/mattermost/assets/5334504/7b9473c1-5a88-468e-b137-65549e16497f">
<img width="930" alt="Screenshot 2023-06-14 at 5 32 51 PM" src="https://github.com/mattermost/mattermost/assets/5334504/a203b5b0-db56-463e-a963-e024c4d85f13">


#### Release Note
```release-note
NONE
```
