### PR TITLE
Replace `fmt.Sprint` usages with faster alternatives such as `strconv.FormatBool`

### DIFF
--- a/server/channels/api4/hosted_customer.go
+++ b/server/channels/api4/hosted_customer.go
@@ -7,9 +7,9 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -180,7 +180,7 @@ func selfHostedConfirm(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.App.NotifySelfHostedSignupProgress(confirmResponse.Progress, user.Id)
 		}
 
-		if err.Error() == fmt.Sprintf("%d", http.StatusUnprocessableEntity) {
+		if err.Error() == strconv.Itoa(http.StatusUnprocessableEntity) {
 			c.Err = model.NewAppError(where, "api.cloud.app_error", nil, "", http.StatusUnprocessableEntity).Wrap(err)
 			return
 		}
@@ -365,7 +365,7 @@ func selfHostedConfirmExpand(c *Context, w http.ResponseWriter, r *http.Request)
 			c.App.NotifySelfHostedSignupProgress(confirmResponse.Progress, user.Id)
 		}
 
-		if err.Error() == fmt.Sprintf("%d", http.StatusUnprocessableEntity) {
+		if err.Error() == strconv.Itoa(http.StatusUnprocessableEntity) {
 			c.Err = model.NewAppError(where, "api.cloud.app_error", nil, "", http.StatusUnprocessableEntity).Wrap(err)
 			return
 		}

--- a/server/channels/app/notification_email.go
+++ b/server/channels/app/notification_email.go
@@ -9,6 +9,7 @@ import (
 	"html"
 	"html/template"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -343,9 +344,9 @@ func getFormattedPostTime(user *model.User, post *model.Post, useMilitaryTime bo
 
 	return formattedPostTime{
 		Time:     localTime,
-		Year:     fmt.Sprintf("%d", localTime.Year()),
+		Year:     strconv.Itoa(localTime.Year()),
 		Month:    translateFunc(localTime.Month().String()),
-		Day:      fmt.Sprintf("%d", localTime.Day()),
+		Day:      strconv.Itoa(localTime.Day()),
 		Hour:     hour,
 		Minute:   fmt.Sprintf("%02d"+period, localTime.Minute()),
 		TimeZone: zone,

--- a/server/channels/app/platform/session.go
+++ b/server/channels/app/platform/session.go
@@ -5,6 +5,7 @@ package platform
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -229,7 +230,7 @@ func (ps *PlatformService) UpdateSessionsIsGuest(c *request.Context, userID stri
 	}
 
 	for _, session := range sessions {
-		session.AddProp(model.SessionPropIsGuest, fmt.Sprintf("%t", isGuest))
+		session.AddProp(model.SessionPropIsGuest, strconv.FormatBool(isGuest))
 		err := ps.Store.Session().UpdateProps(session)
 		if err != nil {
 			mlog.Warn("Unable to update isGuest session", mlog.Err(err))

--- a/server/channels/store/searchtest/helper.go
+++ b/server/channels/store/searchtest/helper.go
@@ -4,7 +4,7 @@
 package searchtest
 
 import (
-	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -352,7 +352,7 @@ func (th *SearchTestHelper) createPostModel(userID, channelID, message, hashtags
 	return &model.Post{
 		Message:       message,
 		ChannelId:     channelID,
-		PendingPostId: model.NewId() + ":" + fmt.Sprint(model.GetMillis()),
+		PendingPostId: model.NewId() + ":" + strconv.FormatInt(model.GetMillis(), 10),
 		UserId:        userID,
 		Hashtags:      hashtags,
 		IsPinned:      pinned,

--- a/server/channels/utils/hash.go
+++ b/server/channels/utils/hash.go
@@ -5,12 +5,12 @@ package utils
 
 import (
 	"crypto/sha256"
-	"fmt"
+	"encoding/hex"
 )
 
 func HashSha256(text string) string {
 	hash := sha256.New()
 	hash.Write([]byte(text))
 
-	return fmt.Sprintf("%x", hash.Sum(nil))
+	return hex.EncodeToString(hash.Sum(nil))
 }

--- a/server/cmd/mmctl/commands/utils_unix.go
+++ b/server/cmd/mmctl/commands/utils_unix.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"strconv"
 	"syscall"
 
 	"github.com/isacikgoz/prompt"
@@ -38,7 +39,7 @@ func checkValidSocket(socketPath string) error {
 		return fmt.Errorf("cannot get owner of the file %q", socketPath)
 	}
 	// if user id is "0", they are root and we should avoid this check
-	if fmt.Sprint(s.Uid) != cUser.Uid && cUser.Uid != "0" {
+	if strconv.FormatUint(uint64(s.Uid), 10) != cUser.Uid && cUser.Uid != "0" {
 		return fmt.Errorf("owner of the file %q must be the same user running mmctl", socketPath)
 	}
 

--- a/server/config/client.go
+++ b/server/config/client.go
@@ -4,7 +4,6 @@
 package config
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -39,8 +38,8 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 	props["EnableTesting"] = strconv.FormatBool(*c.ServiceSettings.EnableTesting)
 	props["EnableDeveloper"] = strconv.FormatBool(*c.ServiceSettings.EnableDeveloper)
 	props["EnableClientPerformanceDebugging"] = strconv.FormatBool(*c.ServiceSettings.EnableClientPerformanceDebugging)
-	props["PostEditTimeLimit"] = fmt.Sprintf("%v", *c.ServiceSettings.PostEditTimeLimit)
-	props["MinimumHashtagLength"] = fmt.Sprintf("%v", *c.ServiceSettings.MinimumHashtagLength)
+	props["PostEditTimeLimit"] = strconv.Itoa(*c.ServiceSettings.PostEditTimeLimit)
+	props["MinimumHashtagLength"] = strconv.Itoa(*c.ServiceSettings.MinimumHashtagLength)
 	props["EnablePreviewFeatures"] = strconv.FormatBool(*c.ServiceSettings.EnablePreviewFeatures)
 	props["EnableTutorial"] = strconv.FormatBool(*c.ServiceSettings.EnableTutorial)
 	props["EnableOnboardingFlow"] = strconv.FormatBool(*c.ServiceSettings.EnableOnboardingFlow)
@@ -237,8 +236,8 @@ func GenerateLimitedClientConfig(c *model.Config, telemetryID string, license *m
 	props["SiteURL"] = strings.TrimRight(*c.ServiceSettings.SiteURL, "/")
 	props["SiteName"] = *c.TeamSettings.SiteName
 	props["WebsocketURL"] = strings.TrimRight(*c.ServiceSettings.WebsocketURL, "/")
-	props["WebsocketPort"] = fmt.Sprintf("%v", *c.ServiceSettings.WebsocketPort)
-	props["WebsocketSecurePort"] = fmt.Sprintf("%v", *c.ServiceSettings.WebsocketSecurePort)
+	props["WebsocketPort"] = strconv.Itoa(*c.ServiceSettings.WebsocketPort)
+	props["WebsocketSecurePort"] = strconv.Itoa(*c.ServiceSettings.WebsocketSecurePort)
 	props["EnableUserCreation"] = strconv.FormatBool(*c.TeamSettings.EnableUserCreation)
 	props["EnableOpenServer"] = strconv.FormatBool(*c.TeamSettings.EnableOpenServer)
 	props["EnableJoinLeaveMessageByDefault"] = strconv.FormatBool(*c.TeamSettings.EnableJoinLeaveMessageByDefault)
@@ -288,7 +287,7 @@ func GenerateLimitedClientConfig(c *model.Config, telemetryID string, license *m
 
 	props["PluginsEnabled"] = strconv.FormatBool(*c.PluginSettings.Enable)
 
-	props["PasswordMinimumLength"] = fmt.Sprintf("%v", *c.PasswordSettings.MinimumLength)
+	props["PasswordMinimumLength"] = strconv.Itoa(*c.PasswordSettings.MinimumLength)
 	props["PasswordRequireLowercase"] = strconv.FormatBool(*c.PasswordSettings.Lowercase)
 	props["PasswordRequireUppercase"] = strconv.FormatBool(*c.PasswordSettings.Uppercase)
 	props["PasswordRequireNumber"] = strconv.FormatBool(*c.PasswordSettings.Number)

--- a/server/platform/services/searchengine/bleveengine/testlib.go
+++ b/server/platform/services/searchengine/bleveengine/testlib.go
@@ -4,7 +4,7 @@
 package bleveengine
 
 import (
-	"fmt"
+	"strconv"
 
 	"github.com/mattermost/mattermost/server/public/model"
 )
@@ -13,7 +13,7 @@ func createPost(userId string, channelId string) *model.Post {
 	post := &model.Post{
 		Message:       model.NewRandomString(15),
 		ChannelId:     channelId,
-		PendingPostId: model.NewId() + ":" + fmt.Sprint(model.GetMillis()),
+		PendingPostId: model.NewId() + ":" + strconv.FormatInt(model.GetMillis(), 10),
 		UserId:        userId,
 		CreateAt:      1000000,
 	}


### PR DESCRIPTION
#### Summary

Optimizes server code by replacing `fmt.Sprint` usages with faster alternatives such as `strconv.FormatBool`
cf https://github.com/catenacyber/gostrconv

#### Ticket Link

No ticket, just optimization...

#### Screenshots

No UI changes (only server)

#### Release Note


```release-note
NONE
```
