### PR TITLE
Use | and \ vs. >

### DIFF
--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -78,10 +78,10 @@ jobs:
           require_tests: true
       - name: Report retried tests via webhook
         if: ${{ steps.report.outputs.retried > 0 }}
-        run: >
-          curl
-            --fail
-            -X POST
-            -H "Content-Type: application/json"
-            -d "{\"text\":\"#### ⚠️  One or more flaky tests detected ⚠️\\n* Failing job: [github.com/mattermost/mattermost:${{ inputs.name }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\\n* If this is your pull request, double check your code to ensure you haven't introduced a flaky test.\\n* If this occurred on master or a release branch, reply to this message if you're willing to help.\\n* Submit a separate pull request to skip the flaky tests (e.g. [23360](https://github.com/mattermost/mattermost/pull/23360)) and file JIRA ticket (e.g. [MM-52743](https://mattermost.atlassian.net/browse/MM-52743)) for later investigation.\\n* Finally, reply to this message with a link to the created JIRA ticket.\\ncc @devs\"}"
+        run: |
+          curl \
+            --fail \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "{\"text\":\"#### ⚠️  One or more flaky tests detected ⚠️\\n* Failing job: [github.com/mattermost/mattermost:${{ inputs.name }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\\n* If this is your pull request, double check your code to ensure you haven't introduced a flaky test.\\n* If this occurred on master or a release branch, reply to this message if you're willing to help.\\n* Submit a separate pull request to skip the flaky tests (e.g. [23360](https://github.com/mattermost/mattermost/pull/23360)) and file JIRA ticket (e.g. [MM-52743](https://mattermost.atlassian.net/browse/MM-52743)) for later investigation.\\n* Finally, reply to this message with a link to the created JIRA ticket.\\ncc @devs\"}" \
             ${{ secrets.MM_COMMUNITY_DEVELOPERS_INCOMING_WEBHOOK_FROM_GH_ACTIONS }}


### PR DESCRIPTION
#### Summary
GitHub actions' YAML supports the `>` directive to a multi-line command to be merged into a single line, but requires that all segments have no leading whitespace otherwise they get silently ignored.

Since this is not nearly as obvious as one might expect, fallback to just the `|` syntax using `\` to extend the lines and keep the overall formatting, fixing the reporting of retried tests via curl webhook.

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
