### PR TITLE
Update minimum supported Firefox version

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9900,7 +9900,7 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",
-    "translation": "Version 102+"
+    "translation": "Version 115+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.safari",


### PR DESCRIPTION
Update minimum required Firefox version to v115+ per request at https://community.mattermost.com/private-core/pl/ozre94egk38dzx7e5c4tcwzxuw. There is a bug in PDF previews that's fixed by updating it, but it requires a newer version of Firefox than we currently support.

```release-note
Update minimum required Firefox version to 115+.
```