### PR TITLE
[MM-54318] Add file storage information to support package

### DIFF
--- a/server/channels/app/support_packet.go
+++ b/server/channels/app/support_packet.go
@@ -121,20 +121,31 @@ func (a *App) generateSupportPacketYaml() (*model.FileData, error) {
 
 	// Creating the struct for support packet yaml file
 	supportPacket := model.SupportPacket{
-		LicenseTo:             licenseTo,
-		ServerOS:              runtime.GOOS,
-		ServerArchitecture:    runtime.GOARCH,
-		ServerVersion:         model.CurrentVersion,
-		BuildHash:             model.BuildHash,
+		// Build information
+		ServerOS:           runtime.GOOS,
+		ServerArchitecture: runtime.GOARCH,
+		ServerVersion:      model.CurrentVersion,
+		BuildHash:          model.BuildHash,
+
+		// DB
 		DatabaseType:          databaseType,
 		DatabaseVersion:       databaseVersion,
 		DatabaseSchemaVersion: databaseSchemaVersion,
-		LdapVendorName:        vendorName,
-		LdapVendorVersion:     vendorVersion,
-		ElasticServerVersion:  elasticServerVersion,
-		ElasticServerPlugins:  elasticServerPlugins,
-		ActiveUsers:           int(uniqueUserCount),
+
+		// LDAP
+		LdapVendorName:    vendorName,
+		LdapVendorVersion: vendorVersion,
+
+		// Elastic Search
+		ElasticServerVersion: elasticServerVersion,
+		ElasticServerPlugins: elasticServerPlugins,
+
+		// License
+		LicenseTo:             licenseTo,
 		LicenseSupportedUsers: supportedUsers,
+
+		// Server stats
+		ActiveUsers: int(uniqueUserCount),
 
 		// Jobs
 		DataRetentionJobs:          dataRetentionJobs,

--- a/server/channels/app/support_packet.go
+++ b/server/channels/app/support_packet.go
@@ -67,6 +67,11 @@ func (a *App) generateSupportPacketYaml() (*model.FileData, error) {
 		elasticServerPlugins = a.Srv().Platform().SearchEngine.ElasticsearchEngine.GetPlugins()
 	}
 
+	var clusterID string
+	if a.Cluster() != nil {
+		clusterID = a.Cluster().GetClusterId()
+	}
+
 	fileDriver := a.Srv().Platform().FileBackend().Driver()
 
 	fileStatus := model.StatusOk
@@ -139,6 +144,9 @@ func (a *App) generateSupportPacketYaml() (*model.FileData, error) {
 		DatabaseType:          databaseType,
 		DatabaseVersion:       databaseVersion,
 		DatabaseSchemaVersion: databaseSchemaVersion,
+
+		// Cluster
+		ClusterID: clusterID,
 
 		// File store
 		FileDriver: fileDriver,

--- a/server/channels/app/support_packet.go
+++ b/server/channels/app/support_packet.go
@@ -67,6 +67,14 @@ func (a *App) generateSupportPacketYaml() (*model.FileData, error) {
 		elasticServerPlugins = a.Srv().Platform().SearchEngine.ElasticsearchEngine.GetPlugins()
 	}
 
+	fileDriver := a.Srv().Platform().FileBackend().Driver()
+
+	fileStatus := model.StatusOk
+	err := a.Srv().Platform().FileBackend().TestConnection()
+	if err != nil {
+		fileStatus = model.StatusFail + ": " + err.Error()
+	}
+
 	// Here we are getting information regarding LDAP
 	ldapInterface := a.ch.Ldap
 	var vendorName, vendorVersion string
@@ -131,6 +139,10 @@ func (a *App) generateSupportPacketYaml() (*model.FileData, error) {
 		DatabaseType:          databaseType,
 		DatabaseVersion:       databaseVersion,
 		DatabaseSchemaVersion: databaseSchemaVersion,
+
+		// File store
+		FileDriver: fileDriver,
+		FileStatus: fileStatus,
 
 		// LDAP
 		LdapVendorName:    vendorName,

--- a/server/channels/app/support_packet.go
+++ b/server/channels/app/support_packet.go
@@ -72,7 +72,7 @@ func (a *App) generateSupportPacketYaml() (*model.FileData, error) {
 		clusterID = a.Cluster().GetClusterId()
 	}
 
-	fileDriver := a.Srv().Platform().FileBackend().Driver()
+	fileDriver := a.Srv().Platform().FileBackend().DriverName()
 
 	fileStatus := model.StatusOk
 	err := a.Srv().Platform().FileBackend().TestConnection()

--- a/server/channels/app/support_packet_test.go
+++ b/server/channels/app/support_packet_test.go
@@ -61,6 +61,7 @@ func TestGenerateSupportPacketYaml(t *testing.T) {
 
 		assert.Equal(t, 3, packet.ActiveUsers) // from InitBasic.
 		assert.Equal(t, licenseUsers, packet.LicenseSupportedUsers)
+		assert.Empty(t, packet.ClusterID)
 		assert.Equal(t, "local", packet.FileDriver)
 		assert.Equal(t, "OK", packet.FileStatus)
 	})

--- a/server/channels/app/support_packet_test.go
+++ b/server/channels/app/support_packet_test.go
@@ -69,7 +69,7 @@ func TestGenerateSupportPacketYaml(t *testing.T) {
 	t.Run("filestore fails", func(t *testing.T) {
 		fb := &fmocks.FileBackend{}
 		platform.SetFileStore(fb)(th.Server.Platform())
-		fb.On("Driver").Return("mock")
+		fb.On("DriverName").Return("mock")
 		fb.On("TestConnection").Return(errors.New("all broken"))
 
 		fileData, err := th.App.generateSupportPacketYaml()

--- a/server/channels/app/support_packet_test.go
+++ b/server/channels/app/support_packet_test.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"errors"
 	"os"
 	"testing"
 
@@ -12,6 +13,8 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/v8/channels/app/platform"
+	fmocks "github.com/mattermost/mattermost/server/v8/platform/shared/filestore/mocks"
 )
 
 func TestCreatePluginsFile(t *testing.T) {
@@ -45,16 +48,41 @@ func TestGenerateSupportPacketYaml(t *testing.T) {
 	license.Features.Users = model.NewInt(licenseUsers)
 	th.App.Srv().SetLicense(license)
 
-	// Happy path where we have a support packet yaml file without any warnings
-	fileData, err := th.App.generateSupportPacketYaml()
-	require.NotNil(t, fileData)
-	assert.Equal(t, "support_packet.yaml", fileData.Filename)
-	assert.Positive(t, len(fileData.Body))
-	assert.NoError(t, err)
-	var packet model.SupportPacket
-	require.NoError(t, yaml.Unmarshal(fileData.Body, &packet))
-	assert.Equal(t, 3, packet.ActiveUsers) // from InitBasic.
-	assert.Equal(t, licenseUsers, packet.LicenseSupportedUsers)
+	t.Run("Happy path", func(t *testing.T) {
+		// Happy path where we have a support packet yaml file without any warnings
+
+		fileData, err := th.App.generateSupportPacketYaml()
+		require.NotNil(t, fileData)
+		assert.Equal(t, "support_packet.yaml", fileData.Filename)
+		assert.Positive(t, len(fileData.Body))
+		assert.NoError(t, err)
+		var packet model.SupportPacket
+		require.NoError(t, yaml.Unmarshal(fileData.Body, &packet))
+
+		assert.Equal(t, 3, packet.ActiveUsers) // from InitBasic.
+		assert.Equal(t, licenseUsers, packet.LicenseSupportedUsers)
+		assert.Equal(t, "local", packet.FileDriver)
+		assert.Equal(t, "OK", packet.FileStatus)
+	})
+
+	t.Run("filestore fails", func(t *testing.T) {
+		fb := &fmocks.FileBackend{}
+		platform.SetFileStore(fb)(th.Server.Platform())
+		fb.On("Driver").Return("mock")
+		fb.On("TestConnection").Return(errors.New("all broken"))
+
+		fileData, err := th.App.generateSupportPacketYaml()
+		require.NotNil(t, fileData)
+		assert.Equal(t, "support_packet.yaml", fileData.Filename)
+		assert.Positive(t, len(fileData.Body))
+		assert.NoError(t, err)
+		var packet model.SupportPacket
+		require.NoError(t, yaml.Unmarshal(fileData.Body, &packet))
+
+		assert.Equal(t, "mock", packet.FileDriver)
+		assert.Equal(t, "FAIL: all broken", packet.FileStatus)
+	})
+
 }
 
 func TestGenerateSupportPacket(t *testing.T) {

--- a/server/platform/shared/filestore/filesstore.go
+++ b/server/platform/shared/filestore/filesstore.go
@@ -23,6 +23,7 @@ type ReadCloseSeeker interface {
 }
 
 type FileBackend interface {
+	Driver() string
 	TestConnection() error
 
 	Reader(path string) (ReadCloseSeeker, error)

--- a/server/platform/shared/filestore/filesstore.go
+++ b/server/platform/shared/filestore/filesstore.go
@@ -23,7 +23,7 @@ type ReadCloseSeeker interface {
 }
 
 type FileBackend interface {
-	Driver() string
+	DriverName() string
 	TestConnection() error
 
 	Reader(path string) (ReadCloseSeeker, error)

--- a/server/platform/shared/filestore/localstore.go
+++ b/server/platform/shared/filestore/localstore.go
@@ -68,7 +68,7 @@ func copyFile(src, dst string) (err error) {
 	return
 }
 
-func (b *LocalFileBackend) Driver() string {
+func (b *LocalFileBackend) DriverName() string {
 	return driverLocal
 }
 

--- a/server/platform/shared/filestore/localstore.go
+++ b/server/platform/shared/filestore/localstore.go
@@ -68,6 +68,10 @@ func copyFile(src, dst string) (err error) {
 	return
 }
 
+func (b *LocalFileBackend) Driver() string {
+	return driverLocal
+}
+
 func (b *LocalFileBackend) TestConnection() error {
 	f := bytes.NewReader([]byte("testingwrite"))
 	if _, err := writeFileLocally(f, filepath.Join(b.directory, TestFilePath)); err != nil {

--- a/server/platform/shared/filestore/mocks/FileBackend.go
+++ b/server/platform/shared/filestore/mocks/FileBackend.go
@@ -57,8 +57,8 @@ func (_m *FileBackend) CopyFile(oldPath string, newPath string) error {
 	return r0
 }
 
-// Driver provides a mock function with given fields:
-func (_m *FileBackend) Driver() string {
+// DriverName provides a mock function with given fields:
+func (_m *FileBackend) DriverName() string {
 	ret := _m.Called()
 
 	var r0 string

--- a/server/platform/shared/filestore/mocks/FileBackend.go
+++ b/server/platform/shared/filestore/mocks/FileBackend.go
@@ -57,6 +57,20 @@ func (_m *FileBackend) CopyFile(oldPath string, newPath string) error {
 	return r0
 }
 
+// Driver provides a mock function with given fields:
+func (_m *FileBackend) Driver() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // FileExists provides a mock function with given fields: path
 func (_m *FileBackend) FileExists(path string) (bool, error) {
 	ret := _m.Called(path)

--- a/server/platform/shared/filestore/s3store.go
+++ b/server/platform/shared/filestore/s3store.go
@@ -184,7 +184,7 @@ func (b *S3FileBackend) s3New(isCloud bool) (*s3.Client, error) {
 	return s3Clnt, nil
 }
 
-func (b *S3FileBackend) Driver() string {
+func (b *S3FileBackend) DriverName() string {
 	return driverS3
 }
 

--- a/server/platform/shared/filestore/s3store.go
+++ b/server/platform/shared/filestore/s3store.go
@@ -184,6 +184,10 @@ func (b *S3FileBackend) s3New(isCloud bool) (*s3.Client, error) {
 	return s3Clnt, nil
 }
 
+func (b *S3FileBackend) Driver() string {
+	return driverS3
+}
+
 func (b *S3FileBackend) TestConnection() error {
 	exists := true
 	var err error

--- a/server/public/model/system.go
+++ b/server/public/model/system.go
@@ -94,6 +94,11 @@ type SupportPacket struct {
 	MasterDbConnections   int    `yaml:"master_db_connections"`
 	ReplicaDbConnections  int    `yaml:"read_db_connections"`
 
+	// File store
+
+	FileDriver string `yaml:"file_driver"`
+	FileStatus string `yaml:"file_status"`
+
 	// LDAP
 
 	LdapVendorName    string `yaml:"ldap_vendor_name,omitempty"`

--- a/server/public/model/system.go
+++ b/server/public/model/system.go
@@ -94,6 +94,10 @@ type SupportPacket struct {
 	MasterDbConnections   int    `yaml:"master_db_connections"`
 	ReplicaDbConnections  int    `yaml:"read_db_connections"`
 
+	// Cluster
+
+	ClusterID string `yaml:"cluster_id"`
+
 	// File store
 
 	FileDriver string `yaml:"file_driver"`

--- a/server/public/model/system.go
+++ b/server/public/model/system.go
@@ -78,31 +78,50 @@ type ServerBusyState struct {
 }
 
 type SupportPacket struct {
-	LicenseTo             string   `yaml:"license_to"`
-	ServerOS              string   `yaml:"server_os"`
-	ServerArchitecture    string   `yaml:"server_architecture"`
-	ServerVersion         string   `yaml:"server_version"`
-	BuildHash             string   `yaml:"build_hash,omitempty"`
-	DatabaseType          string   `yaml:"database_type"`
-	DatabaseVersion       string   `yaml:"database_version"`
-	DatabaseSchemaVersion string   `yaml:"database_schema_version"`
-	LdapVendorName        string   `yaml:"ldap_vendor_name,omitempty"`
-	LdapVendorVersion     string   `yaml:"ldap_vendor_version,omitempty"`
-	ElasticServerVersion  string   `yaml:"elastic_server_version,omitempty"`
-	ElasticServerPlugins  []string `yaml:"elastic_server_plugins,omitempty"`
-	ActiveUsers           int      `yaml:"active_users"`
-	LicenseSupportedUsers int      `yaml:"license_supported_users,omitempty"`
-	TotalChannels         int      `yaml:"total_channels"`
-	TotalPosts            int      `yaml:"total_posts"`
-	TotalTeams            int      `yaml:"total_teams"`
-	DailyActiveUsers      int      `yaml:"daily_active_users"`
-	MonthlyActiveUsers    int      `yaml:"monthly_active_users"`
-	WebsocketConnections  int      `yaml:"websocket_connections"`
-	MasterDbConnections   int      `yaml:"master_db_connections"`
-	ReplicaDbConnections  int      `yaml:"read_db_connections"`
-	InactiveUserCount     int      `yaml:"inactive_user_count"`
+	// Build information
+
+	ServerOS           string `yaml:"server_os"`
+	ServerArchitecture string `yaml:"server_architecture"`
+	ServerVersion      string `yaml:"server_version"`
+	BuildHash          string `yaml:"build_hash,omitempty"`
+
+	// DB
+
+	DatabaseType          string `yaml:"database_type"`
+	DatabaseVersion       string `yaml:"database_version"`
+	DatabaseSchemaVersion string `yaml:"database_schema_version"`
+	WebsocketConnections  int    `yaml:"websocket_connections"`
+	MasterDbConnections   int    `yaml:"master_db_connections"`
+	ReplicaDbConnections  int    `yaml:"read_db_connections"`
+
+	// LDAP
+
+	LdapVendorName    string `yaml:"ldap_vendor_name,omitempty"`
+	LdapVendorVersion string `yaml:"ldap_vendor_version,omitempty"`
+
+	// Elastic Search
+
+	ElasticServerVersion string   `yaml:"elastic_server_version,omitempty"`
+	ElasticServerPlugins []string `yaml:"elastic_server_plugins,omitempty"`
+
+	// License information
+
+	LicenseTo string `yaml:"license_to"`
+
+	LicenseSupportedUsers int `yaml:"license_supported_users,omitempty"`
+
+	// Server stats
+
+	ActiveUsers        int `yaml:"active_users"`
+	DailyActiveUsers   int `yaml:"daily_active_users"`
+	MonthlyActiveUsers int `yaml:"monthly_active_users"`
+	InactiveUserCount  int `yaml:"inactive_user_count"`
+	TotalPosts         int `yaml:"total_posts"`
+	TotalChannels      int `yaml:"total_channels"`
+	TotalTeams         int `yaml:"total_teams"`
 
 	// Jobs
+
 	DataRetentionJobs          []*Job `yaml:"data_retention_jobs"`
 	MessageExportJobs          []*Job `yaml:"message_export_jobs"`
 	ElasticPostIndexingJobs    []*Job `yaml:"elastic_post_indexing_jobs"`

--- a/server/public/model/system.go
+++ b/server/public/model/system.go
@@ -78,14 +78,14 @@ type ServerBusyState struct {
 }
 
 type SupportPacket struct {
-	// Build information
+	/* Build information */
 
 	ServerOS           string `yaml:"server_os"`
 	ServerArchitecture string `yaml:"server_architecture"`
 	ServerVersion      string `yaml:"server_version"`
 	BuildHash          string `yaml:"build_hash,omitempty"`
 
-	// DB
+	/* DB */
 
 	DatabaseType          string `yaml:"database_type"`
 	DatabaseVersion       string `yaml:"database_version"`
@@ -94,32 +94,31 @@ type SupportPacket struct {
 	MasterDbConnections   int    `yaml:"master_db_connections"`
 	ReplicaDbConnections  int    `yaml:"read_db_connections"`
 
-	// Cluster
+	/* Cluster */
 
 	ClusterID string `yaml:"cluster_id"`
 
-	// File store
+	/* File store */
 
 	FileDriver string `yaml:"file_driver"`
 	FileStatus string `yaml:"file_status"`
 
-	// LDAP
+	/* LDAP */
 
 	LdapVendorName    string `yaml:"ldap_vendor_name,omitempty"`
 	LdapVendorVersion string `yaml:"ldap_vendor_version,omitempty"`
 
-	// Elastic Search
+	/* Elastic Search */
 
 	ElasticServerVersion string   `yaml:"elastic_server_version,omitempty"`
 	ElasticServerPlugins []string `yaml:"elastic_server_plugins,omitempty"`
 
-	// License information
+	/* License */
 
-	LicenseTo string `yaml:"license_to"`
+	LicenseTo             string `yaml:"license_to"`
+	LicenseSupportedUsers int    `yaml:"license_supported_users,omitempty"`
 
-	LicenseSupportedUsers int `yaml:"license_supported_users,omitempty"`
-
-	// Server stats
+	/* Server stats */
 
 	ActiveUsers        int `yaml:"active_users"`
 	DailyActiveUsers   int `yaml:"daily_active_users"`
@@ -129,7 +128,7 @@ type SupportPacket struct {
 	TotalChannels      int `yaml:"total_channels"`
 	TotalTeams         int `yaml:"total_teams"`
 
-	// Jobs
+	/* Jobs */
 
 	DataRetentionJobs          []*Job `yaml:"data_retention_jobs"`
 	MessageExportJobs          []*Job `yaml:"message_export_jobs"`


### PR DESCRIPTION
#### Summary
6dbb6d2a02aa815eaec534b6c3d241788ba581d6 adds two pieces of information about the file storage to the support package: `file_driver`, which contains the driver type, and `file_status`, which contains status information about the file store. That should make it easier to spot if the file store is misconfigured.


51bbfc9cdfe881cd8acdd389e55e31d015fc0250 orders the fields in the support package by type, which makes it easier to read the information.

f789c67404413a7f5889535c99acd2e2fed0dc4d adds the cluster ID. This allows the matching of multiple support packages to the nodes. 

![Screenshot from 2023-09-05 14-37-51](https://github.com/mattermost/mattermost/assets/16541325/906c5e98-099c-4236-9928-db10f69f86b5)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54318

#### Release Note
```release-note
Add file storage information to support package
```
