### PR TITLE
MM-56359: Skip TestUploadLicenseFile

### DIFF
--- a/server/channels/api4/license_test.go
+++ b/server/channels/api4/license_test.go
@@ -53,6 +53,7 @@ func TestGetOldClientLicense(t *testing.T) {
 }
 
 func TestUploadLicenseFile(t *testing.T) {
+	t.Skip("MM-56359")
 	th := Setup(t)
 	defer th.TearDown()
 	client := th.Client


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/MM-56359

Introduced in https://github.com/mattermost/mattermost/pull/21364.

```release-note
NONE
```
