### PR TITLE
Wipe LDAP filter when running make config-ldap

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -676,6 +676,9 @@ config-ldap: ## Configures LDAP.
 	@sed -i'' -e 's|"BaseDN": ".*"|"BaseDN": "dc=mm,dc=test,dc=com"|g' ../config/config.json
 	@sed -i'' -e 's|"BindUsername": ".*"|"BindUsername": "cn=admin,dc=mm,dc=test,dc=com"|g' ../config/config.json
 	@sed -i'' -e 's|"BindPassword": ".*"|"BindPassword": "mostest"|g' ../config/config.json
+	@sed -i'' -e 's|"UserFilter": ".*"|"UserFilter": ""|g' ../config/config.json
+	@sed -i'' -e 's|"GroupFilter": ".*"|"GroupFilter": ""|g' ../config/config.json
+	@sed -i'' -e 's|"GuestFilter": ".*"|"GuestFilter": ""|g' ../config/config.json
 	@sed -i'' -e 's|"FirstNameAttribute": ".*"|"FirstNameAttribute": "cn"|g' ../config/config.json
 	@sed -i'' -e 's|"LastNameAttribute": ".*"|"LastNameAttribute": "sn"|g' ../config/config.json
 	@sed -i'' -e 's|"NicknameAttribute": ".*"|"NicknameAttribute": "cn"|g' ../config/config.json


### PR DESCRIPTION
#### Summary
I was assuming that `make config-ldap` would create a "ready to go" configuration. In ma case, I had an old filter setting the config, resulting in missing LDAP data.

The makefile command now clears any LDAP filters.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
