### PR TITLE
Allow developers to set a custom go version via env variables

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -99,8 +99,8 @@ GOFLAGS ?= $(GOFLAGS:)
 # We need to export GOBIN to allow it to be set
 # for processes spawned from the Makefile
 export GOBIN ?= $(PWD)/bin
-GO=go
-DELVE=dlv
+GO ?= go
+DELVE ?= dlv
 LDFLAGS += -X "github.com/mattermost/mattermost/server/public/model.BuildNumber=$(BUILD_NUMBER)"
 LDFLAGS += -X "github.com/mattermost/mattermost/server/public/model.BuildDate=$(BUILD_DATE)"
 LDFLAGS += -X "github.com/mattermost/mattermost/server/public/model.BuildHash=$(BUILD_HASH)"


### PR DESCRIPTION
#### Summary
Developers might want to use a different go version then one installed as `go`. They can now do that by setting the `GO` env variable (same for `DELVE`).

See https://go.dev/doc/manage-install for more information on how to install different go versions.

Once go1.21 is widely adopted, the `GOTOOLCHAIN` variable will serve the same purpose. See https://go.dev/blog/toolchain for more details.

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
