### PR TITLE
migrating database_settings.test.jsx to typescript

### DIFF
--- a/webapp/channels/src/components/admin_console/__snapshots__/database_settings.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/__snapshots__/database_settings.test.tsx.snap
@@ -86,6 +86,7 @@ exports[`components/DatabaseSettings should match snapshot 1`] = `
         </div>
       </div>
       <AdminTextSetting
+        disabled={false}
         helpText={
           <Memo(MemoizedFormattedMessage)
             defaultMessage="Maximum number of idle connections held open to the database."
@@ -106,6 +107,7 @@ exports[`components/DatabaseSettings should match snapshot 1`] = `
         value={10}
       />
       <AdminTextSetting
+        disabled={false}
         helpText={
           <Memo(MemoizedFormattedMessage)
             defaultMessage="Maximum number of open connections held open to the database."
@@ -126,6 +128,7 @@ exports[`components/DatabaseSettings should match snapshot 1`] = `
         value={100}
       />
       <AdminTextSetting
+        disabled={false}
         helpText={
           <Memo(MemoizedFormattedMessage)
             defaultMessage="The number of seconds to wait for a response from the database after opening a connection and sending the query. Errors that you see in the UI or in the logs as a result of a query timeout can vary depending on the type of query."
@@ -146,6 +149,7 @@ exports[`components/DatabaseSettings should match snapshot 1`] = `
         value={10}
       />
       <AdminTextSetting
+        disabled={false}
         helpText={
           <Memo(MemoizedFormattedMessage)
             defaultMessage="Maximum lifetime for a connection to the database in milliseconds."
@@ -166,6 +170,7 @@ exports[`components/DatabaseSettings should match snapshot 1`] = `
         value={10}
       />
       <AdminTextSetting
+        disabled={false}
         helpText={
           <Memo(MemoizedFormattedMessage)
             defaultMessage="Maximum idle time for a connection to the database in milliseconds."
@@ -186,6 +191,7 @@ exports[`components/DatabaseSettings should match snapshot 1`] = `
         value={20}
       />
       <AdminTextSetting
+        disabled={false}
         helpText={
           <Memo(MemoizedFormattedMessage)
             defaultMessage="Minimum number of characters in a hashtag. This must be greater than or equal to 2. MySQL databases must be configured to support searching strings shorter than three characters, <link>see documentation</link>."

--- a/webapp/channels/src/components/admin_console/database_settings.test.tsx
+++ b/webapp/channels/src/components/admin_console/database_settings.test.tsx
@@ -4,6 +4,9 @@
 import {shallow} from 'enzyme';
 import React from 'react';
 
+import type {AdminConfig} from '@mattermost/types/config';
+import type {DeepPartial} from '@mattermost/types/utilities';
+
 import DatabaseSettings from 'components/admin_console/database_settings';
 
 jest.mock('actions/admin_actions.jsx', () => {
@@ -26,10 +29,6 @@ describe('components/DatabaseSettings', () => {
         },
     };
     test('should match snapshot', () => {
-        const props = {
-            ...baseProps,
-            value: [],
-        };
         const config = {
             SqlSettings: {
                 MaxIdleConns: 10,
@@ -44,11 +43,16 @@ describe('components/DatabaseSettings', () => {
             ServiceSettings: {
                 MinimumHashtagLength: 10,
             },
+        } as DeepPartial<AdminConfig>;
+        const props = {
+            ...baseProps,
+            value: [],
+            config,
+            isDisabled: false,
         };
         const wrapper = shallow(
             <DatabaseSettings
                 {...props}
-                config={config}
             />,
         );
         expect(wrapper).toMatchSnapshot();

--- a/webapp/channels/src/components/admin_console/database_settings.test.tsx
+++ b/webapp/channels/src/components/admin_console/database_settings.test.tsx
@@ -4,9 +4,6 @@
 import {shallow} from 'enzyme';
 import React from 'react';
 
-import type {AdminConfig} from '@mattermost/types/config';
-import type {DeepPartial} from '@mattermost/types/utilities';
-
 import DatabaseSettings from 'components/admin_console/database_settings';
 
 jest.mock('actions/admin_actions.jsx', () => {
@@ -43,7 +40,7 @@ describe('components/DatabaseSettings', () => {
             ServiceSettings: {
                 MinimumHashtagLength: 10,
             },
-        } as DeepPartial<AdminConfig>;
+        };
         const props = {
             ...baseProps,
             value: [],


### PR DESCRIPTION
#### Summary

This PR migrates the database_settings.test.jsx to typescript. This should be
done with the migration of the `database_settings.jsx`, but wasn't done, so
I've done it separately.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52825

#### Release Note
```release-note
NONE
```