### PR TITLE
[MM-55412] Use go-style error handling in team_controller

### DIFF
--- a/webapp/channels/src/components/team_controller/team_controller.tsx
+++ b/webapp/channels/src/components/team_controller/team_controller.tsx
@@ -150,26 +150,26 @@ function TeamController(props: Props) {
     }, []);
 
     async function initTeamOrRedirect(team: Team) {
-        try {
-            await props.initializeTeam(team);
-            setTeam(team);
-        } catch (error) {
+        const {data: joinedTeam, error} = await props.initializeTeam(team) as ActionResult<Team, ServerError>; // Fix in MM-46907;
+        if (error) {
             history.push('/error?type=team_not_found');
+            return;
+        }
+        if (joinedTeam) {
+            setTeam(joinedTeam);
         }
     }
 
     async function joinTeamOrRedirect(teamNameParam: string, joinedOnFirstLoad: boolean) {
         setTeam(null);
 
-        try {
-            const {data: joinedTeam} = await props.joinTeam(teamNameParam, joinedOnFirstLoad) as ActionResult<Team, ServerError>; // Fix in MM-46907;
-            if (joinedTeam) {
-                setTeam(joinedTeam);
-            } else {
-                throw new Error('Unable to join team');
-            }
-        } catch (error) {
+        const {data: joinedTeam, error} = await props.joinTeam(teamNameParam, joinedOnFirstLoad) as ActionResult<Team, ServerError>; // Fix in MM-46907;
+        if (error) {
             history.push('/error?type=team_not_found');
+            return;
+        }
+        if (joinedTeam) {
+            setTeam(joinedTeam);
         }
     }
 


### PR DESCRIPTION
#### Summary
Instead of using `try` and `catch` use a go-style of returning actually errors for anticipated issues and let exceptions happen for things that are - well- exceptionally.

I tried adding a snapshot test to ensure the component renders as expected when `initializeTeam` or `joinTeam` throws, but it's hard to mock all the props.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55412

#### Release Note
```release-note
NONE
```
