### PR TITLE
[MM-56522] Fix margin on landing page remember preference checkbox

### DIFF
--- a/webapp/channels/src/sass/routes/_get-app.scss
+++ b/webapp/channels/src/sass/routes/_get-app.scss
@@ -303,6 +303,7 @@
 
     .get-app__buttons {
         margin-top: 25px;
+        margin-bottom: 25px;
     }
 
     .get-app__preference {


### PR DESCRIPTION
#### Summary
The margin between the buttons and the "Remember my preference" box was missing. This PR adds the margin to the bottom as well to space properly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56522

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="470" alt="image" src="https://github.com/mattermost/mattermost/assets/52460000/374cf7fc-6401-4cf3-834c-2c5bfa739632"> | <img width="485" alt="image" src="https://github.com/mattermost/mattermost/assets/52460000/7fd71778-270f-4d07-b52d-b457786a641f"> |

```release-note
NONE
```
