### PR TITLE
[MM-56284] Remove non-generic StoreResult

### DIFF
--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -1401,18 +1401,18 @@ func (a *App) updateChannelMember(c request.CTX, member *model.ChannelMember) (*
 }
 
 func (a *App) DeleteChannel(c request.CTX, channel *model.Channel, userID string) *model.AppError {
-	ihc := make(chan store.GenericStoreResult[[]*model.IncomingWebhook], 1)
-	ohc := make(chan store.GenericStoreResult[[]*model.OutgoingWebhook], 1)
+	ihc := make(chan store.StoreResult[[]*model.IncomingWebhook], 1)
+	ohc := make(chan store.StoreResult[[]*model.OutgoingWebhook], 1)
 
 	go func() {
 		webhooks, err := a.Srv().Store().Webhook().GetIncomingByChannel(channel.Id)
-		ihc <- store.GenericStoreResult[[]*model.IncomingWebhook]{Data: webhooks, NErr: err}
+		ihc <- store.StoreResult[[]*model.IncomingWebhook]{Data: webhooks, NErr: err}
 		close(ihc)
 	}()
 
 	go func() {
 		outgoingHooks, err := a.Srv().Store().Webhook().GetOutgoingByChannel(channel.Id, -1, -1)
-		ohc <- store.GenericStoreResult[[]*model.OutgoingWebhook]{Data: outgoingHooks, NErr: err}
+		ohc <- store.StoreResult[[]*model.OutgoingWebhook]{Data: outgoingHooks, NErr: err}
 		close(ohc)
 	}()
 
@@ -2210,16 +2210,16 @@ func (a *App) GetChannelUnread(c request.CTX, channelID, userID string) (*model.
 }
 
 func (a *App) JoinChannel(c request.CTX, channel *model.Channel, userID string) *model.AppError {
-	userChan := make(chan store.GenericStoreResult[*model.User], 1)
-	memberChan := make(chan store.GenericStoreResult[*model.ChannelMember], 1)
+	userChan := make(chan store.StoreResult[*model.User], 1)
+	memberChan := make(chan store.StoreResult[*model.ChannelMember], 1)
 	go func() {
 		user, err := a.Srv().Store().User().Get(context.Background(), userID)
-		userChan <- store.GenericStoreResult[*model.User]{Data: user, NErr: err}
+		userChan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(userChan)
 	}()
 	go func() {
 		member, err := a.Srv().Store().Channel().GetMember(context.Background(), channel.Id, userID)
-		memberChan <- store.GenericStoreResult[*model.ChannelMember]{Data: member, NErr: err}
+		memberChan <- store.StoreResult[*model.ChannelMember]{Data: member, NErr: err}
 		close(memberChan)
 	}()
 
@@ -2311,24 +2311,24 @@ func (a *App) postJoinTeamMessage(c request.CTX, user *model.User, channel *mode
 }
 
 func (a *App) LeaveChannel(c request.CTX, channelID string, userID string) *model.AppError {
-	sc := make(chan store.GenericStoreResult[*model.Channel], 1)
+	sc := make(chan store.StoreResult[*model.Channel], 1)
 	go func() {
 		channel, err := a.Srv().Store().Channel().Get(channelID, true)
-		sc <- store.GenericStoreResult[*model.Channel]{Data: channel, NErr: err}
+		sc <- store.StoreResult[*model.Channel]{Data: channel, NErr: err}
 		close(sc)
 	}()
 
-	uc := make(chan store.GenericStoreResult[*model.User], 1)
+	uc := make(chan store.StoreResult[*model.User], 1)
 	go func() {
 		user, err := a.Srv().Store().User().Get(context.Background(), userID)
-		uc <- store.GenericStoreResult[*model.User]{Data: user, NErr: err}
+		uc <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uc)
 	}()
 
-	mcc := make(chan store.GenericStoreResult[int64], 1)
+	mcc := make(chan store.StoreResult[int64], 1)
 	go func() {
 		count, err := a.Srv().Store().Channel().GetMemberCount(channelID, false)
-		mcc <- store.GenericStoreResult[int64]{Data: count, NErr: err}
+		mcc <- store.StoreResult[int64]{Data: count, NErr: err}
 		close(mcc)
 	}()
 

--- a/server/channels/app/command.go
+++ b/server/channels/app/command.go
@@ -368,24 +368,24 @@ func (a *App) tryExecuteCustomCommand(c request.CTX, args *model.CommandArgs, tr
 		return nil, nil, model.NewAppError("ExecuteCommand", "api.command.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	chanChan := make(chan store.GenericStoreResult[*model.Channel], 1)
+	chanChan := make(chan store.StoreResult[*model.Channel], 1)
 	go func() {
 		channel, err := a.Srv().Store().Channel().Get(args.ChannelId, true)
-		chanChan <- store.GenericStoreResult[*model.Channel]{Data: channel, NErr: err}
+		chanChan <- store.StoreResult[*model.Channel]{Data: channel, NErr: err}
 		close(chanChan)
 	}()
 
-	teamChan := make(chan store.GenericStoreResult[*model.Team], 1)
+	teamChan := make(chan store.StoreResult[*model.Team], 1)
 	go func() {
 		team, err := a.Srv().Store().Team().Get(args.TeamId)
-		teamChan <- store.GenericStoreResult[*model.Team]{Data: team, NErr: err}
+		teamChan <- store.StoreResult[*model.Team]{Data: team, NErr: err}
 		close(teamChan)
 	}()
 
-	userChan := make(chan store.GenericStoreResult[*model.User], 1)
+	userChan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
 		user, err := a.Srv().Store().User().Get(context.Background(), args.UserId)
-		userChan <- store.GenericStoreResult[*model.User]{Data: user, NErr: err}
+		userChan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(userChan)
 	}()
 

--- a/server/channels/app/integration_action.go
+++ b/server/channels/app/integration_action.go
@@ -70,24 +70,24 @@ func (a *App) DoPostActionWithCookie(c request.CTX, postID, actionId, userID, se
 
 	// See if the post exists in the DB, if so ignore the cookie.
 	// Start all queries here for parallel execution
-	pchan := make(chan store.GenericStoreResult[*model.Post], 1)
+	pchan := make(chan store.StoreResult[*model.Post], 1)
 	go func() {
 		post, err := a.Srv().Store().Post().GetSingle(postID, false)
-		pchan <- store.GenericStoreResult[*model.Post]{Data: post, NErr: err}
+		pchan <- store.StoreResult[*model.Post]{Data: post, NErr: err}
 		close(pchan)
 	}()
 
-	cchan := make(chan store.GenericStoreResult[*model.Channel], 1)
+	cchan := make(chan store.StoreResult[*model.Channel], 1)
 	go func() {
 		channel, err := a.Srv().Store().Channel().GetForPost(postID)
-		cchan <- store.GenericStoreResult[*model.Channel]{Data: channel, NErr: err}
+		cchan <- store.StoreResult[*model.Channel]{Data: channel, NErr: err}
 		close(cchan)
 	}()
 
-	userChan := make(chan store.GenericStoreResult[*model.User], 1)
+	userChan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
 		user, err := a.Srv().Store().User().Get(context.Background(), upstreamRequest.UserId)
-		userChan <- store.GenericStoreResult[*model.User]{Data: user, NErr: err}
+		userChan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(userChan)
 	}()
 
@@ -175,7 +175,7 @@ func (a *App) DoPostActionWithCookie(c request.CTX, postID, actionId, userID, se
 		upstreamURL = action.Integration.URL
 	}
 
-	teamChan := make(chan store.GenericStoreResult[*model.Team], 1)
+	teamChan := make(chan store.StoreResult[*model.Team], 1)
 
 	go func() {
 		defer close(teamChan)
@@ -186,7 +186,7 @@ func (a *App) DoPostActionWithCookie(c request.CTX, postID, actionId, userID, se
 		}
 
 		team, err := a.Srv().Store().Team().Get(upstreamRequest.TeamId)
-		teamChan <- store.GenericStoreResult[*model.Team]{Data: team, NErr: err}
+		teamChan <- store.StoreResult[*model.Team]{Data: team, NErr: err}
 	}()
 
 	ur := <-userChan

--- a/server/channels/app/notification.go
+++ b/server/channels/app/notification.go
@@ -43,46 +43,46 @@ func (a *App) SendNotifications(c request.CTX, post *model.Post, team *model.Tea
 
 	isCRTAllowed := *a.Config().ServiceSettings.CollapsedThreads != model.CollapsedThreadsDisabled
 
-	pchan := make(chan store.GenericStoreResult[map[string]*model.User], 1)
+	pchan := make(chan store.StoreResult[map[string]*model.User], 1)
 	go func() {
 		props, err := a.Srv().Store().User().GetAllProfilesInChannel(context.Background(), channel.Id, true)
-		pchan <- store.GenericStoreResult[map[string]*model.User]{Data: props, NErr: err}
+		pchan <- store.StoreResult[map[string]*model.User]{Data: props, NErr: err}
 		close(pchan)
 	}()
 
-	cmnchan := make(chan store.GenericStoreResult[map[string]model.StringMap], 1)
+	cmnchan := make(chan store.StoreResult[map[string]model.StringMap], 1)
 	go func() {
 		props, err := a.Srv().Store().Channel().GetAllChannelMembersNotifyPropsForChannel(channel.Id, true)
-		cmnchan <- store.GenericStoreResult[map[string]model.StringMap]{Data: props, NErr: err}
+		cmnchan <- store.StoreResult[map[string]model.StringMap]{Data: props, NErr: err}
 		close(cmnchan)
 	}()
 
-	var gchan chan store.GenericStoreResult[map[string]*model.Group]
+	var gchan chan store.StoreResult[map[string]*model.Group]
 	if a.allowGroupMentions(c, post) {
-		gchan = make(chan store.GenericStoreResult[map[string]*model.Group], 1)
+		gchan = make(chan store.StoreResult[map[string]*model.Group], 1)
 		go func() {
 			groupsMap, err := a.getGroupsAllowedForReferenceInChannel(channel, team)
-			gchan <- store.GenericStoreResult[map[string]*model.Group]{Data: groupsMap, NErr: err}
+			gchan <- store.StoreResult[map[string]*model.Group]{Data: groupsMap, NErr: err}
 			close(gchan)
 		}()
 	}
 
-	var fchan chan store.GenericStoreResult[[]*model.FileInfo]
+	var fchan chan store.StoreResult[[]*model.FileInfo]
 	if len(post.FileIds) != 0 {
-		fchan = make(chan store.GenericStoreResult[[]*model.FileInfo], 1)
+		fchan = make(chan store.StoreResult[[]*model.FileInfo], 1)
 		go func() {
 			fileInfos, err := a.Srv().Store().FileInfo().GetForPost(post.Id, true, false, true)
-			fchan <- store.GenericStoreResult[[]*model.FileInfo]{Data: fileInfos, NErr: err}
+			fchan <- store.StoreResult[[]*model.FileInfo]{Data: fileInfos, NErr: err}
 			close(fchan)
 		}()
 	}
 
-	var tchan chan store.GenericStoreResult[[]string]
+	var tchan chan store.StoreResult[[]string]
 	if isCRTAllowed && post.RootId != "" {
-		tchan = make(chan store.GenericStoreResult[[]string], 1)
+		tchan = make(chan store.StoreResult[[]string], 1)
 		go func() {
 			followers, err := a.Srv().Store().Thread().GetThreadFollowers(post.RootId, true)
-			tchan <- store.GenericStoreResult[[]string]{Data: followers, NErr: err}
+			tchan <- store.StoreResult[[]string]{Data: followers, NErr: err}
 			close(tchan)
 		}()
 	}
@@ -627,26 +627,26 @@ func (a *App) RemoveNotifications(c request.CTX, post *model.Post, channel *mode
 			team = &model.Team{}
 		}
 
-		pCh := make(chan store.GenericStoreResult[map[string]*model.User], 1)
+		pCh := make(chan store.StoreResult[map[string]*model.User], 1)
 		go func() {
 			props, err := a.Srv().Store().User().GetAllProfilesInChannel(context.Background(), channel.Id, true)
-			pCh <- store.GenericStoreResult[map[string]*model.User]{Data: props, NErr: err}
+			pCh <- store.StoreResult[map[string]*model.User]{Data: props, NErr: err}
 			close(pCh)
 		}()
 
-		cmnCh := make(chan store.GenericStoreResult[map[string]model.StringMap], 1)
+		cmnCh := make(chan store.StoreResult[map[string]model.StringMap], 1)
 		go func() {
 			props, err := a.Srv().Store().Channel().GetAllChannelMembersNotifyPropsForChannel(channel.Id, true)
-			cmnCh <- store.GenericStoreResult[map[string]model.StringMap]{Data: props, NErr: err}
+			cmnCh <- store.StoreResult[map[string]model.StringMap]{Data: props, NErr: err}
 			close(cmnCh)
 		}()
 
-		var gCh chan store.GenericStoreResult[map[string]*model.Group]
+		var gCh chan store.StoreResult[map[string]*model.Group]
 		if a.allowGroupMentions(c, post) {
-			gCh = make(chan store.GenericStoreResult[map[string]*model.Group], 1)
+			gCh = make(chan store.StoreResult[map[string]*model.Group], 1)
 			go func() {
 				groupsMap, err := a.getGroupsAllowedForReferenceInChannel(channel, team)
-				gCh <- store.GenericStoreResult[map[string]*model.Group]{Data: groupsMap, NErr: err}
+				gCh <- store.StoreResult[map[string]*model.Group]{Data: groupsMap, NErr: err}
 				close(gCh)
 			}()
 		}

--- a/server/channels/app/team.go
+++ b/server/channels/app/team.go
@@ -555,17 +555,17 @@ func (a *App) sendUpdatedMemberRoleEvent(userID string, member *model.TeamMember
 }
 
 func (a *App) AddUserToTeam(c request.CTX, teamID string, userID string, userRequestorId string) (*model.Team, *model.TeamMember, *model.AppError) {
-	tchan := make(chan store.GenericStoreResult[*model.Team], 1)
+	tchan := make(chan store.StoreResult[*model.Team], 1)
 	go func() {
 		team, err := a.Srv().Store().Team().Get(teamID)
-		tchan <- store.GenericStoreResult[*model.Team]{Data: team, NErr: err}
+		tchan <- store.StoreResult[*model.Team]{Data: team, NErr: err}
 		close(tchan)
 	}()
 
-	uchan := make(chan store.GenericStoreResult[*model.User], 1)
+	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
 		user, err := a.Srv().Store().User().Get(context.Background(), userID)
-		uchan <- store.GenericStoreResult[*model.User]{Data: user, NErr: err}
+		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()
 
@@ -636,17 +636,17 @@ func (a *App) AddUserToTeamByToken(c request.CTX, userID string, tokenID string)
 
 	tokenData := model.MapFromJSON(strings.NewReader(token.Extra))
 
-	tchan := make(chan store.GenericStoreResult[*model.Team], 1)
+	tchan := make(chan store.StoreResult[*model.Team], 1)
 	go func() {
 		team, err := a.Srv().Store().Team().Get(tokenData["teamId"])
-		tchan <- store.GenericStoreResult[*model.Team]{Data: team, NErr: err}
+		tchan <- store.StoreResult[*model.Team]{Data: team, NErr: err}
 		close(tchan)
 	}()
 
-	uchan := make(chan store.GenericStoreResult[*model.User], 1)
+	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
 		user, err := a.Srv().Store().User().Get(context.Background(), userID)
-		uchan <- store.GenericStoreResult[*model.User]{Data: user, NErr: err}
+		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()
 
@@ -712,17 +712,17 @@ func (a *App) AddUserToTeamByToken(c request.CTX, userID string, tokenID string)
 }
 
 func (a *App) AddUserToTeamByInviteId(c request.CTX, inviteId string, userID string) (*model.Team, *model.TeamMember, *model.AppError) {
-	tchan := make(chan store.GenericStoreResult[*model.Team], 1)
+	tchan := make(chan store.StoreResult[*model.Team], 1)
 	go func() {
 		team, err := a.Srv().Store().Team().GetByInviteId(inviteId)
-		tchan <- store.GenericStoreResult[*model.Team]{Data: team, NErr: err}
+		tchan <- store.StoreResult[*model.Team]{Data: team, NErr: err}
 		close(tchan)
 	}()
 
-	uchan := make(chan store.GenericStoreResult[*model.User], 1)
+	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
 		user, err := a.Srv().Store().User().Get(context.Background(), userID)
-		uchan <- store.GenericStoreResult[*model.User]{Data: user, NErr: err}
+		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()
 
@@ -1146,17 +1146,17 @@ func (a *App) GetTeamUnread(teamID, userID string) (*model.TeamUnread, *model.Ap
 }
 
 func (a *App) RemoveUserFromTeam(c request.CTX, teamID string, userID string, requestorId string) *model.AppError {
-	tchan := make(chan store.GenericStoreResult[*model.Team], 1)
+	tchan := make(chan store.StoreResult[*model.Team], 1)
 	go func() {
 		team, err := a.Srv().Store().Team().Get(teamID)
-		tchan <- store.GenericStoreResult[*model.Team]{Data: team, NErr: err}
+		tchan <- store.StoreResult[*model.Team]{Data: team, NErr: err}
 		close(tchan)
 	}()
 
-	uchan := make(chan store.GenericStoreResult[*model.User], 1)
+	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
 		user, err := a.Srv().Store().User().Get(context.Background(), userID)
-		uchan <- store.GenericStoreResult[*model.User]{Data: user, NErr: err}
+		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()
 
@@ -1336,17 +1336,17 @@ func (a *App) postRemoveFromTeamMessage(c request.CTX, user *model.User, channel
 }
 
 func (a *App) prepareInviteNewUsersToTeam(teamID, senderId string, channelIds []string) (*model.User, *model.Team, []*model.Channel, *model.AppError) {
-	tchan := make(chan store.GenericStoreResult[*model.Team], 1)
+	tchan := make(chan store.StoreResult[*model.Team], 1)
 	go func() {
 		team, err := a.Srv().Store().Team().Get(teamID)
-		tchan <- store.GenericStoreResult[*model.Team]{Data: team, NErr: err}
+		tchan <- store.StoreResult[*model.Team]{Data: team, NErr: err}
 		close(tchan)
 	}()
 
-	uchan := make(chan store.GenericStoreResult[*model.User], 1)
+	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
 		user, err := a.Srv().Store().User().Get(context.Background(), senderId)
-		uchan <- store.GenericStoreResult[*model.User]{Data: user, NErr: err}
+		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()
 
@@ -1473,22 +1473,22 @@ func (a *App) prepareInviteGuestsToChannels(teamID string, guestsInvite *model.G
 		return nil, nil, nil, err
 	}
 
-	tchan := make(chan store.GenericStoreResult[*model.Team], 1)
+	tchan := make(chan store.StoreResult[*model.Team], 1)
 	go func() {
 		team, err := a.Srv().Store().Team().Get(teamID)
-		tchan <- store.GenericStoreResult[*model.Team]{Data: team, NErr: err}
+		tchan <- store.StoreResult[*model.Team]{Data: team, NErr: err}
 		close(tchan)
 	}()
-	cchan := make(chan store.GenericStoreResult[[]*model.Channel], 1)
+	cchan := make(chan store.StoreResult[[]*model.Channel], 1)
 	go func() {
 		channels, err := a.Srv().Store().Channel().GetChannelsByIds(guestsInvite.Channels, false)
-		cchan <- store.GenericStoreResult[[]*model.Channel]{Data: channels, NErr: err}
+		cchan <- store.StoreResult[[]*model.Channel]{Data: channels, NErr: err}
 		close(cchan)
 	}()
-	uchan := make(chan store.GenericStoreResult[*model.User], 1)
+	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
 		user, err := a.Srv().Store().User().Get(context.Background(), senderId)
-		uchan <- store.GenericStoreResult[*model.User]{Data: user, NErr: err}
+		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()
 
@@ -1861,16 +1861,16 @@ func (a *App) RestoreTeam(teamID string) *model.AppError {
 }
 
 func (a *App) GetTeamStats(teamID string, restrictions *model.ViewUsersRestrictions) (*model.TeamStats, *model.AppError) {
-	tchan := make(chan store.GenericStoreResult[int64], 1)
+	tchan := make(chan store.StoreResult[int64], 1)
 	go func() {
 		totalMemberCount, err := a.Srv().Store().Team().GetTotalMemberCount(teamID, restrictions)
-		tchan <- store.GenericStoreResult[int64]{Data: totalMemberCount, NErr: err}
+		tchan <- store.StoreResult[int64]{Data: totalMemberCount, NErr: err}
 		close(tchan)
 	}()
-	achan := make(chan store.GenericStoreResult[int64], 1)
+	achan := make(chan store.StoreResult[int64], 1)
 	go func() {
 		memberCount, err := a.Srv().Store().Team().GetActiveMemberCount(teamID, restrictions)
-		achan <- store.GenericStoreResult[int64]{Data: memberCount, NErr: err}
+		achan <- store.StoreResult[int64]{Data: memberCount, NErr: err}
 		close(achan)
 	}()
 

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -1604,17 +1604,17 @@ func (a *App) UpdateUserRolesWithUser(c request.CTX, user *model.User, newRoles 
 	}
 
 	user.Roles = newRoles
-	uchan := make(chan store.GenericStoreResult[*model.UserUpdate], 1)
+	uchan := make(chan store.StoreResult[*model.UserUpdate], 1)
 	go func() {
 		userUpdate, err := a.Srv().Store().User().Update(c, user, true)
-		uchan <- store.GenericStoreResult[*model.UserUpdate]{Data: userUpdate, NErr: err}
+		uchan <- store.StoreResult[*model.UserUpdate]{Data: userUpdate, NErr: err}
 		close(uchan)
 	}()
 
-	schan := make(chan store.GenericStoreResult[string], 1)
+	schan := make(chan store.StoreResult[string], 1)
 	go func() {
 		id, err := a.Srv().Store().Session().UpdateRoles(user.Id, newRoles)
-		schan <- store.GenericStoreResult[string]{Data: id, NErr: err}
+		schan <- store.StoreResult[string]{Data: id, NErr: err}
 		close(schan)
 	}()
 

--- a/server/channels/app/webhook.go
+++ b/server/channels/app/webhook.go
@@ -664,10 +664,10 @@ func (a *App) HandleIncomingWebhook(c request.CTX, hookID string, req *model.Inc
 		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	hchan := make(chan store.GenericStoreResult[*model.IncomingWebhook], 1)
+	hchan := make(chan store.StoreResult[*model.IncomingWebhook], 1)
 	go func() {
 		webhook, err := a.Srv().Store().Webhook().GetIncoming(hookID, true)
-		hchan <- store.GenericStoreResult[*model.IncomingWebhook]{Data: webhook, NErr: err}
+		hchan <- store.StoreResult[*model.IncomingWebhook]{Data: webhook, NErr: err}
 		close(hchan)
 	}()
 
@@ -690,10 +690,10 @@ func (a *App) HandleIncomingWebhook(c request.CTX, hookID string, req *model.Inc
 	}
 	hook = result.Data
 
-	uchan := make(chan store.GenericStoreResult[*model.User], 1)
+	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
 		user, err := a.Srv().Store().User().Get(context.Background(), hook.UserId)
-		uchan <- store.GenericStoreResult[*model.User]{Data: user, NErr: err}
+		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()
 
@@ -712,7 +712,7 @@ func (a *App) HandleIncomingWebhook(c request.CTX, hookID string, req *model.Inc
 	}
 
 	var channel *model.Channel
-	var cchan chan store.GenericStoreResult[*model.Channel]
+	var cchan chan store.StoreResult[*model.Channel]
 
 	if channelName != "" {
 		if channelName[0] == '@' {
@@ -726,17 +726,17 @@ func (a *App) HandleIncomingWebhook(c request.CTX, hookID string, req *model.Inc
 			}
 			channel = ch
 		} else if channelName[0] == '#' {
-			cchan = make(chan store.GenericStoreResult[*model.Channel], 1)
+			cchan = make(chan store.StoreResult[*model.Channel], 1)
 			go func() {
 				chnn, chnnErr := a.Srv().Store().Channel().GetByName(hook.TeamId, channelName[1:], true)
-				cchan <- store.GenericStoreResult[*model.Channel]{Data: chnn, NErr: chnnErr}
+				cchan <- store.StoreResult[*model.Channel]{Data: chnn, NErr: chnnErr}
 				close(cchan)
 			}()
 		} else {
-			cchan = make(chan store.GenericStoreResult[*model.Channel], 1)
+			cchan = make(chan store.StoreResult[*model.Channel], 1)
 			go func() {
 				chnn, chnnErr := a.Srv().Store().Channel().GetByName(hook.TeamId, channelName, true)
-				cchan <- store.GenericStoreResult[*model.Channel]{Data: chnn, NErr: chnnErr}
+				cchan <- store.StoreResult[*model.Channel]{Data: chnn, NErr: chnnErr}
 				close(cchan)
 			}()
 		}

--- a/server/channels/store/searchlayer/user_layer.go
+++ b/server/channels/store/searchlayer/user_layer.go
@@ -122,17 +122,17 @@ func (s *SearchUserStore) autocompleteUsersInChannelByEngine(engine searchengine
 		return nil, err
 	}
 
-	uchan := make(chan store.GenericStoreResult[[]*model.User], 1)
+	uchan := make(chan store.StoreResult[[]*model.User], 1)
 	go func() {
 		users, nErr := s.UserStore.GetProfileByIds(context.Background(), uchanIds, nil, false)
-		uchan <- store.GenericStoreResult[[]*model.User]{Data: users, NErr: nErr}
+		uchan <- store.StoreResult[[]*model.User]{Data: users, NErr: nErr}
 		close(uchan)
 	}()
 
-	nuchan := make(chan store.GenericStoreResult[[]*model.User], 1)
+	nuchan := make(chan store.StoreResult[[]*model.User], 1)
 	go func() {
 		users, nErr := s.UserStore.GetProfileByIds(context.Background(), nuchanIds, nil, false)
-		nuchan <- store.GenericStoreResult[[]*model.User]{Data: users, NErr: nErr}
+		nuchan <- store.StoreResult[[]*model.User]{Data: users, NErr: nErr}
 		close(nuchan)
 	}()
 

--- a/server/channels/store/sqlstore/post_store.go
+++ b/server/channels/store/sqlstore/post_store.go
@@ -1230,16 +1230,16 @@ func (s *SqlPostStore) GetPosts(options model.GetPostsOptions, _ bool, sanitizeO
 	}
 	offset := options.PerPage * options.Page
 
-	rpc := make(chan store.GenericStoreResult[[]*model.Post], 1)
+	rpc := make(chan store.StoreResult[[]*model.Post], 1)
 	go func() {
 		posts, err := s.getRootPosts(options.ChannelId, offset, options.PerPage, options.SkipFetchThreads, options.IncludeDeleted)
-		rpc <- store.GenericStoreResult[[]*model.Post]{Data: posts, NErr: err}
+		rpc <- store.StoreResult[[]*model.Post]{Data: posts, NErr: err}
 		close(rpc)
 	}()
-	cpc := make(chan store.GenericStoreResult[[]*model.Post], 1)
+	cpc := make(chan store.StoreResult[[]*model.Post], 1)
 	go func() {
 		posts, err := s.getParentsPosts(options.ChannelId, offset, options.PerPage, options.SkipFetchThreads, options.IncludeDeleted)
-		cpc <- store.GenericStoreResult[[]*model.Post]{Data: posts, NErr: err}
+		cpc <- store.StoreResult[[]*model.Post]{Data: posts, NErr: err}
 		close(cpc)
 	}()
 
@@ -2769,7 +2769,7 @@ func (s *SqlPostStore) SearchPostsForUser(rctx request.CTX, paramsList []*model.
 
 	var wg sync.WaitGroup
 
-	pchan := make(chan store.GenericStoreResult[*model.PostList], len(paramsList))
+	pchan := make(chan store.StoreResult[*model.PostList], len(paramsList))
 
 	for _, params := range paramsList {
 		// remove any unquoted term that contains only non-alphanumeric chars
@@ -2781,7 +2781,7 @@ func (s *SqlPostStore) SearchPostsForUser(rctx request.CTX, paramsList []*model.
 		go func(params *model.SearchParams) {
 			defer wg.Done()
 			postList, err := s.search(teamId, userId, params, false, false)
-			pchan <- store.GenericStoreResult[*model.PostList]{Data: postList, NErr: err}
+			pchan <- store.StoreResult[*model.PostList]{Data: postList, NErr: err}
 		}(params)
 	}
 

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -16,17 +16,7 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/product"
 )
 
-// Deprecated: Use GenericStoreResult instead.
-type StoreResult struct {
-	Data any
-
-	// NErr a temporary field used by the new code for the AppError migration. This will later become Err when the entire store is migrated.
-	NErr error
-}
-
-// GenericStoreResult is a type safe version of StoreResult.
-// Once all the code is migrated to use GenericStoreResult, it should be renamed to StoreResult.
-type GenericStoreResult[T any] struct {
+type StoreResult[T any] struct {
 	Data T
 
 	// NErr a temporary field used by the new code for the AppError migration. This will later become Err when the entire store is migrated.

--- a/server/platform/services/telemetry/telemetry.go
+++ b/server/platform/services/telemetry/telemetry.go
@@ -281,17 +281,17 @@ func (ts *TelemetryService) trackActivity() {
 	var incomingWebhooksCount int64
 	var outgoingWebhooksCount int64
 
-	activeUsersDailyCountChan := make(chan store.GenericStoreResult[int64], 1)
+	activeUsersDailyCountChan := make(chan store.StoreResult[int64], 1)
 	go func() {
 		count, err := ts.dbStore.User().AnalyticsActiveCount(DayMilliseconds, model.UserCountOptions{IncludeBotAccounts: false, IncludeDeleted: false})
-		activeUsersDailyCountChan <- store.GenericStoreResult[int64]{Data: count, NErr: err}
+		activeUsersDailyCountChan <- store.StoreResult[int64]{Data: count, NErr: err}
 		close(activeUsersDailyCountChan)
 	}()
 
-	activeUsersMonthlyCountChan := make(chan store.GenericStoreResult[int64], 1)
+	activeUsersMonthlyCountChan := make(chan store.StoreResult[int64], 1)
 	go func() {
 		count, err := ts.dbStore.User().AnalyticsActiveCount(MonthMilliseconds, model.UserCountOptions{IncludeBotAccounts: false, IncludeDeleted: false})
-		activeUsersMonthlyCountChan <- store.GenericStoreResult[int64]{Data: count, NErr: err}
+		activeUsersMonthlyCountChan <- store.StoreResult[int64]{Data: count, NErr: err}
 		close(activeUsersMonthlyCountChan)
 	}()
 


### PR DESCRIPTION
#### Summary
The campain started with https://github.com/mattermost/mattermost/pull/25086 is over. All code has been migrated to use the generic variant of `StoreResult`, which is `GenericStoreResult` and hence, `StoreResult` can be removed and `GenericStoreResult` renamed back to `StoreResult`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56284


#### Screenshots
```release-note
NONE
```

