### PR TITLE
[MM-54014] Run tests in public/...

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -151,8 +151,7 @@ DIST_PATH_OSX_ARM64=$(DIST_ROOT)/osx_arm64/mattermost
 DIST_PATH_WIN=$(DIST_ROOT)/windows/mattermost
 
 # Packages lists
-TE_PACKAGES=$(shell $(GO) list ./... | grep -vE 'server/v8/cmd/mmctl')
-SUITE_PACKAGES=$(shell $(GO) list ./...| grep -vE 'server/v8/cmd/mmctl')
+TE_PACKAGES=$(shell $(GO) list ./public/...)$(shell $(GO) list ./... | grep -vE 'server/v8/cmd/mmctl')
 MMCTL_PACKAGES=$(shell $(GO) list ./... | grep -E 'server/v8/cmd/mmctl')
 
 TEMPLATES_DIR=templates
@@ -442,7 +441,7 @@ gotestsum:
 test-compile: gotestsum ## Compile tests.
 	@echo COMPILE TESTS
 
-	for package in $(SUITE_PACKAGES) $(EE_PACKAGES); do \
+	for package in $(TE_PACKAGES) $(EE_PACKAGES); do \
 		$(GO) test $(GOFLAGS) -c $$package; \
 	done
 
@@ -487,7 +486,7 @@ test-server: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)
 test-server: export GOTESTSUM_JUNITFILE := $(GOTESTSUM_JUNITFILE)
 test-server: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
 test-server: test-server-pre
-	$(GOBIN)/gotestsum --rerun-fails=3 --packages="$(SUITE_PACKAGES) $(EE_PACKAGES)" -- $(GOFLAGS) -timeout=90m
+	$(GOBIN)/gotestsum --rerun-fails=3 --packages="$(TE_PACKAGES) $(EE_PACKAGES)" -- $(GOFLAGS) -timeout=90m
 ifneq ($(IS_CI),true)
   ifneq ($(MM_NO_DOCKER),true)
     ifneq ($(TEMP_DOCKER_SERVICES),)
@@ -512,10 +511,10 @@ test-server-quick: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
 test-server-quick: check-prereqs-enterprise ## Runs only quick tests.
 ifeq ($(BUILD_ENTERPRISE_READY),true)
 	@echo Running all tests
-	$(GOBIN)/gotestsum --packages="$(SUITE_PACKAGES) $(EE_PACKAGES)" -- $(GOFLAGS) -short
+	$(GOBIN)/gotestsum --packages="$(TE_PACKAGES) $(EE_PACKAGES)" -- $(GOFLAGS) -short
 else
 	@echo Running only TE tests
-	$(GOBIN)/gotestsum --packages="$(SUITE_PACKAGES)" -- $(GOFLAGS) -short
+	$(GOBIN)/gotestsum --packages="$(TE_PACKAGES)" -- $(GOFLAGS) -short
 endif
 
 internal-test-web-client: ## Runs web client tests.

--- a/server/Makefile
+++ b/server/Makefile
@@ -151,7 +151,7 @@ DIST_PATH_OSX_ARM64=$(DIST_ROOT)/osx_arm64/mattermost
 DIST_PATH_WIN=$(DIST_ROOT)/windows/mattermost
 
 # Packages lists
-TE_PACKAGES=$(shell $(GO) list ./public/...)$(shell $(GO) list ./... | grep -vE 'server/v8/cmd/mmctl')
+TE_PACKAGES=$(shell $(GO) list ./public/...) $(shell $(GO) list ./... | grep -vE 'server/v8/cmd/mmctl')
 MMCTL_PACKAGES=$(shell $(GO) list ./... | grep -E 'server/v8/cmd/mmctl')
 
 TEMPLATES_DIR=templates

--- a/server/public/model/config_test.go
+++ b/server/public/model/config_test.go
@@ -317,37 +317,12 @@ func TestConfigDefaultNPSPluginState(t *testing.T) {
 }
 
 func TestConfigDefaultChannelExportPluginState(t *testing.T) {
-	t.Run("should enable ChannelExport plugin by default on enterprise-ready builds", func(t *testing.T) {
+	t.Run("should not enable ChannelExport plugin by default", func(t *testing.T) {
 		BuildEnterpriseReady = "true"
 		c1 := Config{}
 		c1.SetDefaults()
 
-		assert.True(t, c1.PluginSettings.PluginStates["com.mattermost.plugin-channel-export"].Enable)
-	})
-
-	t.Run("should not enable ChannelExport plugin by default on non-enterprise-ready builds", func(t *testing.T) {
-		BuildEnterpriseReady = ""
-		c1 := Config{}
-		c1.SetDefaults()
-
 		assert.Nil(t, c1.PluginSettings.PluginStates["com.mattermost.plugin-channel-export"])
-	})
-
-	t.Run("should not re-enable ChannelExport plugin after it has been disabled", func(t *testing.T) {
-		BuildEnterpriseReady = ""
-		c1 := Config{
-			PluginSettings: PluginSettings{
-				PluginStates: map[string]*PluginState{
-					"com.mattermost.plugin-channel-export": {
-						Enable: false,
-					},
-				},
-			},
-		}
-
-		c1.SetDefaults()
-
-		assert.False(t, c1.PluginSettings.PluginStates["com.mattermost.plugin-channel-export"].Enable)
 	})
 }
 

--- a/server/public/model/service_environment_test.go
+++ b/server/public/model/service_environment_test.go
@@ -17,9 +17,11 @@ import (
 // to smoketests before releasing.
 func TestGetServiceEnvironment(t *testing.T) {
 	t.Run("no env defaults to test (without production tag)", func(t *testing.T) {
+		t.Skip("https://mattermost.atlassian.net/browse/MM-54197")
 		require.Equal(t, model.ServiceEnvironmentTest, model.GetServiceEnvironment())
 	})
 	t.Run("empty string defaults to test (without production tag)", func(t *testing.T) {
+		t.Skip("https://mattermost.atlassian.net/browse/MM-54197")
 		os.Setenv("MM_SERVICEENVIRONMENT", "")
 		defer os.Unsetenv("MM_SERVICEENVIRONMENT")
 		require.Equal(t, model.ServiceEnvironmentTest, model.GetServiceEnvironment())

--- a/server/public/plugin/environment_test.go
+++ b/server/public/plugin/environment_test.go
@@ -73,26 +73,4 @@ func TestAvailablePlugins(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, bundles, 0)
 	})
-
-	t.Run("Should not load bundles on blocklist", func(t *testing.T) {
-		bundle := model.BundleInfo{
-			Manifest: &model.Manifest{
-				Id:      "playbooks",
-				Version: "1",
-			},
-		}
-		err := os.Mkdir(filepath.Join(dir, "plugin4"), 0700)
-		require.NoError(t, err)
-		defer os.RemoveAll(filepath.Join(dir, "plugin4"))
-
-		path := filepath.Join(dir, "plugin4", "plugin.json")
-		manifestJSON, jsonErr := json.Marshal(bundle.Manifest)
-		require.NoError(t, jsonErr)
-		err = os.WriteFile(path, manifestJSON, 0644)
-		require.NoError(t, err)
-
-		bundles, err := env.Available()
-		require.NoError(t, err)
-		require.Len(t, bundles, 0)
-	})
 }

--- a/server/public/pluginapi/plugin_test.go
+++ b/server/public/pluginapi/plugin_test.go
@@ -63,7 +63,7 @@ func TestInstallPluginFromURL(t *testing.T) {
 		api.On("GetServerVersion").Return("5.19.0")
 		client := pluginapi.NewClient(api, &plugintest.Driver{})
 
-		tarData, err := os.ReadFile(filepath.Join("../../../tests", "testplugin.tar.gz"))
+		tarData, err := os.ReadFile(filepath.Join("../../tests", "testplugin.tar.gz"))
 		require.NoError(t, err)
 		expectedManifest := &model.Manifest{Id: "testplugin"}
 		api.On("InstallPlugin", mock.Anything, false).Return(expectedManifest, nil)


### PR DESCRIPTION
#### Summary
Since `server/public` was introduced as a separate module, all tests in that module not longer get run as part of the standard make file targets like `test-server`. This lead to a couple of broken tests.

This PR fixes the broken tests and ensure that all tests in `server/public` are run as part of CI.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54014

#### Release Note
```release-note
NONE
```
