### PR TITLE
MM-52804 - Implement SendPushNotification plugin api method

### DIFF
--- a/server/channels/app/plugin_api.go
+++ b/server/channels/app/plugin_api.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1261,4 +1262,35 @@ func (api *PluginAPI) GetUploadSession(uploadID string) (*model.UploadSession, e
 		return nil, err
 	}
 	return fi, nil
+}
+
+// SendPushNotification will attempt to send a push notification to `notification.User`, using
+// `notification.Post` as the source of the notification. Note: the NotificationWillBePushed hook will
+// be run after SendPushNotification is called.
+func (api *PluginAPI) SendPushNotification(notification *model.PluginPushNotification) error {
+	var profiles map[string]*model.User
+	var err error
+	if notification.Channel.Type == model.ChannelTypeGroup {
+		if profiles, err = api.app.Srv().Store().User().GetAllProfilesInChannel(context.Background(), notification.Channel.Id, true); err != nil {
+			return err
+		}
+	}
+
+	sender, appErr := api.app.GetUser(notification.Post.UserId)
+	if appErr != nil {
+		return appErr
+	}
+	user, appErr := api.app.GetUser(notification.UserID)
+	if appErr != nil {
+		return appErr
+	}
+
+	postNotification := &PostNotification{
+		Post:       notification.Post,
+		Channel:    notification.Channel,
+		ProfileMap: profiles,
+		Sender:     sender,
+	}
+	api.app.sendPushNotification(postNotification, user, false, false, "")
+	return nil
 }

--- a/server/channels/app/plugin_api_test.go
+++ b/server/channels/app/plugin_api_test.go
@@ -19,6 +19,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -2203,4 +2204,88 @@ func TestConfigurationWillBeSavedHook(t *testing.T) {
 			"custom_key": "custom_val",
 		}, newCfg.PluginSettings.Plugins["custom_plugin"])
 	})
+}
+
+func TestSendPushNotification(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+	api := th.SetupPluginAPI()
+
+	// Create 3 users, each having 2 sessions.
+	type userSession struct {
+		user    *model.User
+		session *model.Session
+	}
+	var userSessions []userSession
+	for i := 0; i < 3; i++ {
+		u := th.CreateUser()
+		sess, err := th.App.CreateSession(&model.Session{
+			UserId:    u.Id,
+			DeviceId:  "deviceID" + u.Id,
+			ExpiresAt: model.GetMillis() + 100000,
+		})
+		require.Nil(t, err)
+		// We don't need to track the 2nd session.
+		_, err = th.App.CreateSession(&model.Session{
+			UserId:    u.Id,
+			DeviceId:  "deviceID" + u.Id,
+			ExpiresAt: model.GetMillis() + 100000,
+		})
+		require.Nil(t, err)
+		_, err = th.App.AddTeamMember(th.Context, th.BasicTeam.Id, u.Id)
+		require.Nil(t, err)
+		th.AddUserToChannel(u, th.BasicChannel)
+		userSessions = append(userSessions, userSession{
+			user:    u,
+			session: sess,
+		})
+	}
+
+	handler := &testPushNotificationHandler{
+		t:        t,
+		behavior: "simple",
+	}
+	pushServer := httptest.NewServer(
+		http.HandlerFunc(handler.handleReq),
+	)
+	defer pushServer.Close()
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.EmailSettings.PushNotificationContents = model.FullNotification
+		*cfg.EmailSettings.PushNotificationServer = pushServer.URL
+	})
+
+	var wg sync.WaitGroup
+	for _, data := range userSessions {
+		wg.Add(1)
+		go func(user model.User) {
+			defer wg.Done()
+			post := th.CreatePost(th.BasicChannel)
+			post.Message = "started a conversation"
+			notification := &model.PluginPushNotification{
+				Post:    post,
+				Channel: th.BasicChannel,
+				UserID:  user.Id,
+			}
+			appErr := api.SendPushNotification(notification)
+			require.Nil(t, appErr)
+		}(*data.user)
+	}
+	wg.Wait()
+
+	// Hack to let the worker goroutines complete.
+	time.Sleep(1 * time.Second)
+	// Server side verification.
+	var numMessages int
+	for _, n := range handler.notifications() {
+		switch n.Type {
+		case model.PushTypeMessage:
+			numMessages++
+			assert.Equal(t, th.BasicChannel.Id, n.ChannelId)
+			assert.Equal(t, fmt.Sprintf("@%s: started a conversation", th.BasicUser.GetDisplayName(model.ShowUsername)), n.Message)
+		default:
+			assert.Fail(t, "should not receive any other push notification types")
+		}
+	}
+	assert.Equal(t, 6, numMessages)
 }

--- a/server/public/plugin/hooks.go
+++ b/server/public/plugin/hooks.go
@@ -292,6 +292,9 @@ type Hooks interface {
 	// To reject a push notification, return an non-empty string describing why the notification
 	// was rejected.
 	//
+	// Note that this method will be called for push notification sent by plugins, including
+	// the plugin that created the push notification.
+	//
 	// Minimum server version: 9.0
 	NotificationWillBePushed(pushNotification *model.PluginPushNotification) string
 }


### PR DESCRIPTION
#### Summary
- The intention of this method is to allow plugins to send their own push notifications. It uses the `model.PluginPushNotification` struct added in #24263 which is what's needed to send a push notification to all connected sessions for UserID.
- Note: Plugins will be constrained by the existing `getPushNotificationMessage` rules, i.e. we can't override the server's `cfg.EmailSettings.PushNotificationContents` setting `id_loaded` setting. But if it is set to `full`, we will still be constrained to a push notification that reads: `@SenderName: post message` (for GMs). The designs for Calls notifications have the message as: `SenderName is inviting you to a call`, but this constraint will turn that into: `@SenderName: is inviting you to a call` (for GMs). For DMs it sends two lines, like: `SenderName <next line> post.Message` without additional formatting.
- I'm considering adding a new flag to `app.sendPushNotification`, something like `noNameSeparator`, so we can have: `@SenderName is inviting you to a call` for GMs and `SenderName <next line> is inviting you to a call` for DMs. Would appreciate thoughts on it.
- Companion to #24263 

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-53924

#### Release Note
```release-note
Added a `NotificationWillBePushed` plugin api method which allows plugins to send push notifications to a specific user's mobile sessions.
```
