### PR TITLE
MM-54723 - Fixing btn icon sizes for RHS

### DIFF
--- a/webapp/channels/src/sass/components/_buttons.scss
+++ b/webapp/channels/src/sass/components/_buttons.scss
@@ -52,7 +52,6 @@ button {
         padding: 0;
         background-color: transparent;
         color: rgba(var(--center-channel-color-rgb), 0.56);
-        font-size: 24px;
 
         &:hover {
             background-color: rgba(var(--center-channel-color-rgb), 0.08);
@@ -66,39 +65,48 @@ button {
         }
 
         i {
-            font-size: inherit;
+            font-size: 24px;
         }
 
         &.btn-xs {
             width: 24px;
             height: 24px;
-            font-size: 14.4px;
 
             &.btn-compact {
                 width: 20px;
                 height: 20px;
+            }
+
+            i {
+                font-size: 14.4px;
             }
         }
 
         &.btn-sm {
             width: 32px;
             height: 32px;
-            font-size: 18px;
 
             &.btn-compact {
                 width: 28px;
                 height: 28px;
+            }
+
+            i {
+                font-size: 18px;
             }
         }
 
         &.btn-lg {
             width: 48px;
             height: 48px;
-            font-size: 31.2px;
 
             &.btn-compact {
                 width: 36px;
                 height: 36px;
+            }
+
+            i {
+                font-size: 31.2px;
             }
         }
     }


### PR DESCRIPTION
#### Summary
MM-54723 - Updating btn icon sizes

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-54723

#### Screenshots
**Before**
<img width="402" alt="Screenshot 2023-10-03 at 11 40 01 AM" src="https://github.com/mattermost/mattermost/assets/11034289/9213b58f-b234-4cf4-9929-bcc03cfe9e4a">

**After**
<img width="401" alt="Screenshot 2023-10-03 at 11 38 51 AM" src="https://github.com/mattermost/mattermost/assets/11034289/bb4f77ae-e87c-47af-a63e-3fae885807fd">


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
