### PR TITLE
Bump to latest mmjstool

### DIFF
--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -163,7 +163,7 @@
     "jest-junit": "12.2.0",
     "jest-styled-components": "7.1.1",
     "jest-watch-typeahead": "0.6.4",
-    "mmjstool": "github:mattermost/mattermost-utilities#e65ab00f22628cbdee736fd2e4f192f07225e82d",
+    "mmjstool": "github:mattermost/mattermost-utilities#d88289ce1d30da1936d9a17e9bed0cdb52de0a10",
     "nock": "13.2.8",
     "prettier": "2.3.2",
     "react-router-enzyme-context": "1.2.0",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -210,7 +210,7 @@
         "jest-junit": "12.2.0",
         "jest-styled-components": "7.1.1",
         "jest-watch-typeahead": "0.6.4",
-        "mmjstool": "github:mattermost/mattermost-utilities#e65ab00f22628cbdee736fd2e4f192f07225e82d",
+        "mmjstool": "github:mattermost/mattermost-utilities#d88289ce1d30da1936d9a17e9bed0cdb52de0a10",
         "nock": "13.2.8",
         "prettier": "2.3.2",
         "react-router-enzyme-context": "1.2.0",
@@ -16245,8 +16245,8 @@
     },
     "node_modules/mmjstool": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/mattermost/mattermost-utilities.git#e65ab00f22628cbdee736fd2e4f192f07225e82d",
-      "integrity": "sha512-1HUeyYpzVSMy9ezfBLL3i3+T2UVjtxr3XHYpJnUm74MnwKYNV/e8uUT1txAElaQ0aFf1wE6xRh7S/M+6Dmotzw==",
+      "resolved": "git+ssh://git@github.com/mattermost/mattermost-utilities.git#d88289ce1d30da1936d9a17e9bed0cdb52de0a10",
+      "integrity": "sha512-Fia3OL1qvMCBy8B9GpZVyqcMz/7NvQfxVJ6KWxegqQt0rSIkqI0f7UveAWGCxD6XoPHPcCCtdvuklBWjBxzgIQ==",
       "dev": true,
       "dependencies": {
         "estree-walk": "^2.2.0",
@@ -35698,7 +35698,7 @@
         "mark.js": "8.11.1",
         "marked": "github:mattermost/marked#2ef7f28cc7718e3f551c4ce9ea75fdd7580c2008",
         "memoize-one": "6.0.0",
-        "mmjstool": "github:mattermost/mattermost-utilities#e65ab00f22628cbdee736fd2e4f192f07225e82d",
+        "mmjstool": "github:mattermost/mattermost-utilities#d88289ce1d30da1936d9a17e9bed0cdb52de0a10",
         "moment-timezone": "0.5.38",
         "nock": "13.2.8",
         "p-queue": "7.3.0",
@@ -36346,10 +36346,10 @@
       "dev": true
     },
     "mmjstool": {
-      "version": "git+ssh://git@github.com/mattermost/mattermost-utilities.git#e65ab00f22628cbdee736fd2e4f192f07225e82d",
-      "integrity": "sha512-1HUeyYpzVSMy9ezfBLL3i3+T2UVjtxr3XHYpJnUm74MnwKYNV/e8uUT1txAElaQ0aFf1wE6xRh7S/M+6Dmotzw==",
+      "version": "git+ssh://git@github.com/mattermost/mattermost-utilities.git#d88289ce1d30da1936d9a17e9bed0cdb52de0a10",
+      "integrity": "sha512-Fia3OL1qvMCBy8B9GpZVyqcMz/7NvQfxVJ6KWxegqQt0rSIkqI0f7UveAWGCxD6XoPHPcCCtdvuklBWjBxzgIQ==",
       "dev": true,
-      "from": "mmjstool@github:mattermost/mattermost-utilities#e65ab00f22628cbdee736fd2e4f192f07225e82d",
+      "from": "mmjstool@github:mattermost/mattermost-utilities#d88289ce1d30da1936d9a17e9bed0cdb52de0a10",
       "requires": {
         "estree-walk": "^2.2.0",
         "filehound": "^1.17.5",


### PR DESCRIPTION
#### Summary
Bump to latest mmjstool so `defineMessage` is also handle by `i18n-extract`

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
