### PR TITLE
Migrate to idiomatic error handling in support_package.go

### DIFF
--- a/server/channels/app/support_packet.go
+++ b/server/channels/app/support_packet.go
@@ -90,6 +90,10 @@ func (a *App) generateSupportPacketYaml() (*model.FileData, error) {
 	if err != nil {
 		rErr = multierror.Append(errors.Wrap(err, "error while getting ES post aggregation jobs"))
 	}
+	blevePostIndexing, _ := a.Srv().Store().Job().GetAllByTypePage(model.JobTypeBlevePostIndexing, 0, 2)
+	if err != nil {
+		rErr = multierror.Append(errors.Wrap(err, "error while getting bleve post indexing jobs"))
+	}
 	ldapSyncJobs, err := a.Srv().Store().Job().GetAllByTypePage(model.JobTypeLdapSync, 0, 2)
 	if err != nil {
 		rErr = multierror.Append(errors.Wrap(err, "error while getting LDAP sync jobs"))
@@ -136,6 +140,7 @@ func (a *App) generateSupportPacketYaml() (*model.FileData, error) {
 		LicenseSupportedUsers:      supportedUsers,
 		ElasticPostIndexingJobs:    elasticPostIndexing,
 		ElasticPostAggregationJobs: elasticPostAggregation,
+		BlevePostIndexingJobs:      blevePostIndexing,
 		LdapSyncJobs:               ldapSyncJobs,
 		MessageExportJobs:          messageExport,
 		DataRetentionJobs:          dataRetentionJobs,

--- a/server/channels/app/support_packet.go
+++ b/server/channels/app/support_packet.go
@@ -198,7 +198,7 @@ func (a *App) createPluginsFile() (*model.FileData, error) {
 
 func (a *App) getNotificationsLog() (*model.FileData, error) {
 	if !*a.Config().NotificationLogSettings.EnableFile {
-		return nil, errors.New("Unable to retrieve notifications.log because LogSettings: EnableFile is false in config.json")
+		return nil, errors.New("Unable to retrieve notifications.log because LogSettings: EnableFile is set to false")
 	}
 
 	notificationsLog := config.GetNotificationsLogFileLocation(*a.Config().LogSettings.FileLocation)
@@ -216,7 +216,7 @@ func (a *App) getNotificationsLog() (*model.FileData, error) {
 
 func (a *App) getMattermostLog() (*model.FileData, error) {
 	if !*a.Config().LogSettings.EnableFile {
-		return nil, errors.New("Unable to retrieve mattermost.log because LogSettings: EnableFile is false in config.json")
+		return nil, errors.New("Unable to retrieve mattermost.log because LogSettings: EnableFile is set to false")
 	}
 
 	mattermostLog := config.GetLogFileLocation(*a.Config().LogSettings.FileLocation)

--- a/server/channels/app/support_packet.go
+++ b/server/channels/app/support_packet.go
@@ -5,11 +5,11 @@ package app
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"runtime"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
@@ -25,7 +25,7 @@ func (a *App) GenerateSupportPacket() []model.FileData {
 	fileDatas := []model.FileData{}
 
 	// A array of the functions that we can iterate through since they all have the same return value
-	functions := []func() (*model.FileData, string){
+	functions := []func() (*model.FileData, error){
 		a.generateSupportPacketYaml,
 		a.createPluginsFile,
 		a.createSanitizedConfigFile,
@@ -34,12 +34,12 @@ func (a *App) GenerateSupportPacket() []model.FileData {
 	}
 
 	for _, fn := range functions {
-		fileData, warning := fn()
+		fileData, err := fn()
 
 		if fileData != nil {
 			fileDatas = append(fileDatas, *fileData)
 		} else {
-			warnings = append(warnings, warning)
+			warnings = append(warnings, err.Error())
 		}
 	}
 
@@ -55,7 +55,9 @@ func (a *App) GenerateSupportPacket() []model.FileData {
 	return fileDatas
 }
 
-func (a *App) generateSupportPacketYaml() (*model.FileData, string) {
+func (a *App) generateSupportPacketYaml() (*model.FileData, error) {
+	var rErr error
+
 	// Here we are getting information regarding Elastic Search
 	var elasticServerVersion string
 	var elasticServerPlugins []string
@@ -78,21 +80,36 @@ func (a *App) generateSupportPacketYaml() (*model.FileData, string) {
 
 	uniqueUserCount, err := a.Srv().Store().User().Count(model.UserCountOptions{})
 	if err != nil {
-		return nil, errors.Wrap(err, "error while getting user count").Error()
+		rErr = multierror.Append(errors.Wrap(err, "error while getting user count"))
 	}
-
-	analytics, err := a.GetAnalytics("standard", "")
-	if analytics == nil {
-		return nil, errors.Wrap(err, "error while getting analytics").Error()
+	elasticPostIndexing, err := a.Srv().Store().Job().GetAllByTypePage(model.JobTypeElasticsearchPostIndexing, 0, 2)
+	if err != nil {
+		rErr = multierror.Append(errors.Wrap(err, "error while getting ES post indexing jobs"))
 	}
-
-	elasticPostIndexing, _ := a.Srv().Store().Job().GetAllByTypePage("elasticsearch_post_indexing", 0, 2)
-	elasticPostAggregation, _ := a.Srv().Store().Job().GetAllByTypePage("elasticsearch_post_aggregation", 0, 2)
-	ldapSyncJobs, _ := a.Srv().Store().Job().GetAllByTypePage("ldap_sync", 0, 2)
-	messageExport, _ := a.Srv().Store().Job().GetAllByTypePage("message_export", 0, 2)
-	dataRetentionJobs, _ := a.Srv().Store().Job().GetAllByTypePage("data_retention", 0, 2)
-	complianceJobs, _ := a.Srv().Store().Job().GetAllByTypePage("compliance", 0, 2)
-	migrationJobs, _ := a.Srv().Store().Job().GetAllByTypePage("migrations", 0, 2)
+	elasticPostAggregation, _ := a.Srv().Store().Job().GetAllByTypePage(model.JobTypeElasticsearchPostAggregation, 0, 2)
+	if err != nil {
+		rErr = multierror.Append(errors.Wrap(err, "error while getting ES post aggregation jobs"))
+	}
+	ldapSyncJobs, err := a.Srv().Store().Job().GetAllByTypePage(model.JobTypeLdapSync, 0, 2)
+	if err != nil {
+		rErr = multierror.Append(errors.Wrap(err, "error while getting LDAP sync jobs"))
+	}
+	messageExport, err := a.Srv().Store().Job().GetAllByTypePage(model.JobTypeMessageExport, 0, 2)
+	if err != nil {
+		rErr = multierror.Append(errors.Wrap(err, "error while getting message export jobs"))
+	}
+	dataRetentionJobs, err := a.Srv().Store().Job().GetAllByTypePage(model.JobTypeDataRetention, 0, 2)
+	if err != nil {
+		rErr = multierror.Append(errors.Wrap(err, "error while getting data retention jobs"))
+	}
+	complianceJobs, err := a.Srv().Store().Job().GetAllByTypePage("compliance", 0, 2)
+	if err != nil {
+		rErr = multierror.Append(errors.Wrap(err, "error while getting compliance jobs"))
+	}
+	migrationJobs, err := a.Srv().Store().Job().GetAllByTypePage(model.JobTypeMigrations, 0, 2)
+	if err != nil {
+		rErr = multierror.Append(errors.Wrap(err, "error while getting migration jobs"))
+	}
 
 	licenseTo := ""
 	supportedUsers := 0
@@ -117,15 +134,6 @@ func (a *App) generateSupportPacketYaml() (*model.FileData, string) {
 		ElasticServerPlugins:       elasticServerPlugins,
 		ActiveUsers:                int(uniqueUserCount),
 		LicenseSupportedUsers:      supportedUsers,
-		TotalChannels:              int(analytics[0].Value) + int(analytics[1].Value),
-		TotalPosts:                 int(analytics[2].Value),
-		TotalTeams:                 int(analytics[4].Value),
-		WebsocketConnections:       int(analytics[5].Value),
-		MasterDbConnections:        int(analytics[6].Value),
-		ReplicaDbConnections:       int(analytics[7].Value),
-		DailyActiveUsers:           int(analytics[8].Value),
-		MonthlyActiveUsers:         int(analytics[9].Value),
-		InactiveUserCount:          int(analytics[10].Value),
 		ElasticPostIndexingJobs:    elasticPostIndexing,
 		ElasticPostAggregationJobs: elasticPostAggregation,
 		LdapSyncJobs:               ldapSyncJobs,
@@ -135,108 +143,103 @@ func (a *App) generateSupportPacketYaml() (*model.FileData, string) {
 		MigrationJobs:              migrationJobs,
 	}
 
+	analytics, appErr := a.GetAnalytics("standard", "")
+	if appErr != nil {
+		rErr = multierror.Append(errors.Wrap(appErr, "error while getting analytics"))
+	}
+	if len(analytics) < 11 {
+		rErr = multierror.Append(errors.New("not enought analytics information found"))
+	} else {
+		supportPacket.TotalChannels = int(analytics[0].Value) + int(analytics[1].Value)
+		supportPacket.TotalPosts = int(analytics[2].Value)
+		supportPacket.TotalTeams = int(analytics[4].Value)
+		supportPacket.WebsocketConnections = int(analytics[5].Value)
+		supportPacket.MasterDbConnections = int(analytics[6].Value)
+		supportPacket.ReplicaDbConnections = int(analytics[7].Value)
+		supportPacket.DailyActiveUsers = int(analytics[8].Value)
+		supportPacket.MonthlyActiveUsers = int(analytics[9].Value)
+		supportPacket.InactiveUserCount = int(analytics[10].Value)
+	}
+
 	// Marshal to a Yaml File
 	supportPacketYaml, err := yaml.Marshal(&supportPacket)
-	if err == nil {
-		fileData := model.FileData{
-			Filename: "support_packet.yaml",
-			Body:     supportPacketYaml,
-		}
-		return &fileData, ""
+	if err != nil {
+		rErr = multierror.Append(errors.Wrap(err, "failed to marshal support package into yaml"))
 	}
 
-	warning := fmt.Sprintf("yaml.Marshal(&supportPacket) Error: %s", err.Error())
-	return nil, warning
+	fileData := &model.FileData{
+		Filename: "support_packet.yaml",
+		Body:     supportPacketYaml,
+	}
+	return fileData, rErr
 }
 
-func (a *App) createPluginsFile() (*model.FileData, string) {
-	var warning string
-
+func (a *App) createPluginsFile() (*model.FileData, error) {
 	// Getting the plugins installed on the server, prettify it, and then add them to the file data array
 	pluginsResponse, appErr := a.GetPlugins()
-	if appErr == nil {
-		pluginsPrettyJSON, err := json.MarshalIndent(pluginsResponse, "", "    ")
-		if err == nil {
-			fileData := model.FileData{
-				Filename: "plugins.json",
-				Body:     pluginsPrettyJSON,
-			}
-
-			return &fileData, ""
-		}
-
-		warning = fmt.Sprintf("json.MarshalIndent(pluginsResponse) Error: %s", err.Error())
-	} else {
-		warning = fmt.Sprintf("c.App.GetPlugins() Error: %s", appErr.Error())
+	if appErr != nil {
+		return nil, errors.Wrap(appErr, "failed to get plugin list for support package")
 	}
 
-	return nil, warning
-}
-
-func (a *App) getNotificationsLog() (*model.FileData, string) {
-	var warning string
-
-	// Getting notifications.log
-	if *a.Config().NotificationLogSettings.EnableFile {
-		// notifications.log
-		notificationsLog := config.GetNotificationsLogFileLocation(*a.Config().LogSettings.FileLocation)
-
-		notificationsLogFileData, notificationsLogFileDataErr := os.ReadFile(notificationsLog)
-
-		if notificationsLogFileDataErr == nil {
-			fileData := model.FileData{
-				Filename: "notifications.log",
-				Body:     notificationsLogFileData,
-			}
-			return &fileData, ""
-		}
-
-		warning = fmt.Sprintf("os.ReadFile(notificationsLog) Error: %s", notificationsLogFileDataErr.Error())
-
-	} else {
-		warning = "Unable to retrieve notifications.log because LogSettings: EnableFile is false in config.json"
+	pluginsPrettyJSON, err := json.MarshalIndent(pluginsResponse, "", "    ")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal plugin list into json")
 	}
 
-	return nil, warning
+	fileData := &model.FileData{
+		Filename: "plugins.json",
+		Body:     pluginsPrettyJSON,
+	}
+	return fileData, nil
+
 }
 
-func (a *App) getMattermostLog() (*model.FileData, string) {
-	var warning string
-
-	// Getting mattermost.log
-	if *a.Config().LogSettings.EnableFile {
-		// mattermost.log
-		mattermostLog := config.GetLogFileLocation(*a.Config().LogSettings.FileLocation)
-
-		mattermostLogFileData, mattermostLogFileDataErr := os.ReadFile(mattermostLog)
-
-		if mattermostLogFileDataErr == nil {
-			fileData := model.FileData{
-				Filename: "mattermost.log",
-				Body:     mattermostLogFileData,
-			}
-			return &fileData, ""
-		}
-		warning = fmt.Sprintf("os.ReadFile(mattermostLog) Error: %s", mattermostLogFileDataErr.Error())
-
-	} else {
-		warning = "Unable to retrieve mattermost.log because LogSettings: EnableFile is false in config.json"
+func (a *App) getNotificationsLog() (*model.FileData, error) {
+	if !*a.Config().NotificationLogSettings.EnableFile {
+		return nil, errors.New("Unable to retrieve notifications.log because LogSettings: EnableFile is false in config.json")
 	}
 
-	return nil, warning
+	notificationsLog := config.GetNotificationsLogFileLocation(*a.Config().LogSettings.FileLocation)
+	notificationsLogFileData, err := os.ReadFile(notificationsLog)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed read notifcation log file at path %s", notificationsLog)
+	}
+
+	fileData := &model.FileData{
+		Filename: "notifications.log",
+		Body:     notificationsLogFileData,
+	}
+	return fileData, nil
 }
 
-func (a *App) createSanitizedConfigFile() (*model.FileData, string) {
+func (a *App) getMattermostLog() (*model.FileData, error) {
+	if !*a.Config().LogSettings.EnableFile {
+		return nil, errors.New("Unable to retrieve mattermost.log because LogSettings: EnableFile is false in config.json")
+	}
+
+	mattermostLog := config.GetLogFileLocation(*a.Config().LogSettings.FileLocation)
+	mattermostLogFileData, err := os.ReadFile(mattermostLog)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed read mattermost log file at path %s", mattermostLog)
+	}
+
+	fileData := &model.FileData{
+		Filename: "mattermost.log",
+		Body:     mattermostLogFileData,
+	}
+	return fileData, nil
+}
+
+func (a *App) createSanitizedConfigFile() (*model.FileData, error) {
 	// Getting sanitized config, prettifying it, and then adding it to our file data array
 	sanitizedConfigPrettyJSON, err := json.MarshalIndent(a.GetSanitizedConfig(), "", "    ")
-	if err == nil {
-		fileData := model.FileData{
-			Filename: "sanitized_config.json",
-			Body:     sanitizedConfigPrettyJSON,
-		}
-		return &fileData, ""
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to sanitized config into json")
 	}
 
-	warning := fmt.Sprintf("json.MarshalIndent(c.App.GetSanitizedConfig()) Error: %s", err.Error())
-	return nil, warning
+	fileData := &model.FileData{
+		Filename: "sanitized_config.json",
+		Body:     sanitizedConfigPrettyJSON,
+	}
+	return fileData, nil
 }

--- a/server/channels/app/support_packet.go
+++ b/server/channels/app/support_packet.go
@@ -110,10 +110,6 @@ func (a *App) generateSupportPacketYaml() (*model.FileData, error) {
 	if err != nil {
 		rErr = multierror.Append(errors.Wrap(err, "error while getting migration jobs"))
 	}
-	complianceJobs, err := a.Srv().Store().Job().GetAllByTypePage("compliance", 0, 2)
-	if err != nil {
-		rErr = multierror.Append(errors.Wrap(err, "error while getting compliance jobs"))
-	}
 
 	licenseTo := ""
 	supportedUsers := 0
@@ -147,7 +143,6 @@ func (a *App) generateSupportPacketYaml() (*model.FileData, error) {
 		BlevePostIndexingJobs:      blevePostIndexingJobs,
 		LdapSyncJobs:               ldapSyncJobs,
 		MigrationJobs:              migrationJobs,
-		ComplianceJobs:             complianceJobs,
 	}
 
 	analytics, appErr := a.GetAnalytics("standard", "")

--- a/server/channels/app/support_packet_test.go
+++ b/server/channels/app/support_packet_test.go
@@ -68,12 +68,15 @@ func TestGenerateSupportPacket(t *testing.T) {
 	require.NoError(t, err)
 
 	fileDatas := th.App.GenerateSupportPacket()
+	var rFileNames []string
 	testFiles := []string{"support_packet.yaml", "plugins.json", "sanitized_config.json", "mattermost.log", "notifications.log"}
-	for i, fileData := range fileDatas {
+	for _, fileData := range fileDatas {
 		require.NotNil(t, fileData)
-		assert.Equal(t, testFiles[i], fileData.Filename)
 		assert.Positive(t, len(fileData.Body))
+
+		rFileNames = append(rFileNames, fileData.Filename)
 	}
+	assert.ElementsMatch(t, testFiles, rFileNames)
 
 	// Remove these two files and ensure that warning.txt file is generated
 	err = os.Remove("notifications.log")
@@ -82,11 +85,14 @@ func TestGenerateSupportPacket(t *testing.T) {
 	require.NoError(t, err)
 	fileDatas = th.App.GenerateSupportPacket()
 	testFiles = []string{"support_packet.yaml", "plugins.json", "sanitized_config.json", "warning.txt"}
-	for i, fileData := range fileDatas {
+	rFileNames = nil
+	for _, fileData := range fileDatas {
 		require.NotNil(t, fileData)
-		assert.Equal(t, testFiles[i], fileData.Filename)
 		assert.Positive(t, len(fileData.Body))
+
+		rFileNames = append(rFileNames, fileData.Filename)
 	}
+	assert.ElementsMatch(t, testFiles, rFileNames)
 }
 
 func TestGetNotificationsLog(t *testing.T) {

--- a/server/channels/app/support_packet_test.go
+++ b/server/channels/app/support_packet_test.go
@@ -100,7 +100,7 @@ func TestGetNotificationsLog(t *testing.T) {
 
 	fileData, err := th.App.getNotificationsLog()
 	assert.Nil(t, fileData)
-	assert.ErrorContains(t, err, "Unable to retrieve notifications.log because LogSettings: EnableFile is false in config.json")
+	assert.ErrorContains(t, err, "Unable to retrieve notifications.log because LogSettings: EnableFile is set to false")
 
 	// Enable notifications file but delete any notifications file to get an error trying to read the file
 	th.App.UpdateConfig(func(cfg *model.Config) {
@@ -138,7 +138,7 @@ func TestGetMattermostLog(t *testing.T) {
 
 	fileData, err := th.App.getMattermostLog()
 	assert.Nil(t, fileData)
-	assert.ErrorContains(t, err, "Unable to retrieve mattermost.log because LogSettings: EnableFile is false in config.json")
+	assert.ErrorContains(t, err, "Unable to retrieve mattermost.log because LogSettings: EnableFile is set to false")
 
 	// We enable the setting but delete any mattermost log file
 	th.App.UpdateConfig(func(cfg *model.Config) {

--- a/server/public/model/system.go
+++ b/server/public/model/system.go
@@ -103,6 +103,7 @@ type SupportPacket struct {
 	InactiveUserCount          int      `yaml:"inactive_user_count"`
 	ElasticPostIndexingJobs    []*Job   `yaml:"elastic_post_indexing_jobs"`
 	ElasticPostAggregationJobs []*Job   `yaml:"elastic_post_aggregation_jobs"`
+	BlevePostIndexingJobs      []*Job   `yaml:"bleve_post_indexin_jobs"`
 	LdapSyncJobs               []*Job   `yaml:"ldap_sync_jobs"`
 	MessageExportJobs          []*Job   `yaml:"message_export_jobs"`
 	DataRetentionJobs          []*Job   `yaml:"data_retention_jobs"`

--- a/server/public/model/system.go
+++ b/server/public/model/system.go
@@ -78,37 +78,39 @@ type ServerBusyState struct {
 }
 
 type SupportPacket struct {
-	LicenseTo                  string   `yaml:"license_to"`
-	ServerOS                   string   `yaml:"server_os"`
-	ServerArchitecture         string   `yaml:"server_architecture"`
-	ServerVersion              string   `yaml:"server_version"`
-	BuildHash                  string   `yaml:"build_hash,omitempty"`
-	DatabaseType               string   `yaml:"database_type"`
-	DatabaseVersion            string   `yaml:"database_version"`
-	DatabaseSchemaVersion      string   `yaml:"database_schema_version"`
-	LdapVendorName             string   `yaml:"ldap_vendor_name,omitempty"`
-	LdapVendorVersion          string   `yaml:"ldap_vendor_version,omitempty"`
-	ElasticServerVersion       string   `yaml:"elastic_server_version,omitempty"`
-	ElasticServerPlugins       []string `yaml:"elastic_server_plugins,omitempty"`
-	ActiveUsers                int      `yaml:"active_users"`
-	LicenseSupportedUsers      int      `yaml:"license_supported_users,omitempty"`
-	TotalChannels              int      `yaml:"total_channels"`
-	TotalPosts                 int      `yaml:"total_posts"`
-	TotalTeams                 int      `yaml:"total_teams"`
-	DailyActiveUsers           int      `yaml:"daily_active_users"`
-	MonthlyActiveUsers         int      `yaml:"monthly_active_users"`
-	WebsocketConnections       int      `yaml:"websocket_connections"`
-	MasterDbConnections        int      `yaml:"master_db_connections"`
-	ReplicaDbConnections       int      `yaml:"read_db_connections"`
-	InactiveUserCount          int      `yaml:"inactive_user_count"`
-	ElasticPostIndexingJobs    []*Job   `yaml:"elastic_post_indexing_jobs"`
-	ElasticPostAggregationJobs []*Job   `yaml:"elastic_post_aggregation_jobs"`
-	BlevePostIndexingJobs      []*Job   `yaml:"bleve_post_indexin_jobs"`
-	LdapSyncJobs               []*Job   `yaml:"ldap_sync_jobs"`
-	MessageExportJobs          []*Job   `yaml:"message_export_jobs"`
-	DataRetentionJobs          []*Job   `yaml:"data_retention_jobs"`
-	ComplianceJobs             []*Job   `yaml:"compliance_jobs"`
-	MigrationJobs              []*Job   `yaml:"migration_jobs"`
+	LicenseTo             string   `yaml:"license_to"`
+	ServerOS              string   `yaml:"server_os"`
+	ServerArchitecture    string   `yaml:"server_architecture"`
+	ServerVersion         string   `yaml:"server_version"`
+	BuildHash             string   `yaml:"build_hash,omitempty"`
+	DatabaseType          string   `yaml:"database_type"`
+	DatabaseVersion       string   `yaml:"database_version"`
+	DatabaseSchemaVersion string   `yaml:"database_schema_version"`
+	LdapVendorName        string   `yaml:"ldap_vendor_name,omitempty"`
+	LdapVendorVersion     string   `yaml:"ldap_vendor_version,omitempty"`
+	ElasticServerVersion  string   `yaml:"elastic_server_version,omitempty"`
+	ElasticServerPlugins  []string `yaml:"elastic_server_plugins,omitempty"`
+	ActiveUsers           int      `yaml:"active_users"`
+	LicenseSupportedUsers int      `yaml:"license_supported_users,omitempty"`
+	TotalChannels         int      `yaml:"total_channels"`
+	TotalPosts            int      `yaml:"total_posts"`
+	TotalTeams            int      `yaml:"total_teams"`
+	DailyActiveUsers      int      `yaml:"daily_active_users"`
+	MonthlyActiveUsers    int      `yaml:"monthly_active_users"`
+	WebsocketConnections  int      `yaml:"websocket_connections"`
+	MasterDbConnections   int      `yaml:"master_db_connections"`
+	ReplicaDbConnections  int      `yaml:"read_db_connections"`
+	InactiveUserCount     int      `yaml:"inactive_user_count"`
+
+	// Jobs
+	DataRetentionJobs          []*Job `yaml:"data_retention_jobs"`
+	MessageExportJobs          []*Job `yaml:"message_export_jobs"`
+	ElasticPostIndexingJobs    []*Job `yaml:"elastic_post_indexing_jobs"`
+	ElasticPostAggregationJobs []*Job `yaml:"elastic_post_aggregation_jobs"`
+	BlevePostIndexingJobs      []*Job `yaml:"bleve_post_indexin_jobs"`
+	LdapSyncJobs               []*Job `yaml:"ldap_sync_jobs"`
+	MigrationJobs              []*Job `yaml:"migration_jobs"`
+	ComplianceJobs             []*Job `yaml:"compliance_jobs"`
 }
 
 type FileData struct {


### PR DESCRIPTION
#### Summary
This PR contains a couple of changes to the support package code:
- Update `support_package.go` to use idiomatic error handling [c5a7d54](https://github.com/mattermost/mattermost/pull/24382/commits/c5a7d54b07bd73c93d492d9fa44b4f7a114349a8)
- Add `bleve_post_indexing` jobs to support package [47b8818](https://github.com/mattermost/mattermost/pull/24382/commits/47b88184593dd8703877779a2b8c6cb255d3bbfa)
- Reorder code to match `model/job.go` for better readability [c78a72e](https://github.com/mattermost/mattermost/pull/24382/commits/c78a72ea6c65b884f848bbbda065f709fb17c94f)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54245

#### Release Note
```release-note
NONE
```
