### PR TITLE
setup-node for master build from server

### DIFF
--- a/.github/workflows/server-ci-template.yml
+++ b/.github/workflows/server-ci-template.yml
@@ -271,6 +271,13 @@ jobs:
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
+      - name: ci/setup-node
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        id: setup_node
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: 'webapp/package-lock.json'
       - name: Run setup-go-work
         run: make setup-go-work
       - name: Build


### PR DESCRIPTION
#### Summary
Fix `master` build issues introduced by https://github.com/mattermost/mattermost/pull/24217. Since that PR only touched webapp assets, the server pipeline wasn't run at all during the PR. I'm opting not to fix that for now, but it's probably something to revisit.

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
