### PR TITLE
CLD-6507 - Fix the monorepo-checker CI job

### DIFF
--- a/.github/workflows/server-ci-artifacts.yml
+++ b/.github/workflows/server-ci-artifacts.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: cd/checkout-mattermost
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: cd/determine-if-monorepo
         id: determine-if-monorepo
         run: |


### PR DESCRIPTION
#### Summary

In the [previous PR](https://github.com/mattermost/mattermost/pull/25279), I added a job to check if we're running in a monorepo or not, for the `Server CI Artifacts` workflow.

However, I forgot to specify the `ref` we're checking out to do this check: this means currently we're always checking out `master`, which is always a monorepo, which is no problem for monorepo pipelines but also doesn't help `release-7.x` branches.

Here i leverage the `github.event.workflow_run` to get the SHA of the commit where the initiating workflow had completed.

Docs on that:
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
- https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-6507

#### Release Note
```release-note
NONE
```
