### PR TITLE
Don't start grafana/prometheus by default

### DIFF
--- a/server/build/docker-compose.yml
+++ b/server/build/docker-compose.yml
@@ -56,9 +56,7 @@ services:
       - inbucket
       - openldap
       - elasticsearch
-      - prometheus
-      - grafana
-    command: postgres:5432 mysql:3306 minio:9000 inbucket:9001 openldap:389 elasticsearch:9200 prometheus:9090 grafana:3000
+    command: postgres:5432 mysql:3306 minio:9000 inbucket:9001 openldap:389 elasticsearch:9200
 
 networks:
   mm-test:

--- a/server/build/gitlab-dc.mysql.yml
+++ b/server/build/gitlab-dc.mysql.yml
@@ -90,9 +90,7 @@ services:
       - inbucket
       - openldap
       - elasticsearch
-      - prometheus
-      - grafana
-    command: mysql:3306 minio:9000 inbucket:9001 openldap:389 elasticsearch:9200 prometheus:9090 grafana:3000
+    command: mysql:3306 minio:9000 inbucket:9001 openldap:389 elasticsearch:9200
     networks:
       default:
 

--- a/server/build/gitlab-dc.postgres.yml
+++ b/server/build/gitlab-dc.postgres.yml
@@ -88,9 +88,7 @@ services:
       - inbucket
       - openldap
       - elasticsearch
-      - prometheus
-      - grafana
-    command: postgres:5432 minio:9000 inbucket:9001 openldap:389 elasticsearch:9200 prometheus:9090 grafana:3000
+    command: postgres:5432 minio:9000 inbucket:9001 openldap:389 elasticsearch:9200
     networks:
       default:
 


### PR DESCRIPTION
#### Summary
Don't list Prometheus and Grafana as targets in the `start_dependencies` target of the docker compose file used in CI and local development. These can still be started by hand, but will no longer waste resources in CI, nor fail builds spuriously if they fail to come online.

Most relevantly, fixes this:
<img width="583" alt="image" src="https://github.com/mattermost/mattermost/assets/1023171/4c6bdb27-f732-46b5-a001-38e0c7d4d1a7">

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
