### PR TITLE
[MM-55631] Remove extra call to Draft().Get()

### DIFF
--- a/server/channels/api4/drafts.go
+++ b/server/channels/api4/drafts.go
@@ -135,7 +135,7 @@ func deleteDraft(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := c.App.DeleteDraft(c.AppContext, userID, channelID, rootID, connectionID); err != nil {
+	if err := c.App.DeleteDraft(c.AppContext, draft, connectionID); err != nil {
 		c.Err = err
 		return
 	}

--- a/server/channels/app/app_iface.go
+++ b/server/channels/app/app_iface.go
@@ -523,7 +523,7 @@ type AppIface interface {
 	DeleteBrandImage() *model.AppError
 	DeleteChannel(c request.CTX, channel *model.Channel, userID string) *model.AppError
 	DeleteCommand(commandID string) *model.AppError
-	DeleteDraft(rctx request.CTX, userID, channelID, rootID, connectionID string) (*model.Draft, *model.AppError)
+	DeleteDraft(rctx request.CTX, draft *model.Draft, connectionID string) *model.AppError
 	DeleteEmoji(c request.CTX, emoji *model.Emoji) *model.AppError
 	DeleteEphemeralPost(userID, postID string)
 	DeleteExport(name string) *model.AppError

--- a/server/channels/app/draft.go
+++ b/server/channels/app/draft.go
@@ -139,18 +139,13 @@ func (a *App) getFileInfosForDraft(rctx request.CTX, draft *model.Draft) ([]*mod
 	return fileInfos, nil
 }
 
-func (a *App) DeleteDraft(rctx request.CTX, userID, channelID, rootID, connectionID string) (*model.Draft, *model.AppError) {
+func (a *App) DeleteDraft(rctx request.CTX, draft *model.Draft, connectionID string) *model.AppError {
 	if !*a.Config().ServiceSettings.AllowSyncedDrafts {
-		return nil, model.NewAppError("DeleteDraft", "app.draft.feature_disabled", nil, "", http.StatusNotImplemented)
+		return model.NewAppError("DeleteDraft", "app.draft.feature_disabled", nil, "", http.StatusNotImplemented)
 	}
 
-	draft, nErr := a.Srv().Store().Draft().Get(userID, channelID, rootID, false)
-	if nErr != nil {
-		return nil, model.NewAppError("DeleteDraft", "app.draft.get.app_error", nil, nErr.Error(), http.StatusBadRequest)
-	}
-
-	if err := a.Srv().Store().Draft().Delete(userID, channelID, rootID); err != nil {
-		return nil, model.NewAppError("DeleteDraft", "app.draft.delete.app_error", nil, err.Error(), http.StatusInternalServerError)
+	if err := a.Srv().Store().Draft().Delete(draft.UserId, draft.ChannelId, draft.RootId); err != nil {
+		return model.NewAppError("DeleteDraft", "app.draft.delete.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	draftJSON, jsonErr := json.Marshal(draft)
@@ -162,5 +157,5 @@ func (a *App) DeleteDraft(rctx request.CTX, userID, channelID, rootID, connectio
 	message.Add("draft", string(draftJSON))
 	a.Publish(message)
 
-	return draft, nil
+	return nil
 }

--- a/server/channels/app/draft_test.go
+++ b/server/channels/app/draft_test.go
@@ -383,14 +383,8 @@ func TestDeleteDraft(t *testing.T) {
 	assert.Nil(t, createDraftErr)
 
 	t.Run("delete draft", func(t *testing.T) {
-		draftResp, err := th.App.DeleteDraft(th.Context, user.Id, channel.Id, "", "")
+		err := th.App.DeleteDraft(th.Context, draft1, "")
 		assert.Nil(t, err)
-
-		assert.Equal(t, draft1.Message, draftResp.Message)
-		assert.Equal(t, draft1.ChannelId, draftResp.ChannelId)
-
-		assert.Equal(t, draft1.Message, draftResp.Message)
-		assert.Equal(t, draft1.ChannelId, draftResp.ChannelId)
 	})
 
 	t.Run("delete drafts feature flag", func(t *testing.T) {
@@ -402,7 +396,7 @@ func TestDeleteDraft(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.AllowSyncedDrafts = false })
 		defer th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.AllowSyncedDrafts = true })
 
-		_, err := th.App.DeleteDraft(th.Context, user.Id, channel.Id, "", "")
+		err := th.App.DeleteDraft(th.Context, draft1, "")
 		assert.NotNil(t, err)
 	})
 }

--- a/server/channels/app/opentracing/opentracing_layer.go
+++ b/server/channels/app/opentracing/opentracing_layer.go
@@ -3049,7 +3049,7 @@ func (a *OpenTracingAppLayer) DeleteCommand(commandID string) *model.AppError {
 	return resultVar0
 }
 
-func (a *OpenTracingAppLayer) DeleteDraft(rctx request.CTX, userID string, channelID string, rootID string, connectionID string) (*model.Draft, *model.AppError) {
+func (a *OpenTracingAppLayer) DeleteDraft(rctx request.CTX, draft *model.Draft, connectionID string) *model.AppError {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.DeleteDraft")
 
@@ -3061,14 +3061,14 @@ func (a *OpenTracingAppLayer) DeleteDraft(rctx request.CTX, userID string, chann
 	}()
 
 	defer span.Finish()
-	resultVar0, resultVar1 := a.app.DeleteDraft(rctx, userID, channelID, rootID, connectionID)
+	resultVar0 := a.app.DeleteDraft(rctx, draft, connectionID)
 
-	if resultVar1 != nil {
-		span.LogFields(spanlog.Error(resultVar1))
+	if resultVar0 != nil {
+		span.LogFields(spanlog.Error(resultVar0))
 		ext.Error.Set(span, true)
 	}
 
-	return resultVar0, resultVar1
+	return resultVar0
 }
 
 func (a *OpenTracingAppLayer) DeleteEmoji(c request.CTX, emoji *model.Emoji) *model.AppError {


### PR DESCRIPTION
#### Summary
We have an extra unnecessary call to `Store().Draft().Get()` that we can remove here.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55631

```release-note
NONE
```
