### PR TITLE
[MM-53636] Add channel/team name back for the Saved Posts view

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/messaging/post_pre_header_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/post_pre_header_spec.js
@@ -40,6 +40,19 @@ describe('Post PreHeader', () => {
             // * Assert the preHeader is displayed and works as expected
             verifySavedPost(postId, message);
 
+            // # Click the saved link
+            cy.get('@savedLink').click();
+
+            // * Check that the saved post shows the channel name
+            cy.findByTestId('search-item-container').within(() => {
+                cy.get('span.search-channel__name').
+                    should('be.visible').
+                    and('have.text', 'Off-Topic');
+            });
+
+            // # Close the RHS
+            cy.get('#searchResultsCloseButton').should('be.visible').click();
+
             // # Click again the center save icon of a post
             cy.clickPostSaveIcon(postId);
 

--- a/webapp/channels/src/components/post/post_component.tsx
+++ b/webapp/channels/src/components/post/post_component.tsx
@@ -528,7 +528,7 @@ const PostComponent = (props: Props): JSX.Element => {
                         className='search-channel__name__container'
                         aria-hidden='true'
                     >
-                        {Boolean(isSearchResultItem) &&
+                        {(Boolean(isSearchResultItem) || props.isFlaggedPosts) &&
                         <span className='search-channel__name'>
                             {channelDisplayName}
                         </span>
@@ -542,7 +542,7 @@ const PostComponent = (props: Props): JSX.Element => {
                             />
                         </span>
                         }
-                        {Boolean(isSearchResultItem) && Boolean(props.teamDisplayName) &&
+                        {(Boolean(isSearchResultItem) || props.isFlaggedPosts) && Boolean(props.teamDisplayName) &&
                         <span className='search-team__name'>
                             {props.teamDisplayName}
                         </span>


### PR DESCRIPTION
#### Summary
A change I made recently [here](https://github.com/mattermost/mattermost/pull/23649) caused an issue where the Saved Posts section would not show the Channel/Team names at all.

This PR restores those specifically for the Saved Posts view.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53636

#### Screenshots
![Screenshot 2023-07-25 at 11 55 54 AM](https://github.com/mattermost/mattermost/assets/52460000/6a803ac7-fb19-4992-9481-8fb8c2943b92)

-->
```release-note
Fixed an issue where the Saved Posts section would not show the channel and team names
```
