### PR TITLE
MM-53709: Handle older non-encoded paths in bifrost

### DIFF
--- a/server/platform/shared/filestore/filesstore_test.go
+++ b/server/platform/shared/filestore/filesstore_test.go
@@ -136,7 +136,8 @@ func (s *FileBackendTestSuite) TestEncode() {
 	}()
 
 	originalPath := "dir1/test+.png"
-	encodedPath := s3Backend.prefixedPath(originalPath)
+	encodedPath, err := s3Backend.prefixedPath(originalPath)
+	s.NoError(err)
 	b := []byte("test")
 	written, err := s3Backend.WriteFile(bytes.NewReader(b), encodedPath)
 	s.Nil(err)


### PR DESCRIPTION
We do a check to see if a non-encoded path is present
or not, and in that case, choose not to encode it.

This accrues an additional StatFile call. But after
we have encoded all paths to the new style, we will
get rid of this.

https://mattermost.atlassian.net/browse/MM-53709

```release-note
NONE
```
