### PR TITLE
[MM-54829] Convert LocalizedInput of 'emoji_list.tsx' to regular input component

### DIFF
--- a/webapp/channels/src/components/emoji/emoji_list/emoji_list.tsx
+++ b/webapp/channels/src/components/emoji/emoji_list/emoji_list.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import type {ChangeEvent, ChangeEventHandler} from 'react';
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, injectIntl, type IntlShape} from 'react-intl';
 
 import type {CustomEmoji} from '@mattermost/types/emojis';
 import type {ServerError} from '@mattermost/types/errors';
@@ -13,13 +13,10 @@ import {Emoji} from 'mattermost-redux/constants';
 
 import EmojiListItem from 'components/emoji/emoji_list_item';
 import LoadingScreen from 'components/loading_screen';
-import LocalizedInput from 'components/localized_input/localized_input';
 import SaveButton from 'components/save_button';
 import NextIcon from 'components/widgets/icons/fa_next_icon';
 import PreviousIcon from 'components/widgets/icons/fa_previous_icon';
 import SearchIcon from 'components/widgets/icons/fa_search_icon';
-
-import {t} from 'utils/i18n';
 
 const EMOJI_PER_PAGE = 50;
 const EMOJI_SEARCH_DELAY_MILLISECONDS = 200;
@@ -35,6 +32,7 @@ interface Props {
      * Function to scroll list to top.
      */
     scrollToTop: () => void;
+    intl: IntlShape;
     actions: {
 
         /**
@@ -58,7 +56,7 @@ interface State {
     missingPages: boolean;
 }
 
-export default class EmojiList extends React.PureComponent<Props, State> {
+class EmojiList extends React.PureComponent<Props, State> {
     private searchTimeout: NodeJS.Timeout | null;
 
     constructor(props: Props) {
@@ -269,13 +267,10 @@ export default class EmojiList extends React.PureComponent<Props, State> {
                 <div className='backstage-filters'>
                     <div className='backstage-filter__search'>
                         <SearchIcon/>
-                        <LocalizedInput
+                        <input
                             type='search'
                             className='form-control'
-                            placeholder={{
-                                id: t('emoji_list.search'),
-                                defaultMessage: 'Search Custom Emoji',
-                            }}
+                            placeholder={this.props.intl.formatMessage({id: 'emoji_list.search', defaultMessage: 'Search Custom Emoji'})}
                             onChange={this.onSearchChange}
                             style={style.search}
                         />
@@ -340,3 +335,5 @@ export default class EmojiList extends React.PureComponent<Props, State> {
 const style = {
     search: {flexGrow: 0, flexShrink: 0},
 };
+
+export default injectIntl(EmojiList);


### PR DESCRIPTION
#### Summary
Replaces the 'LocalizedInput' component in `webapp/channels/src/components/emoji/emoji_list/emoji_list.tsx` to a regular input component

#### Ticket Link
Fixes No Github issue
Jira https://mattermost.atlassian.net/browse/MM-54829

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
