### PR TITLE
[MM-53429] Add endpoint to fetch followed thread ids per team, remove use of post metadata to check if thread is followed

### DIFF
--- a/server/channels/app/app_iface.go
+++ b/server/channels/app/app_iface.go
@@ -655,6 +655,7 @@ type AppIface interface {
 	GetFlaggedPosts(userID string, offset int, limit int) (*model.PostList, *model.AppError)
 	GetFlaggedPostsForChannel(userID, channelID string, offset int, limit int) (*model.PostList, *model.AppError)
 	GetFlaggedPostsForTeam(userID, teamID string, offset int, limit int) (*model.PostList, *model.AppError)
+	GetFollowedPostIdsForUser(userID, teamID string) ([]string, error)
 	GetGlobalRetentionPolicy() (*model.GlobalRetentionPolicy, *model.AppError)
 	GetGroup(id string, opts *model.GetGroupOpts, viewRestrictions *model.ViewUsersRestrictions) (*model.Group, *model.AppError)
 	GetGroupByName(name string, opts model.GroupSearchOpts) (*model.Group, *model.AppError)

--- a/server/channels/app/opentracing/opentracing_layer.go
+++ b/server/channels/app/opentracing/opentracing_layer.go
@@ -6468,6 +6468,28 @@ func (a *OpenTracingAppLayer) GetFlaggedPostsForTeam(userID string, teamID strin
 	return resultVar0, resultVar1
 }
 
+func (a *OpenTracingAppLayer) GetFollowedPostIdsForUser(userID string, teamID string) ([]string, error) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetFollowedPostIdsForUser")
+
+	a.ctx = newCtx
+	a.app.Srv().Store().SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store().SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := a.app.GetFollowedPostIdsForUser(userID, teamID)
+
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
 func (a *OpenTracingAppLayer) GetGlobalRetentionPolicy() (*model.GlobalRetentionPolicy, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetGlobalRetentionPolicy")

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -1984,6 +1984,10 @@ func (a *App) GetThreadMembershipsForUser(userID, teamID string) ([]*model.Threa
 	return a.Srv().Store().Thread().GetMembershipsForUser(userID, teamID)
 }
 
+func (a *App) GetFollowedPostIdsForUser(userID, teamID string) ([]string, error) {
+	return a.Srv().Store().Thread().GetFollowedPostIdsForUser(userID, teamID)
+}
+
 func (a *App) GetPostIfAuthorized(c request.CTX, postID string, session *model.Session, includeDeleted bool) (*model.Post, *model.AppError) {
 	post, err := a.GetSinglePost(postID, includeDeleted)
 	if err != nil {

--- a/server/channels/store/opentracinglayer/opentracinglayer.go
+++ b/server/channels/store/opentracinglayer/opentracinglayer.go
@@ -10287,6 +10287,24 @@ func (s *OpenTracingLayerThreadStore) Get(id string) (*model.Thread, error) {
 	return result, err
 }
 
+func (s *OpenTracingLayerThreadStore) GetFollowedPostIdsForUser(userId string, teamId string) ([]string, error) {
+	origCtx := s.Root.Store.Context()
+	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ThreadStore.GetFollowedPostIdsForUser")
+	s.Root.Store.SetContext(newCtx)
+	defer func() {
+		s.Root.Store.SetContext(origCtx)
+	}()
+
+	defer span.Finish()
+	result, err := s.ThreadStore.GetFollowedPostIdsForUser(userId, teamId)
+	if err != nil {
+		span.LogFields(spanlog.Error(err))
+		ext.Error.Set(span, true)
+	}
+
+	return result, err
+}
+
 func (s *OpenTracingLayerThreadStore) GetMembershipForUser(userId string, postID string) (*model.ThreadMembership, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ThreadStore.GetMembershipForUser")

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -11752,6 +11752,27 @@ func (s *RetryLayerThreadStore) Get(id string) (*model.Thread, error) {
 
 }
 
+func (s *RetryLayerThreadStore) GetFollowedPostIdsForUser(userId string, teamId string) ([]string, error) {
+
+	tries := 0
+	for {
+		result, err := s.ThreadStore.GetFollowedPostIdsForUser(userId, teamId)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerThreadStore) GetMembershipForUser(userId string, postID string) (*model.ThreadMembership, error) {
 
 	tries := 0

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -335,6 +335,7 @@ type ThreadStore interface {
 	UpdateMembership(membership *model.ThreadMembership) (*model.ThreadMembership, error)
 	GetMembershipsForUser(userId, teamID string) ([]*model.ThreadMembership, error)
 	GetMembershipForUser(userId, postID string) (*model.ThreadMembership, error)
+	GetFollowedPostIdsForUser(userId, teamId string) ([]string, error)
 	DeleteMembershipForUser(userId, postID string) error
 	MaintainMembership(userID, postID string, opts ThreadMembershipOpts) (*model.ThreadMembership, error)
 	PermanentDeleteBatchForRetentionPolicies(now, globalPolicyEndTime, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)

--- a/server/channels/store/storetest/mocks/ThreadStore.go
+++ b/server/channels/store/storetest/mocks/ThreadStore.go
@@ -93,6 +93,32 @@ func (_m *ThreadStore) Get(id string) (*model.Thread, error) {
 	return r0, r1
 }
 
+// GetFollowedPostIdsForUser provides a mock function with given fields: userId, teamId
+func (_m *ThreadStore) GetFollowedPostIdsForUser(userId string, teamId string) ([]string, error) {
+	ret := _m.Called(userId, teamId)
+
+	var r0 []string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, string) ([]string, error)); ok {
+		return rf(userId, teamId)
+	}
+	if rf, ok := ret.Get(0).(func(string, string) []string); ok {
+		r0 = rf(userId, teamId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(userId, teamId)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetMembershipForUser provides a mock function with given fields: userId, postID
 func (_m *ThreadStore) GetMembershipForUser(userId string, postID string) (*model.ThreadMembership, error) {
 	ret := _m.Called(userId, postID)

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -9261,6 +9261,22 @@ func (s *TimerLayerThreadStore) Get(id string) (*model.Thread, error) {
 	return result, err
 }
 
+func (s *TimerLayerThreadStore) GetFollowedPostIdsForUser(userId string, teamId string) ([]string, error) {
+	start := time.Now()
+
+	result, err := s.ThreadStore.GetFollowedPostIdsForUser(userId, teamId)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("ThreadStore.GetFollowedPostIdsForUser", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerThreadStore) GetMembershipForUser(userId string, postID string) (*model.ThreadMembership, error) {
 	start := time.Now()
 

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -1966,6 +1966,10 @@
     "translation": "Unable to write the file."
   },
   {
+    "id": "api.getFollowedPostIdsForUser.error",
+    "translation": "Unable to get followed post ids"
+  },
+  {
     "id": "api.getThreadsForUser.bad_only_params",
     "translation": "OnlyThreads and OnlyTotals parameters to getThreadsForUser are mutually exclusive"
   },

--- a/webapp/channels/src/components/threading/global_threads_link/global_threads_link.tsx
+++ b/webapp/channels/src/components/threading/global_threads_link/global_threads_link.tsx
@@ -9,7 +9,7 @@ import {Link, useRouteMatch, useLocation, matchPath} from 'react-router-dom';
 
 import {PulsatingDot} from '@mattermost/components';
 
-import {getThreadCounts} from 'mattermost-redux/actions/threads';
+import {getFollowedThreads, getThreadCounts} from 'mattermost-redux/actions/threads';
 import {getInt, isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {
     getThreadCountsInCurrentTeam, getThreadsInCurrentTeam,
@@ -80,6 +80,7 @@ const GlobalThreadsLink = () => {
         // load counts if necessary
         if (isFeatureEnabled) {
             dispatch(getThreadCounts(currentUserId, currentTeamId));
+            dispatch(getFollowedThreads(currentUserId, currentTeamId));
         }
     }, [currentUserId, currentTeamId, isFeatureEnabled]);
 

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/threads.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/threads.ts
@@ -111,6 +111,23 @@ export function getThreadCounts(userId: string, teamId: string) {
     };
 }
 
+export function getFollowedThreads(userId: string, teamId: string) {
+    return async (dispatch: DispatchFunc) => {
+        let ids: string[];
+
+        try {
+            ids = await Client4.getFollowedPostIdsForUser(userId, teamId);
+        } catch (error) {
+            dispatch(logError(error));
+            return {error};
+        }
+
+        ids.forEach((id) => handleFollowChanged(dispatch, id, teamId, true));
+
+        return {data: ids};
+    };
+}
+
 export function getCountsAndThreadsSince(userId: string, teamId: string, since?: number) {
     return async (dispatch: DispatchFunc) => {
         const response = await dispatch(fetchThreads(userId, teamId, {since, totalsOnly: false, threadsOnly: false, extended: true}));

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/index.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/index.ts
@@ -66,11 +66,6 @@ export const threadsReducer = (state: ThreadsState['threads'] = {}, action: Gene
     }
     case ThreadTypes.FOLLOW_CHANGED_THREAD: {
         const {id, following} = action.data;
-
-        if (!state[id]) {
-            return state;
-        }
-
         return {
             ...state,
             [id]: {

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/threads.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/threads.ts
@@ -94,7 +94,7 @@ export function makeGetThreadOrSynthetic(): (state: GlobalState, rootPost: Post)
                 reply_count: rootPost.reply_count,
                 participants: rootPost.participants,
                 last_reply_at: rootPost.last_reply_at ?? 0,
-                is_following: thread?.is_following ?? rootPost.is_following ?? null,
+                is_following: thread?.is_following ?? false,
                 post: {
                     user_id: rootPost.user_id,
                     channel_id: rootPost.channel_id,

--- a/webapp/platform/client/src/client4.ts
+++ b/webapp/platform/client/src/client4.ts
@@ -2074,6 +2074,13 @@ export default class Client4 {
         );
     };
 
+    getFollowedPostIdsForUser = (userId: UserProfile['id'] = 'me', teamId: Team['id']) => {
+        return this.doFetch<string[]>(
+            `${this.getUserThreadsRoute(userId, teamId)}/following`,
+            {method: 'get'}
+        );
+    };
+
     updateThreadReadForUser = (userId: string, teamId: string, threadId: string, timestamp: number) => {
         const url = `${this.getUserThreadRoute(userId, teamId, threadId)}/read/${timestamp}`;
         return this.doFetch<UserThread>(


### PR DESCRIPTION
#### Summary
When viewing a channel, a user can click on a thread and hit Follow, but if the page is refreshed the user's following status will not be shown. This is being caused by the fact that we are caching existing posts, and the post metadata which contains the `is_following` flag is also cached. So if no new posts were created, or nothing else is done to invalidate that cache, we will never get a new value.

This PR adds a new endpoint: `getFollowedThreadIdsForUser`, that specifically checks the `ThreadMemberships` table upon each page load and gets the up to date `Following` flag, so that the data shown to the user is accurate. We also drop reliance on the post metadata since it can't be trusted for this case.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53429

```release-note
Fixed an issue where the Following status of a thread may not be accurate after a page refresh.
```
