### PR TITLE
MM-54201 Unify user and group mention parsing logic

### DIFF
--- a/server/channels/app/mention_keywords.go
+++ b/server/channels/app/mention_keywords.go
@@ -15,6 +15,7 @@ const (
 	mentionableGroupPrefix = "group:"
 )
 
+// A MentionableID stores the ID of a single User/Group with information about which type of object it refers to.
 type MentionableID string
 
 func MentionableUserID(userID string) MentionableID {
@@ -43,6 +44,7 @@ func (id MentionableID) AsGroupID() (groupID string, ok bool) {
 	return idString[len(mentionableGroupPrefix):], true
 }
 
+// MentionKeywords is a collection of mention keywords and the IDs of the objects that have a given keyword.
 type MentionKeywords map[string][]MentionableID
 
 func (k MentionKeywords) AddUser(profile *model.User, channelNotifyProps map[string]string, status *model.Status, allowChannelMentions bool) MentionKeywords {
@@ -53,10 +55,10 @@ func (k MentionKeywords) AddUser(profile *model.User, channelNotifyProps map[str
 
 	// Add all the user's mention keys
 	for _, mentionKey := range profile.GetMentionKeys() {
-		// note that these are made lower case so that we can do a case insensitive check for them
-		mentionKey = strings.ToLower(mentionKey)
-
 		if mentionKey != "" {
+			// Note that these are made lower case so that we can do a case insensitive check for them
+			mentionKey = strings.ToLower(mentionKey)
+
 			k[mentionKey] = append(k[mentionKey], mentionableID)
 		}
 	}
@@ -84,7 +86,7 @@ func (k MentionKeywords) AddUser(profile *model.User, channelNotifyProps map[str
 	return k
 }
 
-func (k MentionKeywords) AddUserID(userID string, keyword string) MentionKeywords {
+func (k MentionKeywords) AddUserKeyword(userID string, keyword string) MentionKeywords {
 	k[keyword] = append(k[keyword], MentionableUserID(userID))
 
 	return k

--- a/server/channels/app/mention_keywords.go
+++ b/server/channels/app/mention_keywords.go
@@ -6,6 +6,8 @@ package app
 import (
 	"fmt"
 	"strings"
+
+	"github.com/mattermost/mattermost/server/public/model"
 )
 
 const (
@@ -14,6 +16,14 @@ const (
 )
 
 type MentionableID string
+
+func MentionableUserID(userID string) MentionableID {
+	return MentionableID(fmt.Sprint(mentionableUserPrefix, userID))
+}
+
+func MentionableGroupID(groupID string) MentionableID {
+	return MentionableID(fmt.Sprint(mentionableGroupPrefix, groupID))
+}
 
 func (id MentionableID) AsUserID() (userID string, ok bool) {
 	idString := string(id)
@@ -35,18 +45,64 @@ func (id MentionableID) AsGroupID() (groupID string, ok bool) {
 
 type MentionKeywords map[string][]MentionableID
 
-func (k MentionKeywords) AddUser(userID string, keyword string) {
+func (k MentionKeywords) AddUser(profile *model.User, channelNotifyProps map[string]string, status *model.Status, allowChannelMentions bool) MentionKeywords {
+	mentionableID := MentionableUserID(profile.Id)
+
+	userMention := "@" + strings.ToLower(profile.Username)
+	k[userMention] = append(k[userMention], mentionableID)
+
+	// Add all the user's mention keys
+	for _, mentionKey := range profile.GetMentionKeys() {
+		// note that these are made lower case so that we can do a case insensitive check for them
+		mentionKey = strings.ToLower(mentionKey)
+
+		if mentionKey != "" {
+			k[mentionKey] = append(k[mentionKey], mentionableID)
+		}
+	}
+
+	// If turned on, add the user's case sensitive first name
+	if profile.NotifyProps[model.FirstNameNotifyProp] == "true" && profile.FirstName != "" {
+		k[profile.FirstName] = append(k[profile.FirstName], mentionableID)
+	}
+
+	// Add @channel and @all to k if user has them turned on and the server allows them
+	if allowChannelMentions {
+		// Ignore channel mentions if channel is muted and channel mention setting is default
+		ignoreChannelMentions := channelNotifyProps[model.IgnoreChannelMentionsNotifyProp] == model.IgnoreChannelMentionsOn || (channelNotifyProps[model.MarkUnreadNotifyProp] == model.UserNotifyMention && channelNotifyProps[model.IgnoreChannelMentionsNotifyProp] == model.IgnoreChannelMentionsDefault)
+
+		if profile.NotifyProps[model.ChannelMentionsNotifyProp] == "true" && !ignoreChannelMentions {
+			k["@channel"] = append(k["@channel"], mentionableID)
+			k["@all"] = append(k["@all"], mentionableID)
+
+			if status != nil && status.Status == model.StatusOnline {
+				k["@here"] = append(k["@here"], mentionableID)
+			}
+		}
+	}
+
+	return k
+}
+
+func (k MentionKeywords) AddUserID(userID string, keyword string) MentionKeywords {
 	k[keyword] = append(k[keyword], MentionableUserID(userID))
+
+	return k
 }
 
-func (k MentionKeywords) AddGroup(groupID string, keyword string) {
-	k[keyword] = append(k[keyword], MentionableGroupID(groupID))
+func (k MentionKeywords) AddGroup(group *model.Group) MentionKeywords {
+	if group.Name != nil {
+		keyword := "@" + *group.Name
+		k[keyword] = append(k[keyword], MentionableGroupID(group.Id))
+	}
+
+	return k
 }
 
-func MentionableUserID(userID string) MentionableID {
-	return MentionableID(fmt.Sprint(mentionableUserPrefix, userID))
-}
+func (k MentionKeywords) AddGroupsMap(groups map[string]*model.Group) MentionKeywords {
+	for _, group := range groups {
+		k.AddGroup(group)
+	}
 
-func MentionableGroupID(groupID string) MentionableID {
-	return MentionableID(fmt.Sprint(mentionableGroupPrefix, groupID))
+	return k
 }

--- a/server/channels/app/mention_keywords.go
+++ b/server/channels/app/mention_keywords.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	mentionableUserPrefix  = "user:"
+	mentionableGroupPrefix = "group:"
+)
+
+type MentionableID string
+
+func (id MentionableID) AsUserID() (userID string, ok bool) {
+	idString := string(id)
+	if !strings.HasPrefix(idString, mentionableUserPrefix) {
+		return "", false
+	}
+
+	return idString[len(mentionableUserPrefix):], true
+}
+
+func (id MentionableID) AsGroupID() (groupID string, ok bool) {
+	idString := string(id)
+	if !strings.HasPrefix(idString, mentionableGroupPrefix) {
+		return "", false
+	}
+
+	return idString[len(mentionableGroupPrefix):], true
+}
+
+type MentionKeywords map[string][]MentionableID
+
+func (k MentionKeywords) AddUser(userID string, keyword string) {
+	k[keyword] = append(k[keyword], MentionableUserID(userID))
+}
+
+func (k MentionKeywords) AddGroup(groupID string, keyword string) {
+	k[keyword] = append(k[keyword], MentionableGroupID(groupID))
+}
+
+func MentionableUserID(userID string) MentionableID {
+	return MentionableID(fmt.Sprint(mentionableUserPrefix, userID))
+}
+
+func MentionableGroupID(groupID string) MentionableID {
+	return MentionableID(fmt.Sprint(mentionableGroupPrefix, groupID))
+}

--- a/server/channels/app/mention_keywords_test.go
+++ b/server/channels/app/mention_keywords_test.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+func mapsToMentionKeywords(m map[string][]string) MentionKeywords {
+	keywords := make(MentionKeywords, len(m))
+	for key, ids := range m {
+		keywords[key] = make([]MentionableID, len(ids))
+		for i, id := range ids {
+			keywords[key][i] = MentionableUserID(id)
+		}
+	}
+	return keywords
+}

--- a/server/channels/app/mention_keywords_test.go
+++ b/server/channels/app/mention_keywords_test.go
@@ -3,13 +3,290 @@
 
 package app
 
-func mapsToMentionKeywords(m map[string][]string) MentionKeywords {
-	keywords := make(MentionKeywords, len(m))
-	for key, ids := range m {
-		keywords[key] = make([]MentionableID, len(ids))
-		for i, id := range ids {
-			keywords[key][i] = MentionableUserID(id)
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func mapsToMentionKeywords(userKeywords map[string][]string, groups map[string]*model.Group) MentionKeywords {
+	keywords := make(MentionKeywords, len(userKeywords)+len(groups))
+
+	for keyword, ids := range userKeywords {
+		for _, id := range ids {
+			keywords[keyword] = append(keywords[keyword], MentionableUserID(id))
 		}
 	}
+
+	for _, group := range groups {
+		keyword := "@" + *group.Name
+		keywords[keyword] = append(keywords[keyword], MentionableGroupID(group.Id))
+	}
+
 	return keywords
+}
+
+func TestMentionKeywords_AddUserProfile(t *testing.T) {
+	t.Run("should add @user", func(t *testing.T) {
+		user := &model.User{
+			Id:       model.NewId(),
+			Username: "user",
+		}
+		channelNotifyProps := map[string]string{}
+
+		keywords := MentionKeywords{}
+		keywords.AddUser(user, channelNotifyProps, nil, false)
+
+		assert.Contains(t, keywords["@user"], MentionableUserID(user.Id))
+	})
+
+	t.Run("should add custom mention keywords", func(t *testing.T) {
+		user := &model.User{
+			Id:       model.NewId(),
+			Username: "user",
+			NotifyProps: map[string]string{
+				model.MentionKeysNotifyProp: "apple,BANANA,OrAnGe",
+			},
+		}
+		channelNotifyProps := map[string]string{}
+
+		keywords := MentionKeywords{}
+		keywords.AddUser(user, channelNotifyProps, nil, false)
+
+		assert.Contains(t, keywords["apple"], MentionableUserID(user.Id))
+		assert.Contains(t, keywords["banana"], MentionableUserID(user.Id))
+		assert.Contains(t, keywords["orange"], MentionableUserID(user.Id))
+	})
+
+	t.Run("should not add empty custom keywords", func(t *testing.T) {
+		user := &model.User{
+			Id:       model.NewId(),
+			Username: "user",
+			NotifyProps: map[string]string{
+				model.MentionKeysNotifyProp: ",,",
+			},
+		}
+		channelNotifyProps := map[string]string{}
+
+		keywords := MentionKeywords{}
+		keywords.AddUser(user, channelNotifyProps, nil, false)
+
+		assert.Nil(t, keywords[""])
+	})
+
+	t.Run("should add case sensitive first name if enabled", func(t *testing.T) {
+		user := &model.User{
+			Id:        model.NewId(),
+			Username:  "user",
+			FirstName: "William",
+			LastName:  "Robert",
+			NotifyProps: map[string]string{
+				model.FirstNameNotifyProp: "true",
+			},
+		}
+		channelNotifyProps := map[string]string{}
+
+		keywords := MentionKeywords{}
+		keywords.AddUser(user, channelNotifyProps, nil, false)
+
+		assert.Contains(t, keywords["William"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["william"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["Robert"], MentionableUserID(user.Id))
+	})
+
+	t.Run("should not add case sensitive first name if enabled but empty First Name", func(t *testing.T) {
+		user := &model.User{
+			Id:        model.NewId(),
+			Username:  "user",
+			FirstName: "",
+			LastName:  "Robert",
+			NotifyProps: map[string]string{
+				model.FirstNameNotifyProp: "true",
+			},
+		}
+		channelNotifyProps := map[string]string{}
+
+		keywords := MentionKeywords{}
+		keywords.AddUser(user, channelNotifyProps, nil, false)
+
+		assert.NotContains(t, keywords[""], MentionableUserID(user.Id))
+	})
+
+	t.Run("should not add case sensitive first name if disabled", func(t *testing.T) {
+		user := &model.User{
+			Id:        model.NewId(),
+			Username:  "user",
+			FirstName: "William",
+			LastName:  "Robert",
+			NotifyProps: map[string]string{
+				model.FirstNameNotifyProp: "false",
+			},
+		}
+		channelNotifyProps := map[string]string{}
+
+		keywords := MentionKeywords{}
+		keywords.AddUser(user, channelNotifyProps, nil, false)
+
+		assert.NotContains(t, keywords["William"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["william"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["Robert"], MentionableUserID(user.Id))
+	})
+
+	t.Run("should add @channel/@all/@here when allowed", func(t *testing.T) {
+		user := &model.User{
+			Id:       model.NewId(),
+			Username: "user",
+			NotifyProps: map[string]string{
+				model.ChannelMentionsNotifyProp: "true",
+			},
+		}
+		channelNotifyProps := map[string]string{}
+		status := &model.Status{
+			Status: model.StatusOnline,
+		}
+
+		keywords := MentionKeywords{}
+		keywords.AddUser(user, channelNotifyProps, status, true)
+
+		assert.Contains(t, keywords["@channel"], MentionableUserID(user.Id))
+		assert.Contains(t, keywords["@all"], MentionableUserID(user.Id))
+		assert.Contains(t, keywords["@here"], MentionableUserID(user.Id))
+	})
+
+	t.Run("should not add @channel/@all/@here when not allowed", func(t *testing.T) {
+		user := &model.User{
+			Id:       model.NewId(),
+			Username: "user",
+			NotifyProps: map[string]string{
+				model.ChannelMentionsNotifyProp: "true",
+			},
+		}
+		channelNotifyProps := map[string]string{}
+		status := &model.Status{
+			Status: model.StatusOnline,
+		}
+
+		keywords := MentionKeywords{}
+		keywords.AddUser(user, channelNotifyProps, status, false)
+
+		assert.NotContains(t, keywords["@channel"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@all"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@here"], MentionableUserID(user.Id))
+	})
+
+	t.Run("should not add @channel/@all/@here when disabled for user", func(t *testing.T) {
+		user := &model.User{
+			Id:       model.NewId(),
+			Username: "user",
+			NotifyProps: map[string]string{
+				model.ChannelMentionsNotifyProp: "false",
+			},
+		}
+		channelNotifyProps := map[string]string{}
+		status := &model.Status{
+			Status: model.StatusOnline,
+		}
+
+		keywords := MentionKeywords{}
+		keywords.AddUser(user, channelNotifyProps, status, true)
+
+		assert.NotContains(t, keywords["@channel"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@all"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@here"], MentionableUserID(user.Id))
+	})
+
+	t.Run("should not add @channel/@all/@here when disabled for channel", func(t *testing.T) {
+		user := &model.User{
+			Id:       model.NewId(),
+			Username: "user",
+			NotifyProps: map[string]string{
+				model.ChannelMentionsNotifyProp: "true",
+			},
+		}
+		channelNotifyProps := map[string]string{
+			model.IgnoreChannelMentionsNotifyProp: model.IgnoreChannelMentionsOn,
+		}
+		status := &model.Status{
+			Status: model.StatusOnline,
+		}
+
+		keywords := MentionKeywords{}
+		keywords.AddUser(user, channelNotifyProps, status, true)
+
+		assert.NotContains(t, keywords["@channel"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@all"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@here"], MentionableUserID(user.Id))
+	})
+
+	t.Run("should not add @channel/@all/@here when channel is muted and channel mention setting is not updated by user", func(t *testing.T) {
+		user := &model.User{
+			Id:       model.NewId(),
+			Username: "user",
+			NotifyProps: map[string]string{
+				model.ChannelMentionsNotifyProp: "true",
+			},
+		}
+		channelNotifyProps := map[string]string{
+			model.MarkUnreadNotifyProp:            model.UserNotifyMention,
+			model.IgnoreChannelMentionsNotifyProp: model.IgnoreChannelMentionsDefault,
+		}
+		status := &model.Status{
+			Status: model.StatusOnline,
+		}
+
+		keywords := MentionKeywords{}
+		keywords.AddUser(user, channelNotifyProps, status, true)
+
+		assert.NotContains(t, keywords["@channel"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@all"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@here"], MentionableUserID(user.Id))
+	})
+
+	t.Run("should not add @here when when user is not online", func(t *testing.T) {
+		user := &model.User{
+			Id:       model.NewId(),
+			Username: "user",
+			NotifyProps: map[string]string{
+				model.ChannelMentionsNotifyProp: "true",
+			},
+		}
+		channelNotifyProps := map[string]string{}
+		status := &model.Status{
+			Status: model.StatusAway,
+		}
+
+		keywords := MentionKeywords{}
+		keywords.AddUser(user, channelNotifyProps, status, true)
+
+		assert.Contains(t, keywords["@channel"], MentionableUserID(user.Id))
+		assert.Contains(t, keywords["@all"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@here"], MentionableUserID(user.Id))
+	})
+
+	t.Run("should add for multiple users", func(t *testing.T) {
+		user1 := &model.User{
+			Id:       model.NewId(),
+			Username: "user1",
+			NotifyProps: map[string]string{
+				model.ChannelMentionsNotifyProp: "true",
+			},
+		}
+		user2 := &model.User{
+			Id:       model.NewId(),
+			Username: "user2",
+			NotifyProps: map[string]string{
+				model.ChannelMentionsNotifyProp: "true",
+			},
+		}
+
+		keywords := MentionKeywords{}
+		keywords.AddUser(user1, map[string]string{}, nil, true)
+		keywords.AddUser(user2, map[string]string{}, nil, true)
+
+		assert.Contains(t, keywords["@user1"], MentionableUserID(user1.Id))
+		assert.Contains(t, keywords["@user2"], MentionableUserID(user2.Id))
+		assert.Contains(t, keywords["@all"], MentionableUserID(user1.Id))
+		assert.Contains(t, keywords["@all"], MentionableUserID(user2.Id))
+	})
 }

--- a/server/channels/app/mention_parser_standard.go
+++ b/server/channels/app/mention_parser_standard.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
-
-	"github.com/mattermost/mattermost/server/public/model"
 )
 
 // Have the compiler confirm *StandardMentionParser implements MentionParser
@@ -16,15 +14,13 @@ var _ MentionParser = &StandardMentionParser{}
 
 type StandardMentionParser struct {
 	keywords MentionKeywords
-	groups   map[string]*model.Group
 
 	results *MentionResults
 }
 
-func makeStandardMentionParser(keywords MentionKeywords, groups map[string]*model.Group) *StandardMentionParser {
+func makeStandardMentionParser(keywords MentionKeywords) *StandardMentionParser {
 	return &StandardMentionParser{
 		keywords: keywords,
-		groups:   groups,
 
 		results: &MentionResults{},
 	}
@@ -118,8 +114,6 @@ func (p *StandardMentionParser) checkForMention(word string) bool {
 		mentionType = KeywordMention
 	}
 
-	checkForGroupMention(p.results, word, p.groups)
-
 	if ids, match := p.keywords[strings.ToLower(word)]; match {
 		p.addMentions(ids, mentionType)
 		return true
@@ -139,37 +133,9 @@ func (p *StandardMentionParser) addMentions(ids []MentionableID, mentionType Men
 		if userID, ok := id.AsUserID(); ok {
 			p.results.addMention(userID, mentionType)
 		} else if groupID, ok := id.AsGroupID(); ok {
-			p.results.GroupMentions[groupID] = &model.Group{}
+			p.results.addGroupMention(groupID)
 		}
 	}
-}
-
-func checkForGroupMention(m *MentionResults, word string, groups map[string]*model.Group) bool {
-	if strings.HasPrefix(word, "@") {
-		word = word[1:]
-	} else {
-		// Only allow group mentions when mentioned directly with @group-name
-		return false
-	}
-
-	group, groupFound := groups[word]
-	if !groupFound {
-		group = groups[strings.ToLower(word)]
-	}
-
-	if group == nil {
-		return false
-	}
-
-	if m.GroupMentions == nil {
-		m.GroupMentions = make(map[string]*model.Group)
-	}
-
-	if group.Name != nil {
-		m.GroupMentions[*group.Name] = group
-	}
-
-	return true
 }
 
 // isKeywordMultibyte checks if a word containing a multibyte character contains a multibyte keyword

--- a/server/channels/app/mention_parser_standard_test.go
+++ b/server/channels/app/mention_parser_standard_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIsKeywordMultibyte(t *testing.T) {
@@ -110,7 +109,7 @@ func TestIsKeywordMultibyte(t *testing.T) {
 				},
 			}
 
-			m := getExplicitMentions(post, mapsToMentionKeywords(tc.Keywords), tc.Groups)
+			m := getExplicitMentions(post, mapsToMentionKeywords(tc.Keywords, tc.Groups))
 			assert.EqualValues(t, tc.Expected, m)
 		})
 	}
@@ -205,7 +204,7 @@ func TestCheckForMentionUsers(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			p := makeStandardMentionParser(mapsToMentionKeywords(tc.Keywords), nil)
+			p := makeStandardMentionParser(mapsToMentionKeywords(tc.Keywords, nil))
 			p.checkForMention(tc.Word)
 
 			assert.EqualValues(t, tc.Expected, p.Results())
@@ -213,53 +212,77 @@ func TestCheckForMentionUsers(t *testing.T) {
 	}
 }
 
-func TestCheckForGroupMention(t *testing.T) {
+func TestCheckForMentionGroups(t *testing.T) {
+	groupID1 := model.NewId()
+	groupID2 := model.NewId()
+
 	for name, tc := range map[string]struct {
 		Word     string
 		Groups   map[string]*model.Group
-		Expected bool
+		Expected *MentionResults
 	}{
 		"No groups": {
 			Word:     "nothing",
 			Groups:   map[string]*model.Group{},
-			Expected: false,
+			Expected: &MentionResults{},
 		},
 		"No matching groups": {
-			Word:     "nothing",
-			Groups:   map[string]*model.Group{"engineering": {Name: model.NewString("engineering")}, "developers": {Name: model.NewString("developers")}},
-			Expected: false,
+			Word: "nothing",
+			Groups: map[string]*model.Group{
+				groupID1: {Id: groupID1, Name: model.NewString("engineering")},
+				groupID2: {Id: groupID2, Name: model.NewString("developers")},
+			},
+			Expected: &MentionResults{},
 		},
 		"matching group with no @": {
-			Word:     "engineering",
-			Groups:   map[string]*model.Group{"engineering": {Name: model.NewString("engineering")}, "developers": {Name: model.NewString("developers")}},
-			Expected: false,
+			Word: "engineering",
+			Groups: map[string]*model.Group{
+				groupID1: {Id: groupID1, Name: model.NewString("engineering")},
+				groupID2: {Id: groupID2, Name: model.NewString("developers")},
+			},
+			Expected: &MentionResults{},
 		},
 		"matching group with preceding @": {
-			Word:     "@engineering",
-			Groups:   map[string]*model.Group{"engineering": {Name: model.NewString("engineering")}, "developers": {Name: model.NewString("developers")}},
-			Expected: true,
+			Word: "@engineering",
+			Groups: map[string]*model.Group{
+				groupID1: {Id: groupID1, Name: model.NewString("engineering")},
+				groupID2: {Id: groupID2, Name: model.NewString("developers")},
+			},
+			Expected: &MentionResults{
+				GroupMentions: map[string]MentionType{
+					groupID1: GroupMention,
+				},
+			},
 		},
 		"matching upper case group with preceding @": {
-			Word:     "@Engineering",
-			Groups:   map[string]*model.Group{"engineering": {Name: model.NewString("engineering")}, "developers": {Name: model.NewString("developers")}},
-			Expected: true,
+			Word: "@Engineering",
+			Groups: map[string]*model.Group{
+				groupID1: {Id: groupID1, Name: model.NewString("engineering")},
+				groupID2: {Id: groupID2, Name: model.NewString("developers")},
+			},
+			Expected: &MentionResults{
+				GroupMentions: map[string]MentionType{
+					groupID1: GroupMention,
+				},
+			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			mr := &MentionResults{}
-			groupFound := checkForGroupMention(mr, tc.Word, tc.Groups)
+			p := makeStandardMentionParser(mapsToMentionKeywords(nil, tc.Groups))
+			p.checkForMention(tc.Word)
 
-			if groupFound {
-				require.Equal(t, len(mr.GroupMentions), 1)
-			}
+			mr := p.Results()
 
-			require.Equal(t, tc.Expected, groupFound)
+			assert.EqualValues(t, tc.Expected, mr)
 		})
 	}
 }
 
 func TestProcessText(t *testing.T) {
-	id1 := model.NewId()
+	userID1 := model.NewId()
+
+	groupID1 := model.NewId()
+	groupID2 := model.NewId()
 
 	for name, tc := range map[string]struct {
 		Text     string
@@ -269,47 +292,59 @@ func TestProcessText(t *testing.T) {
 	}{
 		"Mention user in text": {
 			Text:     "hello user @user1",
-			Keywords: map[string][]string{"@user1": {id1}},
-			Groups:   map[string]*model.Group{"engineering": {Name: model.NewString("engineering")}, "developers": {Name: model.NewString("developers")}},
+			Keywords: map[string][]string{"@user1": {userID1}},
+			Groups: map[string]*model.Group{
+				groupID1: {Id: groupID1, Name: model.NewString("engineering")},
+				groupID2: {Id: groupID2, Name: model.NewString("developers")},
+			},
 			Expected: &MentionResults{
 				Mentions: map[string]MentionType{
-					id1: KeywordMention,
+					userID1: KeywordMention,
 				},
 			},
 		},
 		"Mention user after ending a sentence with full stop": {
 			Text:     "hello user.@user1",
-			Keywords: map[string][]string{"@user1": {id1}},
-			Groups:   map[string]*model.Group{"engineering": {Name: model.NewString("engineering")}, "developers": {Name: model.NewString("developers")}},
+			Keywords: map[string][]string{"@user1": {userID1}},
+			Groups: map[string]*model.Group{
+				groupID1: {Id: groupID1, Name: model.NewString("engineering")},
+				groupID2: {Id: groupID2, Name: model.NewString("developers")},
+			},
 			Expected: &MentionResults{
 				Mentions: map[string]MentionType{
-					id1: KeywordMention,
+					userID1: KeywordMention,
 				},
 			},
 		},
 		"Mention user after hyphen": {
 			Text:     "hello user-@user1",
-			Keywords: map[string][]string{"@user1": {id1}},
+			Keywords: map[string][]string{"@user1": {userID1}},
 			Expected: &MentionResults{
 				Mentions: map[string]MentionType{
-					id1: KeywordMention,
+					userID1: KeywordMention,
 				},
 			},
 		},
 		"Mention user after colon": {
 			Text:     "hello user:@user1",
-			Keywords: map[string][]string{"@user1": {id1}},
-			Groups:   map[string]*model.Group{"engineering": {Name: model.NewString("engineering")}, "developers": {Name: model.NewString("developers")}},
+			Keywords: map[string][]string{"@user1": {userID1}},
+			Groups: map[string]*model.Group{
+				groupID1: {Id: groupID1, Name: model.NewString("engineering")},
+				groupID2: {Id: groupID2, Name: model.NewString("developers")},
+			},
 			Expected: &MentionResults{
 				Mentions: map[string]MentionType{
-					id1: KeywordMention,
+					userID1: KeywordMention,
 				},
 			},
 		},
 		"Mention here after colon": {
 			Text:     "hello all:@here",
 			Keywords: map[string][]string{},
-			Groups:   map[string]*model.Group{"engineering": {Name: model.NewString("engineering")}, "developers": {Name: model.NewString("developers")}},
+			Groups: map[string]*model.Group{
+				groupID1: {Id: groupID1, Name: model.NewString("engineering")},
+				groupID2: {Id: groupID2, Name: model.NewString("developers")},
+			},
 			Expected: &MentionResults{
 				HereMentioned: true,
 			},
@@ -317,7 +352,10 @@ func TestProcessText(t *testing.T) {
 		"Mention all after hyphen": {
 			Text:     "hello all-@all",
 			Keywords: map[string][]string{},
-			Groups:   map[string]*model.Group{"engineering": {Name: model.NewString("engineering")}, "developers": {Name: model.NewString("developers")}},
+			Groups: map[string]*model.Group{
+				groupID1: {Id: groupID1, Name: model.NewString("engineering")},
+				groupID2: {Id: groupID2, Name: model.NewString("developers")},
+			},
 			Expected: &MentionResults{
 				AllMentioned: true,
 			},
@@ -325,7 +363,10 @@ func TestProcessText(t *testing.T) {
 		"Mention channel after full stop": {
 			Text:     "hello channel.@channel",
 			Keywords: map[string][]string{},
-			Groups:   map[string]*model.Group{"engineering": {Name: model.NewString("engineering")}, "developers": {Name: model.NewString("developers")}},
+			Groups: map[string]*model.Group{
+				groupID1: {Id: groupID1, Name: model.NewString("engineering")},
+				groupID2: {Id: groupID2, Name: model.NewString("developers")},
+			},
 			Expected: &MentionResults{
 				ChannelMentioned: true,
 			},
@@ -333,46 +374,57 @@ func TestProcessText(t *testing.T) {
 		"Mention other potential users or system calls": {
 			Text:     "hello @potentialuser and @otherpotentialuser",
 			Keywords: map[string][]string{},
-			Groups:   map[string]*model.Group{"engineering": {Name: model.NewString("engineering")}, "developers": {Name: model.NewString("developers")}},
+			Groups: map[string]*model.Group{
+				groupID1: {Id: groupID1, Name: model.NewString("engineering")},
+				groupID2: {Id: groupID2, Name: model.NewString("developers")},
+			},
 			Expected: &MentionResults{
 				OtherPotentialMentions: []string{"potentialuser", "otherpotentialuser"},
 			},
 		},
 		"Mention a real user and another potential user": {
 			Text:     "@user1, you can use @systembot to get help",
-			Keywords: map[string][]string{"@user1": {id1}},
-			Groups:   map[string]*model.Group{"engineering": {Name: model.NewString("engineering")}, "developers": {Name: model.NewString("developers")}},
+			Keywords: map[string][]string{"@user1": {userID1}},
+			Groups: map[string]*model.Group{
+				groupID1: {Id: groupID1, Name: model.NewString("engineering")},
+				groupID2: {Id: groupID2, Name: model.NewString("developers")},
+			},
 			Expected: &MentionResults{
 				Mentions: map[string]MentionType{
-					id1: KeywordMention,
+					userID1: KeywordMention,
 				},
 				OtherPotentialMentions: []string{"systembot"},
 			},
 		},
 		"Mention a group": {
 			Text:     "@engineering",
-			Keywords: map[string][]string{"@user1": {id1}},
-			Groups:   map[string]*model.Group{"engineering": {Name: model.NewString("engineering")}, "developers": {Name: model.NewString("developers")}},
+			Keywords: map[string][]string{"@user1": {userID1}},
+			Groups: map[string]*model.Group{
+				groupID1: {Id: groupID1, Name: model.NewString("engineering")},
+				groupID2: {Id: groupID2, Name: model.NewString("developers")},
+			},
 			Expected: &MentionResults{
-				GroupMentions:          map[string]*model.Group{"engineering": {Name: model.NewString("engineering")}},
-				OtherPotentialMentions: []string{"engineering"},
+				GroupMentions: map[string]MentionType{groupID1: GroupMention},
 			},
 		},
 		"Mention a real user and another potential user and a group": {
 			Text:     "@engineering @user1, you can use @systembot to get help from",
-			Keywords: map[string][]string{"@user1": {id1}},
-			Groups:   map[string]*model.Group{"engineering": {Name: model.NewString("engineering")}, "developers": {Name: model.NewString("developers")}},
+			Keywords: map[string][]string{"@user1": {userID1}},
+			Groups: map[string]*model.Group{
+				groupID1: {Id: groupID1, Name: model.NewString("engineering")},
+				groupID2: {Id: groupID2, Name: model.NewString("developers")},
+			},
 			Expected: &MentionResults{
 				Mentions: map[string]MentionType{
-					id1: KeywordMention,
+					userID1: KeywordMention,
 				},
-				GroupMentions:          map[string]*model.Group{"engineering": {Name: model.NewString("engineering")}},
-				OtherPotentialMentions: []string{"engineering", "systembot"},
+				GroupMentions:          map[string]MentionType{groupID1: GroupMention},
+				OtherPotentialMentions: []string{"systembot"},
 			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			p := makeStandardMentionParser(mapsToMentionKeywords(tc.Keywords), tc.Groups)
+			p := makeStandardMentionParser(mapsToMentionKeywords(tc.Keywords, tc.Groups))
 			p.ProcessText(tc.Text)
 
 			assert.EqualValues(t, tc.Expected, p.Results())

--- a/server/channels/app/mention_parser_standard_test.go
+++ b/server/channels/app/mention_parser_standard_test.go
@@ -110,7 +110,7 @@ func TestIsKeywordMultibyte(t *testing.T) {
 				},
 			}
 
-			m := getExplicitMentions(post, tc.Keywords, tc.Groups)
+			m := getExplicitMentions(post, mapsToMentionKeywords(tc.Keywords), tc.Groups)
 			assert.EqualValues(t, tc.Expected, m)
 		})
 	}
@@ -205,7 +205,7 @@ func TestCheckForMentionUsers(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			p := makeStandardMentionParser(tc.Keywords, nil)
+			p := makeStandardMentionParser(mapsToMentionKeywords(tc.Keywords), nil)
 			p.checkForMention(tc.Word)
 
 			assert.EqualValues(t, tc.Expected, p.Results())
@@ -372,7 +372,7 @@ func TestProcessText(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			p := makeStandardMentionParser(tc.Keywords, tc.Groups)
+			p := makeStandardMentionParser(mapsToMentionKeywords(tc.Keywords), tc.Groups)
 			p.ProcessText(tc.Text)
 
 			assert.EqualValues(t, tc.Expected, p.Results())

--- a/server/channels/app/mention_results.go
+++ b/server/channels/app/mention_results.go
@@ -37,7 +37,7 @@ type MentionResults struct {
 	// Mentions maps the ID of each user that was mentioned to how they were mentioned.
 	Mentions map[string]MentionType
 
-	// Contains maps the ID of each group that was mentioned to how it was mentioned.
+	// GroupMentions maps the ID of each group that was mentioned to how it was mentioned.
 	GroupMentions map[string]MentionType
 
 	// OtherPotentialMentions contains a list of strings that looked like mentions, but didn't have

--- a/server/channels/app/mention_results.go
+++ b/server/channels/app/mention_results.go
@@ -3,10 +3,6 @@
 
 package app
 
-import (
-	"github.com/mattermost/mattermost/server/public/model"
-)
-
 const (
 	// Different types of mentions ordered by their priority from lowest to highest
 
@@ -38,11 +34,11 @@ const (
 type MentionType int
 
 type MentionResults struct {
-	// Mentions contains the ID of each user that was mentioned and how they were mentioned.
+	// Mentions maps the ID of each user that was mentioned to how they were mentioned.
 	Mentions map[string]MentionType
 
-	// Contains a map of groups that were mentioned
-	GroupMentions map[string]*model.Group
+	// Contains maps the ID of each group that was mentioned to how it was mentioned.
+	GroupMentions map[string]MentionType
 
 	// OtherPotentialMentions contains a list of strings that looked like mentions, but didn't have
 	// a corresponding keyword.
@@ -84,4 +80,12 @@ func (m *MentionResults) addMention(userID string, mentionType MentionType) {
 
 func (m *MentionResults) removeMention(userID string) {
 	delete(m.Mentions, userID)
+}
+
+func (m *MentionResults) addGroupMention(groupID string) {
+	if m.GroupMentions == nil {
+		m.GroupMentions = make(map[string]MentionType)
+	}
+
+	m.GroupMentions[groupID] = GroupMention
 }

--- a/server/channels/app/notification.go
+++ b/server/channels/app/notification.go
@@ -124,14 +124,15 @@ func (a *App) SendNotifications(c request.CTX, post *model.Post, team *model.Tea
 	var allActivityPushUserIds []string
 	if channel.Type != model.ChannelTypeDirect {
 		// Iterate through all groups that were mentioned and insert group members into the list of mentions or potential mentions
-		for _, group := range mentions.GroupMentions {
+		for groupID := range mentions.GroupMentions {
+			group := groups[groupID]
 			anyUsersMentionedByGroup, err := a.insertGroupMentions(group, channel, profileMap, mentions)
 			if err != nil {
 				return nil, err
 			}
 
 			if !anyUsersMentionedByGroup {
-				a.sendNoUsersNotifiedByGroupInChannel(c, sender, post, channel, group)
+				a.sendNoUsersNotifiedByGroupInChannel(c, sender, post, channel, groups[groupID])
 			}
 		}
 
@@ -170,7 +171,7 @@ func (a *App) SendNotifications(c request.CTX, post *model.Post, team *model.Tea
 				threadParticipants[rootPost.UserId] = true
 			}
 			if channel.Type != model.ChannelTypeDirect {
-				rootMentions = getExplicitMentions(rootPost, keywords, groups)
+				rootMentions = getExplicitMentions(rootPost, keywords)
 				for id := range rootMentions.Mentions {
 					threadParticipants[id] = true
 				}
@@ -674,9 +675,9 @@ func (a *App) RemoveNotifications(c request.CTX, post *model.Post, channel *mode
 		mentions, _ := a.getExplicitMentionsAndKeywords(c, post, channel, profileMap, groups, channelMemberNotifyPropsMap, nil)
 
 		userIDs := []string{}
-		for _, group := range mentions.GroupMentions {
+		for groupID := range mentions.GroupMentions {
 			for page := 0; ; page++ {
-				groupMemberPage, count, appErr := a.GetGroupMemberUsersPage(group.Id, page, 100, &model.ViewUsersRestrictions{Channels: []string{channel.Id}})
+				groupMemberPage, count, appErr := a.GetGroupMemberUsersPage(groupID, page, 100, &model.ViewUsersRestrictions{Channels: []string{channel.Id}})
 				if appErr != nil {
 					return appErr
 				}
@@ -768,9 +769,9 @@ func (a *App) getExplicitMentionsAndKeywords(c request.CTX, post *model.Post, ch
 		}
 	} else {
 		allowChannelMentions = a.allowChannelMentions(c, post, len(profileMap))
-		keywords = a.getMentionKeywordsInChannel(profileMap, allowChannelMentions, channelMemberNotifyPropsMap)
+		keywords = a.getMentionKeywordsInChannel(profileMap, allowChannelMentions, channelMemberNotifyPropsMap, groups)
 
-		mentions = getExplicitMentions(post, keywords, groups)
+		mentions = getExplicitMentions(post, keywords)
 
 		// Add a GM mention to all members of a GM channel
 		if channel.Type == model.ChannelTypeGroup {
@@ -1045,8 +1046,8 @@ func splitAtFinal(items []string) (preliminary []string, final string) {
 
 // Given a message and a map mapping mention keywords to the users who use them, returns a map of mentioned
 // users and a slice of potential mention users not in the channel and whether or not @here was mentioned.
-func getExplicitMentions(post *model.Post, keywords MentionKeywords, groups map[string]*model.Group) *MentionResults {
-	parser := makeStandardMentionParser(keywords, groups)
+func getExplicitMentions(post *model.Post, keywords MentionKeywords) *MentionResults {
+	parser := makeStandardMentionParser(keywords)
 
 	buf := ""
 	mentionsEnabledFields := getMentionsEnabledFields(post)
@@ -1147,7 +1148,7 @@ func (a *App) getGroupsAllowedForReferenceInChannel(channel *model.Channel, team
 		}
 		for _, group := range groups {
 			if group.Group.Name != nil {
-				groupsMap[*group.Group.Name] = &group.Group
+				groupsMap[group.Id] = &group.Group
 			}
 		}
 		return groupsMap, nil
@@ -1159,7 +1160,7 @@ func (a *App) getGroupsAllowedForReferenceInChannel(channel *model.Channel, team
 	}
 	for _, group := range groups {
 		if group.Name != nil {
-			groupsMap[*group.Name] = group
+			groupsMap[group.Id] = group
 		}
 	}
 
@@ -1168,18 +1169,19 @@ func (a *App) getGroupsAllowedForReferenceInChannel(channel *model.Channel, team
 
 // Given a map of user IDs to profiles, returns a list of mention
 // keywords for all users in the channel.
-func (a *App) getMentionKeywordsInChannel(profiles map[string]*model.User, allowChannelMentions bool, channelMemberNotifyPropsMap map[string]model.StringMap) MentionKeywords {
+func (a *App) getMentionKeywordsInChannel(profiles map[string]*model.User, allowChannelMentions bool, channelMemberNotifyPropsMap map[string]model.StringMap, groups map[string]*model.Group) MentionKeywords {
 	keywords := make(MentionKeywords)
 
 	for _, profile := range profiles {
-		addMentionKeywordsForUser(
-			keywords,
+		keywords.AddUser(
 			profile,
 			channelMemberNotifyPropsMap[profile.Id],
 			a.GetStatusFromCache(profile.Id),
 			allowChannelMentions,
 		)
 	}
+
+	keywords.AddGroupsMap(groups)
 
 	return keywords
 }
@@ -1225,46 +1227,6 @@ func (a *App) insertGroupMentions(group *model.Group, channel *model.Channel, pr
 	}
 
 	return isGroupOrDirect || len(groupMembers) > 0, nil
-}
-
-// addMentionKeywordsForUser adds the mention keywords for a given user to the given keyword map. Returns the provided keyword map.
-func addMentionKeywordsForUser(keywords MentionKeywords, profile *model.User, channelNotifyProps map[string]string, status *model.Status, allowChannelMentions bool) MentionKeywords {
-	mentionableID := MentionableUserID(profile.Id)
-
-	userMention := "@" + strings.ToLower(profile.Username)
-	keywords[userMention] = append(keywords[userMention], mentionableID)
-
-	// Add all the user's mention keys
-	for _, k := range profile.GetMentionKeys() {
-		// note that these are made lower case so that we can do a case insensitive check for them
-		key := strings.ToLower(k)
-
-		if key != "" {
-			keywords[key] = append(keywords[key], mentionableID)
-		}
-	}
-
-	// If turned on, add the user's case sensitive first name
-	if profile.NotifyProps[model.FirstNameNotifyProp] == "true" && profile.FirstName != "" {
-		keywords[profile.FirstName] = append(keywords[profile.FirstName], mentionableID)
-	}
-
-	// Add @channel and @all to keywords if user has them turned on and the server allows them
-	if allowChannelMentions {
-		// Ignore channel mentions if channel is muted and channel mention setting is default
-		ignoreChannelMentions := channelNotifyProps[model.IgnoreChannelMentionsNotifyProp] == model.IgnoreChannelMentionsOn || (channelNotifyProps[model.MarkUnreadNotifyProp] == model.UserNotifyMention && channelNotifyProps[model.IgnoreChannelMentionsNotifyProp] == model.IgnoreChannelMentionsDefault)
-
-		if profile.NotifyProps[model.ChannelMentionsNotifyProp] == "true" && !ignoreChannelMentions {
-			keywords["@channel"] = append(keywords["@channel"], mentionableID)
-			keywords["@all"] = append(keywords["@all"], mentionableID)
-
-			if status != nil && status.Status == model.StatusOnline {
-				keywords["@here"] = append(keywords["@here"], mentionableID)
-			}
-		}
-	}
-
-	return keywords
 }
 
 // Represents either an email or push notification and contains the fields required to send it to any user.

--- a/server/channels/app/notification_test.go
+++ b/server/channels/app/notification_test.go
@@ -1020,7 +1020,7 @@ func TestGetExplicitMentions(t *testing.T) {
 				},
 			}
 
-			m := getExplicitMentions(post, tc.Keywords, tc.Groups)
+			m := getExplicitMentions(post, mapsToMentionKeywords(tc.Keywords), tc.Groups)
 
 			assert.EqualValues(t, tc.Expected, m)
 		})
@@ -1081,7 +1081,7 @@ func TestGetExplicitMentionsAtHere(t *testing.T) {
 
 	t.Run("Mention @here and someone", func(t *testing.T) {
 		id := model.NewId()
-		m := getExplicitMentions(&model.Post{Message: "@here @user @potential"}, map[string][]string{"@user": {id}}, nil)
+		m := getExplicitMentions(&model.Post{Message: "@here @user @potential"}, mapsToMentionKeywords(map[string][]string{"@user": {id}}), nil)
 		require.True(t, m.HereMentioned, "should've mentioned @here with \"@here @user\"")
 		require.Len(t, m.Mentions, 1)
 		require.Equal(t, KeywordMention, m.Mentions[id], "should've mentioned @user with \"@here @user\"")
@@ -1091,7 +1091,11 @@ func TestGetExplicitMentionsAtHere(t *testing.T) {
 
 	t.Run("Username ending with period", func(t *testing.T) {
 		id := model.NewId()
-		m := getExplicitMentions(&model.Post{Message: "@potential. test"}, map[string][]string{"@user": {id}}, nil)
+		m := getExplicitMentions(
+			&model.Post{Message: "@potential. test"},
+			mapsToMentionKeywords(map[string][]string{"@user": {id}}),
+			nil,
+		)
 		require.Equal(t, len(m.OtherPotentialMentions), 1, "should've potential mentions for @potential")
 		assert.Equal(t, "potential", m.OtherPotentialMentions[0])
 	})
@@ -1206,6 +1210,7 @@ func TestGetMentionKeywords(t *testing.T) {
 			"mention_keys": "User,@User,MENTION",
 		},
 	}
+	mentionableUser1ID := MentionableUserID(user1.Id)
 
 	channelMemberNotifyPropsMap1Off := map[string]model.StringMap{
 		user1.Id: {
@@ -1214,18 +1219,18 @@ func TestGetMentionKeywords(t *testing.T) {
 	}
 
 	profiles := map[string]*model.User{user1.Id: user1}
-	mentions := th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMap1Off)
-	require.Len(t, mentions, 3, "should've returned three mention keywords")
+	keywords := th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMap1Off)
+	require.Len(t, keywords, 3, "should've returned three mention keywords")
 
-	ids, ok := mentions["user"]
+	ids, ok := keywords["user"]
 	require.True(t, ok)
-	require.Equal(t, user1.Id, ids[0], "should've returned mention key of user")
-	ids, ok = mentions["@user"]
+	require.Equal(t, mentionableUser1ID, ids[0], "should've returned mention key of user")
+	ids, ok = keywords["@user"]
 	require.True(t, ok)
-	require.Equal(t, user1.Id, ids[0], "should've returned mention key of @user")
-	ids, ok = mentions["mention"]
+	require.Equal(t, mentionableUser1ID, ids[0], "should've returned mention key of @user")
+	ids, ok = keywords["mention"]
 	require.True(t, ok)
-	require.Equal(t, user1.Id, ids[0], "should've returned mention key of mention")
+	require.Equal(t, mentionableUser1ID, ids[0], "should've returned mention key of mention")
 
 	// user with first name mention enabled
 	user2 := &model.User{
@@ -1236,6 +1241,7 @@ func TestGetMentionKeywords(t *testing.T) {
 			"first_name": "true",
 		},
 	}
+	mentionableUser2ID := MentionableUserID(user2.Id)
 
 	channelMemberNotifyPropsMap2Off := map[string]model.StringMap{
 		user2.Id: {
@@ -1244,12 +1250,12 @@ func TestGetMentionKeywords(t *testing.T) {
 	}
 
 	profiles = map[string]*model.User{user2.Id: user2}
-	mentions = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMap2Off)
-	require.Len(t, mentions, 2, "should've returned two mention keyword")
+	keywords = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMap2Off)
+	require.Len(t, keywords, 2, "should've returned two mention keyword")
 
-	ids, ok = mentions["First"]
+	ids, ok = keywords["First"]
 	require.True(t, ok)
-	require.Equal(t, user2.Id, ids[0], "should've returned mention key of First")
+	require.Equal(t, mentionableUser2ID, ids[0], "should've returned mention key of First")
 
 	// user with @channel/@all mentions enabled
 	user3 := &model.User{
@@ -1260,6 +1266,7 @@ func TestGetMentionKeywords(t *testing.T) {
 			"channel": "true",
 		},
 	}
+	mentionableUser3ID := MentionableUserID(user3.Id)
 
 	// Channel-wide mentions are not ignored on channel level
 	channelMemberNotifyPropsMap3Off := map[string]model.StringMap{
@@ -1268,14 +1275,14 @@ func TestGetMentionKeywords(t *testing.T) {
 		},
 	}
 	profiles = map[string]*model.User{user3.Id: user3}
-	mentions = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMap3Off)
-	require.Len(t, mentions, 3, "should've returned three mention keywords")
-	ids, ok = mentions["@channel"]
+	keywords = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMap3Off)
+	require.Len(t, keywords, 3, "should've returned three mention keywords")
+	ids, ok = keywords["@channel"]
 	require.True(t, ok)
-	require.Equal(t, user3.Id, ids[0], "should've returned mention key of @channel")
-	ids, ok = mentions["@all"]
+	require.Equal(t, mentionableUser3ID, ids[0], "should've returned mention key of @channel")
+	ids, ok = keywords["@all"]
 	require.True(t, ok)
-	require.Equal(t, user3.Id, ids[0], "should've returned mention key of @all")
+	require.Equal(t, mentionableUser3ID, ids[0], "should've returned mention key of @all")
 
 	// Channel member notify props is set to default
 	channelMemberNotifyPropsMapDefault := map[string]model.StringMap{
@@ -1284,26 +1291,26 @@ func TestGetMentionKeywords(t *testing.T) {
 		},
 	}
 	profiles = map[string]*model.User{user3.Id: user3}
-	mentions = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMapDefault)
-	require.Len(t, mentions, 3, "should've returned three mention keywords")
-	ids, ok = mentions["@channel"]
+	keywords = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMapDefault)
+	require.Len(t, keywords, 3, "should've returned three mention keywords")
+	ids, ok = keywords["@channel"]
 	require.True(t, ok)
-	require.Equal(t, user3.Id, ids[0], "should've returned mention key of @channel")
-	ids, ok = mentions["@all"]
+	require.Equal(t, mentionableUser3ID, ids[0], "should've returned mention key of @channel")
+	ids, ok = keywords["@all"]
 	require.True(t, ok)
-	require.Equal(t, user3.Id, ids[0], "should've returned mention key of @all")
+	require.Equal(t, mentionableUser3ID, ids[0], "should've returned mention key of @all")
 
 	// Channel member notify props is empty
 	channelMemberNotifyPropsMapEmpty := map[string]model.StringMap{}
 	profiles = map[string]*model.User{user3.Id: user3}
-	mentions = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMapEmpty)
-	require.Len(t, mentions, 3, "should've returned three mention keywords")
-	ids, ok = mentions["@channel"]
+	keywords = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMapEmpty)
+	require.Len(t, keywords, 3, "should've returned three mention keywords")
+	ids, ok = keywords["@channel"]
 	require.True(t, ok)
-	require.Equal(t, user3.Id, ids[0], "should've returned mention key of @channel")
-	ids, ok = mentions["@all"]
+	require.Equal(t, mentionableUser3ID, ids[0], "should've returned mention key of @channel")
+	ids, ok = keywords["@all"]
 	require.True(t, ok)
-	require.Equal(t, user3.Id, ids[0], "should've returned mention key of @all")
+	require.Equal(t, mentionableUser3ID, ids[0], "should've returned mention key of @all")
 
 	// Channel-wide mentions are ignored channel level
 	channelMemberNotifyPropsMap3On := map[string]model.StringMap{
@@ -1311,8 +1318,8 @@ func TestGetMentionKeywords(t *testing.T) {
 			"ignore_channel_mentions": model.IgnoreChannelMentionsOn,
 		},
 	}
-	mentions = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMap3On)
-	require.NotEmpty(t, mentions, "should've not returned any keywords")
+	keywords = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMap3On)
+	require.NotEmpty(t, keywords, "should've not returned any keywords")
 
 	// user with all types of mentions enabled
 	user4 := &model.User{
@@ -1325,6 +1332,7 @@ func TestGetMentionKeywords(t *testing.T) {
 			"channel":      "true",
 		},
 	}
+	mentionableUser4ID := MentionableUserID(user4.Id)
 
 	// Channel-wide mentions are not ignored on channel level
 	channelMemberNotifyPropsMap4Off := map[string]model.StringMap{
@@ -1334,26 +1342,26 @@ func TestGetMentionKeywords(t *testing.T) {
 	}
 
 	profiles = map[string]*model.User{user4.Id: user4}
-	mentions = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMap4Off)
-	require.Len(t, mentions, 6, "should've returned six mention keywords")
-	ids, ok = mentions["user"]
+	keywords = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMap4Off)
+	require.Len(t, keywords, 6, "should've returned six mention keywords")
+	ids, ok = keywords["user"]
 	require.True(t, ok)
-	require.Equal(t, user4.Id, ids[0], "should've returned mention key of user")
-	ids, ok = mentions["@user"]
+	require.Equal(t, mentionableUser4ID, ids[0], "should've returned mention key of user")
+	ids, ok = keywords["@user"]
 	require.True(t, ok)
-	require.Equal(t, user4.Id, ids[0], "should've returned mention key of @user")
-	ids, ok = mentions["mention"]
+	require.Equal(t, mentionableUser4ID, ids[0], "should've returned mention key of @user")
+	ids, ok = keywords["mention"]
 	require.True(t, ok)
-	require.Equal(t, user4.Id, ids[0], "should've returned mention key of mention")
-	ids, ok = mentions["First"]
+	require.Equal(t, mentionableUser4ID, ids[0], "should've returned mention key of mention")
+	ids, ok = keywords["First"]
 	require.True(t, ok)
-	require.Equal(t, user4.Id, ids[0], "should've returned mention key of First")
-	ids, ok = mentions["@channel"]
+	require.Equal(t, mentionableUser4ID, ids[0], "should've returned mention key of First")
+	ids, ok = keywords["@channel"]
 	require.True(t, ok)
-	require.Equal(t, user4.Id, ids[0], "should've returned mention key of @channel")
-	ids, ok = mentions["@all"]
+	require.Equal(t, mentionableUser4ID, ids[0], "should've returned mention key of @channel")
+	ids, ok = keywords["@all"]
 	require.True(t, ok)
-	require.Equal(t, user4.Id, ids[0], "should've returned mention key of @all")
+	require.Equal(t, mentionableUser4ID, ids[0], "should've returned mention key of @all")
 
 	// Channel-wide mentions are ignored on channel level
 	channelMemberNotifyPropsMap4On := map[string]model.StringMap{
@@ -1361,22 +1369,23 @@ func TestGetMentionKeywords(t *testing.T) {
 			"ignore_channel_mentions": model.IgnoreChannelMentionsOn,
 		},
 	}
-	mentions = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMap4On)
-	require.Len(t, mentions, 4, "should've returned four mention keywords")
-	ids, ok = mentions["user"]
+	keywords = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMap4On)
+	require.Len(t, keywords, 4, "should've returned four mention keywords")
+	ids, ok = keywords["user"]
 	require.True(t, ok)
-	require.Equal(t, user4.Id, ids[0], "should've returned mention key of user")
-	ids, ok = mentions["@user"]
+	require.Equal(t, mentionableUser4ID, ids[0], "should've returned mention key of user")
+	ids, ok = keywords["@user"]
 	require.True(t, ok)
-	require.Equal(t, user4.Id, ids[0], "should've returned mention key of @user")
-	ids, ok = mentions["mention"]
+	require.Equal(t, mentionableUser4ID, ids[0], "should've returned mention key of @user")
+	ids, ok = keywords["mention"]
 	require.True(t, ok)
-	require.Equal(t, user4.Id, ids[0], "should've returned mention key of mention")
-	ids, ok = mentions["First"]
+	require.Equal(t, mentionableUser4ID, ids[0], "should've returned mention key of mention")
+	ids, ok = keywords["First"]
 	require.True(t, ok)
-	require.Equal(t, user4.Id, ids[0], "should've returned mention key of First")
-	dup_count := func(list []string) map[string]int {
-		duplicate_frequency := make(map[string]int)
+	require.Equal(t, mentionableUser4ID, ids[0], "should've returned mention key of First")
+
+	dup_count := func(list []MentionableID) map[MentionableID]int {
+		duplicate_frequency := make(map[MentionableID]int)
 
 		for _, item := range list {
 			// check if the item/element exist in the duplicate_frequency map
@@ -1415,78 +1424,78 @@ func TestGetMentionKeywords(t *testing.T) {
 			"ignore_channel_mentions": model.IgnoreChannelMentionsOff,
 		},
 	}
-	mentions = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMap5Off)
-	require.Len(t, mentions, 6, "should've returned six mention keywords")
-	ids, ok = mentions["user"]
+	keywords = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMap5Off)
+	require.Len(t, keywords, 6, "should've returned six mention keywords")
+	ids, ok = keywords["user"]
 	require.True(t, ok)
 	require.Len(t, ids, 2)
-	require.False(t, ids[0] != user1.Id && ids[1] != user1.Id, "should've mentioned user1  with user")
-	require.False(t, ids[0] != user4.Id && ids[1] != user4.Id, "should've mentioned user4  with user")
-	idsMap := dup_count(mentions["@user"])
+	require.False(t, ids[0] != mentionableUser1ID && ids[1] != mentionableUser1ID, "should've mentioned user1  with user")
+	require.False(t, ids[0] != mentionableUser4ID && ids[1] != mentionableUser4ID, "should've mentioned user4  with user")
+	idsMap := dup_count(keywords["@user"])
 	require.True(t, ok)
 	require.Len(t, idsMap, 4)
-	require.Equal(t, idsMap[user1.Id], 2, "should've mentioned user1 with @user")
-	require.Equal(t, idsMap[user4.Id], 2, "should've mentioned user4 with @user")
+	require.Equal(t, idsMap[mentionableUser1ID], 2, "should've mentioned user1 with @user")
+	require.Equal(t, idsMap[mentionableUser4ID], 2, "should've mentioned user4 with @user")
 
-	ids, ok = mentions["mention"]
+	ids, ok = keywords["mention"]
 	require.True(t, ok)
 	require.Len(t, ids, 2)
-	require.False(t, ids[0] != user1.Id && ids[1] != user1.Id, "should've mentioned user1 with mention")
-	require.False(t, ids[0] != user4.Id && ids[1] != user4.Id, "should've mentioned user4 with mention")
-	ids, ok = mentions["First"]
+	require.False(t, ids[0] != mentionableUser1ID && ids[1] != mentionableUser1ID, "should've mentioned user1 with mention")
+	require.False(t, ids[0] != mentionableUser4ID && ids[1] != mentionableUser4ID, "should've mentioned user4 with mention")
+	ids, ok = keywords["First"]
 	require.True(t, ok)
 	require.Len(t, ids, 2)
-	require.False(t, ids[0] != user2.Id && ids[1] != user2.Id, "should've mentioned user2 with First")
-	require.False(t, ids[0] != user4.Id && ids[1] != user4.Id, "should've mentioned user4 with First")
-	ids, ok = mentions["@channel"]
+	require.False(t, ids[0] != mentionableUser2ID && ids[1] != mentionableUser2ID, "should've mentioned user2 with First")
+	require.False(t, ids[0] != mentionableUser4ID && ids[1] != mentionableUser4ID, "should've mentioned user4 with First")
+	ids, ok = keywords["@channel"]
 	require.True(t, ok)
 	require.Len(t, ids, 2)
-	require.False(t, ids[0] != user3.Id && ids[1] != user3.Id, "should've mentioned user3 with @channel")
-	require.False(t, ids[0] != user4.Id && ids[1] != user4.Id, "should've mentioned user4 with @channel")
-	ids, ok = mentions["@all"]
+	require.False(t, ids[0] != mentionableUser3ID && ids[1] != mentionableUser3ID, "should've mentioned user3 with @channel")
+	require.False(t, ids[0] != mentionableUser4ID && ids[1] != mentionableUser4ID, "should've mentioned user4 with @channel")
+	ids, ok = keywords["@all"]
 	require.True(t, ok)
 	require.Len(t, ids, 2)
-	require.False(t, ids[0] != user3.Id && ids[1] != user3.Id, "should've mentioned user3 with @all")
-	require.False(t, ids[0] != user4.Id && ids[1] != user4.Id, "should've mentioned user4 with @all")
+	require.False(t, ids[0] != mentionableUser3ID && ids[1] != mentionableUser3ID, "should've mentioned user3 with @all")
+	require.False(t, ids[0] != mentionableUser4ID && ids[1] != mentionableUser4ID, "should've mentioned user4 with @all")
 
 	// multiple users and more than MaxNotificationsPerChannel
-	mentions = th.App.getMentionKeywordsInChannel(profiles, false, channelMemberNotifyPropsMap4Off)
-	require.Len(t, mentions, 4, "should've returned four mention keywords")
-	_, ok = mentions["@channel"]
+	keywords = th.App.getMentionKeywordsInChannel(profiles, false, channelMemberNotifyPropsMap4Off)
+	require.Len(t, keywords, 4, "should've returned four mention keywords")
+	_, ok = keywords["@channel"]
 	require.False(t, ok, "should not have mentioned any user with @channel")
-	_, ok = mentions["@all"]
+	_, ok = keywords["@all"]
 	require.False(t, ok, "should not have mentioned any user with @all")
-	_, ok = mentions["@here"]
+	_, ok = keywords["@here"]
 	require.False(t, ok, "should not have mentioned any user with @here")
 	// no special mentions
 	profiles = map[string]*model.User{
 		user1.Id: user1,
 	}
-	mentions = th.App.getMentionKeywordsInChannel(profiles, false, channelMemberNotifyPropsMap4Off)
-	require.Len(t, mentions, 3, "should've returned three mention keywords")
-	ids, ok = mentions["user"]
+	keywords = th.App.getMentionKeywordsInChannel(profiles, false, channelMemberNotifyPropsMap4Off)
+	require.Len(t, keywords, 3, "should've returned three mention keywords")
+	ids, ok = keywords["user"]
 	require.True(t, ok)
 	require.Len(t, ids, 1)
-	require.Equal(t, user1.Id, ids[0], "should've mentioned user1 with user")
-	ids, ok = mentions["@user"]
+	require.Equal(t, mentionableUser1ID, ids[0], "should've mentioned user1 with user")
+	ids, ok = keywords["@user"]
 
 	require.True(t, ok)
 	require.Len(t, ids, 2)
-	require.Equal(t, user1.Id, ids[0], "should've mentioned user1 twice with @user")
-	require.Equal(t, user1.Id, ids[1], "should've mentioned user1 twice with @user")
+	require.Equal(t, mentionableUser1ID, ids[0], "should've mentioned user1 twice with @user")
+	require.Equal(t, mentionableUser1ID, ids[1], "should've mentioned user1 twice with @user")
 
-	ids, ok = mentions["mention"]
+	ids, ok = keywords["mention"]
 	require.True(t, ok)
 	require.Len(t, ids, 1)
-	require.Equal(t, user1.Id, ids[0], "should've mentioned user1 with user")
+	require.Equal(t, mentionableUser1ID, ids[0], "should've mentioned user1 with user")
 
-	_, ok = mentions["First"]
+	_, ok = keywords["First"]
 	require.False(t, ok, "should not have mentioned user1 with First")
-	_, ok = mentions["@channel"]
+	_, ok = keywords["@channel"]
 	require.False(t, ok, "should not have mentioned any user with @channel")
-	_, ok = mentions["@all"]
+	_, ok = keywords["@all"]
 	require.False(t, ok, "should not have mentioned any user with @all")
-	_, ok = mentions["@here"]
+	_, ok = keywords["@here"]
 	require.False(t, ok, "should not have mentioned any user with @here")
 
 	// user with empty mention keys
@@ -1506,11 +1515,11 @@ func TestGetMentionKeywords(t *testing.T) {
 	}
 
 	profiles = map[string]*model.User{userNoMentionKeys.Id: userNoMentionKeys}
-	mentions = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMapEmptyOff)
-	assert.Equal(t, 1, len(mentions), "should've returned one mention keyword")
-	ids, ok = mentions["@user"]
+	keywords = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMapEmptyOff)
+	assert.Equal(t, 1, len(keywords), "should've returned one mention keyword")
+	ids, ok = keywords["@user"]
 	assert.True(t, ok)
-	assert.Equal(t, userNoMentionKeys.Id, ids[0], "should've returned mention key of @user")
+	assert.Equal(t, MentionableUserID(userNoMentionKeys.Id), ids[0], "should've returned mention key of @user")
 }
 
 func TestAddMentionKeywordsForUser(t *testing.T) {
@@ -1521,10 +1530,10 @@ func TestAddMentionKeywordsForUser(t *testing.T) {
 		}
 		channelNotifyProps := map[string]string{}
 
-		keywords := map[string][]string{}
+		keywords := MentionKeywords{}
 		addMentionKeywordsForUser(keywords, user, channelNotifyProps, nil, false)
 
-		assert.Contains(t, keywords["@user"], user.Id)
+		assert.Contains(t, keywords["@user"], MentionableUserID(user.Id))
 	})
 
 	t.Run("should add custom mention keywords", func(t *testing.T) {
@@ -1537,12 +1546,12 @@ func TestAddMentionKeywordsForUser(t *testing.T) {
 		}
 		channelNotifyProps := map[string]string{}
 
-		keywords := map[string][]string{}
+		keywords := MentionKeywords{}
 		addMentionKeywordsForUser(keywords, user, channelNotifyProps, nil, false)
 
-		assert.Contains(t, keywords["apple"], user.Id)
-		assert.Contains(t, keywords["banana"], user.Id)
-		assert.Contains(t, keywords["orange"], user.Id)
+		assert.Contains(t, keywords["apple"], MentionableUserID(user.Id))
+		assert.Contains(t, keywords["banana"], MentionableUserID(user.Id))
+		assert.Contains(t, keywords["orange"], MentionableUserID(user.Id))
 	})
 
 	t.Run("should not add empty custom keywords", func(t *testing.T) {
@@ -1555,7 +1564,7 @@ func TestAddMentionKeywordsForUser(t *testing.T) {
 		}
 		channelNotifyProps := map[string]string{}
 
-		keywords := map[string][]string{}
+		keywords := MentionKeywords{}
 		addMentionKeywordsForUser(keywords, user, channelNotifyProps, nil, false)
 
 		assert.Nil(t, keywords[""])
@@ -1573,12 +1582,12 @@ func TestAddMentionKeywordsForUser(t *testing.T) {
 		}
 		channelNotifyProps := map[string]string{}
 
-		keywords := map[string][]string{}
+		keywords := MentionKeywords{}
 		addMentionKeywordsForUser(keywords, user, channelNotifyProps, nil, false)
 
-		assert.Contains(t, keywords["William"], user.Id)
-		assert.NotContains(t, keywords["william"], user.Id)
-		assert.NotContains(t, keywords["Robert"], user.Id)
+		assert.Contains(t, keywords["William"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["william"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["Robert"], MentionableUserID(user.Id))
 	})
 
 	t.Run("should not add case sensitive first name if enabled but empty First Name", func(t *testing.T) {
@@ -1593,10 +1602,10 @@ func TestAddMentionKeywordsForUser(t *testing.T) {
 		}
 		channelNotifyProps := map[string]string{}
 
-		keywords := map[string][]string{}
+		keywords := MentionKeywords{}
 		addMentionKeywordsForUser(keywords, user, channelNotifyProps, nil, false)
 
-		assert.NotContains(t, keywords[""], user.Id)
+		assert.NotContains(t, keywords[""], MentionableUserID(user.Id))
 	})
 
 	t.Run("should not add case sensitive first name if disabled", func(t *testing.T) {
@@ -1611,12 +1620,12 @@ func TestAddMentionKeywordsForUser(t *testing.T) {
 		}
 		channelNotifyProps := map[string]string{}
 
-		keywords := map[string][]string{}
+		keywords := MentionKeywords{}
 		addMentionKeywordsForUser(keywords, user, channelNotifyProps, nil, false)
 
-		assert.NotContains(t, keywords["William"], user.Id)
-		assert.NotContains(t, keywords["william"], user.Id)
-		assert.NotContains(t, keywords["Robert"], user.Id)
+		assert.NotContains(t, keywords["William"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["william"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["Robert"], MentionableUserID(user.Id))
 	})
 
 	t.Run("should add @channel/@all/@here when allowed", func(t *testing.T) {
@@ -1632,12 +1641,12 @@ func TestAddMentionKeywordsForUser(t *testing.T) {
 			Status: model.StatusOnline,
 		}
 
-		keywords := map[string][]string{}
+		keywords := MentionKeywords{}
 		addMentionKeywordsForUser(keywords, user, channelNotifyProps, status, true)
 
-		assert.Contains(t, keywords["@channel"], user.Id)
-		assert.Contains(t, keywords["@all"], user.Id)
-		assert.Contains(t, keywords["@here"], user.Id)
+		assert.Contains(t, keywords["@channel"], MentionableUserID(user.Id))
+		assert.Contains(t, keywords["@all"], MentionableUserID(user.Id))
+		assert.Contains(t, keywords["@here"], MentionableUserID(user.Id))
 	})
 
 	t.Run("should not add @channel/@all/@here when not allowed", func(t *testing.T) {
@@ -1653,12 +1662,12 @@ func TestAddMentionKeywordsForUser(t *testing.T) {
 			Status: model.StatusOnline,
 		}
 
-		keywords := map[string][]string{}
+		keywords := MentionKeywords{}
 		addMentionKeywordsForUser(keywords, user, channelNotifyProps, status, false)
 
-		assert.NotContains(t, keywords["@channel"], user.Id)
-		assert.NotContains(t, keywords["@all"], user.Id)
-		assert.NotContains(t, keywords["@here"], user.Id)
+		assert.NotContains(t, keywords["@channel"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@all"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@here"], MentionableUserID(user.Id))
 	})
 
 	t.Run("should not add @channel/@all/@here when disabled for user", func(t *testing.T) {
@@ -1674,12 +1683,12 @@ func TestAddMentionKeywordsForUser(t *testing.T) {
 			Status: model.StatusOnline,
 		}
 
-		keywords := map[string][]string{}
+		keywords := MentionKeywords{}
 		addMentionKeywordsForUser(keywords, user, channelNotifyProps, status, true)
 
-		assert.NotContains(t, keywords["@channel"], user.Id)
-		assert.NotContains(t, keywords["@all"], user.Id)
-		assert.NotContains(t, keywords["@here"], user.Id)
+		assert.NotContains(t, keywords["@channel"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@all"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@here"], MentionableUserID(user.Id))
 	})
 
 	t.Run("should not add @channel/@all/@here when disabled for channel", func(t *testing.T) {
@@ -1697,12 +1706,12 @@ func TestAddMentionKeywordsForUser(t *testing.T) {
 			Status: model.StatusOnline,
 		}
 
-		keywords := map[string][]string{}
+		keywords := MentionKeywords{}
 		addMentionKeywordsForUser(keywords, user, channelNotifyProps, status, true)
 
-		assert.NotContains(t, keywords["@channel"], user.Id)
-		assert.NotContains(t, keywords["@all"], user.Id)
-		assert.NotContains(t, keywords["@here"], user.Id)
+		assert.NotContains(t, keywords["@channel"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@all"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@here"], MentionableUserID(user.Id))
 	})
 
 	t.Run("should not add @channel/@all/@here when channel is muted and channel mention setting is not updated by user", func(t *testing.T) {
@@ -1721,12 +1730,12 @@ func TestAddMentionKeywordsForUser(t *testing.T) {
 			Status: model.StatusOnline,
 		}
 
-		keywords := map[string][]string{}
+		keywords := MentionKeywords{}
 		addMentionKeywordsForUser(keywords, user, channelNotifyProps, status, true)
 
-		assert.NotContains(t, keywords["@channel"], user.Id)
-		assert.NotContains(t, keywords["@all"], user.Id)
-		assert.NotContains(t, keywords["@here"], user.Id)
+		assert.NotContains(t, keywords["@channel"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@all"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@here"], MentionableUserID(user.Id))
 	})
 
 	t.Run("should not add @here when when user is not online", func(t *testing.T) {
@@ -1742,12 +1751,12 @@ func TestAddMentionKeywordsForUser(t *testing.T) {
 			Status: model.StatusAway,
 		}
 
-		keywords := map[string][]string{}
+		keywords := MentionKeywords{}
 		addMentionKeywordsForUser(keywords, user, channelNotifyProps, status, true)
 
-		assert.Contains(t, keywords["@channel"], user.Id)
-		assert.Contains(t, keywords["@all"], user.Id)
-		assert.NotContains(t, keywords["@here"], user.Id)
+		assert.Contains(t, keywords["@channel"], MentionableUserID(user.Id))
+		assert.Contains(t, keywords["@all"], MentionableUserID(user.Id))
+		assert.NotContains(t, keywords["@here"], MentionableUserID(user.Id))
 	})
 
 	t.Run("should add for multiple users", func(t *testing.T) {
@@ -1766,14 +1775,14 @@ func TestAddMentionKeywordsForUser(t *testing.T) {
 			},
 		}
 
-		keywords := map[string][]string{}
+		keywords := MentionKeywords{}
 		addMentionKeywordsForUser(keywords, user1, map[string]string{}, nil, true)
 		addMentionKeywordsForUser(keywords, user2, map[string]string{}, nil, true)
 
-		assert.Contains(t, keywords["@user1"], user1.Id)
-		assert.Contains(t, keywords["@user2"], user2.Id)
-		assert.Contains(t, keywords["@all"], user1.Id)
-		assert.Contains(t, keywords["@all"], user2.Id)
+		assert.Contains(t, keywords["@user1"], MentionableUserID(user1.Id))
+		assert.Contains(t, keywords["@user2"], MentionableUserID(user2.Id))
+		assert.Contains(t, keywords["@all"], MentionableUserID(user1.Id))
+		assert.Contains(t, keywords["@all"], MentionableUserID(user2.Id))
 	})
 }
 

--- a/server/channels/app/notification_test.go
+++ b/server/channels/app/notification_test.go
@@ -1764,7 +1764,11 @@ func TestGetMentionKeywords_Groups(t *testing.T) {
 				tc.ChannelMemberNotifyProps,
 				tc.Groups,
 			)
-			assert.EqualValues(t, tc.Expected, keywords)
+
+			require.Equal(t, len(tc.Expected), len(keywords))
+			for keyword, ids := range tc.Expected {
+				assert.ElementsMatch(t, ids, keywords[keyword])
+			}
 		})
 	}
 }

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -1753,7 +1753,7 @@ func (a *App) countThreadMentions(c request.CTX, user *model.User, post *model.P
 	}
 
 	keywords := addMentionKeywordsForUser(
-		map[string][]string{},
+		MentionKeywords{},
 		user,
 		map[string]string{},
 		&model.Status{Status: model.StatusOnline}, // Assume the user is online since they would've triggered this
@@ -1836,7 +1836,7 @@ func (a *App) countMentionsFromPost(c request.CTX, user *model.User, post *model
 	}
 
 	keywords := addMentionKeywordsForUser(
-		map[string][]string{},
+		MentionKeywords{},
 		user,
 		channelMember.NotifyProps,
 		&model.Status{Status: model.StatusOnline}, // Assume the user is online since they would've triggered this
@@ -1961,7 +1961,7 @@ func isCommentMention(user *model.User, post *model.Post, otherPosts map[string]
 	return mentioned
 }
 
-func isPostMention(user *model.User, post *model.Post, keywords map[string][]string, otherPosts map[string]*model.Post, mentionedByThread map[string]bool, checkForCommentMentions bool) bool {
+func isPostMention(user *model.User, post *model.Post, keywords MentionKeywords, otherPosts map[string]*model.Post, mentionedByThread map[string]bool, checkForCommentMentions bool) bool {
 	// Prevent the user from mentioning themselves
 	if post.UserId == user.Id && post.GetProp("from_webhook") != "true" {
 		return false

--- a/server/channels/app/post_persistent_notification.go
+++ b/server/channels/app/post_persistent_notification.go
@@ -197,10 +197,10 @@ func (a *App) forEachPersistentNotificationPost(posts []*model.Post, fn func(pos
 	return nil
 }
 
-func (a *App) persistentNotificationsAuxiliaryData(channelsMap map[string]*model.Channel, teamsMap map[string]*model.Team) (map[string]map[string]*model.Group, map[string]model.UserMap, map[string]map[string][]string, map[string]map[string]model.StringMap, error) {
+func (a *App) persistentNotificationsAuxiliaryData(channelsMap map[string]*model.Channel, teamsMap map[string]*model.Team) (map[string]map[string]*model.Group, map[string]model.UserMap, map[string]MentionKeywords, map[string]map[string]model.StringMap, error) {
 	channelGroupMap := make(map[string]map[string]*model.Group, len(channelsMap))
 	channelProfileMap := make(map[string]model.UserMap, len(channelsMap))
-	channelKeywords := make(map[string]map[string][]string, len(channelsMap))
+	channelKeywords := make(map[string]MentionKeywords, len(channelsMap))
 	channelNotifyProps := make(map[string]map[string]model.StringMap, len(channelsMap))
 	for _, c := range channelsMap {
 		// In DM, notifications can't be send to any 3rd person.
@@ -225,14 +225,14 @@ func (a *App) persistentNotificationsAuxiliaryData(channelsMap map[string]*model
 			return nil, nil, nil, nil, errors.Wrapf(err, "failed to get profiles for channel %s", c.Id)
 		}
 
-		channelKeywords[c.Id] = make(map[string][]string, len(profileMap))
+		channelKeywords[c.Id] = make(MentionKeywords, len(profileMap))
 		validProfileMap := make(map[string]*model.User, len(profileMap))
-		for k, v := range profileMap {
-			if v.IsBot {
+		for userID, user := range profileMap {
+			if user.IsBot {
 				continue
 			}
-			validProfileMap[k] = v
-			channelKeywords[c.Id]["@"+v.Username] = []string{k}
+			validProfileMap[userID] = user
+			channelKeywords[c.Id].AddUser(userID, "@"+user.Username)
 		}
 		channelProfileMap[c.Id] = validProfileMap
 	}

--- a/server/channels/app/post_persistent_notification.go
+++ b/server/channels/app/post_persistent_notification.go
@@ -235,7 +235,7 @@ func (a *App) persistentNotificationsAuxiliaryData(channelsMap map[string]*model
 				continue
 			}
 			validProfileMap[userID] = user
-			channelKeywords[c.Id].AddUserID(userID, "@"+user.Username)
+			channelKeywords[c.Id].AddUserKeyword(userID, "@"+user.Username)
 		}
 		channelProfileMap[c.Id] = validProfileMap
 	}


### PR DESCRIPTION
#### Summary
This is the third PR for this ticket following https://github.com/mattermost/mattermost/pull/24932 and https://github.com/mattermost/mattermost/pull/24936. All 3 together are hopefully going to set us up well to swap the mention parsing logic more easily. The other two are mostly moving code around, but this is the one that really changes code, so more care should be taken when reviewing it.

For this, I wanted to make it so that the parsing of user and group mentions are handled by the exact same code because we don't really care if `@someone` is one person or multiple people at this step of the process. To do this, I removed the group mention specific code from the `StandardMentionParser` and made it so that I could add groups to the map of "mention keywords" that we look for when searching through the text.

#### Ticket Link
MM-54201

#### Related Pull Requests
https://github.com/mattermost/mattermost/pull/24932
https://github.com/mattermost/mattermost/pull/24936

#### Release Note
```release-note
Performed cleanup in preparation for adding multi-word mention support
```
