### PR TITLE
MM-53639 - fix firefox not detecting non-formatted paste action on ctrl|cmd+shift+v

### DIFF
--- a/webapp/channels/src/components/advanced_create_post/advanced_create_post.tsx
+++ b/webapp/channels/src/components/advanced_create_post/advanced_create_post.tsx
@@ -266,6 +266,8 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
     private lastOrientation?: string;
     private saveDraftFrame?: number | null;
     private isDraftSubmitting = false;
+    private isNonFormattedPaste = false;
+    private timeoutId: number | null = null;
 
     private topDiv: React.RefObject<HTMLFormElement>;
     private textboxRef: React.RefObject<TextboxClass>;
@@ -355,6 +357,9 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
         window.removeEventListener('beforeunload', this.unloadHandler);
         this.removeOrientationListeners();
         this.saveDraftWithShow();
+        if (this.timeoutId !== null) {
+            clearTimeout(this.timeoutId);
+        }
     }
 
     getChannelMemberCountsByGroup = () => {
@@ -929,7 +934,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
 
         const hasSelection = !isNil(selectionStart) && !isNil(selectionEnd) && selectionStart < selectionEnd;
         const hasTextUrl = isTextUrl(clipboardData);
-        const hasHTMLLinks = hasHtmlLink(clipboardData);
+        const hasHTMLLinks = !this.isNonFormattedPaste && hasHtmlLink(clipboardData);
         const htmlTable = getHtmlTable(clipboardData);
         const shouldApplyLinkMarkdown = hasSelection && hasTextUrl;
         const shouldApplyGithubCodeBlock = htmlTable && isGitHubCodeBlock(htmlTable.className);
@@ -1134,6 +1139,16 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
     handleKeyDown = (e: React.KeyboardEvent<TextboxElement>) => {
         const messageIsEmpty = this.state.message.length === 0;
         const draftMessageIsEmpty = this.props.draft.message.length === 0;
+
+        // fix for FF not capturing the paste without formatting event when using ctrl|cmd + shift + v
+        if (e.key === KeyCodes.V[0] && e.metaKey) {
+            if (e.shiftKey) {
+                this.isNonFormattedPaste = true;
+                this.timeoutId = window.setTimeout(() => {
+                    this.isNonFormattedPaste = false;
+                }, 250);
+            }
+        }
 
         const ctrlOrMetaKeyPressed = e.ctrlKey || e.metaKey;
         const ctrlEnterKeyCombo = (this.props.ctrlSend || this.props.codeBlockOnCtrlEnter) &&


### PR DESCRIPTION
#### Summary
Firefox was not removing the `text/html` from the `ClipboardEvent.ClipboardData.types` array and neither the data from it. This was causing the Cmd + Shift + V not working as expected and not pasting text without format.

This PR adds a check on keydown event to detect this particular keys combination and making sure it always paste non-formatted text on Cmd|Ctrl + Shift + V key strokes combination.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53639

#### Screenshots
Before:

https://github.com/mattermost/mattermost/assets/10082627/6c60d875-6dcb-4b88-a464-0211b5c88078


After:
Firefox:

https://github.com/mattermost/mattermost/assets/10082627/53c9f660-a2ac-4b7b-853b-8ddda9c0cf40


Chrome:

https://github.com/mattermost/mattermost/assets/10082627/613a05b6-281b-4f5f-9a50-f5c5fd2b6517



#### Release Note
```release-note
NONE
```
