### PR TITLE
[MM-53881] Make sure export filestore won't use bifrost

### DIFF
--- a/server/channels/app/platform/service.go
+++ b/server/channels/app/platform/service.go
@@ -251,7 +251,8 @@ func New(sc ServiceConfig, options ...Option) (*PlatformService, error) {
 	if ps.exportFilestore == nil {
 		ps.exportFilestore = ps.filestore
 		if *ps.Config().FileSettings.DedicatedExportStore {
-			backend, errFileBack := filestore.NewFileBackend(filestore.NewExportFileBackendSettingsFromConfig(&ps.Config().FileSettings, license != nil && *license.Features.Compliance, false))
+			mlog.Info("Setting up dedicated export filestore", mlog.String("driver_name", *ps.Config().FileSettings.ExportDriverName))
+			backend, errFileBack := filestore.NewExportFileBackend(filestore.NewExportFileBackendSettingsFromConfig(&ps.Config().FileSettings, license != nil && *license.Features.Compliance, false))
 			if errFileBack != nil {
 				return nil, fmt.Errorf("failed to initialize export filebackend: %w", errFileBack)
 			}

--- a/server/platform/shared/filestore/filesstore.go
+++ b/server/platform/shared/filestore/filesstore.go
@@ -125,10 +125,24 @@ func (settings *FileBackendSettings) CheckMandatoryS3Fields() error {
 	return nil
 }
 
+// NewFileBackend creates a new file backend
 func NewFileBackend(settings FileBackendSettings) (FileBackend, error) {
+	return newFileBackend(settings, true)
+}
+
+// NewExportFileBackend creates a new file backend for exports, that will not attempt to use bifrost.
+func NewExportFileBackend(settings FileBackendSettings) (FileBackend, error) {
+	return newFileBackend(settings, false)
+}
+
+func newFileBackend(settings FileBackendSettings, canBeCloud bool) (FileBackend, error) {
 	switch settings.DriverName {
 	case driverS3:
-		backend, err := NewS3FileBackend(settings)
+		newBackendFn := NewS3FileBackend
+		if !canBeCloud {
+			newBackendFn = NewS3FileBackendWithoutBifrost
+		}
+		backend, err := newBackendFn(settings)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to connect to the s3 backend")
 		}

--- a/server/platform/shared/filestore/s3store.go
+++ b/server/platform/shared/filestore/s3store.go
@@ -93,7 +93,7 @@ func NewS3FileBackend(settings FileBackendSettings) (*S3FileBackend, error) {
 	return newS3FileBackend(settings, os.Getenv("MM_CLOUD_FILESTORE_BIFROST") != "")
 }
 
-// NewS3FileBackendWithoutBifrost returns an instance of an S3FileBackend assuming we are not on cloud.
+// NewS3FileBackendWithoutBifrost returns an instance of an S3FileBackend that will not use bifrost.
 func NewS3FileBackendWithoutBifrost(settings FileBackendSettings) (*S3FileBackend, error) {
 	return newS3FileBackend(settings, false)
 }


### PR DESCRIPTION
#### Summary

This PR:

- ensures that the export filestore will not use Bifrost
- Adds an INFO log at startup to let admins we are using a dedicated filestore for exports

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53881

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
