### PR TITLE
Convert Menu Header component from class based to function based component

### DIFF
--- a/webapp/channels/src/components/widgets/menu/menu_header.tsx
+++ b/webapp/channels/src/components/widgets/menu/menu_header.tsx
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-
 import './menu_header.scss';
 
 type Props = {
@@ -14,17 +13,12 @@ type Props = {
 /**
  * @deprecated Use the "webapp/channels/src/components/menu" instead.
  */
-export default class MenuHeader extends React.PureComponent<Props> {
-    public render() {
-        const {children, onClick} = this.props;
+const MenuHeader: React.FC<Props> = ({ children, onClick }) => {
+    return (
+        <li className='MenuHeader' onClick={onClick}>
+            {children}
+        </li>
+    );
+};
 
-        return (
-            <li
-                className='MenuHeader'
-                onClick={onClick}
-            >
-                {children}
-            </li>
-        );
-    }
-}
+export default MenuHeader;

--- a/webapp/channels/src/components/widgets/menu/menu_header.tsx
+++ b/webapp/channels/src/components/widgets/menu/menu_header.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import type {FC} from 'react';
+
 import './menu_header.scss';
 
 type Props = {
@@ -14,12 +14,15 @@ type Props = {
 /**
  * @deprecated Use the "webapp/channels/src/components/menu" instead.
  */
-const MenuHeader: React.FC<Props> = ({ children, onClick }) => {
-    return (
-        <li className='MenuHeader' onClick={onClick}>
+const MenuHeader = ({children, onClick}: Props) => {
+        return (
+        <li
+            className='MenuHeader'
+            onClick={onClick}
+        >
             {children}
         </li>
     );
 };
 
-export default MenuHeader;
+export default React.memo(MenuHeader);

--- a/webapp/channels/src/components/widgets/menu/menu_header.tsx
+++ b/webapp/channels/src/components/widgets/menu/menu_header.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import type {FC} from 'react';
 import './menu_header.scss';
 
 type Props = {


### PR DESCRIPTION
#### Summary
This PR converts the MenuHeader component from class based component to functional based component

#### Ticket Link
Fixes #24763

#### Screenshots

#### Release Note
```
NONE
```
