### PR TITLE
MM-54737 Fix error when updating a GM/DM

### DIFF
--- a/webapp/channels/src/actions/websocket_actions.jsx
+++ b/webapp/channels/src/actions/websocket_actions.jsx
@@ -644,7 +644,8 @@ export function handleChannelUpdatedEvent(msg) {
 
         if (channel.id === getCurrentChannelId(state)) {
             // using channel's team_id to ensure we always redirect to current channel even if channel's team changes.
-            getHistory().replace(`${getRelativeTeamUrl(state, channel.team_id)}/channels/${channel.name}`);
+            const teamId = channel.team_id || getCurrentTeamId(state);
+            getHistory().replace(`${getRelativeTeamUrl(state, teamId)}/channels/${channel.name}`);
         }
     };
 }


### PR DESCRIPTION
#### Summary
We changed how we deal with the history replace after a channel updated event to use the channel id, to handle team changes.

Nevertheless, the channel may change for other reasons, like updating the channel header. In GMs/DMs this resulted in a JavaScript error.

Now we make sure the teamId is always defined, taking the one from the channel, and if there is none (is a GM or a DM) we use the current one (which we assume always defined).

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-54737

#### Release Note
```release-note
Fix issue when updating the header of GMs.
```
