### PR TITLE
reverted to the old favicon path

### DIFF
--- a/api/v4/html/ssr_template.hbs
+++ b/api/v4/html/ssr_template.hbs
@@ -6,7 +6,7 @@
   <title>Mattermost API Reference</title>
   <!-- needed for adaptive design -->
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="shortcut icon" href="./favicon.ico">
+  <link rel="shortcut icon" href="./static/favicon.ico">
   <style>
     body {
       padding: 0;


### PR DESCRIPTION
#### Summary

This pull request fixes a regression introduced by https://github.com/mattermost/mattermost/issues/24504 by removing the "static" folder in the favicon's url path definition the folder duplication issue stopped occuring in the dev environment but introduced a breaking change in production since the favicon no longer loads in production, I have restored the old favicon url path definition.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54449

#### Screenshots

See issue: https://github.com/mattermost/mattermost/issues/24504

#### Release Note
```release-note
NONE
```