### PR TITLE
Optimize mmctl CI run

### DIFF
--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -47,6 +47,9 @@ jobs:
           docker-compose --ansi never ps
       - name: Run mmctl Tests
         run: |
+          if [[ ${{ github.ref_name }} == 'master' ]]; then
+            export MMCTL_TESTFLAGS="-timeout 30m -race"
+          fi
           docker run --net ghactions_mm-test \
             --ulimit nofile=8096:8096 \
             --env-file=server/build/dotenv/test.env \
@@ -56,7 +59,7 @@ jobs:
             -v $PWD:/mattermost \
             -w /mattermost/server \
             $BUILD_IMAGE \
-            make test-mmctl-coverage BUILD_NUMBER=$GITHUB_HEAD_REF-$GITHUB_RUN_ID
+            make test-mmctl BUILD_NUMBER=$GITHUB_HEAD_REF-$GITHUB_RUN_ID
       - name: Stop docker compose
         run: |
           cd server/build

--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: ${{ env.go-version }}
+          cache-dependency-path: server/go.sum
       - name: Run setup-go-work
         run: |
           cd server

--- a/server/Makefile
+++ b/server/Makefile
@@ -64,7 +64,7 @@ GOTESTSUM_JSONFILE ?= gotestsum.json
 
 # mmctl
 MMCTL_BUILD_TAGS =
-MMCTL_TESTFLAGS = -timeout 30m -race
+MMCTL_TESTFLAGS ?= -timeout 30m
 MMCTL_PKG = github.com/mattermost/mattermost/server/v8/cmd/mmctl/commands
 LDFLAGS += -X "$(MMCTL_PKG).gitCommit=$(BUILD_HASH)"
 LDFLAGS += -X "$(MMCTL_PKG).gitTreeState=$(GIT_TREESTATE)"


### PR DESCRIPTION
- Remove coverage mode. They increase run time by 3x.
- Remove -race mode in PR builds. They increase run time by 2x and memory consumption as well.

```release-note
NONE
```
