### PR TITLE
Promoting Simplified Chinese from Alpha to Beta

### DIFF
--- a/webapp/channels/src/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/webapp/channels/src/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -382,7 +382,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 19,
-                  "text": "中文 (简体) (Alpha)",
+                  "text": "中文 (简体) (Beta)",
                   "value": "zh-CN",
                 },
                 Object {
@@ -518,7 +518,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 19,
-                  "text": "中文 (简体) (Alpha)",
+                  "text": "中文 (简体) (Beta)",
                   "value": "zh-CN",
                 },
                 Object {

--- a/webapp/channels/src/i18n/i18n.jsx
+++ b/webapp/channels/src/i18n/i18n.jsx
@@ -146,7 +146,7 @@ const languages = {
     },
     'zh-CN': {
         value: 'zh-CN',
-        name: '中文 (简体) (Alpha)',
+        name: '中文 (简体) (Beta)',
         order: 19,
         url: zhCN,
     },


### PR DESCRIPTION
#### Summary
Promoting Simplified Chinese from Alpha to Beta across the platform
Thanks to our new translators for Simplified Chinese we can promote it back to beta 

#### Release Note
```release-note
Promoted Simplified Chinese language to Beta.
```
