### PR TITLE
fix: Show proper version on about modal

### DIFF
--- a/webapp/channels/src/components/about_build_modal/about_build_modal.test.tsx
+++ b/webapp/channels/src/components/about_build_modal/about_build_modal.test.tsx
@@ -39,7 +39,7 @@ describe('components/AboutBuildModal', () => {
             BuildEnterpriseReady: 'true',
             Version: '3.6.0',
             SchemaVersion: '77',
-            BuildNumber: '3.6.2',
+            BuildNumber: '123456',
             SQLDriverName: 'Postgres',
             BuildHash: 'abcdef1234567890',
             BuildHashEnterprise: '0123456789abcdef',
@@ -55,8 +55,9 @@ describe('components/AboutBuildModal', () => {
 
     test('should match snapshot for enterprise edition', () => {
         renderAboutBuildModal({config, license});
-        expect(screen.getByTestId('aboutModalVersion')).toHaveTextContent('Mattermost Version: 3.6.2');
+        expect(screen.getByTestId('aboutModalVersion')).toHaveTextContent('Mattermost Version: 3.6.0');
         expect(screen.getByTestId('aboutModalDBVersionString')).toHaveTextContent('Database Schema Version: 77');
+        expect(screen.getByTestId('aboutModalBuildNumber')).toHaveTextContent('Build Number: 123456');
         expect(screen.getByText('Mattermost Enterprise Edition')).toBeInTheDocument();
         expect(screen.getByText('Modern communication from behind your firewall.')).toBeInTheDocument();
         expect(screen.getByRole('link', {name: 'mattermost.com'})).toHaveAttribute('href', 'https://mattermost.com/?utm_source=mattermost&utm_medium=in-product&utm_content=about_build_modal&uid=&sid=');
@@ -75,8 +76,9 @@ describe('components/AboutBuildModal', () => {
         };
 
         renderAboutBuildModal({config: teamConfig, license: {}});
-        expect(screen.getByTestId('aboutModalVersion')).toHaveTextContent('Mattermost Version: 3.6.2');
+        expect(screen.getByTestId('aboutModalVersion')).toHaveTextContent('Mattermost Version: 3.6.0');
         expect(screen.getByTestId('aboutModalDBVersionString')).toHaveTextContent('Database Schema Version: 77');
+        expect(screen.getByTestId('aboutModalBuildNumber')).toHaveTextContent('Build Number: 123456');
         expect(screen.getByText('Mattermost Team Edition')).toBeInTheDocument();
         expect(screen.getByText('All your team communication in one place, instantly searchable and accessible anywhere.')).toBeInTheDocument();
         expect(screen.getByRole('link', {name: 'mattermost.com/community/'})).toHaveAttribute('href', 'https://mattermost.com/community/?utm_source=mattermost&utm_medium=in-product&utm_content=about_build_modal&uid=&sid=');
@@ -111,7 +113,7 @@ describe('components/AboutBuildModal', () => {
         expect(screen.getByRole('link', {name: 'mobile'})).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-mobile/blob/master/NOTICE.txt');
     });
 
-    test('should show dev if this is a dev build', () => {
+    test('should show n/a if this is a dev build', () => {
         const sameBuildConfig = {
             ...config,
             BuildEnterpriseReady: 'false',
@@ -125,31 +127,7 @@ describe('components/AboutBuildModal', () => {
 
         expect(screen.getByTestId('aboutModalVersion')).toHaveTextContent('Mattermost Version: dev');
         expect(screen.getByTestId('aboutModalDBVersionString')).toHaveTextContent('Database Schema Version: 77');
-        expect(screen.getByText('Mattermost Team Edition')).toBeInTheDocument();
-        expect(screen.getByText('All your team communication in one place, instantly searchable and accessible anywhere.')).toBeInTheDocument();
-        expect(screen.getByRole('link', {name: 'mattermost.com/community/'})).toHaveAttribute('href', 'https://mattermost.com/community/?utm_source=mattermost&utm_medium=in-product&utm_content=about_build_modal&uid=&sid=');
-        expect(screen.queryByText('EE Build Hash: 0123456789abcdef')).not.toBeInTheDocument();
-
-        expect(screen.getByRole('link', {name: 'server'})).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-server/blob/master/NOTICE.txt');
-        expect(screen.getByRole('link', {name: 'desktop'})).toHaveAttribute('href', 'https://github.com/mattermost/desktop/blob/master/NOTICE.txt');
-        expect(screen.getByRole('link', {name: 'mobile'})).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-mobile/blob/master/NOTICE.txt');
-    });
-
-    test('should show ci if a ci build', () => {
-        const differentBuildConfig = {
-            ...config,
-            BuildEnterpriseReady: 'false',
-            BuildHashEnterprise: '',
-            Version: '3.6.0',
-            SchemaVersion: '77',
-            BuildNumber: '123',
-        };
-
-        renderAboutBuildModal({config: differentBuildConfig, license: {}});
-
-        expect(screen.getByTestId('aboutModalVersion')).toHaveTextContent('Mattermost Version: ci');
-        expect(screen.getByTestId('aboutModalDBVersionString')).toHaveTextContent('Database Schema Version: 77');
-        expect(screen.getByTestId('aboutModalBuildNumber')).toHaveTextContent('Build Number: 123');
+        expect(screen.getByTestId('aboutModalBuildNumber')).toHaveTextContent('Build Number: n/a');
         expect(screen.getByText('Mattermost Team Edition')).toBeInTheDocument();
         expect(screen.getByText('All your team communication in one place, instantly searchable and accessible anywhere.')).toBeInTheDocument();
         expect(screen.getByRole('link', {name: 'mattermost.com/community/'})).toHaveAttribute('href', 'https://mattermost.com/community/?utm_source=mattermost&utm_medium=in-product&utm_content=about_build_modal&uid=&sid=');

--- a/webapp/channels/src/components/about_build_modal/about_build_modal.tsx
+++ b/webapp/channels/src/components/about_build_modal/about_build_modal.tsx
@@ -170,24 +170,17 @@ export default class AboutBuildModal extends React.PureComponent<Props, State> {
             </ExternalLink>
         );
 
-        // Only show build number if it's a number (so only builds from Jenkins)
-        let buildnumber: JSX.Element | null = (
+        const buildnumber: JSX.Element | null = (
             <div data-testid='aboutModalBuildNumber'>
                 <FormattedMessage
                     id='about.buildnumber'
                     defaultMessage='Build Number:'
                 />
-                <span id='buildnumberString'>{'\u00a0' + config.BuildNumber}</span>
+                <span id='buildnumberString'>{'\u00a0' + (config.BuildNumber === 'dev' ? 'n/a' : config.BuildNumber)}</span>
             </div>
         );
-        if (isNaN(Number(config.BuildNumber))) {
-            buildnumber = null;
-        }
 
-        let mmversion: string | undefined = config.BuildNumber;
-        if (!isNaN(Number(config.BuildNumber))) {
-            mmversion = 'ci';
-        }
+        const mmversion: string | undefined = config.BuildNumber === 'dev' ? config.BuildNumber : config.Version;
 
         return (
             <Modal


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Change the version we depict on the about modal. 
- Show the proper version regardless the environment
- Always show the build number . No need to keep that a secret. 
- Show `n/a` buildNumber when local development and `dev` as version

Related issue: https://github.com/mattermost/mattermost/issues/24034
#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
https://mattermost.atlassian.net/browse/CLD-6573

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
