### PR TITLE
[GH-23969]: issue solved:- double command when sent a command in thread [MM: 23955]

### DIFF
--- a/webapp/channels/src/components/post/post_component.tsx
+++ b/webapp/channels/src/components/post/post_component.tsx
@@ -174,10 +174,9 @@ const PostComponent = (props: Props): JSX.Element => {
 
     // Double Command Bug solution, this makes sure that the system message post that should be in root doesn't show in channels
     if(post.channel_id && post.root_id && post.type == "system_ephemeral" ) {
-        console.log("MESSAGE THATT SHOULD BE IN THREAD", post.channel_id, post.root_id, post.type, props.location) 
-        if(props.location === Locations.RHS_COMMENT || props.location === Locations.RHS_ROOT) {
-            console.log("continue")
-        } else {
+        // console.log("MESSAGE THATT SHOULD BE IN THREAD", post.channel_id, post.root_id, post.type, props.location) 
+        if(!(props.location === Locations.RHS_COMMENT || props.location === Locations.RHS_ROOT)) {
+            // console.log("continue")
             return <></>
         }
     }

--- a/webapp/channels/src/components/post/post_component.tsx
+++ b/webapp/channels/src/components/post/post_component.tsx
@@ -172,6 +172,16 @@ const PostComponent = (props: Props): JSX.Element => {
         }
     }, [hasReceivedA11yFocus, shouldHighlight]);
 
+    // Double Command Bug solution, this makes sure that the system message post that should be in root doesn't show in channels
+    if(post.channel_id && post.root_id && post.type == "system_ephemeral" ) {
+        console.log("MESSAGE THATT SHOULD BE IN THREAD", post.channel_id, post.root_id, post.type, props.location) 
+        if(props.location === Locations.RHS_COMMENT || props.location === Locations.RHS_ROOT) {
+            console.log("continue")
+        } else {
+            return <></>
+        }
+    }
+
     useEffect(() => {
         if (a11yActive) {
             postRef.current?.dispatchEvent(new Event(A11yCustomEventTypes.UPDATE));


### PR DESCRIPTION

#### Summary

This pull request addresses the issue related to displaying commands in both the thread message and the channel in Mattermost. The problem was occurring due to an issue in the post component. To resolve this, I have implemented a check to prevent the command from being duplicated in the thread message.

- Changes Made

Added a check in the post component to prevent displaying the command in both the thread message and the channel.
Resolved the issue by ensuring that the command is shown only once, either in the thread or the channel.
This change improves the user experience by eliminating the duplication of commands in Mattermost threads and channels. It enhances the clarity and readability of conversations within the platform.

Steps to reproduce
- Open a thread
- Type /online and hit Enter

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/23969
JIRA: https://mattermost.atlassian.net/browse/MM-53506
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/23969
JIRA: https://mattermost.atlassian.net/browse/MM-53506
-->

#### Screenshots

For an easier comparison of UI changes a table (template below) can be used.

|  <img width="1280" alt="image" src="https://github.com/mattermost/mattermost/assets/91266702/ebdcd52f-b4bb-41b3-ac42-3db54b760dcd">  |  ![image](https://github.com/mattermost/mattermost/assets/91266702/2b8a3c6d-e752-412d-a330-32b144dc127f)  |
|----|----|

#### Release Note
NONE 
