### PR TITLE
Revert s3 path prefix normalization for plugins

### DIFF
--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -874,17 +874,7 @@ func (ch *Channels) getPluginsFromFolder() (map[string]*pluginSignaturePath, *mo
 
 func (ch *Channels) getPluginsFromFilePaths(fileStorePaths []string) map[string]*pluginSignaturePath {
 	pluginSignaturePathMap := make(map[string]*pluginSignaturePath)
-
-	fsPrefix := ""
-	if *ch.cfgSvc.Config().FileSettings.DriverName == model.ImageDriverS3 {
-		ptr := ch.cfgSvc.Config().FileSettings.AmazonS3PathPrefix
-		if ptr != nil && *ptr != "" {
-			fsPrefix = *ptr + "/"
-		}
-	}
-
 	for _, path := range fileStorePaths {
-		path = strings.TrimPrefix(path, fsPrefix)
 		if strings.HasSuffix(path, ".tar.gz") {
 			id := strings.TrimSuffix(filepath.Base(path), ".tar.gz")
 			helper := &pluginSignaturePath{
@@ -896,7 +886,6 @@ func (ch *Channels) getPluginsFromFilePaths(fileStorePaths []string) map[string]
 		}
 	}
 	for _, path := range fileStorePaths {
-		path = strings.TrimPrefix(path, fsPrefix)
 		if strings.HasSuffix(path, ".tar.gz.sig") {
 			id := strings.TrimSuffix(filepath.Base(path), ".tar.gz.sig")
 			if val, ok := pluginSignaturePathMap[id]; !ok {


### PR DESCRIPTION
#### Summary
This reverts 0af0a4eff45b133fb36496a73b839f55005aae02. During the [implementation](https://github.com/mattermost/mattermost/pull/15910) of the original change we [discussed](https://github.com/mattermost/mattermost/pull/15910#issuecomment-705925227) fixing the underlying issue. When we did [fix](https://github.com/mattermost/mattermost/pull/15949) the underlying issue, we didn't revert these changes.

Revert it now to simplify the code in anticipation of more changes to come re: pre-packaged plugins.

##### Testing

I've tested in the linked Setup Cloud Test Server, verifying that a prefix is configured:

<img width="918" alt="CleanShot 2023-08-03 at 13 58 05@2x" src="https://github.com/mattermost/mattermost/assets/1023171/0e8ff80b-88a9-4a1a-80f4-6ff4be751bf8">

and then that a plugin can be installed and activated from the marketplace:

<img width="918" alt="CleanShot 2023-08-03 at 13 59 11@2x" src="https://github.com/mattermost/mattermost/assets/1023171/628ff519-3f6a-4b63-9df6-cb797733e422">

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
