### PR TITLE
[MM-54486] Copy pasting images from chrome fails (#24718)

### DIFF
--- a/webapp/channels/src/components/file_upload/file_upload.test.tsx
+++ b/webapp/channels/src/components/file_upload/file_upload.test.tsx
@@ -7,7 +7,7 @@ import {FileInfo} from '@mattermost/types/files';
 
 import {General} from 'mattermost-redux/constants';
 
-import FileUpload, {FileUpload as FileUploadClass} from 'components/file_upload/file_upload';
+import FileUpload, {type FileUpload as FileUploadClass} from 'components/file_upload/file_upload';
 
 import {clearFileInput} from 'utils/utils';
 import {FilesWillUploadHook} from 'types/store/plugins';
@@ -229,7 +229,11 @@ describe('components/FileUpload', () => {
         const event = new Event('paste');
         event.preventDefault = jest.fn();
         const getAsString = jest.fn();
-        (event as any).clipboardData = {items: [{getAsString, kind: 'string', type: 'text/plain'}], types: ['text/plain'], getData: () => {}};
+        (event as any).clipboardData = {items: [{getAsString, kind: 'string', type: 'text/plain'}],
+            types: ['text/plain'],
+            getData: () => {
+                return '';
+            }};
 
         const wrapper = shallowWithIntl(
             <FileUpload

--- a/webapp/channels/src/components/file_upload/file_upload.tsx
+++ b/webapp/channels/src/components/file_upload/file_upload.tsx
@@ -14,6 +14,7 @@ import dragster from 'utils/dragster';
 import Constants from 'utils/constants';
 import DelayedAction from 'utils/delayed_action';
 import {cmdOrCtrlPressed, isKeyPressed} from 'utils/keyboard';
+import {hasPlainText, createFileFromClipboardDataItem} from 'utils/paste';
 import {
     isIosChrome,
     isMobileApp,
@@ -59,10 +60,6 @@ const holders = defineMessages({
     zeroBytesFile: {
         id: 'file_upload.zeroBytesFile',
         defaultMessage: 'You are uploading an empty file: {filename}',
-    },
-    pasted: {
-        id: 'file_upload.pasted',
-        defaultMessage: 'Image Pasted at ',
     },
     uploadFile: {
         id: 'file_upload.upload_files',
@@ -447,10 +444,12 @@ export class FileUpload extends PureComponent<Props, State> {
 
     containsEventTarget = (targetElement: HTMLInputElement | null, eventTarget: EventTarget | null) => targetElement && targetElement.contains(eventTarget as Node);
 
+    /**
+     * This paste handler sole responsibility is to detect if the clipboard data contains "files" and pass them to the upload file handler.
+     */
     pasteUpload = (e: ClipboardEvent) => {
-        const {formatMessage} = this.props.intl;
-
-        if (!e.clipboardData || !e.clipboardData.items || e.clipboardData.getData('text/html')) {
+        // If the clipboard data doesn't contain anything or it contains plain text, do nothing and let the browser and other handlers do their thing.
+        if (!e.clipboardData || !e.clipboardData.items || hasPlainText(e.clipboardData)) {
             return;
         }
 
@@ -461,53 +460,28 @@ export class FileUpload extends PureComponent<Props, State> {
 
         this.props.onUploadError(null);
 
-        const items = [];
-        for (let i = 0; i < e.clipboardData.items.length; i++) {
-            const item = e.clipboardData.items[i];
+        const fileClipboardItems = Array.
+            from(e.clipboardData.items).
+            filter((item) => item.kind === 'file');
 
-            if (item.kind !== 'file') {
-                continue;
-            }
-
-            items.push(item);
-        }
-
-        if (items && items.length > 0) {
+        if (fileClipboardItems.length > 0) {
             if (!this.props.canUploadFiles) {
-                this.props.onUploadError(localizeMessage('file_upload.disabled', 'File attachments are disabled.'));
+                this.props.onUploadError(this.props.intl.formatMessage({id: 'file_upload.disabled', defaultMessage: 'File attachments are disabled.'}));
                 return;
             }
 
-            e.preventDefault();
+            const fileNamePrefixIfNoName = this.props.intl.formatMessage({id: 'file_upload.pasted', defaultMessage: 'Image Pasted at '});
 
-            const files = [];
+            const fileList = fileClipboardItems.
+                map((fileClipboardItem) => createFileFromClipboardDataItem(fileClipboardItem, fileNamePrefixIfNoName)).
+                filter((file): file is NonNullable<typeof file> => file !== null);
 
-            for (let i = 0; i < items.length; i++) {
-                const file = items[i].getAsFile();
+            if (fileList.length > 0) {
+                // Prevent default will stop event propagation to other handlers such as those in advanced text editor
+                // so we do that here because we want to only paste the files from the clipboard and not other content.
+                e.preventDefault();
 
-                if (!file) {
-                    continue;
-                }
-
-                const now = new Date();
-                const hour = now.getHours().toString().padStart(2, '0');
-                const minute = now.getMinutes().toString().padStart(2, '0');
-
-                let ext = '';
-                if (file.name && file.name.includes('.')) {
-                    ext = file.name.substr(file.name.lastIndexOf('.'));
-                } else if (items[i].type.includes('/')) {
-                    ext = '.' + items[i].type.split('/')[1].toLowerCase();
-                }
-
-                const name = file.name || formatMessage(holders.pasted) + now.getFullYear() + '-' + (now.getMonth() + 1) + '-' + now.getDate() + ' ' + hour + '-' + minute + ext;
-
-                const newFile: File = new File([file], name, {type: file.type});
-                files.push(newFile);
-            }
-
-            if (files.length > 0) {
-                this.checkPluginHooksAndUploadFiles(files);
+                this.checkPluginHooksAndUploadFiles(fileList);
                 this.props.onFileUploadChange();
             }
         }
@@ -735,7 +709,6 @@ export class FileUpload extends PureComponent<Props, State> {
         }
 
         return (
-
             <div className={uploadsRemaining <= 0 ? ' style--none btn-file__disabled' : 'style--none'}>
                 {bodyAction}
             </div>

--- a/webapp/channels/src/utils/paste.test.tsx
+++ b/webapp/channels/src/utils/paste.test.tsx
@@ -1,7 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {parseHtmlTable, getHtmlTable, formatMarkdownMessage, formatGithubCodePaste, formatMarkdownLinkMessage, isTextUrl} from './paste';
+import {
+    parseHtmlTable,
+    getHtmlTable,
+    formatMarkdownMessage,
+    formatGithubCodePaste,
+    formatMarkdownLinkMessage,
+    isTextUrl,
+    hasPlainText,
+    createFileFromClipboardDataItem,
+} from './paste';
 
 const validClipboardData: any = {
     items: [1],
@@ -219,5 +228,124 @@ describe('isTextUrl', () => {
         };
 
         expect(isTextUrl(clipboardData)).toBe(false);
+    });
+});
+
+describe('hasPlainText', () => {
+    test('Should return true when clipboard data has plain text', () => {
+        const clipboardData = {
+            ...validClipboardData,
+            types: ['text/plain'],
+            getData: () => {
+                return 'plain text';
+            },
+        };
+
+        expect(hasPlainText(clipboardData)).toBe(true);
+    });
+
+    test('Should return true when clipboard data has plain text along with other types', () => {
+        const clipboardData = {
+            ...validClipboardData,
+            types: ['text/html', 'text/plain'],
+            getData: () => {
+                return 'plain text';
+            },
+        };
+
+        expect(hasPlainText(clipboardData)).toBe(true);
+    });
+
+    test('Should return false when clipboard data has empty text', () => {
+        const clipboardData = {
+            ...validClipboardData,
+            types: ['text/html', 'text/plain'],
+            getData: () => {
+                return '';
+            },
+        };
+
+        expect(hasPlainText(clipboardData)).toBe(false);
+    });
+
+    test('Should return false when clipboard data doesnt not have plain text type', () => {
+        const clipboardData = {
+            ...validClipboardData,
+            types: ['text/html'],
+            getData: () => {
+                return 'plain text without type';
+            },
+        };
+
+        expect(hasPlainText(clipboardData)).toBe(false);
+    });
+});
+
+describe('createFileFromClipboardDataItem', () => {
+    test('should return a file from a clipboard item', () => {
+        const item = {
+            getAsFile: jest.fn(() => ({
+                name: 'test1.png',
+                type: 'image/png',
+            })),
+            type: 'image/png',
+        } as unknown as DataTransferItem;
+
+        const file = createFileFromClipboardDataItem(item, '') as File;
+        expect(file).toBeInstanceOf(File);
+        expect(file.name).toEqual('test1.png');
+        expect(file.type).toEqual('image/png');
+    });
+
+    test('should return null if getAsFile is not a file', () => {
+        const item = {
+            getAsFile: jest.fn(() => null),
+        } as unknown as DataTransferItem;
+
+        const file = createFileFromClipboardDataItem(item, '');
+        expect(file).toBeNull();
+    });
+
+    test('Should return correct file name when file name is not available', () => {
+        const item = {
+            getAsFile: jest.fn(() => ({
+                type: 'image/jpeg',
+            })),
+            type: 'image/jpeg',
+        } as unknown as DataTransferItem;
+
+        const now = new Date();
+
+        const file = createFileFromClipboardDataItem(item, 'pasted') as File;
+
+        expect(file).toBeInstanceOf(File);
+        expect(file.name).toBe(`pasted${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()} ${now.getHours().toString().padStart(2, '0')}-${now.getMinutes().toString().padStart(2, '0')}.jpeg`);
+        expect(file.type).toBe('image/jpeg');
+    });
+
+    test('Should return correct file extension when file name contains extension', () => {
+        const item = {
+            getAsFile: jest.fn(() => ({
+                name: 'test.jpeg',
+            })),
+            type: 'image/jpeg',
+        } as unknown as DataTransferItem;
+
+        const file = createFileFromClipboardDataItem(item, 'pasted') as File;
+
+        expect(file.name).toContain('.jpeg');
+    });
+
+    test('Should return correct file extension when file name doesnt contains extension', () => {
+        const item = {
+            getAsFile: jest.fn(() => ({
+                type: 'image/JPEG',
+            })),
+            type: 'image/jpeg',
+        } as unknown as DataTransferItem;
+
+        const file = createFileFromClipboardDataItem(item, 'pasted') as File;
+
+        expect(file.name).toContain('.jpeg');
     });
 });

--- a/webapp/channels/src/utils/paste.tsx
+++ b/webapp/channels/src/utils/paste.tsx
@@ -10,6 +10,7 @@ export function parseHtmlTable(html: string): HTMLTableElement | null {
 }
 
 export function getHtmlTable(clipboardData: DataTransfer): HTMLTableElement | null {
+    // Check if clipboard data has html as one of its types
     if (Array.from(clipboardData.types).indexOf('text/html') === -1) {
         return null;
     }
@@ -40,6 +41,18 @@ export function isGitHubCodeBlock(tableClassName: string): boolean {
 export function isTextUrl(clipboardData: DataTransfer): boolean {
     const clipboardText = clipboardData.getData('text/plain');
     return clipboardText.startsWith('http://') || clipboardText.startsWith('https://');
+}
+
+/**
+ * Checks if the clipboard data contains plain text from list of types.
+**/
+export function hasPlainText(clipboardData: DataTransfer): boolean {
+    if (Array.from(clipboardData.types).includes('text/plain')) {
+        const clipboardText = clipboardData.getData('text/plain');
+
+        return clipboardText.trim().length > 0;
+    }
+    return false;
 }
 
 function isTableWithoutHeaderRow(table: HTMLTableElement): boolean {
@@ -139,4 +152,35 @@ export function formatMarkdownLinkMessage({message, clipboardData, selectionStar
 
     const markdownLink = `[${selectedText}](${clipboardUrl})`;
     return markdownLink;
+}
+
+export function createFileFromClipboardDataItem(item: DataTransferItem, fileNamePrefixIfNoName: string): File | null {
+    const file = item.getAsFile();
+
+    if (!file) {
+        return null;
+    }
+
+    let ext = '';
+    if (file.name && file.name.includes('.')) {
+        ext = file.name.slice(file.name.lastIndexOf('.'));
+    } else if (item.type.includes('/')) {
+        ext = '.' + item.type.slice(item.type.lastIndexOf('/') + 1).toLowerCase();
+    }
+
+    let name = '';
+    if (file.name) {
+        name = file.name;
+    } else {
+        const now = new Date();
+        const year = now.getFullYear();
+        const month = now.getMonth() + 1;
+        const date = now.getDate();
+        const hour = now.getHours().toString().padStart(2, '0');
+        const minute = now.getMinutes().toString().padStart(2, '0');
+
+        name = `${fileNamePrefixIfNoName}${year}-${month}-${date} ${hour}-${minute}${ext}`;
+    }
+
+    return new File([file as Blob], name, {type: file.type});
 }


### PR DESCRIPTION
#### Summary
Cherry pick of https://github.com/mattermost/mattermost/pull/24718 on v8.1

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
