### PR TITLE
remove legacy "Build API specification" workflow

### DIFF
--- a/.github/workflows/server-ci-template.yml
+++ b/.github/workflows/server-ci-template.yml
@@ -132,33 +132,6 @@ jobs:
         run: make migrations-extract
       - name: Check migration files
         run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the migrations using make migrations-extract"; exit 1; fi
-  build-api-spec:
-    name: Build API specification
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        working-directory: server
-    steps:
-      - name: Checkout mattermost project
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - name: Setup Go
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-        with:
-          go-version: ${{ env.go-version }}
-          cache-dependency-path: |
-            server/go.sum
-            server/public/go.sum
-      - name: Run setup-go-work
-        run: make setup-go-work
-      - name: Checkout mattermost-api-reference
-        run: |
-          cd ../..
-          git clone --depth=1 --no-single-branch https://github.com/mattermost/mattermost-api-reference.git
-          cd mattermost-api-reference
-          echo "Trying to checkout the same branch on mattermost-api-reference as mattermost"
-          git checkout $GITHUB_HEAD_REF || git checkout $GITHUB_BASE_REF || true
-          make build
-          cd ../mattermost
   check-email-templates:
     name: Generate email templates
     runs-on: ubuntu-22.04


### PR DESCRIPTION
#### Summary
Now that the API source is part of the monorepo, this is already handled by the new api workflow, and can simply be removed.

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
