### PR TITLE
MM-49063 Silence warning when lastViewedAt is undefined

### DIFF
--- a/webapp/channels/src/components/post_view/post_list/index.tsx
+++ b/webapp/channels/src/components/post_view/post_list/index.tsx
@@ -36,7 +36,7 @@ const memoizedGetLatestPostId = memoizeResult((postIds: string[]) => getLatestPo
 
 interface Props {
     focusedPostId?: string;
-    unreadChunkTimeStamp: number;
+    unreadChunkTimeStamp?: number;
     changeUnreadChunkTimeStamp: (lastViewedAt: number) => void;
     channelId: string;
 }

--- a/webapp/channels/src/components/post_view/post_list/index.tsx
+++ b/webapp/channels/src/components/post_view/post_list/index.tsx
@@ -75,7 +75,10 @@ function makeMapStateToProps() {
             atOldestPost = Boolean(chunk.oldest);
         }
 
-        const shouldHideNewMessageIndicator = shouldStartFromBottomWhenUnread && !isPostsChunkIncludingUnreadsPosts(state, chunk!, unreadChunkTimeStamp);
+        let shouldHideNewMessageIndicator = false;
+        if (unreadChunkTimeStamp != null) {
+            shouldHideNewMessageIndicator = shouldStartFromBottomWhenUnread && !isPostsChunkIncludingUnreadsPosts(state, chunk!, unreadChunkTimeStamp);
+        }
 
         if (postIds) {
             formattedPostIds = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages: !shouldHideNewMessageIndicator});

--- a/webapp/channels/src/components/post_view/post_view.tsx
+++ b/webapp/channels/src/components/post_view/post_view.tsx
@@ -10,7 +10,7 @@ import {Preferences} from 'utils/constants';
 import PostList from './post_list';
 
 interface Props {
-    lastViewedAt: number;
+    lastViewedAt?: number;
     channelLoading: boolean;
     channelId: string;
     focusedPostId?: string;
@@ -18,7 +18,7 @@ interface Props {
 }
 
 interface State {
-    unreadChunkTimeStamp: number;
+    unreadChunkTimeStamp?: number;
     loaderForChangeOfPostsChunk: boolean;
     channelLoading: boolean;
     shouldStartFromBottomWhenUnread: boolean;


### PR DESCRIPTION
#### Summary
I thought the case where this warning occurred had been previously fixed, but this component is still sometimes rendered before that value is loaded.

Looking at the `PostList` component, it seems to have handling for before a channel is loaded, so I *think* that case is okay, but I can't be 100% sure of that since all this code is rather convoluted. We should really rewrite it all at some point. Given that this is just silencing a warning that's existed for ages now, I don't think there's anything particularly wrong here at the moment though

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49063

#### Release Note
```release-note
NONE
```
