### PR TITLE
MM-54762: Remove shallow copy while setting event sequence

### DIFF
--- a/server/public/model/websocket_message.go
+++ b/server/public/model/websocket_message.go
@@ -268,9 +268,8 @@ func (ev *WebSocketEvent) SetBroadcast(broadcast *WebsocketBroadcast) *WebSocket
 }
 
 func (ev *WebSocketEvent) SetSequence(seq int64) *WebSocketEvent {
-	evCopy := ev.Copy()
-	evCopy.sequence = seq
-	return evCopy
+	ev.sequence = seq
+	return ev
 }
 
 func (ev *WebSocketEvent) IsValid() bool {

--- a/server/public/model/websocket_message_test.go
+++ b/server/public/model/websocket_message_test.go
@@ -240,15 +240,19 @@ func TestWebSocketEventDeepCopy(t *testing.T) {
 
 var err error
 
-func BenchmarkEncodeJSON(b *testing.B) {
+func BenchmarkEncodeEvent(b *testing.B) {
 	message := NewWebSocketEvent(WebsocketEventUserAdded, "", "channelID", "", nil, "")
 	message.Add("user_id", "userID")
 	message.Add("team_id", "teamID")
 
 	ev := message.PrecomputeJSON()
 
+	var seq int64
 	enc := json.NewEncoder(io.Discard)
+	// This tries to emulate the event encoding step.
 	for i := 0; i < b.N; i++ {
+		ev = ev.SetSequence(seq)
 		err = ev.Encode(enc)
+		seq++
 	}
 }


### PR DESCRIPTION
I am leaning towards this being a bad idea, but I wanted to put
this up since it didn't take much time.

Overall, from the profile below, we can see that 7.87% of the total
CPU time is going in creating this shallow copy. This is at scale
with 80k concurrent users.

![profile](https://github.com/mattermost/mattermost/assets/1774000/18b9fc5c-fbd7-434b-8a80-e672c3730f37)


Removing this doesn't hurt because for every web_conn send,
the value will get overwritten again with whatever sequence value
that web_conn has. But it becomes extremely fragile and folks
need to tread very carefully around this code because
it can start to become racy very easily which can again lead
to the old impression of "websocket code is buggy, so nobody
should touch it".

Curious to know what you guys think.

```
goos: linux
goarch: amd64
pkg: github.com/mattermost/mattermost/server/public/model
cpu: Intel(R) Core(TM) i5-8265U CPU @ 1.60GHz
              │  base.txt   │              new.txt               │
              │   sec/op    │   sec/op     vs base               │
EncodeEvent-8   1.760µ ± 2%   1.695µ ± 3%  -3.69% (p=0.001 n=10)

              │  base.txt  │              new.txt              │
              │    B/op    │    B/op     vs base               │
EncodeEvent-8   528.0 ± 0%   480.0 ± 0%  -9.09% (p=0.000 n=10)

              │  base.txt  │              new.txt               │
              │ allocs/op  │ allocs/op   vs base                │
EncodeEvent-8   5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.000 n=10)
```

```release-note
NONE
```
