### PR TITLE
MM-53747: Bifrost: write original paths

### DIFF
--- a/server/platform/shared/filestore/filesstore_test.go
+++ b/server/platform/shared/filestore/filesstore_test.go
@@ -124,34 +124,6 @@ func (s *FileBackendTestSuite) TestReadWriteFile() {
 	s.EqualValues(readString, "test")
 }
 
-func (s *FileBackendTestSuite) TestEncode() {
-	s3Backend, ok := s.backend.(*S3FileBackend)
-	// This test is only for S3backend.
-	if !ok {
-		return
-	}
-	s3Backend.isCloud = true
-	defer func() {
-		s3Backend.isCloud = false
-	}()
-
-	originalPath := "dir1/test+.png"
-	encodedPath, err := s3Backend.prefixedPath(originalPath)
-	s.NoError(err)
-	b := []byte("test")
-	written, err := s3Backend.WriteFile(bytes.NewReader(b), encodedPath)
-	s.Nil(err)
-	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
-	defer s3Backend.RemoveFile(encodedPath)
-
-	files, err := s3Backend.ListDirectory("dir1")
-	s.Nil(err)
-	s.Require().Len(files, 1)
-	// There's another layer of encoding since the backend is Minio
-	// and it doesn't store the path unescaped.
-	s.Equal("dir1/test%252B.png", files[0])
-}
-
 func (s *FileBackendTestSuite) TestReadWriteFileContext() {
 	type ContextWriter interface {
 		WriteFileContext(context.Context, io.Reader, string) (int64, error)

--- a/server/platform/shared/filestore/s3store.go
+++ b/server/platform/shared/filestore/s3store.go
@@ -342,7 +342,7 @@ func (b *S3FileBackend) CopyFile(oldPath, newPath string) error {
 	if err != nil {
 		return errors.Wrapf(err, "unable to prefix path %s", oldPath)
 	}
-	newPath = b.prefixedPathFast(newPath)
+	newPath = filepath.Join(b.pathPrefix, newPath)
 	srcOpts := s3.CopySrcOptions{
 		Bucket: b.bucket,
 		Object: oldPath,
@@ -373,7 +373,7 @@ func (b *S3FileBackend) MoveFile(oldPath, newPath string) error {
 	if err != nil {
 		return errors.Wrapf(err, "unable to prefix path %s", oldPath)
 	}
-	newPath = b.prefixedPathFast(newPath)
+	newPath = filepath.Join(b.pathPrefix, newPath)
 	srcOpts := s3.CopySrcOptions{
 		Bucket: b.bucket,
 		Object: oldPath,
@@ -414,7 +414,7 @@ func (b *S3FileBackend) WriteFile(fr io.Reader, path string) (int64, error) {
 
 func (b *S3FileBackend) WriteFileContext(ctx context.Context, fr io.Reader, path string) (int64, error) {
 	var contentType string
-	path = b.prefixedPathFast(path)
+	path = filepath.Join(b.pathPrefix, path)
 	if ext := filepath.Ext(path); isFileExtImage(ext) {
 		contentType = getImageMimeType(ext)
 	} else {
@@ -630,16 +630,6 @@ func (b *S3FileBackend) GeneratePublicLink(path string) (string, time.Duration, 
 	}
 
 	return req.String(), b.presignExpires, nil
-}
-
-// prefixedPathFast is a variation of prefixedPath
-// where we don't check for the file path. This is for cases
-// where we know the file won't exist - like while writing a new file.
-func (b *S3FileBackend) prefixedPathFast(s string) string {
-	if b.isCloud {
-		s = s3utils.EncodePath(s)
-	}
-	return filepath.Join(b.pathPrefix, s)
 }
 
 func (b *S3FileBackend) lookupOriginalPath(s string) (bool, error) {


### PR DESCRIPTION
Now that we have identified the true fix
from Bifrost side, we will slowly revert
the changes that have happened.

Starting with this first fix, we will revert
to writing out non-encoded paths while still
doing the double read. This will break uploading
files with + for a short while, and then
the new Bifrost fix should fix that as well.

https://mattermost.atlassian.net/browse/MM-53747

```release-note
NONE
```
