### PR TITLE
[GH-24042] Fixed vertical padding for slash command menu items

### DIFF
--- a/webapp/channels/src/sass/components/_suggestion-list.scss
+++ b/webapp/channels/src/sass/components/_suggestion-list.scss
@@ -77,7 +77,10 @@
 
     &::-webkit-scrollbar-thumb {
         border: 1px solid v(center-channel-bg);
-        background-color: rgba(var(--center-channel-color-rgb), 0.24) !important;
+        background-color: rgba(
+            var(--center-channel-color-rgb),
+            0.24
+        ) !important;
         border-radius: 4px;
     }
 
@@ -162,7 +165,7 @@
         width: 100%;
         height: 1px;
         background: rgba(var(--center-channel-color-rgb), 0.08);
-        content: '';
+        content: "";
     }
 }
 
@@ -171,7 +174,7 @@
     margin: 7px 10px 2px;
     line-height: 21px;
 
-    >span {
+    > span {
         position: relative;
         z-index: 5;
         display: inline-block;
@@ -185,7 +188,7 @@
     z-index: 101;
     display: flex;
     width: 100%;
-    height: 4rem;
+    height: 4.8rem;
     align-items: center;
     padding: 0 2.4rem;
     margin: 0;


### PR DESCRIPTION

[Town Square - asd Mattermost.webm](https://github.com/mattermost/mattermost/assets/134006296/0aa248a7-06f6-48ff-b1e0-2a08f4dace88)


This pull request adjusts the vertical padding for slash command menu items to improve the visual separation between menu items. It addresses issue #24042.

Fixed https://github.com/mattermost/mattermost/issues/24042
