### PR TITLE
Fix scrollbar color on Chrome

### DIFF
--- a/webapp/channels/src/sass/components/_scrollbar.scss
+++ b/webapp/channels/src/sass/components/_scrollbar.scss
@@ -10,7 +10,7 @@
 }
 
 ::-webkit-scrollbar-thumb {
-    background: rgba(0, 0, 0, 0.2);
+    background: rgba(var(--center-channel-color-rgb), 0.4);
     border-radius: $border-rad * 2;
 }
 

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -415,9 +415,6 @@ export function applyTheme(theme: Theme) {
         changeCss('.app__body .emoji-picker .nav-tabs li a', 'fill:' + theme.centerChannelColor);
         changeCss('.app__body .post .post-collapse__show-more-button', `border-color:${changeOpacity(theme.centerChannelColor, 0.1)}`);
         changeCss('.app__body .post .post-collapse__show-more-line', `background-color:${changeOpacity(theme.centerChannelColor, 0.1)}`);
-        if (!UserAgent.isFirefox() && !UserAgent.isInternetExplorer() && !UserAgent.isEdge()) {
-            changeCss('::-webkit-scrollbar-thumb', 'background:' + changeOpacity(theme.centerChannelColor, 0.4))
-        }
     }
 
     if (theme.newMessageSeparator) {

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -415,6 +415,9 @@ export function applyTheme(theme: Theme) {
         changeCss('.app__body .emoji-picker .nav-tabs li a', 'fill:' + theme.centerChannelColor);
         changeCss('.app__body .post .post-collapse__show-more-button', `border-color:${changeOpacity(theme.centerChannelColor, 0.1)}`);
         changeCss('.app__body .post .post-collapse__show-more-line', `background-color:${changeOpacity(theme.centerChannelColor, 0.1)}`);
+        if (!UserAgent.isFirefox() && !UserAgent.isInternetExplorer() && !UserAgent.isEdge()) {
+            changeCss('::-webkit-scrollbar-thumb', 'background:' + changeOpacity(theme.centerChannelColor, 0.4))
+        }
     }
 
     if (theme.newMessageSeparator) {


### PR DESCRIPTION
#### Summary
On https://github.com/mattermost/mattermost/pull/23604 I removed a scrollbar css that was creating conflict that was not supposed to be removed, but changed. This caused the scrollbar not showing as it should on certain themes (specially dark ones). I brought it back with the correct values and now it is applying the right color and it is not conflicting.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53225

#### Release Note
Since this is going to release along #23604 , those are the release notes to be used.
```release-note
NONE
```
