### PR TITLE
MM-54580: Fix panic in jobs/base_workers.go

### DIFF
--- a/server/channels/jobs/base_workers.go
+++ b/server/channels/jobs/base_workers.go
@@ -83,11 +83,14 @@ func (worker *SimpleWorker) DoJob(job *model.Job) {
 	c := request.EmptyContext(worker.logger)
 
 	var appErr *model.AppError
+	// We keep the reference to the old job because GetJob might return nil.
+	oldJob := job
 	// We get the job again because ClaimJob changes the job status.
 	job, appErr = worker.jobServer.GetJob(c, job.Id)
 	if appErr != nil {
-		job.Logger.Error("SimpleWorker: job execution error", mlog.Err(appErr))
-		worker.setJobError(job, appErr)
+		oldJob.Logger.Error("SimpleWorker: job execution error", mlog.Err(appErr))
+		worker.setJobError(oldJob, appErr)
+		return
 	}
 
 	err := worker.execute(job)

--- a/server/channels/jobs/base_workers.go
+++ b/server/channels/jobs/base_workers.go
@@ -82,16 +82,14 @@ func (worker *SimpleWorker) DoJob(job *model.Job) {
 
 	c := request.EmptyContext(worker.logger)
 
-	var appErr *model.AppError
-	// We keep the reference to the old job because GetJob might return nil.
-	oldJob := job
 	// We get the job again because ClaimJob changes the job status.
-	job, appErr = worker.jobServer.GetJob(c, job.Id)
+	newJob, appErr := worker.jobServer.GetJob(c, job.Id)
 	if appErr != nil {
-		oldJob.Logger.Error("SimpleWorker: job execution error", mlog.Err(appErr))
-		worker.setJobError(oldJob, appErr)
+		job.Logger.Error("SimpleWorker: job execution error", mlog.Err(appErr))
+		worker.setJobError(job, appErr)
 		return
 	}
+	job = newJob
 
 	err := worker.execute(job)
 	if err != nil {

--- a/server/channels/jobs/base_workers_test.go
+++ b/server/channels/jobs/base_workers_test.go
@@ -15,13 +15,11 @@ import (
 
 func TestSimpleWorkerPanic(t *testing.T) {
 	jobServer, mockStore, mockMetrics := makeJobServer(t)
-	logger := mlog.CreateConsoleTestLogger(t)
-	jobServer.logger = logger
 
 	job := &model.Job{
 		Id:     "job_id",
 		Type:   "job_type",
-		Logger: logger,
+		Logger: jobServer.logger.(*mlog.Logger),
 	}
 
 	exec := func(_ *model.Job) error {

--- a/server/channels/jobs/base_workers_test.go
+++ b/server/channels/jobs/base_workers_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package jobs
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimpleWorkerPanic(t *testing.T) {
+	jobServer, mockStore, mockMetrics := makeJobServer(t)
+	logger := mlog.CreateConsoleTestLogger(t)
+	jobServer.logger = logger
+
+	job := &model.Job{
+		Id:     "job_id",
+		Type:   "job_type",
+		Logger: logger,
+	}
+
+	exec := func(_ *model.Job) error {
+		return nil
+	}
+
+	isEnabled := func(_ *model.Config) bool {
+		return true
+	}
+
+	mockStore.JobStore.On("UpdateStatusOptimistically", "job_id", model.JobStatusPending, model.JobStatusInProgress).Return(true, nil)
+	mockStore.JobStore.On("UpdateOptimistically", mock.AnythingOfType("*model.Job"), model.JobStatusInProgress).Return(true, nil)
+	mockStore.JobStore.On("Get", mock.AnythingOfType("*request.Context"), "job_id").Return(nil, errors.New("test"))
+	mockMetrics.On("IncrementJobActive", "job_type")
+	mockMetrics.On("DecrementJobActive", "job_type")
+	sWorker := NewSimpleWorker("test", jobServer, exec, isEnabled)
+
+	require.NotPanics(t, func() {
+		sWorker.DoJob(job)
+	})
+}

--- a/server/channels/jobs/jobs_test.go
+++ b/server/channels/jobs/jobs_test.go
@@ -38,6 +38,7 @@ func makeJobServer(t *testing.T) (*JobServer, *storetest.Store, *mocks.MetricsIn
 		ConfigService: configService,
 		Store:         mockStore,
 		metrics:       mockMetrics,
+		logger:        mlog.CreateConsoleTestLogger(t),
 	}
 
 	return jobServer, mockStore, mockMetrics


### PR DESCRIPTION
If GetJob fails, we would return a nil job and then try to log
with that. To prevent this, we keep a reference to the old job
and log with that in the error case.

https://mattermost.atlassian.net/browse/MM-54580

```release-note
Fix a panic where a simple worker would crash if if failed to get a job.
```
