### PR TITLE
[MM-55109] Replace usage of LocalizedIcon in 'group_member_list.tsx' with i/span tags

### DIFF
--- a/webapp/channels/src/components/user_group_popover/__snapshots__/user_group_popover.test.tsx.snap
+++ b/webapp/channels/src/components/user_group_popover/__snapshots__/user_group_popover.test.tsx.snap
@@ -202,12 +202,20 @@ exports[`component/user_group_popover should match snapshot 1`] = `
                                 className="CloseButton-lhxEdi gyMeQZ btn btn-sm btn-compact btn-icon"
                                 onClick={[Function]}
                               >
-                                
+                                <LocalizedIcon
+                                  ariaLabel={
+                                    Object {
+                                      "defaultMessage": "Close",
+                                      "id": "user_group_popover.close",
+                                    }
+                                  }
+                                  className="icon icon-close"
+                                >
                                   <i
                                     aria-label="Close"
                                     className="icon icon-close"
                                   />
-                               
+                                </LocalizedIcon>
                               </button>
                             </CloseButton>
                           </div>

--- a/webapp/channels/src/components/user_group_popover/__snapshots__/user_group_popover.test.tsx.snap
+++ b/webapp/channels/src/components/user_group_popover/__snapshots__/user_group_popover.test.tsx.snap
@@ -1261,7 +1261,6 @@ exports[`component/user_group_popover should match snapshot 1`] = `
                                                           onMouseOver={[Function]}
                                                         >
                                                           <i
-                                                            aria-label="Close"
                                                             className="icon icon-send"
                                                           />
                                                         </button>
@@ -1470,7 +1469,6 @@ exports[`component/user_group_popover should match snapshot 1`] = `
                                                           onMouseOver={[Function]}
                                                         >
                                                           <i
-                                                            aria-label="Close"
                                                             className="icon icon-send"
                                                           />
                                                         </button>
@@ -1679,7 +1677,6 @@ exports[`component/user_group_popover should match snapshot 1`] = `
                                                           onMouseOver={[Function]}
                                                         >
                                                           <i
-                                                            aria-label="Close"
                                                             className="icon icon-send"
                                                           />
                                                         </button>
@@ -1888,7 +1885,6 @@ exports[`component/user_group_popover should match snapshot 1`] = `
                                                           onMouseOver={[Function]}
                                                         >
                                                           <i
-                                                            aria-label="Close"
                                                             className="icon icon-send"
                                                           />
                                                         </button>
@@ -2097,7 +2093,6 @@ exports[`component/user_group_popover should match snapshot 1`] = `
                                                           onMouseOver={[Function]}
                                                         >
                                                           <i
-                                                            aria-label="Close"
                                                             className="icon icon-send"
                                                           />
                                                         </button>

--- a/webapp/channels/src/components/user_group_popover/__snapshots__/user_group_popover.test.tsx.snap
+++ b/webapp/channels/src/components/user_group_popover/__snapshots__/user_group_popover.test.tsx.snap
@@ -202,20 +202,12 @@ exports[`component/user_group_popover should match snapshot 1`] = `
                                 className="CloseButton-lhxEdi gyMeQZ btn btn-sm btn-compact btn-icon"
                                 onClick={[Function]}
                               >
-                                <LocalizedIcon
-                                  ariaLabel={
-                                    Object {
-                                      "defaultMessage": "Close",
-                                      "id": "user_group_popover.close",
-                                    }
-                                  }
-                                  className="icon icon-close"
-                                >
+                                
                                   <i
                                     aria-label="Close"
                                     className="icon icon-close"
                                   />
-                                </LocalizedIcon>
+                               
                               </button>
                             </CloseButton>
                           </div>
@@ -1260,20 +1252,10 @@ exports[`component/user_group_popover should match snapshot 1`] = `
                                                           onMouseOut={[Function]}
                                                           onMouseOver={[Function]}
                                                         >
-                                                          <LocalizedIcon
-                                                            ariaLabel={
-                                                              Object {
-                                                                "defaultMessage": "Close",
-                                                                "id": "user_group_popover.close",
-                                                              }
-                                                            }
+                                                          <i
+                                                            aria-label="Close"
                                                             className="icon icon-send"
-                                                          >
-                                                            <i
-                                                              aria-label="Close"
-                                                              className="icon icon-send"
-                                                            />
-                                                          </LocalizedIcon>
+                                                          />
                                                         </button>
                                                       </DMButton>
                                                     </OverlayTrigger>
@@ -1479,20 +1461,10 @@ exports[`component/user_group_popover should match snapshot 1`] = `
                                                           onMouseOut={[Function]}
                                                           onMouseOver={[Function]}
                                                         >
-                                                          <LocalizedIcon
-                                                            ariaLabel={
-                                                              Object {
-                                                                "defaultMessage": "Close",
-                                                                "id": "user_group_popover.close",
-                                                              }
-                                                            }
+                                                          <i
+                                                            aria-label="Close"
                                                             className="icon icon-send"
-                                                          >
-                                                            <i
-                                                              aria-label="Close"
-                                                              className="icon icon-send"
-                                                            />
-                                                          </LocalizedIcon>
+                                                          />
                                                         </button>
                                                       </DMButton>
                                                     </OverlayTrigger>
@@ -1698,20 +1670,10 @@ exports[`component/user_group_popover should match snapshot 1`] = `
                                                           onMouseOut={[Function]}
                                                           onMouseOver={[Function]}
                                                         >
-                                                          <LocalizedIcon
-                                                            ariaLabel={
-                                                              Object {
-                                                                "defaultMessage": "Close",
-                                                                "id": "user_group_popover.close",
-                                                              }
-                                                            }
+                                                          <i
+                                                            aria-label="Close"
                                                             className="icon icon-send"
-                                                          >
-                                                            <i
-                                                              aria-label="Close"
-                                                              className="icon icon-send"
-                                                            />
-                                                          </LocalizedIcon>
+                                                          />
                                                         </button>
                                                       </DMButton>
                                                     </OverlayTrigger>
@@ -1917,20 +1879,10 @@ exports[`component/user_group_popover should match snapshot 1`] = `
                                                           onMouseOut={[Function]}
                                                           onMouseOver={[Function]}
                                                         >
-                                                          <LocalizedIcon
-                                                            ariaLabel={
-                                                              Object {
-                                                                "defaultMessage": "Close",
-                                                                "id": "user_group_popover.close",
-                                                              }
-                                                            }
+                                                          <i
+                                                            aria-label="Close"
                                                             className="icon icon-send"
-                                                          >
-                                                            <i
-                                                              aria-label="Close"
-                                                              className="icon icon-send"
-                                                            />
-                                                          </LocalizedIcon>
+                                                          />
                                                         </button>
                                                       </DMButton>
                                                     </OverlayTrigger>
@@ -2136,20 +2088,10 @@ exports[`component/user_group_popover should match snapshot 1`] = `
                                                           onMouseOut={[Function]}
                                                           onMouseOver={[Function]}
                                                         >
-                                                          <LocalizedIcon
-                                                            ariaLabel={
-                                                              Object {
-                                                                "defaultMessage": "Close",
-                                                                "id": "user_group_popover.close",
-                                                              }
-                                                            }
+                                                          <i
+                                                            aria-label="Close"
                                                             className="icon icon-send"
-                                                          >
-                                                            <i
-                                                              aria-label="Close"
-                                                              className="icon icon-send"
-                                                            />
-                                                          </LocalizedIcon>
+                                                          />
                                                         </button>
                                                       </DMButton>
                                                     </OverlayTrigger>

--- a/webapp/channels/src/components/user_group_popover/group_member_list/__snapshots__/group_member_list.test.tsx.snap
+++ b/webapp/channels/src/components/user_group_popover/group_member_list/__snapshots__/group_member_list.test.tsx.snap
@@ -530,20 +530,10 @@ exports[`component/user_group_popover/group_member_list should match snapshot 1`
                                           onMouseOut={[Function]}
                                           onMouseOver={[Function]}
                                         >
-                                          <LocalizedIcon
-                                            ariaLabel={
-                                              Object {
-                                                "defaultMessage": "Close",
-                                                "id": "user_group_popover.close",
-                                              }
-                                            }
+                                          <i
+                                            aria-label="Close"
                                             className="icon icon-send"
-                                          >
-                                            <i
-                                              aria-label="Close"
-                                              className="icon icon-send"
-                                            />
-                                          </LocalizedIcon>
+                                          />
                                         </button>
                                       </DMButton>
                                     </OverlayTrigger>
@@ -749,20 +739,10 @@ exports[`component/user_group_popover/group_member_list should match snapshot 1`
                                           onMouseOut={[Function]}
                                           onMouseOver={[Function]}
                                         >
-                                          <LocalizedIcon
-                                            ariaLabel={
-                                              Object {
-                                                "defaultMessage": "Close",
-                                                "id": "user_group_popover.close",
-                                              }
-                                            }
+                                          <i
+                                            aria-label="Close"
                                             className="icon icon-send"
-                                          >
-                                            <i
-                                              aria-label="Close"
-                                              className="icon icon-send"
-                                            />
-                                          </LocalizedIcon>
+                                          />
                                         </button>
                                       </DMButton>
                                     </OverlayTrigger>
@@ -968,20 +948,10 @@ exports[`component/user_group_popover/group_member_list should match snapshot 1`
                                           onMouseOut={[Function]}
                                           onMouseOver={[Function]}
                                         >
-                                          <LocalizedIcon
-                                            ariaLabel={
-                                              Object {
-                                                "defaultMessage": "Close",
-                                                "id": "user_group_popover.close",
-                                              }
-                                            }
+                                          <i
+                                            aria-label="Close"
                                             className="icon icon-send"
-                                          >
-                                            <i
-                                              aria-label="Close"
-                                              className="icon icon-send"
-                                            />
-                                          </LocalizedIcon>
+                                          />
                                         </button>
                                       </DMButton>
                                     </OverlayTrigger>
@@ -1187,20 +1157,10 @@ exports[`component/user_group_popover/group_member_list should match snapshot 1`
                                           onMouseOut={[Function]}
                                           onMouseOver={[Function]}
                                         >
-                                          <LocalizedIcon
-                                            ariaLabel={
-                                              Object {
-                                                "defaultMessage": "Close",
-                                                "id": "user_group_popover.close",
-                                              }
-                                            }
+                                          <i
+                                            aria-label="Close"
                                             className="icon icon-send"
-                                          >
-                                            <i
-                                              aria-label="Close"
-                                              className="icon icon-send"
-                                            />
-                                          </LocalizedIcon>
+                                          />
                                         </button>
                                       </DMButton>
                                     </OverlayTrigger>
@@ -1406,20 +1366,10 @@ exports[`component/user_group_popover/group_member_list should match snapshot 1`
                                           onMouseOut={[Function]}
                                           onMouseOver={[Function]}
                                         >
-                                          <LocalizedIcon
-                                            ariaLabel={
-                                              Object {
-                                                "defaultMessage": "Close",
-                                                "id": "user_group_popover.close",
-                                              }
-                                            }
+                                          <i
+                                            aria-label="Close"
                                             className="icon icon-send"
-                                          >
-                                            <i
-                                              aria-label="Close"
-                                              className="icon icon-send"
-                                            />
-                                          </LocalizedIcon>
+                                          />
                                         </button>
                                       </DMButton>
                                     </OverlayTrigger>

--- a/webapp/channels/src/components/user_group_popover/group_member_list/__snapshots__/group_member_list.test.tsx.snap
+++ b/webapp/channels/src/components/user_group_popover/group_member_list/__snapshots__/group_member_list.test.tsx.snap
@@ -531,7 +531,6 @@ exports[`component/user_group_popover/group_member_list should match snapshot 1`
                                           onMouseOver={[Function]}
                                         >
                                           <i
-                                            aria-label="Close"
                                             className="icon icon-send"
                                           />
                                         </button>
@@ -740,7 +739,6 @@ exports[`component/user_group_popover/group_member_list should match snapshot 1`
                                           onMouseOver={[Function]}
                                         >
                                           <i
-                                            aria-label="Close"
                                             className="icon icon-send"
                                           />
                                         </button>
@@ -949,7 +947,6 @@ exports[`component/user_group_popover/group_member_list should match snapshot 1`
                                           onMouseOver={[Function]}
                                         >
                                           <i
-                                            aria-label="Close"
                                             className="icon icon-send"
                                           />
                                         </button>
@@ -1158,7 +1155,6 @@ exports[`component/user_group_popover/group_member_list should match snapshot 1`
                                           onMouseOver={[Function]}
                                         >
                                           <i
-                                            aria-label="Close"
                                             className="icon icon-send"
                                           />
                                         </button>
@@ -1367,7 +1363,6 @@ exports[`component/user_group_popover/group_member_list should match snapshot 1`
                                           onMouseOver={[Function]}
                                         >
                                           <i
-                                            aria-label="Close"
                                             className="icon icon-send"
                                           />
                                         </button>

--- a/webapp/channels/src/components/user_group_popover/group_member_list/group_member_list.tsx
+++ b/webapp/channels/src/components/user_group_popover/group_member_list/group_member_list.tsx
@@ -14,13 +14,11 @@ import type {ServerError} from '@mattermost/types/errors';
 import type {Group} from '@mattermost/types/groups';
 import type {UserProfile} from '@mattermost/types/users';
 
-
 import NoResultsIndicator from 'components/no_results_indicator';
 import {NoResultsVariant} from 'components/no_results_indicator/types';
 import LoadingSpinner from 'components/widgets/loading/loading_spinner';
 import SimpleTooltip from 'components/widgets/simple_tooltip';
 import Avatar from 'components/widgets/users/avatar';
-
 
 import * as Utils from 'utils/utils';
 
@@ -199,7 +197,6 @@ const GroupMemberList = (props: Props) => {
                             >
                                 <i
                                     className='icon icon-send'
-                                    aria-label={formatMessage({id: 'user_group_popover.close', defaultMessage: 'Close'})}
                                 />
                             </DMButton>
                         </SimpleTooltip>

--- a/webapp/channels/src/components/user_group_popover/group_member_list/group_member_list.tsx
+++ b/webapp/channels/src/components/user_group_popover/group_member_list/group_member_list.tsx
@@ -14,14 +14,14 @@ import type {ServerError} from '@mattermost/types/errors';
 import type {Group} from '@mattermost/types/groups';
 import type {UserProfile} from '@mattermost/types/users';
 
-import LocalizedIcon from 'components/localized_icon';
+
 import NoResultsIndicator from 'components/no_results_indicator';
 import {NoResultsVariant} from 'components/no_results_indicator/types';
 import LoadingSpinner from 'components/widgets/loading/loading_spinner';
 import SimpleTooltip from 'components/widgets/simple_tooltip';
 import Avatar from 'components/widgets/users/avatar';
 
-import {t} from 'utils/i18n';
+
 import * as Utils from 'utils/utils';
 
 import {Load} from '../constants';
@@ -197,9 +197,9 @@ const GroupMemberList = (props: Props) => {
                                     {user: name})}
                                 onClick={() => showDirectChannel(user)}
                             >
-                                <LocalizedIcon
+                                <i
                                     className='icon icon-send'
-                                    ariaLabel={{id: t('user_group_popover.close'), defaultMessage: 'Close'}}
+                                    aria-label={formatMessage({id: 'user_group_popover.close', defaultMessage: 'Close'})}
                                 />
                             </DMButton>
                         </SimpleTooltip>


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Replaced the usage of LocalizedIcon in 'group_member_list.tsx' with i tag
#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-55109

Fixes [#25101](https://github.com/mattermost/mattermost/issues/25101)
#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
  NONE
```
