### PR TITLE
MM-55146_fix activate/deactivate ux when ldap users

### DIFF
--- a/webapp/channels/src/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.test.tsx
+++ b/webapp/channels/src/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.test.tsx
@@ -22,6 +22,8 @@ describe('components/admin_console/system_users/system_users_dropdown/system_use
         username: 'other-user',
     });
 
+    const mockMouseEvent = TestHelper.getMockMouseButtonEvent();
+
     const requiredProps: Props = {
         user,
         mfaEnabled: true,
@@ -57,11 +59,20 @@ describe('components/admin_console/system_users/system_users_dropdown/system_use
     test('handleMakeActive() should have called updateUserActive', async () => {
         const wrapper = shallow<SystemUsersDropdown>(<SystemUsersDropdown {...requiredProps}/>);
 
-        const event = {preventDefault: jest.fn()};
-        wrapper.instance().handleMakeActive(event);
+        wrapper.instance().handleMakeActive(mockMouseEvent, false);
 
         expect(requiredProps.actions.updateUserActive).toHaveBeenCalledTimes(1);
         expect(requiredProps.actions.updateUserActive).toHaveBeenCalledWith(requiredProps.user.id, true);
+    });
+
+    test('handleMakeActive() should not have called updateUserActive if user auth service is LDAP', async () => {
+        const ldapUserProps = {...requiredProps, user: {...requiredProps.user, auth_service: 'ldap'}};
+
+        const wrapper = shallow<SystemUsersDropdown>(<SystemUsersDropdown {...ldapUserProps}/>);
+
+        wrapper.instance().handleMakeActive(mockMouseEvent, true);
+
+        expect(requiredProps.actions.updateUserActive).toHaveBeenCalledTimes(0);
     });
 
     test('handleMakeActive() should have called onError', async () => {
@@ -70,8 +81,7 @@ describe('components/admin_console/system_users/system_users_dropdown/system_use
         const props = {...requiredProps, actions: {...requiredProps.actions, updateUserActive}};
         const wrapper = shallow<SystemUsersDropdown>(<SystemUsersDropdown {...props}/>);
 
-        const event = {preventDefault: jest.fn()};
-        await wrapper.instance().handleMakeActive(event);
+        await wrapper.instance().handleMakeActive(mockMouseEvent, false);
 
         expect(requiredProps.onError).toHaveBeenCalledTimes(1);
         expect(requiredProps.onError).toHaveBeenCalledWith({id: retVal.error.server_error_id, ...retVal.error});
@@ -84,6 +94,18 @@ describe('components/admin_console/system_users/system_users_dropdown/system_use
 
         expect(requiredProps.actions.updateUserActive).toHaveBeenCalledTimes(1);
         expect(requiredProps.actions.updateUserActive).toHaveBeenCalledWith(requiredProps.user.id, false);
+    });
+
+    test('handleShowDeactivateMemberModal() should not have show the deactivation modal if user auth service is LDAP', async () => {
+        const ldapUserProps = {...requiredProps, user: {...requiredProps.user, auth_service: 'ldap'}};
+
+        const wrapper = shallow<SystemUsersDropdown>(<SystemUsersDropdown {...ldapUserProps}/>);
+
+        await wrapper.instance().handleShowDeactivateMemberModal(mockMouseEvent, true);
+
+        wrapper.update();
+
+        expect(wrapper.state('showDeactivateMemberModal')).toBeFalsy();
     });
 
     test('handleDeactivateMember() should have called onError', async () => {
@@ -121,8 +143,7 @@ describe('components/admin_console/system_users/system_users_dropdown/system_use
     test('handleShowDeactivateMemberModal should not call the loadBots if the setting is not true', async () => {
         const wrapper = shallow<SystemUsersDropdown>(<SystemUsersDropdown {...requiredProps}/>);
 
-        const event = {preventDefault: jest.fn()};
-        await wrapper.instance().handleShowDeactivateMemberModal(event);
+        await wrapper.instance().handleShowDeactivateMemberModal(mockMouseEvent, false);
 
         expect(requiredProps.actions.loadBots).toHaveBeenCalledTimes(0);
     });
@@ -135,8 +156,7 @@ describe('components/admin_console/system_users/system_users_dropdown/system_use
         };
         const wrapper = shallow<SystemUsersDropdown>(<SystemUsersDropdown {...{...requiredProps, config: overrideConfig, bots: {}}}/>);
 
-        const event = {preventDefault: jest.fn()};
-        await wrapper.instance().handleShowDeactivateMemberModal(event);
+        await wrapper.instance().handleShowDeactivateMemberModal(mockMouseEvent, false);
 
         expect(requiredProps.actions.loadBots).toHaveBeenCalledTimes(1);
     });

--- a/webapp/channels/src/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.tsx
+++ b/webapp/channels/src/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.tsx
@@ -84,8 +84,12 @@ export default class SystemUsersDropdown extends React.PureComponent<Props, Stat
         };
     }
 
-    handleMakeActive = (e: {preventDefault: () => void}) => {
+    handleMakeActive = (e: React.MouseEvent<HTMLButtonElement>, disableActivationToggle: boolean) => {
         e.preventDefault();
+        e.stopPropagation();
+        if (disableActivationToggle) {
+            return;
+        }
         this.props.actions.updateUserActive(this.props.user.id, true).
             then(this.onUpdateActiveResult);
     };
@@ -123,8 +127,11 @@ export default class SystemUsersDropdown extends React.PureComponent<Props, Stat
         adminResetMfa(this.props.user.id, null, this.props.onError);
     };
 
-    handleShowDeactivateMemberModal = async (e: {preventDefault: () => void}) => {
+    handleShowDeactivateMemberModal = async (e: React.MouseEvent<HTMLButtonElement>, disableActivationToggle: boolean) => {
         e.preventDefault();
+        if (disableActivationToggle) {
+            return;
+        }
         if (this.shouldDisableBotsWhenOwnerIsDeactivated()) {
             await this.props.actions.loadBots(
                 Constants.Integrations.START_PAGE_NUM,
@@ -637,6 +644,12 @@ export default class SystemUsersDropdown extends React.PureComponent<Props, Stat
         const demoteToGuestModal = this.renderDemoteToGuestModal();
         const createGroupSyncablesMembershipsModal = this.renderCreateGroupSyncablesMembershipsModal();
 
+        const getExtraText = (disableActivationToggle: boolean) => {
+            return disableActivationToggle ? {
+                extraText: Utils.localizeMessage('admin.user_item.managedByLdap', 'Managed by LDAP'),
+            } : {};
+        };
+
         const {index, totalUsers} = this.props;
         return (
             <React.Fragment>
@@ -664,15 +677,17 @@ export default class SystemUsersDropdown extends React.PureComponent<Props, Stat
                     >
                         <Menu.ItemAction
                             show={showMakeActive}
-                            onClick={this.handleMakeActive}
+                            onClick={(e: React.MouseEvent<HTMLButtonElement>) => this.handleMakeActive(e, disableActivationToggle)}
                             text={Utils.localizeMessage('admin.user_item.makeActive', 'Activate')}
                             disabled={disableActivationToggle}
+                            {...getExtraText(disableActivationToggle)}
                         />
                         <Menu.ItemAction
                             show={showMakeNotActive}
-                            onClick={this.handleShowDeactivateMemberModal}
+                            onClick={(e: React.MouseEvent<HTMLButtonElement>) => this.handleShowDeactivateMemberModal(e, disableActivationToggle)}
                             text={Utils.localizeMessage('admin.user_item.makeInactive', 'Deactivate')}
                             disabled={disableActivationToggle}
+                            {...getExtraText(disableActivationToggle)}
                         />
                         <Menu.ItemAction
                             show={showManageRoles}

--- a/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss
+++ b/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss
@@ -91,6 +91,20 @@
             text-overflow: ellipsis;
             white-space: nowrap;
 
+            &.disabled {
+                color: rgba(var(--center-channel-color-rgb), 0.48);
+                cursor: default;
+                pointer-events: none;
+
+                &:hover {
+                    background: none;
+                }
+
+                .icon {
+                    color: rgba(var(--center-channel-color-rgb), 0.48);
+                }
+            }
+
             &.MenuItem__with-help {
                 display: block;
                 height: auto;

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -2552,6 +2552,7 @@
   "admin.user_item.makeInactive": "Deactivate",
   "admin.user_item.makeMember": "Make Team Member",
   "admin.user_item.makeTeamAdmin": "Make Team Admin",
+  "admin.user_item.managedByLdap": "Managed by LDAP",
   "admin.user_item.manageRoles": "Manage Roles",
   "admin.user_item.manageTeams": "Manage Teams",
   "admin.user_item.manageTokens": "Manage Tokens",

--- a/webapp/channels/src/utils/test_helper.ts
+++ b/webapp/channels/src/utils/test_helper.ts
@@ -559,4 +559,15 @@ export class TestHelper {
             ...override,
         };
     }
+
+    public static getMockMouseButtonEvent() {
+        return {
+            preventDefault: jest.fn(),
+            stopPropagation: jest.fn(),
+            currentTarget: {
+                click: jest.fn(),
+                value: 'test value',
+            },
+        } as unknown as React.MouseEvent<HTMLButtonElement>;
+    }
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR fixes the css styles when the activate/deactivate users button is disabled. Also indicates in a sub-legend that the process of activation/deactivation must be done via LDAP.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
https://mattermost.atlassian.net/browse/MM-55146
#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->
Before:

https://github.com/mattermost/mattermost/assets/10082627/7fb0502f-8e9d-47bb-8ea2-a71da71c8c64

After:

https://github.com/mattermost/mattermost/assets/10082627/0d307b97-6171-425d-a7f3-3d0a2249e93e

<img width="324" alt="Screenshot 2023-10-26 at 15 11 47" src="https://github.com/mattermost/mattermost/assets/10082627/fbef926f-c4d7-4fa7-932b-4e41b4471858">

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
