### PR TITLE
[MM-54837] Convert LocalizedInput of 'permission_team_scheme_settings.tsx' to regular input component

### DIFF
--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/__snapshots__/permission_team_scheme_settings.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/__snapshots__/permission_team_scheme_settings.test.tsx.snap
@@ -92,17 +92,11 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
                 id="admin.permissions.teamScheme.schemeNameLabel"
               />
             </label>
-            <LocalizedInput
+            <input
               className="form-control"
               disabled={false}
               id="scheme-name"
               onChange={[Function]}
-              placeholder={
-                Object {
-                  "defaultMessage": "Scheme Name",
-                  "id": "admin.permissions.teamScheme.schemeNamePlaceholder",
-                }
-              }
               type="text"
               value="Test scheme"
             />
@@ -422,17 +416,11 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
                 id="admin.permissions.teamScheme.schemeNameLabel"
               />
             </label>
-            <LocalizedInput
+            <input
               className="form-control"
               disabled={false}
               id="scheme-name"
               onChange={[Function]}
-              placeholder={
-                Object {
-                  "defaultMessage": "Scheme Name",
-                  "id": "admin.permissions.teamScheme.schemeNamePlaceholder",
-                }
-              }
               type="text"
               value="Test scheme"
             />
@@ -775,17 +763,11 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
                 id="admin.permissions.teamScheme.schemeNameLabel"
               />
             </label>
-            <LocalizedInput
+            <input
               className="form-control"
               disabled={false}
               id="scheme-name"
               onChange={[Function]}
-              placeholder={
-                Object {
-                  "defaultMessage": "Scheme Name",
-                  "id": "admin.permissions.teamScheme.schemeNamePlaceholder",
-                }
-              }
               type="text"
               value="Test scheme"
             />
@@ -1196,17 +1178,11 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
                 id="admin.permissions.teamScheme.schemeNameLabel"
               />
             </label>
-            <LocalizedInput
+            <input
               className="form-control"
               disabled={false}
               id="scheme-name"
               onChange={[Function]}
-              placeholder={
-                Object {
-                  "defaultMessage": "Scheme Name",
-                  "id": "admin.permissions.teamScheme.schemeNamePlaceholder",
-                }
-              }
               type="text"
               value=""
             />

--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.test.tsx
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.test.tsx
@@ -90,6 +90,9 @@ describe('components/admin_console/permission_schemes_settings/permission_team_s
         },
         teams: [
         ],
+        intl: {
+            formatMessage: jest.fn(),
+        },
         actions: {
             loadRolesIfNeeded: jest.fn().mockReturnValue(Promise.resolve()),
             loadRole: jest.fn(),

--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.test.tsx
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.test.tsx
@@ -4,7 +4,7 @@
 import {shallow} from 'enzyme';
 import React from 'react';
 
-import PermissionTeamSchemeSettings from 'components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings';
+import {PermissionTeamSchemeSettings} from 'components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings';
 
 describe('components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings', () => {
     const defaultProps = {

--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.tsx
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.tsx
@@ -82,7 +82,7 @@ type State = {
     schemeDescription: string | undefined;
 };
 
-class PermissionTeamSchemeSettings extends React.PureComponent<Props & RouteComponentProps, State> {
+export class PermissionTeamSchemeSettings extends React.PureComponent<Props & RouteComponentProps, State> {
     constructor(props: Props & RouteComponentProps) {
         super(props);
         this.state = {

--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.tsx
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, injectIntl, type IntlShape} from 'react-intl';
 import type {RouteComponentProps} from 'react-router-dom';
 
 import type {ClientConfig, ClientLicense} from '@mattermost/types/config';
@@ -18,7 +18,6 @@ import BlockableLink from 'components/admin_console/blockable_link';
 import ExternalLink from 'components/external_link';
 import FormError from 'components/form_error';
 import LoadingScreen from 'components/loading_screen';
-import LocalizedInput from 'components/localized_input/localized_input';
 import SaveButton from 'components/save_button';
 import TeamSelectorModal from 'components/team_selector_modal';
 import AdminHeader from 'components/widgets/admin_console/admin_header';
@@ -48,6 +47,7 @@ export type Props = {
     teams: Team[];
     isDisabled: boolean;
     config: Partial<ClientConfig>;
+    intl: IntlShape;
     actions: {
         loadRolesIfNeeded: (roles: Iterable<string>) => ActionFunc;
         loadScheme: (schemeId: string) => Promise<ActionResult>;
@@ -82,7 +82,7 @@ type State = {
     schemeDescription: string | undefined;
 };
 
-export default class PermissionTeamSchemeSettings extends React.PureComponent<Props & RouteComponentProps, State> {
+class PermissionTeamSchemeSettings extends React.PureComponent<Props & RouteComponentProps, State> {
     constructor(props: Props & RouteComponentProps) {
         super(props);
         this.state = {
@@ -650,14 +650,14 @@ export default class PermissionTeamSchemeSettings extends React.PureComponent<Pr
                                             defaultMessage='Scheme Name:'
                                         />
                                     </label>
-                                    <LocalizedInput
-                                        id='scheme-name'
+                                    <input
                                         className='form-control'
+                                        disabled={this.props.isDisabled}
+                                        id='scheme-name'
+                                        placeholder={this.props.intl.formatMessage({id: 'admin.permissions.teamScheme.schemeNamePlaceholder', defaultMessage: 'Scheme Name'})}
                                         type='text'
                                         value={schemeName}
-                                        placeholder={{id: t('admin.permissions.teamScheme.schemeNamePlaceholder'), defaultMessage: 'Scheme Name'}}
                                         onChange={this.handleNameChange}
-                                        disabled={this.props.isDisabled}
                                     />
                                 </div>
                                 <div className='form-group'>
@@ -844,3 +844,5 @@ export default class PermissionTeamSchemeSettings extends React.PureComponent<Pr
         );
     };
 }
+
+export default injectIntl(PermissionTeamSchemeSettings);


### PR DESCRIPTION
#### Summary

Replace `LocalizedInput` component in `webapp/channels/src/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.tsx` to a regular input.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/24834
Jira https://mattermost.atlassian.net/browse/MM-54837

#### Screenshots

The field is highlighted in this screenshot (has a focus):

![Screenshot 2023-10-19 at 11 38 54](https://github.com/mattermost/mattermost/assets/15943863/2b832966-f80a-40a7-98c6-a3d1bae6c148)

#### Release Note
```
NONE
```