### PR TITLE
[MM-52207] Grammarly plugin not detected in Mattermost desktop

### DIFF
--- a/webapp/channels/src/components/__snapshots__/autosize_textarea.test.tsx.snap
+++ b/webapp/channels/src/components/__snapshots__/autosize_textarea.test.tsx.snap
@@ -18,13 +18,16 @@ exports[`components/AutosizeTextarea should match snapshot, init 1`] = `
       }
     }
   />
+  <label
+    className="sr-only"
+    id="autosize_textarea-label"
+  />
   <textarea
-    aria-label=""
+    aria-labelledby="autosize_textarea-label"
     data-testid="autosize_textarea"
     dir="auto"
     height={0}
     id="autosize_textarea"
-    role="textbox"
     rows={1}
   />
   <div

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -682,10 +682,14 @@ const AdvanceTextEditor = ({
                         className='AdvancedTextEditor__cell a11y__region'
                     >
                         {labels}
-                        <label id="advancedTextEditorCellAriaLabel" style={{ display: "none", visibility: "hidden", height: 0 }}>{Utils.localizeMessage(
-                            'channelView.login.successfull',
-                            'Login Successfull',
-                        ) + ' ' + ariaLabelMessageInput}</label>
+                        <label
+                            id='advancedTextEditorCellAriaLabel'
+                            style={{display: 'none', visibility: 'hidden', height: 0}}
+                        >
+                            {Utils.localizeMessage(
+                                'channelView.login.successfull',
+                                'Login Successfull',
+                            ) + ' ' + ariaLabelMessageInput}</label>
                         <Textbox
                             hasLabels={Boolean(labels)}
                             suggestionList={RhsSuggestionList}

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -683,8 +683,8 @@ const AdvanceTextEditor = ({
                     >
                         {labels}
                         <label
-                            id='advancedTextEditorCellAriaLabel'
-                            style={{display: 'none', visibility: 'hidden', height: 0}}
+                            id={`advancedTextEditorLabel-${location}`}
+                            className="sr-only"
                         >
                             {Utils.localizeMessage(
                                 'channelView.login.successfull',

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -682,6 +682,10 @@ const AdvanceTextEditor = ({
                         className='AdvancedTextEditor__cell a11y__region'
                     >
                         {labels}
+                        <label id="advancedTextEditorCellAriaLabel" style={{ display: "none", visibility: "hidden", height: 0 }}>{Utils.localizeMessage(
+                            'channelView.login.successfull',
+                            'Login Successfull',
+                        ) + ' ' + ariaLabelMessageInput}</label>
                         <Textbox
                             hasLabels={Boolean(labels)}
                             suggestionList={RhsSuggestionList}

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -684,7 +684,7 @@ const AdvanceTextEditor = ({
                         {labels}
                         <label
                             id={`advancedTextEditorLabel-${location}`}
-                            className="sr-only"
+                            className='sr-only'
                         >
                             {Utils.localizeMessage(
                                 'channelView.login.successfull',

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -50,6 +50,7 @@ import ShowFormat from './show_formatting';
 import TexteditorActions from './texteditor_actions';
 import ToggleFormattingBar from './toggle_formatting_bar';
 
+
 import './advanced_text_editor.scss';
 
 const KeyCodes = Constants.KeyCodes;
@@ -686,10 +687,8 @@ const AdvanceTextEditor = ({
                             id={`advancedTextEditorLabel-${location}`}
                             className='sr-only'
                         >
-                            {Utils.localizeMessage(
-                                'channelView.login.successfull',
-                                'Login Successfull',
-                            ) + ' ' + ariaLabelMessageInput}</label>
+                            {formatMessage({id: 'channelView.login.successfull', defaultMessage: 'Login Successfull'}) + ' ' + ariaLabelMessageInput}
+                            </label>
                         <Textbox
                             hasLabels={Boolean(labels)}
                             suggestionList={RhsSuggestionList}


### PR DESCRIPTION
#### Summary
The aria-label attribute has been modified, and it is impacting the text-area property. Grammarly couldn't detect the issue since the text-area was affected.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/22970
Jira: https://mattermost.atlassian.net/browse/MM-52207

#### Screenshots
|<img width="1148" alt="before" src="https://github.com/mattermost/mattermost/assets/62356575/4bf7b054-9b23-48c8-a56f-4b3191715220"> | <img width="1158" alt="after" src="https://github.com/mattermost/mattermost/assets/62356575/311ea521-fbee-4992-a55e-da78290d4a49"> |

#### Release Note

```release-note
NONE
```
