### PR TITLE
Fix mismatched receiver name on method PostMetadata.Auditable

### DIFF
--- a/server/public/model/post_metadata.go
+++ b/server/public/model/post_metadata.go
@@ -30,9 +30,9 @@ type PostMetadata struct {
 	Acknowledgements []*PostAcknowledgement `json:"acknowledgements,omitempty"`
 }
 
-func (pm *PostMetadata) Auditable() map[string]any {
-	embeds := make([]map[string]any, 0, len(pm.Embeds))
-	for _, pe := range pm.Embeds {
+func (p *PostMetadata) Auditable() map[string]any {
+	embeds := make([]map[string]any, 0, len(p.Embeds))
+	for _, pe := range p.Embeds {
 		embeds = append(embeds, pe.Auditable())
 	}
 	if len(embeds) == 0 {
@@ -41,12 +41,12 @@ func (pm *PostMetadata) Auditable() map[string]any {
 
 	return map[string]any{
 		"embeds":           embeds,
-		"emojis":           pm.Emojis,
-		"files":            pm.Files,
-		"images":           pm.Images,
-		"reactions":        pm.Reactions,
-		"priority":         pm.Priority,
-		"acknowledgements": pm.Acknowledgements,
+		"emojis":           p.Emojis,
+		"files":            p.Files,
+		"images":           p.Images,
+		"reactions":        p.Reactions,
+		"priority":         p.Priority,
+		"acknowledgements": p.Acknowledgements,
 	}
 }
 


### PR DESCRIPTION
#### Summary
This PR fixes a receiver name mismatch for method `Postmetadata.Auditable` introduced by https://github.com/mattermost/mattermost/pull/23745.  

**This was caught via linter check for 7.x release branches, but is not caught by master linter settings.**

@amyblais this is already applied to 7.8, 7.9, 7.10 via cherry-picks for the original PR.

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
