### PR TITLE
Fixes #25120 - Horizontal scrollbar appearing on slash command autocomplete

### DIFF
--- a/webapp/channels/src/sass/components/_suggestion-list.scss
+++ b/webapp/channels/src/sass/components/_suggestion-list.scss
@@ -99,9 +99,9 @@
 
 .slash-command__icon {
     display: flex;
-    width: 3.2rem;
-    height: 3.2rem;
-    flex: 0 0 3.2rem;
+    width: 3.7rem;
+    height: 3.7rem;
+    flex: 0 0 3.7rem;
     align-items: center;
     justify-content: center;
     background: rgba(var(--center-channel-color-rgb), 0.08);
@@ -120,10 +120,12 @@
 }
 
 .slash-command__desc {
+    overflow: hidden;
     margin: 2px 0 0;
     font-size: 12px;
-    line-height: 1.6;
+    line-height: 1.2;
     opacity: 0.56;
+    white-space: break-spaces;
 }
 
 .suggestion-list__content--top {
@@ -185,7 +187,7 @@
     z-index: 101;
     display: flex;
     width: 100%;
-    height: 4rem;
+    height: 5rem;
     align-items: center;
     padding: 0 2.4rem;
     margin: 0;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR fixes the horizontal scrollbar when the command description overflows while searching for slash commands. Instead, the description is now wrapped.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/25120
Jira https://mattermost.atlassian.net/browse/MM-55088
-->

#### Screenshots
|  before  |  after  |
|----|----|
| ![image](https://github.com/mattermost/mattermost/assets/10843836/70dbe7ab-01ff-4b40-a729-c4ecda12fdad) | <img width="573" alt="image" src="https://github.com/mattermost/mattermost/assets/10843836/7fd3dffd-f549-4ebf-a911-5a713a64fc7d"> |



#### Release Note
```release-note
NONE
```
