### PR TITLE
Update var after name change in fn declaration

### DIFF
--- a/server/channels/app/import_functions.go
+++ b/server/channels/app/import_functions.go
@@ -591,7 +591,7 @@ func (a *App) importUser(rctx request.CTX, data *imports.UserImportData, dryRun 
 			}
 		}
 		if password != "" {
-			if appErr = a.UpdatePassword(c, user, password); appErr != nil {
+			if appErr = a.UpdatePassword(rctx, user, password); appErr != nil {
 				return appErr
 			}
 		} else {


### PR DESCRIPTION
This PR that was merged ~1 hour ago broke master: https://github.com/mattermost/mattermost/pull/25270/files#diff-a3c04c38b2ce558df05bc4a5e2bf71dcbbf1c936ccc5e95be1786e7120fd7672R986. `c` is undefined there

That's because `importUser(c request.CTX..` was changed to `rctx` yesterday: https://github.com/mattermost/mattermost/pull/25037/files#diff-4eacf1d8c10cc246fa3ef5eea492bc9b4377a747832d4ced007fe341cf3da46fR334 


This PR fixes the issue.

### Release Note

```release-note
NONE
```
