### PR TITLE
MM-56147 Add GetPreferenceForUser plugin API

### DIFF
--- a/server/channels/app/plugin_api.go
+++ b/server/channels/app/plugin_api.go
@@ -270,6 +270,10 @@ func (api *PluginAPI) GetUsersInTeam(teamID string, page int, perPage int) ([]*m
 	return api.app.GetUsersInTeam(options)
 }
 
+func (api *PluginAPI) GetPreferenceForUser(userID, category, name string) (*model.Preference, *model.AppError) {
+	return api.app.GetPreferenceByCategoryAndNameForUser(userID, category, name)
+}
+
 func (api *PluginAPI) GetPreferencesForUser(userID string) ([]model.Preference, *model.AppError) {
 	return api.app.GetPreferencesForUser(userID)
 }

--- a/server/channels/app/plugin_api_test.go
+++ b/server/channels/app/plugin_api_test.go
@@ -163,6 +163,42 @@ func TestPublicFilesPathConfiguration(t *testing.T) {
 	assert.Equal(t, publicFilesPath, publicFilesFolderInTest)
 }
 
+func TestPluginAPIGetUserPreference(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+	api := th.SetupPluginAPI()
+
+	err := api.UpdatePreferencesForUser(th.BasicUser.Id, []model.Preference{
+		{
+			UserId:   th.BasicUser.Id,
+			Category: model.PreferenceCategoryDisplaySettings,
+			Name:     model.PreferenceNameUseMilitaryTime,
+			Value:    "true",
+		},
+		{
+			UserId:   th.BasicUser.Id,
+			Category: "test_category",
+			Name:     "test_key",
+			Value:    "test_value",
+		},
+	})
+	require.Nil(t, err)
+
+	preference, err := api.GetPreferenceForUser(th.BasicUser.Id, model.PreferenceCategoryDisplaySettings, model.PreferenceNameUseMilitaryTime)
+
+	require.Nil(t, err)
+	assert.Equal(t, model.PreferenceCategoryDisplaySettings, preference.Category)
+	assert.Equal(t, model.PreferenceNameUseMilitaryTime, preference.Name)
+	assert.Equal(t, "true", preference.Value)
+
+	preference, err = api.GetPreferenceForUser(th.BasicUser.Id, "test_category", "test_key")
+
+	require.Nil(t, err)
+	assert.Equal(t, "test_category", preference.Category)
+	assert.Equal(t, "test_key", preference.Name)
+	assert.Equal(t, "test_value", preference.Value)
+}
+
 func TestPluginAPIGetUserPreferences(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()

--- a/server/public/plugin/api.go
+++ b/server/public/plugin/api.go
@@ -166,6 +166,13 @@ type API interface {
 	// Minimum server version: 5.6
 	GetUsersInTeam(teamID string, page int, perPage int) ([]*model.User, *model.AppError)
 
+	// GetPreferenceForUser gets a single preference for a user.
+	//
+	// @tag User
+	// @tag Preference
+	// Minimum server version: 9.5
+	GetPreferenceForUser(userID, category, name string) (*model.Preference, *model.AppError)
+
 	// GetPreferencesForUser gets a user's preferences.
 	//
 	// @tag User

--- a/server/public/plugin/api_timer_layer_generated.go
+++ b/server/public/plugin/api_timer_layer_generated.go
@@ -195,6 +195,13 @@ func (api *apiTimerLayer) GetUsersInTeam(teamID string, page int, perPage int) (
 	return _returnsA, _returnsB
 }
 
+func (api *apiTimerLayer) GetPreferenceForUser(userID, category, name string) (*model.Preference, *model.AppError) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := api.apiImpl.GetPreferenceForUser(userID, category, name)
+	api.recordTime(startTime, "GetPreferenceForUser", _returnsB == nil)
+	return _returnsA, _returnsB
+}
+
 func (api *apiTimerLayer) GetPreferencesForUser(userID string) ([]model.Preference, *model.AppError) {
 	startTime := timePkg.Now()
 	_returnsA, _returnsB := api.apiImpl.GetPreferencesForUser(userID)

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -1598,6 +1598,37 @@ func (s *apiRPCServer) GetUsersInTeam(args *Z_GetUsersInTeamArgs, returns *Z_Get
 	return nil
 }
 
+type Z_GetPreferenceForUserArgs struct {
+	A string
+	B string
+	C string
+}
+
+type Z_GetPreferenceForUserReturns struct {
+	A *model.Preference
+	B *model.AppError
+}
+
+func (g *apiRPCClient) GetPreferenceForUser(userID, category, name string) (*model.Preference, *model.AppError) {
+	_args := &Z_GetPreferenceForUserArgs{userID, category, name}
+	_returns := &Z_GetPreferenceForUserReturns{}
+	if err := g.client.Call("Plugin.GetPreferenceForUser", _args, _returns); err != nil {
+		log.Printf("RPC call to GetPreferenceForUser API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) GetPreferenceForUser(args *Z_GetPreferenceForUserArgs, returns *Z_GetPreferenceForUserReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetPreferenceForUser(userID, category, name string) (*model.Preference, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.GetPreferenceForUser(args.A, args.B, args.C)
+	} else {
+		return encodableError(fmt.Errorf("API GetPreferenceForUser called but not implemented."))
+	}
+	return nil
+}
+
 type Z_GetPreferencesForUserArgs struct {
 	A string
 }

--- a/server/public/plugin/plugintest/api.go
+++ b/server/public/plugin/plugintest/api.go
@@ -1942,6 +1942,34 @@ func (_m *API) GetPostsSince(channelId string, time int64) (*model.PostList, *mo
 	return r0, r1
 }
 
+// GetPreferenceForUser provides a mock function with given fields: userID, category, name
+func (_m *API) GetPreferenceForUser(userID string, category string, name string) (*model.Preference, *model.AppError) {
+	ret := _m.Called(userID, category, name)
+
+	var r0 *model.Preference
+	var r1 *model.AppError
+	if rf, ok := ret.Get(0).(func(string, string, string) (*model.Preference, *model.AppError)); ok {
+		return rf(userID, category, name)
+	}
+	if rf, ok := ret.Get(0).(func(string, string, string) *model.Preference); ok {
+		r0 = rf(userID, category, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Preference)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, string, string) *model.AppError); ok {
+		r1 = rf(userID, category, name)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // GetPreferencesForUser provides a mock function with given fields: userID
 func (_m *API) GetPreferencesForUser(userID string) ([]model.Preference, *model.AppError) {
 	ret := _m.Called(userID)


### PR DESCRIPTION
#### Summary
For the MS Teams plugin, we're storing the user's "primary platform" in preferences. While we could get all of a user's preferences and iterate through those to find the value of that preference, that seems wasteful when we have 95% of the code to get a single preference value already.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56147

#### Release Note
```release-note
Added GetPreferenceForUser plugin API
```
