### PR TITLE
Add CPU profile to support package

### DIFF
--- a/server/channels/app/support_packet_test.go
+++ b/server/channels/app/support_packet_test.go
@@ -69,7 +69,7 @@ func TestGenerateSupportPacket(t *testing.T) {
 
 	fileDatas := th.App.GenerateSupportPacket()
 	var rFileNames []string
-	testFiles := []string{"support_packet.yaml", "plugins.json", "sanitized_config.json", "mattermost.log", "notifications.log"}
+	testFiles := []string{"support_packet.yaml", "plugins.json", "sanitized_config.json", "mattermost.log", "notifications.log", "cpu.prof"}
 	for _, fileData := range fileDatas {
 		require.NotNil(t, fileData)
 		assert.Positive(t, len(fileData.Body))
@@ -84,7 +84,7 @@ func TestGenerateSupportPacket(t *testing.T) {
 	err = os.Remove("mattermost.log")
 	require.NoError(t, err)
 	fileDatas = th.App.GenerateSupportPacket()
-	testFiles = []string{"support_packet.yaml", "plugins.json", "sanitized_config.json", "warning.txt"}
+	testFiles = []string{"support_packet.yaml", "plugins.json", "sanitized_config.json", "warning.txt", "cpu.prof"}
 	rFileNames = nil
 	for _, fileData := range fileDatas {
 		require.NotNil(t, fileData)


### PR DESCRIPTION
#### Summary
Add the CPU profile to the support package which makes it easier to debug performance issues.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54290

#### Screenshots
![Screenshot from 2023-09-05 14-46-57](https://github.com/mattermost/mattermost/assets/16541325/c4717189-9d43-4450-aca2-6f5b8415f441)

#### Release Note
```release-note
Add CPU profile to support package
```
