### PR TITLE
[MM-56398] Fix date range query for user reporting

### DIFF
--- a/server/channels/api4/report.go
+++ b/server/channels/api4/report.go
@@ -89,7 +89,7 @@ func fillReportingBaseOptions(values url.Values) model.ReportingBaseOptions {
 		pageSize = int(pageSizeStr)
 	}
 
-	return model.ReportingBaseOptions{
+	options := model.ReportingBaseOptions{
 		Direction:       direction,
 		SortColumn:      sortColumn,
 		SortDesc:        values.Get("sort_direction") == "desc",
@@ -98,6 +98,8 @@ func fillReportingBaseOptions(values url.Values) model.ReportingBaseOptions {
 		FromId:          values.Get("from_id"),
 		DateRange:       values.Get("date_range"),
 	}
+	options.PopulateDateRange(time.Now())
+	return options
 }
 
 func fillUserReportOptions(values url.Values) (*model.UserReportOptions, *model.AppError) {
@@ -112,7 +114,7 @@ func fillUserReportOptions(values url.Values) (*model.UserReportOptions, *model.
 		return nil, model.NewAppError("getUsersForReporting", "api.getUsersForReporting.invalid_active_filter", nil, "", http.StatusBadRequest)
 	}
 
-	options := &model.UserReportOptions{
+	return &model.UserReportOptions{
 
 		Team:         teamFilter,
 		Role:         values.Get("role_filter"),
@@ -120,7 +122,5 @@ func fillUserReportOptions(values url.Values) (*model.UserReportOptions, *model.
 		HideActive:   hideActive,
 		HideInactive: hideInactive,
 		SearchTerm:   values.Get("search_term"),
-	}
-	options.PopulateDateRange(time.Now())
-	return options, nil
+	}, nil
 }

--- a/server/channels/store/sqlstore/user_store.go
+++ b/server/channels/store/sqlstore/user_store.go
@@ -2377,35 +2377,33 @@ func (us SqlUserStore) GetUserReport(filter *model.UserReportOptions) ([]*model.
 	}
 
 	if isPostgres {
-		query = query.LeftJoin("PostStats ps ON ps.UserId = u.Id")
+		joinSql := sq.And{sq.Eq{"ps.UserId": "u.Id"}}
 		if filter.StartAt > 0 {
 			startDate := time.UnixMilli(filter.StartAt)
-			query = query.Where(sq.Or{
-				sq.Expr("ps.UserId IS NULL"),
-				sq.GtOrEq{"ps.Day": startDate.Format("2006-01-02")},
-			})
+			joinSql = append(joinSql, sq.GtOrEq{"ps.Day": startDate.Format("2006-01-02")})
 		}
 		if filter.EndAt > 0 {
 			endDate := time.UnixMilli(filter.EndAt)
-			query = query.Where(sq.Or{
-				sq.Expr("ps.UserId IS NULL"),
-				sq.Lt{"ps.Day": endDate.Format("2006-01-02")},
-			})
+			joinSql = append(joinSql, sq.Lt{"ps.Day": endDate.Format("2006-01-02")})
 		}
+		sql, args, err := joinSql.ToSql()
+		if err != nil {
+			return nil, err
+		}
+		query = query.LeftJoin("PostStats ps ON "+sql, args...)
 	} else {
-		query = query.LeftJoin("Posts p on p.UserId = u.Id")
+		joinSql := sq.And{sq.Eq{"ps.UserId": "u.Id"}}
 		if filter.StartAt > 0 {
-			query = query.Where(sq.Or{
-				sq.Expr("p.UserId IS NULL"),
-				sq.GtOrEq{"p.CreateAt": filter.StartAt},
-			})
+			joinSql = append(joinSql, sq.GtOrEq{"p.CreateAt": filter.StartAt})
 		}
 		if filter.EndAt > 0 {
-			query = query.Where(sq.Or{
-				sq.Expr("p.UserId IS NULL"),
-				sq.Lt{"p.CreateAt": filter.EndAt},
-			})
+			joinSql = append(joinSql, sq.Lt{"p.CreateAt": filter.EndAt})
 		}
+		sql, args, err := joinSql.ToSql()
+		if err != nil {
+			return nil, err
+		}
+		query = query.LeftJoin("Posts p ON "+sql, args...)
 	}
 
 	query = applyUserReportFilter(query, filter, isPostgres)
@@ -2428,8 +2426,10 @@ func (us SqlUserStore) GetUserReport(filter *model.UserReportOptions) ([]*model.
 			OrderBy(filter.SortColumn+" "+reverseSortDirection, "Id")
 	}
 
+	sql, _, err := parentQuery.ToSql()
+	mlog.Debug(sql)
 	userResults := []*model.UserReportQuery{}
-	err := us.GetReplicaX().SelectBuilder(&userResults, parentQuery)
+	err = us.GetReplicaX().SelectBuilder(&userResults, parentQuery)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get users for reporting")
 	}


### PR DESCRIPTION
#### Summary
Found 2 issues when trying to query for date range that are fixed here:
- The actual date range was being populated as part of the wrong object, so I've moved that over
- The actual SQL query was eliminating all users outside of the date range if they didn't have any stats within it, so I've changed the query to work off of the JOIN instead of its own WHERE clause (which can't work).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56398

```release-note
NONE
```
