### PR TITLE
MM-54774 - update session roles when promote/demote guests (#25156)

### DIFF
--- a/server/channels/app/platform/session.go
+++ b/server/channels/app/platform/session.go
@@ -223,8 +223,13 @@ func (ps *PlatformService) ExtendSessionExpiry(session *model.Session, newExpiry
 	return nil
 }
 
-func (ps *PlatformService) UpdateSessionsIsGuest(userID string, isGuest bool) error {
-	sessions, err := ps.GetSessions(userID)
+func (ps *PlatformService) UpdateSessionsIsGuest(user *model.User, isGuest bool) error {
+	sessions, err := ps.GetSessions(user.Id)
+	if err != nil {
+		return err
+	}
+
+	_, err = ps.Store.Session().UpdateRoles(user.Id, user.GetRawRoles())
 	if err != nil {
 		return err
 	}

--- a/server/channels/app/platform/session_test.go
+++ b/server/channels/app/platform/session_test.go
@@ -4,6 +4,7 @@
 package platform
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -147,16 +148,16 @@ func TestUpdateSessionsIsGuest(t *testing.T) {
 		session.Roles = "fake_role"
 		th.Service.SetSessionExpireInHours(session, 24)
 
-		session, _ = th.Service.CreateSession(th.Context, session)
+		session, _ = th.Service.CreateSession(session)
 
 		demotedUser, err := th.Service.Store.User().DemoteUserToGuest(user.Id)
 		require.NoError(t, err)
 		require.Equal(t, model.SystemGuestRoleId, demotedUser.Roles)
 
-		err = th.Service.UpdateSessionsIsGuest(th.Context, demotedUser, true)
+		err = th.Service.UpdateSessionsIsGuest(demotedUser, true)
 		require.NoError(t, err)
 
-		session, err = th.Service.GetSession(th.Context, session.Id)
+		session, err = th.Service.GetSession(session.Id)
 		require.NoError(t, err)
 		require.Equal(t, model.SystemGuestRoleId, session.Roles)
 		require.Equal(t, "true", session.Props[model.SessionPropIsGuest])
@@ -172,17 +173,17 @@ func TestUpdateSessionsIsGuest(t *testing.T) {
 		session.Roles = "fake_role"
 		th.Service.SetSessionExpireInHours(session, 24)
 
-		session, _ = th.Service.CreateSession(th.Context, session)
+		session, _ = th.Service.CreateSession(session)
 
 		err := th.Service.Store.User().PromoteGuestToUser(user.Id)
 		require.NoError(t, err)
 
-		promotedUser, err := th.Service.Store.User().Get(th.Context.Context(), user.Id)
+		promotedUser, err := th.Service.Store.User().Get(context.Background(), user.Id)
 		require.NoError(t, err)
-		err = th.Service.UpdateSessionsIsGuest(th.Context, promotedUser, false)
+		err = th.Service.UpdateSessionsIsGuest(promotedUser, false)
 		require.NoError(t, err)
 
-		session, err = th.Service.GetSession(th.Context, session.Id)
+		session, err = th.Service.GetSession(session.Id)
 		require.NoError(t, err)
 		require.Equal(t, model.SystemUserRoleId, session.Roles)
 		require.Equal(t, "false", session.Props[model.SessionPropIsGuest])

--- a/server/channels/app/platform/session_test.go
+++ b/server/channels/app/platform/session_test.go
@@ -132,3 +132,59 @@ func TestOAuthRevokeAccessToken(t *testing.T) {
 	err = th.Service.RevokeAccessToken(accessData.Token)
 	require.NoError(t, err)
 }
+
+func TestUpdateSessionsIsGuest(t *testing.T) {
+	th := Setup(t)
+	defer th.TearDown()
+
+	t.Run("Test session is demoted", func(t *testing.T) {
+		user := th.CreateUserOrGuest(false)
+
+		session := &model.Session{}
+		session.CreateAt = model.GetMillis()
+		session.UserId = user.Id
+		session.Token = model.NewId()
+		session.Roles = "fake_role"
+		th.Service.SetSessionExpireInHours(session, 24)
+
+		session, _ = th.Service.CreateSession(th.Context, session)
+
+		demotedUser, err := th.Service.Store.User().DemoteUserToGuest(user.Id)
+		require.NoError(t, err)
+		require.Equal(t, model.SystemGuestRoleId, demotedUser.Roles)
+
+		err = th.Service.UpdateSessionsIsGuest(th.Context, demotedUser, true)
+		require.NoError(t, err)
+
+		session, err = th.Service.GetSession(th.Context, session.Id)
+		require.NoError(t, err)
+		require.Equal(t, model.SystemGuestRoleId, session.Roles)
+		require.Equal(t, "true", session.Props[model.SessionPropIsGuest])
+	})
+
+	t.Run("Test session is promoted", func(t *testing.T) {
+		user := th.CreateUserOrGuest(true)
+
+		session := &model.Session{}
+		session.CreateAt = model.GetMillis()
+		session.UserId = user.Id
+		session.Token = model.NewId()
+		session.Roles = "fake_role"
+		th.Service.SetSessionExpireInHours(session, 24)
+
+		session, _ = th.Service.CreateSession(th.Context, session)
+
+		err := th.Service.Store.User().PromoteGuestToUser(user.Id)
+		require.NoError(t, err)
+
+		promotedUser, err := th.Service.Store.User().Get(th.Context.Context(), user.Id)
+		require.NoError(t, err)
+		err = th.Service.UpdateSessionsIsGuest(th.Context, promotedUser, false)
+		require.NoError(t, err)
+
+		session, err = th.Service.GetSession(th.Context, session.Id)
+		require.NoError(t, err)
+		require.Equal(t, model.SystemUserRoleId, session.Roles)
+		require.Equal(t, "false", session.Props[model.SessionPropIsGuest])
+	})
+}

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -2299,7 +2299,7 @@ func (a *App) PromoteGuestToUser(c *request.Context, user *model.User, requestor
 		c.Logger().Warn("Failed to get user on promote guest to user", mlog.Err(err))
 	} else {
 		a.sendUpdatedUserEvent(*promotedUser)
-		if uErr := a.ch.srv.platform.UpdateSessionsIsGuest(promotedUser.Id, promotedUser.IsGuest()); uErr != nil {
+		if uErr := a.ch.srv.platform.UpdateSessionsIsGuest(promotedUser, promotedUser.IsGuest()); uErr != nil {
 			c.Logger().Warn("Unable to update user sessions", mlog.String("user_id", promotedUser.Id), mlog.Err(uErr))
 		}
 	}
@@ -2344,7 +2344,7 @@ func (a *App) DemoteUserToGuest(c request.CTX, user *model.User) *model.AppError
 	}
 
 	a.sendUpdatedUserEvent(*demotedUser)
-	if uErr := a.ch.srv.platform.UpdateSessionsIsGuest(demotedUser.Id, demotedUser.IsGuest()); uErr != nil {
+	if uErr := a.ch.srv.platform.UpdateSessionsIsGuest(demotedUser, demotedUser.IsGuest()); uErr != nil {
 		c.Logger().Warn("Unable to update user sessions", mlog.String("user_id", demotedUser.Id), mlog.Err(uErr))
 	}
 


### PR DESCRIPTION


Co-authored-by: Mattermost Build <build@mattermost.com>
(cherry picked from commit 818a48190ed0c27e231fd82d545142a10f440ee0)

Cherry-pick - https://github.com/mattermost/mattermost/pull/25156
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Update session roles when user/guest is promoted/demoted.
```
