### PR TITLE
Fix initialization when a prepackaged plugin is broken for whatever reason

### DIFF
--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -937,7 +937,7 @@ func (ch *Channels) processPrepackagedPlugins(pluginsDir string) []*plugin.Prepa
 				if errors.As(err, &appErr) && appErr.Id == "app.plugin.skip_installation.app_error" {
 					return
 				}
-				ch.srv.Log().Error("Failed to install prepackaged plugin", mlog.String("plugin_id", p.Manifest.Id), mlog.String("bundle_path", psPath.bundlePath), mlog.Err(err))
+				ch.srv.Log().Error("Failed to install prepackaged plugin", mlog.String("bundle_path", psPath.bundlePath), mlog.Err(err))
 				return
 			}
 			prepackagedPlugins <- p


### PR DESCRIPTION
#### Summary
If there is a pre-packaged plugin broken, for any reason, the system was
generating a panic on the error handling, this bug was introduced in the commit
8372267739c80a15b468a6c61a160ad5ae2fb98d  

The reason for this to happen is that we are using `p` to log the manifest id,
when the p itself is not being created because we are handling exactly the
creation error there.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```