### PR TITLE
Fix race in JobServer.HandleJobPanic 

### DIFF
--- a/server/public/model/job.go
+++ b/server/public/model/job.go
@@ -134,6 +134,10 @@ func (j *Job) InitLogger(logger mlog.LoggerIFace) {
 	)
 }
 
+func (j *Job) LogClone() interface{} {
+	return j.Auditable()
+}
+
 type Worker interface {
 	Run()
 	Stop()

--- a/server/public/model/job.go
+++ b/server/public/model/job.go
@@ -134,7 +134,7 @@ func (j *Job) InitLogger(logger mlog.LoggerIFace) {
 	)
 }
 
-func (j *Job) LogClone() interface{} {
+func (j *Job) LogClone() any {
 	return j.Auditable()
 }
 


### PR DESCRIPTION
#### Summary
Fixes a race in `JobServer.HandleJobPanic` by implementing `mlog.LogCloner` in `model.Job`

See https://community.mattermost.com/core/pl/99jzw5wdiirxxjwg397zdsxauo

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
