### PR TITLE
gap of 8px between modal footer buttons when opened in mobile (Web App)

### DIFF
--- a/webapp/channels/src/sass/components/_modal.scss
+++ b/webapp/channels/src/sass/components/_modal.scss
@@ -137,7 +137,11 @@
     }
 
     .modal-footer {
+        display: flex;
         background: var(--center-channel-bg);
+        flex-wrap: wrap;
+        justify-content: end;
+        grid-row-gap: 8px;
 
         &.modal-footer--invisible {
             overflow: hidden;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

I fixed the issue where there was no gap between buttons in modal footer when second button is wrapped to next line, like in convert channel modal. I took into consideration all modals used in web app and made code accordingly. 

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

Fixes https://github.com/mattermost/mattermost/issues/25434
Jira https://mattermost.atlassian.net/browse/MM-55140

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

Before:-

![mattermost3ss](https://github.com/mattermost/mattermost/assets/91268931/bbc56199-3598-48af-8229-3faf01d0e353)

After:-
![mattermost1ss](https://github.com/mattermost/mattermost/assets/91268931/b4bd68d3-00cf-4bb3-8440-695fe0b69989)


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->

```release-note
Added gap of 8px between buttons in modal footer when opened in mobile.
```
