### PR TITLE
GH-24220: Fix member count shown as zero when searching in browse channel modal

### DIFF
--- a/webapp/channels/src/components/browse_channels/browse_channels.tsx
+++ b/webapp/channels/src/components/browse_channels/browse_channels.tsx
@@ -197,6 +197,10 @@ export default class BrowseChannels extends React.PureComponent<Props, State> {
                     }
 
                     if (data) {
+                        const channelIDsForMemberCount = data.map((channel: Channel) => channel.id);
+                        if (channelIDsForMemberCount.length > 0) {
+                            this.props.actions.getChannelsMemberCount(channelIDsForMemberCount);
+                        }
                         this.setSearchResults(data);
                     } else {
                         this.setState({searchedChannels: [], searching: false});


### PR DESCRIPTION
#### Summary
This fixes an issue when user searching a channel in browse channel modal, the member count displayed zero as incorrectly

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/24220

#### Screenshots
**before**

https://github.com/mattermost/mattermost/assets/37421564/2f907845-8d68-4ec7-a59a-c8e14b6e6184 

**after**

https://github.com/mattermost/mattermost/assets/37421564/df52d084-b99c-4045-94f4-0c2a711a8891

#### Release Note
```release-note
NONE
```
