### PR TITLE
Fix username collision for shared channels sync update

### DIFF
--- a/server/platform/services/sharedchannel/service.go
+++ b/server/platform/services/sharedchannel/service.go
@@ -70,11 +70,6 @@ type errNotFound interface {
 	IsErrNotFound() bool
 }
 
-// errInvalidInput allows checking against Store.ErrInvalidInput errors without making Store a dependency.
-type errInvalidInput interface {
-	InvalidInputInfo() (entity string, field string, value any)
-}
-
 // Service provides shared channel synchronization.
 type Service struct {
 	server       ServerIface

--- a/server/platform/services/sharedchannel/sync_recv.go
+++ b/server/platform/services/sharedchannel/sync_recv.go
@@ -14,7 +14,6 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/public/shared/request"
-	"github.com/mattermost/mattermost/server/v8/channels/store"
 	"github.com/mattermost/mattermost/server/v8/platform/services/remotecluster"
 )
 
@@ -249,16 +248,16 @@ func (scs *Service) insertSyncUser(user *model.User, channel *model.Channel, rc 
 		user.Email = mungEmail(rc.Name, model.UserEmailMaxLength)
 
 		if userSaved, err = scs.server.GetStore().User().Save(user); err != nil {
-			e, ok := err.(errInvalidInput)
+			field, ok := isConflictError(err)
 			if !ok {
 				break
 			}
-			_, field, value := e.InvalidInputInfo()
 			if field == "email" || field == "username" {
 				// username or email collision; try again with different suffix
 				scs.server.Log().Log(mlog.LvlSharedChannelServiceWarn, "Collision inserting sync user",
 					mlog.String("field", field),
-					mlog.Any("value", value),
+					mlog.String("username", user.Username),
+					mlog.String("email", user.Email),
 					mlog.Int("attempt", i),
 					mlog.Err(err),
 				)
@@ -303,14 +302,14 @@ func (scs *Service) updateSyncUser(patch *model.UserPatch, user *model.User, cha
 		user.Email = mungEmail(rc.Name, model.UserEmailMaxLength)
 
 		if update, err = scs.server.GetStore().User().Update(user, false); err != nil {
-			var errConflict *store.ErrConflict
-			if !errors.As(err, &errConflict) {
+			field, ok := isConflictError(err)
+			if !ok {
 				break
 			}
-			if errConflict.Resource == "Email" || errConflict.Resource == "Username" {
+			if field == "email" || field == "username" {
 				// username or email collision; try again with different suffix
 				scs.server.Log().Log(mlog.LvlSharedChannelServiceWarn, "Collision updating sync user",
-					mlog.String("field", errConflict.Resource),
+					mlog.String("field", field),
 					mlog.String("username", user.Username),
 					mlog.String("email", user.Email),
 					mlog.Int("attempt", i),

--- a/server/platform/services/sharedchannel/util.go
+++ b/server/platform/services/sharedchannel/util.go
@@ -4,10 +4,12 @@
 package sharedchannel
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/v8/channels/store"
 )
 
 // fixMention replaces any mentions in a post for the user with the user's real username.
@@ -98,4 +100,18 @@ func mungEmail(remotename string, maxLen int) string {
 		s = s[:maxLen]
 	}
 	return s
+}
+
+func isConflictError(err error) (string, bool) {
+	var errConflict *store.ErrConflict
+	if errors.As(err, &errConflict) {
+		return strings.ToLower(errConflict.Resource), true
+	}
+
+	var errInput *store.ErrInvalidInput
+	if errors.As(err, &errInput) {
+		_, field, _ := errInput.InvalidInputInfo()
+		return strings.ToLower(field), true
+	}
+	return "", false
 }


### PR DESCRIPTION
#### Summary
When updating a remote user via Shared Channel sync, the username or email may be changed.  If a collision occurs, the username is munged until it is unique.  This is done by checking the specific error code from the user store.

Unfortunately the user store is inconsistent in the error types for collisions between inserting users and updating users.   
`SqlUserStore.Save` returns `store.ErrInvalidInput` on collision.  `SqlUserStore.Update` returns `store.ErrConflict` on collision.  

Shared Channels was looking for `store.ErrInvalidInput` when updating and failing to detect collisions.  This only happens when a username or email is changed.

The fix is resilient to User.Store becoming consistent in the future.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55983

#### Release Note
```release-note
NONE
```
