### PR TITLE
MM-53485

### DIFF
--- a/webapp/channels/src/components/profile_popover/profile_popover.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover.tsx
@@ -531,6 +531,7 @@ class ProfilePopover extends React.PureComponent<ProfilePopoverProps, ProfilePop
             );
             dataContent.push(
                 <div
+                    title={position}
                     className='overflow--ellipsis text-nowrap'
                     key='user-popover-position'
                 >


### PR DESCRIPTION
#### Summary
When looking at the profile popover with a "job position" that extends past the available space, resulting in the ellipses at the end, I always want to hover over the title so I can read the whole title, but hovering currently doesn't do anything

We should add a standard tooltip to truncated job titles so that the full title can be read when hovering.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/23944
[Jira https://mattermost.atlassian.net/browse/MM-XXX](https://mattermost.atlassian.net/browse/MM-53485)


#### Screenshots
I will attach in comments

Hey, this is my first contribution. It would be helpful if someone could review it.