### PR TITLE
Prevent modifying non-English i18n files

### DIFF
--- a/.github/workflows/i18n-ci-pr.yml
+++ b/.github/workflows/i18n-ci-pr.yml
@@ -1,0 +1,20 @@
+name: i18n CI PR
+on:
+  pull_request:
+    paths:
+      - "server/i18n/**"
+      - "webapp/channels/src/i18n/**"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# This file just imports the template yml
+# and runs it with concurrency. We have to do this in this way
+# because the concurrency label cannot be added conditionally
+# and it _always_ cancels pending workflows. So master CI builds
+# always kept getting canceled.
+
+jobs:
+  pr-ci:
+    uses: ./.github/workflows/i18n-ci-template.yml
+    secrets: inherit

--- a/.github/workflows/i18n-ci-template.yml
+++ b/.github/workflows/i18n-ci-template.yml
@@ -1,0 +1,30 @@
+# Base CI template which is called from i18n-ci-pr.yml
+
+name: i18n CI Template
+on:
+  workflow_call:
+
+jobs:
+  check-files:
+    name: Check only English translation files changed
+    runs-on: ubuntu-22.04
+    if: github.event.pull_request.user.login != 'weblate' # Allow weblate to modify non-English
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@95690f9ece77c1740f4a55b7f1de9023ed6b1f87 # v39.2.3
+        with:
+          files: |
+            server/i18n/*.json
+            webapp/channels/src/i18n/*.json
+            !server/i18n/en.json
+            !webapp/channels/src/i18n/en.json
+
+      - name: Check changed files
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          echo "::error title=Non-English i18n files changed::Only PRs from weblate should modify non-English translation files."
+          exit 1


### PR DESCRIPTION
#### Summary
Only the @weblate user should be allowed to modify non-English translation files. Enforce this with a CI check, noting that in exceptional cases an admin can still force merge when a future (but now far less likely) merge conflict has to be resolved.

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
