### PR TITLE
secrets: inherit, to fix flaky tests report

### DIFF
--- a/.github/workflows/server-ci-master.yml
+++ b/.github/workflows/server-ci-master.yml
@@ -12,3 +12,4 @@ env:
 jobs:
   master-ci:
     uses: ./.github/workflows/server-ci-template.yml
+    secrets: inherit

--- a/.github/workflows/server-ci-pr.yml
+++ b/.github/workflows/server-ci-pr.yml
@@ -19,3 +19,4 @@ concurrency:
 jobs:
   pr-ci:
     uses: ./.github/workflows/server-ci-template.yml
+    secrets: inherit

--- a/.github/workflows/server-ci-template.yml
+++ b/.github/workflows/server-ci-template.yml
@@ -234,6 +234,7 @@ jobs:
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10&binary_parameters=yes
       drivername: postgres
       logsartifact: postgres-binary-server-test-logs
+    secrets: inherit
   test-postgres-normal:
     name: Postgres
     needs: check-mattermost-vet
@@ -243,6 +244,7 @@ jobs:
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
       drivername: postgres
       logsartifact: postgres-server-test-logs
+    secrets: inherit
   test-mysql:
     name: MySQL
     needs: check-mattermost-vet
@@ -252,6 +254,7 @@ jobs:
       datasource: mmuser:mostest@tcp(mysql:3306)/mattermost_test?charset=utf8mb4,utf8&multiStatements=true&maxAllowedPacket=4194304
       drivername: mysql
       logsartifact: mysql-server-test-logs
+    secrets: inherit
   test-mmctl:
     name: Run mmctl tests
     needs: check-mattermost-vet


### PR DESCRIPTION
#### Summary
Leverage `secrets: inherit` to make the secret available for reporting flaky test back to https://community.mattermost.com.

#### Ticket Link
See discussion at https://community.mattermost.com/core/pl/ws4kz3746frjzj7o43uib487fe.

#### Release Note
```release-note
NONE
```
