### PR TITLE
Updated mmctl export create command flag

### DIFF
--- a/server/cmd/mmctl/commands/export.go
+++ b/server/cmd/mmctl/commands/export.go
@@ -99,8 +99,8 @@ func init() {
 	_ = ExportCreateCmd.Flags().MarkHidden("attachments")
 	_ = ExportCreateCmd.Flags().MarkDeprecated("attachments", "the tool now includes attachments by default. The flag will be removed in a future version.")
 
-	ExportCreateCmd.Flags().Bool("no-attachments", false, "Set to true to exclude file attachments in the export file.")
-	ExportCreateCmd.Flags().Bool("include-archived-channels", false, "Set to true to include archived channels in the export file.")
+	ExportCreateCmd.Flags().Bool("no-attachments", false, "Exclude file attachments from the export file.")
+	ExportCreateCmd.Flags().Bool("include-archived-channels", false, "Include archived channels in the export file.")
 
 	ExportDownloadCmd.Flags().Bool("resume", false, "Set to true to resume an export download.")
 	_ = ExportDownloadCmd.Flags().MarkHidden("resume")

--- a/server/cmd/mmctl/docs/mmctl_export_create.rst
+++ b/server/cmd/mmctl/docs/mmctl_export_create.rst
@@ -21,8 +21,8 @@ Options
 ::
 
   -h, --help                        help for create
-      --include-archived-channels   Set to true to include archived channels in the export file.
-      --no-attachments              Set to true to exclude file attachments in the export file.
+      --include-archived-channels   Include archived channels in the export file.
+      --no-attachments              Omit file attachments in the export file.
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#### Summary
Updated mmctl export create command flag to align with product documentation (updated via https://github.com/mattermost/docs/pull/6796)

#### Release Note

```release-note
NONE
```
