### PR TITLE
Bump golang.org/x/image dependency

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c
 	github.com/yuin/goldmark v1.6.0
 	golang.org/x/crypto v0.18.0
-	golang.org/x/image v0.14.0
+	golang.org/x/image v0.15.0
 	golang.org/x/net v0.20.0
 	golang.org/x/sync v0.5.0
 	golang.org/x/term v0.16.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -648,8 +648,8 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/exp v0.0.0-20231214170342-aacd6d4b4611 h1:qCEDpW1G+vcj3Y7Fy52pEM1AWm3abj8WimGYejI3SC4=
 golang.org/x/exp v0.0.0-20231214170342-aacd6d4b4611/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
-golang.org/x/image v0.14.0 h1:tNgSxAFe3jC4uYqvZdTr84SZoM1KfwdC9SKIFrLjFn4=
-golang.org/x/image v0.14.0/go.mod h1:HUYqC05R2ZcZ3ejNQsIHQDQiwWM4JBqmm6MKANTp4LE=
+golang.org/x/image v0.15.0 h1:kOELfmgrmJlw4Cdb7g/QGuB3CvDrXbqEIww/pNtNBm8=
+golang.org/x/image v0.15.0/go.mod h1:HUYqC05R2ZcZ3ejNQsIHQDQiwWM4JBqmm6MKANTp4LE=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=


### PR DESCRIPTION
#### Summary

Bump golang.org/x/image dependency

#### Ticket Link

I do not have a ticket... How do I get one ? (This is my second contribution...)

The problem is that an user can crash the server with a malformed webp image (like `UklGRjEAAABXRUJQVlA4WAoAAAAAAAAAAAAAAAAAVlA4WAoAAAAQAAAA////////QUxQSAEAAAAA` base64-decoded). This got fixed in golang.org/x/image v0.15 (by https://go-review.googlesource.com/c/image/+/551416 precisely)

This was deemed out of scope on HackerOne as "Denial of service attacks that only affect yourself"

Stack trace from the server is 
```
runtime: out of memory: cannot allocate 281474976710656-byte block (136282112 in use)
fatal error: out of memory

goroutine 739 [running]:
runtime.throw({0x278aad6?, 0x800000000?})
        runtime/panic.go:1047 +0x5d fp=0xc0054c9478 sp=0xc0054c9448 pc=0x438d1d
runtime.(*mcache).allocLarge(0x0?, 0x1000000000000, 0x1)
        runtime/mcache.go:236 +0x179 fp=0xc0054c94c0 sp=0xc0054c9478 pc=0x418a39
runtime.mallocgc(0x1000000000000, 0x239bea0, 0x1)
        runtime/malloc.go:1053 +0x4fe fp=0xc0054c9528 sp=0xc0054c94c0 pc=0x40f65e
runtime.makeslice(0xc004e03b00?, 0xc0048fc780?, 0x8?)
        runtime/slice.go:103 +0x52 fp=0xc0054c9550 sp=0xc0054c9528 pc=0x451212
golang.org/x/image/webp.readAlpha({0x2e22380, 0xc0052da8d0}, 0x48fc780?, 0xc0?, 0x1?)
        golang.org/x/image@v0.8.0/webp/decode.go:157 +0x2a5 fp=0xc0054c95e8 sp=0xc0054c9550 pc=0x18935c5
golang.org/x/image/webp.decode({0x2e1e5c0?, 0xc004e03b00?}, 0x0)
        golang.org/x/image@v0.8.0/webp/decode.go:68 +0x334 fp=0xc0054c96f8 sp=0xc0054c95e8 pc=0x1892d74
golang.org/x/image/webp.Decode({0x2e1e5c0?, 0xc004e03b00?})
        golang.org/x/image@v0.8.0/webp/decode.go:255 +0x25 fp=0xc0054c9720 sp=0xc0054c96f8 pc=0x18939e5
image.Decode({0x2e23b60?, 0xc0052da8b8?})
        image/format.go:93 +0xae fp=0xc0054c97b0 sp=0xc0054c9720 pc=0xb82d8e
github.com/mattermost/mattermost/server/v8/channels/app/imaging.(*Decoder).DecodeMemBounded(0xc002b0fe50, {0x2e23b60, 0xc0052da8b8})
        github.com/mattermost/mattermost/server/v8/channels/app/imaging/decode.go:83 +0x110 fp=0xc0054c9898 sp=0xc0054c97b0 pc=0x18829b0
github.com/mattermost/mattermost/server/v8/channels/app.(*UploadFileTask).postprocessImage(0xc00160f680, {0x2e23b60?, 0xc0052da8b8?})
        github.com/mattermost/mattermost/server/v8/channels/app/file.go:884 +0x171 fp=0xc0054c99b0 sp=0xc0054c9898 pc=0x1d8ea51
github.com/mattermost/mattermost/server/v8/channels/app.(*App).UploadFileX(0xc0052da6d0, {0x2e4a570, 0xc0029da6c0}, {0xc00540bb00, 0x1a}, {0xc0048fc608, 0x8}, {0x2e235c0?, 0xc0006803f0}, {0xc00547f860, ...})
        github.com/mattermost/mattermost/server/v8/channels/app/file.go:791 +0xba5 fp=0xc0054ca1c0 sp=0xc0054c99b0 pc=0x1d8d145
github.com/mattermost/mattermost/server/v8/channels/api4.uploadFileMultipart(0xc0010a9d60, 0xc005405300, {0x2e23500, 0xc00547c3a8}, {0x2800?, 0x415628?, 0x43f7960?})
        github.com/mattermost/mattermost/server/v8/channels/api4/file.go:315 +0xd23 fp=0xc0054ca4e0 sp=0xc0054ca1c0 pc=0x213dc63
github.com/mattermost/mattermost/server/v8/channels/api4.uploadFileMultipart(0xc0010a9d60, 0xc005405300, {0x0, 0x0}, {0x1a?, 0xc0011f75fc?, 0x43f7960?})
        github.com/mattermost/mattermost/server/v8/channels/api4/file.go:252 +0x1249 fp=0xc0054ca800 sp=0xc0054ca4e0 pc=0x213e189
github.com/mattermost/mattermost/server/v8/channels/api4.uploadFileStream(0xc0010a9d60, {0x2e2da20, 0xc0036cb880}, 0xc005405300)
        github.com/mattermost/mattermost/server/v8/channels/api4/file.go:111 +0x23e fp=0xc0054ca998 sp=0xc0054ca800 pc=0x213be5e
github.com/mattermost/mattermost/server/v8/channels/web.Handler.ServeHTTP({0xc002cc2000, 0x2954798, {0x34bddf6, 0x10}, 0x1, 0x0, 0x0, 0x0, 0x1, 0x0, ...}, ...)
        github.com/mattermost/mattermost/server/v8/channels/web/handlers.go:364 +0x357d fp=0xc0054cb5f0 sp=0xc0054ca998 pc=0x20d42fd
github.com/mattermost/mattermost/server/v8/channels/web.(*Handler).ServeHTTP(0x43b49e0?, {0x2e2f940?, 0xc001c7e280?}, 0x4?)
        <autogenerated>:1 +0xa5 fp=0xc0054cb688 sp=0xc0054cb5f0 pc=0x20e6d85
github.com/klauspost/compress/gzhttp.NewWrapper.func1.1({0x2e2f130, 0xc00500d7a0}, 0xc00547ef90?)
        github.com/klauspost/compress@v1.16.6/gzhttp/compress.go:486 +0x35a fp=0xc0054cb828 sp=0xc0054cb688 pc=0x1ed597a
net/http.HandlerFunc.ServeHTTP(0xc005405200?, {0x2e2f130?, 0xc00500d7a0?}, 0x258ea00?)
        net/http/server.go:2122 +0x2f fp=0xc0054cb850 sp=0xc0054cb828 pc=0x743e4f
github.com/gorilla/mux.(*Router).ServeHTTP(0xc0003bc480, {0x2e2f130, 0xc00500d7a0}, 0xc005405100)
        github.com/gorilla/mux@v1.8.0/mux.go:210 +0x1cf fp=0xc0054cb978 sp=0xc0054cb850 pc=0xa0fb8f
github.com/getsentry/sentry-go/http.(*Handler).handle.func1({0x2e2f130, 0xc00500d7a0}, 0xc005405000)
        github.com/getsentry/sentry-go@v0.22.0/http/sentryhttp.go:110 +0x42b fp=0xc0054cbaa8 sp=0xc0054cb978 pc=0x1ab4cab
net/http.HandlerFunc.ServeHTTP(0x0?, {0x2e2f130?, 0xc00500d7a0?}, 0x7517f4?)
        net/http/server.go:2122 +0x2f fp=0xc0054cbad0 sp=0xc0054cbaa8 pc=0x743e4f
net/http.serverHandler.ServeHTTP({0x2e2a180?}, {0x2e2f130, 0xc00500d7a0}, 0xc005405000)
        net/http/server.go:2936 +0x316 fp=0xc0054cbb80 sp=0xc0054cbad0 pc=0x747456
net/http.(*conn).serve(0xc005390000, {0x2e30b08, 0xc002395bc0})
        net/http/server.go:1995 +0x612 fp=0xc0054cbfb8 sp=0xc0054cbb80 pc=0x742972
net/http.(*Server).Serve.func3()
        net/http/server.go:3089 +0x2e fp=0xc0054cbfe0 sp=0xc0054cbfb8 pc=0x747dae
runtime.goexit()
        runtime/asm_amd64.s:1598 +0x1 fp=0xc0054cbfe8 sp=0xc0054cbfe0 pc=0x46ef61
created by net/http.(*Server).Serve
        net/http/server.go:3089 +0x5ed
```

#### Screenshots
No changes

#### Release Note
```release-note
NONE
```
