### PR TITLE
[MM-54841] Convert LocalizedInput of 'oauth_to_email.tsx' to regular input component

### DIFF
--- a/webapp/channels/src/components/claim/components/oauth_to_email.tsx
+++ b/webapp/channels/src/components/claim/components/oauth_to_email.tsx
@@ -133,4 +133,4 @@ const OAuthToEmail = (props: Props) => {
     );
 };
 
-export default injectIntl(OAuthToEmail);
+export default OAuthToEmail;

--- a/webapp/channels/src/components/claim/components/oauth_to_email.tsx
+++ b/webapp/channels/src/components/claim/components/oauth_to_email.tsx
@@ -3,7 +3,7 @@
 
 import classNames from 'classnames';
 import React, {useRef, useState} from 'react';
-import {FormattedMessage, injectIntl, type IntlShape} from 'react-intl';
+import {FormattedMessage, type IntlShape} from 'react-intl';
 
 import type {AuthChangeResponse} from '@mattermost/types/users';
 

--- a/webapp/channels/src/components/claim/components/oauth_to_email.tsx
+++ b/webapp/channels/src/components/claim/components/oauth_to_email.tsx
@@ -71,8 +71,6 @@ const OAuthToEmail = (props: Props) => {
     };
 
     const uiType = `${(props.currentType === Constants.SAML_SERVICE ? Constants.SAML_SERVICE.toUpperCase() : toTitleCase(props.currentType || ''))} SSO`;
-    const placeholderPasswordMessage = intl.formatMessage({id: t('claim.oauth_to_email.newPwd'), defaultMessage: 'New Password'});
-    const placeholderConfirmMessage = intl.formatMessage({id: t('claim.oauth_to_email.confirm'), defaultMessage: 'Confirm Password'});
 
     return (
         <>
@@ -103,7 +101,10 @@ const OAuthToEmail = (props: Props) => {
                         className='form-control'
                         name='password'
                         ref={passwordInput}
-                        placeholder={placeholderPasswordMessage}
+                        placeholder={intl.formatMessage({
+                            id: t('claim.oauth_to_email.newPwd'),
+                            defaultMessage: 'New Password',
+                        })}
                         spellCheck='false'
                     />
                 </div>
@@ -113,7 +114,10 @@ const OAuthToEmail = (props: Props) => {
                         className='form-control'
                         name='passwordconfirm'
                         ref={passwordConfirmInput}
-                        placeholder={placeholderConfirmMessage}
+                        placeholder={intl.formatMessage({
+                            id: t('claim.oauth_to_email.confirm'),
+                            defaultMessage: 'Confirm Password',
+                        })}
                         spellCheck='false'
                     />
                 </div>

--- a/webapp/channels/src/components/claim/components/oauth_to_email.tsx
+++ b/webapp/channels/src/components/claim/components/oauth_to_email.tsx
@@ -3,13 +3,11 @@
 
 import classNames from 'classnames';
 import React, {useRef, useState} from 'react';
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, injectIntl, type IntlShape} from 'react-intl';
 
 import type {AuthChangeResponse} from '@mattermost/types/users';
 
 import {oauthToEmail} from 'actions/admin_actions.jsx';
-
-import LocalizedInput from 'components/localized_input/localized_input';
 
 import Constants from 'utils/constants';
 import {t} from 'utils/i18n';
@@ -23,6 +21,7 @@ type Props = {
     email: string | null;
     siteName?: string;
     passwordConfig?: ReturnType<typeof getPasswordConfig>;
+    intl: IntlShape;
 }
 
 const OAuthToEmail = (props: Props) => {
@@ -72,8 +71,8 @@ const OAuthToEmail = (props: Props) => {
     };
 
     const uiType = `${(props.currentType === Constants.SAML_SERVICE ? Constants.SAML_SERVICE.toUpperCase() : toTitleCase(props.currentType || ''))} SSO`;
-    const placeholderPasswordMessage = {id: t('claim.oauth_to_email.newPwd'), defaultMessage: 'New Password'};
-    const placeholderConfirmMessage = {id: t('claim.oauth_to_email.confirm'), defaultMessage: 'Confirm Password'};
+    const placeholderPasswordMessage = props.intl.formatMessage({id: t('claim.oauth_to_email.newPwd'), defaultMessage: 'New Password'});
+    const placeholderConfirmMessage = props.intl.formatMessage({id: t('claim.oauth_to_email.confirm'), defaultMessage: 'Confirm Password'});
 
     return (
         <>
@@ -99,7 +98,7 @@ const OAuthToEmail = (props: Props) => {
                     />
                 </p>
                 <div className={classNames('form-group', {'has-error': error})}>
-                    <LocalizedInput
+                    <input
                         type='password'
                         className='form-control'
                         name='password'
@@ -109,7 +108,7 @@ const OAuthToEmail = (props: Props) => {
                     />
                 </div>
                 <div className={classNames('form-group', {'has-error': error})}>
-                    <LocalizedInput
+                    <input
                         type='password'
                         className='form-control'
                         name='passwordconfirm'
@@ -134,4 +133,4 @@ const OAuthToEmail = (props: Props) => {
     );
 };
 
-export default OAuthToEmail;
+export default injectIntl(OAuthToEmail);

--- a/webapp/channels/src/components/claim/components/oauth_to_email.tsx
+++ b/webapp/channels/src/components/claim/components/oauth_to_email.tsx
@@ -3,7 +3,7 @@
 
 import classNames from 'classnames';
 import React, {useRef, useState} from 'react';
-import {FormattedMessage, type IntlShape} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
 
 import type {AuthChangeResponse} from '@mattermost/types/users';
 
@@ -21,10 +21,10 @@ type Props = {
     email: string | null;
     siteName?: string;
     passwordConfig?: ReturnType<typeof getPasswordConfig>;
-    intl: IntlShape;
 }
 
 const OAuthToEmail = (props: Props) => {
+    const intl = useIntl();
     const passwordInput = useRef<HTMLInputElement>(null);
     const passwordConfirmInput = useRef<HTMLInputElement>(null);
 
@@ -71,8 +71,8 @@ const OAuthToEmail = (props: Props) => {
     };
 
     const uiType = `${(props.currentType === Constants.SAML_SERVICE ? Constants.SAML_SERVICE.toUpperCase() : toTitleCase(props.currentType || ''))} SSO`;
-    const placeholderPasswordMessage = props.intl.formatMessage({id: t('claim.oauth_to_email.newPwd'), defaultMessage: 'New Password'});
-    const placeholderConfirmMessage = props.intl.formatMessage({id: t('claim.oauth_to_email.confirm'), defaultMessage: 'Confirm Password'});
+    const placeholderPasswordMessage = intl.formatMessage({id: t('claim.oauth_to_email.newPwd'), defaultMessage: 'New Password'});
+    const placeholderConfirmMessage = intl.formatMessage({id: t('claim.oauth_to_email.confirm'), defaultMessage: 'Confirm Password'});
 
     return (
         <>

--- a/webapp/channels/src/components/claim/components/oauth_to_email.tsx
+++ b/webapp/channels/src/components/claim/components/oauth_to_email.tsx
@@ -10,7 +10,6 @@ import type {AuthChangeResponse} from '@mattermost/types/users';
 import {oauthToEmail} from 'actions/admin_actions.jsx';
 
 import Constants from 'utils/constants';
-import {t} from 'utils/i18n';
 import {isValidPassword, localizeMessage, toTitleCase} from 'utils/utils';
 import type {getPasswordConfig} from 'utils/utils';
 
@@ -102,7 +101,7 @@ const OAuthToEmail = (props: Props) => {
                         name='password'
                         ref={passwordInput}
                         placeholder={intl.formatMessage({
-                            id: t('claim.oauth_to_email.newPwd'),
+                            id: 'claim.oauth_to_email.newPwd',
                             defaultMessage: 'New Password',
                         })}
                         spellCheck='false'
@@ -115,7 +114,7 @@ const OAuthToEmail = (props: Props) => {
                         name='passwordconfirm'
                         ref={passwordConfirmInput}
                         placeholder={intl.formatMessage({
-                            id: t('claim.oauth_to_email.confirm'),
+                            id: 'claim.oauth_to_email.confirm',
                             defaultMessage: 'Confirm Password',
                         })}
                         spellCheck='false'


### PR DESCRIPTION
#### Summary
Converted `LocalizedInput` components in `oauth_to_email.tsx` to `input` and added `React-Intl AP` to accommodate translated strings.

#### Ticket Link:
Fixes https://github.com/mattermost/mattermost/issues/24830
Jira https://mattermost.atlassian.net/browse/MM-54841

#### Release Note
```
NONE
```