### PR TITLE
Fix flaky test introduced in #24602

### DIFF
--- a/server/channels/app/post_test.go
+++ b/server/channels/app/post_test.go
@@ -513,7 +513,7 @@ func TestUpdatePostPluginHooks(t *testing.T) {
 				}
 
 				func (p *MyPlugin) MessageWillBeUpdated(c *plugin.Context, newPost, oldPost *model.Post) (*model.Post, string) {
-					newPost.Message = newPost.Message + " 2"
+					newPost.Message = "2 " + newPost.Message
 					return newPost, ""
 				}
 
@@ -541,7 +541,7 @@ func TestUpdatePostPluginHooks(t *testing.T) {
 		updatedPost, err := th.App.UpdatePost(th.Context, post, false)
 		require.Nil(t, err)
 		require.NotNil(t, updatedPost)
-		require.Equal(t, "new message 1 2", updatedPost.Message)
+		require.Equal(t, "2 new message 1", updatedPost.Message)
 	})
 }
 


### PR DESCRIPTION
#### Summary
Apparently, the order of execution of the hooks is not deterministic, causing in some circumstances the final message to be `new message 2 1` instead of `new message 1 2`.

In order to avoid make this deterministic, instead of adding to the end of the message the string, one of the plugins will add it to the end, and the other to the beginning. That way it is properly deterministic.

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
