### PR TITLE
MM-55042 Fixes permissions checks

### DIFF
--- a/server/channels/store/storetest/channel_store.go
+++ b/server/channels/store/storetest/channel_store.go
@@ -3524,6 +3524,10 @@ func testChannelStoreGetChannels(t *testing.T, ss store.Store) {
 	_, ok = ids4[o1.Id]
 	require.True(t, ok, "missing channel")
 
+	ids5, err := ss.Channel().GetAllChannelMembersForUser(model.NewId(), true, true)
+	require.NoError(t, err)
+	require.True(t, len(ids5) == 0)
+
 	// Sleeping to guarantee that the
 	// UpdateAt is different.
 	// The proper way would be to set UpdateAt during channel creation itself,


### PR DESCRIPTION

#### Summary
Fixes permissions check on SessionHasPermissionToTeams and SessionHasPermissionToChannels. Previous check didn't check individual channels, but rather access to any channel in the list.

The ticket only required SessionHasPermissionToChannels, but SessionHasPermissionToTeams had the same issue. Also added unit tests for both functions.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-55042

#### Release Note
```release-note
None
```
