### PR TITLE
MM-54325 Have web app build script return error codes on failure

### DIFF
--- a/webapp/scripts/build.js
+++ b/webapp/scripts/build.js
@@ -6,7 +6,7 @@
 const chalk = require('chalk');
 const concurrently = require('concurrently');
 
-const {getPlatformCommands} = require('./utils.js');
+const {getExitCode, getPlatformCommands} = require('./utils.js');
 
 async function buildAll() {
     console.log(chalk.inverse.bold('Building subpackages...') + '\n');
@@ -20,9 +20,9 @@ async function buildAll() {
         );
 
         await result;
-    } catch (e) {
-        console.error(chalk.inverse.bold.red('Failed to build subpackages'), e);
-        return;
+    } catch (closeEvents) {
+        console.error(chalk.inverse.bold.red('Failed to build subpackages'), closeEvents);
+        return getExitCode(closeEvents);
     }
 
     console.log('\n' + chalk.inverse.bold('Subpackages built! Building web app...') + '\n');
@@ -34,12 +34,15 @@ async function buildAll() {
             {command: 'npm:build --workspace=channels', name: 'webapp', prefixColor: 'cyan'},
         ]);
         await result;
-    } catch (e) {
-        console.error(chalk.inverse.bold.red('Failed to build web app'), e);
-        return;
+    } catch (closeEvents) {
+        console.error(chalk.inverse.bold.red('Failed to build web app'), closeEvents);
+        return getExitCode(closeEvents);
     }
 
-    console.log('\n' + chalk.inverse.bold('Web app built! '));
+    console.log('\n' + chalk.inverse.bold('Web app built!'));
+    return 0;
 }
 
-buildAll();
+buildAll().then((exitCode) => {
+    process.exitCode = exitCode;
+});

--- a/webapp/scripts/dev-server.js
+++ b/webapp/scripts/dev-server.js
@@ -25,7 +25,16 @@ async function watchAllWithDevServer() {
             killOthers: 'failure',
         },
     );
-    await result;
+
+    let exitCode = 0;
+    try {
+        await result;
+    } catch (closeEvents) {
+        exitCode = getExitCode(closeEvents, 0);
+    }
+    return exitCode;
 }
 
-watchAllWithDevServer();
+watchAllWithDevServer().then((exitCode) => {
+    process.exit(exitCode);
+});

--- a/webapp/scripts/run.js
+++ b/webapp/scripts/run.js
@@ -7,7 +7,7 @@ const chalk = require('chalk');
 const concurrently = require('concurrently');
 
 const {makeRunner} = require('./runner.js');
-const {getPlatformCommands} = require('./utils.js');
+const {getExitCode, getPlatformCommands} = require('./utils.js');
 
 async function watchAll(useRunner) {
     if (!useRunner) {
@@ -41,9 +41,18 @@ async function watchAll(useRunner) {
         }
     });
 
-    await result;
+    let exitCode = 0;
+    try {
+        await result;
+    } catch (closeEvents) {
+        exitCode = getExitCode(closeEvents, 0);
+    }
+    return exitCode;
 }
 
 const useRunner = process.argv[2] === '--runner' || process.env.MM_USE_WEBAPP_RUNNER;
 
-watchAll(useRunner);
+watchAll(useRunner).then((exitCode) => {
+    process.exit(exitCode);
+});
+

--- a/webapp/scripts/utils.js
+++ b/webapp/scripts/utils.js
@@ -42,6 +42,21 @@ function getColorForWorkspace(workspace) {
     return index === -1 ? chalk.white : workspaceColors[index % workspaceColors.length];
 }
 
+/**
+ * @param {import("concurrently").CloseEvent[]} closeEvents - An array of CloseEvents thrown by concurrently when waiting on a result
+ * @param {number} codeOnSignal - Which error code to return when the process is interrupted
+ */
+function getExitCode(closeEvents, codeOnSignal = 1) {
+    const exitCode = closeEvents.find((event) => !event.killed && event.exitCode > 0)?.exitCode;
+
+    if (typeof exitCode === 'string') {
+        return codeOnSignal
+    } else {
+        return exitCode;
+    }
+}
+
 module.exports = {
+    getExitCode,
     getPlatformCommands,
 };


### PR DESCRIPTION
#### Summary
Currently, the web app's `make build`/`npm run build` script actually swallows errors because it runs the per-package build scripts in a try/catch. It now gets the error code from the subprocesses properly and sets the exit code before Node exits.

I also added that code to the `run` and `dev-server` scripts, mostly because it suppresses an error when `run --runner` terminates. If we want to cherry-pick this PR, I can pull that out into a separate PR since I don't know if anyone uses `--runner` except for me.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54325

#### Screenshots
Showing failures in both the build of a subpackage and in the web app itself
![Screenshot 2023-10-05 at 12 30 45 PM](https://github.com/mattermost/mattermost/assets/3277310/063f151d-0831-499f-9881-4258ed41fd73)

#### Release Note
```release-note
NONE
```
