### PR TITLE
Update version of JS subpackages to 9.0.0

### DIFF
--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -3,7 +3,7 @@
   "browser": {
     "./client/web_client.jsx": "./client/browser_web_client.jsx"
   },
-  "version": "8.0.0",
+  "version": "9.0.0",
   "private": true,
   "dependencies": {
     "@floating-ui/react-dom": "1.0.0",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -50,7 +50,7 @@
     },
     "channels": {
       "name": "mattermost-webapp",
-      "version": "8.0.0",
+      "version": "9.0.0",
       "dependencies": {
         "@floating-ui/react-dom": "1.0.0",
         "@floating-ui/react-dom-interactions": "0.10.3",
@@ -23616,7 +23616,7 @@
     },
     "platform/client": {
       "name": "@mattermost/client",
-      "version": "8.0.0",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.0"
@@ -23688,7 +23688,7 @@
     },
     "platform/types": {
       "name": "@mattermost/types",
-      "version": "8.0.0",
+      "version": "9.0.0",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^4.3"

--- a/webapp/platform/client/package.json
+++ b/webapp/platform/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/client",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "JavaScript/TypeScript client for Mattermost",
   "keywords": [
     "mattermost"

--- a/webapp/platform/types/package.json
+++ b/webapp/platform/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/types",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "Shared type definitions used by the Mattermost web app",
   "keywords": [
     "mattermost"


### PR DESCRIPTION
#### Summary
I'm a bit later than I'd like to be for this, but at least it's still before the release has been cut unlike the last 2 releases

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54344

#### Release Note
```release-note
NONE
```
