### PR TITLE
Cherrypick of #24342 for v9.2

### DIFF
--- a/server/channels/app/migrations.go
+++ b/server/channels/app/migrations.go
@@ -555,20 +555,27 @@ func (s *Server) doPostPriorityConfigDefaultTrueMigration() {
 }
 
 func (s *Server) doElasticsearchFixChannelIndex(c *request.Context) {
+	s.AddLicenseListener(func(oldLicense, newLicense *model.License) {
+		s.elasticsearchFixChannelIndex(c, newLicense)
+	})
+
+	s.elasticsearchFixChannelIndex(c, s.License())
+}
+
+func (s *Server) elasticsearchFixChannelIndex(c *request.Context, license *model.License) {
+	if model.BuildEnterpriseReady != "true" || license == nil || !*license.Features.Elasticsearch {
+		mlog.Debug("Skipping triggering Elasticsearch channel index fix job as build is not Enterprise ready")
+		return
+	}
+
 	// If the migration is already marked as completed, don't do it again.
 	if _, err := s.Store().System().GetByName(model.MigrationKeyElasticsearchFixChannelIndex); err == nil {
+		mlog.Debug("Skipping triggering Elasticsearch channel index fix job as it is already marked completed in database")
 		return
 	}
 
-	license := s.License()
-	if model.BuildEnterpriseReady != "true" || license == nil || !*license.Features.Elasticsearch {
-		mlog.Info("Skipping triggering Elasticsearch channel index fix job as build is not Enterprise ready")
-		return
-	}
-
-	if _, appErr := s.Jobs.CreateJob(c, model.JobTypeElasticsearchFixChannelIndex, nil); appErr != nil {
+	if _, appErr := s.Jobs.CreateJobOnce(c, model.JobTypeElasticsearchFixChannelIndex, nil); appErr != nil {
 		mlog.Fatal("failed to start job for fixing Elasticsearch channels index", mlog.Err(appErr))
-		return
 	}
 }
 


### PR DESCRIPTION
#### Summary
Cherrypick of #24342 for v9.2

#### Release Note
```release-note
Updated the fix to run on license change on running server, thus removing the step to restart Mattermost server for the fix to take affect.
```
