### PR TITLE
MM-56201: Suppress typing events when out of scope

### DIFF
--- a/server/channels/app/web_conn_test.go
+++ b/server/channels/app/web_conn_test.go
@@ -165,17 +165,17 @@ func TestWebConnShouldSendEvent(t *testing.T) {
 	t.Run("should not send typing event unless in scope", func(t *testing.T) {
 		event2 := model.NewWebSocketEvent(model.WebsocketEventTyping, "", th.BasicChannel.Id, "", nil, "")
 		// Basic, unset case
-		basicUserWc.SetActiveChannelID("<>")
-		basicUserWc.SetActiveThreadChannelID("<>")
+		basicUserWc.SetActiveChannelID(platform.UnsetPresenceIndicator)
+		basicUserWc.SetActiveThreadChannelID(platform.UnsetPresenceIndicator)
 		assert.True(t, basicUserWc.ShouldSendEvent(event2))
 
 		// Active channel is set to something else, thread unset
 		basicUserWc.SetActiveChannelID("ch1")
-		basicUserWc.SetActiveThreadChannelID("<>")
+		basicUserWc.SetActiveThreadChannelID(platform.UnsetPresenceIndicator)
 		assert.True(t, basicUserWc.ShouldSendEvent(event2))
 
 		// Active channel is unset, thread set
-		basicUserWc.SetActiveChannelID("<>")
+		basicUserWc.SetActiveChannelID(platform.UnsetPresenceIndicator)
 		basicUserWc.SetActiveThreadChannelID("ch1")
 		assert.True(t, basicUserWc.ShouldSendEvent(event2))
 


### PR DESCRIPTION
We do not send the typing event when the originating
channel is not the active channel or active channel thread.

https://mattermost.atlassian.net/browse/MM-56201

```release-note
NONE
```
