### PR TITLE
MM-54260: Browse Channel Modal - Fix member count on private channels and when there is only 1 member in the channel

### DIFF
--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -2312,6 +2312,10 @@ func (s SqlChannelStore) GetChannelsMemberCount(channelIDs []string) (_ map[stri
 	defer rows.Close()
 
 	memberCounts := make(map[string]int64)
+	// Initialize member counts for channels with zero members
+	for _, channelID := range channelIDs {
+		memberCounts[channelID] = 0
+	}
 	for rows.Next() {
 		var channelID string
 		var count int64

--- a/webapp/channels/src/components/browse_channels/browse_channels.tsx
+++ b/webapp/channels/src/components/browse_channels/browse_channels.tsx
@@ -116,6 +116,7 @@ export default class BrowseChannels extends React.PureComponent<Props, State> {
                 return result.data ? result.data.map((channel) => channel.id) : [];
             },
             );
+            this.props.privateChannels.forEach((channel) => channelIDsForMemberCount.push(channel.id));
             if (channelIDsForMemberCount.length > 0) {
                 this.props.actions.getChannelsMemberCount(channelIDsForMemberCount);
             }


### PR DESCRIPTION
#### Summary
This PR fixes two issues
a) when a channel has only 1 member and when that user leaves the channel, users still see 1 as member count in the browse channel modal 
b) private channels member count always shown as zero

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-54260

#### Screenshots

a) when a channel has only 1 member and when that user leaves the channel, users still see 1 as member count in the browse channel modal 

**before**

https://github.com/mattermost/mattermost/assets/37421564/0557de99-0622-453f-917f-0d230d7e2d65


**after**

https://github.com/mattermost/mattermost/assets/37421564/809ac64c-2379-4467-9d2a-c74c9cff4265




b) private channels member count always shown as zero

**before**

https://github.com/mattermost/mattermost/assets/37421564/054675f1-e61c-4497-8ff9-a8b305438c82



**after**

https://github.com/mattermost/mattermost/assets/37421564/13f08c47-a4cd-4a0e-aa07-9ec04d801e11



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
