### PR TITLE
Fix Webpack warnings

### DIFF
--- a/webapp/channels/src/sass/responsive/_tablet.scss
+++ b/webapp/channels/src/sass/responsive/_tablet.scss
@@ -130,16 +130,6 @@
 
 // Tablet and desktop
 @media screen and (min-width: 769px) {
-    // ensure the global header always sits on top of its immediate sibling
-    > header {
-        z-index: 2;
-
-        + * {
-            position: relative;
-            z-index: 1;
-        }
-    }
-
     .search-help-popover {
         width: 274px;
     }

--- a/webapp/channels/webpack.config.js
+++ b/webapp/channels/webpack.config.js
@@ -5,12 +5,13 @@
 
 const path = require('path');
 const url = require('url');
+
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const ExternalTemplateRemotesPlugin = require('external-remotes-plugin');
-const webpack = require('webpack');
-const {ModuleFederationPlugin} = require('webpack').container;
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const webpack = require('webpack');
+const {ModuleFederationPlugin} = require('webpack').container;
 const WebpackPwaManifest = require('webpack-pwa-manifest');
 
 // const {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer');
@@ -337,7 +338,6 @@ async function initializeModuleFederation() {
                 '@mattermost/client',
                 '@mattermost/types',
                 'luxon',
-                'prop-types',
             ], false),
 
             // Other containers will be forced to use the exact versions of shared modules that the web app provides.


### PR DESCRIPTION
#### Summary
These warnings have been printed by Webpack for ages, but they get really annoying if using `make dev`

That CSS has never done anything since it's always been invalid, and since we're not actively using module federation, I don't think we need to fix the version of prop-types. By the time we actually get back to module federation, we'll hopefully all be on TypeScript so we won't need that library anyway

#### Release Note
```release-note
NONE
```
