### PR TITLE
[MM-24088] Add support for APNG (Animated PNG) image format

### DIFF
--- a/server/channels/app/file.go
+++ b/server/channels/app/file.go
@@ -841,7 +841,7 @@ func (t *UploadFileTask) preprocessImage() *model.AppError {
 		return t.newAppError("api.file.upload_file.large_image_detailed.app_error", http.StatusBadRequest)
 	}
 
-	t.fileinfo.HasPreviewImage = true
+	t.fileinfo.HasPreviewImage = false
 	nameWithoutExtension := t.Name[:strings.LastIndex(t.Name, ".")]
 	t.fileinfo.PreviewPath = t.pathPrefix() + nameWithoutExtension + "_preview." + getFileExtFromMimeType(t.fileinfo.MimeType)
 	t.fileinfo.ThumbnailPath = t.pathPrefix() + nameWithoutExtension + "_thumb." + getFileExtFromMimeType(t.fileinfo.MimeType)

--- a/webapp/channels/src/components/file_preview/__snapshots__/file_preview.test.tsx.snap
+++ b/webapp/channels/src/components/file_preview/__snapshots__/file_preview.test.tsx.snap
@@ -15,11 +15,14 @@ exports[`FilePreview should match snapshot 1`] = `
         className="post-image normal"
         style={
           Object {
-            "backgroundImage": "url(/api/v4/files/file_id_1/thumbnail)",
             "backgroundSize": "cover",
           }
         }
-      />
+      >
+        <img
+          src="/api/v4/files/file_id_1"
+        />
+      </div>
     </div>
     <div
       className="post-image__details"
@@ -119,11 +122,14 @@ exports[`FilePreview should match snapshot when props are changed 1`] = `
         className="post-image normal"
         style={
           Object {
-            "backgroundImage": "url(/api/v4/files/file_id_1/thumbnail)",
             "backgroundSize": "cover",
           }
         }
-      />
+      >
+        <img
+          src="/api/v4/files/file_id_1"
+        />
+      </div>
     </div>
     <div
       className="post-image__details"
@@ -223,11 +229,14 @@ exports[`FilePreview should match snapshot when props are changed 2`] = `
         className="post-image normal"
         style={
           Object {
-            "backgroundImage": "url(/api/v4/files/file_id_1/thumbnail)",
             "backgroundSize": "cover",
           }
         }
-      />
+      >
+        <img
+          src="/api/v4/files/file_id_1"
+        />
+      </div>
     </div>
     <div
       className="post-image__details"
@@ -296,11 +305,14 @@ exports[`FilePreview should match snapshot when props are changed 2`] = `
         className="post-image normal"
         style={
           Object {
-            "backgroundImage": "url(/api/v4/files/file_id_2/thumbnail)",
             "backgroundSize": "cover",
           }
         }
-      />
+      >
+        <img
+          src="/api/v4/files/file_id_2"
+        />
+      </div>
     </div>
     <div
       className="post-image__details"

--- a/webapp/channels/src/components/file_preview/file_preview.tsx
+++ b/webapp/channels/src/components/file_preview/file_preview.tsx
@@ -75,10 +75,11 @@ export default class FilePreview extends React.PureComponent<Props> {
                     <div
                         className={imageClassName}
                         style={{
-                            backgroundImage: `url(${thumbnailUrl})`,
                             backgroundSize: 'cover',
                         }}
-                    />
+                    >
+                        <img src={getFileUrl(info.id)}/>
+                    </div>
                 );
             } else {
                 className += ' custom-file';


### PR DESCRIPTION
Added support for APNG image format 
Added support for APNG image format during preview and enabled animation for APNG in the chat
Resolves https://github.com/mattermost/mattermost/issues/24088
Ticket Link
Github : https://github.com/mattermost/mattermost/issues/24088

SCREENSHOTS
BEFORE
![BEFORE](https://github.com/mattermost/mattermost/assets/26576656/58b97d4a-8d8c-4912-8589-dae23cd6e45d)

AFTER
<img width="634" alt="AFTER" src="https://github.com/mattermost/mattermost/assets/26576656/586e1e39-12b5-4994-b941-0ae8fdc4127d">

```release-note
NONE
```
