### PR TITLE
MM-35269: RHS Search Results: View Thread link button

### DIFF
--- a/webapp/channels/src/components/post/post_options.tsx
+++ b/webapp/channels/src/components/post/post_options.tsx
@@ -3,8 +3,6 @@
 
 import React, {ReactNode, useEffect, useRef, useState} from 'react';
 
-import {FormattedMessage} from 'react-intl';
-
 import {Posts} from 'mattermost-redux/constants/index';
 import {isPostEphemeral} from 'mattermost-redux/utils/post_utils';
 
@@ -20,6 +18,7 @@ import CommentIcon from 'components/common/comment_icon';
 import {Emoji} from '@mattermost/types/emojis';
 import {Post} from '@mattermost/types/posts';
 import classnames from 'classnames';
+import ThreadsViewer from 'components/threading/global_threads_link/threadsView';
 
 type Props = {
     post: Post;
@@ -205,31 +204,16 @@ const PostOptions = (props: Props): JSX.Element => {
     } else if (isPostDeleted || (systemMessage && !props.canDelete)) {
         options = null;
     } else if (props.location === Locations.SEARCH) {
-        const hasCRTFooter = props.collapsedThreadsEnabled && !post.root_id && (post.reply_count > 0 || post.is_following);
         options = (
             <div className='col__controls post-menu'>
-                {dotMenu}
-                {flagIcon}
-                {props.canReply && !hasCRTFooter &&
-                    <CommentIcon
-                        location={props.location}
-                        handleCommentClick={props.handleCommentClick}
-                        commentCount={props.replyCount}
-                        postId={post.id}
-                        searchStyle={'search-item__comment'}
-                        extraClass={props.replyCount ? 'icon--visible' : ''}
-                    />
-                }
-                <a
+                <ThreadsViewer
+                    location={props.location}
+                    handleJumpClick={props.handleJumpClick}
+                    postId={post.id}
                     href='#'
-                    onClick={props.handleJumpClick}
-                    className='search-item__jump'
-                >
-                    <FormattedMessage
-                        id='search_item.jump'
-                        defaultMessage='Jump'
-                    />
-                </a>
+                />
+                {flagIcon}
+                {dotMenu}
             </div>
         );
     } else if (!props.isPostBeingEdited) {

--- a/webapp/channels/src/components/threading/global_threads_link/thread_icon_rhs.tsx
+++ b/webapp/channels/src/components/threading/global_threads_link/thread_icon_rhs.tsx
@@ -1,0 +1,24 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {useIntl} from 'react-intl';
+
+export default function ThreadIconRHS(props: React.HTMLAttributes<HTMLSpanElement>) {
+    const {formatMessage} = useIntl();
+    return (
+        <span {...props}>
+            <svg
+                width='16px'
+                height='14px'
+                viewBox='0 0 16 14'
+                role='img'
+                aria-label={formatMessage({id: 'generic_icons.thread', defaultMessage: 'View Thread'})}
+            >
+                <path
+                    d='M11.7952 0.00524884C12.1312 0.00524884 12.4144 0.125249 12.6448 0.365248C12.8848 0.595648 13.0048 0.878848 13.0048 1.21485V8.41485C13.0048 8.75085 12.8848 9.03405 12.6448 9.26445C12.4144 9.49485 12.1312 9.61005 11.7952 9.61005H3.4L0.9952 12.0148V1.21485C0.9952 0.878848 1.1104 0.595648 1.3408 0.365248C1.5808 0.125249 1.8688 0.00524884 2.2048 0.00524884H11.7952ZM2.2048 1.21485V9.10605L2.896 8.41485H11.7952V1.21485H2.2048ZM3.4 3.01485H10.6V4.21005H3.4V3.01485ZM3.4 5.40525H8.8V6.61485H3.4V5.40525Z'
+                />
+            </svg>
+        </span>
+    );
+}

--- a/webapp/channels/src/components/threading/global_threads_link/threadsView.tsx
+++ b/webapp/channels/src/components/threading/global_threads_link/threadsView.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import {localizeMessage} from 'utils/utils';
+
+import OverlayTrigger from 'components/overlay_trigger';
+import Tooltip from 'components/tooltip';
+import {Locations} from 'utils/constants';
+import ThreadIconRHS from './thread_icon_rhs';
+
+type Props = {
+    location: keyof typeof Locations;
+    handleJumpClick: React.EventHandler<React.MouseEvent>;
+    postId?: string;
+    href: string;
+}
+
+export default class ThreadsViewer extends React.PureComponent<Props> {
+    public static defaultProps: Partial<Props> = {
+        location: 'CENTER',
+    };
+
+    public render(): JSX.Element {
+        const iconStyle = 'post-menu__item';
+
+        const tooltip = (
+            <Tooltip
+                id='thread-icon-tooltip'
+                className='hidden-xs'
+            >
+                <FormattedMessage
+                    id='post_info.viewThread_icon.tooltip.thread'
+                    defaultMessage='View Thread'
+                />
+            </Tooltip>
+        );
+
+        return (
+            <OverlayTrigger
+                delayShow={500}
+                placement='top'
+                overlay={tooltip}
+            >
+                <button
+                    type='button'
+                    id={`${this.props.location}_commentIcon_${this.props.postId}`}
+                    aria-label={localizeMessage('post_info.viewThread_icon.tooltip.thread', 'View Thread').toLowerCase()}
+                    className={iconStyle}
+                    onClick={this.props.handleJumpClick}
+                >
+                    <ThreadIconRHS className='icon--small icon--thread'/>
+                </button>
+            </OverlayTrigger>
+        );
+    }
+}
+

--- a/webapp/channels/src/sass/components/_icons.scss
+++ b/webapp/channels/src/sass/components/_icons.scss
@@ -21,6 +21,10 @@
     height: 14px;
 }
 
+.icon--thread {
+    padding-top: 2px;
+}
+
 .icon--standard {
     width: 20px;
     height: 20px;

--- a/webapp/channels/src/sass/components/_search.scss
+++ b/webapp/channels/src/sass/components/_search.scss
@@ -335,20 +335,6 @@
     top: -9px;
     right: 0;
     font-size: 13px;
-
-    a {
-        vertical-align: top;
-    }
-
-    .search-item__jump {
-        position: relative;
-        padding: 5px 4px 0;
-        border-radius: 4px;
-        color: rgba(var(--center-channel-color-rgb), 0.4);
-        font-size: 12px;
-        font-weight: 600;
-        text-decoration: none;
-    }
 }
 
 .search-item-time {


### PR DESCRIPTION

Problem: The overlay of the menu search bar was different from what they wanted

![137028820-dcf89f4a-357f-42ef-94c2-b4cedddfe3ea](https://github.com/GitStartHQ/client-mattermost-server/assets/102544529/206bc947-b767-49bc-80e4-43f37540053d)

Solution: I organized the existing menu buttons and created a new one (view thread) with the same functionality as the existing button (jump).
I also removed the reply button, since now we will have the new view thread functionality (it can be placed back in the menu)

![image](https://github.com/GitStartHQ/client-mattermost-server/assets/102544529/4744266f-ada4-4ec3-8f95-297fdb825f3e)

https://www.loom.com/share/d4aeb0b6fe9147999b5f1f0248425e24

Fixes:  [#18579](https://github.com/mattermost/mattermost/issues/18579)
JIRA: https://mattermost.atlassian.net/browse/MM-35269

```release-note
RHS Search Results: View Thread link button
```

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
