### PR TITLE
Update minimum supported Edge version

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9892,7 +9892,7 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "Version 112+"
+    "translation": "Version 116+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",


### PR DESCRIPTION
Update minimum required Edge version to v116+ as the minimum supported Chrome version was recently updated to v116+. Chrome and Edge are using the same code base and they normally need to be on the same version.

```release-note
Update minimum required Edge version to 116+.
```