### PR TITLE
Wrap "remember this choice" control in a <label>

### DIFF
--- a/webapp/channels/src/components/linking_landing_page/linking_landing_page.tsx
+++ b/webapp/channels/src/components/linking_landing_page/linking_landing_page.tsx
@@ -393,16 +393,18 @@ export default class LinkingLandingPage extends PureComponent<Props, State> {
                     </a>
                 </div>
                 <div className='get-app__preference'>
-                    <button
-                        className={`get-app__checkbox ${this.state.rememberChecked ? 'checked' : ''}`}
-                        onClick={this.handleChecked}
-                    >
-                        {this.renderCheckboxIcon()}
-                    </button>
-                    <FormattedMessage
-                        id='get_app.rememberMyPreference'
-                        defaultMessage='Remember my preference'
-                    />
+                    <label>
+                        <button
+                            className={`get-app__checkbox ${this.state.rememberChecked ? 'checked' : ''}`}
+                            onClick={this.handleChecked}
+                        >
+                            {this.renderCheckboxIcon()}
+                        </button>
+                        <FormattedMessage
+                            id='get_app.rememberMyPreference'
+                            defaultMessage='Remember my preference'
+                        />
+                    </label>
                 </div>
                 {this.renderDownloadLinkSection()}
             </div>


### PR DESCRIPTION
#### Summary

Make the "remember this choice" input/control easier to hit

> Associating a <label> with a form control, such as [<input>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) or [<textarea>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) offers some major advantages:
> 
> - The label text is not only visually associated with its corresponding text input; it is programmatically associated with it too. This means that, for example, a screen reader will read out the label when the user is focused on the form input, making it easier for an assistive technology user to understand what data should be entered.
> - When a user clicks or touches/taps a label, the browser passes the focus to its associated input (the resulting event is also raised for the input). That increased hit area for focusing the input provides an advantage to anyone trying to activate it — including those using a touch-screen device.

-- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label

#### Release Note

```release-note
NONE
```
