### PR TITLE
MM-53513 Update styles of slack attachment buttons

### DIFF
--- a/webapp/channels/src/components/post_view/message_attachments/action_button/action_button.test.tsx
+++ b/webapp/channels/src/components/post_view/message_attachments/action_button/action_button.test.tsx
@@ -49,8 +49,7 @@ describe('components/post_view/message_attachments/action_button.jsx', () => {
 
         const button = screen.getByRole('button');
 
-        expect(button).toHaveStyle(`borderColor: ${changeOpacity(Preferences.THEMES.denim.onlineIndicator, 0.25)}`);
-        expect(button).toHaveStyle('borderWidth: 2');
+        expect(button).toHaveStyle(`background-color: ${changeOpacity(Preferences.THEMES.denim.onlineIndicator, 0.08)}`);
         expect(button).toHaveStyle(`color: ${Preferences.THEMES.denim.onlineIndicator}`);
     });
 
@@ -65,8 +64,7 @@ describe('components/post_view/message_attachments/action_button.jsx', () => {
 
         const button = screen.getByRole('button');
 
-        expect(button).toHaveStyle(`borderColor: ${changeOpacity(Preferences.THEMES.indigo.errorTextColor, 0.25)}`);
-        expect(button).toHaveStyle('borderWidth: 2');
+        expect(button).toHaveStyle(`background-color: ${changeOpacity(Preferences.THEMES.indigo.errorTextColor, 0.08)}`);
         expect(button).toHaveStyle(`color: ${Preferences.THEMES.indigo.errorTextColor}`);
     });
 
@@ -79,9 +77,8 @@ describe('components/post_view/message_attachments/action_button.jsx', () => {
         render(<ActionButton {...props}/>);
         const button = screen.getByRole('button');
 
-        expect(button).toHaveStyle(`borderColor: ${changeOpacity(Preferences.THEMES.denim.onlineIndicator, 0.25)}`);
-        expect(button).toHaveStyle('borderWidth: 2');
-        expect(button).toHaveStyle(`color: ${Preferences.THEMES.denim.onlineIndicator}`);
+        expect(button).toHaveStyle(`background-color: ${changeOpacity('#339970', 0.08)}`);
+        expect(button).toHaveStyle(`color: ${'#339970'}`);
     });
 
     test('should have correct styles when provided hex color', () => {
@@ -93,8 +90,7 @@ describe('components/post_view/message_attachments/action_button.jsx', () => {
         render(<ActionButton {...props}/>);
         const button = screen.getByRole('button');
 
-        expect(button).toHaveStyle(`borderColor: ${changeOpacity(props.action.style, 0.25)}`);
-        expect(button).toHaveStyle('borderWidth: 2');
+        expect(button).toHaveStyle(`background-color: ${changeOpacity(props.action.style, 0.08)}`);
         expect(button).toHaveStyle(`color: ${props.action.style}`);
     });
 

--- a/webapp/channels/src/components/post_view/message_attachments/action_button/action_button.tsx
+++ b/webapp/channels/src/components/post_view/message_attachments/action_button/action_button.tsx
@@ -2,13 +2,12 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import styled, {css} from 'styled-components'
+import styled, {css} from 'styled-components';
 
 import type {PostAction, PostActionOption} from '@mattermost/types/integration_actions';
 
 import type {Theme} from 'mattermost-redux/selectors/entities/preferences';
 import {changeOpacity} from 'mattermost-redux/utils/theme_utils';
-
 
 import Markdown from 'components/markdown';
 import LoadingWrapper from 'components/widgets/loading/loading_wrapper';

--- a/webapp/channels/src/components/post_view/message_attachments/action_button/action_button.tsx
+++ b/webapp/channels/src/components/post_view/message_attachments/action_button/action_button.tsx
@@ -23,12 +23,12 @@ type Props = {
 export default class ActionButton extends React.PureComponent<Props> {
     getStatusColors(theme: Theme) {
         return {
-            good: '#00c100',
-            warning: '#dede01',
+            good: '#339970',
+            warning: '#CC8F00',
             danger: theme.errorTextColor,
             default: theme.centerChannelColor,
             primary: theme.buttonBg,
-            success: theme.onlineIndicator,
+            success: `#339970`,
         } as Record<string, string>;
     }
 
@@ -45,15 +45,15 @@ export default class ActionButton extends React.PureComponent<Props> {
 
             if (hexColor) {
                 customButtonStyle = {
-                    borderColor: changeOpacity(hexColor, 0.25),
                     color: hexColor,
-                    borderWidth: 2,
+                    backgroundColor: changeOpacity(hexColor, 0.08),
                 };
             }
         }
 
         return (
-            <button
+            <button 
+                className="btn btn-sm"
                 data-action-id={action.id}
                 data-action-cookie={action.cookie}
                 disabled={disabled}

--- a/webapp/channels/src/components/post_view/message_attachments/action_button/action_button.tsx
+++ b/webapp/channels/src/components/post_view/message_attachments/action_button/action_button.tsx
@@ -52,8 +52,8 @@ export default class ActionButton extends React.PureComponent<Props> {
         }
 
         return (
-            <button 
-                className="btn btn-sm"
+            <button
+                className='btn btn-sm'
                 data-action-id={action.id}
                 data-action-cookie={action.cookie}
                 disabled={disabled}

--- a/webapp/channels/src/components/post_view/message_attachments/action_button/action_button.tsx
+++ b/webapp/channels/src/components/post_view/message_attachments/action_button/action_button.tsx
@@ -2,11 +2,13 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import styled, {css} from 'styled-components'
 
 import type {PostAction, PostActionOption} from '@mattermost/types/integration_actions';
 
 import type {Theme} from 'mattermost-redux/selectors/entities/preferences';
 import {changeOpacity} from 'mattermost-redux/utils/theme_utils';
+
 
 import Markdown from 'components/markdown';
 import LoadingWrapper from 'components/widgets/loading/loading_wrapper';
@@ -28,38 +30,31 @@ export default class ActionButton extends React.PureComponent<Props> {
             danger: theme.errorTextColor,
             default: theme.centerChannelColor,
             primary: theme.buttonBg,
-            success: `#339970`,
+            success: '#339970',
         } as Record<string, string>;
     }
 
     render() {
         const {action, handleAction, disabled, theme} = this.props;
-        let customButtonStyle;
+        let hexColor: string | null | undefined;
 
         if (action.style) {
             const STATUS_COLORS = this.getStatusColors(theme);
-            const hexColor =
+            hexColor =
                 STATUS_COLORS[action.style] ||
                 theme[action.style] ||
                 (action.style.match('^#(?:[0-9a-fA-F]{3}){1,2}$') && action.style);
-
-            if (hexColor) {
-                customButtonStyle = {
-                    color: hexColor,
-                    backgroundColor: changeOpacity(hexColor, 0.08),
-                };
-            }
         }
 
         return (
-            <button
-                className='btn btn-sm'
+            <ActionBtn
                 data-action-id={action.id}
                 data-action-cookie={action.cookie}
                 disabled={disabled}
                 key={action.id}
                 onClick={(e) => handleAction(e, this.props.action.options)}
-                style={customButtonStyle}
+                className='btn btn-sm'
+                hexColor={hexColor}
             >
                 <LoadingWrapper
                     loading={this.props.actionExecuting}
@@ -74,7 +69,21 @@ export default class ActionButton extends React.PureComponent<Props> {
                         }}
                     />
                 </LoadingWrapper>
-            </button>
+            </ActionBtn>
         );
     }
 }
+
+type ActionBtnProps = {hexColor: string | null | undefined};
+const ActionBtn = styled.button<ActionBtnProps>`
+    ${({hexColor}) => hexColor && css`
+        background-color: ${changeOpacity(hexColor, 0.08)} !important;
+        color: ${hexColor} !important;
+        &:hover {
+            background-color: ${changeOpacity(hexColor, 0.12)} !important;
+        }
+        &:active {
+            background-color: ${changeOpacity(hexColor, 0.16)} !important;
+        }
+    `}
+`;

--- a/webapp/channels/src/sass/layout/_webhooks.scss
+++ b/webapp/channels/src/sass/layout/_webhooks.scss
@@ -374,9 +374,9 @@
                 border: none;
                 margin-top: 8px;
                 background-color: rgba(var(--center-channel-color-rgb), 0.08);
-                outline: 0;
                 color: var(--center-channel-color);
                 font-size: 13px;
+                outline: 0;
 
                 &:hover {
                     background-color: rgba(var(--center-channel-color-rgb), 0.12);

--- a/webapp/channels/src/sass/layout/_webhooks.scss
+++ b/webapp/channels/src/sass/layout/_webhooks.scss
@@ -373,8 +373,8 @@
             button {
                 border: none;
                 margin-top: 8px;
-                outline: 0;
                 background-color: rgba(var(--center-channel-color-rgb), 0.08);
+                outline: 0;
                 color: var(--center-channel-color);
                 font-size: 13px;
 

--- a/webapp/channels/src/sass/layout/_webhooks.scss
+++ b/webapp/channels/src/sass/layout/_webhooks.scss
@@ -371,9 +371,9 @@
             }
 
             button {
+                border: none;
                 margin-top: 8px;
                 outline: 0;
-                border: none;
                 background-color: rgba(var(--center-channel-color-rgb), 0.08);
                 color: var(--center-channel-color);
                 font-size: 13px;
@@ -384,8 +384,8 @@
                 }
 
                 &[disabled] {
-                    opacity: 0.5;
                     cursor: auto;
+                    opacity: 0.5;
                 }
 
                 a {

--- a/webapp/channels/src/sass/layout/_webhooks.scss
+++ b/webapp/channels/src/sass/layout/_webhooks.scss
@@ -4,7 +4,7 @@
     padding: 0 13px 15px;
     border: 1px solid;
     margin-top: 10px;
-    border-radius: 3px;
+    border-radius: 4px;
 
     @include alpha-property(background, $black, 0.1);
 }
@@ -371,19 +371,25 @@
             }
 
             button {
-                height: auto;
-                padding: 6px 12px;
-                border-width: 1px;
-                border-style: solid;
-                margin: 8px 8px 0 0;
-                border-radius: 3px;
-                font-size: 13px;
-                font-weight: 700;
+                border: none;
                 outline: 0;
+                margin-top: 8px;
+                font-size: 13px;
+                color: var(--center-channel-color);
+                background-color: rgba(var(--center-channel-color-rgb), 0.08);
+
+                &:hover {
+                    background-color: rgba(var(--center-channel-color-rgb), 0.12);
+                    text-decoration: none;
+                }
 
                 &[disabled] {
                     cursor: auto;
                     opacity: 0.5;
+                }
+
+                a {
+                    color: inherit;
                 }
             }
 

--- a/webapp/channels/src/sass/layout/_webhooks.scss
+++ b/webapp/channels/src/sass/layout/_webhooks.scss
@@ -371,12 +371,12 @@
             }
 
             button {
-                border: none;
-                outline: 0;
                 margin-top: 8px;
-                font-size: 13px;
-                color: var(--center-channel-color);
+                outline: 0;
+                border: none;
                 background-color: rgba(var(--center-channel-color-rgb), 0.08);
+                color: var(--center-channel-color);
+                font-size: 13px;
 
                 &:hover {
                     background-color: rgba(var(--center-channel-color-rgb), 0.12);
@@ -384,8 +384,8 @@
                 }
 
                 &[disabled] {
-                    cursor: auto;
                     opacity: 0.5;
+                    cursor: auto;
                 }
 
                 a {


### PR DESCRIPTION
#### Summary
This PR improves the styling for the slack attachment buttons and aligns them better with the new button classes that are now available since merging https://github.com/mattermost/mattermost/pull/24483#event-10460608133.

This also resolves theming issues that have been reported with dark themes for slack attachment buttons.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/23968
Jira https://mattermost.atlassian.net/browse/MM-53513

#### Screenshots

**Denim Theme**
<table>
<tr>
<td>Before</td>
<td><img width="989" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/e8198fb8-8576-4993-a685-44fe41d65929"></td>
</tr>
<tr>
<td>After</td>
<td><img width="988" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/093a71d2-5683-4f5c-b482-102a9cf4aaba"></td>
</tr>
</table>

**Onyx Theme**
<table>
<tr>
<td>Before</td>
<td><img width="988" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/d933e55c-0dc6-42ef-b7d9-f9b644a04c62"></td>
</tr>
<tr>
<td>After</td>
<td><img width="984" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/33cd7f52-ef92-4f47-bcc8-3c4065f4617b"></td>
</tr>
</table>

#### Release Note

```release-note
NONE
```


