### PR TITLE
Fix auto delete post when dismissed by a plugin

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/actions/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/posts.ts
@@ -276,7 +276,8 @@ export function createPost(post: Post, files: any[] = []) {
                     error.server_error_id === 'api.post.create_post.town_square_read_only' ||
                     error.server_error_id === 'plugin.message_will_be_posted.dismiss_post'
                 ) {
-                    actions.push(removePost(data) as any);
+                    // RemovePost is a Thunk, and not handled by batchActions
+                    dispatch(removePost(data));
                 } else {
                     actions.push(receivedPost(data, crtEnabled));
                 }


### PR DESCRIPTION
#### Summary
When a plugin dismissed a post, this was done correctly on the back-end, but the front-end kept the post visible without any trace of the post being rejected.

This was because batchActions does not seem to support thunks, so we should call dispatch directly on the `removePost` function.

We may have to do this in other parts of the app, but we will look into it at a different time.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55200

#### Release Note
```release-note
Fix error where posts dismissed by a plugin were not properly removed from the view.
```
