### PR TITLE
#WIP: Show elastic search version in about box

### DIFF
--- a/server/channels/app/platform/config.go
+++ b/server/channels/app/platform/config.go
@@ -336,6 +336,10 @@ func (ps *PlatformService) ClientConfigWithComputed() map[string]string {
 		respCfg["SchemaVersion"] = strconv.Itoa(ver)
 	}
 
+	if ps.SearchEngine.ElasticsearchEngine != nil {
+		respCfg["ElasticSearchVersion"] = ps.SearchEngine.ElasticsearchEngine.GetFullVersion()
+	}
+
 	return respCfg
 }
 

--- a/webapp/channels/src/components/about_build_modal/about_build_modal.tsx
+++ b/webapp/channels/src/components/about_build_modal/about_build_modal.tsx
@@ -254,6 +254,15 @@ export default class AboutBuildModal extends React.PureComponent<Props, State> {
                                     />
                                     {'\u00a0' + config.SQLDriverName}
                                 </div>
+                                <div data-testid='aboutElasticSearchVersion' hidden={config.ElasticSearchVersion == ""}>
+                                    <FormattedMessage
+                                        id='about.esversion'
+                                        defaultMessage='Elasticsearch Version:'
+                                    />
+                                    <span id='versionString'>
+                                        {'\u00a0' + config.ElasticSearchVersion}
+                                    </span>
+                                </div>
                             </div>
                             {licensee}
                         </div>

--- a/webapp/platform/types/src/config.ts
+++ b/webapp/platform/types/src/config.ts
@@ -40,6 +40,7 @@ export type ClientConfig = {
     DiagnosticId: string;
     DiagnosticsEnabled: string;
     DisableRefetchingOnBrowserFocus: string;
+    ElasticSearchVersion: string;
     EmailLoginButtonBorderColor: string;
     EmailLoginButtonColor: string;
     EmailLoginButtonTextColor: string;


### PR DESCRIPTION
#### Summary
Displays the current ElasticSearch version in the about box if the search engine is enabled

#### Ticket Link
--

#### Screenshots
![Screenshot 2023-09-01 at 14 22 46](https://github.com/mattermost/mattermost/assets/812088/8ef3008e-88dc-4d2f-9480-6ccd066982d5)

#### Release Note

-->
```release-note

```
