### PR TITLE
MM-53683: Remove people product flag

### DIFF
--- a/e2e-tests/playwright/support/server/default_config.ts
+++ b/e2e-tests/playwright/support/server/default_config.ts
@@ -674,7 +674,6 @@ const defaultServerConfig: AdminConfig = {
         SendWelcomePost: true,
         PostPriority: true,
         WysiwygEditor: false,
-        PeopleProduct: false,
         ThreadsEverywhere: false,
         OnboardingTourTips: true,
         DeprecateCloudFree: false,

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -37,8 +37,6 @@ type FeatureFlags struct {
 	// Enable WYSIWYG text editor
 	WysiwygEditor bool
 
-	PeopleProduct bool
-
 	OnboardingTourTips bool
 
 	DeprecateCloudFree bool
@@ -58,7 +56,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.NormalizeLdapDNs = false
 	f.GraphQL = false
 	f.CallsEnabled = true
-	f.PeopleProduct = false
 	f.DeprecateCloudFree = false
 	f.WysiwygEditor = false
 	f.OnboardingTourTips = true


### PR DESCRIPTION
#### Summary
Removes unused `FeatureFlags.PeopleProduct`

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-53683

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
