### PR TITLE
[MM-54440] Add link to notification docs in the Settings modal

### DIFF
--- a/webapp/channels/src/components/user_settings/notifications/__snapshots__/user_settings_notifications.test.tsx.snap
+++ b/webapp/channels/src/components/user_settings/notifications/__snapshots__/user_settings_notifications.test.tsx.snap
@@ -40,12 +40,28 @@ Object {
         <div
           class="user-settings"
         >
-          <h3
-            class="tab-header"
-            id="notificationSettingsTitle"
+          <div
+            class="notificationSettingsModalHeader"
           >
-            Notifications
-          </h3>
+            <h3
+              class="tab-header"
+              id="notificationSettingsTitle"
+            >
+              Notifications
+            </h3>
+            <a
+              href="https://mattermost.com/pl/about-notifications?utm_source=mattermost&utm_medium=in-product&utm_content=&uid=&sid="
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <i
+                class="icon icon-help-circle-outline"
+              />
+              <span>
+                Learn more about notifications
+              </span>
+            </a>
+          </div>
           <div
             class="divider-dark first"
           />
@@ -248,12 +264,28 @@ Object {
       <div
         class="user-settings"
       >
-        <h3
-          class="tab-header"
-          id="notificationSettingsTitle"
+        <div
+          class="notificationSettingsModalHeader"
         >
-          Notifications
-        </h3>
+          <h3
+            class="tab-header"
+            id="notificationSettingsTitle"
+          >
+            Notifications
+          </h3>
+          <a
+            href="https://mattermost.com/pl/about-notifications?utm_source=mattermost&utm_medium=in-product&utm_content=&uid=&sid="
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <i
+              class="icon icon-help-circle-outline"
+            />
+            <span>
+              Learn more about notifications
+            </span>
+          </a>
+        </div>
         <div
           class="divider-dark first"
         />

--- a/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.scss
+++ b/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.scss
@@ -3,3 +3,34 @@
         margin-block-start: 10px;
     }
 }
+
+.notificationSettingsModalHeader {
+    display: flex;
+
+    > span {
+        align-self: center;
+        margin-left: auto;
+
+        a {
+            display: flex;
+
+            &:hover,
+            &:active,
+            &:focus {
+                color: var(--button-bg);
+                text-decoration: none;
+            }
+
+            > i {
+                margin-top: -1px;
+                font-size: 16px;
+            }
+
+            > span {
+                font-size: 12px;
+                font-weight: 600;
+                line-height: 16px;
+            }
+        }
+    }
+}

--- a/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.tsx
+++ b/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.tsx
@@ -15,6 +15,7 @@ import type {UserNotifyProps, UserProfile} from '@mattermost/types/users';
 
 import type {ActionResult} from 'mattermost-redux/types/actions';
 
+import ExternalLink from 'components/external_link';
 import LocalizedIcon from 'components/localized_icon';
 import SettingItem from 'components/setting_item';
 import SettingItemMax from 'components/setting_item_max';
@@ -1085,15 +1086,29 @@ class NotificationsTab extends React.PureComponent<Props, State> {
                     ref={this.wrapperRef}
                     className='user-settings'
                 >
-                    <h3
-                        id='notificationSettingsTitle'
-                        className='tab-header'
-                    >
+                    <div className='notificationSettingsModalHeader'>
+                        <h3
+                            id='notificationSettingsTitle'
+                            className='tab-header'
+                        >
+                            <FormattedMessage
+                                id='user.settings.notifications.header'
+                                defaultMessage='Notifications'
+                            />
+                        </h3>
                         <FormattedMessage
-                            id='user.settings.notifications.header'
-                            defaultMessage='Notifications'
+                            id='user.settings.notifications.learnMore'
+                            defaultMessage='<a>Learn more about notifications</a>'
+                            values={{
+                                a: (chunks: string) => ((
+                                    <ExternalLink href='https://mattermost.com/pl/about-notifications'>
+                                        <i className='icon icon-help-circle-outline'/>
+                                        <span>{chunks}</span>
+                                    </ExternalLink>
+                                )),
+                            }}
                         />
-                    </h3>
+                    </div>
                     <div className='divider-dark first'/>
                     <DesktopNotificationSettings
                         activity={this.state.desktopActivity}


### PR DESCRIPTION
#### Summary
Added a link to the notification docs in the Notification Settings modal, to help user understand how our notifications works a little better.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54440

```release-note
Add link to notification docs in the Settings modal
```
