### PR TITLE
Improve websocket logging (#24259)

### DIFF
--- a/app/platform/web_conn.go
+++ b/app/platform/web_conn.go
@@ -98,9 +98,7 @@ type WebConn struct {
 	deadQueuePointer int
 	// active indicates whether there is an open websocket connection attached
 	// to this webConn or not.
-	// It is not used as an atomic, because there is no need to.
-	// So do not use this outside the web hub.
-	active bool
+	active atomic.Bool
 	// reuseCount indicates how many times this connection has been reused.
 	// This is used to differentiate between a fresh connection and
 	// a reused connection.
@@ -218,7 +216,6 @@ func (ps *PlatformService) NewWebConn(cfg *WebConnConfig, suite SuiteIFace, runn
 		UserId:             cfg.Session.UserId,
 		T:                  cfg.TFunc,
 		Locale:             cfg.Locale,
-		active:             cfg.Active,
 		reuseCount:         cfg.ReuseCount,
 		endWritePump:       make(chan struct{}),
 		pumpFinished:       make(chan struct{}),
@@ -226,6 +223,7 @@ func (ps *PlatformService) NewWebConn(cfg *WebConnConfig, suite SuiteIFace, runn
 		lastLogTimeSlow:    time.Now(),
 		lastLogTimeFull:    time.Now(),
 	}
+	wc.active.Store(cfg.Active)
 
 	wc.SetSession(&cfg.Session)
 	wc.SetSessionToken(cfg.Session.Token)
@@ -293,7 +291,7 @@ func (wc *WebConn) GetConnectionID() string {
 // are inactive or not.
 func areAllInactive(conns []*WebConn) bool {
 	for _, conn := range conns {
-		if conn.active {
+		if conn.active.Load() {
 			return false
 		}
 	}
@@ -470,7 +468,7 @@ func (wc *WebConn) writePump() {
 				continue
 			}
 
-			if len(wc.send) >= sendFullWarn && time.Since(wc.lastLogTimeFull) > websocketSuppressWarnThreshold {
+			if wc.active.Load() && len(wc.send) >= sendFullWarn && time.Since(wc.lastLogTimeFull) > websocketSuppressWarnThreshold {
 				logData := []mlog.Field{
 					mlog.String("user_id", wc.UserId),
 					mlog.String("type", msg.EventType()),
@@ -722,7 +720,7 @@ func (wc *WebConn) ShouldSendEvent(msg *model.WebSocketEvent) bool {
 		case model.WebsocketEventTyping,
 			model.WebsocketEventStatusChange,
 			model.WebsocketEventChannelViewed:
-			if time.Since(wc.lastLogTimeSlow) > websocketSuppressWarnThreshold {
+			if wc.active.Load() && time.Since(wc.lastLogTimeSlow) > websocketSuppressWarnThreshold {
 				mlog.Warn(
 					"websocket.slow: dropping message",
 					mlog.String("user_id", wc.UserId),

--- a/app/platform/web_hub_test.go
+++ b/app/platform/web_hub_test.go
@@ -377,8 +377,8 @@ func TestHubConnIndexInactive(t *testing.T) {
 	wc1 := &WebConn{
 		Platform: th.Service,
 		UserId:   model.NewId(),
-		active:   true,
 	}
+	wc1.active.Store(true)
 	wc1.SetConnectionID("conn1")
 	wc1.SetSession(&model.Session{})
 
@@ -386,16 +386,16 @@ func TestHubConnIndexInactive(t *testing.T) {
 	wc2 := &WebConn{
 		Platform: th.Service,
 		UserId:   model.NewId(),
-		active:   true,
 	}
+	wc2.active.Store(true)
 	wc2.SetConnectionID("conn2")
 	wc2.SetSession(&model.Session{})
 
 	wc3 := &WebConn{
 		Platform: th.Service,
 		UserId:   wc2.UserId,
-		active:   false,
 	}
+	wc3.active.Store(false)
 	wc3.SetConnectionID("conn3")
 	wc3.SetSession(&model.Session{})
 


### PR DESCRIPTION
After reliable websockets were introduced,
we would keep pushing to a webConn even after
the client has disconnected. This would lead
to the websocket.slow/full and eventually
the disconnect messages which unnecessarily
confuse the admin.

We don't log them if the connection is inactive.

We use the active field and convert it to an atomic
to use more widely.

```release-note
NONE
```
