### PR TITLE
MM-53475 : Migrate 'components/suggestion/emoticon_provider.test.jsx' to TypeScript

### DIFF
--- a/webapp/channels/src/components/suggestion/emoticon_provider.test.tsx
+++ b/webapp/channels/src/components/suggestion/emoticon_provider.test.tsx
@@ -8,6 +8,8 @@ import EmoticonProvider, {
     MIN_EMOTICON_LENGTH,
     EMOJI_CATEGORY_SUGGESTION_BLOCKLIST,
 } from './emoticon_provider';
+import { CustomEmoji } from '@mattermost/types/src/emojis';
+import { Emoji } from '@mattermost/types/src/emojis';
 
 jest.mock('selectors/emojis', () => ({
     getEmojiMap: jest.fn(),
@@ -16,8 +18,10 @@ jest.mock('selectors/emojis', () => ({
 
 describe('components/EmoticonProvider', () => {
     const resultsCallback = jest.fn();
+    const getEmojiMap = jest.fn();
+    const getRecentEmojisNames = jest.fn();;
     const emoticonProvider = new EmoticonProvider();
-    const customEmojis = new Map([
+    const customEmojis = new Map<string,CustomEmoji>([
         ['thumbsdown-custom', {name: 'thumbsdown-custom', category: 'custom'}],
         ['thumbsup-custom', {name: 'thumbsup-custom', category: 'custom'}],
         ['lithuania-custom', {name: 'lithuania-custom', category: 'custom'}],
@@ -53,8 +57,8 @@ describe('components/EmoticonProvider', () => {
         emoticonProvider.handlePretextChanged(pretext, resultsCallback);
         expect(resultsCallback).toHaveBeenCalled();
         const args = resultsCallback.mock.calls[0][0];
-        const results = args.items.filter((item) => item.name.indexOf('skin') === -1);
-        expect(results.map((item) => item.name)).toEqual([
+        const results = args.items.filter((item:Emoji) => item.name.indexOf('skin') === -1);
+        expect(results.map((item:Emoji) => item.name)).toEqual([
             'thumbsup', // thumbsup is a special case where it always appears before thumbsdown
             'thumbsdown',
             'thunder_cloud_and_rain',
@@ -86,7 +90,7 @@ describe('components/EmoticonProvider', () => {
             const name = `blocklisted-${index}`;
             return [name, {name, category}];
         });
-        const customEmojisWithBlocklist = new Map([
+        const customEmojisWithBlocklist = new Map<string,CustomEmoji>([
             ...blocklistedEmojis,
             ['not-blocklisted', {name: 'not-blocklisted', category: 'custom'}],
         ]);
@@ -113,8 +117,8 @@ describe('components/EmoticonProvider', () => {
             emoticonProvider.handlePretextChanged(pretext, resultsCallback);
             expect(resultsCallback).toHaveBeenCalled();
             const args = resultsCallback.mock.calls[0][0];
-            const results = args.items.filter((item) => item.name.indexOf('skin') === -1);
-            expect(results.map((item) => item.name)).toEqual([
+            const results = args.items.filter((item:Emoji) => item.name.indexOf('skin') === -1);
+            expect(results.map((item:Emoji) => item.name)).toEqual([
                 'thumbsup',
                 'thunder_cloud_and_rain',
                 'thumbsdown',
@@ -135,8 +139,8 @@ describe('components/EmoticonProvider', () => {
         emoticonProvider.handlePretextChanged(pretext, resultsCallback);
         expect(resultsCallback).toHaveBeenCalled();
         const args = resultsCallback.mock.calls[0][0];
-        const results = args.items.filter((item) => item.name.indexOf('skin') === -1);
-        expect(results.map((item) => item.name)).toEqual([
+        const results = args.items.filter((item:Emoji) => item.name.indexOf('skin') === -1);
+        expect(results.map((item:Emoji) => item.name)).toEqual([
             'thumbsdown-custom',
             'lithuania-custom',
             'thumbsup',
@@ -156,8 +160,8 @@ describe('components/EmoticonProvider', () => {
         emoticonProvider.handlePretextChanged(pretext, resultsCallback);
         expect(resultsCallback).toHaveBeenCalled();
         const args = resultsCallback.mock.calls[0][0];
-        const results = args.items.filter((item) => item.name.indexOf('skin') === -1);
-        expect(results.map((item) => item.name)).toEqual([
+        const results = args.items.filter((item:Emoji) => item.name.indexOf('skin') === -1);
+        expect(results.map((item:Emoji) => item.name)).toEqual([
             'thumbsup',
             'thumbsdown',
             'thumbsdown-custom',
@@ -177,8 +181,8 @@ describe('components/EmoticonProvider', () => {
         emoticonProvider.handlePretextChanged(pretext, resultsCallback);
         expect(resultsCallback).toHaveBeenCalled();
         const args = resultsCallback.mock.calls[0][0];
-        const results = args.items.filter((item) => item.name.indexOf('skin') === -1);
-        expect(results.map((item) => item.name)).toEqual([
+        const results = args.items.filter((item:Emoji) => item.name.indexOf('skin') === -1);
+        expect(results.map((item:Emoji) => item.name)).toEqual([
             'thumbsup',
             'thumbsup-custom',
             'thumbsdown',


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
Migrated emoticon_provider.test.jsx to emoticon_provider.test.tsx 
-->

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/23931
Jira https://mattermost.atlassian.net/browse/MM-53475


#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |
NA
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates). NONE
* API additions—new endpoint, new response fields, or newly accepted request parameters. NONE
* Database changes (any). NONE
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes.  NONE
* Websocket additions or changes. NONE
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating). NONE
* New features and improvements, including behavioral changes, UI changes, and CLI changes. NONE
* Bug fixes and fixes of previous known issues. NONE
* Deprecation warnings, breaking changes, or compatibility notes. NONE

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.NONE

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
NONE
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.

```

```
NONE
```
-->
```release-note
NONE

```
