### PR TITLE
Update subpackage versions to 8.1.1

### DIFF
--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -3,7 +3,7 @@
   "browser": {
     "./client/web_client.jsx": "./client/browser_web_client.jsx"
   },
-  "version": "8.0.0",
+  "version": "8.1.1",
   "private": true,
   "dependencies": {
     "@floating-ui/react-dom": "1.0.0",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -50,7 +50,7 @@
     },
     "channels": {
       "name": "mattermost-webapp",
-      "version": "8.0.0",
+      "version": "8.1.1",
       "dependencies": {
         "@floating-ui/react-dom": "1.0.0",
         "@floating-ui/react-dom-interactions": "0.10.3",
@@ -23698,7 +23698,7 @@
     },
     "platform/client": {
       "name": "@mattermost/client",
-      "version": "8.0.0",
+      "version": "8.1.1",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.0"
@@ -23770,7 +23770,7 @@
     },
     "platform/types": {
       "name": "@mattermost/types",
-      "version": "8.0.0",
+      "version": "8.1.1",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^4.3"
@@ -35721,8 +35721,8 @@
         "@deanwhillier/jest-matchmedia-mock": "1.2.0",
         "@floating-ui/react-dom": "1.0.0",
         "@floating-ui/react-dom-interactions": "0.10.3",
-        "@giphy/js-fetch-api": "*",
-        "@giphy/react-components": "*",
+        "@giphy/js-fetch-api": "5.1.0",
+        "@giphy/react-components": "8.1.0",
         "@guyplusplus/turndown-plugin-gfm": "1.0.7",
         "@hot-loader/react-dom": "17.0.2",
         "@mattermost/client": "*",

--- a/webapp/platform/client/package.json
+++ b/webapp/platform/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/client",
-  "version": "8.0.0",
+  "version": "8.1.1",
   "description": "JavaScript/TypeScript client for Mattermost",
   "keywords": [
     "mattermost"

--- a/webapp/platform/types/package.json
+++ b/webapp/platform/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/types",
-  "version": "8.0.0",
+  "version": "8.1.1",
   "description": "Shared type definitions used by the Mattermost web app",
   "keywords": [
     "mattermost"


### PR DESCRIPTION
I missed getting these version numbers updated before work started on 8.1.1, so I figure I'll just skip releasing 8.1.0 versions of these packages and release them for 8.1.1 when that ships.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54164

#### Release Note
```release-note
NONE
```
