### PR TITLE
MM-53289 Default boards to be on.

### DIFF
--- a/server/config/diff_test.go
+++ b/server/config/diff_test.go
@@ -813,6 +813,9 @@ func TestDiff(t *testing.T) {
 						"playbooks": {
 							Enable: true,
 						},
+						"focalboard": {
+							Enable: true,
+						},
 					},
 				},
 			},
@@ -845,6 +848,9 @@ func TestDiff(t *testing.T) {
 						"playbooks": {
 							Enable: true,
 						},
+						"focalboard": {
+							Enable: true,
+						},
 					},
 				},
 			},
@@ -867,6 +873,9 @@ func TestDiff(t *testing.T) {
 							Enable: true,
 						},
 						"playbooks": {
+							Enable: true,
+						},
+						"focalboard": {
 							Enable: true,
 						},
 					},

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -2929,6 +2929,11 @@ func (s *PluginSettings) SetDefaults(ls LogSettings) {
 		s.PluginStates[PluginIdNPS] = &PluginState{Enable: ls.EnableDiagnostics == nil || *ls.EnableDiagnostics}
 	}
 
+	if s.PluginStates[PluginIdFocalboard] == nil {
+		// Enable the focalboard plugin by default
+		s.PluginStates[PluginIdFocalboard] = &PluginState{Enable: true}
+	}
+
 	if s.PluginStates[PluginIdCalls] == nil {
 		// Enable the calls plugin by default
 		s.PluginStates[PluginIdCalls] = &PluginState{Enable: true}


### PR DESCRIPTION

#### Summary

Boards should be default enabled for 6.29 cloud release. 

This will need to be reverted from release-8.0 after creation from cloud release.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-53289

#### Release Note
```release-note
NONE
```
