### PR TITLE
config-reset: -tags production

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -708,10 +708,10 @@ config-ldap: ## Configures LDAP.
 	@sed -i'' -e 's|"GroupDisplayNameAttribute": ".*"|"GroupDisplayNameAttribute": "cn"|g' config/config.json
 	@sed -i'' -e 's|"GroupIdAttribute": ".*"|"GroupIdAttribute": "entryUUID"|g' config/config.json
 
-config-reset: ## Resets the config/config.json file to the default.
-	@echo Resetting configuration to default
+config-reset: ## Resets the config/config.json file to the default production values.
+	@echo Resetting configuration to production default
 	rm -f config/config.json
-	OUTPUT_CONFIG=$(PWD)/config/config.json $(GO) $(GOFLAGS) run ./scripts/config_generator
+	OUTPUT_CONFIG=$(PWD)/config/config.json $(GO) $(GOFLAGS) run -tags production ./scripts/config_generator
 
 diff-config: ## Compares default configuration between two mattermost versions
 	@./scripts/diff-config.sh


### PR DESCRIPTION
#### Summary
Somewhere in the build pipeline, we run `make config-reset` to generate a default `config.json` to include with the tarball. Unfortunately, this was being built without the `-tags production` signal that changes the default service environment to `production`, and in turn caused the `CWS` environment to default to testing. The trial licenses returned by the testing environment aren't compatible with the production environment, preventing new customers from starting trials by themselves.

As an immediate workaround, customers can simply delete the `config.json` included with the tarball and start the server anew. Without any further configuration, it will correctly default to the `production` service environment and use the correct `CWS` environment.

Fix the tarball generation by adding `-tags production` to the `config-reset` Makefile target. We don't add a dev version of this for now, as it's not really needed given the server creates the right value on startup.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/CLD-6137

#### Screenshots
Before:
```sh
$ make config-reset && cat config/config.json| grep CWS
Resetting configuration to default
rm -f config/config.json
OUTPUT_CONFIG=/Users/jesse/Documents/mattermost/src/mattermost/server/config/config.json go  run ./scripts/config_generator
    "CWSURL": "https://portal.test.cloud.mattermost.com",
    "CWSAPIURL": "https://api.internal.test.cloud.mattermost.com",
    "CWSMock": false
```

After:
```sh
$ make config-reset && cat config/config.json| grep CWS
Resetting configuration to production default
rm -f config/config.json
OUTPUT_CONFIG=/Users/jesse/Documents/mattermost/src/mattermost/server/config/config.json go  run -tags production ./scripts/config_generator
    "CWSURL": "https://customers.mattermost.com",
    "CWSAPIURL": "https://portal.internal.prod.cloud.mattermost.com",
    "CWSMock": false
```

#### Release Note
```release-note
Fix an issue preventing successful activation of trial licenses.
```
