### PR TITLE
Improve Redux types part 3/Remove old ActionFunc

### DIFF
--- a/webapp/channels/src/actions/apps.ts
+++ b/webapp/channels/src/actions/apps.ts
@@ -10,7 +10,7 @@ import type {Post} from '@mattermost/types/posts';
 
 import {Client4} from 'mattermost-redux/client';
 import {AppCallResponseTypes} from 'mattermost-redux/constants/apps';
-import type {ActionFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
 import {cleanForm} from 'mattermost-redux/utils/apps';
 
 import {openModal} from 'actions/views/modals';
@@ -237,7 +237,7 @@ export function openAppsModal(form: AppForm, context: AppContext): AnyAction {
     });
 }
 
-export function postEphemeralCallResponseForPost(response: AppCallResponse, message: string, post: Post): ActionFunc {
+export function postEphemeralCallResponseForPost(response: AppCallResponse, message: string, post: Post) {
     return sendEphemeralPost(
         message,
         post.channel_id,
@@ -246,7 +246,7 @@ export function postEphemeralCallResponseForPost(response: AppCallResponse, mess
     );
 }
 
-export function postEphemeralCallResponseForChannel(response: AppCallResponse, message: string, channelID: string): ActionFunc {
+export function postEphemeralCallResponseForChannel(response: AppCallResponse, message: string, channelID: string) {
     return sendEphemeralPost(
         message,
         channelID,
@@ -255,7 +255,7 @@ export function postEphemeralCallResponseForChannel(response: AppCallResponse, m
     );
 }
 
-export function postEphemeralCallResponseForContext(response: AppCallResponse, message: string, context: AppContext): ActionFunc {
+export function postEphemeralCallResponseForContext(response: AppCallResponse, message: string, context: AppContext) {
     return sendEphemeralPost(
         message,
         context.channel_id,
@@ -264,7 +264,7 @@ export function postEphemeralCallResponseForContext(response: AppCallResponse, m
     );
 }
 
-export function postEphemeralCallResponseForCommandArgs(response: AppCallResponse, message: string, args: CommandArgs): ActionFunc {
+export function postEphemeralCallResponseForCommandArgs(response: AppCallResponse, message: string, args: CommandArgs) {
     return sendEphemeralPost(
         message,
         args.channel_id,

--- a/webapp/channels/src/actions/apps.ts
+++ b/webapp/channels/src/actions/apps.ts
@@ -1,8 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction, Action as ReduxAction} from 'redux';
-import type {ThunkAction} from 'redux-thunk';
+import type {AnyAction} from 'redux';
 
 import type {AppCallResponse, AppForm, AppCallRequest, AppContext, AppBinding} from '@mattermost/types/apps';
 import type {CommandArgs} from '@mattermost/types/integrations';
@@ -10,7 +9,7 @@ import type {Post} from '@mattermost/types/posts';
 
 import {Client4} from 'mattermost-redux/client';
 import {AppCallResponseTypes} from 'mattermost-redux/constants/apps';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 import {cleanForm} from 'mattermost-redux/utils/apps';
 
 import {openModal} from 'actions/views/modals';
@@ -23,13 +22,10 @@ import {ModalIdentifiers} from 'utils/constants';
 import {getSiteURL, shouldOpenInNewTab} from 'utils/url';
 
 import type {DoAppCallResult} from 'types/apps';
-import type {GlobalState} from 'types/store';
 
 import {sendEphemeralPost} from './global_actions';
 
-export type AppsActionFunc<Res = unknown> = ThunkAction<Promise<Res>, GlobalState, unknown, ReduxAction>;
-
-export function handleBindingClick<Res=unknown>(binding: AppBinding, context: AppContext, intl: any): AppsActionFunc<DoAppCallResult<Res>> {
+export function handleBindingClick<Res=unknown>(binding: AppBinding, context: AppContext, intl: any): ThunkActionFunc<Promise<DoAppCallResult<Res>>> {
     return async (dispatch) => {
         // Fetch form
         let form = binding.form;
@@ -80,7 +76,7 @@ export function handleBindingClick<Res=unknown>(binding: AppBinding, context: Ap
     };
 }
 
-export function doAppSubmit<Res=unknown>(inCall: AppCallRequest, intl: any): ThunkAction<Promise<DoAppCallResult<Res>>, GlobalState, unknown, ReduxAction> {
+export function doAppSubmit<Res=unknown>(inCall: AppCallRequest, intl: any): ThunkActionFunc<Promise<DoAppCallResult<Res>>> {
     return async () => {
         try {
             const call: AppCallRequest = {
@@ -144,7 +140,7 @@ export function doAppSubmit<Res=unknown>(inCall: AppCallRequest, intl: any): Thu
     };
 }
 
-export function doAppFetchForm<Res=unknown>(call: AppCallRequest, intl: any): ThunkAction<Promise<DoAppCallResult<Res>>, GlobalState, unknown, ReduxAction> {
+export function doAppFetchForm<Res=unknown>(call: AppCallRequest, intl: any): ThunkActionFunc<Promise<DoAppCallResult<Res>>> {
     return async () => {
         try {
             const res = await Client4.executeAppCall(call, false) as AppCallResponse<Res>;
@@ -181,7 +177,7 @@ export function doAppFetchForm<Res=unknown>(call: AppCallRequest, intl: any): Th
     };
 }
 
-export function doAppLookup<Res=unknown>(call: AppCallRequest, intl: any): ThunkAction<Promise<DoAppCallResult<Res>>, GlobalState, unknown, ReduxAction> {
+export function doAppLookup<Res=unknown>(call: AppCallRequest, intl: any): ThunkActionFunc<Promise<DoAppCallResult<Res>>> {
     return async () => {
         try {
             const res = await Client4.executeAppCall(call, false) as AppCallResponse<Res>;

--- a/webapp/channels/src/actions/channel_actions.ts
+++ b/webapp/channels/src/actions/channel_actions.ts
@@ -14,7 +14,7 @@ import {getChannelByName, getUnreadChannelIds, getChannel} from 'mattermost-redu
 import {getMyChannelMemberships} from 'mattermost-redux/selectors/entities/common';
 import {getCurrentTeamUrl, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {ActionFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {trackEvent} from 'actions/telemetry_actions.jsx';
 import {loadNewDMIfNeeded, loadNewGMIfNeeded, loadProfilesForSidebar} from 'actions/user_actions';
@@ -76,7 +76,7 @@ export function openGroupChannelToUserIds(userIds: Array<UserProfile['id']>): Ne
     };
 }
 
-export function loadChannelsForCurrentUser(): ActionFunc {
+export function loadChannelsForCurrentUser(): NewActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const unreads = getUnreadChannelIds(state);
@@ -96,7 +96,7 @@ export function loadChannelsForCurrentUser(): ActionFunc {
     };
 }
 
-export function searchMoreChannels(term: string, showArchivedChannels: boolean, hideJoinedChannels: boolean): ActionFunc<Channel[], ServerError> {
+export function searchMoreChannels(term: string, showArchivedChannels: boolean, hideJoinedChannels: boolean): NewActionFuncAsync<Channel[]> { // HARRISONTODO unused
     return async (dispatch, getState) => {
         const state = getState();
         const teamId = getCurrentTeamId(state);

--- a/webapp/channels/src/actions/channel_actions.ts
+++ b/webapp/channels/src/actions/channel_actions.ts
@@ -31,7 +31,7 @@ export function openDirectChannelToUserId(userId: UserProfile['id']): NewActionF
         const channel = getChannelByName(state, channelName);
 
         if (!channel) {
-            return dispatch(ChannelActions.createDirectChannel(currentUserId, userId) as any); // HARRISONTODO ActionFunc needs migration
+            return dispatch(ChannelActions.createDirectChannel(currentUserId, userId));
         }
 
         trackEvent('api', 'api_channels_join_direct');

--- a/webapp/channels/src/actions/cloud.tsx
+++ b/webapp/channels/src/actions/cloud.tsx
@@ -5,12 +5,13 @@ import type {Stripe} from '@stripe/stripe-js';
 import {getCode} from 'country-list';
 
 import type {Address, CloudCustomerPatch, Feedback, WorkspaceDeletionRequest} from '@mattermost/types/cloud';
+import type {ServerError} from '@mattermost/types/errors';
 
 import {CloudTypes} from 'mattermost-redux/action_types';
 import {getCloudCustomer, getCloudProducts, getCloudSubscription, getInvoices} from 'mattermost-redux/actions/cloud';
 import {Client4} from 'mattermost-redux/client';
 import {getCloudErrors} from 'mattermost-redux/selectors/entities/cloud';
-import type {ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import type {NewActionFunc, ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 import {trackEvent} from 'actions/telemetry_actions.jsx';
 
@@ -19,6 +20,7 @@ import {getConfirmCardSetup} from 'components/payment_form/stripe';
 import {getBlankAddressWithCountry} from 'utils/utils';
 
 import type {StripeSetupIntent, BillingDetails} from 'types/cloud/sku';
+import type {GlobalState} from 'types/store';
 
 // Returns true for success, and false for any error
 export function completeStripeAddPaymentMethod(
@@ -120,9 +122,9 @@ export function subscribeCloudSubscription(
     };
 }
 
-export function requestCloudTrial(page: string, subscriptionId: string, email = ''): ActionFunc {
+export function requestCloudTrial(page: string, subscriptionId: string, email = ''): ThunkActionFunc<Promise<boolean>> {
     trackEvent('api', 'api_request_cloud_trial_license', {from_page: page});
-    return async (dispatch: DispatchFunc): Promise<any> => {
+    return async (dispatch) => {
         try {
             const newSubscription = await Client4.requestCloudTrial(subscriptionId, email);
             dispatch({
@@ -160,8 +162,8 @@ export function validateWorkspaceBusinessEmail() {
     };
 }
 
-export function getCloudLimits(): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
+export function getCloudLimits(): ThunkActionFunc<Promise<boolean | ServerError>> {
+    return async (dispatch) => {
         try {
             dispatch({
                 type: CloudTypes.CLOUD_LIMITS_REQUEST,
@@ -183,8 +185,8 @@ export function getCloudLimits(): ActionFunc {
     };
 }
 
-export function getMessagesUsage(): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
+export function getMessagesUsage(): ThunkActionFunc<Promise<boolean | ServerError>> {
+    return async (dispatch) => {
         try {
             const result = await Client4.getPostsUsage();
             if (result) {
@@ -200,8 +202,8 @@ export function getMessagesUsage(): ActionFunc {
     };
 }
 
-export function getFilesUsage(): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
+export function getFilesUsage(): ThunkActionFunc<Promise<boolean | ServerError>> {
+    return async (dispatch) => {
         try {
             const result = await Client4.getFilesUsage();
 
@@ -220,8 +222,8 @@ export function getFilesUsage(): ActionFunc {
     };
 }
 
-export function getTeamsUsage(): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
+export function getTeamsUsage(): ThunkActionFunc<Promise<boolean | ServerError>> {
+    return async (dispatch) => {
         try {
             const result = await Client4.getTeamsUsage();
             if (result) {
@@ -248,8 +250,8 @@ export function deleteWorkspace(deletionRequest: WorkspaceDeletionRequest) {
     };
 }
 
-export function retryFailedCloudFetches() {
-    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function retryFailedCloudFetches(): NewActionFunc<boolean, GlobalState> {
+    return (dispatch, getState) => {
         const errors = getCloudErrors(getState());
         if (Object.keys(errors).length === 0) {
             return {data: true};

--- a/webapp/channels/src/actions/global_actions.tsx
+++ b/webapp/channels/src/actions/global_actions.tsx
@@ -24,7 +24,7 @@ import {getConfig, isPerformanceDebuggingEnabled} from 'mattermost-redux/selecto
 import {getBool, getIsOnboardingFlowEnabled, isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeamId, getMyTeams, getTeam, getMyTeamMember, getTeamMemberships, getActiveTeamsList} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser, getCurrentUserId, isFirstAdmin} from 'mattermost-redux/selectors/entities/users';
-import type {ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import type {DispatchFunc, GetStateFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
 import {calculateUnreadCount} from 'mattermost-redux/utils/channel_utils';
 
 import {handleNewPost} from 'actions/post_actions';
@@ -169,8 +169,8 @@ export function showMobileSubMenuModal(elements: any[]) { // TODO Use more speci
     dispatch(openModal(submenuModalData));
 }
 
-export function sendEphemeralPost(message: string, channelId?: string, parentId?: string, userId?: string): ActionFunc {
-    return (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
+export function sendEphemeralPost(message: string, channelId?: string, parentId?: string, userId?: string): NewActionFuncAsync {
+    return (doDispatch, doGetState) => {
         const timestamp = Utils.getTimestamp();
         const post = {
             id: Utils.generateId(),
@@ -188,8 +188,8 @@ export function sendEphemeralPost(message: string, channelId?: string, parentId?
     };
 }
 
-export function sendGenericPostMessage(message: string, channelId?: string, parentId?: string, userId?: string): ActionFunc {
-    return (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
+export function sendGenericPostMessage(message: string, channelId?: string, parentId?: string, userId?: string): NewActionFuncAsync { // HARRISONTODO unused
+    return (doDispatch, doGetState) => {
         const timestamp = Utils.getTimestamp();
         const post = {
             id: Utils.generateId(),

--- a/webapp/channels/src/actions/global_actions.tsx
+++ b/webapp/channels/src/actions/global_actions.tsx
@@ -169,7 +169,7 @@ export function showMobileSubMenuModal(elements: any[]) { // TODO Use more speci
     dispatch(openModal(submenuModalData));
 }
 
-export function sendEphemeralPost(message: string, channelId?: string, parentId?: string, userId?: string): NewActionFuncAsync {
+export function sendEphemeralPost(message: string, channelId?: string, parentId?: string, userId?: string): NewActionFuncAsync<boolean, GlobalState> {
     return (doDispatch, doGetState) => {
         const timestamp = Utils.getTimestamp();
         const post = {
@@ -188,7 +188,7 @@ export function sendEphemeralPost(message: string, channelId?: string, parentId?
     };
 }
 
-export function sendGenericPostMessage(message: string, channelId?: string, parentId?: string, userId?: string): NewActionFuncAsync { // HARRISONTODO unused
+export function sendGenericPostMessage(message: string, channelId?: string, parentId?: string, userId?: string): NewActionFuncAsync<boolean, GlobalState> { // HARRISONTODO unused
     return (doDispatch, doGetState) => {
         const timestamp = Utils.getTimestamp();
         const post = {

--- a/webapp/channels/src/actions/hosted_customer.tsx
+++ b/webapp/channels/src/actions/hosted_customer.tsx
@@ -5,7 +5,8 @@ import type {Stripe} from '@stripe/stripe-js';
 import {getCode} from 'country-list';
 
 import type {CreateSubscriptionRequest} from '@mattermost/types/cloud';
-import type {SelfHostedExpansionRequest} from '@mattermost/types/hosted_customer';
+import type {ServerError} from '@mattermost/types/errors';
+import type {SelfHostedExpansionRequest, SelfHostedSignupSuccessResponse} from '@mattermost/types/hosted_customer';
 import {SelfHostedSignupProgress} from '@mattermost/types/hosted_customer';
 import type {ValueOf} from '@mattermost/types/utilities';
 
@@ -13,11 +14,12 @@ import {HostedCustomerTypes} from 'mattermost-redux/action_types';
 import {bindClientFunc} from 'mattermost-redux/actions/helpers';
 import {Client4} from 'mattermost-redux/client';
 import {getSelfHostedErrors} from 'mattermost-redux/selectors/entities/hosted_customer';
-import type {ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import type {NewActionFunc, NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 import {getConfirmCardSetup} from 'components/payment_form/stripe';
 
 import type {StripeSetupIntent, BillingDetails} from 'types/cloud/sku';
+import type {GlobalState} from 'types/store';
 
 function selfHostedNeedsConfirmation(progress: ValueOf<typeof SelfHostedSignupProgress>): boolean {
     switch (progress) {
@@ -40,8 +42,8 @@ export function confirmSelfHostedSignup(
     billingDetails: BillingDetails,
     initialProgress: ValueOf<typeof SelfHostedSignupProgress>,
     subscriptionRequest: CreateSubscriptionRequest,
-): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
+): NewActionFuncAsync<SelfHostedSignupSuccessResponse['license'] | false> {
+    return async (dispatch) => {
         const cardSetupFunction = getConfirmCardSetup(cwsMockMode);
         const confirmCardSetup = cardSetupFunction(stripe.confirmCardSetup);
 
@@ -118,8 +120,8 @@ export function confirmSelfHostedSignup(
     };
 }
 
-export function getSelfHostedProducts(): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
+export function getSelfHostedProducts(): ThunkActionFunc<Promise<boolean | ServerError>> {
+    return async (dispatch) => {
         try {
             dispatch({
                 type: HostedCustomerTypes.SELF_HOSTED_PRODUCTS_REQUEST,
@@ -141,8 +143,8 @@ export function getSelfHostedProducts(): ActionFunc {
     };
 }
 
-export function getSelfHostedInvoices(): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
+export function getSelfHostedInvoices(): ThunkActionFunc<Promise<boolean | ServerError>> {
+    return async (dispatch) => {
         try {
             dispatch({
                 type: HostedCustomerTypes.SELF_HOSTED_INVOICES_REQUEST,
@@ -163,8 +165,8 @@ export function getSelfHostedInvoices(): ActionFunc {
         return true;
     };
 }
-export function retryFailedHostedCustomerFetches() {
-    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function retryFailedHostedCustomerFetches(): NewActionFunc<boolean, GlobalState> {
+    return (dispatch, getState) => {
         const errors = getSelfHostedErrors(getState());
         if (Object.keys(errors).length === 0) {
             return {data: true};
@@ -207,8 +209,8 @@ export function confirmSelfHostedExpansion(
     billingDetails: BillingDetails,
     initialProgress: ValueOf<typeof SelfHostedSignupProgress>,
     expansionRequest: SelfHostedExpansionRequest,
-): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
+): NewActionFuncAsync<SelfHostedSignupSuccessResponse['license'] | false> {
+    return async (dispatch) => {
         const cardSetupFunction = getConfirmCardSetup(cwsMockMode);
         const confirmCardSetup = cardSetupFunction(stripe.confirmCardSetup);
 

--- a/webapp/channels/src/actions/integration_actions.tsx
+++ b/webapp/channels/src/actions/integration_actions.tsx
@@ -7,7 +7,7 @@ import * as IntegrationActions from 'mattermost-redux/actions/integrations';
 import {getProfilesByIds} from 'mattermost-redux/actions/users';
 import {appsEnabled} from 'mattermost-redux/selectors/entities/apps';
 import {getUser} from 'mattermost-redux/selectors/entities/users';
-import type {ActionFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
 
 const DEFAULT_PAGE_SIZE = 100;
 
@@ -21,7 +21,7 @@ export function loadIncomingHooksAndProfilesForTeam(teamId: string, page = 0, pe
     };
 }
 
-export function loadProfilesForIncomingHooks(hooks: IncomingWebhook[]): ActionFunc {
+export function loadProfilesForIncomingHooks(hooks: IncomingWebhook[]): NewActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const profilesToLoad: {[key: string]: boolean} = {};
@@ -52,7 +52,7 @@ export function loadOutgoingHooksAndProfilesForTeam(teamId: string, page = 0, pe
     };
 }
 
-export function loadProfilesForOutgoingHooks(hooks: OutgoingWebhook[]): ActionFunc {
+export function loadProfilesForOutgoingHooks(hooks: OutgoingWebhook[]): NewActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const profilesToLoad: {[key: string]: boolean} = {};
@@ -73,7 +73,7 @@ export function loadProfilesForOutgoingHooks(hooks: OutgoingWebhook[]): ActionFu
     };
 }
 
-export function loadCommandsAndProfilesForTeam(teamId: string): ActionFunc {
+export function loadCommandsAndProfilesForTeam(teamId: string): NewActionFuncAsync {
     return async (dispatch) => {
         const {data} = await dispatch(IntegrationActions.getCustomTeamCommands(teamId));
         if (data) {
@@ -83,7 +83,7 @@ export function loadCommandsAndProfilesForTeam(teamId: string): ActionFunc {
     };
 }
 
-export function loadProfilesForCommands(commands: Command[]): ActionFunc {
+export function loadProfilesForCommands(commands: Command[]): NewActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const profilesToLoad: {[key: string]: boolean} = {};
@@ -117,7 +117,7 @@ export function loadOAuthAppsAndProfiles(page = 0, perPage = DEFAULT_PAGE_SIZE):
     };
 }
 
-export function loadProfilesForOAuthApps(apps: OAuthApp[]): ActionFunc {
+export function loadProfilesForOAuthApps(apps: OAuthApp[]): NewActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const profilesToLoad: {[key: string]: boolean} = {};

--- a/webapp/channels/src/actions/new_post.ts
+++ b/webapp/channels/src/actions/new_post.ts
@@ -17,7 +17,7 @@ import * as PostSelectors from 'mattermost-redux/selectors/entities/posts';
 import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getThread} from 'mattermost-redux/selectors/entities/threads';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import type {DispatchFunc, GetStateFunc, NewActionFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
 import {
     isFromWebhook,
     isSystemMessage,
@@ -37,15 +37,15 @@ export type NewPostMessageProps = {
     team_id: string;
 }
 
-export function completePostReceive(post: Post, websocketMessageProps: NewPostMessageProps, fetchedChannelMember?: boolean): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function completePostReceive(post: Post, websocketMessageProps: NewPostMessageProps, fetchedChannelMember?: boolean): NewActionFuncAsync<boolean, GlobalState> {
+    return async (dispatch, getState) => {
         const state = getState();
         const rootPost = PostSelectors.getPost(state, post.root_id);
         if (post.root_id && !rootPost) {
             const result = await dispatch(PostActions.getPostThread(post.root_id));
 
             if ('error' in result) {
-                return result;
+                return {error: result.error};
             }
         }
         const actions: Redux.AnyAction[] = [];
@@ -77,7 +77,9 @@ export function completePostReceive(post: Post, websocketMessageProps: NewPostMe
             dispatch(setThreadRead(post));
         }
 
-        return dispatch(sendDesktopNotification(post, websocketMessageProps) as unknown as ActionFunc);
+        dispatch(sendDesktopNotification(post, websocketMessageProps));
+
+        return {data: true};
     };
 }
 
@@ -125,10 +127,10 @@ export function setChannelReadAndViewed(dispatch: DispatchFunc, getState: GetSta
     return actionsToMarkChannelAsUnread(getState, websocketMessageProps.team_id, post.channel_id, websocketMessageProps.mentions, fetchedChannelMember, post.root_id === '', post?.metadata?.priority?.priority);
 }
 
-export function setThreadRead(post: Post) {
+export function setThreadRead(post: Post): NewActionFunc<boolean, GlobalState> {
     const getThreadLastViewedAt = makeGetThreadLastViewedAt();
-    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const state = getState() as GlobalState;
+    return (dispatch, getState) => {
+        const state = getState();
 
         const thread = getThread(state, post.root_id);
 

--- a/webapp/channels/src/actions/notification_actions.jsx
+++ b/webapp/channels/src/actions/notification_actions.jsx
@@ -53,6 +53,9 @@ const getNotificationSoundFromChannelMemberAndUser = (member, user) => {
     return user.notify_props?.desktop_notification_sound ? user.notify_props.desktop_notification_sound : 'Bing';
 };
 
+/**
+ * @returns {import('mattermost-redux/types/actions').ThunkActionFunc<void>}
+ */
 export function sendDesktopNotification(post, msgProps) {
     return async (dispatch, getState) => {
         const state = getState();

--- a/webapp/channels/src/actions/post_actions.ts
+++ b/webapp/channels/src/actions/post_actions.ts
@@ -47,8 +47,8 @@ import type {GlobalState} from 'types/store';
 import {completePostReceive} from './new_post';
 import type {NewPostMessageProps} from './new_post';
 
-export function handleNewPost(post: Post, msg?: {data?: NewPostMessageProps & GroupChannel}) {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function handleNewPost(post: Post, msg?: {data?: NewPostMessageProps & GroupChannel}): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         let websocketMessageProps = {};
         const state = getState();
         if (msg) {

--- a/webapp/channels/src/actions/post_actions.ts
+++ b/webapp/channels/src/actions/post_actions.ts
@@ -15,7 +15,7 @@ import * as PostSelectors from 'mattermost-redux/selectors/entities/posts';
 import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
-import type {DispatchFunc, GetStateFunc, NewActionFunc, NewActionFuncAsync, NewActionFuncOldVariantDoNotUse} from 'mattermost-redux/types/actions';
+import type {DispatchFunc, GetStateFunc, NewActionFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
 import {canEditPost, comparePosts} from 'mattermost-redux/utils/post_utils';
 
 import {addRecentEmoji, addRecentEmojis} from 'actions/emoji_actions';
@@ -146,7 +146,7 @@ function storeCommentDraft(rootPostId: string, draft: null) {
     };
 }
 
-export function submitReaction(postId: string, action: string, emojiName: string): NewActionFuncOldVariantDoNotUse {
+export function submitReaction(postId: string, action: string, emojiName: string): NewActionFunc<unknown, GlobalState> {
     return (dispatch, getState) => {
         const state = getState() as GlobalState;
         const getIsReactionAlreadyAddedToPost = makeGetIsReactionAlreadyAddedToPost();
@@ -162,9 +162,9 @@ export function submitReaction(postId: string, action: string, emojiName: string
     };
 }
 
-export function toggleReaction(postId: string, emojiName: string): NewActionFuncOldVariantDoNotUse {
-    return (dispatch, getState) => {
-        const state = getState() as GlobalState;
+export function toggleReaction(postId: string, emojiName: string): NewActionFuncAsync<unknown, GlobalState> {
+    return async (dispatch, getState) => {
+        const state = getState();
         const getIsReactionAlreadyAddedToPost = makeGetIsReactionAlreadyAddedToPost();
 
         const isReactionAlreadyAddedToPost = getIsReactionAlreadyAddedToPost(state, postId, emojiName);

--- a/webapp/channels/src/actions/post_actions.ts
+++ b/webapp/channels/src/actions/post_actions.ts
@@ -355,14 +355,14 @@ export function markMostRecentPostInChannelAsUnread(channelId: string) {
 }
 
 // Action called by DeletePostModal when the post is deleted
-export function deleteAndRemovePost(post: Post): NewActionFuncAsync<boolean> {
+export function deleteAndRemovePost(post: Post): NewActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         const {error} = await dispatch(PostActions.deletePost(post));
         if (error) {
             return {error};
         }
 
-        if (post.id === getSelectedPostId(getState() as GlobalState)) {
+        if (post.id === getSelectedPostId(getState())) {
             dispatch({
                 type: ActionTypes.SELECT_POST,
                 postId: '',
@@ -371,7 +371,7 @@ export function deleteAndRemovePost(post: Post): NewActionFuncAsync<boolean> {
             });
         }
 
-        if (post.id === getSelectedPostCardId(getState() as GlobalState)) {
+        if (post.id === getSelectedPostCardId(getState())) {
             dispatch({
                 type: ActionTypes.SELECT_POST_CARD,
                 postId: '',
@@ -381,7 +381,7 @@ export function deleteAndRemovePost(post: Post): NewActionFuncAsync<boolean> {
 
         if (post.root_id === '') {
             const key = StoragePrefixes.COMMENT_DRAFT + post.id;
-            if (getGlobalItem(getState() as GlobalState, key, null)) {
+            if (getGlobalItem(getState(), key, null)) {
                 dispatch(removeDraft(key, post.channel_id, post.id));
             }
         }

--- a/webapp/channels/src/actions/post_actions.ts
+++ b/webapp/channels/src/actions/post_actions.ts
@@ -47,7 +47,7 @@ import type {GlobalState} from 'types/store';
 import {completePostReceive} from './new_post';
 import type {NewPostMessageProps} from './new_post';
 
-export function handleNewPost(post: Post, msg?: {data?: NewPostMessageProps & GroupChannel}): NewActionFuncAsync {
+export function handleNewPost(post: Post, msg?: {data?: NewPostMessageProps & GroupChannel}): NewActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         let websocketMessageProps = {};
         const state = getState();

--- a/webapp/channels/src/actions/status_actions.ts
+++ b/webapp/channels/src/actions/status_actions.ts
@@ -8,7 +8,7 @@ import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels'
 import {getPostsInCurrentChannel} from 'mattermost-redux/selectors/entities/posts';
 import {getDirectShowPreferences} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {ActionFunc, DispatchFunc, GetStateFunc, NewActionFunc} from 'mattermost-redux/types/actions';
+import type {NewActionFunc, ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 import {loadCustomEmojisForCustomStatusesByUserIds} from 'actions/emoji_actions';
 
@@ -16,8 +16,8 @@ import {Constants} from 'utils/constants';
 
 import type {GlobalState} from 'types/store';
 
-export function loadStatusesForChannelAndSidebar(): ActionFunc {
-    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function loadStatusesForChannelAndSidebar(): NewActionFunc<boolean, GlobalState> {
+    return (dispatch, getState) => {
         const state = getState();
         const statusesToLoad: Record<string, true> = {};
 
@@ -25,7 +25,7 @@ export function loadStatusesForChannelAndSidebar(): ActionFunc {
         const postsInChannel = getPostsInCurrentChannel(state);
 
         if (postsInChannel) {
-            const posts = postsInChannel.slice(0, (state as GlobalState).views.channel.postVisibility[channelId] || 0);
+            const posts = postsInChannel.slice(0, state.views.channel.postVisibility[channelId] || 0);
             for (const post of posts) {
                 if (post.user_id) {
                     statusesToLoad[post.user_id] = true;
@@ -66,8 +66,8 @@ export function loadStatusesForProfilesList(users: UserProfile[] | null): NewAct
     };
 }
 
-export function loadStatusesForProfilesMap(users: Record<string, UserProfile> | null) {
-    return (dispatch: DispatchFunc) => {
+export function loadStatusesForProfilesMap(users: Record<string, UserProfile> | null): NewActionFunc {
+    return (dispatch) => {
         if (users == null) {
             return {data: false};
         }
@@ -85,8 +85,8 @@ export function loadStatusesForProfilesMap(users: Record<string, UserProfile> | 
     };
 }
 
-export function loadStatusesByIds(userIds: string[]) {
-    return (dispatch: DispatchFunc) => {
+export function loadStatusesByIds(userIds: string[]): NewActionFunc {
+    return (dispatch) => {
         if (userIds.length === 0) {
             return {data: false};
         }
@@ -97,8 +97,8 @@ export function loadStatusesByIds(userIds: string[]) {
     };
 }
 
-export function loadProfilesMissingStatus(users: UserProfile[]) {
-    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function loadProfilesMissingStatus(users: UserProfile[]): NewActionFunc {
+    return (dispatch, getState) => {
         const state = getState();
         const statuses = state.entities.users.statuses;
 
@@ -118,8 +118,8 @@ export function loadProfilesMissingStatus(users: UserProfile[]) {
 
 let intervalId: NodeJS.Timeout;
 
-export function startPeriodicStatusUpdates() {
-    return (dispatch: DispatchFunc) => {
+export function startPeriodicStatusUpdates(): ThunkActionFunc<void, GlobalState> { // HARRISONTODO unused
+    return (dispatch) => {
         clearInterval(intervalId);
 
         intervalId = setInterval(
@@ -131,6 +131,6 @@ export function startPeriodicStatusUpdates() {
     };
 }
 
-export function stopPeriodicStatusUpdates() {
+export function stopPeriodicStatusUpdates() { // HARRISONTODO used but does nothing
     clearInterval(intervalId);
 }

--- a/webapp/channels/src/actions/team_actions.ts
+++ b/webapp/channels/src/actions/team_actions.ts
@@ -15,7 +15,7 @@ import {getUser} from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {ActionFunc, DispatchFunc, GetStateFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 import {getHistory} from 'utils/browser_history';
 import {Preferences} from 'utils/constants';
@@ -88,8 +88,8 @@ export function addUsersToTeam(teamId: Team['id'], userIds: Array<UserProfile['i
     };
 }
 
-export function switchTeam(url: string, team?: Team) {
-    return (dispatch: DispatchFunc) => {
+export function switchTeam(url: string, team?: Team): ThunkActionFunc<void> {
+    return (dispatch) => {
         // In Channels, the team argument is undefined, and team switching is done by pushing a URL onto history.
         // In other products, a team is passed instead of a URL because the current team isn't tied to the page URL.
         //
@@ -103,8 +103,8 @@ export function switchTeam(url: string, team?: Team) {
     };
 }
 
-export function updateTeamsOrderForUser(teamIds: Array<Team['id']>) {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function updateTeamsOrderForUser(teamIds: Array<Team['id']>): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
         const teamOrderPreferences = [{
@@ -113,11 +113,11 @@ export function updateTeamsOrderForUser(teamIds: Array<Team['id']>) {
             category: Preferences.TEAMS_ORDER,
             value: teamIds.join(','),
         }];
-        dispatch(savePreferences(currentUserId, teamOrderPreferences));
+        return dispatch(savePreferences(currentUserId, teamOrderPreferences));
     };
 }
 
-export function getGroupMessageMembersCommonTeams(channelId: string): ActionFunc<Team[], ServerError> {
+export function getGroupMessageMembersCommonTeams(channelId: string): NewActionFuncAsync<Team[]> {
     return async (dispatch) => {
         let teams: Team[];
 

--- a/webapp/channels/src/actions/views/channel_sidebar.ts
+++ b/webapp/channels/src/actions/views/channel_sidebar.ts
@@ -45,10 +45,10 @@ export function createCategory(teamId: string, displayName: string, channelIds?:
             });
         }
 
-        const result: any = await dispatch(createCategoryRedux(teamId, displayName, channelIds));
+        const result = await dispatch(createCategoryRedux(teamId, displayName, channelIds));
         return dispatch({
             type: ActionTypes.ADD_NEW_CATEGORY_ID,
-            data: result.data.id,
+            data: result.data!.id,
         });
     };
 }

--- a/webapp/channels/src/actions/views/create_comment.tsx
+++ b/webapp/channels/src/actions/views/create_comment.tsx
@@ -143,7 +143,7 @@ export function submitCommand(channelId: string, rootId: string, draft: PostDraf
     };
 }
 
-export function makeOnSubmit(channelId: string, rootId: string, latestPostId: string): (draft: PostDraft, options?: {ignoreSlash?: boolean}) => NewActionFuncAsync {
+export function makeOnSubmit(channelId: string, rootId: string, latestPostId: string): (draft: PostDraft, options?: {ignoreSlash?: boolean}) => NewActionFuncAsync<boolean, GlobalState> {
     return (draft, options = {}) => async (dispatch, getState) => {
         const {message} = draft;
 

--- a/webapp/channels/src/actions/views/drafts.ts
+++ b/webapp/channels/src/actions/views/drafts.ts
@@ -14,7 +14,7 @@ import {Client4} from 'mattermost-redux/client';
 import Preferences from 'mattermost-redux/constants/preferences';
 import {syncedDraftsAreAllowedAndEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import type {NewActionFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {setGlobalItem} from 'actions/storage';
 import {makeGetDrafts} from 'selectors/drafts';
@@ -36,11 +36,11 @@ type Draft = {
  * Gets drafts stored on the server and reconciles them with any locally stored drafts.
  * @param teamId Only drafts for the given teamId will be fetched.
  */
-export function getDrafts(teamId: string) {
+export function getDrafts(teamId: string): NewActionFuncAsync<boolean, GlobalState> {
     const getLocalDrafts = makeGetDrafts(false);
 
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const state = getState() as GlobalState;
+    return async (dispatch, getState) => {
+        const state = getState();
 
         let serverDrafts: Draft[] = [];
         try {
@@ -70,14 +70,14 @@ export function getDrafts(teamId: string) {
     };
 }
 
-export function removeDraft(key: string, channelId: string, rootId = '') {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const state = getState() as GlobalState;
+export function removeDraft(key: string, channelId: string, rootId = ''): NewActionFuncAsync<boolean, GlobalState> {
+    return async (dispatch, getState) => {
+        const state = getState();
 
         dispatch(setGlobalItem(key, {message: '', fileInfos: [], uploadsInProgress: []}));
 
         if (syncedDraftsAreAllowedAndEnabled(state)) {
-            const connectionId = getConnectionId(getState() as GlobalState);
+            const connectionId = getConnectionId(getState());
 
             try {
                 await Client4.deleteDraft(channelId, rootId, connectionId);
@@ -92,9 +92,9 @@ export function removeDraft(key: string, channelId: string, rootId = '') {
     };
 }
 
-export function updateDraft(key: string, value: PostDraft|null, rootId = '', save = false) {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const state = getState() as GlobalState;
+export function updateDraft(key: string, value: PostDraft|null, rootId = '', save = false): NewActionFuncAsync<boolean, GlobalState> {
+    return async (dispatch, getState) => {
+        const state = getState();
         let updatedValue: PostDraft|null = null;
         if (value) {
             const timestamp = new Date().getTime();
@@ -139,8 +139,8 @@ function upsertDraft(draft: PostDraft, userId: UserProfile['id'], rootId = '', c
     return Client4.upsertDraft(newDraft, connectionId);
 }
 
-export function setDraftsTourTipPreference(initializationState: Record<string, boolean>): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function setDraftsTourTipPreference(initializationState: Record<string, boolean>): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
         const preference: PreferenceType = {
@@ -154,8 +154,8 @@ export function setDraftsTourTipPreference(initializationState: Record<string, b
     };
 }
 
-export function setGlobalDraft(key: string, value: PostDraft|null, isRemote: boolean) {
-    return (dispatch: DispatchFunc) => {
+export function setGlobalDraft(key: string, value: PostDraft|null, isRemote: boolean): NewActionFunc {
+    return (dispatch) => {
         dispatch(setGlobalItem(key, value));
         dispatch(setGlobalDraftSource(key, isRemote));
         return {data: true};

--- a/webapp/channels/src/actions/views/login.ts
+++ b/webapp/channels/src/actions/views/login.ts
@@ -9,10 +9,10 @@ import {UserTypes} from 'mattermost-redux/action_types';
 import {logError} from 'mattermost-redux/actions/errors';
 import {loadRolesIfNeeded} from 'mattermost-redux/actions/roles';
 import {Client4} from 'mattermost-redux/client';
-import type {ActionFunc, DispatchFunc} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
 
-export function login(loginId: string, password: string, mfaToken = ''): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
+export function login(loginId: string, password: string, mfaToken = ''): NewActionFuncAsync {
+    return async (dispatch) => {
         dispatch({type: UserTypes.LOGIN_REQUEST, data: null});
 
         try {
@@ -45,8 +45,8 @@ export function login(loginId: string, password: string, mfaToken = ''): ActionF
     };
 }
 
-export function loginWithDesktopToken(token: string): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
+export function loginWithDesktopToken(token: string): NewActionFuncAsync {
+    return async (dispatch) => {
         dispatch({type: UserTypes.LOGIN_REQUEST, data: null});
 
         try {
@@ -79,8 +79,8 @@ export function loginWithDesktopToken(token: string): ActionFunc {
     };
 }
 
-export function loginById(id: string, password: string): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
+export function loginById(id: string, password: string): NewActionFuncAsync {
+    return async (dispatch) => {
         dispatch({type: UserTypes.LOGIN_REQUEST, data: null});
 
         try {

--- a/webapp/channels/src/actions/views/profile_popover.ts
+++ b/webapp/channels/src/actions/views/profile_popover.ts
@@ -3,9 +3,9 @@
 
 import {getChannelMember} from 'mattermost-redux/actions/channels';
 import {getTeamMember} from 'mattermost-redux/actions/teams';
-import type {NewActionFuncOldVariantDoNotUse} from 'mattermost-redux/types/actions';
+import type {ThunkActionFunc} from 'mattermost-redux/types/actions';
 
-export function getMembershipForEntities(teamId: string, userId: string, channelId?: string): NewActionFuncOldVariantDoNotUse {
+export function getMembershipForEntities(teamId: string, userId: string, channelId?: string): ThunkActionFunc<unknown> {
     return (dispatch) => {
         return Promise.all([
             dispatch(getTeamMember(teamId, userId)),

--- a/webapp/channels/src/actions/views/rhs.ts
+++ b/webapp/channels/src/actions/views/rhs.ts
@@ -24,7 +24,7 @@ import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentTimezone} from 'mattermost-redux/selectors/entities/timezone';
 import {getCurrentUser, getCurrentUserMentionKeys} from 'mattermost-redux/selectors/entities/users';
-import type {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import type {DispatchFunc, GetStateFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {trackEvent} from 'actions/telemetry_actions.jsx';
 import {getSearchTerms, getRhsState, getPluggableId, getFilesSearchExtFilter, getPreviousRhsState} from 'selectors/rhs';
@@ -314,8 +314,8 @@ export function toggleRHSPlugin(pluggableId: string) {
     };
 }
 
-export function showFlaggedPosts() {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function showFlaggedPosts(): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const teamId = getCurrentTeamId(state);
 
@@ -325,7 +325,7 @@ export function showFlaggedPosts() {
         });
 
         const results = await dispatch(getFlaggedPosts());
-        let data: any;
+        let data;
         if ('data' in results) {
             data = results.data;
         }
@@ -349,9 +349,9 @@ export function showFlaggedPosts() {
     };
 }
 
-export function showPinnedPosts(channelId?: string) {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const state = getState() as GlobalState;
+export function showPinnedPosts(channelId?: string): NewActionFuncAsync<boolean, GlobalState> {
+    return async (dispatch, getState) => {
+        const state = getState();
         const currentChannelId = getCurrentChannelId(state);
         const teamId = getCurrentTeamId(state);
 
@@ -368,7 +368,7 @@ export function showPinnedPosts(channelId?: string) {
 
         const results = await dispatch(getPinnedPosts(channelId || currentChannelId));
 
-        let data: any;
+        let data;
         if ('data' in results) {
             data = results.data;
         }

--- a/webapp/channels/src/components/admin_console/plugin_management/plugin_management.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_management/plugin_management.tsx
@@ -11,6 +11,7 @@ import type {AdminConfig} from '@mattermost/types/config';
 import type {DeepPartial} from '@mattermost/types/utilities';
 
 import PluginState from 'mattermost-redux/constants/plugins';
+import type {ActionResult} from 'mattermost-redux/types/actions';
 
 import ConfirmModal from 'components/confirm_modal';
 import ExternalLink from 'components/external_link';
@@ -460,13 +461,13 @@ type Props = BaseProps & {
     plugins: any;
     appsFeatureFlagEnabled: boolean;
     actions: {
-        uploadPlugin: (fileData: File, force: boolean) => any;
-        removePlugin: (pluginId: string) => any;
-        getPlugins: () => unknown;
-        getPluginStatuses: () => any;
-        enablePlugin: (pluginId: string) => any;
-        disablePlugin: (pluginId: string) => any;
-        installPluginFromUrl: (url: string, force: boolean) => any;
+        uploadPlugin: (fileData: File, force: boolean) => Promise<ActionResult>;
+        removePlugin: (pluginId: string) => Promise<ActionResult>;
+        getPlugins: () => Promise<ActionResult>;
+        getPluginStatuses: () => Promise<ActionResult>;
+        enablePlugin: (pluginId: string) => Promise<ActionResult>;
+        disablePlugin: (pluginId: string) => Promise<ActionResult>;
+        installPluginFromUrl: (url: string, force: boolean) => Promise<ActionResult>;
     };
 } & WrappedComponentProps;
 

--- a/webapp/channels/src/components/admin_console/system_users/revoke_sessions_button/index.tsx
+++ b/webapp/channels/src/components/admin_console/system_users/revoke_sessions_button/index.tsx
@@ -5,11 +5,8 @@ import React, {useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useDispatch} from 'react-redux';
 
-import type {ServerError} from '@mattermost/types/errors';
-
 import {revokeSessionsForAllUsers} from 'mattermost-redux/actions/users';
 import {Permissions} from 'mattermost-redux/constants';
-import type {ActionResult} from 'mattermost-redux/types/actions';
 
 import {emitUserLoggedOutEvent} from 'actions/global_actions';
 
@@ -26,7 +23,7 @@ function RevokeSessionsButton() {
     }
 
     async function handleModalConfirm() {
-        const {data} = await dispatch(revokeSessionsForAllUsers()) as ActionResult<boolean, ServerError>;
+        const {data} = await dispatch(revokeSessionsForAllUsers());
 
         if (data) {
             emitUserLoggedOutEvent();

--- a/webapp/channels/src/components/advanced_create_post/index.ts
+++ b/webapp/channels/src/components/advanced_create_post/index.ts
@@ -30,7 +30,7 @@ import {get, getInt, getBool, isCustomGroupsEnabled} from 'mattermost-redux/sele
 import {haveICurrentChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, getStatusForUserId, getUser, isCurrentUserGuestUser} from 'mattermost-redux/selectors/entities/users';
-import type {GetStateFunc, DispatchFunc} from 'mattermost-redux/types/actions.js';
+import type {NewActionFuncAsync} from 'mattermost-redux/types/actions.js';
 
 import {executeCommand} from 'actions/command';
 import {runMessageWillBePostedHooks, runSlashCommandWillBePostedHooks} from 'actions/hooks';
@@ -142,8 +142,8 @@ function onSubmitPost(post: Post, fileInfos: FileInfo[]) {
     };
 }
 
-function setDraft(key: string, value: PostDraft | null, draftChannelId: string, save = false) {
-    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+function setDraft(key: string, value: PostDraft | null, draftChannelId: string, save = false): NewActionFuncAsync<boolean, GlobalState> {
+    return (dispatch, getState) => {
         const channelId = draftChannelId || getCurrentChannelId(getState());
         let updatedValue = null;
         if (value) {

--- a/webapp/channels/src/components/announcement_bar/configuration_bar/configuration_bar.tsx
+++ b/webapp/channels/src/components/announcement_bar/configuration_bar/configuration_bar.tsx
@@ -10,6 +10,8 @@ import {Link} from 'react-router-dom';
 import type {ClientConfig, WarnMetricStatus} from '@mattermost/types/config';
 import type {PreferenceType} from '@mattermost/types/preferences';
 
+import type {ActionResult} from 'mattermost-redux/types/actions';
+
 import {trackEvent} from 'actions/telemetry_actions';
 
 import PurchaseLink from 'components/announcement_bar/purchase_link/purchase_link';
@@ -45,9 +47,7 @@ type Props = {
     warnMetricsStatus?: Record<string, WarnMetricStatus>;
     actions: {
         dismissNotice: (notice: string) => void;
-        savePreferences: (userId: string, preferences: PreferenceType[]) => Promise<{
-            data: boolean;
-        }>;
+        savePreferences: (userId: string, preferences: PreferenceType[]) => Promise<ActionResult>;
     };
 };
 

--- a/webapp/channels/src/components/apps_form/apps_form_component.tsx
+++ b/webapp/channels/src/components/apps_form/apps_form_component.tsx
@@ -111,7 +111,7 @@ export class AppsForm extends React.PureComponent<Props, State> {
 
         if (fieldErrors && Object.keys(fieldErrors).length >= 0) {
             hasErrors = true;
-            if (checkIfErrorsMatchElements(fieldErrors as any, elements)) {
+            if (checkIfErrorsMatchElements(fieldErrors, elements)) {
                 state.fieldErrors = {};
                 for (const [key, value] of Object.entries(fieldErrors)) {
                     state.fieldErrors[key] = (<Markdown message={value}/>);

--- a/webapp/channels/src/components/browse_channels/browse_channels.tsx
+++ b/webapp/channels/src/components/browse_channels/browse_channels.tsx
@@ -201,7 +201,7 @@ export default class BrowseChannels extends React.PureComponent<Props, State> {
         const searchTimeoutId = window.setTimeout(
             async () => {
                 try {
-                    const {data} = await this.props.actions.searchAllChannels(term, {team_ids: [this.props.teamId], nonAdminSearch: true, include_deleted: true}) as ActionResult<Channel[]>; // HARRISONTODO
+                    const {data} = await this.props.actions.searchAllChannels(term, {team_ids: [this.props.teamId], nonAdminSearch: true, include_deleted: true}) as ActionResult<Channel[]>;
                     if (searchTimeoutId !== this.searchTimeoutId) {
                         return;
                     }

--- a/webapp/channels/src/components/channel_layout/channel_identifier_router/actions.ts
+++ b/webapp/channels/src/components/channel_layout/channel_identifier_router/actions.ts
@@ -12,7 +12,7 @@ import {Client4} from 'mattermost-redux/client';
 import {getChannelByName, getOtherChannels, getChannel, getChannelsNameMapInTeam, getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
 import {getTeamByName} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser, getCurrentUserId, getUserByUsername as selectUserByUsername, getUser as selectUser, getUserByEmail as selectUserByEmail} from 'mattermost-redux/selectors/entities/users';
-import type {GetStateFunc, DispatchFunc, ActionFunc} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
 import * as UserUtils from 'mattermost-redux/utils/user_utils';
 
 import {openDirectChannelToUserId} from 'actions/channel_actions';
@@ -29,8 +29,8 @@ const LENGTH_OF_GROUP_ID = 40;
 const LENGTH_OF_USER_ID_PAIR = 54;
 const USER_ID_PAIR_REGEXP = new RegExp(`^[a-zA-Z0-9]{${LENGTH_OF_ID}}__[a-zA-Z0-9]{${LENGTH_OF_ID}}$`);
 
-export function onChannelByIdentifierEnter({match, history}: MatchAndHistory): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function onChannelByIdentifierEnter({match, history}: MatchAndHistory): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const {path, identifier, team} = match.params;
 
@@ -124,8 +124,8 @@ export async function getPathFromIdentifier(state: GlobalState, path: string, id
     return 'error';
 }
 
-export function goToChannelByChannelId(match: Match, history: History): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function goToChannelByChannelId(match: Match, history: History): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
         const channelId = identifier.toLowerCase();
@@ -140,7 +140,7 @@ export function goToChannelByChannelId(match: Match, history: History): ActionFu
                 handleChannelJoinError(match, history, getRedirectChannelNameForTeam(state, teamObj!.id));
                 return {data: undefined};
             }
-            channel = dispatchResult.data.channel;
+            channel = dispatchResult.data!.channel;
         }
 
         if (channel.type === Constants.DM_CHANNEL) {
@@ -154,8 +154,8 @@ export function goToChannelByChannelId(match: Match, history: History): ActionFu
     };
 }
 
-export function goToChannelByChannelName(match: Match, history: History): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function goToChannelByChannelName(match: Match, history: History): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
         const channelName = identifier.toLowerCase();
@@ -169,7 +169,7 @@ export function goToChannelByChannelName(match: Match, history: History): Action
         if (!channel) {
             const getChannelDispatchResult = await dispatch(getChannelByNameAndTeamName(team, channelName, true));
             if ('data' in getChannelDispatchResult) {
-                channel = getChannelDispatchResult.data;
+                channel = getChannelDispatchResult.data!;
             }
         }
 
@@ -191,7 +191,7 @@ export function goToChannelByChannelName(match: Match, history: History): Action
             if (isSystemAdmin) {
                 if (channel?.type === Constants.PRIVATE_CHANNEL) {
                     const joinPromptResult = await dispatch(joinPrivateChannelPrompt(teamObj, channel.display_name));
-                    if ('data' in joinPromptResult && !joinPromptResult.data.join) {
+                    if ('data' in joinPromptResult && !joinPromptResult.data!.join) {
                         return {data: undefined};
                     }
                 }
@@ -201,15 +201,15 @@ export function goToChannelByChannelName(match: Match, history: History): Action
             if ('error' in joinChannelDispatchResult) {
                 if (!channel) {
                     const getChannelDispatchResult = await dispatch(getChannelByNameAndTeamName(team, channelName, true));
-                    if ('error' in getChannelDispatchResult || getChannelDispatchResult.data.delete_at === 0) {
+                    if ('error' in getChannelDispatchResult || getChannelDispatchResult.data!.delete_at === 0) {
                         await dispatch(fetchChannelsAndMembers(teamObj!.id));
                         handleChannelJoinError(match, history, getRedirectChannelNameForTeam(state, teamObj!.id));
                         return {data: undefined};
                     }
-                    channel = getChannelDispatchResult.data;
+                    channel = getChannelDispatchResult.data!;
                 }
             } else {
-                channel = joinChannelDispatchResult.data.channel;
+                channel = joinChannelDispatchResult.data!.channel;
             }
         }
 
@@ -224,8 +224,8 @@ export function goToChannelByChannelName(match: Match, history: History): Action
     };
 }
 
-function goToDirectChannelByUsername(match: Match, history: History): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+function goToDirectChannelByUsername(match: Match, history: History): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
         const username = identifier.slice(1, identifier.length).toLowerCase();
@@ -239,7 +239,7 @@ function goToDirectChannelByUsername(match: Match, history: History): ActionFunc
                 handleError(match, history, getRedirectChannelNameForTeam(state, teamObj!.id));
                 return {data: undefined};
             }
-            user = dispatchResult.data;
+            user = dispatchResult.data!;
         }
 
         const directChannelDispatchRes = await dispatch(openDirectChannelToUserId(user.id));
@@ -249,13 +249,13 @@ function goToDirectChannelByUsername(match: Match, history: History): ActionFunc
             return {data: undefined};
         }
 
-        doChannelChange(directChannelDispatchRes.data);
+        doChannelChange(directChannelDispatchRes.data!);
         return {data: undefined};
     };
 }
 
-export function goToDirectChannelByUserId(match: Match, history: History, userId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function goToDirectChannelByUserId(match: Match, history: History, userId: string): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const {team} = match.params;
         const teamObj = getTeamByName(state, team);
@@ -268,7 +268,7 @@ export function goToDirectChannelByUserId(match: Match, history: History, userId
                 handleError(match, history, getRedirectChannelNameForTeam(state, teamObj!.id));
                 return {data: undefined};
             }
-            user = dispatchResult.data;
+            user = dispatchResult.data!;
         }
 
         history.replace(`/${team}/messages/@${user.username}`);
@@ -276,8 +276,8 @@ export function goToDirectChannelByUserId(match: Match, history: History, userId
     };
 }
 
-export function goToDirectChannelByUserIds(match: Match, history: History): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function goToDirectChannelByUserIds(match: Match, history: History): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
         const userId = Utils.getUserIdFromChannelId(identifier.toLowerCase(), getCurrentUserId(getState()));
@@ -291,7 +291,7 @@ export function goToDirectChannelByUserIds(match: Match, history: History): Acti
                 handleError(match, history, getRedirectChannelNameForTeam(state, teamObj!.id));
                 return {data: undefined};
             }
-            user = dispatchResult.data;
+            user = dispatchResult.data!;
         }
 
         history.replace(`/${team}/messages/@${user.username}`);
@@ -299,8 +299,8 @@ export function goToDirectChannelByUserIds(match: Match, history: History): Acti
     };
 }
 
-export function goToDirectChannelByEmail(match: Match, history: History): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function goToDirectChannelByEmail(match: Match, history: History): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
         const email = identifier.toLowerCase();
@@ -314,7 +314,7 @@ export function goToDirectChannelByEmail(match: Match, history: History): Action
                 handleError(match, history, getRedirectChannelNameForTeam(state, teamObj!.id));
                 return {data: undefined};
             }
-            user = dispatchResult.data;
+            user = dispatchResult.data!;
         }
 
         history.replace(`/${team}/messages/@${user.username}`);
@@ -322,8 +322,8 @@ export function goToDirectChannelByEmail(match: Match, history: History): Action
     };
 }
 
-function goToGroupChannelByGroupId(match: Match, history: History): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+function goToGroupChannelByGroupId(match: Match, history: History): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const {identifier, team} = match.params;
         const groupId = identifier.toLowerCase();
@@ -339,7 +339,7 @@ function goToGroupChannelByGroupId(match: Match, history: History): ActionFunc {
                 handleError(match, history, getRedirectChannelNameForTeam(state, teamObj!.id));
                 return {data: undefined};
             }
-            channel = dispatchResult.data.channel;
+            channel = dispatchResult.data!.channel;
         }
 
         dispatch(markGroupChannelOpen(channel!.id));

--- a/webapp/channels/src/components/cloud_start_trial/cloud_start_trial_btn.tsx
+++ b/webapp/channels/src/components/cloud_start_trial/cloud_start_trial_btn.tsx
@@ -6,8 +6,6 @@ import type {ReactNode} from 'react';
 import {useIntl} from 'react-intl';
 import {useDispatch} from 'react-redux';
 
-import type {DispatchFunc} from 'mattermost-redux/types/actions';
-
 import {requestCloudTrial, validateWorkspaceBusinessEmail, getCloudLimits} from 'actions/cloud';
 import {trackEvent} from 'actions/telemetry_actions';
 import {openModal, closeModal} from 'actions/views/modals';
@@ -52,7 +50,7 @@ const CloudStartTrialButton = ({
     disabled = false,
 }: CloudStartTrialBtnProps) => {
     const {formatMessage} = useIntl();
-    const dispatch = useDispatch<DispatchFunc>();
+    const dispatch = useDispatch();
     const subscription = useGetSubscription();
     const [openBusinessEmailModal, setOpenBusinessEmailModal] = useState(false);
     const [status, setLoadStatus] = useState(TrialLoadStatus.NotStarted);

--- a/webapp/channels/src/components/common/hooks/usePreference.ts
+++ b/webapp/channels/src/components/common/hooks/usePreference.ts
@@ -9,10 +9,10 @@ import type {PreferenceType} from '@mattermost/types/preferences';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 import {getMyPreferences} from 'mattermost-redux/selectors/entities/preferences';
-import type {ActionFunc} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
 import {getPreferenceKey} from 'mattermost-redux/utils/preference_utils';
 
-export default function usePreference(category: string, name: string): [string | undefined, (value: string) => ActionFunc] {
+export default function usePreference(category: string, name: string): [string | undefined, (value: string) => NewActionFuncAsync] {
     const dispatch = useDispatch();
 
     const userId = useSelector(getCurrentUserId);

--- a/webapp/channels/src/components/common/hooks/usePreference.ts
+++ b/webapp/channels/src/components/common/hooks/usePreference.ts
@@ -9,10 +9,10 @@ import type {PreferenceType} from '@mattermost/types/preferences';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 import {getMyPreferences} from 'mattermost-redux/selectors/entities/preferences';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionResult} from 'mattermost-redux/types/actions';
 import {getPreferenceKey} from 'mattermost-redux/utils/preference_utils';
 
-export default function usePreference(category: string, name: string): [string | undefined, (value: string) => NewActionFuncAsync] {
+export default function usePreference(category: string, name: string): [string | undefined, (value: string) => Promise<ActionResult>] {
     const dispatch = useDispatch();
 
     const userId = useSelector(getCurrentUserId);

--- a/webapp/channels/src/components/convert_gm_to_channel_modal/convert_gm_to_channel_modal.tsx
+++ b/webapp/channels/src/components/convert_gm_to_channel_modal/convert_gm_to_channel_modal.tsx
@@ -11,11 +11,9 @@ import './convert_gm_to_channel_modal.scss';
 
 import {GenericModal} from '@mattermost/components';
 import type {Channel} from '@mattermost/types/channels';
-import type {ServerError} from '@mattermost/types/errors';
 import type {Team} from '@mattermost/types/teams';
 import type {UserProfile} from '@mattermost/types/users';
 
-import type {ActionResult} from 'mattermost-redux/types/actions';
 import {displayUsername} from 'mattermost-redux/utils/user_utils';
 
 import {getGroupMessageMembersCommonTeams} from 'actions/team_actions';
@@ -85,7 +83,7 @@ const ConvertGmToChannelModal = (props: Props) => {
 
     useEffect(() => {
         const work = async () => {
-            const response = await dispatch(getGroupMessageMembersCommonTeams(props.channel.id)) as ActionResult<Team[], ServerError>;
+            const response = await dispatch(getGroupMessageMembersCommonTeams(props.channel.id));
             if (!mounted.current) {
                 return;
             }

--- a/webapp/channels/src/components/integrations/commands_container/commands_container.tsx
+++ b/webapp/channels/src/components/integrations/commands_container/commands_container.tsx
@@ -9,6 +9,8 @@ import type {Team} from '@mattermost/types/teams';
 import type {UserProfile} from '@mattermost/types/users';
 import type {RelationOneToOne} from '@mattermost/types/utilities';
 
+import type {ActionResult} from 'mattermost-redux/types/actions';
+
 import AddCommand from 'components/integrations/add_command';
 import ConfirmIntegration from 'components/integrations/confirm_integration';
 import EditCommand from 'components/integrations/edit_command';
@@ -72,7 +74,7 @@ type Props = {
         /**
          * The function to call to fetch team commands
          */
-        loadCommandsAndProfilesForTeam: (teamId: string) => any; // TechDebt-TODO: This needs to be changed to 'Promise<void>'
+        loadCommandsAndProfilesForTeam: (teamId: string) => Promise<ActionResult>;
     };
 
     /**

--- a/webapp/channels/src/components/interactive_dialog/interactive_dialog.tsx
+++ b/webapp/channels/src/components/interactive_dialog/interactive_dialog.tsx
@@ -5,9 +5,9 @@ import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
-import type {DialogSubmission, DialogElement as TDialogElement} from '@mattermost/types/integrations';
+import type {DialogSubmission, SubmitDialogResponse, DialogElement as TDialogElement} from '@mattermost/types/integrations';
 
-import type {ActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionResult} from 'mattermost-redux/types/actions';
 import {
     checkDialogElementForError,
     checkIfErrorsMatchElements,
@@ -33,7 +33,7 @@ export type Props = {
     state?: string;
     onExited?: () => void;
     actions: {
-        submitInteractiveDialog: (submission: DialogSubmission) => ActionFunc;
+        submitInteractiveDialog: (submission: DialogSubmission) => Promise<ActionResult<SubmitDialogResponse>>;
     };
     emojiMap: EmojiMap;
 }
@@ -42,7 +42,7 @@ type State = {
     show: boolean;
     values: Record<string, string | number | boolean>;
     error: string | null;
-    errors: Record<string, JSX.Element>;
+    errors: Record<string, React.ReactNode>;
     submitting: boolean;
 }
 
@@ -116,7 +116,7 @@ export default class InteractiveDialog extends React.PureComponent<Props, State>
 
         this.setState({submitting: true});
 
-        const {data}: any = await this.props.actions.submitInteractiveDialog(dialog) ?? {};
+        const {data} = await this.props.actions.submitInteractiveDialog(dialog) ?? {};
 
         this.setState({submitting: false});
 

--- a/webapp/channels/src/components/login/login.test.tsx
+++ b/webapp/channels/src/components/login/login.test.tsx
@@ -9,7 +9,6 @@ import {MemoryRouter} from 'react-router-dom';
 import type {ClientConfig} from '@mattermost/types/config';
 
 import {RequestStatus} from 'mattermost-redux/constants';
-import type {ActionFunc} from 'mattermost-redux/types/actions';
 
 import LocalStorageStore from 'stores/local_storage_store';
 
@@ -35,7 +34,7 @@ let mockConfig: Partial<ClientConfig>;
 jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux') as typeof import('react-redux'),
     useSelector: (selector: (state: typeof mockState) => unknown) => selector(mockState),
-    useDispatch: jest.fn(() => (action: ActionFunc) => action),
+    useDispatch: jest.fn(() => (action: unknown) => action),
 }));
 
 jest.mock('react-router-dom', () => ({

--- a/webapp/channels/src/components/new_channel_modal/new_channel_modal.tsx
+++ b/webapp/channels/src/components/new_channel_modal/new_channel_modal.tsx
@@ -19,7 +19,6 @@ import Preferences from 'mattermost-redux/constants/preferences';
 import {get as getPreference} from 'mattermost-redux/selectors/entities/preferences';
 import {haveICurrentChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
-import type {DispatchFunc} from 'mattermost-redux/types/actions';
 
 import {switchToChannel} from 'actions/views/channel';
 import {closeModal} from 'actions/views/modals';
@@ -64,7 +63,7 @@ const NewChannelModal = () => {
 
     const canCreatePublicChannel = useSelector((state: GlobalState) => (currentTeamId ? haveICurrentChannelPermission(state, Permissions.CREATE_PUBLIC_CHANNEL) : false));
     const canCreatePrivateChannel = useSelector((state: GlobalState) => (currentTeamId ? haveICurrentChannelPermission(state, Permissions.CREATE_PRIVATE_CHANNEL) : false));
-    const dispatch = useDispatch<DispatchFunc>();
+    const dispatch = useDispatch();
 
     const [type, setType] = useState(getChannelTypeFromPermissions(canCreatePublicChannel, canCreatePrivateChannel));
     const [displayName, setDisplayName] = useState('');
@@ -123,13 +122,13 @@ const NewChannelModal = () => {
             // If template selected, create a new board from this template
             if (canCreateFromPluggable && createBoardFromChannelPlugin) {
                 try {
-                    addBoardToChannel(newChannel.id);
+                    addBoardToChannel(newChannel!.id);
                 } catch (e: any) {
                     // eslint-disable-next-line no-console
                     console.log(e.message);
                 }
             }
-            dispatch(switchToChannel(newChannel));
+            dispatch(switchToChannel(newChannel!));
         } catch (e) {
             onCreateChannelError({message: formatMessage({id: 'channel_modal.error.generic', defaultMessage: 'Something went wrong. Please try again.'})});
         }

--- a/webapp/channels/src/components/plugin_marketplace/marketplace_modal.test.tsx
+++ b/webapp/channels/src/components/plugin_marketplace/marketplace_modal.test.tsx
@@ -7,8 +7,6 @@ import React from 'react';
 import type {MarketplacePlugin} from '@mattermost/types/marketplace';
 import {AuthorType, ReleaseStage} from '@mattermost/types/marketplace';
 
-import type {ActionFunc} from 'mattermost-redux/types/actions';
-
 import {ModalIdentifiers} from 'utils/constants';
 
 import type {GlobalState} from 'types/store';
@@ -22,7 +20,7 @@ let mockState: GlobalState;
 jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux') as typeof import('react-redux'),
     useSelector: (selector: (state: typeof mockState) => unknown) => selector(mockState),
-    useDispatch: jest.fn(() => (action: ActionFunc) => action),
+    useDispatch: jest.fn(() => (action: unknown) => action),
 }));
 
 describe('components/marketplace/', () => {

--- a/webapp/channels/src/components/plugin_marketplace/marketplace_modal.tsx
+++ b/webapp/channels/src/components/plugin_marketplace/marketplace_modal.tsx
@@ -18,7 +18,6 @@ import {getPluginStatuses} from 'mattermost-redux/actions/admin';
 import {setFirstAdminVisitMarketplaceStatus} from 'mattermost-redux/actions/general';
 import {getFirstAdminVisitMarketplaceStatus, getLicense} from 'mattermost-redux/selectors/entities/general';
 import {streamlinedMarketplaceEnabled} from 'mattermost-redux/selectors/entities/preferences';
-import type {ActionResult} from 'mattermost-redux/types/actions';
 
 import {fetchListing, filterListing} from 'actions/marketplace';
 import {trackEvent} from 'actions/telemetry_actions.jsx';
@@ -82,7 +81,7 @@ const MarketplaceModal = ({
     const [serverError, setServerError] = React.useState(false);
 
     const doFetchListing = useCallback(async () => {
-        const {error} = await dispatch(fetchListing()) as ActionResult;
+        const {error} = await dispatch(fetchListing());
 
         if (error) {
             setServerError(true);
@@ -94,7 +93,7 @@ const MarketplaceModal = ({
     const doSearch = useCallback(async () => {
         trackEvent('plugins', 'ui_marketplace_search', {filter});
 
-        const {error} = await dispatch(filterListing(filter)) as ActionResult;
+        const {error} = await dispatch(filterListing(filter));
 
         if (error) {
             setServerError(true);

--- a/webapp/channels/src/components/post/actions.ts
+++ b/webapp/channels/src/components/post/actions.ts
@@ -3,7 +3,7 @@
 
 import {removePost} from 'mattermost-redux/actions/posts';
 import type {ExtendedPost} from 'mattermost-redux/actions/posts';
-import type {DispatchFunc} from 'mattermost-redux/types/actions';
+import type {NewActionFunc} from 'mattermost-redux/types/actions';
 
 import {removeDraft} from 'actions/views/drafts';
 import {closeRightHandSide} from 'actions/views/rhs';
@@ -18,8 +18,8 @@ import type {GlobalState} from 'types/store';
  * This action is called when the deleted post which is shown as 'deleted' in the RHS is then removed from the channel manually.
  * @param post Deleted post
  */
-export function removePostCloseRHSDeleteDraft(post: ExtendedPost) {
-    return (dispatch: DispatchFunc, getState: () => GlobalState) => {
+export function removePostCloseRHSDeleteDraft(post: ExtendedPost): NewActionFunc<boolean, GlobalState> {
+    return (dispatch, getState) => {
         if (isThreadOpen(getState(), post.id)) {
             dispatch(closeRightHandSide());
         }

--- a/webapp/channels/src/components/post_view/combined_system_message/combined_system_message.test.tsx
+++ b/webapp/channels/src/components/post_view/combined_system_message/combined_system_message.test.tsx
@@ -6,7 +6,6 @@ import React from 'react';
 import type {UserProfile} from '@mattermost/types/users';
 
 import {General, Posts} from 'mattermost-redux/constants';
-import type {ActionFunc} from 'mattermost-redux/types/actions';
 
 import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
@@ -14,7 +13,6 @@ import CombinedSystemMessage from './combined_system_message';
 import type {CombinedSystemMessage as CombinedSystemMessageType} from './combined_system_message';
 
 describe('components/post_view/CombinedSystemMessage', () => {
-    function emptyFunc() {} // eslint-disable-line no-empty-function
     const userProfiles = [
         {id: 'added_user_id_1', username: 'AddedUser1'},
         {id: 'added_user_id_2', username: 'AddedUser2'},
@@ -48,8 +46,8 @@ describe('components/post_view/CombinedSystemMessage', () => {
         teammateNameDisplay: General.TEAMMATE_NAME_DISPLAY.SHOW_USERNAME,
         userProfiles,
         actions: {
-            getMissingProfilesByIds: emptyFunc as unknown as (userIds: string[]) => ActionFunc,
-            getMissingProfilesByUsernames: emptyFunc as unknown as (usernames: string[]) => ActionFunc,
+            getMissingProfilesByIds: jest.fn(),
+            getMissingProfilesByUsernames: jest.fn(),
         },
     };
 

--- a/webapp/channels/src/components/profile_popover_call_button/profile_popover_call_button.tsx
+++ b/webapp/channels/src/components/profile_popover_call_button/profile_popover_call_button.tsx
@@ -7,7 +7,6 @@ import {useDispatch} from 'react-redux';
 import type {Channel, ChannelMembership} from '@mattermost/types/channels';
 
 import {createDirectChannel} from 'mattermost-redux/actions/channels';
-import type {ActionResult} from 'mattermost-redux/types/actions';
 
 import {Constants} from 'utils/constants';
 
@@ -44,7 +43,7 @@ export default function ProfilePopoverCallButton({pluginCallComponents, channelM
 
     const getDmChannel = async () => {
         if (!dmChannel) {
-            const {data} = await dispatch(createDirectChannel(currentUserId, userId)) as ActionResult;
+            const {data} = await dispatch(createDirectChannel(currentUserId, userId));
             if (data) {
                 return data;
             }

--- a/webapp/channels/src/components/self_hosted_purchases/self_hosted_purchase_modal/index.tsx
+++ b/webapp/channels/src/components/self_hosted_purchases/self_hosted_purchase_modal/index.tsx
@@ -22,7 +22,6 @@ import {getLicense} from 'mattermost-redux/selectors/entities/general';
 import {getSelfHostedProducts, getSelfHostedSignupProgress} from 'mattermost-redux/selectors/entities/hosted_customer';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
-import type {DispatchFunc} from 'mattermost-redux/types/actions';
 
 import {confirmSelfHostedSignup} from 'actions/hosted_customer';
 import {trackEvent, pageVisited} from 'actions/telemetry_actions';
@@ -328,7 +327,7 @@ export default function SelfHostedPurchaseModal(props: Props) {
     });
 
     const [state, dispatch] = useReducer(reducer, initialState);
-    const reduxDispatch = useDispatch<DispatchFunc>();
+    const reduxDispatch = useDispatch();
 
     const cardRef = useRef<CardInputType | null>(null);
     const modalRef = useRef();

--- a/webapp/channels/src/components/sidebar/sidebar_category/index.ts
+++ b/webapp/channels/src/components/sidebar/sidebar_category/index.ts
@@ -10,7 +10,6 @@ import type {ChannelCategory} from '@mattermost/types/channel_categories';
 import {setCategoryCollapsed, setCategorySorting} from 'mattermost-redux/actions/channel_categories';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {getCurrentUser, getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 import {isAdmin} from 'mattermost-redux/utils/user_utils';
 
 import {getDraggingState, makeGetFilteredChannelIdsForCategory} from 'selectors/views/channel_sidebar';
@@ -36,7 +35,7 @@ function makeMapStateToProps() {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             setCategoryCollapsed,

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_direct_channel/sidebar_direct_channel.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_direct_channel/sidebar_direct_channel.tsx
@@ -10,6 +10,7 @@ import type {PreferenceType} from '@mattermost/types/preferences';
 import type {UserProfile} from '@mattermost/types/users';
 
 import {Client4} from 'mattermost-redux/client';
+import type {ActionResult} from 'mattermost-redux/types/actions';
 
 import {trackEvent} from 'actions/telemetry_actions';
 
@@ -29,7 +30,7 @@ type Props = {
     redirectChannel: string;
     active: boolean;
     actions: {
-        savePreferences: (userId: string, preferences: PreferenceType[]) => Promise<{data: boolean}>;
+        savePreferences: (userId: string, preferences: PreferenceType[]) => Promise<ActionResult>;
         leaveDirectChannel: (channelId: string) => Promise<{data: boolean}>;
     };
 };

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_group_channel/sidebar_group_channel.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_group_channel/sidebar_group_channel.tsx
@@ -6,6 +6,8 @@ import React, {memo, useCallback} from 'react';
 import type {Channel} from '@mattermost/types/channels';
 import type {PreferenceType} from '@mattermost/types/preferences';
 
+import type {ActionResult} from 'mattermost-redux/types/actions';
+
 import {trackEvent} from 'actions/telemetry_actions';
 
 import SidebarChannelLink from 'components/sidebar/sidebar_channel/sidebar_channel_link';
@@ -21,7 +23,7 @@ type Props = {
     active: boolean;
     membersCount: number;
     actions: {
-        savePreferences: (userId: string, preferences: PreferenceType[]) => Promise<{data: boolean}>;
+        savePreferences: (userId: string, preferences: PreferenceType[]) => Promise<ActionResult>;
     };
 };
 

--- a/webapp/channels/src/components/signup/signup.tsx
+++ b/webapp/channels/src/components/signup/signup.tsx
@@ -18,7 +18,6 @@ import {Client4} from 'mattermost-redux/client';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 import {getIsOnboardingFlowEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {DispatchFunc} from 'mattermost-redux/types/actions';
 import {isEmail} from 'mattermost-redux/utils/helpers';
 
 import {redirectUserToDefaultTeam} from 'actions/global_actions';
@@ -71,7 +70,7 @@ type SignupProps = {
 const Signup = ({onCustomizeHeader}: SignupProps) => {
     const intl = useIntl();
     const {formatMessage} = intl;
-    const dispatch = useDispatch<DispatchFunc>();
+    const dispatch = useDispatch();
     const history = useHistory();
     const {search} = useLocation();
 
@@ -607,7 +606,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
                 return;
             }
 
-            await handleSignupSuccess(user, data as UserProfile);
+            await handleSignupSuccess(user, data as UserProfile); // HARRISONTODO remove type assertion
             if (subscribeToSecurityNewsletter) {
                 subscribeToSecurityNewsletterFunc();
             }

--- a/webapp/channels/src/components/signup/signup.tsx
+++ b/webapp/channels/src/components/signup/signup.tsx
@@ -606,7 +606,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
                 return;
             }
 
-            await handleSignupSuccess(user, data as UserProfile); // HARRISONTODO remove type assertion
+            await handleSignupSuccess(user, data!);
             if (subscribeToSecurityNewsletter) {
                 subscribeToSecurityNewsletterFunc();
             }

--- a/webapp/channels/src/components/system_notice/system_notice.tsx
+++ b/webapp/channels/src/components/system_notice/system_notice.tsx
@@ -14,7 +14,7 @@ import MattermostLogo from 'components/widgets/icons/mattermost_logo';
 
 import {Preferences} from 'utils/constants';
 
-interface Props extends WrappedComponentProps {
+export interface Props extends WrappedComponentProps {
     currentUserId: string;
     notices: Notice[];
     preferences: {[key: string]: any};

--- a/webapp/channels/src/components/team_controller/actions/index.ts
+++ b/webapp/channels/src/components/team_controller/actions/index.ts
@@ -13,15 +13,16 @@ import {getTeamByName, selectTeam} from 'mattermost-redux/actions/teams';
 import {getLicense} from 'mattermost-redux/selectors/entities/general';
 import {isCustomGroupsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
-import type {ActionFunc} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {loadStatusesForChannelAndSidebar} from 'actions/status_actions';
 import {addUserToTeam} from 'actions/team_actions';
 import LocalStorageStore from 'stores/local_storage_store';
 
 import {isSuccess} from 'types/actions';
+import type {GlobalState} from 'types/store';
 
-export function initializeTeam(team: Team): ActionFunc<Team, ServerError> {
+export function initializeTeam(team: Team): NewActionFuncAsync<Team, GlobalState> {
     return async (dispatch, getState) => {
         dispatch(selectTeam(team.id));
 
@@ -76,7 +77,7 @@ export function initializeTeam(team: Team): ActionFunc<Team, ServerError> {
     };
 }
 
-export function joinTeam(teamname: string, joinedOnFirstLoad: boolean): ActionFunc<Team, ServerError> {
+export function joinTeam(teamname: string, joinedOnFirstLoad: boolean): NewActionFuncAsync<Team, GlobalState> {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUser = getCurrentUser(state);

--- a/webapp/channels/src/components/threading/thread_viewer/thread_viewer.tsx
+++ b/webapp/channels/src/components/threading/thread_viewer/thread_viewer.tsx
@@ -9,7 +9,7 @@ import type {Channel} from '@mattermost/types/channels';
 import type {Post} from '@mattermost/types/posts';
 import type {UserThread} from '@mattermost/types/threads';
 
-import type {ActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionResult} from 'mattermost-redux/types/actions';
 
 import deferComponentRender from 'components/deferComponentRender';
 import FileUploadOverlay from 'components/file_upload_overlay';
@@ -38,9 +38,9 @@ export type Props = Attrs & {
     socketConnectionStatus: boolean;
     actions: {
         fetchRHSAppsBindings: (channelId: string, rootID: string) => unknown;
-        getNewestPostThread: (rootId: string) => Promise<any>|ActionFunc;
-        getPostThread: (rootId: string, fetchThreads: boolean) => Promise<any>|ActionFunc;
-        getThread: (userId: string, teamId: string, threadId: string, extended: boolean) => Promise<any>|ActionFunc;
+        getNewestPostThread: (rootId: string) => Promise<ActionResult>;
+        getPostThread: (rootId: string, fetchThreads: boolean) => Promise<ActionResult>;
+        getThread: (userId: string, teamId: string, threadId: string, extended: boolean) => Promise<ActionResult>;
         selectPostCard: (post: Post) => void;
         updateThreadLastOpened: (threadId: string, lastViewedAt: number) => unknown;
         updateThreadRead: (userId: string, teamId: string, threadId: string, timestamp: number) => unknown;

--- a/webapp/channels/src/components/user_settings/notifications/email_notification_setting/email_notification_setting.tsx
+++ b/webapp/channels/src/components/user_settings/notifications/email_notification_setting/email_notification_setting.tsx
@@ -7,6 +7,7 @@ import {FormattedMessage} from 'react-intl';
 import type {PreferenceType} from '@mattermost/types/preferences';
 import type {UserNotifyProps} from '@mattermost/types/users';
 
+import type {ActionResult} from 'mattermost-redux/types/actions';
 import {getEmailInterval} from 'mattermost-redux/utils/notify_props';
 
 import SettingItemMax from 'components/setting_item_max';
@@ -36,8 +37,7 @@ type Props = {
     sendEmailNotifications: boolean;
     enableEmailBatching: boolean;
     actions: {
-        savePreferences: (currentUserId: string, emailIntervalPreference: PreferenceType[]) =>
-        Promise<{data: boolean}>;
+        savePreferences: (currentUserId: string, emailIntervalPreference: PreferenceType[]) => Promise<ActionResult>;
     };
 };
 

--- a/webapp/channels/src/components/user_settings/sidebar/limit_visible_gms_dms/limit_visible_gms_dms.tsx
+++ b/webapp/channels/src/components/user_settings/sidebar/limit_visible_gms_dms/limit_visible_gms_dms.tsx
@@ -10,6 +10,7 @@ import type {ValueType} from 'react-select';
 import type {PreferenceType} from '@mattermost/types/preferences';
 
 import {Preferences} from 'mattermost-redux/constants';
+import type {ActionResult} from 'mattermost-redux/types/actions';
 
 import SettingItemMax from 'components/setting_item_max';
 import SettingItemMin from 'components/setting_item_min';
@@ -26,7 +27,7 @@ type Props = {
     active: boolean;
     areAllSectionsInactive: boolean;
     currentUserId: string;
-    savePreferences: (userId: string, preferences: PreferenceType[]) => Promise<{data: boolean}>;
+    savePreferences: (userId: string, preferences: PreferenceType[]) => Promise<ActionResult>;
     dmGmLimit: number;
     updateSection: (section: string) => void;
 }

--- a/webapp/channels/src/components/user_settings/sidebar/show_unreads_category/show_unreads_category.tsx
+++ b/webapp/channels/src/components/user_settings/sidebar/show_unreads_category/show_unreads_category.tsx
@@ -8,6 +8,7 @@ import {FormattedMessage} from 'react-intl';
 import type {PreferenceType} from '@mattermost/types/preferences';
 
 import {Preferences} from 'mattermost-redux/constants';
+import type {ActionResult} from 'mattermost-redux/types/actions';
 
 import SettingItemMax from 'components/setting_item_max';
 import SettingItemMin from 'components/setting_item_min';
@@ -19,7 +20,7 @@ type Props = {
     active: boolean;
     areAllSectionsInactive: boolean;
     currentUserId: string;
-    savePreferences: (userId: string, preferences: PreferenceType[]) => Promise<{data: boolean}>;
+    savePreferences: (userId: string, preferences: PreferenceType[]) => Promise<ActionResult>;
     showUnreadsCategory: boolean;
     updateSection: (section: string) => void;
 }

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/admin.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/admin.ts
@@ -27,7 +27,7 @@ import type {
 import {AdminTypes} from 'mattermost-redux/action_types';
 import {getUsersLimits} from 'mattermost-redux/actions/limits';
 import {Client4} from 'mattermost-redux/client';
-import type {ActionFunc, DispatchFunc, GetStateFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
@@ -388,8 +388,8 @@ export function removeLicense(): NewActionFuncAsync<boolean> {
     };
 }
 
-export function getPrevTrialLicense(): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getPrevTrialLicense(): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         let data;
         try {
             data = await Client4.getPrevTrialLicense();
@@ -403,8 +403,8 @@ export function getPrevTrialLicense(): ActionFunc {
     };
 }
 
-export function getAnalytics(name: string, teamId = ''): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getAnalytics(name: string, teamId = ''): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         let data;
         try {
             data = await Client4.getAnalytics(name, teamId);
@@ -424,28 +424,28 @@ export function getAnalytics(name: string, teamId = ''): ActionFunc {
     };
 }
 
-export function getStandardAnalytics(teamId = ''): ActionFunc {
+export function getStandardAnalytics(teamId = '') {
     return getAnalytics('standard', teamId);
 }
 
-export function getAdvancedAnalytics(teamId = ''): ActionFunc {
+export function getAdvancedAnalytics(teamId = '') {
     return getAnalytics('extra_counts', teamId);
 }
 
-export function getPostsPerDayAnalytics(teamId = ''): ActionFunc {
+export function getPostsPerDayAnalytics(teamId = '') {
     return getAnalytics('post_counts_day', teamId);
 }
 
-export function getBotPostsPerDayAnalytics(teamId = ''): ActionFunc {
+export function getBotPostsPerDayAnalytics(teamId = '') {
     return getAnalytics('bot_post_counts_day', teamId);
 }
 
-export function getUsersPerDayAnalytics(teamId = ''): ActionFunc {
+export function getUsersPerDayAnalytics(teamId = '') {
     return getAnalytics('user_counts_with_posts_day', teamId);
 }
 
-export function uploadPlugin(fileData: File, force = false): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function uploadPlugin(fileData: File, force = false): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         let data;
         try {
             data = await Client4.uploadPlugin(fileData, force);
@@ -459,7 +459,7 @@ export function uploadPlugin(fileData: File, force = false): ActionFunc {
     };
 }
 
-export function installPluginFromUrl(url: string, force = false): ActionFunc {
+export function installPluginFromUrl(url: string, force = false): NewActionFuncAsync {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -695,7 +695,7 @@ export function getDataRetentionCustomPolicyChannels(id: string, page = 0, perPa
 }
 
 export function searchDataRetentionCustomPolicyTeams(id: string, term: string, opts: TeamSearchOpts): NewActionFuncAsync<DataRetentionCustomPolicies> {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+    return async (dispatch, getState) => {
         let data;
         try {
             data = await Client4.searchDataRetentionCustomPolicyTeams(id, term, opts);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/boards.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/boards.ts
@@ -4,14 +4,14 @@
 import type {PreferenceType} from '@mattermost/types/preferences';
 
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {savePreferences} from './preferences';
 
 import {Preferences} from '../constants';
 
-export function setNewChannelWithBoardPreference(initializationState: Record<string, boolean>): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function setNewChannelWithBoardPreference(initializationState: Record<string, boolean>): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
         const preference: PreferenceType = {

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/channel_categories.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/channel_categories.ts
@@ -21,20 +21,18 @@ import {
 } from 'mattermost-redux/selectors/entities/channel_categories';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import type {
-    ActionFunc,
-    DispatchFunc,
-    GetStateFunc,
+    NewActionFuncAsync,
     ThunkActionFunc,
 } from 'mattermost-redux/types/actions';
 import {insertMultipleWithoutDuplicates, insertWithoutDuplicates, removeItem} from 'mattermost-redux/utils/array_utils';
 
 import {General} from '../constants';
 
-export function expandCategory(categoryId: string) {
+export function expandCategory(categoryId: string) { // HARRISONTODO unused
     return setCategoryCollapsed(categoryId, false);
 }
 
-export function collapseCategory(categoryId: string) {
+export function collapseCategory(categoryId: string) { // HARRISONTODO unused
     return setCategoryCollapsed(categoryId, true);
 }
 
@@ -50,8 +48,8 @@ export function setCategorySorting(categoryId: string, sorting: CategorySorting)
     });
 }
 
-export function patchCategory(categoryId: string, patch: Partial<ChannelCategory>): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function patchCategory(categoryId: string, patch: Partial<ChannelCategory>): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
 
@@ -83,8 +81,8 @@ export function patchCategory(categoryId: string, patch: Partial<ChannelCategory
     };
 }
 
-export function setCategoryMuted(categoryId: string, muted: boolean) {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function setCategoryMuted(categoryId: string, muted: boolean): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const category = getCategory(state, categoryId);
 
@@ -99,7 +97,7 @@ export function setCategoryMuted(categoryId: string, muted: boolean) {
 
         const updated = result.data as ChannelCategory;
 
-        return dispatch(batchActions([
+        dispatch(batchActions([
             {
                 type: ChannelCategoryTypes.RECEIVED_CATEGORY,
                 data: updated,
@@ -112,11 +110,13 @@ export function setCategoryMuted(categoryId: string, muted: boolean) {
                 },
             }))),
         ]));
+
+        return {data: true};
     };
 }
 
-function updateCategory(category: ChannelCategory) {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+function updateCategory(category: ChannelCategory): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
 
@@ -171,8 +171,8 @@ export function fetchMyCategories(teamId: string, isWebSocket?: boolean): ThunkA
 //
 // Unless setOnServer is true, this only affects the categories on this client. If it is set to true, this updates
 // categories on the server too.
-export function addChannelToInitialCategory(channel: Channel, setOnServer = false): ActionFunc {
-    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function addChannelToInitialCategory(channel: Channel, setOnServer = false): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const categories = Object.values(getAllCategoriesByIds(state));
 
@@ -228,15 +228,15 @@ export function addChannelToInitialCategory(channel: Channel, setOnServer = fals
 // addChannelToCategory returns an action that can be dispatched to add a channel to a given category without specifying
 // its order. The channel will be removed from its previous category (if any) on the given category's team and it will be
 // placed first in its new category.
-export function addChannelToCategory(categoryId: string, channelId: string): ActionFunc {
+export function addChannelToCategory(categoryId: string, channelId: string): NewActionFuncAsync {
     return moveChannelToCategory(categoryId, channelId, 0, false);
 }
 
 // moveChannelToCategory returns an action that moves a channel into a category and puts it at the given index at the
 // category. The channel will also be removed from its previous category (if any) on that category's team. The category's
 // order will also be set to manual by default.
-export function moveChannelToCategory(categoryId: string, channelId: string, newIndex: number, setManualSorting = true) {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function moveChannelToCategory(categoryId: string, channelId: string, newIndex: number, setManualSorting = true): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const targetCategory = getCategory(state, categoryId);
         const currentUserId = getCurrentUserId(state);
@@ -293,8 +293,8 @@ export function moveChannelToCategory(categoryId: string, channelId: string, new
     };
 }
 
-export function moveChannelsToCategory(categoryId: string, channelIds: string[], newIndex: number, setManualSorting = true) {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function moveChannelsToCategory(categoryId: string, channelIds: string[], newIndex: number, setManualSorting = true): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const targetCategory = getCategory(state, categoryId);
         const currentUserId = getCurrentUserId(state);
@@ -372,8 +372,8 @@ export function moveChannelsToCategory(categoryId: string, channelIds: string[],
     };
 }
 
-export function moveCategory(teamId: string, categoryId: string, newIndex: number) {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function moveCategory(teamId: string, categoryId: string, newIndex: number): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const order = getCategoryIdsForTeam(state, teamId)!;
         const currentUserId = getCurrentUserId(state);
@@ -421,8 +421,8 @@ export function receivedCategoryOrder(teamId: string, order: string[]) {
     };
 }
 
-export function createCategory(teamId: string, displayName: string, channelIds: Array<Channel['id']> = []): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function createCategory(teamId: string, displayName: string, channelIds: Array<Channel['id']> = []): NewActionFuncAsync<ChannelCategory> {
+    return async (dispatch, getState) => {
         const currentUserId = getCurrentUserId(getState());
 
         let newCategory;
@@ -445,14 +445,14 @@ export function createCategory(teamId: string, displayName: string, channelIds: 
     };
 }
 
-export function renameCategory(categoryId: string, displayName: string): ActionFunc {
+export function renameCategory(categoryId: string, displayName: string) {
     return patchCategory(categoryId, {
         display_name: displayName,
     });
 }
 
-export function deleteCategory(categoryId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function deleteCategory(categoryId: string): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const category = getCategory(state, categoryId);
         const currentUserId = getCurrentUserId(state);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/channel_categories.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/channel_categories.ts
@@ -24,7 +24,7 @@ import type {
     ActionFunc,
     DispatchFunc,
     GetStateFunc,
-    NewActionFuncOldVariantDoNotUse,
+    ThunkActionFunc,
 } from 'mattermost-redux/types/actions';
 import {insertMultipleWithoutDuplicates, insertWithoutDuplicates, removeItem} from 'mattermost-redux/utils/array_utils';
 
@@ -135,7 +135,7 @@ function updateCategory(category: ChannelCategory) {
     };
 }
 
-export function fetchMyCategories(teamId: string, isWebSocket?: boolean): NewActionFuncOldVariantDoNotUse {
+export function fetchMyCategories(teamId: string, isWebSocket?: boolean): ThunkActionFunc<unknown> {
     return async (dispatch, getState) => {
         const currentUserId = getCurrentUserId(getState());
 

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/channels.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/channels.ts
@@ -32,7 +32,7 @@ import {
 } from 'mattermost-redux/selectors/entities/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
-import type {ActionFunc, DispatchFunc, GetStateFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {GetStateFunc, NewActionFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
 import {getChannelByName} from 'mattermost-redux/utils/channel_utils';
 
 import {addChannelToInitialCategory, addChannelToCategory} from './channel_categories';
@@ -51,8 +51,8 @@ export function selectChannel(channelId: string) {
     };
 }
 
-export function createChannel(channel: Channel, userId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function createChannel(channel: Channel, userId: string): NewActionFuncAsync<Channel> {
+    return async (dispatch, getState) => {
         let created;
         try {
             created = await Client4.createChannel(channel);
@@ -102,8 +102,8 @@ export function createChannel(channel: Channel, userId: string): ActionFunc {
     };
 }
 
-export function createDirectChannel(userId: string, otherUserId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function createDirectChannel(userId: string, otherUserId: string): NewActionFuncAsync<Channel> {
+    return async (dispatch, getState) => {
         dispatch({type: ChannelTypes.CREATE_CHANNEL_REQUEST, data: null});
 
         let created;
@@ -165,8 +165,8 @@ export function createDirectChannel(userId: string, otherUserId: string): Action
     };
 }
 
-export function markGroupChannelOpen(channelId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function markGroupChannelOpen(channelId: string): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const {currentUserId} = getState().entities.users;
 
         const preferences: PreferenceType[] = [
@@ -283,8 +283,8 @@ export function patchChannel(channelId: string, patch: Partial<Channel>): NewAct
     };
 }
 
-export function updateChannel(channel: Channel): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function updateChannel(channel: Channel): NewActionFuncAsync { // HARRISONTODO unused
+    return async (dispatch, getState) => {
         dispatch({type: ChannelTypes.UPDATE_CHANNEL_REQUEST, data: null});
 
         let updated;
@@ -499,8 +499,8 @@ export function getChannelTimezones(channelId: string): NewActionFuncAsync<strin
     };
 }
 
-export function fetchChannelsAndMembers(teamId: string): ActionFunc<{channels: ServerChannel[]; channelMembers: ChannelMembership[]}> {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function fetchChannelsAndMembers(teamId: string): NewActionFuncAsync<{channels: ServerChannel[]; channelMembers: ChannelMembership[]}> {
+    return async (dispatch, getState) => {
         let channels;
         let channelMembers;
         try {
@@ -615,8 +615,8 @@ export function getChannelMembers(channelId: string, page = 0, perPage: number =
     };
 }
 
-export function leaveChannel(channelId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function leaveChannel(channelId: string): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const {currentUserId} = state.entities.users;
         const {channels, myMembers} = state.entities.channels;
@@ -759,8 +759,8 @@ export function unarchiveChannel(channelId: string): NewActionFuncAsync {
     };
 }
 
-export function updateApproximateViewTime(channelId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function updateApproximateViewTime(channelId: string): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const {currentUserId} = getState().entities.users;
 
         const {myPreferences} = getState().entities.preferences;
@@ -777,8 +777,8 @@ export function updateApproximateViewTime(channelId: string): ActionFunc {
     };
 }
 
-export function readMultipleChannels(channelIds: string[]): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function readMultipleChannels(channelIds: string[]): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         let response;
         try {
             response = await Client4.readMultipleChannels(channelIds);
@@ -1136,8 +1136,8 @@ export function removeChannelMember(channelId: string, userId: string): NewActio
     };
 }
 
-export function updateChannelMemberRoles(channelId: string, userId: string, roles: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function updateChannelMemberRoles(channelId: string, userId: string, roles: string): NewActionFuncAsync { // HARRISONTODO unused
+    return async (dispatch, getState) => {
         try {
             await Client4.updateChannelMemberRoles(channelId, userId, roles);
         } catch (error) {
@@ -1158,8 +1158,8 @@ export function updateChannelMemberRoles(channelId: string, userId: string, role
     };
 }
 
-export function updateChannelHeader(channelId: string, header: string): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
+export function updateChannelHeader(channelId: string, header: string): NewActionFuncAsync { // HARRISONTODO unused
+    return async (dispatch) => {
         Client4.trackEvent('action', 'action_channels_update_header', {channel_id: channelId});
 
         dispatch({
@@ -1174,8 +1174,8 @@ export function updateChannelHeader(channelId: string, header: string): ActionFu
     };
 }
 
-export function updateChannelPurpose(channelId: string, purpose: string): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
+export function updateChannelPurpose(channelId: string, purpose: string): NewActionFuncAsync { // HARRISONTODO unused
+    return async (dispatch) => {
         Client4.trackEvent('action', 'action_channels_update_purpose', {channel_id: channelId});
 
         dispatch({
@@ -1190,8 +1190,8 @@ export function updateChannelPurpose(channelId: string, purpose: string): Action
     };
 }
 
-export function markChannelAsRead(channelId: string, skipUpdateViewTime = false): ActionFunc {
-    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function markChannelAsRead(channelId: string, skipUpdateViewTime = false): NewActionFunc {
+    return (dispatch, getState) => {
         if (skipUpdateViewTime) {
             dispatch(updateApproximateViewTime(channelId));
         }
@@ -1206,8 +1206,8 @@ export function markChannelAsRead(channelId: string, skipUpdateViewTime = false)
     };
 }
 
-export function markMultipleChannelsAsRead(channelTimes: Record<string, number>): ActionFunc {
-    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function markMultipleChannelsAsRead(channelTimes: Record<string, number>): NewActionFunc {
+    return (dispatch, getState) => {
         const actions: AnyAction[] = [];
         for (const id of Object.keys(channelTimes)) {
             actions.push(...actionsToMarkChannelAsRead(getState, id, channelTimes[id]));
@@ -1221,8 +1221,8 @@ export function markMultipleChannelsAsRead(channelTimes: Record<string, number>)
     };
 }
 
-export function markChannelAsViewedOnServer(channelId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function markChannelAsViewedOnServer(channelId: string): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         try {
             await Client4.viewMyChannel(channelId);
         } catch (error) {
@@ -1378,8 +1378,8 @@ export function getMyChannelMember(channelId: string) {
     });
 }
 
-export function loadMyChannelMemberAndRole(channelId: string) {
-    return async (dispatch: DispatchFunc) => {
+export function loadMyChannelMemberAndRole(channelId: string): NewActionFuncAsync {
+    return async (dispatch) => {
         const result = await dispatch(getMyChannelMember(channelId));
         const roles = result.data?.roles.split(' ');
         if (roles && roles.length > 0) {
@@ -1390,8 +1390,8 @@ export function loadMyChannelMemberAndRole(channelId: string) {
 }
 
 // favoriteChannel moves the provided channel into the current team's Favorites category.
-export function favoriteChannel(channelId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function favoriteChannel(channelId: string): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const channel = getChannelSelector(state, channelId);
         const category = getCategoryInTeamByType(state, channel.team_id || getCurrentTeamId(state), CategoryTypes.FAVORITES);
@@ -1407,8 +1407,8 @@ export function favoriteChannel(channelId: string): ActionFunc {
 }
 
 // unfavoriteChannel moves the provided channel into the current team's Channels/DMs category.
-export function unfavoriteChannel(channelId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function unfavoriteChannel(channelId: string): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const channel = getChannelSelector(state, channelId);
         const category = getCategoryInTeamByType(

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/channels.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/channels.ts
@@ -407,8 +407,8 @@ export function updateChannelNotifyProps(userId: string, channelId: string, prop
     };
 }
 
-export function getChannelByNameAndTeamName(teamName: string, channelName: string, includeDeleted = false): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getChannelByNameAndTeamName(teamName: string, channelName: string, includeDeleted = false): NewActionFuncAsync<Channel> {
+    return async (dispatch, getState) => {
         let data;
         try {
             data = await Client4.getChannelByNameAndTeamName(teamName, channelName, includeDeleted);
@@ -540,8 +540,8 @@ export function fetchChannelsAndMembers(teamId: string): ActionFunc<{channels: S
     };
 }
 
-export function fetchAllMyTeamsChannelsAndChannelMembersREST(): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function fetchAllMyTeamsChannelsAndChannelMembersREST(): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const {currentUserId} = state.entities.users;
         let channels;

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/emojis.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/emojis.ts
@@ -10,7 +10,7 @@ import type {GlobalState} from '@mattermost/types/store';
 import {EmojiTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
 import {getCustomEmojisByName as selectCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
-import type {GetStateFunc, DispatchFunc, ActionFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
 import {parseEmojiNamesFromText} from 'mattermost-redux/utils/emoji_utils';
 
 import {logError} from './errors';
@@ -45,8 +45,8 @@ export function getCustomEmoji(emojiId: string) {
     });
 }
 
-export function getCustomEmojiByName(name: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getCustomEmojiByName(name: string): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         let data;
 
         try {
@@ -72,8 +72,8 @@ export function getCustomEmojiByName(name: string): ActionFunc {
     };
 }
 
-export function getCustomEmojisByName(names: string[]): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getCustomEmojisByName(names: string[]): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const neededNames = filterNeededCustomEmojis(getState(), names);
 
         if (neededNames.length === 0) {
@@ -120,7 +120,9 @@ export function getCustomEmojisByName(names: string[]): ActionFunc {
             }
         }
 
-        return dispatch(actions.length > 1 ? batchActions(actions) : actions[0]);
+        dispatch(actions.length > 1 ? batchActions(actions) : actions[0]);
+
+        return {data: true};
     };
 }
 
@@ -133,8 +135,8 @@ function filterNeededCustomEmojis(state: GlobalState, names: string[]) {
     });
 }
 
-export function getCustomEmojisInText(text: string): ActionFunc {
-    return (dispatch: DispatchFunc) => {
+export function getCustomEmojisInText(text: string): NewActionFuncAsync {
+    return async (dispatch) => {
         if (!text) {
             return {data: true};
         }
@@ -173,8 +175,8 @@ export function getCustomEmojis(
     };
 }
 
-export function loadProfilesForCustomEmojis(emojis: CustomEmoji[]): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function loadProfilesForCustomEmojis(emojis: CustomEmoji[]): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const usersToLoad: Record<string, boolean> = {};
         emojis.forEach((emoji: CustomEmoji) => {
             if (!getState().entities.users.profiles[emoji.creator_id]) {
@@ -192,8 +194,8 @@ export function loadProfilesForCustomEmojis(emojis: CustomEmoji[]): ActionFunc {
     };
 }
 
-export function deleteCustomEmoji(emojiId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function deleteCustomEmoji(emojiId: string): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         try {
             await Client4.deleteCustomEmoji(emojiId);
         } catch (error) {
@@ -237,8 +239,8 @@ export function searchCustomEmojis(term: string, options: any = {}, loadUsers = 
     };
 }
 
-export function autocompleteCustomEmojis(name: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function autocompleteCustomEmojis(name: string): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         let data;
         try {
             data = await Client4.autocompleteCustomEmoji(name);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/errors.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/errors.ts
@@ -9,21 +9,13 @@ import type {ServerError} from '@mattermost/types/errors';
 
 import {ErrorTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
-import type {DispatchFunc, ActionFunc} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
 
-export function dismissErrorObject(index: number) {
+export function dismissError(index: number) {
     return {
         type: ErrorTypes.DISMISS_ERROR,
         index,
         data: null,
-    };
-}
-
-export function dismissError(index: number): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
-        dispatch(dismissErrorObject(index));
-
-        return {data: true};
     };
 }
 
@@ -36,7 +28,7 @@ export function getLogErrorAction(error: ErrorObject, displayable = false) {
     };
 }
 
-export function logError(error: ServerError, displayable = false, consoleError = false): ActionFunc<boolean> {
+export function logError(error: ServerError, displayable = false, consoleError = false): NewActionFuncAsync<boolean> {
     return async (dispatch, getState) => {
         if (error.server_error_id === 'api.context.session_expired.app_error') {
             return {data: true};
@@ -81,10 +73,9 @@ export function logError(error: ServerError, displayable = false, consoleError =
     };
 }
 
-export function clearErrors(): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
-        dispatch({type: ErrorTypes.CLEAR_ERRORS, data: null});
-
-        return {data: true};
+export function clearErrors() {
+    return {
+        type: ErrorTypes.CLEAR_ERRORS,
+        data: null,
     };
 }

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/files.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/files.ts
@@ -6,7 +6,7 @@ import type {Post} from '@mattermost/types/posts';
 
 import {FileTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
-import type {DispatchFunc, GetStateFunc, ActionFunc} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
@@ -18,8 +18,8 @@ export function receivedFiles(files: Map<string, FileSearchResultItem>) {
     };
 }
 
-export function getMissingFilesByPosts(posts: Post[]) {
-    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getMissingFilesByPosts(posts: Post[]): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const {files} = getState().entities.files;
         const postIds = posts.reduce((curr: Array<Post['id']>, post: Post) => {
             const {file_ids: fileIds} = post;
@@ -31,18 +31,16 @@ export function getMissingFilesByPosts(posts: Post[]) {
             return curr;
         }, []);
 
-        const promises: Array<Promise<any>> = [];
-
         for (const id of postIds) {
             dispatch(getFilesForPost(id));
         }
 
-        return {data: promises};
+        return {data: true};
     };
 }
 
-export function getFilesForPost(postId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getFilesForPost(postId: string): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         let files;
 
         try {

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/general.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/general.ts
@@ -8,14 +8,14 @@ import type {SystemSetting} from '@mattermost/types/general';
 
 import {GeneralTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
-import type {GetStateFunc, DispatchFunc, ActionFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
 import {loadRolesIfNeeded} from './roles';
 
-export function getClientConfig(): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getClientConfig(): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         let data;
         try {
             data = await Client4.getClientConfigOld();
@@ -33,8 +33,8 @@ export function getClientConfig(): ActionFunc {
     };
 }
 
-export function getDataRetentionPolicy(): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getDataRetentionPolicy(): NewActionFuncAsync { // HARRISONTODO unused
+    return async (dispatch, getState) => {
         let data;
         try {
             data = await Client4.getDataRetentionPolicy();
@@ -76,7 +76,7 @@ export function logClientError(message: string, level = LogLevel.Error) {
     });
 }
 
-export function setServerVersion(serverVersion: string): ActionFunc {
+export function setServerVersion(serverVersion: string): NewActionFuncAsync {
     return async (dispatch) => {
         dispatch({type: GeneralTypes.RECEIVED_SERVER_VERSION, data: serverVersion});
         dispatch(loadRolesIfNeeded([]));
@@ -90,8 +90,8 @@ export function setUrl(url: string) {
     return true;
 }
 
-export function getWarnMetricsStatus(): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getWarnMetricsStatus(): NewActionFuncAsync { // HARRISONTODO unused
+    return async (dispatch, getState) => {
         let data;
         try {
             data = await Client4.getWarnMetricsStatus();
@@ -105,8 +105,8 @@ export function getWarnMetricsStatus(): ActionFunc {
     };
 }
 
-export function setFirstAdminVisitMarketplaceStatus(): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
+export function setFirstAdminVisitMarketplaceStatus(): NewActionFuncAsync {
+    return async (dispatch) => {
         try {
             await Client4.setFirstAdminVisitMarketplaceStatus();
         } catch (e) {
@@ -118,8 +118,8 @@ export function setFirstAdminVisitMarketplaceStatus(): ActionFunc {
     };
 }
 
-export function getFirstAdminVisitMarketplaceStatus(): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getFirstAdminVisitMarketplaceStatus(): NewActionFuncAsync { // HARRISONTODO unused
+    return async (dispatch, getState) => {
         let data;
         try {
             data = await Client4.getFirstAdminVisitMarketplaceStatus();

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/integrations.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/integrations.ts
@@ -3,14 +3,14 @@
 
 import {batchActions} from 'redux-batched-actions';
 
-import type {Command, CommandArgs, DialogSubmission, IncomingWebhook, OAuthApp, OutgoingWebhook} from '@mattermost/types/integrations';
+import type {Command, CommandArgs, DialogSubmission, IncomingWebhook, OAuthApp, OutgoingWebhook, SubmitDialogResponse} from '@mattermost/types/integrations';
 
 import {IntegrationTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {DispatchFunc, GetStateFunc, ActionFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
@@ -380,8 +380,8 @@ export function regenOAuthAppSecret(appId: string) {
     });
 }
 
-export function submitInteractiveDialog(submission: DialogSubmission): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function submitInteractiveDialog(submission: DialogSubmission): NewActionFuncAsync<SubmitDialogResponse> {
+    return async (dispatch, getState) => {
         const state = getState();
         submission.channel_id = getCurrentChannelId(state);
         submission.team_id = getCurrentTeamId(state);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/posts.ts
@@ -1229,7 +1229,7 @@ export function getNeededAtMentionedUsernamesAndGroups(state: GlobalState, posts
 
 export type ExtendedPost = Post & { system_post_ids?: string[] };
 
-export function removePost(post: ExtendedPost): NewActionFunc {
+export function removePost(post: ExtendedPost): NewActionFunc<boolean> {
     return (dispatch, getState) => {
         if (post.type === Posts.POST_TYPES.COMBINED_USER_ACTIVITY && post.system_post_ids) {
             const state = getState();

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/preferences.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/preferences.ts
@@ -8,7 +8,7 @@ import {Client4} from 'mattermost-redux/client';
 import {getMyPreferences as getMyPreferencesSelector, makeGetCategory} from 'mattermost-redux/selectors/entities/preferences';
 import type {Theme} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {GetStateFunc, DispatchFunc, ActionFunc} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 import {getPreferenceKey} from 'mattermost-redux/utils/preference_utils';
 
 import {getChannelAndMyMember, getMyChannelMember} from './channels';
@@ -17,8 +17,8 @@ import {getProfilesByIds, getProfilesInChannel} from './users';
 
 import {Preferences} from '../constants';
 
-export function deletePreferences(userId: string, preferences: PreferenceType[]): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function deletePreferences(userId: string, preferences: PreferenceType[]): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const myPreferences = getMyPreferencesSelector(state);
         const currentPreferences = preferences.map((pref) => myPreferences[getPreferenceKey(pref.category, pref.name)]);
@@ -50,8 +50,8 @@ export function getMyPreferences() {
     });
 }
 
-export function makeDirectChannelVisibleIfNecessary(otherUserId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function makeDirectChannelVisibleIfNecessary(otherUserId: string): NewActionFuncAsync { // HARRISONTODO unused
+    return async (dispatch, getState) => {
         const state = getState();
         const myPreferences = getMyPreferencesSelector(state);
         const currentUserId = getCurrentUserId(state);
@@ -73,8 +73,8 @@ export function makeDirectChannelVisibleIfNecessary(otherUserId: string): Action
     };
 }
 
-export function makeGroupMessageVisibleIfNecessary(channelId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function makeGroupMessageVisibleIfNecessary(channelId: string): NewActionFuncAsync { // HARRISONTODO unused
+    return async (dispatch, getState) => {
         const state = getState();
         const myPreferences = getMyPreferencesSelector(state);
         const currentUserId = getCurrentUserId(state);
@@ -104,8 +104,8 @@ export function makeGroupMessageVisibleIfNecessary(channelId: string): ActionFun
     };
 }
 
-export function setActionsMenuInitialisationState(initializationState: Record<string, boolean>) {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function setActionsMenuInitialisationState(initializationState: Record<string, boolean>): ThunkActionFunc<void> {
+    return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
         const preference: PreferenceType = {
@@ -118,8 +118,8 @@ export function setActionsMenuInitialisationState(initializationState: Record<st
     };
 }
 
-export function setCustomStatusInitialisationState(initializationState: Record<string, boolean>) {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function setCustomStatusInitialisationState(initializationState: Record<string, boolean>): ThunkActionFunc<void> {
+    return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
         const preference: PreferenceType = {
@@ -132,8 +132,8 @@ export function setCustomStatusInitialisationState(initializationState: Record<s
     };
 }
 
-export function savePreferences(userId: string, preferences: PreferenceType[]) {
-    return async (dispatch: DispatchFunc) => {
+export function savePreferences(userId: string, preferences: PreferenceType[]): NewActionFuncAsync {
+    return async (dispatch) => {
         (async function savePreferencesWrapper() {
             try {
                 dispatch({
@@ -154,8 +154,8 @@ export function savePreferences(userId: string, preferences: PreferenceType[]) {
     };
 }
 
-export function saveTheme(teamId: string, theme: Theme): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function saveTheme(teamId: string, theme: Theme): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
         const preference: PreferenceType = {
@@ -170,8 +170,8 @@ export function saveTheme(teamId: string, theme: Theme): ActionFunc {
     };
 }
 
-export function deleteTeamSpecificThemes(): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function deleteTeamSpecificThemes(): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
 
         const themePreferences: PreferenceType[] = makeGetCategory()(state, Preferences.CATEGORY_THEME);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/search.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/search.ts
@@ -11,7 +11,7 @@ import {SearchTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {ActionResult, DispatchFunc, GetStateFunc, ActionFunc, NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionResult, NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 import {getChannelAndMyMember, getChannelMembers} from './channels';
 import {logError} from './errors';
@@ -44,8 +44,8 @@ export function getMissingChannelsFromPosts(posts: PostList['posts']): ThunkActi
     };
 }
 
-export function getMissingChannelsFromFiles(files: Map<string, FileSearchResultItem>): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getMissingChannelsFromFiles(files: Map<string, FileSearchResultItem>): ThunkActionFunc<Promise<ActionResult[]>> {
+    return async (dispatch, getState) => {
         const {
             channels,
             membersInChannel,
@@ -130,7 +130,7 @@ export function getMorePostsForSearch(): NewActionFuncAsync {
     };
 }
 
-export function clearSearch(): ActionFunc {
+export function clearSearch(): NewActionFuncAsync {
     return async (dispatch) => {
         dispatch({type: SearchTypes.REMOVE_SEARCH_POSTS});
         dispatch({type: SearchTypes.REMOVE_SEARCH_FILES});
@@ -139,8 +139,8 @@ export function clearSearch(): ActionFunc {
     };
 }
 
-export function searchFilesWithParams(teamId: string, params: SearchParameter): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function searchFilesWithParams(teamId: string, params: SearchParameter): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const isGettingMore = params.page > 0;
         dispatch({
             type: SearchTypes.SEARCH_FILES_REQUEST,
@@ -182,12 +182,12 @@ export function searchFilesWithParams(teamId: string, params: SearchParameter): 
     };
 }
 
-export function searchFiles(teamId: string, terms: string, isOrSearch: boolean, includeDeletedChannels: boolean) {
+export function searchFiles(teamId: string, terms: string, isOrSearch: boolean, includeDeletedChannels: boolean) { // HARRISONTODO unused
     return searchFilesWithParams(teamId, {terms, is_or_search: isOrSearch, include_deleted_channels: includeDeletedChannels, page: 0, per_page: WEBAPP_SEARCH_PER_PAGE});
 }
 
-export function getMoreFilesForSearch(): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getMoreFilesForSearch(): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const teamId = getCurrentTeamId(getState());
         const {params, isFilesEnd} = getState().entities.search.current[teamId];
         if (!isFilesEnd) {
@@ -199,8 +199,8 @@ export function getMoreFilesForSearch(): ActionFunc {
     };
 }
 
-export function getFlaggedPosts(): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getFlaggedPosts(): NewActionFuncAsync<PostList> {
+    return async (dispatch, getState) => {
         const state = getState();
         const userId = getCurrentUserId(state);
 
@@ -233,8 +233,8 @@ export function getFlaggedPosts(): ActionFunc {
     };
 }
 
-export function getPinnedPosts(channelId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getPinnedPosts(channelId: string): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         dispatch({type: SearchTypes.SEARCH_PINNED_POSTS_REQUEST});
 
         let result;
@@ -243,7 +243,7 @@ export function getPinnedPosts(channelId: string): ActionFunc {
 
             const profilesAndStatuses = getMentionsAndStatusesForPosts(result.posts, dispatch, getState);
             const missingChannels = dispatch(getMissingChannelsFromPosts(result.posts));
-            const arr: [Promise<any>, Promise<any>] = [profilesAndStatuses, missingChannels];
+            const arr = [profilesAndStatuses, missingChannels];
             await Promise.all(arr);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
@@ -269,7 +269,7 @@ export function getPinnedPosts(channelId: string): ActionFunc {
     };
 }
 
-export function clearPinnedPosts(channelId: string): ActionFunc {
+export function clearPinnedPosts(channelId: string): NewActionFuncAsync { // HARRISONTODO unused
     return async (dispatch) => {
         dispatch({
             type: SearchTypes.REMOVE_SEARCH_PINNED_POSTS,
@@ -282,7 +282,7 @@ export function clearPinnedPosts(channelId: string): ActionFunc {
     };
 }
 
-export function removeSearchTerms(teamId: string, terms: string): ActionFunc {
+export function removeSearchTerms(teamId: string, terms: string): NewActionFuncAsync { // HARRISONTODO unused
     return async (dispatch) => {
         dispatch({
             type: SearchTypes.REMOVE_SEARCH_TERM,

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/search.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/search.ts
@@ -11,7 +11,7 @@ import {SearchTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {ActionResult, DispatchFunc, GetStateFunc, ActionFunc, NewActionFuncAsync, NewActionFuncOldVariantDoNotUse} from 'mattermost-redux/types/actions';
+import type {ActionResult, DispatchFunc, GetStateFunc, ActionFunc, NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 import {getChannelAndMyMember, getChannelMembers} from './channels';
 import {logError} from './errors';
@@ -21,7 +21,7 @@ import {getMentionsAndStatusesForPosts, receivedPosts} from './posts';
 
 const WEBAPP_SEARCH_PER_PAGE = 20;
 
-export function getMissingChannelsFromPosts(posts: PostList['posts']): NewActionFuncOldVariantDoNotUse {
+export function getMissingChannelsFromPosts(posts: PostList['posts']): ThunkActionFunc<unknown> {
     return async (dispatch, getState) => {
         const {
             channels,

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/teams.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/teams.ts
@@ -20,7 +20,7 @@ import {isCompatibleWithJoinViewTeamPermissions} from 'mattermost-redux/selector
 import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {GetStateFunc, DispatchFunc, ActionFunc, ActionResult, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionResult, DispatchFunc, GetStateFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 async function getProfilesAndStatusesForMembers(userIds: string[], dispatch: DispatchFunc, getState: GetStateFunc) {
@@ -73,8 +73,8 @@ export function getMyTeams() {
 // The argument skipCurrentTeam is a (not ideal) workaround for CRT mention counts. Unread mentions are stored in the reducer per
 // team but we do not track unread mentions for DMs/GMs independently. This results in a bit of funky logic and edge case bugs
 // that need workarounds like this. In the future we should fix the root cause with better APIs and redux state.
-export function getMyTeamUnreads(collapsedThreads: boolean, skipCurrentTeam = false): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getMyTeamUnreads(collapsedThreads: boolean, skipCurrentTeam = false): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         let unreads;
         try {
             unreads = await Client4.getMyTeamUnreads(collapsedThreads);
@@ -126,7 +126,7 @@ export function getTeamByName(teamName: string) {
 }
 
 export function getTeams(page = 0, perPage: number = General.TEAMS_CHUNK_SIZE, includeTotalCount = false, excludePolicyConstrained = false): NewActionFuncAsync {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+    return async (dispatch, getState) => {
         let data;
 
         dispatch({type: TeamTypes.GET_TEAMS_REQUEST, data});
@@ -365,8 +365,8 @@ export function getTeamMembers(teamId: string, page = 0, perPage: number = Gener
     });
 }
 
-export function getTeamMember(teamId: string, userId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getTeamMember(teamId: string, userId: string): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         let member;
         try {
             const memberRequest = Client4.getTeamMember(teamId, userId);
@@ -484,8 +484,8 @@ export function addUserToTeam(teamId: string, userId: string): NewActionFuncAsyn
     };
 }
 
-export function addUsersToTeam(teamId: string, userIds: string[]): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function addUsersToTeam(teamId: string, userIds: string[]): NewActionFuncAsync { // HARRISONTODO unused
+    return async (dispatch, getState) => {
         let members;
         try {
             members = await Client4.addUsersToTeam(teamId, userIds);
@@ -598,8 +598,8 @@ export function removeUserFromTeam(teamId: string, userId: string): NewActionFun
     };
 }
 
-export function updateTeamMemberRoles(teamId: string, userId: string, roles: string[]): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function updateTeamMemberRoles(teamId: string, userId: string, roles: string[]): NewActionFuncAsync { // HARRISONTODO unused
+    return async (dispatch, getState) => {
         try {
             await Client4.updateTeamMemberRoles(teamId, userId, roles);
         } catch (error) {
@@ -707,8 +707,8 @@ export function checkIfTeamExists(teamName: string): NewActionFuncAsync<boolean>
     };
 }
 
-export function joinTeam(inviteId: string, teamId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function joinTeam(inviteId: string, teamId: string): NewActionFuncAsync { // HARRISONTODO
+    return async (dispatch, getState) => {
         dispatch({type: TeamTypes.JOIN_TEAM_REQUEST, data: null});
 
         const state = getState();

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
@@ -21,7 +21,7 @@ import {General} from 'mattermost-redux/constants';
 import {getServerVersion} from 'mattermost-redux/selectors/entities/general';
 import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId, getUsers} from 'mattermost-redux/selectors/entities/users';
-import type {ActionFunc, DispatchFunc, GetStateFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {DispatchFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
 import {isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
 
 export function generateMfaSecret(userId: string) {
@@ -33,8 +33,8 @@ export function generateMfaSecret(userId: string) {
     });
 }
 
-export function createUser(user: UserProfile, token: string, inviteId: string, redirect: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function createUser(user: UserProfile, token: string, inviteId: string, redirect: string): NewActionFuncAsync<UserProfile> {
+    return async (dispatch, getState) => {
         let created;
 
         try {
@@ -56,8 +56,8 @@ export function createUser(user: UserProfile, token: string, inviteId: string, r
     };
 }
 
-export function loadMe(): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function loadMe(): NewActionFuncAsync<boolean> {
+    return async (dispatch, getState) => {
         // Sometimes the server version is set in one or the other
         const serverVersion = getState().entities.general.serverVersion || Client4.getServerVersion();
         dispatch(setServerVersion(serverVersion));
@@ -85,8 +85,8 @@ export function loadMe(): ActionFunc {
     };
 }
 
-export function logout(): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
+export function logout(): NewActionFuncAsync {
+    return async (dispatch) => {
         dispatch({type: UserTypes.LOGOUT_REQUEST, data: null});
 
         try {
@@ -151,8 +151,8 @@ export function getProfiles(page = 0, perPage: number = General.PROFILE_CHUNK_SI
     };
 }
 
-export function getMissingProfilesByIds(userIds: string[]): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getMissingProfilesByIds(userIds: string[]): NewActionFuncAsync<UserProfile[]> {
+    return async (dispatch, getState) => {
         const {profiles} = getState().entities.users;
         const missingIds: string[] = [];
         userIds.forEach((id) => {
@@ -170,8 +170,8 @@ export function getMissingProfilesByIds(userIds: string[]): ActionFunc {
     };
 }
 
-export function getMissingProfilesByUsernames(usernames: string[]): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getMissingProfilesByUsernames(usernames: string[]): NewActionFuncAsync<UserProfile[]> {
+    return async (dispatch, getState) => {
         const {profiles} = getState().entities.users;
 
         const usernameProfiles = Object.values(profiles).reduce((acc, profile: any) => {
@@ -193,8 +193,8 @@ export function getMissingProfilesByUsernames(usernames: string[]): ActionFunc {
     };
 }
 
-export function getProfilesByIds(userIds: string[], options?: any): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getProfilesByIds(userIds: string[], options?: any): NewActionFuncAsync<UserProfile[]> { // HARRISONTODO this could be replaced by getMissingProfilesByIds in most cases
+    return async (dispatch, getState) => {
         let profiles: UserProfile[];
 
         try {
@@ -214,8 +214,8 @@ export function getProfilesByIds(userIds: string[], options?: any): ActionFunc {
     };
 }
 
-export function getProfilesByUsernames(usernames: string[]): ActionFunc<UserProfile[]> {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getProfilesByUsernames(usernames: string[]): NewActionFuncAsync<UserProfile[]> { // HARRISONTODO this could be replaced by getMissingProfilesByUsernames in most cases
+    return async (dispatch, getState) => {
         let profiles;
 
         try {
@@ -292,8 +292,8 @@ export function getProfilesNotInTeam(teamId: string, groupConstrained: boolean, 
     };
 }
 
-export function getProfilesWithoutTeam(page: number, perPage: number = General.PROFILE_CHUNK_SIZE, options: any = {}): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getProfilesWithoutTeam(page: number, perPage: number = General.PROFILE_CHUNK_SIZE, options: any = {}): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         let profiles = null;
         try {
             profiles = await Client4.getProfilesWithoutTeam(page, perPage, options);
@@ -351,8 +351,8 @@ export function getProfilesInChannel(channelId: string, page: number, perPage: n
     };
 }
 
-export function getProfilesInGroupChannels(channelsIds: string[]): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getProfilesInGroupChannels(channelsIds: string[]): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         let channelProfiles;
 
         try {
@@ -621,8 +621,8 @@ export function getStatus(userId: string) {
     });
 }
 
-export function setStatus(status: UserStatus): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function setStatus(status: UserStatus): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         try {
             await Client4.updateStatus(status);
         } catch (error) {
@@ -715,7 +715,7 @@ export function revokeAllSessionsForUser(userId: string): NewActionFuncAsync<boo
     };
 }
 
-export function revokeSessionsForAllUsers(): ActionFunc<boolean, ServerError> {
+export function revokeSessionsForAllUsers(): NewActionFuncAsync<boolean> {
     return async (dispatch, getState) => {
         try {
             await Client4.revokeSessionsForAllUsers();
@@ -967,8 +967,8 @@ export function updateUserRoles(userId: string, roles: string): NewActionFuncAsy
     };
 }
 
-export function updateUserMfa(userId: string, activate: boolean, code = ''): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function updateUserMfa(userId: string, activate: boolean, code = ''): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         try {
             await Client4.updateUserMfa(userId, activate, code);
         } catch (error) {
@@ -1209,8 +1209,8 @@ export function getUserAccessToken(tokenId: string): NewActionFuncAsync<UserAcce
     };
 }
 
-export function getUserAccessTokens(page = 0, perPage: number = General.PROFILE_CHUNK_SIZE): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function getUserAccessTokens(page = 0, perPage: number = General.PROFILE_CHUNK_SIZE): NewActionFuncAsync { // HARRISONTODO unused
+    return async (dispatch, getState) => {
         let data;
 
         try {
@@ -1326,15 +1326,15 @@ export function getKnownUsers() {
     });
 }
 
-export function clearUserAccessTokens(): ActionFunc {
+export function clearUserAccessTokens(): NewActionFuncAsync {
     return async (dispatch) => {
         dispatch({type: UserTypes.CLEAR_MY_USER_ACCESS_TOKENS, data: null});
         return {data: true};
     };
 }
 
-export function checkForModifiedUsers() {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function checkForModifiedUsers(): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         const users = getUsers(state);
         const lastDisconnectAt = state.websocket.lastDisconnectAt;

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
@@ -193,7 +193,7 @@ export function getMissingProfilesByUsernames(usernames: string[]): NewActionFun
     };
 }
 
-export function getProfilesByIds(userIds: string[], options?: any): NewActionFuncAsync<UserProfile[]> { // HARRISONTODO this could be replaced by getMissingProfilesByIds in most cases
+export function getProfilesByIds(userIds: string[], options?: any): NewActionFuncAsync<UserProfile[]> {
     return async (dispatch, getState) => {
         let profiles: UserProfile[];
 
@@ -214,7 +214,7 @@ export function getProfilesByIds(userIds: string[], options?: any): NewActionFun
     };
 }
 
-export function getProfilesByUsernames(usernames: string[]): NewActionFuncAsync<UserProfile[]> { // HARRISONTODO this could be replaced by getMissingProfilesByUsernames in most cases
+export function getProfilesByUsernames(usernames: string[]): NewActionFuncAsync<UserProfile[]> {
     return async (dispatch, getState) => {
         let profiles;
 

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/websocket.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/websocket.ts
@@ -5,12 +5,12 @@ import {batchActions} from 'redux-batched-actions';
 
 import {UserTypes} from 'mattermost-redux/action_types';
 import {getCurrentUserId, getUsers} from 'mattermost-redux/selectors/entities/users';
-import type {ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {getKnownUsers} from './users';
 
-export function removeNotVisibleUsers(): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+export function removeNotVisibleUsers(): NewActionFuncAsync {
+    return async (dispatch, getState) => {
         const state = getState();
         let knownUsers: Set<string>;
         try {

--- a/webapp/channels/src/packages/mattermost-redux/src/types/actions.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/types/actions.ts
@@ -29,7 +29,7 @@ export type ActionResult<Data = any, Error = any> = {
     error?: Error;
 };
 
-export type DispatchFunc = (action: Action | NewActionFunc<unknown, any> | NewActionFuncAsync<unknown, any> | NewActionFuncOldVariantDoNotUse<unknown, any>, getState?: GetStateFunc | null) => Promise<ActionResult>;
+export type DispatchFunc = (action: Action | NewActionFunc<unknown, any> | NewActionFuncAsync<unknown, any> | ThunkActionFunc<any>, getState?: GetStateFunc | null) => Promise<ActionResult>;
 
 /**
  * Return type of a redux action.
@@ -54,9 +54,9 @@ export type NewActionFunc<Data = unknown, State extends GlobalState = GlobalStat
 export type NewActionFuncAsync<Data = unknown, State extends GlobalState = GlobalState> = BaseThunkAction<Promise<ActionResult<Data>>, State, unknown, ReduxAction>;
 
 /**
- * NewActionFuncOldVariantDoNotUse is a (hopefully) temporary type to let us migrate actions which previously returned
- * an array of promises to use a ThunkAction without having to modify their logic yet.
+ * ThunkActionFunc is a type that extends ActionFunc with defaults that match our other ActionFunc variants to save
+ * users from having to manually specify GlobalState and other arguments.
+ *
+ * NewActionFunc or NewActionFuncAsync should generally be preferred, but this type is available for legacy code.
  */
-export type NewActionFuncOldVariantDoNotUse<Data = unknown, State extends GlobalState = GlobalState> = BaseThunkAction<Data, State, unknown, ReduxAction>;
-
-export type ThunkActionFunc<ReturnType, State extends GlobalState = GlobalState> = BaseThunkAction<ReturnType, State, unknown, AnyAction>
+export type ThunkActionFunc<ReturnType, State extends GlobalState = GlobalState> = BaseThunkAction<ReturnType, State, unknown, AnyAction>;

--- a/webapp/channels/src/packages/mattermost-redux/src/types/actions.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/types/actions.ts
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import type {Action as ReduxAction, AnyAction} from 'redux';
-import type {BatchAction} from 'redux-batched-actions';
 import type {ThunkAction as BaseThunkAction} from 'redux-thunk';
 
 import type {GlobalState} from '@mattermost/types/store';
@@ -17,9 +16,6 @@ import 'redux-thunk/extend-redux';
 
 export type GetStateFunc = () => GlobalState;
 export type GenericAction = AnyAction;
-type Thunk = (b: DispatchFunc, a: GetStateFunc) => Promise<ActionResult> | ActionResult;
-
-type Action = GenericAction | Thunk | BatchAction | ActionFunc;
 
 /**
  * ActionResult should be the return value of most Thunk action creators.
@@ -29,17 +25,7 @@ export type ActionResult<Data = any, Error = any> = {
     error?: Error;
 };
 
-export type DispatchFunc = (action: Action | NewActionFunc<unknown, any> | NewActionFuncAsync<unknown, any> | ThunkActionFunc<any>, getState?: GetStateFunc | null) => Promise<ActionResult>;
-
-/**
- * Return type of a redux action.
- * @usage
- * ActionFunc<ReturnTypeOfData, ErrorType>
- */
-export type ActionFunc<Data = any, Error = any> = (
-    dispatch: DispatchFunc,
-    getState: GetStateFunc
-) => Promise<ActionResult<Data, Error> | Array<ActionResult<Data, Error>>> | ActionResult<Data, Error>;
+export type DispatchFunc = (action: AnyAction | NewActionFunc<unknown, any> | NewActionFuncAsync<unknown, any> | ThunkActionFunc<any>, getState?: GetStateFunc | null) => Promise<ActionResult>;
 
 /**
  * NewActionFunc should be the return type of most non-async Thunk action creators. If that action requires web app

--- a/webapp/channels/src/packages/mattermost-redux/src/types/actions.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/types/actions.ts
@@ -3,7 +3,7 @@
 
 import type {Action as ReduxAction, AnyAction} from 'redux';
 import type {BatchAction} from 'redux-batched-actions';
-import type {ThunkAction} from 'redux-thunk';
+import type {ThunkAction as BaseThunkAction} from 'redux-thunk';
 
 import type {GlobalState} from '@mattermost/types/store';
 
@@ -45,16 +45,18 @@ export type ActionFunc<Data = any, Error = any> = (
  * NewActionFunc should be the return type of most non-async Thunk action creators. If that action requires web app
  * state, the second type parameter should be used to pass the version of GlobalState from 'types/store'.
  */
-export type NewActionFunc<Data = unknown, State extends GlobalState = GlobalState> = ThunkAction<ActionResult<Data>, State, unknown, ReduxAction>;
+export type NewActionFunc<Data = unknown, State extends GlobalState = GlobalState> = BaseThunkAction<ActionResult<Data>, State, unknown, ReduxAction>;
 
 /**
  * NewActionFunc should be the return type of most async Thunk action creators. If that action requires web app
  * state, the second type parameter should be used to pass the version of GlobalState from 'types/store'.
  */
-export type NewActionFuncAsync<Data = unknown, State extends GlobalState = GlobalState> = ThunkAction<Promise<ActionResult<Data>>, State, unknown, ReduxAction>;
+export type NewActionFuncAsync<Data = unknown, State extends GlobalState = GlobalState> = BaseThunkAction<Promise<ActionResult<Data>>, State, unknown, ReduxAction>;
 
 /**
  * NewActionFuncOldVariantDoNotUse is a (hopefully) temporary type to let us migrate actions which previously returned
  * an array of promises to use a ThunkAction without having to modify their logic yet.
  */
-export type NewActionFuncOldVariantDoNotUse<Data = unknown, State extends GlobalState = GlobalState> = ThunkAction<Data, State, unknown, ReduxAction>;
+export type NewActionFuncOldVariantDoNotUse<Data = unknown, State extends GlobalState = GlobalState> = BaseThunkAction<Data, State, unknown, ReduxAction>;
+
+export type ThunkActionFunc<ReturnType, State extends GlobalState = GlobalState> = BaseThunkAction<ReturnType, State, unknown, AnyAction>

--- a/webapp/channels/src/packages/mattermost-redux/src/utils/integration_utils.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/utils/integration_utils.ts
@@ -70,9 +70,7 @@ export function checkDialogElementForError(elem: DialogElement, value: any): Dia
 // If we're returned errors that don't match any of the elements we have,
 // ignore them and complete the dialog
 
-export function checkIfErrorsMatchElements(errors: {
-    [x: string]: DialogError;
-} = {}, elements: DialogElement[] = []) {
+export function checkIfErrorsMatchElements(errors: Record<string, string> = {}, elements: DialogElement[] = []) {
     for (const name in errors) {
         if (!errors.hasOwnProperty(name)) {
             continue;


### PR DESCRIPTION
#### Summary
Continuing from https://github.com/mattermost/mattermost/pull/25915, this is 99% type changes as I moved everything else over from the old `ActionFunc` and to `NewActionFunc*`. I also decided to replace `NewActionFuncVariantDoNotUse` with `ThunkActionFunc` since that name seems nicer.

I still tried to minimize non-type changes in this PR. The few places where I did that were:
1. Changing a non-async function that returns a promise to be async
2. Changing an action creator that returns `(dispatch) => dispatch({type: 'action'})` to just return the action directly
3. Returning `{data: true}` from a couple actions that previously returned `dispatch(...)`

Next steps are:
1. (Definitely) Rename `NewActionFunc*` to `ActionFunc*` since I didn't want to do it in this PR because that'd make the diff even harder to read
2. (Definitely) Figure out what to do with `DispatchFunc` since it still returns a lot of anys
4. (Definitely) Clean up the HARRISONTODO comments I've left myself
5. (Maybe) Improve the type of `ActionResult` so that you don't get errors about `data` being undefined after checking for an error.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56619

#### Release Note
```release-note
NONE
```
