### PR TITLE
Fix issue where users may not follow links to private messages they belong to

### DIFF
--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -3992,6 +3992,12 @@ func TestPostReminder(t *testing.T) {
 func TestPostGetInfo(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
+
+	defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+	th.RemovePermissionFromRole(model.PermissionManagePrivateChannelMembers.Id, model.SystemUserRoleId)
+	th.RemovePermissionFromRole(model.PermissionManagePrivateChannelMembers.Id, model.ChannelUserRoleId)
+	th.RemovePermissionFromRole(model.PermissionManagePrivateChannelMembers.Id, model.TeamUserRoleId)
+
 	client := th.Client
 	sysadminClient := th.SystemAdminClient
 	sysadminClient.AddTeamMember(context.Background(), th.BasicTeam.Id, th.SystemAdminUser.Id)

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -2296,19 +2296,26 @@ func (a *App) GetPostInfo(c request.CTX, postID string) (*model.PostInfo, *model
 	}
 
 	hasPermissionToAccessChannel := false
-	if channel.Type == model.ChannelTypeOpen {
+
+	_, channelMemberErr := a.GetChannelMember(c, channel.Id, userID)
+
+	if channelMemberErr == nil {
 		hasPermissionToAccessChannel = true
-	} else if channel.Type == model.ChannelTypePrivate {
-		hasPermissionToAccessChannel = a.HasPermissionToChannel(c, userID, channel.Id, model.PermissionManagePrivateChannelMembers)
-	} else if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
-		hasPermissionToAccessChannel = a.HasPermissionToChannel(c, userID, channel.Id, model.PermissionReadChannelContent)
+	}
+
+	if !hasPermissionToAccessChannel {
+		if channel.Type == model.ChannelTypeOpen {
+			hasPermissionToAccessChannel = true
+		} else if channel.Type == model.ChannelTypePrivate {
+			hasPermissionToAccessChannel = a.HasPermissionToChannel(c, userID, channel.Id, model.PermissionManagePrivateChannelMembers)
+		} else if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
+			hasPermissionToAccessChannel = a.HasPermissionToChannel(c, userID, channel.Id, model.PermissionReadChannelContent)
+		}
 	}
 
 	if !hasPermissionToAccessChannel {
 		return nil, notFoundError
 	}
-
-	_, channelMemberErr := a.GetChannelMember(c, channel.Id, userID)
 
 	info := model.PostInfo{
 		ChannelId:          channel.Id,


### PR DESCRIPTION
#### Summary
On https://github.com/mattermost/mattermost/pull/24701 we started using the Post Info endpoint. This had a bug that we did not caught on that PR.

The problem is that we are checking permissions before checking membership. If a user is a member of the channel, they have access to the channel, no matter their permissions. But the code was first checking the manage private channel members permission, which can be revoked in the settings.

The issue is fixed by checking first for the channel membership.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-56575

#### Release Note
```release-note
Fix issue where with certain configuration, users were not able to navigate through links to private channels they are member of.
```
