### PR TITLE
shared/filestore/localstore.go: remove unnecessary warning

### DIFF
--- a/server/platform/shared/filestore/filesstore_test.go
+++ b/server/platform/shared/filestore/filesstore_test.go
@@ -391,7 +391,7 @@ func (s *FileBackendTestSuite) TestListDirectoryRecursively() {
 	b := []byte("test")
 	path1 := "19700101/" + randomString()
 	path2 := "19800101/" + randomString()
-	longPath := "19800102/this/is/a/way/too/long/path/for/this/function/to/handle" + randomString()
+	longPath := "19800102" + strings.Repeat("/toomuch", MaxRecursionDepth+1) + randomString()
 
 	paths, err := s.backend.ListDirectoryRecursively("19700101")
 	s.Nil(err)

--- a/server/platform/shared/filestore/localstore.go
+++ b/server/platform/shared/filestore/localstore.go
@@ -211,7 +211,6 @@ func appendRecursively(basePath, path string, maxDepth int) ([]string, error) {
 		}
 		if dirEntry.IsDir() {
 			if maxDepth <= 0 {
-				mlog.Warn("Max Depth reached", mlog.String("path", entryPath))
 				results = append(results, entryPath)
 				continue // we'll ignore it if max depth is reached.
 			}

--- a/server/platform/shared/filestore/localstore.go
+++ b/server/platform/shared/filestore/localstore.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	TestFilePath = "/testfile"
+	TestFilePath      = "/testfile"
+	MaxRecursionDepth = 50
 )
 
 type LocalFileBackend struct {
@@ -211,6 +212,7 @@ func appendRecursively(basePath, path string, maxDepth int) ([]string, error) {
 		}
 		if dirEntry.IsDir() {
 			if maxDepth <= 0 {
+				mlog.Warn("Max depth reached, skipping any further directories", mlog.Int("depth", maxDepth), mlog.String("path", entryPath))
 				results = append(results, entryPath)
 				continue // we'll ignore it if max depth is reached.
 			}
@@ -227,11 +229,26 @@ func appendRecursively(basePath, path string, maxDepth int) ([]string, error) {
 }
 
 func (b *LocalFileBackend) ListDirectory(path string) ([]string, error) {
-	return appendRecursively(b.directory, path, 0)
+	results := []string{}
+	dirEntries, err := os.ReadDir(filepath.Join(b.directory, path))
+	if err != nil {
+		if os.IsNotExist(err) {
+			// ideally os.ErrNotExist should've been returned but to keep the
+			// consistency, leaving it as is before.
+			return results, nil
+		}
+		// same here, ideally we shouldn't return the empty slice
+		return results, errors.Wrapf(err, "unable to list the directory %s", path)
+	}
+	for _, dirEntry := range dirEntries {
+		results = append(results, filepath.Join(path, dirEntry.Name()))
+	}
+
+	return results, nil
 }
 
 func (b *LocalFileBackend) ListDirectoryRecursively(path string) ([]string, error) {
-	return appendRecursively(b.directory, path, 10)
+	return appendRecursively(b.directory, path, MaxRecursionDepth)
 }
 
 func (b *LocalFileBackend) RemoveDirectory(path string) error {


### PR DESCRIPTION

#### Summary
I didn't get why this was there anyway, if `maxDepth` is `0`, we just stop recursion anyway. This is also not an actionable item from the administrator point of view right?

I mean this always warns when using local filebackend's list directory method.

```Go
func (b *LocalFileBackend) ListDirectory(path string) ([]string, error) {
	return appendRecursively(b.directory, path, 0)
}
```


#### Release Note

```release-note
NONE
```
