### PR TITLE
MM-54158: S3PathMigration: Re-initialize stop chan

### DIFF
--- a/server/channels/jobs/s3_path_migration/s3_path_migration.go
+++ b/server/channels/jobs/s3_path_migration/s3_path_migration.go
@@ -52,6 +52,9 @@ func MakeWorker(jobServer *jobs.JobServer, store store.Store, fileBackend filest
 
 func (worker *S3PathMigrationWorker) Run() {
 	mlog.Debug("Worker started", mlog.String("worker", worker.name))
+	// We have to re-assign the stop channel again, because
+	// it might happen that the job was restarted due to a config change.
+	worker.stop = make(chan bool, 1)
 
 	defer func() {
 		mlog.Debug("Worker finished", mlog.String("worker", worker.name))


### PR DESCRIPTION
This got missed out in the initial PR review.

There's been only one instance of this, and that too in a spinwick
so it's not widepsread. We will cp this if we see more crashes.

https://mattermost.atlassian.net/browse/MM-54158

```release-note
NONE
```
