### PR TITLE
MM-55293 + MM-36719 - Updating emoji icon on hover and on popover

### DIFF
--- a/webapp/channels/src/components/post_view/post_recent_reactions/post_recent_reactions.tsx
+++ b/webapp/channels/src/components/post_view/post_recent_reactions/post_recent_reactions.tsx
@@ -14,7 +14,6 @@ import Tooltip from 'components/tooltip';
 
 import {Locations} from 'utils/constants';
 
-
 import EmojiItem from './recent_reactions_emoji_item';
 
 type LocationTypes = 'CENTER' | 'RHS_ROOT' | 'RHS_COMMENT';

--- a/webapp/channels/src/components/post_view/post_recent_reactions/post_recent_reactions.tsx
+++ b/webapp/channels/src/components/post_view/post_recent_reactions/post_recent_reactions.tsx
@@ -6,12 +6,14 @@ import React from 'react';
 import type {Emoji} from '@mattermost/types/emojis';
 
 import Permissions from 'mattermost-redux/constants/permissions';
+import {getEmojiImageUrl} from 'mattermost-redux/utils/emoji_utils';
 
 import OverlayTrigger from 'components/overlay_trigger';
 import ChannelPermissionGate from 'components/permissions_gates/channel_permission_gate';
 import Tooltip from 'components/tooltip';
 
 import {Locations} from 'utils/constants';
+
 
 import EmojiItem from './recent_reactions_emoji_item';
 
@@ -100,6 +102,13 @@ export default class PostRecentReactions extends React.PureComponent<Props, Stat
                             id='post_info.emoji.tooltip'
                             className='hidden-xs'
                         >
+                            <div>
+                                <img
+                                    className='Reaction__emoji Reaction__emoji--large'
+                                    src={getEmojiImageUrl(emoji)}
+                                    width={48}
+                                />
+                            </div>
                             {this.emojiName(emoji, this.props.locale)}
                         </Tooltip>
                     }

--- a/webapp/channels/src/components/post_view/reaction/__snapshots__/reaction.test.tsx.snap
+++ b/webapp/channels/src/components/post_view/reaction/__snapshots__/reaction.test.tsx.snap
@@ -13,6 +13,12 @@ exports[`components/post_view/Reaction should apply read-only class if user does
         canAddReactions={false}
         canRemoveReactions={true}
         currentUserReacted={false}
+        emojiIcon={
+          <img
+            className="Reaction__emoji emoticon"
+            src="emoji_image_url"
+          />
+        }
         emojiName="smile"
         reactions={
           Array [
@@ -97,6 +103,12 @@ exports[`components/post_view/Reaction should apply read-only class if user does
         canAddReactions={true}
         canRemoveReactions={false}
         currentUserReacted={true}
+        emojiIcon={
+          <img
+            className="Reaction__emoji emoticon"
+            src="emoji_image_url"
+          />
+        }
         emojiName="smile"
         reactions={
           Array [
@@ -181,6 +193,12 @@ exports[`components/post_view/Reaction should match snapshot 1`] = `
         canAddReactions={true}
         canRemoveReactions={true}
         currentUserReacted={false}
+        emojiIcon={
+          <img
+            className="Reaction__emoji emoticon"
+            src="emoji_image_url"
+          />
+        }
         emojiName="smile"
         reactions={
           Array [
@@ -265,6 +283,12 @@ exports[`components/post_view/Reaction should match snapshot when a current user
         canAddReactions={true}
         canRemoveReactions={true}
         currentUserReacted={true}
+        emojiIcon={
+          <img
+            className="Reaction__emoji emoticon"
+            src="emoji_image_url"
+          />
+        }
         emojiName="smile"
         reactions={
           Array [

--- a/webapp/channels/src/components/post_view/reaction/reaction.scss
+++ b/webapp/channels/src/components/post_view/reaction/reaction.scss
@@ -2,11 +2,11 @@
 @import 'sass/utils/functions';
 
 .reaction-emoji--large img {
-    width: 56px;
+    width: 48px;
     max-width: none;
-    height: 56px;
+    height: 48px;
     max-height: none;
-    margin: 4px 0;
+    margin: 4px 0 8px;
 }
 
 .Reaction {
@@ -71,6 +71,14 @@
         margin: 0 2px 0 0;
         object-fit: contain;
         vertical-align: middle;
+
+        &--large {
+            width: 48px;
+            max-width: none;
+            height: 48px;
+            max-height: none;
+            margin: 4px 0 8px;
+        }
     }
 
     &__emoji--post-menu {

--- a/webapp/channels/src/components/post_view/reaction/reaction.scss
+++ b/webapp/channels/src/components/post_view/reaction/reaction.scss
@@ -1,6 +1,14 @@
 @import 'sass/utils/mixins';
 @import 'sass/utils/functions';
 
+.reaction-emoji--large img {
+    width: 56px;
+    max-width: none;
+    height: 56px;
+    max-height: none;
+    margin: 4px 0;
+}
+
 .Reaction {
     @include button-style--none;
 

--- a/webapp/channels/src/components/post_view/reaction/reaction.scss
+++ b/webapp/channels/src/components/post_view/reaction/reaction.scss
@@ -6,7 +6,7 @@
     max-width: none;
     height: 48px;
     max-height: none;
-    margin: 4px 0 8px;
+    margin: 4px 0;
 }
 
 .Reaction {
@@ -77,7 +77,7 @@
             max-width: none;
             height: 48px;
             max-height: none;
-            margin: 4px 0 8px;
+            margin: 4px 0;
         }
     }
 

--- a/webapp/channels/src/components/post_view/reaction/reaction.tsx
+++ b/webapp/channels/src/components/post_view/reaction/reaction.tsx
@@ -210,6 +210,13 @@ export default class Reaction extends React.PureComponent<Props, State> {
             ariaLabelEmoji = `${Utils.localizeMessage('reaction.removeReact.ariaLabel', 'remove reaction')} ${emojiNameWithSpaces}`;
         }
 
+        const emojiIcon = (
+            <img
+                className='Reaction__emoji emoticon'
+                src={this.props.emojiImageUrl}
+            />
+        );
+
         return (
             <OverlayTrigger
                 delayShow={500}
@@ -222,6 +229,7 @@ export default class Reaction extends React.PureComponent<Props, State> {
                             canRemoveReactions={canRemoveReactions}
                             currentUserReacted={currentUserReacted}
                             emojiName={emojiName}
+                            emojiIcon={emojiIcon}
                             reactions={reactions}
                         />
                     </Tooltip>
@@ -236,10 +244,7 @@ export default class Reaction extends React.PureComponent<Props, State> {
                     ref={this.reactionButtonRef}
                 >
                     <span className='d-flex align-items-center'>
-                        <img
-                            className='Reaction__emoji emoticon'
-                            src={this.props.emojiImageUrl}
-                        />
+                        {emojiIcon}
                         <span
                             ref={this.reactionCountRef}
                             className='Reaction__count'

--- a/webapp/channels/src/components/post_view/reaction/reaction_tooltip/reaction_tooltip.tsx
+++ b/webapp/channels/src/components/post_view/reaction/reaction_tooltip/reaction_tooltip.tsx
@@ -11,6 +11,7 @@ type Props = {
     canRemoveReactions: boolean;
     currentUserReacted: boolean;
     emojiName: string;
+    emojiIcon: React.ReactNode; // Add this line
     reactions: ReactionType[];
     users: string[];
 };
@@ -20,6 +21,7 @@ const ReactionTooltip: React.FC<Props> = (props: Props) => {
         canAddReactions,
         canRemoveReactions,
         currentUserReacted,
+        emojiIcon,
         emojiName,
         reactions,
         users,
@@ -130,6 +132,7 @@ const ReactionTooltip: React.FC<Props> = (props: Props) => {
 
     return (
         <>
+            <div className='reaction-emoji--large'>{emojiIcon}</div>
             {tooltip}
             <br/>
             {clickTooltip}

--- a/webapp/channels/src/components/post_view/reaction/reaction_tooltip/reaction_tooltip.tsx
+++ b/webapp/channels/src/components/post_view/reaction/reaction_tooltip/reaction_tooltip.tsx
@@ -11,7 +11,7 @@ type Props = {
     canRemoveReactions: boolean;
     currentUserReacted: boolean;
     emojiName: string;
-    emojiIcon: React.ReactNode; // Add this line
+    emojiIcon: React.ReactNode;
     reactions: ReactionType[];
     users: string[];
 };

--- a/webapp/channels/src/sass/components/_emoticons.scss
+++ b/webapp/channels/src/sass/components/_emoticons.scss
@@ -544,6 +544,10 @@ $emoji-footer-height:  $emoji-footer-border-width + $emoji-half-height + $emoji-
     &.selected,
     &:hover {
         background-color: rgba(var(--center-channel-color-rgb), 0.16);
+
+        img {
+            transform: scale(1.35);
+        }
     }
 
     &:active {
@@ -556,6 +560,8 @@ $emoji-footer-height:  $emoji-footer-border-width + $emoji-half-height + $emoji-
 
     img {
         position: relative;
+        transform: scale(1);
+        transition: transform 1s ease-in-out;
 
         &.emoji-category--custom {
             top: auto;

--- a/webapp/channels/src/sass/components/_emoticons.scss
+++ b/webapp/channels/src/sass/components/_emoticons.scss
@@ -561,7 +561,7 @@ $emoji-footer-height:  $emoji-footer-border-width + $emoji-half-height + $emoji-
     img {
         position: relative;
         transform: scale(1);
-        transition: transform 1s ease-in-out;
+        transition: transform 0.2s ease-in-out;
 
         &.emoji-category--custom {
             top: auto;

--- a/webapp/channels/src/sass/components/_tooltip.scss
+++ b/webapp/channels/src/sass/components/_tooltip.scss
@@ -6,6 +6,10 @@
     pointer-events: none;
     word-wrap: break-word;
 
+    &.in {
+        opacity: 1;
+    }
+
     &#announcement-bar__tooltip {
         width: 50%;
         max-width: 100%;
@@ -15,12 +19,25 @@
     .tooltip-inner {
         max-width: 100%;
         padding: 4px 8px;
+        background: rgba(0, 0, 0, 0.9);
         box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
         font-size: 12px;
         font-weight: 600;
         line-height: 18px;
         text-align: center;
         word-break: break-word;
+    }
+
+    &.top {
+        .tooltip-arrow {
+            box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
+        }
+    }
+
+    &.bottom {
+        .tooltip-arrow {
+            box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
+        }
     }
 
     &.text-nowrap {


### PR DESCRIPTION
#### Summary
MM-55293 + MM-36719 - Updating emoji icon on hover and on popover

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-36719
Fixes https://mattermost.atlassian.net/browse/MM-55293

#### Screenshots
<img width="324" alt="Screenshot 2023-11-15 at 12 33 35 AM" src="https://github.com/mattermost/mattermost/assets/11034289/e77e79e1-38bc-4a7a-9ac7-f04faf96d51a">
<img width="419" alt="Screenshot 2023-11-15 at 12 33 40 AM" src="https://github.com/mattermost/mattermost/assets/11034289/09635f21-5d83-4365-bc04-564c6830ee4a">



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
