### PR TITLE
Renamed channel index fix migration key

### DIFF
--- a/server/channels/testlib/store.go
+++ b/server/channels/testlib/store.go
@@ -72,7 +72,7 @@ func GetMockStoreForSetupFunctions() *mocks.Store {
 	systemStore.On("GetByName", model.MigrationKeyAddCustomUserGroupsPermissionRestore).Return(&model.System{Name: model.MigrationKeyAddCustomUserGroupsPermissionRestore, Value: "true"}, nil)
 	systemStore.On("GetByName", "CustomGroupAdminRoleCreationMigrationComplete").Return(&model.System{Name: model.MigrationKeyAddPlayboosksManageRolesPermissions, Value: "true"}, nil)
 	systemStore.On("GetByName", "products_boards").Return(&model.System{Name: "products_boards", Value: "true"}, nil)
-	systemStore.On("GetByName", "elasticsearch_fix_channel_index_migration_complete").Return(&model.System{Name: "elasticsearch_fix_channel_index_migration_complete", Value: "true"}, nil)
+	systemStore.On("GetByName", "elasticsearch_fix_channel_index_migration").Return(&model.System{Name: "elasticsearch_fix_channel_index_migration", Value: "true"}, nil)
 	systemStore.On("InsertIfExists", mock.AnythingOfType("*model.System")).Return(&model.System{}, nil).Once()
 	systemStore.On("Save", mock.AnythingOfType("*model.System")).Return(nil)
 

--- a/server/public/model/migration.go
+++ b/server/public/model/migration.go
@@ -40,5 +40,5 @@ const (
 	MigrationKeyAddPlayboosksManageRolesPermissions    = "playbooks_manage_roles"
 	MigrationKeyAddProductsBoardsPermissions           = "products_boards"
 	MigrationKeyAddCustomUserGroupsPermissionRestore   = "custom_groups_permission_restore"
-	MigrationKeyElasticsearchFixChannelIndex           = "elasticsearch_fix_channel_index_migration_complete"
+	MigrationKeyElasticsearchFixChannelIndex           = "elasticsearch_fix_channel_index_migration"
 )


### PR DESCRIPTION
#### Summary
The rename is needed to allow the fix to rerun as the fix in previous patch didn't do the job in a case.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49257

#### Release Note
```release-note
NONE
```
