### PR TITLE
[MM-55336] Fixed team name alignment in channel switcher

### DIFF
--- a/webapp/channels/src/sass/components/_suggestion-list.scss
+++ b/webapp/channels/src/sass/components/_suggestion-list.scss
@@ -342,6 +342,7 @@
         right: 20px;
         overflow: hidden;
         max-width: 20%;
+        text-align: right;
         text-overflow: ellipsis;
         white-space: nowrap;
     }


### PR DESCRIPTION
#### Summary
Fixed a bug where team name in channel switcher was not right-aligned.

The bug was caused by #24800 when it accidentally increased the width of div that contained team name.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-55336

#### Screenshots
![Screenshot 2023-11-14 at 9 57 58 AM](https://github.com/mattermost/mattermost/assets/18575143/e66b5f94-310f-472c-aa52-824199509220)

#### Release Note
```release-note
none
```
