### PR TITLE
MM-56565 Add filter to connectFakeWebSocket to fix flakiness

### DIFF
--- a/server/channels/app/channel_test.go
+++ b/server/channels/app/channel_test.go
@@ -2736,9 +2736,11 @@ func TestPatchChannelMembersNotifyProps(t *testing.T) {
 		th.AddUserToChannel(user1, channel2)
 		th.AddUserToChannel(user2, channel1)
 
-		messages1, closeWS1 := connectFakeWebSocket(t, th, user1.Id, "")
+		eventTypesFilter := []model.WebsocketEventType{model.WebsocketEventChannelMemberUpdated}
+
+		messages1, closeWS1 := connectFakeWebSocket(t, th, user1.Id, "", eventTypesFilter)
 		defer closeWS1()
-		messages2, closeWS2 := connectFakeWebSocket(t, th, user2.Id, "")
+		messages2, closeWS2 := connectFakeWebSocket(t, th, user2.Id, "", eventTypesFilter)
 		defer closeWS2()
 
 		_, appErr := th.App.PatchChannelMembersNotifyProps(th.Context, []*model.ChannelMemberIdentifier{


### PR DESCRIPTION
#### Summary
Instead of having `connectFakeWebSocket` always read the first two WS messages and assume it knows what they are, I added a new parameter to let test code specify which WS message types it cares about in the test and which should be discarded.

#### Ticket Link
MM-56565

#### Release Note
```release-note
NONE
```
