### PR TITLE
Disable skipping SendNotifyAdminPosts test

### DIFF
--- a/server/channels/app/notify_admin_test.go
+++ b/server/channels/app/notify_admin_test.go
@@ -19,7 +19,6 @@ import (
 const PluginIdGithub = "github"
 
 func Test_SendNotifyAdminPosts(t *testing.T) {
-	t.Skip("MM-52743")
 	t.Run("no error sending non trial upgrade post when no notifications are available", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()


### PR DESCRIPTION
#### Summary
Removes skipping from the `SendNotifyAdminPosts` test. The data race seems to be related to the boards product startup, which is not part of the tests anymore. I've tried to reproduce it with no success in the current `master`, so proposing to simply reenable the test.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52743

#### Release Note
```release-note
NONE
```
