### PR TITLE
Upgrade & verify prepackaged plugins in prep for remote marketplace decommissioning.

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -157,7 +157,7 @@ MMCTL_PACKAGES=$(shell $(GO) list ./... | grep -E 'server/v8/cmd/mmctl')
 TEMPLATES_DIR=templates
 
 # Plugins Packages
-PLUGIN_PACKAGES ?= mattermost-plugin-antivirus-v0.1.2
+PLUGIN_PACKAGES ?= mattermost-plugin-antivirus-v1.0.0
 PLUGIN_PACKAGES += mattermost-plugin-autolink-v1.4.0
 PLUGIN_PACKAGES += mattermost-plugin-aws-SNS-v1.2.0
 PLUGIN_PACKAGES += mattermost-plugin-calls-v0.18.0

--- a/server/Makefile
+++ b/server/Makefile
@@ -174,7 +174,7 @@ PLUGIN_PACKAGES += mattermost-plugin-nps-v1.3.2
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.3.4
 PLUGIN_PACKAGES += mattermost-plugin-todo-v0.6.1
 PLUGIN_PACKAGES += mattermost-plugin-welcomebot-v1.3.0
-PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.6.0
+PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.6.2
 PLUGIN_PACKAGES += mattermost-plugin-apps-v1.2.2
 PLUGIN_PACKAGES += focalboard-v7.11.2
 


### PR DESCRIPTION
#### Summary

Cloud instances do not presently list prepackaged plugins in the in-product marketplace, they instead rely on remote marketplace listings, which is being disabled in #24311.

`mattermost-plugin-zoom` v1.6.0 is the current prepackaged version, and is the presently the only prepackaged plugin that is not Cloud-compatible.

**This updates zoom prepackaged to 1.6.2.** Prior to 1.6.1, the zoom plugin had separate cloud and on-prem specific versions. (See: https://github.com/mattermost/mattermost-marketplace/blob/production/plugins.json.) 


**See below table for audit on cloud-readiness of prepackaged plugins.** 
(Add'l context: after https://github.com/mattermost/mattermost/commit/ad142c958e32d3222c5e4560b8cdc63b4b736691, only GitHub, GitLab, Jira, ServiceNow, Zoom, + other supported 1st-party plugins are listed in the in-product marketplace—but other transitionally packaged plugins may be still installed via that flow until https://github.com/mattermost/mattermost/pull/24222 is merged)

| Plugin | Prepackaged Version | Remote Marketplace Version | Hosting | Notes | Action(s) |
| ------ | ------------------- | -------------------------- | ------- | ----- | --------- |
| Calls | 0.18.0 | 0.18.0 | any |  |  |
| GitHub | 2.1.6 | 2.1.6 | any |  |  |
| GitLab | 1.6.0 | 1.6.0 | any |  |  |
| Jira | 2.3.5 | 3.2.5 | any |  |  |
| Playbooks | 1.38.0 | 1.28.2 | any |  |  |
| Servicenow | 2.3.4 | 2.3.4 | any |  |  |
| User Satisfaction Surveys | 1.3.2 | 1.1.0 | any |  |  |
| Zoom | 1.6.0 | 1.6.2 | 1.6.0: on-prem, 1.6.1: any | Cloud-supported in >=1.6.1 | **Upgrade prepackaged version to 1.6.2** |
| (All other plugins—transitionally packaged) | - | - | (any) | | |
| Antivirus (transitional) | 0.1.2 | 1.0.0 | 0.1.2: on-prem, 1.0.0: any | ~Cloud-supported in >=1.0.0~ [1]  | **Upgrade prepackaged version to 1.0.0** |
| Welcome Bot (transitional) | 1.3.0 | 1.3.0 | 1.2.0: on-prem, 1.3.0: any | ~Cloud-supported in >=1.3.0~ [1]  |  |

[1] - Clarification: Antivirus 1.0.0 and Welcome Bot 1.3.0 not cloud-compatible—they are no longer available in the in-product marketplace, however, as of https://github.com/mattermost/mattermost/commit/ad142c958e32d3222c5e4560b8cdc63b4b736691.

#### Ticket Link
- (relates to) https://mattermost.atlassian.net/browse/MM-53559

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Upgraded prepackaged plugins mattermost-plugin-zoom to v1.6.2, and mattermost-plugin-antivirus to v1.0.0
```
