### PR TITLE
[MM-53254] Fix make pluginapi

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -403,7 +403,7 @@ mmctl-mocks: ## Creates mocks for mmctl
 	$(GOBIN)/mockgen -destination=cmd/mmctl/mocks/client_mock.go -copyright_file=cmd/mmctl/mocks/copyright.txt -package=mocks github.com/mattermost/mattermost/server/v8/cmd/mmctl/client Client
 
 pluginapi: ## Generates api and hooks glue code for plugins
-	$(GO) generate $(GOFLAGS) ./public/plugin
+	-cd ./public && $(GO) generate $(GOFLAGS) ./plugin
 
 mocks: store-mocks telemetry-mocks filestore-mocks ldap-mocks plugin-mocks einterfaces-mocks searchengine-mocks sharedchannel-mocks misc-mocks email-mocks platform-mocks mmctl-mocks
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -403,7 +403,7 @@ mmctl-mocks: ## Creates mocks for mmctl
 	$(GOBIN)/mockgen -destination=cmd/mmctl/mocks/client_mock.go -copyright_file=cmd/mmctl/mocks/copyright.txt -package=mocks github.com/mattermost/mattermost/server/v8/cmd/mmctl/client Client
 
 pluginapi: ## Generates api and hooks glue code for plugins
-	-cd ./public && $(GO) generate $(GOFLAGS) ./plugin
+	cd ./public && $(GO) generate $(GOFLAGS) ./plugin
 
 mocks: store-mocks telemetry-mocks filestore-mocks ldap-mocks plugin-mocks einterfaces-mocks searchengine-mocks sharedchannel-mocks misc-mocks email-mocks platform-mocks mmctl-mocks
 


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost/pull/23345 moved the `public` directory under the new `public` go module. This broke the `pluginapi` make target, as it doesn't pick up the `//go:generate` directives any longer.

I suppose the reason is the newly added go module. This PR fixes the issue by running `go generate` from inside the `public` module.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53254

#### Release Note
```release-note
NONE
```
