### PR TITLE
[MM-55009] Remove pre-fetch preference and set new pre fetch limits

### DIFF
--- a/webapp/channels/src/components/data_prefetch/data_prefetch.test.tsx
+++ b/webapp/channels/src/components/data_prefetch/data_prefetch.test.tsx
@@ -68,8 +68,6 @@ describe('/components/data_prefetch', () => {
             last_post_at: 1235,
             last_root_post_at: 1235,
         })],
-        disableWebappPrefetchAllowed: false,
-        dataPrefetchEnabled: true,
     };
 
     beforeEach(() => {

--- a/webapp/channels/src/components/data_prefetch/data_prefetch.tsx
+++ b/webapp/channels/src/components/data_prefetch/data_prefetch.tsx
@@ -22,8 +22,6 @@ type Props = {
 
     unreadChannels: Channel[];
 
-    disableWebappPrefetchAllowed: boolean;
-    dataPrefetchEnabled: boolean;
     actions: {
         prefetchChannelPosts: (channelId: string, delay?: number) => Promise<any>;
         trackPreloadedChannels: (prefetchQueueObj: Record<string, string[]>) => void;
@@ -55,20 +53,15 @@ export default class DataPrefetch extends React.PureComponent<Props> {
     private prefetchTimeout?: number;
 
     async componentDidUpdate(prevProps: Props) {
-        const {currentChannelId, prefetchQueueObj, sidebarLoaded, disableWebappPrefetchAllowed, dataPrefetchEnabled} = this.props;
-        const enablePrefetch = (!disableWebappPrefetchAllowed) || (disableWebappPrefetchAllowed && dataPrefetchEnabled);
+        const {currentChannelId, prefetchQueueObj, sidebarLoaded} = this.props;
         if (currentChannelId && sidebarLoaded && (!prevProps.currentChannelId || !prevProps.sidebarLoaded)) {
             queue.add(async () => this.prefetchPosts(currentChannelId));
             await loadProfilesForSidebar();
-            if (enablePrefetch) {
-                this.prefetchData();
-            }
+            this.prefetchData();
         } else if (prevProps.prefetchQueueObj !== prefetchQueueObj) {
             clearTimeout(this.prefetchTimeout);
             await queue.clear();
-            if (enablePrefetch) {
-                this.prefetchData();
-            }
+            this.prefetchData();
         }
 
         if (currentChannelId && sidebarLoaded && (!prevProps.currentChannelId || !prevProps.sidebarLoaded)) {

--- a/webapp/channels/src/components/user_settings/advanced/index.ts
+++ b/webapp/channels/src/components/user_settings/advanced/index.ts
@@ -7,7 +7,7 @@ import type {ActionCreatorsMapObject, Dispatch} from 'redux';
 
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {updateUserActive, revokeAllSessionsForUser} from 'mattermost-redux/actions/users';
-import {getConfig, isPerformanceDebuggingEnabled} from 'mattermost-redux/selectors/entities/general';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {get, getUnreadScrollPositionPreference, makeGetCategory, syncedDraftsAreAllowed} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import type {ActionFunc} from 'mattermost-redux/types/actions';
@@ -27,7 +27,6 @@ function makeMapStateToProps() {
 
         const enablePreviewFeatures = config.EnablePreviewFeatures === 'true';
         const enableUserDeactivation = config.EnableUserDeactivation === 'true';
-        const disableWebappPrefetchAllowed = isPerformanceDebuggingEnabled(state);
         const enableJoinLeaveMessage = config.EnableJoinLeaveMessageByDefault === 'true';
 
         return {
@@ -42,8 +41,6 @@ function makeMapStateToProps() {
             enablePreviewFeatures,
             enableUserDeactivation,
             syncedDraftsAreAllowed: syncedDraftsAreAllowed(state),
-            disableWebappPrefetchAllowed,
-            dataPrefetchEnabled: get(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'data_prefetch', 'true'),
         };
     };
 }

--- a/webapp/channels/src/components/user_settings/advanced/user_settings_advanced.test.tsx
+++ b/webapp/channels/src/components/user_settings/advanced/user_settings_advanced.test.tsx
@@ -47,8 +47,6 @@ describe('components/user_settings/display/UserSettingsDisplay', () => {
         enablePreviewFeatures: false,
         enableUserDeactivation: false,
         syncedDraftsAreAllowed: true,
-        disableWebappPrefetchAllowed: false,
-        dataPrefetchEnabled: 'true',
     };
 
     test('should have called handleSubmit', async () => {

--- a/webapp/channels/src/components/user_settings/advanced/user_settings_advanced.tsx
+++ b/webapp/channels/src/components/user_settings/advanced/user_settings_advanced.tsx
@@ -36,7 +36,6 @@ type Settings = {
     formatting: Props['formatting'];
     join_leave: Props['joinLeave'];
     sync_drafts: Props['syncDrafts'];
-    data_prefetch: Props['dataPrefetchEnabled'];
 };
 
 export type Props = {
@@ -55,8 +54,6 @@ export type Props = {
     enablePreviewFeatures: boolean;
     enableUserDeactivation: boolean;
     syncedDraftsAreAllowed: boolean;
-    disableWebappPrefetchAllowed: boolean;
-    dataPrefetchEnabled: string;
     actions: {
         savePreferences: (userId: string, preferences: PreferenceType[]) => Promise<ActionResult>;
         updateUserActive: (userId: string, active: boolean) => Promise<ActionResult>;
@@ -90,7 +87,6 @@ export default class AdvancedSettingsDisplay extends React.PureComponent<Props, 
             formatting: this.props.formatting,
             join_leave: this.props.joinLeave,
             sync_drafts: this.props.syncDrafts,
-            data_prefetch: this.props.dataPrefetchEnabled,
             [Preferences.UNREAD_SCROLL_POSITION]: this.props.unreadScrollPosition,
         };
 
@@ -579,93 +575,6 @@ export default class AdvancedSettingsDisplay extends React.PureComponent<Props, 
         );
     };
 
-    renderDataPrefetchSection = () => {
-        const active = this.props.activeSection === AdvancedSections.DATA_PREFETCH;
-        let max = null;
-        if (active) {
-            max = (
-                <SettingItemMax
-                    title={
-                        <FormattedMessage
-                            id='user.settings.advance.dataPrefetch.Title'
-                            defaultMessage='Allow Mattermost to prefetch channel posts'
-                        />
-                    }
-                    inputs={[
-                        <fieldset key='syncDraftsSetting'>
-                            <legend className='form-legend hidden-label'>
-                                <FormattedMessage
-                                    id='user.settings.advance.dataPrefetch.Title'
-                                    defaultMessage='Allow Mattermost to prefetch channel posts'
-                                />
-                            </legend>
-                            <div className='radio'>
-                                <label>
-                                    <input
-                                        id='dataPrefetchOn'
-                                        type='radio'
-                                        name='dataPrefetch'
-                                        checked={this.state.settings.data_prefetch !== 'false'}
-                                        onChange={this.updateSetting.bind(this, 'data_prefetch', 'true')}
-                                    />
-                                    <FormattedMessage
-                                        id='user.settings.advance.on'
-                                        defaultMessage='On'
-                                    />
-                                </label>
-                                <br/>
-                            </div>
-                            <div className='radio'>
-                                <label>
-                                    <input
-                                        id='dataPrefetchOff'
-                                        type='radio'
-                                        name='dataPrefetch'
-                                        checked={this.state.settings.data_prefetch === 'false'}
-                                        onChange={this.updateSetting.bind(this, 'data_prefetch', 'false')}
-                                    />
-                                    <FormattedMessage
-                                        id='user.settings.advance.off'
-                                        defaultMessage='Off'
-                                    />
-                                </label>
-                                <br/>
-                            </div>
-                            <div className='mt-5'>
-                                <FormattedMessage
-                                    id='user.settings.advance.dataPrefetch.Desc'
-                                    defaultMessage='When disabled, messages and user information will be fetched on each channel load instead of being pre-fetched on startup. Disabling prefetch is recommended for users with a high unread channel count in order to improve application performance.'
-                                />
-                            </div>
-                        </fieldset>,
-                    ]}
-                    setting={AdvancedSections.DATA_PREFETCH}
-                    submit={this.handleSubmit.bind(this, ['data_prefetch'])}
-                    saving={this.state.isSaving}
-                    serverError={this.state.serverError}
-                    updateSection={this.handleUpdateSection}
-                />
-            );
-        }
-
-        return (
-            <SettingItem
-                active={active}
-                areAllSectionsInactive={this.props.activeSection === ''}
-                title={
-                    <FormattedMessage
-                        id='user.settings.advance.dataPrefetch.Title'
-                        defaultMessage='Allow Mattermost to prefetch channel posts'
-                    />
-                }
-                describe={this.renderOnOffLabel(this.state.settings.data_prefetch)}
-                section={AdvancedSections.DATA_PREFETCH}
-                updateSection={this.handleUpdateSection}
-                max={max}
-            />
-        );
-    };
-
     renderFeatureLabel(feature: string): ReactNode {
         switch (feature) {
         case 'MARKDOWN_PREVIEW':
@@ -986,15 +895,6 @@ export default class AdvancedSettingsDisplay extends React.PureComponent<Props, 
             }
         }
 
-        let dataPrefetchSection = null;
-        let dataPrefetchSectionDivider = null;
-        if (this.props.disableWebappPrefetchAllowed) {
-            dataPrefetchSection = this.renderDataPrefetchSection();
-            if (syncDraftsSection) {
-                dataPrefetchSectionDivider = <div className='divider-light'/>;
-            }
-        }
-
         return (
             <div>
                 <div className='modal-header'>
@@ -1053,8 +953,6 @@ export default class AdvancedSettingsDisplay extends React.PureComponent<Props, 
                     {unreadScrollPositionSection}
                     {syncDraftsSectionDivider}
                     {syncDraftsSection}
-                    {dataPrefetchSectionDivider}
-                    {dataPrefetchSection}
                     <div className='divider-dark'/>
                     {makeConfirmationModal}
                 </div>

--- a/webapp/channels/src/packages/mattermost-redux/src/constants/preferences.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/constants/preferences.ts
@@ -55,7 +55,6 @@ const Preferences = {
     ADVANCED_CODE_BLOCK_ON_CTRL_ENTER: 'code_block_ctrl_enter',
     ADVANCED_SEND_ON_CTRL_ENTER: 'send_on_ctrl_enter',
     ADVANCED_SYNC_DRAFTS: 'sync_drafts',
-    ADVANCED_DATA_PREFETCH: 'data_prefetch',
     CATEGORY_WHATS_NEW_MODAL: 'whats_new_modal',
     HAS_SEEN_SIDEBAR_WHATS_NEW_MODAL: 'has_seen_sidebar_whats_new_modal',
 

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -1014,7 +1014,6 @@ export const AdvancedSections = {
     PREVIEW_FEATURES: 'advancedPreviewFeatures',
     PERFORMANCE_DEBUGGING: 'performanceDebugging',
     SYNC_DRAFTS: 'syncDrafts',
-    DATA_PREFETCH: 'dataPrefetch',
 };
 
 export const RHSStates = {


### PR DESCRIPTION
#### Summary
The goal of this is to find a balance for pre-fetching and making the webapp more usable for people with a high number of unread channels. After experimenting on Community we came up with these limits.

1. <10 unread channels. Prefetch everything.

2. 10-20 unread. Prefetch only mentions, capped to 10.

3. ">20 unread. Don't prefetch anything.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55009

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Remove pre-fetch preference and set new pre fetch limits for the webapp
```
