### PR TITLE
MM-55450: Handle error in db migrate phase

### DIFF
--- a/server/channels/store/sqlstore/migrate.go
+++ b/server/channels/store/sqlstore/migrate.go
@@ -37,7 +37,10 @@ func NewMigrator(settings model.SqlSettings, dryRun bool) (*Migrator, error) {
 		wgMonitor:   &sync.WaitGroup{},
 	}
 
-	ss.initConnection()
+	err := ss.initConnection()
+	if err != nil {
+		return nil, fmt.Errorf("error in initializing connection: %w", err)
+	}
 
 	ver, err := ss.GetDbVersion(true)
 	if err != nil {


### PR DESCRIPTION
We were not handling the error from initConnection.

https://mattermost.atlassian.net/browse/MM-55450
```release-note
NONE
```
