### PR TITLE
plugins: further logging tweaks, fixes

### DIFF
--- a/server/channels/app/plugin_install.go
+++ b/server/channels/app/plugin_install.go
@@ -403,7 +403,7 @@ func (ch *Channels) installExtractedPlugin(manifest *model.Manifest, fromPluginD
 			}
 
 			if version.LTE(existingVersion) {
-				logger.Warn("Skipping local installation of plugin since existing version is newer", mlog.String("version", version.String()), mlog.String("existing_version", existingVersion.String()))
+				logger.Warn("Skipping local installation of plugin since not a newer version", mlog.String("version", version.String()), mlog.String("existing_version", existingVersion.String()))
 				return nil, model.NewAppError("installExtractedPlugin", "app.plugin.skip_installation.app_error", map[string]any{"Id": manifest.Id}, "", http.StatusInternalServerError)
 			}
 		}


### PR DESCRIPTION
#### Summary
Fix a logging issue for prepackaged plugins error handling trying to reference a `nil` pointer, and update a few more instances of the global logger.

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-53355

#### Release Note
```release-note
NONE
```
