### PR TITLE
Fix flaky test introduced in #24495

### DIFF
--- a/server/channels/app/post_metadata_test.go
+++ b/server/channels/app/post_metadata_test.go
@@ -2834,7 +2834,7 @@ func TestSanitizePostMetadataForUserAndChannel(t *testing.T) {
 		}()
 
 		publicChannel, err := th.App.CreateChannel(th.Context, &model.Channel{
-			Name:      "private_chanenl",
+			Name:      model.NewId(),
 			Type:      model.ChannelTypeOpen,
 			TeamId:    th.BasicTeam.Id,
 			CreatorId: th.SystemAdminUser.Id,
@@ -2956,7 +2956,7 @@ func TestSanitizePostMetadataForUser(t *testing.T) {
 
 	t.Run("should remove embeds for not accessible channels", func(t *testing.T) {
 		privateChannel, err := th.App.CreateChannel(th.Context, &model.Channel{
-			Name:      "private_chanenl",
+			Name:      model.NewId(),
 			Type:      model.ChannelTypePrivate,
 			TeamId:    th.BasicTeam.Id,
 			CreatorId: th.SystemAdminUser.Id,
@@ -3010,7 +3010,7 @@ func TestSanitizePostMetadataForUser(t *testing.T) {
 
 	t.Run("should remove embeds for archived channels if the config does not allow it", func(t *testing.T) {
 		publicChannel, err := th.App.CreateChannel(th.Context, &model.Channel{
-			Name:      "private_chanenl",
+			Name:      model.NewId(),
 			Type:      model.ChannelTypeOpen,
 			TeamId:    th.BasicTeam.Id,
 			CreatorId: th.SystemAdminUser.Id,


### PR DESCRIPTION
#### Summary
Since we were using static channel names, in the same test suite we had conflicts when creating new channels. I changed all the occurrences of the offending string (which also had a typo and not always made sense) with `model.NewId()`, which should never collide.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
