### PR TITLE
Automated cherry pick of #24438

### DIFF
--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -3,7 +3,7 @@
   "browser": {
     "./client/web_client.jsx": "./client/browser_web_client.jsx"
   },
-  "version": "8.0.0",
+  "version": "9.0.0",
   "private": true,
   "dependencies": {
     "@floating-ui/react-dom": "1.0.0",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -50,7 +50,7 @@
     },
     "channels": {
       "name": "mattermost-webapp",
-      "version": "8.0.0",
+      "version": "9.0.0",
       "dependencies": {
         "@floating-ui/react-dom": "1.0.0",
         "@floating-ui/react-dom-interactions": "0.10.3",
@@ -23698,7 +23698,7 @@
     },
     "platform/client": {
       "name": "@mattermost/client",
-      "version": "8.0.0",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.0"
@@ -23770,7 +23770,7 @@
     },
     "platform/types": {
       "name": "@mattermost/types",
-      "version": "8.0.0",
+      "version": "9.0.0",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^4.3"

--- a/webapp/platform/client/package.json
+++ b/webapp/platform/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/client",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "JavaScript/TypeScript client for Mattermost",
   "keywords": [
     "mattermost"

--- a/webapp/platform/types/package.json
+++ b/webapp/platform/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/types",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "Shared type definitions used by the Mattermost web app",
   "keywords": [
     "mattermost"


### PR DESCRIPTION
Cherry pick of #24438 on release-9.0.

/cc  @hmhealey

```release-note
NONE
```