### PR TITLE
[MM-53930] Reset AuthData field to a user's email

### DIFF
--- a/server/channels/api4/user.go
+++ b/server/channels/api4/user.go
@@ -3469,13 +3469,7 @@ func resetUserAuthDataToEmail(c *Context, w http.ResponseWriter, r *http.Request
 
 	// Check the auth service matches our offerings
 	if authService == "" || (authService != model.UserAuthServiceSaml && authService != model.ServiceOpenid && authService != model.UserAuthServiceGitlab && authService != model.ServiceGoogle && authService != model.ServiceOffice365) {
-		c.Err = model.NewAppError("api.resetUserAuthDataToEmail", "api.admin.users.invalid_auth_type.app_error", nil, "", http.StatusBadRequest)
-		return
-	}
-
-	// Check they have the right license level to use SAML
-	if authService == model.UserAuthServiceSaml && (c.App.Channels().License() == nil || !*c.App.Channels().License().Features.SAML) {
-		c.Err = model.NewAppError("api.resetUserAuthDataToEmail", "api.admin.users.invalid_auth_type.saml_license.app_error", nil, "", http.StatusNotImplemented)
+		c.Err = model.NewAppError("api.resetUserAuthDataToEmail", "api.admin.users.invalid_auth_type.app_error", map[string]any{"AuthService": authService}, "", http.StatusBadRequest)
 		return
 	}
 
@@ -3487,8 +3481,8 @@ func resetUserAuthDataToEmail(c *Context, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if (authService == model.ServiceOpenid || authService == model.ServiceGoogle || authService == model.ServiceOffice365) && licenseErr != nil {
-		c.Err = model.NewAppError("api.resetUserAuthDataToEmail", "api.admin.users.invalid_auth_type.license_level.app_error", nil, "", http.StatusNotImplemented)
+	if (authService == model.ServiceOpenid || authService == model.ServiceGoogle || authService == model.ServiceOffice365 || authService == model.UserAuthServiceSaml) && licenseErr != nil {
+		c.Err = model.NewAppError("api.resetUserAuthDataToEmail", "api.admin.users.invalid_auth_type.license_level.app_error", map[string]any{"AuthService": authService}, "", http.StatusNotImplemented)
 		return
 	}
 

--- a/server/channels/app/app_iface.go
+++ b/server/channels/app/app_iface.go
@@ -1009,6 +1009,7 @@ type AppIface interface {
 	ResetPasswordFromToken(c request.CTX, userSuppliedTokenString, newPassword string) *model.AppError
 	ResetPermissionsSystem() *model.AppError
 	ResetSamlAuthDataToEmail(includeDeleted bool, dryRun bool, userIDs []string) (numAffected int, appErr *model.AppError)
+	ResetUserAuthDataToEmail(authType string, includeDeleted bool, dryRun bool, userIDs []string) (numAffected int, appErr *model.AppError)
 	RestoreChannel(c request.CTX, channel *model.Channel, userID string) (*model.Channel, *model.AppError)
 	RestoreGroup(groupID string) (*model.Group, *model.AppError)
 	RestoreTeam(teamID string) *model.AppError

--- a/server/channels/app/oauthproviders/gitlab/gitlab.go
+++ b/server/channels/app/oauthproviders/gitlab/gitlab.go
@@ -105,5 +105,8 @@ func (gp *GitLabProvider) GetUserFromIdToken(_ request.CTX, idToken string) (*mo
 }
 
 func (gp *GitLabProvider) IsSameUser(_ request.CTX, dbUser, oauthUser *model.User) bool {
+	if *dbUser.AuthData == oauthUser.Email {
+		return true
+	}
 	return dbUser.AuthData == oauthUser.AuthData
 }

--- a/server/channels/app/opentracing/opentracing_layer.go
+++ b/server/channels/app/opentracing/opentracing_layer.go
@@ -14398,6 +14398,28 @@ func (a *OpenTracingAppLayer) ResetSamlAuthDataToEmail(includeDeleted bool, dryR
 	return resultVar0, resultVar1
 }
 
+func (a *OpenTracingAppLayer) ResetUserAuthDataToEmail(authType string, includeDeleted bool, dryRun bool, userIDs []string) (numAffected int, appErr *model.AppError) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.ResetUserAuthDataToEmail")
+
+	a.ctx = newCtx
+	a.app.Srv().Store().SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store().SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := a.app.ResetUserAuthDataToEmail(authType, includeDeleted, dryRun, userIDs)
+
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
 func (a *OpenTracingAppLayer) ResolvePersistentNotification(c request.CTX, post *model.Post, loggedInUserID string) *model.AppError {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.ResolvePersistentNotification")

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -2817,3 +2817,12 @@ func (a *App) UserIsFirstAdmin(user *model.User) bool {
 
 	return true
 }
+
+func (a *App) ResetUserAuthDataToEmail(authService string, includeDeleted bool, dryRun bool, userIDs []string) (numAffected int, appErr *model.AppError) {
+	numAffected, err := a.Srv().Store().User().ResetAuthDataToEmailForUsers(authService, userIDs, includeDeleted, dryRun)
+	if err != nil {
+		appErr = model.NewAppError("ResetAuthDataToEmail", "api.admin.user.failure_reset_authdata_to_email.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+		return
+	}
+	return
+}

--- a/server/cmd/mmctl/client/client.go
+++ b/server/cmd/mmctl/client/client.go
@@ -150,4 +150,5 @@ type Client interface {
 	ResetSamlAuthDataToEmail(ctx context.Context, includeDeleted bool, dryRun bool, userIDs []string) (int64, *model.Response, error)
 	GenerateSupportPacket(ctx context.Context) ([]byte, *model.Response, error)
 	GetOAuthApps(ctx context.Context, page, perPage int) ([]*model.OAuthApp, *model.Response, error)
+	ResetUserAuthDataToEmail(ctx context.Context, authService string, includeDeleted bool, dryRun bool, userIDs []string) (int64, *model.Response, error)
 }

--- a/server/cmd/mmctl/commands/user_test.go
+++ b/server/cmd/mmctl/commands/user_test.go
@@ -2803,3 +2803,69 @@ func (s *MmctlUnitTestSuite) TestDemoteUserToGuestCmd() {
 		s.Require().Equal(fmt.Sprintf("unable to demote user %s: %s", emailArg, "some-error"), printer.GetErrorLines()[0])
 	})
 }
+
+func (s *MmctlUnitTestSuite) TestSsoAuthDataReset() {
+	s.Run("Reset auth data without confirmation returns an error", func() {
+		cmd := &cobra.Command{}
+		err := ssoAuthDataResetCmdF(s.client, cmd, nil)
+		s.Require().NotNil(err)
+		s.Require().EqualError(err, "could not proceed, either enable --confirm flag or use an interactive shell to complete operation: this is not an interactive shell")
+	})
+
+	s.Run("Reset openid auth data without errors", func() {
+		printer.Clean()
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("yes", true, "")
+		outputMessage := "1 user records were changed.\n"
+
+		s.client.
+			EXPECT().
+			ResetUserAuthDataToEmail(context.Background(), "openid", false, false, []string{}).
+			Return(int64(1), &model.Response{}, nil).
+			Times(1)
+
+		err := ssoAuthDataResetCmdF(s.client, cmd, nil)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], outputMessage)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Reset saml auth data dry run", func() {
+		printer.Clean()
+		outputMessage := "1 user records would be affected.\n"
+
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("dry-run", true, "")
+
+		s.client.
+			EXPECT().
+			ResetUserAuthDataToEmail(context.Background(), "saml", false, false, []string{}).
+			Return(int64(1), &model.Response{}, nil).
+			Times(1)
+
+		err := ssoAuthDataResetCmdF(s.client, cmd, nil)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], outputMessage)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Reset office365 auth data with specified users", func() {
+		printer.Clean()
+		users := []string{"user1"}
+		s.client.
+			EXPECT().
+			ResetUserAuthDataToEmail(context.Background(), "office365", false, false, users).
+			Return(int64(1), &model.Response{}, nil).
+			Times(1)
+
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("yes", true, "")
+		cmd.Flags().StringSlice("users", users, "")
+
+		err := ssoAuthDataResetCmdF(s.client, cmd, nil)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}

--- a/server/cmd/mmctl/mocks/client_mock.go
+++ b/server/cmd/mmctl/mocks/client_mock.go
@@ -1791,6 +1791,22 @@ func (mr *MockClientMockRecorder) ResetSamlAuthDataToEmail(arg0, arg1, arg2, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetSamlAuthDataToEmail", reflect.TypeOf((*MockClient)(nil).ResetSamlAuthDataToEmail), arg0, arg1, arg2, arg3)
 }
 
+// ResetUserAuthDataToEmail mocks base method.
+func (m *MockClient) ResetUserAuthDataToEmail(arg0 context.Context, arg1 string, arg2, arg3 bool, arg4 []string) (int64, *model.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResetUserAuthDataToEmail", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(*model.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ResetUserAuthDataToEmail indicates an expected call of ResetUserAuthDataToEmail.
+func (mr *MockClientMockRecorder) ResetUserAuthDataToEmail(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetUserAuthDataToEmail", reflect.TypeOf((*MockClient)(nil).ResetUserAuthDataToEmail), arg0, arg1, arg2, arg3, arg4)
+}
+
 // RestoreChannel mocks base method.
 func (m *MockClient) RestoreChannel(arg0 context.Context, arg1 string) (*model.Channel, *model.Response, error) {
 	m.ctrl.T.Helper()

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -192,6 +192,22 @@
     "translation": "Unable to upload file. File is too large."
   },
   {
+    "id": "api.admin.user.failure_reset_authdata_to_email.app_error",
+    "translation": "Failed to reset authdata to email"
+  },
+  {
+    "id": "api.admin.users.invalid_auth_type.app_error",
+    "translation": "{{.AuthService}} is not supported for auth data reset"
+  },
+  {
+    "id": "api.admin.users.invalid_auth_type.gitlab_license.app_error",
+    "translation": "Your license does not support Gitlab OpenId"
+  },
+  {
+    "id": "api.admin.users.invalid_auth_type.license_level.app_error",
+    "translation": "Your license does not support {{.AuthService}}"
+  },
+  {
     "id": "api.back_to_app",
     "translation": "Back to {{.SiteName}}"
   },

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -3546,6 +3546,15 @@ func (o *Config) GetSSOService(service string) *SSOSettings {
 	return nil
 }
 
+func (o *Config) IsSSOServiceUsingOpenId(service string) bool {
+	sso := o.GetSSOService(service)
+	if sso == nil {
+		return false
+	}
+
+	return strings.Contains(*sso.Scope, ServiceOpenid)
+}
+
 func ConfigFromJSON(data io.Reader) *Config {
 	var o *Config
 	json.NewDecoder(data).Decode(&o)


### PR DESCRIPTION
#### Summary
There is a use case for sysadmins where re-activated users need to have a new oAuth/OpenID/SAML ID but the sysadmin might not be able to get that ID easily. If we give them a mechanism to reset the AuthData field to the user's email, on first login we can update the user's authdata field to their correct ID. We already support this for SAML but we also need oAuth and OpenId support.

I added a new endpoint POST `api/v4/users/reset_auth_data` and mmctl command to allow this. I copied the existing logic from the SAML version but this version will work for any of the given auth methods. By default it will reset every user's authData field but allows for the following post body:
```
{
	"auth_service":      string,
	"include_deleted": bool,
	"dry_run":               bool,
	"user_ids":             []string,
}
```

`auth_service`*: Must be one of the following: saml, office365, google, gitlab or openid
`include_deleted`: include deleted users in the migration
`dry_run`: returns a count of the number of affected users
`user_ids`: list of user ids to update

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53930

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
New endpoint POST api/v4/users/reset_auth_data which will reset the authdata field of users.
Body:
{
	"auth_service":      string,
	"include_deleted": bool,
	"dry_run":               bool,
	"user_ids":             []string,
}
 - `auth_service`*: Must be one of the following: saml, office365, google, gitlab or openid.
 - `include_deleted`: include deleted users in the migration.
 - `dry_run`: returns a count of the number of affected users.
 - `user_ids`: list of user ids to update.

Also added a new mmctl command to support the endpoint, mmctl user auth-data-reset [auth_service].
```
