### PR TITLE
updates on the migration template

### DIFF
--- a/server/tests/template.load
+++ b/server/tests/template.load
@@ -37,4 +37,6 @@ AFTER LOAD DO
      $$ UPDATE {{ .source_schema }}.db_migrations set name='add_createat_to_teamembers' where version=92; $$,
      $$ CREATE INDEX IF NOT EXISTS idx_posts_message_txt ON {{ .source_schema }}.posts USING gin(to_tsvector('english', message)); $$,
      $$ CREATE INDEX IF NOT EXISTS idx_fileinfo_content_txt ON {{ .source_schema }}.fileinfo USING gin(to_tsvector('english', content)); $$,
-     $$ ALTER SCHEMA {{ .source_schema }} RENAME TO public; $$;
+     $$ ALTER SCHEMA {{ .source_schema }} RENAME TO public; $$,
+     $$ SELECT pg_catalog.set_config('search_path', '"$user", public', false); $$,
+     $$ ALTER USER {{ .pg_user }} SET SEARCH_PATH TO 'public'; $$;

--- a/server/tests/template.load
+++ b/server/tests/template.load
@@ -5,7 +5,7 @@ LOAD DATABASE
 WITH data only,
      workers = 8, concurrency = 1,
      multiple readers per thread, rows per range = 50000,
-     create no tables,
+     create no tables, create no indexes,
      preserve index names
 
 SET PostgreSQL PARAMETERS
@@ -26,12 +26,15 @@ CAST column Channels.Type to "channel_type" drop typemod,
      type tinyint when (<= precision 4) to boolean using tinyint-to-boolean,
      type json to jsonb drop typemod
 
-MATERIALIZE VIEWS exclude_products
-     excluding table names matching ~<IR_>, ~<focalboard>
+EXCLUDING TABLE NAMES MATCHING ~<IR_>, ~<focalboard>
 
 BEFORE LOAD DO
-     $$ ALTER SCHEMA public RENAME TO {{ .source_schema }}; $$
+     $$ ALTER SCHEMA public RENAME TO {{ .source_schema }}; $$,
+     $$ DROP INDEX IF EXISTS idx_posts_message_txt; $$,
+     $$ DROP INDEX IF EXISTS idx_fileinfo_content_txt; $$
 
 AFTER LOAD DO
      $$ UPDATE {{ .source_schema }}.db_migrations set name='add_createat_to_teamembers' where version=92; $$,
+     $$ CREATE INDEX IF NOT EXISTS idx_posts_message_txt ON {{ .source_schema }}.posts USING gin(to_tsvector('english', message)); $$,
+     $$ CREATE INDEX IF NOT EXISTS idx_fileinfo_content_txt ON {{ .source_schema }}.fileinfo USING gin(to_tsvector('english', content)); $$,
      $$ ALTER SCHEMA {{ .source_schema }} RENAME TO public; $$;


### PR DESCRIPTION
#### Summary
Some findings along the migration documentation has been applied:
- Drop/Create index requirements can be eliminated by adding them into the `pgLoader` configuration itself.
- We don't need to use `MATERIALIZE VIEWS` clause.
- Restore `SEARCH_PATH` after the migration, this was preventing mm-server to find `public` schema.

#### Release Note

```release-note
NONE
```
