### PR TITLE
[MM-56266] Check for public channels when getting channel member counts to avoid 403 errors

### DIFF
--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -698,9 +698,17 @@ func getChannelsMemberCount(c *Context, w http.ResponseWriter, r *http.Request) 
 	}
 
 	channelIDs := model.ArrayFromJSON(r.Body)
-	if !c.App.SessionHasPermissionToChannels(c.AppContext, *c.AppContext.Session(), channelIDs, model.PermissionReadChannel) {
-		c.SetPermissionError(model.PermissionReadChannel)
+	channels, err := c.App.GetChannels(c.AppContext, channelIDs)
+	if err != nil {
+		c.Err = err
 		return
+	}
+
+	for _, channel := range channels {
+		if !c.App.HasPermissionToReadChannel(c.AppContext, c.AppContext.Session().UserId, channel) {
+			c.SetPermissionError(model.PermissionReadChannel)
+			return
+		}
 	}
 
 	channelsMemberCount, err := c.App.GetChannelsMemberCount(c.AppContext, channelIDs)

--- a/server/channels/api4/channel_test.go
+++ b/server/channels/api4/channel_test.go
@@ -4634,7 +4634,9 @@ func TestGetChannelsMemberCount(t *testing.T) {
 	client := th.Client
 
 	channel1 := th.CreatePublicChannel()
-	channel2 := th.CreatePublicChannel()
+	channel2 := th.CreatePrivateChannel()
+	channel3 := th.CreatePrivateChannel()
+	th.RemoveUserFromChannel(th.BasicUser, channel3)
 
 	user1 := th.CreateUser()
 	user2 := th.CreateUser()
@@ -4669,7 +4671,7 @@ func TestGetChannelsMemberCount(t *testing.T) {
 	})
 
 	t.Run("Should fail due to permissions", func(t *testing.T) {
-		_, resp, err := client.GetChannelsMemberCount(context.Background(), []string{"junk"})
+		_, resp, err := client.GetChannelsMemberCount(context.Background(), []string{channel3.Id})
 		require.Error(t, err)
 		CheckForbiddenStatus(t, resp)
 		CheckErrorID(t, err, "api.context.permissions.app_error")
@@ -4691,6 +4693,13 @@ func TestGetChannelsMemberCount(t *testing.T) {
 		require.Error(t, err)
 		CheckForbiddenStatus(t, resp)
 		CheckErrorID(t, err, "api.context.permissions.app_error")
+	})
+
+	t.Run("Should not fail for public channels that the user is not a member of", func(t *testing.T) {
+		th.LoginBasic2()
+		channelIDs := []string{channel1.Id}
+		_, _, err := client.GetChannelsMemberCount(context.Background(), channelIDs)
+		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
#### Summary
We weren't accounting for public channels that users were not a member on when checking permissions for channel member stats. This PR runs the `HasPermissionToReadChannel` method on all channels passed up, which will not fail on a public channel assuming the user can see the public channel in the first place.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56266

```release-note
NONE
```
