### PR TITLE
Re-add package target to web app Makefile

### DIFF
--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -3,6 +3,7 @@ junit.xml
 node_modules
 *.tsbuildinfo
 .rollup.cache
+*.tar.gz
 
 channels/dist
 playbooks/dist

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -76,6 +76,14 @@ clean: ## Clears cached; deletes node_modules and dist directories
 	npm run clean --workspaces --if-present
 	rm -rf node_modules
 
+.PHONY: package
+package: node_modules dist ## Generates ./mattermost-webapp.tar.gz for use by someone customizing the web app
+	mkdir tmp
+	mv channels/dist tmp/client
+	tar -C tmp -czf mattermost-webapp.tar.gz client
+	mv tmp/client channels/dist
+	rmdir tmp
+
 ## Help documentation à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 .PHONY: help
 help:


### PR DESCRIPTION
#### Summary
We removed this at some point after the monorepo migration because we no longer needed to upload the web app as an artifact, but our customization docs refer to using that to customize the web app.

#### Release Note
```release-note
NONE
```
