### PR TITLE
Update documentation on JS API client

### DIFF
--- a/api/v4/source/introduction.yaml
+++ b/api/v4/source/introduction.yaml
@@ -57,7 +57,9 @@ tags:
 
       #### Official Drivers
 
-      * [Mattermost JavaScript Driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.ts)
+      * Mattermost JavaScript/TypeScript Driver
+        * [NPM](https://www.npmjs.com/package/@mattermost/client)
+        * [Source](https://github.com/mattermost/mattermost/tree/master/webapp/platform/client)
 
       * [Mattermost Golang Driver](https://github.com/mattermost/mattermost/blob/master/server/public/model/client4.go)
 

--- a/webapp/platform/client/README.md
+++ b/webapp/platform/client/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@mattermost/client?style=flat)](https://www.npmjs.com/package/@mattermost/client)
 
-This package contains the JavaScript/TypeScript client for [Mattermost](https://github.com/mattermost/mattermost-server). It's used by [the Mattermost web app](https://github.com/mattermost/mattermost-webapp) and related projects.
+This package contains the JavaScript/TypeScript client for [Mattermost](https://github.com/mattermost/mattermost). It's used by [the Mattermost web app](https://github.com/mattermost/mattermost/tree/master/webapp/channels) and related projects.
 
 ## Installation
 

--- a/webapp/platform/client/README.md
+++ b/webapp/platform/client/README.md
@@ -1,6 +1,64 @@
 # Mattermost Client
 
+[![npm version](https://img.shields.io/npm/v/@mattermost/client?style=flat)](https://www.npmjs.com/package/@mattermost/client)
+
 This package contains the JavaScript/TypeScript client for [Mattermost](https://github.com/mattermost/mattermost-server). It's used by [the Mattermost web app](https://github.com/mattermost/mattermost-webapp) and related projects.
+
+## Installation
+
+### JavaScript
+
+```sh
+$ npm install @mattermost/client
+```
+
+### TypeScript
+
+```sh
+$ npm install @mattermost/client @mattermost/types
+```
+
+## Usage
+
+To use the client, create an instance of `Client4`, set the server URL, and log in, and then you can start making requests.
+
+```js
+import {Client4} from '@mattermost/client';
+
+const client = new Client4();
+client4.setUrl('https://mymattermostserver.example.com');
+
+client4.login('username', 'password').then((user) => {
+    // ...
+});
+```
+
+If you already have a session token or a user access token, you can call `Client4.setToken` instead of logging in.
+
+```js
+import {Client4} from '@mattermost/client';
+
+const client = new Client4();
+client4.setUrl('https://mymattermostserver.example.com');
+
+client4.setToken('accesstoken');
+```
+
+If needed, methods exist to set other headers such as the User-Agent (`Client4.setUserAgent`), the CSRF token (`Client4.setCSRF`), or any extra headers you wish to include (`Client4.setHeader`).
+
+Methods of `Client4` which make requests to the server return a `Promise` which does the following:
+
+- On success, the promise resolves to a `ClientResponse<T>` object which contains the the [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) (`response`), a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of headers (`headers`), and the data sent from the server (`data`).
+- On an error, the promise rejects with a `ClientError` which contains the error message and the URL being requested. If the error happened on the server, the status code and an error ID (`server_error_id`) are included.
+
+```js
+let user;
+try {
+    user = (await client.getUser('userid')).data;
+} catch (e) {
+    console.error(`An error occurred when making a request to ${e.url}: ${e.message}`);
+}
+```
 
 ## Compilation and Packaging
 


### PR DESCRIPTION
#### Summary
I noticed earlier that https://api.mattermost.com hasn't pointed to the correct location of the API client since before that was moved into the web app repo and it was shipped as part of its own package, so I wanted to update that. At the same time, I also realized that the documentation on the NPM package was lacking, so I added a bit more information to the README as well.

#### Release Note
```release-note
NONE
```
