### PR TITLE
MM-27291: Extend channel header with parent as render prop

### DIFF
--- a/webapp/channels/src/components/channel_header/channel_header.tsx
+++ b/webapp/channels/src/components/channel_header/channel_header.tsx
@@ -507,13 +507,14 @@ class ChannelHeader extends React.PureComponent<Props, State> {
 
             memberListButton = (
                 <HeaderIconWrapper
-                    iconComponent={membersIcon}
                     ariaLabel={true}
                     buttonClass={membersIconClass}
                     buttonId={'member_rhs'}
                     onClick={this.toggleChannelMembersRHS}
                     tooltipKey={'channelMembers'}
-                />
+                >
+                    {membersIcon}
+                </HeaderIconWrapper>
             );
         }
 
@@ -555,22 +556,24 @@ class ChannelHeader extends React.PureComponent<Props, State> {
                     {memberListButton}
 
                     <HeaderIconWrapper
-                        iconComponent={pinnedIcon}
                         ariaLabel={true}
                         buttonClass={pinnedIconClass}
                         buttonId={'channelHeaderPinButton'}
                         onClick={this.showPinnedPosts}
                         tooltipKey={'pinnedPosts'}
-                    />
+                    >
+                        {pinnedIcon}
+                    </HeaderIconWrapper>
                     {this.props.isFileAttachmentsEnabled &&
                         <HeaderIconWrapper
-                            iconComponent={channelFilesIcon}
                             ariaLabel={true}
                             buttonClass={channelFilesIconClass}
                             buttonId={'channelHeaderFilesButton'}
                             onClick={this.showChannelFiles}
                             tooltipKey={'channelFiles'}
-                        />
+                        >
+                            {channelFilesIcon}
+                        </HeaderIconWrapper>
                     }
                     {hasGuestsText}
                     <div
@@ -664,22 +667,24 @@ class ChannelHeader extends React.PureComponent<Props, State> {
                     {memberListButton}
 
                     <HeaderIconWrapper
-                        iconComponent={pinnedIcon}
                         ariaLabel={true}
                         buttonClass={pinnedIconClass}
                         buttonId={'channelHeaderPinButton'}
                         onClick={this.showPinnedPosts}
                         tooltipKey={'pinnedPosts'}
-                    />
+                    >
+                        {pinnedIcon}
+                    </HeaderIconWrapper>
                     {this.props.isFileAttachmentsEnabled &&
                         <HeaderIconWrapper
-                            iconComponent={channelFilesIcon}
                             ariaLabel={true}
                             buttonClass={channelFilesIconClass}
                             buttonId={'channelHeaderFilesButton'}
                             onClick={this.showChannelFiles}
                             tooltipKey={'channelFiles'}
-                        />
+                        >
+                            {channelFilesIcon}
+                        </HeaderIconWrapper>
                     }
                     {hasGuestsText}
                     {editMessage}

--- a/webapp/channels/src/components/channel_header/channel_info_button.tsx
+++ b/webapp/channels/src/components/channel_header/channel_info_button.tsx
@@ -61,9 +61,10 @@ const ChannelInfoButton = ({channel}: Props) => {
             buttonId='channel-info-btn'
             onClick={toggleRHS}
             ariaLabel={true}
-            iconComponent={<Icon className='icon-information-outline'/>}
             tooltipKey={tooltipKey}
-        />
+        >
+            <Icon className='icon-information-outline'/>
+        </HeaderIconWrapper>
     );
 };
 

--- a/webapp/channels/src/components/channel_header/components/header_icon_wrapper.tsx
+++ b/webapp/channels/src/components/channel_header/components/header_icon_wrapper.tsx
@@ -21,7 +21,7 @@ type Props = {
     ariaLabel?: boolean;
     buttonClass?: string;
     buttonId: string;
-    iconComponent: React.ReactNode;
+    children: React.ReactNode;
     onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
     tooltipKey: string;
     tooltipText?: React.ReactNode;
@@ -42,7 +42,7 @@ const HeaderIconWrapper = (props: Props) => {
         ariaLabel,
         buttonClass,
         buttonId,
-        iconComponent,
+        children,
         onClick,
         tooltipKey,
         tooltipText,
@@ -163,7 +163,7 @@ const HeaderIconWrapper = (props: Props) => {
                         className={buttonClass || 'channel-header__icon'}
                         onClick={onClick}
                     >
-                        {iconComponent}
+                        {children}
                     </button>
                 </OverlayTrigger>
                 {boardsEnabled &&
@@ -184,7 +184,7 @@ const HeaderIconWrapper = (props: Props) => {
                     className={buttonClass || 'channel-header__icon'}
                     onClick={onClick}
                 >
-                    {iconComponent}
+                    {children}
                 </button>
             </div>
             {boardsEnabled &&

--- a/webapp/channels/src/components/search/search.tsx
+++ b/webapp/channels/src/components/search/search.tsx
@@ -366,12 +366,6 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
 
     const renderMentionButton = (): JSX.Element => (
         <HeaderIconWrapper
-            iconComponent={
-                <MentionsIcon
-                    className='icon icon--standard'
-                    aria-hidden='true'
-                />
-            }
             ariaLabel={true}
             buttonClass={classNames(
                 'channel-header__icon',
@@ -381,14 +375,16 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
             onClick={searchMentions}
             tooltipKey={'recentMentions'}
             isRhsOpen={props.isRhsOpen}
-        />
+        >
+            <MentionsIcon
+                className='icon icon--standard'
+                aria-hidden='true'
+            />
+        </HeaderIconWrapper>
     );
 
     const renderFlagBtn = (): JSX.Element => (
         <HeaderIconWrapper
-            iconComponent={
-                <FlagIcon className='icon icon--standard'/>
-            }
             ariaLabel={true}
             buttonClass={classNames(
                 'channel-header__icon ',
@@ -398,7 +394,9 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
             onClick={getFlagged}
             tooltipKey={'flaggedPosts'}
             isRhsOpen={props.isRhsOpen}
-        />
+        >
+            <FlagIcon className='icon icon--standard'/>
+        </HeaderIconWrapper>
     );
 
     const renderHintPopover = (): JSX.Element => {
@@ -485,17 +483,16 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
         if (hideSearchBar) {
             return (
                 <HeaderIconWrapper
-                    iconComponent={
-                        <SearchIcon
-                            className='icon icon--standard'
-                            aria-hidden='true'
-                        />
-                    }
                     ariaLabel={true}
                     buttonId={'channelHeaderSearchButton'}
                     onClick={searchButtonClick}
                     tooltipKey={'search'}
-                />
+                >
+                    <SearchIcon
+                        className='icon icon--standard'
+                        aria-hidden='true'
+                    />
+                </HeaderIconWrapper>
             );
         }
 

--- a/webapp/channels/src/plugins/channel_header_plug/channel_header_plug.tsx
+++ b/webapp/channels/src/plugins/channel_header_plug/channel_header_plug.tsx
@@ -13,7 +13,6 @@ import type {AppBinding} from '@mattermost/types/apps';
 import type {Channel, ChannelMembership} from '@mattermost/types/channels';
 
 import {AppCallResponseTypes} from 'mattermost-redux/constants/apps';
-import type {Theme} from 'mattermost-redux/selectors/entities/preferences';
 
 import HeaderIconWrapper from 'components/channel_header/components/header_icon_wrapper';
 import OverlayTrigger from 'components/overlay_trigger';
@@ -30,7 +29,6 @@ type CustomMenuProps = {
     children?: React.ReactNode;
     onClose: () => void;
     rootCloseEvent?: 'click' | 'mousedown';
-    bsRole: string;
 }
 
 class CustomMenu extends React.PureComponent<CustomMenuProps> {
@@ -66,7 +64,6 @@ type CustomToggleProps = {
     children?: React.ReactNode;
     dropdownOpen?: boolean;
     onClick?: (e: React.MouseEvent) => void;
-    bsRole: string;
 }
 
 class CustomToggle extends React.PureComponent<CustomToggleProps> {
@@ -104,7 +101,6 @@ type ChannelHeaderPlugProps = {
     appsEnabled: boolean;
     channel: Channel;
     channelMember?: ChannelMembership;
-    theme: Theme;
     sidebarOpen: boolean;
     shouldShowAppBar: boolean;
     actions: {
@@ -297,7 +293,6 @@ class ChannelHeaderPlug extends React.PureComponent<ChannelHeaderPlugProps, Chan
                     open={this.state.dropdownOpen}
                 >
                     <CustomToggle
-                        bsRole='toggle'
                         dropdownOpen={this.state.dropdownOpen}
                     >
                         <OverlayTrigger
@@ -330,7 +325,6 @@ class ChannelHeaderPlug extends React.PureComponent<ChannelHeaderPlugProps, Chan
                         </OverlayTrigger>
                     </CustomToggle>
                     <CustomMenu
-                        bsRole='menu'
                         open={this.state.dropdownOpen}
                         onClose={this.onClose}
                     >

--- a/webapp/channels/src/plugins/channel_header_plug/channel_header_plug.tsx
+++ b/webapp/channels/src/plugins/channel_header_plug/channel_header_plug.tsx
@@ -169,13 +169,14 @@ class ChannelHeaderPlug extends React.PureComponent<ChannelHeaderPlugProps, Chan
             <HeaderIconWrapper
                 key={'channelHeaderButton' + plug.id}
                 buttonClass='channel-header__icon'
-                iconComponent={plug.icon!}
                 onClick={() => this.fireAction(plug.action!)}
                 buttonId={plug.id}
                 tooltipKey={'plugin'}
                 tooltipText={plug.tooltipText ? plug.tooltipText : plug.dropdownText}
                 pluginId={plug.pluginId}
-            />
+            >
+                {plug.icon}
+            </HeaderIconWrapper>
         );
     };
 
@@ -236,18 +237,17 @@ class ChannelHeaderPlug extends React.PureComponent<ChannelHeaderPlugProps, Chan
             <HeaderIconWrapper
                 key={`channelHeaderButton_${binding.app_id}_${binding.location}`}
                 buttonClass='channel-header__icon style--none'
-                iconComponent={(
-                    <img
-                        src={binding.icon}
-                        width='24'
-                        height='24'
-                    />
-                )}
                 onClick={() => this.onBindingClick(binding)}
                 buttonId={`${binding.app_id}_${binding.location}`}
                 tooltipKey={'plugin'}
                 tooltipText={binding.label}
-            />
+            >
+                <img
+                    src={binding.icon}
+                    width='24'
+                    height='24'
+                />
+            </HeaderIconWrapper>
         );
     };
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Extend channel header with parent as render prop

#### Ticket Link
<!--
If applicable, please include both or either of the following links:
-->

Fixes https://github.com/mattermost/mattermost/issues/22467
Jira https://mattermost.atlassian.net/browse/MM-27291

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Plugins: You can now conditionally hide and style ChannelHeaderButton registered via new registerParentAwareChannelHeaderButtonAction API
```
