### PR TITLE
upgrade gotestsum@v1.11.0

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -415,7 +415,7 @@ check-style: plugin-checker vet golangci-lint ## Runs style/lint checks
 
 
 gotestsum:
-	$(GO) install gotest.tools/gotestsum@v1.7.0
+	$(GO) install gotest.tools/gotestsum@v1.11.0
 
 test-compile: gotestsum ## Compile tests.
 	@echo COMPILE TESTS


### PR DESCRIPTION
#### Summary
`master` is currently failing to download and install `gotestsum@1.7.0`:
```
go: gotest.tools/gotestsum@v1.7.0: gotest.tools/gotestsum@v1.7.0: verifying module: gotest.tools/gotestsum@v1.7.0: Get "https://sum.golang.org/lookup/gotest.tools/gotestsum@v1.7.0": EOF
```

Upgrade this to `gotestsum@v1.11.0`.

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
