### PR TITLE
MM-52792: Backport to 7.8 (#24195)

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -5,6 +5,7 @@ package api4
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -73,6 +74,12 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	if !hasPermission {
 		c.SetPermissionError(model.PermissionCreatePost)
 		return
+	}
+	if *c.App.Config().ServiceSettings.ExperimentalEnableHardenedMode {
+		if reservedProps := post.ContainsIntegrationsReservedProps(); len(reservedProps) > 0 && !c.AppContext.Session().IsIntegration() {
+			c.SetInvalidParamWithDetails("props", fmt.Sprintf("Cannot use props reserved for integrations. props: %v", reservedProps))
+			return
+		}
 	}
 
 	if post.CreateAt != 0 && !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageSystem) {
@@ -750,6 +757,13 @@ func updatePost(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if *c.App.Config().ServiceSettings.ExperimentalEnableHardenedMode {
+		if reservedProps := post.ContainsIntegrationsReservedProps(); len(reservedProps) > 0 && !c.AppContext.Session().IsIntegration() {
+			c.SetInvalidParamWithDetails("props", fmt.Sprintf("Cannot use props reserved for integrations. props: %v", reservedProps))
+			return
+		}
+	}
+
 	if !c.App.SessionHasPermissionToChannelByPost(*c.AppContext.Session(), c.Params.PostId, model.PermissionEditPost) {
 		c.SetPermissionError(model.PermissionEditPost)
 		return
@@ -805,6 +819,13 @@ func patchPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	audit.AddEventParameter(auditRec, "id", c.Params.PostId)
 	audit.AddEventParameterAuditable(auditRec, "patch", &post)
 	defer c.LogAuditRecWithLevel(auditRec, app.LevelContent)
+
+	if *c.App.Config().ServiceSettings.ExperimentalEnableHardenedMode {
+		if reservedProps := post.ContainsIntegrationsReservedProps(); len(reservedProps) > 0 && !c.AppContext.Session().IsIntegration() {
+			c.SetInvalidParamWithDetails("props", fmt.Sprintf("Cannot use props reserved for integrations. props: %v", reservedProps))
+			return
+		}
+	}
 
 	// Updating the file_ids of a post is not a supported operation and will be ignored
 	post.FileIds = nil

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -172,6 +172,26 @@ func TestCreatePost(t *testing.T) {
 		}
 	})
 
+	t.Run("err with integrations-reserved props", func(t *testing.T) {
+		originalHardenedModeSetting := *th.App.Config().ServiceSettings.ExperimentalEnableHardenedMode
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.ExperimentalEnableHardenedMode = true
+		})
+
+		defer th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.ExperimentalEnableHardenedMode = originalHardenedModeSetting
+		})
+
+		_, postResp, postErr := client.CreatePost(context.Background(), &model.Post{
+			ChannelId: th.BasicChannel.Id,
+			Message:   "with props",
+			Props:     model.StringInterface{model.PostPropsFromWebhook: "true"},
+		})
+
+		require.Error(t, postErr)
+		CheckBadRequestStatus(t, postResp)
+	})
+
 	post.RootId = ""
 	post.Type = model.PostTypeSystemGeneric
 	_, resp, err := client.CreatePost(post)
@@ -245,7 +265,7 @@ func TestCreatePostWithOAuthClient(t *testing.T) {
 		Message:   "test message",
 	})
 	require.NoError(t, err)
-	assert.NotContains(t, post.GetProps(), "from_oauth_app", "contains from_oauth_app prop when not using OAuth client")
+	assert.NotContains(t, post.GetProps(), model.PostPropsFromOAuthApp, fmt.Sprintf("contains %s prop when not using OAuth client", model.PostPropsOverrideUsername))
 
 	client := th.CreateClient()
 	client.SetOAuthToken(session.Token)
@@ -255,7 +275,28 @@ func TestCreatePostWithOAuthClient(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Contains(t, post.GetProps(), "from_oauth_app", "missing from_oauth_app prop when using OAuth client")
+	assert.Contains(t, post.GetProps(), model.PostPropsFromOAuthApp, fmt.Sprintf("missing %s prop when using OAuth client", model.PostPropsOverrideUsername))
+
+	t.Run("allow username and icon overrides", func(t *testing.T) {
+		originalHardenedModeSetting := *th.App.Config().ServiceSettings.ExperimentalEnableHardenedMode
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.ExperimentalEnableHardenedMode = true
+		})
+
+		defer th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.ExperimentalEnableHardenedMode = originalHardenedModeSetting
+		})
+
+		post, _, err = client.CreatePost(context.Background(), &model.Post{
+			ChannelId: th.BasicChannel.Id,
+			Message:   "test message",
+			Props:     model.StringInterface{model.PostPropsOverrideUsername: "newUsernameValue", model.PostPropsOverrideIconURL: "iconUrlOverrideValue"},
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, post.GetProps(), model.PostPropsOverrideUsername, fmt.Sprintf("missing %s prop when using OAuth client", model.PostPropsOverrideUsername))
+		assert.Contains(t, post.GetProps(), model.PostPropsOverrideIconURL, fmt.Sprintf("missing %s prop when using OAuth client", model.PostPropsOverrideIconURL))
+	})
 }
 
 func TestCreatePostEphemeral(t *testing.T) {
@@ -850,6 +891,26 @@ func TestUpdatePost(t *testing.T) {
 		assert.NotEqual(t, rpost3.Attachments(), rrupost3.Attachments())
 	})
 
+	t.Run("err with integrations-reserved props", func(t *testing.T) {
+		originalHardenedModeSetting := *th.App.Config().ServiceSettings.ExperimentalEnableHardenedMode
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.ExperimentalEnableHardenedMode = true
+		})
+
+		defer th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.ExperimentalEnableHardenedMode = originalHardenedModeSetting
+		})
+
+		_, resp, err := client.UpdatePost(rpost.Id, &model.Post{
+			ChannelId: th.BasicChannel.Id,
+			Message:   "with props",
+			Props:     model.StringInterface{model.PostPropsFromWebhook: "true"},
+		})
+
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+	})
+
 	t.Run("logged out", func(t *testing.T) {
 		client.Logout()
 		_, resp, err := client.UpdatePost(rpost.Id, rpost)
@@ -1034,6 +1095,33 @@ func TestPatchPost(t *testing.T) {
 
 		_, _, err = client.PatchPost(post.Id, patch)
 		require.NoError(t, err)
+	})
+
+	t.Run("err with integrations-reserved props", func(t *testing.T) {
+
+		originalHardenedModeSetting := *th.App.Config().ServiceSettings.ExperimentalEnableHardenedMode
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.ExperimentalEnableHardenedMode = true
+		})
+
+		defer th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.ExperimentalEnableHardenedMode = originalHardenedModeSetting
+		})
+
+		post := &model.Post{
+			ChannelId: channel.Id,
+			Message:   "#hashtag a message",
+			CreateAt:  model.GetMillis() - 2000,
+		}
+		post, _, createErr := th.SystemAdminClient.CreatePost(post)
+		require.NoError(t, createErr)
+
+		patch := &model.PostPatch{}
+		patch.Props = &model.StringInterface{model.PostPropsFromWebhook: "true"}
+		_, patchResp, patchErr := client.PatchPost(post.Id, patch)
+
+		require.Error(t, patchErr)
+		CheckBadRequestStatus(t, patchResp)
 	})
 }
 

--- a/app/post.go
+++ b/app/post.go
@@ -78,8 +78,8 @@ func (a *App) CreatePostAsUser(c request.CTX, post *model.Post, currentSessionId
 	// the post does NOT have from_webhook prop set (e.g. Zapier app), and
 	// the post does NOT have from_bot set (e.g. from discovering the user is a bot within CreatePost), and
 	// the post is NOT a reply post with CRT enabled
-	_, fromWebhook := post.GetProps()["from_webhook"]
-	_, fromBot := post.GetProps()["from_bot"]
+	_, fromWebhook := post.GetProps()[model.PostPropsFromWebhook]
+	_, fromBot := post.GetProps()[model.PostPropsFromBot]
 	isCRTReply := post.RootId != "" && a.IsCRTEnabledForUser(c, post.UserId)
 	if !fromWebhook && !fromBot && !isCRTReply {
 		if _, err := a.MarkChannelsAsViewed(c, []string{post.ChannelId}, post.UserId, currentSessionId, true); err != nil {
@@ -200,11 +200,11 @@ func (a *App) CreatePost(c request.CTX, post *model.Post, channel *model.Channel
 	}
 
 	if user.IsBot {
-		post.AddProp("from_bot", "true")
+		post.AddProp(model.PostPropsFromBot, "true")
 	}
 
 	if c.Session().IsOAuth {
-		post.AddProp("from_oauth_app", "true")
+		post.AddProp(model.PostPropsFromOAuthApp, "true")
 	}
 
 	var ephemeralPost *model.Post

--- a/model/post.go
+++ b/model/post.go
@@ -62,15 +62,18 @@ const (
 
 	PropsAddChannelMember = "add_channel_member"
 
-	PostPropsAddedUserId       = "addedUserId"
-	PostPropsDeleteBy          = "deleteBy"
-	PostPropsOverrideIconURL   = "override_icon_url"
-	PostPropsOverrideIconEmoji = "override_icon_emoji"
-
+	PostPropsAddedUserId              = "addedUserId"
+	PostPropsDeleteBy                 = "deleteBy"
+	PostPropsOverrideIconURL          = "override_icon_url"
+	PostPropsOverrideIconEmoji        = "override_icon_emoji"
+	PostPropsOverrideUsername         = "override_username"
+	PostPropsFromWebhook              = "from_webhook"
+	PostPropsFromBot                  = "from_bot"
+	PostPropsFromOAuthApp             = "from_oauth_app"
+	PostPropsWebhookDisplayName       = "webhook_display_name"
 	PostPropsMentionHighlightDisabled = "mentionHighlightDisabled"
 	PostPropsGroupHighlightDisabled   = "disable_group_highlight"
-
-	PostPropsPreviewedPost = "previewed_post"
+	PostPropsPreviewedPost            = "previewed_post"
 
 	PostPriorityUrgent               = "urgent"
 	PostPropsRequestedAck            = "requested_ack"
@@ -458,6 +461,39 @@ func (o *Post) SanitizeProps() {
 	for _, p := range o.Participants {
 		p.Sanitize(map[string]bool{})
 	}
+}
+
+func (o *Post) ContainsIntegrationsReservedProps() []string {
+	return containsIntegrationsReservedProps(o.GetProps())
+}
+
+func (o *PostPatch) ContainsIntegrationsReservedProps() []string {
+	if o == nil || o.Props == nil {
+		return nil
+	}
+	return containsIntegrationsReservedProps(*o.Props)
+}
+
+func containsIntegrationsReservedProps(props StringInterface) []string {
+	foundProps := []string{}
+
+	if props != nil {
+		reservedProps := []string{
+			PostPropsFromWebhook,
+			PostPropsOverrideUsername,
+			PostPropsWebhookDisplayName,
+			PostPropsOverrideIconURL,
+			PostPropsOverrideIconEmoji,
+		}
+
+		for _, key := range reservedProps {
+			if _, ok := props[key]; ok {
+				foundProps = append(foundProps, key)
+			}
+		}
+	}
+
+	return foundProps
 }
 
 func (o *Post) PreSave() {

--- a/model/post_test.go
+++ b/model/post_test.go
@@ -141,6 +141,41 @@ func TestPostSanitizeProps(t *testing.T) {
 	require.NotNil(t, post3.GetProp("attachments"))
 }
 
+func TestPost_ContainsIntegrationsReservedProps(t *testing.T) {
+	post1 := &Post{
+		Message: "test",
+	}
+	keys1 := post1.ContainsIntegrationsReservedProps()
+	require.Len(t, keys1, 0)
+
+	post2 := &Post{
+		Message: "test",
+		Props: StringInterface{
+			"from_webhook":         "true",
+			"webhook_display_name": "overridden_display_name",
+			"override_username":    "overridden_username",
+			"override_icon_url":    "a-custom-url",
+			"override_icon_emoji":  ":custom_emoji_name:",
+		},
+	}
+	keys2 := post2.ContainsIntegrationsReservedProps()
+	require.Len(t, keys2, 5)
+}
+
+func TestPostPatch_ContainsIntegrationsReservedProps(t *testing.T) {
+	postPatch1 := &PostPatch{
+		Props: &StringInterface{
+			"from_webhook": "true",
+		},
+	}
+	keys1 := postPatch1.ContainsIntegrationsReservedProps()
+	require.Len(t, keys1, 1)
+
+	postPatch2 := &PostPatch{}
+	keys2 := postPatch2.ContainsIntegrationsReservedProps()
+	require.Len(t, keys2, 0)
+}
+
 func TestPost_AttachmentsEqual(t *testing.T) {
 	post1 := &Post{}
 	post2 := &Post{}

--- a/model/session.go
+++ b/model/session.go
@@ -214,6 +214,34 @@ func (s *Session) IsOAuthUser() bool {
 	return isOAuthUser
 }
 
+func (s *Session) IsBotUser() bool {
+	val, ok := s.Props[SessionPropIsBot]
+	if !ok {
+		return false
+	}
+	if val == SessionPropIsBotValue {
+		return true
+	}
+	return false
+}
+
+func (s *Session) IsUserAccessToken() bool {
+	val, ok := s.Props[SessionPropType]
+	if !ok {
+		return false
+	}
+	if val == SessionTypeUserAccessToken {
+		return true
+	}
+	return false
+}
+
+// Returns true when session is authenticated as a bot, by personal access token, or is an OAuth app.
+// Does not indicate other forms of integrations e.g. webhooks, slash commands, etc.
+func (s *Session) IsIntegration() bool {
+	return s.IsBotUser() || s.IsUserAccessToken() || s.IsOAuth
+}
+
 func (s *Session) IsSSOLogin() bool {
 	return s.IsOAuthUser() || s.IsSaml()
 }

--- a/model/session_test.go
+++ b/model/session_test.go
@@ -133,3 +133,23 @@ func TestSessionIsOAuthUser(t *testing.T) {
 		})
 	}
 }
+
+func TestIsIntegration(t *testing.T) {
+	testCases := []struct {
+		Description   string
+		Session       Session
+		IsIntegration bool
+	}{
+		{"False on empty props", Session{}, false},
+		{"True when is OAuth App", Session{IsOAuth: true}, true},
+		{"True when session is bot", Session{Props: StringMap{SessionPropIsBot: SessionPropIsBotValue}}, true},
+		{"True when session is user access token", Session{Props: StringMap{SessionPropType: SessionTypeUserAccessToken}}, true},
+		{"Not affected by Props[UserAuthServiceIsOAuth]", Session{Props: StringMap{UserAuthServiceIsOAuth: strconv.FormatBool(true)}}, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			require.Equal(t, tc.IsIntegration, tc.Session.IsIntegration())
+		})
+	}
+}

--- a/web/context.go
+++ b/web/context.go
@@ -221,6 +221,10 @@ func (c *Context) SetInvalidParam(parameter string) {
 	c.Err = NewInvalidParamError(parameter)
 }
 
+func (c *Context) SetInvalidParamWithDetails(parameter string, details string) {
+	c.Err = NewInvalidParamDetailedError(parameter, details)
+}
+
 func (c *Context) SetInvalidParamWithErr(parameter string, err error) {
 	c.Err = NewInvalidParamError(parameter).Wrap(err)
 }
@@ -269,6 +273,10 @@ func (c *Context) HandleEtag(etag string, routeName string, w http.ResponseWrite
 	return false
 }
 
+func NewInvalidParamDetailedError(parameter string, details string) *model.AppError {
+	err := model.NewAppError("Context", "api.context.invalid_body_param.app_error", map[string]any{"Name": parameter}, details, http.StatusBadRequest)
+	return err
+}
 func NewInvalidParamError(parameter string) *model.AppError {
 	err := model.NewAppError("Context", "api.context.invalid_body_param.app_error", map[string]any{"Name": parameter}, "", http.StatusBadRequest)
 	return err


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Cherry pick of #24195 onto `release-7.8`

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
