### PR TITLE
Update subpackage versions for 9.2

### DIFF
--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -3,7 +3,7 @@
   "browser": {
     "./client/web_client.jsx": "./client/browser_web_client.jsx"
   },
-  "version": "9.1.0",
+  "version": "9.2.0",
   "private": true,
   "dependencies": {
     "@floating-ui/react-dom": "1.0.0",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -51,7 +51,7 @@
     },
     "channels": {
       "name": "mattermost-webapp",
-      "version": "9.1.0",
+      "version": "9.2.0",
       "dependencies": {
         "@floating-ui/react-dom": "1.0.0",
         "@floating-ui/react-dom-interactions": "0.10.3",
@@ -23621,7 +23621,7 @@
     },
     "platform/client": {
       "name": "@mattermost/client",
-      "version": "9.1.0",
+      "version": "9.2.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.0"
@@ -23641,7 +23641,7 @@
     },
     "platform/components": {
       "name": "@mattermost/components",
-      "version": "8.0.0",
+      "version": "9.2.0",
       "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.17.0",
         "@rollup/plugin-babel": "^5.3.1",
@@ -23712,7 +23712,7 @@
     },
     "platform/types": {
       "name": "@mattermost/types",
-      "version": "9.1.0",
+      "version": "9.2.0",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^4.3"

--- a/webapp/platform/client/package.json
+++ b/webapp/platform/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/client",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "description": "JavaScript/TypeScript client for Mattermost",
   "keywords": [
     "mattermost"

--- a/webapp/platform/components/package.json
+++ b/webapp/platform/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/components",
-  "version": "8.0.0",
+  "version": "9.2.0",
   "private": true,
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/webapp/platform/types/package.json
+++ b/webapp/platform/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/types",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "description": "Shared type definitions used by the Mattermost web app",
   "keywords": [
     "mattermost"


### PR DESCRIPTION
#### Summary
`release-9.1` has been branched so we can update these now for the following release.

Note that I didn't update the ESLint plugin version since it's not dependent on the MM server version. We're also not likely to update it as often.

#### Release Note
```release-note
Update versions of NPM packages for 9.2
```
