### PR TITLE
MM-54505: re-enable remote marketplace functionality

### DIFF
--- a/server/channels/api4/plugin_test.go
+++ b/server/channels/api4/plugin_test.go
@@ -462,8 +462,6 @@ func TestDisableOnRemove(t *testing.T) {
 }
 
 func TestGetMarketplacePlugins(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE", "false")
-	defer os.Unsetenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE")
 
 	th := Setup(t)
 	defer th.TearDown()
@@ -685,8 +683,6 @@ func TestGetMarketplacePlugins(t *testing.T) {
 }
 
 func TestGetInstalledMarketplacePlugins(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE", "false")
-	defer os.Unsetenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE")
 
 	samplePlugins := []*model.MarketplacePlugin{
 		{
@@ -831,8 +827,6 @@ func TestGetInstalledMarketplacePlugins(t *testing.T) {
 }
 
 func TestSearchGetMarketplacePlugins(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE", "false")
-	defer os.Unsetenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE")
 
 	samplePlugins := []*model.MarketplacePlugin{
 		{
@@ -959,8 +953,6 @@ func TestSearchGetMarketplacePlugins(t *testing.T) {
 }
 
 func TestGetLocalPluginInMarketplace(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE", "false")
-	defer os.Unsetenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE")
 
 	th := Setup(t)
 	defer th.TearDown()
@@ -1123,8 +1115,6 @@ func TestGetLocalPluginInMarketplace(t *testing.T) {
 }
 
 func TestGetRemotePluginInMarketplace(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE", "false")
-	defer os.Unsetenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE")
 
 	th := Setup(t)
 	defer th.TearDown()
@@ -1181,69 +1171,7 @@ func TestGetRemotePluginInMarketplace(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestRemoteMarketplaceDisabledByStreamlinedMarketplaceFlag(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE")
-
-	th := Setup(t)
-	defer th.TearDown()
-
-	marketplacePlugins := []*model.MarketplacePlugin{
-		{
-			BaseMarketplacePlugin: &model.BaseMarketplacePlugin{
-				HomepageURL: "https://example.com/mattermost/mattermost-plugin-nps",
-				IconData:    "https://example.com/icon.svg",
-				DownloadURL: "www.github.com/example",
-				Manifest: &model.Manifest{
-					Id:               "marketplace.test",
-					Name:             "marketplacetest",
-					Description:      "a marketplace plugin",
-					Version:          "0.1.2",
-					MinServerVersion: "",
-				},
-			},
-			InstalledVersion: "",
-		},
-	}
-
-	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		res.WriteHeader(http.StatusOK)
-		json, err := json.Marshal([]*model.MarketplacePlugin{marketplacePlugins[0]})
-		require.NoError(t, err)
-		res.Write(json)
-	}))
-	defer testServer.Close()
-
-	th.App.UpdateConfig(func(cfg *model.Config) {
-		*cfg.PluginSettings.Enable = true
-		*cfg.PluginSettings.EnableMarketplace = true
-		*cfg.PluginSettings.EnableRemoteMarketplace = true
-		*cfg.PluginSettings.EnableUploads = true
-		*cfg.PluginSettings.MarketplaceURL = testServer.URL
-	})
-
-	prepackagePlugin := &plugin.PrepackagedPlugin{
-		Manifest: &model.Manifest{
-			Version: "0.0.1",
-			Id:      "prepackaged.test",
-		},
-	}
-
-	env := th.App.GetPluginsEnvironment()
-	env.SetPrepackagedPlugins([]*plugin.PrepackagedPlugin{prepackagePlugin}, nil)
-
-	// No marketplace plugins returned
-	plugins, _, err := th.SystemAdminClient.GetMarketplacePlugins(context.Background(), &model.MarketplacePluginFilter{})
-	require.NoError(t, err)
-
-	// Only returns the prepackaged plugins
-	require.Len(t, plugins, 1)
-	require.Equal(t, prepackagePlugin.Manifest, plugins[0].Manifest)
-}
-
 func TestGetPrepackagedPluginInMarketplace(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE", "false")
-	defer os.Unsetenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE")
 
 	th := Setup(t)
 	defer th.TearDown()
@@ -1376,8 +1304,6 @@ func TestGetPrepackagedPluginInMarketplace(t *testing.T) {
 }
 
 func TestInstallMarketplacePlugin(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE", "false")
-	defer os.Unsetenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE")
 
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
@@ -1729,8 +1655,6 @@ func TestInstallMarketplacePlugin(t *testing.T) {
 }
 
 func TestInstallMarketplacePluginPrepackagedDisabled(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE", "false")
-	defer os.Unsetenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE")
 
 	path, _ := fileutils.FindDir("tests")
 

--- a/server/channels/api4/system_test.go
+++ b/server/channels/api4/system_test.go
@@ -855,8 +855,6 @@ func TestPushNotificationAck(t *testing.T) {
 }
 
 func TestCompleteOnboarding(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE", "false")
-	defer os.Unsetenv("MM_FEATUREFLAGS_STREAMLINEDMARKETPLACE")
 	th := Setup(t)
 	defer th.TearDown()
 

--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -552,7 +552,7 @@ func (a *App) GetPlugins() (*model.PluginsResponse, *model.AppError) {
 func (a *App) GetMarketplacePlugins(filter *model.MarketplacePluginFilter) ([]*model.MarketplacePlugin, *model.AppError) {
 	plugins := map[string]*model.MarketplacePlugin{}
 
-	if *a.Config().PluginSettings.EnableRemoteMarketplace && !a.Config().FeatureFlags.StreamlinedMarketplace && !filter.LocalOnly {
+	if *a.Config().PluginSettings.EnableRemoteMarketplace && !filter.LocalOnly {
 		p, appErr := a.getRemotePlugins()
 		if appErr != nil {
 			return nil, appErr

--- a/server/channels/app/plugin_install.go
+++ b/server/channels/app/plugin_install.go
@@ -289,7 +289,7 @@ func (ch *Channels) InstallMarketplacePlugin(request *model.InstallMarketplacePl
 		signatureFile = bytes.NewReader(prepackagedPlugin.Signature)
 	}
 
-	if *ch.cfgSvc.Config().PluginSettings.EnableRemoteMarketplace && !ch.cfgSvc.Config().FeatureFlags.StreamlinedMarketplace {
+	if *ch.cfgSvc.Config().PluginSettings.EnableRemoteMarketplace {
 		var plugin *model.BaseMarketplacePlugin
 		plugin, appErr = ch.getRemoteMarketplacePlugin(request.Id, request.Version)
 		// The plugin might only be prepackaged and not on the Marketplace.

--- a/webapp/channels/src/components/plugin_marketplace/__snapshots__/marketplace_modal.test.tsx.snap
+++ b/webapp/channels/src/components/plugin_marketplace/__snapshots__/marketplace_modal.test.tsx.snap
@@ -76,16 +76,8 @@ exports[`components/marketplace/ doesn't show web marketplace banner in FeatureF
       <div
         className="GenericModal__body"
       >
-        <MarketplaceList
-          filter=""
-          listRef={
-            Object {
-              "current": null,
-            }
-          }
-          listing={Array []}
-          noResultsMessage="No plugins found"
-          page={0}
+        <LoadingScreen
+          className="loading"
         />
       </div>
     </ModalBody>
@@ -169,49 +161,8 @@ exports[`components/marketplace/ hides search, shows web marketplace banner in F
       <div
         className="GenericModal__body"
       >
-        <MarketplaceList
-          filter=""
-          listRef={
-            Object {
-              "current": null,
-            }
-          }
-          listing={
-            Array [
-              Object {
-                "author_type": "mattermost",
-                "download_url": "https://github.com/mattermost/mattermost-plugin-nps/releases/download/v1.0.3/com.mattermost.nps-1.0.3.tar.gz",
-                "enterprise": false,
-                "homepage_url": "https://github.com/mattermost/mattermost-plugin-nps",
-                "installed_version": "",
-                "manifest": Object {
-                  "description": "This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost",
-                  "id": "com.mattermost.nps",
-                  "min_server_version": "5.14.0",
-                  "name": "User Satisfaction Surveys",
-                  "version": "1.0.3",
-                },
-                "release_stage": "production",
-              },
-              Object {
-                "author_type": "mattermost",
-                "download_url": "https://github.com/mattermost/mattermost-test/releases/download/v1.0.3/com.mattermost.nps-1.0.3.tar.gz",
-                "enterprise": false,
-                "homepage_url": "https://github.com/mattermost/mattermost-test",
-                "installed_version": "1.0.3",
-                "manifest": Object {
-                  "description": "This plugin is to test",
-                  "id": "com.mattermost.test",
-                  "min_server_version": "5.14.0",
-                  "name": "Test",
-                  "version": "1.0.3",
-                },
-                "release_stage": "production",
-              },
-            ]
-          }
-          noResultsMessage="No plugins found"
-          page={0}
+        <LoadingScreen
+          className="loading"
         />
       </div>
     </ModalBody>

--- a/webapp/channels/src/components/plugin_marketplace/marketplace_modal.tsx
+++ b/webapp/channels/src/components/plugin_marketplace/marketplace_modal.tsx
@@ -251,13 +251,17 @@ const MarketplaceModal = ({
         >
             {isStreamlinedMarketplaceEnabled ? (
                 <>
-                    <MarketplaceList
-                        listRef={listRef}
-                        listing={listing}
-                        page={page}
-                        filter={filter}
-                        noResultsMessage={formatMessage({id: 'marketplace_modal.no_plugins', defaultMessage: 'No plugins found'})}
-                    />
+                    {loading ? (
+                        <LoadingScreen className='loading'/>
+                    ) : (
+                        <MarketplaceList
+                            listRef={listRef}
+                            listing={listing}
+                            page={page}
+                            filter={filter}
+                            noResultsMessage={formatMessage({id: 'marketplace_modal.no_plugins', defaultMessage: 'No plugins found'})}
+                        />
+                    )}
                 </>
             ) : (
                 <Tabs


### PR DESCRIPTION
#### Summary
As a follow up to #24311, and in relation to https://github.com/mattermost/mattermost-marketplace/pull/384, this re-enables remote marketplace functionality and adds back the loading screen. `FeatureFlags.StreamlinedMarketplace` now only affects marketplace UI.  



https://github.com/mattermost/mattermost/assets/11724372/9b29656c-7078-4b25-af26-64088c3ee8b8



#### Ticket Link

- https://mattermost.atlassian.net/browse/MM-54505

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Re-enables remote marketplace functionality (if configured as per `PluginSettings.EnableRemoteMarketplace`)
```
