### PR TITLE
Modify the Dockerfile to run the container with an arbitrary user ID.…

### DIFF
--- a/server/build/Dockerfile
+++ b/server/build/Dockerfile
@@ -6,11 +6,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Some ENV variables
 ENV PATH="/mattermost/bin:${PATH}"
-ARG PUID=2000
-ARG PGID=2000
 ARG MM_PACKAGE="https://releases.mattermost.com/9.1.2/mattermost-9.1.2-linux-amd64.tar.gz?src=docker"
 
-# # Install needed packages and indirect dependencies
+# Install needed packages and indirect dependencies
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   ca-certificates \
@@ -23,23 +21,23 @@ RUN apt-get update \
   tzdata \
   && rm -rf /var/lib/apt/lists/*
 
-# Set mattermost group/user and download Mattermost
+# Set mattermost directories and permissions
 RUN mkdir -p /mattermost/data /mattermost/plugins /mattermost/client/plugins \
-  && addgroup -gid ${PGID} mattermost \
-  && adduser -q --disabled-password --uid ${PUID} --gid ${PGID} --gecos "" --home /mattermost mattermost \
   && if [ -n "$MM_PACKAGE" ]; then curl $MM_PACKAGE | tar -xvz ; \
   else echo "please set the MM_PACKAGE" ; exit 127 ; fi \
-  && chown -R mattermost:mattermost /mattermost /mattermost/data /mattermost/plugins /mattermost/client/plugins
+  && chmod -R g=u /mattermost /mattermost/data /mattermost/plugins /mattermost/client/plugins
 
-# We should refrain from running as privileged user
-USER mattermost
+# OpenShift runs containers using an arbitrarily assigned user ID
+# The following lines modify the permissions so that the group root can access the necessary files
+RUN chgrp -R 0 /mattermost && \
+    chmod -R g=u /mattermost /etc/passwd
 
-#Healthcheck to make sure container is ready
+# Healthcheck to make sure container is ready
 HEALTHCHECK --interval=30s --timeout=10s \
   CMD curl -f http://localhost:8065/api/v4/system/ping || exit 1
 
 # Configure entrypoint and command
-COPY --chown=mattermost:mattermost --chmod=765 entrypoint.sh /
+COPY --chmod=755 entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 WORKDIR /mattermost
 CMD ["mattermost"]


### PR DESCRIPTION
#### Summary
This pull request introduces changes to the Dockerfile to allow MAttermost to run as an arbitrary user. OpenShift enforces a strict security model that does not allow containers to run as root or with a specific user ID. The proposed changes ensure that the Mattermost container can run under these conditions.

Key Changes
User and Group Creation: Removed the steps for creating a specific user and group (mattermost). OpenShift assigns a random user ID that belongs to the root group for running the container, making these steps unnecessary.

File Permissions: Updated the file permissions of the Mattermost directories and the entrypoint.sh script. The changes include setting the permissions to be group-writable (chmod -R g=u) and setting the group to root (chgrp -R 0). This ensures that the arbitrary user assigned by OpenShift has the necessary permissions to access and modify these files.

Executable Permissions for entrypoint.sh: Set the correct executable permissions for the entrypoint.sh script using --chmod=755 in the COPY command.

#### Release Note
```release-note
Enhanced Mattermost Dockerfile for improved compatibility with OpenShift, including permission adjustments and user handling to support arbitrary user IDs.
```
