### PR TITLE
[MM-55119] Replace usage of LocalizedIcon in 'fa_previous_icon.tsx' with i/span tags

### DIFF
--- a/webapp/channels/src/components/widgets/icons/fa_previous_icon.tsx
+++ b/webapp/channels/src/components/widgets/icons/fa_previous_icon.tsx
@@ -3,27 +3,20 @@
 
 import classNames from 'classnames';
 import React from 'react';
-import {defineMessage} from 'react-intl';
-
-import LocalizedIcon from 'components/localized_icon';
+import {useIntl} from 'react-intl';
 
 type Props = {
     additionalClassName?: string;
 }
 
-const iconTitle = defineMessage({
-    id: 'generic_icons.previous',
-    defaultMessage: 'Previous Icon',
-});
-
 const PreviousIcon = ({additionalClassName}: Props) => {
+    const {formatMessage} = useIntl();
     return (
-        <LocalizedIcon
+        <i
             className={classNames('icon icon-chevron-left', additionalClassName)}
-            title={iconTitle}
+            title={formatMessage({id: 'generic_icons.previous', defaultMessage: 'Previous Icon'})}
         />
     );
 };
 
 export default React.memo(PreviousIcon);
-

--- a/webapp/channels/src/components/widgets/icons/fa_previous_icon.tsx
+++ b/webapp/channels/src/components/widgets/icons/fa_previous_icon.tsx
@@ -11,6 +11,7 @@ type Props = {
 
 const PreviousIcon = ({additionalClassName}: Props) => {
     const {formatMessage} = useIntl();
+    
     return (
         <i
             className={classNames('icon icon-chevron-left', additionalClassName)}

--- a/webapp/channels/src/components/widgets/icons/fa_previous_icon.tsx
+++ b/webapp/channels/src/components/widgets/icons/fa_previous_icon.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 const PreviousIcon = ({additionalClassName}: Props) => {
     const {formatMessage} = useIntl();
-    
+
     return (
         <i
             className={classNames('icon icon-chevron-left', additionalClassName)}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR replaces the usage of LocalizedIcon with i tag in `webapp/channels/src/components/widgets/icons/fa_previous_icon.tsx` file.

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-55119

Fixes : #25091 

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
