### PR TITLE
MM-54219 - Fix: Improve limits on redirectLocationDataCache

### DIFF
--- a/server/channels/api4/system.go
+++ b/server/channels/api4/system.go
@@ -596,6 +596,17 @@ func getRedirectLocation(c *Context, w http.ResponseWriter, r *http.Request) {
 	}()
 
 	location = res.Header.Get("Location")
+
+	// If the location length is > 2100, we can probably ignore. Fixes https://mattermost.atlassian.net/browse/MM-54219
+	// see: https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
+	if len(location) > 2100 {
+		// Treating as a "failure". Cache failures to prevent retries.
+		redirectLocationDataCache.SetWithExpiry(url, "", 1*time.Hour)
+		// Always return a success status and a JSON string to limit information returned to client.
+		w.Write([]byte(model.MapToJSON(m)))
+		return
+	}
+
 	redirectLocationDataCache.SetWithExpiry(url, location, 1*time.Hour)
 	m["location"] = location
 

--- a/server/channels/api4/system.go
+++ b/server/channels/api4/system.go
@@ -598,7 +598,6 @@ func getRedirectLocation(c *Context, w http.ResponseWriter, r *http.Request) {
 	location = res.Header.Get("Location")
 
 	// If the location length is > 2100, we can probably ignore. Fixes https://mattermost.atlassian.net/browse/MM-54219
-	// see: https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
 	if len(location) > 2100 {
 		// Treating as a "failure". Cache failures to prevent retries.
 		redirectLocationDataCache.SetWithExpiry(url, "", 1*time.Hour)

--- a/server/channels/api4/system.go
+++ b/server/channels/api4/system.go
@@ -26,9 +26,11 @@ import (
 )
 
 const (
-	RedirectLocationCacheSize = 10000
-	DefaultServerBusySeconds  = 3600
-	MaxServerBusySeconds      = 86400
+	RedirectLocationCacheSize     = 10000
+	RedirectLocationMaximumLength = 2100
+	RedirectLocationCacheExpiry   = 1 * time.Hour
+	DefaultServerBusySeconds      = 3600
+	MaxServerBusySeconds          = 86400
 )
 
 var redirectLocationDataCache = cache.NewLRU(cache.LRUOptions{
@@ -585,7 +587,7 @@ func getRedirectLocation(c *Context, w http.ResponseWriter, r *http.Request) {
 	res, err := client.Head(url)
 	if err != nil {
 		// Cache failures to prevent retries.
-		redirectLocationDataCache.SetWithExpiry(url, "", 1*time.Hour)
+		redirectLocationDataCache.SetWithExpiry(url, "", RedirectLocationCacheExpiry)
 		// Always return a success status and a JSON string to limit information returned to client.
 		w.Write([]byte(model.MapToJSON(m)))
 		return
@@ -598,15 +600,15 @@ func getRedirectLocation(c *Context, w http.ResponseWriter, r *http.Request) {
 	location = res.Header.Get("Location")
 
 	// If the location length is > 2100, we can probably ignore. Fixes https://mattermost.atlassian.net/browse/MM-54219
-	if len(location) > 2100 {
+	if len(location) > RedirectLocationMaximumLength {
 		// Treating as a "failure". Cache failures to prevent retries.
-		redirectLocationDataCache.SetWithExpiry(url, "", 1*time.Hour)
+		redirectLocationDataCache.SetWithExpiry(url, "", RedirectLocationCacheExpiry)
 		// Always return a success status and a JSON string to limit information returned to client.
 		w.Write([]byte(model.MapToJSON(m)))
 		return
 	}
 
-	redirectLocationDataCache.SetWithExpiry(url, location, 1*time.Hour)
+	redirectLocationDataCache.SetWithExpiry(url, location, RedirectLocationCacheExpiry)
 	m["location"] = location
 
 	w.Write([]byte(model.MapToJSON(m)))

--- a/server/channels/app/notification_push.go
+++ b/server/channels/app/notification_push.go
@@ -126,6 +126,7 @@ func (a *App) sendPushNotificationToAllSessions(msg *model.PushNotification, use
 		tmpMessage.SetDeviceIdAndPlatform(session.DeviceId)
 		tmpMessage.AckId = model.NewId()
 
+		a.Log().Error(fmt.Sprintf("<><> sending pushNotification: %#+v\n", tmpMessage))
 		err := a.sendToPushProxy(tmpMessage, session)
 		if err != nil {
 			a.NotificationsLog().Error("Notification error",

--- a/server/channels/app/notification_push.go
+++ b/server/channels/app/notification_push.go
@@ -126,7 +126,6 @@ func (a *App) sendPushNotificationToAllSessions(msg *model.PushNotification, use
 		tmpMessage.SetDeviceIdAndPlatform(session.DeviceId)
 		tmpMessage.AckId = model.NewId()
 
-		a.Log().Error(fmt.Sprintf("<><> sending pushNotification: %#+v\n", tmpMessage))
 		err := a.sendToPushProxy(tmpMessage, session)
 		if err != nil {
 			a.NotificationsLog().Error("Notification error",


### PR DESCRIPTION
#### Summary
- Treat redirect urls over a certain size as failures
- After discussion with @jupenur and looking at a good summary of browser and crawler support, 2100 seems like a good length to support. https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
- This endpoint is used by mobile to get expanded links.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-54219

I've attached before and after heap profiles, [heap-profiles.zip](https://github.com/mattermost/mattermost/files/12480522/heap-profiles.zip) . The before fix before/after shows the cache hitting 613MB, the after fix before/after shows this is fixed. I also included a `heap-after-fix-after-test-smaller-location` which shows the effect of requesting 3000 locations that just fit the location limit (length of 2000). There's basically no effect on the cache size, so we can handle it with our normal protections.

#### Release Note
```release-note
Improved the size limits on the redirectLocationDataCache to prevent potential out of memory errors.
```
