### PR TITLE
Update deprecated io/ioutil package to os package

### DIFF
--- a/server/cmd/mmctl/commands/auth_utils.go
+++ b/server/cmd/mmctl/commands/auth_utils.go
@@ -5,7 +5,6 @@ package commands
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -105,7 +104,7 @@ func ReadCredentialsList() (*CredentialsList, error) {
 		return nil, errors.WithMessage(err, "cannot read user credentials, maybe you need to use login first")
 	}
 
-	fileContents, err := ioutil.ReadFile(configPath)
+	fileContents, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, errors.WithMessage(err, "there was a problem reading the credentials file")
 	}
@@ -167,7 +166,7 @@ func SaveCredentialsList(credentialsList *CredentialsList) error {
 
 	marshaledCredentialsList, _ := json.MarshalIndent(credentialsList, "", "    ")
 
-	if err := ioutil.WriteFile(configPath, marshaledCredentialsList, 0600); err != nil {
+	if err := os.WriteFile(configPath, marshaledCredentialsList, 0600); err != nil {
 		return errors.WithMessage(err, "cannot save the credentials")
 	}
 
@@ -220,7 +219,7 @@ func SetUser(newUser *user.User) {
 // will read the scret from file, if there is one
 func readSecretFromFile(file string, secret *string) error {
 	if file != "" {
-		b, err := ioutil.ReadFile(file)
+		b, err := os.ReadFile(file)
 		if err != nil {
 			return err
 		}

--- a/server/cmd/mmctl/commands/auth_utils_test.go
+++ b/server/cmd/mmctl/commands/auth_utils_test.go
@@ -4,7 +4,6 @@
 package commands
 
 import (
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -26,7 +25,7 @@ func TestResolveConfigFilePath(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("should return the default config file location if nothing else is set", func(t *testing.T) {
-		tmp, _ := ioutil.TempDir("", "mmctl-")
+		tmp, _ := os.MkdirTemp("", "mmctl-")
 		defer os.RemoveAll(tmp)
 		testUser.HomeDir = tmp
 		SetUser(testUser)
@@ -40,7 +39,7 @@ func TestResolveConfigFilePath(t *testing.T) {
 	})
 
 	t.Run("should return config file location from xdg environment variable", func(t *testing.T) {
-		tmp, _ := ioutil.TempDir("", "mmctl-")
+		tmp, _ := os.MkdirTemp("", "mmctl-")
 		defer os.RemoveAll(tmp)
 		testUser.HomeDir = tmp
 		SetUser(testUser)
@@ -55,7 +54,7 @@ func TestResolveConfigFilePath(t *testing.T) {
 	})
 
 	t.Run("should return the user-defined config file path if one is set", func(t *testing.T) {
-		tmp, _ := ioutil.TempDir("", "mmctl-")
+		tmp, _ := os.MkdirTemp("", "mmctl-")
 		defer os.RemoveAll(tmp)
 
 		testUser.HomeDir = "path/should/be/ignored"
@@ -72,7 +71,7 @@ func TestResolveConfigFilePath(t *testing.T) {
 	})
 
 	t.Run("should resolve config file path if $HOME variable is used", func(t *testing.T) {
-		tmp, _ := ioutil.TempDir("", "mmctl-")
+		tmp, _ := os.MkdirTemp("", "mmctl-")
 		defer os.RemoveAll(tmp)
 
 		testUser.HomeDir = "path/should/be/ignored"
@@ -89,7 +88,7 @@ func TestResolveConfigFilePath(t *testing.T) {
 	})
 
 	t.Run("should create the user-defined config file path if one is set", func(t *testing.T) {
-		tmp, _ := ioutil.TempDir("", "mmctl-")
+		tmp, _ := os.MkdirTemp("", "mmctl-")
 		defer os.RemoveAll(tmp)
 
 		testUser.HomeDir = "path/should/be/ignored"
@@ -112,7 +111,7 @@ func TestResolveConfigFilePath(t *testing.T) {
 	})
 
 	t.Run("should return error if the config flag is set to a directory", func(t *testing.T) {
-		tmp, _ := ioutil.TempDir("", "mmctl-")
+		tmp, _ := os.MkdirTemp("", "mmctl-")
 		defer os.RemoveAll(tmp)
 
 		testUser.HomeDir = "path/should/be/ignored"
@@ -129,7 +128,7 @@ func TestResolveConfigFilePath(t *testing.T) {
 }
 
 func TestReadSecretFromFile(t *testing.T) {
-	f, err := ioutil.TempFile(t.TempDir(), "mmctl")
+	f, err := os.CreateTemp(t.TempDir(), "mmctl")
 	require.NoError(t, err)
 
 	_, err = f.WriteString("test-pass")

--- a/server/cmd/mmctl/commands/config.go
+++ b/server/cmd/mmctl/commands/config.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"reflect"
@@ -368,7 +367,7 @@ func configSetCmdF(c client.Client, _ *cobra.Command, args []string) error {
 }
 
 func configPatchCmdF(c client.Client, _ *cobra.Command, args []string) error {
-	configBytes, err := ioutil.ReadFile(args[0])
+	configBytes, err := os.ReadFile(args[0])
 	if err != nil {
 		return err
 	}
@@ -402,7 +401,7 @@ func configEditCmdF(c client.Client, _ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	file, err := ioutil.TempFile(os.TempDir(), "mmctl-*.json")
+	file, err := os.CreateTemp(os.TempDir(), "mmctl-*.json")
 	if err != nil {
 		return err
 	}
@@ -428,7 +427,7 @@ func configEditCmdF(c client.Client, _ *cobra.Command, _ []string) error {
 		return cmdErr
 	}
 
-	newConfigBytes, err := ioutil.ReadFile(file.Name())
+	newConfigBytes, err := os.ReadFile(file.Name())
 	if err != nil {
 		return err
 	}

--- a/server/cmd/mmctl/commands/config_e2e_test.go
+++ b/server/cmd/mmctl/commands/config_e2e_test.go
@@ -4,7 +4,6 @@
 package commands
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -46,10 +45,10 @@ func (s *MmctlE2ETestSuite) TestConfigResetCmdE2E() {
 func (s *MmctlE2ETestSuite) TestConfigPatchCmd() {
 	s.SetupTestHelper().InitBasic()
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "config_*.json")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "config_*.json")
 	s.Require().Nil(err)
 
-	invalidFile, err := ioutil.TempFile(os.TempDir(), "invalid_config_*.json")
+	invalidFile, err := os.CreateTemp(os.TempDir(), "invalid_config_*.json")
 	s.Require().Nil(err)
 
 	_, err = tmpFile.Write([]byte(configFilePayload))
@@ -180,7 +179,7 @@ func (s *MmctlE2ETestSuite) TestConfigEditCmd() {
 sed -i'old' 's/\"EnableSVGs\": false/\"EnableSVGs\": true/' $1
 rm $1'old'`
 
-		file, err := ioutil.TempFile(os.TempDir(), "config_edit_*.sh")
+		file, err := os.CreateTemp(os.TempDir(), "config_edit_*.sh")
 		s.Require().Nil(err)
 		defer func() {
 			os.Remove(file.Name())

--- a/server/cmd/mmctl/commands/config_test.go
+++ b/server/cmd/mmctl/commands/config_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -589,10 +588,10 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 }
 
 func (s *MmctlUnitTestSuite) TestConfigPatchCmd() {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "config_*.json")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "config_*.json")
 	s.Require().Nil(err)
 
-	invalidFile, err := ioutil.TempFile(os.TempDir(), "invalid_config_*.json")
+	invalidFile, err := os.CreateTemp(os.TempDir(), "invalid_config_*.json")
 	s.Require().Nil(err)
 
 	_, err = tmpFile.Write([]byte(configFilePayload))

--- a/server/cmd/mmctl/commands/export_e2e_test.go
+++ b/server/cmd/mmctl/commands/export_e2e_test.go
@@ -5,7 +5,6 @@ package commands
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -264,9 +263,9 @@ func (s *MmctlE2ETestSuite) TestExportDownloadCmdF() {
 		s.Require().Empty(printer.GetLines())
 		s.Require().Empty(printer.GetErrorLines())
 
-		expected, err := ioutil.ReadFile(exportFilePath)
+		expected, err := os.ReadFile(exportFilePath)
 		s.Require().Nil(err)
-		actual, err := ioutil.ReadFile(downloadPath)
+		actual, err := os.ReadFile(downloadPath)
 		s.Require().Nil(err)
 
 		s.Require().Equal(expected, actual)

--- a/server/cmd/mmctl/commands/license.go
+++ b/server/cmd/mmctl/commands/license.go
@@ -6,7 +6,7 @@ package commands
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"os"
 
 	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/client"
 	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/printer"
@@ -71,7 +71,7 @@ func uploadLicenseCmdF(c client.Client, cmd *cobra.Command, args []string) error
 		return errors.New("enter one license file to upload")
 	}
 
-	fileBytes, err := ioutil.ReadFile(args[0])
+	fileBytes, err := os.ReadFile(args[0])
 	if err != nil {
 		return err
 	}

--- a/server/cmd/mmctl/commands/license_e2e_test.go
+++ b/server/cmd/mmctl/commands/license_e2e_test.go
@@ -5,7 +5,6 @@ package commands
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -48,7 +47,7 @@ func (s *MmctlE2ETestSuite) TestUploadLicenseCmdF() {
 	s.SetupEnterpriseTestHelper().InitBasic()
 
 	// create temporary file
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "testLicense-")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "testLicense-")
 	s.Require().NoError(err)
 
 	license := model.NewTestLicense()

--- a/server/cmd/mmctl/commands/license_test.go
+++ b/server/cmd/mmctl/commands/license_test.go
@@ -5,7 +5,6 @@ package commands
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -57,7 +56,7 @@ func (s *MmctlUnitTestSuite) TestRemoveLicenseCmd() {
 
 func (s *MmctlUnitTestSuite) TestUploadLicenseCmdF() {
 	// create temporary file
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "testLicense-")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "testLicense-")
 	if err != nil {
 		panic(err)
 	}

--- a/server/cmd/mmctl/commands/plugin_test.go
+++ b/server/cmd/mmctl/commands/plugin_test.go
@@ -5,7 +5,6 @@ package commands
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -23,7 +22,7 @@ import (
 func (s *MmctlUnitTestSuite) TestPluginAddCmd() {
 	s.Run("Add 1 plugin", func() {
 		printer.Clean()
-		tmpFile, err := ioutil.TempFile("", "tmpPlugin")
+		tmpFile, err := os.CreateTemp("", "tmpPlugin")
 		s.Require().Nil(err)
 		defer os.Remove(tmpFile.Name())
 
@@ -43,7 +42,7 @@ func (s *MmctlUnitTestSuite) TestPluginAddCmd() {
 
 	s.Run("Add 1 plugin, with force active", func() {
 		printer.Clean()
-		tmpFile, err := ioutil.TempFile("", "tmpPlugin")
+		tmpFile, err := os.CreateTemp("", "tmpPlugin")
 		s.Require().Nil(err)
 		defer os.Remove(tmpFile.Name())
 
@@ -73,7 +72,7 @@ func (s *MmctlUnitTestSuite) TestPluginAddCmd() {
 
 	s.Run("Add 1 plugin with error", func() {
 		printer.Clean()
-		tmpFile, err := ioutil.TempFile("", "tmpPlugin")
+		tmpFile, err := os.CreateTemp("", "tmpPlugin")
 		s.Require().Nil(err)
 		defer os.Remove(tmpFile.Name())
 
@@ -98,7 +97,7 @@ func (s *MmctlUnitTestSuite) TestPluginAddCmd() {
 		mockError := errors.New("plugin add error")
 
 		for idx, arg := range args {
-			tmpFile, err := ioutil.TempFile("", "tmpPlugin")
+			tmpFile, err := os.CreateTemp("", "tmpPlugin")
 			s.Require().Nil(err)
 			defer os.Remove(tmpFile.Name())
 			if arg == "fail" {

--- a/server/cmd/mmctl/commands/sampledata.go
+++ b/server/cmd/mmctl/commands/sampledata.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -159,8 +158,8 @@ func processProfileImagesDir(profileImagesPath, tmpDir, bulk string) ([]string, 
 	if !profileImagesStat.IsDir() {
 		return nil, fmt.Errorf("profile-images parameters must be a directory")
 	}
-	var profileImagesFiles []os.FileInfo
-	profileImagesFiles, err = ioutil.ReadDir(profileImagesPath)
+	var profileImagesFiles []os.DirEntry
+	profileImagesFiles, err = os.ReadDir(profileImagesPath)
 	if err != nil {
 		return nil, fmt.Errorf("invalid profile-images parameter: %w", err)
 	}
@@ -224,7 +223,7 @@ func sampledataCmdF(c client.Client, command *cobra.Command, args []string) erro
 	var err error
 	switch bulk {
 	case "":
-		tmpDir, err = ioutil.TempDir("", "mmctl-sampledata-")
+		tmpDir, err = os.MkdirTemp("", "mmctl-sampledata-")
 		if err != nil {
 			return fmt.Errorf("unable to create temporary directory")
 		}

--- a/server/cmd/mmctl/commands/sampledata_test.go
+++ b/server/cmd/mmctl/commands/sampledata_test.go
@@ -4,7 +4,6 @@
 package commands
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/printer"
@@ -49,7 +48,7 @@ func (s *MmctlUnitTestSuite) TestSampledataCmd() {
 	s.Run("should not fail with less than 6 users and no group channels", func() {
 		printer.Clean()
 
-		tmpFile, err := ioutil.TempFile("", "mmctl-sampledata-test-")
+		tmpFile, err := os.CreateTemp("", "mmctl-sampledata-test-")
 		s.Require().NoError(err)
 		tmpFile.Close()
 		defer os.Remove(tmpFile.Name())

--- a/server/cmd/mmctl/commands/user.go
+++ b/server/cmd/mmctl/commands/user.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/mattermost/mattermost/server/public/model"
 
@@ -913,7 +913,7 @@ func migrateAuthToSamlCmdF(c client.Client, cmd *cobra.Command, userArgs []strin
 	if !auto {
 		matchesFile := userArgs[2]
 
-		file, err := ioutil.ReadFile(matchesFile)
+		file, err := os.ReadFile(matchesFile)
 		if err != nil {
 			return fmt.Errorf("could not read file: %w", err)
 		}

--- a/server/cmd/mmctl/commands/user_test.go
+++ b/server/cmd/mmctl/commands/user_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
@@ -2492,7 +2491,7 @@ func (s *MmctlUnitTestSuite) TestMigrateAuthCmd() {
 		fromAuth := "email"
 		toAuth := "saml"
 
-		file, err := ioutil.TempFile("", "users.json")
+		file, err := os.CreateTemp("", "users.json")
 		s.Require().NoError(err)
 		defer os.Remove(file.Name())
 		usersFile := file.Name()

--- a/server/cmd/mmctl/commands/utils.go
+++ b/server/cmd/mmctl/commands/utils.go
@@ -7,7 +7,6 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -47,7 +46,7 @@ func zipDir(zipPath, dir string) error {
 
 func addToZip(zipWriter *zip.Writer, basedir, path string) error {
 	dirPath := filepath.Join(basedir, path)
-	fileInfos, err := ioutil.ReadDir(dirPath)
+	fileInfos, err := os.ReadDir(dirPath)
 	if err != nil {
 		return fmt.Errorf("cannot read directory %q: %w", dirPath, err)
 	}

--- a/server/cmd/mmctl/commands/utils_unix_test.go
+++ b/server/cmd/mmctl/commands/utils_unix_test.go
@@ -4,7 +4,6 @@
 package commands
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -15,7 +14,7 @@ import (
 func TestCheckValidSocket(t *testing.T) {
 	t.Skip("https://mattermost.atlassian.net/browse/MM-54264")
 	t.Run("should return error if the file is not a socket", func(t *testing.T) {
-		f, err := ioutil.TempFile(os.TempDir(), "mmctl_socket_")
+		f, err := os.CreateTemp(os.TempDir(), "mmctl_socket_")
 		require.NoError(t, err)
 		defer os.Remove(f.Name())
 		require.NoError(t, os.Chmod(f.Name(), 0600))
@@ -24,7 +23,7 @@ func TestCheckValidSocket(t *testing.T) {
 	})
 
 	t.Run("should return error if the file has not the right permissions", func(t *testing.T) {
-		f, err := ioutil.TempFile(os.TempDir(), "mmctl_socket_")
+		f, err := os.CreateTemp(os.TempDir(), "mmctl_socket_")
 		require.NoError(t, err)
 		require.NoError(t, os.Remove(f.Name()))
 
@@ -37,7 +36,7 @@ func TestCheckValidSocket(t *testing.T) {
 	})
 
 	t.Run("should return nil if the file is a socket and has the right permissions", func(t *testing.T) {
-		f, err := ioutil.TempFile(os.TempDir(), "mmctl_socket_")
+		f, err := os.CreateTemp(os.TempDir(), "mmctl_socket_")
 		require.NoError(t, err)
 		require.NoError(t, os.Remove(f.Name()))
 

--- a/tools/mmgotool/commands/i18n.go
+++ b/tools/mmgotool/commands/i18n.go
@@ -11,7 +11,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -109,7 +108,7 @@ func init() {
 }
 
 func getBaseFileSrcStrings(mattermostDir string) ([]Translation, error) {
-	jsonFile, err := ioutil.ReadFile(path.Join(mattermostDir, "i18n", "en.json"))
+	jsonFile, err := os.ReadFile(path.Join(mattermostDir, "i18n", "en.json"))
 	if err != nil {
 		return nil, err
 	}
@@ -495,7 +494,7 @@ func extractFromPath(path string, info os.FileInfo, err error, i18nStrings map[s
 		return nil
 	}
 
-	src, err := ioutil.ReadFile(path)
+	src, err := os.ReadFile(path)
 	if err != nil {
 		panic(err)
 	}
@@ -580,7 +579,7 @@ func checkEmptySrcCmdF(command *cobra.Command, args []string) error {
 		}
 		translationDir = portalDir
 	}
-	srcJSON, err := ioutil.ReadFile(path.Join(translationDir, "en.json"))
+	srcJSON, err := os.ReadFile(path.Join(translationDir, "en.json"))
 	if err != nil {
 		return err
 	}
@@ -647,7 +646,7 @@ func cleanEmptyCmdF(command *cobra.Command, args []string) error {
 	}
 
 	var shippedFiles []string
-	files, err := ioutil.ReadDir(translationDir)
+	files, err := os.ReadDir(translationDir)
 	if err != nil {
 		return err
 	}
@@ -676,7 +675,7 @@ func cleanEmptyCmdF(command *cobra.Command, args []string) error {
 }
 
 func clean(translationDir string, file string, dryRun bool, check bool) (*string, error) {
-	oldJSON, err := ioutil.ReadFile(path.Join(translationDir, file))
+	oldJSON, err := os.ReadFile(path.Join(translationDir, file))
 	if err != nil {
 		return nil, err
 	}
@@ -704,7 +703,7 @@ func clean(translationDir string, file string, dryRun bool, check bool) (*string
 	if err != nil {
 		return nil, err
 	}
-	if err = ioutil.WriteFile(filename, newJSON, fileInfo.Mode().Perm()); err != nil {
+	if err = os.WriteFile(filename, newJSON, fileInfo.Mode().Perm()); err != nil {
 		return nil, err
 	}
 	return &result, nil


### PR DESCRIPTION
#### Summary

I think it would be better to change the io/ioutil package to the os package.
Please check the [link](https://go.dev/doc/go1.16#ioutil) and code and thank you.

https://go.dev/doc/go1.16#ioutil

#### Ticket Link

#### Screenshots

#### Release Note

```
Remove deprecated io/ioutil package
```
