### PR TITLE
Removes enterprise deletion from nuke make target

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -709,7 +709,6 @@ clean: stop-docker ## Clean up everything except persistent server data.
 	rm -f mattermost.log.jsonl
 	rm -f npm-debug.log
 	rm -f .prepare-go
-	rm -f enterprise
 	rm -f cover.out
 	rm -f ecover.out
 	rm -f *.out


### PR DESCRIPTION
#### Summary
This PR removes the `enterprise` folder deletion from the `make nuke` target, as after https://github.com/mattermost/mattermost/pull/24879 this is not necessary anymore.

#### Release Note
```release-note
NONE
```
