### PR TITLE
Revert "MM-53879: Fix recursive loading of license"

### DIFF
--- a/server/channels/api4/system.go
+++ b/server/channels/api4/system.go
@@ -319,7 +319,11 @@ func invalidateCaches(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c.App.Srv().InvalidateAllCaches()
+	appErr := c.App.Srv().InvalidateAllCaches()
+	if appErr != nil {
+		c.Err = appErr
+		return
+	}
 
 	auditRec.Success()
 

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -3909,7 +3909,8 @@ func TestLoginWithLag(t *testing.T) {
 		_, _, err := th.Client.Login(context.Background(), th.BasicUser.Email, th.BasicUser.Password)
 		require.NoError(t, err)
 
-		th.App.Srv().InvalidateAllCaches()
+		appErr = th.App.Srv().InvalidateAllCaches()
+		require.Nil(t, appErr)
 
 		session, appErr := th.App.GetSession(th.Client.AuthToken)
 		require.Nil(t, appErr)

--- a/server/channels/app/admin.go
+++ b/server/channels/app/admin.go
@@ -137,8 +137,8 @@ func (a *App) GetClusterStatus() []*model.ClusterInfo {
 	return infos
 }
 
-func (s *Server) InvalidateAllCaches() {
-	s.platform.InvalidateAllCaches()
+func (s *Server) InvalidateAllCaches() *model.AppError {
+	return s.platform.InvalidateAllCaches()
 }
 
 func (s *Server) InvalidateAllCachesSkipSend() {

--- a/server/channels/app/license.go
+++ b/server/channels/app/license.go
@@ -131,6 +131,10 @@ func (s *Server) License() *model.License {
 	return s.platform.License()
 }
 
+func (s *Server) LoadLicense() {
+	s.platform.LoadLicense()
+}
+
 func (s *Server) SaveLicense(licenseBytes []byte) (*model.License, *model.AppError) {
 	return s.platform.SaveLicense(licenseBytes)
 }

--- a/server/channels/app/license_test.go
+++ b/server/channels/app/license_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-package platform
+package app
 
 import (
 	"testing"
@@ -16,8 +16,8 @@ func TestLoadLicense(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()
 
-	th.Service.LoadLicense()
-	require.Nil(t, th.Service.License(), "shouldn't have a valid license")
+	th.App.Srv().LoadLicense()
+	require.Nil(t, th.App.Srv().License(), "shouldn't have a valid license")
 }
 
 func TestSaveLicense(t *testing.T) {
@@ -26,7 +26,7 @@ func TestSaveLicense(t *testing.T) {
 
 	b1 := []byte("junk")
 
-	_, err := th.Service.SaveLicense(b1)
+	_, err := th.App.Srv().SaveLicense(b1)
 	require.NotNil(t, err, "shouldn't have saved license")
 }
 
@@ -34,7 +34,7 @@ func TestRemoveLicense(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()
 
-	err := th.Service.RemoveLicense()
+	err := th.App.Srv().RemoveLicense()
 	require.Nil(t, err, "should have removed license")
 }
 
@@ -47,7 +47,7 @@ func TestSetLicense(t *testing.T) {
 	l1.Customer = &model.Customer{}
 	l1.StartsAt = model.GetMillis() - 1000
 	l1.ExpiresAt = model.GetMillis() + 100000
-	ok := th.Service.SetLicense(l1)
+	ok := th.App.Srv().SetLicense(l1)
 	require.True(t, ok, "license should have worked")
 
 	l3 := &model.License{}
@@ -55,7 +55,7 @@ func TestSetLicense(t *testing.T) {
 	l3.Customer = &model.Customer{}
 	l3.StartsAt = model.GetMillis() + 10000
 	l3.ExpiresAt = model.GetMillis() + 100000
-	ok = th.Service.SetLicense(l3)
+	ok = th.App.Srv().SetLicense(l3)
 	require.True(t, ok, "license should have passed")
 }
 
@@ -65,7 +65,7 @@ func TestGetSanitizedClientLicense(t *testing.T) {
 
 	setLicense(th, nil)
 
-	m := th.Service.GetSanitizedClientLicense()
+	m := th.App.Srv().GetSanitizedClientLicense()
 
 	_, ok := m["Name"]
 	assert.False(t, ok)
@@ -79,14 +79,14 @@ func TestGenerateRenewalToken(t *testing.T) {
 
 	t.Run("renewal token generated correctly", func(t *testing.T) {
 		setLicense(th, nil)
-		token, appErr := th.Service.GenerateRenewalToken(JWTDefaultTokenExpiration)
+		token, appErr := th.App.Srv().GenerateRenewalToken(JWTDefaultTokenExpiration)
 		require.Nil(t, appErr)
 		require.NotEmpty(t, token)
 	})
 
 	t.Run("return error if there is no active license", func(t *testing.T) {
-		th.Service.SetLicense(nil)
-		_, appErr := th.Service.GenerateRenewalToken(JWTDefaultTokenExpiration)
+		th.App.Srv().SetLicense(nil)
+		_, appErr := th.App.Srv().GenerateRenewalToken(JWTDefaultTokenExpiration)
 		require.NotNil(t, appErr)
 	})
 }
@@ -105,5 +105,5 @@ func setLicense(th *TestHelper, customer *model.Customer) {
 	l1.SkuShortName = "SKU SHORT NAME"
 	l1.StartsAt = model.GetMillis() - 1000
 	l1.ExpiresAt = model.GetMillis() + 100000
-	th.Service.SetLicense(l1)
+	th.App.Srv().SetLicense(l1)
 }

--- a/server/channels/app/notification_test.go
+++ b/server/channels/app/notification_test.go
@@ -99,7 +99,8 @@ func TestSendNotifications(t *testing.T) {
 
 	_, appErr = th.App.UpdateActive(th.Context, th.BasicUser2, false)
 	require.Nil(t, appErr)
-	th.App.Srv().InvalidateAllCaches()
+	appErr = th.App.Srv().InvalidateAllCaches()
+	require.Nil(t, appErr)
 
 	post3, appErr := th.App.CreatePostMissingChannel(th.Context, &model.Post{
 		UserId:    th.BasicUser.Id,

--- a/server/channels/app/oauth.go
+++ b/server/channels/app/oauth.go
@@ -113,7 +113,9 @@ func (a *App) DeleteOAuthApp(appID string) *model.AppError {
 		return model.NewAppError("DeleteOAuthApp", "app.oauth.delete_app.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
-	a.Srv().InvalidateAllCaches()
+	if err := a.Srv().InvalidateAllCaches(); err != nil {
+		mlog.Warn("error in invalidating cache", mlog.Err(err))
+	}
 
 	return nil
 }

--- a/server/channels/app/platform/cluster_handlers.go
+++ b/server/channels/app/platform/cluster_handlers.go
@@ -17,7 +17,6 @@ func (ps *PlatformService) RegisterClusterHandlers() {
 	ps.clusterIFace.RegisterClusterMessageHandler(model.ClusterEventPublish, ps.ClusterPublishHandler)
 	ps.clusterIFace.RegisterClusterMessageHandler(model.ClusterEventUpdateStatus, ps.ClusterUpdateStatusHandler)
 	ps.clusterIFace.RegisterClusterMessageHandler(model.ClusterEventInvalidateAllCaches, ps.ClusterInvalidateAllCachesHandler)
-	ps.clusterIFace.RegisterClusterMessageHandler(model.ClusterEventLoadLicense, ps.LoadLicenseClusterHandler)
 	ps.clusterIFace.RegisterClusterMessageHandler(model.ClusterEventInvalidateCacheForChannelMembersNotifyProps, ps.clusterInvalidateCacheForChannelMembersNotifyPropHandler)
 	ps.clusterIFace.RegisterClusterMessageHandler(model.ClusterEventInvalidateCacheForChannelByName, ps.clusterInvalidateCacheForChannelByNameHandler)
 	ps.clusterIFace.RegisterClusterMessageHandler(model.ClusterEventInvalidateCacheForUser, ps.clusterInvalidateCacheForUserHandler)
@@ -155,27 +154,10 @@ func (ps *PlatformService) InvalidateAllCachesSkipSend() {
 	ps.Store.Webhook().ClearCaches()
 
 	linkCache.Purge()
+	ps.LoadLicense()
 }
 
-func (ps *PlatformService) LoadLicenseClusterHandler(_ *model.ClusterMessage) {
-	ps.loadLicense()
-}
-
-func (ps *PlatformService) TriggerLoadLicense() {
-	ps.loadLicense()
-
-	if ps.clusterIFace != nil {
-		msg := &model.ClusterMessage{
-			Event:            model.ClusterEventLoadLicense,
-			SendType:         model.ClusterSendReliable,
-			WaitForAllToSend: true,
-		}
-
-		ps.clusterIFace.SendClusterMessage(msg)
-	}
-}
-
-func (ps *PlatformService) InvalidateAllCaches() {
+func (ps *PlatformService) InvalidateAllCaches() *model.AppError {
 	ps.InvalidateAllCachesSkipSend()
 
 	if ps.clusterIFace != nil {
@@ -188,4 +170,6 @@ func (ps *PlatformService) InvalidateAllCaches() {
 
 		ps.clusterIFace.SendClusterMessage(msg)
 	}
+
+	return nil
 }

--- a/server/channels/app/platform/license.go
+++ b/server/channels/app/platform/license.go
@@ -46,7 +46,7 @@ func (ps *PlatformService) License() *model.License {
 	return ps.licenseValue.Load()
 }
 
-func (ps *PlatformService) loadLicense() {
+func (ps *PlatformService) LoadLicense() {
 	// ENV var overrides all other sources of license.
 	licenseStr := os.Getenv(LicenseEnv)
 	if licenseStr != "" {
@@ -325,6 +325,9 @@ func (ps *PlatformService) RequestTrialLicense(trialRequest *model.TrialLicenseR
 	if _, err := ps.SaveLicense([]byte(licenseResponse["license"])); err != nil {
 		return err
 	}
+
+	ps.ReloadConfig()
+	ps.InvalidateAllCaches()
 
 	return nil
 }

--- a/server/channels/app/platform/service.go
+++ b/server/channels/app/platform/service.go
@@ -292,7 +292,7 @@ func New(sc ServiceConfig, options ...Option) (*PlatformService, error) {
 
 	// Step 7: Init License
 	if model.BuildEnterpriseReady == "true" {
-		ps.TriggerLoadLicense()
+		ps.LoadLicense()
 	}
 
 	// Step 8: Init Metrics Server depends on step 6 (store) and 7 (license)
@@ -353,7 +353,9 @@ func (ps *PlatformService) Start() error {
 		message := model.NewWebSocketEvent(model.WebsocketEventConfigChanged, "", "", "", nil, "")
 
 		message.Add("config", ps.ClientConfigWithComputed())
-		ps.Publish(message)
+		ps.Go(func() {
+			ps.Publish(message)
+		})
 
 		if err := ps.ReconfigureLogger(); err != nil {
 			mlog.Error("Error re-configuring logging after config change", mlog.Err(err))
@@ -366,7 +368,9 @@ func (ps *PlatformService) Start() error {
 
 		message := model.NewWebSocketEvent(model.WebsocketEventLicenseChanged, "", "", "", nil, "")
 		message.Add("license", ps.GetSanitizedClientLicense())
-		ps.Publish(message)
+		ps.Go(func() {
+			ps.Publish(message)
+		})
 
 	})
 	return nil

--- a/server/cmd/mattermost/commands/init.go
+++ b/server/cmd/mattermost/commands/init.go
@@ -49,6 +49,10 @@ func initDBCommandContext(configDSN string, readOnlyConfigStore bool, options ..
 
 	a := app.New(app.ServerConnector(s.Channels()))
 
+	if model.BuildEnterpriseReady == "true" {
+		a.Srv().LoadLicense()
+	}
+
 	return a, nil
 }
 

--- a/server/cmd/mattermost/commands/jobserver.go
+++ b/server/cmd/mattermost/commands/jobserver.go
@@ -41,6 +41,8 @@ func jobserverCmdF(command *cobra.Command, args []string) error {
 	}
 	defer a.Srv().Shutdown()
 
+	a.Srv().LoadLicense()
+
 	// Run jobs
 	mlog.Info("Starting Mattermost job server")
 	defer mlog.Info("Stopped Mattermost job server")

--- a/server/public/model/cluster_message.go
+++ b/server/public/model/cluster_message.go
@@ -9,7 +9,6 @@ const (
 	ClusterEventPublish                                     ClusterEvent = "publish"
 	ClusterEventUpdateStatus                                ClusterEvent = "update_status"
 	ClusterEventInvalidateAllCaches                         ClusterEvent = "inv_all_caches"
-	ClusterEventLoadLicense                                 ClusterEvent = "load_license"
 	ClusterEventInvalidateCacheForReactions                 ClusterEvent = "inv_reactions"
 	ClusterEventInvalidateCacheForChannelMembersNotifyProps ClusterEvent = "inv_channel_members_notify_props"
 	ClusterEventInvalidateCacheForChannelByName             ClusterEvent = "inv_channel_name"


### PR DESCRIPTION
Reverts mattermost/mattermost#24200

The PR missed testing in HA scenarios and introduced a regression. Reverting for now.

@agarciamontoro - We can probably pin to the exact version of 8.1 you are using to prevent regressing to the old behavior again.

https://mattermost.atlassian.net/browse/MM-54442