### PR TITLE
[MM-55112] Replace usage of LocalizedIcon in 'user_settings_notifications.tsx' with i/span tags

### DIFF
--- a/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.tsx
+++ b/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.tsx
@@ -17,12 +17,10 @@ import type {UserNotifyProps, UserProfile} from '@mattermost/types/users';
 import type {ActionResult} from 'mattermost-redux/types/actions';
 
 import ExternalLink from 'components/external_link';
-import LocalizedIcon from 'components/localized_icon';
 import SettingItem from 'components/setting_item';
 import SettingItemMax from 'components/setting_item_max';
 
 import Constants, {NotificationLevels} from 'utils/constants';
-import {t} from 'utils/i18n';
 import {stopTryNotificationRing} from 'utils/notification_sounds';
 import {a11yFocus} from 'utils/utils';
 
@@ -1068,12 +1066,12 @@ class NotificationsTab extends React.PureComponent<Props, State> {
                         ref={this.drawerRef}
                     >
                         <div className='modal-back'>
-                            <LocalizedIcon
+                            <i
                                 className='fa fa-angle-left'
-                                ariaLabel={{
-                                    id: t('generic_icons.collapse'),
+                                aria-label={this.props.intl.formatMessage({
+                                    id: 'generic_icons.collapse',
                                     defaultMessage: 'Collapse Icon',
-                                }}
+                                })}
                                 onClick={this.props.collapseModal}
                             />
                         </div>


### PR DESCRIPTION
#### Summary
This PR implements the following changes in `user_settings_notifications.tsx`:
- replaced `LocalizedIcon` with `i` tag
- replaced `t` function with `intl.formatMessage` in `aria-label` prop

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/25098
Jira https://mattermost.atlassian.net/browse/MM-55112


#### Screenshots

|  before  |  after  |
|----|----|
| ![before](https://github.com/mattermost/mattermost/assets/75561750/d2722b50-6bce-4a9f-8616-4ca8ddae700d)  | ![after](https://github.com/mattermost/mattermost/assets/75561750/60f50a07-6c24-4489-8938-ae5542f0fa35) |


#### Release Note
```release-note
NONE
```
