### PR TITLE
[MM-53430] Don't stop the `isDraftSubmitting` flow when the notification modal is popped

### DIFF
--- a/webapp/channels/src/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/webapp/channels/src/components/advanced_create_comment/advanced_create_comment.tsx
@@ -650,7 +650,6 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
 
         if (memberNotifyCount > 0) {
             this.showNotifyAllModal(mentions, channelTimezoneCount, memberNotifyCount);
-            this.isDraftSubmitting = false;
             return;
         }
 

--- a/webapp/channels/src/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/webapp/channels/src/components/advanced_create_comment/advanced_create_comment.tsx
@@ -475,6 +475,9 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
                 channelTimezoneCount,
                 memberNotifyCount,
                 onConfirm: () => this.handleNotifyAllConfirmation(),
+                onExited: () => {
+                    this.isDraftSubmitting = false;
+                },
             },
         });
     };

--- a/webapp/channels/src/components/advanced_create_post/advanced_create_post.tsx
+++ b/webapp/channels/src/components/advanced_create_post/advanced_create_post.tsx
@@ -689,7 +689,6 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             return;
         } else if (memberNotifyCount > 0) {
             this.showNotifyAllModal(mentions, channelTimezoneCount, memberNotifyCount);
-            this.isDraftSubmitting = false;
             return;
         }
 

--- a/webapp/channels/src/components/advanced_create_post/advanced_create_post.tsx
+++ b/webapp/channels/src/components/advanced_create_post/advanced_create_post.tsx
@@ -585,6 +585,9 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
                 channelTimezoneCount,
                 memberNotifyCount,
                 onConfirm: () => this.handleNotifyAllConfirmation(),
+                onExited: () => {
+                    this.isDraftSubmitting = false;
+                },
             },
         });
     };


### PR DESCRIPTION
#### Summary
When trying to send an `@here` (or other global mention) in the RHS, if you press Enter without blurring the post box, it would keep your draft when the message was sent.

This is being caused by the state updating when the textbox is blurred after pressing Enter. The component is supposed to save the draft as is when it's blurred, but only if the post is not mid-submission.

The fix here was then to have the component still be in "submitting" state while the modal was open, and only clear it if the message was chosen not to be sent.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53430

```release-note
Fix an issue where the draft would persist after sending an `@here` mention in the RHS
```
