### PR TITLE
[MM-54832] Convert LocalizedInput of 'password_reset_send_link.tsx' to regular input component

### DIFF
--- a/webapp/channels/src/components/password_reset_send_link/__snapshots__/password_reset_send_link.test.tsx.snap
+++ b/webapp/channels/src/components/password_reset_send_link/__snapshots__/password_reset_send_link.test.tsx.snap
@@ -28,17 +28,11 @@ exports[`components/PasswordResetSendLink should match snapshot 1`] = `
         <div
           className="form-group"
         >
-          <LocalizedInput
+          <input
             autoFocus={true}
             className="form-control"
             id="passwordResetEmailInput"
             name="email"
-            placeholder={
-              Object {
-                "defaultMessage": "Email",
-                "id": "password_send.email",
-              }
-            }
             spellCheck="false"
             type="email"
           />

--- a/webapp/channels/src/components/password_reset_send_link/password_reset_send_link.test.tsx
+++ b/webapp/channels/src/components/password_reset_send_link/password_reset_send_link.test.tsx
@@ -5,15 +5,18 @@ import {shallow} from 'enzyme';
 import React from 'react';
 import {MemoryRouter} from 'react-router-dom';
 
-import {mountWithIntl} from 'tests/helpers/intl-test-helper';
+import {mountWithIntl, type MockIntl} from 'tests/helpers/intl-test-helper';
 
-import PasswordResetSendLink from './password_reset_send_link';
+import {PasswordResetSendLink} from './password_reset_send_link';
 
 describe('components/PasswordResetSendLink', () => {
     const baseProps = {
         actions: {
             sendPasswordResetEmail: jest.fn().mockResolvedValue({data: true}),
         },
+        intl: {
+            formatMessage: jest.fn(),
+        } as MockIntl,
     };
 
     it('should match snapshot', () => {

--- a/webapp/channels/src/components/password_reset_send_link/password_reset_send_link.tsx
+++ b/webapp/channels/src/components/password_reset_send_link/password_reset_send_link.tsx
@@ -2,21 +2,19 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, injectIntl, type IntlShape} from 'react-intl';
 
 import type {ServerError} from '@mattermost/types/errors';
 
 import {isEmail} from 'mattermost-redux/utils/helpers';
 
 import BackButton from 'components/common/back_button';
-import LocalizedInput from 'components/localized_input/localized_input';
-
-import {t} from 'utils/i18n';
 
 interface Props {
     actions: {
         sendPasswordResetEmail: (email: string) => Promise<{data: any; error: ServerError}>;
     };
+    intl: IntlShape;
 }
 
 interface State {
@@ -24,7 +22,7 @@ interface State {
     updateText: React.ReactNode;
 }
 
-export default class PasswordResetSendLink extends React.PureComponent<Props, State> {
+export class PasswordResetSendLink extends React.PureComponent<Props, State> {
     state = {
         error: null,
         updateText: null,
@@ -123,15 +121,15 @@ export default class PasswordResetSendLink extends React.PureComponent<Props, St
                                 />
                             </p>
                             <div className={formClass}>
-                                <LocalizedInput
+                                <input
                                     id='passwordResetEmailInput'
                                     type='email'
                                     className='form-control'
                                     name='email'
-                                    placeholder={{
-                                        id: t('password_send.email'),
+                                    placeholder={this.props.intl.formatMessage({
+                                        id: 'password_send.email',
                                         defaultMessage: 'Email',
-                                    }}
+                                    })}
                                     ref={this.emailInput}
                                     spellCheck='false'
                                     autoFocus={true}
@@ -155,3 +153,5 @@ export default class PasswordResetSendLink extends React.PureComponent<Props, St
         );
     }
 }
+
+export default injectIntl(PasswordResetSendLink);

--- a/webapp/channels/src/tests/helpers/intl-test-helper.tsx
+++ b/webapp/channels/src/tests/helpers/intl-test-helper.tsx
@@ -114,3 +114,7 @@ export function mountWithIntl<T extends ReactElement | IntlInjectedElement>(elem
         },
     );
 }
+
+export interface MockIntl extends IntlShape {
+    formatMessage: jest.Mock;
+}


### PR DESCRIPTION
#### Summary

Replace `LocalizedInput` component in `webapp/channels/src/components/password_reset_send_link/password_reset_send_link.tsx` to a regular input.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/24824
Jira https://mattermost.atlassian.net/browse/MM-54832

#### Screenshots

![Screenshot 2023-10-19 at 18 02 50](https://github.com/mattermost/mattermost/assets/15943863/51f80622-c03c-4746-94d4-aedf638009a8)

#### Release Note
```
NONE
```