### PR TITLE
Remove accidentally included trace logs

### DIFF
--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -1971,8 +1971,6 @@ func (s SqlChannelStore) PatchMultipleMembersNotifyProps(members []*model.Channe
 	}
 	defer finalizeTransactionX(transaction, &err)
 
-	transaction.trace = true
-
 	result, err := transaction.ExecBuilder(builder)
 	if err != nil {
 		return nil, errors.Wrap(err, "PatchMultipleMembersNotifyProps: Failed to update ChannelMembers")


### PR DESCRIPTION
#### Summary
Whoops. One of my previous PRs left in some extra trace logging I meant to remove

#### Release Note
```release-note
NONE
```
