### PR TITLE
Fix prop types for "markdown_image_expand" component

### DIFF
--- a/webapp/channels/src/components/markdown_image_expand/index.ts
+++ b/webapp/channels/src/components/markdown_image_expand/index.ts
@@ -1,28 +1,37 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {bindActionCreators, Dispatch} from 'redux';
+import {ReactNode} from 'react';
+import {connect, ConnectedProps} from 'react-redux';
 
-import {connect} from 'react-redux';
-
-import {GenericAction} from 'mattermost-redux/types/actions';
+import {Post} from '@mattermost/types/posts';
 
 import {toggleInlineImageVisibility} from 'actions/post_actions';
 import {isInlineImageVisible} from 'selectors/posts';
 import {GlobalState} from 'types/store';
 
-import MarkdownImageExpand, {Props} from './markdown_image_expand';
+import MarkdownImageExpand from './markdown_image_expand';
 
-const mapStateToProps = (state: GlobalState, {postId, imageKey}: Props) => {
+export type OwnProps = {
+    postId: Post['id'];
+    imageKey: string;
+    alt: string;
+    onToggle?: (visible: boolean) => void;
+    children: ReactNode;
+}
+
+const mapStateToProps = (state: GlobalState, {postId, imageKey}: OwnProps) => {
     return {
         isExpanded: isInlineImageVisible(state, postId, imageKey),
     };
 };
 
-const mapDispatchToProps = (dispatch: Dispatch<GenericAction>) => {
-    return {
-        actions: bindActionCreators({toggleInlineImageVisibility}, dispatch),
-    };
+const mapDispatchToProps = {
+    toggleInlineImageVisibility,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(MarkdownImageExpand);
+const connector = connect(mapStateToProps, mapDispatchToProps);
+
+export type PropsFromRedux = ConnectedProps<typeof connector>;
+
+export default connector(MarkdownImageExpand);

--- a/webapp/channels/src/components/markdown_image_expand/markdown_image_expand.test.tsx
+++ b/webapp/channels/src/components/markdown_image_expand/markdown_image_expand.test.tsx
@@ -17,7 +17,7 @@ describe('components/MarkdownImageExpand', () => {
                 isExpanded={false}
                 imageKey={'1'}
                 onToggle={toggleHandler}
-                actions={{toggleInlineImageVisibility: imageCollapseHandler}}
+                toggleInlineImageVisibility={imageCollapseHandler}
             >{'An image to expand'}</MarkdownImageExpand>,
         );
 
@@ -34,7 +34,7 @@ describe('components/MarkdownImageExpand', () => {
                 isExpanded={true}
                 imageKey={'1'}
                 onToggle={toggleHandler}
-                actions={{toggleInlineImageVisibility: imageCollapseHandler}}
+                toggleInlineImageVisibility={imageCollapseHandler}
             >{'An image to expand'}</MarkdownImageExpand>,
         );
 
@@ -51,7 +51,7 @@ describe('components/MarkdownImageExpand', () => {
                 isExpanded={true}
                 imageKey={'1'}
                 onToggle={toggleHandler}
-                actions={{toggleInlineImageVisibility: imageCollapseHandler}}
+                toggleInlineImageVisibility={imageCollapseHandler}
             >{'An image to expand'}</MarkdownImageExpand>,
         );
 
@@ -70,7 +70,7 @@ describe('components/MarkdownImageExpand', () => {
                 isExpanded={false}
                 imageKey={'1'}
                 onToggle={toggleHandler}
-                actions={{toggleInlineImageVisibility: imageCollapseHandler}}
+                toggleInlineImageVisibility={imageCollapseHandler}
             >{'An image to expand'}</MarkdownImageExpand>,
         );
 

--- a/webapp/channels/src/components/markdown_image_expand/markdown_image_expand.tsx
+++ b/webapp/channels/src/components/markdown_image_expand/markdown_image_expand.tsx
@@ -2,25 +2,18 @@
 // See LICENSE.txt for license information.
 
 import React, {useEffect} from 'react';
+
+import type {OwnProps, PropsFromRedux} from './index';
+
 import './markdown_image_expand.scss';
 
-export type Props = {
-    alt: string;
-    imageKey: string;
-    children: React.ReactNode;
-    isExpanded: boolean;
-    postId: string;
-    onToggle?: (isExpanded: boolean) => void;
-    actions: {
-        toggleInlineImageVisibility: (postId: string, imageKey: string) => void;
-    };
-};
+type Props = OwnProps & PropsFromRedux;
 
-const MarkdownImageExpand: React.FC<Props> = ({children, alt, isExpanded, postId, actions, onToggle, imageKey}: Props) => {
-    const {toggleInlineImageVisibility} = actions;
-
+const MarkdownImageExpand: React.FC<Props> = ({children, alt, isExpanded, postId, toggleInlineImageVisibility, onToggle, imageKey}: Props) => {
     useEffect(() => {
-        onToggle?.(isExpanded);
+        if (onToggle) {
+            onToggle(isExpanded);
+        }
     }, [isExpanded]);
 
     const handleToggleButtonClick = () => {


### PR DESCRIPTION
#### Summary
In a community PR https://github.com/mattermost/mattermost/pull/23524 it was discovered we didn't type the component MarkdownImageExpand.

QA:
Verify images are correctly expanded and collapsed in Center or RHS

#### Ticket Link
n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
