### PR TITLE
MM52237 - prevent fetching fileCount from unnecessary places

### DIFF
--- a/webapp/channels/src/actions/global_actions.tsx
+++ b/webapp/channels/src/actions/global_actions.tsx
@@ -65,7 +65,7 @@ export function emitChannelClickEvent(channel: Channel) {
         const currentChannelId = getCurrentChannelId(state);
         const previousRhsState = getPreviousRhsState(state);
 
-        dispatch(getChannelStats(chan.id, true));
+        dispatch(getChannelStats(chan.id));
 
         const penultimate = LocalStorageStore.getPreviousChannelName(userId, teamId);
         const penultimateType = LocalStorageStore.getPreviousViewedType(userId, teamId);

--- a/webapp/channels/src/components/channel_info_rhs/menu.tsx
+++ b/webapp/channels/src/components/channel_info_rhs/menu.tsx
@@ -99,7 +99,7 @@ interface MenuProps {
         showChannelFiles: (channelId: string) => void;
         showPinnedPosts: (channelId: string | undefined) => void;
         showChannelMembers: (channelId: string) => void;
-        getChannelStats: (channelId: string) => Promise<{data: ChannelStats}>;
+        getChannelStats: (channelId: string, excludeFilesCount: boolean) => Promise<{data: ChannelStats}>;
     };
 }
 
@@ -112,7 +112,7 @@ const Menu = ({channel, channelStats, isArchived, className, actions}: MenuProps
     const fileCount = channelStats?.files_count >= 0 ? channelStats?.files_count : 0;
 
     useEffect(() => {
-        actions.getChannelStats(channel.id).then(() => {
+        actions.getChannelStats(channel.id, false).then(() => {
             setLoadingStats(false);
         });
         return () => {

--- a/webapp/channels/src/components/channel_info_rhs/menu.tsx
+++ b/webapp/channels/src/components/channel_info_rhs/menu.tsx
@@ -99,7 +99,7 @@ interface MenuProps {
         showChannelFiles: (channelId: string) => void;
         showPinnedPosts: (channelId: string | undefined) => void;
         showChannelMembers: (channelId: string) => void;
-        getChannelStats: (channelId: string, excludeFilesCount: boolean) => Promise<{data: ChannelStats}>;
+        getChannelStats: (channelId: string, includeFileCount: boolean) => Promise<{data: ChannelStats}>;
     };
 }
 
@@ -112,7 +112,7 @@ const Menu = ({channel, channelStats, isArchived, className, actions}: MenuProps
     const fileCount = channelStats?.files_count >= 0 ? channelStats?.files_count : 0;
 
     useEffect(() => {
-        actions.getChannelStats(channel.id, false).then(() => {
+        actions.getChannelStats(channel.id, true).then(() => {
             setLoadingStats(false);
         });
         return () => {

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/channels.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/channels.test.ts
@@ -1937,7 +1937,7 @@ describe('Actions.Channels', () => {
 
     it('getChannelStats', async () => {
         nock(Client4.getBaseRoute()).
-            get(`/channels/${TestHelper.basicChannel!.id}/stats`).
+            get(`/channels/${TestHelper.basicChannel!.id}/stats?exclude_files_count=true`).
             reply(200, {channel_id: TestHelper.basicChannel!.id, member_count: 1});
 
         await store.dispatch(Actions.getChannelStats(TestHelper.basicChannel!.id));
@@ -1970,7 +1970,7 @@ describe('Actions.Channels', () => {
         await store.dispatch(Actions.joinChannel(TestHelper.basicUser!.id, TestHelper.basicTeam!.id, channelId));
 
         nock(Client4.getBaseRoute()).
-            get(`/channels/${TestHelper.basicChannel!.id}/stats`).
+            get(`/channels/${TestHelper.basicChannel!.id}/stats?exclude_files_count=true`).
             reply(200, {channel_id: TestHelper.basicChannel!.id, member_count: 1});
 
         await store.dispatch(Actions.getChannelStats(channelId));
@@ -2041,7 +2041,7 @@ describe('Actions.Channels', () => {
         await store.dispatch(Actions.joinChannel(TestHelper.basicUser!.id, TestHelper.basicTeam!.id, channelId));
 
         nock(Client4.getBaseRoute()).
-            get(`/channels/${TestHelper.basicChannel!.id}/stats`).
+            get(`/channels/${TestHelper.basicChannel!.id}/stats?exclude_files_count=true`).
             reply(200, {channel_id: TestHelper.basicChannel!.id, member_count: 1});
 
         await store.dispatch(Actions.getChannelStats(channelId));

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/channels.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/channels.ts
@@ -1063,11 +1063,11 @@ export function searchGroupChannels(term: string): ActionFunc {
     });
 }
 
-export function getChannelStats(channelId: string, excludeFilesCount?: boolean): ActionFunc {
+export function getChannelStats(channelId: string, includeFileCount?: boolean): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         let stat;
         try {
-            stat = await Client4.getChannelStats(channelId, excludeFilesCount);
+            stat = await Client4.getChannelStats(channelId, includeFileCount);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/posts.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/posts.test.ts
@@ -1118,7 +1118,7 @@ describe('Actions.Posts', () => {
         const {dispatch, getState} = store;
 
         nock(Client4.getBaseRoute()).
-            get(`/channels/${TestHelper.basicChannel!.id}/stats`).
+            get(`/channels/${TestHelper.basicChannel!.id}/stats?exclude_files_count=true`).
             reply(200, {channel_id: TestHelper.basicChannel!.id, member_count: 1, pinnedpost_count: 0});
 
         await dispatch(getChannelStats(TestHelper.basicChannel!.id));
@@ -1157,7 +1157,7 @@ describe('Actions.Posts', () => {
         const {dispatch, getState} = store;
 
         nock(Client4.getBaseRoute()).
-            get(`/channels/${TestHelper.basicChannel!.id}/stats`).
+            get(`/channels/${TestHelper.basicChannel!.id}/stats?exclude_files_count=true`).
             reply(200, {channel_id: TestHelper.basicChannel!.id, member_count: 1, pinnedpost_count: 0});
 
         await dispatch(getChannelStats(TestHelper.basicChannel!.id));

--- a/webapp/platform/client/src/client4.ts
+++ b/webapp/platform/client/src/client4.ts
@@ -1747,7 +1747,7 @@ export default class Client4 {
         );
     };
 
-    getChannelStats = (channelId: string, excludeFilesCount = false) => {
+    getChannelStats = (channelId: string, excludeFilesCount = true) => {
         const param = excludeFilesCount ? `?exclude_files_count=${excludeFilesCount}` : '';
         return this.doFetch<ChannelStats>(
             `${this.getChannelRoute(channelId)}/stats${param}`,

--- a/webapp/platform/client/src/client4.ts
+++ b/webapp/platform/client/src/client4.ts
@@ -1747,8 +1747,8 @@ export default class Client4 {
         );
     };
 
-    getChannelStats = (channelId: string, excludeFilesCount = true) => {
-        const param = excludeFilesCount ? `?exclude_files_count=${excludeFilesCount}` : '';
+    getChannelStats = (channelId: string, includeFileCount = false) => {
+        const param = !includeFileCount ? '?exclude_files_count=true' : '';
         return this.doFetch<ChannelStats>(
             `${this.getChannelRoute(channelId)}/stats${param}`,
             {method: 'get'},


### PR DESCRIPTION
#### Summary
This PR is a follow up to https://github.com/mattermost/mattermost/pull/23793 and is intended to go to v8.0 where the query that was causing the original problem will be fixed. The intention of this PR is to prevent fetching the fileCount unnecessarily from some other places like the system console or when adding/removing users from a channel where this data is not needed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53237

#### Screenshots

https://github.com/mattermost/mattermost/assets/10082627/ebddeedc-63c6-4eb0-b5a4-f36cb88d00e1



#### Release Note
```release-note
NONE
```
