### PR TITLE
CLD-6003 - Upload smoketest results, better server logs

### DIFF
--- a/.github/workflows/e2e-tests-ci.yml
+++ b/.github/workflows/e2e-tests-ci.yml
@@ -99,6 +99,15 @@ jobs:
       - name: ci/e2e-smoketests
         run: |
           make
+      - name: ci/e2e-smoketests-store-results
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: e2e-smoketests-results
+          path: |
+            e2e-tests/cypress/logs/
+            e2e-tests/cypress/results/
+      - name: ci/e2e-smoketests-assert-results
+        run: |
           # Assert that the run contained 0 failures
           CYPRESS_FAILURES=$(find cypress/results -name '*.json' | xargs -l jq -r '.stats.failures' | jq -s add)
           echo "Cypress run completed with $CYPRESS_FAILURES failures"

--- a/e2e-tests/.ci/server.run_cypress.sh
+++ b/e2e-tests/.ci/server.run_cypress.sh
@@ -43,4 +43,4 @@ else
 fi
 
 # Collect server logs
-${MME2E_DC_SERVER} exec -T -- server cat /mattermost/logs/mattermost.log >../cypress/logs/mattermost.log
+${MME2E_DC_SERVER} logs --no-log-prefix -- server > 2>&1 cypress/logs/mattermost.log

--- a/e2e-tests/.ci/server.run_cypress.sh
+++ b/e2e-tests/.ci/server.run_cypress.sh
@@ -43,4 +43,4 @@ else
 fi
 
 # Collect server logs
-${MME2E_DC_SERVER} logs --no-log-prefix -- server > 2>&1 cypress/logs/mattermost.log
+${MME2E_DC_SERVER} logs --no-log-prefix -- server >../cypress/logs/mattermost.log 2>&1


### PR DESCRIPTION
#### Summary

Uploading of smoketest run results (including debug-level server logs and screenshot of failures), for better debuggability whenever it fails.

Example with failing test cases (so that screenshots are included): https://github.com/mattermost/mattermost/actions/runs/5625322158

#### Ticket Link

Indirectly related, this is the investigation that prompted this improvement: https://mattermost.atlassian.net/browse/CLD-6003

#### Release Note

```release-note
NONE
```