### PR TITLE
Add unique index on `pluginid` to `remoteclusters` table

### DIFF
--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -234,6 +234,8 @@ channels/db/migrations/mysql/000117_msteams_shared_channels.down.sql
 channels/db/migrations/mysql/000117_msteams_shared_channels.up.sql
 channels/db/migrations/mysql/000118_create_index_poststats.down.sql
 channels/db/migrations/mysql/000118_create_index_poststats.up.sql
+channels/db/migrations/mysql/000119_msteams_shared_channels_idx.down.sql
+channels/db/migrations/mysql/000119_msteams_shared_channels_idx.up.sql
 channels/db/migrations/postgres/000001_create_teams.down.sql
 channels/db/migrations/postgres/000001_create_teams.up.sql
 channels/db/migrations/postgres/000002_create_team_members.down.sql
@@ -468,3 +470,5 @@ channels/db/migrations/postgres/000117_msteams_shared_channels.down.sql
 channels/db/migrations/postgres/000117_msteams_shared_channels.up.sql
 channels/db/migrations/postgres/000118_create_index_poststats.down.sql
 channels/db/migrations/postgres/000118_create_index_poststats.up.sql
+channels/db/migrations/postgres/000119_msteams_shared_channels_idx.down.sql
+channels/db/migrations/postgres/000119_msteams_shared_channels_idx.up.sql

--- a/server/channels/db/migrations/mysql/000119_msteams_shared_channels_idx.down.sql
+++ b/server/channels/db/migrations/mysql/000119_msteams_shared_channels_idx.down.sql
@@ -1,0 +1,14 @@
+SET @preparedStatement = (SELECT IF(
+    (
+        SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE table_name = 'RemoteClusters'
+        AND table_schema = DATABASE()
+        AND index_name = 'remote_clusters_pluginid_unique'
+    ) > 0,
+    'DROP INDEX remote_clusters_pluginid_unique ON RemoteClusters;',
+    'SELECT 1;'
+));
+
+PREPARE dropIndexIfExists FROM @preparedStatement;
+EXECUTE dropIndexIfExists;
+DEALLOCATE PREPARE dropIndexIfExists;

--- a/server/channels/db/migrations/mysql/000119_msteams_shared_channels_idx.up.sql
+++ b/server/channels/db/migrations/mysql/000119_msteams_shared_channels_idx.up.sql
@@ -1,0 +1,14 @@
+SET @preparedStatement = (SELECT IF(
+    (
+        SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE table_name = 'RemoteClusters'
+        AND table_schema = DATABASE()
+        AND index_name = 'remote_clusters_pluginid_unique'
+    ) > 0,
+    'SELECT 1;',
+    'CREATE UNIQUE INDEX remote_clusters_pluginid_unique ON RemoteClusters (PluginID);'
+));
+
+PREPARE createIndexIfNotExists FROM @preparedStatement;
+EXECUTE createIndexIfNotExists;
+DEALLOCATE PREPARE createIndexIfNotExists;

--- a/server/channels/db/migrations/postgres/000119_msteams_shared_channels_idx.down.sql
+++ b/server/channels/db/migrations/postgres/000119_msteams_shared_channels_idx.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS remote_clusters_pluginid_unique;

--- a/server/channels/db/migrations/postgres/000119_msteams_shared_channels_idx.up.sql
+++ b/server/channels/db/migrations/postgres/000119_msteams_shared_channels_idx.up.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX IF NOT EXISTS remote_clusters_pluginid_unique ON remoteclusters (pluginid);


### PR DESCRIPTION
#### Summary
Addendum to PR https://github.com/mattermost/mattermost/pull/25565 where I forgot to add a unique index to the new PluginID column.   This is needed as the column must have unique values and there will be frequent look-ups based on this column.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55965

#### Release Note
```release-note
NONE
```
