### PR TITLE
MM-52280: Generate higher contrast for some usernames

### DIFF
--- a/webapp/channels/src/components/user_profile/user.test.ts
+++ b/webapp/channels/src/components/user_profile/user.test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import ColorContrastChecker from 'color-contrast-checker';
+
+import {cachedUserNameColors, generateColor} from './utils';
+
+const CONSTRAST_CHECKER = new ColorContrastChecker();
+const BACKGROUND_COLOR = '#ACC8E5';
+
+describe('components/user_profile/utils', () => {
+    test.each([
+        ['Ross_Bednar', '#ac538a', 2.7],
+        ['Geovany95', '#1f9335', 2.2],
+        ['Madisen25', '#56862d', 2.5],
+        ['Gerard17', '#783a54', 4.5],
+        ['Alia30', '#392d86', 4.5],
+        ['Darien.Prosacco97', '#862d6d', 4.5],
+        ['Alf48', '#5354ac', 3.7],
+        ['Darron_Orn-Walsh49', '#3a5878', 4.2],
+    ])('should generate best color contrast', (userName, expected, ratio) => {
+        cachedUserNameColors.clear();
+
+        const actual = generateColor(userName, BACKGROUND_COLOR);
+        expect(actual).toBe(expected);
+        expect(
+            CONSTRAST_CHECKER.isLevelCustom(actual, BACKGROUND_COLOR, ratio),
+        ).toBeTruthy();
+    });
+});

--- a/webapp/channels/src/components/user_profile/user.test.ts
+++ b/webapp/channels/src/components/user_profile/user.test.ts
@@ -10,14 +10,14 @@ const BACKGROUND_COLOR = '#ACC8E5';
 
 describe('components/user_profile/utils', () => {
     test.each([
-        ['Ross_Bednar', '#ac538a', 2.7],
-        ['Geovany95', '#1f9335', 2.2],
-        ['Madisen25', '#56862d', 2.5],
+        ['Ross_Bednar', '#432dd2', 4.5],
+        ['Geovany95', '#2d3086', 4.5],
+        ['Madisen25', '#52783a', 2.9],
         ['Gerard17', '#783a54', 4.5],
         ['Alia30', '#392d86', 4.5],
         ['Darien.Prosacco97', '#862d6d', 4.5],
-        ['Alf48', '#5354ac', 3.7],
-        ['Darron_Orn-Walsh49', '#3a5878', 4.2],
+        ['Alf48', '#4053bf', 3.7],
+        ['Darron_Orn-Walsh49', '#742d86', 4.5],
     ])('should generate best color contrast', (userName, expected, ratio) => {
         cachedUserNameColors.clear();
 

--- a/webapp/channels/src/components/user_profile/utils.ts
+++ b/webapp/channels/src/components/user_profile/utils.ts
@@ -22,7 +22,7 @@ export function generateColor(username: string, background: string): string {
     const colorHash = new ColorHash();
 
     const backgroundLuminance = checker.hexToLuminance(background);
-    for (let tries = 3; tries > 0; tries--) {
+    for (let tries = 10; tries > 0; tries--) {
         const textColor = colorHash.hex(userAndSalt);
 
         const cr = checker.getContrastRatio(

--- a/webapp/channels/src/components/user_profile/utils.ts
+++ b/webapp/channels/src/components/user_profile/utils.ts
@@ -4,27 +4,44 @@
 import ColorContrastChecker from 'color-contrast-checker';
 import ColorHash from 'color-hash';
 
-const cachedColors = new Map<string, string>();
+const REQUIRED_COLOR_RATIO = 4.5;
+
+export const cachedUserNameColors = new Map<string, string>();
 
 export function generateColor(username: string, background: string): string {
     const cacheKey = `${username}-${background}`;
-    const cachedColor = cachedColors.get(cacheKey);
+    const cachedColor = cachedUserNameColors.get(cacheKey);
     if (cachedColor) {
         return cachedColor;
     }
 
     let userColor = background;
+    let contrastRatio = 1;
     let userAndSalt = username;
     const checker = new ColorContrastChecker();
     const colorHash = new ColorHash();
 
-    let tries = 3;
-    while (!checker.isLevelCustom(userColor, background, 4.5) && tries > 0) {
-        userColor = colorHash.hex(userAndSalt);
+    const backgroundLuminance = checker.hexToLuminance(background);
+    for (let tries = 3; tries > 0; tries--) {
+        const textColor = colorHash.hex(userAndSalt);
+
+        const cr = checker.getContrastRatio(
+            checker.hexToLuminance(textColor),
+            backgroundLuminance,
+        );
+
+        if (cr > contrastRatio) {
+            userColor = textColor;
+            contrastRatio = cr;
+        }
+
+        if (cr >= REQUIRED_COLOR_RATIO) {
+            break;
+        }
+
         userAndSalt += 'salt';
-        tries--;
     }
 
-    cachedColors.set(cacheKey, userColor);
+    cachedUserNameColors.set(cacheKey, userColor);
     return userColor;
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Generate higher contrast for some usernames

I've kept the 3 tries but return the best value instead of the last one.
Added test to check that it works.

For the record I've tested increasing the number of tries but it isn't especially better:
| tries | # over 4.5 | worst ratio |
| ----- | ---------- | ----------- |
| 03    | 3/8        | 2.29        |
| 04    | 3/8        | 2.5         |
| 05    | 5/8        | 2.5         |
| 06    | 5/8        | 2.64        |
| 07    | 6/8        | 2.64        |
| 08    | 6/8        | 2.95        |
| 09    | 6/8        | 2.95        |
| 10    | 6/8        | 2.95        |

This is in contrast with the previous implementation:
| tries | # over 4.5 | worst ratio |
| ----- | ---------- | ----------- |
| 03    | 3/8        | 1.07        |
| 04    | 3/8        | 1.05        |
| 05    | 5/8        | 1.35        |
| 06    | 5/8        | 1.04        |
| 07    | 6/8        | 1.20        |
| 08    | 6/8        | 1.88        |
| 09    | 6/8        | 1.67        |
| 10    | 6/8        | 1.66        |

I've also tried to use tested hex color as salt instead of "salt" but it isn't really better:
| tries | # over 4.5 | worst ratio |
| ----- | ---------- | ----------- |
| 3     | 3/8        | 1.74        |
| 4     | 4/8        | 1.83        |
| 5     | 4/8        | 1.83        |
| 6     | 4/8        | 1.83        |
| 7     | 6/8        | 2.93        |
| 8     | 6/8        | 2.93        |
| 9     | 7/8        | 3.61        |
| 10    | 7/8        | 3.61        |

Perhaps we could switch to 5 tries but if we need better ratio for every username we should switch to something else than hex from salted string. I've found prior art here:
- https://github.com/jxnblk/hello-color
- https://github.com/Tanaguru/Contrast-Finder
- https://github.com/material-foundation/material-color-utilities

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

-->
Fixes https://github.com/mattermost/mattermost/issues/23018
Jira https://mattermost.atlassian.net/browse/MM-52280

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Generate higher contrast for some usernames
```
