### PR TITLE
Update minimum supported Edge version

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9769,7 +9769,7 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "Version 110+"
+    "translation": "Version 112+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",


### PR DESCRIPTION
Update minimum required Edge version to v112+ as the minimum supported Chrome version was recently updated to v112+. Chrome and Edge are using the same code base and they normally need to be on the same version.

```release-note
Update minimum required Edge version to 112+.
```