### PR TITLE
report master/release-* failures

### DIFF
--- a/.github/workflows/workflow-failure-check.yml
+++ b/.github/workflows/workflow-failure-check.yml
@@ -1,0 +1,19 @@
+name: Report on master workflow failure
+on:
+  workflow_run:
+    workflows: [Server CI Master, Web App CI Master]
+    types: [completed]
+
+jobs:
+  on-failure:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure'
+    steps:
+      name: Report failure
+        run: |
+          curl \
+            --fail \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "{\"text\":\"#### ⚠️  ${{github.repository}}/${{ github.event.workflow_run.head_branch }} - ${{github.event.workflow_run.name}} build failure ⚠️\\nThe build is failing: [view failure](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}).\\n\"}" \
+            ${{ secrets.MM_COMMUNITY_DEVELOPERS_INCOMING_WEBHOOK_FROM_GH_ACTIONS }}


### PR DESCRIPTION
#### Summary
The `master` build has been failing for some time now with minimal visibility. In general, this often catches us by surprise because we don't have anything wired up to notify developers. While this will be "noisy" when `master` is broken, it's by design as we should all consider shared ownership of a working build to be of utmost importance.

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
