### PR TITLE
Sanitize user in update user response

### DIFF
--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -1285,7 +1285,13 @@ func (a *App) UpdateUser(c request.CTX, user *model.User, sendNotifications bool
 		}(user.Id)
 	}
 
-	a.SanitizeProfile(newUser, a.SessionHasPermissionTo(*c.Session(), model.PermissionManageSystem))
+	// notifyProps := newUser.NotifyProps
+	// a.SanitizeProfile(newUser, a.SessionHasPermissionTo(*c.Session(), model.PermissionManageSystem))
+	// if newUser.Id == c.Session().UserId {
+	// 	newUser.NotifyProps = notifyProps
+	// }
+
+	user.Sanitize(map[string]bool{})
 
 	return newUser, nil
 }

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -1285,6 +1285,8 @@ func (a *App) UpdateUser(c request.CTX, user *model.User, sendNotifications bool
 		}(user.Id)
 	}
 
+	a.SanitizeProfile(newUser, a.SessionHasPermissionTo(*c.Session(), model.PermissionManageSystem))
+
 	return newUser, nil
 }
 

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -1285,7 +1285,7 @@ func (a *App) UpdateUser(c request.CTX, user *model.User, sendNotifications bool
 		}(user.Id)
 	}
 
-	user.Sanitize(map[string]bool{})
+	newUser.Sanitize(map[string]bool{})
 
 	return newUser, nil
 }

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -1285,12 +1285,6 @@ func (a *App) UpdateUser(c request.CTX, user *model.User, sendNotifications bool
 		}(user.Id)
 	}
 
-	// notifyProps := newUser.NotifyProps
-	// a.SanitizeProfile(newUser, a.SessionHasPermissionTo(*c.Session(), model.PermissionManageSystem))
-	// if newUser.Id == c.Session().UserId {
-	// 	newUser.NotifyProps = notifyProps
-	// }
-
 	user.Sanitize(map[string]bool{})
 
 	return newUser, nil

--- a/server/channels/app/user_test.go
+++ b/server/channels/app/user_test.go
@@ -205,6 +205,7 @@ func TestUpdateUser(t *testing.T) {
 		require.Nil(t, err)
 		require.NotNil(t, u)
 		require.Less(t, u.LastPictureUpdate, iLastPictureUpdate)
+		require.Empty(t, u.Password)
 	})
 
 	t.Run("fails if profile picture is updated when user has custom profile picture and username is changed", func(t *testing.T) {
@@ -1731,11 +1732,12 @@ func TestPatchUser(t *testing.T) {
 	})
 
 	t.Run("Patch username with a new username", func(t *testing.T) {
-		_, err := th.App.PatchUser(th.Context, testUser.Id, &model.UserPatch{
+		u, err := th.App.PatchUser(th.Context, testUser.Id, &model.UserPatch{
 			Username: model.NewString(model.NewId()),
 		}, true)
 
 		require.Nil(t, err)
+		require.Empty(t, u.Password)
 	})
 }
 


### PR DESCRIPTION
#### Summary
When a user updates their `username` the response by the api was not sanitized.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54226

#### Release Note
```release-note

```
