### PR TITLE
Use .nvmrc for determining the node image used for E2E tests

### DIFF
--- a/e2e-tests/.ci/.e2erc
+++ b/e2e-tests/.ci/.e2erc
@@ -7,6 +7,7 @@ export MME2E_UID=$(id -u)
 # Default the optional variables that are used in the docker-compose file
 export SERVER_IMAGE_DEFAULT="mattermostdevelopment/mm-ee-test:$(git rev-parse --short=7 HEAD)"
 export SERVER_IMAGE=${SERVER_IMAGE:-$SERVER_IMAGE_DEFAULT}
+export NODE_VERSION_REQUIRED=$(cat ../../.nvmrc)
 
 # Function definitions
 mme2e_log () { echo "[$(date +%Y-%m-%dT%H:%M:%S%Z)]" "$@"; }

--- a/e2e-tests/.ci/server.override.yml
+++ b/e2e-tests/.ci/server.override.yml
@@ -107,14 +107,14 @@ services:
       # https://github.com/cypress-io/cypress/issues/1243
       CI: "1"
       # Ensure we're independent from the global node environment
-      PATH: /app/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      PATH: /cypress/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     ulimits:
       nofile:
         soft: 8096
         hard: 1048576
-    working_dir: /app
+    working_dir: /cypress
     volumes:
-      - "../../e2e-tests/cypress/:/app"
+      - "../../e2e-tests/cypress/:/cypress"
 
   utils:
     image: "mattermostdevelopment/mirrored-golang:1.19.5"

--- a/e2e-tests/.ci/server.override.yml
+++ b/e2e-tests/.ci/server.override.yml
@@ -54,7 +54,7 @@ services:
         condition: service_healthy
 
   webhook-interactions:
-    image:  mattermostdevelopment/mirrored-node:18.17.1
+    image:  mattermostdevelopment/mirrored-node:${NODE_VERSION_REQUIRED}
     command: sh -c "npm install -g axios express client-oauth2@larkox/js-client-oauth2#e24e2eb5dfcbbbb3a59d095e831dbe0012b0ac49 && exec node webhook_serve.js"
     environment:
       NODE_PATH: /usr/local/lib/node_modules/
@@ -72,7 +72,7 @@ services:
           - webhook-interactions
 
   cypress:
-    image: "mattermostdevelopment/mirrored-cypress-browsers-public:node16.14.2-slim-chrome100-ff99-edge"
+    image: "mattermostdevelopment/mirrored-cypress-browsers-public:node-18.16.1-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1"
     entrypoint: [ "/bin/bash", "-c" ]
     command: [ "until [ -f /var/run/mm_terminate ]; do sleep 5; done" ]
     env_file:

--- a/server/scripts/mirror-docker-images.json
+++ b/server/scripts/mirror-docker-images.json
@@ -37,6 +37,8 @@
   "node": {
     "16.10.0": "node:16.10.0",
     "16.17.0": "node:16.17.0",
+    "18": "node:18@sha256:11e9c297fc51f6f65f7d0c7c8a8581e5721f2f16de43ceff1a199fd3ef609f95",
+    "18.17": "node:18.17@sha256:11e9c297fc51f6f65f7d0c7c8a8581e5721f2f16de43ceff1a199fd3ef609f95",
     "18.17.1": "node:18.17.1@sha256:11e9c297fc51f6f65f7d0c7c8a8581e5721f2f16de43ceff1a199fd3ef609f95"
   }
 }


### PR DESCRIPTION
#### Summary

As mentioned [here](https://github.com/mattermost/mattermost/pull/24283#issuecomment-1696080783), it'd be better to use `.nvmrc` as a single source of truth for the Node version required within the repo.

This cannot be done everywhere (e.g. the cypress image is monolithic), but for the node image that we mirror we can do that.

This PR:
- Creates the required images
- Updates the node image reference in the server.override.yml file, to indirectly utilize `.nvmrc`
- Fixes a minor annoyance that caused `e2e-tests/cypress/package-lock.json` to change everytime e2e tests were run locally

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-6206

#### Release Note

```release-note
NONE
```
