### PR TITLE
MM-56083 Add UpdateChannelMembersNotifications plugin API

### DIFF
--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -1360,15 +1360,62 @@ func (a *App) UpdateChannelMemberNotifyProps(c request.CTX, data map[string]stri
 	a.invalidateCacheForChannelMembersNotifyProps(member.ChannelId)
 
 	// Notify the clients that the member notify props changed
+	err = a.sendUpdateChannelMemberNotifyPropsEvent(member)
+	if err != nil {
+		return nil, model.NewAppError("UpdateChannelMemberNotifyProps", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+
+	return member, nil
+}
+
+func (a *App) UpdateChannelMembersNotifyProps(c request.CTX, members []*model.ChannelMember) ([]*model.ChannelMember, *model.AppError) {
+	updated, err := a.Srv().Store().Channel().UpdateMultipleMembersNotifyProps(members)
+	if err != nil {
+		var appErr *model.AppError
+		switch {
+		case errors.As(err, &appErr):
+			return nil, appErr
+		default:
+			return nil, model.NewAppError("UpdateMultipleMembersNotifyProps", "app.channel.update_channel_members_notify_props.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+		}
+	}
+
+	// Invalidate caches for the users and channels that have changed
+	userIds := make(map[string]bool)
+	channelIds := make(map[string]bool)
+	for _, member := range updated {
+		userIds[member.UserId] = true
+		channelIds[member.ChannelId] = true
+	}
+
+	for userId := range userIds {
+		a.InvalidateCacheForUser(userId)
+	}
+	for channelId := range channelIds {
+		a.invalidateCacheForChannelMembersNotifyProps(channelId)
+	}
+
+	// Notify clients that their notify props have changed
+	for _, member := range updated {
+		err := a.sendUpdateChannelMemberNotifyPropsEvent(member)
+		if err != nil {
+			c.Logger().Warn("Failed to send WebSocket event for updated channel member notify props", mlog.Err(err))
+		}
+	}
+
+	return updated, nil
+}
+
+func (a *App) sendUpdateChannelMemberNotifyPropsEvent(member *model.ChannelMember) error {
 	evt := model.NewWebSocketEvent(model.WebsocketEventChannelMemberUpdated, "", "", member.UserId, nil, "")
 	memberJSON, jsonErr := json.Marshal(member)
 	if jsonErr != nil {
-		return nil, model.NewAppError("UpdateChannelMemberNotifyProps", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(jsonErr)
+		return jsonErr
 	}
 	evt.Add("channelMember", string(memberJSON))
 	a.Publish(evt)
 
-	return member, nil
+	return nil
 }
 
 func (a *App) updateChannelMember(c request.CTX, member *model.ChannelMember) (*model.ChannelMember, *model.AppError) {

--- a/server/channels/app/plugin_api.go
+++ b/server/channels/app/plugin_api.go
@@ -611,6 +611,10 @@ func (api *PluginAPI) UpdateChannelMemberNotifications(channelID, userID string,
 	return api.app.UpdateChannelMemberNotifyProps(api.ctx, notifications, channelID, userID)
 }
 
+func (api *PluginAPI) UpdateChannelMembersNotifications(members []*model.ChannelMember) ([]*model.ChannelMember, *model.AppError) {
+	return api.app.UpdateChannelMembersNotifyProps(api.ctx, members)
+}
+
 func (api *PluginAPI) DeleteChannelMember(channelID, userID string) *model.AppError {
 	return api.app.LeaveChannel(api.ctx, channelID, userID)
 }

--- a/server/channels/app/plugin_api_test.go
+++ b/server/channels/app/plugin_api_test.go
@@ -2365,3 +2365,32 @@ func TestPluginServeMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "METRICS SUBPATH", string(body))
 }
+
+func TestPluginUpdateChannelMembersNotifications(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	api := th.SetupPluginAPI()
+
+	channel := th.CreateChannel(th.Context, th.BasicTeam)
+	th.AddUserToChannel(th.BasicUser, channel)
+	th.AddUserToChannel(th.BasicUser2, channel)
+
+	member1, err := api.GetChannelMember(channel.Id, th.BasicUser.Id)
+	require.Nil(t, err)
+	member2, err := api.GetChannelMember(channel.Id, th.BasicUser2.Id)
+	require.Nil(t, err)
+
+	member1.NotifyProps["test_field"] = "test_value"
+	member2.NotifyProps[model.ChannelMentionsNotifyProp] = "false"
+
+	updated, err := api.UpdateChannelMembersNotifications([]*model.ChannelMember{
+		member1,
+		member2,
+	})
+
+	require.Nil(t, err)
+
+	assert.Equal(t, member1.NotifyProps, updated[0].NotifyProps)
+	assert.Equal(t, member2.NotifyProps, updated[1].NotifyProps)
+}

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -235,6 +235,7 @@ type ChannelStore interface {
 	// UpdateMemberNotifyProps patches the notifyProps field with the given props map.
 	// It replaces existing fields and creates new ones which don't exist.
 	UpdateMemberNotifyProps(channelID, userID string, props map[string]string) (*model.ChannelMember, error)
+	UpdateMultipleMembersNotifyProps(members []*model.ChannelMember) ([]*model.ChannelMember, error)
 	GetMembers(channelID string, offset, limit int) (model.ChannelMembers, error)
 	GetMember(ctx context.Context, channelID string, userID string) (*model.ChannelMember, error)
 	// GetMemberOnly is a lite version of GetMember where it does not join

--- a/server/channels/store/storetest/channel_store.go
+++ b/server/channels/store/storetest/channel_store.go
@@ -90,6 +90,7 @@ func TestChannelStore(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore
 	t.Run("SaveMultipleMembers", func(t *testing.T) { testChannelSaveMultipleMembers(t, rctx, ss) })
 	t.Run("UpdateMember", func(t *testing.T) { testChannelUpdateMember(t, rctx, ss) })
 	t.Run("UpdateMemberNotifyProps", func(t *testing.T) { testChannelUpdateMemberNotifyProps(t, rctx, ss) })
+	t.Run("UpdateMultipleMembersNotifyProps", func(t *testing.T) { testChannelUpdateMultipleMembersNotifyProps(t, rctx, ss) })
 	t.Run("UpdateMultipleMembers", func(t *testing.T) { testChannelUpdateMultipleMembers(t, rctx, ss) })
 	t.Run("RemoveMember", func(t *testing.T) { testChannelRemoveMember(t, rctx, ss) })
 	t.Run("RemoveMembers", func(t *testing.T) { testChannelRemoveMembers(t, rctx, ss) })
@@ -3279,6 +3280,219 @@ func testChannelUpdateMemberNotifyProps(t *testing.T, rctx request.CTX, ss store
 		var invErr *store.ErrInvalidInput
 		require.ErrorAs(t, err, &invErr)
 		require.Nil(t, member)
+	})
+}
+
+func testChannelUpdateMultipleMembersNotifyProps(t *testing.T, rctx request.CTX, ss store.Store) {
+	channel, err := ss.Channel().Save(&model.Channel{
+		Name: model.NewId(),
+		Type: model.ChannelTypeOpen,
+	}, -1)
+	require.NoError(t, err)
+
+	t.Run("should save one channel members' notify props at once", func(t *testing.T) {
+		user, err := ss.User().Save(&model.User{Username: model.NewId(), Email: MakeEmail()})
+		require.NoError(t, err)
+		_, err = ss.Channel().SaveMember(&model.ChannelMember{
+			ChannelId:   channel.Id,
+			UserId:      user.Id,
+			NotifyProps: model.GetDefaultChannelNotifyProps(),
+		})
+		require.NoError(t, err)
+
+		// Confirm the channel member was saved right
+		original, err := ss.Channel().GetMember(rctx.Context(), channel.Id, user.Id)
+		require.NoError(t, err)
+
+		require.Equal(t, model.ChannelNotifyDefault, original.NotifyProps[model.DesktopNotifyProp])
+
+		// Save the channel member
+		notifyProps := model.StringMap(model.CopyStringMap(original.NotifyProps))
+		notifyProps[model.PushNotifyProp] = model.ChannelNotifyMention
+		require.NotEqual(t, notifyProps[model.PushNotifyProp], original.NotifyProps[model.PushNotifyProp])
+
+		_, err = ss.Channel().UpdateMultipleMembersNotifyProps([]*model.ChannelMember{
+			{
+				ChannelId:   original.ChannelId,
+				UserId:      original.UserId,
+				NotifyProps: notifyProps,
+			},
+		})
+
+		require.NoError(t, err)
+
+		// Ensure the other fields in the database haven't changed
+		member, err := ss.Channel().GetMember(rctx.Context(), channel.Id, user.Id)
+		require.NoError(t, err)
+
+		assert.Equal(t, notifyProps[model.DesktopNotifyProp], member.NotifyProps[model.DesktopNotifyProp])
+	})
+
+	t.Run("should save multiple channel members' notify props at once", func(t *testing.T) {
+		user1, err := ss.User().Save(&model.User{Username: model.NewId(), Email: MakeEmail()})
+		require.NoError(t, err)
+		user2, err := ss.User().Save(&model.User{Username: model.NewId(), Email: MakeEmail()})
+		require.NoError(t, err)
+		user3, err := ss.User().Save(&model.User{Username: model.NewId(), Email: MakeEmail()})
+		require.NoError(t, err)
+		original1, err := ss.Channel().SaveMember(&model.ChannelMember{
+			ChannelId:   channel.Id,
+			UserId:      user1.Id,
+			NotifyProps: model.GetDefaultChannelNotifyProps(),
+		})
+		require.NoError(t, err)
+		original2, err := ss.Channel().SaveMember(&model.ChannelMember{
+			ChannelId:   channel.Id,
+			UserId:      user2.Id,
+			NotifyProps: model.GetDefaultChannelNotifyProps(),
+		})
+		require.NoError(t, err)
+		original3, err := ss.Channel().SaveMember(&model.ChannelMember{
+			ChannelId:   channel.Id,
+			UserId:      user3.Id,
+			NotifyProps: model.GetDefaultChannelNotifyProps(),
+		})
+		require.NoError(t, err)
+
+		// Save the channel member
+		notifyProps1 := model.StringMap(model.CopyStringMap(original1.NotifyProps))
+		notifyProps1[model.DesktopNotifyProp] = model.ChannelNotifyMention
+		require.NotEqual(t, notifyProps1[model.DesktopNotifyProp], original1.NotifyProps[model.DesktopNotifyProp])
+		notifyProps2 := model.StringMap(model.CopyStringMap(original2.NotifyProps))
+		notifyProps2[model.PushNotifyProp] = model.ChannelNotifyMention
+		require.NotEqual(t, notifyProps2[model.PushNotifyProp], original2.NotifyProps[model.PushNotifyProp])
+		notifyProps3 := model.StringMap(model.CopyStringMap(original3.NotifyProps))
+		notifyProps3[model.EmailNotifyProp] = "true"
+		require.NotEqual(t, notifyProps3[model.EmailNotifyProp], original3.NotifyProps[model.EmailNotifyProp])
+
+		_, err = ss.Channel().UpdateMultipleMembersNotifyProps([]*model.ChannelMember{
+			{
+				ChannelId:   original1.ChannelId,
+				UserId:      original1.UserId,
+				NotifyProps: notifyProps1,
+			},
+			{
+				ChannelId:   original2.ChannelId,
+				UserId:      original2.UserId,
+				NotifyProps: notifyProps2,
+			},
+			{
+				ChannelId:   original3.ChannelId,
+				UserId:      original3.UserId,
+				NotifyProps: notifyProps3,
+			},
+		})
+
+		require.NoError(t, err)
+
+		// Ensure the other fields in the database haven't changed
+		member1, err := ss.Channel().GetMember(rctx.Context(), channel.Id, user1.Id)
+		require.NoError(t, err)
+		member2, err := ss.Channel().GetMember(rctx.Context(), channel.Id, user2.Id)
+		require.NoError(t, err)
+		member3, err := ss.Channel().GetMember(rctx.Context(), channel.Id, user3.Id)
+		require.NoError(t, err)
+
+		assert.Equal(t, notifyProps1[model.DesktopNotifyProp], member1.NotifyProps[model.DesktopNotifyProp])
+		assert.Equal(t, notifyProps2[model.PushNotifyProp], member2.NotifyProps[model.PushNotifyProp])
+		assert.Equal(t, notifyProps3[model.EmailNotifyProp], member3.NotifyProps[model.EmailNotifyProp])
+	})
+
+	t.Run("should not modify other fields of the channel member", func(t *testing.T) {
+		user, err := ss.User().Save(&model.User{Username: model.NewId(), Email: MakeEmail()})
+		require.NoError(t, err)
+		original, err := ss.Channel().SaveMember(&model.ChannelMember{
+			ChannelId:    channel.Id,
+			UserId:       user.Id,
+			NotifyProps:  model.GetDefaultChannelNotifyProps(),
+			LastViewedAt: 1234,
+		})
+		require.NoError(t, err)
+
+		// Save the channel member
+		notifyProps := model.StringMap(model.CopyStringMap(original.NotifyProps))
+		notifyProps[model.PushNotifyProp] = model.ChannelNotifyMention
+		require.NotEqual(t, notifyProps[model.PushNotifyProp], original.NotifyProps[model.PushNotifyProp])
+
+		_, err = ss.Channel().UpdateMultipleMembersNotifyProps([]*model.ChannelMember{
+			{
+				ChannelId:    channel.Id,
+				UserId:       user.Id,
+				LastViewedAt: 5678,
+				NotifyProps:  notifyProps,
+			},
+		})
+
+		require.NoError(t, err)
+
+		// Ensure the other fields in the database haven't changed
+		member, err := ss.Channel().GetMember(rctx.Context(), channel.Id, user.Id)
+		require.NoError(t, err)
+
+		assert.Equal(t, original.LastViewedAt, member.LastViewedAt)
+		assert.Equal(t, notifyProps, member.NotifyProps)
+	})
+
+	t.Run("should not erase unspecified notify props values", func(t *testing.T) {
+		user, err := ss.User().Save(&model.User{Username: model.NewId(), Email: MakeEmail()})
+		require.NoError(t, err)
+		original, err := ss.Channel().SaveMember(&model.ChannelMember{
+			ChannelId:   channel.Id,
+			UserId:      user.Id,
+			NotifyProps: model.GetDefaultChannelNotifyProps(),
+		})
+		require.NoError(t, err)
+
+		// Save the channel member
+		notifyProps := model.StringMap{
+			model.DesktopNotifyProp:    original.NotifyProps[model.DesktopNotifyProp],
+			model.MarkUnreadNotifyProp: original.NotifyProps[model.MarkUnreadNotifyProp],
+			"another_key":              "another_value",
+		}
+
+		_, err = ss.Channel().UpdateMultipleMembersNotifyProps([]*model.ChannelMember{
+			{
+				ChannelId:   channel.Id,
+				UserId:      user.Id,
+				NotifyProps: notifyProps,
+			},
+		})
+
+		require.NoError(t, err)
+
+		// Ensure the value in the database didn't change
+		member, err := ss.Channel().GetMember(rctx.Context(), channel.Id, user.Id)
+		require.NoError(t, err)
+
+		assert.Equal(t, model.ChannelNotifyDefault, member.NotifyProps[model.DesktopNotifyProp])
+		assert.Equal(t, notifyProps["another_key"], member.NotifyProps["another_key"])
+	})
+
+	t.Run("should not allow saving invalid notify props", func(t *testing.T) {
+		user, err := ss.User().Save(&model.User{Username: model.NewId(), Email: MakeEmail()})
+		require.NoError(t, err)
+		original, err := ss.Channel().SaveMember(&model.ChannelMember{
+			ChannelId:   channel.Id,
+			UserId:      user.Id,
+			NotifyProps: model.GetDefaultChannelNotifyProps(),
+		})
+		require.NoError(t, err)
+
+		// Save the channel member
+		notifyProps := model.StringMap{
+			model.DesktopNotifyProp:    original.NotifyProps[model.DesktopNotifyProp],
+			model.MarkUnreadNotifyProp: "garbage",
+		}
+
+		_, err = ss.Channel().UpdateMultipleMembersNotifyProps([]*model.ChannelMember{
+			{
+				ChannelId:   channel.Id,
+				UserId:      user.Id,
+				NotifyProps: notifyProps,
+			},
+		})
+
+		assert.NotNil(t, err)
 	})
 }
 

--- a/server/channels/store/storetest/channel_store.go
+++ b/server/channels/store/storetest/channel_store.go
@@ -3311,7 +3311,7 @@ func testChannelUpdateMultipleMembersNotifyProps(t *testing.T, rctx request.CTX,
 		notifyProps[model.PushNotifyProp] = model.ChannelNotifyMention
 		require.NotEqual(t, notifyProps[model.PushNotifyProp], original.NotifyProps[model.PushNotifyProp])
 
-		_, err = ss.Channel().UpdateMultipleMembersNotifyProps([]*model.ChannelMember{
+		updated, err := ss.Channel().UpdateMultipleMembersNotifyProps([]*model.ChannelMember{
 			{
 				ChannelId:   original.ChannelId,
 				UserId:      original.UserId,
@@ -3320,6 +3320,8 @@ func testChannelUpdateMultipleMembersNotifyProps(t *testing.T, rctx request.CTX,
 		})
 
 		require.NoError(t, err)
+
+		assert.Equal(t, notifyProps, updated[0].NotifyProps)
 
 		// Ensure the other fields in the database haven't changed
 		member, err := ss.Channel().GetMember(rctx.Context(), channel.Id, user.Id)
@@ -3365,7 +3367,7 @@ func testChannelUpdateMultipleMembersNotifyProps(t *testing.T, rctx request.CTX,
 		notifyProps3[model.EmailNotifyProp] = "true"
 		require.NotEqual(t, notifyProps3[model.EmailNotifyProp], original3.NotifyProps[model.EmailNotifyProp])
 
-		_, err = ss.Channel().UpdateMultipleMembersNotifyProps([]*model.ChannelMember{
+		updated, err := ss.Channel().UpdateMultipleMembersNotifyProps([]*model.ChannelMember{
 			{
 				ChannelId:   original1.ChannelId,
 				UserId:      original1.UserId,
@@ -3384,6 +3386,10 @@ func testChannelUpdateMultipleMembersNotifyProps(t *testing.T, rctx request.CTX,
 		})
 
 		require.NoError(t, err)
+
+		assert.Equal(t, notifyProps1, updated[0].NotifyProps)
+		assert.Equal(t, notifyProps2, updated[1].NotifyProps)
+		assert.Equal(t, notifyProps3, updated[2].NotifyProps)
 
 		// Ensure the other fields in the database haven't changed
 		member1, err := ss.Channel().GetMember(rctx.Context(), channel.Id, user1.Id)
@@ -3414,7 +3420,7 @@ func testChannelUpdateMultipleMembersNotifyProps(t *testing.T, rctx request.CTX,
 		notifyProps[model.PushNotifyProp] = model.ChannelNotifyMention
 		require.NotEqual(t, notifyProps[model.PushNotifyProp], original.NotifyProps[model.PushNotifyProp])
 
-		_, err = ss.Channel().UpdateMultipleMembersNotifyProps([]*model.ChannelMember{
+		updated, err := ss.Channel().UpdateMultipleMembersNotifyProps([]*model.ChannelMember{
 			{
 				ChannelId:    channel.Id,
 				UserId:       user.Id,
@@ -3424,6 +3430,8 @@ func testChannelUpdateMultipleMembersNotifyProps(t *testing.T, rctx request.CTX,
 		})
 
 		require.NoError(t, err)
+
+		assert.Equal(t, notifyProps, updated[0].NotifyProps)
 
 		// Ensure the other fields in the database haven't changed
 		member, err := ss.Channel().GetMember(rctx.Context(), channel.Id, user.Id)
@@ -3450,7 +3458,7 @@ func testChannelUpdateMultipleMembersNotifyProps(t *testing.T, rctx request.CTX,
 			"another_key":              "another_value",
 		}
 
-		_, err = ss.Channel().UpdateMultipleMembersNotifyProps([]*model.ChannelMember{
+		updated, err := ss.Channel().UpdateMultipleMembersNotifyProps([]*model.ChannelMember{
 			{
 				ChannelId:   channel.Id,
 				UserId:      user.Id,
@@ -3459,6 +3467,10 @@ func testChannelUpdateMultipleMembersNotifyProps(t *testing.T, rctx request.CTX,
 		})
 
 		require.NoError(t, err)
+
+		updatedNotifyProps := updated[0].NotifyProps
+		assert.Equal(t, original.NotifyProps[model.ChannelNotifyDefault], updatedNotifyProps[model.ChannelNotifyDefault])
+		assert.Equal(t, notifyProps["another_key"], updatedNotifyProps["another_key"])
 
 		// Ensure the value in the database didn't change
 		member, err := ss.Channel().GetMember(rctx.Context(), channel.Id, user.Id)

--- a/server/channels/store/storetest/mocks/ChannelStore.go
+++ b/server/channels/store/storetest/mocks/ChannelStore.go
@@ -2536,6 +2536,32 @@ func (_m *ChannelStore) UpdateMultipleMembers(members []*model.ChannelMember) ([
 	return r0, r1
 }
 
+// UpdateMultipleMembersNotifyProps provides a mock function with given fields: members
+func (_m *ChannelStore) UpdateMultipleMembersNotifyProps(members []*model.ChannelMember) ([]*model.ChannelMember, error) {
+	ret := _m.Called(members)
+
+	var r0 []*model.ChannelMember
+	var r1 error
+	if rf, ok := ret.Get(0).(func([]*model.ChannelMember) ([]*model.ChannelMember, error)); ok {
+		return rf(members)
+	}
+	if rf, ok := ret.Get(0).(func([]*model.ChannelMember) []*model.ChannelMember); ok {
+		r0 = rf(members)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.ChannelMember)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func([]*model.ChannelMember) error); ok {
+		r1 = rf(members)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // UpdateSidebarCategories provides a mock function with given fields: userID, teamID, categories
 func (_m *ChannelStore) UpdateSidebarCategories(userID string, teamID string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, []*model.SidebarCategoryWithChannels, error) {
 	ret := _m.Called(userID, teamID, categories)

--- a/server/public/model/channel_member.go
+++ b/server/public/model/channel_member.go
@@ -116,6 +116,19 @@ func (o *ChannelMember) IsValid() *AppError {
 		return NewAppError("ChannelMember.IsValid", "model.channel_member.is_valid.user_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
+	if appErr := o.IsNotifyPropsValid(); appErr != nil {
+		return appErr
+	}
+
+	if len(o.Roles) > UserRolesMaxLength {
+		return NewAppError("ChannelMember.IsValid", "model.channel_member.is_valid.roles_limit.app_error",
+			map[string]any{"Limit": UserRolesMaxLength}, "", http.StatusBadRequest)
+	}
+
+	return nil
+}
+
+func (o *ChannelMember) IsNotifyPropsValid() *AppError {
 	notifyLevel := o.NotifyProps[DesktopNotifyProp]
 	if len(notifyLevel) > 20 || !IsChannelNotifyLevelValid(notifyLevel) {
 		return NewAppError("ChannelMember.IsValid", "model.channel_member.is_valid.notify_level.app_error", nil, "notify_level="+notifyLevel, http.StatusBadRequest)
@@ -148,11 +161,6 @@ func (o *ChannelMember) IsValid() *AppError {
 		if len(channelAutoFollowThreads) > 3 || !IsChannelAutoFollowThreadsValid(channelAutoFollowThreads) {
 			return NewAppError("ChannelMember.IsValid", "model.channel_member.is_valid.channel_auto_follow_threads_value.app_error", nil, "channel_auto_follow_threads="+channelAutoFollowThreads, http.StatusBadRequest)
 		}
-	}
-
-	if len(o.Roles) > UserRolesMaxLength {
-		return NewAppError("ChannelMember.IsValid", "model.channel_member.is_valid.roles_limit.app_error",
-			map[string]any{"Limit": UserRolesMaxLength}, "", http.StatusBadRequest)
 	}
 
 	jsonStringNotifyProps := string(ToJSON(o.NotifyProps))

--- a/server/public/plugin/api.go
+++ b/server/public/plugin/api.go
@@ -593,6 +593,14 @@ type API interface {
 	// Minimum server version: 5.2
 	UpdateChannelMemberNotifications(channelId, userID string, notifications map[string]string) (*model.ChannelMember, *model.AppError)
 
+	// UpdateChannelMemberNotifications updates the notification properties for multiple channel members.
+	// Other changes made to the channel memberships will be ignored.
+	//
+	// @tag Channel
+	// @tag User
+	// Minimum server version: 9.5
+	UpdateChannelMembersNotifications(members []*model.ChannelMember) ([]*model.ChannelMember, *model.AppError)
+
 	// GetGroup gets a group by ID.
 	//
 	// @tag Group

--- a/server/public/plugin/api_timer_layer_generated.go
+++ b/server/public/plugin/api_timer_layer_generated.go
@@ -650,6 +650,13 @@ func (api *apiTimerLayer) UpdateChannelMemberNotifications(channelId, userID str
 	return _returnsA, _returnsB
 }
 
+func (api *apiTimerLayer) UpdateChannelMembersNotifications(members []*model.ChannelMember) ([]*model.ChannelMember, *model.AppError) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := api.apiImpl.UpdateChannelMembersNotifications(members)
+	api.recordTime(startTime, "UpdateChannelMembersNotifications", _returnsB == nil)
+	return _returnsA, _returnsB
+}
+
 func (api *apiTimerLayer) GetGroup(groupId string) (*model.Group, *model.AppError) {
 	startTime := timePkg.Now()
 	_returnsA, _returnsB := api.apiImpl.GetGroup(groupId)

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -3527,6 +3527,35 @@ func (s *apiRPCServer) UpdateChannelMemberNotifications(args *Z_UpdateChannelMem
 	return nil
 }
 
+type Z_UpdateChannelMembersNotificationsArgs struct {
+	A []*model.ChannelMember
+}
+
+type Z_UpdateChannelMembersNotificationsReturns struct {
+	A []*model.ChannelMember
+	B *model.AppError
+}
+
+func (g *apiRPCClient) UpdateChannelMembersNotifications(members []*model.ChannelMember) ([]*model.ChannelMember, *model.AppError) {
+	_args := &Z_UpdateChannelMembersNotificationsArgs{members}
+	_returns := &Z_UpdateChannelMembersNotificationsReturns{}
+	if err := g.client.Call("Plugin.UpdateChannelMembersNotifications", _args, _returns); err != nil {
+		log.Printf("RPC call to UpdateChannelMembersNotifications API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) UpdateChannelMembersNotifications(args *Z_UpdateChannelMembersNotificationsArgs, returns *Z_UpdateChannelMembersNotificationsReturns) error {
+	if hook, ok := s.impl.(interface {
+		UpdateChannelMembersNotifications(members []*model.ChannelMember) ([]*model.ChannelMember, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.UpdateChannelMembersNotifications(args.A)
+	} else {
+		return encodableError(fmt.Errorf("API UpdateChannelMembersNotifications called but not implemented."))
+	}
+	return nil
+}
+
 type Z_GetGroupArgs struct {
 	A string
 }

--- a/server/public/plugin/plugintest/api.go
+++ b/server/public/plugin/plugintest/api.go
@@ -3857,6 +3857,34 @@ func (_m *API) UpdateChannelMemberRoles(channelId string, userID string, newRole
 	return r0, r1
 }
 
+// UpdateChannelMembersNotifications provides a mock function with given fields: members
+func (_m *API) UpdateChannelMembersNotifications(members []*model.ChannelMember) ([]*model.ChannelMember, *model.AppError) {
+	ret := _m.Called(members)
+
+	var r0 []*model.ChannelMember
+	var r1 *model.AppError
+	if rf, ok := ret.Get(0).(func([]*model.ChannelMember) ([]*model.ChannelMember, *model.AppError)); ok {
+		return rf(members)
+	}
+	if rf, ok := ret.Get(0).(func([]*model.ChannelMember) []*model.ChannelMember); ok {
+		r0 = rf(members)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.ChannelMember)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func([]*model.ChannelMember) *model.AppError); ok {
+		r1 = rf(members)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // UpdateChannelSidebarCategories provides a mock function with given fields: userID, teamID, categories
 func (_m *API) UpdateChannelSidebarCategories(userID string, teamID string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, *model.AppError) {
 	ret := _m.Called(userID, teamID, categories)

--- a/server/public/utils/utils.go
+++ b/server/public/utils/utils.go
@@ -12,3 +12,18 @@ func Contains[T comparable](slice []T, item T) bool {
 	}
 	return false
 }
+
+func RemoveDuplicates[T comparable](slice []T) []T {
+	var result []T
+	seen := make(map[T]bool)
+	for _, item := range slice {
+		if seen[item] {
+			continue
+		}
+
+		result = append(result, item)
+		seen[item] = true
+	}
+
+	return result
+}


### PR DESCRIPTION
#### Summary
This bulk version of `UpdateChannelMemberNotifications` is needed by the MS Teams Sync plugin because we want the plugin to be able to mute all linked channels for a linked user when they say that MS Teams is their primary platform. We're also going to set an extra notify prop to keep track that the channel was automuted by the plugin so that we can un-mute them if they change their primary platform or become unlinked.

It'll look something like this
```go
func autoMuteAllChannelsForUser(channelId, userId string) {
	var members []*model.ChannelMember

	page := 0
	for true {
		allMembers := pluginApi.GetChannelMembersForUser("", channelId, page, 50)
		for _, member := range allMembers {
			if !channelIsLinked(member.ChannelId) {
				continue
			}

			member.NotifyProps[model.MarkUnreadNotifyProp] = model.ChannelNotifyMention
			member.NotifyProps["msteams_automute"] = "true"
			members = append(members, member)
		}

		if len(allMembers < 50) {
			break
		}

		page += 1
	}

	pluginApi.UpdateChannelMembersNotifications(members)
}
```

The API also accepts multiple members for multiple users at once because we'll have to something similar because linking a channel should automute it for all linked users who have MS Teams as their primary platform as well

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56083

#### Release Note
```release-note
Added UpdateChannelMembersNotifications plugin API
```
