### PR TITLE
Fixed a bug that prevent post deletion

### DIFF
--- a/server/channels/app/post_metadata.go
+++ b/server/channels/app/post_metadata.go
@@ -218,9 +218,17 @@ func (a *App) SanitizePostMetadataForUser(c request.CTX, post *model.Post, userI
 	}
 
 	if previewedChannel != nil && !a.HasPermissionToReadChannel(c, userID, previewedChannel) {
+		// Remove all permalink embeds and only keep non-permalink embeds.
+		// We always have only one permalink embed even if the post
+		// contains multiple permalinks.
+		var newEmbeds []*model.PostEmbed
 		for _, embed := range post.Metadata.Embeds {
-			embed.Data = nil
+			if embed.Type != model.PostEmbedPermalink {
+				newEmbeds = append(newEmbeds, embed)
+			}
 		}
+
+		post.Metadata.Embeds = newEmbeds
 	}
 
 	return post, nil

--- a/server/channels/app/post_metadata_test.go
+++ b/server/channels/app/post_metadata_test.go
@@ -2868,3 +2868,60 @@ func TestSanitizePostMetaDataForAudit(t *testing.T) {
 		}
 	}
 }
+
+func TestSanitizePostMetadataForUser(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	privateChannel, err := th.App.CreateChannel(th.Context, &model.Channel{
+		Name:      "private_chanenl",
+		Type:      model.ChannelTypePrivate,
+		TeamId:    th.BasicTeam.Id,
+		CreatorId: th.SystemAdminUser.Id,
+	}, true)
+
+	require.Nil(t, err)
+	require.NotEmpty(t, privateChannel.Id)
+
+	post := &model.Post{
+		Id:     "post_id_1",
+		UserId: th.BasicUser.Id,
+		Metadata: &model.PostMetadata{
+			Embeds: []*model.PostEmbed{
+				{
+					Type: model.PostEmbedPermalink,
+					Data: &model.PreviewPost{
+						PostID: "permalink_post_id",
+						Post: &model.Post{
+							Id:        "permalink_post_id",
+							Message:   "permalink post message",
+							ChannelId: privateChannel.Id,
+						},
+					},
+				},
+				{
+					Type: model.PostEmbedPermalink,
+					Data: &model.PreviewPost{
+						PostID: "permalink_post_id_2",
+						Post: &model.Post{
+							Id:        "permalink_post_id_2",
+							Message:   "permalink post message 2",
+							ChannelId: privateChannel.Id,
+						},
+					},
+				},
+				{
+					Type: model.PostEmbedLink,
+					URL:  "https://mattermost.com",
+				},
+			},
+		},
+	}
+
+	sanitizedPost, err := th.App.SanitizePostMetadataForUser(th.Context, post, th.BasicUser.Id)
+	require.Nil(t, err)
+	require.NotNil(t, sanitizedPost)
+
+	require.Equal(t, 1, len(sanitizedPost.Metadata.Embeds))
+	require.Equal(t, model.PostEmbedLink, sanitizedPost.Metadata.Embeds[0].Type)
+}

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
@@ -218,7 +218,7 @@ export function handlePosts(state: RelationOneToOne<Post, Post> = {}, action: Ge
                 const newEmbeds: PostEmbed[] = [];
 
                 for (const embed of otherPost.metadata.embeds) {
-                   if (embed.type === 'permalink' && embed.data && (embed.data as PostPreviewMetadata).post_id === post.id) {
+                    if (embed.type === 'permalink' && embed.data && (embed.data as PostPreviewMetadata).post_id === post.id) {
                         // skip if the embed is the deleted post
                         continue;
                     }

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
@@ -218,14 +218,7 @@ export function handlePosts(state: RelationOneToOne<Post, Post> = {}, action: Ge
                 const newEmbeds: PostEmbed[] = [];
 
                 for (const embed of otherPost.metadata.embeds) {
-                    if (embed.type === 'permalink' && embed.data && !('post_id' in embed.data)) {
-                        // eslint-disable-next-line no-console
-                        console.error('post_id missing in post embed data for permalink.');
-                        // eslint-disable-next-line no-console
-                        console.error(embed.data);
-                    }
-
-                    if (embed.type === 'permalink' && (embed.data as PostPreviewMetadata).post_id === post.id) {
+                   if (embed.type === 'permalink' && embed.data && (embed.data as PostPreviewMetadata).post_id === post.id) {
                         // skip if the embed is the deleted post
                         continue;
                     }


### PR DESCRIPTION
#### Summary
Deleting entire embed object instead of only it's data when its a permalink embed and user doesn't have access to the linked post.
Also removed debug logs from webapp added previously for debugging this issue.

#### Ticket Link
```release-note
NONE
```
