### PR TITLE
Added debug log for missing post id in embedded permalink

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
@@ -219,7 +219,9 @@ export function handlePosts(state: RelationOneToOne<Post, Post> = {}, action: Ge
 
                 for (const embed of otherPost.metadata.embeds) {
                     if (embed.type === 'permalink' && embed.data && !('post_id' in embed.data)) {
+                        // eslint-disable-next-line no-console
                         console.error('post_id missing in post embed data for permalink.');
+                        // eslint-disable-next-line no-console
                         console.error(embed.data);
                     }
 

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
@@ -218,7 +218,7 @@ export function handlePosts(state: RelationOneToOne<Post, Post> = {}, action: Ge
                 const newEmbeds: PostEmbed[] = [];
 
                 for (const embed of otherPost.metadata.embeds) {
-                    if (embed.type === 'permalink' && (embed.data as PostPreviewMetadata).post_id === post.id) {
+                    if (embed.type === 'permalink' && embed.data && 'post_id' in embed.data && (embed.data as PostPreviewMetadata).post_id === post.id) {
                         // skip if the embed is the deleted post
                         continue;
                     }

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
@@ -28,6 +28,7 @@ import {
 } from '@mattermost/types/utilities';
 
 import {TopThread} from '@mattermost/types/insights';
+import {isDevModeEnabled} from "../../../../../selectors/general";
 
 export function removeUnneededMetadata(post: Post) {
     if (!post.metadata) {
@@ -218,7 +219,12 @@ export function handlePosts(state: RelationOneToOne<Post, Post> = {}, action: Ge
                 const newEmbeds: PostEmbed[] = [];
 
                 for (const embed of otherPost.metadata.embeds) {
-                    if (embed.type === 'permalink' && embed.data && 'post_id' in embed.data && (embed.data as PostPreviewMetadata).post_id === post.id) {
+                    if (embed.type === 'permalink' && embed.data && !('post_id' in embed.data)) {
+                        console.error('post_id missing in post embed data for permalink.');
+                        console.error(embed.data);
+                    }
+
+                    if (embed.type === 'permalink' && (embed.data as PostPreviewMetadata).post_id === post.id) {
                         // skip if the embed is the deleted post
                         continue;
                     }

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
@@ -28,7 +28,6 @@ import {
 } from '@mattermost/types/utilities';
 
 import {TopThread} from '@mattermost/types/insights';
-import {isDevModeEnabled} from "../../../../../selectors/general";
 
 export function removeUnneededMetadata(post: Post) {
     if (!post.metadata) {


### PR DESCRIPTION
#### Summary
Adds stricter checks before accessing post permalink embed data post id, basically following whats being done in other location. I couldn't reproduce the bug llocally amd am still thinking of scenarios where this could occur, but meanwhile adding stricter checks before accessing values.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53138

#### Release Note
```release-note
NONE
```
