### PR TITLE
[MM-52943] fix: enable Elasticsearch properly on restart

### DIFF
--- a/server/channels/app/platform/searchengine.go
+++ b/server/channels/app/platform/searchengine.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (ps *PlatformService) StartSearchEngine() (string, string) {
-	if ps.SearchEngine.ElasticsearchEngine != nil && ps.SearchEngine.ElasticsearchEngine.IsActive() {
+	if ps.SearchEngine.ElasticsearchEngine != nil && ps.SearchEngine.ElasticsearchEngine.IsEnabled() {
 		ps.Go(func() {
 			if err := ps.SearchEngine.ElasticsearchEngine.Start(); err != nil {
 				ps.Log().Error(err.Error())

--- a/server/platform/services/searchengine/bleveengine/bleve.go
+++ b/server/platform/services/searchengine/bleveengine/bleve.go
@@ -220,7 +220,7 @@ func (b *BleveEngine) Stop() *model.AppError {
 }
 
 func (b *BleveEngine) IsEnabled() bool {
-	return b.IsActive()
+	return b.IsIndexingEnabled()
 }
 
 func (b *BleveEngine) IsActive() bool {

--- a/server/platform/services/searchengine/bleveengine/bleve.go
+++ b/server/platform/services/searchengine/bleveengine/bleve.go
@@ -219,6 +219,10 @@ func (b *BleveEngine) Stop() *model.AppError {
 	return b.closeIndexes()
 }
 
+func (b *BleveEngine) IsEnabled() bool {
+	return b.IsActive()
+}
+
 func (b *BleveEngine) IsActive() bool {
 	return atomic.LoadInt32(&b.ready) == 1
 }

--- a/server/platform/services/searchengine/interface.go
+++ b/server/platform/services/searchengine/interface.go
@@ -17,6 +17,8 @@ type SearchEngineInterface interface {
 	GetPlugins() []string
 	UpdateConfig(cfg *model.Config)
 	GetName() string
+	// IsEnabled returns a boolean indicating whether the engine is enabled in the settings
+	IsEnabled() bool
 	IsActive() bool
 	IsIndexingEnabled() bool
 	IsSearchEnabled() bool

--- a/server/platform/services/searchengine/mocks/SearchEngineInterface.go
+++ b/server/platform/services/searchengine/mocks/SearchEngineInterface.go
@@ -326,6 +326,20 @@ func (_m *SearchEngineInterface) IsAutocompletionEnabled() bool {
 	return r0
 }
 
+// IsEnabled provides a mock function with given fields:
+func (_m *SearchEngineInterface) IsEnabled() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // IsIndexingEnabled provides a mock function with given fields:
 func (_m *SearchEngineInterface) IsIndexingEnabled() bool {
 	ret := _m.Called()


### PR DESCRIPTION
#### Summary

During some investigation of Elasticsearch issues, I found out that the Elasticsearch engine wasn't properly booting on a server restart. Putting a breakpoint on the `Start()` method of the engine showed that this was only called on a configuration or license change (as it should be), but the initial call wasn't going through because the `IsActive()` checks for the engine to be enabled, and the `Start()` method takes care of that (but it's never called). 

I've added a new method to the interface `IsEnabled()` that will return if the engine is enabled regardless if it is currently running or not.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-52943

#### Screenshots
--

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
fix: properly start elasticsearch on startup if enabled
```
