### PR TITLE
[MM-56258] Extend the width of the "User is typing" message in a thread

### DIFF
--- a/webapp/channels/src/sass/components/_post-right.scss
+++ b/webapp/channels/src/sass/components/_post-right.scss
@@ -158,7 +158,7 @@
         .msg-typing {
             display: block;
             min-width: 1px;
-            max-width: 230px;
+            max-width: 100%;
             height: 20px;
             margin: 2px 0;
             float: left;


### PR DESCRIPTION
#### Summary
This PR extends the width of the `MsgTyping` component to the full width of the post textbox in a thread.
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/25829
Jira https://mattermost.atlassian.net/browse/MM-56258

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="389" alt="Screenshot 2024-01-06 at 17 25 42" src="https://github.com/mattermost/mattermost/assets/37827647/e438aa4b-3e76-4de1-8079-2838099919d5"> | <img width="396" alt="Screenshot 2024-01-06 at 17 25 13" src="https://github.com/mattermost/mattermost/assets/37827647/b991f070-cf97-41d0-aba7-e364ef1671e1">|


#### Release Note
```
NONE
```
