### PR TITLE
MM-49627: Suppress transformation of embedded images via image proxy

### DIFF
--- a/server/channels/app/post_metadata.go
+++ b/server/channels/app/post_metadata.go
@@ -585,6 +585,11 @@ func (a *App) containsPermalink(post *model.Post) bool {
 func (a *App) getLinkMetadata(c request.CTX, requestURL string, timestamp int64, isNewPost bool, previewedPostPropVal string) (*opengraph.OpenGraph, *model.PostImage, *model.Permalink, error) {
 	requestURL = resolveMetadataURL(requestURL, a.GetSiteURL())
 
+	// If it's an embedded image, nothing to do.
+	if strings.HasPrefix(requestURL, "data:image/") {
+		return nil, nil, nil, nil
+	}
+
 	timestamp = model.FloorToNearestHour(timestamp)
 
 	// Check cache

--- a/server/channels/app/post_metadata.go
+++ b/server/channels/app/post_metadata.go
@@ -586,7 +586,7 @@ func (a *App) getLinkMetadata(c request.CTX, requestURL string, timestamp int64,
 	requestURL = resolveMetadataURL(requestURL, a.GetSiteURL())
 
 	// If it's an embedded image, nothing to do.
-	if strings.HasPrefix(requestURL, "data:image/") {
+	if strings.HasPrefix(strings.ToLower(requestURL), "data:image/") {
 		return nil, nil, nil, nil
 	}
 

--- a/server/platform/services/imageproxy/imageproxy.go
+++ b/server/platform/services/imageproxy/imageproxy.go
@@ -124,7 +124,7 @@ func (proxy *ImageProxy) GetImageDirect(imageURL string) (io.ReadCloser, string,
 // GetProxiedImageURL takes the URL of an image and returns a URL that can be used to view that image through the
 // image proxy.
 func (proxy *ImageProxy) GetProxiedImageURL(imageURL string) string {
-	if imageURL == "" || proxy.siteURL == nil || strings.HasPrefix(imageURL, "data:image/") {
+	if imageURL == "" || proxy.siteURL == nil || strings.HasPrefix(strings.ToLower(imageURL), "data:image/") {
 		return imageURL
 	}
 	// Parse url, return siteURL in case of failure.

--- a/server/platform/services/imageproxy/imageproxy.go
+++ b/server/platform/services/imageproxy/imageproxy.go
@@ -124,7 +124,7 @@ func (proxy *ImageProxy) GetImageDirect(imageURL string) (io.ReadCloser, string,
 // GetProxiedImageURL takes the URL of an image and returns a URL that can be used to view that image through the
 // image proxy.
 func (proxy *ImageProxy) GetProxiedImageURL(imageURL string) string {
-	if imageURL == "" || proxy.siteURL == nil {
+	if imageURL == "" || proxy.siteURL == nil || strings.HasPrefix(imageURL, "data:image/") {
 		return imageURL
 	}
 	// Parse url, return siteURL in case of failure.

--- a/server/platform/services/imageproxy/imageproxy_test.go
+++ b/server/platform/services/imageproxy/imageproxy_test.go
@@ -66,6 +66,11 @@ func TestGetProxiedImageURL(t *testing.T) {
 			Input:    "https://mattermost.example.com@anothersite.com/static/logo.png",
 			Expected: "https://mattermost.example.com/api/v4/image?url=https%3A%2F%2Fmattermost.example.com%40anothersite.com%2Fstatic%2Flogo.png",
 		},
+		{
+			Name:     "should not proxy embedded image",
+			Input:    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==",
+			Expected: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==",
+		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			assert.Equal(t, test.Expected, proxy.GetProxiedImageURL(test.Input))


### PR DESCRIPTION
There was no check for embedded images which made "copy text" paste
the siteURL instead of the actual image content.

This does not change the behavior of actually rendering the image
which is how other sites behave as well.

https://mattermost.atlassian.net/browse/MM-49627
```release-note
NONE
```
