### PR TITLE
MM-51676 - korean chars create duplicate categories

### DIFF
--- a/webapp/channels/src/components/edit_category_modal/edit_category_modal.tsx
+++ b/webapp/channels/src/components/edit_category_modal/edit_category_modal.tsx
@@ -32,22 +32,21 @@ type Props = {
 
 type State = {
     categoryName: string;
-    isProcessing: boolean;
 }
 
 export default class EditCategoryModal extends React.PureComponent<Props, State> {
     timeoutId: NodeJS.Timeout | null = null;
+    isProcessing = false;
     constructor(props: Props) {
         super(props);
 
         this.state = {
             categoryName: props.initialCategoryName || '',
-            isProcessing: false,
         };
     }
 
     handleClear = () => {
-        this.setState({categoryName: '', isProcessing: false});
+        this.setState({categoryName: ''});
     };
 
     handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -58,13 +57,6 @@ export default class EditCategoryModal extends React.PureComponent<Props, State>
         this.handleClear();
     };
 
-    handleEnterKeyEvent = (e?: React.KeyboardEvent<HTMLDivElement>) => {
-        if (e && e.nativeEvent.isComposing) {
-            return;
-        }
-        this.handleConfirm();
-    };
-
     componentWillUnmount() {
         if (this.timeoutId) {
             clearTimeout(this.timeoutId);
@@ -72,21 +64,19 @@ export default class EditCategoryModal extends React.PureComponent<Props, State>
     }
 
     handleConfirm = () => {
-        if (this.state.isProcessing) {
+        if (this.isProcessing) {
             return;
         }
-        this.setState({isProcessing: true});
-        this.timeoutId = setTimeout(() => this.setState({isProcessing: false}), ACTION_WAIT_MS);
+        this.isProcessing = true;
+        this.timeoutId = setTimeout(() => {
+            this.isProcessing = false;
+        }, ACTION_WAIT_MS);
 
         if (this.props.categoryId) {
             this.props.actions.renameCategory(this.props.categoryId, this.state.categoryName);
         } else {
             this.props.actions.createCategory(this.props.currentTeamId, this.state.categoryName, this.props.channelIdsToAdd);
-            trackEvent('ui', 'ui_sidebar_created_category', {
-                currentTeam: this.props.currentTeamId,
-                categoryName: this.state.categoryName,
-                channelds: this.props.channelIdsToAdd,
-            });
+            trackEvent('ui', 'ui_sidebar_created_category');
         }
     };
 
@@ -155,7 +145,7 @@ export default class EditCategoryModal extends React.PureComponent<Props, State>
                 modalHeaderText={modalHeaderText}
                 confirmButtonText={editButtonText}
                 onExited={this.props.onExited}
-                handleEnterKeyPress={this.handleEnterKeyEvent}
+                handleEnterKeyPress={this.handleConfirm}
                 handleConfirm={this.handleConfirm}
                 handleCancel={this.handleCancel}
                 isConfirmDisabled={this.isConfirmDisabled()}

--- a/webapp/channels/src/components/modal_controller/modal_controller.tsx
+++ b/webapp/channels/src/components/modal_controller/modal_controller.tsx
@@ -5,8 +5,8 @@ import React from 'react';
 
 type Modal = {
     open: boolean;
-    dialogProps: Record<string, any>;
     dialogType: React.ComponentType;
+    dialogProps?: Record<string, any>;
 }
 
 type Props = {
@@ -64,7 +64,7 @@ export default class ModalController extends React.PureComponent<Props> {
         }
 
         return (
-            <>{modalOutput}</>
+            modalOutput
         );
     }
 }

--- a/webapp/platform/components/src/generic_modal/generic_modal.tsx
+++ b/webapp/platform/components/src/generic_modal/generic_modal.tsx
@@ -16,7 +16,7 @@ export type Props = {
     show?: boolean;
     handleCancel?: () => void;
     handleConfirm?: () => void;
-    handleEnterKeyPress?: () => void;
+    handleEnterKeyPress?: (event?: React.KeyboardEvent<HTMLDivElement>) => void;
     handleKeydown?: (event?: React.KeyboardEvent<HTMLDivElement>) => void;
     confirmButtonText?: React.ReactNode;
     confirmButtonClassName?: string;
@@ -105,7 +105,7 @@ export class GenericModal extends React.PureComponent<Props, State> {
                 this.onHide();
             }
             if (this.props.handleEnterKeyPress) {
-                this.props.handleEnterKeyPress();
+                this.props.handleEnterKeyPress(event);
             }
         }
         this.props.handleKeydown?.(event);

--- a/webapp/platform/components/src/generic_modal/generic_modal.tsx
+++ b/webapp/platform/components/src/generic_modal/generic_modal.tsx
@@ -16,7 +16,7 @@ export type Props = {
     show?: boolean;
     handleCancel?: () => void;
     handleConfirm?: () => void;
-    handleEnterKeyPress?: (event?: React.KeyboardEvent<HTMLDivElement>) => void;
+    handleEnterKeyPress?: () => void;
     handleKeydown?: (event?: React.KeyboardEvent<HTMLDivElement>) => void;
     confirmButtonText?: React.ReactNode;
     confirmButtonClassName?: string;
@@ -101,11 +101,14 @@ export class GenericModal extends React.PureComponent<Props, State> {
 
     private onEnterKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
         if (event.key === 'Enter') {
+            if (event.nativeEvent.isComposing) {
+                return;
+            }
             if (this.props.autoCloseOnConfirmButton) {
                 this.onHide();
             }
             if (this.props.handleEnterKeyPress) {
-                this.props.handleEnterKeyPress(event);
+                this.props.handleEnterKeyPress();
             }
         }
         this.props.handleKeydown?.(event);


### PR DESCRIPTION
#### Summary
A customer reported that while creating a new category using Korean characters, two categories were created instead of one. Also, it was reported that sometimes dbl-clicking quickly the Create Category button would end in the creation of two categories. During investigation it was found that dbl-enter keypress will also trigger the creation twice.

The root cause of the Korean characters issue is because the IME ([Input Method Editor](https://www.w3.org/TR/ime-api/#background)) used for Korean input, you can notice that when using Korean keyboard while you type several characters together it kind of waits and then summarize those chars and enters a Korean syllable in the place of the other characters. This means that keystrokes are entered and depending on which chars it creates a Korean syllable, and then it is shown in the input. This process causes multiple key events being triggered causing the event listener to trigger the create function to be called twice.

This PR fixes these issues by:

1)In the keypress event validate that the event is actually the final and wanted event by the user (pressing enter to create the category) by checking the `event.isComposing` property from the `reactSynteticEvent.nativeEvent,` you can verify if the event is coming from the composition process or ir is the final Enter Key Press event. Ignoring the intermediate events makes the trick.

2)Keeping track of the action handler execution and make sure it only executes every amount of time, this way preventing double click or double enter keypress before the expected workflow is completed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51676

#### Screenshots
Before:

https://github.com/mattermost/mattermost/assets/10082627/a321a3df-4398-4a79-a2ff-a2e3af2ca52f




After:

https://github.com/mattermost/mattermost/assets/10082627/b4a7f738-6334-439e-96c2-866a4d8832ce




#### Release Note
```release-note
NONE
```
