### PR TITLE
[MM-55121] Replace usage of LocalizedIcon in 'fa_success_icon.tsx' with i/span tags

### DIFF
--- a/webapp/channels/src/components/admin_console/request_button/__snapshots__/request_button.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/request_button/__snapshots__/request_button.test.tsx.snap
@@ -382,20 +382,10 @@ exports[`components/admin_console/request_button/request_button.jsx should match
             className="alert alert-success"
           >
             <SuccessIcon>
-              <LocalizedIcon
+              <i
                 className="fa fa-check"
-                title={
-                  Object {
-                    "defaultMessage": "Success Icon",
-                    "id": "generic_icons.success",
-                  }
-                }
-              >
-                <i
-                  className="fa fa-check"
-                  title="Success Icon"
-                />
-              </LocalizedIcon>
+                title="Success Icon"
+              />
             </SuccessIcon>
             <FormattedMessage
               defaultMessage="Success Message"

--- a/webapp/channels/src/components/widgets/icons/fa_success_icon.tsx
+++ b/webapp/channels/src/components/widgets/icons/fa_success_icon.tsx
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-
 import {useIntl} from 'react-intl';
 
 export default function SuccessIcon() {

--- a/webapp/channels/src/components/widgets/icons/fa_success_icon.tsx
+++ b/webapp/channels/src/components/widgets/icons/fa_success_icon.tsx
@@ -3,15 +3,15 @@
 
 import React from 'react';
 
-import LocalizedIcon from 'components/localized_icon';
-
-import {t} from 'utils/i18n';
+import {useIntl} from 'react-intl';
 
 export default function SuccessIcon() {
+    const {formatMessage} = useIntl();
+
     return (
-        <LocalizedIcon
+        <i
             className='fa fa-check'
-            title={{id: t('generic_icons.success'), defaultMessage: 'Success Icon'}}
+            title={formatMessage({id: 'generic_icons.success', defaultMessage: 'Success Icon'})}
         />
     );
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Replaced the usage of LocalizedIcon in 'fa_success_icon.tsx' with i tag
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
Fixes #25089 

Jira https://mattermost.atlassian.net/browse/MM-55121


<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
