### PR TITLE
[MM-55408] Fixed a bug where channel admin wasn't set when converting GM to private channel

### DIFF
--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -3561,6 +3561,13 @@ func (a *App) ConvertGroupMessageToChannel(c request.CTX, convertedByUserId stri
 
 	_ = a.setSidebarCategoriesForConvertedGroupMessage(c, gmConversionRequest, users)
 	_ = a.postMessageForConvertGroupMessageToChannel(c, gmConversionRequest.ChannelID, convertedByUserId, users)
+
+	// the user conversion the GM becomes the channel admin.
+	_, appErr = a.UpdateChannelMemberSchemeRoles(c, gmConversionRequest.ChannelID, convertedByUserId, false, true, true)
+	if appErr != nil {
+		return nil, appErr
+	}
+
 	return updatedChannel, nil
 }
 

--- a/server/channels/app/channel_test.go
+++ b/server/channels/app/channel_test.go
@@ -2542,7 +2542,9 @@ func TestConvertGroupMessageToChannel(t *testing.T) {
 	mockChannelStore.On("InvalidateChannelByName", "team_id_1", "new_name").Times(1)
 	mockChannelStore.On("InvalidateChannelByName", "dm", "")
 	mockChannelStore.On("GetMember", sqlstore.WithMaster(context.Background()), "channelidchannelidchanneli", "user_id_1").Return(&model.ChannelMember{}, nil).Times(1)
-	mockChannelStore.On("GetMember", context.Background(), "channelidchannelidchanneli", "user_id_1").Return(&model.ChannelMember{}, nil).Times(1)
+	mockChannelStore.On("GetMember", context.Background(), "channelidchannelidchanneli", "user_id_1").Return(&model.ChannelMember{}, nil).Times(2)
+	mockChannelStore.On("UpdateMember", mock.AnythingOfType("*model.ChannelMember")).Return(&model.ChannelMember{UserId: "user_id_1"}, nil)
+	mockChannelStore.On("InvalidateAllChannelMembersForUser", "user_id_1").Return()
 	mockChannelStore.On("InvalidatePinnedPostCount", "channelidchannelidchanneli")
 	mockChannelStore.On("GetAllChannelMembersNotifyPropsForChannel", "channelidchannelidchanneli", true).Return(map[string]model.StringMap{}, nil)
 	mockChannelStore.On("IncrementMentionCount", "", []string{}, true, false).Return(nil)
@@ -2623,11 +2625,17 @@ func TestConvertGroupMessageToChannel(t *testing.T) {
 		{Id: "user_id_2", Username: "user_id_2"},
 	}, nil)
 	mockUserStore.On("GetAllProfilesInChannel", mock.Anything, mock.Anything, mock.Anything).Return(map[string]*model.User{}, nil)
+	mockUserStore.On("InvalidateProfilesInChannelCacheByUser", "user_id_1").Return()
+	mockUserStore.On("InvalidateProfileCacheForUser", "user_id_1").Return()
 
 	mockPostStore := mocks.PostStore{}
 	mockStore.On("Post").Return(&mockPostStore)
 	mockPostStore.On("Save", mock.AnythingOfType("*model.Post")).Return(&model.Post{}, nil)
 	mockPostStore.On("InvalidateLastPostTimeCache", "channelidchannelidchanneli")
+
+	mockSystemStore := mocks.SystemStore{}
+	mockStore.On("System").Return(&mockSystemStore)
+	mockSystemStore.On("GetByName", model.MigrationKeyAdvancedPermissionsPhase2).Return(nil, nil)
 
 	var err error
 


### PR DESCRIPTION
#### Summary
Fixed a bug where channel admin wasn't being set when converting GM to private channel. The user who converts the channel becomes the admin.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-55408

#### Release Note
```release-note
Fixed a bug where channel admin wasn't being set when converting GM to private channel. The user who converts the channel becomes the channel admin.
```
