### PR TITLE
Create mmctl release pipeline

### DIFF
--- a/.github/workflows/mmctl-release.yml
+++ b/.github/workflows/mmctl-release.yml
@@ -10,7 +10,7 @@ on:
   #      type: string
   #      required: true
   #    dry_run:
-  #      type: boolean
+  #      type: string    # Use "false" to enable the actual run
   #      required: false
 
 defaults:
@@ -51,7 +51,8 @@ jobs:
       GOOS: "${{ matrix.os }}"
       GOARCH: "${{ matrix.arch }}"
       DRY_RUN: "${{ inputs.dry_run || true }}"
-      TAR_FILENAME: "mmctl-${{ matrix.os }}-${{ matrix.arch }}.tar"
+      RELEASE_VERSION: "${{ inputs.release_version || 'prerelease' }}"
+      TAR_FILENAME: "mmctl-${{ inputs.release_version || 'prerelease' }}-${{ matrix.os }}-${{ matrix.arch }}.tar"
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -65,20 +66,26 @@ jobs:
       - name: ci/mmctl-package
         run: |
           make mmctl-build
-          tar -cvf build/${TAR_FILENAME} bin/mmctl*
+          tar -cvf build/${TAR_FILENAME} bin/mmctl*  # For windows, the binary is named 'mmctl.exe'
           md5sum < build/${TAR_FILENAME} | cut -d ' ' -f 1 | tee build/${TAR_FILENAME}.md5.txt
       - name: ci/mmctl-upload-jobartifact
         uses: actions/upload-artifact@v3
         with:
           name: "mmctl-${{ matrix.os }}-${{ matrix.arch }}"
           path: server/build/mmctl-*
+      - name: ci/configure-aws-credentials
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.MM_SERVER_RELEASES_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.MM_SERVER_RELEASES_AWS_SECRET_ACCESS_KEY }}
       - name: ci/mmctl-upload-s3
         run: |
-          if [ "$DRY_RUN" != "false" ]; then
-            echo "Running in dry run mode, not uploading artifacts to S3."
-            exit 0
-          fi
-          echo "TODO: not in a dry run, must upload to S3"
+          DRY_RUN_FLAG="--dryrun"
+          [ "$DRY_RUN" = "false" ] && DRY_RUN_FLAG=""
+          for SUFFIX in "" ".md5.txt"; do
+            aws s3 cp ${DRY_RUN_FLAG} build/${TAR_FILENAME}${SUFFIX} s3://releasetest.mattermost.com/${RELEASE_VERSION}/${TAR_FILENAME}${SUFFIX} --acl public-read --cache-control "no-cache"
+          done
 
   update-failure-final-status:
     runs-on: ubuntu-22.04

--- a/.github/workflows/mmctl-release.yml
+++ b/.github/workflows/mmctl-release.yml
@@ -1,0 +1,114 @@
+name: E2E Tests
+on:
+  # TODO testing, remove this before merging
+  push:
+  ## This workflow gets triggered from the Argo Events platform.
+  ## Check the following repo for details: https://github.com/mattermost/delivery-platform
+  #workflow_dispatch:
+  #  inputs:
+  #    release_version:
+  #      type: string
+  #      required: true
+  #    dry_run:
+  #      type: boolean
+  #      required: false
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  go-version: "1.19.5"
+
+jobs:
+  update-initial-status:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: mattermost/actions/delivery/update-commit-status@main
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          repository_full_name: ${{ github.repository }}
+          commit_sha: ${{ github.sha }}
+          context: mmctl/publish
+          description: Publish mmctl binaries
+          status: pending
+
+  build:
+    runs-on: ubuntu-22.04
+    needs:
+      - update-initial-status
+    defaults:
+      run:
+        working-directory: server
+    strategy:
+      matrix:
+        os: [linux, darwin, windows]
+        arch: [amd64, arm64]
+        exclude:
+          - os: windows
+            arch: arm64
+    env:
+      GOBIN: "bin"
+      GOOS: "${{ matrix.os }}"
+      GOARCH: "${{ matrix.arch }}"
+      DRY_RUN: "${{ inputs.dry_run || true }}" # NB: booleans get templated out as 0 and 1
+    steps:
+      - name: ci/checkout-repo
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: ci/setup-go
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        with:
+          go-version: ${{ env.go-version }}
+          cache-dependency-path: |
+            server/go.sum
+            server/public/go.sum
+      - name: ci/mmctl-package
+        run: |
+          make mmctl-build
+          tar -cf build/mmctl-${GOOS}-${GOARCH}.tar bin/mmctl
+          md5sum <build/mmctl-${GOOS}-${GOARCH}.tar | cut -d ' ' -f 1 > build/mmctl-${GOOS}-${GOARCH}.tar.md5.txt
+      - name: ci/mmctl-upload-jobartifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: "mmctl-${{ matrix.os }}-${{ matrix.arch }}"
+          path: build/mmctl-*
+      - name: ci/mmctl-upload-s3
+        run: |
+          if [ "$DRY_RUN" != "0" ]; then
+            echo "Running in dry run mode, not uploading artifacts to S3."
+            exit 0
+          fi
+          echo "TODO: not in a dry run, must upload to S3"
+
+  update-failure-final-status:
+    runs-on: ubuntu-22.04
+    if: failure() || cancelled()
+    needs:
+      - smoketests
+    steps:
+      - uses: mattermost/actions/delivery/update-commit-status@main
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          repository_full_name: ${{ github.repository }}
+          commit_sha: ${{ github.sha }}
+          context: mmctl/publish
+          description: Publish mmctl binaries
+          status: failure
+
+  update-success-final-status:
+    runs-on: ubuntu-22.04
+    if: success()
+    needs:
+      - smoketests
+    steps:
+      - uses: mattermost/actions/delivery/update-commit-status@main
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          repository_full_name: ${{ github.repository }}
+          commit_sha: ${{ github.sha }}
+          context: mmctl/publish
+          description: Publish mmctl binaries
+          status: success

--- a/.github/workflows/mmctl-release.yml
+++ b/.github/workflows/mmctl-release.yml
@@ -52,7 +52,6 @@ jobs:
       GOARCH: "${{ matrix.arch }}"
       DRY_RUN: "${{ inputs.dry_run || true }}"
       RELEASE_VERSION: "${{ inputs.release_version || 'prerelease' }}"
-      TAR_FILENAME: "mmctl-${{ inputs.release_version || 'prerelease' }}-${{ matrix.os }}-${{ matrix.arch }}.tar"
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -65,14 +64,26 @@ jobs:
             server/public/go.sum
       - name: ci/mmctl-package
         run: |
+          mkdir -p .mmctl-build
           make mmctl-build
-          tar -cvf build/${TAR_FILENAME} bin/mmctl*  # For windows, the binary is named 'mmctl.exe'
-          md5sum < build/${TAR_FILENAME} | cut -d ' ' -f 1 | tee build/${TAR_FILENAME}.md5.txt
+          case $GOOS in
+          windows )
+            ARCHIVE_PATH=".mmctl-build/${GOOS}_${GOARCH}.zip"
+            zip ${ARCHIVE_PATH} bin/mmctl.exe
+            rm bin/mmctl.exe
+            ;;
+          * )
+            ARCHIVE_PATH=".mmctl-build/${GOOS}_${GOARCH}.tar"
+            tar -cvf ${ARCHIVE_PATH} bin/mmctl
+            rm bin/mmctl
+            ;;
+          esac
+          md5sum < ${ARCHIVE_PATH} | cut -d ' ' -f 1 | tee ${ARCHIVE_PATH}.md5.txt
       - name: ci/mmctl-upload-jobartifact
         uses: actions/upload-artifact@v3
         with:
-          name: "mmctl-${{ matrix.os }}-${{ matrix.arch }}"
-          path: server/build/mmctl-*
+          name: "${{ matrix.os }}_${{ matrix.arch }}"
+          path: server/.mmctl-build/*
       - name: ci/configure-aws-credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
@@ -83,9 +94,7 @@ jobs:
         run: |
           DRY_RUN_FLAG="--dryrun"
           [ "$DRY_RUN" = "false" ] && DRY_RUN_FLAG=""
-          for SUFFIX in "" ".md5.txt"; do
-            aws s3 cp ${DRY_RUN_FLAG} build/${TAR_FILENAME}${SUFFIX} s3://releasetest.mattermost.com/${RELEASE_VERSION}/${TAR_FILENAME}${SUFFIX} --acl public-read --cache-control "no-cache"
-          done
+          aws s3 cp ${DRY_RUN_FLAG} .mmctl-build/* s3://releases.mattermost.com/${RELEASE_VERSION}/ --acl public-read --cache-control "no-cache" --recursive
 
   update-failure-final-status:
     runs-on: ubuntu-22.04

--- a/.github/workflows/mmctl-release.yml
+++ b/.github/workflows/mmctl-release.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           DRY_RUN_FLAG="--dryrun"
           [ "$DRY_RUN" = "false" ] && DRY_RUN_FLAG=""
-          aws s3 cp ${DRY_RUN_FLAG} .mmctl-build/* s3://releases.mattermost.com/${RELEASE_VERSION}/ --acl public-read --cache-control "no-cache" --recursive
+          aws s3 cp ${DRY_RUN_FLAG} .mmctl-build/ s3://releases.mattermost.com/${RELEASE_VERSION}/ --acl public-read --cache-control "no-cache" --recursive
 
   update-failure-final-status:
     runs-on: ubuntu-22.04

--- a/.github/workflows/mmctl-release.yml
+++ b/.github/workflows/mmctl-release.yml
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: failure() || cancelled()
     needs:
-      - smoketests
+      - build
     steps:
       - uses: mattermost/actions/delivery/update-commit-status@main
         env:
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: success()
     needs:
-      - smoketests
+      - build
     steps:
       - uses: mattermost/actions/delivery/update-commit-status@main
         env:

--- a/.github/workflows/mmctl-release.yml
+++ b/.github/workflows/mmctl-release.yml
@@ -1,17 +1,15 @@
 name: mmctl release
 on:
-  # TODO testing, remove this before merging
-  push:
-  ## This workflow gets triggered from the Argo Events platform.
-  ## Check the following repo for details: https://github.com/mattermost/delivery-platform
-  #workflow_dispatch:
-  #  inputs:
-  #    release_version:
-  #      type: string
-  #      required: true
-  #    dry_run:
-  #      type: string    # Use "false" to enable the actual run
-  #      required: false
+  # This workflow gets triggered from the Argo Events platform.
+  # Check the following repo for details: https://github.com/mattermost/delivery-platform
+  workflow_dispatch:
+    inputs:
+      release_version:
+        type: string
+        required: true
+      dry_run:
+        type: string    # Use "false" to enable the actual run
+        required: false
 
 defaults:
   run:
@@ -94,7 +92,7 @@ jobs:
         run: |
           DRY_RUN_FLAG="--dryrun"
           [ "$DRY_RUN" = "false" ] && DRY_RUN_FLAG=""
-          aws s3 cp ${DRY_RUN_FLAG} .mmctl-build/ s3://releases.mattermost.com/${RELEASE_VERSION}/ --acl public-read --cache-control "no-cache" --recursive
+          aws s3 cp ${DRY_RUN_FLAG} .mmctl-build/ s3://releases.mattermost.com/mmctl/${RELEASE_VERSION}/ --acl public-read --cache-control "no-cache" --recursive
 
   update-failure-final-status:
     runs-on: ubuntu-22.04

--- a/.github/workflows/mmctl-release.yml
+++ b/.github/workflows/mmctl-release.yml
@@ -1,4 +1,4 @@
-name: E2E Tests
+name: mmctl release
 on:
   # TODO testing, remove this before merging
   push:

--- a/.github/workflows/mmctl-release.yml
+++ b/.github/workflows/mmctl-release.yml
@@ -99,11 +99,31 @@ jobs:
         run: |
           aws s3 cp .mmctl-build/ s3://releases.mattermost.com/mmctl/${{ needs.expose-incoming-variables.outputs.ref_name }}/ --acl public-read --cache-control "no-cache" --recursive
 
+  cloudfront-invalidate:
+    runs-on: ubuntu-22.04
+    needs:
+      - expose-incoming-variables
+      - build
+    env:
+      CF_DISTRIBUTION: "E38T4CYCA0KCH8"
+    steps:
+      - name: ci/configure-aws-credentials
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.MM_SERVER_RELEASES_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.MM_SERVER_RELEASES_AWS_SECRET_ACCESS_KEY }}
+      - name: ci/mmctl-upload-s3
+        run: |
+          INVALIDATION_ID=$(aws cloudfront create-invalidation --distribution-id $CF_DISTRIBUTION --paths "/mmctl/${{ needs.expose-incoming-variables.outputs.ref_name }}" | jq -r '.Invalidation.Id')
+          aws configure set preview.cloudfront true
+          aws cloudfront wait invalidation-completed --id $INVALIDATION_ID --distribution-id $CF_DISTRIBUTION
+
   update-failure-final-status:
     runs-on: ubuntu-22.04
     if: failure() || cancelled()
     needs:
-      - build
+      - cloudfront-invalidate
     steps:
       - uses: mattermost/actions/delivery/update-commit-status@main
         env:
@@ -119,7 +139,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: success()
     needs:
-      - build
+      - cloudfront-invalidate
     steps:
       - uses: mattermost/actions/delivery/update-commit-status@main
         env:

--- a/.github/workflows/mmctl-release.yml
+++ b/.github/workflows/mmctl-release.yml
@@ -16,6 +16,7 @@ on:
 defaults:
   run:
     shell: bash
+    working-directory: server
 
 env:
   go-version: "1.19.5"
@@ -38,9 +39,6 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
       - update-initial-status
-    defaults:
-      run:
-        working-directory: server
     strategy:
       matrix:
         os: [linux, darwin, windows]
@@ -52,7 +50,8 @@ jobs:
       GOBIN: "bin"
       GOOS: "${{ matrix.os }}"
       GOARCH: "${{ matrix.arch }}"
-      DRY_RUN: "${{ inputs.dry_run || true }}" # NB: booleans get templated out as 0 and 1
+      DRY_RUN: "${{ inputs.dry_run || true }}"
+      TAR_FILENAME: "mmctl-${{ matrix.os }}-${{ matrix.arch }}.tar"
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -66,16 +65,16 @@ jobs:
       - name: ci/mmctl-package
         run: |
           make mmctl-build
-          tar -cf build/mmctl-${GOOS}-${GOARCH}.tar bin/mmctl
-          md5sum <build/mmctl-${GOOS}-${GOARCH}.tar | cut -d ' ' -f 1 > build/mmctl-${GOOS}-${GOARCH}.tar.md5.txt
+          tar -cvf build/${TAR_FILENAME} bin/mmctl*
+          md5sum < build/${TAR_FILENAME} | cut -d ' ' -f 1 | tee build/${TAR_FILENAME}.md5.txt
       - name: ci/mmctl-upload-jobartifact
         uses: actions/upload-artifact@v3
         with:
           name: "mmctl-${{ matrix.os }}-${{ matrix.arch }}"
-          path: build/mmctl-*
+          path: server/build/mmctl-*
       - name: ci/mmctl-upload-s3
         run: |
-          if [ "$DRY_RUN" != "0" ]; then
+          if [ "$DRY_RUN" != "false" ]; then
             echo "Running in dry run mode, not uploading artifacts to S3."
             exit 0
           fi

--- a/.github/workflows/mmctl-release.yml
+++ b/.github/workflows/mmctl-release.yml
@@ -4,11 +4,12 @@ on:
   # Check the following repo for details: https://github.com/mattermost/delivery-platform
   workflow_dispatch:
     inputs:
-      release_version:
-        type: string
+      payload:
+        description: "The triggerer payload"
         required: true
+        type: string
       dry_run:
-        type: string    # Use "false" to enable the actual run
+        type: string # True if left empty. Set to "false" to enable the S3 upload
         required: false
 
 defaults:
@@ -33,10 +34,20 @@ jobs:
           description: Publish mmctl binaries
           status: pending
 
+  expose-incoming-variables:
+    runs-on: ubuntu-22.04
+    outputs:
+      ref_name: ${{ env.TRIGGERER_BRANCH }}
+    steps:
+      - uses: mattermost/actions/delivery/expose-events-vars@a74f6d87f847326c04d326bf1908da40cb9b3556
+        with:
+          payload: ${{ inputs.payload }}
+
   build:
     runs-on: ubuntu-22.04
     needs:
       - update-initial-status
+      - expose-incoming-variables
     strategy:
       matrix:
         os: [linux, darwin, windows]
@@ -49,7 +60,6 @@ jobs:
       GOOS: "${{ matrix.os }}"
       GOARCH: "${{ matrix.arch }}"
       DRY_RUN: "${{ inputs.dry_run || true }}"
-      RELEASE_VERSION: "${{ inputs.release_version || 'prerelease' }}"
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -92,7 +102,7 @@ jobs:
         run: |
           DRY_RUN_FLAG="--dryrun"
           [ "$DRY_RUN" = "false" ] && DRY_RUN_FLAG=""
-          aws s3 cp ${DRY_RUN_FLAG} .mmctl-build/ s3://releases.mattermost.com/mmctl/${RELEASE_VERSION}/ --acl public-read --cache-control "no-cache" --recursive
+          aws s3 cp ${DRY_RUN_FLAG} .mmctl-build/ s3://releases.mattermost.com/mmctl/${{ needs.expose-incoming-variables.outputs.ref_name }}/ --acl public-read --cache-control "no-cache" --recursive
 
   update-failure-final-status:
     runs-on: ubuntu-22.04

--- a/.github/workflows/mmctl-release.yml
+++ b/.github/workflows/mmctl-release.yml
@@ -8,9 +8,6 @@ on:
         description: "The triggerer payload"
         required: true
         type: string
-      dry_run:
-        type: string # True if left empty. Set to "false" to enable the S3 upload
-        required: false
 
 defaults:
   run:
@@ -88,7 +85,7 @@ jobs:
           esac
           md5sum < ${ARCHIVE_PATH} | cut -d ' ' -f 1 | tee ${ARCHIVE_PATH}.md5.txt
       - name: ci/mmctl-upload-jobartifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: "${{ matrix.os }}_${{ matrix.arch }}"
           path: server/.mmctl-build/*
@@ -100,9 +97,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.MM_SERVER_RELEASES_AWS_SECRET_ACCESS_KEY }}
       - name: ci/mmctl-upload-s3
         run: |
-          DRY_RUN_FLAG="--dryrun"
-          [ "$DRY_RUN" = "false" ] && DRY_RUN_FLAG=""
-          aws s3 cp ${DRY_RUN_FLAG} .mmctl-build/ s3://releases.mattermost.com/mmctl/${{ needs.expose-incoming-variables.outputs.ref_name }}/ --acl public-read --cache-control "no-cache" --recursive
+          aws s3 cp .mmctl-build/ s3://releases.mattermost.com/mmctl/${{ needs.expose-incoming-variables.outputs.ref_name }}/ --acl public-read --cache-control "no-cache" --recursive
 
   update-failure-final-status:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
#### Summary

mmctl recently moved to the monorepo, so there's no new code being pushed to [the old mmctl repo](https://github.com/mattermost/mmctl). However, the release pipelines are still publishing mmctl versions to it.

For mattermos >=v8.0 we want to publish mmctl using the monorepo code insteadò.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-5793

#### Release Note

```release-note
NONE
```
