### PR TITLE
CP: MM-54580: Fix panic in jobs/base_workers.go

### DIFF
--- a/server/channels/jobs/base_workers.go
+++ b/server/channels/jobs/base_workers.go
@@ -78,13 +78,14 @@ func (worker *SimpleWorker) DoJob(job *model.Job) {
 		return
 	}
 
-	var appErr *model.AppError
 	// We get the job again because ClaimJob changes the job status.
-	job, appErr = worker.jobServer.GetJob(job.Id)
+	newJob, appErr := worker.jobServer.GetJob(job.Id)
 	if appErr != nil {
 		mlog.Error("SimpleWorker: job execution error", mlog.String("worker", worker.name), mlog.String("job_id", job.Id), mlog.Err(appErr))
 		worker.setJobError(job, appErr)
+		return
 	}
+	job = newJob
 
 	err := worker.execute(job)
 	if err != nil {

--- a/server/channels/jobs/base_workers_test.go
+++ b/server/channels/jobs/base_workers_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package jobs
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimpleWorkerPanic(t *testing.T) {
+	jobServer, mockStore, mockMetrics := makeJobServer(t)
+
+	job := &model.Job{
+		Id:   "job_id",
+		Type: "job_type",
+	}
+
+	exec := func(_ *model.Job) error {
+		return nil
+	}
+
+	isEnabled := func(_ *model.Config) bool {
+		return true
+	}
+
+	mockStore.JobStore.On("UpdateStatusOptimistically", "job_id", model.JobStatusPending, model.JobStatusInProgress).Return(true, nil)
+	mockStore.JobStore.On("UpdateOptimistically", mock.AnythingOfType("*model.Job"), model.JobStatusInProgress).Return(true, nil)
+	mockStore.JobStore.On("Get", "job_id").Return(nil, errors.New("test"))
+	mockMetrics.On("IncrementJobActive", "job_type")
+	mockMetrics.On("DecrementJobActive", "job_type")
+	sWorker := NewSimpleWorker("test", jobServer, exec, isEnabled)
+
+	require.NotPanics(t, func() {
+		sWorker.DoJob(job)
+	})
+}


### PR DESCRIPTION
If GetJob fails, we would return a nil job and then try to log
with that. To prevent this, we keep a reference to the old job
and log with that in the error case.

https://mattermost.atlassian.net/browse/MM-54580

```release-note
Fix a panic where a simple worker would crash if if failed to get a job.
```
