### PR TITLE
MM-56087 Change Move Thread hotkey to force close menu

### DIFF
--- a/webapp/channels/src/components/dot_menu/dot_menu.tsx
+++ b/webapp/channels/src/components/dot_menu/dot_menu.tsx
@@ -385,8 +385,8 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
 
         // move thread
         case Keyboard.isKeyPressed(event, Constants.KeyCodes.W):
+            forceCloseMenu();
             this.handleMoveThreadMenuItemActivated(event);
-            this.props.handleDropdownOpened(false);
             break;
 
             // pin / unpin


### PR DESCRIPTION
#### Summary
To get around the issue where MUI and React Bootstrap fight for focus, we have to ensure the menu is fully closed before the modal starts to fade in. `handleDropdownOpened` doesn't do that fast enough, but `forceCloseMenu` does. I think that's because the former lets the menu fade out while the latter just closes it immediately

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56087

#### Release Note
```release-note
NONE
```
