### PR TITLE
[MM-54820] Convert ./components/channel_header_mobile/unmute_channel_button/unmute_channel_button.tsx from Class Component to Function Component

### DIFF
--- a/webapp/channels/src/components/channel_header_mobile/unmute_channel_button/unmute_channel_button.test.tsx
+++ b/webapp/channels/src/components/channel_header_mobile/unmute_channel_button/unmute_channel_button.test.tsx
@@ -22,7 +22,7 @@ describe('components/ChannelHeaderMobile/UnmuteChannelButton', () => {
     };
 
     it('should match snapshot', () => {
-        const wrapper = shallow<typeof UnmuteChannelButton>(<UnmuteChannelButton {...baseProps}/>);
+        const wrapper = shallow(<UnmuteChannelButton {...baseProps}/>);
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -31,7 +31,7 @@ describe('components/ChannelHeaderMobile/UnmuteChannelButton', () => {
         const props = baseProps;
         props.actions.updateChannelNotifyProps = jest.fn();
 
-        const wrapper = shallow<typeof UnmuteChannelButton>(<UnmuteChannelButton {...props}/>);
+        const wrapper = shallow(<UnmuteChannelButton {...props}/>);
         wrapper.simulate('click');
 
         expect(props.actions.updateChannelNotifyProps).toBeCalledWith(

--- a/webapp/channels/src/components/channel_header_mobile/unmute_channel_button/unmute_channel_button.test.tsx
+++ b/webapp/channels/src/components/channel_header_mobile/unmute_channel_button/unmute_channel_button.test.tsx
@@ -22,7 +22,7 @@ describe('components/ChannelHeaderMobile/UnmuteChannelButton', () => {
     };
 
     it('should match snapshot', () => {
-        const wrapper = shallow<UnmuteChannelButton>(<UnmuteChannelButton {...baseProps}/>);
+        const wrapper = shallow<typeof UnmuteChannelButton>(<UnmuteChannelButton {...baseProps}/>);
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -31,7 +31,7 @@ describe('components/ChannelHeaderMobile/UnmuteChannelButton', () => {
         const props = baseProps;
         props.actions.updateChannelNotifyProps = jest.fn();
 
-        const wrapper = shallow<UnmuteChannelButton>(<UnmuteChannelButton {...props}/>);
+        const wrapper = shallow<typeof UnmuteChannelButton>(<UnmuteChannelButton {...props}/>);
         wrapper.simulate('click');
 
         expect(props.actions.updateChannelNotifyProps).toBeCalledWith(

--- a/webapp/channels/src/components/channel_header_mobile/unmute_channel_button/unmute_channel_button.tsx
+++ b/webapp/channels/src/components/channel_header_mobile/unmute_channel_button/unmute_channel_button.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {memo} from 'react';
+import React from 'react';
 
 import type {ChannelNotifyProps} from '@mattermost/types/channels';
 
@@ -17,7 +17,7 @@ type Props = {
     actions: Actions;
 };
 
-const UnmuteChannelButton = memo(({user, channel, actions}: Props) => {
+const UnmuteChannelButton = React.memo(({user, channel, actions}: Props) => {
     const handleClick = () => {
         actions.updateChannelNotifyProps(user.id, channel.id, {mark_unread: NotificationLevels.ALL} as ChannelNotifyProps);
     };

--- a/webapp/channels/src/components/channel_header_mobile/unmute_channel_button/unmute_channel_button.tsx
+++ b/webapp/channels/src/components/channel_header_mobile/unmute_channel_button/unmute_channel_button.tsx
@@ -17,7 +17,7 @@ type Props = {
     actions: Actions;
 };
 
-const UnmuteChannelButton = React.memo(({user, channel, actions}: Props) => {
+const UnmuteChannelButton = ({user, channel, actions}: Props) => {
     const handleClick = () => {
         actions.updateChannelNotifyProps(user.id, channel.id, {mark_unread: NotificationLevels.ALL} as ChannelNotifyProps);
     };
@@ -31,6 +31,6 @@ const UnmuteChannelButton = React.memo(({user, channel, actions}: Props) => {
             <span className='fa fa-bell-slash-o icon'/>
         </button>
     );
-});
+};
 
-export default UnmuteChannelButton;
+export default React.memo(UnmuteChannelButton);

--- a/webapp/channels/src/components/channel_header_mobile/unmute_channel_button/unmute_channel_button.tsx
+++ b/webapp/channels/src/components/channel_header_mobile/unmute_channel_button/unmute_channel_button.tsx
@@ -8,7 +8,7 @@ import type {ChannelNotifyProps} from '@mattermost/types/channels';
 import {NotificationLevels} from 'utils/constants';
 
 type Actions = {
-    updateChannelNotifyProps: (userId: string, channelId: string, props: ChannelNotifyProps) => void;
+    updateChannelNotifyProps: (userId: string, channelId: string, props: Pick<ChannelNotifyProps, 'mark_unread'>) => void;
 };
 
 type Props = {
@@ -19,7 +19,7 @@ type Props = {
 
 const UnmuteChannelButton = ({user, channel, actions}: Props) => {
     const handleClick = () => {
-        actions.updateChannelNotifyProps(user.id, channel.id, {mark_unread: NotificationLevels.ALL} as ChannelNotifyProps);
+        actions.updateChannelNotifyProps(user.id, channel.id, {mark_unread: NotificationLevels.ALL});
     };
 
     return (

--- a/webapp/channels/src/components/channel_header_mobile/unmute_channel_button/unmute_channel_button.tsx
+++ b/webapp/channels/src/components/channel_header_mobile/unmute_channel_button/unmute_channel_button.tsx
@@ -9,36 +9,28 @@ import {NotificationLevels} from 'utils/constants';
 
 type Actions = {
     updateChannelNotifyProps: (userId: string, channelId: string, props: ChannelNotifyProps) => void;
-}
+};
 
 type Props = {
     user: { id: string };
     channel: { id: string };
     actions: Actions;
-}
+};
 
-export default class UnmuteChannelButton extends React.PureComponent<Props> {
-    handleClick = (): void => {
-        const {
-            user,
-            channel,
-            actions: {
-                updateChannelNotifyProps,
-            },
-        } = this.props;
-
-        updateChannelNotifyProps(user.id, channel.id, {mark_unread: NotificationLevels.ALL} as ChannelNotifyProps);
+const UnmuteChannelButton = ({user, channel, actions}: Props) => {
+    const handleClick = () => {
+        actions.updateChannelNotifyProps(user.id, channel.id, {mark_unread: NotificationLevels.ALL} as ChannelNotifyProps);
     };
 
-    render(): JSX.Element {
-        return (
-            <button
-                type='button'
-                className='navbar-toggle icon icon__mute'
-                onClick={this.handleClick}
-            >
-                <span className='fa fa-bell-slash-o icon'/>
-            </button>
-        );
-    }
-}
+    return (
+        <button
+            type='button'
+            className='navbar-toggle icon icon__mute'
+            onClick={handleClick}
+        >
+            <span className='fa fa-bell-slash-o icon'/>
+        </button>
+    );
+};
+
+export default UnmuteChannelButton;

--- a/webapp/channels/src/components/channel_header_mobile/unmute_channel_button/unmute_channel_button.tsx
+++ b/webapp/channels/src/components/channel_header_mobile/unmute_channel_button/unmute_channel_button.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {memo} from 'react';
 
 import type {ChannelNotifyProps} from '@mattermost/types/channels';
 
@@ -17,7 +17,7 @@ type Props = {
     actions: Actions;
 };
 
-const UnmuteChannelButton = ({user, channel, actions}: Props) => {
+const UnmuteChannelButton = memo(({user, channel, actions}: Props) => {
     const handleClick = () => {
         actions.updateChannelNotifyProps(user.id, channel.id, {mark_unread: NotificationLevels.ALL} as ChannelNotifyProps);
     };
@@ -31,6 +31,6 @@ const UnmuteChannelButton = ({user, channel, actions}: Props) => {
             <span className='fa fa-bell-slash-o icon'/>
         </button>
     );
-};
+});
 
 export default UnmuteChannelButton;


### PR DESCRIPTION
#### Summary
This pull request migrates the existing unmute_channel_button component to a react functional component.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/24781
Jira: https://mattermost.atlassian.net/browse/MM-54820

#### Release Note
```release-note
NONE
```
