### PR TITLE
[MM-47431] Refactor action creators to dispatch thunk

### DIFF
--- a/webapp/channels/src/actions/admin_actions.jsx
+++ b/webapp/channels/src/actions/admin_actions.jsx
@@ -38,7 +38,7 @@ export async function adminResetMfa(userId, success, error) {
 }
 
 export async function getClusterStatus(success, error) {
-    const {data, error: err} = await AdminActions.getClusterStatus()(dispatch, getState);
+    const {data, error: err} = await dispatch(AdminActions.getClusterStatus());
     if (data && success) {
         success(data);
     } else if (err && error) {
@@ -47,7 +47,7 @@ export async function getClusterStatus(success, error) {
 }
 
 export async function ldapTest(success, error) {
-    const {data, error: err} = await AdminActions.testLdap()(dispatch, getState);
+    const {data, error: err} = await dispatch(AdminActions.testLdap());
     if (data && success) {
         success(data);
     } else if (err && error) {
@@ -56,7 +56,7 @@ export async function ldapTest(success, error) {
 }
 
 export async function invalidateAllCaches(success, error) {
-    const {data, error: err} = await AdminActions.invalidateCaches()(dispatch, getState);
+    const {data, error: err} = await dispatch(AdminActions.invalidateCaches());
     if (data && success) {
         success(data);
     } else if (err && error) {
@@ -65,7 +65,7 @@ export async function invalidateAllCaches(success, error) {
 }
 
 export async function recycleDatabaseConnection(success, error) {
-    const {data, error: err} = await AdminActions.recycleDatabase()(dispatch, getState);
+    const {data, error: err} = await dispatch(AdminActions.recycleDatabase());
     if (data && success) {
         success(data);
     } else if (err && error) {
@@ -83,7 +83,7 @@ export async function adminResetEmail(user, success, error) {
 }
 
 export async function samlCertificateStatus(success, error) {
-    const {data, error: err} = await AdminActions.getSamlCertificateStatus()(dispatch, getState);
+    const {data, error: err} = await dispatch(AdminActions.getSamlCertificateStatus());
     if (data && success) {
         success(data);
     } else if (err && error) {
@@ -147,7 +147,7 @@ export async function uploadBrandImage(brandImage, success, error) {
 }
 
 export async function deleteBrandImage(success, error) {
-    const {data, error: err} = await AdminActions.deleteBrandImage()(dispatch, getState);
+    const {data, error: err} = await dispatch(AdminActions.deleteBrandImage());
     if (data && success) {
         success(data);
     } else if (err && error) {
@@ -200,7 +200,7 @@ export async function uploadIdpSamlCertificate(file, success, error) {
 }
 
 export async function removePublicSamlCertificate(success, error) {
-    const {data, error: err} = await AdminActions.removePublicSamlCertificate()(dispatch, getState);
+    const {data, error: err} = await dispatch(AdminActions.removePublicSamlCertificate());
     if (data && success) {
         success(data);
     } else if (err && error) {
@@ -209,7 +209,7 @@ export async function removePublicSamlCertificate(success, error) {
 }
 
 export async function removePrivateSamlCertificate(success, error) {
-    const {data, error: err} = await AdminActions.removePrivateSamlCertificate()(dispatch, getState);
+    const {data, error: err} = await dispatch(AdminActions.removePrivateSamlCertificate());
     if (data && success) {
         success(data);
     } else if (err && error) {
@@ -218,7 +218,7 @@ export async function removePrivateSamlCertificate(success, error) {
 }
 
 export async function removePublicLdapCertificate(success, error) {
-    const {data, error: err} = await AdminActions.removePublicLdapCertificate()(dispatch, getState);
+    const {data, error: err} = await dispatch(AdminActions.removePublicLdapCertificate());
     if (data && success) {
         success(data);
     } else if (err && error) {
@@ -227,7 +227,7 @@ export async function removePublicLdapCertificate(success, error) {
 }
 
 export async function removePrivateLdapCertificate(success, error) {
-    const {data, error: err} = await AdminActions.removePrivateLdapCertificate()(dispatch, getState);
+    const {data, error: err} = await dispatch(AdminActions.removePrivateLdapCertificate());
     if (data && success) {
         success(data);
     } else if (err && error) {
@@ -236,7 +236,7 @@ export async function removePrivateLdapCertificate(success, error) {
 }
 
 export async function removeIdpSamlCertificate(success, error) {
-    const {data, error: err} = await AdminActions.removeIdpSamlCertificate()(dispatch, getState);
+    const {data, error: err} = await dispatch(AdminActions.removeIdpSamlCertificate());
     if (data && success) {
         success(data);
     } else if (err && error) {
@@ -274,7 +274,7 @@ export async function elasticsearchTest(config, success, error) {
 }
 
 export async function testS3Connection(success, error) {
-    const {data, error: err} = await AdminActions.testS3Connection()(dispatch, getState);
+    const {data, error: err} = await dispatch(AdminActions.testS3Connection());
     if (data && success) {
         success(data);
     } else if (err && error) {
@@ -283,7 +283,7 @@ export async function testS3Connection(success, error) {
 }
 
 export async function elasticsearchPurgeIndexes(success, error) {
-    const {data, error: err} = await AdminActions.purgeElasticsearchIndexes()(dispatch, getState);
+    const {data, error: err} = await dispatch(AdminActions.purgeElasticsearchIndexes());
     if (data && success) {
         success(data);
     } else if (err && error) {


### PR DESCRIPTION
#### Summary
Changed action creators of the form `Fn(args)(dispatch, getState)` to be `dispatch(Fn(args))`
#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/21345
Jira https://mattermost.atlassian.net/browse/MM-47431

#### Release Note
Refactored **admin_actions.jsx** with regex find
```release-note
await (\w*).(\w*)\((\w*)\)\(dispatch, getState\);
```
and replace
```release-note
await dispatch($1.$2($3));
```