### PR TITLE
[MM-55122] Replaced the usage of LocalizedIcon in 'fa_warning_icon.tsx' with i/span tags

### DIFF
--- a/webapp/channels/src/components/admin_console/request_button/__snapshots__/request_button.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/request_button/__snapshots__/request_button.test.tsx.snap
@@ -117,7 +117,6 @@ exports[`components/admin_console/request_button/request_button.jsx should match
           >
             <injectIntl(WarningIcon)>
               <WarningIcon
-                additionalClassName={null}
                 intl={
                   Object {
                     "$t": [Function],
@@ -285,7 +284,6 @@ exports[`components/admin_console/request_button/request_button.jsx should match
           >
             <injectIntl(WarningIcon)>
               <WarningIcon
-                additionalClassName={null}
                 intl={
                   Object {
                     "$t": [Function],

--- a/webapp/channels/src/components/admin_console/request_button/__snapshots__/request_button.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/request_button/__snapshots__/request_button.test.tsx.snap
@@ -115,15 +115,46 @@ exports[`components/admin_console/request_button/request_button.jsx should match
           <div
             className="alert alert-warning"
           >
-            <WarningIcon
-              additionalClassName={null}
-            >
-              <LocalizedIcon
-                className="fa fa-warning"
-                title={
+            <injectIntl(WarningIcon)>
+              <WarningIcon
+                additionalClassName={null}
+                intl={
                   Object {
-                    "defaultMessage": "Warning Icon",
-                    "id": "generic_icons.warning",
+                    "$t": [Function],
+                    "defaultFormats": Object {},
+                    "defaultLocale": "en",
+                    "defaultRichTextElements": undefined,
+                    "fallbackOnEmptyString": true,
+                    "formatDate": [Function],
+                    "formatDateTimeRange": [Function],
+                    "formatDateToParts": [Function],
+                    "formatDisplayName": [Function],
+                    "formatList": [Function],
+                    "formatListToParts": [Function],
+                    "formatMessage": [Function],
+                    "formatNumber": [Function],
+                    "formatNumberToParts": [Function],
+                    "formatPlural": [Function],
+                    "formatRelativeTime": [Function],
+                    "formatTime": [Function],
+                    "formatTimeToParts": [Function],
+                    "formats": Object {},
+                    "formatters": Object {
+                      "getDateTimeFormat": [Function],
+                      "getDisplayNames": [Function],
+                      "getListFormat": [Function],
+                      "getMessageFormat": [Function],
+                      "getNumberFormat": [Function],
+                      "getPluralRules": [Function],
+                      "getRelativeTimeFormat": [Function],
+                    },
+                    "locale": "en",
+                    "messages": Object {},
+                    "onError": [Function],
+                    "onWarn": [Function],
+                    "textComponent": "span",
+                    "timeZone": "Etc/UTC",
+                    "wrapRichTextChunksInFragment": undefined,
                   }
                 }
               >
@@ -131,8 +162,8 @@ exports[`components/admin_console/request_button/request_button.jsx should match
                   className="fa fa-warning"
                   title="Warning Icon"
                 />
-              </LocalizedIcon>
-            </WarningIcon>
+              </WarningIcon>
+            </injectIntl(WarningIcon)>
             <FormattedMessage
               defaultMessage="Error Message: {error}"
               id="error.message"
@@ -252,15 +283,46 @@ exports[`components/admin_console/request_button/request_button.jsx should match
           <div
             className="alert alert-warning"
           >
-            <WarningIcon
-              additionalClassName={null}
-            >
-              <LocalizedIcon
-                className="fa fa-warning"
-                title={
+            <injectIntl(WarningIcon)>
+              <WarningIcon
+                additionalClassName={null}
+                intl={
                   Object {
-                    "defaultMessage": "Warning Icon",
-                    "id": "generic_icons.warning",
+                    "$t": [Function],
+                    "defaultFormats": Object {},
+                    "defaultLocale": "en",
+                    "defaultRichTextElements": undefined,
+                    "fallbackOnEmptyString": true,
+                    "formatDate": [Function],
+                    "formatDateTimeRange": [Function],
+                    "formatDateToParts": [Function],
+                    "formatDisplayName": [Function],
+                    "formatList": [Function],
+                    "formatListToParts": [Function],
+                    "formatMessage": [Function],
+                    "formatNumber": [Function],
+                    "formatNumberToParts": [Function],
+                    "formatPlural": [Function],
+                    "formatRelativeTime": [Function],
+                    "formatTime": [Function],
+                    "formatTimeToParts": [Function],
+                    "formats": Object {},
+                    "formatters": Object {
+                      "getDateTimeFormat": [Function],
+                      "getDisplayNames": [Function],
+                      "getListFormat": [Function],
+                      "getMessageFormat": [Function],
+                      "getNumberFormat": [Function],
+                      "getPluralRules": [Function],
+                      "getRelativeTimeFormat": [Function],
+                    },
+                    "locale": "en",
+                    "messages": Object {},
+                    "onError": [Function],
+                    "onWarn": [Function],
+                    "textComponent": "span",
+                    "timeZone": "Etc/UTC",
+                    "wrapRichTextChunksInFragment": undefined,
                   }
                 }
               >
@@ -268,8 +330,8 @@ exports[`components/admin_console/request_button/request_button.jsx should match
                   className="fa fa-warning"
                   title="Warning Icon"
                 />
-              </LocalizedIcon>
-            </WarningIcon>
+              </WarningIcon>
+            </injectIntl(WarningIcon)>
             <FormattedMessage
               defaultMessage="Error Message: {error}"
               id="error.message"

--- a/webapp/channels/src/components/widgets/icons/fa_warning_icon.tsx
+++ b/webapp/channels/src/components/widgets/icons/fa_warning_icon.tsx
@@ -2,11 +2,10 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {injectIntl} from 'react-intl';
-import type {IntlShape} from 'react-intl';
+import {injectIntl, type IntlShape} from 'react-intl';
 
 type Props = {
-    additionalClassName?: string | null;
+    additionalClassName?: string;
     intl: IntlShape;
 }
 

--- a/webapp/channels/src/components/widgets/icons/fa_warning_icon.tsx
+++ b/webapp/channels/src/components/widgets/icons/fa_warning_icon.tsx
@@ -6,7 +6,7 @@ import {injectIntl} from 'react-intl';
 import type {IntlShape} from 'react-intl';
 
 type Props = {
-    additionalClassName: string | null;
+    additionalClassName?: string | null;
     intl: IntlShape;
 }
 

--- a/webapp/channels/src/components/widgets/icons/fa_warning_icon.tsx
+++ b/webapp/channels/src/components/widgets/icons/fa_warning_icon.tsx
@@ -2,27 +2,28 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-
-import LocalizedIcon from 'components/localized_icon';
-
-import {t} from 'utils/i18n';
+import {injectIntl} from 'react-intl';
+import type {IntlShape} from 'react-intl';
 
 type Props = {
     additionalClassName: string | null;
+    intl: IntlShape;
 }
 
-export default class WarningIcon extends React.PureComponent<Props> {
-    public static defaultProps: Props = {
+class WarningIcon extends React.PureComponent<Props> {
+    public static defaultProps: Partial<Props> = {
         additionalClassName: null,
     };
 
     public render(): JSX.Element {
         const className = 'fa fa-warning' + (this.props.additionalClassName ? ' ' + this.props.additionalClassName : '');
         return (
-            <LocalizedIcon
+            <i
                 className={className}
-                title={{id: t('generic_icons.warning'), defaultMessage: 'Warning Icon'}}
+                title={this.props.intl.formatMessage({id: 'generic_icons.warning', defaultMessage: 'Warning Icon'})}
             />
         );
     }
 }
+
+export default injectIntl(WarningIcon);

--- a/webapp/channels/src/components/widgets/icons/fa_warning_icon.tsx
+++ b/webapp/channels/src/components/widgets/icons/fa_warning_icon.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import classNames from 'classnames';
 import React from 'react';
 import {injectIntl, type IntlShape} from 'react-intl';
 
@@ -10,15 +11,10 @@ type Props = {
 }
 
 class WarningIcon extends React.PureComponent<Props> {
-    public static defaultProps: Partial<Props> = {
-        additionalClassName: null,
-    };
-
     public render(): JSX.Element {
-        const className = 'fa fa-warning' + (this.props.additionalClassName ? ' ' + this.props.additionalClassName : '');
         return (
             <i
-                className={className}
+                className={classNames('fa fa-warning', this.props.additionalClassName)}
                 title={this.props.intl.formatMessage({id: 'generic_icons.warning', defaultMessage: 'Warning Icon'})}
             />
         );


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Replaced the usage of LocalizedIcon in 'fa_warning_icon.tsx' with i tag
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
Fixes #25088

Jira https://mattermost.atlassian.net/browse/MM-55122


<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
