### PR TITLE
enable redux-devtools in all environments

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/store/configureStore.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/store/configureStore.ts
@@ -8,7 +8,7 @@ import {
     Store,
 } from 'redux';
 import thunk from 'redux-thunk';
-import {composeWithDevToolsDevelopmentOnly} from '@redux-devtools/extension';
+import {composeWithDevTools} from '@redux-devtools/extension';
 
 import {GlobalState} from '@mattermost/types/store';
 
@@ -39,7 +39,7 @@ export default function configureStore<S extends GlobalState>({
         ...preloadedState,
     };
 
-    const composeEnhancers = composeWithDevToolsDevelopmentOnly({
+    const composeEnhancers = composeWithDevTools({
         shouldHotReload: false,
         trace: true,
         traceLimit: 25,

--- a/webapp/channels/src/stores/redux_store.jsx
+++ b/webapp/channels/src/stores/redux_store.jsx
@@ -8,9 +8,4 @@ import configureStore from 'store';
 
 const store = configureStore();
 
-// eslint-disable-next-line no-process-env
-if (process.env.NODE_ENV !== 'production' || window.location.origin === 'https://community.mattermost.com') {
-    window.store = store;
-}
-
 export default store;

--- a/webapp/channels/src/stores/redux_store.jsx
+++ b/webapp/channels/src/stores/redux_store.jsx
@@ -8,4 +8,8 @@ import configureStore from 'store';
 
 const store = configureStore();
 
+// Export the store to simplify debugging in production environments. This is not a supported API,
+// and should not be relied upon by plugins.
+window.store = store;
+
 export default store;


### PR DESCRIPTION
#### Summary
[Redux DevTools](https://github.com/reduxjs/redux-devtools) gives developers and users insight into the client-side state of the Mattermost application. Instead of restricting this to developer builds, allow it for production builds too, simplifying debugging when an issue reproduces in production but not in a development environment.

There is no performance overhead unless the devtools are installed and opened by the enduser. There should be no security impact, since all this information is already client-side. Furthermore, major websites expose Redux in production: e.g. https://cbc.ca and https://medium.com/.

While we're in here, remove the community-specific override that allow direct access to the store via `window.store`. This doesn't help outside of this one instance, and is now redundant with the availability of the Redux DevTools.

#### Ticket Link
None

#### Release Note
```release-note
Allow using https://github.com/reduxjs/redux-devtools in production builds.
```
