### PR TITLE
MM-53467 Unrevert changes that update current user object

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/account_settings/profile/mm_53377_regression_test_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/account_settings/profile/mm_53377_regression_test_spec.js
@@ -1,0 +1,94 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. #. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @channels
+
+describe('MM-53377 Regression tests', () => {
+    let testTeam;
+    let testUser;
+    let testUser2;
+
+    before(() => {
+        cy.apiUpdateConfig({
+            PrivacySettings: {
+                ShowEmailAddress: false,
+                ShowFullName: false,
+            },
+        });
+
+        cy.apiInitSetup().then(({team, user, offTopicUrl}) => {
+            testTeam = team;
+            testUser = user;
+
+            cy.apiCreateUser().then((payload) => {
+                testUser2 = payload.user;
+                cy.apiAddUserToTeam(testTeam.id, payload.user.id);
+            });
+
+            cy.visit(offTopicUrl);
+        });
+    });
+
+    beforeEach(() => {
+        // # Login as testUser
+        cy.apiLogin(testUser);
+    });
+
+    it('should still have your email loaded after using the at-mention autocomplete', () => {
+        // * Ensure that this user is not an admin
+        cy.wrap(testUser).its('roles').should('equal', 'system_user');
+
+        // # Send a couple at mentions, quickly enough that the at mention autocomplete won't appear
+        cy.uiPostMessageQuickly(`@${testUser.username} @${testUser2.username}`);
+
+        // # Open the profile popover for the current user
+        cy.contains('.mention-link', `@${testUser.username}`).click();
+
+        // * Ensure that all fields are visible for the current user
+        cy.get('#user-profile-popover').within(() => {
+            cy.findByText(`@${testUser.username}`).should('exist');
+            cy.findByText(`${testUser.first_name} ${testUser.last_name}`).should('exist');
+            cy.findByText(testUser.email).should('exist');
+        });
+
+        // # Click anywhere to close profile popover
+        cy.get('#channelHeaderInfo').click();
+
+        // # Open the profile popover for another user
+        cy.contains('.mention-link', `@${testUser2.username}`).click();
+
+        // * Ensure that only the username is visible for another user
+        cy.get('#user-profile-popover').within(() => {
+            cy.findByText(`@${testUser2.username}`).should('exist');
+            cy.findByText(`${testUser2.first_name} ${testUser2.last_name}`).should('not.exist');
+            cy.findByText(testUser2.email).should('not.exist');
+        });
+
+        // # Start to type another at mention so that the autocomplete loads
+        cy.get('#post_textbox').type(`@${testUser.username}`);
+
+        // # Wait for the autocomplete to appear with the current user in it
+        cy.get('.suggestion-list').within(() => {
+            cy.findByText(`@${testUser.username}`);
+        });
+
+        // # Clear the post textbox to hide the autocomplete
+        cy.get('#post_textbox').clear();
+
+        // # Open the profile popover for the current user again
+        cy.contains('.mention-link', `@${testUser.username}`).click();
+
+        // * Ensure that all fields are still visible for the current user
+        cy.get('#user-profile-popover').within(() => {
+            cy.findByText(`@${testUser.username}`).should('exist');
+            cy.findByText(`${testUser.first_name} ${testUser.last_name}`).should('exist');
+            cy.findByText(testUser.email).should('exist');
+        });
+    });
+});

--- a/webapp/channels/src/actions/websocket_actions.jsx
+++ b/webapp/channels/src/actions/websocket_actions.jsx
@@ -234,7 +234,7 @@ export function reconnect() {
             // we can request for getPosts again when socket is connected
             dispatch(getPosts(currentChannelId));
         }
-        StatusActions.loadStatusesForChannelAndSidebar();
+        dispatch(StatusActions.loadStatusesForChannelAndSidebar());
 
         const crtEnabled = isCollapsedThreadsEnabled(state);
         dispatch(TeamActions.getMyTeamUnreads(crtEnabled, true));

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
@@ -35,7 +35,6 @@ import {getServerVersion} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUserId, getUsers} from 'mattermost-redux/selectors/entities/users';
 import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 
-import {removeUserFromList} from 'mattermost-redux/utils/user_utils';
 import {isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
 import {General} from 'mattermost-redux/constants';
 
@@ -215,12 +214,10 @@ export function getFilteredUsersStats(options: GetFilteredUsersStatsOpts = {}, u
 
 export function getProfiles(page = 0, perPage: number = General.PROFILE_CHUNK_SIZE, options: any = {}): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const {currentUserId} = getState().entities.users;
         let profiles: UserProfile[];
 
         try {
             profiles = await Client4.getProfiles(page, perPage, options);
-            removeUserFromList(currentUserId, profiles);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));
@@ -303,12 +300,10 @@ export function getProfilesByIds(userIds: string[], options?: any): ActionFunc {
 
 export function getProfilesByUsernames(usernames: string[]): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const {currentUserId} = getState().entities.users;
         let profiles;
 
         try {
             profiles = await Client4.getProfilesByUsernames(usernames);
-            removeUserFromList(currentUserId, profiles);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));
@@ -326,7 +321,6 @@ export function getProfilesByUsernames(usernames: string[]): ActionFunc {
 
 export function getProfilesInTeam(teamId: string, page: number, perPage: number = General.PROFILE_CHUNK_SIZE, sort = '', options: any = {}): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const {currentUserId} = getState().entities.users;
         let profiles;
 
         try {
@@ -345,7 +339,7 @@ export function getProfilesInTeam(teamId: string, page: number, perPage: number 
             },
             {
                 type: UserTypes.RECEIVED_PROFILES_LIST,
-                data: removeUserFromList(currentUserId, [...profiles]),
+                data: profiles,
             },
         ]));
 
@@ -415,7 +409,6 @@ export enum ProfilesInChannelSortBy {
 
 export function getProfilesInChannel(channelId: string, page: number, perPage: number = General.PROFILE_CHUNK_SIZE, sort = '', options: {active?: boolean} = {}): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const {currentUserId} = getState().entities.users;
         let profiles;
 
         try {
@@ -434,7 +427,7 @@ export function getProfilesInChannel(channelId: string, page: number, perPage: n
             },
             {
                 type: UserTypes.RECEIVED_PROFILES_LIST,
-                data: removeUserFromList(currentUserId, [...profiles]),
+                data: profiles,
             },
         ]));
 
@@ -444,7 +437,6 @@ export function getProfilesInChannel(channelId: string, page: number, perPage: n
 
 export function getProfilesInGroupChannels(channelsIds: string[]): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const {currentUserId} = getState().entities.users;
         let channelProfiles;
 
         try {
@@ -468,7 +460,7 @@ export function getProfilesInGroupChannels(channelsIds: string[]): ActionFunc {
                     },
                     {
                         type: UserTypes.RECEIVED_PROFILES_LIST,
-                        data: removeUserFromList(currentUserId, [...profiles]),
+                        data: profiles,
                     },
                 );
             }
@@ -482,7 +474,6 @@ export function getProfilesInGroupChannels(channelsIds: string[]): ActionFunc {
 
 export function getProfilesNotInChannel(teamId: string, channelId: string, groupConstrained: boolean, page: number, perPage: number = General.PROFILE_CHUNK_SIZE): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const {currentUserId} = getState().entities.users;
         let profiles;
 
         try {
@@ -503,7 +494,7 @@ export function getProfilesNotInChannel(teamId: string, channelId: string, group
             },
             {
                 type: UserTypes.RECEIVED_PROFILES_LIST,
-                data: removeUserFromList(currentUserId, [...profiles]),
+                data: profiles,
             },
         ]));
 
@@ -564,7 +555,6 @@ export function updateMyTermsOfServiceStatus(termsOfServiceId: string, accepted:
 
 export function getProfilesInGroup(groupId: string, page = 0, perPage: number = General.PROFILE_CHUNK_SIZE, sort = ''): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const {currentUserId} = getState().entities.users;
         let profiles;
 
         try {
@@ -583,7 +573,7 @@ export function getProfilesInGroup(groupId: string, page = 0, perPage: number = 
             },
             {
                 type: UserTypes.RECEIVED_PROFILES_LIST,
-                data: removeUserFromList(currentUserId, [...profiles]),
+                data: profiles,
             },
         ]));
 
@@ -593,7 +583,6 @@ export function getProfilesInGroup(groupId: string, page = 0, perPage: number = 
 
 export function getProfilesNotInGroup(groupId: string, page = 0, perPage: number = General.PROFILE_CHUNK_SIZE): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const {currentUserId} = getState().entities.users;
         let profiles;
 
         try {
@@ -612,7 +601,7 @@ export function getProfilesNotInGroup(groupId: string, page = 0, perPage: number
             },
             {
                 type: UserTypes.RECEIVED_PROFILES_LIST,
-                data: removeUserFromList(currentUserId, [...profiles]),
+                data: profiles,
             },
         ]));
 
@@ -844,9 +833,6 @@ export function autocompleteUsers(term: string, teamId = '', channelId = '', opt
 }): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         dispatch({type: UserTypes.AUTOCOMPLETE_USERS_REQUEST, data: null});
-
-        const {currentUserId} = getState().entities.users;
-
         let data;
         try {
             data = await Client4.autocompleteUsers(term, teamId, channelId, options);
@@ -861,7 +847,6 @@ export function autocompleteUsers(term: string, teamId = '', channelId = '', opt
         if (data.out_of_channel) {
             users = [...users, ...data.out_of_channel];
         }
-        removeUserFromList(currentUserId, users);
         const actions: AnyAction[] = [{
             type: UserTypes.RECEIVED_PROFILES_LIST,
             data: users,
@@ -904,8 +889,6 @@ export function autocompleteUsers(term: string, teamId = '', channelId = '', opt
 
 export function searchProfiles(term: string, options: any = {}): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const {currentUserId} = getState().entities.users;
-
         let profiles;
         try {
             profiles = await Client4.searchUsers(term, options);
@@ -915,7 +898,7 @@ export function searchProfiles(term: string, options: any = {}): ActionFunc {
             return {error};
         }
 
-        const actions: AnyAction[] = [{type: UserTypes.RECEIVED_PROFILES_LIST, data: removeUserFromList(currentUserId, [...profiles])}];
+        const actions: AnyAction[] = [{type: UserTypes.RECEIVED_PROFILES_LIST, data: profiles}];
 
         if (options.in_channel_id) {
             actions.push({

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
@@ -277,12 +277,10 @@ export function getMissingProfilesByUsernames(usernames: string[]): ActionFunc {
 
 export function getProfilesByIds(userIds: string[], options?: any): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const {currentUserId} = getState().entities.users;
         let profiles: UserProfile[];
 
         try {
             profiles = await Client4.getProfilesByIds(userIds, options);
-            removeUserFromList(currentUserId, profiles);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.test.ts
@@ -4,6 +4,9 @@
 import {UserTypes, ChannelTypes} from 'mattermost-redux/action_types';
 import {GenericAction} from 'mattermost-redux/types/actions';
 import reducer from 'mattermost-redux/reducers/entities/users';
+
+import {TestHelper} from 'utils/test_helper';
+
 type ReducerState = ReturnType<typeof reducer>;
 
 describe('Reducers.users', () => {
@@ -671,6 +674,37 @@ describe('Reducers.users', () => {
 
             const newState = reducer(state as unknown as ReducerState, action);
             expect(newState.profilesNotInGroup).toEqual(expectedState.profilesNotInGroup);
+        });
+    });
+    describe('profiles', () => {
+        it('UserTypes.RECEIVED_PROFILES_LIST, should merge existing users with new ones', () => {
+            const firstUser = TestHelper.getUserMock({id: 'first_user_id'});
+            const secondUser = TestHelper.getUserMock({id: 'seocnd_user_id'});
+            const thirdUser = TestHelper.getUserMock({id: 'third_user_id'});
+            const partialUpdatedFirstUser = {
+                ...firstUser,
+                update_at: 123456789,
+            };
+            Reflect.deleteProperty(partialUpdatedFirstUser, 'email');
+            Reflect.deleteProperty(partialUpdatedFirstUser, 'notify_props');
+            const state = {
+                profiles: {
+                    first_user_id: firstUser,
+                    second_user_id: secondUser,
+                },
+            };
+            const action = {
+                type: UserTypes.RECEIVED_PROFILES_LIST,
+                data: [
+                    partialUpdatedFirstUser,
+                    thirdUser,
+                ],
+            };
+            const {profiles: newProfiles} = reducer(state as unknown as ReducerState, action);
+
+            expect(newProfiles.first_user_id).toEqual({...firstUser, ...partialUpdatedFirstUser});
+            expect(newProfiles.second_user_id).toEqual(secondUser);
+            expect(newProfiles.third_user_id).toEqual(thirdUser);
         });
     });
 });

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.ts
@@ -105,7 +105,7 @@ function removeProfileFromSet(state: RelationOneToMany<Team, UserProfile>, actio
 function currentUserId(state = '', action: GenericAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_ME: {
-        const data = action.data || action.payload;
+        const data = action.data;
 
         return data.id;
     }
@@ -173,65 +173,81 @@ function myAudits(state = [], action: GenericAction) {
     }
 }
 
+function receiveUserProfile(state: IDMappedObjects<UserProfile>, received: UserProfile) {
+    const existing = state[received.id];
+
+    if (!existing) {
+        // No existing data to merge with
+        return {
+            ...state,
+            [received.id]: received,
+        };
+    }
+
+    const merged = {
+        ...existing,
+        ...received,
+    };
+
+    // MM-53377:
+    // For non-admin users, certain API responses don't return details for the current user that would be sanitized
+    // out for others. This currently includes:
+    // - email (if PrivacySettings.ShowEmailAddress is false)
+    // - first_name/last_name (if PrivacySettings.ShowFullName is false)
+    // - last_password_update
+    // - auth_service
+    // - notify_props
+    //
+    // Because email, first_name, last_name, and auth_service can all be empty strings regularly, we can't just
+    // merge the received user and the existing one together like we normally would. Instead, we can use the
+    // existence of existing.notify_props or existing.last_password_update to determine which object has that extra
+    // data so that it can take precedence. Those fields are:
+    // 1. Never empty or zero by Go standards
+    // 2. Only ever sent to the current user, not even to admins, so we know that the object contains privileged data
+    //
+    // Note that admins may have the email/name/auth_service of other users loaded as well. This does not prevent that
+    // data from being replaced when merging sanitized user objects. There doesn't seem to be a way for us to detect
+    // whether the object is sanitized for admins.
+    if (existing.notify_props && (!received.notify_props || Object.keys(received.notify_props).length === 0)) {
+        merged.email = existing.email;
+        merged.first_name = existing.first_name;
+        merged.last_name = existing.last_name;
+        merged.last_password_update = existing.last_password_update;
+        merged.auth_service = existing.auth_service;
+        merged.notify_props = existing.notify_props;
+    }
+
+    if (isEqual(existing, merged)) {
+        return state;
+    }
+
+    return {
+        ...state,
+        [merged.id]: merged,
+    };
+}
+
 function profiles(state: IDMappedObjects<UserProfile> = {}, action: GenericAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_ME:
     case UserTypes.RECEIVED_PROFILE: {
-        const data = action.data || action.payload;
-        const user = {...data};
-        const oldUser = state[data.id];
-        if (oldUser) {
-            user.terms_of_service_id = oldUser.terms_of_service_id;
-            user.terms_of_service_create_at = oldUser.terms_of_service_create_at;
+        const user = action.data;
 
-            if (isEqual(user, oldUser)) {
-                return state;
-            }
-        }
-
-        return {
-            ...state,
-            [data.id]: user,
-        };
+        return receiveUserProfile(state, user);
     }
     case UserTypes.RECEIVED_PROFILES_LIST: {
         const users: UserProfile[] = action.data;
 
-        return users.reduce((nextState, user) => {
-            const oldUser = nextState[user.id] || {};
-
-            if (isEqual(user, oldUser)) {
-                return nextState;
-            }
-
-            return {
-                ...nextState,
-                [user.id]: {
-                    ...oldUser,
-                    ...user,
-                },
-            };
-        }, state);
+        return users.reduce(receiveUserProfile, state);
     }
     case UserTypes.RECEIVED_PROFILES: {
         const users: UserProfile[] = Object.values(action.data);
 
-        return users.reduce((nextState, user) => {
-            const oldUser = nextState[user.id];
-
-            if (oldUser && isEqual(user, oldUser)) {
-                return nextState;
-            }
-
-            return {
-                ...nextState,
-                [user.id]: user,
-            };
-        }, state);
+        return users.reduce(receiveUserProfile, state);
     }
 
     case UserTypes.RECEIVED_TERMS_OF_SERVICE_STATUS: {
-        const data = action.data || action.payload;
+        const data = action.data;
         return {
             ...state,
             [data.user_id]: {

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.ts
@@ -198,15 +198,18 @@ function profiles(state: IDMappedObjects<UserProfile> = {}, action: GenericActio
         const users: UserProfile[] = action.data;
 
         return users.reduce((nextState, user) => {
-            const oldUser = nextState[user.id];
+            const oldUser = nextState[user.id] || {};
 
-            if (oldUser && isEqual(user, oldUser)) {
+            if (isEqual(user, oldUser)) {
                 return nextState;
             }
 
             return {
                 ...nextState,
-                [user.id]: user,
+                [user.id]: {
+                    ...oldUser,
+                    ...user,
+                },
             };
         }, state);
     }


### PR DESCRIPTION
#### Summary
This is blocked on https://github.com/mattermost/mattermost/pull/23912 since it reverts that while fixing the regression that it caused. Those now-unreverted fixes were about ensuring that the current user object would be updated by without refreshing (see https://mattermost.atlassian.net/browse/MM-52546).

Unfortunately, that caused the web app to lose privileged information that it had about the current user (first_name, last_name, email, auth_service) because it would be overwritten by values coming from sanitized versions of the user object. With the changes that were added, some of the ways this could happen are as simple as:

1. Having a GM channel in your LHS
2. Seeing yourself in the at mention autocomplete

We always sanitize user objects before sending them to the client, but we aren't very consistent with how we do that, so we often over-sanitize them. Typically, APIs like `getUser` return everything for the current user (minus things like the user's hashed password), almost everything for an admin (more on that below), and only the sanitized data for other, non-admin users. Some APIs will only return sanitized objects though, and those responses will be missing the privileged fields for non-admins.

Our usual method of merging objects with `{...old, ...new}` doesn't work for those fields because they're sent down to the client as `""` when sanitized out. But we also can't simply ignore empty values for those fields because they can all be empty normally. For example, you don't need to have your first/last name set in MM, and your auth_service will be set to `""` if you use email/password login.

To get around that, we can use the existence of the `notify_props` or `last_password_update` fields to tell us whether or not a user object contains privileged information. Those fields are only ever returned to the current user via APIs like `getUser`, and they're always non-zero (in Go terms), so if a user object has one of those, we can guarantee that it contains 100% correct values for those privileged fields. If we find one on the old object and not the new one when receiving data from the server, we know that we need to keep the previous value of those privileged fields.

```js
const merged = {...old, ...new};
if (old.notify_props && !new.notify_props) {
    merged.auth_service = old.auth_service;
    // and so on with the other fields
}
```

**tl;dr: We thought we could simply merge user objects together to ensure "privileged data" wasn't lost, but that didn't work because those values would be defined as empty strings which is also a valid value for them. This looks for a privileged field (notify_props) that can never be empty and uses that to help merge them manually.**


Let me know if any of that doesn't make sense. I also tried to describe that in a comment in the reducer as well so that we're less likely to accidentally break this in the future.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53467

#### Related Pull Requests
This reverts https://github.com/mattermost/mattermost/pull/23912
This re-adds https://github.com/mattermost/mattermost/pull/23219 and https://github.com/mattermost/mattermost/pull/23071

#### Release Note
```release-note
Updates the current user object more frequently without 
```
