### PR TITLE
[MM-54402] Change protocol transform method for Desktop Auth to be compliant with web standards

### DIFF
--- a/webapp/channels/src/components/desktop_auth_token.tsx
+++ b/webapp/channels/src/components/desktop_auth_token.tsx
@@ -85,13 +85,12 @@ const DesktopAuthToken: React.FC<Props> = ({href, onLogin}: Props) => {
 
     const forwardToDesktopApp = () => {
         const url = new URL(window.location.href);
+        let protocol = 'mattermost';
         if (url.searchParams.get('isDesktopDev')) {
-            url.protocol = 'mattermost-dev';
-        } else {
-            url.protocol = 'mattermost';
+            protocol = 'mattermost-dev';
         }
 
-        window.location.href = url.toString();
+        window.location.href = url.toString().replace(url.protocol, `${protocol}:`);
     };
 
     useEffect(() => {


### PR DESCRIPTION
#### Summary
Firefox revealed an issue with how we are changing the protocol of the current `href` to the `mattermost` protocol to be opened in the Desktop App. Normally, the `protocol` field of the `URL` object isn't supposed to be mutable, but Chrome (and presumably other WebKit-based browsers) allows this.

This PR changes to a solution that should be more compliant and should avoid the issue for Firefox users.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54402

```release-note
NONE
```
