### PR TITLE
(makefile) Injecting test data should not stop the server

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -515,7 +515,7 @@ cover: ## Runs the golang coverage tool. You must run the unit tests first.
 	$(GO) tool cover -html=cover.out
 	$(GO) tool cover -html=ecover.out
 
-test-data: run-server inject-test-data ## start a local instance and add test data to it.
+test-data: run-server inject-test-data stop-server ## start a local instance and add test data to it.
 
 inject-test-data: # add test data to the local instance.
 	@if ! ./scripts/wait-for-system-start.sh; then \
@@ -532,8 +532,6 @@ inject-test-data: # add test data to the local instance.
 	@echo Login with a system admin account username=sysadmin password=Sys@dmin-sample1
 	@echo Login with a regular account username=user-1 password=SampleUs@r-1
 	@echo ========================================================================
-
-	make stop-server
 
 test-mmctl-unit: export MM_SERVER_PATH := $(MM_SERVER_PATH)
 test-mmctl-unit: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)


### PR DESCRIPTION
#### Summary
The `inject-test-data` command has been introduced to inject test data in a running instance, this PR fixes the behavior by removing the stop-server instruction, but adding it to the `test-data` command to not break any workflow relying on this.

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
