### PR TITLE
Adds update channel bookmark sort order endpoint

### DIFF
--- a/api/v4/source/bookmarks.yaml
+++ b/api/v4/source/bookmarks.yaml
@@ -147,3 +147,58 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+
+  /api/v4/channels/{channel_id}/bookmarks/{bookmark_id}/sort_order:
+    post:
+      tags:
+        - bookmarks
+      summary: Update channel bookmark's order
+      description: |
+        Updates the order of a channel bookmark, setting its new order
+        from the parameters and updating the rest of the bookmarks of
+        the channel to accomodate for this change.
+
+        __Minimum server version__: 9.4
+
+        ##### Permissions
+        Must have the `order_bookmark_public_channel` or
+        `order_bookmark_private_channel` depending on the channel
+        type. If the channel is a DM or GM, must be a non-guest
+        member.
+      operationId: UpdateChannelBookmarkSortOrder
+      parameters:
+        - name: channel_id
+          in: path
+          description: Channel GUID
+          required: true
+          schema:
+            type: string
+        - name: bookmark_id
+          in: path
+          description: Bookmark GUID
+          required: true
+          schema:
+            type: string
+      body:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: number
+              format: int64
+              description: The new sort order for the Channel Bookmark
+      responses:
+        "200":
+          description: Channel Bookmark Sort Order update successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ChannelBookmarkWithFileInfo"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"

--- a/server/channels/api4/channel_bookmark.go
+++ b/server/channels/api4/channel_bookmark.go
@@ -217,6 +217,11 @@ func updateChannelBookmarkSortOrder(c *Context, w http.ResponseWriter, r *http.R
 		return
 	}
 
+	if newSortOrder < 0 {
+		c.SetInvalidParam("channelBookmarkSortOrder")
+		return
+	}
+
 	auditRec := c.MakeAuditRecord("updateChannelBookmarkSortOrder", audit.Fail)
 	defer c.LogAuditRec(auditRec)
 

--- a/server/channels/api4/channel_bookmark_test.go
+++ b/server/channels/api4/channel_bookmark_test.go
@@ -528,48 +528,7 @@ func TestEditChannelBookmark(t *testing.T) {
 		require.Nil(t, gucb)
 	})
 
-	t.Run("a user should be able to edit another usrer's bookmark", func(t *testing.T) {
-		channelBookmark := &model.ChannelBookmark{
-			ChannelId:   th.BasicChannel.Id,
-			DisplayName: "Link bookmark test",
-			LinkUrl:     "https://mattermost.com",
-			Type:        model.ChannelBookmarkLink,
-			Emoji:       ":smile:",
-		}
-
-		cb, resp, err := th.Client.CreateChannelBookmark(context.Background(), channelBookmark)
-		require.NoError(t, err)
-		CheckCreatedStatus(t, resp)
-		require.NotNil(t, cb)
-
-		patch := &model.ChannelBookmarkPatch{
-			DisplayName: model.NewString("Edited bookmark test"),
-			LinkUrl:     model.NewString("http://edited.url"),
-		}
-
-		// create a client for basic user 2
-		client2 := th.CreateClient()
-		_, _, lErr := client2.Login(context.Background(), th.BasicUser2.Username, "Pa$$word11")
-		require.NoError(t, lErr)
-
-		ucb, resp, err := client2.UpdateChannelBookmark(context.Background(), cb.ChannelId, cb.Id, patch)
-		require.NoError(t, err)
-		CheckOKStatus(t, resp)
-
-		// Deleted should contain old channel bookmark
-		require.NotNil(t, ucb.Deleted)
-		require.Equal(t, cb.DisplayName, ucb.Deleted.DisplayName)
-		require.Equal(t, cb.LinkUrl, ucb.Deleted.LinkUrl)
-		require.Equal(t, th.BasicUser.Id, ucb.Deleted.OwnerId)
-
-		// Updated should contain the new channel bookmark
-		require.NotNil(t, ucb.Updated)
-		require.Equal(t, *patch.DisplayName, ucb.Updated.DisplayName)
-		require.Equal(t, *patch.LinkUrl, ucb.Updated.LinkUrl)
-		require.Equal(t, th.BasicUser2.Id, ucb.Updated.OwnerId)
-	})
-
-	t.Run("a user should be able to edit another usrer's bookmark", func(t *testing.T) {
+	t.Run("a user should be able to edit another user's bookmark", func(t *testing.T) {
 		channelBookmark := &model.ChannelBookmark{
 			ChannelId:   th.BasicChannel.Id,
 			DisplayName: "Link bookmark test",

--- a/server/channels/api4/channel_bookmark_test.go
+++ b/server/channels/api4/channel_bookmark_test.go
@@ -748,6 +748,24 @@ func TestUpdateChannelBookmarkSortOrder(t *testing.T) {
 				expectedError:  true,
 				expectedStatus: http.StatusForbidden,
 			},
+			{
+				name:           "public channel with permissions, setting order to a negative number, should fail",
+				channelId:      th.BasicChannel.Id,
+				bookmarkId:     publicBookmark2.Id,
+				sortOrder:      -1,
+				userClient:     th.Client,
+				expectedError:  true,
+				expectedStatus: http.StatusBadRequest,
+			},
+			{
+				name:           "public channel with permissions, setting order to a number greater than the amount of bookmarks of the channel, should fail",
+				channelId:      th.BasicChannel.Id,
+				bookmarkId:     publicBookmark2.Id,
+				sortOrder:      300,
+				userClient:     th.Client,
+				expectedError:  true,
+				expectedStatus: http.StatusBadRequest,
+			},
 		}
 
 		for _, tc := range testCases {

--- a/server/channels/api4/channel_bookmark_test.go
+++ b/server/channels/api4/channel_bookmark_test.go
@@ -569,6 +569,47 @@ func TestEditChannelBookmark(t *testing.T) {
 		require.Equal(t, th.BasicUser2.Id, ucb.Updated.OwnerId)
 	})
 
+	t.Run("a user should be able to edit another usrer's bookmark", func(t *testing.T) {
+		channelBookmark := &model.ChannelBookmark{
+			ChannelId:   th.BasicChannel.Id,
+			DisplayName: "Link bookmark test",
+			LinkUrl:     "https://mattermost.com",
+			Type:        model.ChannelBookmarkLink,
+			Emoji:       ":smile:",
+		}
+
+		cb, resp, err := th.Client.CreateChannelBookmark(context.Background(), channelBookmark)
+		require.NoError(t, err)
+		CheckCreatedStatus(t, resp)
+		require.NotNil(t, cb)
+
+		patch := &model.ChannelBookmarkPatch{
+			DisplayName: model.NewString("Edited bookmark test"),
+			LinkUrl:     model.NewString("http://edited.url"),
+		}
+
+		// create a client for basic user 2
+		client2 := th.CreateClient()
+		_, _, lErr := client2.Login(context.Background(), th.BasicUser2.Username, "Pa$$word11")
+		require.NoError(t, lErr)
+
+		ucb, resp, err := client2.UpdateChannelBookmark(context.Background(), cb.ChannelId, cb.Id, patch)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+
+		// Deleted should contain old channel bookmark
+		require.NotNil(t, ucb.Deleted)
+		require.Equal(t, cb.DisplayName, ucb.Deleted.DisplayName)
+		require.Equal(t, cb.LinkUrl, ucb.Deleted.LinkUrl)
+		require.Equal(t, th.BasicUser.Id, ucb.Deleted.OwnerId)
+
+		// Updated should contain the new channel bookmark
+		require.NotNil(t, ucb.Updated)
+		require.Equal(t, *patch.DisplayName, ucb.Updated.DisplayName)
+		require.Equal(t, *patch.LinkUrl, ucb.Updated.LinkUrl)
+		require.Equal(t, th.BasicUser2.Id, ucb.Updated.OwnerId)
+	})
+
 	t.Run("a websockets event should be fired as part of editing a bookmark", func(t *testing.T) {
 		webSocketClient, err := th.CreateWebSocketClient()
 		require.NoError(t, err)

--- a/server/channels/api4/channel_bookmark_test.go
+++ b/server/channels/api4/channel_bookmark_test.go
@@ -428,11 +428,11 @@ func TestEditChannelBookmark(t *testing.T) {
 
 	t.Run("a user should always be able to edit channel bookmarks on DMs and GMs", func(t *testing.T) {
 		// this should work independently of the permissions applied
-		th.RemovePermissionFromRole(model.PermissionAddBookmarkPublicChannel.Id, model.ChannelUserRoleId)
-		th.RemovePermissionFromRole(model.PermissionAddBookmarkPrivateChannel.Id, model.ChannelUserRoleId)
+		th.RemovePermissionFromRole(model.PermissionEditBookmarkPublicChannel.Id, model.ChannelUserRoleId)
+		th.RemovePermissionFromRole(model.PermissionEditBookmarkPrivateChannel.Id, model.ChannelUserRoleId)
 		defer func() {
-			th.AddPermissionToRole(model.PermissionAddBookmarkPublicChannel.Id, model.ChannelUserRoleId)
-			th.AddPermissionToRole(model.PermissionAddBookmarkPrivateChannel.Id, model.ChannelUserRoleId)
+			th.AddPermissionToRole(model.PermissionEditBookmarkPublicChannel.Id, model.ChannelUserRoleId)
+			th.AddPermissionToRole(model.PermissionEditBookmarkPrivateChannel.Id, model.ChannelUserRoleId)
 		}()
 
 		// DM
@@ -820,11 +820,11 @@ func TestUpdateChannelBookmarkSortOrder(t *testing.T) {
 
 	t.Run("a user should always be able to update the channel bookmarks sort order on DMs and GMs", func(t *testing.T) {
 		// this should work independently of the permissions applied
-		th.RemovePermissionFromRole(model.PermissionAddBookmarkPublicChannel.Id, model.ChannelUserRoleId)
-		th.RemovePermissionFromRole(model.PermissionAddBookmarkPrivateChannel.Id, model.ChannelUserRoleId)
+		th.RemovePermissionFromRole(model.PermissionOrderBookmarkPublicChannel.Id, model.ChannelUserRoleId)
+		th.RemovePermissionFromRole(model.PermissionOrderBookmarkPrivateChannel.Id, model.ChannelUserRoleId)
 		defer func() {
-			th.AddPermissionToRole(model.PermissionAddBookmarkPublicChannel.Id, model.ChannelUserRoleId)
-			th.AddPermissionToRole(model.PermissionAddBookmarkPrivateChannel.Id, model.ChannelUserRoleId)
+			th.AddPermissionToRole(model.PermissionOrderBookmarkPublicChannel.Id, model.ChannelUserRoleId)
+			th.AddPermissionToRole(model.PermissionOrderBookmarkPrivateChannel.Id, model.ChannelUserRoleId)
 		}()
 
 		// DM

--- a/server/channels/api4/channel_bookmark_test.go
+++ b/server/channels/api4/channel_bookmark_test.go
@@ -661,3 +661,355 @@ func TestEditChannelBookmark(t *testing.T) {
 		require.Equal(t, "Edited bookmark test", ucb.Updated.DisplayName)
 	})
 }
+
+func TestUpdateChannelBookmarkSortOrder(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	createBookmark := func(name, channelId string) *model.ChannelBookmark {
+		return &model.ChannelBookmark{
+			ChannelId:   channelId,
+			DisplayName: name,
+			Type:        model.ChannelBookmarkLink,
+			LinkUrl:     "https://sample.com",
+		}
+	}
+
+	th.Context.Session().UserId = th.BasicUser.Id // set the user for the session
+
+	publicBookmark1, err := th.App.CreateChannelBookmark(th.Context, createBookmark("one", th.BasicChannel.Id), "")
+	require.Nil(t, err)
+	publicBookmark2, err := th.App.CreateChannelBookmark(th.Context, createBookmark("two", th.BasicChannel.Id), "")
+	require.Nil(t, err)
+	publicBookmark3, err := th.App.CreateChannelBookmark(th.Context, createBookmark("three", th.BasicChannel.Id), "")
+	require.Nil(t, err)
+	_, err = th.App.CreateChannelBookmark(th.Context, createBookmark("four", th.BasicChannel.Id), "")
+	require.Nil(t, err)
+
+	privateBookmark1, err := th.App.CreateChannelBookmark(th.Context, createBookmark("one", th.BasicPrivateChannel.Id), "")
+	require.Nil(t, err)
+	privateBookmark2, err := th.App.CreateChannelBookmark(th.Context, createBookmark("two", th.BasicPrivateChannel.Id), "")
+	require.Nil(t, err)
+	_, err = th.App.CreateChannelBookmark(th.Context, createBookmark("three", th.BasicPrivateChannel.Id), "")
+	require.Nil(t, err)
+	privateBookmark4, err := th.App.CreateChannelBookmark(th.Context, createBookmark("four", th.BasicPrivateChannel.Id), "")
+	require.Nil(t, err)
+
+	t.Run("should not work without a license", func(t *testing.T) {
+		_, _, err := th.Client.UpdateChannelBookmarkSortOrder(context.Background(), th.BasicChannel.Id, model.NewId(), 1)
+		CheckErrorID(t, err, "api.channel.bookmark.channel_bookmark.license.error")
+	})
+
+	// enable guest accounts and add the license
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.GuestAccountsSettings.Enable = true })
+	th.App.Srv().SetLicense(model.NewTestLicense())
+
+	// create a guest user and add it to the basic team and public/private channels
+	guest, cgErr := th.App.CreateGuest(th.Context, &model.User{
+		Email:         "test_guest@sample.com",
+		Username:      "test_guest",
+		Nickname:      "test_guest",
+		Password:      "Password1",
+		EmailVerified: true,
+	})
+	require.Nil(t, cgErr)
+
+	_, _, tErr := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, guest.Id, th.SystemAdminUser.Id)
+	require.Nil(t, tErr)
+	th.AddUserToChannel(guest, th.BasicChannel)
+	th.AddUserToChannel(guest, th.BasicPrivateChannel)
+
+	// create a client to use in tests
+	guestClient := th.CreateClient()
+	_, _, lErr := guestClient.Login(context.Background(), guest.Username, "Password1")
+	require.NoError(t, lErr)
+
+	t.Run("a user updating a bookmark's order in public and private channels", func(t *testing.T) {
+		testCases := []struct {
+			name             string
+			channelId        string
+			bookmarkId       string
+			sortOrder        int64
+			userClient       *model.Client4
+			removePermission string
+			expectedError    bool
+			expectedStatus   int
+		}{
+			{
+				name:           "public channel with permissions, should succeed",
+				channelId:      th.BasicChannel.Id,
+				bookmarkId:     publicBookmark2.Id,
+				sortOrder:      3,
+				userClient:     th.Client,
+				expectedStatus: http.StatusOK,
+			},
+			{
+				name:           "private channel with permissions, should succeed",
+				channelId:      th.BasicPrivateChannel.Id,
+				bookmarkId:     privateBookmark1.Id,
+				sortOrder:      3,
+				userClient:     th.Client,
+				expectedStatus: http.StatusOK,
+			},
+			{
+				name:             "public channel without permissions, should fail",
+				channelId:        th.BasicChannel.Id,
+				bookmarkId:       publicBookmark1.Id,
+				sortOrder:        3,
+				userClient:       th.Client,
+				removePermission: model.PermissionOrderBookmarkPublicChannel.Id,
+				expectedError:    true,
+				expectedStatus:   http.StatusForbidden,
+			},
+			{
+				name:             "private channel without permissions, should fail",
+				channelId:        th.BasicPrivateChannel.Id,
+				bookmarkId:       privateBookmark2.Id,
+				sortOrder:        1,
+				userClient:       th.Client,
+				removePermission: model.PermissionOrderBookmarkPrivateChannel.Id,
+				expectedError:    true,
+				expectedStatus:   http.StatusForbidden,
+			},
+			{
+				name:           "guest user in a public channel, should fail",
+				channelId:      th.BasicChannel.Id,
+				bookmarkId:     publicBookmark3.Id,
+				sortOrder:      2,
+				userClient:     guestClient,
+				expectedError:  true,
+				expectedStatus: http.StatusForbidden,
+			},
+			{
+				name:           "guest user in a private channel, should fail",
+				channelId:      th.BasicPrivateChannel.Id,
+				bookmarkId:     privateBookmark4.Id,
+				sortOrder:      2,
+				userClient:     guestClient,
+				expectedError:  true,
+				expectedStatus: http.StatusForbidden,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				if tc.removePermission != "" {
+					th.RemovePermissionFromRole(tc.removePermission, model.ChannelUserRoleId)
+					defer th.AddPermissionToRole(tc.removePermission, model.ChannelUserRoleId)
+				}
+
+				// first we capture and later restore original bookmark's sort order
+				originalBookmark, appErr := th.App.GetBookmark(tc.bookmarkId, false)
+				require.Nil(t, appErr)
+				defer func() {
+					th.App.UpdateChannelBookmarkSortOrder(originalBookmark.Id, originalBookmark.ChannelId, originalBookmark.SortOrder, "")
+				}()
+
+				bookmarks, resp, err := tc.userClient.UpdateChannelBookmarkSortOrder(context.Background(), tc.channelId, tc.bookmarkId, tc.sortOrder)
+				if tc.expectedError {
+					require.Error(t, err)
+					require.Nil(t, bookmarks)
+				} else {
+					require.NoError(t, err)
+					require.Len(t, bookmarks, 4)
+
+					// find and compare bookmark's new sort order
+					var bookmark *model.ChannelBookmarkWithFileInfo
+					for _, b := range bookmarks {
+						if b.Id == tc.bookmarkId {
+							bookmark = b
+							break
+						}
+					}
+					require.NotNil(t, bookmark, "updated bookmark should be in the client's response")
+					require.Equal(t, tc.sortOrder, bookmark.SortOrder)
+				}
+				checkHTTPStatus(t, resp, tc.expectedStatus)
+			})
+		}
+	})
+
+	t.Run("trying to update the order of a nonexistent bookmark should fail", func(t *testing.T) {
+		bookmarks, resp, err := th.Client.UpdateChannelBookmarkSortOrder(context.Background(), th.BasicChannel.Id, model.NewId(), 1)
+		require.Error(t, err)
+		CheckNotFoundStatus(t, resp)
+		require.Nil(t, bookmarks)
+	})
+
+	t.Run("trying to update the order of an already deleted bookmark should fail", func(t *testing.T) {
+		channelBookmark := &model.ChannelBookmark{
+			ChannelId:   th.BasicChannel.Id,
+			DisplayName: "Link bookmark test",
+			LinkUrl:     "https://mattermost.com",
+			Type:        model.ChannelBookmarkLink,
+			Emoji:       ":smile:",
+		}
+
+		cb, resp, err := th.Client.CreateChannelBookmark(context.Background(), channelBookmark)
+		CheckCreatedStatus(t, resp)
+		require.NoError(t, err)
+		require.NotNil(t, cb)
+
+		_, appErr := th.App.DeleteChannelBookmark(cb.Id, "")
+		require.Nil(t, appErr)
+
+		bookmarks, resp, err := th.Client.UpdateChannelBookmarkSortOrder(context.Background(), th.BasicChannel.Id, cb.Id, 1)
+		require.Error(t, err)
+		CheckNotFoundStatus(t, resp)
+		require.Nil(t, bookmarks)
+	})
+
+	t.Run("a user should always be able to update the channel bookmarks sort order on DMs and GMs", func(t *testing.T) {
+		// this should work independently of the permissions applied
+		th.RemovePermissionFromRole(model.PermissionAddBookmarkPublicChannel.Id, model.ChannelUserRoleId)
+		th.RemovePermissionFromRole(model.PermissionAddBookmarkPrivateChannel.Id, model.ChannelUserRoleId)
+		defer func() {
+			th.AddPermissionToRole(model.PermissionAddBookmarkPublicChannel.Id, model.ChannelUserRoleId)
+			th.AddPermissionToRole(model.PermissionAddBookmarkPrivateChannel.Id, model.ChannelUserRoleId)
+		}()
+
+		// DM
+		dm, dmErr := th.App.GetOrCreateDirectChannel(th.Context, th.BasicUser.Id, guest.Id)
+		require.Nil(t, dmErr)
+
+		dmBookmark1, appErr := th.App.CreateChannelBookmark(th.Context, createBookmark("one", dm.Id), "")
+		require.Nil(t, appErr)
+		dmBookmark2, appErr := th.App.CreateChannelBookmark(th.Context, createBookmark("two", dm.Id), "")
+		require.Nil(t, appErr)
+
+		bookmarks, resp, err := th.Client.UpdateChannelBookmarkSortOrder(context.Background(), dm.Id, dmBookmark1.Id, 1)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.Len(t, bookmarks, 2)
+		require.Equal(t, dmBookmark2.Id, bookmarks[0].Id)
+		require.Equal(t, int64(0), bookmarks[0].SortOrder)
+		require.Equal(t, dmBookmark1.Id, bookmarks[1].Id)
+		require.Equal(t, int64(1), bookmarks[1].SortOrder)
+
+		// GM
+		gm, appErr := th.App.CreateGroupChannel(th.Context, []string{th.BasicUser.Id, th.SystemAdminUser.Id, guest.Id}, th.BasicUser.Id)
+		require.Nil(t, appErr)
+
+		gmBookmark1, appErr := th.App.CreateChannelBookmark(th.Context, createBookmark("one", gm.Id), "")
+		require.Nil(t, appErr)
+		gmBookmark2, appErr := th.App.CreateChannelBookmark(th.Context, createBookmark("two", gm.Id), "")
+		require.Nil(t, appErr)
+
+		bookmarks, resp, err = th.Client.UpdateChannelBookmarkSortOrder(context.Background(), gm.Id, gmBookmark2.Id, 0)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.Len(t, bookmarks, 2)
+		require.Equal(t, gmBookmark2.Id, bookmarks[0].Id)
+		require.Equal(t, int64(0), bookmarks[0].SortOrder)
+		require.Equal(t, gmBookmark1.Id, bookmarks[1].Id)
+		require.Equal(t, int64(1), bookmarks[1].SortOrder)
+	})
+
+	t.Run("a guest should not be able to edit channel bookmarks sort order on DMs and GMs", func(t *testing.T) {
+		// DM
+		dm, dmErr := th.App.GetOrCreateDirectChannel(th.Context, th.BasicUser.Id, guest.Id)
+		require.Nil(t, dmErr)
+
+		dmBookmark1, appErr := th.App.CreateChannelBookmark(th.Context, createBookmark("one", dm.Id), "")
+		require.Nil(t, appErr)
+		_, appErr = th.App.CreateChannelBookmark(th.Context, createBookmark("two", dm.Id), "")
+		require.Nil(t, appErr)
+
+		bookmarks, resp, err := guestClient.UpdateChannelBookmarkSortOrder(context.Background(), dm.Id, dmBookmark1.Id, 1)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+		require.Nil(t, bookmarks)
+
+		// GM
+		gm, appErr := th.App.CreateGroupChannel(th.Context, []string{th.BasicUser.Id, th.SystemAdminUser.Id, guest.Id}, th.BasicUser.Id)
+		require.Nil(t, appErr)
+
+		_, appErr = th.App.CreateChannelBookmark(th.Context, createBookmark("one", gm.Id), "")
+		require.Nil(t, appErr)
+		gmBookmark2, appErr := th.App.CreateChannelBookmark(th.Context, createBookmark("two", gm.Id), "")
+		require.Nil(t, appErr)
+
+		bookmarks, resp, err = guestClient.UpdateChannelBookmarkSortOrder(context.Background(), gm.Id, gmBookmark2.Id, 0)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+		require.Nil(t, bookmarks)
+	})
+
+	t.Run("a user should be able to edit another user's bookmark sort order", func(t *testing.T) {
+		channelBookmark := &model.ChannelBookmark{
+			ChannelId:   th.BasicChannel.Id,
+			DisplayName: "Link bookmark test",
+			LinkUrl:     "https://mattermost.com",
+			Type:        model.ChannelBookmarkLink,
+			Emoji:       ":smile:",
+		}
+
+		cb, resp, err := th.Client.CreateChannelBookmark(context.Background(), channelBookmark)
+		require.NoError(t, err)
+		CheckCreatedStatus(t, resp)
+		require.NotNil(t, cb)
+
+		// create a client for basic user 2
+		client2 := th.CreateClient()
+		_, _, lErr := client2.Login(context.Background(), th.BasicUser2.Username, "Pa$$word11")
+		require.NoError(t, lErr)
+
+		bookmarks, resp, err := client2.UpdateChannelBookmarkSortOrder(context.Background(), th.BasicChannel.Id, cb.Id, 0)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.NotEmpty(t, bookmarks)
+		require.Equal(t, cb.Id, bookmarks[0].Id)
+		require.Equal(t, int64(0), bookmarks[0].SortOrder)
+	})
+
+	t.Run("a websockets event should be fired as part of editing a bookmark's sort order", func(t *testing.T) {
+		webSocketClient, err := th.CreateWebSocketClient()
+		require.NoError(t, err)
+		webSocketClient.Listen()
+		defer webSocketClient.Close()
+
+		bookmark := &model.ChannelBookmark{
+			ChannelId:   th.BasicChannel.Id,
+			DisplayName: "Link bookmark test",
+			LinkUrl:     "https://mattermost.com",
+			Type:        model.ChannelBookmarkLink,
+			Emoji:       ":smile:",
+		}
+
+		// set the user for the session
+		originalSessionUserId := th.Context.Session().UserId
+		th.Context.Session().UserId = th.BasicUser.Id
+		defer func() { th.Context.Session().UserId = originalSessionUserId }()
+
+		cb, appErr := th.App.CreateChannelBookmark(th.Context, bookmark, "")
+		require.Nil(t, appErr)
+		require.NotNil(t, cb)
+
+		bookmarks, resp, err := th.Client.UpdateChannelBookmarkSortOrder(context.Background(), th.BasicChannel.Id, cb.Id, 0)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.NotEmpty(t, bookmarks)
+
+		var received bool
+		var bl []*model.ChannelBookmarkWithFileInfo
+	loop:
+		for {
+			select {
+			case event := <-webSocketClient.EventChannel:
+				if event.EventType() == model.WebsocketEventChannelBookmarkSorted {
+					err := json.Unmarshal([]byte(event.GetData()["bookmarks"].(string)), &bl)
+					require.NoError(t, err)
+					received = true
+					break loop
+				}
+			case <-time.After(2 * time.Second):
+				break loop
+			}
+		}
+
+		require.True(t, received)
+		require.NotEmpty(t, bl)
+		require.Equal(t, cb.Id, bl[0].Id)
+		require.Equal(t, int64(0), bl[0].SortOrder)
+	})
+}

--- a/server/channels/app/channel_bookmark.go
+++ b/server/channels/app/channel_bookmark.go
@@ -131,6 +131,7 @@ func (a *App) UpdateChannelBookmarkSortOrder(bookmarkId, channelId string, newIn
 		return nil, model.NewAppError("UpdateSortOrder", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(jsonErr)
 	}
 	message.Add("bookmarks", string(bookmarkJSON))
+	a.Publish(message)
 
 	return bookmarks, nil
 }

--- a/server/channels/store/sqlstore/channel_bookmark_store.go
+++ b/server/channels/store/sqlstore/channel_bookmark_store.go
@@ -197,7 +197,7 @@ func (s *SqlChannelBookmarkStore) UpdateSortOrder(bookmarkId, channelId string, 
 	}
 
 	if (int(newIndex) > len(bookmarks)-1) || newIndex < 0 {
-		return nil, errors.New("new sort order out of bounds")
+		return nil, store.NewErrInvalidInput("ChannelBookmark", "SortOrder", newIndex)
 	}
 
 	currentIndex := -1
@@ -211,7 +211,7 @@ func (s *SqlChannelBookmarkStore) UpdateSortOrder(bookmarkId, channelId string, 
 	}
 
 	if currentIndex == -1 {
-		return nil, errors.New("bookmark to sort not found")
+		return nil, store.NewErrNotFound("ChannelBookmark", bookmarkId)
 	}
 
 	bookmarks = utils.RemoveElementFromSliceAtIndex(bookmarks, currentIndex)

--- a/server/channels/store/storetest/channel_bookmark.go
+++ b/server/channels/store/storetest/channel_bookmark.go
@@ -314,15 +314,20 @@ func testUpdateSortOrderChannelBookmark(t *testing.T, rctx request.CTX, ss store
 	})
 
 	t.Run("change order of bookmarks error when new index is out of bounds", func(t *testing.T) {
+		var iiErr *store.ErrInvalidInput
 		_, err = ss.ChannelBookmark().UpdateSortOrder(bookmark3.Id, channelId, -1)
 		assert.Error(t, err)
+		assert.ErrorAs(t, err, &iiErr)
 		_, err = ss.ChannelBookmark().UpdateSortOrder(bookmark3.Id, channelId, 5)
 		assert.Error(t, err)
+		assert.ErrorAs(t, err, &iiErr)
 	})
 
 	t.Run("change order of bookmarks error when bookmark not found", func(t *testing.T) {
 		_, err = ss.ChannelBookmark().UpdateSortOrder(model.NewId(), channelId, 0)
 		assert.Error(t, err)
+		var nfErr *store.ErrNotFound
+		assert.ErrorAs(t, err, &nfErr)
 	})
 }
 

--- a/server/channels/web/params.go
+++ b/server/channels/web/params.go
@@ -93,11 +93,11 @@ type Params struct {
 	GroupSource               model.GroupSource
 	FilterHasMember           string
 	IncludeChannelMemberCount string
-	ChannelBookmarkId         string
 
 	//Bookmarks
-	IncludeBookmarks bool
-	BookmarksSince   int64
+	ChannelBookmarkId string
+	IncludeBookmarks  bool
+	BookmarksSince    int64
 
 	// Cloud
 	InvoiceId string

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -260,6 +260,18 @@
     "translation": "Failed to update the channel bookmark."
   },
   {
+    "id": "api.channel.bookmark.update_channel_bookmark_sort_order.direct_or_group_channels.forbidden.app_error",
+    "translation": "Failed to update the channel bookmark's sort order."
+  },
+  {
+    "id": "api.channel.bookmark.update_channel_bookmark_sort_order.direct_or_group_channels_by_guests.forbidden.app_error",
+    "translation": "Failed to update the channel bookmark's sort order."
+  },
+  {
+    "id": "api.channel.bookmark.update_channel_bookmark_sort_order.forbidden.app_error",
+    "translation": "Failed to update the channel bookmark's sort order."
+  },
+  {
     "id": "api.channel.change_channel_privacy.private_to_public",
     "translation": "This channel has been converted to a Public Channel and can be joined by any team member."
   },

--- a/server/public/model/client4.go
+++ b/server/public/model/client4.go
@@ -8930,3 +8930,24 @@ func (c *Client4) UpdateChannelBookmark(ctx context.Context, channelId, bookmark
 	}
 	return &ucb, BuildResponse(r), nil
 }
+
+// UpdateChannelBookmarkSortOrder updates a channel bookmark's sort order based on the provided new index.
+func (c *Client4) UpdateChannelBookmarkSortOrder(ctx context.Context, channelId, bookmarkId string, sortOrder int64) ([]*ChannelBookmarkWithFileInfo, *Response, error) {
+	buf, err := json.Marshal(sortOrder)
+	if err != nil {
+		return nil, nil, NewAppError("UpdateChannelBookmarkSortOrder", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	r, err := c.DoAPIPostBytes(ctx, c.bookmarkRoute(channelId, bookmarkId)+"/sort_order", buf)
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	var b []*ChannelBookmarkWithFileInfo
+	if r.StatusCode == http.StatusNotModified {
+		return b, BuildResponse(r), nil
+	}
+	if err := json.NewDecoder(r.Body).Decode(&b); err != nil {
+		return nil, nil, NewAppError("UpdateChannelBookmarkSortOrder", "api.unmarshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	return b, BuildResponse(r), nil
+}


### PR DESCRIPTION
#### Summary
This PR adds the update channel bookmarks sort order endpoint. Sits on top of https://github.com/mattermost/mattermost/pull/25653, so it should be merged after it

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54420

#### Release Note
```release-note
Added update channel bookmark sort order endpoint at /api/v4/channels/{channel_id}/bookmarks/{bookmark_id}/sort_order.
```
