### PR TITLE
Fix - Run artifacts workflow only for monorepo branches

### DIFF
--- a/.github/workflows/server-ci-artifacts.yml
+++ b/.github/workflows/server-ci-artifacts.yml
@@ -54,7 +54,7 @@ jobs:
           aws-region: us-east-1
           aws-access-key-id: ${{ secrets.PR_BUILDS_BUCKET_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PR_BUILDS_BUCKET_AWS_SECRET_ACCESS_KEY }}
-        if: needs['determine-if-monorepo'].outputs.is_monorepo
+        if: needs['determine-if-monorepo'].outputs.is_monorepo == 'true'
 
       - name: cd/download-artifacts-from-PR-workflow
         uses: dawidd6/action-download-artifact@0c49384d39ceb023b8040f480a25596fd6cf441b # v2.26.0
@@ -64,7 +64,7 @@ jobs:
           workflow_conclusion: success
           name: server-dist-artifact
           path: server/dist
-        if: needs['determine-if-monorepo'].outputs.is_monorepo
+        if: needs['determine-if-monorepo'].outputs.is_monorepo == 'true'
 
       - name: cd/generate-packages-file-list
         working-directory: ./server/dist
@@ -72,11 +72,11 @@ jobs:
           echo "PACKAGES_FILE_LIST<<EOF" >> "${GITHUB_ENV}"
           ls | grep -E "*.(tar.gz|zip)$" >> "${GITHUB_ENV}"
           echo "EOF" >> "${GITHUB_ENV}"
-        if: needs['determine-if-monorepo'].outputs.is_monorepo
+        if: needs['determine-if-monorepo'].outputs.is_monorepo == 'true'
 
       - name: cd/upload-artifacts-to-s3
         run: aws s3 sync server/dist/ s3://pr-builds.mattermost.com/mattermost/commit/${{ github.event.workflow_run.head_sha }}/ --cache-control no-cache --no-progress --acl public-read
-        if: needs['determine-if-monorepo'].outputs.is_monorepo
+        if: needs['determine-if-monorepo'].outputs.is_monorepo == 'true'
 
       - name: cd/generate-summary
         run: |
@@ -89,19 +89,20 @@ jobs:
             do 
               echo "|[${package}](https://s3.amazonaws.com/pr-builds.mattermost.com/mattermost/commit/${{ github.event.workflow_run.head_sha }}/${package})|" >> "${GITHUB_STEP_SUMMARY}"
           done
-        if: needs['determine-if-monorepo'].outputs.is_monorepo
+        if: needs['determine-if-monorepo'].outputs.is_monorepo == 'true'
 
   build-docker:
     runs-on: ubuntu-22.04
     needs:
       - upload-artifacts
+      - determine-if-monorepo
     steps:
       - name: cd/docker-login
         uses: docker/login-action@3da7dc6e2b31f99ef2cb9fb4c50fb0971e0d0139 # v2.1.0
         with:
           username: mattermostdev
           password: ${{ secrets.DOCKERHUB_DEV_TOKEN }}
-        if: needs['determine-if-monorepo'].outputs.is_monorepo
+        if: needs['determine-if-monorepo'].outputs.is_monorepo == 'true'
 
       - name: cd/download-artifacts-from-PR-workflow
         uses: dawidd6/action-download-artifact@0c49384d39ceb023b8040f480a25596fd6cf441b # v2.26.0
@@ -111,11 +112,11 @@ jobs:
           workflow_conclusion: success
           name: server-build-artifact
           path: server/build/
-        if: needs['determine-if-monorepo'].outputs.is_monorepo
+        if: needs['determine-if-monorepo'].outputs.is_monorepo == 'true'
 
       - name: cd/setup-docker-buildx
         uses: docker/setup-buildx-action@11e8a2e2910826a92412015c515187a2d6750279 # v2.4
-        if: needs['determine-if-monorepo'].outputs.is_monorepo
+        if: needs['determine-if-monorepo'].outputs.is_monorepo == 'true'
 
       - name: cd/docker-build-and-push
         env:
@@ -124,7 +125,7 @@ jobs:
           export TAG=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)
           cd server/build
           docker buildx build --no-cache --platform linux/amd64 --push --build-arg MM_PACKAGE=$MM_PACKAGE -t mattermostdevelopment/mm-te-test:${TAG} .
-        if: needs['determine-if-monorepo'].outputs.is_monorepo
+        if: needs['determine-if-monorepo'].outputs.is_monorepo == 'true'
 
   update-failure-final-status:
     if: failure() || cancelled()

--- a/.github/workflows/server-ci-artifacts.yml
+++ b/.github/workflows/server-ci-artifacts.yml
@@ -24,10 +24,28 @@ jobs:
           description: Artifacts upload and build for mattermost team platform
           status: pending
 
+  ## We need to determine if we're trying to merge to a pre-8.x branch, but 'workflow_run' doesn't give us information about the target branch.
+  ## But we can determine this also by checking if we're in the monorepo directory structure or not.
+  determine-if-monorepo:
+    runs-on: ubuntu-22.04
+    needs:
+      - update-initial-status
+    steps:
+      - name: cd/checkout-mattermost
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: cd/determine-if-monorepo
+        run: |
+          # Assert that the 'server' directory doesn't exist. But if it does, set 'is_monorepo=true'
+          IS_MONOREPO=$([  -d server ] || echo -n 'true')" #TESTING remove me
+          #IS_MONOREPO=$([ ! -d server ] || echo -n 'true')"
+          echo "is_monorepo=$IS_MONOREPO" | tee -a "$GITHUB_OUTPUT"
+
   upload-artifacts:
     runs-on: ubuntu-22.04
     needs:
       - update-initial-status
+      - determine-if-monorepo
+    if: needs['determine-if-monorepo'].outputs.is_monorepo
     steps:
       - name: cd/configure-aws-credentials
         uses: aws-actions/configure-aws-credentials@04b98b3f9e85f563fb061be8751a0352327246b0 #v3.0.1
@@ -103,6 +121,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
       - build-docker
+      - determine-if-monorepo
     steps:
       - uses: mattermost/actions/delivery/update-commit-status@a74f6d87f847326c04d326bf1908da40cb9b3556
         env:
@@ -119,6 +138,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
       - build-docker
+      - determine-if-monorepo
     steps:
       - uses: mattermost/actions/delivery/update-commit-status@a74f6d87f847326c04d326bf1908da40cb9b3556
         env:

--- a/.github/workflows/server-ci-artifacts.yml
+++ b/.github/workflows/server-ci-artifacts.yml
@@ -30,22 +30,23 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
       - update-initial-status
+    outputs:
+      is_monorepo: "${{ steps['determine-if-monorepo'].outputs.is_monorepo }}"
     steps:
       - name: cd/checkout-mattermost
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: cd/determine-if-monorepo
+        id: determine-if-monorepo
         run: |
           # Assert that the 'server' directory doesn't exist. But if it does, set 'is_monorepo=true'
-          IS_MONOREPO=$([  -d server ] || echo -n 'true')" #TESTING remove me
-          #IS_MONOREPO=$([ ! -d server ] || echo -n 'true')"
-          echo "is_monorepo=$IS_MONOREPO" | tee -a "$GITHUB_OUTPUT"
+          IS_MONOREPO=$([ ! -d server ] || echo -n 'true')
+          echo "is_monorepo=$IS_MONOREPO" | tee --append "$GITHUB_OUTPUT"
 
   upload-artifacts:
     runs-on: ubuntu-22.04
     needs:
       - update-initial-status
       - determine-if-monorepo
-    if: needs['determine-if-monorepo'].outputs.is_monorepo
     steps:
       - name: cd/configure-aws-credentials
         uses: aws-actions/configure-aws-credentials@04b98b3f9e85f563fb061be8751a0352327246b0 #v3.0.1
@@ -53,6 +54,7 @@ jobs:
           aws-region: us-east-1
           aws-access-key-id: ${{ secrets.PR_BUILDS_BUCKET_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PR_BUILDS_BUCKET_AWS_SECRET_ACCESS_KEY }}
+        if: needs['determine-if-monorepo'].outputs.is_monorepo
 
       - name: cd/download-artifacts-from-PR-workflow
         uses: dawidd6/action-download-artifact@0c49384d39ceb023b8040f480a25596fd6cf441b # v2.26.0
@@ -62,6 +64,7 @@ jobs:
           workflow_conclusion: success
           name: server-dist-artifact
           path: server/dist
+        if: needs['determine-if-monorepo'].outputs.is_monorepo
 
       - name: cd/generate-packages-file-list
         working-directory: ./server/dist
@@ -69,9 +72,11 @@ jobs:
           echo "PACKAGES_FILE_LIST<<EOF" >> "${GITHUB_ENV}"
           ls | grep -E "*.(tar.gz|zip)$" >> "${GITHUB_ENV}"
           echo "EOF" >> "${GITHUB_ENV}"
+        if: needs['determine-if-monorepo'].outputs.is_monorepo
 
       - name: cd/upload-artifacts-to-s3
         run: aws s3 sync server/dist/ s3://pr-builds.mattermost.com/mattermost/commit/${{ github.event.workflow_run.head_sha }}/ --cache-control no-cache --no-progress --acl public-read
+        if: needs['determine-if-monorepo'].outputs.is_monorepo
 
       - name: cd/generate-summary
         run: |
@@ -84,6 +89,7 @@ jobs:
             do 
               echo "|[${package}](https://s3.amazonaws.com/pr-builds.mattermost.com/mattermost/commit/${{ github.event.workflow_run.head_sha }}/${package})|" >> "${GITHUB_STEP_SUMMARY}"
           done
+        if: needs['determine-if-monorepo'].outputs.is_monorepo
 
   build-docker:
     runs-on: ubuntu-22.04
@@ -95,6 +101,7 @@ jobs:
         with:
           username: mattermostdev
           password: ${{ secrets.DOCKERHUB_DEV_TOKEN }}
+        if: needs['determine-if-monorepo'].outputs.is_monorepo
 
       - name: cd/download-artifacts-from-PR-workflow
         uses: dawidd6/action-download-artifact@0c49384d39ceb023b8040f480a25596fd6cf441b # v2.26.0
@@ -104,9 +111,11 @@ jobs:
           workflow_conclusion: success
           name: server-build-artifact
           path: server/build/
+        if: needs['determine-if-monorepo'].outputs.is_monorepo
 
       - name: cd/setup-docker-buildx
         uses: docker/setup-buildx-action@11e8a2e2910826a92412015c515187a2d6750279 # v2.4
+        if: needs['determine-if-monorepo'].outputs.is_monorepo
 
       - name: cd/docker-build-and-push
         env:
@@ -115,6 +124,7 @@ jobs:
           export TAG=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)
           cd server/build
           docker buildx build --no-cache --platform linux/amd64 --push --build-arg MM_PACKAGE=$MM_PACKAGE -t mattermostdevelopment/mm-te-test:${TAG} .
+        if: needs['determine-if-monorepo'].outputs.is_monorepo
 
   update-failure-final-status:
     if: failure() || cancelled()

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -58,5 +58,3 @@ Notes:
 
 ##### For code changes:
 * `make fmt-ci` to format and check yaml files and shell scripts.
-
-#### DUMMY CHANGE

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -58,3 +58,5 @@ Notes:
 
 ##### For code changes:
 * `make fmt-ci` to format and check yaml files and shell scripts.
+
+#### DUMMY CHANGE


### PR DESCRIPTION
#### Summary

Workflows running on PRs targeting `release-7x` are currently failing, see for example https://github.com/mattermost/mattermost/pull/25185
The root cause is that the `Server CI Artifacts` workflow only supports the monorepo branches. This PR will exclude problematic jobs if the workflow is not running in a monorepo (= `release-7.x` branches)

I tested this implementation in [this other PR](https://github.com/mattermost/test-private-project/pull/4):
- You can see how the changes would run respectively for the [release-9.1](https://github.com/mattermost/test-private-project/actions/runs/6735834974/job/18309939502) and the [release-7.8](https://github.com/mattermost/test-private-project/actions/runs/6735918005/job/18310201227) branches.
- I also tested that if there's no step running for a job, then the result of the job is to succeed. So we aren't introducing any problem with the `update-*-final-status` jobs.
- The reason this couldn't simply be tested within this very same PR, is because we're calling the problem workflow using `workflow_run`, which reads the workflow file from the `master` branch, rather than this PR (you can verify this by seeing the content of `Server CI Artifacts` job, which doesn't contain the changes introduced by this PR).

Other notes:
- We cannot prevent the workflow from running based on _target branches_ ([docs on this](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#using-filters-to-target-specific-branches-for-workflow-run-events)), nor get any target branch information in any Variable or Context, as `workflow_run` has no concept of PR and target branches. So I had to implement the mechanism myself.
- I had to apply the conditional on every _step_, rather than at job level. If I didn't, then the `update-*-final-status` wouldn't have run.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-6507

#### Release Note

```release-note
NONE
```