### PR TITLE
Modify healthcheck command for postgres in dev setup

### DIFF
--- a/server/build/docker-compose.common.yml
+++ b/server/build/docker-compose.common.yml
@@ -51,9 +51,9 @@ services:
     volumes:
      - "./docker/postgres.conf:/etc/postgresql/postgresql.conf"
     healthcheck:
-      test: [ "CMD", "pg_isready", "-h", "localhost" ]
-      interval: 5s
-      timeout: 10s
+      test: pg_isready -U mmuser -d mattermost_test
+      interval: 10s
+      timeout: 3s
       retries: 3
   minio:
     image: "minio/minio:RELEASE.2019-10-11T00-38-09Z"

--- a/server/build/docker-compose.common.yml
+++ b/server/build/docker-compose.common.yml
@@ -52,8 +52,8 @@ services:
      - "./docker/postgres.conf:/etc/postgresql/postgresql.conf"
     healthcheck:
       test: pg_isready -U mmuser -d mattermost_test
-      interval: 10s
-      timeout: 3s
+      interval: 5s
+      timeout: 10s
       retries: 3
   minio:
     image: "minio/minio:RELEASE.2019-10-11T00-38-09Z"


### PR DESCRIPTION
#### Summary
When starting the dev container I noticed it was attempting to connect every 3s to `root` with db `root. This modifies that command to use the real username, and database.

The original error it showed was:

```
FATAL: role "root" does not exist
```
I'm not sure how much it matters in the long run, but I was debugging exhausted connections in my dev setup and this was sending me down the wrong path. 

```release-note
NONE
```