### PR TITLE
Cypress/E2E: Make pushNotificationServer configurable in E2E via env

### DIFF
--- a/e2e-tests/cypress/cypress.config.ts
+++ b/e2e-tests/cypress/cypress.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
         minioS3Endpoint: 'localhost:9000',
         minioS3SSL: false,
         numberOfTrialUsers: 100,
+        pushNotificationServer: 'https://push-test.mattermost.com',
         resetBeforeTest: false,
         runLDAPSync: true,
         secondServerURL: 'http://localhost/s/p',

--- a/e2e-tests/cypress/tests/support/api/cloud_default_config.json
+++ b/e2e-tests/cypress/tests/support/api/cloud_default_config.json
@@ -106,7 +106,10 @@
         "ManagedResourcePaths": "",
         "EnableCustomGroups": true,
         "SelfHostedPurchase": true,
-        "AllowSyncedDrafts": true
+        "AllowSyncedDrafts": true,
+        "UniqueEmojiReactionLimitPerPost": 50,
+        "RefreshPostStatsRunTime": "00:00",
+        "MaximumPayloadSizeBytes": 100000
     },
     "TeamSettings": {
         "SiteName": "Mattermost",
@@ -167,8 +170,6 @@
         "ConnectionSecurity": "",
         "SendPushNotifications": true,
         "PushNotificationServer": "https://push-test.mattermost.com",
-        "PushNotificationServerType": "custom",
-        "PushNotificationServerLocation": "us",
         "PushNotificationContents": "generic",
         "PushNotificationBuffer": 1000,
         "EnableEmailBatching": false,
@@ -366,7 +367,9 @@
         "EnableFileDeletion": false,
         "EnableBoardsDeletion": false,
         "MessageRetentionDays": 365,
+        "MessageRetentionHours": 0,
         "FileRetentionDays": 365,
+        "FileRetentionHours": 0,
         "BoardsRetentionDays": 365,
         "DeletionJobStartTime": "02:00",
         "BatchSize": 3000,
@@ -385,7 +388,9 @@
             "SMTPUsername": "",
             "SMTPPassword": "",
             "EmailAddress": "",
-            "SMTPServerTimeout": 1800
+            "SMTPServerTimeout": 1800,
+            "CustomSMTPServerName": "",
+            "CustomSMTPPort": "25"
         }
     },
     "ProductSettings": {},
@@ -417,7 +422,8 @@
         "ChimeraOAuthProxyURL": ""
     },
     "DisplaySettings": {
-        "CustomURLSchemes": []
+        "CustomURLSchemes": [],
+        "MaxMarkdownNodes": 0
     },
     "GuestAccountsSettings": {
         "Enable": true,
@@ -439,5 +445,14 @@
     "ExportSettings": {
         "Directory": "./export",
         "RetentionDays": 30
+    },
+    "WranglerSettings": {
+        "PermittedWranglerRoles": [],
+        "AllowedEmailDomain": [],
+        "MoveThreadMaxCount": 100,
+        "MoveThreadToAnotherTeamEnable": false,
+        "MoveThreadFromPrivateChannelEnable": false,
+        "MoveThreadFromDirectMessageChannelEnable": false,
+        "MoveThreadFromGroupMessageChannelEnable": false
     }
 }

--- a/e2e-tests/cypress/tests/support/api/on_prem_default_config.json
+++ b/e2e-tests/cypress/tests/support/api/on_prem_default_config.json
@@ -24,6 +24,7 @@
         "EnableIncomingWebhooks": true,
         "EnableOutgoingWebhooks": true,
         "EnableCommands": true,
+        "OutgoingIntegrationRequestsTimeout": 30,
         "EnablePostUsernameOverride": false,
         "EnablePostIconOverride": false,
         "GoogleDeveloperKey": "",
@@ -106,7 +107,10 @@
         "ManagedResourcePaths": "",
         "EnableCustomGroups": true,
         "SelfHostedPurchase": true,
-        "AllowSyncedDrafts": true
+        "AllowSyncedDrafts": true,
+        "UniqueEmojiReactionLimitPerPost": 50,
+        "RefreshPostStatsRunTime": "00:00",
+        "MaximumPayloadSizeBytes": 100000
     },
     "TeamSettings": {
         "SiteName": "Mattermost",
@@ -170,7 +174,8 @@
         "VerboseDiagnostics": false,
         "EnableSentry": false,
         "AdvancedLoggingJSON": {},
-        "AdvancedLoggingConfig": ""
+        "AdvancedLoggingConfig": "",
+        "MaxFieldSize": 2048
     },
     "ExperimentalAuditSettings": {
         "FileEnabled": false,
@@ -264,8 +269,6 @@
         "ConnectionSecurity": "",
         "SendPushNotifications": true,
         "PushNotificationServer": "https://push-test.mattermost.com",
-        "PushNotificationServerType": "custom",
-        "PushNotificationServerLocation": "us",
         "PushNotificationContents": "generic",
         "PushNotificationBuffer": 1000,
         "EnableEmailBatching": false,
@@ -534,7 +537,9 @@
         "EnableFileDeletion": false,
         "EnableBoardsDeletion": false,
         "MessageRetentionDays": 365,
+        "MessageRetentionHours": 0,
         "FileRetentionDays": 365,
+        "FileRetentionHours": 0,
         "BoardsRetentionDays": 365,
         "DeletionJobStartTime": "02:00",
         "BatchSize": 3000,
@@ -553,7 +558,9 @@
             "SMTPUsername": "",
             "SMTPPassword": "",
             "EmailAddress": "",
-            "SMTPServerTimeout": 1800
+            "SMTPServerTimeout": 1800,
+            "CustomSMTPServerName": "",
+            "CustomSMTPPort": "25"
         }
     },
     "JobSettings": {
@@ -591,7 +598,8 @@
         "ChimeraOAuthProxyURL": ""
     },
     "DisplaySettings": {
-        "CustomURLSchemes": []
+        "CustomURLSchemes": [],
+        "MaxMarkdownNodes": 0
     },
     "GuestAccountsSettings": {
         "Enable": true,
@@ -613,5 +621,14 @@
     "ExportSettings": {
         "Directory": "./export",
         "RetentionDays": 30
+    },
+    "WranglerSettings": {
+        "PermittedWranglerRoles": [],
+        "AllowedEmailDomain": [],
+        "MoveThreadMaxCount": 100,
+        "MoveThreadToAnotherTeamEnable": false,
+        "MoveThreadFromPrivateChannelEnable": false,
+        "MoveThreadFromDirectMessageChannelEnable": false,
+        "MoveThreadFromGroupMessageChannelEnable": false
     }
 }

--- a/e2e-tests/cypress/tests/support/api/system.js
+++ b/e2e-tests/cypress/tests/support/api/system.js
@@ -109,6 +109,9 @@ export const getDefaultConfig = () => {
         ElasticsearchSettings: {
             ConnectionURL: cypressEnv.elasticsearchConnectionURL,
         },
+        EmailSettings: {
+            PushNotificationServer: cypressEnv.pushNotificationServer,
+        },
         LdapSettings: {
             LdapServer: cypressEnv.ldapServer,
             LdapPort: cypressEnv.ldapPort,

--- a/e2e-tests/playwright/support/server/default_config.ts
+++ b/e2e-tests/playwright/support/server/default_config.ts
@@ -12,6 +12,7 @@ import {
     PluginSettings,
     ClusterSettings,
     CollapsedThreads,
+    EmailSettings,
 } from '@mattermost/types/config';
 import testConfig from '@e2e-test.config';
 
@@ -21,6 +22,7 @@ export function getOnPremServerConfig(): AdminConfig {
 
 type TestAdminConfig = {
     ClusterSettings: Partial<ClusterSettings>;
+    EmailSettings: Partial<EmailSettings>;
     ExperimentalSettings: Partial<ExperimentalSettings>;
     PasswordSettings: Partial<PasswordSettings>;
     PluginSettings: Partial<PluginSettings>;
@@ -34,6 +36,9 @@ const onPremServerConfig = (): Partial<TestAdminConfig> => {
         ClusterSettings: {
             Enable: testConfig.haClusterEnabled,
             ClusterName: testConfig.haClusterName,
+        },
+        EmailSettings: {
+            PushNotificationServer: testConfig.pushNotificationServer,
         },
         PasswordSettings: {
             MinimumLength: 5,
@@ -60,6 +65,7 @@ const onPremServerConfig = (): Partial<TestAdminConfig> => {
         ServiceSettings: {
             SiteURL: testConfig.baseURL,
             EnableOnboardingFlow: false,
+            GiphySdkKey: 's0glxvzVg9azvPipKxcPLpXV0q1x1fVP',
         },
         TeamSettings: {
             EnableOpenServer: true,
@@ -69,7 +75,7 @@ const onPremServerConfig = (): Partial<TestAdminConfig> => {
 };
 
 // Should be based only from the generated default config from ./server via "make config-reset"
-// Based on v9.1 server
+// Based on v9.5 server
 const defaultServerConfig: AdminConfig = {
     ServiceSettings: {
         SiteURL: '',
@@ -132,7 +138,7 @@ const defaultServerConfig: AdminConfig = {
         WebsocketPort: 80,
         WebserverMode: 'gzip',
         EnableGifPicker: true,
-        GiphySdkKey: 's0glxvzVg9azvPipKxcPLpXV0q1x1fVP',
+        GiphySdkKey: '',
         EnableCustomEmoji: true,
         EnableEmojiPicker: true,
         PostEditTimeLimit: -1,
@@ -180,8 +186,9 @@ const defaultServerConfig: AdminConfig = {
         EnableCustomGroups: true,
         SelfHostedPurchase: true,
         AllowSyncedDrafts: true,
-        UniqueEmojiReactionLimitPerPost: 25,
+        UniqueEmojiReactionLimitPerPost: 50,
         RefreshPostStatsRunTime: '00:00',
+        MaximumPayloadSizeBytes: 100000,
     },
     TeamSettings: {
         SiteName: 'Mattermost',
@@ -247,6 +254,7 @@ const defaultServerConfig: AdminConfig = {
         EnableSentry: true,
         AdvancedLoggingJSON: {},
         AdvancedLoggingConfig: '',
+        MaxFieldSize: 2048,
     },
     ExperimentalAuditSettings: {
         FileEnabled: false,
@@ -707,7 +715,12 @@ const defaultServerConfig: AdminConfig = {
         DeprecateCloudFree: false,
         CloudReverseTrial: false,
         EnableExportDirectDownload: false,
+        MoveThreadsEnabled: false,
         StreamlinedMarketplace: true,
+        CloudIPFiltering: false,
+        ConsumePostHook: false,
+        CloudAnnualRenewals: false,
+        OutgoingOAuthConnections: false,
     },
     ImportSettings: {
         Directory: './import',
@@ -720,10 +733,10 @@ const defaultServerConfig: AdminConfig = {
     WranglerSettings: {
         PermittedWranglerRoles: [],
         AllowedEmailDomain: [],
-        MoveThreadMaxCount: 30,
-        MoveThreadToAnotherTeamEnable: true,
-        MoveThreadFromPrivateChannelEnable: true,
-        MoveThreadFromDirectMessageChannelEnable: true,
-        MoveThreadFromGroupMessageChannelEnable: true,
+        MoveThreadMaxCount: 100,
+        MoveThreadToAnotherTeamEnable: false,
+        MoveThreadFromPrivateChannelEnable: false,
+        MoveThreadFromDirectMessageChannelEnable: false,
+        MoveThreadFromGroupMessageChannelEnable: false,
     },
 };

--- a/e2e-tests/playwright/test.config.ts
+++ b/e2e-tests/playwright/test.config.ts
@@ -20,6 +20,7 @@ const config: TestConfig = {
     haClusterEnabled: parseBool(process.env.PW_HA_CLUSTER_ENABLED, false),
     haClusterNodeCount: parseNumber(process.env.PW_HA_CLUSTER_NODE_COUNT, 2),
     haClusterName: process.env.PW_HA_CLUSTER_NAME || 'mm_dev_cluster',
+    pushNotificationServer: process.env.PW_PUSH_NOTIFICATION_SERVER || 'https://push-test.mattermost.com',
     resetBeforeTest: parseBool(process.env.PW_RESET_BEFORE_TEST, false),
     // CI
     isCI: !!process.env.CI,

--- a/e2e-tests/playwright/types.ts
+++ b/e2e-tests/playwright/types.ts
@@ -20,6 +20,7 @@ export type TestConfig = {
     haClusterEnabled: boolean;
     haClusterNodeCount: number;
     haClusterName: string;
+    pushNotificationServer: string;
     // CI
     isCI: boolean;
     // Playwright

--- a/webapp/platform/types/src/config.ts
+++ b/webapp/platform/types/src/config.ts
@@ -388,6 +388,7 @@ export type ServiceSettings = {
     PersistentNotificationMaxRecipients: number;
     UniqueEmojiReactionLimitPerPost: number;
     RefreshPostStatsRunTime: string;
+    MaximumPayloadSizeBytes: number;
 };
 
 export type TeamSettings = {
@@ -456,6 +457,7 @@ export type LogSettings = {
     EnableSentry: boolean;
     AdvancedLoggingConfig: string;
     AdvancedLoggingJSON: Record<string, any>;
+    MaxFieldSize: number;
 };
 
 export type ExperimentalAuditSettings = {


### PR DESCRIPTION
#### Summary
- Made pushNotificationServer configurable in E2E via env

Others:
- Updated the server config
- Updated config types

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-6922

#### Screenshots
n/a

#### Release Note
```release-note
NONE
```
