### PR TITLE
MM-53377 Revert "[MM-52547] Include current user profile in every redux action (#23219)"

### DIFF
--- a/webapp/channels/src/actions/websocket_actions.jsx
+++ b/webapp/channels/src/actions/websocket_actions.jsx
@@ -234,7 +234,7 @@ export function reconnect() {
             // we can request for getPosts again when socket is connected
             dispatch(getPosts(currentChannelId));
         }
-        dispatch(StatusActions.loadStatusesForChannelAndSidebar());
+        StatusActions.loadStatusesForChannelAndSidebar();
 
         const crtEnabled = isCollapsedThreadsEnabled(state);
         dispatch(TeamActions.getMyTeamUnreads(crtEnabled, true));

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
@@ -35,6 +35,7 @@ import {getServerVersion} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUserId, getUsers} from 'mattermost-redux/selectors/entities/users';
 import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 
+import {removeUserFromList} from 'mattermost-redux/utils/user_utils';
 import {isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
 import {General} from 'mattermost-redux/constants';
 
@@ -214,10 +215,12 @@ export function getFilteredUsersStats(options: GetFilteredUsersStatsOpts = {}, u
 
 export function getProfiles(page = 0, perPage: number = General.PROFILE_CHUNK_SIZE, options: any = {}): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const {currentUserId} = getState().entities.users;
         let profiles: UserProfile[];
 
         try {
             profiles = await Client4.getProfiles(page, perPage, options);
+            removeUserFromList(currentUserId, profiles);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));
@@ -298,10 +301,12 @@ export function getProfilesByIds(userIds: string[], options?: any): ActionFunc {
 
 export function getProfilesByUsernames(usernames: string[]): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const {currentUserId} = getState().entities.users;
         let profiles;
 
         try {
             profiles = await Client4.getProfilesByUsernames(usernames);
+            removeUserFromList(currentUserId, profiles);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));
@@ -319,6 +324,7 @@ export function getProfilesByUsernames(usernames: string[]): ActionFunc {
 
 export function getProfilesInTeam(teamId: string, page: number, perPage: number = General.PROFILE_CHUNK_SIZE, sort = '', options: any = {}): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const {currentUserId} = getState().entities.users;
         let profiles;
 
         try {
@@ -337,7 +343,7 @@ export function getProfilesInTeam(teamId: string, page: number, perPage: number 
             },
             {
                 type: UserTypes.RECEIVED_PROFILES_LIST,
-                data: profiles,
+                data: removeUserFromList(currentUserId, [...profiles]),
             },
         ]));
 
@@ -407,6 +413,7 @@ export enum ProfilesInChannelSortBy {
 
 export function getProfilesInChannel(channelId: string, page: number, perPage: number = General.PROFILE_CHUNK_SIZE, sort = '', options: {active?: boolean} = {}): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const {currentUserId} = getState().entities.users;
         let profiles;
 
         try {
@@ -425,7 +432,7 @@ export function getProfilesInChannel(channelId: string, page: number, perPage: n
             },
             {
                 type: UserTypes.RECEIVED_PROFILES_LIST,
-                data: profiles,
+                data: removeUserFromList(currentUserId, [...profiles]),
             },
         ]));
 
@@ -435,6 +442,7 @@ export function getProfilesInChannel(channelId: string, page: number, perPage: n
 
 export function getProfilesInGroupChannels(channelsIds: string[]): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const {currentUserId} = getState().entities.users;
         let channelProfiles;
 
         try {
@@ -458,7 +466,7 @@ export function getProfilesInGroupChannels(channelsIds: string[]): ActionFunc {
                     },
                     {
                         type: UserTypes.RECEIVED_PROFILES_LIST,
-                        data: profiles,
+                        data: removeUserFromList(currentUserId, [...profiles]),
                     },
                 );
             }
@@ -472,6 +480,7 @@ export function getProfilesInGroupChannels(channelsIds: string[]): ActionFunc {
 
 export function getProfilesNotInChannel(teamId: string, channelId: string, groupConstrained: boolean, page: number, perPage: number = General.PROFILE_CHUNK_SIZE): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const {currentUserId} = getState().entities.users;
         let profiles;
 
         try {
@@ -492,7 +501,7 @@ export function getProfilesNotInChannel(teamId: string, channelId: string, group
             },
             {
                 type: UserTypes.RECEIVED_PROFILES_LIST,
-                data: profiles,
+                data: removeUserFromList(currentUserId, [...profiles]),
             },
         ]));
 
@@ -553,6 +562,7 @@ export function updateMyTermsOfServiceStatus(termsOfServiceId: string, accepted:
 
 export function getProfilesInGroup(groupId: string, page = 0, perPage: number = General.PROFILE_CHUNK_SIZE, sort = ''): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const {currentUserId} = getState().entities.users;
         let profiles;
 
         try {
@@ -571,7 +581,7 @@ export function getProfilesInGroup(groupId: string, page = 0, perPage: number = 
             },
             {
                 type: UserTypes.RECEIVED_PROFILES_LIST,
-                data: profiles,
+                data: removeUserFromList(currentUserId, [...profiles]),
             },
         ]));
 
@@ -581,6 +591,7 @@ export function getProfilesInGroup(groupId: string, page = 0, perPage: number = 
 
 export function getProfilesNotInGroup(groupId: string, page = 0, perPage: number = General.PROFILE_CHUNK_SIZE): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const {currentUserId} = getState().entities.users;
         let profiles;
 
         try {
@@ -599,7 +610,7 @@ export function getProfilesNotInGroup(groupId: string, page = 0, perPage: number
             },
             {
                 type: UserTypes.RECEIVED_PROFILES_LIST,
-                data: profiles,
+                data: removeUserFromList(currentUserId, [...profiles]),
             },
         ]));
 
@@ -831,6 +842,9 @@ export function autocompleteUsers(term: string, teamId = '', channelId = '', opt
 }): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         dispatch({type: UserTypes.AUTOCOMPLETE_USERS_REQUEST, data: null});
+
+        const {currentUserId} = getState().entities.users;
+
         let data;
         try {
             data = await Client4.autocompleteUsers(term, teamId, channelId, options);
@@ -845,6 +859,7 @@ export function autocompleteUsers(term: string, teamId = '', channelId = '', opt
         if (data.out_of_channel) {
             users = [...users, ...data.out_of_channel];
         }
+        removeUserFromList(currentUserId, users);
         const actions: AnyAction[] = [{
             type: UserTypes.RECEIVED_PROFILES_LIST,
             data: users,
@@ -887,6 +902,8 @@ export function autocompleteUsers(term: string, teamId = '', channelId = '', opt
 
 export function searchProfiles(term: string, options: any = {}): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const {currentUserId} = getState().entities.users;
+
         let profiles;
         try {
             profiles = await Client4.searchUsers(term, options);
@@ -896,7 +913,7 @@ export function searchProfiles(term: string, options: any = {}): ActionFunc {
             return {error};
         }
 
-        const actions: AnyAction[] = [{type: UserTypes.RECEIVED_PROFILES_LIST, data: profiles}];
+        const actions: AnyAction[] = [{type: UserTypes.RECEIVED_PROFILES_LIST, data: removeUserFromList(currentUserId, [...profiles])}];
 
         if (options.in_channel_id) {
             actions.push({

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
@@ -280,10 +280,12 @@ export function getMissingProfilesByUsernames(usernames: string[]): ActionFunc {
 
 export function getProfilesByIds(userIds: string[], options?: any): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const {currentUserId} = getState().entities.users;
         let profiles: UserProfile[];
 
         try {
             profiles = await Client4.getProfilesByIds(userIds, options);
+            removeUserFromList(currentUserId, profiles);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.test.ts
@@ -4,9 +4,6 @@
 import {UserTypes, ChannelTypes} from 'mattermost-redux/action_types';
 import {GenericAction} from 'mattermost-redux/types/actions';
 import reducer from 'mattermost-redux/reducers/entities/users';
-
-import {TestHelper} from 'utils/test_helper';
-
 type ReducerState = ReturnType<typeof reducer>;
 
 describe('Reducers.users', () => {
@@ -674,37 +671,6 @@ describe('Reducers.users', () => {
 
             const newState = reducer(state as unknown as ReducerState, action);
             expect(newState.profilesNotInGroup).toEqual(expectedState.profilesNotInGroup);
-        });
-    });
-    describe('profiles', () => {
-        it('UserTypes.RECEIVED_PROFILES_LIST, should merge existing users with new ones', () => {
-            const firstUser = TestHelper.getUserMock({id: 'first_user_id'});
-            const secondUser = TestHelper.getUserMock({id: 'seocnd_user_id'});
-            const thirdUser = TestHelper.getUserMock({id: 'third_user_id'});
-            const partialUpdatedFirstUser = {
-                ...firstUser,
-                update_at: 123456789,
-            };
-            Reflect.deleteProperty(partialUpdatedFirstUser, 'email');
-            Reflect.deleteProperty(partialUpdatedFirstUser, 'notify_props');
-            const state = {
-                profiles: {
-                    first_user_id: firstUser,
-                    second_user_id: secondUser,
-                },
-            };
-            const action = {
-                type: UserTypes.RECEIVED_PROFILES_LIST,
-                data: [
-                    partialUpdatedFirstUser,
-                    thirdUser,
-                ],
-            };
-            const {profiles: newProfiles} = reducer(state as unknown as ReducerState, action);
-
-            expect(newProfiles.first_user_id).toEqual({...firstUser, ...partialUpdatedFirstUser});
-            expect(newProfiles.second_user_id).toEqual(secondUser);
-            expect(newProfiles.third_user_id).toEqual(thirdUser);
         });
     });
 });

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.ts
@@ -198,18 +198,15 @@ function profiles(state: IDMappedObjects<UserProfile> = {}, action: GenericActio
         const users: UserProfile[] = action.data;
 
         return users.reduce((nextState, user) => {
-            const oldUser = nextState[user.id] || {};
+            const oldUser = nextState[user.id];
 
-            if (isEqual(user, oldUser)) {
+            if (oldUser && isEqual(user, oldUser)) {
                 return nextState;
             }
 
             return {
                 ...nextState,
-                [user.id]: {
-                    ...oldUser,
-                    ...user,
-                },
+                [user.id]: user,
             };
         }, state);
     }


### PR DESCRIPTION
#### Summary
We've found some cases where this change meant that certain fields which are only set for the current user object are erased because the user is replaced by a sanitized version of the object like others would receive. The most difficult case that causes the most issues here is the `auth_service` field which track's the user's login method. That field is sanitized to be the empty string, but it's also the empty string if the user uses email/password login, so we can't differentiate between the two cases to merge the objects smartly.

We'll hopefully reintroduce this code shortly, but for the time being, we're reverting it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53377
https://mattermost.atlassian.net/browse/MM-53216
https://mattermost.atlassian.net/browse/MM-53422

#### Release Note
```release-note
Revert a change which can cause the web app to forget the current user's authentication method
```
