### PR TITLE
MM-50460 Remove max-width from AdvancedTextEditor

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -366,7 +366,6 @@ const AdvanceTextEditor = ({
 
         if (!message) {
             // if we do not have a message we can just render the default state
-            input.style.maxWidth = `${maxWidth}px`;
             setShowFormattingSpacer(false);
             return;
         }
@@ -377,10 +376,8 @@ const AdvanceTextEditor = ({
         const currentWidth = width + inputPaddingX;
 
         if (currentWidth >= maxWidth) {
-            input.style.maxWidth = '100%';
             setShowFormattingSpacer(true);
         } else {
-            input.style.maxWidth = `${maxWidth}px`;
             setShowFormattingSpacer(false);
         }
     }, [message, input]);


### PR DESCRIPTION
#### Summary
I ended up making a bunch more changes to these components that I'll submit separately, but the root of this problem can actually be solved just by removing the max-width on the textbox like was done in https://github.com/mattermost/mattermost/pull/22744. I guess the max-width was needed with a previous version of the AdvancedTextEditor, but the current code mostly uses right padding to prevent the textbox from overlapping with the controls on the right.

@yasserfaraazkhan There's a bug case with this that was reported in the above PR ([this one](https://github.com/mattermost/mattermost/pull/22744)) where the text can sometimes overlap the controls on the right, but it only happens  if the post text contains a bunch of repeated spaces. It turns out there's a few other issues with the AutosizeTextarea that figures out how big the text is, and I'm going to submit a fix for those issues separately since the required changes are much larger

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50460

#### Screenshots

|  before  |  after  |
|----|----|
|<img width="1168" alt="Screen Shot 2023-07-07 at 1 07 09 PM" src="https://github.com/mattermost/mattermost/assets/3277310/2ba9f5ed-7093-48f6-a14b-d8c7b208c6de"> | <img width="1168" alt="Screen Shot 2023-07-07 at 1 06 40 PM" src="https://github.com/mattermost/mattermost/assets/3277310/85c55a96-d989-41ab-a3fa-0ed30bd911b4">|
|<img width="607" alt="Screen Shot 2023-07-07 at 1 09 12 PM" src="https://github.com/mattermost/mattermost/assets/3277310/b8cb0c47-0f23-4e8d-82a3-5b057eb5604b">|<img width="607" alt="Screen Shot 2023-07-07 at 1 09 25 PM" src="https://github.com/mattermost/mattermost/assets/3277310/5496058c-6d6f-435a-bf71-b0a86738150e">|

#### Release Note
```release-note
Fixed clickable area of post textboxes being too small
```
