### PR TITLE
[MM-51852] Update getProfilesInCalls selector

### DIFF
--- a/webapp/channels/src/components/profile_popover/index.ts
+++ b/webapp/channels/src/components/profile_popover/index.ts
@@ -51,20 +51,15 @@ function getDefaultChannelId(state: GlobalState) {
 }
 
 export function checkUserInCall(state: GlobalState, userId: string) {
-    let isUserInCall = false;
-
-    const profilesInCalls = getProfilesInCalls(state);
-    Object.keys(profilesInCalls).forEach((channelId) => {
-        const profiles = profilesInCalls[channelId] || [];
-
-        for (const user of profiles) {
-            if (user.id === userId) {
-                isUserInCall = true;
-                break;
+    for (const profilesMap of Object.values(getProfilesInCalls(state))) {
+        for (const profile of Object.values(profilesMap || {})) {
+            if (profile?.id === userId) {
+                return true;
             }
         }
-    });
-    return isUserInCall;
+    }
+
+    return false;
 }
 
 function makeMapStateToProps() {

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/common.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/common.ts
@@ -71,10 +71,10 @@ export function getUsers(state: GlobalState): IDMappedObjects<UserProfile> {
 
 // Calls
 
-export function getProfilesInCalls(state: GlobalState): Record<string, UserProfile[]> {
+export function getProfilesInCalls(state: GlobalState): Record<string, Record<string, UserProfile>> {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    return state[CALLS_PLUGIN].profiles || state[CALLS_PLUGIN].voiceConnectedProfiles || {};
+    return state[CALLS_PLUGIN].profiles || {};
 }
 
 export function getCallsConfig(state: GlobalState): CallsConfig {


### PR DESCRIPTION
#### Summary

We are making a breaking change to the `profiles` reducer for Calls as we introduce multi session support  (https://github.com/mattermost/mattermost-plugin-calls/pull/518). Unfortunately keeping backwards compatibility is rather inconvenient as we'd have to leave a reducer around just for that. I am thinking of bumping the minimum MM server version requirement for the plugin instead to keep things clean on both sides.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51852

#### Release Note

```release-note
NONE
```
