### PR TITLE
MM-53519-Remove boards as reserved word

### DIFF
--- a/server/public/model/team_test.go
+++ b/server/public/model/team_test.go
@@ -93,7 +93,6 @@ var tReservedDomains = []struct {
 	{"Admin-punch", true},
 	{"spin-punch-admin", false},
 	{"playbooks", true},
-	{"boards", true},
 }
 
 func TestReservedTeamName(t *testing.T) {

--- a/server/public/model/utils.go
+++ b/server/public/model/utils.go
@@ -632,7 +632,6 @@ var reservedName = []string{
 	"plugins",
 	"post",
 	"signup",
-	"boards",
 	"playbooks",
 }
 

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -1546,7 +1546,6 @@ export const Constants = {
         'help',
         'plugins',
         'playbooks',
-        'boards',
     ],
     RESERVED_USERNAMES: [
         'valet',


### PR DESCRIPTION
#### Summary
Because boards in no longer a product, it does not need to be a reserved word.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-53519

#### Screenshots
#### Release Note
```release-note
NONE
```
