### PR TITLE
Fix logger panic in migration scheduler

### DIFF
--- a/server/channels/jobs/migrations/scheduler.go
+++ b/server/channels/jobs/migrations/scheduler.go
@@ -74,7 +74,12 @@ func (scheduler *Scheduler) ScheduleJob(c *request.Context, cfg *model.Config, p
 		}
 
 		if state == MigrationStateUnscheduled {
-			job.Logger.Debug("Scheduling a new job for migration.", mlog.String("scheduler", model.JobTypeMigrations), mlog.String("migration_key", key))
+			// GetMigrationState can return a nil job
+			logger := scheduler.jobServer.Logger()
+			if job != nil {
+				logger = job.Logger
+			}
+			logger.Debug("Scheduling a new job for migration.", mlog.String("scheduler", model.JobTypeMigrations), mlog.String("migration_key", key))
 			return scheduler.createJob(c, key, job)
 		}
 


### PR DESCRIPTION
#### Summary
`GetMigrationState` can return a `nil` job, which leads to the panic. Use the job server's logger in this case.

#### Ticket Link
https://community.mattermost.com/core/pl/99jzw5wdiirxxjwg397zdsxauo

#### Release Note
```release-note
NONE
```
