### PR TITLE
[MM-53408] server/user_store: avoid antijoin for IsEmpty query

### DIFF
--- a/server/channels/store/sqlstore/user_store.go
+++ b/server/channels/store/sqlstore/user_store.go
@@ -2140,7 +2140,11 @@ func (us SqlUserStore) IsEmpty(excludeBots bool) (bool, error) {
 		From("Users")
 
 	if excludeBots {
-		builder = builder.LeftJoin("Bots ON Users.Id = Bots.UserId").Where("Bots.UserId IS NULL")
+		if isPostgreSQL := us.DriverName() == model.DatabaseDriverPostgres; isPostgreSQL {
+			builder = builder.LeftJoin("Bots ON Users.Id = Bots.UserId").Where("Bots.UserId IS NULL")
+		} else {
+			builder = builder.Where(sq.Expr("Users.Id NOT IN (SELECT UserId FROM Bots)"))
+		}
 	}
 
 	builder = builder.Suffix(")")


### PR DESCRIPTION

#### Summary
Fix `userstore.IsEmpty` call to avoid `LEFT JOIN .. IS NULL` for MySQL

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53408

#### Release Note

```release-note
NONE
```
