### PR TITLE
fix TestGetServiceEnvironment

### DIFF
--- a/server/public/model/service_environment_test.go
+++ b/server/public/model/service_environment_test.go
@@ -16,15 +16,13 @@ import (
 // semantics at the unit test level. Validating the default, enterprise service environment is left
 // to smoketests before releasing.
 func TestGetServiceEnvironment(t *testing.T) {
-	t.Run("no env defaults to test (without production tag)", func(t *testing.T) {
-		t.Skip("https://mattermost.atlassian.net/browse/MM-54197")
-		require.Equal(t, model.ServiceEnvironmentTest, model.GetServiceEnvironment())
+	t.Run("no env defaults to dev (without production tag)", func(t *testing.T) {
+		require.Equal(t, model.ServiceEnvironmentDev, model.GetServiceEnvironment())
 	})
-	t.Run("empty string defaults to test (without production tag)", func(t *testing.T) {
-		t.Skip("https://mattermost.atlassian.net/browse/MM-54197")
+	t.Run("empty string defaults to dev (without production tag)", func(t *testing.T) {
 		os.Setenv("MM_SERVICEENVIRONMENT", "")
 		defer os.Unsetenv("MM_SERVICEENVIRONMENT")
-		require.Equal(t, model.ServiceEnvironmentTest, model.GetServiceEnvironment())
+		require.Equal(t, model.ServiceEnvironmentDev, model.GetServiceEnvironment())
 	})
 	t.Run("production", func(t *testing.T) {
 		os.Setenv("MM_SERVICEENVIRONMENT", "production")


### PR DESCRIPTION
#### Summary
A late change to the service environment functionality had us defaulting to `dev` instead of `test` without the `production` build tag. Unfortunately, because these tests were unintentionally being skipped within the submodule, the failure wasn't caught at the time. A simple update addresses the unit tests.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-54197

#### Release Note
```release-note
NONE
```
