### PR TITLE
drop public submodule replace directive

### DIFF
--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -30,6 +30,11 @@ jobs:
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: ${{ env.go-version }}
+      - name: Run setup-go-work
+        run: |
+          cd server
+          make setup-go-work
+      - name: Checkout mattermost-api-reference
       - name: Run docker compose
         run: |
           cd server/build

--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -34,7 +34,6 @@ jobs:
         run: |
           cd server
           make setup-go-work
-      - name: Checkout mattermost-api-reference
       - name: Run docker compose
         run: |
           cd server/build

--- a/.github/workflows/server-ci-template.yml
+++ b/.github/workflows/server-ci-template.yml
@@ -47,6 +47,8 @@ jobs:
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
+      - name: Run setup-go-work
+        run: make setup-go-work
       - name: Run go mod tidy
         run: make modules-tidy
       - name: Check modules
@@ -67,7 +69,7 @@ jobs:
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
-      - name: Setup go.work
+      - name: Run setup-go-work
         run: make setup-go-work
       - name: Run golangci
         run: make golangci-lint
@@ -87,6 +89,8 @@ jobs:
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
+      - name: Run setup-go-work
+        run: make setup-go-work
       - name: Run make-gen-serialized
         run: make gen-serialized
       - name: Check serialized
@@ -107,10 +111,10 @@ jobs:
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
-      - name: Reset config
-        run: make config-reset
       - name: Run setup-go-work
         run: make setup-go-work
+      - name: Reset config
+        run: make config-reset
       - name: Run plugin-checker
         run: make plugin-checker
       - name: Run mattermost-vet
@@ -141,6 +145,8 @@ jobs:
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
+      - name: Run setup-go-work
+        run: make setup-go-work
       - name: Checkout mattermost-api-reference
         run: |
           cd ..
@@ -181,6 +187,8 @@ jobs:
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
+      - name: Run setup-go-work
+        run: make setup-go-work
       - name: Generate store layers
         run: make store-layers
       - name: Check generated code
@@ -201,6 +209,8 @@ jobs:
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
+      - name: Run setup-go-work
+        run: make setup-go-work
       - name: Generate app layers
         run: make app-layers
       - name: Check generated code
@@ -208,6 +218,9 @@ jobs:
   check-mmctl-docs:
     name: Check mmctl docs
     runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: server
     steps:
       - name: Checkout mattermost-server
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -218,10 +231,11 @@ jobs:
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
+      - name: Run setup-go-work
+        run: make setup-go-work
       - name: Check docs
         run: |
           echo "Making sure docs are updated"
-          cd server
           make mmctl-docs
           if [[ -n $(git status --porcelain) ]]; then echo "Please update the mmctl docs using make mmctl-docs"; exit 1; fi
   test-postgres-binary:
@@ -281,6 +295,8 @@ jobs:
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
+      - name: Run setup-go-work
+        run: make setup-go-work
       - name: Build
         run: |
           make config-reset

--- a/.github/workflows/server-ci-template.yml
+++ b/.github/workflows/server-ci-template.yml
@@ -135,6 +135,9 @@ jobs:
   build-api-spec:
     name: Build API specification
     runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -149,7 +152,7 @@ jobs:
         run: make setup-go-work
       - name: Checkout mattermost-api-reference
         run: |
-          cd ..
+          cd ../..
           git clone --depth=1 --no-single-branch https://github.com/mattermost/mattermost-api-reference.git
           cd mattermost-api-reference
           echo "Trying to checkout the same branch on mattermost-api-reference as mattermost"

--- a/server/go.mod
+++ b/server/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/mattermost/gziphandler v0.0.1
 	github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d
 	github.com/mattermost/logr/v2 v2.0.16
-	github.com/mattermost/mattermost/server/public v0.0.4
+	github.com/mattermost/mattermost/server/public v0.0.6
 	github.com/mattermost/morph v1.0.5-0.20230511171014-e76e25978d56
 	github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0
 	github.com/mattermost/squirrel v0.2.0
@@ -250,5 +250,3 @@ exclude (
 	github.com/dyatlov/go-opengraph v0.0.0-20210112100619-dae8665a5b09
 	github.com/willf/bitset v1.2.0
 )
-
-replace github.com/mattermost/mattermost/server/public => ./public

--- a/server/go.sum
+++ b/server/go.sum
@@ -513,6 +513,8 @@ github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d h1:/RJ/UV7M5c7L2TQ
 github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
 github.com/mattermost/logr/v2 v2.0.16 h1:jnePX4cPskC3WDFvUardh/xZfxNdsFXbEERJQ1kUEDE=
 github.com/mattermost/logr/v2 v2.0.16/go.mod h1:1dm/YhTpozsqANXxo5Pi5zYLBsal2xY0pX+JZNbzYJY=
+github.com/mattermost/mattermost/server/public v0.0.6 h1:FUaJ+P36E3Tt12Umdm8p1h7sZNUeObDk3p3aFTaBkCo=
+github.com/mattermost/mattermost/server/public v0.0.6/go.mod h1:Y7Ht1haGGrsuYzX73HhpSe2VnbGLuZj2/tsQslHd2/M=
 github.com/mattermost/morph v1.0.5-0.20230511171014-e76e25978d56 h1:SjFYbWvmuf73d/KaYlnHosPpB3/k38ebr1WWw9X5XKc=
 github.com/mattermost/morph v1.0.5-0.20230511171014-e76e25978d56/go.mod h1:gD+EaqX2UMyyuzmF4PFh4r33XneQ8Nzi+0E8nXjMa3A=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0 h1:G9tL6JXRBMzjuD1kkBtcnd42kUiT6QDwxfFYu7adM6o=


### PR DESCRIPTION
#### Summary
During development of the public/ submodule, a replace directive remained that was both unnecessary and harmful as discussed in https://community.mattermost.com/private-core/pl/w77sh7igwpfb9ecj5o4jjjbbyo.

Remove that, and bump the explicit dependency (even though we use go.work) to v0.0.6 so the import paths match (e.g. `mattermost` vs `mattermost-server`).

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
