### PR TITLE
MM-54261: re-scope css to intended target

### DIFF
--- a/webapp/channels/src/components/post_edit_history/__snapshots__/post_edit_history.test.tsx.snap
+++ b/webapp/channels/src/components/post_edit_history/__snapshots__/post_edit_history.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`components/post_edit_history should display error screen if errors are present 1`] = `
 <div>
   <div
-    class="sidebar-right__body"
+    class="sidebar-right__body sidebar-right__edit-post-history"
     id="rhsContainer"
   >
     <div
@@ -118,7 +118,7 @@ exports[`components/post_edit_history should display error screen if errors are 
 exports[`components/post_edit_history should match snapshot 1`] = `
 <div>
   <div
-    class="sidebar-right__body"
+    class="sidebar-right__body sidebar-right__edit-post-history"
     id="rhsContainer"
   >
     <div

--- a/webapp/channels/src/components/post_edit_history/post_edit_history.scss
+++ b/webapp/channels/src/components/post_edit_history/post_edit_history.scss
@@ -1,4 +1,4 @@
-.scrollbar--view {
+.sidebar-right__edit-post-history .scrollbar--view {
     display: flex;
     flex-direction: column;
 }

--- a/webapp/channels/src/components/post_edit_history/post_edit_history.tsx
+++ b/webapp/channels/src/components/post_edit_history/post_edit_history.tsx
@@ -107,7 +107,7 @@ const PostEditHistory = ({
         return (
             <div
                 id='rhsContainer'
-                className='sidebar-right__body'
+                className='sidebar-right__body sidebar-right__edit-post-history'
             >
                 <LoadingScreen
                     style={{
@@ -138,7 +138,7 @@ const PostEditHistory = ({
     return (
         <div
             id='rhsContainer'
-            className='sidebar-right__body'
+            className='sidebar-right__body sidebar-right__edit-post-history'
         >
             <Scrollbars
                 ref={scrollbars}


### PR DESCRIPTION
#### Summary
Fixes a CSS scoping issue to resolve a styling issue in playbooks RHS that has overlapping content. The root problem may have caused issues in other places—this would fix those, too, if any occurred. 

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-54261
#### Screenshots

|  before  |  after  |
|----|----|
| ![CleanShot 2023-08-28 at 12 04 19@2x](https://github.com/mattermost/mattermost/assets/11724372/a4a7f393-5cb1-4b0f-92d4-5a8adc602f72) | ![CleanShot 2023-08-28 at 12 03 54@2x](https://github.com/mattermost/mattermost/assets/11724372/b3e1dc27-b88f-4f35-9537-8c011b4a3271) |


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
