### PR TITLE
fix yaml formatting issue

### DIFF
--- a/.github/workflows/workflow-failure-check.yml
+++ b/.github/workflows/workflow-failure-check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'failure'
     steps:
-      name: Report failure
+      - name: Report failure
         run: |
           curl \
             --fail \


### PR DESCRIPTION
#### Summary
Looks like my check to report when `master` fails had a YAML syntax check. Somehow I had hoped GitHub's CI would test this even though it doesn't run on PRs, but it looks like I need to be more careful with my editor setup instead. (Suggestions welcome!)

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
