### PR TITLE
MM-54349 Increase timeout for ConfirmModalRedux test

### DIFF
--- a/webapp/channels/src/components/confirm_modal_redux/confirm_modal_redux.test.tsx
+++ b/webapp/channels/src/components/confirm_modal_redux/confirm_modal_redux.test.tsx
@@ -30,7 +30,7 @@ describe('ConfirmModalRedux', () => {
         wrapper.find('#confirmModalButton').simulate('click');
 
         expect(wrapper.find(Modal).prop('show')).toBe(false);
-    }, 1000);
+    }, 5000);
 
     test('should call onExited after cancelling', (done) => {
         baseProps.onExited.mockImplementation(() => done());
@@ -47,5 +47,5 @@ describe('ConfirmModalRedux', () => {
         wrapper.find('#cancelModalButton').simulate('click');
 
         expect(wrapper.find(Modal).prop('show')).toBe(false);
-    }, 1000);
+    }, 5000);
 });


### PR DESCRIPTION
#### Summary
Since Node 18, web app unit tests take longer to run in CI. These tests time out when they fail, and we give them a much lower timeout than any other test. Since they run slower with Node 18, I assume they've become flaky because that timeout is too low now.

#### Ticket Link
MM-54349

#### Release Note
```release-note
NONE
```
