### PR TITLE
MM-53427 - don't allow deletedAt to be set when creating user

### DIFF
--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -41,6 +41,7 @@ func TestCreateUser(t *testing.T) {
 		Username:      GenerateTestUsername(),
 		Roles:         model.SystemAdminRoleId + " " + model.SystemUserRoleId,
 		EmailVerified: true,
+		DeleteAt:      1,
 	}
 
 	ruser, resp, err := th.Client.CreateUser(context.Background(), &user)
@@ -53,6 +54,7 @@ func TestCreateUser(t *testing.T) {
 
 	require.Equal(t, user.Nickname, ruser.Nickname, "nickname didn't match")
 	require.Equal(t, model.SystemUserRoleId, ruser.Roles, "did not clear roles")
+	require.Equal(t, int64(0), ruser.DeleteAt, "did not reset deleteAt")
 
 	CheckUserSanitization(t, ruser)
 

--- a/server/public/model/user.go
+++ b/server/public/model/user.go
@@ -669,6 +669,7 @@ func (u *User) SanitizeInput(isAdmin bool) {
 		u.AuthService = ""
 		u.EmailVerified = false
 	}
+	u.DeleteAt = 0
 	u.LastPasswordUpdate = 0
 	u.LastPictureUpdate = 0
 	u.FailedAttempts = 0


### PR DESCRIPTION

#### Summary
Don't allow `deleteAt` field to be set when creating a new user

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-53427

#### Release Note
```release-note
NONE
```
