### PR TITLE
Improves accessibility of RHS channel list items

### DIFF
--- a/webapp/channels/src/components/sidebar/sidebar_category/__snapshots__/sidebar_category.test.tsx.snap
+++ b/webapp/channels/src/components/sidebar/sidebar_category/__snapshots__/sidebar_category.test.tsx.snap
@@ -24,6 +24,21 @@ exports[`components/sidebar/sidebar_category should match snapshot 2`] = `
 <div
   className=""
 >
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    className="sr-only"
+  >
+    <MemoizedFormattedMessage
+      defaultMessage="{count, number} {count, plural, one {channel} other {channels}}"
+      id="sidebar_left.sidebar_channel_menu.channel_count_aria_live"
+      values={
+        Object {
+          "count": 1,
+        }
+      }
+    />
+  </div>
   <SidebarCategoryHeader
     displayName="custom_category_1"
     isCollapsed={false}
@@ -55,6 +70,7 @@ exports[`components/sidebar/sidebar_category should match snapshot 2`] = `
     className="SidebarChannelGroup_content"
   >
     <ul
+      aria-label="custom_category_1"
       className="NavGroupContent"
       role="list"
     >
@@ -97,6 +113,11 @@ exports[`components/sidebar/sidebar_category should match snapshot when collapse
 <div
   className=""
 >
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    className="sr-only"
+  />
   <SidebarCategoryHeader
     displayName="custom_category_1"
     isCollapsed={true}
@@ -128,6 +149,7 @@ exports[`components/sidebar/sidebar_category should match snapshot when collapse
     className="SidebarChannelGroup_content"
   >
     <ul
+      aria-label="custom_category_1"
       className="NavGroupContent"
       role="list"
     >
@@ -170,6 +192,21 @@ exports[`components/sidebar/sidebar_category should match snapshot when isNewCat
 <div
   className=""
 >
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    className="sr-only"
+  >
+    <MemoizedFormattedMessage
+      defaultMessage="{count, number} {count, plural, one {channel} other {channels}}"
+      id="sidebar_left.sidebar_channel_menu.channel_count_aria_live"
+      values={
+        Object {
+          "count": 0,
+        }
+      }
+    />
+  </div>
   <SidebarCategoryHeader
     displayName="custom_category_1"
     isCollapsed={false}
@@ -207,6 +244,7 @@ exports[`components/sidebar/sidebar_category should match snapshot when isNewCat
     className="SidebarChannelGroup_content"
   >
     <ul
+      aria-label="custom_category_1"
       className="NavGroupContent"
       role="list"
     >
@@ -270,6 +308,21 @@ exports[`components/sidebar/sidebar_category should match snapshot when sorting 
 <div
   className=""
 >
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    className="sr-only"
+  >
+    <MemoizedFormattedMessage
+      defaultMessage="{count, number} {count, plural, one {channel} other {channels}}"
+      id="sidebar_left.sidebar_channel_menu.channel_count_aria_live"
+      values={
+        Object {
+          "count": 1,
+        }
+      }
+    />
+  </div>
   <SidebarCategoryHeader
     displayName="custom_category_1"
     isCollapsed={false}
@@ -347,6 +400,7 @@ exports[`components/sidebar/sidebar_category should match snapshot when sorting 
     className="SidebarChannelGroup_content"
   >
     <ul
+      aria-label="custom_category_1"
       className="NavGroupContent"
       role="list"
     >
@@ -393,6 +447,21 @@ exports[`components/sidebar/sidebar_category should match snapshot when the cate
 <div
   className=""
 >
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    className="sr-only"
+  >
+    <MemoizedFormattedMessage
+      defaultMessage="{count, number} {count, plural, one {channel} other {channels}}"
+      id="sidebar_left.sidebar_channel_menu.channel_count_aria_live"
+      values={
+        Object {
+          "count": 1,
+        }
+      }
+    />
+  </div>
   <SidebarCategoryHeader
     displayName="custom_category_1"
     isCollapsed={false}
@@ -470,6 +539,7 @@ exports[`components/sidebar/sidebar_category should match snapshot when the cate
     className="SidebarChannelGroup_content"
   >
     <ul
+      aria-label="custom_category_1"
       className="NavGroupContent"
       role="list"
     />

--- a/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category.tsx
@@ -14,9 +14,8 @@ import {trackEvent} from 'actions/telemetry_actions';
 import OverlayTrigger from 'components/overlay_trigger';
 import Tooltip from 'components/tooltip';
 import {DraggingState} from 'types/store';
-import Constants, {A11yCustomEventTypes, DraggingStateTypes, DraggingStates} from 'utils/constants';
+import {DraggingStateTypes, DraggingStates} from 'utils/constants';
 import {t} from 'utils/i18n';
-import {isKeyPressed} from 'utils/keyboard';
 import SidebarChannel from '../sidebar_channel';
 import {SidebarCategoryHeader} from '../sidebar_category_header';
 import InviteMembersButton from '../invite_members_button';
@@ -74,38 +73,6 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
             this.newDropBoxRef.current.classList.add('animating');
         }
     }
-
-    componentDidMount() {
-        this.categoryTitleRef.current?.addEventListener(A11yCustomEventTypes.ACTIVATE, this.handleA11yActivateEvent);
-        this.categoryTitleRef.current?.addEventListener(A11yCustomEventTypes.DEACTIVATE, this.handleA11yDeactivateEvent);
-    }
-
-    componentWillUnmount() {
-        this.categoryTitleRef.current?.removeEventListener(A11yCustomEventTypes.ACTIVATE, this.handleA11yActivateEvent);
-        this.categoryTitleRef.current?.removeEventListener(A11yCustomEventTypes.DEACTIVATE, this.handleA11yDeactivateEvent);
-
-        if (this.a11yKeyDownRegistered) {
-            this.handleA11yDeactivateEvent();
-        }
-    }
-
-    handleA11yActivateEvent = () => {
-        this.categoryTitleRef.current?.addEventListener('keydown', this.handleA11yKeyDown);
-
-        this.a11yKeyDownRegistered = true;
-    };
-
-    handleA11yDeactivateEvent = () => {
-        this.categoryTitleRef.current?.removeEventListener('keydown', this.handleA11yKeyDown);
-
-        this.a11yKeyDownRegistered = false;
-    };
-
-    handleA11yKeyDown = (e: KeyboardEvent<HTMLButtonElement>['nativeEvent']) => {
-        if (isKeyPressed(e, Constants.KeyCodes.ENTER)) {
-            this.handleCollapse();
-        }
-    };
 
     renderChannel = (channelId: string, index: number) => {
         const {setChannelRef, category, draggingState} = this.props;
@@ -361,6 +328,19 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
                                                 draggingOver: droppableSnapshot.isDraggingOver,
                                             })}
                                         >
+                                            <div
+                                                className='sr-only'
+                                                aria-live='polite'
+                                                aria-atomic='true'
+                                            >
+                                                {(!category.collapsed) && (
+                                                    <FormattedMessage
+                                                        id='sidebar_left.sidebar_channel_menu.channel_count_aria_live'
+                                                        defaultMessage='{count, number} {count, plural, one {channel} other {channels}}'
+                                                        values={{count: category.channel_ids.length}}
+                                                    />
+                                                )}
+                                            </div>
                                             <SidebarCategoryHeader
                                                 ref={this.categoryTitleRef}
                                                 displayName={displayName}
@@ -382,6 +362,7 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
                                                 <ul
                                                     role='list'
                                                     className='NavGroupContent'
+                                                    aria-label={displayName}
                                                 >
                                                     {this.renderNewDropBox(droppableSnapshot.isDraggingOver)}
                                                     {renderedChannels}

--- a/webapp/channels/src/components/sidebar/sidebar_category_header.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_category_header.tsx
@@ -60,6 +60,7 @@ export const SidebarCategoryHeader = React.forwardRef((props: Props, ref?: React
                 className={classNames('SidebarChannelGroupHeader_groupButton')}
                 aria-label={props.displayName}
                 onClick={props.onClick}
+                aria-expanded={!props.isCollapsed}
             >
                 <i
                     className={classNames('icon icon-chevron-down', {

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -4799,6 +4799,7 @@
   "sidebar_left.sidebar_category.newDropBoxLabel": "Drag channels here...",
   "sidebar_left.sidebar_category.newLabel": "new",
   "sidebar_left.sidebar_channel_menu.addMembers": "Add Members",
+  "sidebar_left.sidebar_channel_menu.channel_count_aria_live": "{count, number} {count, plural, one {channel} other {channels}}",
   "sidebar_left.sidebar_channel_menu.channels": "Channels",
   "sidebar_left.sidebar_channel_menu.copyLink": "Copy Link",
   "sidebar_left.sidebar_channel_menu.dropdownAriaLabel": "Edit channel menu",


### PR DESCRIPTION
#### Summary
This change aims to address some raised accessibility issues with the LHS channel list.

It addresses two separate issues (1 is a general bug, the other is for accessibility):
1. When hitting **Enter** on a channel category it would not collapse (but with **Spacebar** it would)
    - Fixed by removing (seemingly) unnecessary listeners for the **Enter** key which would cause `handleCollapse` to be called twice
2. Screen reader is missing appropriate context for collapse/expand actions
    - Addressed by:
        - Adding `aria-expanded` to the "collapse" button
            - This causes screen readers to read out "collapsed" and "expanded" when activating a channel sidebar category header
        - Adding a conditional `aria-live` div with the channel count
            - This adds on to the "expanded" readout to cause the screen reader to issue a message like `1 channel expanded` or `2 channels expanded`

In the original issue there is some mention about the readouts incorrectly reading out "You Have lifted an item in Position 1" but in my investigation this is a non-issue as it only reads this message out when you tab past the collapse button into the draggable control.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/21415
Jira https://mattermost.atlassian.net/browse/MM-47597



#### Release Note
```release-note
Fixed issue with ENTER key not collapsing channel categories
```
