### PR TITLE
Fix channel switcher routing for DMs with remote users

### DIFF
--- a/webapp/channels/src/utils/path.ts
+++ b/webapp/channels/src/utils/path.ts
@@ -14,6 +14,7 @@ export const TEAM_NAME_PATH_PATTERN = '[a-z0-9\\-_]+';
 // - Group Channel Name (40 length UID)
 // - DM Name (userID__userID)
 // - Username prefixed by a @
+// - Username prefixed by a @, with colon and remote name e.g. @username:companyname
 // - User ID
 // - Email
-export const IDENTIFIER_PATH_PATTERN = '[@a-zA-Z\\-_0-9][@a-zA-Z\\-_0-9.]*';
+export const IDENTIFIER_PATH_PATTERN = '[@a-zA-Z\\-_0-9][@a-zA-Z\\-_0-9.:]*';


### PR DESCRIPTION
#### Summary
This PR fixes an issue where the webapp cannot switch to a DM channel when the other user is a remote user (shared channel) with a colon in the user name.  The underlying issue is the URLs for DM channels are [now validated via regex](https://github.com/mattermost/mattermost/pull/24622) and failed due to the presence of a colon in the DM username.

The fix is to allow colons in the `IDENTIFIER_PATH_PATTERN`  regex used to validate channel URLs.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56530

```release-note
Fixes switching to a Direct Message channel with a shared channel user (user from another server).
```
