### PR TITLE
[MM-54128] api4/user: Deduplicate userids for getUsersByIds endpoint

### DIFF
--- a/server/channels/api4/user.go
+++ b/server/channels/api4/user.go
@@ -957,6 +957,10 @@ func getUsersByIds(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// we remove the duplicate IDs as it can bring a significant load to the
+	// database.
+	userIDs = model.RemoveDuplicateStrings(userIDs)
+
 	sinceString := r.URL.Query().Get("since")
 
 	options := &store.UserGetByIdsOpts{

--- a/server/channels/api4/user_local.go
+++ b/server/channels/api4/user_local.go
@@ -231,12 +231,16 @@ func localGetUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func localGetUsersByIds(c *Context, w http.ResponseWriter, r *http.Request) {
-	userIds := model.ArrayFromJSON(r.Body)
+	userIDs := model.ArrayFromJSON(r.Body)
 
-	if len(userIds) == 0 {
+	if len(userIDs) == 0 {
 		c.SetInvalidParam("user_ids")
 		return
 	}
+
+	// we remove the duplicate IDs as it can bring a significant load to the
+	// database.
+	userIDs = model.RemoveDuplicateStrings(userIDs)
 
 	sinceString := r.URL.Query().Get("since")
 
@@ -253,7 +257,7 @@ func localGetUsersByIds(c *Context, w http.ResponseWriter, r *http.Request) {
 		options.Since = since
 	}
 
-	users, appErr := c.App.GetUsersByIds(userIds, options)
+	users, appErr := c.App.GetUsersByIds(userIDs, options)
 	if appErr != nil {
 		c.Err = appErr
 		return

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -1725,6 +1725,13 @@ func TestGetUsersByIds(t *testing.T) {
 
 			require.Len(t, users, 1, "1 user should be returned")
 		})
+
+		t.Run("should only return unique users when multiple IDs are requested", func(t *testing.T) {
+			users, _, err := client.GetUsersByIds(context.Background(), []string{th.BasicUser.Id, th.BasicUser.Id, th.BasicUser.Id})
+			require.NoError(t, err)
+
+			require.Len(t, users, 1, "1 user should be returned")
+		})
 	})
 
 	t.Run("should return error when not logged in", func(t *testing.T) {


### PR DESCRIPTION


#### Summary
Add de-duplication for user ids for the `getUsersByIds` endoint

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54128


#### Release Note

```release-note
NONE
```
