### PR TITLE
MM-54443 - Fix: registerDesktopNotificationHook is missing

### DIFF
--- a/webapp/channels/src/plugins/registry.ts
+++ b/webapp/channels/src/plugins/registry.ts
@@ -1177,4 +1177,52 @@ export default class PluginRegistry {
             data,
         });
     });
+
+    // Register a hook to intercept desktop notifications before they occur.
+    // Accepts a function to run before the desktop notification is triggered.
+    // The function has the following signature:
+    //   (post: Post, msgProps: NewPostMessageProps, channel: Channel,
+    //    teamId: string, args: DesktopNotificationArgs) => Promise<{
+    //         error?: string;
+    //         args?: DesktopNotificationArgs;
+    //     }>)
+    //
+    // DesktopNotificationArgs is the following type:
+    //   export type DesktopNotificationArgs = {
+    //     title: string;
+    //     body: string;
+    //     silent: boolean;
+    //     soundName: string;
+    //     url: string;
+    //     notify: boolean;
+    // };
+    //
+    // To stop a desktop notification and allow subsequent hooks to process the notification, return:
+    //   {args: {...args, notify: false}}
+    // To enable a desktop notification and allow subsequent hooks to process the notification, return:
+    //   {args: {...args, notify: true}}
+    // To stop a desktop notification and prevent subsequent hooks from processing the notification, return either:
+    //   {error: 'log this error'}, or {}
+    // To allow subsequent hooks to process the notification, return:
+    //   {args}, or null or undefined (thanks js)
+    //
+    // The args returned by the hook will be used as the args for the next hook, until all hooks are
+    // completed. The resulting args will be used as the arguments for the `notifyMe` function.
+    //
+    // Returns a unique identifier.
+    registerDesktopNotificationHook = reArg(['hook'], ({hook}) => {
+        const id = generateId();
+
+        store.dispatch({
+            type: ActionTypes.RECEIVED_PLUGIN_COMPONENT,
+            name: 'DesktopNotificationHooks',
+            data: {
+                id,
+                pluginId: this.id,
+                hook,
+            },
+        });
+
+        return id;
+    });
 }


### PR DESCRIPTION
#### Summary
- Part of the PR https://github.com/mattermost/mattermost-plugin-calls/pull/452 was accidentally removed by https://github.com/mattermost/mattermost/pull/23952
- This PR replaces what was removed
- @amyblais I'm not certain if any of the on-prem MM versions were shipped with this missing... But I hope this can be cherry picked into cloud and whatever necessary.

#### Ticket Link


#### Release Note
```release-note
NONE
```
