### PR TITLE
Fix mung of usernames on collision in shared channels; tilde is not a valid character

### DIFF
--- a/server/platform/services/sharedchannel/util.go
+++ b/server/platform/services/sharedchannel/util.go
@@ -45,12 +45,14 @@ func sanitizeUserForSync(user *model.User) *model.User {
 	return user
 }
 
+const MungUsernameSeparator = "-"
+
 // mungUsername creates a new username by combining username and remote cluster name, plus
 // a suffix to create uniqueness. If the resulting username exceeds the max length then
 // it is truncated and ellipses added.
 func mungUsername(username string, remotename string, suffix string, maxLen int) string {
 	if suffix != "" {
-		suffix = "~" + suffix
+		suffix = MungUsernameSeparator + suffix
 	}
 
 	// If the username already contains a colon then another server already munged it.

--- a/server/platform/services/sharedchannel/util_test.go
+++ b/server/platform/services/sharedchannel/util_test.go
@@ -25,25 +25,25 @@ func Test_mungUsername(t *testing.T) {
 		{"everything empty", args{username: "", remotename: "", suffix: "", maxLen: 64}, ":"},
 
 		{"no trunc, no suffix", args{username: "bart", remotename: "example.com", suffix: "", maxLen: 64}, "bart:example.com"},
-		{"no trunc, suffix", args{username: "bart", remotename: "example.com", suffix: "2", maxLen: 64}, "bart~2:example.com"},
+		{"no trunc, suffix", args{username: "bart", remotename: "example.com", suffix: "2", maxLen: 64}, "bart-2:example.com"},
 
 		{"trunc remote, no suffix", args{username: "bart", remotename: "example1234567890.com", suffix: "", maxLen: 24}, "bart:example123456789..."},
-		{"trunc remote, suffix", args{username: "bart", remotename: "example1234567890.com", suffix: "2", maxLen: 24}, "bart~2:example1234567..."},
+		{"trunc remote, suffix", args{username: "bart", remotename: "example1234567890.com", suffix: "2", maxLen: 24}, "bart-2:example1234567..."},
 
 		{"trunc both, no suffix", args{username: R(24, "A"), remotename: R(24, "B"), suffix: "", maxLen: 24}, "AAAAAAAAA...:BBBBBBBB..."},
-		{"trunc both, suffix", args{username: R(24, "A"), remotename: R(24, "B"), suffix: "10", maxLen: 24}, "AAAAAA~10...:BBBBBBBB..."},
+		{"trunc both, suffix", args{username: R(24, "A"), remotename: R(24, "B"), suffix: "10", maxLen: 24}, "AAAAAA-10...:BBBBBBBB..."},
 
 		{"trunc user, no suffix", args{username: R(40, "A"), remotename: "abc", suffix: "", maxLen: 24}, "AAAAAAAAAAAAAAAAA...:abc"},
-		{"trunc user, suffix", args{username: R(40, "A"), remotename: "abc", suffix: "11", maxLen: 24}, "AAAAAAAAAAAAAA~11...:abc"},
+		{"trunc user, suffix", args{username: R(40, "A"), remotename: "abc", suffix: "11", maxLen: 24}, "AAAAAAAAAAAAAA-11...:abc"},
 
 		{"trunc user, remote, no suffix", args{username: R(40, "A"), remotename: "abcdefghijk", suffix: "", maxLen: 24}, "AAAAAAAAA...:abcdefghijk"},
-		{"trunc user, remote, suffix", args{username: R(40, "A"), remotename: "abcdefghijk", suffix: "19", maxLen: 24}, "AAAAAA~19...:abcdefghijk"},
+		{"trunc user, remote, suffix", args{username: R(40, "A"), remotename: "abcdefghijk", suffix: "19", maxLen: 24}, "AAAAAA-19...:abcdefghijk"},
 
 		{"short user, long remote, no suffix", args{username: "bart", remotename: R(40, "B"), suffix: "", maxLen: 24}, "bart:BBBBBBBBBBBBBBBB..."},
 		{"long user, short remote, no suffix", args{username: R(40, "A"), remotename: "abc.com", suffix: "", maxLen: 24}, "AAAAAAAAAAAAA...:abc.com"},
 
-		{"short user, long remote, suffix", args{username: "bart", remotename: R(40, "B"), suffix: "12", maxLen: 24}, "bart~12:BBBBBBBBBBBBB..."},
-		{"long user, short remote, suffix", args{username: R(40, "A"), remotename: "abc.com", suffix: "12", maxLen: 24}, "AAAAAAAAAA~12...:abc.com"},
+		{"short user, long remote, suffix", args{username: "bart", remotename: R(40, "B"), suffix: "12", maxLen: 24}, "bart-12:BBBBBBBBBBBBB..."},
+		{"long user, short remote, suffix", args{username: R(40, "A"), remotename: "abc.com", suffix: "12", maxLen: 24}, "AAAAAAAAAA-12...:abc.com"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#### Summary
When a remote username collides with an existing local one, the remote username is modified to make it unique.  The mung method used a tilde plus number, however the tilde is not a valid username character and the user create call fails.

`SharedChannelServiceError [2023-11-29 15:48:17.466 -05:00] Error upserting sync user remote=tower channel_id=7n6nd4gyp7y6xcdduf9oadc9so user_id=f1zbmzur8iyafjjnq8pqxwqn7w  error="error inserting sync user f1zbmzur8iyafjjnq8pqxwqn7w: User.IsValid:  Username must begin with a letter, and contain between 3 to 22 lowercase characters made up of numbers, letters, and the symbols ".", "-", and "_".,  user_id=f1zbmzur8iyafjjnq8pqxwqn7w username=dlauder~2:tower"`

The tilde has been changed to a valid character '-'.     `dlauder~2:tower`  -->  `dlauder-2:tower`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55979

#### Release Note
```release-note
NONE
```
