### PR TITLE
Update vacuuming parameters for some tables

### DIFF
--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -218,6 +218,8 @@ channels/db/migrations/mysql/000108_remove_orphaned_oauth_preferences.down.sql
 channels/db/migrations/mysql/000108_remove_orphaned_oauth_preferences.up.sql
 channels/db/migrations/mysql/000109_create_persistent_notifications.down.sql
 channels/db/migrations/mysql/000109_create_persistent_notifications.up.sql
+channels/db/migrations/mysql/000110_update_vacuuming.down.sql
+channels/db/migrations/mysql/000110_update_vacuuming.up.sql
 channels/db/migrations/postgres/000001_create_teams.down.sql
 channels/db/migrations/postgres/000001_create_teams.up.sql
 channels/db/migrations/postgres/000002_create_team_members.down.sql
@@ -436,3 +438,5 @@ channels/db/migrations/postgres/000108_remove_orphaned_oauth_preferences.down.sq
 channels/db/migrations/postgres/000108_remove_orphaned_oauth_preferences.up.sql
 channels/db/migrations/postgres/000109_create_persistent_notifications.down.sql
 channels/db/migrations/postgres/000109_create_persistent_notifications.up.sql
+channels/db/migrations/postgres/000110_update_vacuuming.down.sql
+channels/db/migrations/postgres/000110_update_vacuuming.up.sql

--- a/server/channels/db/migrations/mysql/000110_update_vacuuming.down.sql
+++ b/server/channels/db/migrations/mysql/000110_update_vacuuming.down.sql
@@ -1,0 +1,1 @@
+-- Only applicable to Postgres

--- a/server/channels/db/migrations/mysql/000110_update_vacuuming.up.sql
+++ b/server/channels/db/migrations/mysql/000110_update_vacuuming.up.sql
@@ -1,0 +1,1 @@
+-- Only applicable to Postgres

--- a/server/channels/db/migrations/postgres/000110_update_vacuuming.down.sql
+++ b/server/channels/db/migrations/postgres/000110_update_vacuuming.down.sql
@@ -1,0 +1,4 @@
+alter table posts set (autovacuum_vacuum_scale_factor = 0.2, autovacuum_analyze_scale_factor = 0.1);
+alter table threadmemberships set (autovacuum_vacuum_scale_factor = 0.2, autovacuum_analyze_scale_factor = 0.1);
+alter table fileinfo set (autovacuum_vacuum_scale_factor = 0.2, autovacuum_analyze_scale_factor = 0.1);
+alter table preferences set (autovacuum_vacuum_scale_factor = 0.2, autovacuum_analyze_scale_factor = 0.1);

--- a/server/channels/db/migrations/postgres/000110_update_vacuuming.up.sql
+++ b/server/channels/db/migrations/postgres/000110_update_vacuuming.up.sql
@@ -1,0 +1,4 @@
+alter table posts set (autovacuum_vacuum_scale_factor = 0.1, autovacuum_analyze_scale_factor = 0.05);
+alter table threadmemberships set (autovacuum_vacuum_scale_factor = 0.1, autovacuum_analyze_scale_factor = 0.05);
+alter table fileinfo set (autovacuum_vacuum_scale_factor = 0.1, autovacuum_analyze_scale_factor = 0.05);
+alter table preferences set (autovacuum_vacuum_scale_factor = 0.1, autovacuum_analyze_scale_factor = 0.05);


### PR DESCRIPTION
After some analysis of vacuuming statistics of our large
Postgres customers, it was observed that the default vacuuming
thresholds for some tables are not optimal enough for our workload.

We need more frequent vacuuming for some tables. The analysis
showed that the top 4 tables that needed rectification
were posts, preferences, threadmemberships and fileinfo.

So we reduce the threshold by half for those tables, triggering
autovacuum and autoanalyze doubly often.

```release-note
NONE
```
