### PR TITLE
[MM-53195] services/telemetry: regen client config right after assigning diagnostic ID to platform

### DIFF
--- a/server/channels/app/platform/service.go
+++ b/server/channels/app/platform/service.go
@@ -381,6 +381,7 @@ func (ps *PlatformService) ShutdownConfig() error {
 
 func (ps *PlatformService) SetTelemetryId(id string) {
 	ps.telemetryId = id
+	ps.regenerateClientConfig()
 }
 
 func (ps *PlatformService) SetLogger(logger *mlog.Logger) {

--- a/server/channels/app/platform/service.go
+++ b/server/channels/app/platform/service.go
@@ -381,6 +381,12 @@ func (ps *PlatformService) ShutdownConfig() error {
 
 func (ps *PlatformService) SetTelemetryId(id string) {
 	ps.telemetryId = id
+
+	ps.PostTelemetryIdHook()
+}
+
+// PostTelemetryIdHook triggers necessary events to propagate telemtery ID
+func (ps *PlatformService) PostTelemetryIdHook() {
 	ps.regenerateClientConfig()
 }
 

--- a/server/channels/app/platform/service_test.go
+++ b/server/channels/app/platform/service_test.go
@@ -168,3 +168,19 @@ func TestShutdown(t *testing.T) {
 		require.Zero(t, atomic.LoadInt32(&th.Service.goroutineCount))
 	})
 }
+
+func TestSetTelemetryId(t *testing.T) {
+	t.Run("ensure client config is regenerated after setting the telemetry id", func(t *testing.T) {
+		th := Setup(t)
+		defer th.TearDown()
+
+		clientConfig := th.Service.LimitedClientConfig()
+		require.Empty(t, clientConfig["DiagnosticId"])
+
+		id := model.NewId()
+		th.Service.SetTelemetryId(id)
+
+		clientConfig = th.Service.LimitedClientConfig()
+		require.Equal(t, clientConfig["DiagnosticId"], id)
+	})
+}

--- a/server/platform/services/telemetry/telemetry.go
+++ b/server/platform/services/telemetry/telemetry.go
@@ -146,7 +146,7 @@ func (ts *TelemetryService) ensureTelemetryID() error {
 	var err error
 
 	for i := 0; i < DBAccessAttempts; i++ {
-		ts.log.Info("Ensuring the telemetry ID", mlog.String("id", id))
+		ts.log.Info("Ensuring the telemetry ID..")
 		systemID := &model.System{Name: model.SystemTelemetryId, Value: id}
 		systemID, err = ts.dbStore.System().InsertIfExists(systemID)
 		if err != nil {
@@ -156,6 +156,7 @@ func (ts *TelemetryService) ensureTelemetryID() error {
 		}
 
 		ts.TelemetryID = systemID.Value
+		ts.log.Info("telemetry ID is set", mlog.String("id", ts.TelemetryID))
 		return nil
 	}
 


### PR DESCRIPTION


#### Summary
We need to regenerate client config immedeately after we update the diagnostic ID (ie. telemetry ID) as there is a possibilty we don't compute client config for a while and this makes client config to miss diagnostic ID.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53195

#### Release Note

```release-note
NONE
```
