### PR TITLE
Fix flaky test api4/Test_applyIPFilters

### DIFF
--- a/server/channels/api4/ip_filtering.go
+++ b/server/channels/api4/ip_filtering.go
@@ -83,6 +83,17 @@ func applyIPFilters(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec.Success()
 
+	cloudWorkspaceOwnerEmailAddress := ""
+	if c.App.License().IsCloud() {
+		portalUserCustomer, cErr := c.App.Cloud().GetCloudCustomer(c.AppContext.Session().UserId)
+		if cErr != nil {
+			mlog.Error("Failed to get portal user customer", mlog.Err(cErr))
+		}
+		if cErr == nil && portalUserCustomer != nil {
+			cloudWorkspaceOwnerEmailAddress = portalUserCustomer.Email
+		}
+	}
+
 	go func() {
 		initiatingUser, err := c.App.Srv().Store().User().GetProfileByIds(context.Background(), []string{c.AppContext.Session().UserId}, nil, true)
 		if err != nil {
@@ -92,17 +103,6 @@ func applyIPFilters(c *Context, w http.ResponseWriter, r *http.Request) {
 		users, err := c.App.Srv().Store().User().GetSystemAdminProfiles()
 		if err != nil {
 			mlog.Error("Failed to get system admins", mlog.Err(err))
-		}
-
-		cloudWorkspaceOwnerEmailAddress := ""
-		if c.App.License().IsCloud() {
-			portalUserCustomer, cErr := c.App.Cloud().GetCloudCustomer(c.AppContext.Session().UserId)
-			if cErr != nil {
-				mlog.Error("Failed to get portal user customer", mlog.Err(cErr))
-			}
-			if cErr == nil && portalUserCustomer != nil {
-				cloudWorkspaceOwnerEmailAddress = portalUserCustomer.Email
-			}
 		}
 
 		for _, user := range users {

--- a/server/channels/api4/ip_filtering.go
+++ b/server/channels/api4/ip_filtering.go
@@ -83,7 +83,7 @@ func applyIPFilters(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec.Success()
 
-	c.App.Srv().Go(func() {
+	go func() {
 		initiatingUser, err := c.App.Srv().Store().User().GetProfileByIds(context.Background(), []string{c.AppContext.Session().UserId}, nil, true)
 		if err != nil {
 			mlog.Error("Failed to get initiating user", mlog.Err(err))
@@ -110,7 +110,7 @@ func applyIPFilters(c *Context, w http.ResponseWriter, r *http.Request) {
 				mlog.Error("Error while sending IP filters changed email", mlog.Err(err))
 			}
 		}
-	})
+	}()
 
 	if err := json.NewEncoder(w).Encode(updatedAllowedRanges); err != nil {
 		c.Err = model.NewAppError("getIPFilters", "api.context.ip_filtering.get_ip_filters.app_error", nil, err.Error(), http.StatusInternalServerError)

--- a/server/channels/api4/ip_filtering_test.go
+++ b/server/channels/api4/ip_filtering_test.go
@@ -151,8 +151,6 @@ func Test_applyIPFilters(t *testing.T) {
 		ExpiresAt:    model.GetMillis() + 100000,
 	}
 
-	// lic := model.NewTestLicense("cloud")
-	// lic.SkuShortName = model.LicenseShortSkuEnterprise
 	// Initialize the allowedRanges variable
 	t.Run("No license returns 501", func(t *testing.T) {
 		os.Setenv("MM_FEATUREFLAGS_CLOUDIPFILTERING", "true")

--- a/server/channels/api4/ip_filtering_test.go
+++ b/server/channels/api4/ip_filtering_test.go
@@ -140,28 +140,28 @@ func Test_applyIPFilters(t *testing.T) {
 	lic.Id = "testlicenseid"
 
 	// Initialize the allowedRanges variable
-	// t.Run("No license returns 501", func(t *testing.T) {
-	// 	os.Setenv("MM_FEATUREFLAGS_CLOUDIPFILTERING", "true")
-	// 	defer os.Unsetenv("MM_FEATUREFLAGS_CLOUDIPFILTERING")
-	// 	th := Setup(t).InitBasic()
-	// 	defer th.TearDown()
+	t.Run("No license returns 501", func(t *testing.T) {
+		os.Setenv("MM_FEATUREFLAGS_CLOUDIPFILTERING", "true")
+		defer os.Unsetenv("MM_FEATUREFLAGS_CLOUDIPFILTERING")
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
 
-	// 	ipFiltering := &mocks.IPFilteringInterface{}
-	// 	ipFilteringImpl := th.App.Srv().IPFiltering
-	// 	defer func() {
-	// 		th.App.Srv().IPFiltering = ipFilteringImpl
-	// 	}()
-	// 	th.App.Srv().IPFiltering = ipFiltering
+		ipFiltering := &mocks.IPFilteringInterface{}
+		ipFilteringImpl := th.App.Srv().IPFiltering
+		defer func() {
+			th.App.Srv().IPFiltering = ipFilteringImpl
+		}()
+		th.App.Srv().IPFiltering = ipFiltering
 
-	// 	th.App.Srv().RemoveLicense()
+		th.App.Srv().RemoveLicense()
 
-	// 	th.Client.Login(context.Background(), th.BasicUser.Email, th.BasicUser.Password)
+		th.Client.Login(context.Background(), th.BasicUser.Email, th.BasicUser.Password)
 
-	// 	ipFilters, r, err := th.Client.ApplyIPFilters(context.Background(), allowedRanges)
-	// 	require.Error(t, err)
-	// 	require.Nil(t, ipFilters)
-	// 	require.Equal(t, 501, r.StatusCode)
-	// })
+		ipFilters, r, err := th.Client.ApplyIPFilters(context.Background(), allowedRanges)
+		require.Error(t, err)
+		require.Nil(t, ipFilters)
+		require.Equal(t, 501, r.StatusCode)
+	})
 
 	t.Run("License but no feature flag returns 501", func(t *testing.T) {
 		os.Setenv("MM_FEATUREFLAGS_CLOUDIPFILTERING", "false")

--- a/server/channels/api4/ip_filtering_test.go
+++ b/server/channels/api4/ip_filtering_test.go
@@ -136,20 +136,7 @@ func Test_applyIPFilters(t *testing.T) {
 		},
 	}
 
-	lic := &model.License{
-		Features: &model.Features{
-			CustomPermissionsSchemes: model.NewBool(false),
-			Cloud:                    model.NewBool(true),
-		},
-		Customer: &model.Customer{
-			Name:  "TestName",
-			Email: "test@example.com",
-		},
-		SkuName:      "SKU NAME",
-		SkuShortName: model.LicenseShortSkuEnterprise,
-		StartsAt:     model.GetMillis() - 1000,
-		ExpiresAt:    model.GetMillis() + 100000,
-	}
+	lic := model.NewTestLicenseSKU(model.LicenseShortSkuEnterprise, "cloud")
 
 	// Initialize the allowedRanges variable
 	t.Run("No license returns 501", func(t *testing.T) {

--- a/server/channels/api4/ip_filtering_test.go
+++ b/server/channels/api4/ip_filtering_test.go
@@ -137,30 +137,31 @@ func Test_applyIPFilters(t *testing.T) {
 	}
 
 	lic := model.NewTestLicenseSKU(model.LicenseShortSkuEnterprise, "cloud")
+	lic.Id = "testlicenseid"
 
 	// Initialize the allowedRanges variable
-	t.Run("No license returns 501", func(t *testing.T) {
-		os.Setenv("MM_FEATUREFLAGS_CLOUDIPFILTERING", "true")
-		defer os.Unsetenv("MM_FEATUREFLAGS_CLOUDIPFILTERING")
-		th := Setup(t).InitBasic()
-		defer th.TearDown()
+	// t.Run("No license returns 501", func(t *testing.T) {
+	// 	os.Setenv("MM_FEATUREFLAGS_CLOUDIPFILTERING", "true")
+	// 	defer os.Unsetenv("MM_FEATUREFLAGS_CLOUDIPFILTERING")
+	// 	th := Setup(t).InitBasic()
+	// 	defer th.TearDown()
 
-		ipFiltering := &mocks.IPFilteringInterface{}
-		ipFilteringImpl := th.App.Srv().IPFiltering
-		defer func() {
-			th.App.Srv().IPFiltering = ipFilteringImpl
-		}()
-		th.App.Srv().IPFiltering = ipFiltering
+	// 	ipFiltering := &mocks.IPFilteringInterface{}
+	// 	ipFilteringImpl := th.App.Srv().IPFiltering
+	// 	defer func() {
+	// 		th.App.Srv().IPFiltering = ipFilteringImpl
+	// 	}()
+	// 	th.App.Srv().IPFiltering = ipFiltering
 
-		th.App.Srv().RemoveLicense()
+	// 	th.App.Srv().RemoveLicense()
 
-		th.Client.Login(context.Background(), th.BasicUser.Email, th.BasicUser.Password)
+	// 	th.Client.Login(context.Background(), th.BasicUser.Email, th.BasicUser.Password)
 
-		ipFilters, r, err := th.Client.ApplyIPFilters(context.Background(), allowedRanges)
-		require.Error(t, err)
-		require.Nil(t, ipFilters)
-		require.Equal(t, 501, r.StatusCode)
-	})
+	// 	ipFilters, r, err := th.Client.ApplyIPFilters(context.Background(), allowedRanges)
+	// 	require.Error(t, err)
+	// 	require.Nil(t, ipFilters)
+	// 	require.Equal(t, 501, r.StatusCode)
+	// })
 
 	t.Run("License but no feature flag returns 501", func(t *testing.T) {
 		os.Setenv("MM_FEATUREFLAGS_CLOUDIPFILTERING", "false")


### PR DESCRIPTION
#### Summary
Master pipeline has a flaky test - it seems that there is some propagation issue with both the license and the cloud mock, and their usage inside a go routine. See thread here for more discussion on the issue: https://community.mattermost.com/private-core/pl/taeawck8up8cpqesimi5sro96y

For now I've opted to move the license and cloud check outside of the go routine, resolving the flakiness. Will follow up later with the server team to try and figure out the root cause of the propagation issues

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-6627

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
