### PR TITLE
[MM-56464] Log reason for failed login events

### DIFF
--- a/server/channels/api4/user.go
+++ b/server/channels/api4/user.go
@@ -1865,6 +1865,9 @@ func login(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// Log the error before masking it to ensure it's at least in the logs.
+		c.LogErrorByCode(c.Err)
+
 		config := c.App.Config()
 		enableUsername := *config.EmailSettings.EnableSignInWithUsername
 		enableEmail := *config.EmailSettings.EnableSignInWithEmail

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -5534,7 +5534,7 @@ func TestLoginErrorMessage(t *testing.T) {
 	})
 	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, "wrong")
 	CheckErrorID(t, err, "api.user.login.invalid_credentials_username")
-	testlib.AssertLog(t, th.LogBuffer, mlog.LvlDebug.Name, "Unable to find an existing account matching your credentials. This team may require an invite from the team owner to join.")
+	testlib.AssertLog(t, th.LogBuffer, mlog.LvlDebug.Name, "Unable to find an existing account matching your login ID.")
 	_, err = io.Copy(io.Discard, th.LogBuffer) // Clear log buffer
 	require.NoError(t, err)
 
@@ -5562,7 +5562,7 @@ func TestLoginErrorMessage(t *testing.T) {
 	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, "wrong")
 	CheckErrorID(t, err, "api.user.login.invalid_credentials_sso")
 
-	testlib.AssertLog(t, th.LogBuffer, mlog.LvlDebug.Name, "Unable to find an existing account matching your credentials. This team may require an invite from the team owner to join.")
+	testlib.AssertLog(t, th.LogBuffer, mlog.LvlDebug.Name, "Unable to find an existing account matching your login ID.")
 	_, err = io.Copy(io.Discard, th.LogBuffer) // Clear log buffer
 	require.NoError(t, err)
 }

--- a/server/channels/web/handlers.go
+++ b/server/channels/web/handlers.go
@@ -367,7 +367,15 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Handle errors that have occurred
 	if c.Err != nil {
 		c.Err.RequestId = c.AppContext.RequestId()
-		c.LogErrorByCode(c.Err)
+
+		// Don't log masked errors from user login. The login handler already logged the unmasked ones.
+		if c.Err.Id != "api.user.login.invalid_credentials_sso" &&
+			c.Err.Id != "api.user.login.invalid_credentials_username" &&
+			c.Err.Id != "api.user.login.invalid_credentials_email" &&
+			c.Err.Id != "api.user.login.invalid_credentials_email_username" {
+			c.LogErrorByCode(c.Err)
+		}
+
 		// The locale translation needs to happen after we have logged it.
 		// We don't want the server logs to be translated as per user locale.
 		c.Err.Translate(c.AppContext.T)

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10064,7 +10064,7 @@
   },
   {
     "id": "store.sql_user.get_for_login.app_error",
-    "translation": "Unable to find an existing account matching your credentials. This team may require an invite from the team owner to join."
+    "translation": "Unable to find an existing account matching your login ID."
   },
   {
     "id": "system.message.name",


### PR DESCRIPTION
#### Summary
The `/users/login` (rightfully) masks most of the errors which are returned to the user. To make it easier for admins to debug login issues, the original error is now logged before the masking happens.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56464

#### Release Note
```release-note
Log reason for failed login events
```
