### PR TITLE
[MM-54494] Update selector to get profiles connected to calls

### DIFF
--- a/webapp/channels/src/components/profile_popover/index.ts
+++ b/webapp/channels/src/components/profile_popover/index.ts
@@ -13,7 +13,7 @@ import {
     getChannelByName,
     getChannelMember,
 } from 'mattermost-redux/selectors/entities/channels';
-import {getCallsConfig, getCalls} from 'mattermost-redux/selectors/entities/common';
+import {getCallsConfig, getProfilesInCalls} from 'mattermost-redux/selectors/entities/common';
 import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
 import {
     getCurrentTeam,
@@ -53,11 +53,11 @@ function getDefaultChannelId(state: GlobalState) {
 export function checkUserInCall(state: GlobalState, userId: string) {
     let isUserInCall = false;
 
-    const calls = getCalls(state);
-    Object.keys(calls).forEach((channelId) => {
-        const usersInCall = calls[channelId] || [];
+    const profilesInCalls = getProfilesInCalls(state);
+    Object.keys(profilesInCalls).forEach((channelId) => {
+        const profiles = profilesInCalls[channelId] || [];
 
-        for (const user of usersInCall) {
+        for (const user of profiles) {
             if (user.id === userId) {
                 isUserInCall = true;
                 break;

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/common.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/common.ts
@@ -71,10 +71,10 @@ export function getUsers(state: GlobalState): IDMappedObjects<UserProfile> {
 
 // Calls
 
-export function getCalls(state: GlobalState): Record<string, UserProfile[]> {
+export function getProfilesInCalls(state: GlobalState): Record<string, UserProfile[]> {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    return state[CALLS_PLUGIN].voiceConnectedProfiles || {};
+    return state[CALLS_PLUGIN].profiles || state[CALLS_PLUGIN].voiceConnectedProfiles || {};
 }
 
 export function getCallsConfig(state: GlobalState): CallsConfig {

--- a/webapp/channels/src/selectors/calls.ts
+++ b/webapp/channels/src/selectors/calls.ts
@@ -9,7 +9,7 @@ import type {GlobalState} from 'types/store';
 
 export function isCallsEnabled(state: GlobalState, minVersion = '0.4.2') {
     return Boolean(state.plugins.plugins[suitePluginIds.calls] &&
-        semver.gte(state.plugins.plugins[suitePluginIds.calls].version || '0.0.0', minVersion));
+        semver.gte(String(semver.clean(state.plugins.plugins[suitePluginIds.calls].version || '0.0.0')), minVersion));
 }
 
 // isCallsRingingEnabledOnServer is the flag for the ringing/notification feature in calls


### PR DESCRIPTION
#### Summary

Latest version of Calls included a refactor of our redux store and I completely forgot we were relying on it on this side which is breaking functionality and in 7.10 even causing a crash. 

Ideally we'd port this functionality on the other side through a pluggable and avoid this altogether but now we need to keep some sort of compatibility so we are exporting both names from the plugin (see related PR).

I'll also plan to add an E2E test on the Calls side since we should have caught it prior to release.

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/524

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54494

#### Release Note

```release-note
NONE
```
