### PR TITLE
MM-53879: Remove call to LoadLicense from platform.New

### DIFF
--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -269,6 +269,14 @@ func NewServer(options ...Option) (*Server, error) {
 		product.CommandKey:         app,
 	}
 
+	// We can only start the metrics once the license is loaded, and before the
+	// platform starts.
+	// Step 3: Start metrics
+	err = s.platform.StartMetrics()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to start metrics")
+	}
+
 	// It is important to initialize the hub only after the global logger is set
 	// to avoid race conditions while logging from inside the hub.
 	// Step 4: Start platform


### PR DESCRIPTION
#### Summary
`PlatformService.LoadLicense` is called in the init process at least twice:
1.  Indirectly in `app.NewServer`, in step 1, via `platform.New`
2. Directly in `app.NewServer`, after step 2.

Now, there are several constraints in play here:
- `LoadLicense` seems to be dependent on the user service (see #19733), so we need to defer the loading of the license after that (that's why we have the direct call to LoadLicense mentioned in 2).
- The initialization of the metrics server, which happens in `platform.New`, depends on the license to be loaded. `platform.New` solved this by simply calling `LoadLicense` before initializing the metrics server (the call mentioned in 1). But alas! this was happening before the user service was up.

The solution is to refactor the initialization of the metrics server from `platform.New` to a different function `PlatformServer.StartMetrics` (which is still dependent on the license to be loaded), remove the call to `LoadLicense` in `platform.New`, and let `app.NewServer` call `PlatformServer.StartMetrics` only after the license is loaded there.

But wait, how was this working at all?! Well, the initialization of the metrics server does add a license listener that restarts the server if the license changes, so whenever the license changed in `app.NewServer` after step 2, the metrics server restarted and it saw the valid license.

All this seems to have created the problem we saw in https://mattermost.atlassian.net/browse/MM-53879, but I cannot 100% explain what the sequence of the events there is, since I still don't understand why the metrics server couldn't be stopped, returning instead a `context deadline exceeded` error. My guess is that the initial call to `restartMetrics` and the one inside the license listener conflicted in funny ways, but I don't have full evidence for this.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53879

#### Screenshots
--

#### Release Note
```release-note
NONE
```
