### PR TITLE
.npmrc: engine-strict

### DIFF
--- a/webapp/.npmrc
+++ b/webapp/.npmrc
@@ -1,2 +1,3 @@
 save-exact=true
 legacy-peer-deps=true
+engine-strict=true


### PR DESCRIPTION
#### Summary
Enforce the existing `engine` directives requiring node at `16.x` and npm at `7.x`, failing with a clear error message if a mismatch exists (e.g. my npm version is wrong below):

```
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: undefined
npm ERR! notsup Not compatible with your version of node/npm: undefined
npm ERR! notsup Required: {"node":"^16.10.0","npm":"^7.24.0"}
npm ERR! notsup Actual:   {"npm":"8.5.0","node":"v16.14.2"}

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/jesse/.npm/_logs/2023-08-08T15_09_40_758Z-debug-0.log
```

This change makes the version mismatch exceedingly and immediately clear instead of the developer having to infer from an obscure error much later on in the installation process.

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
