### PR TITLE
[MM-55739] Allow admins to pipe the output of mmctl websocket into JSON parser

### DIFF
--- a/server/cmd/mmctl/commands/websockets.go
+++ b/server/cmd/mmctl/commands/websockets.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -31,7 +32,7 @@ func websocketCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	c.Listen()
-	fmt.Println("Press CTRL+C to exit")
+	fmt.Fprintln(os.Stderr, "Press CTRL+C to exit")
 	for {
 		event := <-c.EventChannel
 		data, err := event.ToJSON()


### PR DESCRIPTION
#### Summary
```
$ go run ./cmd/mmctl websocket | jq
Press CTRL+C to exit
{
  "event": "hello",
  "data": {
    "connection_id": "beysw7hhzp8f3ffjnpzze3jg9o",
    "server_version": "9.3.0.dev.97d03412b550c574d4c52eb26ff90aa3.true"
  },
  "broadcast": {
    "omit_users": null,
    "user_id": "8p4nu3hy1irwup8pkxwaj7togc",
    "channel_id": "",
    "team_id": "",
    "connection_id": "",
    "omit_connection_id": ""
  },
  "seq": 0
}
{
  "event": "draft_created",
  "data": {
    "draft": "{\"create_at\":1701082100948,\"update_at\":1701082101001,\"delete_at\":0,\"user_id\":\"8p4nu3hy1irwup8pkxwaj7togc\",\"channel_id\":\"3ofx38t6jtbxjpchiw5paf56so\",\"root_id\":\"\",\"message\":\"asd \",\"props\":{},\"metadata\":{}}"
  },
  "broadcast": {
    "omit_users": null,
    "user_id": "8p4nu3hy1irwup8pkxwaj7togc",
    "channel_id": "3ofx38t6jtbxjpchiw5paf56so",
    "team_id": "",
    "connection_id": "",
    "omit_connection_id": "fo1b64bgojyd5g4twe4xkw1i8o"
  },
  "seq": 1
}
```
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55739

#### Release Note
```release-note
Allow admins to pipe the output of `mmctl websocket` into JSON parser
```
