### PR TITLE
[MM-55165] Remove target=_blank from file preview links

### DIFF
--- a/webapp/channels/src/components/file_info_preview/__snapshots__/file_info_preview.test.tsx.snap
+++ b/webapp/channels/src/components/file_info_preview/__snapshots__/file_info_preview.test.tsx.snap
@@ -4,10 +4,9 @@ exports[`components/FileInfoPreview should match snapshot, can download files 1`
 <div
   className="file-details__container"
 >
-  <ExternalLink
+  <a
     className="file-details__preview"
     href="https://pre-release.mattermost.com/api/v4/files/rqir81f7a7ft8m6j6ej7g1txuo"
-    location="file_info_preview"
   >
     <span
       className="file-details__preview-helper"
@@ -16,7 +15,7 @@ exports[`components/FileInfoPreview should match snapshot, can download files 1`
       alt="file preview"
       src={null}
     />
-  </ExternalLink>
+  </a>
   <div
     className="file-details"
   >

--- a/webapp/channels/src/components/file_info_preview/file_info_preview.tsx
+++ b/webapp/channels/src/components/file_info_preview/file_info_preview.tsx
@@ -5,8 +5,6 @@ import React from 'react';
 
 import type {FileInfo} from '@mattermost/types/files';
 
-import ExternalLink from 'components/external_link';
-
 import * as Utils from 'utils/utils';
 
 type Props = {
@@ -36,17 +34,16 @@ export default class FileInfoPreview extends React.PureComponent<Props> {
         let preview = null;
         if (this.props.canDownloadFiles) {
             preview = (
-                <ExternalLink
+                <a
                     className='file-details__preview'
                     href={fileUrl}
-                    location='file_info_preview'
                 >
                     <span className='file-details__preview-helper'/>
                     <img
                         alt={'file preview'}
                         src={Utils.getFileIconPath(fileInfo)}
                     />
-                </ExternalLink>
+                </a>
             );
         } else {
             preview = (


### PR DESCRIPTION
#### Summary
When clicking a file preview link in the Desktop App, users would be redirected out to the browser since the link we provided included `target=_blank`, which forces a new window/tab.

This PR removes that so that it should open in the same window. I thought initially this could be an issue with files where we don't support previewing but the browser does, however, it seems that we force those to be downloaded anyways so this works.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55165

```release-note
Fixed an issue where Desktop App clients would be shown an error when trying to open file preview links
```
