### PR TITLE
Update supported Chromium version

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9797,7 +9797,7 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "Version 112+"
+    "translation": "Version 116+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",


### PR DESCRIPTION
Updated Chromium minimum supported version to v116+. Desktop app v5.5 release includes Electron v26.1.0, which includes Chromium v116 (https://releases.electronjs.org/release/v26.1.0). 

```release-note
Updated Chromium minimum supported version to 116+.
```
