### PR TITLE
Fix typos caused by applyTheme migration

### DIFF
--- a/webapp/channels/src/sass/components/_files.scss
+++ b/webapp/channels/src/sass/components/_files.scss
@@ -208,7 +208,7 @@
             max-width: 100%;
             min-height: 40px;
             max-height: $max-image-height;
-            border-color: rgba(var(--center-channel-color), 0.12);
+            border-color: rgba(var(--center-channel-color-rgb), 0.12);
             border-radius: 4px;
             transition: all 0.1s linear;
 

--- a/webapp/channels/src/sass/components/_modal.scss
+++ b/webapp/channels/src/sass/components/_modal.scss
@@ -669,7 +669,7 @@
         flex: 32px 0 0;
         align-items: center;
         justify-content: center;
-        background: rgba(var(--center-channel-color), 0.2);
+        background: rgba(var(--center-channel-color-rgb), 0.2);
         border-radius: 50%;
     }
 

--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -667,7 +667,7 @@
         }
 
         .post__body {
-            color: rbga(var(--center-channel-color-rgb), 0.6);
+            color: rgba(var(--center-channel-color-rgb), 0.6);
         }
     }
 
@@ -1540,10 +1540,11 @@
         }
     }
 
+    // This class is used for the "Commented on" messages with CRT disabled
     .post__link {
         overflow: hidden;
         margin: 2px 0 5px;
-        color: rgba(var(--center-channel-color), 0.65);
+        color: rgba(var(--center-channel-color-rgb), 0.65);
         font-size: 13px;
         text-overflow: ellipsis;
         -webkit-user-select: none; /* Chrome all / Safari all */


### PR DESCRIPTION
#### Summary
This seems straightforward enough of a fix.

I've been thinking of adding an scss helper function so that we don't need to remember to use `var(--theme-variable)` or `rgba(var(--theme-variable-rgb), 0.5)` exactly, but that seems like it'll result in a lot of changes, so I'd be hesitant to do that.

#### Release Note
```release-note
NONE
```
