### PR TITLE
[CLD-6536] Adjustments to cloud annual renewal announcement bar

### DIFF
--- a/server/channels/api4/cloud.go
+++ b/server/channels/api4/cloud.go
@@ -112,7 +112,7 @@ func getSubscription(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if model.GetServiceEnvironment() != model.ServiceEnvironmentTest {
-
+		subscription.SimulatedCurrentTimeMs = nil
 	}
 
 	if !c.App.Config().FeatureFlags.CloudAnnualRenewals {

--- a/server/channels/api4/cloud.go
+++ b/server/channels/api4/cloud.go
@@ -111,6 +111,10 @@ func getSubscription(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if model.GetServiceEnvironment() != model.ServiceEnvironmentTest {
+
+	}
+
 	if !c.App.Config().FeatureFlags.CloudAnnualRenewals {
 		subscription.WillRenew = ""
 		subscription.CancelAt = nil

--- a/server/channels/app/cloud.go
+++ b/server/channels/app/cloud.go
@@ -285,6 +285,10 @@ func (a *App) DoSubscriptionRenewalCheck() {
 		return
 	}
 
+	if subscription.IsFreeTrial == "true" {
+		return // Don't send renewal emails for free trials
+	}
+
 	sysVar, err := a.Srv().Store().System().GetByName(model.CloudRenewalEmail)
 	if err != nil {
 		// We only care about the error if it wasn't a not found error

--- a/server/channels/app/cloud.go
+++ b/server/channels/app/cloud.go
@@ -322,13 +322,13 @@ func (a *App) DoSubscriptionRenewalCheck() {
 
 	// Only send the email if within the period and it's not already been sent
 	// This allows the email to send on day 59 if for whatever reason it was unable to on day 60
-	if daysToExpiration <= 60 && daysToExpiration > 30 && prevSentEmail != 60 {
+	if daysToExpiration <= 60 && daysToExpiration > 30 && prevSentEmail != 60 && !(prevSentEmail < 60) {
 		emailFunc = a.Srv().EmailService.SendCloudRenewalEmail60
 		prevSentEmail = 60
-	} else if daysToExpiration <= 30 && daysToExpiration > 7 && prevSentEmail != 30 {
+	} else if daysToExpiration <= 30 && daysToExpiration > 7 && prevSentEmail != 30 && !(prevSentEmail < 30) {
 		emailFunc = a.Srv().EmailService.SendCloudRenewalEmail30
 		prevSentEmail = 30
-	} else if daysToExpiration <= 7 && daysToExpiration > 3 && prevSentEmail != 7 {
+	} else if daysToExpiration <= 7 && daysToExpiration >= 0 && prevSentEmail != 7 {
 		emailFunc = a.Srv().EmailService.SendCloudRenewalEmail7
 		prevSentEmail = 7
 	}

--- a/webapp/channels/src/components/admin_console/billing/billing_subscriptions/billing_subscriptions.tsx
+++ b/webapp/channels/src/components/admin_console/billing/billing_subscriptions/billing_subscriptions.tsx
@@ -96,6 +96,11 @@ export const CloudAnnualRenewalBanner = () => {
         message: <></>,
     };
 
+    // If outside the 60 day window or on a trial, don't show this banner.
+    if (daysUntilExpiration > 60 || subscription.is_free_trial === 'true') {
+        return null;
+    }
+
     if (daysUntilExpiration <= 7) {
         alertBannerProps.mode = 'danger';
     }

--- a/webapp/channels/src/components/admin_console/billing/billing_subscriptions/billing_subscriptions.tsx
+++ b/webapp/channels/src/components/admin_console/billing/billing_subscriptions/billing_subscriptions.tsx
@@ -11,7 +11,7 @@ import useGetSubscription from 'components/common/hooks/useGetSubscription';
 import useOpenCloudPurchaseModal from 'components/common/hooks/useOpenCloudPurchaseModal';
 import useOpenSalesLink from 'components/common/hooks/useOpenSalesLink';
 
-import {daysToExpiration} from 'utils/cloud_utils';
+import {daysToCancellation, daysToExpiration} from 'utils/cloud_utils';
 
 export const creditCardExpiredBanner = (setShowCreditCardBanner: (value: boolean) => void) => {
     return (
@@ -69,7 +69,7 @@ export const CloudAnnualRenewalBanner = () => {
         return null;
     }
     const daysUntilExpiration = daysToExpiration(subscription);
-    const daysUntilCancelation = daysToExpiration(subscription);
+    const daysUntilCancelation = daysToCancellation(subscription);
     const renewButton = (
         <button
             className='btn btn-primary'

--- a/webapp/channels/src/components/admin_console/billing/billing_subscriptions/billing_subscriptions.tsx
+++ b/webapp/channels/src/components/admin_console/billing/billing_subscriptions/billing_subscriptions.tsx
@@ -68,8 +68,8 @@ export const CloudAnnualRenewalBanner = () => {
     if (!subscription || !subscription.cancel_at || (subscription.will_renew === 'true' && !subscription.delinquent_since)) {
         return null;
     }
-    const daysUntilExpiration = daysToExpiration(subscription?.end_at);
-    const daysUntilCancelation = daysToExpiration(subscription?.cancel_at);
+    const daysUntilExpiration = daysToExpiration(subscription);
+    const daysUntilCancelation = daysToExpiration(subscription);
     const renewButton = (
         <button
             className='btn btn-primary'

--- a/webapp/channels/src/components/announcement_bar/cloud_annual_renewal/index.tsx
+++ b/webapp/channels/src/components/announcement_bar/cloud_annual_renewal/index.tsx
@@ -59,7 +59,7 @@ const CloudAnnualRenewalAnnouncementBar = () => {
             return 0;
         }
 
-        return daysToExpiration(subscription.end_at);
+        return daysToExpiration(subscription);
     }, [subscription]);
 
     const handleDismiss = (banner: string) => {

--- a/webapp/channels/src/components/announcement_bar/cloud_annual_renewal/index.tsx
+++ b/webapp/channels/src/components/announcement_bar/cloud_annual_renewal/index.tsx
@@ -89,7 +89,7 @@ const CloudAnnualRenewalAnnouncementBar = () => {
             ...defaultProps,
             type: '',
         };
-        if (between(daysUntilExpiration, 31, 60) && !hasDismissed60DayBanner) {
+        if (between(daysUntilExpiration, 31, 60)) {
             if (hasDismissed60DayBanner) {
                 return null;
             }
@@ -112,6 +112,7 @@ const CloudAnnualRenewalAnnouncementBar = () => {
                 handleClose: () => handleDismiss(CloudBanners.ANNUAL_RENEWAL_30_DAY),
             };
         } else if (between(daysUntilExpiration, 0, 7) && !isDelinquencySubscription()) {
+            // This banner is not dismissable
             bannerProps = {
                 ...defaultProps,
                 message: (<>{formatMessage({id: 'cloud_annual_renewal.banner.message.7', defaultMessage: 'Your annual subscription expires in {days} days. Failure to renew will result in your workspace being deleted.'}, {days: daysUntilExpiration})}</>),
@@ -119,13 +120,16 @@ const CloudAnnualRenewalAnnouncementBar = () => {
                 type: AnnouncementBarTypes.CRITICAL,
                 showCloseButton: false,
             };
+        } else {
+            // If none of the above, return null, so that a blank announcement bar isn't visible
+            return null;
         }
 
         return <AnnouncementBar {...bannerProps}/>;
     }, [daysUntilExpiration, hasDismissed60DayBanner, hasDismissed30DayBanner]);
 
     // Delinquent subscriptions will have a cancel_at time, but the banner is handled separately
-    if (!cloudAnnualRenewalsEnabled || !subscription || !subscription.cancel_at || subscription.will_renew === 'true' || isDelinquencySubscription() || !isAdmin || daysUntilExpiration > 60) {
+    if (!cloudAnnualRenewalsEnabled || !subscription || !subscription.cancel_at || subscription.is_free_trial === 'true' || subscription.will_renew === 'true' || isDelinquencySubscription() || !isAdmin || daysUntilExpiration > 60) {
         return null;
     }
 

--- a/webapp/channels/src/components/purchase_modal/index.ts
+++ b/webapp/channels/src/components/purchase_modal/index.ts
@@ -34,7 +34,7 @@ function mapStateToProps(state: GlobalState) {
     const subscription = state.entities.cloud.subscription;
 
     const isDelinquencyModal = Boolean(state.entities.cloud.subscription?.delinquent_since);
-    const isRenewalModal = daysToExpiration(state.entities.cloud.subscription) <= 60 && !isDelinquencyModal && getConfig(state).FeatureFlags?.CloudAnnualRenewals;
+    const isRenewalModal = daysToExpiration(state.entities.cloud.subscription) <= 60 && state.entities.cloud.subscription?.is_free_trial === 'false' && !isDelinquencyModal && getConfig(state).FeatureFlags?.CloudAnnualRenewals;
     const products = state.entities.cloud!.products;
     const yearlyProducts = findOnlyYearlyProducts(products || {});
 

--- a/webapp/channels/src/components/purchase_modal/index.ts
+++ b/webapp/channels/src/components/purchase_modal/index.ts
@@ -34,7 +34,7 @@ function mapStateToProps(state: GlobalState) {
     const subscription = state.entities.cloud.subscription;
 
     const isDelinquencyModal = Boolean(state.entities.cloud.subscription?.delinquent_since);
-    const isRenewalModal = daysToExpiration(Number(state.entities.cloud.subscription?.end_at)) <= 60 && !isDelinquencyModal && getConfig(state).FeatureFlags?.CloudAnnualRenewals;
+    const isRenewalModal = daysToExpiration(Number(state.entities.cloud.subscription?.end_at)) <= 60 && state.entities.cloud.subscription?.is_free_trial === 'false' && !isDelinquencyModal && getConfig(state).FeatureFlags?.CloudAnnualRenewals;
     const products = state.entities.cloud!.products;
     const yearlyProducts = findOnlyYearlyProducts(products || {});
 

--- a/webapp/channels/src/components/purchase_modal/index.ts
+++ b/webapp/channels/src/components/purchase_modal/index.ts
@@ -34,7 +34,7 @@ function mapStateToProps(state: GlobalState) {
     const subscription = state.entities.cloud.subscription;
 
     const isDelinquencyModal = Boolean(state.entities.cloud.subscription?.delinquent_since);
-    const isRenewalModal = daysToExpiration(Number(state.entities.cloud.subscription?.end_at)) <= 60 && state.entities.cloud.subscription?.is_free_trial === 'false' && !isDelinquencyModal && getConfig(state).FeatureFlags?.CloudAnnualRenewals;
+    const isRenewalModal = daysToExpiration(state.entities.cloud.subscription) <= 60 && !isDelinquencyModal && getConfig(state).FeatureFlags?.CloudAnnualRenewals;
     const products = state.entities.cloud!.products;
     const yearlyProducts = findOnlyYearlyProducts(products || {});
 

--- a/webapp/channels/src/utils/cloud_utils.ts
+++ b/webapp/channels/src/utils/cloud_utils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {CloudCustomer, InvoiceLineItem} from '@mattermost/types/cloud';
+import type {CloudCustomer, InvoiceLineItem, Subscription} from '@mattermost/types/cloud';
 
 import {trackEvent} from 'actions/telemetry_actions';
 
@@ -47,9 +47,13 @@ export function openExternalPricingLink() {
 
 export const FREEMIUM_TO_ENTERPRISE_TRIAL_LENGTH_DAYS = 30;
 
-export function daysToExpiration(expirationDate: number): number {
-    const now = new Date();
-    const expiration = new Date(expirationDate);
+export function daysToExpiration(subscription?: Subscription): number {
+    let now = new Date();
+    // If the backend is passing a simulated_current_time_ms, use that instead of the current time
+    if (subscription?.simulated_current_time_ms) {
+        now = new Date(subscription?.simulated_current_time_ms);
+    }
+    const expiration = new Date(subscription?.end_at || 0);
     const diff = expiration.getTime() - now.getTime();
     return Math.ceil(diff / (1000 * 3600 * 24));
 }

--- a/webapp/channels/src/utils/cloud_utils.ts
+++ b/webapp/channels/src/utils/cloud_utils.ts
@@ -49,6 +49,7 @@ export const FREEMIUM_TO_ENTERPRISE_TRIAL_LENGTH_DAYS = 30;
 
 export function daysToExpiration(subscription?: Subscription): number {
     let now = new Date();
+
     // If the backend is passing a simulated_current_time_ms, use that instead of the current time
     if (subscription?.simulated_current_time_ms) {
         now = new Date(subscription?.simulated_current_time_ms);

--- a/webapp/channels/src/utils/cloud_utils.ts
+++ b/webapp/channels/src/utils/cloud_utils.ts
@@ -47,14 +47,22 @@ export function openExternalPricingLink() {
 
 export const FREEMIUM_TO_ENTERPRISE_TRIAL_LENGTH_DAYS = 30;
 
-export function daysToExpiration(subscription?: Subscription): number {
+export function daysUntil(end?: number, simulatedCurrentTimeMs?: number) {
     let now = new Date();
 
-    // If the backend is passing a simulated_current_time_ms, use that instead of the current time
-    if (subscription?.simulated_current_time_ms) {
-        now = new Date(subscription?.simulated_current_time_ms);
+    if (simulatedCurrentTimeMs) {
+        now = new Date(simulatedCurrentTimeMs);
     }
-    const expiration = new Date(subscription?.end_at || 0);
+
+    const expiration = new Date(end || 0);
     const diff = expiration.getTime() - now.getTime();
     return Math.ceil(diff / (1000 * 3600 * 24));
+}
+
+export function daysToExpiration(subscription?: Subscription): number {
+    return daysUntil(subscription?.end_at, subscription?.simulated_current_time_ms);
+}
+
+export function daysToCancellation(subscription?: Subscription): number {
+    return daysUntil(subscription?.cancel_at, subscription?.simulated_current_time_ms);
 }

--- a/webapp/platform/types/src/cloud.ts
+++ b/webapp/platform/types/src/cloud.ts
@@ -51,6 +51,7 @@ export type Subscription = {
     billing_type?: string;
     cancel_at?: number;
     will_renew?: string;
+    simulated_current_time_ms?: number;
 }
 
 export type Product = {


### PR DESCRIPTION
#### Summary
The annual renewal announcement bar has a small bug where after you dismiss the 60 day one it will never enter the condition to return null. I've removed the check that's causing the issue, and put an else to return null at the end of the if/else if chain. 

I've also added a small check in 2 places so that the banners and emails for renewals aren't sent to those subscriptions that are on a trial, because their start/end dates will be within the 60 day renewal period due to the way Stripe handles CurrentPeriodStart and CurrentPeriodEnd while that subscription is trialing.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-6950

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
