### PR TITLE
MM-53228: Adding schema version to cluster info

### DIFF
--- a/server/public/model/cluster_info.go
+++ b/server/public/model/cluster_info.go
@@ -4,9 +4,10 @@
 package model
 
 type ClusterInfo struct {
-	Id         string `json:"id"`
-	Version    string `json:"version"`
-	ConfigHash string `json:"config_hash"`
-	IPAddress  string `json:"ipaddress"`
-	Hostname   string `json:"hostname"`
+	Id            string `json:"id"`
+	Version       string `json:"version"`
+	SchemaVersion string `json:"schema_version"`
+	ConfigHash    string `json:"config_hash"`
+	IPAddress     string `json:"ipaddress"`
+	Hostname      string `json:"hostname"`
 }

--- a/webapp/channels/src/components/admin_console/cluster_table.tsx
+++ b/webapp/channels/src/components/admin_console/cluster_table.tsx
@@ -15,6 +15,7 @@ type Props = {
         config_hash: string;
         hostname: string;
         ipaddress: string;
+        schema_version: string;
     }>;
     reload: (e: MouseEvent<HTMLButtonElement>) => void;
 }

--- a/webapp/channels/src/components/admin_console/cluster_table.tsx
+++ b/webapp/channels/src/components/admin_console/cluster_table.tsx
@@ -130,6 +130,7 @@ export default class ClusterTable extends PureComponent<Props> {
                     <td style={style.clusterCell}>{versionMismatch} {clusterInfo.version}</td>
                     <td style={style.clusterCell}><div className='config-hash'>{configMismatch} {clusterInfo.config_hash}</div></td>
                     <td style={style.clusterCell}>{clusterInfo.ipaddress}</td>
+                    <td style={style.clusterCell}>{clusterInfo.schema_version}</td>
                 </tr>
             );
         });
@@ -183,6 +184,12 @@ export default class ClusterTable extends PureComponent<Props> {
                                 <FormattedMessage
                                     id='admin.cluster.status_table.url'
                                     defaultMessage='Gossip Address'
+                                />
+                            </th>
+                            <th>
+                                <FormattedMessage
+                                    id='admin.cluster.status_table.schema_version'
+                                    defaultMessage='DB Schema Version'
                                 />
                             </th>
                         </tr>

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -556,6 +556,7 @@
   "admin.cluster.status_table.config_hash": "Config File MD5",
   "admin.cluster.status_table.hostname": "Hostname",
   "admin.cluster.status_table.reload": " Reload Cluster Status",
+  "admin.cluster.status_table.schema_version": "DB Schema Version",
   "admin.cluster.status_table.status": "Status",
   "admin.cluster.status_table.url": "Gossip Address",
   "admin.cluster.status_table.version": "Version",

--- a/webapp/platform/types/src/admin.ts
+++ b/webapp/platform/types/src/admin.ts
@@ -70,6 +70,7 @@ export type ClusterInfo = {
     config_hash: string;
     ipaddress: string;
     hostname: string;
+    schema_version: string;
 };
 
 export type AnalyticsRow = {


### PR DESCRIPTION
With the schema version available, a job can query for
the cluster info to confirm whether or not all nodes
in a cluster are upgraded to the same version or not.

This will help it in determining whether to start
the job or not.

https://mattermost.atlassian.net/browse/MM-53228

```release-note
NONE
```
