### PR TITLE
MM-53274 - Add a "feature flag" for Calls ringing

### DIFF
--- a/webapp/channels/src/components/user_settings/notifications/desktop_notification_setting/desktop_notification_settings.test.tsx
+++ b/webapp/channels/src/components/user_settings/notifications/desktop_notification_setting/desktop_notification_settings.test.tsx
@@ -33,7 +33,7 @@ describe('components/user_settings/notifications/DesktopNotificationSettings', (
         threads: NotificationLevels.ALL,
         callsSelectedSound: 'Dynamic',
         callsSound: 'false',
-        isCallsEnabled: false,
+        isCallsRingingEnabled: false,
     };
 
     test('should match snapshot, on max setting', () => {

--- a/webapp/channels/src/components/user_settings/notifications/desktop_notification_setting/desktop_notification_settings.test.tsx
+++ b/webapp/channels/src/components/user_settings/notifications/desktop_notification_setting/desktop_notification_settings.test.tsx
@@ -54,7 +54,7 @@ describe('components/user_settings/notifications/DesktopNotificationSettings', (
     });
 
     test('should match snapshot, on max setting with Calls enabled', () => {
-        const props = {...baseProps, isCallsEnabled: true};
+        const props = {...baseProps, isCallsRingingEnabled: true};
         const wrapper = shallow(
             <DesktopNotificationSettings {...props}/>,
         );
@@ -63,7 +63,7 @@ describe('components/user_settings/notifications/DesktopNotificationSettings', (
     });
 
     test('should match snapshot, on max setting with Calls enabled, calls sound true', () => {
-        const props = {...baseProps, isCallsEnabled: true, callsSound: 'true'};
+        const props = {...baseProps, isCallsRingingEnabled: true, callsSound: 'true'};
         const wrapper = shallow(
             <DesktopNotificationSettings {...props}/>,
         );

--- a/webapp/channels/src/components/user_settings/notifications/desktop_notification_setting/desktop_notification_settings.tsx
+++ b/webapp/channels/src/components/user_settings/notifications/desktop_notification_setting/desktop_notification_settings.tsx
@@ -35,7 +35,7 @@ type Props = {
     selectedSound: string;
     callsSelectedSound: string;
     isCollapsedThreadsEnabled: boolean;
-    isCallsEnabled: boolean;
+    isCallsRingingEnabled: boolean;
 };
 
 type State = {
@@ -164,7 +164,7 @@ export default class DesktopNotificationSettings extends React.PureComponent<Pro
                     /></div>);
             }
 
-            if (this.props.isCallsEnabled) {
+            if (this.props.isCallsRingingEnabled) {
                 const callsSoundRadio = [false, false];
                 if (this.props.callsSound === 'false') {
                     callsSoundRadio[1] = true;

--- a/webapp/channels/src/components/user_settings/notifications/index.ts
+++ b/webapp/channels/src/components/user_settings/notifications/index.ts
@@ -12,7 +12,7 @@ import {ActionFunc} from 'mattermost-redux/types/actions';
 import {GlobalState} from 'types/store';
 
 import UserSettingsNotifications, {Props} from './user_settings_notifications';
-import {isCallsEnabled} from 'selectors/calls';
+import {isCallsEnabled, isCallsRingingEnabled} from 'selectors/calls';
 
 function mapStateToProps(state: GlobalState) {
     const config = getConfig(state);
@@ -24,7 +24,7 @@ function mapStateToProps(state: GlobalState) {
         sendPushNotifications,
         enableAutoResponder,
         isCollapsedThreadsEnabled: isCollapsedThreadsEnabled(state),
-        isCallsEnabled: isCallsEnabled(state, '0.17.0'),
+        isCallsRingingEnabled: isCallsEnabled(state, '0.17.0') && isCallsRingingEnabled(state),
     };
 }
 

--- a/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.test.tsx
+++ b/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.test.tsx
@@ -27,7 +27,7 @@ describe('components/user_settings/display/UserSettingsDisplay', () => {
         isCollapsedThreadsEnabled: false,
         sendPushNotifications: false,
         enableAutoResponder: false,
-        isCallsEnabled: true,
+        isCallsRingingEnabled: true,
     };
 
     test('should have called handleSubmit', async () => {

--- a/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.tsx
+++ b/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.tsx
@@ -36,7 +36,7 @@ export type Props = {
         updateMe: (user: UserProfile) => Promise<ActionResult>;
     };
     isCollapsedThreadsEnabled: boolean;
-    isCallsEnabled: boolean;
+    isCallsRingingEnabled: boolean;
 }
 
 type State = {
@@ -1058,7 +1058,7 @@ export default class NotificationsTab extends React.PureComponent<Props, State> 
                         callsSelectedSound={this.state.callsNotificationSound || 'default'}
                         isCollapsedThreadsEnabled={this.props.isCollapsedThreadsEnabled}
                         areAllSectionsInactive={this.props.activeSection === ''}
-                        isCallsEnabled={this.props.isCallsEnabled}
+                        isCallsRingingEnabled={this.props.isCallsRingingEnabled}
                     />
                     <div className='divider-light'/>
                     <EmailNotificationSetting

--- a/webapp/channels/src/selectors/calls.ts
+++ b/webapp/channels/src/selectors/calls.ts
@@ -6,6 +6,12 @@ import {suitePluginIds} from 'utils/constants';
 import semver from 'semver';
 
 export function isCallsEnabled(state: GlobalState, minVersion = '0.4.2') {
-    return state.plugins.plugins[suitePluginIds.calls] &&
-        semver.gte(state.plugins.plugins[suitePluginIds.calls].version || '0.0.0', minVersion);
+    return Boolean(state.plugins.plugins[suitePluginIds.calls] &&
+        semver.gte(state.plugins.plugins[suitePluginIds.calls].version || '0.0.0', minVersion));
+}
+
+export function isCallsRingingEnabled(state: GlobalState) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    return Boolean(state[`plugins-${suitePluginIds.calls}`]?.callsConfig?.EnableRinging);
 }


### PR DESCRIPTION
#### Summary
- Because we'll be shipping Calls ringing in 8.0 without mobile support, we want to have a kind of 'feature flag' which will default off for now.
- This PR looks at that value from the calls plugin, if it exists, and turns on/off the calls ringing desktop notifications settings accordingly.

/cc @amyblais This feature flags the calls ringing notification setting, so I think it's low risk enough for 8.0 branch, if that's ok with you?

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-53274
- Related Calls PR: https://github.com/mattermost/mattermost-plugin-calls/pull/449

#### Release Note

```release-note
NONE
```

