### PR TITLE
Debug smoketests

### DIFF
--- a/e2e-tests/.ci/server.override.yml
+++ b/e2e-tests/.ci/server.override.yml
@@ -121,6 +121,8 @@ services:
     image: "mattermostdevelopment/mirrored-golang:1.19.5"
     entrypoint: [ "/bin/bash", "-c" ]
     command: [ "until [ -f /var/run/mm_terminate ]; do sleep 5; done" ]
+    environment:
+      MM_SERVICEENVIRONMENT: "test" # Currently required for running the config_generator with the right environment
     working_dir: "/opt/mattermost-server"
     volumes:
     - "../../:/opt/mattermost-server"

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "April",
-    "translation": "DummyChange"
+    "translation": "April"
   },
   {
     "id": "August",

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "April",
-    "translation": "April"
+    "translation": "DummyChange"
   },
   {
     "id": "August",


### PR DESCRIPTION
#### Summary

While debugging smoketest failures, I noticed a small inconsistency in the usage of the `MM_SERVICEENVIRONMENT` variable: it is defined only for the `server` container, but is actually essential also for the `utils` container, since that's the container that generates the configuration for the server (which is impacted by that variable's value).

Note that specifying the variable value is a no-op: this PR sets it to its default value for the test builds (same as for the server container) so setting it has actually zero effect. However it's important to know of its impact within that file, thus it's valuable to set it explicitly for discoverability reasons. E.g. if we need to change it for testing, having it explicitly set makes it easier not to forget it must be changed for the utils container as well.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-5961

#### Release Note
```release-note
NONE
```
