### PR TITLE
[MM-56362] Disable post stats for MySQL

### DIFF
--- a/server/channels/store/sqlstore/user_store.go
+++ b/server/channels/store/sqlstore/user_store.go
@@ -2324,12 +2324,6 @@ func (us SqlUserStore) GetUserReport(filter *model.UserReportOptions) ([]*model.
 			"COUNT(ps.Day) AS DaysActive",
 			"SUM(ps.NumPosts) AS TotalPosts",
 		)
-	} else {
-		selectColumns = append(selectColumns,
-			"MAX(p.CreateAt) AS LastPostDate",
-			"COUNT(DATE(FROM_UNIXTIME(p.CreateAt / 1000))) AS DaysActive",
-			"COUNT(p.Id) AS TotalPosts",
-		)
 	}
 
 	sortDirection := "ASC"
@@ -2391,19 +2385,6 @@ func (us SqlUserStore) GetUserReport(filter *model.UserReportOptions) ([]*model.
 			return nil, err
 		}
 		query = query.LeftJoin("PostStats ps ON ps.UserId = u.Id AND "+sql, args...)
-	} else {
-		joinSql := sq.And{}
-		if filter.StartAt > 0 {
-			joinSql = append(joinSql, sq.GtOrEq{"p.CreateAt": filter.StartAt})
-		}
-		if filter.EndAt > 0 {
-			joinSql = append(joinSql, sq.Lt{"p.CreateAt": filter.EndAt})
-		}
-		sql, args, err := joinSql.ToSql()
-		if err != nil {
-			return nil, err
-		}
-		query = query.LeftJoin("Posts p ON p.UserId = u.Id AND "+sql, args...)
 	}
 
 	query = applyUserReportFilter(query, filter, isPostgres)

--- a/server/channels/store/storetest/user_store.go
+++ b/server/channels/store/storetest/user_store.go
@@ -98,7 +98,7 @@ func TestUserStore(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
 	t.Run("GetKnownUsers", func(t *testing.T) { testGetKnownUsers(t, rctx, ss) })
 	t.Run("GetUsersWithInvalidEmails", func(t *testing.T) { testGetUsersWithInvalidEmails(t, rctx, ss) })
 	t.Run("UpdateLastLogin", func(t *testing.T) { testUpdateLastLogin(t, rctx, ss) })
-	t.Run("GetUserReport", func(t *testing.T) { testGetUserReport(t, rctx, ss) })
+	t.Run("GetUserReport", func(t *testing.T) { testGetUserReport(t, rctx, ss, s) })
 }
 
 func testUserStoreSave(t *testing.T, rctx request.CTX, ss store.Store) {
@@ -6189,7 +6189,7 @@ func testUpdateLastLogin(t *testing.T, rctx request.CTX, ss store.Store) {
 	require.Equal(t, int64(1234567890), user.LastLogin)
 }
 
-func testGetUserReport(t *testing.T, rctx request.CTX, ss store.Store) {
+func testGetUserReport(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
 	numRegularUsers := 90
 	numSysAdmins := 10
 	numInactiveUsers := 15
@@ -6415,6 +6415,11 @@ func testGetUserReport(t *testing.T, rctx request.CTX, ss store.Store) {
 	})
 
 	t.Run("should return accurate post stats for various date ranges", func(t *testing.T) {
+		// These stats are disabled for MySQL
+		if s.DriverName() == model.DatabaseDriverMysql {
+			return
+		}
+
 		userReport, err := ss.User().GetUserReport(&model.UserReportOptions{
 			ReportingBaseOptions: model.ReportingBaseOptions{
 				SortColumn: "Username",


### PR DESCRIPTION
#### Summary
This PR turns off the post stats for MySQL users, as the performance is not up to par.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56362

```release-note
NONE
```
