### PR TITLE
Improve Redux types part 6/Remove GenericAction

### DIFF
--- a/webapp/channels/src/components/access_history_modal/index.ts
+++ b/webapp/channels/src/components/access_history_modal/index.ts
@@ -7,7 +7,6 @@ import type {Dispatch} from 'redux';
 
 import {getUserAudits} from 'mattermost-redux/actions/users';
 import {getCurrentUserId, getUserAudits as getCurrentUserAudits} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import type {GlobalState} from 'types/store';
 
@@ -20,7 +19,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             getUserAudits,

--- a/webapp/channels/src/components/actions_menu/index.ts
+++ b/webapp/channels/src/components/actions_menu/index.ts
@@ -16,7 +16,6 @@ import {isMarketplaceEnabled} from 'mattermost-redux/selectors/entities/general'
 import {haveICurrentTeamPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 import {isCombinedUserActivityPost} from 'mattermost-redux/utils/post_list';
 import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
 import {isSystemAdmin} from 'mattermost-redux/utils/user_utils';
@@ -73,7 +72,7 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             handleBindingClick,

--- a/webapp/channels/src/components/add_groups_to_team_modal/index.ts
+++ b/webapp/channels/src/components/add_groups_to_team_modal/index.ts
@@ -11,7 +11,6 @@ import type {Team} from '@mattermost/types/teams';
 import {getGroupsNotAssociatedToTeam, linkGroupSyncable, getAllGroupsAssociatedToTeam} from 'mattermost-redux/actions/groups';
 import {getGroupsNotAssociatedToTeam as selectGroupsNotAssociatedToTeam} from 'mattermost-redux/selectors/entities/groups';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {setModalSearchTerm} from 'actions/views/search';
 
@@ -48,7 +47,7 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             getGroupsNotAssociatedToTeam,

--- a/webapp/channels/src/components/admin_console/admin_navbar_dropdown/index.ts
+++ b/webapp/channels/src/components/admin_console/admin_navbar_dropdown/index.ts
@@ -7,7 +7,6 @@ import type {Dispatch} from 'redux';
 
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 import {getMyTeams} from 'mattermost-redux/selectors/entities/teams';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {deferNavigation} from 'actions/admin_actions.jsx';
 import {getCurrentLocale} from 'selectors/i18n';
@@ -32,7 +31,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             deferNavigation,

--- a/webapp/channels/src/components/admin_console/manage_roles_modal/index.ts
+++ b/webapp/channels/src/components/admin_console/manage_roles_modal/index.ts
@@ -6,7 +6,6 @@ import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
 import {updateUserRoles} from 'mattermost-redux/actions/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import type {GlobalState} from 'types/store';
 
@@ -18,7 +17,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             updateUserRoles,

--- a/webapp/channels/src/components/admin_console/manage_teams_modal/index.tsx
+++ b/webapp/channels/src/components/admin_console/manage_teams_modal/index.tsx
@@ -6,7 +6,6 @@ import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
 import {updateTeamMemberSchemeRoles, getTeamMembersForUser, getTeamsForUser, removeUserFromTeam} from 'mattermost-redux/actions/teams';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {getCurrentLocale} from 'selectors/i18n';
 
@@ -20,7 +19,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             getTeamMembersForUser,

--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/team_in_list/index.tsx
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/team_in_list/index.tsx
@@ -9,7 +9,6 @@ import type {GlobalState} from '@mattermost/types/store';
 
 import {getTeamStats as loadTeamStats} from 'mattermost-redux/actions/teams';
 import {getTeamStats} from 'mattermost-redux/selectors/entities/teams';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import TeamInList from './team_in_list';
 
@@ -19,7 +18,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             loadTeamStats,

--- a/webapp/channels/src/components/admin_console/plugin_management/index.ts
+++ b/webapp/channels/src/components/admin_console/plugin_management/index.ts
@@ -15,7 +15,6 @@ import {
     disablePlugin,
 } from 'mattermost-redux/actions/admin';
 import {appsFeatureFlagEnabled} from 'mattermost-redux/selectors/entities/apps';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import PluginManagement from './plugin_management';
 
@@ -27,7 +26,7 @@ function mapStateToProps(state: any) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             uploadPlugin,

--- a/webapp/channels/src/components/admin_console/revoke_token_button/index.ts
+++ b/webapp/channels/src/components/admin_console/revoke_token_button/index.ts
@@ -6,11 +6,10 @@ import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
 import {revokeUserAccessToken} from 'mattermost-redux/actions/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import RevokeTokenButton from './revoke_token_button';
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             revokeUserAccessToken,

--- a/webapp/channels/src/components/admin_console/server_logs/index.ts
+++ b/webapp/channels/src/components/admin_console/server_logs/index.ts
@@ -7,7 +7,6 @@ import type {Dispatch} from 'redux';
 
 import {getLogs, getPlainLogs} from 'mattermost-redux/actions/admin';
 import * as Selectors from 'mattermost-redux/selectors/entities/admin';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import type {GlobalState} from 'types/store';
 
@@ -23,7 +22,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             getLogs,

--- a/webapp/channels/src/components/admin_console/system_user_detail/index.ts
+++ b/webapp/channels/src/components/admin_console/system_user_detail/index.ts
@@ -11,7 +11,6 @@ import {addUserToTeam} from 'mattermost-redux/actions/teams';
 import {updateUserActive} from 'mattermost-redux/actions/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getUser} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {setNavigationBlocked} from 'actions/admin_actions.jsx';
 
@@ -31,7 +30,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     const apiActions = bindActionCreators({
         updateUserActive,
         addUserToTeam,

--- a/webapp/channels/src/components/admin_console/system_user_detail/team_list/index.ts
+++ b/webapp/channels/src/components/admin_console/system_user_detail/team_list/index.ts
@@ -11,7 +11,6 @@ import {
     removeUserFromTeam,
     updateTeamMemberSchemeRoles,
 } from 'mattermost-redux/actions/teams';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {getCurrentLocale} from 'selectors/i18n';
 
@@ -25,7 +24,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             getTeamsData: getTeamsForUser,

--- a/webapp/channels/src/components/admin_console/team_channel_settings/team/details/index.ts
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/team/details/index.ts
@@ -15,7 +15,6 @@ import {
 import {getTeam as fetchTeam, membersMinusGroupMembers, patchTeam, removeUserFromTeam, updateTeamMemberSchemeRoles, addUserToTeam, deleteTeam, unarchiveTeam} from 'mattermost-redux/actions/teams';
 import {getAllGroups, getGroupsAssociatedToTeam} from 'mattermost-redux/selectors/entities/groups';
 import {getTeam} from 'mattermost-redux/selectors/entities/teams';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {setNavigationBlocked} from 'actions/admin_actions';
 
@@ -46,7 +45,7 @@ function mapStateToProps(state: GlobalState, props: OwnProps) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             getTeam: fetchTeam,

--- a/webapp/channels/src/components/announcement_bar/cloud_trial_announcement_bar/index.ts
+++ b/webapp/channels/src/components/announcement_bar/cloud_trial_announcement_bar/index.ts
@@ -11,7 +11,6 @@ import {getConfig} from 'mattermost-redux/selectors/entities/admin';
 import {getLicense} from 'mattermost-redux/selectors/entities/general';
 import {makeGetCategory} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUser, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {openModal} from 'actions/views/modals';
 
@@ -51,7 +50,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators(
             {

--- a/webapp/channels/src/components/announcement_bar/configuration_bar/index.ts
+++ b/webapp/channels/src/components/announcement_bar/configuration_bar/index.ts
@@ -8,7 +8,6 @@ import type {Dispatch} from 'redux';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {get as getPreference} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {dismissNotice} from 'actions/views/notice';
 
@@ -34,7 +33,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             dismissNotice,

--- a/webapp/channels/src/components/announcement_bar/default_announcement_bar/index.ts
+++ b/webapp/channels/src/components/announcement_bar/default_announcement_bar/index.ts
@@ -5,8 +5,6 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import {incrementAnnouncementBarCount, decrementAnnouncementBarCount} from 'actions/views/announcement_bar';
 import {getAnnouncementBarCount} from 'selectors/views/announcement_bar';
 
@@ -20,7 +18,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             incrementAnnouncementBarCount,

--- a/webapp/channels/src/components/announcement_bar/index.ts
+++ b/webapp/channels/src/components/announcement_bar/index.ts
@@ -13,7 +13,6 @@ import {getConfig, getLicense, warnMetricsStatus as getWarnMetricsStatus} from '
 import {haveISystemPermission} from 'mattermost-redux/selectors/entities/roles';
 import {isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 import {getDisplayableErrors} from 'mattermost-redux/selectors/errors';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {dismissNotice} from 'actions/views/notice';
 
@@ -49,7 +48,7 @@ function mapStateToProps(state: GlobalState) {
 }
 
 //
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     const dismissFirstError = dismissError.bind(null, 0);
     return {
         actions: bindActionCreators({

--- a/webapp/channels/src/components/announcement_bar/renewal_link/index.ts
+++ b/webapp/channels/src/components/announcement_bar/renewal_link/index.ts
@@ -5,13 +5,11 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import {openModal} from 'actions/views/modals';
 
 import RenewalLink from './renewal_link';
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators(
             {

--- a/webapp/channels/src/components/audit_table/index.ts
+++ b/webapp/channels/src/components/audit_table/index.ts
@@ -7,7 +7,6 @@ import type {Dispatch} from 'redux';
 
 import {getMissingProfilesByIds} from 'mattermost-redux/actions/users';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import type {GlobalState} from 'types/store';
 
@@ -19,7 +18,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             getMissingProfilesByIds,

--- a/webapp/channels/src/components/channel_header_dropdown/menu_items/close_channel/index.ts
+++ b/webapp/channels/src/components/channel_header_dropdown/menu_items/close_channel/index.ts
@@ -5,13 +5,11 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import {goToLastViewedChannel} from 'actions/views/channel';
 
 import CloseChannel from './close_channel';
 
-const mapDispatchToProps = (dispatch: Dispatch<GenericAction>) => ({
+const mapDispatchToProps = (dispatch: Dispatch) => ({
     actions: bindActionCreators({
         goToLastViewedChannel,
     }, dispatch),

--- a/webapp/channels/src/components/channel_header_dropdown/menu_items/leave_channel/index.ts
+++ b/webapp/channels/src/components/channel_header_dropdown/menu_items/leave_channel/index.ts
@@ -6,14 +6,12 @@ import type {ConnectedProps} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import {leaveChannel} from 'actions/views/channel';
 import {openModal} from 'actions/views/modals';
 
 import LeaveChannel from './leave_channel';
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             leaveChannel,

--- a/webapp/channels/src/components/channel_header_dropdown/menu_items/open_members_rhs/index.ts
+++ b/webapp/channels/src/components/channel_header_dropdown/menu_items/open_members_rhs/index.ts
@@ -5,8 +5,6 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import {showChannelMembers} from 'actions/views/rhs';
 import {getIsRhsOpen, getRhsState} from 'selectors/rhs';
 
@@ -20,7 +18,7 @@ const mapStateToProps = (state: GlobalState) => ({
     rhsOpen: getIsRhsOpen(state) && getRhsState(state) === RHSStates.CHANNEL_MEMBERS,
 });
 
-const mapDispatchToProps = (dispatch: Dispatch<GenericAction>) => ({
+const mapDispatchToProps = (dispatch: Dispatch) => ({
     actions: bindActionCreators({
         showChannelMembers,
     }, dispatch),

--- a/webapp/channels/src/components/channel_header_dropdown/menu_items/toggle_favorite_channel/index.ts
+++ b/webapp/channels/src/components/channel_header_dropdown/menu_items/toggle_favorite_channel/index.ts
@@ -6,11 +6,10 @@ import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
 import {favoriteChannel, unfavoriteChannel} from 'mattermost-redux/actions/channels';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import ToggleFavoriteChannel from './toggle_favorite_channel';
 
-const mapDispatchToProps = (dispatch: Dispatch<GenericAction>) => ({
+const mapDispatchToProps = (dispatch: Dispatch) => ({
     actions: bindActionCreators({
         favoriteChannel,
         unfavoriteChannel,

--- a/webapp/channels/src/components/channel_header_dropdown/menu_items/toggle_info/index.ts
+++ b/webapp/channels/src/components/channel_header_dropdown/menu_items/toggle_info/index.ts
@@ -5,8 +5,6 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import {closeRightHandSide, showChannelInfo} from 'actions/views/rhs';
 import {getIsRhsOpen, getRhsState} from 'selectors/rhs';
 
@@ -20,7 +18,7 @@ const mapStateToProps = (state: GlobalState) => ({
     rhsOpen: getIsRhsOpen(state) && getRhsState(state) === RHSStates.CHANNEL_INFO,
 });
 
-const mapDispatchToProps = (dispatch: Dispatch<GenericAction>) => ({
+const mapDispatchToProps = (dispatch: Dispatch) => ({
     actions: bindActionCreators({
         closeRightHandSide,
         showChannelInfo,

--- a/webapp/channels/src/components/channel_header_dropdown/menu_items/view_pinned_posts/index.ts
+++ b/webapp/channels/src/components/channel_header_dropdown/menu_items/view_pinned_posts/index.ts
@@ -5,8 +5,6 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import {closeRightHandSide, showPinnedPosts} from 'actions/views/rhs';
 import {getRhsState} from 'selectors/rhs';
 
@@ -20,7 +18,7 @@ const mapStateToProps = (state: GlobalState) => ({
     hasPinnedPosts: getRhsState(state) === RHSStates.PIN,
 });
 
-const mapDispatchToProps = (dispatch: Dispatch<GenericAction>) => ({
+const mapDispatchToProps = (dispatch: Dispatch) => ({
     actions: bindActionCreators({
         closeRightHandSide,
         showPinnedPosts,

--- a/webapp/channels/src/components/channel_header_mobile/collapse_lhs_button/index.ts
+++ b/webapp/channels/src/components/channel_header_mobile/collapse_lhs_button/index.ts
@@ -5,13 +5,11 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import {toggle as toggleLhs} from 'actions/views/lhs';
 
 import CollapseLhsButton from './collapse_lhs_button';
 
-const mapDispatchToProps = (dispatch: Dispatch<GenericAction>) => ({
+const mapDispatchToProps = (dispatch: Dispatch) => ({
     actions: bindActionCreators({
         toggleLhs,
     }, dispatch),

--- a/webapp/channels/src/components/channel_header_mobile/collapse_rhs_button/index.ts
+++ b/webapp/channels/src/components/channel_header_mobile/collapse_rhs_button/index.ts
@@ -5,13 +5,11 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import {toggleMenu as toggleRhsMenu} from 'actions/views/rhs';
 
 import CollapseRhsButton from './collapse_rhs_button';
 
-const mapDispatchToProps = (dispatch: Dispatch<GenericAction>) => ({
+const mapDispatchToProps = (dispatch: Dispatch) => ({
     actions: bindActionCreators({
         toggleRhsMenu,
     }, dispatch),

--- a/webapp/channels/src/components/channel_header_mobile/show_search_button/index.ts
+++ b/webapp/channels/src/components/channel_header_mobile/show_search_button/index.ts
@@ -5,13 +5,11 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import {openRHSSearch} from 'actions/views/rhs';
 
 import ShowSearchButton from './show_search_button';
 
-const mapDispatchToProps = (dispatch: Dispatch<GenericAction>) => ({
+const mapDispatchToProps = (dispatch: Dispatch) => ({
     actions: bindActionCreators({
         openRHSSearch,
     }, dispatch),

--- a/webapp/channels/src/components/channel_header_mobile/unmute_channel_button/index.ts
+++ b/webapp/channels/src/components/channel_header_mobile/unmute_channel_button/index.ts
@@ -6,11 +6,10 @@ import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
 import {updateChannelNotifyProps} from 'mattermost-redux/actions/channels';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import UnmuteChannelButton from './unmute_channel_button';
 
-const mapDispatchToProps = (dispatch: Dispatch<GenericAction>) => ({
+const mapDispatchToProps = (dispatch: Dispatch) => ({
     actions: bindActionCreators({
         updateChannelNotifyProps,
     }, dispatch),

--- a/webapp/channels/src/components/channel_layout/channel_identifier_router/index.ts
+++ b/webapp/channels/src/components/channel_layout/channel_identifier_router/index.ts
@@ -6,12 +6,10 @@ import {withRouter} from 'react-router-dom';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import {onChannelByIdentifierEnter} from './actions';
 import ChannelIdentifierRouter from './channel_identifier_router';
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             onChannelByIdentifierEnter,

--- a/webapp/channels/src/components/emoji/emoji_list_item/index.ts
+++ b/webapp/channels/src/components/emoji/emoji_list_item/index.ts
@@ -8,7 +8,6 @@ import type {Dispatch} from 'redux';
 import {deleteCustomEmoji} from 'mattermost-redux/actions/emojis';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getUser, getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {getDisplayNameByUser} from 'utils/utils';
 
@@ -30,7 +29,7 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             deleteCustomEmoji,

--- a/webapp/channels/src/components/file_attachment/index.ts
+++ b/webapp/channels/src/components/file_attachment/index.ts
@@ -7,7 +7,6 @@ import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {openModal} from 'actions/views/modals';
 import {getFilesDropdownPluginMenuItems} from 'selectors/plugins';
@@ -29,7 +28,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             openModal,

--- a/webapp/channels/src/components/file_attachment_list/index.ts
+++ b/webapp/channels/src/components/file_attachment_list/index.ts
@@ -10,7 +10,6 @@ import type {Post} from '@mattermost/types/posts';
 
 import {makeGetFilesForPost} from 'mattermost-redux/selectors/entities/files';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {openModal} from 'actions/views/modals';
 import {getCurrentLocale} from 'selectors/i18n';
@@ -53,7 +52,7 @@ function makeMapStateToProps() {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             openModal,

--- a/webapp/channels/src/components/file_search_results/index.tsx
+++ b/webapp/channels/src/components/file_search_results/index.tsx
@@ -9,7 +9,6 @@ import type {Dispatch} from 'redux';
 import type {FileInfo} from '@mattermost/types/files';
 
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {openModal} from 'actions/views/modals';
 
@@ -34,7 +33,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             openModal,

--- a/webapp/channels/src/components/get_public_link_modal/index.ts
+++ b/webapp/channels/src/components/get_public_link_modal/index.ts
@@ -10,7 +10,6 @@ import type {GlobalState} from '@mattermost/types/store';
 
 import {getFilePublicLink} from 'mattermost-redux/actions/files';
 import * as Selectors from 'mattermost-redux/selectors/entities/files';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import GetPublicLinkModal from './get_public_link_modal';
 
@@ -21,7 +20,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             getFilePublicLink,

--- a/webapp/channels/src/components/global_header/center_controls/user_guide_dropdown/index.ts
+++ b/webapp/channels/src/components/global_header/center_controls/user_guide_dropdown/index.ts
@@ -11,7 +11,6 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getIsOnboardingFlowEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 import {isFirstAdmin} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {openModal} from 'actions/views/modals';
 import {getUserGuideDropdownPluginMenuItems} from 'selectors/plugins';
@@ -36,7 +35,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             openModal,

--- a/webapp/channels/src/components/global_header/right_controls/settings_button/index.ts
+++ b/webapp/channels/src/components/global_header/right_controls/settings_button/index.ts
@@ -5,13 +5,11 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import {openModal} from 'actions/views/modals';
 
 import SettingsButton from './settings_button';
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             openModal,

--- a/webapp/channels/src/components/integrations/bots/index.ts
+++ b/webapp/channels/src/components/integrations/bots/index.ts
@@ -17,7 +17,6 @@ import {getExternalBotAccounts} from 'mattermost-redux/selectors/entities/bots';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getAppsBotIDs} from 'mattermost-redux/selectors/entities/integrations';
 import * as UserSelectors from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import Bots from './bots';
 
@@ -48,7 +47,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             fetchAppsBotIDs,

--- a/webapp/channels/src/components/intl_provider/index.tsx
+++ b/webapp/channels/src/components/intl_provider/index.tsx
@@ -5,8 +5,6 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import {loadTranslations} from 'actions/views/root';
 import {getCurrentLocale, getTranslations} from 'selectors/i18n';
 
@@ -23,7 +21,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             loadTranslations,

--- a/webapp/channels/src/components/leave_channel_modal/index.ts
+++ b/webapp/channels/src/components/leave_channel_modal/index.ts
@@ -5,13 +5,11 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import {leaveChannel} from 'actions/views/channel';
 
 import LeaveChannelModal from './leave_channel_modal';
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             leaveChannel,

--- a/webapp/channels/src/components/leave_team_modal/index.ts
+++ b/webapp/channels/src/components/leave_team_modal/index.ts
@@ -9,7 +9,6 @@ import {removeUserFromTeam as leaveTeam} from 'mattermost-redux/actions/teams';
 import {getMyChannels} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, getCurrentUser} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {toggleSideBarRightMenuAction} from 'actions/global_actions';
 
@@ -45,7 +44,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             leaveTeam,

--- a/webapp/channels/src/components/logged_in/index.ts
+++ b/webapp/channels/src/components/logged_in/index.ts
@@ -10,7 +10,7 @@ import {autoUpdateTimezone} from 'mattermost-redux/actions/timezone';
 import {getChannel, getCurrentChannelId, isManuallyUnread} from 'mattermost-redux/selectors/entities/channels';
 import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUser, shouldShowTermsOfService} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 import {getChannelURL} from 'selectors/urls';
 
@@ -55,7 +55,7 @@ const getChannelURLAction = (channelId: string, teamId: string, url: string): Th
     return getHistory().push(getChannelURL(state, channel, teamId));
 };
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             autoUpdateTimezone,

--- a/webapp/channels/src/components/main_menu/index.tsx
+++ b/webapp/channels/src/components/main_menu/index.tsx
@@ -19,7 +19,6 @@ import {
     getCurrentRelativeTeamUrl,
 } from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser, isFirstAdmin} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {openModal} from 'actions/views/modals';
 import {showMentions, showFlaggedPosts, closeRightHandSide, closeMenu as closeRhsMenu} from 'actions/views/rhs';
@@ -94,7 +93,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             openModal,

--- a/webapp/channels/src/components/new_replies_banner/index.ts
+++ b/webapp/channels/src/components/new_replies_banner/index.ts
@@ -10,7 +10,6 @@ import type {Post} from '@mattermost/types/posts';
 import {createSelector} from 'mattermost-redux/selectors/create_selector';
 import {makeGetPostsForThread} from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {updateThreadToastStatus} from 'actions/views/threads';
 
@@ -51,7 +50,7 @@ function makeMapStateToProps() {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             updateThreadToastStatus,

--- a/webapp/channels/src/components/post_view/channel_intro_message/index.ts
+++ b/webapp/channels/src/components/post_view/channel_intro_message/index.ts
@@ -11,7 +11,6 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {get} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getProfilesInCurrentChannel, getCurrentUserId, getUser, getTotalUsersStats as getTotalUsersStatsSelector} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {getCurrentLocale} from 'selectors/i18n';
 
@@ -54,7 +53,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             getTotalUsersStats,

--- a/webapp/channels/src/components/post_view/combined_system_message/index.ts
+++ b/webapp/channels/src/components/post_view/combined_system_message/index.ts
@@ -11,7 +11,6 @@ import {getMissingProfilesByIds, getMissingProfilesByUsernames} from 'mattermost
 import {Preferences} from 'mattermost-redux/constants';
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUser, makeGetProfilesByIdsAndUsernames} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import CombinedSystemMessage from './combined_system_message';
 
@@ -36,7 +35,7 @@ function makeMapStateToProps() {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             getMissingProfilesByIds,

--- a/webapp/channels/src/components/post_view/failed_post_options/index.ts
+++ b/webapp/channels/src/components/post_view/failed_post_options/index.ts
@@ -6,13 +6,12 @@ import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
 import {removePost} from 'mattermost-redux/actions/posts';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {createPost} from 'actions/post_actions';
 
 import FailedPostOptions from './failed_post_options';
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             createPost,

--- a/webapp/channels/src/components/post_view/post_add_channel_member/index.ts
+++ b/webapp/channels/src/components/post_view/post_add_channel_member/index.ts
@@ -12,7 +12,6 @@ import {removePost} from 'mattermost-redux/actions/posts';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import PostAddChannelMember from './post_add_channel_member';
 
@@ -37,7 +36,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             addChannelMember,

--- a/webapp/channels/src/components/post_view/post_attachment_opengraph/index.ts
+++ b/webapp/channels/src/components/post_view/post_attachment_opengraph/index.ts
@@ -9,7 +9,6 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getOpenGraphMetadataForUrl} from 'mattermost-redux/selectors/entities/posts';
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {editPost} from 'actions/views/posts';
 import {arePreviewsCollapsed} from 'selectors/preferences';
@@ -45,7 +44,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({editPost}, dispatch),
     };

--- a/webapp/channels/src/components/post_view/post_body_additional_content/index.ts
+++ b/webapp/channels/src/components/post_view/post_body_additional_content/index.ts
@@ -6,7 +6,6 @@ import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
 import {appsEnabled} from 'mattermost-redux/selectors/entities/apps';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {toggleEmbedVisibility} from 'actions/post_actions';
 import {isEmbedVisible} from 'selectors/posts';
@@ -27,7 +26,7 @@ function mapStateToProps(state: GlobalState, ownProps: Omit<Props, 'appsEnabled'
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({toggleEmbedVisibility}, dispatch),
     };

--- a/webapp/channels/src/components/post_view/post_list_row/index.ts
+++ b/webapp/channels/src/components/post_view/post_list_row/index.ts
@@ -9,7 +9,6 @@ import {getCloudLimits, getCloudLimitsLoaded} from 'mattermost-redux/selectors/e
 import {getCurrentChannelId, getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 import {getLimitedViews, getPost} from 'mattermost-redux/selectors/entities/posts';
 import {getUsage} from 'mattermost-redux/selectors/entities/usage';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {emitShortcutReactToLastPostFrom} from 'actions/post_actions';
 import {getShortcutReactToLastPostEmittedFrom} from 'selectors/emojis';
@@ -56,7 +55,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     return props;
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             emitShortcutReactToLastPostFrom,

--- a/webapp/channels/src/components/post_view/post_message_preview/index.ts
+++ b/webapp/channels/src/components/post_view/post_message_preview/index.ts
@@ -14,7 +14,6 @@ import {getPost, isPostPriorityEnabled} from 'mattermost-redux/selectors/entitie
 import {get} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 import {getUser} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {toggleEmbedVisibility} from 'actions/post_actions';
 import {isEmbedVisible} from 'selectors/posts';
@@ -67,7 +66,7 @@ function makeMapStateToProps() {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({toggleEmbedVisibility}, dispatch),
     };

--- a/webapp/channels/src/components/post_view/post_recent_reactions/index.ts
+++ b/webapp/channels/src/components/post_view/post_recent_reactions/index.ts
@@ -7,8 +7,6 @@ import type {Dispatch} from 'redux';
 
 import type {Emoji} from '@mattermost/types/emojis';
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import {toggleReaction} from 'actions/post_actions';
 import {getEmojiMap} from 'selectors/emojis';
 import {getCurrentLocale} from 'selectors/i18n';
@@ -17,7 +15,7 @@ import type {GlobalState} from 'types/store';
 
 import PostReaction from './post_recent_reactions';
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             toggleReaction,

--- a/webapp/channels/src/components/post_view/reaction/index.ts
+++ b/webapp/channels/src/components/post_view/reaction/index.ts
@@ -16,7 +16,6 @@ import {createSelector} from 'mattermost-redux/selectors/create_selector';
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 import {canAddReactions, canRemoveReactions} from 'mattermost-redux/selectors/entities/reactions';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 import {getEmojiImageUrl} from 'mattermost-redux/utils/emoji_utils';
 
 import {addReaction} from 'actions/post_actions';
@@ -69,7 +68,7 @@ function makeMapStateToProps() {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             addReaction,

--- a/webapp/channels/src/components/post_view/reaction_list/index.ts
+++ b/webapp/channels/src/components/post_view/reaction_list/index.ts
@@ -9,7 +9,6 @@ import type {Post} from '@mattermost/types/posts';
 
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {canAddReactions} from 'mattermost-redux/selectors/entities/reactions';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {toggleReaction} from 'actions/post_actions';
 
@@ -40,7 +39,7 @@ function makeMapStateToProps() {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             toggleReaction,

--- a/webapp/channels/src/components/search/user_guide_dropdown/index.ts
+++ b/webapp/channels/src/components/search/user_guide_dropdown/index.ts
@@ -7,7 +7,6 @@ import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {openModal} from 'actions/views/modals';
 
@@ -24,7 +23,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             openModal,

--- a/webapp/channels/src/components/sidebar/channel_filter/index.ts
+++ b/webapp/channels/src/components/sidebar/channel_filter/index.ts
@@ -6,7 +6,6 @@ import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
 import {getMyTeams} from 'mattermost-redux/selectors/entities/teams';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {setUnreadFilterEnabled} from 'actions/views/channel_sidebar';
 import {isUnreadFilterEnabled} from 'selectors/views/channel_sidebar';
@@ -24,7 +23,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             setUnreadFilterEnabled,

--- a/webapp/channels/src/components/sidebar/mobile_sidebar_header/contents/index.ts
+++ b/webapp/channels/src/components/sidebar/mobile_sidebar_header/contents/index.ts
@@ -7,7 +7,6 @@ import type {Dispatch} from 'redux';
 
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {openModal} from 'actions/views/modals';
 
@@ -27,7 +26,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             openModal,

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_link/index.ts
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_link/index.ts
@@ -11,7 +11,6 @@ import {makeGetChannelUnreadCount} from 'mattermost-redux/selectors/entities/cha
 import {getCurrentUserId, getMyChannelMemberships} from 'mattermost-redux/selectors/entities/common';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getInt} from 'mattermost-redux/selectors/entities/preferences';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 import {isChannelMuted} from 'mattermost-redux/utils/channel_utils';
 
 import {markMostRecentPostInChannelAsUnread, unsetEditingPost} from 'actions/post_actions';
@@ -67,7 +66,7 @@ function makeMapStateToProps() {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             markMostRecentPostInChannelAsUnread,

--- a/webapp/channels/src/components/sidebar/sidebar_list/index.ts
+++ b/webapp/channels/src/components/sidebar/sidebar_list/index.ts
@@ -10,7 +10,6 @@ import {getCurrentChannelId, getUnreadChannelIds} from 'mattermost-redux/selecto
 import {shouldShowUnreadsCategory, isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getThreadCountsInCurrentTeam} from 'mattermost-redux/selectors/entities/threads';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {switchToChannelById} from 'actions/views/channel';
 import {
@@ -59,7 +58,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             close,

--- a/webapp/channels/src/components/sidebar_right_menu/index.ts
+++ b/webapp/channels/src/components/sidebar_right_menu/index.ts
@@ -7,7 +7,6 @@ import type {Dispatch} from 'redux';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {openMenu as openRhsMenu} from 'actions/views/rhs';
 import {getIsRhsMenuOpen} from 'selectors/rhs';
@@ -31,7 +30,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             openRhsMenu,

--- a/webapp/channels/src/components/single_image_view/index.ts
+++ b/webapp/channels/src/components/single_image_view/index.ts
@@ -8,7 +8,6 @@ import type {Dispatch} from 'redux';
 
 import {getFilePublicLink} from 'mattermost-redux/actions/files';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {toggleEmbedVisibility} from 'actions/post_actions';
 import {openModal} from 'actions/views/modals';
@@ -28,7 +27,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             toggleEmbedVisibility,

--- a/webapp/channels/src/components/status_dropdown/index.ts
+++ b/webapp/channels/src/components/status_dropdown/index.ts
@@ -12,7 +12,6 @@ import {Preferences} from 'mattermost-redux/constants';
 import {get, getBool, getInt} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTimezone} from 'mattermost-redux/selectors/entities/timezone';
 import {getCurrentUser, getStatusForUserId} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {openModal} from 'actions/views/modals';
 import {setStatusDropdown} from 'actions/views/status_dropdown';
@@ -58,7 +57,7 @@ function makeMapStateToProps() {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             openModal,

--- a/webapp/channels/src/components/team_members_dropdown/index.ts
+++ b/webapp/channels/src/components/team_members_dropdown/index.ts
@@ -19,7 +19,6 @@ import {getUser, updateUserActive} from 'mattermost-redux/actions/users';
 import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentRelativeTeamUrl, getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {removeUserFromTeamAndGetStats} from 'actions/team_actions';
 
@@ -34,7 +33,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             getMyTeamMembers,

--- a/webapp/channels/src/components/threading/thread_viewer/index.ts
+++ b/webapp/channels/src/components/threading/thread_viewer/index.ts
@@ -18,7 +18,6 @@ import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/pre
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getThread} from 'mattermost-redux/selectors/entities/threads';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {selectPostCard} from 'actions/views/rhs';
 import {updateThreadLastOpened} from 'actions/views/threads';
@@ -71,7 +70,7 @@ function makeMapStateToProps() {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             fetchRHSAppsBindings,

--- a/webapp/channels/src/components/unreads_status_handler/index.ts
+++ b/webapp/channels/src/components/unreads_status_handler/index.ts
@@ -13,7 +13,6 @@ import type {GlobalState} from '@mattermost/types/store';
 import {getCurrentChannel, getUnreadStatus} from 'mattermost-redux/selectors/entities/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import UnreadsStatusHandler from './unreads_status_handler';
 
@@ -36,7 +35,7 @@ function mapStateToProps(state: GlobalState, {location: {pathname}}: Props): Com
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
         }, dispatch),

--- a/webapp/channels/src/components/user_settings/advanced/join_leave_section/index.ts
+++ b/webapp/channels/src/components/user_settings/advanced/join_leave_section/index.ts
@@ -10,7 +10,6 @@ import {Preferences} from 'mattermost-redux/constants';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {get as getPreference} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions.js';
 
 import type {GlobalState} from 'types/store';
 
@@ -33,7 +32,7 @@ export function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             savePreferences,

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/helpers.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/helpers.ts
@@ -5,7 +5,7 @@ import type {ServerError} from '@mattermost/types/errors';
 
 import {UserTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
-import type {GenericAction, DispatchFunc, GetStateFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {DispatchFunc, GetStateFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {logError} from './errors';
 
@@ -28,7 +28,7 @@ function dispatcher(type: ActionType, data: any, dispatch: DispatchFunc) {
     }
 }
 
-export function requestData(type: ActionType): GenericAction {
+export function requestData(type: ActionType) {
     return {
         type,
         data: null,

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/admin.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/admin.test.ts
@@ -4,7 +4,6 @@
 import {AdminTypes, UserTypes} from 'mattermost-redux/action_types';
 import PluginState from 'mattermost-redux/constants/plugins';
 import reducer, {convertAnalyticsRowsToStats} from 'mattermost-redux/reducers/entities/admin';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 import deepFreezeAndThrowOnMutation from 'mattermost-redux/utils/deep_freeze';
 
 type ReducerState = ReturnType<typeof reducer>;
@@ -13,10 +12,10 @@ describe('reducers.entities.admin', () => {
     describe('pluginStatuses', () => {
         it('initial state', () => {
             const state = {};
-            const action = {};
+            const action = {type: undefined};
             const expectedState = {};
 
-            const actualState = reducer({pluginStatuses: state} as ReducerState, action as GenericAction);
+            const actualState = reducer({pluginStatuses: state} as ReducerState, action);
             expect(actualState.pluginStatuses).toEqual(expectedState);
         });
 
@@ -602,10 +601,10 @@ describe('reducers.entities.admin', () => {
     describe('ldapGroups', () => {
         it('initial state', () => {
             const state = {};
-            const action = {};
+            const action = {type: undefined};
             const expectedState = {};
 
-            const actualState = reducer({ldapGroups: state} as ReducerState, action as GenericAction);
+            const actualState = reducer({ldapGroups: state} as ReducerState, action);
             expect(actualState.ldapGroups).toEqual(expectedState);
         });
 
@@ -868,10 +867,10 @@ describe('reducers.entities.admin', () => {
     describe('Data Retention', () => {
         it('initial state', () => {
             const state = {};
-            const action = {};
+            const action = {type: undefined};
             const expectedState = {};
 
-            const actualState = reducer({dataRetentionCustomPolicies: state} as ReducerState, action as GenericAction);
+            const actualState = reducer({dataRetentionCustomPolicies: state} as ReducerState, action);
             expect(actualState.dataRetentionCustomPolicies).toEqual(expectedState);
         });
 

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/admin.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/admin.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {ClusterInfo, AnalyticsRow} from '@mattermost/types/admin';
@@ -18,9 +19,8 @@ import type {RelationOneToOne, IDMappedObjects} from '@mattermost/types/utilitie
 import {AdminTypes, UserTypes} from 'mattermost-redux/action_types';
 import {Stats} from 'mattermost-redux/constants';
 import PluginState from 'mattermost-redux/constants/plugins';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
-function logs(state: string[] = [], action: GenericAction) {
+function logs(state: string[] = [], action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_LOGS: {
         return action.data;
@@ -33,7 +33,7 @@ function logs(state: string[] = [], action: GenericAction) {
     }
 }
 
-function plainLogs(state: string[] = [], action: GenericAction) {
+function plainLogs(state: string[] = [], action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_PLAIN_LOGS: {
         return action.data;
@@ -46,7 +46,7 @@ function plainLogs(state: string[] = [], action: GenericAction) {
     }
 }
 
-function audits(state: Record<string, Audit> = {}, action: GenericAction) {
+function audits(state: Record<string, Audit> = {}, action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_AUDITS: {
         const nextState = {...state};
@@ -63,7 +63,7 @@ function audits(state: Record<string, Audit> = {}, action: GenericAction) {
     }
 }
 
-function config(state: Partial<AdminConfig> = {}, action: GenericAction) {
+function config(state: Partial<AdminConfig> = {}, action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_CONFIG: {
         return action.data;
@@ -90,7 +90,7 @@ function config(state: Partial<AdminConfig> = {}, action: GenericAction) {
     }
 }
 
-function prevTrialLicense(state: Partial<AdminConfig> = {}, action: GenericAction) {
+function prevTrialLicense(state: Partial<AdminConfig> = {}, action: AnyAction) {
     switch (action.type) {
     case AdminTypes.PREV_TRIAL_LICENSE_SUCCESS: {
         return action.data;
@@ -100,7 +100,7 @@ function prevTrialLicense(state: Partial<AdminConfig> = {}, action: GenericActio
     }
 }
 
-function environmentConfig(state: Partial<EnvironmentConfig> = {}, action: GenericAction) {
+function environmentConfig(state: Partial<EnvironmentConfig> = {}, action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_ENVIRONMENT_CONFIG: {
         return action.data;
@@ -113,7 +113,7 @@ function environmentConfig(state: Partial<EnvironmentConfig> = {}, action: Gener
     }
 }
 
-function complianceReports(state: Record<string, Compliance> = {}, action: GenericAction) {
+function complianceReports(state: Record<string, Compliance> = {}, action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_COMPLIANCE_REPORT: {
         const nextState = {...state};
@@ -135,7 +135,7 @@ function complianceReports(state: Record<string, Compliance> = {}, action: Gener
     }
 }
 
-function clusterInfo(state: ClusterInfo[] = [], action: GenericAction) {
+function clusterInfo(state: ClusterInfo[] = [], action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_CLUSTER_STATUS: {
         return action.data;
@@ -148,7 +148,7 @@ function clusterInfo(state: ClusterInfo[] = [], action: GenericAction) {
     }
 }
 
-function samlCertStatus(state: Partial<SamlCertificateStatus> = {}, action: GenericAction) {
+function samlCertStatus(state: Partial<SamlCertificateStatus> = {}, action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_SAML_CERT_STATUS: {
         return action.data;
@@ -250,7 +250,7 @@ export function convertAnalyticsRowsToStats(data: AnalyticsRow[], name: string):
     return stats;
 }
 
-function analytics(state: Record<string, number | AnalyticsRow[]> = {}, action: GenericAction) {
+function analytics(state: Record<string, number | AnalyticsRow[]> = {}, action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_SYSTEM_ANALYTICS: {
         const stats = convertAnalyticsRowsToStats(action.data, action.name);
@@ -264,7 +264,7 @@ function analytics(state: Record<string, number | AnalyticsRow[]> = {}, action: 
     }
 }
 
-function teamAnalytics(state: RelationOneToOne<Team, Record<string, number | AnalyticsRow[]>> = {}, action: GenericAction) {
+function teamAnalytics(state: RelationOneToOne<Team, Record<string, number | AnalyticsRow[]>> = {}, action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_TEAM_ANALYTICS: {
         const nextState = {...state};
@@ -281,7 +281,7 @@ function teamAnalytics(state: RelationOneToOne<Team, Record<string, number | Ana
     }
 }
 
-function userAccessTokens(state: Record<string, UserAccessToken> = {}, action: GenericAction) {
+function userAccessTokens(state: Record<string, UserAccessToken> = {}, action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_USER_ACCESS_TOKEN: {
         return {...state, [action.data.id]: action.data};
@@ -324,7 +324,7 @@ function userAccessTokens(state: Record<string, UserAccessToken> = {}, action: G
     }
 }
 
-function userAccessTokensByUser(state: RelationOneToOne<UserProfile, Record<string, UserAccessToken>> = {}, action: GenericAction) {
+function userAccessTokensByUser(state: RelationOneToOne<UserProfile, Record<string, UserAccessToken>> = {}, action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_USER_ACCESS_TOKEN: { // UserAccessToken
         const nextUserState: UserAccessToken | Record<string, UserAccessToken> = {...(state[action.data.user_id] || {})};
@@ -400,7 +400,7 @@ function userAccessTokensByUser(state: RelationOneToOne<UserProfile, Record<stri
     }
 }
 
-function plugins(state: Record<string, PluginRedux> = {}, action: GenericAction) {
+function plugins(state: Record<string, PluginRedux> = {}, action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_PLUGINS: {
         const nextState = {...state};
@@ -446,7 +446,7 @@ function plugins(state: Record<string, PluginRedux> = {}, action: GenericAction)
     }
 }
 
-function pluginStatuses(state: Record<string, PluginStatusRedux> = {}, action: GenericAction) {
+function pluginStatuses(state: Record<string, PluginStatusRedux> = {}, action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_PLUGIN_STATUSES: {
         const nextState: any = {};
@@ -547,7 +547,7 @@ function pluginStatuses(state: Record<string, PluginStatusRedux> = {}, action: G
     }
 }
 
-function ldapGroupsCount(state = 0, action: GenericAction) {
+function ldapGroupsCount(state = 0, action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_LDAP_GROUPS:
         return action.data.count;
@@ -558,7 +558,7 @@ function ldapGroupsCount(state = 0, action: GenericAction) {
     }
 }
 
-function ldapGroups(state: Record<string, MixedUnlinkedGroupRedux> = {}, action: GenericAction) {
+function ldapGroups(state: Record<string, MixedUnlinkedGroupRedux> = {}, action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_LDAP_GROUPS: {
         const nextState: any = {};
@@ -614,7 +614,7 @@ function ldapGroups(state: Record<string, MixedUnlinkedGroupRedux> = {}, action:
     }
 }
 
-function samlMetadataResponse(state: Partial<SamlMetadataResponse> = {}, action: GenericAction) {
+function samlMetadataResponse(state: Partial<SamlMetadataResponse> = {}, action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_SAML_METADATA_RESPONSE: {
         return action.data;
@@ -624,7 +624,7 @@ function samlMetadataResponse(state: Partial<SamlMetadataResponse> = {}, action:
     }
 }
 
-function dataRetentionCustomPolicies(state: IDMappedObjects<DataRetentionCustomPolicy> = {}, action: GenericAction): IDMappedObjects<DataRetentionCustomPolicy> {
+function dataRetentionCustomPolicies(state: IDMappedObjects<DataRetentionCustomPolicy> = {}, action: AnyAction): IDMappedObjects<DataRetentionCustomPolicy> {
     switch (action.type) {
     case AdminTypes.CREATE_DATA_RETENTION_CUSTOM_POLICY_SUCCESS:
     case AdminTypes.RECEIVED_DATA_RETENTION_CUSTOM_POLICY:
@@ -658,7 +658,7 @@ function dataRetentionCustomPolicies(state: IDMappedObjects<DataRetentionCustomP
         return state;
     }
 }
-function dataRetentionCustomPoliciesCount(state = 0, action: GenericAction) {
+function dataRetentionCustomPoliciesCount(state = 0, action: AnyAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_DATA_RETENTION_CUSTOM_POLICIES:
         return action.data.total_count;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/apps.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/apps.ts
@@ -1,15 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
-import type {AppBinding, AppCommandFormMap, AppsState} from '@mattermost/types/apps';
+import type {AppBinding, AppCommandFormMap} from '@mattermost/types/apps';
 
 import {AppsTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 import {validateBindings} from 'mattermost-redux/utils/apps';
 
-export function mainBindings(state: AppBinding[] = [], action: GenericAction): AppBinding[] {
+export function mainBindings(state: AppBinding[] = [], action: AnyAction): AppBinding[] {
     switch (action.type) {
     case AppsTypes.FAILED_TO_FETCH_APP_BINDINGS: {
         if (!state.length) {
@@ -34,7 +34,7 @@ export function mainBindings(state: AppBinding[] = [], action: GenericAction): A
     }
 }
 
-function mainForms(state: AppCommandFormMap = {}, action: GenericAction): AppCommandFormMap {
+function mainForms(state: AppCommandFormMap = {}, action: AnyAction): AppCommandFormMap {
     switch (action.type) {
     case AppsTypes.RECEIVED_APP_BINDINGS:
         return {};
@@ -56,7 +56,7 @@ const main = combineReducers({
     forms: mainForms,
 });
 
-function rhsBindings(state: AppBinding[] = [], action: GenericAction): AppBinding[] {
+function rhsBindings(state: AppBinding[] = [], action: AnyAction): AppBinding[] {
     switch (action.type) {
     case AppsTypes.RECEIVED_APP_RHS_BINDINGS: {
         const bindings = action.data;
@@ -67,7 +67,7 @@ function rhsBindings(state: AppBinding[] = [], action: GenericAction): AppBindin
     }
 }
 
-function rhsForms(state: AppCommandFormMap = {}, action: GenericAction): AppCommandFormMap {
+function rhsForms(state: AppCommandFormMap = {}, action: AnyAction): AppCommandFormMap {
     switch (action.type) {
     case AppsTypes.RECEIVED_APP_RHS_BINDINGS:
         return {};
@@ -89,7 +89,7 @@ const rhs = combineReducers({
     forms: rhsForms,
 });
 
-export function pluginEnabled(state = true, action: GenericAction): boolean {
+export function pluginEnabled(state = true, action: AnyAction): boolean {
     switch (action.type) {
     case AppsTypes.APPS_PLUGIN_ENABLED: {
         return true;
@@ -109,8 +109,8 @@ export function pluginEnabled(state = true, action: GenericAction): boolean {
     }
 }
 
-export default (combineReducers({
+export default combineReducers({
     main,
     rhs,
     pluginEnabled,
-}) as (b: AppsState, a: GenericAction) => AppsState);
+});

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/bots.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/bots.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {Bot} from '@mattermost/types/bots';
 
 import {BotTypes, UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
-function accounts(state: Record<string, Bot> = {}, action: GenericAction) {
+function accounts(state: Record<string, Bot> = {}, action: AnyAction) {
     switch (action.type) {
     case BotTypes.RECEIVED_BOT_ACCOUNTS: {
         const newBots = action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channel_categories.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channel_categories.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {ChannelCategory} from '@mattermost/types/channel_categories';
@@ -9,10 +10,9 @@ import type {Team} from '@mattermost/types/teams';
 import type {IDMappedObjects, RelationOneToOne} from '@mattermost/types/utilities';
 
 import {ChannelCategoryTypes, TeamTypes, UserTypes, ChannelTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 import {removeItem} from 'mattermost-redux/utils/array_utils';
 
-export function byId(state: IDMappedObjects<ChannelCategory> = {}, action: GenericAction) {
+export function byId(state: IDMappedObjects<ChannelCategory> = {}, action: AnyAction) {
     switch (action.type) {
     case ChannelCategoryTypes.RECEIVED_CATEGORIES: {
         const categories: ChannelCategory[] = action.data;
@@ -132,7 +132,7 @@ export function byId(state: IDMappedObjects<ChannelCategory> = {}, action: Gener
     }
 }
 
-export function orderByTeam(state: RelationOneToOne<Team, Array<ChannelCategory['id']>> = {}, action: GenericAction) {
+export function orderByTeam(state: RelationOneToOne<Team, Array<ChannelCategory['id']>> = {}, action: AnyAction) {
     switch (action.type) {
     case ChannelCategoryTypes.RECEIVED_CATEGORY_ORDER: {
         const teamId: string = action.data.teamId;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channels.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channels.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {isEqual} from 'lodash';
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {
@@ -23,12 +24,11 @@ import type {
 import {AdminTypes, ChannelTypes, UserTypes, SchemeTypes, GroupTypes, PostTypes} from 'mattermost-redux/action_types';
 import {General} from 'mattermost-redux/constants';
 import {MarkUnread} from 'mattermost-redux/constants/channels';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 import {channelListToMap, splitRoles} from 'mattermost-redux/utils/channel_utils';
 
 import messageCounts from './channels/message_counts';
 
-function removeMemberFromChannels(state: RelationOneToOne<Channel, Record<string, ChannelMembership>>, action: GenericAction) {
+function removeMemberFromChannels(state: RelationOneToOne<Channel, Record<string, ChannelMembership>>, action: AnyAction) {
     const nextState = {...state};
     Object.keys(state).forEach((channel) => {
         nextState[channel] = {...nextState[channel]};
@@ -37,7 +37,7 @@ function removeMemberFromChannels(state: RelationOneToOne<Channel, Record<string
     return nextState;
 }
 
-function channelListToSet(state: any, action: GenericAction) {
+function channelListToSet(state: any, action: AnyAction) {
     const nextState = {...state};
 
     action.data.forEach((channel: Channel) => {
@@ -49,7 +49,7 @@ function channelListToSet(state: any, action: GenericAction) {
     return nextState;
 }
 
-function removeChannelFromSet(state: any, action: GenericAction) {
+function removeChannelFromSet(state: any, action: AnyAction) {
     const id = action.data.team_id;
     const nextSet = new Set(state[id]);
     nextSet.delete(action.data.id);
@@ -59,7 +59,7 @@ function removeChannelFromSet(state: any, action: GenericAction) {
     };
 }
 
-function currentChannelId(state = '', action: GenericAction) {
+function currentChannelId(state = '', action: AnyAction) {
     switch (action.type) {
     case ChannelTypes.SELECT_CHANNEL:
         return action.data;
@@ -70,7 +70,7 @@ function currentChannelId(state = '', action: GenericAction) {
     }
 }
 
-function channels(state: IDMappedObjects<Channel> = {}, action: GenericAction) {
+function channels(state: IDMappedObjects<Channel> = {}, action: AnyAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL: {
         const channel: Channel = toClientChannel(action.data);
@@ -250,7 +250,7 @@ function toClientChannel(serverChannel: ServerChannel): Channel {
     return channel;
 }
 
-function channelsInTeam(state: RelationOneToMany<Team, Channel> = {}, action: GenericAction) {
+function channelsInTeam(state: RelationOneToMany<Team, Channel> = {}, action: AnyAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL: {
         const nextSet = new Set(state[action.data.team_id]);
@@ -276,7 +276,7 @@ function channelsInTeam(state: RelationOneToMany<Team, Channel> = {}, action: Ge
     }
 }
 
-export function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = {}, action: GenericAction) {
+export function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = {}, action: AnyAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER: {
         const channelMember: ChannelMembership = action.data;
@@ -536,7 +536,7 @@ function receiveChannelMember(state: RelationOneToOne<Channel, ChannelMembership
     };
 }
 
-function membersInChannel(state: RelationOneToOne<Channel, Record<string, ChannelMembership>> = {}, action: GenericAction) {
+function membersInChannel(state: RelationOneToOne<Channel, Record<string, ChannelMembership>> = {}, action: AnyAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER:
     case ChannelTypes.RECEIVED_CHANNEL_MEMBER: {
@@ -609,7 +609,7 @@ function membersInChannel(state: RelationOneToOne<Channel, Record<string, Channe
     }
 }
 
-function stats(state: RelationOneToOne<Channel, ChannelStats> = {}, action: GenericAction) {
+function stats(state: RelationOneToOne<Channel, ChannelStats> = {}, action: AnyAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL_STATS: {
         const nextState = {...state};
@@ -710,7 +710,7 @@ function stats(state: RelationOneToOne<Channel, ChannelStats> = {}, action: Gene
     }
 }
 
-function channelsMemberCount(state: Record<string, number> = {}, action: GenericAction) {
+function channelsMemberCount(state: Record<string, number> = {}, action: AnyAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNELS_MEMBER_COUNT: {
         const memberCount = action.data;
@@ -726,7 +726,7 @@ function channelsMemberCount(state: Record<string, number> = {}, action: Generic
     }
 }
 
-function groupsAssociatedToChannel(state: any = {}, action: GenericAction) {
+function groupsAssociatedToChannel(state: any = {}, action: AnyAction) {
     switch (action.type) {
     case GroupTypes.RECEIVED_ALL_GROUPS_ASSOCIATED_TO_CHANNELS_IN_TEAM: {
         const {groupsByChannelId} = action.data;
@@ -798,7 +798,7 @@ function groupsAssociatedToChannel(state: any = {}, action: GenericAction) {
     }
 }
 
-function updateChannelMemberSchemeRoles(state: any, action: GenericAction) {
+function updateChannelMemberSchemeRoles(state: any, action: AnyAction) {
     const {channelId, userId, isSchemeUser, isSchemeAdmin} = action.data;
     const channel = state[channelId];
     if (channel) {
@@ -820,7 +820,7 @@ function updateChannelMemberSchemeRoles(state: any, action: GenericAction) {
     return state;
 }
 
-function totalCount(state = 0, action: GenericAction) {
+function totalCount(state = 0, action: AnyAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_TOTAL_CHANNEL_COUNT: {
         return action.data;
@@ -830,7 +830,7 @@ function totalCount(state = 0, action: GenericAction) {
     }
 }
 
-export function manuallyUnread(state: RelationOneToOne<Channel, boolean> = {}, action: GenericAction) {
+export function manuallyUnread(state: RelationOneToOne<Channel, boolean> = {}, action: AnyAction) {
     switch (action.type) {
     case ChannelTypes.REMOVE_MANUALLY_UNREAD: {
         if (state[action.data.channelId]) {
@@ -854,7 +854,7 @@ export function manuallyUnread(state: RelationOneToOne<Channel, boolean> = {}, a
     }
 }
 
-export function channelModerations(state: any = {}, action: GenericAction) {
+export function channelModerations(state: any = {}, action: AnyAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL_MODERATIONS: {
         const {channelId, moderations} = action.data;
@@ -868,7 +868,7 @@ export function channelModerations(state: any = {}, action: GenericAction) {
     }
 }
 
-export function channelMemberCountsByGroup(state: any = {}, action: GenericAction) {
+export function channelMemberCountsByGroup(state: any = {}, action: AnyAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL_MEMBER_COUNTS_BY_GROUP: {
         const {channelId, memberCounts} = action.data;
@@ -902,7 +902,7 @@ export function channelMemberCountsByGroup(state: any = {}, action: GenericActio
     }
 }
 
-function roles(state: RelationOneToOne<Channel, Set<string>> = {}, action: GenericAction) {
+function roles(state: RelationOneToOne<Channel, Set<string>> = {}, action: AnyAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER: {
         const channelMember = action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channels/message_counts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channels/message_counts.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
+
 import type {
     Channel,
     ChannelMessageCount,
@@ -15,9 +17,8 @@ import {
     SchemeTypes,
 } from 'mattermost-redux/action_types';
 import {General} from 'mattermost-redux/constants';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
-export default function messageCounts(state: RelationOneToOne<Channel, ChannelMessageCount> = {}, action: GenericAction): RelationOneToOne<Channel, ChannelMessageCount> {
+export default function messageCounts(state: RelationOneToOne<Channel, ChannelMessageCount> = {}, action: AnyAction): RelationOneToOne<Channel, ChannelMessageCount> {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL: {
         const channel: ServerChannel = action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/cloud.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/cloud.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {SelfHostedSignupProgress} from '@mattermost/types/cloud';
@@ -8,9 +9,8 @@ import type {Product, Subscription, CloudCustomer, Invoice, Limits, LicenseSelfS
 import type {ValueOf} from '@mattermost/types/utilities';
 
 import {CloudTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
-export function subscription(state: Subscription | null = null, action: GenericAction) {
+export function subscription(state: Subscription | null = null, action: AnyAction) {
     switch (action.type) {
     case CloudTypes.RECEIVED_CLOUD_SUBSCRIPTION: {
         return action.data;
@@ -20,7 +20,7 @@ export function subscription(state: Subscription | null = null, action: GenericA
     }
 }
 
-function customer(state: CloudCustomer | null = null, action: GenericAction) {
+function customer(state: CloudCustomer | null = null, action: AnyAction) {
     switch (action.type) {
     case CloudTypes.RECEIVED_CLOUD_CUSTOMER: {
         return action.data;
@@ -30,7 +30,7 @@ function customer(state: CloudCustomer | null = null, action: GenericAction) {
     }
 }
 
-export function subscriptionStats(state: LicenseSelfServeStatusReducer | null = null, action: GenericAction): LicenseSelfServeStatusReducer | null {
+export function subscriptionStats(state: LicenseSelfServeStatusReducer | null = null, action: AnyAction): LicenseSelfServeStatusReducer | null {
     switch (action.type) {
     case CloudTypes.LICENSE_SELF_SERVE_STATS_REQUEST: {
         return {
@@ -55,7 +55,7 @@ export function subscriptionStats(state: LicenseSelfServeStatusReducer | null = 
     }
 }
 
-function products(state: Record<string, Product> | null = null, action: GenericAction) {
+function products(state: Record<string, Product> | null = null, action: AnyAction) {
     switch (action.type) {
     case CloudTypes.RECEIVED_CLOUD_PRODUCTS: {
         const productList: Product[] = action.data;
@@ -73,7 +73,7 @@ function products(state: Record<string, Product> | null = null, action: GenericA
     }
 }
 
-function invoices(state: Record<string, Invoice> | null = null, action: GenericAction) {
+function invoices(state: Record<string, Invoice> | null = null, action: AnyAction) {
     switch (action.type) {
     case CloudTypes.RECEIVED_CLOUD_INVOICES: {
         const invoiceList: Invoice[] = action.data;
@@ -99,7 +99,7 @@ const emptyLimits = {
     limits: {},
     limitsLoaded: false,
 };
-export function limits(state: LimitsReducer = emptyLimits, action: GenericAction) {
+export function limits(state: LimitsReducer = emptyLimits, action: AnyAction) {
     switch (action.type) {
     case CloudTypes.RECEIVED_CLOUD_LIMITS: {
         return {
@@ -123,7 +123,7 @@ export interface ErrorsReducer {
     trueUpReview?: true;
 }
 const emptyErrors = {};
-export function errors(state: ErrorsReducer = emptyErrors, action: GenericAction) {
+export function errors(state: ErrorsReducer = emptyErrors, action: AnyAction) {
     switch (action.type) {
     case CloudTypes.CLOUD_SUBSCRIPTION_FAILED: {
         return {...state, subscription: true};
@@ -205,7 +205,7 @@ interface SelfHostedSignupReducer {
 const initialSelfHostedSignup = {
     progress: SelfHostedSignupProgress.START,
 };
-function selfHostedSignup(state: SelfHostedSignupReducer = initialSelfHostedSignup, action: GenericAction): SelfHostedSignupReducer {
+function selfHostedSignup(state: SelfHostedSignupReducer = initialSelfHostedSignup, action: AnyAction): SelfHostedSignupReducer {
     switch (action.type) {
     case CloudTypes.RECEIVED_SELF_HOSTED_SIGNUP_PROGRESS:
         return {

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/emojis.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/emojis.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
-import type {EmojisState, CustomEmoji} from '@mattermost/types/emojis';
+import type {CustomEmoji} from '@mattermost/types/emojis';
 import type {Post} from '@mattermost/types/posts';
 import type {IDMappedObjects} from '@mattermost/types/utilities';
 
 import {EmojiTypes, PostTypes, UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
-export function customEmoji(state: IDMappedObjects<CustomEmoji> = {}, action: GenericAction): IDMappedObjects<CustomEmoji> {
+export function customEmoji(state: IDMappedObjects<CustomEmoji> = {}, action: AnyAction): IDMappedObjects<CustomEmoji> {
     switch (action.type) {
     case EmojiTypes.RECEIVED_CUSTOM_EMOJI: {
         const emoji: CustomEmoji = action.data;
@@ -75,7 +75,7 @@ function storeEmojisForPost(state: IDMappedObjects<CustomEmoji>, post: Post): ID
     return post.metadata.emojis.reduce(storeEmoji, state);
 }
 
-function nonExistentEmoji(state: Set<string> = new Set(), action: GenericAction): Set<string> {
+function nonExistentEmoji(state: Set<string> = new Set(), action: AnyAction): Set<string> {
     switch (action.type) {
     case EmojiTypes.CUSTOM_EMOJI_DOES_NOT_EXIST: {
         if (!state.has(action.data)) {
@@ -115,11 +115,11 @@ function nonExistentEmoji(state: Set<string> = new Set(), action: GenericAction)
     }
 }
 
-export default (combineReducers({
+export default combineReducers({
 
     // object where every key is the custom emoji id and has an object with the custom emoji details
     customEmoji,
 
     // set containing custom emoji names that do not exist
     nonExistentEmoji,
-}) as (b: EmojisState, a: GenericAction) => EmojisState);
+});

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/files.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/files.ts
@@ -1,15 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {FileInfo, FileSearchResultItem} from '@mattermost/types/files';
 import type {Post} from '@mattermost/types/posts';
 
 import {FileTypes, PostTypes, UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
-export function files(state: Record<string, FileInfo> = {}, action: GenericAction) {
+export function files(state: Record<string, FileInfo> = {}, action: AnyAction) {
     switch (action.type) {
     case FileTypes.RECEIVED_UPLOAD_FILES:
     case FileTypes.RECEIVED_FILES_FOR_POST: {
@@ -60,7 +60,7 @@ export function files(state: Record<string, FileInfo> = {}, action: GenericActio
     }
 }
 
-export function filesFromSearch(state: Record<string, FileSearchResultItem> = {}, action: GenericAction) {
+export function filesFromSearch(state: Record<string, FileSearchResultItem> = {}, action: AnyAction) {
     switch (action.type) {
     case FileTypes.RECEIVED_FILES_FOR_SEARCH: {
         return {...state,
@@ -112,7 +112,7 @@ function storeFilesForPost(state: Record<string, FileInfo>, post: Post) {
     }, state);
 }
 
-export function fileIdsByPostId(state: Record<string, string[]> = {}, action: GenericAction) {
+export function fileIdsByPostId(state: Record<string, string[]> = {}, action: AnyAction) {
     switch (action.type) {
     case FileTypes.RECEIVED_FILES_FOR_POST: {
         const {data, postId} = action;
@@ -166,7 +166,7 @@ function storeFilesIdsForPost(state: Record<string, string[]>, post: Post) {
     };
 }
 
-function filePublicLink(state: {link: string} = {link: ''}, action: GenericAction) {
+function filePublicLink(state: {link: string} = {link: ''}, action: AnyAction) {
     switch (action.type) {
     case FileTypes.RECEIVED_FILE_PUBLIC_LINK: {
         return action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/general.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/general.test.ts
@@ -3,7 +3,6 @@
 
 import {GeneralTypes} from 'mattermost-redux/action_types';
 import reducer from 'mattermost-redux/reducers/entities/general';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 type ReducerState = ReturnType<typeof reducer>
 
@@ -11,10 +10,10 @@ describe('reducers.entities.general', () => {
     describe('firstAdminVisitMarketplaceStatus', () => {
         it('initial state', () => {
             const state = {};
-            const action = {};
+            const action = {type: undefined};
             const expectedState = {};
 
-            const actualState = reducer({firstAdminVisitMarketplaceStatus: state} as ReducerState, action as GenericAction);
+            const actualState = reducer({firstAdminVisitMarketplaceStatus: state} as ReducerState, action);
             expect(actualState.firstAdminVisitMarketplaceStatus).toEqual(expectedState);
         });
 

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/general.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/general.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {ClientLicense, ClientConfig} from '@mattermost/types/config';
 
 import {GeneralTypes, UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
-function config(state: Partial<ClientConfig> = {}, action: GenericAction) {
+function config(state: Partial<ClientConfig> = {}, action: AnyAction) {
     switch (action.type) {
     case GeneralTypes.CLIENT_CONFIG_RECEIVED:
         return Object.assign({}, state, action.data);
@@ -23,7 +23,7 @@ function config(state: Partial<ClientConfig> = {}, action: GenericAction) {
     }
 }
 
-function dataRetentionPolicy(state: any = {}, action: GenericAction) {
+function dataRetentionPolicy(state: any = {}, action: AnyAction) {
     switch (action.type) {
     case GeneralTypes.RECEIVED_DATA_RETENTION_POLICY:
         return action.data;
@@ -34,7 +34,7 @@ function dataRetentionPolicy(state: any = {}, action: GenericAction) {
     }
 }
 
-function license(state: ClientLicense = {}, action: GenericAction) {
+function license(state: ClientLicense = {}, action: AnyAction) {
     switch (action.type) {
     case GeneralTypes.CLIENT_LICENSE_RECEIVED:
         return action.data;
@@ -48,7 +48,7 @@ function license(state: ClientLicense = {}, action: GenericAction) {
     }
 }
 
-function serverVersion(state = '', action: GenericAction) {
+function serverVersion(state = '', action: AnyAction) {
     switch (action.type) {
     case GeneralTypes.RECEIVED_SERVER_VERSION:
         return action.data;
@@ -59,7 +59,7 @@ function serverVersion(state = '', action: GenericAction) {
     }
 }
 
-function warnMetricsStatus(state: any = {}, action: GenericAction) {
+function warnMetricsStatus(state: any = {}, action: AnyAction) {
     switch (action.type) {
     case GeneralTypes.WARN_METRICS_STATUS_RECEIVED:
         return action.data;
@@ -80,7 +80,7 @@ function warnMetricsStatus(state: any = {}, action: GenericAction) {
     }
 }
 
-function firstAdminVisitMarketplaceStatus(state = false, action: GenericAction) {
+function firstAdminVisitMarketplaceStatus(state = false, action: AnyAction) {
     switch (action.type) {
     case GeneralTypes.FIRST_ADMIN_VISIT_MARKETPLACE_STATUS_RECEIVED:
         return action.data;
@@ -90,7 +90,7 @@ function firstAdminVisitMarketplaceStatus(state = false, action: GenericAction) 
     }
 }
 
-function firstAdminCompleteSetup(state = false, action: GenericAction) {
+function firstAdminCompleteSetup(state = false, action: AnyAction) {
     switch (action.type) {
     case GeneralTypes.FIRST_ADMIN_COMPLETE_SETUP_RECEIVED:
         return action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/groups.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/groups.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {GroupChannel, GroupSyncablesState, GroupTeam, Group} from '@mattermost/types/groups';
 
 import {GroupTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
-function syncables(state: Record<string, GroupSyncablesState> = {}, action: GenericAction) {
+function syncables(state: Record<string, GroupSyncablesState> = {}, action: AnyAction) {
     switch (action.type) {
     case GroupTypes.RECEIVED_GROUP_TEAMS: {
         return {
@@ -141,7 +141,7 @@ function syncables(state: Record<string, GroupSyncablesState> = {}, action: Gene
     }
 }
 
-function myGroups(state: string[] = [], action: GenericAction) {
+function myGroups(state: string[] = [], action: AnyAction) {
     switch (action.type) {
     case GroupTypes.ADD_MY_GROUP: {
         const groupId = action.id;
@@ -185,7 +185,7 @@ function myGroups(state: string[] = [], action: GenericAction) {
     }
 }
 
-function stats(state: any = {}, action: GenericAction) {
+function stats(state: any = {}, action: AnyAction) {
     switch (action.type) {
     case GroupTypes.RECEIVED_GROUP_STATS: {
         const stat = action.data;
@@ -199,7 +199,7 @@ function stats(state: any = {}, action: GenericAction) {
     }
 }
 
-function groups(state: Record<string, Group> = {}, action: GenericAction) {
+function groups(state: Record<string, Group> = {}, action: AnyAction) {
     switch (action.type) {
     case GroupTypes.CREATE_GROUP_SUCCESS:
     case GroupTypes.PATCHED_GROUP:

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/hosted_customer.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/hosted_customer.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {Invoice, Product} from '@mattermost/types/cloud';
@@ -9,7 +10,6 @@ import type {TrueUpReviewProfileReducer, TrueUpReviewStatusReducer} from '@matte
 import type {ValueOf} from '@mattermost/types/utilities';
 
 import {HostedCustomerTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 interface SelfHostedProducts {
     products: Record<string, Product>;
@@ -29,7 +29,7 @@ const initialInvoices = {
     invoicesLoaded: false,
 };
 
-function products(state: SelfHostedProducts = initialProducts, action: GenericAction) {
+function products(state: SelfHostedProducts = initialProducts, action: AnyAction) {
     switch (action.type) {
     case HostedCustomerTypes.RECEIVED_SELF_HOSTED_PRODUCTS: {
         const productList: Product[] = action.data;
@@ -51,7 +51,7 @@ function products(state: SelfHostedProducts = initialProducts, action: GenericAc
     }
 }
 
-function invoices(state: SelfHostedInvoices = initialInvoices, action: GenericAction) {
+function invoices(state: SelfHostedInvoices = initialInvoices, action: AnyAction) {
     switch (action.type) {
     case HostedCustomerTypes.RECEIVED_SELF_HOSTED_INVOICES: {
         const invoiceList: Invoice[] = action.data;
@@ -74,7 +74,7 @@ function invoices(state: SelfHostedInvoices = initialInvoices, action: GenericAc
 }
 
 type SignupProgress = ValueOf<typeof SelfHostedSignupProgress>;
-function signupProgress(state = SelfHostedSignupProgress.START, action: GenericAction): SignupProgress {
+function signupProgress(state = SelfHostedSignupProgress.START, action: AnyAction): SignupProgress {
     switch (action.type) {
     case HostedCustomerTypes.RECEIVED_SELF_HOSTED_SIGNUP_PROGRESS: {
         if (!action.data) {
@@ -93,7 +93,7 @@ export interface ErrorsReducer {
 }
 
 const emptyErrors = {};
-export function errors(state: ErrorsReducer = emptyErrors, action: GenericAction) {
+export function errors(state: ErrorsReducer = emptyErrors, action: AnyAction) {
     switch (action.type) {
     case HostedCustomerTypes.SELF_HOSTED_PRODUCTS_FAILED: {
         return {...state, products: true};
@@ -122,7 +122,7 @@ export function errors(state: ErrorsReducer = emptyErrors, action: GenericAction
     }
 }
 
-function trueUpReviewProfile(state: TrueUpReviewProfileReducer | null = null, action: GenericAction) {
+function trueUpReviewProfile(state: TrueUpReviewProfileReducer | null = null, action: AnyAction) {
     switch (action.type) {
     case HostedCustomerTypes.RECEIVED_TRUE_UP_REVIEW_BUNDLE: {
         return {
@@ -142,7 +142,7 @@ function trueUpReviewProfile(state: TrueUpReviewProfileReducer | null = null, ac
     }
 }
 
-function trueUpReviewStatus(state: TrueUpReviewStatusReducer | null = null, action: GenericAction) {
+function trueUpReviewStatus(state: TrueUpReviewStatusReducer | null = null, action: AnyAction) {
     switch (action.type) {
     case HostedCustomerTypes.RECEIVED_TRUE_UP_REVIEW_STATUS: {
         return {

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/integrations.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/integrations.ts
@@ -1,15 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {Command, IncomingWebhook, OutgoingWebhook, OAuthApp} from '@mattermost/types/integrations';
 import type {IDMappedObjects} from '@mattermost/types/utilities';
 
 import {IntegrationTypes, UserTypes, ChannelTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
-function incomingHooks(state: IDMappedObjects<IncomingWebhook> = {}, action: GenericAction) {
+function incomingHooks(state: IDMappedObjects<IncomingWebhook> = {}, action: AnyAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_INCOMING_HOOK: {
         const nextState = {...state};
@@ -52,7 +52,7 @@ function incomingHooks(state: IDMappedObjects<IncomingWebhook> = {}, action: Gen
     }
 }
 
-function outgoingHooks(state: IDMappedObjects<OutgoingWebhook> = {}, action: GenericAction) {
+function outgoingHooks(state: IDMappedObjects<OutgoingWebhook> = {}, action: AnyAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_OUTGOING_HOOK: {
         const nextState = {...state};
@@ -95,7 +95,7 @@ function outgoingHooks(state: IDMappedObjects<OutgoingWebhook> = {}, action: Gen
     }
 }
 
-function commands(state: IDMappedObjects<Command> = {}, action: GenericAction) {
+function commands(state: IDMappedObjects<Command> = {}, action: AnyAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_COMMANDS:
     case IntegrationTypes.RECEIVED_CUSTOM_TEAM_COMMANDS: {
@@ -141,7 +141,7 @@ function commands(state: IDMappedObjects<Command> = {}, action: GenericAction) {
     }
 }
 
-function systemCommands(state: IDMappedObjects<Command> = {}, action: GenericAction) {
+function systemCommands(state: IDMappedObjects<Command> = {}, action: AnyAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_COMMANDS: {
         const nextCommands: Record<string, Command> = {};
@@ -169,7 +169,7 @@ function systemCommands(state: IDMappedObjects<Command> = {}, action: GenericAct
     }
 }
 
-function oauthApps(state: IDMappedObjects<OAuthApp> = {}, action: GenericAction) {
+function oauthApps(state: IDMappedObjects<OAuthApp> = {}, action: AnyAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_OAUTH_APPS: {
         const nextState = {...state};
@@ -196,7 +196,7 @@ function oauthApps(state: IDMappedObjects<OAuthApp> = {}, action: GenericAction)
     }
 }
 
-function appsOAuthAppIDs(state: string[] = [], action: GenericAction) {
+function appsOAuthAppIDs(state: string[] = [], action: AnyAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_APPS_OAUTH_APP_IDS: {
         if (state.length === 0 && action.data.length === 0) {
@@ -224,7 +224,7 @@ function appsOAuthAppIDs(state: string[] = [], action: GenericAction) {
     }
 }
 
-function appsBotIDs(state: string[] = [], action: GenericAction) {
+function appsBotIDs(state: string[] = [], action: AnyAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_APPS_BOT_IDS: {
         if (!action.data) {
@@ -256,7 +256,7 @@ function appsBotIDs(state: string[] = [], action: GenericAction) {
     }
 }
 
-function dialogTriggerId(state = '', action: GenericAction) {
+function dialogTriggerId(state = '', action: AnyAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_DIALOG_TRIGGER_ID:
         return action.data;
@@ -265,7 +265,7 @@ function dialogTriggerId(state = '', action: GenericAction) {
     }
 }
 
-function dialog(state = '', action: GenericAction) {
+function dialog(state = '', action: AnyAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_DIALOG:
         return action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/jobs.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/jobs.ts
@@ -1,15 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
-import type {JobsState, JobType, Job, JobsByType} from '@mattermost/types/jobs';
+import type {JobType, Job, JobsByType} from '@mattermost/types/jobs';
 import type {IDMappedObjects} from '@mattermost/types/utilities';
 
 import {JobTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
-function jobs(state: IDMappedObjects<Job> = {}, action: GenericAction): IDMappedObjects<Job> {
+function jobs(state: IDMappedObjects<Job> = {}, action: AnyAction): IDMappedObjects<Job> {
     switch (action.type) {
     case JobTypes.RECEIVED_JOB: {
         const nextState = {...state};
@@ -28,7 +28,7 @@ function jobs(state: IDMappedObjects<Job> = {}, action: GenericAction): IDMapped
     }
 }
 
-function jobsByTypeList(state: JobsByType = {}, action: GenericAction): JobsByType {
+function jobsByTypeList(state: JobsByType = {}, action: AnyAction): JobsByType {
     switch (action.type) {
     case JobTypes.RECEIVED_JOBS_BY_TYPE: {
         const nextState = {...state};
@@ -42,11 +42,11 @@ function jobsByTypeList(state: JobsByType = {}, action: GenericAction): JobsByTy
     }
 }
 
-export default (combineReducers({
+export default combineReducers({
 
     // object where every key is the job id and has an object with the job details
     jobs,
 
     // object where every key is a job type and contains a list of jobs.
     jobsByTypeList,
-}) as (b: JobsState, a: GenericAction) => JobsState);
+});

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/limits.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/limits.ts
@@ -1,12 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {LimitsTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
-function usersLimits(state = {}, action: GenericAction) {
+function usersLimits(state = {}, action: AnyAction) {
     switch (action.type) {
     case LimitsTypes.RECIEVED_USERS_LIMITS: {
         const usersLimits = action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
+
 import type {
     OpenGraphMetadata,
     Post,
@@ -22,7 +24,6 @@ import type {
 import {ChannelTypes, PostTypes, UserTypes, ThreadTypes, CloudTypes} from 'mattermost-redux/action_types';
 import {Posts} from 'mattermost-redux/constants';
 import {PostTypes as PostConstant} from 'mattermost-redux/constants/posts';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 import {comparePosts, isPermalink, shouldUpdatePost} from 'mattermost-redux/utils/post_utils';
 
 export function removeUnneededMetadata(post: Post) {
@@ -98,7 +99,7 @@ export function removeUnneededMetadata(post: Post) {
     };
 }
 
-export function nextPostsReplies(state: {[x in Post['id']]: number} = {}, action: GenericAction) {
+export function nextPostsReplies(state: {[x in Post['id']]: number} = {}, action: AnyAction) {
     switch (action.type) {
     case PostTypes.RECEIVED_POST:
     case PostTypes.RECEIVED_NEW_POST: {
@@ -157,7 +158,7 @@ export function nextPostsReplies(state: {[x in Post['id']]: number} = {}, action
     }
 }
 
-export function handlePosts(state: RelationOneToOne<Post, Post> = {}, action: GenericAction) {
+export function handlePosts(state: RelationOneToOne<Post, Post> = {}, action: AnyAction) {
     switch (action.type) {
     case PostTypes.RECEIVED_POST:
     case PostTypes.RECEIVED_NEW_POST: {
@@ -380,7 +381,7 @@ function handlePostReceived(nextState: any, post: Post, nestedPermalinkLevel?: n
     return currentState;
 }
 
-export function handlePendingPosts(state: string[] = [], action: GenericAction) {
+export function handlePendingPosts(state: string[] = [], action: AnyAction) {
     switch (action.type) {
     case PostTypes.RECEIVED_NEW_POST: {
         const post = action.data;
@@ -446,7 +447,7 @@ export function handlePendingPosts(state: string[] = [], action: GenericAction) 
     }
 }
 
-export function postsInChannel(state: Record<string, PostOrderBlock[]> = {}, action: GenericAction, prevPosts: IDMappedObjects<Post>, nextPosts: Record<string, Post>) {
+export function postsInChannel(state: Record<string, PostOrderBlock[]> = {}, action: AnyAction, prevPosts: IDMappedObjects<Post>, nextPosts: Record<string, Post>) {
     switch (action.type) {
     case PostTypes.RESET_POSTS_IN_CHANNEL: {
         return {};
@@ -936,7 +937,7 @@ export function mergePostOrder(left: string[], right: string[], posts: Record<st
     return result;
 }
 
-export function postsInThread(state: RelationOneToMany<Post, Post> = {}, action: GenericAction, prevPosts: Record<string, Post>) {
+export function postsInThread(state: RelationOneToMany<Post, Post> = {}, action: AnyAction, prevPosts: Record<string, Post>) {
     switch (action.type) {
     case PostTypes.RECEIVED_NEW_POST:
     case PostTypes.RECEIVED_POST: {
@@ -1135,7 +1136,7 @@ export function postsInThread(state: RelationOneToMany<Post, Post> = {}, action:
     }
 }
 
-function selectedPostId(state = '', action: GenericAction) {
+function selectedPostId(state = '', action: AnyAction) {
     switch (action.type) {
     case PostTypes.RECEIVED_POST_SELECTED:
         return action.data;
@@ -1146,7 +1147,7 @@ function selectedPostId(state = '', action: GenericAction) {
     }
 }
 
-export function postEditHistory(state: Post[] = [], action: GenericAction) {
+export function postEditHistory(state: Post[] = [], action: AnyAction) {
     switch (action.type) {
     case PostTypes.RECEIVED_POST_HISTORY:
         return action.data;
@@ -1157,7 +1158,7 @@ export function postEditHistory(state: Post[] = [], action: GenericAction) {
     }
 }
 
-function currentFocusedPostId(state = '', action: GenericAction) {
+function currentFocusedPostId(state = '', action: AnyAction) {
     switch (action.type) {
     case PostTypes.RECEIVED_FOCUSED_POST:
         return action.data;
@@ -1168,7 +1169,7 @@ function currentFocusedPostId(state = '', action: GenericAction) {
     }
 }
 
-export function reactions(state: RelationOneToOne<Post, Record<string, Reaction>> = {}, action: GenericAction) {
+export function reactions(state: RelationOneToOne<Post, Record<string, Reaction>> = {}, action: AnyAction) {
     switch (action.type) {
     case PostTypes.RECEIVED_REACTIONS: {
         const reactionsList = action.data;
@@ -1241,7 +1242,7 @@ export function reactions(state: RelationOneToOne<Post, Record<string, Reaction>
     }
 }
 
-export function acknowledgements(state: RelationOneToOne<Post, Record<UserProfile['id'], number>> = {}, action: GenericAction) {
+export function acknowledgements(state: RelationOneToOne<Post, Record<UserProfile['id'], number>> = {}, action: AnyAction) {
     switch (action.type) {
     case PostTypes.CREATE_ACK_POST_SUCCESS: {
         const ack = action.data as PostAcknowledgement;
@@ -1353,7 +1354,7 @@ function storeAcknowledgementsForPost(state: any, post: Post) {
     };
 }
 
-export function openGraph(state: RelationOneToOne<Post, Record<string, OpenGraphMetadata>> = {}, action: GenericAction) {
+export function openGraph(state: RelationOneToOne<Post, Record<string, OpenGraphMetadata>> = {}, action: AnyAction) {
     switch (action.type) {
     case PostTypes.RECEIVED_NEW_POST:
     case PostTypes.RECEIVED_POST: {
@@ -1417,7 +1418,7 @@ function messagesHistory(state: Partial<MessageHistory> = {
         post: -1,
         comment: -1,
     },
-}, action: GenericAction) {
+}, action: AnyAction) {
     switch (action.type) {
     case PostTypes.ADD_MESSAGE_INTO_HISTORY: {
         const nextIndex: Record<string, number> = {};
@@ -1499,7 +1500,7 @@ export const zeroStateLimitedViews = {
 
 export function limitedViews(
     state: PostsState['limitedViews'] = zeroStateLimitedViews,
-    action: GenericAction,
+    action: AnyAction,
 ): PostsState['limitedViews'] {
     switch (action.type) {
     case PostTypes.RECEIVED_POSTS:
@@ -1565,7 +1566,7 @@ export function limitedViews(
     }
 }
 
-export default function reducer(state: Partial<PostsState> = {}, action: GenericAction) {
+export default function reducer(state: Partial<PostsState> = {}, action: AnyAction) {
     const nextPosts = handlePosts(state.posts, action);
     const nextPostsInChannel = postsInChannel(state.postsInChannel, action, state.posts!, nextPosts);
 

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/preferences.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/preferences.ts
@@ -1,12 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {PreferenceType} from '@mattermost/types/preferences';
 
 import {PreferenceTypes, UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 function getKey(preference: PreferenceType) {
     return `${preference.category}--${preference.name}`;
@@ -24,7 +24,7 @@ function setAllPreferences(preferences: PreferenceType[]): any {
     return nextState;
 }
 
-function myPreferences(state: Record<string, PreferenceType> = {}, action: GenericAction) {
+function myPreferences(state: Record<string, PreferenceType> = {}, action: AnyAction) {
     switch (action.type) {
     case PreferenceTypes.RECEIVED_ALL_PREFERENCES:
         return setAllPreferences(action.data);

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/roles.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/roles.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {Role} from '@mattermost/types/roles';
 
 import {RoleTypes, UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
-function pending(state: Set<string> = new Set(), action: GenericAction) {
+function pending(state: Set<string> = new Set(), action: AnyAction) {
     switch (action.type) {
     case RoleTypes.SET_PENDING_ROLES:
         return action.data;
@@ -19,7 +19,7 @@ function pending(state: Set<string> = new Set(), action: GenericAction) {
     }
 }
 
-function roles(state: Record<string, Role> = {}, action: GenericAction) {
+function roles(state: Record<string, Role> = {}, action: AnyAction) {
     switch (action.type) {
     case RoleTypes.RECEIVED_ROLES: {
         if (action.data) {

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/schemes.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/schemes.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
-import type {SchemesState, Scheme} from '@mattermost/types/schemes';
+import type {Scheme} from '@mattermost/types/schemes';
 
 import {SchemeTypes, UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 function schemes(state: {
     [x: string]: Scheme;
-} = {}, action: GenericAction): {
+} = {}, action: AnyAction): {
         [x: string]: Scheme;
     } {
     switch (action.type) {
@@ -45,6 +45,6 @@ function schemes(state: {
     }
 }
 
-export default (combineReducers({
+export default combineReducers({
     schemes,
-}) as (b: SchemesState, a: GenericAction) => SchemesState);
+});

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/search.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/search.test.ts
@@ -7,18 +7,17 @@ import {
     UserTypes,
 } from 'mattermost-redux/action_types';
 import reducer from 'mattermost-redux/reducers/entities/search';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 type SearchState = ReturnType<typeof reducer>;
 
 describe('reducers.entities.search', () => {
     describe('results', () => {
         it('initial state', () => {
-            const inputState = undefined; // eslint-disable-line no-undef
-            const action = {};
+            const inputState = undefined;
+            const action = {type: undefined};
             const expectedState: any = [];
 
-            const actualState = reducer({results: inputState} as SearchState, action as GenericAction);
+            const actualState = reducer({results: inputState} as SearchState, action);
             expect(actualState.results).toEqual(expectedState);
         });
 
@@ -116,11 +115,11 @@ describe('reducers.entities.search', () => {
 
     describe('fileResults', () => {
         it('initial state', () => {
-            const inputState = undefined; // eslint-disable-line no-undef
-            const action = {};
+            const inputState = undefined;
+            const action = {type: undefined};
             const expectedState: string[] = [];
 
-            const actualState = reducer({fileResults: inputState} as SearchState, action as GenericAction);
+            const actualState = reducer({fileResults: inputState} as SearchState, action);
             expect(actualState.fileResults).toEqual(expectedState);
         });
 
@@ -187,11 +186,11 @@ describe('reducers.entities.search', () => {
 
     describe('matches', () => {
         it('initial state', () => {
-            const inputState = undefined; // eslint-disable-line no-undef
-            const action = {};
+            const inputState = undefined;
+            const action = {type: undefined};
             const expectedState = {};
 
-            const actualState = reducer({matches: inputState} as SearchState, action as GenericAction);
+            const actualState = reducer({matches: inputState} as SearchState, action);
             expect(actualState.matches).toEqual(expectedState);
         });
 

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/search.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/search.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {Post} from '@mattermost/types/posts';
@@ -9,9 +10,8 @@ import type {Search} from '@mattermost/types/search';
 
 import {PostTypes, PreferenceTypes, SearchTypes, UserTypes} from 'mattermost-redux/action_types';
 import {Preferences} from 'mattermost-redux/constants';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
-function results(state: string[] = [], action: GenericAction) {
+function results(state: string[] = [], action: AnyAction) {
     switch (action.type) {
     case SearchTypes.RECEIVED_SEARCH_POSTS: {
         if (action.isGettingMore) {
@@ -38,7 +38,7 @@ function results(state: string[] = [], action: GenericAction) {
     }
 }
 
-function fileResults(state: string[] = [], action: GenericAction) {
+function fileResults(state: string[] = [], action: AnyAction) {
     switch (action.type) {
     case SearchTypes.RECEIVED_SEARCH_FILES: {
         if (action.isGettingMore) {
@@ -55,7 +55,7 @@ function fileResults(state: string[] = [], action: GenericAction) {
     }
 }
 
-function matches(state: Record<string, string[]> = {}, action: GenericAction) {
+function matches(state: Record<string, string[]> = {}, action: AnyAction) {
     switch (action.type) {
     case SearchTypes.RECEIVED_SEARCH_POSTS:
         if (action.isGettingMore) {
@@ -80,7 +80,7 @@ function matches(state: Record<string, string[]> = {}, action: GenericAction) {
     }
 }
 
-function flagged(state: string[] = [], action: GenericAction) {
+function flagged(state: string[] = [], action: AnyAction) {
     switch (action.type) {
     case SearchTypes.RECEIVED_SEARCH_FLAGGED_POSTS: {
         return action.data.order;
@@ -161,7 +161,7 @@ function removePinnedPost(state: Record<string, string[]>, post: Post) {
     return state;
 }
 
-function pinned(state: Record<string, string[]> = {}, action: GenericAction) {
+function pinned(state: Record<string, string[]> = {}, action: AnyAction) {
     switch (action.type) {
     case SearchTypes.RECEIVED_SEARCH_PINNED_POSTS: {
         const {channelId, pinned: posts} = action.data;
@@ -214,7 +214,7 @@ function pinned(state: Record<string, string[]> = {}, action: GenericAction) {
     }
 }
 
-function recent(state: Record<string, Search[]> = {}, action: GenericAction) {
+function recent(state: Record<string, Search[]> = {}, action: AnyAction) {
     const {data, type} = action;
 
     switch (type) {
@@ -259,7 +259,7 @@ function recent(state: Record<string, Search[]> = {}, action: GenericAction) {
     }
 }
 
-function current(state: any = {}, action: GenericAction) {
+function current(state: any = {}, action: AnyAction) {
     const {data, type} = action;
     switch (type) {
     case SearchTypes.RECEIVED_SEARCH_TERM: {
@@ -282,7 +282,7 @@ function current(state: any = {}, action: GenericAction) {
     }
 }
 
-function isSearchingTerm(state = false, action: GenericAction) {
+function isSearchingTerm(state = false, action: AnyAction) {
     switch (action.type) {
     case SearchTypes.SEARCH_POSTS_REQUEST:
         return !action.isGettingMore;
@@ -293,7 +293,7 @@ function isSearchingTerm(state = false, action: GenericAction) {
     }
 }
 
-function isSearchGettingMore(state = false, action: GenericAction) {
+function isSearchGettingMore(state = false, action: AnyAction) {
     switch (action.type) {
     case SearchTypes.SEARCH_POSTS_REQUEST:
         return action.isGettingMore;
@@ -304,7 +304,7 @@ function isSearchGettingMore(state = false, action: GenericAction) {
     }
 }
 
-function isLimitedResults(state = -1, action: GenericAction): number {
+function isLimitedResults(state = -1, action: AnyAction): number {
     switch (action.type) {
     case SearchTypes.SEARCH_POSTS_REQUEST: {
         if (!action.isGettingMore) {

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/teams.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/teams.test.ts
@@ -3,7 +3,6 @@
 
 import {TeamTypes, AdminTypes} from 'mattermost-redux/action_types';
 import teamsReducer from 'mattermost-redux/reducers/entities/teams';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 import deepFreeze from 'mattermost-redux/utils/deep_freeze';
 
 type ReducerState = ReturnType<typeof teamsReducer>;
@@ -12,7 +11,7 @@ describe('Reducers.teams.myMembers', () => {
     it('initial state', async () => {
         let state = {} as ReducerState;
 
-        state = teamsReducer(state, {} as GenericAction);
+        state = teamsReducer(state, {type: undefined});
         expect(state.myMembers).toEqual({});
     });
 
@@ -32,7 +31,7 @@ describe('Reducers.teams.myMembers', () => {
         expect(state.myMembers).toEqual(testAction.result);
 
         testAction.data = myMember3;
-        state = teamsReducer(state, {} as GenericAction);
+        state = teamsReducer(state, {type: undefined});
         expect(state.myMembers).toEqual(testAction.result);
     });
 
@@ -50,7 +49,7 @@ describe('Reducers.teams.myMembers', () => {
         state = teamsReducer(state, testAction);
         expect(state.myMembers).toEqual(testAction.result);
 
-        state = teamsReducer(state, {} as GenericAction);
+        state = teamsReducer(state, {type: undefined});
         expect(state.myMembers).toEqual(testAction.result);
     });
 

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/teams.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/teams.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {Team, TeamMembership, TeamUnread} from '@mattermost/types/teams';
@@ -8,10 +9,9 @@ import type {UserProfile} from '@mattermost/types/users';
 import type {RelationOneToOne, IDMappedObjects} from '@mattermost/types/utilities';
 
 import {AdminTypes, ChannelTypes, TeamTypes, UserTypes, SchemeTypes, GroupTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 import {teamListToMap} from 'mattermost-redux/utils/team_utils';
 
-function currentTeamId(state = '', action: GenericAction) {
+function currentTeamId(state = '', action: AnyAction) {
     switch (action.type) {
     case TeamTypes.SELECT_TEAM:
         return action.data;
@@ -23,7 +23,7 @@ function currentTeamId(state = '', action: GenericAction) {
     }
 }
 
-function teams(state: IDMappedObjects<Team> = {}, action: GenericAction) {
+function teams(state: IDMappedObjects<Team> = {}, action: AnyAction) {
     switch (action.type) {
     case TeamTypes.RECEIVED_TEAMS_LIST:
     case SchemeTypes.RECEIVED_SCHEME_TEAMS:
@@ -94,7 +94,7 @@ function teams(state: IDMappedObjects<Team> = {}, action: GenericAction) {
     }
 }
 
-function myMembers(state: RelationOneToOne<Team, TeamMembership> = {}, action: GenericAction) {
+function myMembers(state: RelationOneToOne<Team, TeamMembership> = {}, action: AnyAction) {
     function updateState(receivedTeams: IDMappedObjects<Team> = {}, currentState: RelationOneToOne<Team, TeamMembership> = {}) {
         return Object.keys(receivedTeams).forEach((teamId) => {
             if (receivedTeams[teamId].delete_at > 0 && currentState[teamId]) {
@@ -289,7 +289,7 @@ function myMembers(state: RelationOneToOne<Team, TeamMembership> = {}, action: G
     }
 }
 
-function membersInTeam(state: RelationOneToOne<Team, RelationOneToOne<UserProfile, TeamMembership>> = {}, action: GenericAction) {
+function membersInTeam(state: RelationOneToOne<Team, RelationOneToOne<UserProfile, TeamMembership>> = {}, action: AnyAction) {
     switch (action.type) {
     case TeamTypes.RECEIVED_MEMBER_IN_TEAM: {
         const data = action.data;
@@ -369,7 +369,7 @@ function membersInTeam(state: RelationOneToOne<Team, RelationOneToOne<UserProfil
     }
 }
 
-function stats(state: any = {}, action: GenericAction) {
+function stats(state: any = {}, action: AnyAction) {
     switch (action.type) {
     case TeamTypes.RECEIVED_TEAM_STATS: {
         const stat = action.data;
@@ -395,7 +395,7 @@ function stats(state: any = {}, action: GenericAction) {
     }
 }
 
-function groupsAssociatedToTeam(state: RelationOneToOne<Team, {ids: string[]; totalCount: number}> = {}, action: GenericAction) {
+function groupsAssociatedToTeam(state: RelationOneToOne<Team, {ids: string[]; totalCount: number}> = {}, action: AnyAction) {
     switch (action.type) {
     case GroupTypes.RECEIVED_GROUP_ASSOCIATED_TO_TEAM: {
         const {teamID, groups} = action.data;
@@ -445,7 +445,7 @@ function groupsAssociatedToTeam(state: RelationOneToOne<Team, {ids: string[]; to
     }
 }
 
-function updateTeamMemberSchemeRoles(state: RelationOneToOne<Team, RelationOneToOne<UserProfile, TeamMembership>>, action: GenericAction) {
+function updateTeamMemberSchemeRoles(state: RelationOneToOne<Team, RelationOneToOne<UserProfile, TeamMembership>>, action: AnyAction) {
     const {teamId, userId, isSchemeUser, isSchemeAdmin} = action.data;
     const team = state[teamId];
     if (team) {
@@ -467,7 +467,7 @@ function updateTeamMemberSchemeRoles(state: RelationOneToOne<Team, RelationOneTo
     return state;
 }
 
-function updateMyTeamMemberSchemeRoles(state: RelationOneToOne<Team, TeamMembership>, action: GenericAction) {
+function updateMyTeamMemberSchemeRoles(state: RelationOneToOne<Team, TeamMembership>, action: AnyAction) {
     const {teamId, isSchemeUser, isSchemeAdmin} = action.data;
     const member = state[teamId];
     if (member) {
@@ -483,7 +483,7 @@ function updateMyTeamMemberSchemeRoles(state: RelationOneToOne<Team, TeamMembers
     return state;
 }
 
-function totalCount(state = 0, action: GenericAction) {
+function totalCount(state = 0, action: AnyAction) {
     switch (action.type) {
     case TeamTypes.RECEIVED_TOTAL_TEAM_COUNT: {
         return action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/counts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/counts.ts
@@ -1,13 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
+
 import type {Channel} from '@mattermost/types/channels';
 import type {Team, TeamUnread} from '@mattermost/types/teams';
 import type {ThreadsState, UserThread} from '@mattermost/types/threads';
 
 import {ChannelTypes, TeamTypes, ThreadTypes, UserTypes} from 'mattermost-redux/action_types';
 import {General} from 'mattermost-redux/constants';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import type {ExtraData} from './types';
 
@@ -15,7 +16,7 @@ function isDmGmChannel(channelType: Channel['type']) {
     return channelType === General.DM_CHANNEL || channelType === General.GM_CHANNEL;
 }
 
-function handleAllTeamThreadsRead(state: ThreadsState['counts'], action: GenericAction): ThreadsState['counts'] {
+function handleAllTeamThreadsRead(state: ThreadsState['counts'], action: AnyAction): ThreadsState['counts'] {
     const counts = state[action.data.team_id] ?? {};
     return {
         ...state,
@@ -28,7 +29,7 @@ function handleAllTeamThreadsRead(state: ThreadsState['counts'], action: Generic
     };
 }
 
-function isEqual(state: ThreadsState['counts'], action: GenericAction, unreads: boolean) {
+function isEqual(state: ThreadsState['counts'], action: AnyAction, unreads: boolean) {
     const counts = state[action.data.team_id] ?? {};
 
     const {
@@ -56,7 +57,7 @@ function isEqual(state: ThreadsState['counts'], action: GenericAction, unreads: 
     return true;
 }
 
-function handleReadChangedThread(state: ThreadsState['counts'], action: GenericAction, teamId: string, isUrgent: boolean): ThreadsState['counts'] {
+function handleReadChangedThread(state: ThreadsState['counts'], action: AnyAction, teamId: string, isUrgent: boolean): ThreadsState['counts'] {
     const {
         prevUnreadMentions = 0,
         newUnreadMentions = 0,
@@ -91,7 +92,7 @@ function handleReadChangedThread(state: ThreadsState['counts'], action: GenericA
     };
 }
 
-function handleLeaveTeam(state: ThreadsState['counts'], action: GenericAction): ThreadsState['counts'] {
+function handleLeaveTeam(state: ThreadsState['counts'], action: AnyAction): ThreadsState['counts'] {
     const team: Team = action.data;
 
     if (!state[team.id]) {
@@ -104,7 +105,7 @@ function handleLeaveTeam(state: ThreadsState['counts'], action: GenericAction): 
     return nextState;
 }
 
-function handleLeaveChannel(state: ThreadsState['counts'] = {}, action: GenericAction, extra: ExtraData) {
+function handleLeaveChannel(state: ThreadsState['counts'] = {}, action: AnyAction, extra: ExtraData) {
     if (!extra.threadsToDelete || extra.threadsToDelete.length === 0) {
         return state;
     }
@@ -135,7 +136,7 @@ function handleLeaveChannel(state: ThreadsState['counts'] = {}, action: GenericA
     };
 }
 
-function handleDecrementThreadCounts(state: ThreadsState['counts'], action: GenericAction) {
+function handleDecrementThreadCounts(state: ThreadsState['counts'], action: AnyAction) {
     const {teamId, replies, mentions} = action;
     const counts = state[teamId];
     if (!counts) {
@@ -152,7 +153,7 @@ function handleDecrementThreadCounts(state: ThreadsState['counts'], action: Gene
     };
 }
 
-export function countsIncludingDirectReducer(state: ThreadsState['counts'] = {}, action: GenericAction, extra: ExtraData) {
+export function countsIncludingDirectReducer(state: ThreadsState['counts'] = {}, action: AnyAction, extra: ExtraData) {
     switch (action.type) {
     case ThreadTypes.ALL_TEAM_THREADS_READ:
         return handleAllTeamThreadsRead(state, action);
@@ -219,7 +220,7 @@ export function countsIncludingDirectReducer(state: ThreadsState['counts'] = {},
     return state;
 }
 
-export function countsReducer(state: ThreadsState['counts'] = {}, action: GenericAction, extra: ExtraData) {
+export function countsReducer(state: ThreadsState['counts'] = {}, action: AnyAction, extra: ExtraData) {
     switch (action.type) {
     case ThreadTypes.ALL_TEAM_THREADS_READ:
         return handleAllTeamThreadsRead(state, action);

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/index.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/index.ts
@@ -1,19 +1,20 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
+
 import type {Post} from '@mattermost/types/posts';
 import type {ThreadsState, UserThread} from '@mattermost/types/threads';
 import type {UserProfile} from '@mattermost/types/users';
 import type {IDMappedObjects} from '@mattermost/types/utilities';
 
 import {ChannelTypes, PostTypes, ThreadTypes, UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {countsReducer, countsIncludingDirectReducer} from './counts';
 import {threadsInTeamReducer, unreadThreadsInTeamReducer} from './threadsInTeam';
 import type {ExtraData} from './types';
 
-export const threadsReducer = (state: ThreadsState['threads'] = {}, action: GenericAction, extra: ExtraData) => {
+export const threadsReducer = (state: ThreadsState['threads'] = {}, action: AnyAction, extra: ExtraData) => {
     switch (action.type) {
     case ThreadTypes.RECEIVED_UNREAD_THREADS:
     case ThreadTypes.RECEIVED_THREADS: {
@@ -164,7 +165,7 @@ const initialState = {
 
 // custom combineReducers function
 // enables passing data between reducers
-function reducer(state: ThreadsState = initialState, action: GenericAction): ThreadsState {
+function reducer(state: ThreadsState = initialState, action: AnyAction): ThreadsState {
     const extra: ExtraData = {
         threads: state.threads,
     };

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/threadsInTeam.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/threadsInTeam.ts
@@ -1,12 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
+
 import type {Team} from '@mattermost/types/teams';
 import type {ThreadsState, UserThread} from '@mattermost/types/threads';
 import type {IDMappedObjects, RelationOneToMany} from '@mattermost/types/utilities';
 
 import {ChannelTypes, PostTypes, TeamTypes, ThreadTypes, UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import type {ExtraData} from './types';
 
@@ -22,7 +23,7 @@ function shouldAddThreadId(ids: Array<UserThread['id']>, thread: UserThread, thr
     });
 }
 
-function handlePostRemoved(state: State, action: GenericAction): State {
+function handlePostRemoved(state: State, action: AnyAction): State {
     const post = action.data;
     if (post.root_id) {
         return state;
@@ -89,7 +90,7 @@ function handleSingleTeamReceivedThread(state: State, thread: UserThread, teamId
     return state;
 }
 
-export function handleReceivedThread(state: State, action: GenericAction, extra: ExtraData) {
+export function handleReceivedThread(state: State, action: AnyAction, extra: ExtraData) {
     const {thread, team_id: teamId} = action.data;
 
     if (!teamId) {
@@ -102,7 +103,7 @@ export function handleReceivedThread(state: State, action: GenericAction, extra:
 // add the thread only if it's 'newer' than other threads
 // older threads will be added by scrolling so no need to manually add.
 // furthermore manually adding older thread will BREAK pagination
-export function handleFollowChanged(state: State, action: GenericAction, extra: ExtraData) {
+export function handleFollowChanged(state: State, action: AnyAction, extra: ExtraData) {
     const {id, team_id: teamId, following} = action.data;
     const nextSet = new Set(state[teamId] || []);
 
@@ -140,7 +141,7 @@ export function handleFollowChanged(state: State, action: GenericAction, extra: 
     return state;
 }
 
-function handleReceiveThreads(state: State, action: GenericAction) {
+function handleReceiveThreads(state: State, action: AnyAction) {
     const nextSet = new Set(state[action.data.team_id] || []);
 
     action.data.threads.forEach((thread: UserThread) => {
@@ -153,7 +154,7 @@ function handleReceiveThreads(state: State, action: GenericAction) {
     };
 }
 
-function handleLeaveChannel(state: State, action: GenericAction, extra: ExtraData) {
+function handleLeaveChannel(state: State, action: AnyAction, extra: ExtraData) {
     if (!extra.threadsToDelete || extra.threadsToDelete.length === 0) {
         return state;
     }
@@ -182,7 +183,7 @@ function handleLeaveChannel(state: State, action: GenericAction, extra: ExtraDat
     return nextState;
 }
 
-function handleLeaveTeam(state: State, action: GenericAction) {
+function handleLeaveTeam(state: State, action: AnyAction) {
     const team: Team = action.data;
 
     if (!state[team.id]) {
@@ -195,7 +196,7 @@ function handleLeaveTeam(state: State, action: GenericAction) {
     return nextState;
 }
 
-function handleSingleTeamThreadRead(state: ThreadsState['unreadThreadsInTeam'], action: GenericAction, teamId: string, extra: ExtraData) {
+function handleSingleTeamThreadRead(state: ThreadsState['unreadThreadsInTeam'], action: AnyAction, teamId: string, extra: ExtraData) {
     const {
         id,
         newUnreadMentions,
@@ -241,7 +242,7 @@ function handleSingleTeamThreadRead(state: ThreadsState['unreadThreadsInTeam'], 
     };
 }
 
-export const threadsInTeamReducer = (state: ThreadsState['threadsInTeam'] = {}, action: GenericAction, extra: ExtraData) => {
+export const threadsInTeamReducer = (state: ThreadsState['threadsInTeam'] = {}, action: AnyAction, extra: ExtraData) => {
     switch (action.type) {
     case ThreadTypes.RECEIVED_THREAD:
         return handleReceivedThread(state, action, extra);
@@ -261,7 +262,7 @@ export const threadsInTeamReducer = (state: ThreadsState['threadsInTeam'] = {}, 
     return state;
 };
 
-export const unreadThreadsInTeamReducer = (state: ThreadsState['unreadThreadsInTeam'] = {}, action: GenericAction, extra: ExtraData) => {
+export const unreadThreadsInTeamReducer = (state: ThreadsState['unreadThreadsInTeam'] = {}, action: AnyAction, extra: ExtraData) => {
     switch (action.type) {
     case ThreadTypes.READ_CHANGED_THREAD: {
         const {teamId} = action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/typing.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/typing.test.ts
@@ -3,7 +3,6 @@
 
 import {WebsocketEvents} from 'mattermost-redux/constants';
 import typingReducer from 'mattermost-redux/reducers/entities/typing';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import TestHelper from '../../../test/test_helper';
 
@@ -13,7 +12,7 @@ describe('Reducers.Typing', () => {
 
         state = typingReducer(
             state,
-            {} as GenericAction,
+            {type: undefined},
         );
         expect(state).toEqual({});
     });

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/typing.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/typing.ts
@@ -1,12 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
+
 import type {Typing} from '@mattermost/types/typing';
 
 import {WebsocketEvents} from 'mattermost-redux/constants';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
-export default function typing(state: Typing = {}, action: GenericAction): Typing {
+export default function typing(state: Typing = {}, action: AnyAction): Typing {
     const {
         data,
         type,

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/usage.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/usage.ts
@@ -1,10 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
+
 import type {CloudUsage} from '@mattermost/types/cloud';
 
 import {CloudTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 const emptyUsage = {
     files: {
@@ -27,7 +28,7 @@ const emptyUsage = {
 };
 
 // represents the usage associated with this workspace
-export default function usage(state: CloudUsage = emptyUsage, action: GenericAction) {
+export default function usage(state: CloudUsage = emptyUsage, action: AnyAction) {
     switch (action.type) {
     case CloudTypes.RECEIVED_MESSAGES_USAGE: {
         return {

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.test.ts
@@ -6,7 +6,6 @@ import type {IDMappedObjects} from '@mattermost/types/utilities';
 
 import {UserTypes, ChannelTypes} from 'mattermost-redux/action_types';
 import reducer from 'mattermost-redux/reducers/entities/users';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 import deepFreezeAndThrowOnMutation from 'mattermost-redux/utils/deep_freeze';
 
 import {TestHelper} from 'utils/test_helper';
@@ -17,12 +16,12 @@ describe('Reducers.users', () => {
     describe('profilesInChannel', () => {
         it('initial state', () => {
             const state = undefined;
-            const action = {};
+            const action = {type: undefined};
             const expectedState = {
                 profilesInChannel: {},
             };
 
-            const newState = reducer(state, action as GenericAction);
+            const newState = reducer(state, action);
             expect(newState.profilesInChannel).toEqual(expectedState.profilesInChannel);
         });
 
@@ -296,12 +295,12 @@ describe('Reducers.users', () => {
     describe('profilesNotInChannel', () => {
         it('initial state', () => {
             const state = undefined;
-            const action = {};
+            const action = {type: undefined};
             const expectedState = {
                 profilesNotInChannel: {},
             };
 
-            const newState = reducer(state, action as GenericAction);
+            const newState = reducer(state, action);
             expect(newState.profilesNotInChannel).toEqual(expectedState.profilesNotInChannel);
         });
 
@@ -588,12 +587,12 @@ describe('Reducers.users', () => {
     describe('profilesNotInGroup', () => {
         it('initial state', () => {
             const state = undefined;
-            const action = {};
+            const action = {type: undefined};
             const expectedState = {
                 profilesNotInGroup: {},
             };
 
-            const newState = reducer(state, action as GenericAction);
+            const newState = reducer(state, action);
             expect(newState.profilesNotInGroup).toEqual(expectedState.profilesNotInGroup);
         });
 

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import isEqual from 'lodash/isEqual';
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {Channel} from '@mattermost/types/channels';
@@ -11,16 +12,15 @@ import type {UserAccessToken, UserProfile, UserStatus} from '@mattermost/types/u
 import type {RelationOneToMany, IDMappedObjects, RelationOneToOne} from '@mattermost/types/utilities';
 
 import {UserTypes, ChannelTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
-function profilesToSet(state: RelationOneToMany<Team, UserProfile>, action: GenericAction) {
+function profilesToSet(state: RelationOneToMany<Team, UserProfile>, action: AnyAction) {
     const id = action.id;
     const users: UserProfile[] = Object.values(action.data);
 
     return users.reduce((nextState, user) => addProfileToSet(nextState, id, user.id), state);
 }
 
-function profileListToSet(state: RelationOneToMany<Team, UserProfile>, action: GenericAction, replace = false) {
+function profileListToSet(state: RelationOneToMany<Team, UserProfile>, action: AnyAction, replace = false) {
     const id = action.id;
     const users: UserProfile[] = action.data || [];
 
@@ -34,7 +34,7 @@ function profileListToSet(state: RelationOneToMany<Team, UserProfile>, action: G
     return users.reduce((nextState, user) => addProfileToSet(nextState, id, user.id), state);
 }
 
-function removeProfileListFromSet(state: RelationOneToMany<Team, UserProfile>, action: GenericAction) {
+function removeProfileListFromSet(state: RelationOneToMany<Team, UserProfile>, action: AnyAction) {
     const id = action.id;
     const nextSet = new Set(state[id]);
     if (action.data) {
@@ -70,7 +70,7 @@ function addProfileToSet(state: RelationOneToMany<Team, UserProfile>, id: string
     } as RelationOneToMany<Team, UserProfile>;
 }
 
-function removeProfileFromTeams(state: RelationOneToMany<Team, UserProfile>, action: GenericAction) {
+function removeProfileFromTeams(state: RelationOneToMany<Team, UserProfile>, action: AnyAction) {
     const newState = {...state};
     let removed = false;
     Object.keys(state).forEach((key) => {
@@ -82,7 +82,7 @@ function removeProfileFromTeams(state: RelationOneToMany<Team, UserProfile>, act
     return removed ? newState : state;
 }
 
-function removeProfileFromSet(state: RelationOneToMany<Team, UserProfile>, action: GenericAction) {
+function removeProfileFromSet(state: RelationOneToMany<Team, UserProfile>, action: AnyAction) {
     const {id, user_id: userId} = action.data;
 
     if (state[id]) {
@@ -103,7 +103,7 @@ function removeProfileFromSet(state: RelationOneToMany<Team, UserProfile>, actio
     };
 }
 
-function currentUserId(state = '', action: GenericAction) {
+function currentUserId(state = '', action: AnyAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_ME: {
         const data = action.data;
@@ -123,7 +123,7 @@ function currentUserId(state = '', action: GenericAction) {
     return state;
 }
 
-function mySessions(state: Array<{id: string}> = [], action: GenericAction) {
+function mySessions(state: Array<{id: string}> = [], action: AnyAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_SESSIONS:
         return [...action.data];
@@ -161,7 +161,7 @@ function mySessions(state: Array<{id: string}> = [], action: GenericAction) {
     }
 }
 
-function myAudits(state = [], action: GenericAction) {
+function myAudits(state = [], action: AnyAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_AUDITS:
         return [...action.data];
@@ -228,7 +228,7 @@ function receiveUserProfile(state: IDMappedObjects<UserProfile>, received: UserP
     };
 }
 
-function profiles(state: IDMappedObjects<UserProfile> = {}, action: GenericAction) {
+function profiles(state: IDMappedObjects<UserProfile> = {}, action: AnyAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_ME:
     case UserTypes.RECEIVED_PROFILE: {
@@ -274,7 +274,7 @@ function profiles(state: IDMappedObjects<UserProfile> = {}, action: GenericActio
     }
 }
 
-function profilesInTeam(state: RelationOneToMany<Team, UserProfile> = {}, action: GenericAction) {
+function profilesInTeam(state: RelationOneToMany<Team, UserProfile> = {}, action: AnyAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_PROFILE_IN_TEAM:
         return addProfileToSet(state, action.data.id, action.data.user_id);
@@ -302,7 +302,7 @@ function profilesInTeam(state: RelationOneToMany<Team, UserProfile> = {}, action
     }
 }
 
-function profilesNotInTeam(state: RelationOneToMany<Team, UserProfile> = {}, action: GenericAction) {
+function profilesNotInTeam(state: RelationOneToMany<Team, UserProfile> = {}, action: AnyAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_PROFILE_NOT_IN_TEAM:
         return addProfileToSet(state, action.data.id, action.data.user_id);
@@ -330,7 +330,7 @@ function profilesNotInTeam(state: RelationOneToMany<Team, UserProfile> = {}, act
     }
 }
 
-function profilesWithoutTeam(state: Set<string> = new Set(), action: GenericAction) {
+function profilesWithoutTeam(state: Set<string> = new Set(), action: AnyAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_PROFILE_WITHOUT_TEAM: {
         const nextSet = new Set(state);
@@ -356,7 +356,7 @@ function profilesWithoutTeam(state: Set<string> = new Set(), action: GenericActi
     }
 }
 
-function profilesInChannel(state: RelationOneToMany<Channel, UserProfile> = {}, action: GenericAction) {
+function profilesInChannel(state: RelationOneToMany<Channel, UserProfile> = {}, action: AnyAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_PROFILE_IN_CHANNEL:
         return addProfileToSet(state, action.data.id, action.data.user_id);
@@ -388,7 +388,7 @@ function profilesInChannel(state: RelationOneToMany<Channel, UserProfile> = {}, 
     }
 }
 
-function profilesNotInChannel(state: RelationOneToMany<Channel, UserProfile> = {}, action: GenericAction) {
+function profilesNotInChannel(state: RelationOneToMany<Channel, UserProfile> = {}, action: AnyAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_PROFILE_NOT_IN_CHANNEL:
         return addProfileToSet(state, action.data.id, action.data.user_id);
@@ -424,7 +424,7 @@ function profilesNotInChannel(state: RelationOneToMany<Channel, UserProfile> = {
     }
 }
 
-function profilesInGroup(state: RelationOneToMany<Group, UserProfile> = {}, action: GenericAction) {
+function profilesInGroup(state: RelationOneToMany<Group, UserProfile> = {}, action: AnyAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_PROFILES_LIST_IN_GROUP: {
         return profileListToSet(state, action);
@@ -464,7 +464,7 @@ function profilesInGroup(state: RelationOneToMany<Group, UserProfile> = {}, acti
     }
 }
 
-function profilesNotInGroup(state: RelationOneToMany<Group, UserProfile> = {}, action: GenericAction) {
+function profilesNotInGroup(state: RelationOneToMany<Group, UserProfile> = {}, action: AnyAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_PROFILES_FOR_GROUP: {
         const id = action.id;
@@ -500,7 +500,7 @@ function addToState<T>(state: Record<string, T>, key: string, value: T): Record<
     };
 }
 
-function statuses(state: RelationOneToOne<UserProfile, string> = {}, action: GenericAction) {
+function statuses(state: RelationOneToOne<UserProfile, string> = {}, action: AnyAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_STATUS: {
         const userId = action.data.user_id;
@@ -530,7 +530,7 @@ function statuses(state: RelationOneToOne<UserProfile, string> = {}, action: Gen
     }
 }
 
-function isManualStatus(state: RelationOneToOne<UserProfile, boolean> = {}, action: GenericAction) {
+function isManualStatus(state: RelationOneToOne<UserProfile, boolean> = {}, action: AnyAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_STATUS: {
         const userId = action.data.user_id;
@@ -560,7 +560,7 @@ function isManualStatus(state: RelationOneToOne<UserProfile, boolean> = {}, acti
     }
 }
 
-function myUserAccessTokens(state: Record<string, UserAccessToken> = {}, action: GenericAction) {
+function myUserAccessTokens(state: Record<string, UserAccessToken> = {}, action: AnyAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_MY_USER_ACCESS_TOKEN: {
         const nextState = {...state};
@@ -611,7 +611,7 @@ function myUserAccessTokens(state: Record<string, UserAccessToken> = {}, action:
     }
 }
 
-function stats(state = {}, action: GenericAction) {
+function stats(state = {}, action: AnyAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_USER_STATS: {
         const stat = action.data;
@@ -625,7 +625,7 @@ function stats(state = {}, action: GenericAction) {
     }
 }
 
-function filteredStats(state = {}, action: GenericAction) {
+function filteredStats(state = {}, action: AnyAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_FILTERED_USER_STATS: {
         const stat = action.data;
@@ -639,7 +639,7 @@ function filteredStats(state = {}, action: GenericAction) {
     }
 }
 
-function lastActivity(state: RelationOneToOne<UserProfile, string> = {}, action: GenericAction) {
+function lastActivity(state: RelationOneToOne<UserProfile, string> = {}, action: AnyAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_STATUS: {
         const nextState = Object.assign({}, state);

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/errors/index.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/errors/index.ts
@@ -1,9 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
+
 import {ErrorTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
-export default ((state: Array<{error: any;displayable?: boolean;date: string}> = [], action: GenericAction) => {
+
+export default ((state: Array<{error: any;displayable?: boolean;date: string}> = [], action: AnyAction) => {
     switch (action.type) {
     case ErrorTypes.DISMISS_ERROR: {
         const nextState = [...state];

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/admin.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/admin.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
-import type {AdminRequestsStatuses, RequestStatusType} from '@mattermost/types/requests';
+import type {RequestStatusType} from '@mattermost/types/requests';
 
 import {AdminTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-function createCompliance(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function createCompliance(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleRequest(
         AdminTypes.CREATE_COMPLIANCE_REQUEST,
         AdminTypes.CREATE_COMPLIANCE_SUCCESS,
@@ -20,6 +20,6 @@ function createCompliance(state: RequestStatusType = initialRequestState(), acti
     );
 }
 
-export default (combineReducers({
+export default combineReducers({
     createCompliance,
-}) as (b: AdminRequestsStatuses, a: GenericAction) => AdminRequestsStatuses);
+});

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/channels.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/channels.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
-import type {ChannelsRequestsStatuses, RequestStatusType} from '@mattermost/types/requests';
+import type {RequestStatusType} from '@mattermost/types/requests';
 
 import {ChannelTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-function myChannels(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function myChannels(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleRequest(
         ChannelTypes.CHANNELS_REQUEST,
         ChannelTypes.CHANNELS_SUCCESS,
@@ -20,7 +20,7 @@ function myChannels(state: RequestStatusType = initialRequestState(), action: Ge
     );
 }
 
-function createChannel(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function createChannel(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleRequest(
         ChannelTypes.CREATE_CHANNEL_REQUEST,
         ChannelTypes.CREATE_CHANNEL_SUCCESS,
@@ -30,7 +30,7 @@ function createChannel(state: RequestStatusType = initialRequestState(), action:
     );
 }
 
-function updateChannel(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function updateChannel(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleRequest(
         ChannelTypes.UPDATE_CHANNEL_REQUEST,
         ChannelTypes.UPDATE_CHANNEL_SUCCESS,
@@ -40,7 +40,7 @@ function updateChannel(state: RequestStatusType = initialRequestState(), action:
     );
 }
 
-function getChannels(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function getChannels(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleRequest(
         ChannelTypes.GET_CHANNELS_REQUEST,
         ChannelTypes.GET_CHANNELS_SUCCESS,
@@ -50,7 +50,7 @@ function getChannels(state: RequestStatusType = initialRequestState(), action: G
     );
 }
 
-function getAllChannels(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function getAllChannels(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleRequest(
         ChannelTypes.GET_ALL_CHANNELS_REQUEST,
         ChannelTypes.GET_ALL_CHANNELS_SUCCESS,
@@ -60,10 +60,10 @@ function getAllChannels(state: RequestStatusType = initialRequestState(), action
     );
 }
 
-export default (combineReducers({
+export default combineReducers({
     getChannels,
     getAllChannels,
     myChannels,
     createChannel,
     updateChannel,
-}) as (b: ChannelsRequestsStatuses, a: GenericAction) => ChannelsRequestsStatuses);
+});

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/files.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/files.ts
@@ -1,13 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
-import type {FilesRequestsStatuses, RequestStatusType} from '@mattermost/types/requests';
+import type {RequestStatusType} from '@mattermost/types/requests';
 
 import {FileTypes} from 'mattermost-redux/action_types';
 import {RequestStatus} from 'mattermost-redux/constants';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {initialRequestState} from './helpers';
 
@@ -17,7 +17,7 @@ export function handleUploadFilesRequest(
     FAILURE: string,
     CANCEL: string,
     state: RequestStatusType,
-    action: GenericAction,
+    action: AnyAction,
 ): RequestStatusType {
     switch (action.type) {
     case REQUEST:
@@ -55,7 +55,7 @@ export function handleUploadFilesRequest(
     }
 }
 
-function uploadFiles(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function uploadFiles(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleUploadFilesRequest(
         FileTypes.UPLOAD_FILES_REQUEST,
         FileTypes.UPLOAD_FILES_SUCCESS,
@@ -66,6 +66,6 @@ function uploadFiles(state: RequestStatusType = initialRequestState(), action: G
     );
 }
 
-export default (combineReducers({
+export default combineReducers({
     uploadFiles,
-}) as (b: FilesRequestsStatuses, a: GenericAction) => FilesRequestsStatuses);
+});

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/general.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/general.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
-import type {GeneralRequestsStatuses, RequestStatusType} from '@mattermost/types/requests';
+import type {RequestStatusType} from '@mattermost/types/requests';
 
 import {GeneralTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-function websocket(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function websocket(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     if (action.type === GeneralTypes.WEBSOCKET_CLOSED) {
         return initialRequestState();
     }
@@ -24,6 +24,6 @@ function websocket(state: RequestStatusType = initialRequestState(), action: Gen
     );
 }
 
-export default (combineReducers({
+export default combineReducers({
     websocket,
-}) as (b: GeneralRequestsStatuses, a: GenericAction) => GeneralRequestsStatuses);
+});

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/helpers.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/helpers.ts
@@ -1,10 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
+
 import type {RequestStatusType} from '@mattermost/types/requests';
 
 import {RequestStatus} from 'mattermost-redux/constants';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 export function initialRequestState(): RequestStatusType {
     return {
@@ -18,7 +19,7 @@ export function handleRequest(
     SUCCESS: string,
     FAILURE: string,
     state: RequestStatusType,
-    action: GenericAction,
+    action: AnyAction,
 ): RequestStatusType {
     switch (action.type) {
     case REQUEST:

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/posts.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
-import type {PostsRequestsStatuses, RequestStatusType} from '@mattermost/types/requests';
+import type {RequestStatusType} from '@mattermost/types/requests';
 
 import {PostTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-function createPost(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function createPost(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     if (action.type === PostTypes.CREATE_POST_RESET_REQUEST) {
         return initialRequestState();
     }
@@ -24,7 +24,7 @@ function createPost(state: RequestStatusType = initialRequestState(), action: Ge
     );
 }
 
-function editPost(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function editPost(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleRequest(
         PostTypes.EDIT_POST_REQUEST,
         PostTypes.EDIT_POST_SUCCESS,
@@ -34,7 +34,7 @@ function editPost(state: RequestStatusType = initialRequestState(), action: Gene
     );
 }
 
-function getPostThread(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function getPostThread(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleRequest(
         PostTypes.GET_POST_THREAD_REQUEST,
         PostTypes.GET_POST_THREAD_SUCCESS,
@@ -44,8 +44,8 @@ function getPostThread(state: RequestStatusType = initialRequestState(), action:
     );
 }
 
-export default (combineReducers({
+export default combineReducers({
     createPost,
     editPost,
     getPostThread,
-}) as (b: PostsRequestsStatuses, a: GenericAction) => PostsRequestsStatuses);
+});

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/roles.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/roles.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
-import type {RolesRequestsStatuses, RequestStatusType} from '@mattermost/types/requests';
+import type {RequestStatusType} from '@mattermost/types/requests';
 
 import {RoleTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-function getRolesByNames(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function getRolesByNames(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleRequest(
         RoleTypes.ROLES_BY_NAMES_REQUEST,
         RoleTypes.ROLES_BY_NAMES_SUCCESS,
@@ -20,7 +20,7 @@ function getRolesByNames(state: RequestStatusType = initialRequestState(), actio
     );
 }
 
-function getRoleByName(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function getRoleByName(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleRequest(
         RoleTypes.ROLE_BY_NAME_REQUEST,
         RoleTypes.ROLE_BY_NAME_SUCCESS,
@@ -30,7 +30,7 @@ function getRoleByName(state: RequestStatusType = initialRequestState(), action:
     );
 }
 
-function getRole(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function getRole(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleRequest(
         RoleTypes.ROLE_BY_ID_REQUEST,
         RoleTypes.ROLE_BY_ID_SUCCESS,
@@ -40,7 +40,7 @@ function getRole(state: RequestStatusType = initialRequestState(), action: Gener
     );
 }
 
-function editRole(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function editRole(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleRequest(
         RoleTypes.EDIT_ROLE_REQUEST,
         RoleTypes.EDIT_ROLE_SUCCESS,
@@ -50,9 +50,9 @@ function editRole(state: RequestStatusType = initialRequestState(), action: Gene
     );
 }
 
-export default (combineReducers({
+export default combineReducers({
     getRolesByNames,
     getRoleByName,
     getRole,
     editRole,
-}) as (b: RolesRequestsStatuses, a: GenericAction) => RolesRequestsStatuses);
+});

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/search.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/search.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
-import type {SearchRequestsStatuses, RequestStatusType} from '@mattermost/types/requests';
+import type {RequestStatusType} from '@mattermost/types/requests';
 
 import {SearchTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-function flaggedPosts(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function flaggedPosts(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     if (action.type === SearchTypes.REMOVE_SEARCH_POSTS) {
         return initialRequestState();
     }
@@ -24,7 +24,7 @@ function flaggedPosts(state: RequestStatusType = initialRequestState(), action: 
     );
 }
 
-function pinnedPosts(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function pinnedPosts(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     if (action.type === SearchTypes.REMOVE_SEARCH_POSTS) {
         return initialRequestState();
     }
@@ -38,7 +38,7 @@ function pinnedPosts(state: RequestStatusType = initialRequestState(), action: G
     );
 }
 
-export default (combineReducers({
+export default combineReducers({
     flaggedPosts,
     pinnedPosts,
-}) as (b: SearchRequestsStatuses, a: GenericAction) => SearchRequestsStatuses);
+});

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/teams.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/teams.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
-import type {TeamsRequestsStatuses, RequestStatusType} from '@mattermost/types/requests';
+import type {RequestStatusType} from '@mattermost/types/requests';
 
 import {TeamTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-function getMyTeams(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function getMyTeams(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleRequest(
         TeamTypes.MY_TEAMS_REQUEST,
         TeamTypes.MY_TEAMS_SUCCESS,
@@ -20,7 +20,7 @@ function getMyTeams(state: RequestStatusType = initialRequestState(), action: Ge
     );
 }
 
-function getTeams(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function getTeams(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleRequest(
         TeamTypes.GET_TEAMS_REQUEST,
         TeamTypes.GET_TEAMS_SUCCESS,
@@ -30,7 +30,7 @@ function getTeams(state: RequestStatusType = initialRequestState(), action: Gene
     );
 }
 
-function joinTeam(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function joinTeam(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleRequest(
         TeamTypes.JOIN_TEAM_REQUEST,
         TeamTypes.JOIN_TEAM_SUCCESS,
@@ -40,8 +40,8 @@ function joinTeam(state: RequestStatusType = initialRequestState(), action: Gene
     );
 }
 
-export default (combineReducers({
+export default combineReducers({
     getTeams,
     getMyTeams,
     joinTeam,
-}) as (b: TeamsRequestsStatuses, a: GenericAction) => TeamsRequestsStatuses);
+});

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/users.ts
@@ -1,17 +1,17 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
-import type {UsersRequestsStatuses, RequestStatusType} from '@mattermost/types/requests';
+import type {RequestStatusType} from '@mattermost/types/requests';
 
 import {UserTypes} from 'mattermost-redux/action_types';
 import {RequestStatus} from 'mattermost-redux/constants';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-function login(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function login(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     switch (action.type) {
     case UserTypes.LOGIN_REQUEST:
         return {...state, status: RequestStatus.STARTED};
@@ -30,7 +30,7 @@ function login(state: RequestStatusType = initialRequestState(), action: Generic
     }
 }
 
-function logout(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function logout(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     switch (action.type) {
     case UserTypes.LOGOUT_REQUEST:
         return {...state, status: RequestStatus.STARTED};
@@ -49,7 +49,7 @@ function logout(state: RequestStatusType = initialRequestState(), action: Generi
     }
 }
 
-function autocompleteUsers(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function autocompleteUsers(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleRequest(
         UserTypes.AUTOCOMPLETE_USERS_REQUEST,
         UserTypes.AUTOCOMPLETE_USERS_SUCCESS,
@@ -59,7 +59,7 @@ function autocompleteUsers(state: RequestStatusType = initialRequestState(), act
     );
 }
 
-function updateMe(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+function updateMe(state: RequestStatusType = initialRequestState(), action: AnyAction): RequestStatusType {
     return handleRequest(
         UserTypes.UPDATE_ME_REQUEST,
         UserTypes.UPDATE_ME_SUCCESS,
@@ -69,9 +69,9 @@ function updateMe(state: RequestStatusType = initialRequestState(), action: Gene
     );
 }
 
-export default (combineReducers({
+export default combineReducers({
     login,
     logout,
     autocompleteUsers,
     updateMe,
-}) as (b: UsersRequestsStatuses, a: GenericAction) => UsersRequestsStatuses);
+});

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/websocket.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/websocket.ts
@@ -1,8 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
+
 import {GeneralTypes, UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 function getInitialState() {
     return {
@@ -13,7 +14,7 @@ function getInitialState() {
     };
 }
 
-export default function reducer(state = getInitialState(), action: GenericAction) {
+export default function reducer(state = getInitialState(), action: AnyAction) {
     if (!state.connected && action.type === GeneralTypes.WEBSOCKET_SUCCESS) {
         return {
             ...state,

--- a/webapp/channels/src/packages/mattermost-redux/src/types/actions.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/types/actions.ts
@@ -16,7 +16,6 @@ import 'redux-thunk/extend-redux';
 
 export type DispatchFunc = Dispatch;
 export type GetStateFunc = () => GlobalState;
-export type GenericAction = AnyAction;
 
 /**
  * ActionResult should be the return value of most Thunk action creators.

--- a/webapp/channels/src/reducers/plugins/index.ts
+++ b/webapp/channels/src/reducers/plugins/index.ts
@@ -2,13 +2,13 @@
 // See LICENSE.txt for license information.
 
 import remove from 'lodash/remove';
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {ClientPluginManifest} from '@mattermost/types/plugins';
 import type {IDMappedObjects} from '@mattermost/types/utilities';
 
 import {UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 import {extractPluginConfiguration} from 'utils/plugins/plugin_setting_extraction';
@@ -57,7 +57,7 @@ function sortComponents(a: PluginComponent, b: PluginComponent) {
     return 0;
 }
 
-function removePostPluginComponents(state: PluginsState['postTypes'], action: GenericAction) {
+function removePostPluginComponents(state: PluginsState['postTypes'], action: AnyAction) {
     if (!action.data) {
         return state;
     }
@@ -79,7 +79,7 @@ function removePostPluginComponents(state: PluginsState['postTypes'], action: Ge
     return state;
 }
 
-function removePostPluginComponent(state: PluginsState['postTypes'], action: GenericAction) {
+function removePostPluginComponent(state: PluginsState['postTypes'], action: AnyAction) {
     const nextState = {...state};
     const keys = Object.keys(nextState);
     for (let i = 0; i < keys.length; i++) {
@@ -93,7 +93,7 @@ function removePostPluginComponent(state: PluginsState['postTypes'], action: Gen
     return state;
 }
 
-function removePluginComponents(state: PluginsState['components'], action: GenericAction) {
+function removePluginComponents(state: PluginsState['components'], action: AnyAction) {
     if (!action.data) {
         return state;
     }
@@ -121,7 +121,7 @@ function removePluginComponents(state: PluginsState['components'], action: Gener
     return state;
 }
 
-function removePluginComponent(state: PluginsState['components'], action: GenericAction) {
+function removePluginComponent(state: PluginsState['components'], action: AnyAction) {
     let newState = state;
     const types = Object.keys(state);
     for (let i = 0; i < types.length; i++) {
@@ -138,7 +138,7 @@ function removePluginComponent(state: PluginsState['components'], action: Generi
     return newState;
 }
 
-function plugins(state: IDMappedObjects<ClientPluginManifest> = {}, action: GenericAction) {
+function plugins(state: IDMappedObjects<ClientPluginManifest> = {}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_WEBAPP_PLUGINS: {
         if (action.data) {
@@ -195,7 +195,7 @@ const initialComponents: PluginsState['components'] = {
     DesktopNotificationHooks: [],
 };
 
-function components(state: PluginsState['components'] = initialComponents, action: GenericAction) {
+function components(state: PluginsState['components'] = initialComponents, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_PLUGIN_COMPONENT: {
         if (action.name && action.data) {
@@ -232,7 +232,7 @@ function components(state: PluginsState['components'] = initialComponents, actio
     }
 }
 
-function postTypes(state: PluginsState['postTypes'] = {}, action: GenericAction) {
+function postTypes(state: PluginsState['postTypes'] = {}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_PLUGIN_POST_COMPONENT: {
         if (action.data) {
@@ -261,7 +261,7 @@ function postTypes(state: PluginsState['postTypes'] = {}, action: GenericAction)
     }
 }
 
-function postCardTypes(state: PluginsState['postTypes'] = {}, action: GenericAction) {
+function postCardTypes(state: PluginsState['postTypes'] = {}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_PLUGIN_POST_CARD_COMPONENT: {
         if (action.data) {
@@ -290,7 +290,7 @@ function postCardTypes(state: PluginsState['postTypes'] = {}, action: GenericAct
     }
 }
 
-function adminConsoleReducers(state: {[pluginId: string]: any} = {}, action: GenericAction) {
+function adminConsoleReducers(state: {[pluginId: string]: any} = {}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_ADMIN_CONSOLE_REDUCER: {
         if (action.data) {
@@ -323,7 +323,7 @@ function adminConsoleReducers(state: {[pluginId: string]: any} = {}, action: Gen
     }
 }
 
-function adminConsoleCustomComponents(state: {[pluginId: string]: Record<string, AdminConsolePluginComponent>} = {}, action: GenericAction) {
+function adminConsoleCustomComponents(state: {[pluginId: string]: Record<string, AdminConsolePluginComponent>} = {}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_ADMIN_CONSOLE_CUSTOM_COMPONENT: {
         if (!action.data) {
@@ -361,7 +361,7 @@ function adminConsoleCustomComponents(state: {[pluginId: string]: Record<string,
     }
 }
 
-function siteStatsHandlers(state: PluginsState['siteStatsHandlers'] = {}, action: GenericAction) {
+function siteStatsHandlers(state: PluginsState['siteStatsHandlers'] = {}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_PLUGIN_STATS_HANDLER:
         if (action.data) {
@@ -386,7 +386,7 @@ function siteStatsHandlers(state: PluginsState['siteStatsHandlers'] = {}, action
     }
 }
 
-function userSettings(state: PluginsState['userSettings'] = {}, action: GenericAction) {
+function userSettings(state: PluginsState['userSettings'] = {}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_PLUGIN_USER_SETTINGS:
         if (action.data) {

--- a/webapp/channels/src/reducers/storage.test.ts
+++ b/webapp/channels/src/reducers/storage.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import storageReducer from 'reducers/storage';
 
 import {StorageTypes} from 'utils/constants';
@@ -119,7 +117,7 @@ describe('Reducers.Storage', () => {
                     prefix_key2: {value: 2, timestamp: now},
                     not_prefix_key: {value: 3, timestamp: now},
                 },
-            } as unknown as ReducerState, {} as GenericAction);
+            } as unknown as ReducerState, {type: undefined});
 
             const nextState = storageReducer(state, {
                 type: StorageTypes.ACTION_ON_GLOBAL_ITEMS_WITH_PREFIX,
@@ -144,7 +142,7 @@ describe('Reducers.Storage', () => {
                     prefix_key2: {value: 2, timestamp: now},
                     not_prefix_key: {value: 3, timestamp: now},
                 },
-            } as unknown as ReducerState, {} as GenericAction);
+            } as unknown as ReducerState, {type: undefined});
 
             const nextState = storageReducer(state, {
                 type: StorageTypes.ACTION_ON_GLOBAL_ITEMS_WITH_PREFIX,

--- a/webapp/channels/src/reducers/storage.ts
+++ b/webapp/channels/src/reducers/storage.ts
@@ -2,13 +2,13 @@
 // See LICENSE.txt for license information.
 
 import localForage from 'localforage';
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 import {createMigrate, persistReducer, REHYDRATE} from 'redux-persist';
 import type {MigrationManifest, PersistedState} from 'redux-persist';
 
 import {UserTypes} from 'mattermost-redux/action_types';
 import {General} from 'mattermost-redux/constants';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {StoragePrefixes, StorageTypes} from 'utils/constants';
 import {getDraftInfoFromKey} from 'utils/storage_utils';
@@ -18,7 +18,7 @@ type StorageEntry = {
     data: any;
 }
 
-function storage(state: Record<string, any> = {}, action: GenericAction) {
+function storage(state: Record<string, any> = {}, action: AnyAction) {
     switch (action.type) {
     case REHYDRATE: {
         if (!action.payload || action.key !== 'storage') {
@@ -153,7 +153,7 @@ function migrateDrafts(state: any) {
     return drafts;
 }
 
-function initialized(state = false, action: GenericAction) {
+function initialized(state = false, action: AnyAction) {
     switch (action.type) {
     case General.STORE_REHYDRATION_COMPLETE:
         return state || action.complete;

--- a/webapp/channels/src/reducers/views/add_channel_cta_dropdown.ts
+++ b/webapp/channels/src/reducers/views/add_channel_cta_dropdown.ts
@@ -1,13 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
-
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
-export function isOpen(state = false, action: GenericAction) {
+export function isOpen(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.ADD_CHANNEL_CTA_DROPDOWN_TOGGLE:
         return action.open;

--- a/webapp/channels/src/reducers/views/add_channel_dropdown.ts
+++ b/webapp/channels/src/reducers/views/add_channel_dropdown.ts
@@ -1,13 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
-
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
-export function isOpen(state = false, action: GenericAction) {
+export function isOpen(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.ADD_CHANNEL_DROPDOWN_TOGGLE:
         return action.open;

--- a/webapp/channels/src/reducers/views/admin.ts
+++ b/webapp/channels/src/reducers/views/admin.ts
@@ -1,10 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
@@ -14,7 +14,7 @@ const initialState = {
     showNavigationPrompt: false,
 };
 
-function navigationBlock(state = initialState, action: GenericAction) {
+function navigationBlock(state = initialState, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SET_NAVIGATION_BLOCKED:
         return {...state, blocked: action.blocked};
@@ -45,7 +45,7 @@ function navigationBlock(state = initialState, action: GenericAction) {
     }
 }
 
-export function needsLoggedInLimitReachedCheck(state = false, action: GenericAction) {
+export function needsLoggedInLimitReachedCheck(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.NEEDS_LOGGED_IN_LIMIT_REACHED_CHECK:
         return action.data;

--- a/webapp/channels/src/reducers/views/announcement_bar.ts
+++ b/webapp/channels/src/reducers/views/announcement_bar.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
-function announcementBarState(state = {announcementBarCount: 0}, action: GenericAction) {
+function announcementBarState(state = {announcementBarCount: 0}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.TRACK_ANNOUNCEMENT_BAR:
         return {

--- a/webapp/channels/src/reducers/views/browser.ts
+++ b/webapp/channels/src/reducers/views/browser.ts
@@ -1,13 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
-
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes, WindowSizes} from 'utils/constants';
 
-function focused(state = true, action: GenericAction) {
+function focused(state = true, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.BROWSER_CHANGE_FOCUS:
         return action.focus;
@@ -16,7 +15,7 @@ function focused(state = true, action: GenericAction) {
     }
 }
 
-function windowSize(state = WindowSizes.DESKTOP_VIEW, action: GenericAction) {
+function windowSize(state = WindowSizes.DESKTOP_VIEW, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.BROWSER_WINDOW_RESIZED:
         return action.data;

--- a/webapp/channels/src/reducers/views/channel.ts
+++ b/webapp/channels/src/reducers/views/channel.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {ChannelTypes, PostTypes, UserTypes, GeneralTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes, Constants} from 'utils/constants';
 
-function postVisibility(state: {[channelId: string]: number} = {}, action: GenericAction) {
+function postVisibility(state: {[channelId: string]: number} = {}, action: AnyAction) {
     switch (action.type) {
     case ChannelTypes.SELECT_CHANNEL: {
         const nextState = {...state};
@@ -41,7 +41,7 @@ function postVisibility(state: {[channelId: string]: number} = {}, action: Gener
     }
 }
 
-function lastChannelViewTime(state: {[channelId: string]: number} = {}, action: GenericAction) {
+function lastChannelViewTime(state: {[channelId: string]: number} = {}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SELECT_CHANNEL_WITH_MEMBER: {
         if (action.member) {
@@ -69,7 +69,7 @@ function lastChannelViewTime(state: {[channelId: string]: number} = {}, action: 
     }
 }
 
-function loadingPosts(state: {[channelId: string]: boolean} = {}, action: GenericAction) {
+function loadingPosts(state: {[channelId: string]: boolean} = {}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.LOADING_POSTS: {
         const nextState = {...state};
@@ -84,7 +84,7 @@ function loadingPosts(state: {[channelId: string]: boolean} = {}, action: Generi
     }
 }
 
-function focusedPostId(state = '', action: GenericAction) {
+function focusedPostId(state = '', action: AnyAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_FOCUSED_POST:
         return action.data;
@@ -98,7 +98,7 @@ function focusedPostId(state = '', action: GenericAction) {
     }
 }
 
-function mobileView(state = false, action: GenericAction) {
+function mobileView(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_MOBILE_VIEW:
         return action.data;
@@ -109,7 +109,7 @@ function mobileView(state = false, action: GenericAction) {
 }
 
 // lastUnreadChannel tracks if the current channel was unread and if it had mentions when the user switched to it.
-function lastUnreadChannel(state: ({channelId: string; hadMentions: boolean}) | null = null, action: GenericAction) {
+function lastUnreadChannel(state: ({channelId: string; hadMentions: boolean}) | null = null, action: AnyAction) {
     switch (action.type) {
     case ChannelTypes.LEAVE_CHANNEL:
         if (action.data.id === state?.channelId) {
@@ -140,7 +140,7 @@ function lastUnreadChannel(state: ({channelId: string; hadMentions: boolean}) | 
     }
 }
 
-function lastGetPosts(state: {[channelId: string]: number} = {}, action: GenericAction) {
+function lastGetPosts(state: {[channelId: string]: number} = {}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_POSTS_FOR_CHANNEL_AT_TIME:
         return {
@@ -154,7 +154,7 @@ function lastGetPosts(state: {[channelId: string]: number} = {}, action: Generic
     }
 }
 
-function toastStatus(state = false, action: GenericAction) {
+function toastStatus(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SELECT_CHANNEL_WITH_MEMBER:
         return false;
@@ -167,7 +167,7 @@ function toastStatus(state = false, action: GenericAction) {
     }
 }
 
-function channelPrefetchStatus(state: {[channelId: string]: string} = {}, action: GenericAction) {
+function channelPrefetchStatus(state: {[channelId: string]: string} = {}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.PREFETCH_POSTS_FOR_CHANNEL:
         return {

--- a/webapp/channels/src/reducers/views/channel_selector_modal.ts
+++ b/webapp/channels/src/reducers/views/channel_selector_modal.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {Channel} from '@mattermost/types/channels';
 
 import {ChannelTypes, UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
-function channels(state: string[] = [], action: GenericAction) {
+function channels(state: string[] = [], action: AnyAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_ALL_CHANNELS:
         return action.data.map((v: Channel) => v.id);

--- a/webapp/channels/src/reducers/views/channel_sidebar.ts
+++ b/webapp/channels/src/reducers/views/channel_sidebar.ts
@@ -1,19 +1,19 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {ChannelCategory} from '@mattermost/types/channel_categories';
 
 import {ChannelCategoryTypes, UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 import {removeItem} from 'mattermost-redux/utils/array_utils';
 
 import {ActionTypes} from 'utils/constants';
 
 import type {DraggingState} from 'types/store';
 
-export function unreadFilterEnabled(state = false, action: GenericAction) {
+export function unreadFilterEnabled(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SET_UNREAD_FILTER_ENABLED:
         return action.enabled;
@@ -25,7 +25,7 @@ export function unreadFilterEnabled(state = false, action: GenericAction) {
     }
 }
 
-export function draggingState(state: DraggingState = {}, action: GenericAction): DraggingState {
+export function draggingState(state: DraggingState = {}, action: AnyAction): DraggingState {
     switch (action.type) {
     case ActionTypes.SIDEBAR_DRAGGING_SET_STATE:
         return {
@@ -42,7 +42,7 @@ export function draggingState(state: DraggingState = {}, action: GenericAction):
     }
 }
 
-export function newCategoryIds(state: string[] = [], action: GenericAction): string[] {
+export function newCategoryIds(state: string[] = [], action: AnyAction): string[] {
     switch (action.type) {
     case ActionTypes.ADD_NEW_CATEGORY_ID:
         return [...state, action.data];
@@ -74,7 +74,7 @@ export function newCategoryIds(state: string[] = [], action: GenericAction): str
     }
 }
 
-export function multiSelectedChannelIds(state: string[] = [], action: GenericAction): string[] {
+export function multiSelectedChannelIds(state: string[] = [], action: AnyAction): string[] {
     switch (action.type) {
     case ActionTypes.MULTISELECT_CHANNEL:
         // Channel was not previously selected
@@ -116,7 +116,7 @@ export function multiSelectedChannelIds(state: string[] = [], action: GenericAct
     }
 }
 
-export function lastSelectedChannel(state = '', action: GenericAction): string {
+export function lastSelectedChannel(state = '', action: AnyAction): string {
     switch (action.type) {
     case ActionTypes.MULTISELECT_CHANNEL:
     case ActionTypes.MULTISELECT_CHANNEL_ADD:
@@ -129,7 +129,7 @@ export function lastSelectedChannel(state = '', action: GenericAction): string {
     }
 }
 
-function firstChannelName(state = '', action: GenericAction) {
+function firstChannelName(state = '', action: AnyAction) {
     switch (action.type) {
     case ActionTypes.FIRST_CHANNEL_NAME:
         return action.data;

--- a/webapp/channels/src/reducers/views/drafts.ts
+++ b/webapp/channels/src/reducers/views/drafts.ts
@@ -1,13 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
-
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
-function remotes(state: Record<string, boolean> = {}, action: GenericAction) {
+function remotes(state: Record<string, boolean> = {}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SET_DRAFT_SOURCE:
         return {

--- a/webapp/channels/src/reducers/views/emoji.ts
+++ b/webapp/channels/src/reducers/views/emoji.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes, Locations} from 'utils/constants';
 
-function emojiPickerCustomPage(state = 0, action: GenericAction) {
+function emojiPickerCustomPage(state = 0, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.INCREMENT_EMOJI_PICKER_PAGE:
         return state + 1;
@@ -19,7 +19,7 @@ function emojiPickerCustomPage(state = 0, action: GenericAction) {
     }
 }
 
-function shortcutReactToLastPostEmittedFrom(state = '', action: GenericAction) {
+function shortcutReactToLastPostEmittedFrom(state = '', action: AnyAction) {
     switch (action.type) {
     case ActionTypes.EMITTED_SHORTCUT_REACT_TO_LAST_POST:
         if (action.payload === Locations.CENTER) {

--- a/webapp/channels/src/reducers/views/i18n.ts
+++ b/webapp/channels/src/reducers/views/i18n.ts
@@ -1,15 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
-
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
 import type {Translations} from 'types/store/i18n';
 
-function translations(state: Translations = {}, action: GenericAction) {
+function translations(state: Translations = {}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_TRANSLATIONS:
         return {

--- a/webapp/channels/src/reducers/views/lhs.test.ts
+++ b/webapp/channels/src/reducers/views/lhs.test.ts
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import {TeamTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import lhsReducer from 'reducers/views/lhs';
 
@@ -22,7 +21,7 @@ describe('Reducers.LHS', () => {
                 currentStaticPageId: '',
                 size: 'medium',
             },
-            {} as GenericAction,
+            {type: undefined},
         );
 
         expect(nextState).toEqual(initialState);

--- a/webapp/channels/src/reducers/views/lhs.ts
+++ b/webapp/channels/src/reducers/views/lhs.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {TeamTypes, UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {SidebarSize} from 'components/resizable_sidebar/constants';
 
 import {ActionTypes} from 'utils/constants';
 
-function isOpen(state = false, action: GenericAction) {
+function isOpen(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.TOGGLE_LHS:
         return !state;
@@ -32,7 +32,7 @@ function isOpen(state = false, action: GenericAction) {
     }
 }
 
-function size(state = SidebarSize.MEDIUM, action: GenericAction) {
+function size(state = SidebarSize.MEDIUM, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SET_LHS_SIZE:
         return action.size;
@@ -41,7 +41,7 @@ function size(state = SidebarSize.MEDIUM, action: GenericAction) {
     }
 }
 
-function currentStaticPageId(state = '', action: GenericAction) {
+function currentStaticPageId(state = '', action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SELECT_STATIC_PAGE:
         return action.data;

--- a/webapp/channels/src/reducers/views/marketplace.test.ts
+++ b/webapp/channels/src/reducers/views/marketplace.test.ts
@@ -3,8 +3,6 @@
 
 import type {MarketplacePlugin} from '@mattermost/types/marketplace';
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import marketplaceReducer from 'reducers/views/marketplace';
 
 import {ActionTypes, ModalIdentifiers} from 'utils/constants';
@@ -12,7 +10,7 @@ import {ActionTypes, ModalIdentifiers} from 'utils/constants';
 describe('marketplace', () => {
     test('initial state', () => {
         const currentState = {} as never;
-        const action: GenericAction = {} as GenericAction;
+        const action = {type: undefined};
         const expectedState = {
             plugins: [],
             apps: [],
@@ -32,7 +30,7 @@ describe('marketplace', () => {
             errors: {},
             filter: '',
         };
-        const action: GenericAction = {
+        const action = {
             type: ActionTypes.RECEIVED_MARKETPLACE_PLUGINS,
             plugins: [{id: 'plugin1'}, {id: 'plugin2'}],
         };
@@ -57,7 +55,7 @@ describe('marketplace', () => {
         };
 
         it('should set installing for not already installing plugin', () => {
-            const action: GenericAction = {
+            const action = {
                 type: ActionTypes.INSTALLING_MARKETPLACE_ITEM,
                 id: 'plugin2',
             };
@@ -73,7 +71,7 @@ describe('marketplace', () => {
         });
 
         it('should no-op for already installing plugin', () => {
-            const action: GenericAction = {
+            const action = {
                 type: ActionTypes.INSTALLING_MARKETPLACE_ITEM,
                 id: 'plugin1',
             };
@@ -83,7 +81,7 @@ describe('marketplace', () => {
         });
 
         it('should clear error for previously failed plugin', () => {
-            const action: GenericAction = {
+            const action = {
                 type: ActionTypes.INSTALLING_MARKETPLACE_ITEM,
                 id: 'plugin3',
             };
@@ -109,7 +107,7 @@ describe('marketplace', () => {
         };
 
         it('should clear installing', () => {
-            const action: GenericAction = {
+            const action = {
                 type: ActionTypes.INSTALLING_MARKETPLACE_ITEM_SUCCEEDED,
                 id: 'plugin1',
             };
@@ -125,7 +123,7 @@ describe('marketplace', () => {
         });
 
         it('should clear error', () => {
-            const action: GenericAction = {
+            const action = {
                 type: ActionTypes.INSTALLING_MARKETPLACE_ITEM_SUCCEEDED,
                 id: 'plugin3',
             };
@@ -151,7 +149,7 @@ describe('marketplace', () => {
         };
 
         it('should clear installing and set error', () => {
-            const action: GenericAction = {
+            const action = {
                 type: ActionTypes.INSTALLING_MARKETPLACE_ITEM_FAILED,
                 id: 'plugin1',
                 error: 'Failed to intall',
@@ -178,7 +176,7 @@ describe('marketplace', () => {
         };
 
         it('should set filter', () => {
-            const action: GenericAction = {
+            const action = {
                 type: ActionTypes.FILTER_MARKETPLACE_LISTING,
                 filter: 'new',
             };
@@ -204,7 +202,7 @@ describe('marketplace', () => {
         };
 
         it('should no-op for different modal', () => {
-            const action: GenericAction = {
+            const action = {
                 type: ActionTypes.MODAL_CLOSE,
                 modalId: ModalIdentifiers.DELETE_CHANNEL,
             };
@@ -214,7 +212,7 @@ describe('marketplace', () => {
         });
 
         it('should clear state for marketplace modal', () => {
-            const action: GenericAction = {
+            const action = {
                 type: ActionTypes.MODAL_CLOSE,
                 modalId: ModalIdentifiers.PLUGIN_MARKETPLACE,
             };

--- a/webapp/channels/src/reducers/views/marketplace.ts
+++ b/webapp/channels/src/reducers/views/marketplace.ts
@@ -1,17 +1,17 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {MarketplaceApp, MarketplacePlugin} from '@mattermost/types/marketplace';
 
 import {UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes, ModalIdentifiers} from 'utils/constants';
 
 // plugins tracks the set of marketplace plugins returned by the server
-function plugins(state: MarketplacePlugin[] = [], action: GenericAction): MarketplacePlugin[] {
+function plugins(state: MarketplacePlugin[] = [], action: AnyAction): MarketplacePlugin[] {
     switch (action.type) {
     case ActionTypes.RECEIVED_MARKETPLACE_PLUGINS:
         return action.plugins ? action.plugins : [];
@@ -31,7 +31,7 @@ function plugins(state: MarketplacePlugin[] = [], action: GenericAction): Market
 }
 
 // apps tracks the set of marketplace apps returned by the apps plugin
-function apps(state: MarketplaceApp[] = [], action: GenericAction): MarketplaceApp[] {
+function apps(state: MarketplaceApp[] = [], action: AnyAction): MarketplaceApp[] {
     switch (action.type) {
     case ActionTypes.RECEIVED_MARKETPLACE_APPS:
         return action.apps ? action.apps : [];
@@ -51,7 +51,7 @@ function apps(state: MarketplaceApp[] = [], action: GenericAction): MarketplaceA
 }
 
 // installing tracks the items pending installation
-function installing(state: {[id: string]: boolean} = {}, action: GenericAction): {[id: string]: boolean} {
+function installing(state: {[id: string]: boolean} = {}, action: AnyAction): {[id: string]: boolean} {
     switch (action.type) {
     case ActionTypes.INSTALLING_MARKETPLACE_ITEM:
         if (state[action.id]) {
@@ -90,7 +90,7 @@ function installing(state: {[id: string]: boolean} = {}, action: GenericAction):
 }
 
 // errors tracks the error messages for items that failed installation
-function errors(state: {[id: string]: string} = {}, action: GenericAction): {[id: string]: string} {
+function errors(state: {[id: string]: string} = {}, action: AnyAction): {[id: string]: string} {
     switch (action.type) {
     case ActionTypes.INSTALLING_MARKETPLACE_ITEM_FAILED:
         return {
@@ -125,7 +125,7 @@ function errors(state: {[id: string]: string} = {}, action: GenericAction): {[id
 }
 
 // filter tracks the current marketplace search query filter
-function filter(state = '', action: GenericAction): string {
+function filter(state = '', action: AnyAction): string {
     switch (action.type) {
     case ActionTypes.FILTER_MARKETPLACE_LISTING:
         return action.filter;

--- a/webapp/channels/src/reducers/views/modals.test.tsx
+++ b/webapp/channels/src/reducers/views/modals.test.tsx
@@ -4,8 +4,6 @@
 import React from 'react';
 import {Modal} from 'react-bootstrap';
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import {modalState as modalStateReducer} from 'reducers/views/modals';
 
 import {ActionTypes, ModalIdentifiers} from 'utils/constants';
@@ -28,7 +26,7 @@ describe('Reducers.Modals', () => {
     test('Initial state', () => {
         const nextState = modalStateReducer(
             {},
-            {} as GenericAction,
+            {type: undefined},
         );
 
         const expectedState = {};

--- a/webapp/channels/src/reducers/views/modals.ts
+++ b/webapp/channels/src/reducers/views/modals.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {GeneralTypes, UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
 import type {ViewsState} from 'types/store/views';
 
-export function modalState(state: ViewsState['modals']['modalState'] = {}, action: GenericAction) {
+export function modalState(state: ViewsState['modals']['modalState'] = {}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.MODAL_OPEN:
         return {
@@ -34,7 +34,7 @@ export function modalState(state: ViewsState['modals']['modalState'] = {}, actio
     }
 }
 
-export function showLaunchingWorkspace(state = false, action: GenericAction) {
+export function showLaunchingWorkspace(state = false, action: AnyAction) {
     switch (action.type) {
     case GeneralTypes.SHOW_LAUNCHING_WORKSPACE:
         return action.open;

--- a/webapp/channels/src/reducers/views/notice.ts
+++ b/webapp/channels/src/reducers/views/notice.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
-function hasBeenDismissed(state: Record<string, boolean> = {}, action: GenericAction) {
+function hasBeenDismissed(state: Record<string, boolean> = {}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.DISMISS_NOTICE:
         return {...state, [action.data]: true};

--- a/webapp/channels/src/reducers/views/onboarding_tasks.ts
+++ b/webapp/channels/src/reducers/views/onboarding_tasks.ts
@@ -1,13 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
-
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
-export function isShowOnboardingTaskCompletion(state = false, action: GenericAction) {
+export function isShowOnboardingTaskCompletion(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SHOW_ONBOARDING_TASK_COMPLETION:
         return action.open;
@@ -16,7 +15,7 @@ export function isShowOnboardingTaskCompletion(state = false, action: GenericAct
     }
 }
 
-export function isShowOnboardingCompleteProfileTour(state = false, action: GenericAction) {
+export function isShowOnboardingCompleteProfileTour(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SHOW_ONBOARDING_COMPLETE_PROFILE_TOUR:
         return action.open;
@@ -25,7 +24,7 @@ export function isShowOnboardingCompleteProfileTour(state = false, action: Gener
     }
 }
 
-export function isShowOnboardingVisitConsoleTour(state = false, action: GenericAction) {
+export function isShowOnboardingVisitConsoleTour(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SHOW_ONBOARDING_VISIT_CONSOLE_TOUR:
         return action.open;

--- a/webapp/channels/src/reducers/views/posts.ts
+++ b/webapp/channels/src/reducers/views/posts.ts
@@ -1,10 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
@@ -13,7 +13,7 @@ const defaultState = {
     show: false,
 };
 
-function editingPost(state = defaultState, action: GenericAction) {
+function editingPost(state = defaultState, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.TOGGLE_EDITING_POST:
         return {
@@ -28,7 +28,7 @@ function editingPost(state = defaultState, action: GenericAction) {
     }
 }
 
-function menuActions(state: {[postId: string]: {[actionId: string]: {text: string; value: string}}} = {}, action: GenericAction) {
+function menuActions(state: {[postId: string]: {[actionId: string]: {text: string; value: string}}} = {}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SELECT_ATTACHMENT_MENU_ACTION: {
         const nextState = {...state};

--- a/webapp/channels/src/reducers/views/product_menu.ts
+++ b/webapp/channels/src/reducers/views/product_menu.ts
@@ -1,13 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
-
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
-export function switcherOpen(state = false, action: GenericAction) {
+export function switcherOpen(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SET_PRODUCT_SWITCHER_OPEN:
         return action.open;

--- a/webapp/channels/src/reducers/views/rhs.ts
+++ b/webapp/channels/src/reducers/views/rhs.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {
@@ -9,7 +10,6 @@ import {
     SearchTypes,
     UserTypes,
 } from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {SidebarSize} from 'components/resizable_sidebar/constants';
 
@@ -17,7 +17,7 @@ import {ActionTypes, RHSStates} from 'utils/constants';
 
 import type {RhsState} from 'types/store/rhs';
 
-function selectedPostId(state = '', action: GenericAction) {
+function selectedPostId(state = '', action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SELECT_POST:
         return action.postId;
@@ -41,7 +41,7 @@ function selectedPostId(state = '', action: GenericAction) {
 
 // selectedPostFocussedAt keeps track of the last time a post was selected, whether or not it
 // is currently selected.
-function selectedPostFocussedAt(state = 0, action: GenericAction) {
+function selectedPostFocussedAt(state = 0, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SELECT_POST:
         return action.timestamp || 0;
@@ -54,7 +54,7 @@ function selectedPostFocussedAt(state = 0, action: GenericAction) {
     }
 }
 
-function highlightedPostId(state = '', action: GenericAction) {
+function highlightedPostId(state = '', action: AnyAction) {
     switch (action.type) {
     case ActionTypes.HIGHLIGHT_REPLY:
         return action.postId;
@@ -70,7 +70,7 @@ function highlightedPostId(state = '', action: GenericAction) {
 }
 
 // filesSearchExtFilter keeps track of the extension filters used for file search.
-function filesSearchExtFilter(state: string[] = [], action: GenericAction) {
+function filesSearchExtFilter(state: string[] = [], action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SET_FILES_FILTER_BY_EXT:
         return action.data;
@@ -82,7 +82,7 @@ function filesSearchExtFilter(state: string[] = [], action: GenericAction) {
     }
 }
 
-function selectedPostCardId(state = '', action: GenericAction) {
+function selectedPostCardId(state = '', action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SELECT_POST_CARD:
         return action.postId;
@@ -103,7 +103,7 @@ function selectedPostCardId(state = '', action: GenericAction) {
     }
 }
 
-function selectedChannelId(state = '', action: GenericAction) {
+function selectedChannelId(state = '', action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SELECT_POST:
         return action.channelId;
@@ -128,7 +128,7 @@ function selectedChannelId(state = '', action: GenericAction) {
     }
 }
 
-function previousRhsStates(state: any = [], action: GenericAction) {
+function previousRhsStates(state: any = [], action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SELECT_POST:
         if (action.previousRhsState) {
@@ -166,7 +166,7 @@ function previousRhsStates(state: any = [], action: GenericAction) {
     }
 }
 
-function rhsState(state: RhsState = null, action: GenericAction) {
+function rhsState(state: RhsState = null, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_RHS_STATE:
         return action.state;
@@ -184,7 +184,7 @@ function rhsState(state: RhsState = null, action: GenericAction) {
     }
 }
 
-function size(state: SidebarSize = SidebarSize.MEDIUM, action: GenericAction) {
+function size(state: SidebarSize = SidebarSize.MEDIUM, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SET_RHS_SIZE:
         return action.size;
@@ -193,7 +193,7 @@ function size(state: SidebarSize = SidebarSize.MEDIUM, action: GenericAction) {
     }
 }
 
-function searchTerms(state = '', action: GenericAction) {
+function searchTerms(state = '', action: AnyAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_RHS_SEARCH_TERMS:
         return action.terms;
@@ -209,7 +209,7 @@ function searchTerms(state = '', action: GenericAction) {
     }
 }
 
-function searchType(state = '', action: GenericAction) {
+function searchType(state = '', action: AnyAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_RHS_SEARCH_TYPE:
         return action.searchType;
@@ -225,7 +225,7 @@ function searchType(state = '', action: GenericAction) {
     }
 }
 
-function pluggableId(state = '', action: GenericAction) {
+function pluggableId(state = '', action: AnyAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_RHS_STATE:
         if (action.state === RHSStates.PLUGIN) {
@@ -243,7 +243,7 @@ function pluggableId(state = '', action: GenericAction) {
     }
 }
 
-function searchResultsTerms(state = '', action: GenericAction) {
+function searchResultsTerms(state = '', action: AnyAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_RHS_SEARCH_RESULTS_TERMS:
         return action.terms;
@@ -255,7 +255,7 @@ function searchResultsTerms(state = '', action: GenericAction) {
     }
 }
 
-function isSearchingFlaggedPost(state = false, action: GenericAction) {
+function isSearchingFlaggedPost(state = false, action: AnyAction) {
     switch (action.type) {
     case SearchTypes.SEARCH_FLAGGED_POSTS_REQUEST:
         return true;
@@ -270,7 +270,7 @@ function isSearchingFlaggedPost(state = false, action: GenericAction) {
     }
 }
 
-function isSearchingPinnedPost(state = false, action: GenericAction) {
+function isSearchingPinnedPost(state = false, action: AnyAction) {
     switch (action.type) {
     case SearchTypes.SEARCH_PINNED_POSTS_REQUEST:
         return true;
@@ -285,7 +285,7 @@ function isSearchingPinnedPost(state = false, action: GenericAction) {
     }
 }
 
-function isSidebarOpen(state = false, action: GenericAction) {
+function isSidebarOpen(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_RHS_STATE:
         return Boolean(action.state);
@@ -309,7 +309,7 @@ function isSidebarOpen(state = false, action: GenericAction) {
     }
 }
 
-function isSidebarExpanded(state = false, action: GenericAction) {
+function isSidebarExpanded(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SET_RHS_EXPANDED:
         return action.expanded;
@@ -341,7 +341,7 @@ function isSidebarExpanded(state = false, action: GenericAction) {
     }
 }
 
-function isMenuOpen(state = false, action: GenericAction) {
+function isMenuOpen(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.TOGGLE_RHS_MENU:
         return !state;
@@ -363,7 +363,7 @@ function isMenuOpen(state = false, action: GenericAction) {
     }
 }
 
-function editChannelMembers(state = false, action: GenericAction) {
+function editChannelMembers(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SET_EDIT_CHANNEL_MEMBERS:
         return action.active;

--- a/webapp/channels/src/reducers/views/rhs_suppressed.test.ts
+++ b/webapp/channels/src/reducers/views/rhs_suppressed.test.ts
@@ -1,15 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {GenericAction} from 'mattermost-redux/types/actions';
-
 import rhsSuppressed from 'reducers/views/rhs_suppressed';
 
 import {ActionTypes} from 'utils/constants';
 
 describe('Reducers.views.rhsSuppressed', () => {
     test('initialState', () => {
-        expect(rhsSuppressed(undefined, {} as GenericAction)).toBe(false);
+        expect(rhsSuppressed(undefined, {type: undefined})).toBe(false);
     });
 
     test('should handle SUPPRESS_RHS', () => {

--- a/webapp/channels/src/reducers/views/rhs_suppressed.ts
+++ b/webapp/channels/src/reducers/views/rhs_suppressed.ts
@@ -1,14 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
+
 import {UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
 import type {ViewsState} from 'types/store/views';
 
-export default function rhsSuppressed(state: ViewsState['rhsSuppressed'] = false, action: GenericAction): boolean {
+export default function rhsSuppressed(state: ViewsState['rhsSuppressed'] = false, action: AnyAction): boolean {
     switch (action.type) {
     case ActionTypes.SUPPRESS_RHS:
         return true;

--- a/webapp/channels/src/reducers/views/search.ts
+++ b/webapp/channels/src/reducers/views/search.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {SearchTypes} from 'utils/constants';
 
 import type {ViewsState} from 'types/store/views';
 
-function modalSearch(state = '', action: GenericAction) {
+function modalSearch(state = '', action: AnyAction) {
     switch (action.type) {
     case SearchTypes.SET_MODAL_SEARCH: {
         return action.data.trim();
@@ -23,7 +23,7 @@ function modalSearch(state = '', action: GenericAction) {
     }
 }
 
-function popoverSearch(state = '', action: GenericAction) {
+function popoverSearch(state = '', action: AnyAction) {
     switch (action.type) {
     case SearchTypes.SET_POPOVER_SEARCH: {
         return action.data.trim();
@@ -34,7 +34,7 @@ function popoverSearch(state = '', action: GenericAction) {
     }
 }
 
-function channelMembersRhsSearch(state = '', action: GenericAction) {
+function channelMembersRhsSearch(state = '', action: AnyAction) {
     switch (action.type) {
     case SearchTypes.SET_CHANNEL_MEMBERS_RHS_SEARCH: {
         return action.data;
@@ -47,7 +47,7 @@ function channelMembersRhsSearch(state = '', action: GenericAction) {
     }
 }
 
-function modalFilters(state: ViewsState['search']['modalFilters'] = {}, action: GenericAction) {
+function modalFilters(state: ViewsState['search']['modalFilters'] = {}, action: AnyAction) {
     switch (action.type) {
     case SearchTypes.SET_MODAL_FILTERS: {
         const filters = action.data;
@@ -63,7 +63,7 @@ function modalFilters(state: ViewsState['search']['modalFilters'] = {}, action: 
     }
 }
 
-function systemUsersSearch(state: Partial<ViewsState['search']['systemUsersSearch']> = {}, action: GenericAction) {
+function systemUsersSearch(state: Partial<ViewsState['search']['systemUsersSearch']> = {}, action: AnyAction) {
     switch (action.type) {
     case SearchTypes.SET_SYSTEM_USERS_SEARCH: {
         return action.data;
@@ -76,7 +76,7 @@ function systemUsersSearch(state: Partial<ViewsState['search']['systemUsersSearc
     }
 }
 
-function userGridSearch(state: Partial<ViewsState['search']['userGridSearch']> = {}, action: GenericAction) {
+function userGridSearch(state: Partial<ViewsState['search']['userGridSearch']> = {}, action: AnyAction) {
     switch (action.type) {
     case SearchTypes.SET_USER_GRID_SEARCH: {
         const term = action.data.trim();
@@ -100,7 +100,7 @@ function userGridSearch(state: Partial<ViewsState['search']['userGridSearch']> =
     }
 }
 
-function teamListSearch(state = '', action: GenericAction) {
+function teamListSearch(state = '', action: AnyAction) {
     switch (action.type) {
     case SearchTypes.SET_TEAM_LIST_SEARCH: {
         return action.data.trim();
@@ -113,7 +113,7 @@ function teamListSearch(state = '', action: GenericAction) {
     }
 }
 
-function channelListSearch(state: Partial<ViewsState['search']['channelListSearch']> = {}, action: GenericAction) {
+function channelListSearch(state: Partial<ViewsState['search']['channelListSearch']> = {}, action: AnyAction) {
     switch (action.type) {
     case SearchTypes.SET_CHANNEL_LIST_SEARCH: {
         const term = action.data.trim();

--- a/webapp/channels/src/reducers/views/settings.ts
+++ b/webapp/channels/src/reducers/views/settings.ts
@@ -1,14 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
+
 import {UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
 import type {ViewsState} from 'types/store/views';
 
-export default function settings(state: ViewsState['settings'] = {activeSection: '', previousActiveSection: ''}, action: GenericAction) {
+export default function settings(state: ViewsState['settings'] = {activeSection: '', previousActiveSection: ''}, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_ACTIVE_SECTION:
         return {

--- a/webapp/channels/src/reducers/views/status_dropdown.ts
+++ b/webapp/channels/src/reducers/views/status_dropdown.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
-export function isOpen(state = false, action: GenericAction) {
+export function isOpen(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.STATUS_DROPDOWN_TOGGLE:
         return action.open;

--- a/webapp/channels/src/reducers/views/system.ts
+++ b/webapp/channels/src/reducers/views/system.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
-function websocketConnectionErrorCount(state = 0, action: GenericAction) {
+function websocketConnectionErrorCount(state = 0, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.INCREMENT_WS_ERROR_COUNT: {
         return state + 1;

--- a/webapp/channels/src/reducers/views/textbox.ts
+++ b/webapp/channels/src/reducers/views/textbox.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
-function shouldShowPreviewOnCreateComment(state = false, action: GenericAction) {
+function shouldShowPreviewOnCreateComment(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SET_SHOW_PREVIEW_ON_CREATE_COMMENT:
         return action.showPreview;
@@ -20,7 +20,7 @@ function shouldShowPreviewOnCreateComment(state = false, action: GenericAction) 
     }
 }
 
-function shouldShowPreviewOnCreatePost(state = false, action: GenericAction) {
+function shouldShowPreviewOnCreatePost(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SET_SHOW_PREVIEW_ON_CREATE_POST:
         return action.showPreview;
@@ -32,7 +32,7 @@ function shouldShowPreviewOnCreatePost(state = false, action: GenericAction) {
     }
 }
 
-function shouldShowPreviewOnEditChannelHeaderModal(state = false, action: GenericAction) {
+function shouldShowPreviewOnEditChannelHeaderModal(state = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SET_SHOW_PREVIEW_ON_EDIT_CHANNEL_HEADER_MODAL:
         return action.showPreview;

--- a/webapp/channels/src/reducers/views/threads.ts
+++ b/webapp/channels/src/reducers/views/threads.ts
@@ -2,16 +2,16 @@
 // See LICENSE.txt for license information.
 
 import {findKey} from 'lodash';
+import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {PostTypes, UserTypes} from 'mattermost-redux/action_types';
-import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {Threads, ActionTypes} from 'utils/constants';
 
 import type {ViewsState} from 'types/store/views';
 
-export const selectedThreadIdInTeam = (state: ViewsState['threads']['selectedThreadIdInTeam'] = {}, action: GenericAction) => {
+export const selectedThreadIdInTeam = (state: ViewsState['threads']['selectedThreadIdInTeam'] = {}, action: AnyAction) => {
     switch (action.type) {
     case PostTypes.POST_REMOVED: {
         const key = findKey(state, (id) => id === action.data.id);
@@ -36,7 +36,7 @@ export const selectedThreadIdInTeam = (state: ViewsState['threads']['selectedThr
     }
 };
 
-export const lastViewedAt = (state: ViewsState['threads']['lastViewedAt'] = {}, action: GenericAction) => {
+export const lastViewedAt = (state: ViewsState['threads']['lastViewedAt'] = {}, action: AnyAction) => {
     switch (action.type) {
     case Threads.CHANGED_LAST_VIEWED_AT:
         return {
@@ -51,7 +51,7 @@ export const lastViewedAt = (state: ViewsState['threads']['lastViewedAt'] = {}, 
     }
 };
 
-export function manuallyUnread(state: ViewsState['threads']['manuallyUnread'] = {}, action: GenericAction) {
+export function manuallyUnread(state: ViewsState['threads']['manuallyUnread'] = {}, action: AnyAction) {
     switch (action.type) {
     case Threads.CHANGED_LAST_VIEWED_AT:
         return {
@@ -71,7 +71,7 @@ export function manuallyUnread(state: ViewsState['threads']['manuallyUnread'] = 
     }
 }
 
-export function toastStatus(state: ViewsState['threads']['toastStatus'] = false, action: GenericAction) {
+export function toastStatus(state: ViewsState['threads']['toastStatus'] = false, action: AnyAction) {
     switch (action.type) {
     case ActionTypes.SELECT_POST:
         return false;


### PR DESCRIPTION
#### Summary
Based on https://github.com/mattermost/mattermost/pull/26004

Similar to the last PR, this gets rid of our custom `GenericAction` type. Most of it is removing places where we never needed to use it to begin with, but I also went through and replaced all usage of `GenericAction` with Redux's `AnyAction`.

I did this last Friday night, and I'm now realizing that getting rid of `GenericAction` while I got left `DispatchFunc` as an alias of `Dispatch`. If anyone thinks I should either keep both or remove both, let me know, but I'm going to leave this as-is for now so that I stop spending more time on it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56619

#### Release Note
```release-note
NONE
```
