### PR TITLE
Migrate file_upload_settings.jsx to typescript

### DIFF
--- a/webapp/channels/src/components/admin_console/file_upload_setting.tsx
+++ b/webapp/channels/src/components/admin_console/file_upload_setting.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
@@ -9,48 +8,58 @@ import * as Utils from 'utils/utils';
 
 import Setting from './setting';
 
-export default class FileUploadSetting extends Setting {
-    static get propTypes() {
-        return {
-            id: PropTypes.string.isRequired,
-            label: PropTypes.node.isRequired,
-            helpText: PropTypes.node,
-            uploadingText: PropTypes.node,
-            onSubmit: PropTypes.func.isRequired,
-            disabled: PropTypes.bool,
-            fileType: PropTypes.string.isRequired,
-            error: PropTypes.string,
-        };
-    }
+type Props = {
+    id: string
+    label: React.ReactNode
+    helpText?: React.ReactNode,
+    uploadingText?: React.ReactNode,
+    onSubmit: (id: string, file: File, errorCallback: (error: string) => void) => void
+    disabled: boolean,
+    fileType: string,
+    error?: string,
+}
 
-    constructor(props) {
+type State = {
+    fileName: null|string;
+    fileSelected: boolean;
+    serverError?: string;
+    uploading: boolean;
+}
+
+export default class FileUploadSetting extends React.PureComponent<Props, State> {
+    fileInputRef = React.createRef<HTMLInputElement>()
+
+    constructor(props: Props) {
         super(props);
 
         this.state = {
             fileName: null,
             serverError: props.error,
             uploading: false,
+            fileSelected: false,
         };
-        this.fileInputRef = React.createRef();
     }
 
     handleChange = () => {
-        const files = this.fileInputRef.current.files;
+        const files = this.fileInputRef.current?.files;
         if (files && files.length > 0) {
             this.setState({fileSelected: true, fileName: files[0].name});
         }
     };
 
-    handleSubmit = (e) => {
+    handleSubmit = (e: React.MouseEvent) => {
         e.preventDefault();
 
         this.setState({uploading: true});
-        this.props.onSubmit(this.props.id, this.fileInputRef.current.files[0], (error) => {
-            this.setState({uploading: false});
-            if (error) {
-                Utils.clearFileInput(this.fileInputRef.current);
-            }
-        });
+        const file = this.fileInputRef.current?.files?.[0];
+        if (file) {
+            this.props.onSubmit(this.props.id, file, (error) => {
+                this.setState({uploading: false});
+                if (error && this.fileInputRef.current) {
+                    Utils.clearFileInput(this.fileInputRef.current);
+                }
+            });
+        }
     };
 
     render() {


### PR DESCRIPTION
#### Summary
In this PR I migrate the file upload setting type to Typescript.

Also the component was before extending from `Setting` component, but in this case the `Setting` class wasn't providing any functionality so I change it to extend from `React.PureComponent`

#### Ticket Link
Not Yet

#### Release Note
```release-note
NONE
```