### PR TITLE
[MM-53668] Prevent team insight from panicking on missing users.

### DIFF
--- a/store/sqlstore/thread_store.go
+++ b/store/sqlstore/thread_store.go
@@ -6,6 +6,7 @@ package sqlstore
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -1203,6 +1204,9 @@ func postProcessTopThreads(topThreads []*model.TopThread, s *SqlThreadStore, tea
 	// resolve user, root post for each top thread
 	for _, topThread := range topThreads {
 		postCreator := usersMap[topThread.UserId]
+		if postCreator == nil {
+			return nil, fmt.Errorf("failed to get user=%s for top thread=%s", topThread.UserId, topThread.PostId)
+		}
 		topThread.UserInformation = &model.InsightUserInformation{
 			Id:                postCreator.Id,
 			LastPictureUpdate: postCreator.LastPictureUpdate,

--- a/store/storetest/thread_store.go
+++ b/store/storetest/thread_store.go
@@ -1720,8 +1720,6 @@ func testGetTopThreads(t *testing.T, ss store.Store) {
 			UserId:    u1.Id,
 		})
 		require.NoError(t, err)
-
-		// post 2 has replies after 10 ms unix time.
 		post2, err := ss.Post().Save(&model.Post{
 			ChannelId: channel1.Id,
 			UserId:    localUser.Id,

--- a/store/storetest/thread_store.go
+++ b/store/storetest/thread_store.go
@@ -1739,7 +1739,6 @@ func testGetTopThreads(t *testing.T, ss store.Store) {
 
 		// make sure we get an error, no panic
 		_, err = ss.Thread().GetTopThreadsForTeamSince(team1.Id, u1.Id, 12, 0, limit)
-		t.Log(err)
 		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
#### Summary
If a user is missing from the DB (=it's been hard removed), mattermost would panic when trying to build the top threads. This fix prevents the panic from happening and returns an error instead.

Note: This feature (Insight) does not exist anymore, so this is targeted at 7.8.x

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53668

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```
