### PR TITLE
[MM-53821] Include connection ID in webconn related logs

### DIFF
--- a/server/channels/app/platform/web_conn.go
+++ b/server/channels/app/platform/web_conn.go
@@ -477,6 +477,7 @@ func (wc *WebConn) writePump() {
 			if len(wc.send) >= sendFullWarn && time.Since(wc.lastLogTimeFull) > websocketSuppressWarnThreshold {
 				logData := []mlog.Field{
 					mlog.String("user_id", wc.UserId),
+					mlog.String("conn_id", wc.GetConnectionID()),
 					mlog.String("type", msg.EventType()),
 					mlog.Int("size", buf.Len()),
 				}
@@ -730,6 +731,7 @@ func (wc *WebConn) ShouldSendEvent(msg *model.WebSocketEvent) bool {
 				mlog.Warn(
 					"websocket.slow: dropping message",
 					mlog.String("user_id", wc.UserId),
+					mlog.String("conn_id", wc.GetConnectionID()),
 					mlog.String("type", msg.EventType()),
 				)
 				// Reset timer to now.
@@ -842,8 +844,13 @@ func (wc *WebConn) isMemberOfTeam(teamID string) bool {
 func (wc *WebConn) logSocketErr(source string, err error) {
 	// browsers will appear as CloseNoStatusReceived
 	if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
-		mlog.Debug(source+": client side closed socket", mlog.String("user_id", wc.UserId))
+		mlog.Debug(source+": client side closed socket",
+			mlog.String("user_id", wc.UserId),
+			mlog.String("conn_id", wc.GetConnectionID()))
 	} else {
-		mlog.Debug(source+": closing websocket", mlog.String("user_id", wc.UserId), mlog.Err(err))
+		mlog.Debug(source+": closing websocket",
+			mlog.String("user_id", wc.UserId),
+			mlog.String("conn_id", wc.GetConnectionID()),
+			mlog.Err(err))
 	}
 }

--- a/server/channels/app/platform/web_hub.go
+++ b/server/channels/app/platform/web_hub.go
@@ -478,7 +478,9 @@ func (h *Hub) Start() {
 				select {
 				case directMsg.conn.send <- directMsg.msg:
 				default:
-					mlog.Error("webhub.broadcast: cannot send, closing websocket for user", mlog.String("user_id", directMsg.conn.UserId))
+					mlog.Error("webhub.broadcast: cannot send, closing websocket for user",
+						mlog.String("user_id", directMsg.conn.UserId),
+						mlog.String("conn_id", directMsg.conn.GetConnectionID()))
 					close(directMsg.conn.send)
 					connIndex.Remove(directMsg.conn)
 				}
@@ -495,7 +497,9 @@ func (h *Hub) Start() {
 						select {
 						case webConn.send <- msg:
 						default:
-							mlog.Error("webhub.broadcast: cannot send, closing websocket for user", mlog.String("user_id", webConn.UserId))
+							mlog.Error("webhub.broadcast: cannot send, closing websocket for user",
+								mlog.String("user_id", webConn.UserId),
+								mlog.String("conn_id", webConn.GetConnectionID()))
 							close(webConn.send)
 							connIndex.Remove(webConn)
 						}


### PR DESCRIPTION
#### Summary

Full context can be found in the thread attached to the issue. The gist is that tracking connections with no connection ID is a bit hard if not impossible so I am including that info for next time we need to debug ws related issues.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53821

#### Release Note

```release-note
NONE
```
