### PR TITLE
MM-53355: tidy up plugins

### DIFF
--- a/server/channels/app/app_iface.go
+++ b/server/channels/app/app_iface.go
@@ -248,7 +248,8 @@ type AppIface interface {
 	HubRegister(webConn *platform.WebConn)
 	// HubUnregister unregisters a connection from a hub.
 	HubUnregister(webConn *platform.WebConn)
-	// InstallPlugin unpacks and installs a plugin but does not enable or activate it.
+	// InstallPlugin unpacks and installs a plugin but does not enable or activate it unless the the
+	// plugin was already enabled.
 	InstallPlugin(pluginFile io.ReadSeeker, replace bool) (*model.Manifest, *model.AppError)
 	// LogAuditRec logs an audit record using default LvlAuditCLI.
 	LogAuditRec(rec *audit.Record, err error)

--- a/server/channels/app/cluster_handlers.go
+++ b/server/channels/app/cluster_handlers.go
@@ -16,7 +16,7 @@ func (s *Server) clusterInstallPluginHandler(msg *model.ClusterMessage) {
 	if jsonErr := json.Unmarshal(msg.Data, &data); jsonErr != nil {
 		mlog.Warn("Failed to decode from JSON", mlog.Err(jsonErr))
 	}
-	s.Channels().installPluginFromData(data)
+	s.Channels().installPluginFromClusterMessage(data.Id)
 }
 
 func (s *Server) clusterRemovePluginHandler(msg *model.ClusterMessage) {
@@ -24,7 +24,7 @@ func (s *Server) clusterRemovePluginHandler(msg *model.ClusterMessage) {
 	if jsonErr := json.Unmarshal(msg.Data, &data); jsonErr != nil {
 		mlog.Warn("Failed to decode from JSON", mlog.Err(jsonErr))
 	}
-	s.Channels().removePluginFromData(data)
+	s.Channels().removePluginFromClusterMessage(data.Id)
 }
 
 func (s *Server) clusterPluginEventHandler(msg *model.ClusterMessage) {

--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -348,7 +348,7 @@ func (ch *Channels) syncPlugins() *model.AppError {
 			}
 
 			mlog.Info("Syncing plugin from file store", mlog.String("bundle", plugin.path))
-			if _, err := ch.installPluginLocally(reader, signature, installPluginLocallyAlways); err != nil && err.Id != "app.plugin.blocked.app_error" && err.Id != "app.plugin.skip_installation.app_error" {
+			if _, err := ch.installPluginLocally(reader, signature, installPluginLocallyAlways); err != nil && err.Id != "app.plugin.skip_installation.app_error" {
 				mlog.Error("Failed to sync plugin from file store", mlog.String("bundle", plugin.path), mlog.Err(err))
 			}
 		}(plugin)
@@ -924,8 +924,7 @@ func (ch *Channels) processPrepackagedPlugins(pluginsDir string) []*plugin.Prepa
 			p, err := ch.processPrepackagedPlugin(psPath)
 			if err != nil {
 				var appErr *model.AppError
-				// A log line already appears if the plugin is on the blocklist
-				if errors.As(err, &appErr) && (appErr.Id == "app.plugin.blocked.app_error" || appErr.Id == "app.plugin.skip_installation.app_error") {
+				if errors.As(err, &appErr) && appErr.Id == "app.plugin.skip_installation.app_error" {
 					return
 				}
 				mlog.Error("Failed to install prepackaged plugin", mlog.String("path", psPath.path), mlog.Err(err))

--- a/server/channels/app/plugin_install.go
+++ b/server/channels/app/plugin_install.go
@@ -46,7 +46,6 @@ import (
 	"github.com/blang/semver"
 
 	"github.com/mattermost/mattermost/server/public/model"
-	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/public/utils"
 	"github.com/mattermost/mattermost/server/v8/platform/shared/filestore"
@@ -332,12 +331,6 @@ func (ch *Channels) installExtractedPlugin(manifest *model.Manifest, fromPluginD
 	bundles, err := pluginsEnvironment.Available()
 	if err != nil {
 		return nil, model.NewAppError("installExtractedPlugin", "app.plugin.install.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
-	}
-
-	// Check plugin id is not blocked
-	if plugin.PluginIDIsBlocked(manifest.Id) {
-		mlog.Debug("Skipping installation of plugin since plugin is on blocklist. Some plugins are blocked because they are built into this version of Mattermost.", mlog.String("plugin_id", manifest.Id))
-		return nil, model.NewAppError("installExtractedPlugin", "app.plugin.blocked.app_error", map[string]any{"Id": manifest.Id}, "", http.StatusInternalServerError)
 	}
 
 	// Check for plugins installed with the same ID.

--- a/server/channels/app/plugin_install.go
+++ b/server/channels/app/plugin_install.go
@@ -119,11 +119,6 @@ func (ch *Channels) removePluginFromData(data model.PluginEventData) {
 	}
 }
 
-// InstallPluginWithSignature verifies and installs plugin.
-func (ch *Channels) installPluginWithSignature(pluginFile, signature io.ReadSeeker) (*model.Manifest, *model.AppError) {
-	return ch.installPlugin(pluginFile, signature, installPluginLocallyAlways)
-}
-
 // InstallPlugin unpacks and installs a plugin but does not enable or activate it.
 func (a *App) InstallPlugin(pluginFile io.ReadSeeker, replace bool) (*model.Manifest, *model.AppError) {
 	installationStrategy := installPluginLocallyOnlyIfNew
@@ -131,11 +126,7 @@ func (a *App) InstallPlugin(pluginFile io.ReadSeeker, replace bool) (*model.Mani
 		installationStrategy = installPluginLocallyAlways
 	}
 
-	return a.installPlugin(pluginFile, nil, installationStrategy)
-}
-
-func (a *App) installPlugin(pluginFile, signature io.ReadSeeker, installationStrategy pluginInstallationStrategy) (*model.Manifest, *model.AppError) {
-	return a.ch.installPlugin(pluginFile, signature, installationStrategy)
+	return a.ch.installPlugin(pluginFile, nil, installationStrategy)
 }
 
 func (ch *Channels) installPlugin(pluginFile, signature io.ReadSeeker, installationStrategy pluginInstallationStrategy) (*model.Manifest, *model.AppError) {
@@ -244,7 +235,7 @@ func (ch *Channels) InstallMarketplacePlugin(request *model.InstallMarketplacePl
 		return nil, model.NewAppError("InstallMarketplacePlugin", "app.plugin.marketplace_plugins.signature_not_found.app_error", nil, "", http.StatusInternalServerError)
 	}
 
-	manifest, appErr := ch.installPluginWithSignature(pluginFile, signatureFile)
+	manifest, appErr := ch.installPlugin(pluginFile, signatureFile, installPluginLocallyAlways)
 	if appErr != nil {
 		return nil, appErr
 	}

--- a/server/channels/app/plugin_install.go
+++ b/server/channels/app/plugin_install.go
@@ -58,68 +58,77 @@ const managedPluginFileName = ".filestore"
 // fileStorePluginFolder is the folder name in the file store of the plugin bundles installed.
 const fileStorePluginFolder = "plugins"
 
-func (ch *Channels) installPluginFromData(data model.PluginEventData) {
-	mlog.Debug("Installing plugin as per cluster message", mlog.String("plugin_id", data.Id))
+// installPluginFromClusterMessage is called when a peer activates a plugin in the filestore,
+// signalling all other servers to do the same.
+func (ch *Channels) installPluginFromClusterMessage(pluginID string) {
+	logger := ch.srv.Log().With(mlog.String("plugin_id", pluginID))
+
+	logger.Info("Installing plugin as per cluster message")
 
 	pluginSignaturePathMap, appErr := ch.getPluginsFromFolder()
 	if appErr != nil {
-		mlog.Error("Failed to get plugin signatures from filestore. Can't install plugin from data.", mlog.Err(appErr))
+		logger.Error("Failed to get plugin signatures from filestore.", mlog.Err(appErr))
 		return
 	}
-	plugin, ok := pluginSignaturePathMap[data.Id]
+	plugin, ok := pluginSignaturePathMap[pluginID]
 	if !ok {
-		mlog.Error("Failed to get plugin signature from filestore. Can't install plugin from data.", mlog.String("plugin id", data.Id))
+		logger.Error("Failed to get plugin signature from filestore.")
 		return
 	}
 
-	reader, appErr := ch.srv.fileReader(plugin.path)
+	bundle, appErr := ch.srv.fileReader(plugin.bundlePath)
 	if appErr != nil {
-		mlog.Error("Failed to open plugin bundle from file store.", mlog.String("bundle", plugin.path), mlog.Err(appErr))
+		logger.Error("Failed to open plugin bundle from file store.", mlog.Err(appErr))
 		return
 	}
-	defer reader.Close()
+	defer bundle.Close()
 
 	var signature filestore.ReadCloseSeeker
 	if *ch.cfgSvc.Config().PluginSettings.RequirePluginSignature {
 		signature, appErr = ch.srv.fileReader(plugin.signaturePath)
 		if appErr != nil {
-			mlog.Error("Failed to open plugin signature from file store.", mlog.Err(appErr))
+			logger.Error("Failed to open plugin signature from file store.", mlog.Err(appErr))
 			return
 		}
 		defer signature.Close()
 	}
 
-	manifest, appErr := ch.installPluginLocally(reader, signature, installPluginLocallyAlways)
+	manifest, appErr := ch.installPluginLocally(bundle, signature, installPluginLocallyAlways)
 	if appErr != nil {
 		// A log line already appears if the plugin is on the blocklist or skipped
 		if appErr.Id != "app.plugin.blocked.app_error" && appErr.Id != "app.plugin.skip_installation.app_error" {
-			mlog.Error("Failed to sync plugin from file store", mlog.String("bundle", plugin.path), mlog.Err(appErr))
+			logger.Error("Failed to sync plugin from file store", mlog.Err(appErr))
 		}
 		return
 	}
 
 	if err := ch.notifyPluginEnabled(manifest); err != nil {
-		mlog.Error("Failed notify plugin enabled", mlog.Err(err))
+		logger.Error("Failed notify plugin enabled", mlog.Err(err))
 	}
 
 	if err := ch.notifyPluginStatusesChanged(); err != nil {
-		mlog.Error("Failed to notify plugin status changed", mlog.Err(err))
+		logger.Error("Failed to notify plugin status changed", mlog.Err(err))
 	}
 }
 
-func (ch *Channels) removePluginFromData(data model.PluginEventData) {
-	mlog.Debug("Removing plugin as per cluster message", mlog.String("plugin_id", data.Id))
+// removePluginFromClusterMessage is called when a peer removes a plugin, signalling all other
+// servers to do the same.
+func (ch *Channels) removePluginFromClusterMessage(pluginID string) {
+	logger := ch.srv.Log().With(mlog.String("plugin_id", pluginID))
 
-	if err := ch.removePluginLocally(data.Id); err != nil {
-		mlog.Warn("Failed to remove plugin locally", mlog.Err(err), mlog.String("id", data.Id))
+	logger.Info("Removing plugin as per cluster message")
+
+	if err := ch.removePluginLocally(pluginID); err != nil {
+		logger.Error("Failed to remove plugin locally", mlog.Err(err))
 	}
 
 	if err := ch.notifyPluginStatusesChanged(); err != nil {
-		mlog.Warn("failed to notify plugin status changed", mlog.Err(err))
+		logger.Error("failed to notify plugin status changed", mlog.Err(err))
 	}
 }
 
-// InstallPlugin unpacks and installs a plugin but does not enable or activate it.
+// InstallPlugin unpacks and installs a plugin but does not enable or activate it unless the the
+// plugin was already enabled.
 func (a *App) InstallPlugin(pluginFile io.ReadSeeker, replace bool) (*model.Manifest, *model.AppError) {
 	installationStrategy := installPluginLocallyOnlyIfNew
 	if replace {
@@ -129,8 +138,13 @@ func (a *App) InstallPlugin(pluginFile io.ReadSeeker, replace bool) (*model.Mani
 	return a.ch.installPlugin(pluginFile, nil, installationStrategy)
 }
 
-func (ch *Channels) installPlugin(pluginFile, signature io.ReadSeeker, installationStrategy pluginInstallationStrategy) (*model.Manifest, *model.AppError) {
-	manifest, appErr := ch.installPluginLocally(pluginFile, signature, installationStrategy)
+// installPlugin extracts and installs the given plugin bundle (optionally signed) for the
+// current server, activating the plugin if already enabled, installs it to the filestore for
+// cluster peers to use, and then broadcasts the change to connected websockets.
+//
+// The given installation strategy decides how to handle upgrade scenarios.
+func (ch *Channels) installPlugin(bundle, signature io.ReadSeeker, installationStrategy pluginInstallationStrategy) (*model.Manifest, *model.AppError) {
+	manifest, appErr := ch.installPluginLocally(bundle, signature, installationStrategy)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -139,17 +153,42 @@ func (ch *Channels) installPlugin(pluginFile, signature io.ReadSeeker, installat
 		return nil, nil
 	}
 
+	logger := ch.srv.Log().With(mlog.String("plugin_id", manifest.Id))
+
+	appErr = ch.installPluginToFilestore(manifest, bundle, signature)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	if err := ch.notifyPluginEnabled(manifest); err != nil {
+		logger.Warn("Failed notify plugin enabled", mlog.Err(err))
+	}
+
+	if err := ch.notifyPluginStatusesChanged(); err != nil {
+		logger.Warn("Failed to notify plugin status changed", mlog.Err(err))
+	}
+
+	return manifest, nil
+}
+
+// installPluginToFilestore saves the given plugin bundle (optionally signed) to the filestore,
+// notifying cluster peers accordingly.
+func (ch *Channels) installPluginToFilestore(manifest *model.Manifest, bundle, signature io.ReadSeeker) *model.AppError {
 	if signature != nil {
-		signature.Seek(0, 0)
-		if _, appErr = ch.srv.writeFile(signature, getSignatureStorePath(manifest.Id)); appErr != nil {
-			return nil, model.NewAppError("saveSignature", "app.plugin.store_signature.app_error", nil, "", http.StatusInternalServerError).Wrap(appErr)
+		_, err := signature.Seek(0, 0)
+		if err != nil {
+			return model.NewAppError("saveSignature", "app.plugin.store_signature.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+		}
+
+		if _, appErr := ch.srv.writeFile(signature, getSignatureStorePath(manifest.Id)); appErr != nil {
+			return model.NewAppError("saveSignature", "app.plugin.store_signature.app_error", nil, "", http.StatusInternalServerError).Wrap(appErr)
 		}
 	}
 
 	// Store bundle in the file store to allow access from other servers.
-	pluginFile.Seek(0, 0)
-	if _, appErr := ch.srv.writeFile(pluginFile, getBundleStorePath(manifest.Id)); appErr != nil {
-		return nil, model.NewAppError("uploadPlugin", "app.plugin.store_bundle.app_error", nil, "", http.StatusInternalServerError).Wrap(appErr)
+	bundle.Seek(0, 0)
+	if _, appErr := ch.srv.writeFile(bundle, getBundleStorePath(manifest.Id)); appErr != nil {
+		return model.NewAppError("uploadPlugin", "app.plugin.store_bundle.app_error", nil, "", http.StatusInternalServerError).Wrap(appErr)
 	}
 
 	ch.notifyClusterPluginEvent(
@@ -159,20 +198,15 @@ func (ch *Channels) installPlugin(pluginFile, signature io.ReadSeeker, installat
 		},
 	)
 
-	if err := ch.notifyPluginEnabled(manifest); err != nil {
-		mlog.Warn("Failed notify plugin enabled", mlog.Err(err))
-	}
-
-	if err := ch.notifyPluginStatusesChanged(); err != nil {
-		mlog.Warn("Failed to notify plugin status changed", mlog.Err(err))
-	}
-
-	return manifest, nil
+	return nil
 }
 
-// InstallMarketplacePlugin installs a plugin listed in the marketplace server. It will get the plugin bundle
-// from the prepackaged folder, if available, or remotely if EnableRemoteMarketplace is true.
+// InstallMarketplacePlugin installs a plugin listed in the marketplace server. It will get the
+// plugin bundle from the prepackaged folder, if available, or remotely if EnableRemoteMarketplace
+// is true.
 func (ch *Channels) InstallMarketplacePlugin(request *model.InstallMarketplacePluginRequest) (*model.Manifest, *model.AppError) {
+	logger := ch.srv.Log().With(mlog.String("plugin_id", request.Id))
+
 	var pluginFile, signatureFile io.ReadSeeker
 
 	prepackagedPlugin, appErr := ch.getPrepackagedPlugin(request.Id, request.Version)
@@ -195,7 +229,7 @@ func (ch *Channels) InstallMarketplacePlugin(request *model.InstallMarketplacePl
 		plugin, appErr = ch.getRemoteMarketplacePlugin(request.Id, request.Version)
 		// The plugin might only be prepackaged and not on the Marketplace.
 		if appErr != nil && appErr.Id != "app.plugin.marketplace_plugins.not_found.app_error" {
-			mlog.Warn("Failed to reach Marketplace to install plugin", mlog.String("plugin_id", request.Id), mlog.Err(appErr))
+			logger.Warn("Failed to reach Marketplace to install plugin", mlog.Err(appErr))
 		}
 
 		if plugin != nil {
@@ -254,7 +288,11 @@ const (
 	installPluginLocallyAlways
 )
 
-func (ch *Channels) installPluginLocally(pluginFile, signature io.ReadSeeker, installationStrategy pluginInstallationStrategy) (*model.Manifest, *model.AppError) {
+// installPluginLocally extracts and installs the given plugin bundle (optionally signed) for the
+// current server, activating the plugin if already enabled.
+//
+// The given installation strategy decides how to handle upgrade scenarios.
+func (ch *Channels) installPluginLocally(bundle, signature io.ReadSeeker, installationStrategy pluginInstallationStrategy) (*model.Manifest, *model.AppError) {
 	pluginsEnvironment := ch.GetPluginsEnvironment()
 	if pluginsEnvironment == nil {
 		return nil, model.NewAppError("installPluginLocally", "app.plugin.disabled.app_error", nil, "", http.StatusNotImplemented)
@@ -262,7 +300,7 @@ func (ch *Channels) installPluginLocally(pluginFile, signature io.ReadSeeker, in
 
 	// verify signature
 	if signature != nil {
-		if err := ch.verifyPlugin(pluginFile, signature); err != nil {
+		if err := ch.verifyPlugin(bundle, signature); err != nil {
 			return nil, err
 		}
 	}
@@ -273,7 +311,7 @@ func (ch *Channels) installPluginLocally(pluginFile, signature io.ReadSeeker, in
 	}
 	defer os.RemoveAll(tmpDir)
 
-	manifest, pluginDir, appErr := extractPlugin(pluginFile, tmpDir)
+	manifest, pluginDir, appErr := extractPlugin(bundle, tmpDir)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -286,9 +324,10 @@ func (ch *Channels) installPluginLocally(pluginFile, signature io.ReadSeeker, in
 	return manifest, nil
 }
 
-func extractPlugin(pluginFile io.ReadSeeker, extractDir string) (*model.Manifest, string, *model.AppError) {
-	pluginFile.Seek(0, 0)
-	if err := extractTarGz(pluginFile, extractDir); err != nil {
+// extractPlugin unpacks the given plugin bundle into the specified directory.
+func extractPlugin(bundle io.ReadSeeker, extractDir string) (*model.Manifest, string, *model.AppError) {
+	bundle.Seek(0, 0)
+	if err := extractTarGz(bundle, extractDir); err != nil {
 		return nil, "", model.NewAppError("extractPlugin", "app.plugin.extract.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
 
@@ -297,6 +336,8 @@ func extractPlugin(pluginFile io.ReadSeeker, extractDir string) (*model.Manifest
 		return nil, "", model.NewAppError("extractPlugin", "app.plugin.filesystem.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
+	// If the root of the plugin bundle consists of exactly one directory, assume the plugin
+	// is contained therein. Otherwise the root directory is expected to contain the plugin.
 	if len(dir) == 1 && dir[0].IsDir() {
 		extractDir = filepath.Join(extractDir, dir[0].Name())
 	}
@@ -307,13 +348,21 @@ func extractPlugin(pluginFile io.ReadSeeker, extractDir string) (*model.Manifest
 	}
 
 	if !model.IsValidPluginId(manifest.Id) {
-		return nil, "", model.NewAppError("installPluginLocally", "app.plugin.invalid_id.app_error", map[string]any{"Min": model.MinIdLength, "Max": model.MaxIdLength, "Regex": model.ValidIdRegex}, "", http.StatusBadRequest)
+		return nil, "", model.NewAppError("extractPlugin", "app.plugin.invalid_id.app_error", map[string]any{"Min": model.MinIdLength, "Max": model.MaxIdLength, "Regex": model.ValidIdRegex}, "", http.StatusBadRequest)
 	}
 
 	return manifest, extractDir, nil
 }
 
+// installExtractedPlugin installs a plugin previously extracted to a temporary directory,
+// activating the plugin automatically if already enabled by the server configuration.
+//
+// The given installation strategy decides how to handle upgrade scenarios.
 func (ch *Channels) installExtractedPlugin(manifest *model.Manifest, fromPluginDir string, installationStrategy pluginInstallationStrategy) (*model.Manifest, *model.AppError) {
+	logger := ch.srv.Log().With(mlog.String("plugin_id", manifest.Id))
+
+	logger.Info("Installing extracted plugin", mlog.String("version", manifest.Version))
+
 	pluginsEnvironment := ch.GetPluginsEnvironment()
 	if pluginsEnvironment == nil {
 		return nil, model.NewAppError("installExtractedPlugin", "app.plugin.disabled.app_error", nil, "", http.StatusNotImplemented)
@@ -350,30 +399,30 @@ func (ch *Channels) installExtractedPlugin(manifest *model.Manifest, fromPluginD
 
 			existingVersion, err = semver.Parse(existingManifest.Version)
 			if err != nil {
-				return nil, model.NewAppError("installExtractedPlugin", "app.plugin.invalid_version.app_error", nil, "", http.StatusBadRequest)
+				return nil, model.NewAppError("installExtractedPlugin", "app.plugin.invalid_version.app_error", nil, "", http.StatusInternalServerError)
 			}
 
 			if version.LTE(existingVersion) {
-				mlog.Debug("Skipping local installation of plugin since existing version is newer", mlog.String("plugin_id", manifest.Id))
+				logger.Warn("Skipping local installation of plugin since existing version is newer", mlog.String("version", version.String()), mlog.String("existing_version", existingVersion.String()))
 				return nil, model.NewAppError("installExtractedPlugin", "app.plugin.skip_installation.app_error", map[string]any{"Id": manifest.Id}, "", http.StatusInternalServerError)
 			}
 		}
 
-		// Otherwise remove the existing installation prior to install below.
-		mlog.Debug("Removing existing installation of plugin before local install", mlog.String("plugin_id", existingManifest.Id), mlog.String("version", existingManifest.Version))
+		// Otherwise remove the existing installation prior to installing below.
+		logger.Info("Removing existing installation of plugin before local install", mlog.String("existing_version", existingManifest.Version))
 		if err := ch.removePluginLocally(existingManifest.Id); err != nil {
-			return nil, model.NewAppError("installExtractedPlugin", "app.plugin.install_id_failed_remove.app_error", nil, "", http.StatusBadRequest)
+			return nil, model.NewAppError("installExtractedPlugin", "app.plugin.install_id_failed_remove.app_error", nil, "", http.StatusInternalServerError)
 		}
 	}
 
-	pluginPath := filepath.Join(*ch.cfgSvc.Config().PluginSettings.Directory, manifest.Id)
-	err = utils.CopyDir(fromPluginDir, pluginPath)
+	bundlePath := filepath.Join(*ch.cfgSvc.Config().PluginSettings.Directory, manifest.Id)
+	err = utils.CopyDir(fromPluginDir, bundlePath)
 	if err != nil {
 		return nil, model.NewAppError("installExtractedPlugin", "app.plugin.mvdir.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	// Flag plugin locally as managed by the filestore.
-	f, err := os.Create(filepath.Join(pluginPath, managedPluginFileName))
+	f, err := os.Create(filepath.Join(bundlePath, managedPluginFileName))
 	if err != nil {
 		return nil, model.NewAppError("installExtractedPlugin", "app.plugin.flag_managed.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -403,12 +452,13 @@ func (ch *Channels) installExtractedPlugin(manifest *model.Manifest, fromPluginD
 		manifest = updatedManifest
 	}
 
-	mlog.Debug("Installing plugin", mlog.String("plugin_id", manifest.Id), mlog.String("version", manifest.Version))
-
 	return manifest, nil
 }
 
+// RemovePlugin removes a plugin from all servers.
 func (ch *Channels) RemovePlugin(id string) *model.AppError {
+	logger := ch.srv.Log().With(mlog.String("plugin_id", id))
+
 	// Disable plugin before removal to make sure this
 	// plugin remains disabled on re-install.
 	if err := ch.disablePlugin(id); err != nil {
@@ -420,19 +470,19 @@ func (ch *Channels) RemovePlugin(id string) *model.AppError {
 	}
 
 	// Remove bundle from the file store.
-	storePluginFileName := getBundleStorePath(id)
-	bundleExist, err := ch.srv.fileExists(storePluginFileName)
+	bundlePath := getBundleStorePath(id)
+	bundleExists, err := ch.srv.fileExists(bundlePath)
 	if err != nil {
 		return model.NewAppError("removePlugin", "app.plugin.remove_bundle.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
-	if !bundleExist {
+	if !bundleExists {
 		return nil
 	}
-	if err = ch.srv.removeFile(storePluginFileName); err != nil {
+	if err := ch.srv.removeFile(bundlePath); err != nil {
 		return model.NewAppError("removePlugin", "app.plugin.remove_bundle.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
-	if err = ch.removeSignature(id); err != nil {
-		mlog.Warn("Can't remove signature", mlog.Err(err))
+	if err := ch.removeSignature(id); err != nil {
+		logger.Warn("Can't remove signature", mlog.Err(err))
 	}
 
 	ch.notifyClusterPluginEvent(
@@ -443,12 +493,13 @@ func (ch *Channels) RemovePlugin(id string) *model.AppError {
 	)
 
 	if err := ch.notifyPluginStatusesChanged(); err != nil {
-		mlog.Warn("Failed to notify plugin status changed", mlog.Err(err))
+		logger.Warn("Failed to notify plugin status changed", mlog.Err(err))
 	}
 
 	return nil
 }
 
+// removePluginLocally removes the given plugin from the current server.
 func (ch *Channels) removePluginLocally(id string) *model.AppError {
 	pluginsEnvironment := ch.GetPluginsEnvironment()
 	if pluginsEnvironment == nil {
@@ -461,11 +512,11 @@ func (ch *Channels) removePluginLocally(id string) *model.AppError {
 	}
 
 	var manifest *model.Manifest
-	var pluginPath string
+	var unpackedBundlePath string
 	for _, p := range plugins {
 		if p.Manifest != nil && p.Manifest.Id == id {
 			manifest = p.Manifest
-			pluginPath = filepath.Dir(p.ManifestPath)
+			unpackedBundlePath = filepath.Dir(p.ManifestPath)
 			break
 		}
 	}
@@ -478,33 +529,39 @@ func (ch *Channels) removePluginLocally(id string) *model.AppError {
 	pluginsEnvironment.RemovePlugin(id)
 	ch.unregisterPluginCommands(id)
 
-	if err := os.RemoveAll(pluginPath); err != nil {
+	if err := os.RemoveAll(unpackedBundlePath); err != nil {
 		return model.NewAppError("removePlugin", "app.plugin.remove.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	return nil
 }
 
+// removeSignature removes the signature file installed alongside the plugin.
 func (ch *Channels) removeSignature(pluginID string) *model.AppError {
-	filePath := getSignatureStorePath(pluginID)
-	exists, err := ch.srv.fileExists(filePath)
+	logger := ch.srv.Log().With(mlog.String("plugin_id", pluginID))
+
+	signaturePath := getSignatureStorePath(pluginID)
+	exists, err := ch.srv.fileExists(signaturePath)
 	if err != nil {
 		return model.NewAppError("removeSignature", "app.plugin.remove_bundle.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	if !exists {
-		mlog.Debug("no plugin signature to remove", mlog.String("plugin_id", pluginID))
+		logger.Debug("no plugin signature to remove")
 		return nil
 	}
-	if err = ch.srv.removeFile(filePath); err != nil {
+	if err = ch.srv.removeFile(signaturePath); err != nil {
 		return model.NewAppError("removeSignature", "app.plugin.remove_bundle.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	return nil
 }
 
+// getBundleStorePath maps the given plugin id to the file path of the corresponding plugin bundle.
 func getBundleStorePath(id string) string {
 	return filepath.Join(fileStorePluginFolder, fmt.Sprintf("%s.tar.gz", id))
 }
 
+// getSignatureStorePath maps the given plugin id to the file path of the corresponding plugin
+// signature, if one exists.
 func getSignatureStorePath(id string) string {
 	return filepath.Join(fileStorePluginFolder, fmt.Sprintf("%s.tar.gz.sig", id))
 }

--- a/server/channels/app/plugin_install_test.go
+++ b/server/channels/app/plugin_install_test.go
@@ -167,17 +167,6 @@ func TestInstallPluginLocally(t *testing.T) {
 		assertBundleInfoManifests(t, th, []*model.Manifest{manifest})
 	})
 
-	t.Run("doesn't install if ID on block list", func(t *testing.T) {
-		th := Setup(t)
-		defer th.TearDown()
-		cleanExistingBundles(t, th)
-
-		_, appErr := installPlugin(t, th, "com.mattermost.plugin-incident-response", "0.0.1", installPluginLocallyAlways)
-		require.NotNil(t, appErr)
-		require.Equal(t, "app.plugin.blocked.app_error", appErr.Id)
-		assertBundleInfoManifests(t, th, []*model.Manifest{})
-	})
-
 	t.Run("different plugin already installed", func(t *testing.T) {
 		th := Setup(t)
 		defer th.TearDown()

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -6024,10 +6024,6 @@
     "translation": "We encountered an error updating the app."
   },
   {
-    "id": "app.plugin.blocked.app_error",
-    "translation": "Plugin {{.Id}} is on the block list. Some plugins are blocked because they are built into this version of Mattermost."
-  },
-  {
     "id": "app.plugin.cluster.save_config.app_error",
     "translation": "The plugin configuration in your config.json file must be updated manually when using ReadOnlyConfig with clustering enabled."
   },

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -22,12 +22,6 @@ type FeatureFlags struct {
 	// AppsEnabled toggles the Apps framework functionalities both in server and client side
 	AppsEnabled bool
 
-	// Feature flags to control plugin versions
-	PluginPlaybooks  string `plugin_id:"playbooks"`
-	PluginApps       string `plugin_id:"com.mattermost.apps"`
-	PluginFocalboard string `plugin_id:"focalboard"`
-	PluginCalls      string `plugin_id:"com.mattermost.calls"`
-
 	PermalinkPreviews bool
 
 	// CallsEnabled controls whether or not the Calls plugin should be enabled
@@ -64,8 +58,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.TestBoolFeature = false
 	f.EnableRemoteClusterService = false
 	f.AppsEnabled = true
-	f.PluginApps = ""
-	f.PluginFocalboard = ""
 	f.BoardsDataRetention = false
 	f.NormalizeLdapDNs = false
 	f.GraphQL = false
@@ -77,26 +69,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.CloudReverseTrial = false
 	f.EnableExportDirectDownload = false
 	f.DataRetentionConcurrencyEnabled = true
-}
-
-func (f *FeatureFlags) Plugins() map[string]string {
-	rFFVal := reflect.ValueOf(f).Elem()
-	rFFType := reflect.TypeOf(f).Elem()
-
-	pluginVersions := make(map[string]string)
-	for i := 0; i < rFFVal.NumField(); i++ {
-		rFieldVal := rFFVal.Field(i)
-		rFieldType := rFFType.Field(i)
-
-		pluginId, hasPluginId := rFieldType.Tag.Lookup("plugin_id")
-		if !hasPluginId {
-			continue
-		}
-
-		pluginVersions[pluginId] = rFieldVal.String()
-	}
-
-	return pluginVersions
 }
 
 // ToMap returns the feature flags as a map[string]string

--- a/server/public/plugin/environment.go
+++ b/server/public/plugin/environment.go
@@ -103,34 +103,9 @@ func scanSearchPath(path string) ([]*model.BundleInfo, error) {
 	return ret, nil
 }
 
-var pluginIDBlocklist = map[string]bool{
-	"com.mattermost.plugin-incident-response":   true,
-	"com.mattermost.plugin-incident-management": true,
-}
-
-func PluginIDIsBlocked(id string) bool {
-	_, ok := pluginIDBlocklist[id]
-	return ok
-}
-
 // Returns a list of all plugins within the environment.
 func (env *Environment) Available() ([]*model.BundleInfo, error) {
-	rawList, err := scanSearchPath(env.pluginDir)
-	if err != nil {
-		return nil, err
-	}
-
-	// Filter any plugins that match the blocklist
-	filteredList := make([]*model.BundleInfo, 0, len(rawList))
-	for _, bundleInfo := range rawList {
-		if PluginIDIsBlocked(bundleInfo.Manifest.Id) {
-			env.logger.Debug("Plugin ignored by blocklist", mlog.String("plugin_id", bundleInfo.Manifest.Id))
-		} else {
-			filteredList = append(filteredList, bundleInfo)
-		}
-	}
-
-	return filteredList, nil
+	return scanSearchPath(env.pluginDir)
 }
 
 // Returns a list of prepackaged plugins available in the local prepackaged_plugins folder.


### PR DESCRIPTION
#### Summary
Some documentation and organization prior to changing how deprecated, pre-packaged plugins work:
* remove support for feature flag managed plugins (we don't use this anymore)
* remove the plugin blocklist (product mode isn't a thing)
* avoid the use of the global logger
* leverage wrapped loggers (e.g. more consistently logging `plugin_id`)
* promote some logs from `Debug` to `Info` for better visibility

Note that this focuses on just `plugin.go` and `plugin_install.go`, and tries to avoid moving code (we can reorganize the functions into files at at a later date).

There should be no user-facing changes as a result of this PR.

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-53355

#### Release Note
```release-note
Improved logging on plugin initialization, activation, and removal.
```
