### PR TITLE
Set license for group mentions flaky test

### DIFF
--- a/server/channels/app/notification_test.go
+++ b/server/channels/app/notification_test.go
@@ -1089,7 +1089,6 @@ func TestAllowChannelMentions(t *testing.T) {
 }
 
 func TestAllowGroupMentions(t *testing.T) {
-	t.Skip("MM-41972")
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
@@ -1114,6 +1113,9 @@ func TestAllowGroupMentions(t *testing.T) {
 			})
 		}
 	})
+
+	// we set the enterprise license for the rest of the tests
+	th.App.Srv().SetLicense(getLicWithSkuShortName(model.LicenseShortSkuEnterprise))
 
 	t.Run("should return true for a regular post with few channel members", func(t *testing.T) {
 		allowGroupMentions := th.App.allowGroupMentions(th.Context, post)


### PR DESCRIPTION
#### Summary
Manually sets the license expected for a bunch of tests instead of relying on the resulting state from the previous test

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41972

#### Release Note
```release-note
NONE
```
