### PR TITLE
Automated cherry pick of #25370

### DIFF
--- a/webapp/channels/src/components/about_build_modal/about_build_modal.test.tsx
+++ b/webapp/channels/src/components/about_build_modal/about_build_modal.test.tsx
@@ -40,7 +40,7 @@ describe('components/AboutBuildModal', () => {
             BuildEnterpriseReady: 'true',
             Version: '3.6.0',
             SchemaVersion: '77',
-            BuildNumber: '3.6.2',
+            BuildNumber: '123456',
             SQLDriverName: 'Postgres',
             BuildHash: 'abcdef1234567890',
             BuildHashEnterprise: '0123456789abcdef',
@@ -56,8 +56,9 @@ describe('components/AboutBuildModal', () => {
 
     test('should match snapshot for enterprise edition', () => {
         renderAboutBuildModal({config, license});
-        expect(screen.getByTestId('aboutModalVersion')).toHaveTextContent('Mattermost Version: 3.6.2');
+        expect(screen.getByTestId('aboutModalVersion')).toHaveTextContent('Mattermost Version: 3.6.0');
         expect(screen.getByTestId('aboutModalDBVersionString')).toHaveTextContent('Database Schema Version: 77');
+        expect(screen.getByTestId('aboutModalBuildNumber')).toHaveTextContent('Build Number: 123456');
         expect(screen.getByText('Mattermost Enterprise Edition')).toBeInTheDocument();
         expect(screen.getByText('Modern communication from behind your firewall.')).toBeInTheDocument();
         expect(screen.getByRole('link', {name: 'mattermost.com'})).toHaveAttribute('href', 'https://mattermost.com/?utm_source=mattermost&utm_medium=in-product&utm_content=about_build_modal&uid=&sid=');
@@ -76,8 +77,9 @@ describe('components/AboutBuildModal', () => {
         };
 
         renderAboutBuildModal({config: teamConfig, license: {}});
-        expect(screen.getByTestId('aboutModalVersion')).toHaveTextContent('Mattermost Version: 3.6.2');
+        expect(screen.getByTestId('aboutModalVersion')).toHaveTextContent('Mattermost Version: 3.6.0');
         expect(screen.getByTestId('aboutModalDBVersionString')).toHaveTextContent('Database Schema Version: 77');
+        expect(screen.getByTestId('aboutModalBuildNumber')).toHaveTextContent('Build Number: 123456');
         expect(screen.getByText('Mattermost Team Edition')).toBeInTheDocument();
         expect(screen.getByText('All your team communication in one place, instantly searchable and accessible anywhere.')).toBeInTheDocument();
         expect(screen.getByRole('link', {name: 'mattermost.com/community/'})).toHaveAttribute('href', 'https://mattermost.com/community/?utm_source=mattermost&utm_medium=in-product&utm_content=about_build_modal&uid=&sid=');
@@ -112,7 +114,7 @@ describe('components/AboutBuildModal', () => {
         expect(screen.getByRole('link', {name: 'mobile'})).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-mobile/blob/master/NOTICE.txt');
     });
 
-    test('should show dev if this is a dev build', () => {
+    test('should show n/a if this is a dev build', () => {
         const sameBuildConfig = {
             ...config,
             BuildEnterpriseReady: 'false',
@@ -126,31 +128,7 @@ describe('components/AboutBuildModal', () => {
 
         expect(screen.getByTestId('aboutModalVersion')).toHaveTextContent('Mattermost Version: dev');
         expect(screen.getByTestId('aboutModalDBVersionString')).toHaveTextContent('Database Schema Version: 77');
-        expect(screen.getByText('Mattermost Team Edition')).toBeInTheDocument();
-        expect(screen.getByText('All your team communication in one place, instantly searchable and accessible anywhere.')).toBeInTheDocument();
-        expect(screen.getByRole('link', {name: 'mattermost.com/community/'})).toHaveAttribute('href', 'https://mattermost.com/community/?utm_source=mattermost&utm_medium=in-product&utm_content=about_build_modal&uid=&sid=');
-        expect(screen.queryByText('EE Build Hash: 0123456789abcdef')).not.toBeInTheDocument();
-
-        expect(screen.getByRole('link', {name: 'server'})).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-server/blob/master/NOTICE.txt');
-        expect(screen.getByRole('link', {name: 'desktop'})).toHaveAttribute('href', 'https://github.com/mattermost/desktop/blob/master/NOTICE.txt');
-        expect(screen.getByRole('link', {name: 'mobile'})).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-mobile/blob/master/NOTICE.txt');
-    });
-
-    test('should show ci if a ci build', () => {
-        const differentBuildConfig = {
-            ...config,
-            BuildEnterpriseReady: 'false',
-            BuildHashEnterprise: '',
-            Version: '3.6.0',
-            SchemaVersion: '77',
-            BuildNumber: '123',
-        };
-
-        renderAboutBuildModal({config: differentBuildConfig, license: {}});
-
-        expect(screen.getByTestId('aboutModalVersion')).toHaveTextContent('Mattermost Version: ci');
-        expect(screen.getByTestId('aboutModalDBVersionString')).toHaveTextContent('Database Schema Version: 77');
-        expect(screen.getByTestId('aboutModalBuildNumber')).toHaveTextContent('Build Number: 123');
+        expect(screen.getByTestId('aboutModalBuildNumber')).toHaveTextContent('Build Number: n/a');
         expect(screen.getByText('Mattermost Team Edition')).toBeInTheDocument();
         expect(screen.getByText('All your team communication in one place, instantly searchable and accessible anywhere.')).toBeInTheDocument();
         expect(screen.getByRole('link', {name: 'mattermost.com/community/'})).toHaveAttribute('href', 'https://mattermost.com/community/?utm_source=mattermost&utm_medium=in-product&utm_content=about_build_modal&uid=&sid=');

--- a/webapp/channels/src/components/about_build_modal/about_build_modal.tsx
+++ b/webapp/channels/src/components/about_build_modal/about_build_modal.tsx
@@ -171,24 +171,17 @@ export default class AboutBuildModal extends React.PureComponent<Props, State> {
             </ExternalLink>
         );
 
-        // Only show build number if it's a number (so only builds from Jenkins)
-        let buildnumber: JSX.Element | null = (
+        const buildnumber: JSX.Element | null = (
             <div data-testid='aboutModalBuildNumber'>
                 <FormattedMessage
                     id='about.buildnumber'
                     defaultMessage='Build Number:'
                 />
-                <span id='buildnumberString'>{'\u00a0' + config.BuildNumber}</span>
+                <span id='buildnumberString'>{'\u00a0' + (config.BuildNumber === 'dev' ? 'n/a' : config.BuildNumber)}</span>
             </div>
         );
-        if (isNaN(Number(config.BuildNumber))) {
-            buildnumber = null;
-        }
 
-        let mmversion: string | undefined = config.BuildNumber;
-        if (!isNaN(Number(config.BuildNumber))) {
-            mmversion = 'ci';
-        }
+        const mmversion: string | undefined = config.BuildNumber === 'dev' ? config.BuildNumber : config.Version;
 
         return (
             <Modal


### PR DESCRIPTION
Cherry pick of #25370 on release-9.0.

/cc  @toninis

```release-note
NONE
```