### PR TITLE
CLD-5934 Cypress/E2E: Add @plugins_uninstall metadata to sort it last during run

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/plugins/marketplace/disabled_remote_marketplace_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/plugins/marketplace/disabled_remote_marketplace_spec.js
@@ -7,7 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Group: @channels @not_cloud @plugin_marketplace @plugin
+// Group: @channels @not_cloud @plugin_marketplace @plugin @plugins_uninstall
 
 import {githubPlugin} from '../../../../utils/plugins';
 

--- a/e2e-tests/cypress/tests/integration/channels/plugins/marketplace/invalid_marketplace_url_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/plugins/marketplace/invalid_marketplace_url_spec.js
@@ -7,7 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Group: @channels @not_cloud @plugin_marketplace @plugin
+// Group: @channels @not_cloud @plugin_marketplace @plugin @plugins_uninstall
 
 import {githubPlugin} from '../../../../utils/plugins';
 

--- a/e2e-tests/cypress/tests/integration/channels/plugins/marketplace/ui_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/plugins/marketplace/ui_spec.js
@@ -7,7 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Group: @channels @not_cloud @plugin_marketplace @plugin
+// Group: @channels @not_cloud @plugin_marketplace @plugin @plugins_uninstall
 
 import * as TIMEOUTS from '../../../../fixtures/timeouts';
 import {githubPluginOld} from '../../../../utils/plugins';

--- a/e2e-tests/cypress/tests/integration/channels/plugins/plugin_buttons_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/plugins/plugin_buttons_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @channels @plugin @not_cloud
+// Group: @channels @plugin @plugins_uninstall @not_cloud
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 import {demoPlugin, testPlugin} from '../../../utils/plugins';

--- a/e2e-tests/cypress/tests/integration/channels/plugins/upgrade_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/plugins/upgrade_spec.js
@@ -15,7 +15,7 @@
  * under fixtures folder.
  */
 
-// Group: @channels @system_console @plugin @not_cloud
+// Group: @channels @system_console @plugin @plugins_uninstall @not_cloud
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 import {demoPlugin, demoPluginOld} from '../../../utils/plugins';

--- a/e2e-tests/cypress/tests/integration/channels/system_console/search_box_not_cloud_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/system_console/search_box_not_cloud_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @channels @not_cloud @system_console
+// Group: @channels @not_cloud @system_console @plugins_uninstall
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 


### PR DESCRIPTION
#### Summary
- Added @plugins_uninstall metadata to sort it last during run

Note: Updated the filter in CI - https://git.internal.mattermost.com/qa/cypress-ui-automation/-/commit/1ca476ec81645ec980e202ef4b20025e731f8cb0 (to be cherry-picked into `e2e-daily` and `e2e-release`)

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-5934

#### Release Note
```release-note
NONE
```
