### PR TITLE
i18n tooling: localizeMessage, defineMessage#toKeys, i18n-extract-beta

### DIFF
--- a/webapp/channels/.eslintrc.json
+++ b/webapp/channels/.eslintrc.json
@@ -20,6 +20,10 @@
     "react": {
         "pragma": "React",
         "version": "detect"
+    },
+    "formatjs": {
+      "additionalFunctionNames": ["defineMessage","localizeMessage"],
+      "additionalComponentNames": ["FormattedMarkdownMessage"]
     }
   },
   "rules": {
@@ -127,6 +131,15 @@
     ],
     "max-lines": ["warn", {"max": 800, "skipBlankLines": true, "skipComments": true}],
     "formatjs/no-multiple-whitespaces": 2,
+    "formatjs/enforce-default-message": 2,
+    "formatjs/no-multiple-plurals": 1,
+    "formatjs/enforce-placeholders": 2,
+    "formatjs/enforce-id": 2,
+    "formatjs/no-invalid-icu": 2,
+    "formatjs/no-literal-string-in-jsx": 1,
+    "formatjs/prefer-formatted-message": 1,
+    "formatjs/no-useless-message": 1,
+    "formatjs/prefer-pound-in-plural": 0,
     "@typescript-eslint/consistent-type-imports": ["error", {"disallowTypeAnnotations": false}]
   },
   "overrides": [

--- a/webapp/channels/.eslintrc.json
+++ b/webapp/channels/.eslintrc.json
@@ -22,8 +22,7 @@
         "version": "detect"
     },
     "formatjs": {
-      "additionalFunctionNames": ["defineMessage","localizeMessage"],
-      "additionalComponentNames": ["FormattedMarkdownMessage"]
+      "additionalFunctionNames": ["defineMessage","localizeMessage"]
     }
   },
   "rules": {

--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -202,7 +202,7 @@
     "i18n-extract": "npm run mmjstool -- i18n extract-webapp --webapp-dir ./src",
     "i18n-clean-empty": "npm run mmjstool -- i18n clean-empty --webapp-dir ./src",
     "i18n-check-empty-src": "npm run mmjstool -- i18n check-empty-src --webapp-dir ./src",
-    "i18n-extract-beta": "rm -rf src/i18n/en.json && formatjs extract 'src/**/*.{js,jsx,ts,tsx}' --additional-function-names defineMessage,localizeMessage --additional-component-names FormattedMarkdownMessage --ignore 'src/**/*.d.ts' --out-file src/i18n/en.json --id-interpolation-pattern '[sha512:contenthash:base64:6]' --format simple",
+    "i18n-extract-beta": "rm -rf src/i18n/en.json && formatjs extract 'src/**/*.{js,jsx,ts,tsx}' --additional-function-names defineMessage,localizeMessage --ignore 'src/**/*.d.ts' --out-file src/i18n/en.json --id-interpolation-pattern '[sha512:contenthash:base64:6]' --format simple",
     "check-types": "tsc -b",
     "make-emojis": "node --experimental-json-modules build/emoji/make_emojis.mjs"
   }

--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -104,6 +104,7 @@
   },
   "devDependencies": {
     "@deanwhillier/jest-matchmedia-mock": "1.2.0",
+    "@formatjs/cli": "6.2.4",
     "@hot-loader/react-dom": "17.0.2",
     "@mattermost/eslint-plugin": "*",
     "@redux-devtools/extension": "3.2.3",
@@ -201,6 +202,7 @@
     "i18n-extract": "npm run mmjstool -- i18n extract-webapp --webapp-dir ./src",
     "i18n-clean-empty": "npm run mmjstool -- i18n clean-empty --webapp-dir ./src",
     "i18n-check-empty-src": "npm run mmjstool -- i18n check-empty-src --webapp-dir ./src",
+    "i18n-extract-beta": "rm -rf src/i18n/en.json && formatjs extract 'src/**/*.{js,jsx,ts,tsx}' --additional-function-names defineMessage,localizeMessage --additional-component-names FormattedMarkdownMessage --ignore 'src/**/*.d.ts' --out-file src/i18n/en.json --id-interpolation-pattern '[sha512:contenthash:base64:6]' --format simple",
     "check-types": "tsc -b",
     "make-emojis": "node --experimental-json-modules build/emoji/make_emojis.mjs"
   }

--- a/webapp/channels/src/actions/notification_actions.jsx
+++ b/webapp/channels/src/actions/notification_actions.jsx
@@ -224,7 +224,7 @@ export function sendDesktopNotification(post, msgProps) {
         }
 
         if (isCrtReply) {
-            title = Utils.localizeAndFormatMessage(t('notification.crt'), 'Reply in {title}', {title});
+            title = Utils.localizeMessage({id: t('notification.crt'), defaultMessage: 'Reply in {title}'}, {title});
         }
 
         let notifyText = post.message;

--- a/webapp/channels/src/components/integrations/installed_outgoing_webhooks/installed_outgoing_webhooks.tsx
+++ b/webapp/channels/src/components/integrations/installed_outgoing_webhooks/installed_outgoing_webhooks.tsx
@@ -135,25 +135,27 @@ export default class InstalledOutgoingWebhooks extends React.PureComponent<Props
         return displayNameA.localeCompare(displayNameB);
     };
 
-    outgoingWebhooks = (filter: string) => this.props.outgoingWebhooks.
-        sort(this.outgoingWebhookCompare).
-        filter((outgoingWebhook) => matchesFilter(outgoingWebhook, this.props.channels[outgoingWebhook.channel_id], filter)).
-        map((outgoingWebhook) => {
-            const canChange = this.props.canManageOthersWebhooks || this.props.user.id === outgoingWebhook.creator_id;
-            const channel = this.props.channels[outgoingWebhook.channel_id];
-            return (
-                <InstalledOutgoingWebhook
-                    key={outgoingWebhook.id}
-                    outgoingWebhook={outgoingWebhook}
-                    onRegenToken={this.regenOutgoingWebhookToken}
-                    onDelete={this.removeOutgoingHook}
-                    creator={this.props.users[outgoingWebhook.creator_id] || {}}
-                    canChange={canChange}
-                    team={this.props.team}
-                    channel={channel}
-                />
-            );
-        });
+    outgoingWebhooks = (filter: string) => {
+        return this.props.outgoingWebhooks.
+            sort(this.outgoingWebhookCompare).
+            filter((outgoingWebhook) => matchesFilter(outgoingWebhook, this.props.channels[outgoingWebhook.channel_id], filter)).
+            map((outgoingWebhook) => {
+                const canChange = this.props.canManageOthersWebhooks || this.props.user.id === outgoingWebhook.creator_id;
+                const channel = this.props.channels[outgoingWebhook.channel_id];
+                return (
+                    <InstalledOutgoingWebhook
+                        key={outgoingWebhook.id}
+                        outgoingWebhook={outgoingWebhook}
+                        onRegenToken={this.regenOutgoingWebhookToken}
+                        onDelete={this.removeOutgoingHook}
+                        creator={this.props.users[outgoingWebhook.creator_id] || {}}
+                        canChange={canChange}
+                        team={this.props.team}
+                        channel={channel}
+                    />
+                );
+            });
+    };
 
     render() {
         return (
@@ -185,6 +187,9 @@ export default class InstalledOutgoingWebhooks extends React.PureComponent<Props
                 emptyTextSearch={
                     <FormattedMarkdownMessage
                         id='installed_outgoing_webhooks.emptySearch'
+
+                        // BackstageList clones the searchTerm into value
+                        // eslint-disable-next-line formatjs/enforce-placeholders
                         defaultMessage='No outgoing webhooks match {searchTerm}'
                     />
                 }

--- a/webapp/channels/src/components/searchable_channel_list.tsx
+++ b/webapp/channels/src/components/searchable_channel_list.tsx
@@ -23,7 +23,7 @@ import Constants, {ModalIdentifiers} from 'utils/constants';
 import {t} from 'utils/i18n';
 import {isKeyPressed} from 'utils/keyboard';
 import * as UserAgent from 'utils/user_agent';
-import {localizeMessage, localizeAndFormatMessage} from 'utils/utils';
+import {localizeMessage} from 'utils/utils';
 
 import type {FilterType} from './browse_channels/browse_channels';
 import {Filter} from './browse_channels/browse_channels';
@@ -152,11 +152,10 @@ export class SearchableChannelList extends React.PureComponent<Props, State> {
             </div>
         ) : null;
 
-        const channelPurposeContainerAriaLabel = localizeAndFormatMessage(
-            t('more_channels.channel_purpose'),
-            'Channel Information: Membership Indicator: Joined, Member count {memberCount}, Purpose: {channelPurpose}',
-            {memberCount, channelPurpose: channel.purpose || ''},
-        );
+        const channelPurposeContainerAriaLabel = localizeMessage({
+            id: t('more_channels.channel_purpose'),
+            defaultMessage: 'Channel Information: Membership Indicator: Joined, Member count {memberCount}, Purpose: {channelPurpose}',
+        }, {memberCount, channelPurpose: channel.purpose || ''});
 
         const channelPurposeContainer = (
             <div
@@ -349,8 +348,7 @@ export class SearchableChannelList extends React.PureComponent<Props, State> {
             listContent = (
                 <div
                     className='no-channel-message'
-                    aria-label={this.state.channelSearchValue.length > 0 ? localizeAndFormatMessage(t('more_channels.noMore'), 'No results for {text}', {text: this.state.channelSearchValue}) : localizeMessage('widgets.channels_input.empty', 'No channels found')
-                    }
+                    aria-label={this.state.channelSearchValue.length > 0 ? localizeMessage({id: 'more_channels.noMore', defaultMessage: 'No results for {text}'}, {text: this.state.channelSearchValue}) : localizeMessage('widgets.channels_input.empty', 'No channels found')}
                 >
                     <MagnifyingGlassSVG/>
                     <h3 className='primary-message'>
@@ -538,7 +536,7 @@ export class SearchableChannelList extends React.PureComponent<Props, State> {
         } else if (channels.length === 1) {
             channelCountLabel = localizeMessage('more_channels.count_one', '1 Result');
         } else if (channels.length > 1) {
-            channelCountLabel = localizeAndFormatMessage(t('more_channels.count'), '0 Results', {count: channels.length});
+            channelCountLabel = localizeMessage({id: 'more_channels.count', defaultMessage: '{count} Results'}, {count: channels.length});
         } else {
             channelCountLabel = localizeMessage('more_channels.count_zero', '0 Results');
         }

--- a/webapp/channels/src/components/suggestion/command_provider/app_command_parser/app_command_parser_dependencies.ts
+++ b/webapp/channels/src/components/suggestion/command_provider/app_command_parser/app_command_parser_dependencies.ts
@@ -12,7 +12,7 @@ import ReduxStore from 'stores/redux_store';
 
 import {Constants} from 'utils/constants';
 import {isMac} from 'utils/user_agent';
-import {localizeAndFormatMessage} from 'utils/utils';
+import {localizeMessage} from 'utils/utils';
 
 import type {GlobalState} from 'types/store';
 
@@ -125,7 +125,7 @@ export const displayError = (err: string, channelID: string, rootID?: string) =>
 // Shim of mobile-version intl
 export const intlShim = {
     formatMessage: (config: {id: string; defaultMessage: string}, values?: {[name: string]: any}) => {
-        return localizeAndFormatMessage(config.id, config.defaultMessage, values);
+        return localizeMessage(config, values);
     },
 };
 

--- a/webapp/channels/src/utils/i18n.tsx
+++ b/webapp/channels/src/utils/i18n.tsx
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {MessageDescriptor} from 'react-intl';
+
 export function getMonthLong(locale: string): 'short' | 'long' {
     if (locale === 'ko') {
         // Long and short are equivalent in Korean except long has a bug on IE11/Windows 7
@@ -17,8 +19,18 @@ export function t(v: string): string {
     return v;
 }
 
-export interface Message {
-    id: string;
-    defaultMessage: string;
+function toKeys(this: MessageDescriptor, id: string, defaultMessage: string, description = 'description') {
+    return {[id]: this.id, [defaultMessage]: this.defaultMessage, ...this.description ? {[description]: this.description} : null};
+}
+
+export function defineMessage(msg: MessageDescriptor): MessageDescriptor & {toKeys: typeof toKeys} {
+    return {
+        ...msg,
+        toKeys,
+    };
+}
+
+export interface Message extends MessageDescriptor {
     values?: Record<string, any>;
 }
+

--- a/webapp/channels/src/utils/utils.test.tsx
+++ b/webapp/channels/src/utils/utils.test.tsx
@@ -328,15 +328,15 @@ describe('Utils.localizeMessage', () => {
         });
 
         test('with translations', () => {
-            expect(Utils.localizeMessage('test.hello_world', 'Hello, World!')).toEqual('Bonjour tout le monde!');
+            expect(Utils.localizeMessage({id: 'test.hello_world', defaultMessage: 'Hello, World!'})).toEqual('Bonjour tout le monde!');
         });
 
         test('with missing string in translations', () => {
-            expect(Utils.localizeMessage('test.hello_world2', 'Hello, World 2!')).toEqual('Hello, World 2!');
+            expect(Utils.localizeMessage({id: 'test.hello_world2', defaultMessage: 'Hello, World 2!'})).toEqual('Hello, World 2!');
         });
 
         test('with missing string in translations and no default', () => {
-            expect(Utils.localizeMessage('test.hello_world2')).toEqual('test.hello_world2');
+            expect(Utils.localizeMessage({id: 'test.hello_world2'})).toEqual('test.hello_world2');
         });
     });
 
@@ -353,11 +353,11 @@ describe('Utils.localizeMessage', () => {
         });
 
         test('without translations', () => {
-            expect(Utils.localizeMessage('test.hello_world', 'Hello, World!')).toEqual('Hello, World!');
+            expect(Utils.localizeMessage({id: 'test.hello_world', defaultMessage: 'Hello, World!'})).toEqual('Hello, World!');
         });
 
         test('without translations and no default', () => {
-            expect(Utils.localizeMessage('test.hello_world')).toEqual('test.hello_world');
+            expect(Utils.localizeMessage({id: 'test.hello_world'})).toEqual('test.hello_world');
         });
     });
 });

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -33,7 +33,7 @@
         "css-loader": "6.7.3",
         "eslint": "8.37.0",
         "eslint-import-resolver-webpack": "0.13.2",
-        "eslint-plugin-formatjs": "4.9.1",
+        "eslint-plugin-formatjs": "4.11.3",
         "mini-css-extract-plugin": "2.7.5",
         "sass": "1.62.1",
         "sass-loader": "13.2.2",
@@ -150,6 +150,7 @@
       },
       "devDependencies": {
         "@deanwhillier/jest-matchmedia-mock": "1.2.0",
+        "@formatjs/cli": "6.2.4",
         "@hot-loader/react-dom": "17.0.2",
         "@mattermost/eslint-plugin": "*",
         "@redux-devtools/extension": "3.2.3",
@@ -2402,6 +2403,26 @@
     "node_modules/@floating-ui/utils": {
       "version": "0.1.6",
       "license": "MIT"
+    },
+    "node_modules/@formatjs/cli": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/cli/-/cli-6.2.4.tgz",
+      "integrity": "sha512-g1o9O143F5TGB55skib3fKbyjifPa9YoDcX9L07hVJocRKngCcu4JhKViyUSN55KGcN2ttfBomM+wihN6wtBSQ==",
+      "dev": true,
+      "bin": {
+        "formatjs": "bin/formatjs"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "vue": "^3.3.4"
+      },
+      "peerDependenciesMeta": {
+        "vue": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "1.15.0",
@@ -10153,20 +10174,21 @@
       }
     },
     "node_modules/eslint-plugin-formatjs": {
-      "version": "4.9.1",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-formatjs/-/eslint-plugin-formatjs-4.11.3.tgz",
+      "integrity": "sha512-VGmDGbRZexN+rpweaXBoXkZ40mu96zk1fi1A+iVDAhxIyQr4QLZyhHWwMM1JXgGxgGCB90/buxkRl95nzSn10w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@formatjs/icu-messageformat-parser": "2.3.0",
-        "@formatjs/ts-transformer": "3.12.0",
+        "@formatjs/icu-messageformat-parser": "2.7.3",
+        "@formatjs/ts-transformer": "3.13.9",
         "@types/eslint": "7 || 8",
         "@types/picomatch": "^2.3.0",
-        "@typescript-eslint/typescript-estree": "5.45.0",
+        "@typescript-eslint/utils": "^6.5.0",
         "emoji-regex": "^10.2.1",
-        "magic-string": "^0.29.0",
+        "magic-string": "^0.30.0",
         "picomatch": "^2.3.1",
-        "tslib": "2.4.0",
-        "typescript": "^4.7",
+        "tslib": "2.6.2",
+        "typescript": "5",
         "unicode-emoji-utils": "^1.1.1"
       },
       "peerDependencies": {
@@ -10174,45 +10196,58 @@
       }
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.14.3",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.0.tgz",
+      "integrity": "sha512-PEVLoa3zBevWSCZzPIM/lvPCi8P5l4G+NXQMc/CjEiaCWgyHieUoo0nM7Bs0n/NbuQ6JpXEolivQ9pKSBHaDlA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@formatjs/intl-localematcher": "0.2.32",
+        "@formatjs/intl-localematcher": "0.5.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.3.0",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.3.tgz",
+      "integrity": "sha512-X/jy10V9S/vW+qlplqhMUxR8wErQ0mmIYSq4mrjpjDl9mbuGcCILcI1SUYkL5nlM4PJqpc0KOS0bFkkJNPxYRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.14.3",
-        "@formatjs/icu-skeleton-parser": "1.3.18",
+        "@formatjs/ecma402-abstract": "1.18.0",
+        "@formatjs/icu-skeleton-parser": "1.7.0",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.3.18",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.7.0.tgz",
+      "integrity": "sha512-Cfdo/fgbZzpN/jlN/ptQVe0lRHora+8ezrEeg2RfrNjyp+YStwBy7cqDY8k5/z2LzXg6O0AdzAV91XS0zIWv+A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/ecma402-abstract": "1.18.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.2.tgz",
+      "integrity": "sha512-txaaE2fiBMagLrR4jYhxzFO6wEdEG4TPMqrzBAcbr4HFUYzH/YC+lg6OIzKCHm8WgDdyQevxbAAV1OgcXctuGw==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/ts-transformer": {
-      "version": "3.12.0",
+      "version": "3.13.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.13.9.tgz",
+      "integrity": "sha512-J3kmCHOwkc0Tru0ZnBHPVDIwHCcaNh/zB8ZU4VQFBH2jhaOku0drym/hjz+f9/PCKLutd3Q7alUi2+Z2VpBIng==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@formatjs/icu-messageformat-parser": "2.3.0",
+        "@formatjs/icu-messageformat-parser": "2.7.3",
         "@types/json-stable-stringify": "^1.0.32",
         "@types/node": "14 || 16 || 17",
         "chalk": "^4.0.0",
         "json-stable-stringify": "^1.0.1",
         "tslib": "^2.4.0",
-        "typescript": "^4.7"
+        "typescript": "5"
       },
       "peerDependencies": {
         "ts-jest": ">=27"
@@ -10225,15 +10260,40 @@
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@types/node": {
       "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/@types/semver": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.17.0.tgz",
+      "integrity": "sha512-RX7a8lwgOi7am0k17NUO0+ZmMOX4PpjLtLRgLmT1d3lBYdWH4ssBUbwdmc5pdRX8rXon8v9x8vaoOSpkHfcXGA==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "@typescript-eslint/types": "6.17.0",
+        "@typescript-eslint/visitor-keys": "6.17.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/types": {
-      "version": "5.45.0",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.17.0.tgz",
+      "integrity": "sha512-qRKs9tvc3a4RBcL/9PXtKSehI/q8wuU9xYJxe97WFxnzH8NWWtcW3ffNS+EWg8uPvIerhjsEZ+rHtDqOCiH57A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10241,20 +10301,22 @@
       }
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.45.0",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.17.0.tgz",
+      "integrity": "sha512-gVQe+SLdNPfjlJn5VNGhlOhrXz4cajwFd5kAgWtZ9dCZf4XJf8xmgCTLIqec7aha3JwgLI2CK6GY1043FRxZwg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "5.45.0",
-        "@typescript-eslint/visitor-keys": "5.45.0",
+        "@typescript-eslint/types": "6.17.0",
+        "@typescript-eslint/visitor-keys": "6.17.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10266,26 +10328,77 @@
         }
       }
     },
-    "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.45.0",
+    "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/utils": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.17.0.tgz",
+      "integrity": "sha512-LofsSPjN/ITNkzV47hxas2JCsNCEnGhVvocfyOcLzT9c/tSZE7SfhS/iWtzP1lKNOEfLhRTZz6xqI8N2RzweSQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "5.45.0",
-        "eslint-visitor-keys": "^3.3.0"
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.17.0",
+        "@typescript-eslint/types": "6.17.0",
+        "@typescript-eslint/typescript-estree": "6.17.0",
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.17.0.tgz",
+      "integrity": "sha512-H6VwB/k3IuIeQOyYczyyKN8wH6ed8EwliaYHLxOIhyF0dYEIsN8+Bk3GE19qafeMKyZJJHP8+O1HiFhFLUNKSg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.17.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/eslint-plugin-formatjs/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/eslint-plugin-formatjs/node_modules/semver": {
       "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -10296,10 +10409,18 @@
         "node": ">=10"
       }
     },
-    "node_modules/eslint-plugin-formatjs/node_modules/tslib": {
-      "version": "2.4.0",
+    "node_modules/eslint-plugin-formatjs/node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
-      "license": "0BSD"
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/eslint-plugin-header": {
       "version": "3.1.1",
@@ -16613,11 +16734,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.29.0",
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       },
       "engines": {
         "node": ">=12"
@@ -22828,6 +22950,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+      "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
       }
     },
     "node_modules/ts-clone-node": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -38,7 +38,7 @@
     "css-loader": "6.7.3",
     "eslint": "8.37.0",
     "eslint-import-resolver-webpack": "0.13.2",
-    "eslint-plugin-formatjs": "4.9.1",
+    "eslint-plugin-formatjs": "4.11.3",
     "mini-css-extract-plugin": "2.7.5",
     "sass": "1.62.1",
     "sass-loader": "13.2.2",


### PR DESCRIPTION
#### Summary
On the road to support `@formatjs/cli`-based extraction, there is refactoring at-scale that needs to occur. This PR introduces a beta version of `i18n-extract` based on `@formatjs/cli` for development and extraction comparison purposes. 

There are also a few helpers to help with the removal of `t()`:
1. `defineMessage#toKeys` allows inline marking of messages defined as props of reusable component. e.g.
![image](https://github.com/mattermost/mattermost/assets/11724372/fcd1c308-5cbd-49a3-80e6-a2a9fc214cac)
2. `Utils.localizeAndFormatMessage` is removed, and `Utils.localizeMessage` is fully react-intl powered (with extraction!) for legit preexisting use cases outside of the normal react component tree, and includes backwards-compatible fallbacks for gradual migration to normal react-intl where possible. These changes allow normal ICU placeholder logic to re-simplify that which is normally straightforward.
![image](https://github.com/mattermost/mattermost/assets/11724372/1c4ea1c7-bc7a-443c-900d-6995588ef056)
3. `eslint-formatjs-plugin` is upgraded and the following estlint rules are added to validate source-messages. These checks are upstream of placeholder and ICU syntax linting done in Weblate, so it's quite necessary to add these rules to be able to trust our message sources-of-truth.
```
    "formatjs/enforce-default-message": 2,
    "formatjs/no-multiple-plurals": 1, // future use
    "formatjs/enforce-placeholders": 2,
    "formatjs/enforce-id": 2,
    "formatjs/no-invalid-icu": 2,
    "formatjs/no-literal-string-in-jsx": 1,  // future use: ensures untranslated messages don't inadvertently slip in
    "formatjs/prefer-formatted-message": 1,  // future use: use FormattedMessage over intl.formatMessage where possible
    "formatjs/no-useless-message": 1,  // future use
    "formatjs/prefer-pound-in-plural": 0, // future use: changes source during lint-autofix, so not desired atm
```


#### Ticket Link

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
