### PR TITLE
[MM-54836] Convert LocalizedInput of 'compliance_reports.tsx' to regular input component

### DIFF
--- a/webapp/channels/src/components/admin_console/compliance_reports/compliance_reports.tsx
+++ b/webapp/channels/src/components/admin_console/compliance_reports/compliance_reports.tsx
@@ -10,7 +10,7 @@ import type {UserProfile} from '@mattermost/types/users';
 import {Client4} from 'mattermost-redux/client';
 
 import LoadingScreen from 'components/loading_screen';
-import LocalizedInput from 'components/localized_input/localized_input';
+
 import ReloadIcon from 'components/widgets/icons/fa_reload_icon';
 
 import {t} from 'utils/i18n';
@@ -59,7 +59,7 @@ type State = {
     runningReport?: boolean;
 }
 
-export default class ComplianceReports extends React.PureComponent<Props, State> {
+class ComplianceReports extends React.PureComponent<Props, State> {
     private descInput: React.RefObject<HTMLInputElement>;
     private emailsInput: React.RefObject<HTMLInputElement>;
     private fromInput: React.RefObject<HTMLInputElement>;
@@ -345,7 +345,7 @@ export default class ComplianceReports extends React.PureComponent<Props, State>
                                 defaultMessage='Job Name:'
                             />
                         </label>
-                        <LocalizedInput
+                        <input
                             type='text'
                             className='form-control'
                             id='desc'
@@ -361,7 +361,7 @@ export default class ComplianceReports extends React.PureComponent<Props, State>
                                 defaultMessage='From:'
                             />
                         </label>
-                        <LocalizedInput
+                        <input
                             type='text'
                             className='form-control'
                             id='from'
@@ -377,7 +377,7 @@ export default class ComplianceReports extends React.PureComponent<Props, State>
                                 defaultMessage='To:'
                             />
                         </label>
-                        <LocalizedInput
+                        <input
                             type='text'
                             className='form-control'
                             id='to'
@@ -395,7 +395,7 @@ export default class ComplianceReports extends React.PureComponent<Props, State>
                                 defaultMessage='Emails:'
                             />
                         </label>
-                        <LocalizedInput
+                        <input
                             type='text'
                             className='form-control'
                             id='emails'
@@ -411,7 +411,7 @@ export default class ComplianceReports extends React.PureComponent<Props, State>
                                 defaultMessage='Keywords:'
                             />
                         </label>
-                        <LocalizedInput
+                        <input
                             type='text'
                             className='form-control'
                             id='keywords'

--- a/webapp/channels/src/components/admin_console/compliance_reports/compliance_reports.tsx
+++ b/webapp/channels/src/components/admin_console/compliance_reports/compliance_reports.tsx
@@ -59,7 +59,7 @@ type State = {
     runningReport?: boolean;
 }
 
-class ComplianceReports extends React.PureComponent<Props, State> {
+export default class ComplianceReports extends React.PureComponent<Props, State> {
     private descInput: React.RefObject<HTMLInputElement>;
     private emailsInput: React.RefObject<HTMLInputElement>;
     private fromInput: React.RefObject<HTMLInputElement>;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Changed localizedInput in compliance_reports and this pr solves #24825 

#### Ticket Link


Fixes https://github.com/mattermost/mattermost/issues/24825 


#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
