### PR TITLE
Migrate emojiStore to use request.CTX instead of context.Context

### DIFF
--- a/server/channels/app/emoji.go
+++ b/server/channels/app/emoji.go
@@ -5,7 +5,6 @@ package app
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -60,7 +59,7 @@ func (a *App) CreateEmoji(c request.CTX, sessionUserId string, emoji *model.Emoj
 		return nil, model.NewAppError("createEmoji", "api.emoji.create.other_user.app_error", nil, "", http.StatusForbidden)
 	}
 
-	if existingEmoji, err := a.Srv().Store().Emoji().GetByName(context.Background(), emoji.Name, true); err == nil && existingEmoji != nil {
+	if existingEmoji, err := a.Srv().Store().Emoji().GetByName(c, emoji.Name, true); err == nil && existingEmoji != nil {
 		return nil, model.NewAppError("createEmoji", "api.emoji.create.duplicate.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
 
@@ -191,7 +190,7 @@ func (a *App) GetEmoji(c request.CTX, emojiId string) (*model.Emoji, *model.AppE
 		return nil, model.NewAppError("GetEmoji", "api.emoji.storage.app_error", nil, "", http.StatusForbidden)
 	}
 
-	emoji, err := a.Srv().Store().Emoji().Get(c.Context(), emojiId, true)
+	emoji, err := a.Srv().Store().Emoji().Get(c, emojiId, true)
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -214,7 +213,7 @@ func (a *App) GetEmojiByName(c request.CTX, emojiName string) (*model.Emoji, *mo
 		return nil, model.NewAppError("GetEmojiByName", "api.emoji.storage.app_error", nil, "", http.StatusForbidden)
 	}
 
-	emoji, err := a.Srv().Store().Emoji().GetByName(c.Context(), emojiName, true)
+	emoji, err := a.Srv().Store().Emoji().GetByName(c, emojiName, true)
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -247,7 +246,7 @@ func (a *App) GetMultipleEmojiByName(c request.CTX, names []string) ([]*model.Em
 		return []*model.Emoji{}, nil
 	}
 
-	emoji, err := a.Srv().Store().Emoji().GetMultipleByName(c.Context(), names)
+	emoji, err := a.Srv().Store().Emoji().GetMultipleByName(c, names)
 	if err != nil {
 		return nil, model.NewAppError("GetMultipleEmojiByName", "app.emoji.get_by_name.app_error", nil, fmt.Sprintf("names=%v, %v", names, err.Error()), http.StatusInternalServerError)
 	}
@@ -256,7 +255,7 @@ func (a *App) GetMultipleEmojiByName(c request.CTX, names []string) ([]*model.Em
 }
 
 func (a *App) GetEmojiImage(c request.CTX, emojiId string) ([]byte, string, *model.AppError) {
-	_, storeErr := a.Srv().Store().Emoji().Get(c.Context(), emojiId, true)
+	_, storeErr := a.Srv().Store().Emoji().Get(c, emojiId, true)
 	if storeErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -302,7 +301,7 @@ func (a *App) GetEmojiStaticURL(c request.CTX, emojiName string) (string, *model
 		return path.Join(subPath, "/static/emoji", id+".png"), nil
 	}
 
-	emoji, err := a.Srv().Store().Emoji().GetByName(context.Background(), emojiName, true)
+	emoji, err := a.Srv().Store().Emoji().GetByName(c, emojiName, true)
 	if err == nil {
 		return path.Join(subPath, "/api/v4/emoji", emoji.Id, "image"), nil
 	}

--- a/server/channels/app/import_functions.go
+++ b/server/channels/app/import_functions.go
@@ -1953,7 +1953,7 @@ func (a *App) importEmoji(c request.CTX, data *imports.EmojiImportData, dryRun b
 
 	var emoji *model.Emoji
 
-	emoji, err := a.Srv().Store().Emoji().GetByName(context.Background(), *data.Name, true)
+	emoji, err := a.Srv().Store().Emoji().GetByName(c, *data.Name, true)
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		if !errors.As(err, &nfErr) {

--- a/server/channels/app/import_functions_test.go
+++ b/server/channels/app/import_functions_test.go
@@ -4168,7 +4168,7 @@ func TestImportImportEmoji(t *testing.T) {
 	appErr := th.App.importEmoji(th.Context, &data, true)
 	assert.NotNil(t, appErr, "Invalid emoji should have failed dry run")
 
-	emoji, nErr := th.App.Srv().Store().Emoji().GetByName(context.Background(), *data.Name, true)
+	emoji, nErr := th.App.Srv().Store().Emoji().GetByName(th.Context, *data.Name, true)
 	assert.Nil(t, emoji, "Emoji should not have been imported")
 	assert.Error(t, nErr)
 
@@ -4188,7 +4188,7 @@ func TestImportImportEmoji(t *testing.T) {
 	appErr = th.App.importEmoji(th.Context, &data, false)
 	assert.Nil(t, appErr, "Valid emoji should have succeeded apply mode")
 
-	emoji, nErr = th.App.Srv().Store().Emoji().GetByName(context.Background(), *data.Name, true)
+	emoji, nErr = th.App.Srv().Store().Emoji().GetByName(th.Context, *data.Name, true)
 	assert.NotNil(t, emoji, "Emoji should have been imported")
 	assert.NoError(t, nErr, "Emoji should have been imported without any error")
 

--- a/server/channels/store/localcachelayer/channel_layer_test.go
+++ b/server/channels/store/localcachelayer/channel_layer_test.go
@@ -22,7 +22,7 @@ func TestChannelStoreChannelMemberCountsCache(t *testing.T) {
 	countResult := int64(10)
 
 	t.Run("first call not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -38,7 +38,7 @@ func TestChannelStoreChannelMemberCountsCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, second force not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -50,7 +50,7 @@ func TestChannelStoreChannelMemberCountsCache(t *testing.T) {
 	})
 
 	t.Run("first call force not cached, second not cached, third cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -64,7 +64,7 @@ func TestChannelStoreChannelMemberCountsCache(t *testing.T) {
 	})
 
 	t.Run("first call with GetMemberCountFromCache not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestChannelStoreChannelMemberCountsCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, clear cache, second call not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -91,7 +91,7 @@ func TestChannelStoreChannelMemberCountsCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, invalidate cache, second call not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -111,7 +111,7 @@ func TestChannelStoreChannelsMemberCountCache(t *testing.T) {
 	}
 
 	t.Run("first call not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestChannelStoreChannelsMemberCountCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, invalidate cache, second call not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestChannelStoreChannelPinnedPostsCountsCache(t *testing.T) {
 	countResult := int64(10)
 
 	t.Run("first call not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -161,7 +161,7 @@ func TestChannelStoreChannelPinnedPostsCountsCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, second force not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -173,7 +173,7 @@ func TestChannelStoreChannelPinnedPostsCountsCache(t *testing.T) {
 	})
 
 	t.Run("first call force not cached, second not cached, third cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -187,7 +187,7 @@ func TestChannelStoreChannelPinnedPostsCountsCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, clear cache, second call not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -200,7 +200,7 @@ func TestChannelStoreChannelPinnedPostsCountsCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, invalidate cache, second call not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -217,7 +217,7 @@ func TestChannelStoreGuestCountCache(t *testing.T) {
 	countResult := int64(12)
 
 	t.Run("first call not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -233,7 +233,7 @@ func TestChannelStoreGuestCountCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, second force not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -245,7 +245,7 @@ func TestChannelStoreGuestCountCache(t *testing.T) {
 	})
 
 	t.Run("first call force not cached, second not cached, third cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -259,7 +259,7 @@ func TestChannelStoreGuestCountCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, clear cache, second call not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -272,7 +272,7 @@ func TestChannelStoreGuestCountCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, invalidate cache, second call not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -289,7 +289,7 @@ func TestChannelStoreChannel(t *testing.T) {
 	channelId := "channel1"
 	fakeChannel := model.Channel{Id: channelId}
 	t.Run("first call by id not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -305,7 +305,7 @@ func TestChannelStoreChannel(t *testing.T) {
 	})
 
 	t.Run("first call not cached, second force no cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -317,7 +317,7 @@ func TestChannelStoreChannel(t *testing.T) {
 	})
 
 	t.Run("first call force no cached, second not cached, third cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -330,7 +330,7 @@ func TestChannelStoreChannel(t *testing.T) {
 	})
 
 	t.Run("first call not cached, clear cache, second call not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -343,7 +343,7 @@ func TestChannelStoreChannel(t *testing.T) {
 	})
 
 	t.Run("first call not cached, invalidate cache, second call not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)

--- a/server/channels/store/localcachelayer/emoji_layer.go
+++ b/server/channels/store/localcachelayer/emoji_layer.go
@@ -5,10 +5,10 @@ package localcachelayer
 
 import (
 	"bytes"
-	"context"
 	"sync"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 	"github.com/mattermost/mattermost/server/v8/channels/store/sqlstore"
 )
@@ -44,7 +44,7 @@ func (es *LocalCacheEmojiStore) handleClusterInvalidateEmojiIdByName(msg *model.
 	}
 }
 
-func (es *LocalCacheEmojiStore) Get(ctx context.Context, id string, allowFromCache bool) (*model.Emoji, error) {
+func (es *LocalCacheEmojiStore) Get(c request.CTX, id string, allowFromCache bool) (*model.Emoji, error) {
 	if allowFromCache {
 		if emoji, ok := es.getFromCacheById(id); ok {
 			return emoji, nil
@@ -55,12 +55,12 @@ func (es *LocalCacheEmojiStore) Get(ctx context.Context, id string, allowFromCac
 	es.emojiByIdMut.Lock()
 	if es.emojiByIdInvalidations[id] {
 		// And then remove the key from the map.
-		ctx = sqlstore.WithMaster(ctx)
+		c = sqlstore.RequestContextWithMaster(c)
 		delete(es.emojiByIdInvalidations, id)
 	}
 	es.emojiByIdMut.Unlock()
 
-	emoji, err := es.EmojiStore.Get(ctx, id, allowFromCache)
+	emoji, err := es.EmojiStore.Get(c, id, allowFromCache)
 
 	if allowFromCache && err == nil {
 		es.addToCache(emoji)
@@ -69,9 +69,9 @@ func (es *LocalCacheEmojiStore) Get(ctx context.Context, id string, allowFromCac
 	return emoji, err
 }
 
-func (es *LocalCacheEmojiStore) GetByName(ctx context.Context, name string, allowFromCache bool) (*model.Emoji, error) {
+func (es *LocalCacheEmojiStore) GetByName(c request.CTX, name string, allowFromCache bool) (*model.Emoji, error) {
 	if id, ok := model.GetSystemEmojiId(name); ok {
-		return es.Get(ctx, id, allowFromCache)
+		return es.Get(c, id, allowFromCache)
 	}
 
 	if allowFromCache {
@@ -83,13 +83,13 @@ func (es *LocalCacheEmojiStore) GetByName(ctx context.Context, name string, allo
 	// If it was invalidated, then we need to query master.
 	es.emojiByNameMut.Lock()
 	if es.emojiByNameInvalidations[name] {
-		ctx = sqlstore.WithMaster(ctx)
+		c = sqlstore.RequestContextWithMaster(c)
 		// And then remove the key from the map.
 		delete(es.emojiByNameInvalidations, name)
 	}
 	es.emojiByNameMut.Unlock()
 
-	emoji, err := es.EmojiStore.GetByName(ctx, name, allowFromCache)
+	emoji, err := es.EmojiStore.GetByName(c, name, allowFromCache)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (es *LocalCacheEmojiStore) GetByName(ctx context.Context, name string, allo
 	return emoji, nil
 }
 
-func (es *LocalCacheEmojiStore) GetMultipleByName(ctx context.Context, names []string) ([]*model.Emoji, error) {
+func (es *LocalCacheEmojiStore) GetMultipleByName(c request.CTX, names []string) ([]*model.Emoji, error) {
 	emojis := []*model.Emoji{}
 	remainingEmojiNames := make([]string, 0)
 
@@ -112,7 +112,7 @@ func (es *LocalCacheEmojiStore) GetMultipleByName(ctx context.Context, names []s
 			// If it was invalidated, then we need to query master.
 			es.emojiByNameMut.Lock()
 			if es.emojiByNameInvalidations[name] {
-				ctx = sqlstore.WithMaster(ctx)
+				c = sqlstore.RequestContextWithMaster(c)
 				// And then remove the key from the map.
 				delete(es.emojiByNameInvalidations, name)
 			}
@@ -123,7 +123,7 @@ func (es *LocalCacheEmojiStore) GetMultipleByName(ctx context.Context, names []s
 	}
 
 	if len(remainingEmojiNames) > 0 {
-		remainingEmojis, err := es.EmojiStore.GetMultipleByName(ctx, remainingEmojiNames)
+		remainingEmojis, err := es.EmojiStore.GetMultipleByName(c, remainingEmojiNames)
 		if err != nil {
 			return nil, err
 		}

--- a/server/channels/store/localcachelayer/emoji_layer_test.go
+++ b/server/channels/store/localcachelayer/emoji_layer_test.go
@@ -25,8 +25,8 @@ func TestEmojiStoreCache(t *testing.T) {
 	ctxEmoji := model.Emoji{Id: "master", Name: "name123"}
 
 	t.Run("first call by id not cached, second cached and returning same data", func(t *testing.T) {
-		c := request.TestContext()
-		mockStore := getMockStore()
+		c := request.TestContext(t)
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -42,8 +42,8 @@ func TestEmojiStoreCache(t *testing.T) {
 	})
 
 	t.Run("GetByName: first call by name not cached, second cached and returning same data", func(t *testing.T) {
-		c := request.TestContext()
-		mockStore := getMockStore()
+		c := request.TestContext(t)
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -59,8 +59,8 @@ func TestEmojiStoreCache(t *testing.T) {
 	})
 
 	t.Run("GetMultipleByName: first call by name not cached, second cached and returning same data", func(t *testing.T) {
-		c := request.TestContext()
-		mockStore := getMockStore()
+		c := request.TestContext(t)
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -78,8 +78,8 @@ func TestEmojiStoreCache(t *testing.T) {
 	})
 
 	t.Run("GetMultipleByName: multiple elements", func(t *testing.T) {
-		c := request.TestContext()
-		mockStore := getMockStore()
+		c := request.TestContext(t)
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -98,8 +98,8 @@ func TestEmojiStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call by id not cached, second force not cached", func(t *testing.T) {
-		c := request.TestContext()
-		mockStore := getMockStore()
+		c := request.TestContext(t)
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -111,8 +111,8 @@ func TestEmojiStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call by name not cached, second force not cached", func(t *testing.T) {
-		c := request.TestContext()
-		mockStore := getMockStore()
+		c := request.TestContext(t)
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -124,8 +124,8 @@ func TestEmojiStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call by id force not cached, second not cached, third cached", func(t *testing.T) {
-		c := request.TestContext()
-		mockStore := getMockStore()
+		c := request.TestContext(t)
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -139,8 +139,8 @@ func TestEmojiStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call by name force not cached, second not cached, third cached", func(t *testing.T) {
-		c := request.TestContext()
-		mockStore := getMockStore()
+		c := request.TestContext(t)
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -154,8 +154,8 @@ func TestEmojiStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call by id, second call by name and GetMultipleByName cached", func(t *testing.T) {
-		c := request.TestContext()
-		mockStore := getMockStore()
+		c := request.TestContext(t)
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -169,8 +169,8 @@ func TestEmojiStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call by name, second call by id cached", func(t *testing.T) {
-		c := request.TestContext()
-		mockStore := getMockStore()
+		c := request.TestContext(t)
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -182,8 +182,8 @@ func TestEmojiStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call by id not cached, invalidate, and then not cached again", func(t *testing.T) {
-		c := request.TestContext()
-		mockStore := getMockStore()
+		c := request.TestContext(t)
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -196,8 +196,8 @@ func TestEmojiStoreCache(t *testing.T) {
 	})
 
 	t.Run("call by id, use master", func(t *testing.T) {
-		c := request.TestContext()
-		mockStore := getMockStore()
+		c := request.TestContext(t)
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -210,8 +210,8 @@ func TestEmojiStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call by name not cached, invalidate, and then not cached again", func(t *testing.T) {
-		c := request.TestContext()
-		mockStore := getMockStore()
+		c := request.TestContext(t)
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -224,8 +224,8 @@ func TestEmojiStoreCache(t *testing.T) {
 	})
 
 	t.Run("call by name, use master", func(t *testing.T) {
-		c := request.TestContext()
-		mockStore := getMockStore()
+		c := request.TestContext(t)
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)

--- a/server/channels/store/localcachelayer/emoji_layer_test.go
+++ b/server/channels/store/localcachelayer/emoji_layer_test.go
@@ -4,13 +4,13 @@
 package localcachelayer
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/store/storetest"
 	"github.com/mattermost/mattermost/server/v8/channels/store/storetest/mocks"
 )
@@ -25,49 +25,52 @@ func TestEmojiStoreCache(t *testing.T) {
 	ctxEmoji := model.Emoji{Id: "master", Name: "name123"}
 
 	t.Run("first call by id not cached, second cached and returning same data", func(t *testing.T) {
+		c := request.TestContext()
 		mockStore := getMockStore()
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
 
-		emoji, err := cachedStore.Emoji().Get(context.Background(), "123", true)
+		emoji, err := cachedStore.Emoji().Get(c, "123", true)
 		require.NoError(t, err)
 		assert.Equal(t, emoji, &fakeEmoji)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "Get", 1)
-		emoji, err = cachedStore.Emoji().Get(context.Background(), "123", true)
+		emoji, err = cachedStore.Emoji().Get(c, "123", true)
 		require.NoError(t, err)
 		assert.Equal(t, emoji, &fakeEmoji)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "Get", 1)
 	})
 
 	t.Run("GetByName: first call by name not cached, second cached and returning same data", func(t *testing.T) {
+		c := request.TestContext()
 		mockStore := getMockStore()
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
 
-		emoji, err := cachedStore.Emoji().GetByName(context.Background(), "name123", true)
+		emoji, err := cachedStore.Emoji().GetByName(c, "name123", true)
 		require.NoError(t, err)
 		assert.Equal(t, emoji, &fakeEmoji)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "GetByName", 1)
-		emoji, err = cachedStore.Emoji().GetByName(context.Background(), "name123", true)
+		emoji, err = cachedStore.Emoji().GetByName(c, "name123", true)
 		require.NoError(t, err)
 		assert.Equal(t, emoji, &fakeEmoji)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "GetByName", 1)
 	})
 
 	t.Run("GetMultipleByName: first call by name not cached, second cached and returning same data", func(t *testing.T) {
+		c := request.TestContext()
 		mockStore := getMockStore()
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
 
-		emojis, err := cachedStore.Emoji().GetMultipleByName(context.Background(), []string{"name123"})
+		emojis, err := cachedStore.Emoji().GetMultipleByName(c, []string{"name123"})
 		require.NoError(t, err)
 		require.Len(t, emojis, 1)
 		assert.Equal(t, emojis[0], &fakeEmoji)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "GetMultipleByName", 1)
-		emojis, err = cachedStore.Emoji().GetMultipleByName(context.Background(), []string{"name123"})
+		emojis, err = cachedStore.Emoji().GetMultipleByName(c, []string{"name123"})
 		require.NoError(t, err)
 		require.Len(t, emojis, 1)
 		assert.Equal(t, emojis[0], &fakeEmoji)
@@ -75,18 +78,19 @@ func TestEmojiStoreCache(t *testing.T) {
 	})
 
 	t.Run("GetMultipleByName: multiple elements", func(t *testing.T) {
+		c := request.TestContext()
 		mockStore := getMockStore()
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
 
-		emojis, err := cachedStore.Emoji().GetMultipleByName(context.Background(), []string{"name123", "name321"})
+		emojis, err := cachedStore.Emoji().GetMultipleByName(c, []string{"name123", "name321"})
 		require.NoError(t, err)
 		require.Len(t, emojis, 2)
 		assert.Equal(t, emojis[0], &fakeEmoji)
 		assert.Equal(t, emojis[1], &fakeEmoji2)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "GetMultipleByName", 1)
-		emojis, err = cachedStore.Emoji().GetMultipleByName(context.Background(), []string{"name123"})
+		emojis, err = cachedStore.Emoji().GetMultipleByName(c, []string{"name123"})
 		require.NoError(t, err)
 		require.Len(t, emojis, 1)
 		assert.Equal(t, emojis[0], &fakeEmoji)
@@ -94,132 +98,142 @@ func TestEmojiStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call by id not cached, second force not cached", func(t *testing.T) {
+		c := request.TestContext()
 		mockStore := getMockStore()
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
 
-		cachedStore.Emoji().Get(context.Background(), "123", true)
+		cachedStore.Emoji().Get(c, "123", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "Get", 1)
-		cachedStore.Emoji().Get(context.Background(), "123", false)
+		cachedStore.Emoji().Get(c, "123", false)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "Get", 2)
 	})
 
 	t.Run("first call by name not cached, second force not cached", func(t *testing.T) {
+		c := request.TestContext()
 		mockStore := getMockStore()
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
 
-		cachedStore.Emoji().GetByName(context.Background(), "name123", true)
+		cachedStore.Emoji().GetByName(c, "name123", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "GetByName", 1)
-		cachedStore.Emoji().GetByName(context.Background(), "name123", false)
+		cachedStore.Emoji().GetByName(c, "name123", false)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "GetByName", 2)
 	})
 
 	t.Run("first call by id force not cached, second not cached, third cached", func(t *testing.T) {
+		c := request.TestContext()
 		mockStore := getMockStore()
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
 
-		cachedStore.Emoji().Get(context.Background(), "123", false)
+		cachedStore.Emoji().Get(c, "123", false)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "Get", 1)
-		cachedStore.Emoji().Get(context.Background(), "123", true)
+		cachedStore.Emoji().Get(c, "123", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "Get", 2)
-		cachedStore.Emoji().Get(context.Background(), "123", true)
+		cachedStore.Emoji().Get(c, "123", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "Get", 2)
 	})
 
 	t.Run("first call by name force not cached, second not cached, third cached", func(t *testing.T) {
+		c := request.TestContext()
 		mockStore := getMockStore()
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
 
-		cachedStore.Emoji().GetByName(context.Background(), "name123", false)
+		cachedStore.Emoji().GetByName(c, "name123", false)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "GetByName", 1)
-		cachedStore.Emoji().GetByName(context.Background(), "name123", true)
+		cachedStore.Emoji().GetByName(c, "name123", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "GetByName", 2)
-		cachedStore.Emoji().GetByName(context.Background(), "name123", true)
+		cachedStore.Emoji().GetByName(c, "name123", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "GetByName", 2)
 	})
 
 	t.Run("first call by id, second call by name and GetMultipleByName cached", func(t *testing.T) {
+		c := request.TestContext()
 		mockStore := getMockStore()
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
 
-		cachedStore.Emoji().Get(context.Background(), "123", true)
+		cachedStore.Emoji().Get(c, "123", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "Get", 1)
-		cachedStore.Emoji().GetByName(context.Background(), "name123", true)
+		cachedStore.Emoji().GetByName(c, "name123", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "GetByName", 0)
-		cachedStore.Emoji().GetMultipleByName(context.Background(), []string{"name123"})
+		cachedStore.Emoji().GetMultipleByName(c, []string{"name123"})
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "GetMultipleByName", 0)
 	})
 
 	t.Run("first call by name, second call by id cached", func(t *testing.T) {
+		c := request.TestContext()
 		mockStore := getMockStore()
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
 
-		cachedStore.Emoji().GetByName(context.Background(), "name123", true)
+		cachedStore.Emoji().GetByName(c, "name123", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "GetByName", 1)
-		cachedStore.Emoji().Get(context.Background(), "123", true)
+		cachedStore.Emoji().Get(c, "123", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "Get", 0)
 	})
 
 	t.Run("first call by id not cached, invalidate, and then not cached again", func(t *testing.T) {
+		c := request.TestContext()
 		mockStore := getMockStore()
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
 
-		cachedStore.Emoji().Get(context.Background(), "123", true)
+		cachedStore.Emoji().Get(c, "123", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "Get", 1)
 		cachedStore.Emoji().Delete(&fakeEmoji, 0)
-		cachedStore.Emoji().Get(context.Background(), "123", true)
+		cachedStore.Emoji().Get(c, "123", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "Get", 2)
 	})
 
 	t.Run("call by id, use master", func(t *testing.T) {
+		c := request.TestContext()
 		mockStore := getMockStore()
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
 
-		cachedStore.Emoji().Get(context.Background(), "master", true)
+		cachedStore.Emoji().Get(c, "master", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "Get", 1)
 		cachedStore.Emoji().Delete(&ctxEmoji, 0)
-		cachedStore.Emoji().Get(context.Background(), "master", true)
+		cachedStore.Emoji().Get(c, "master", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "Get", 2)
 	})
 
 	t.Run("first call by name not cached, invalidate, and then not cached again", func(t *testing.T) {
+		c := request.TestContext()
 		mockStore := getMockStore()
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
 
-		cachedStore.Emoji().GetByName(context.Background(), "name123", true)
+		cachedStore.Emoji().GetByName(c, "name123", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "GetByName", 1)
 		cachedStore.Emoji().Delete(&fakeEmoji, 0)
-		cachedStore.Emoji().GetByName(context.Background(), "name123", true)
+		cachedStore.Emoji().GetByName(c, "name123", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "GetByName", 2)
 	})
 
 	t.Run("call by name, use master", func(t *testing.T) {
+		c := request.TestContext()
 		mockStore := getMockStore()
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
 
-		cachedStore.Emoji().GetByName(context.Background(), "master", true)
+		cachedStore.Emoji().GetByName(c, "master", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "GetByName", 1)
 		cachedStore.Emoji().Delete(&ctxEmoji, 0)
-		cachedStore.Emoji().GetByName(context.Background(), "master", true)
+		cachedStore.Emoji().GetByName(c, "master", true)
 		mockStore.Emoji().(*mocks.EmojiStore).AssertNumberOfCalls(t, "GetByName", 2)
 	})
 }

--- a/server/channels/store/localcachelayer/file_info_layer_test.go
+++ b/server/channels/store/localcachelayer/file_info_layer_test.go
@@ -22,7 +22,7 @@ func TestFileInfoStoreCache(t *testing.T) {
 	fakeFileInfo := model.FileInfo{PostId: "123"}
 
 	t.Run("first call not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -37,7 +37,7 @@ func TestFileInfoStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, second force no cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -49,7 +49,7 @@ func TestFileInfoStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, invalidate, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)

--- a/server/channels/store/localcachelayer/main_test.go
+++ b/server/channels/store/localcachelayer/main_test.go
@@ -29,7 +29,7 @@ func getMockCacheProvider() cache.Provider {
 	return &mockCacheProvider
 }
 
-func getMockStore() *mocks.Store {
+func getMockStore(t *testing.T) *mocks.Store {
 	mockStore := mocks.Store{}
 
 	fakeReaction := model.Reaction{PostId: "123"}
@@ -76,13 +76,13 @@ func getMockStore() *mocks.Store {
 	mockEmojiStore.On("Get", mock.Anything, "123", true).Return(&fakeEmoji, nil)
 	mockEmojiStore.On("Get", mock.Anything, "123", false).Return(&fakeEmoji, nil)
 	mockEmojiStore.On("Get", mock.IsType(&request.Context{}), "master", true).Return(&ctxEmoji, nil)
-	mockEmojiStore.On("Get", sqlstore.RequestContextWithMaster(request.TestContext()), "master", true).Return(&ctxEmoji, nil)
+	mockEmojiStore.On("Get", sqlstore.RequestContextWithMaster(request.TestContext(t)), "master", true).Return(&ctxEmoji, nil)
 	mockEmojiStore.On("GetByName", mock.Anything, "name123", true).Return(&fakeEmoji, nil)
 	mockEmojiStore.On("GetByName", mock.Anything, "name123", false).Return(&fakeEmoji, nil)
 	mockEmojiStore.On("GetMultipleByName", mock.IsType(&request.Context{}), []string{"name123"}).Return([]*model.Emoji{&fakeEmoji}, nil)
 	mockEmojiStore.On("GetMultipleByName", mock.IsType(&request.Context{}), []string{"name123", "name321"}).Return([]*model.Emoji{&fakeEmoji, &fakeEmoji2}, nil)
 	mockEmojiStore.On("GetByName", mock.IsType(&request.Context{}), "master", true).Return(&ctxEmoji, nil)
-	mockEmojiStore.On("GetByName", sqlstore.RequestContextWithMaster(request.TestContext()), "master", false).Return(&ctxEmoji, nil)
+	mockEmojiStore.On("GetByName", sqlstore.RequestContextWithMaster(request.TestContext(t)), "master", false).Return(&ctxEmoji, nil)
 	mockEmojiStore.On("Delete", &fakeEmoji, int64(0)).Return(nil)
 	mockEmojiStore.On("Delete", &ctxEmoji, int64(0)).Return(nil)
 	mockStore.On("Emoji").Return(&mockEmojiStore)

--- a/server/channels/store/localcachelayer/main_test.go
+++ b/server/channels/store/localcachelayer/main_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 	"github.com/mattermost/mattermost/server/v8/channels/store/sqlstore"
 	"github.com/mattermost/mattermost/server/v8/channels/store/storetest/mocks"
@@ -74,14 +75,14 @@ func getMockStore() *mocks.Store {
 	mockEmojiStore := mocks.EmojiStore{}
 	mockEmojiStore.On("Get", mock.Anything, "123", true).Return(&fakeEmoji, nil)
 	mockEmojiStore.On("Get", mock.Anything, "123", false).Return(&fakeEmoji, nil)
-	mockEmojiStore.On("Get", context.Background(), "master", true).Return(&ctxEmoji, nil)
-	mockEmojiStore.On("Get", sqlstore.WithMaster(context.Background()), "master", true).Return(&ctxEmoji, nil)
+	mockEmojiStore.On("Get", mock.IsType(&request.Context{}), "master", true).Return(&ctxEmoji, nil)
+	mockEmojiStore.On("Get", sqlstore.RequestContextWithMaster(request.TestContext()), "master", true).Return(&ctxEmoji, nil)
 	mockEmojiStore.On("GetByName", mock.Anything, "name123", true).Return(&fakeEmoji, nil)
 	mockEmojiStore.On("GetByName", mock.Anything, "name123", false).Return(&fakeEmoji, nil)
-	mockEmojiStore.On("GetMultipleByName", context.Background(), []string{"name123"}).Return([]*model.Emoji{&fakeEmoji}, nil)
-	mockEmojiStore.On("GetMultipleByName", context.Background(), []string{"name123", "name321"}).Return([]*model.Emoji{&fakeEmoji, &fakeEmoji2}, nil)
-	mockEmojiStore.On("GetByName", context.Background(), "master", true).Return(&ctxEmoji, nil)
-	mockEmojiStore.On("GetByName", sqlstore.WithMaster(context.Background()), "master", false).Return(&ctxEmoji, nil)
+	mockEmojiStore.On("GetMultipleByName", mock.IsType(&request.Context{}), []string{"name123"}).Return([]*model.Emoji{&fakeEmoji}, nil)
+	mockEmojiStore.On("GetMultipleByName", mock.IsType(&request.Context{}), []string{"name123", "name321"}).Return([]*model.Emoji{&fakeEmoji, &fakeEmoji2}, nil)
+	mockEmojiStore.On("GetByName", mock.IsType(&request.Context{}), "master", true).Return(&ctxEmoji, nil)
+	mockEmojiStore.On("GetByName", sqlstore.RequestContextWithMaster(request.TestContext()), "master", false).Return(&ctxEmoji, nil)
 	mockEmojiStore.On("Delete", &fakeEmoji, int64(0)).Return(nil)
 	mockEmojiStore.On("Delete", &ctxEmoji, int64(0)).Return(nil)
 	mockStore.On("Emoji").Return(&mockEmojiStore)

--- a/server/channels/store/localcachelayer/post_layer_test.go
+++ b/server/channels/store/localcachelayer/post_layer_test.go
@@ -29,7 +29,7 @@ func TestPostStoreLastPostTimeCache(t *testing.T) {
 	}
 
 	t.Run("GetEtag: first call not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -46,7 +46,7 @@ func TestPostStoreLastPostTimeCache(t *testing.T) {
 	})
 
 	t.Run("GetEtag: first call not cached, second force no cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestPostStoreLastPostTimeCache(t *testing.T) {
 	})
 
 	t.Run("GetEtag: first call not cached, invalidate, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestPostStoreLastPostTimeCache(t *testing.T) {
 	})
 
 	t.Run("GetEtag: first call not cached, clear caches, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -84,7 +84,7 @@ func TestPostStoreLastPostTimeCache(t *testing.T) {
 	})
 
 	t.Run("GetPostsSince: first call not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -103,7 +103,7 @@ func TestPostStoreLastPostTimeCache(t *testing.T) {
 	})
 
 	t.Run("GetPostsSince: first call not cached, second force no cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestPostStoreLastPostTimeCache(t *testing.T) {
 	})
 
 	t.Run("GetPostsSince: first call not cached, invalidate, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -128,7 +128,7 @@ func TestPostStoreLastPostTimeCache(t *testing.T) {
 	})
 
 	t.Run("GetPostsSince: first call not cached, clear caches, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -146,7 +146,7 @@ func TestPostStoreCache(t *testing.T) {
 	fakeOptions := model.GetPostsOptions{ChannelId: "123", PerPage: 30}
 
 	t.Run("first call not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -161,7 +161,7 @@ func TestPostStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, second force not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -176,7 +176,7 @@ func TestPostStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, invalidate, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)

--- a/server/channels/store/localcachelayer/reaction_layer_test.go
+++ b/server/channels/store/localcachelayer/reaction_layer_test.go
@@ -22,7 +22,7 @@ func TestReactionStoreCache(t *testing.T) {
 	fakeReaction := model.Reaction{PostId: "123"}
 
 	t.Run("first call not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -37,7 +37,7 @@ func TestReactionStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, second force not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -49,7 +49,7 @@ func TestReactionStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, save, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -62,7 +62,7 @@ func TestReactionStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, delete, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)

--- a/server/channels/store/localcachelayer/role_layer_test.go
+++ b/server/channels/store/localcachelayer/role_layer_test.go
@@ -23,7 +23,7 @@ func TestRoleStoreCache(t *testing.T) {
 	fakeRole := model.Role{Id: "123", Name: "role-name"}
 
 	t.Run("first call not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -39,7 +39,7 @@ func TestRoleStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, save, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -52,7 +52,7 @@ func TestRoleStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, delete, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -65,7 +65,7 @@ func TestRoleStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, permanent delete all, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)

--- a/server/channels/store/localcachelayer/scheme_layer_test.go
+++ b/server/channels/store/localcachelayer/scheme_layer_test.go
@@ -22,7 +22,7 @@ func TestSchemeStoreCache(t *testing.T) {
 	fakeScheme := model.Scheme{Id: "123", Name: "scheme-name"}
 
 	t.Run("first call not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -38,7 +38,7 @@ func TestSchemeStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, save, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestSchemeStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, delete, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -64,7 +64,7 @@ func TestSchemeStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, permanent delete all, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)

--- a/server/channels/store/localcachelayer/team_layer_test.go
+++ b/server/channels/store/localcachelayer/team_layer_test.go
@@ -22,7 +22,7 @@ func TestTeamStoreCache(t *testing.T) {
 	fakeUserTeamIds := []string{"1", "2", "3"}
 
 	t.Run("first call not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -39,7 +39,7 @@ func TestTeamStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, second force not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestTeamStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, invalidate, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)

--- a/server/channels/store/localcachelayer/terms_of_service_layer_test.go
+++ b/server/channels/store/localcachelayer/terms_of_service_layer_test.go
@@ -23,7 +23,7 @@ func TestTermsOfServiceStoreTermsOfServiceCache(t *testing.T) {
 	fakeTermsOfService := model.TermsOfService{Id: "123", CreateAt: 11111, UserId: "321", Text: "Terms of service test"}
 
 	t.Run("first call by latest not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -39,7 +39,7 @@ func TestTermsOfServiceStoreTermsOfServiceCache(t *testing.T) {
 	})
 
 	t.Run("first call by id not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -55,7 +55,7 @@ func TestTermsOfServiceStoreTermsOfServiceCache(t *testing.T) {
 	})
 
 	t.Run("first call by id not cached, second force no cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -67,7 +67,7 @@ func TestTermsOfServiceStoreTermsOfServiceCache(t *testing.T) {
 	})
 
 	t.Run("first call latest not cached, second force no cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -79,7 +79,7 @@ func TestTermsOfServiceStoreTermsOfServiceCache(t *testing.T) {
 	})
 
 	t.Run("first call by id force no cached, second not cached, third cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestTermsOfServiceStoreTermsOfServiceCache(t *testing.T) {
 	})
 
 	t.Run("first call latest force no cached, second not cached, third cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -107,7 +107,7 @@ func TestTermsOfServiceStoreTermsOfServiceCache(t *testing.T) {
 	})
 
 	t.Run("first call latest, second call by id cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -119,7 +119,7 @@ func TestTermsOfServiceStoreTermsOfServiceCache(t *testing.T) {
 	})
 
 	t.Run("first call by id not cached, save, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -132,7 +132,7 @@ func TestTermsOfServiceStoreTermsOfServiceCache(t *testing.T) {
 	})
 
 	t.Run("first get latest not cached, save new, then get latest, returning different data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)

--- a/server/channels/store/localcachelayer/user_layer_test.go
+++ b/server/channels/store/localcachelayer/user_layer_test.go
@@ -30,7 +30,7 @@ func TestUserStoreCache(t *testing.T) {
 	}}
 
 	t.Run("first call not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -45,7 +45,7 @@ func TestUserStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, second force not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -60,7 +60,7 @@ func TestUserStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, invalidate, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -76,7 +76,7 @@ func TestUserStoreCache(t *testing.T) {
 	})
 
 	t.Run("should always return a copy of the stored data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -126,7 +126,7 @@ func TestUserStoreProfilesInChannelCache(t *testing.T) {
 	}
 
 	t.Run("first call not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -141,7 +141,7 @@ func TestUserStoreProfilesInChannelCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, second force not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -156,7 +156,7 @@ func TestUserStoreProfilesInChannelCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, invalidate by channel, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -173,7 +173,7 @@ func TestUserStoreProfilesInChannelCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, invalidate by user, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -198,7 +198,7 @@ func TestUserStoreGetCache(t *testing.T) {
 		AuthService: "authService",
 	}
 	t.Run("first call not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -213,7 +213,7 @@ func TestUserStoreGetCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, invalidate, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -230,7 +230,7 @@ func TestUserStoreGetCache(t *testing.T) {
 	})
 
 	t.Run("should always return a copy of the stored data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -273,7 +273,7 @@ func TestUserStoreGetManyCache(t *testing.T) {
 		AuthService: "authService",
 	}
 	t.Run("first call not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -291,7 +291,7 @@ func TestUserStoreGetManyCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, invalidate one user, and then check that one is cached and one is fetched from db", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)

--- a/server/channels/store/localcachelayer/webhook_layer_test.go
+++ b/server/channels/store/localcachelayer/webhook_layer_test.go
@@ -22,7 +22,7 @@ func TestWebhookStoreCache(t *testing.T) {
 	fakeWebhook := model.IncomingWebhook{Id: "123"}
 
 	t.Run("first call not cached, second cached and returning same data", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -38,7 +38,7 @@ func TestWebhookStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, second force not cached", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)
@@ -50,7 +50,7 @@ func TestWebhookStoreCache(t *testing.T) {
 	})
 
 	t.Run("first call not cached, invalidate, and then not cached again", func(t *testing.T) {
-		mockStore := getMockStore()
+		mockStore := getMockStore(t)
 		mockCacheProvider := getMockCacheProvider()
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider)
 		require.NoError(t, err)

--- a/server/channels/store/opentracinglayer/opentracinglayer.go
+++ b/server/channels/store/opentracinglayer/opentracinglayer.go
@@ -3425,7 +3425,7 @@ func (s *OpenTracingLayerEmojiStore) Delete(emoji *model.Emoji, timestamp int64)
 	return err
 }
 
-func (s *OpenTracingLayerEmojiStore) Get(ctx context.Context, id string, allowFromCache bool) (*model.Emoji, error) {
+func (s *OpenTracingLayerEmojiStore) Get(ctx request.CTX, id string, allowFromCache bool) (*model.Emoji, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "EmojiStore.Get")
 	s.Root.Store.SetContext(newCtx)
@@ -3443,7 +3443,7 @@ func (s *OpenTracingLayerEmojiStore) Get(ctx context.Context, id string, allowFr
 	return result, err
 }
 
-func (s *OpenTracingLayerEmojiStore) GetByName(ctx context.Context, name string, allowFromCache bool) (*model.Emoji, error) {
+func (s *OpenTracingLayerEmojiStore) GetByName(ctx request.CTX, name string, allowFromCache bool) (*model.Emoji, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "EmojiStore.GetByName")
 	s.Root.Store.SetContext(newCtx)
@@ -3479,7 +3479,7 @@ func (s *OpenTracingLayerEmojiStore) GetList(offset int, limit int, sort string)
 	return result, err
 }
 
-func (s *OpenTracingLayerEmojiStore) GetMultipleByName(ctx context.Context, names []string) ([]*model.Emoji, error) {
+func (s *OpenTracingLayerEmojiStore) GetMultipleByName(ctx request.CTX, names []string) ([]*model.Emoji, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "EmojiStore.GetMultipleByName")
 	s.Root.Store.SetContext(newCtx)

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -3829,7 +3829,7 @@ func (s *RetryLayerEmojiStore) Delete(emoji *model.Emoji, timestamp int64) error
 
 }
 
-func (s *RetryLayerEmojiStore) Get(ctx context.Context, id string, allowFromCache bool) (*model.Emoji, error) {
+func (s *RetryLayerEmojiStore) Get(ctx request.CTX, id string, allowFromCache bool) (*model.Emoji, error) {
 
 	tries := 0
 	for {
@@ -3850,7 +3850,7 @@ func (s *RetryLayerEmojiStore) Get(ctx context.Context, id string, allowFromCach
 
 }
 
-func (s *RetryLayerEmojiStore) GetByName(ctx context.Context, name string, allowFromCache bool) (*model.Emoji, error) {
+func (s *RetryLayerEmojiStore) GetByName(ctx request.CTX, name string, allowFromCache bool) (*model.Emoji, error) {
 
 	tries := 0
 	for {
@@ -3892,7 +3892,7 @@ func (s *RetryLayerEmojiStore) GetList(offset int, limit int, sort string) ([]*m
 
 }
 
-func (s *RetryLayerEmojiStore) GetMultipleByName(ctx context.Context, names []string) ([]*model.Emoji, error) {
+func (s *RetryLayerEmojiStore) GetMultipleByName(ctx request.CTX, names []string) ([]*model.Emoji, error) {
 
 	tries := 0
 	for {

--- a/server/channels/store/sqlstore/context.go
+++ b/server/channels/store/sqlstore/context.go
@@ -21,10 +21,14 @@ const (
 )
 
 // WithMaster adds the context value that master DB should be selected for this request.
+//
+// Deprecated: This method is deprecated and there's ongoing change to use `request.CTX` across
+// instead of `context.Context`. Please use `RequestContextWithMaster` instead.
 func WithMaster(ctx context.Context) context.Context {
 	return context.WithValue(ctx, storeContextKey(useMaster), true)
 }
 
+// RequestContextWithMaster adds the context value that master DB should be selected for this request.
 func RequestContextWithMaster(c request.CTX) request.CTX {
 	ctx := WithMaster(c.Context())
 	c.SetContext(ctx)

--- a/server/channels/store/sqlstore/context.go
+++ b/server/channels/store/sqlstore/context.go
@@ -5,6 +5,8 @@ package sqlstore
 
 import (
 	"context"
+
+	"github.com/mattermost/mattermost/server/public/shared/request"
 )
 
 // storeContextKey is the base type for all context keys for the store.
@@ -21,6 +23,12 @@ const (
 // WithMaster adds the context value that master DB should be selected for this request.
 func WithMaster(ctx context.Context) context.Context {
 	return context.WithValue(ctx, storeContextKey(useMaster), true)
+}
+
+func RequestContextWithMaster(c request.CTX) request.CTX {
+	ctx := WithMaster(c.Context())
+	c.SetContext(ctx)
+	return c
 }
 
 // hasMaster is a helper function to check whether master DB should be selected or not.

--- a/server/channels/store/sqlstore/emoji_store.go
+++ b/server/channels/store/sqlstore/emoji_store.go
@@ -4,7 +4,6 @@
 package sqlstore
 
 import (
-	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 	"github.com/mattermost/mattermost/server/v8/einterfaces"
 )
@@ -44,21 +44,21 @@ func (es SqlEmojiStore) Save(emoji *model.Emoji) (*model.Emoji, error) {
 	return emoji, nil
 }
 
-func (es SqlEmojiStore) Get(ctx context.Context, id string, allowFromCache bool) (*model.Emoji, error) {
-	return es.getBy(ctx, "Id", id)
+func (es SqlEmojiStore) Get(c request.CTX, id string, allowFromCache bool) (*model.Emoji, error) {
+	return es.getBy(c, "Id", id)
 }
 
-func (es SqlEmojiStore) GetByName(ctx context.Context, name string, allowFromCache bool) (*model.Emoji, error) {
-	return es.getBy(ctx, "Name", name)
+func (es SqlEmojiStore) GetByName(c request.CTX, name string, allowFromCache bool) (*model.Emoji, error) {
+	return es.getBy(c, "Name", name)
 }
 
-func (es SqlEmojiStore) GetMultipleByName(ctx context.Context, names []string) ([]*model.Emoji, error) {
+func (es SqlEmojiStore) GetMultipleByName(c request.CTX, names []string) ([]*model.Emoji, error) {
 	// Creating (?, ?, ?) len(names) number of times.
 	keys := strings.Join(strings.Fields(strings.Repeat("? ", len(names))), ",")
 	args := makeStringArgs(names)
 
 	emojis := []*model.Emoji{}
-	if err := es.DBXFromContext(ctx).Select(&emojis,
+	if err := es.DBXFromContext(c.Context()).Select(&emojis,
 		`SELECT
 			*
 		FROM
@@ -134,10 +134,10 @@ func (es SqlEmojiStore) Search(name string, prefixOnly bool, limit int) ([]*mode
 }
 
 // getBy returns one active (not deleted) emoji, found by any one column (what/key).
-func (es SqlEmojiStore) getBy(ctx context.Context, what, key string) (*model.Emoji, error) {
+func (es SqlEmojiStore) getBy(c request.CTX, what, key string) (*model.Emoji, error) {
 	var emoji model.Emoji
 
-	err := es.DBXFromContext(ctx).Get(&emoji,
+	err := es.DBXFromContext(c.Context()).Get(&emoji,
 		`SELECT
 			*
 		FROM

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -662,9 +662,9 @@ type DesktopTokensStore interface {
 
 type EmojiStore interface {
 	Save(emoji *model.Emoji) (*model.Emoji, error)
-	Get(ctx context.Context, id string, allowFromCache bool) (*model.Emoji, error)
-	GetByName(ctx context.Context, name string, allowFromCache bool) (*model.Emoji, error)
-	GetMultipleByName(ctx context.Context, names []string) ([]*model.Emoji, error)
+	Get(ctx request.CTX, id string, allowFromCache bool) (*model.Emoji, error)
+	GetByName(ctx request.CTX, name string, allowFromCache bool) (*model.Emoji, error)
+	GetMultipleByName(ctx request.CTX, names []string) ([]*model.Emoji, error)
 	GetList(offset, limit int, sort string) ([]*model.Emoji, error)
 	Delete(emoji *model.Emoji, timestamp int64) error
 	Search(name string, prefixOnly bool, limit int) ([]*model.Emoji, error)

--- a/server/channels/store/storetest/emoji_store.go
+++ b/server/channels/store/storetest/emoji_store.go
@@ -53,7 +53,7 @@ func testEmojiSaveDelete(t *testing.T, ss store.Store) {
 }
 
 func testEmojiGet(t *testing.T, ss store.Store) {
-	c := request.TestContext()
+	c := request.TestContext(t)
 
 	emojis := []model.Emoji{
 		{
@@ -94,7 +94,7 @@ func testEmojiGet(t *testing.T, ss store.Store) {
 }
 
 func testEmojiGetByName(t *testing.T, ss store.Store) {
-	c := request.TestContext()
+	c := request.TestContext(t)
 
 	emojis := []model.Emoji{
 		{
@@ -130,7 +130,7 @@ func testEmojiGetByName(t *testing.T, ss store.Store) {
 }
 
 func testEmojiGetMultipleByName(t *testing.T, ss store.Store) {
-	c := request.TestContext()
+	c := request.TestContext(t)
 
 	emojis := []model.Emoji{
 		{

--- a/server/channels/store/storetest/emoji_store.go
+++ b/server/channels/store/storetest/emoji_store.go
@@ -4,11 +4,11 @@
 package storetest
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 
 	"github.com/stretchr/testify/assert"
@@ -53,6 +53,8 @@ func testEmojiSaveDelete(t *testing.T, ss store.Store) {
 }
 
 func testEmojiGet(t *testing.T, ss store.Store) {
+	c := request.TestContext()
+
 	emojis := []model.Emoji{
 		{
 			CreatorId: model.NewId(),
@@ -81,17 +83,19 @@ func testEmojiGet(t *testing.T, ss store.Store) {
 	}()
 
 	for _, emoji := range emojis {
-		_, err := ss.Emoji().Get(context.Background(), emoji.Id, false)
+		_, err := ss.Emoji().Get(c, emoji.Id, false)
 		require.NoErrorf(t, err, "failed to get emoji with id %v", emoji.Id)
 	}
 
 	for _, emoji := range emojis {
-		_, err := ss.Emoji().Get(context.Background(), emoji.Id, true)
+		_, err := ss.Emoji().Get(c, emoji.Id, true)
 		require.NoErrorf(t, err, "failed to get emoji with id %v", emoji.Id)
 	}
 }
 
 func testEmojiGetByName(t *testing.T, ss store.Store) {
+	c := request.TestContext()
+
 	emojis := []model.Emoji{
 		{
 			CreatorId: model.NewId(),
@@ -120,12 +124,14 @@ func testEmojiGetByName(t *testing.T, ss store.Store) {
 	}()
 
 	for _, emoji := range emojis {
-		_, err := ss.Emoji().GetByName(context.Background(), emoji.Name, true)
+		_, err := ss.Emoji().GetByName(c, emoji.Name, true)
 		require.NoErrorf(t, err, "failed to get emoji with name %v", emoji.Name)
 	}
 }
 
 func testEmojiGetMultipleByName(t *testing.T, ss store.Store) {
+	c := request.TestContext()
+
 	emojis := []model.Emoji{
 		{
 			CreatorId: model.NewId(),
@@ -154,26 +160,26 @@ func testEmojiGetMultipleByName(t *testing.T, ss store.Store) {
 	}()
 
 	t.Run("one emoji", func(t *testing.T) {
-		received, err := ss.Emoji().GetMultipleByName(context.Background(), []string{emojis[0].Name})
+		received, err := ss.Emoji().GetMultipleByName(c, []string{emojis[0].Name})
 		require.NoError(t, err, "could not get emoji")
 		require.Len(t, received, 1, "got incorrect emoji")
 		require.Equal(t, *received[0], emojis[0], "got incorrect emoji")
 	})
 
 	t.Run("multiple emojis", func(t *testing.T) {
-		received, err := ss.Emoji().GetMultipleByName(context.Background(), []string{emojis[0].Name, emojis[1].Name, emojis[2].Name})
+		received, err := ss.Emoji().GetMultipleByName(c, []string{emojis[0].Name, emojis[1].Name, emojis[2].Name})
 		require.NoError(t, err, "could not get emojis")
 		require.Len(t, received, 3, "got incorrect emojis")
 	})
 
 	t.Run("one nonexistent emoji", func(t *testing.T) {
-		received, err := ss.Emoji().GetMultipleByName(context.Background(), []string{"ab"})
+		received, err := ss.Emoji().GetMultipleByName(c, []string{"ab"})
 		require.NoError(t, err, "could not get emoji", err)
 		require.Empty(t, received, "got incorrect emoji")
 	})
 
 	t.Run("multiple emojis with nonexistent names", func(t *testing.T) {
-		received, err := ss.Emoji().GetMultipleByName(context.Background(), []string{emojis[0].Name, emojis[1].Name, emojis[2].Name, "abcd", "1234"})
+		received, err := ss.Emoji().GetMultipleByName(c, []string{emojis[0].Name, emojis[1].Name, emojis[2].Name, "abcd", "1234"})
 		require.NoError(t, err, "could not get emojis")
 		require.Len(t, received, 3, "got incorrect emojis")
 	})

--- a/server/channels/store/storetest/mocks/EmojiStore.go
+++ b/server/channels/store/storetest/mocks/EmojiStore.go
@@ -5,9 +5,8 @@
 package mocks
 
 import (
-	context "context"
-
 	model "github.com/mattermost/mattermost/server/public/model"
+	request "github.com/mattermost/mattermost/server/public/shared/request"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -31,15 +30,15 @@ func (_m *EmojiStore) Delete(emoji *model.Emoji, timestamp int64) error {
 }
 
 // Get provides a mock function with given fields: ctx, id, allowFromCache
-func (_m *EmojiStore) Get(ctx context.Context, id string, allowFromCache bool) (*model.Emoji, error) {
+func (_m *EmojiStore) Get(ctx request.CTX, id string, allowFromCache bool) (*model.Emoji, error) {
 	ret := _m.Called(ctx, id, allowFromCache)
 
 	var r0 *model.Emoji
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, bool) (*model.Emoji, error)); ok {
+	if rf, ok := ret.Get(0).(func(request.CTX, string, bool) (*model.Emoji, error)); ok {
 		return rf(ctx, id, allowFromCache)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, bool) *model.Emoji); ok {
+	if rf, ok := ret.Get(0).(func(request.CTX, string, bool) *model.Emoji); ok {
 		r0 = rf(ctx, id, allowFromCache)
 	} else {
 		if ret.Get(0) != nil {
@@ -47,7 +46,7 @@ func (_m *EmojiStore) Get(ctx context.Context, id string, allowFromCache bool) (
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, bool) error); ok {
+	if rf, ok := ret.Get(1).(func(request.CTX, string, bool) error); ok {
 		r1 = rf(ctx, id, allowFromCache)
 	} else {
 		r1 = ret.Error(1)
@@ -57,15 +56,15 @@ func (_m *EmojiStore) Get(ctx context.Context, id string, allowFromCache bool) (
 }
 
 // GetByName provides a mock function with given fields: ctx, name, allowFromCache
-func (_m *EmojiStore) GetByName(ctx context.Context, name string, allowFromCache bool) (*model.Emoji, error) {
+func (_m *EmojiStore) GetByName(ctx request.CTX, name string, allowFromCache bool) (*model.Emoji, error) {
 	ret := _m.Called(ctx, name, allowFromCache)
 
 	var r0 *model.Emoji
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, bool) (*model.Emoji, error)); ok {
+	if rf, ok := ret.Get(0).(func(request.CTX, string, bool) (*model.Emoji, error)); ok {
 		return rf(ctx, name, allowFromCache)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, bool) *model.Emoji); ok {
+	if rf, ok := ret.Get(0).(func(request.CTX, string, bool) *model.Emoji); ok {
 		r0 = rf(ctx, name, allowFromCache)
 	} else {
 		if ret.Get(0) != nil {
@@ -73,7 +72,7 @@ func (_m *EmojiStore) GetByName(ctx context.Context, name string, allowFromCache
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, bool) error); ok {
+	if rf, ok := ret.Get(1).(func(request.CTX, string, bool) error); ok {
 		r1 = rf(ctx, name, allowFromCache)
 	} else {
 		r1 = ret.Error(1)
@@ -109,15 +108,15 @@ func (_m *EmojiStore) GetList(offset int, limit int, sort string) ([]*model.Emoj
 }
 
 // GetMultipleByName provides a mock function with given fields: ctx, names
-func (_m *EmojiStore) GetMultipleByName(ctx context.Context, names []string) ([]*model.Emoji, error) {
+func (_m *EmojiStore) GetMultipleByName(ctx request.CTX, names []string) ([]*model.Emoji, error) {
 	ret := _m.Called(ctx, names)
 
 	var r0 []*model.Emoji
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []string) ([]*model.Emoji, error)); ok {
+	if rf, ok := ret.Get(0).(func(request.CTX, []string) ([]*model.Emoji, error)); ok {
 		return rf(ctx, names)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, []string) []*model.Emoji); ok {
+	if rf, ok := ret.Get(0).(func(request.CTX, []string) []*model.Emoji); ok {
 		r0 = rf(ctx, names)
 	} else {
 		if ret.Get(0) != nil {
@@ -125,7 +124,7 @@ func (_m *EmojiStore) GetMultipleByName(ctx context.Context, names []string) ([]
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+	if rf, ok := ret.Get(1).(func(request.CTX, []string) error); ok {
 		r1 = rf(ctx, names)
 	} else {
 		r1 = ret.Error(1)

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -3139,7 +3139,7 @@ func (s *TimerLayerEmojiStore) Delete(emoji *model.Emoji, timestamp int64) error
 	return err
 }
 
-func (s *TimerLayerEmojiStore) Get(ctx context.Context, id string, allowFromCache bool) (*model.Emoji, error) {
+func (s *TimerLayerEmojiStore) Get(ctx request.CTX, id string, allowFromCache bool) (*model.Emoji, error) {
 	start := time.Now()
 
 	result, err := s.EmojiStore.Get(ctx, id, allowFromCache)
@@ -3155,7 +3155,7 @@ func (s *TimerLayerEmojiStore) Get(ctx context.Context, id string, allowFromCach
 	return result, err
 }
 
-func (s *TimerLayerEmojiStore) GetByName(ctx context.Context, name string, allowFromCache bool) (*model.Emoji, error) {
+func (s *TimerLayerEmojiStore) GetByName(ctx request.CTX, name string, allowFromCache bool) (*model.Emoji, error) {
 	start := time.Now()
 
 	result, err := s.EmojiStore.GetByName(ctx, name, allowFromCache)
@@ -3187,7 +3187,7 @@ func (s *TimerLayerEmojiStore) GetList(offset int, limit int, sort string) ([]*m
 	return result, err
 }
 
-func (s *TimerLayerEmojiStore) GetMultipleByName(ctx context.Context, names []string) ([]*model.Emoji, error) {
+func (s *TimerLayerEmojiStore) GetMultipleByName(ctx request.CTX, names []string) ([]*model.Emoji, error) {
 	start := time.Now()
 
 	result, err := s.EmojiStore.GetMultipleByName(ctx, names)

--- a/server/public/shared/request/context.go
+++ b/server/public/shared/request/context.go
@@ -46,6 +46,13 @@ func EmptyContext(logger mlog.LoggerIFace) *Context {
 	}
 }
 
+// TestContext creates an empty context with a new logger to use in testing where a test helper is
+// not required.
+func TestContext() *Context {
+	logger, _ := mlog.NewLogger()
+	return EmptyContext(logger)
+}
+
 func (c *Context) T(translationID string, args ...any) string {
 	return c.t(translationID, args...)
 }

--- a/server/public/shared/request/context.go
+++ b/server/public/shared/request/context.go
@@ -5,6 +5,7 @@ package request
 
 import (
 	"context"
+	"testing"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/i18n"
@@ -48,8 +49,8 @@ func EmptyContext(logger mlog.LoggerIFace) *Context {
 
 // TestContext creates an empty context with a new logger to use in testing where a test helper is
 // not required.
-func TestContext() *Context {
-	logger, _ := mlog.NewLogger()
+func TestContext(t *testing.T) *Context {
+	logger := mlog.CreateConsoleTestLogger(t)
 	return EmptyContext(logger)
 }
 


### PR DESCRIPTION
#### Summary
Migrate `EmojiStore` methods that make use of a `context.Context` to use `request.CTX` instead.

#### Ticket Link
..

#### Screenshots


#### Release Note
```release-note
Migrate EmojiStore to use request.CTX
```
