### PR TITLE
Disable boards by default in v8

### DIFF
--- a/server/config/diff_test.go
+++ b/server/config/diff_test.go
@@ -813,9 +813,6 @@ func TestDiff(t *testing.T) {
 						"playbooks": {
 							Enable: true,
 						},
-						"focalboard": {
-							Enable: true,
-						},
 					},
 				},
 			},
@@ -848,9 +845,6 @@ func TestDiff(t *testing.T) {
 						"playbooks": {
 							Enable: true,
 						},
-						"focalboard": {
-							Enable: true,
-						},
 					},
 				},
 			},
@@ -873,9 +867,6 @@ func TestDiff(t *testing.T) {
 							Enable: true,
 						},
 						"playbooks": {
-							Enable: true,
-						},
-						"focalboard": {
 							Enable: true,
 						},
 					},

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -2929,11 +2929,6 @@ func (s *PluginSettings) SetDefaults(ls LogSettings) {
 		s.PluginStates[PluginIdNPS] = &PluginState{Enable: ls.EnableDiagnostics == nil || *ls.EnableDiagnostics}
 	}
 
-	if s.PluginStates[PluginIdFocalboard] == nil {
-		// Enable the focalboard plugin by default
-		s.PluginStates[PluginIdFocalboard] = &PluginState{Enable: true}
-	}
-
 	if s.PluginStates[PluginIdCalls] == nil {
 		// Enable the calls plugin by default
 		s.PluginStates[PluginIdCalls] = &PluginState{Enable: true}


### PR DESCRIPTION
#### Summary
This PR reverts https://github.com/mattermost/mattermost/pull/23819, as boards is expected to be default on for the cloud release but off for `v8`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53290

#### Release Note
```release-note
NONE
```
