### PR TITLE
Improve Redux action types part 8/Rename NewActionFunc* back to ActionFunc*

### DIFF
--- a/webapp/channels/src/actions/apps.ts
+++ b/webapp/channels/src/actions/apps.ts
@@ -9,7 +9,7 @@ import type {Post} from '@mattermost/types/posts';
 
 import {Client4} from 'mattermost-redux/client';
 import {AppCallResponseTypes} from 'mattermost-redux/constants/apps';
-import type {NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 import {cleanForm} from 'mattermost-redux/utils/apps';
 
 import {openModal} from 'actions/views/modals';
@@ -207,8 +207,8 @@ export function doAppLookup<Res=unknown>(call: AppCallRequest, intl: any): Thunk
     };
 }
 
-export function makeFetchBindings(location: string): (channelId: string, teamId: string) => NewActionFuncAsync<AppBinding[]> {
-    return (channelId: string, teamId: string): NewActionFuncAsync<AppBinding[]> => {
+export function makeFetchBindings(location: string): (channelId: string, teamId: string) => ActionFuncAsync<AppBinding[]> {
+    return (channelId: string, teamId: string): ActionFuncAsync<AppBinding[]> => {
         return async () => {
             try {
                 const allBindings = await Client4.getAppsBindings(channelId, teamId);

--- a/webapp/channels/src/actions/channel_actions.ts
+++ b/webapp/channels/src/actions/channel_actions.ts
@@ -13,7 +13,7 @@ import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {getChannelByName, getUnreadChannelIds, getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamUrl, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {trackEvent} from 'actions/telemetry_actions.jsx';
 import {loadNewDMIfNeeded, loadNewGMIfNeeded, loadProfilesForSidebar} from 'actions/user_actions';
@@ -22,7 +22,7 @@ import {getHistory} from 'utils/browser_history';
 import {Constants, Preferences, NotificationLevels} from 'utils/constants';
 import {getDirectChannelName} from 'utils/utils';
 
-export function openDirectChannelToUserId(userId: UserProfile['id']): NewActionFuncAsync<Channel> {
+export function openDirectChannelToUserId(userId: UserProfile['id']): ActionFuncAsync<Channel> {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
@@ -63,7 +63,7 @@ export function openDirectChannelToUserId(userId: UserProfile['id']): NewActionF
     };
 }
 
-export function openGroupChannelToUserIds(userIds: Array<UserProfile['id']>): NewActionFuncAsync<Channel> {
+export function openGroupChannelToUserIds(userIds: Array<UserProfile['id']>): ActionFuncAsync<Channel> {
     return async (dispatch, getState) => {
         const result = await dispatch(ChannelActions.createGroupChannel(userIds));
 
@@ -75,7 +75,7 @@ export function openGroupChannelToUserIds(userIds: Array<UserProfile['id']>): Ne
     };
 }
 
-export function loadChannelsForCurrentUser(): NewActionFuncAsync {
+export function loadChannelsForCurrentUser(): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const unreads = getUnreadChannelIds(state);
@@ -95,7 +95,7 @@ export function loadChannelsForCurrentUser(): NewActionFuncAsync {
     };
 }
 
-export function autocompleteChannels(term: string, success: (channels: Channel[]) => void, error?: (err: ServerError) => void): NewActionFuncAsync<boolean> {
+export function autocompleteChannels(term: string, success: (channels: Channel[]) => void, error?: (err: ServerError) => void): ActionFuncAsync<boolean> {
     return async (dispatch, getState) => {
         const state = getState();
         const teamId = getCurrentTeamId(state);
@@ -114,7 +114,7 @@ export function autocompleteChannels(term: string, success: (channels: Channel[]
     };
 }
 
-export function autocompleteChannelsForSearch(term: string, success?: (channels: Channel[]) => void, error?: (err: ServerError) => void): NewActionFuncAsync {
+export function autocompleteChannelsForSearch(term: string, success?: (channels: Channel[]) => void, error?: (err: ServerError) => void): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const teamId = getCurrentTeamId(state);
@@ -133,7 +133,7 @@ export function autocompleteChannelsForSearch(term: string, success?: (channels:
     };
 }
 
-export function addUsersToChannel(channelId: Channel['id'], userIds: Array<UserProfile['id']>): NewActionFuncAsync {
+export function addUsersToChannel(channelId: Channel['id'], userIds: Array<UserProfile['id']>): ActionFuncAsync {
     return async (dispatch) => {
         try {
             const requests = userIds.map((uId) => dispatch(ChannelActions.addChannelMember(channelId, uId)));

--- a/webapp/channels/src/actions/cloud.tsx
+++ b/webapp/channels/src/actions/cloud.tsx
@@ -10,7 +10,7 @@ import {CloudTypes} from 'mattermost-redux/action_types';
 import {getCloudCustomer, getCloudProducts, getCloudSubscription, getInvoices} from 'mattermost-redux/actions/cloud';
 import {Client4} from 'mattermost-redux/client';
 import {getCloudErrors} from 'mattermost-redux/selectors/entities/cloud';
-import type {NewActionFunc, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionFunc, ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 import {trackEvent} from 'actions/telemetry_actions.jsx';
 
@@ -249,7 +249,7 @@ export function deleteWorkspace(deletionRequest: WorkspaceDeletionRequest) {
     };
 }
 
-export function retryFailedCloudFetches(): NewActionFunc<boolean, GlobalState> {
+export function retryFailedCloudFetches(): ActionFunc<boolean, GlobalState> {
     return (dispatch, getState) => {
         const errors = getCloudErrors(getState());
         if (Object.keys(errors).length === 0) {

--- a/webapp/channels/src/actions/command.ts
+++ b/webapp/channels/src/actions/command.ts
@@ -15,7 +15,7 @@ import {isMarketplaceEnabled} from 'mattermost-redux/selectors/entities/general'
 import {haveICurrentTeamPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getCurrentRelativeTeamUrl, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import * as GlobalActions from 'actions/global_actions';
 import * as PostActions from 'actions/post_actions';
@@ -39,7 +39,7 @@ import type {GlobalState} from 'types/store';
 import {doAppSubmit, openAppsModal, postEphemeralCallResponseForCommandArgs} from './apps';
 import {trackEvent} from './telemetry_actions';
 
-export function executeCommand(message: string, args: CommandArgs): NewActionFuncAsync<boolean, GlobalState> {
+export function executeCommand(message: string, args: CommandArgs): ActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         const state = getState() as GlobalState;
 

--- a/webapp/channels/src/actions/global_actions.tsx
+++ b/webapp/channels/src/actions/global_actions.tsx
@@ -24,7 +24,7 @@ import {getConfig, isPerformanceDebuggingEnabled} from 'mattermost-redux/selecto
 import {getBool, getIsOnboardingFlowEnabled, isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeamId, getMyTeams, getTeam, getMyTeamMember, getTeamMemberships, getActiveTeamsList} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser, getCurrentUserId, isFirstAdmin} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 import {calculateUnreadCount} from 'mattermost-redux/utils/channel_utils';
 
 import {handleNewPost} from 'actions/post_actions';
@@ -168,7 +168,7 @@ export function showMobileSubMenuModal(elements: any[]) { // TODO Use more speci
     dispatch(openModal(submenuModalData));
 }
 
-export function sendEphemeralPost(message: string, channelId?: string, parentId?: string, userId?: string): NewActionFuncAsync<boolean, GlobalState> {
+export function sendEphemeralPost(message: string, channelId?: string, parentId?: string, userId?: string): ActionFuncAsync<boolean, GlobalState> {
     return (doDispatch, doGetState) => {
         const timestamp = Utils.getTimestamp();
         const post = {
@@ -209,7 +209,7 @@ export function sendAddToChannelEphemeralPost(user: UserProfile, addedUsername: 
 
 let lastTimeTypingSent = 0;
 export function emitLocalUserTypingEvent(channelId: string, parentPostId: string) {
-    const userTyping: NewActionFuncAsync = async (actionDispatch, actionGetState) => {
+    const userTyping: ActionFuncAsync = async (actionDispatch, actionGetState) => {
         const state = actionGetState();
         const config = getConfig(state);
 

--- a/webapp/channels/src/actions/hooks.js
+++ b/webapp/channels/src/actions/hooks.js
@@ -3,7 +3,7 @@
 
 /**
  * @param {Post} originalPost
- * @returns {NewActionFuncAsync<Post>}
+ * @returns {ActionFuncAsync<Post>}
  */
 export function runMessageWillBePostedHooks(originalPost) {
     return async (dispatch, getState) => {

--- a/webapp/channels/src/actions/hosted_customer.tsx
+++ b/webapp/channels/src/actions/hosted_customer.tsx
@@ -14,7 +14,7 @@ import {HostedCustomerTypes} from 'mattermost-redux/action_types';
 import {bindClientFunc} from 'mattermost-redux/actions/helpers';
 import {Client4} from 'mattermost-redux/client';
 import {getSelfHostedErrors} from 'mattermost-redux/selectors/entities/hosted_customer';
-import type {NewActionFunc, NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionFunc, ActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 import {getConfirmCardSetup} from 'components/payment_form/stripe';
 
@@ -42,7 +42,7 @@ export function confirmSelfHostedSignup(
     billingDetails: BillingDetails,
     initialProgress: ValueOf<typeof SelfHostedSignupProgress>,
     subscriptionRequest: CreateSubscriptionRequest,
-): NewActionFuncAsync<SelfHostedSignupSuccessResponse['license'] | false> {
+): ActionFuncAsync<SelfHostedSignupSuccessResponse['license'] | false> {
     return async (dispatch) => {
         const cardSetupFunction = getConfirmCardSetup(cwsMockMode);
         const confirmCardSetup = cardSetupFunction(stripe.confirmCardSetup);
@@ -165,7 +165,7 @@ export function getSelfHostedInvoices(): ThunkActionFunc<Promise<boolean | Serve
         return true;
     };
 }
-export function retryFailedHostedCustomerFetches(): NewActionFunc<boolean, GlobalState> {
+export function retryFailedHostedCustomerFetches(): ActionFunc<boolean, GlobalState> {
     return (dispatch, getState) => {
         const errors = getSelfHostedErrors(getState());
         if (Object.keys(errors).length === 0) {
@@ -209,7 +209,7 @@ export function confirmSelfHostedExpansion(
     billingDetails: BillingDetails,
     initialProgress: ValueOf<typeof SelfHostedSignupProgress>,
     expansionRequest: SelfHostedExpansionRequest,
-): NewActionFuncAsync<SelfHostedSignupSuccessResponse['license'] | false> {
+): ActionFuncAsync<SelfHostedSignupSuccessResponse['license'] | false> {
     return async (dispatch) => {
         const cardSetupFunction = getConfirmCardSetup(cwsMockMode);
         const confirmCardSetup = cardSetupFunction(stripe.confirmCardSetup);

--- a/webapp/channels/src/actions/integration_actions.tsx
+++ b/webapp/channels/src/actions/integration_actions.tsx
@@ -7,11 +7,11 @@ import * as IntegrationActions from 'mattermost-redux/actions/integrations';
 import {getProfilesByIds} from 'mattermost-redux/actions/users';
 import {appsEnabled} from 'mattermost-redux/selectors/entities/apps';
 import {getUser} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 const DEFAULT_PAGE_SIZE = 100;
 
-export function loadIncomingHooksAndProfilesForTeam(teamId: string, page = 0, perPage = DEFAULT_PAGE_SIZE): NewActionFuncAsync<IncomingWebhook[]> {
+export function loadIncomingHooksAndProfilesForTeam(teamId: string, page = 0, perPage = DEFAULT_PAGE_SIZE): ActionFuncAsync<IncomingWebhook[]> {
     return async (dispatch) => {
         const {data} = await dispatch(IntegrationActions.getIncomingHooks(teamId, page, perPage));
         if (data) {
@@ -21,7 +21,7 @@ export function loadIncomingHooksAndProfilesForTeam(teamId: string, page = 0, pe
     };
 }
 
-export function loadProfilesForIncomingHooks(hooks: IncomingWebhook[]): NewActionFuncAsync {
+export function loadProfilesForIncomingHooks(hooks: IncomingWebhook[]): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const profilesToLoad: {[key: string]: boolean} = {};
@@ -42,7 +42,7 @@ export function loadProfilesForIncomingHooks(hooks: IncomingWebhook[]): NewActio
     };
 }
 
-export function loadOutgoingHooksAndProfilesForTeam(teamId: string, page = 0, perPage = DEFAULT_PAGE_SIZE): NewActionFuncAsync<OutgoingWebhook[]> {
+export function loadOutgoingHooksAndProfilesForTeam(teamId: string, page = 0, perPage = DEFAULT_PAGE_SIZE): ActionFuncAsync<OutgoingWebhook[]> {
     return async (dispatch) => {
         const {data} = await dispatch(IntegrationActions.getOutgoingHooks('', teamId, page, perPage));
         if (data) {
@@ -52,7 +52,7 @@ export function loadOutgoingHooksAndProfilesForTeam(teamId: string, page = 0, pe
     };
 }
 
-export function loadProfilesForOutgoingHooks(hooks: OutgoingWebhook[]): NewActionFuncAsync {
+export function loadProfilesForOutgoingHooks(hooks: OutgoingWebhook[]): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const profilesToLoad: {[key: string]: boolean} = {};
@@ -73,7 +73,7 @@ export function loadProfilesForOutgoingHooks(hooks: OutgoingWebhook[]): NewActio
     };
 }
 
-export function loadCommandsAndProfilesForTeam(teamId: string): NewActionFuncAsync {
+export function loadCommandsAndProfilesForTeam(teamId: string): ActionFuncAsync {
     return async (dispatch) => {
         const {data} = await dispatch(IntegrationActions.getCustomTeamCommands(teamId));
         if (data) {
@@ -83,7 +83,7 @@ export function loadCommandsAndProfilesForTeam(teamId: string): NewActionFuncAsy
     };
 }
 
-export function loadProfilesForCommands(commands: Command[]): NewActionFuncAsync {
+export function loadProfilesForCommands(commands: Command[]): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const profilesToLoad: {[key: string]: boolean} = {};
@@ -104,7 +104,7 @@ export function loadProfilesForCommands(commands: Command[]): NewActionFuncAsync
     };
 }
 
-export function loadOAuthAppsAndProfiles(page = 0, perPage = DEFAULT_PAGE_SIZE): NewActionFuncAsync {
+export function loadOAuthAppsAndProfiles(page = 0, perPage = DEFAULT_PAGE_SIZE): ActionFuncAsync {
     return async (dispatch, getState) => {
         if (appsEnabled(getState())) {
             dispatch(IntegrationActions.getAppsOAuthAppIDs());
@@ -117,7 +117,7 @@ export function loadOAuthAppsAndProfiles(page = 0, perPage = DEFAULT_PAGE_SIZE):
     };
 }
 
-export function loadProfilesForOAuthApps(apps: OAuthApp[]): NewActionFuncAsync {
+export function loadProfilesForOAuthApps(apps: OAuthApp[]): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const profilesToLoad: {[key: string]: boolean} = {};

--- a/webapp/channels/src/actions/invite_actions.ts
+++ b/webapp/channels/src/actions/invite_actions.ts
@@ -11,7 +11,7 @@ import * as TeamActions from 'mattermost-redux/actions/teams';
 import {getChannelMembersInChannels} from 'mattermost-redux/selectors/entities/channels';
 import {getTeamMember} from 'mattermost-redux/selectors/entities/teams';
 import {isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
-import type {DispatchFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {DispatchFunc, ActionFuncAsync} from 'mattermost-redux/types/actions';
 import {isGuest} from 'mattermost-redux/utils/user_utils';
 
 import {addUsersToTeam} from 'actions/team_actions';
@@ -22,7 +22,7 @@ import {ConsolePages} from 'utils/constants';
 import {t} from 'utils/i18n';
 import {localizeMessage} from 'utils/utils';
 
-export function sendMembersInvites(teamId: string, users: UserProfile[], emails: string[]): NewActionFuncAsync<InviteResults> {
+export function sendMembersInvites(teamId: string, users: UserProfile[], emails: string[]): ActionFuncAsync<InviteResults> {
     return async (dispatch, getState) => {
         if (users.length > 0) {
             await dispatch(TeamActions.getTeamMembersByIds(teamId, users.map((u) => u.id)));
@@ -158,7 +158,7 @@ export function sendGuestsInvites(
     users: UserProfile[],
     emails: string[],
     message: string,
-): NewActionFuncAsync<InviteResults> {
+): ActionFuncAsync<InviteResults> {
     return async (dispatch, getState) => {
         const state = getState();
         const sent = [];
@@ -226,7 +226,7 @@ export function sendMembersInvitesToChannels(
     users: UserProfile[],
     emails: string[],
     message: string,
-): NewActionFuncAsync<InviteResults> {
+): ActionFuncAsync<InviteResults> {
     return async (dispatch, getState) => {
         if (users.length > 0) {
             // used to preload in the global store the teammembers info, used later to validate

--- a/webapp/channels/src/actions/marketplace.ts
+++ b/webapp/channels/src/actions/marketplace.ts
@@ -9,7 +9,7 @@ import {AppBindingLocations, AppCallResponseTypes} from 'mattermost-redux/consta
 import {appsEnabled} from 'mattermost-redux/selectors/entities/apps';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
-import type {NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 import {getFilter, getPlugin} from 'selectors/views/marketplace';
 
@@ -24,7 +24,7 @@ import type {GlobalState} from 'types/store';
 import {doAppSubmit, openAppsModal, postEphemeralCallResponseForContext} from './apps';
 
 // fetchPlugins fetches the latest marketplace plugins and apps, subject to any existing search filter.
-export function fetchListing(localOnly = false): NewActionFuncAsync<Array<MarketplacePlugin | MarketplaceApp>, GlobalState> {
+export function fetchListing(localOnly = false): ActionFuncAsync<Array<MarketplacePlugin | MarketplaceApp>, GlobalState> {
     return async (dispatch, getState) => {
         const state = getState();
         const filter = getFilter(state);

--- a/webapp/channels/src/actions/new_post.ts
+++ b/webapp/channels/src/actions/new_post.ts
@@ -17,7 +17,7 @@ import * as PostSelectors from 'mattermost-redux/selectors/entities/posts';
 import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getThread} from 'mattermost-redux/selectors/entities/threads';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {DispatchFunc, GetStateFunc, NewActionFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {DispatchFunc, GetStateFunc, ActionFunc, ActionFuncAsync} from 'mattermost-redux/types/actions';
 import {
     isFromWebhook,
     isSystemMessage,
@@ -37,7 +37,7 @@ export type NewPostMessageProps = {
     team_id: string;
 }
 
-export function completePostReceive(post: Post, websocketMessageProps: NewPostMessageProps, fetchedChannelMember?: boolean): NewActionFuncAsync<boolean, GlobalState> {
+export function completePostReceive(post: Post, websocketMessageProps: NewPostMessageProps, fetchedChannelMember?: boolean): ActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         const state = getState();
         const rootPost = PostSelectors.getPost(state, post.root_id);
@@ -127,7 +127,7 @@ export function setChannelReadAndViewed(dispatch: DispatchFunc, getState: GetSta
     return actionsToMarkChannelAsUnread(getState, websocketMessageProps.team_id, post.channel_id, websocketMessageProps.mentions, fetchedChannelMember, post.root_id === '', post?.metadata?.priority?.priority);
 }
 
-export function setThreadRead(post: Post): NewActionFunc<boolean, GlobalState> {
+export function setThreadRead(post: Post): ActionFunc<boolean, GlobalState> {
     const getThreadLastViewedAt = makeGetThreadLastViewedAt();
     return (dispatch, getState) => {
         const state = getState();

--- a/webapp/channels/src/actions/post_actions.ts
+++ b/webapp/channels/src/actions/post_actions.ts
@@ -15,7 +15,7 @@ import * as PostSelectors from 'mattermost-redux/selectors/entities/posts';
 import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
-import type {DispatchFunc, NewActionFunc, NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {DispatchFunc, ActionFunc, ActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 import {canEditPost, comparePosts} from 'mattermost-redux/utils/post_utils';
 
 import {addRecentEmoji, addRecentEmojis} from 'actions/emoji_actions';
@@ -47,7 +47,7 @@ import type {GlobalState} from 'types/store';
 import {completePostReceive} from './new_post';
 import type {NewPostMessageProps} from './new_post';
 
-export function handleNewPost(post: Post, msg?: {data?: NewPostMessageProps & GroupChannel}): NewActionFuncAsync<boolean, GlobalState> {
+export function handleNewPost(post: Post, msg?: {data?: NewPostMessageProps & GroupChannel}): ActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         let websocketMessageProps = {};
         const state = getState();
@@ -78,7 +78,7 @@ export function handleNewPost(post: Post, msg?: {data?: NewPostMessageProps & Gr
 
 const getPostsForIds = PostSelectors.makeGetPostsForIds();
 
-export function flagPost(postId: string): NewActionFuncAsync {
+export function flagPost(postId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         await dispatch(PostActions.flagPost(postId));
         const state = getState() as GlobalState;
@@ -92,7 +92,7 @@ export function flagPost(postId: string): NewActionFuncAsync {
     };
 }
 
-export function unflagPost(postId: string): NewActionFuncAsync {
+export function unflagPost(postId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         await dispatch(PostActions.unflagPost(postId));
         const state = getState() as GlobalState;
@@ -106,7 +106,7 @@ export function unflagPost(postId: string): NewActionFuncAsync {
     };
 }
 
-export function createPost(post: Post, files: FileInfo[]): NewActionFuncAsync {
+export function createPost(post: Post, files: FileInfo[]): ActionFuncAsync {
     return async (dispatch) => {
         // parse message and emit emoji event
         const emojis = matchEmoticons(post.message);
@@ -132,21 +132,21 @@ export function createPost(post: Post, files: FileInfo[]): NewActionFuncAsync {
     };
 }
 
-function storeDraft(channelId: string, draft: null): NewActionFunc {
+function storeDraft(channelId: string, draft: null): ActionFunc {
     return (dispatch) => {
         dispatch(StorageActions.setGlobalItem('draft_' + channelId, draft));
         return {data: true};
     };
 }
 
-function storeCommentDraft(rootPostId: string, draft: null): NewActionFunc {
+function storeCommentDraft(rootPostId: string, draft: null): ActionFunc {
     return (dispatch) => {
         dispatch(StorageActions.setGlobalItem('comment_draft_' + rootPostId, draft));
         return {data: true};
     };
 }
 
-export function submitReaction(postId: string, action: string, emojiName: string): NewActionFunc<unknown, GlobalState> {
+export function submitReaction(postId: string, action: string, emojiName: string): ActionFunc<unknown, GlobalState> {
     return (dispatch, getState) => {
         const state = getState() as GlobalState;
         const getIsReactionAlreadyAddedToPost = makeGetIsReactionAlreadyAddedToPost();
@@ -162,7 +162,7 @@ export function submitReaction(postId: string, action: string, emojiName: string
     };
 }
 
-export function toggleReaction(postId: string, emojiName: string): NewActionFuncAsync<unknown, GlobalState> {
+export function toggleReaction(postId: string, emojiName: string): ActionFuncAsync<unknown, GlobalState> {
     return async (dispatch, getState) => {
         const state = getState();
         const getIsReactionAlreadyAddedToPost = makeGetIsReactionAlreadyAddedToPost();
@@ -176,7 +176,7 @@ export function toggleReaction(postId: string, emojiName: string): NewActionFunc
     };
 }
 
-export function addReaction(postId: string, emojiName: string): NewActionFunc {
+export function addReaction(postId: string, emojiName: string): ActionFunc {
     const getUniqueEmojiNameReactionsForPost = makeGetUniqueEmojiNameReactionsForPost();
     return (dispatch, getState) => {
         const state = getState() as GlobalState;
@@ -202,7 +202,7 @@ export function addReaction(postId: string, emojiName: string): NewActionFunc {
     };
 }
 
-export function searchForTerm(term: string): NewActionFunc<boolean, GlobalState> {
+export function searchForTerm(term: string): ActionFunc<boolean, GlobalState> {
     return (dispatch) => {
         dispatch(RhsActions.updateSearchTerms(term));
         dispatch(RhsActions.showSearchResults());
@@ -210,7 +210,7 @@ export function searchForTerm(term: string): NewActionFunc<boolean, GlobalState>
     };
 }
 
-function addPostToSearchResults(postId: string): NewActionFunc {
+function addPostToSearchResults(postId: string): ActionFunc {
     return (dispatch, getState) => {
         const state = getState();
         const results = state.entities.search.results;
@@ -251,7 +251,7 @@ function removePostFromSearchResults(postId: string, state: GlobalState, dispatc
     }
 }
 
-export function pinPost(postId: string): NewActionFuncAsync<boolean, GlobalState> {
+export function pinPost(postId: string): ActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         await dispatch(PostActions.pinPost(postId));
         const state = getState();
@@ -264,7 +264,7 @@ export function pinPost(postId: string): NewActionFuncAsync<boolean, GlobalState
     };
 }
 
-export function unpinPost(postId: string): NewActionFuncAsync<boolean, GlobalState> {
+export function unpinPost(postId: string): ActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         await dispatch(PostActions.unpinPost(postId));
         const state = getState();
@@ -277,7 +277,7 @@ export function unpinPost(postId: string): NewActionFuncAsync<boolean, GlobalSta
     };
 }
 
-export function setEditingPost(postId = '', refocusId = '', title = '', isRHS = false): NewActionFunc<boolean> {
+export function setEditingPost(postId = '', refocusId = '', title = '', isRHS = false): ActionFunc<boolean> {
     return (dispatch, getState) => {
         const state = getState();
         const post = PostSelectors.getPost(state, postId);
@@ -316,7 +316,7 @@ export function unsetEditingPost() {
     };
 }
 
-export function markPostAsUnread(post: Post, location?: string): NewActionFuncAsync {
+export function markPostAsUnread(post: Post, location?: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const userId = getCurrentUserId(state);
@@ -337,7 +337,7 @@ export function markPostAsUnread(post: Post, location?: string): NewActionFuncAs
     };
 }
 
-export function markMostRecentPostInChannelAsUnread(channelId: string): NewActionFuncAsync {
+export function markMostRecentPostInChannelAsUnread(channelId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         let state = getState();
         let postId = PostSelectors.getMostRecentPostIdInChannel(state, channelId);
@@ -355,7 +355,7 @@ export function markMostRecentPostInChannelAsUnread(channelId: string): NewActio
 }
 
 // Action called by DeletePostModal when the post is deleted
-export function deleteAndRemovePost(post: Post): NewActionFuncAsync<boolean, GlobalState> {
+export function deleteAndRemovePost(post: Post): ActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         const {error} = await dispatch(PostActions.deletePost(post));
         if (error) {

--- a/webapp/channels/src/actions/status_actions.ts
+++ b/webapp/channels/src/actions/status_actions.ts
@@ -8,13 +8,13 @@ import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels'
 import {getPostsInCurrentChannel} from 'mattermost-redux/selectors/entities/posts';
 import {getDirectShowPreferences} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionFunc} from 'mattermost-redux/types/actions';
 
 import {loadCustomEmojisForCustomStatusesByUserIds} from 'actions/emoji_actions';
 
 import type {GlobalState} from 'types/store';
 
-export function loadStatusesForChannelAndSidebar(): NewActionFunc<boolean, GlobalState> {
+export function loadStatusesForChannelAndSidebar(): ActionFunc<boolean, GlobalState> {
     return (dispatch, getState) => {
         const state = getState();
         const statusesToLoad: Record<string, true> = {};
@@ -47,7 +47,7 @@ export function loadStatusesForChannelAndSidebar(): NewActionFunc<boolean, Globa
     };
 }
 
-export function loadStatusesForProfilesList(users: UserProfile[] | null): NewActionFunc<boolean> {
+export function loadStatusesForProfilesList(users: UserProfile[] | null): ActionFunc<boolean> {
     return (dispatch) => {
         if (users == null) {
             return {data: false};
@@ -64,7 +64,7 @@ export function loadStatusesForProfilesList(users: UserProfile[] | null): NewAct
     };
 }
 
-export function loadStatusesForProfilesMap(users: Record<string, UserProfile> | UserProfile[] | null): NewActionFunc {
+export function loadStatusesForProfilesMap(users: Record<string, UserProfile> | UserProfile[] | null): ActionFunc {
     return (dispatch) => {
         if (users == null) {
             return {data: false};
@@ -83,7 +83,7 @@ export function loadStatusesForProfilesMap(users: Record<string, UserProfile> | 
     };
 }
 
-export function loadStatusesByIds(userIds: string[]): NewActionFunc {
+export function loadStatusesByIds(userIds: string[]): ActionFunc {
     return (dispatch) => {
         if (userIds.length === 0) {
             return {data: false};
@@ -95,7 +95,7 @@ export function loadStatusesByIds(userIds: string[]): NewActionFunc {
     };
 }
 
-export function loadProfilesMissingStatus(users: UserProfile[]): NewActionFunc {
+export function loadProfilesMissingStatus(users: UserProfile[]): ActionFunc {
     return (dispatch, getState) => {
         const state = getState();
         const statuses = state.entities.users.statuses;

--- a/webapp/channels/src/actions/team_actions.ts
+++ b/webapp/channels/src/actions/team_actions.ts
@@ -15,12 +15,12 @@ import {getUser} from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 import {getHistory} from 'utils/browser_history';
 import {Preferences} from 'utils/constants';
 
-export function removeUserFromTeamAndGetStats(teamId: Team['id'], userId: UserProfile['id']): NewActionFuncAsync {
+export function removeUserFromTeamAndGetStats(teamId: Team['id'], userId: UserProfile['id']): ActionFuncAsync {
     return async (dispatch, getState) => {
         const response = await dispatch(TeamActions.removeUserFromTeam(teamId, userId));
         dispatch(getUser(userId));
@@ -30,7 +30,7 @@ export function removeUserFromTeamAndGetStats(teamId: Team['id'], userId: UserPr
     };
 }
 
-export function addUserToTeamFromInvite(token: string, inviteId: string): NewActionFuncAsync<Team> {
+export function addUserToTeamFromInvite(token: string, inviteId: string): ActionFuncAsync<Team> {
     return async (dispatch) => {
         const {data: member, error} = await dispatch(TeamActions.addUserToTeamFromInvite(token, inviteId));
         if (member) {
@@ -52,7 +52,7 @@ export function addUserToTeamFromInvite(token: string, inviteId: string): NewAct
     };
 }
 
-export function addUserToTeam(teamId: Team['id'], userId: UserProfile['id']): NewActionFuncAsync<Team> {
+export function addUserToTeam(teamId: Team['id'], userId: UserProfile['id']): ActionFuncAsync<Team> {
     return async (dispatch) => {
         const {data: member, error} = await dispatch(TeamActions.addUserToTeam(teamId, userId));
         if (member) {
@@ -74,7 +74,7 @@ export function addUserToTeam(teamId: Team['id'], userId: UserProfile['id']): Ne
     };
 }
 
-export function addUsersToTeam(teamId: Team['id'], userIds: Array<UserProfile['id']>): NewActionFuncAsync<TeamMemberWithError[]> {
+export function addUsersToTeam(teamId: Team['id'], userIds: Array<UserProfile['id']>): ActionFuncAsync<TeamMemberWithError[]> {
     return async (dispatch, getState) => {
         const {data, error} = await dispatch(TeamActions.addUsersToTeamGracefully(teamId, userIds));
 
@@ -103,7 +103,7 @@ export function switchTeam(url: string, team?: Team): ThunkActionFunc<void> {
     };
 }
 
-export function updateTeamsOrderForUser(teamIds: Array<Team['id']>): NewActionFuncAsync {
+export function updateTeamsOrderForUser(teamIds: Array<Team['id']>): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
@@ -117,7 +117,7 @@ export function updateTeamsOrderForUser(teamIds: Array<Team['id']>): NewActionFu
     };
 }
 
-export function getGroupMessageMembersCommonTeams(channelId: string): NewActionFuncAsync<Team[]> {
+export function getGroupMessageMembersCommonTeams(channelId: string): ActionFuncAsync<Team[]> {
     return async (dispatch) => {
         let teams: Team[];
 

--- a/webapp/channels/src/actions/user_actions.ts
+++ b/webapp/channels/src/actions/user_actions.ts
@@ -23,7 +23,7 @@ import {
 import {getBool, isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeamId, getTeamMember} from 'mattermost-redux/selectors/entities/teams';
 import * as Selectors from 'mattermost-redux/selectors/entities/users';
-import type {ActionResult, NewActionFunc, NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionResult, ActionFunc, ActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 import {calculateUnreadCount} from 'mattermost-redux/utils/channel_utils';
 
 import {loadCustomEmojisForCustomStatusesByUserIds} from 'actions/emoji_actions';
@@ -40,7 +40,7 @@ export const queue = new PQueue({concurrency: 4});
 const dispatch = store.dispatch;
 const getState = store.getState;
 
-export function loadProfilesAndReloadTeamMembers(page: number, perPage: number, teamId: string, options = {}): NewActionFuncAsync {
+export function loadProfilesAndReloadTeamMembers(page: number, perPage: number, teamId: string, options = {}): ActionFuncAsync {
     return async (doDispatch, doGetState) => {
         const newTeamId = teamId || getCurrentTeamId(doGetState());
         const {data} = await doDispatch(UserActions.getProfilesInTeam(newTeamId, page, perPage, '', options));
@@ -55,7 +55,7 @@ export function loadProfilesAndReloadTeamMembers(page: number, perPage: number, 
     };
 }
 
-export function loadProfilesAndReloadChannelMembers(page: number, perPage?: number, channelId?: string, sort = '', options = {}): NewActionFuncAsync {
+export function loadProfilesAndReloadChannelMembers(page: number, perPage?: number, channelId?: string, sort = '', options = {}): ActionFuncAsync {
     return async (doDispatch, doGetState) => {
         const newChannelId = channelId || getCurrentChannelId(doGetState());
         const {data} = await doDispatch(UserActions.getProfilesInChannel(newChannelId, page, perPage, sort, options));
@@ -70,7 +70,7 @@ export function loadProfilesAndReloadChannelMembers(page: number, perPage?: numb
     };
 }
 
-export function loadProfilesAndTeamMembers(page: number, perPage: number, teamId: string, options?: Record<string, any>): NewActionFuncAsync {
+export function loadProfilesAndTeamMembers(page: number, perPage: number, teamId: string, options?: Record<string, any>): ActionFuncAsync {
     return async (doDispatch, doGetState) => {
         const newTeamId = teamId || getCurrentTeamId(doGetState());
         const {data} = await doDispatch(UserActions.getProfilesInTeam(newTeamId, page, perPage, '', options));
@@ -83,7 +83,7 @@ export function loadProfilesAndTeamMembers(page: number, perPage: number, teamId
     };
 }
 
-export function searchProfilesAndTeamMembers(term = '', options: Record<string, any> = {}): NewActionFuncAsync {
+export function searchProfilesAndTeamMembers(term = '', options: Record<string, any> = {}): ActionFuncAsync {
     return async (doDispatch, doGetState) => {
         const newTeamId = options.team_id || getCurrentTeamId(doGetState());
         const {data} = await doDispatch(UserActions.searchProfiles(term, options));
@@ -98,7 +98,7 @@ export function searchProfilesAndTeamMembers(term = '', options: Record<string, 
     };
 }
 
-export function searchProfilesAndChannelMembers(term: string, options: Record<string, any> = {}): NewActionFuncAsync {
+export function searchProfilesAndChannelMembers(term: string, options: Record<string, any> = {}): ActionFuncAsync {
     return async (doDispatch, doGetState) => {
         const newChannelId = options.in_channel_id || getCurrentChannelId(doGetState());
         const {data} = await doDispatch(UserActions.searchProfiles(term, options));
@@ -113,7 +113,7 @@ export function searchProfilesAndChannelMembers(term: string, options: Record<st
     };
 }
 
-export function loadProfilesAndTeamMembersAndChannelMembers(page: number, perPage: number, teamId: string, channelId: string, options?: {active?: boolean}): NewActionFuncAsync {
+export function loadProfilesAndTeamMembersAndChannelMembers(page: number, perPage: number, teamId: string, channelId: string, options?: {active?: boolean}): ActionFuncAsync {
     return async (doDispatch, doGetState) => {
         const state = doGetState();
         const teamIdParam = teamId || getCurrentTeamId(state);
@@ -131,7 +131,7 @@ export function loadProfilesAndTeamMembersAndChannelMembers(page: number, perPag
     };
 }
 
-export function loadTeamMembersForProfilesList(profiles: UserProfile[], teamId: string, reloadAllMembers = false): NewActionFuncAsync {
+export function loadTeamMembersForProfilesList(profiles: UserProfile[], teamId: string, reloadAllMembers = false): ActionFuncAsync {
     return async (doDispatch, doGetState) => {
         const state = doGetState();
         const teamIdParam = teamId || getCurrentTeamId(state);
@@ -155,7 +155,7 @@ export function loadTeamMembersForProfilesList(profiles: UserProfile[], teamId: 
     };
 }
 
-export function loadProfilesWithoutTeam(page: number, perPage: number, options?: Record<string, any>): NewActionFuncAsync {
+export function loadProfilesWithoutTeam(page: number, perPage: number, options?: Record<string, any>): ActionFuncAsync {
     return async (doDispatch) => {
         const {data} = await doDispatch(UserActions.getProfilesWithoutTeam(page, perPage, options));
 
@@ -165,7 +165,7 @@ export function loadProfilesWithoutTeam(page: number, perPage: number, options?:
     };
 }
 
-export function loadTeamMembersAndChannelMembersForProfilesList(profiles: UserProfile[], teamId: string, channelId: string): NewActionFuncAsync {
+export function loadTeamMembersAndChannelMembersForProfilesList(profiles: UserProfile[], teamId: string, channelId: string): ActionFuncAsync {
     return async (doDispatch, doGetState) => {
         const state = doGetState();
         const teamIdParam = teamId || getCurrentTeamId(state);
@@ -179,7 +179,7 @@ export function loadTeamMembersAndChannelMembersForProfilesList(profiles: UserPr
     };
 }
 
-export function loadChannelMembersForProfilesList(profiles: UserProfile[], channelId: string, reloadAllMembers = false): NewActionFuncAsync {
+export function loadChannelMembersForProfilesList(profiles: UserProfile[], channelId: string, reloadAllMembers = false): ActionFuncAsync {
     return async (doDispatch, doGetState) => {
         const state = doGetState();
         const channelIdParam = channelId || getCurrentChannelId(state);
@@ -203,7 +203,7 @@ export function loadChannelMembersForProfilesList(profiles: UserProfile[], chann
     };
 }
 
-export function loadNewDMIfNeeded(channelId: string): NewActionFuncAsync {
+export function loadNewDMIfNeeded(channelId: string): ActionFuncAsync {
     return async (doDispatch, doGetState) => {
         const state = doGetState();
         const currentUserId = Selectors.getCurrentUserId(state);
@@ -243,7 +243,7 @@ export function loadNewDMIfNeeded(channelId: string): NewActionFuncAsync {
     };
 }
 
-export function loadNewGMIfNeeded(channelId: string): NewActionFuncAsync {
+export function loadNewGMIfNeeded(channelId: string): ActionFuncAsync {
     return async (doDispatch, doGetState) => {
         const state = doGetState();
         const currentUserId = Selectors.getCurrentUserId(state);
@@ -266,7 +266,7 @@ export function loadNewGMIfNeeded(channelId: string): NewActionFuncAsync {
     };
 }
 
-export function loadProfilesForGroupChannels(groupChannels: Channel[]): NewActionFunc {
+export function loadProfilesForGroupChannels(groupChannels: Channel[]): ActionFunc {
     return (doDispatch, doGetState) => {
         const state = doGetState();
         const userIdsInChannels = Selectors.getUserIdsInChannels(state);
@@ -421,7 +421,7 @@ export function autocompleteUsers(username: string): ThunkActionFunc<Promise<Use
     };
 }
 
-export function autoResetStatus(): NewActionFuncAsync<UserStatus> {
+export function autoResetStatus(): ActionFuncAsync<UserStatus> {
     return async (doDispatch) => {
         const {currentUserId} = getState().entities.users;
         const {data: userStatus} = await doDispatch(UserActions.getStatus(currentUserId));

--- a/webapp/channels/src/actions/views/channel.ts
+++ b/webapp/channels/src/actions/views/channel.ts
@@ -42,7 +42,7 @@ import {
 } from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, getUserByUsername} from 'mattermost-redux/selectors/entities/users';
 import {makeAddLastViewAtToProfiles} from 'mattermost-redux/selectors/entities/utils';
-import type {NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 import {getChannelByName} from 'mattermost-redux/utils/channel_utils';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
@@ -61,7 +61,7 @@ import {Constants, ActionTypes, EventTypes, PostRequestTypes} from 'utils/consta
 
 import type {GlobalState} from 'types/store';
 
-export function goToLastViewedChannel(): NewActionFuncAsync {
+export function goToLastViewedChannel(): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const currentChannel = getCurrentChannel(state) || {};
@@ -79,7 +79,7 @@ export function goToLastViewedChannel(): NewActionFuncAsync {
     };
 }
 
-export function switchToChannelById(channelId: string): NewActionFuncAsync {
+export function switchToChannelById(channelId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const channel = getChannel(state, channelId);
@@ -87,7 +87,7 @@ export function switchToChannelById(channelId: string): NewActionFuncAsync {
     };
 }
 
-export function loadIfNecessaryAndSwitchToChannelById(channelId: string): NewActionFuncAsync {
+export function loadIfNecessaryAndSwitchToChannelById(channelId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         let channel = getChannel(state, channelId);
@@ -99,7 +99,7 @@ export function loadIfNecessaryAndSwitchToChannelById(channelId: string): NewAct
     };
 }
 
-export function switchToChannel(channel: Channel & {userId?: string}): NewActionFuncAsync {
+export function switchToChannel(channel: Channel & {userId?: string}): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const selectedTeamId = channel.team_id;
@@ -130,7 +130,7 @@ export function switchToChannel(channel: Channel & {userId?: string}): NewAction
     };
 }
 
-export function joinChannelById(channelId: string): NewActionFuncAsync {
+export function joinChannelById(channelId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
@@ -140,7 +140,7 @@ export function joinChannelById(channelId: string): NewActionFuncAsync {
     };
 }
 
-export function leaveChannel(channelId: string): NewActionFuncAsync {
+export function leaveChannel(channelId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         let state = getState();
         const currentUserId = getCurrentUserId(state);
@@ -191,7 +191,7 @@ export function leaveChannel(channelId: string): NewActionFuncAsync {
     };
 }
 
-export function leaveDirectChannel(channelName: string): NewActionFuncAsync {
+export function leaveDirectChannel(channelName: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
@@ -211,7 +211,7 @@ export function leaveDirectChannel(channelName: string): NewActionFuncAsync {
     };
 }
 
-export function autocompleteUsersInChannel(prefix: string, channelId: string): NewActionFuncAsync<UserAutocomplete> {
+export function autocompleteUsersInChannel(prefix: string, channelId: string): ActionFuncAsync<UserAutocomplete> {
     const addLastViewAtToProfiles = makeAddLastViewAtToProfiles();
     return async (dispatch, getState) => {
         const state = getState();
@@ -235,7 +235,7 @@ export function autocompleteUsersInChannel(prefix: string, channelId: string): N
     };
 }
 
-export function loadUnreads(channelId: string, prefetch = false): NewActionFuncAsync<{atLatestMessage: boolean; atOldestMessage: boolean}> {
+export function loadUnreads(channelId: string, prefetch = false): ActionFuncAsync<{atLatestMessage: boolean; atOldestMessage: boolean}> {
     return async (dispatch) => {
         const time = Date.now();
         if (prefetch) {
@@ -293,7 +293,7 @@ export function loadUnreads(channelId: string, prefetch = false): NewActionFuncA
     };
 }
 
-export function loadPostsAround(channelId: string, focusedPostId: string): NewActionFuncAsync {
+export function loadPostsAround(channelId: string, focusedPostId: string): ActionFuncAsync {
     return async (dispatch) => {
         const {data, error} = await dispatch(PostActions.getPostsAround(channelId, focusedPostId, Posts.POST_CHUNK_SIZE / 2));
         if (error) {
@@ -316,7 +316,7 @@ export function loadPostsAround(channelId: string, focusedPostId: string): NewAc
     };
 }
 
-export function loadLatestPosts(channelId: string): NewActionFuncAsync {
+export function loadLatestPosts(channelId: string): ActionFuncAsync {
     return async (dispatch) => {
         const time = Date.now();
         const {data, error} = await dispatch(PostActions.getPosts(channelId, 0, Posts.POST_CHUNK_SIZE / 2));
@@ -409,7 +409,7 @@ export function loadPosts({
     };
 }
 
-export function syncPostsInChannel(channelId: string, since: number, prefetch = false): NewActionFuncAsync {
+export function syncPostsInChannel(channelId: string, since: number, prefetch = false): ActionFuncAsync {
     return async (dispatch, getState) => {
         const time = Date.now();
         const state = getState();
@@ -461,7 +461,7 @@ export function syncPostsInChannel(channelId: string, since: number, prefetch = 
     };
 }
 
-export function prefetchChannelPosts(channelId: string, jitter?: number): NewActionFuncAsync {
+export function prefetchChannelPosts(channelId: string, jitter?: number): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const recentPostIdInChannel = getMostRecentPostIdInChannel(state, channelId);
@@ -501,7 +501,7 @@ export function updateToastStatus(status: boolean) {
     };
 }
 
-export function deleteChannel(channelId: string): NewActionFuncAsync<boolean, GlobalState> {
+export function deleteChannel(channelId: string): ActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         const res = await dispatch(deleteChannelRedux(channelId));
         if (res.error) {

--- a/webapp/channels/src/actions/views/channel_sidebar.ts
+++ b/webapp/channels/src/actions/views/channel_sidebar.ts
@@ -6,7 +6,7 @@ import {General} from 'mattermost-redux/constants';
 import {CategoryTypes} from 'mattermost-redux/constants/channel_categories';
 import {getCategory, makeGetChannelIdsForCategory} from 'mattermost-redux/selectors/entities/channel_categories';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
-import type {NewActionFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFunc, ActionFuncAsync} from 'mattermost-redux/types/actions';
 import {insertMultipleWithoutDuplicates} from 'mattermost-redux/utils/array_utils';
 
 import {getCategoriesForCurrentTeam, getChannelsInCategoryOrder, getDisplayedChannels} from 'selectors/views/channel_sidebar';
@@ -33,7 +33,7 @@ export function stopDragging() {
     return {type: ActionTypes.SIDEBAR_DRAGGING_STOP};
 }
 
-export function createCategory(teamId: string, displayName: string, channelIds?: string[]): NewActionFuncAsync<unknown, GlobalState> {
+export function createCategory(teamId: string, displayName: string, channelIds?: string[]): ActionFuncAsync<unknown, GlobalState> {
     return async (dispatch, getState) => {
         if (channelIds) {
             const state = getState() as GlobalState;
@@ -61,7 +61,7 @@ export function addChannelsInSidebar(categoryId: string, channelId: string) {
 
 // moveChannelsInSidebar moves channels to a given category in the sidebar, but it accounts for when the target index
 // may have changed due to archived channels not being shown in the sidebar.
-export function moveChannelsInSidebar(categoryId: string, targetIndex: number, draggableChannelId: string, setManualSorting = true): NewActionFuncAsync<unknown, GlobalState> {
+export function moveChannelsInSidebar(categoryId: string, targetIndex: number, draggableChannelId: string, setManualSorting = true): ActionFuncAsync<unknown, GlobalState> {
     return (dispatch, getState) => {
         const state = getState();
         const multiSelectedChannelIds = state.views.channelSidebar.multiSelectedChannelIds;
@@ -137,7 +137,7 @@ export function adjustTargetIndexForMove(state: GlobalState, categoryId: string,
     return Math.max(newIndex - removedChannelsAboveInsert.length, 0);
 }
 
-export function clearChannelSelection(): NewActionFunc<unknown, GlobalState> {
+export function clearChannelSelection(): ActionFunc<unknown, GlobalState> {
     return (dispatch, getState) => {
         const state = getState();
 
@@ -154,7 +154,7 @@ export function clearChannelSelection(): NewActionFunc<unknown, GlobalState> {
     };
 }
 
-export function multiSelectChannelAdd(channelId: string): NewActionFunc<unknown, GlobalState> {
+export function multiSelectChannelAdd(channelId: string): ActionFunc<unknown, GlobalState> {
     return (dispatch, getState) => {
         const state = getState();
         const multiSelectedChannelIds = state.views.channelSidebar.multiSelectedChannelIds;
@@ -177,7 +177,7 @@ export function multiSelectChannelAdd(channelId: string): NewActionFunc<unknown,
 
 // Much of this logic was pulled from the react-beautiful-dnd sample multiselect implementation
 // Found here: https://github.com/atlassian/react-beautiful-dnd/tree/master/stories/src/multi-drag
-export function multiSelectChannelTo(channelId: string): NewActionFunc<unknown, GlobalState> {
+export function multiSelectChannelTo(channelId: string): ActionFunc<unknown, GlobalState> {
     return (dispatch, getState) => {
         const state = getState();
         const multiSelectedChannelIds = state.views.channelSidebar.multiSelectedChannelIds;

--- a/webapp/channels/src/actions/views/create_comment.tsx
+++ b/webapp/channels/src/actions/views/create_comment.tsx
@@ -14,7 +14,7 @@ import {
 } from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFunc, ActionFuncAsync} from 'mattermost-redux/types/actions';
 import {isPostPendingOrFailed} from 'mattermost-redux/utils/post_utils';
 
 import {executeCommand} from 'actions/command';
@@ -47,7 +47,7 @@ export function updateCommentDraft(rootId: string, draft?: PostDraft, save = fal
     return updateDraft(key, draft ?? null, rootId, save);
 }
 
-export function submitPost(channelId: string, rootId: string, draft: PostDraft): NewActionFuncAsync {
+export function submitPost(channelId: string, rootId: string, draft: PostDraft): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
 
@@ -78,7 +78,7 @@ export function submitPost(channelId: string, rootId: string, draft: PostDraft):
     };
 }
 
-export function submitCommand(channelId: string, rootId: string, draft: PostDraft): NewActionFuncAsync<unknown, GlobalState> {
+export function submitCommand(channelId: string, rootId: string, draft: PostDraft): ActionFuncAsync<unknown, GlobalState> {
     return async (dispatch, getState) => {
         const state = getState();
 
@@ -116,7 +116,7 @@ export function submitCommand(channelId: string, rootId: string, draft: PostDraf
     };
 }
 
-export function makeOnSubmit(channelId: string, rootId: string, latestPostId: string): (draft: PostDraft, options?: {ignoreSlash?: boolean}) => NewActionFuncAsync<boolean, GlobalState> {
+export function makeOnSubmit(channelId: string, rootId: string, latestPostId: string): (draft: PostDraft, options?: {ignoreSlash?: boolean}) => ActionFuncAsync<boolean, GlobalState> {
     return (draft, options = {}) => async (dispatch, getState) => {
         const {message} = draft;
 
@@ -191,7 +191,7 @@ function makeGetCurrentUsersLatestReply() {
     );
 }
 
-export function makeOnEditLatestPost(rootId: string): () => NewActionFunc<boolean> {
+export function makeOnEditLatestPost(rootId: string): () => ActionFunc<boolean> {
     const getCurrentUsersLatestPost = makeGetCurrentUsersLatestReply();
 
     return () => (dispatch, getState) => {

--- a/webapp/channels/src/actions/views/drafts.ts
+++ b/webapp/channels/src/actions/views/drafts.ts
@@ -15,7 +15,7 @@ import {Client4} from 'mattermost-redux/client';
 import Preferences from 'mattermost-redux/constants/preferences';
 import {syncedDraftsAreAllowedAndEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFunc, ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {removeGlobalItem, setGlobalItem} from 'actions/storage';
 import {makeGetDrafts} from 'selectors/drafts';
@@ -37,7 +37,7 @@ type Draft = {
  * Gets drafts stored on the server and reconciles them with any locally stored drafts.
  * @param teamId Only drafts for the given teamId will be fetched.
  */
-export function getDrafts(teamId: string): NewActionFuncAsync<boolean, GlobalState> {
+export function getDrafts(teamId: string): ActionFuncAsync<boolean, GlobalState> {
     const getLocalDrafts = makeGetDrafts(false);
 
     return async (dispatch, getState) => {
@@ -98,7 +98,7 @@ export function getDrafts(teamId: string): NewActionFuncAsync<boolean, GlobalSta
     };
 }
 
-export function removeDraft(key: string, channelId: string, rootId = ''): NewActionFuncAsync<boolean, GlobalState> {
+export function removeDraft(key: string, channelId: string, rootId = ''): ActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         const state = getState();
 
@@ -124,7 +124,7 @@ export function removeDraft(key: string, channelId: string, rootId = ''): NewAct
     };
 }
 
-export function updateDraft(key: string, value: PostDraft|null, rootId = '', save = false): NewActionFuncAsync<boolean, GlobalState> {
+export function updateDraft(key: string, value: PostDraft|null, rootId = '', save = false): ActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         const state = getState();
         let updatedValue: PostDraft|null = null;
@@ -171,7 +171,7 @@ function upsertDraft(draft: PostDraft, userId: UserProfile['id'], rootId = '', c
     return Client4.upsertDraft(newDraft, connectionId);
 }
 
-export function setDraftsTourTipPreference(initializationState: Record<string, boolean>): NewActionFuncAsync {
+export function setDraftsTourTipPreference(initializationState: Record<string, boolean>): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
@@ -186,7 +186,7 @@ export function setDraftsTourTipPreference(initializationState: Record<string, b
     };
 }
 
-export function setGlobalDraft(key: string, value: PostDraft|null, isRemote: boolean): NewActionFunc {
+export function setGlobalDraft(key: string, value: PostDraft|null, isRemote: boolean): ActionFunc {
     return (dispatch) => {
         dispatch(setGlobalItem(key, value));
         dispatch(setGlobalDraftSource(key, isRemote));

--- a/webapp/channels/src/actions/views/lhs.ts
+++ b/webapp/channels/src/actions/views/lhs.ts
@@ -3,7 +3,7 @@
 
 import {selectChannel} from 'mattermost-redux/actions/channels';
 import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
-import type {NewActionFunc, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionFunc, ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 import {SidebarSize} from 'components/resizable_sidebar/constants';
 
@@ -80,7 +80,7 @@ export const selectLhsItem = (type: LhsItemType, id?: string): ThunkActionFunc<u
     };
 };
 
-export function switchToLhsStaticPage(id: string): NewActionFunc<boolean, GlobalState> {
+export function switchToLhsStaticPage(id: string): ActionFunc<boolean, GlobalState> {
     return (dispatch, getState) => {
         const state = getState();
         const teamUrl = getCurrentRelativeTeamUrl(state);

--- a/webapp/channels/src/actions/views/login.ts
+++ b/webapp/channels/src/actions/views/login.ts
@@ -9,9 +9,9 @@ import {UserTypes} from 'mattermost-redux/action_types';
 import {logError} from 'mattermost-redux/actions/errors';
 import {loadRolesIfNeeded} from 'mattermost-redux/actions/roles';
 import {Client4} from 'mattermost-redux/client';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
-export function login(loginId: string, password: string, mfaToken = ''): NewActionFuncAsync {
+export function login(loginId: string, password: string, mfaToken = ''): ActionFuncAsync {
     return async (dispatch) => {
         dispatch({type: UserTypes.LOGIN_REQUEST, data: null});
 
@@ -45,7 +45,7 @@ export function login(loginId: string, password: string, mfaToken = ''): NewActi
     };
 }
 
-export function loginWithDesktopToken(token: string): NewActionFuncAsync {
+export function loginWithDesktopToken(token: string): ActionFuncAsync {
     return async (dispatch) => {
         dispatch({type: UserTypes.LOGIN_REQUEST, data: null});
 
@@ -79,7 +79,7 @@ export function loginWithDesktopToken(token: string): NewActionFuncAsync {
     };
 }
 
-export function loginById(id: string, password: string): NewActionFuncAsync {
+export function loginById(id: string, password: string): ActionFuncAsync {
     return async (dispatch) => {
         dispatch({type: UserTypes.LOGIN_REQUEST, data: null});
 

--- a/webapp/channels/src/actions/views/onboarding_tasks.ts
+++ b/webapp/channels/src/actions/views/onboarding_tasks.ts
@@ -3,7 +3,7 @@
 
 import {getCurrentUser, getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 import {getCurrentTeamId, getTeam} from 'mattermost-redux/selectors/entities/teams';
-import type {NewActionFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFunc, ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {getTeamRedirectChannelIfIsAccesible} from 'actions/global_actions';
 import LocalStorageStore from 'stores/local_storage_store';
@@ -15,7 +15,7 @@ import {ActionTypes, Constants, ModalIdentifiers} from 'utils/constants';
 
 import {openModal} from './modals';
 
-export function switchToChannels(): NewActionFuncAsync<boolean> {
+export function switchToChannels(): ActionFuncAsync<boolean> {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
@@ -31,7 +31,7 @@ export function switchToChannels(): NewActionFuncAsync<boolean> {
     };
 }
 
-export function openInvitationsModal(timeout = 1): NewActionFunc {
+export function openInvitationsModal(timeout = 1): ActionFunc {
     return (dispatch) => {
         dispatch(switchToChannels());
         setTimeout(() => {

--- a/webapp/channels/src/actions/views/rhs.ts
+++ b/webapp/channels/src/actions/views/rhs.ts
@@ -24,7 +24,7 @@ import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentTimezone} from 'mattermost-redux/selectors/entities/timezone';
 import {getCurrentUser, getCurrentUserMentionKeys} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFunc, NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionFunc, ActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 import {trackEvent} from 'actions/telemetry_actions.jsx';
 import {getSearchTerms, getRhsState, getPluggableId, getFilesSearchExtFilter, getPreviousRhsState} from 'selectors/rhs';
@@ -37,7 +37,7 @@ import {getBrowserUtcOffset, getUtcOffsetForTimeZone} from 'utils/timezone';
 import type {GlobalState} from 'types/store';
 import type {RhsState} from 'types/store/rhs';
 
-function selectPostFromRightHandSideSearchWithPreviousState(post: Post, previousRhsState?: RhsState): NewActionFuncAsync<boolean, GlobalState> {
+function selectPostFromRightHandSideSearchWithPreviousState(post: Post, previousRhsState?: RhsState): ActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         const postRootId = post.root_id || post.id;
         await dispatch(PostActions.getPostThread(postRootId));
@@ -55,7 +55,7 @@ function selectPostFromRightHandSideSearchWithPreviousState(post: Post, previous
     };
 }
 
-function selectPostCardFromRightHandSideSearchWithPreviousState(post: Post, previousRhsState?: RhsState): NewActionFuncAsync<boolean, GlobalState> {
+function selectPostCardFromRightHandSideSearchWithPreviousState(post: Post, previousRhsState?: RhsState): ActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         const state = getState();
 
@@ -70,7 +70,7 @@ function selectPostCardFromRightHandSideSearchWithPreviousState(post: Post, prev
     };
 }
 
-export function updateRhsState(rhsState: string, channelId?: string, previousRhsState?: RhsState): NewActionFunc<boolean> {
+export function updateRhsState(rhsState: string, channelId?: string, previousRhsState?: RhsState): ActionFunc<boolean> {
     return (dispatch, getState) => {
         const action: AnyAction = {
             type: ActionTypes.UPDATE_RHS_STATE,
@@ -105,7 +105,7 @@ export function openShowEditHistory(post: Post) {
     };
 }
 
-export function goBack(): NewActionFuncAsync<boolean, GlobalState> {
+export function goBack(): ActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         const prevState = getPreviousRhsState(getState());
         const defaultTab = 'channel-info';
@@ -123,7 +123,7 @@ export function selectPostFromRightHandSideSearch(post: Post) {
     return selectPostFromRightHandSideSearchWithPreviousState(post);
 }
 
-export function selectPostFromRightHandSideSearchByPostId(postId: string): NewActionFuncAsync<boolean, GlobalState> {
+export function selectPostFromRightHandSideSearchByPostId(postId: string): ActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         const post = getPost(getState(), postId);
         return dispatch(selectPostFromRightHandSideSearch(post));
@@ -258,7 +258,7 @@ export function showRHSPlugin(pluggableId: string) {
     };
 }
 
-export function showChannelMembers(channelId: string, inEditingMode = false): NewActionFuncAsync<boolean, GlobalState> {
+export function showChannelMembers(channelId: string, inEditingMode = false): ActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         const state = getState();
 
@@ -281,7 +281,7 @@ export function showChannelMembers(channelId: string, inEditingMode = false): Ne
     };
 }
 
-export function hideRHSPlugin(pluggableId: string): NewActionFunc<boolean, GlobalState> {
+export function hideRHSPlugin(pluggableId: string): ActionFunc<boolean, GlobalState> {
     return (dispatch, getState) => {
         const state = getState() as GlobalState;
 
@@ -293,7 +293,7 @@ export function hideRHSPlugin(pluggableId: string): NewActionFunc<boolean, Globa
     };
 }
 
-export function toggleRHSPlugin(pluggableId: string): NewActionFunc<boolean, GlobalState> {
+export function toggleRHSPlugin(pluggableId: string): ActionFunc<boolean, GlobalState> {
     return (dispatch, getState) => {
         const state = getState();
 
@@ -307,7 +307,7 @@ export function toggleRHSPlugin(pluggableId: string): NewActionFunc<boolean, Glo
     };
 }
 
-export function showFlaggedPosts(): NewActionFuncAsync {
+export function showFlaggedPosts(): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const teamId = getCurrentTeamId(state);
@@ -342,7 +342,7 @@ export function showFlaggedPosts(): NewActionFuncAsync {
     };
 }
 
-export function showPinnedPosts(channelId?: string): NewActionFuncAsync<boolean, GlobalState> {
+export function showPinnedPosts(channelId?: string): ActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         const state = getState();
         const currentChannelId = getCurrentChannelId(state);
@@ -385,7 +385,7 @@ export function showPinnedPosts(channelId?: string): NewActionFuncAsync<boolean,
     };
 }
 
-export function showChannelFiles(channelId: string): NewActionFuncAsync<boolean, GlobalState> {
+export function showChannelFiles(channelId: string): ActionFuncAsync<boolean, GlobalState> {
     return async (dispatch, getState) => {
         const state = getState();
         const teamId = getCurrentTeamId(state);
@@ -443,7 +443,7 @@ export function showChannelFiles(channelId: string): NewActionFuncAsync<boolean,
     };
 }
 
-export function showMentions(): NewActionFunc<boolean, GlobalState> {
+export function showMentions(): ActionFunc<boolean, GlobalState> {
     return (dispatch, getState) => {
         const termKeys = getCurrentUserMentionKeys(getState()).filter(({key}) => {
             return key !== '@channel' && key !== '@all' && key !== '@here';
@@ -477,7 +477,7 @@ export function showChannelInfo(channelId: string) {
     };
 }
 
-export function closeRightHandSide(): NewActionFunc {
+export function closeRightHandSide(): ActionFunc {
     return (dispatch) => {
         const actionsBatch: AnyAction[] = [
             {
@@ -531,7 +531,7 @@ export function selectPost(post: Post) {
     };
 }
 
-export function selectPostById(postId: string): NewActionFuncAsync {
+export function selectPostById(postId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const post = getPost(state, postId) ?? (await dispatch(fetchPost(postId))).data;
@@ -562,7 +562,7 @@ export const debouncedClearHighlightReply = debounce((dispatch) => {
     return dispatch(clearHighlightReply);
 }, Constants.PERMALINK_FADEOUT);
 
-export function selectPostAndHighlight(post: Post): NewActionFunc {
+export function selectPostAndHighlight(post: Post): ActionFunc {
     return (dispatch) => {
         dispatch(batchActions([
             selectPost(post),
@@ -579,7 +579,7 @@ export function selectPostCard(post: Post) {
     return {type: ActionTypes.SELECT_POST_CARD, postId: post.id, channelId: post.channel_id};
 }
 
-export function openRHSSearch(): NewActionFunc {
+export function openRHSSearch(): ActionFunc {
     return (dispatch) => {
         dispatch(clearSearch());
         dispatch(updateSearchTerms(''));

--- a/webapp/channels/src/actions/views/root.ts
+++ b/webapp/channels/src/actions/views/root.ts
@@ -4,7 +4,7 @@
 import {getClientConfig, getLicenseConfig} from 'mattermost-redux/actions/general';
 import {loadMe} from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
-import type {NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 import {getCurrentLocale, getTranslations} from 'selectors/i18n';
 
@@ -18,7 +18,7 @@ const pluginTranslationSources: Record<string, TranslationPluginFunction> = {};
 
 export type TranslationPluginFunction = (locale: string) => Translations
 
-export function loadConfigAndMe(): NewActionFuncAsync<boolean> {
+export function loadConfigAndMe(): ActionFuncAsync<boolean> {
     return async (dispatch) => {
         await Promise.all([
             dispatch(getClientConfig()),
@@ -60,7 +60,7 @@ export function unregisterPluginTranslationsSource(pluginId: string) {
     Reflect.deleteProperty(pluginTranslationSources, pluginId);
 }
 
-export function loadTranslations(locale: string, url: string): NewActionFuncAsync {
+export function loadTranslations(locale: string, url: string): ActionFuncAsync {
     return async (dispatch) => {
         const translations = {...en};
         Object.values(pluginTranslationSources).forEach((pluginFunc) => {
@@ -87,7 +87,7 @@ export function loadTranslations(locale: string, url: string): NewActionFuncAsyn
     };
 }
 
-export function registerCustomPostRenderer(type: string, component: any, id: string): NewActionFuncAsync {
+export function registerCustomPostRenderer(type: string, component: any, id: string): ActionFuncAsync {
     return async (dispatch) => {
         // piggyback on plugins state to register a custom post renderer
         dispatch({

--- a/webapp/channels/src/components/advanced_create_post/index.ts
+++ b/webapp/channels/src/components/advanced_create_post/index.ts
@@ -30,7 +30,7 @@ import {get, getInt, getBool, isCustomGroupsEnabled} from 'mattermost-redux/sele
 import {haveICurrentChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, getStatusForUserId, getUser, isCurrentUserGuestUser} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions.js';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions.js';
 
 import {executeCommand} from 'actions/command';
 import {runMessageWillBePostedHooks, runSlashCommandWillBePostedHooks} from 'actions/hooks';
@@ -142,7 +142,7 @@ function onSubmitPost(post: Post, fileInfos: FileInfo[]) {
     };
 }
 
-function setDraft(key: string, value: PostDraft | null, draftChannelId: string, save = false): NewActionFuncAsync<boolean, GlobalState> {
+function setDraft(key: string, value: PostDraft | null, draftChannelId: string, save = false): ActionFuncAsync<boolean, GlobalState> {
     return (dispatch, getState) => {
         const channelId = draftChannelId || getCurrentChannelId(getState());
         let updatedValue = null;

--- a/webapp/channels/src/components/channel_layout/channel_identifier_router/actions.ts
+++ b/webapp/channels/src/components/channel_layout/channel_identifier_router/actions.ts
@@ -12,7 +12,7 @@ import {Client4} from 'mattermost-redux/client';
 import {getChannelByName, getOtherChannels, getChannel, getChannelsNameMapInTeam, getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
 import {getTeamByName} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser, getCurrentUserId, getUserByUsername as selectUserByUsername, getUser as selectUser, getUserByEmail as selectUserByEmail} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 import * as UserUtils from 'mattermost-redux/utils/user_utils';
 
 import {openDirectChannelToUserId} from 'actions/channel_actions';
@@ -29,7 +29,7 @@ const LENGTH_OF_GROUP_ID = 40;
 const LENGTH_OF_USER_ID_PAIR = 54;
 const USER_ID_PAIR_REGEXP = new RegExp(`^[a-zA-Z0-9]{${LENGTH_OF_ID}}__[a-zA-Z0-9]{${LENGTH_OF_ID}}$`);
 
-export function onChannelByIdentifierEnter({match, history}: MatchAndHistory): NewActionFuncAsync {
+export function onChannelByIdentifierEnter({match, history}: MatchAndHistory): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const {path, identifier, team} = match.params;
@@ -124,7 +124,7 @@ export async function getPathFromIdentifier(state: GlobalState, path: string, id
     return 'error';
 }
 
-export function goToChannelByChannelId(match: Match, history: History): NewActionFuncAsync {
+export function goToChannelByChannelId(match: Match, history: History): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
@@ -154,7 +154,7 @@ export function goToChannelByChannelId(match: Match, history: History): NewActio
     };
 }
 
-export function goToChannelByChannelName(match: Match, history: History): NewActionFuncAsync {
+export function goToChannelByChannelName(match: Match, history: History): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
@@ -224,7 +224,7 @@ export function goToChannelByChannelName(match: Match, history: History): NewAct
     };
 }
 
-function goToDirectChannelByUsername(match: Match, history: History): NewActionFuncAsync {
+function goToDirectChannelByUsername(match: Match, history: History): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
@@ -254,7 +254,7 @@ function goToDirectChannelByUsername(match: Match, history: History): NewActionF
     };
 }
 
-export function goToDirectChannelByUserId(match: Match, history: History, userId: string): NewActionFuncAsync {
+export function goToDirectChannelByUserId(match: Match, history: History, userId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const {team} = match.params;
@@ -276,7 +276,7 @@ export function goToDirectChannelByUserId(match: Match, history: History, userId
     };
 }
 
-export function goToDirectChannelByUserIds(match: Match, history: History): NewActionFuncAsync {
+export function goToDirectChannelByUserIds(match: Match, history: History): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
@@ -299,7 +299,7 @@ export function goToDirectChannelByUserIds(match: Match, history: History): NewA
     };
 }
 
-export function goToDirectChannelByEmail(match: Match, history: History): NewActionFuncAsync {
+export function goToDirectChannelByEmail(match: Match, history: History): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
@@ -322,7 +322,7 @@ export function goToDirectChannelByEmail(match: Match, history: History): NewAct
     };
 }
 
-function goToGroupChannelByGroupId(match: Match, history: History): NewActionFuncAsync {
+function goToGroupChannelByGroupId(match: Match, history: History): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const {identifier, team} = match.params;

--- a/webapp/channels/src/components/msg_typing/actions.ts
+++ b/webapp/channels/src/components/msg_typing/actions.ts
@@ -8,7 +8,7 @@ import {General, Preferences, WebsocketEvents} from 'mattermost-redux/constants'
 import {getConfig, isPerformanceDebuggingEnabled} from 'mattermost-redux/selectors/entities/general';
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId, getStatusForUserId} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 function getTimeBetweenTypingEvents(state: GlobalState) {
     const config = getConfig(state);
@@ -45,7 +45,7 @@ export function userStartedTyping(userId: string, channelId: string, rootId: str
     };
 }
 
-function fillInMissingInfo(userId: string): NewActionFuncAsync {
+function fillInMissingInfo(userId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);

--- a/webapp/channels/src/components/permalink_view/actions.ts
+++ b/webapp/channels/src/components/permalink_view/actions.ts
@@ -12,7 +12,7 @@ import {getCurrentChannel, getChannel as getChannelFromRedux} from 'mattermost-r
 import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeam, getTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 import {getUserIdFromChannelName} from 'mattermost-redux/utils/channel_utils';
 import {isSystemAdmin} from 'mattermost-redux/utils/user_utils';
 
@@ -33,7 +33,7 @@ type Option = {
     skipRedirectReplyPermalink: boolean;
 }
 
-function focusRootPost(post: Post, channel: Channel): NewActionFuncAsync {
+function focusRootPost(post: Post, channel: Channel): ActionFuncAsync {
     return async (dispatch, getState) => {
         const postURL = getPostURL(getState() as GlobalState, post);
 
@@ -49,7 +49,7 @@ function focusRootPost(post: Post, channel: Channel): NewActionFuncAsync {
     };
 }
 
-function focusReplyPost(post: Post, channel: Channel, teamId: string, returnTo: string, option: Option): NewActionFuncAsync {
+function focusReplyPost(post: Post, channel: Channel, teamId: string, returnTo: string, option: Option): ActionFuncAsync {
     return async (dispatch, getState) => {
         const {data} = await dispatch(getPostThread(post.root_id));
 

--- a/webapp/channels/src/components/post/actions.ts
+++ b/webapp/channels/src/components/post/actions.ts
@@ -3,7 +3,7 @@
 
 import {removePost} from 'mattermost-redux/actions/posts';
 import type {ExtendedPost} from 'mattermost-redux/actions/posts';
-import type {NewActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionFunc} from 'mattermost-redux/types/actions';
 
 import {removeDraft} from 'actions/views/drafts';
 import {closeRightHandSide} from 'actions/views/rhs';
@@ -18,7 +18,7 @@ import type {GlobalState} from 'types/store';
  * This action is called when the deleted post which is shown as 'deleted' in the RHS is then removed from the channel manually.
  * @param post Deleted post
  */
-export function removePostCloseRHSDeleteDraft(post: ExtendedPost): NewActionFunc<boolean, GlobalState> {
+export function removePostCloseRHSDeleteDraft(post: ExtendedPost): ActionFunc<boolean, GlobalState> {
     return (dispatch, getState) => {
         if (isThreadOpen(getState(), post.id)) {
             dispatch(closeRightHandSide());

--- a/webapp/channels/src/components/team_controller/actions/index.ts
+++ b/webapp/channels/src/components/team_controller/actions/index.ts
@@ -13,7 +13,7 @@ import {getTeamByName, selectTeam} from 'mattermost-redux/actions/teams';
 import {getLicense} from 'mattermost-redux/selectors/entities/general';
 import {isCustomGroupsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {loadStatusesForChannelAndSidebar} from 'actions/status_actions';
 import {addUserToTeam} from 'actions/team_actions';
@@ -22,7 +22,7 @@ import LocalStorageStore from 'stores/local_storage_store';
 import {isSuccess} from 'types/actions';
 import type {GlobalState} from 'types/store';
 
-export function initializeTeam(team: Team): NewActionFuncAsync<Team, GlobalState> {
+export function initializeTeam(team: Team): ActionFuncAsync<Team, GlobalState> {
     return async (dispatch, getState) => {
         dispatch(selectTeam(team.id));
 
@@ -77,7 +77,7 @@ export function initializeTeam(team: Team): NewActionFuncAsync<Team, GlobalState
     };
 }
 
-export function joinTeam(teamname: string, joinedOnFirstLoad: boolean): NewActionFuncAsync<Team, GlobalState> {
+export function joinTeam(teamname: string, joinedOnFirstLoad: boolean): ActionFuncAsync<Team, GlobalState> {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUser = getCurrentUser(state);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/admin.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/admin.ts
@@ -27,7 +27,7 @@ import type {
 import {AdminTypes} from 'mattermost-redux/action_types';
 import {getUsersLimits} from 'mattermost-redux/actions/limits';
 import {Client4} from 'mattermost-redux/client';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
@@ -220,7 +220,7 @@ export function getLdapGroups(page = 0, perPage: number = General.PAGE_SIZE_MAXI
     });
 }
 
-export function linkLdapGroup(key: string): NewActionFuncAsync {
+export function linkLdapGroup(key: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -246,7 +246,7 @@ export function linkLdapGroup(key: string): NewActionFuncAsync {
     };
 }
 
-export function unlinkLdapGroup(key: string): NewActionFuncAsync {
+export function unlinkLdapGroup(key: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.unlinkLdapGroup(key);
@@ -372,7 +372,7 @@ export function uploadLicense(fileData: File) {
     });
 }
 
-export function removeLicense(): NewActionFuncAsync<boolean> {
+export function removeLicense(): ActionFuncAsync<boolean> {
     return async (dispatch, getState) => {
         try {
             await Client4.removeLicense();
@@ -388,7 +388,7 @@ export function removeLicense(): NewActionFuncAsync<boolean> {
     };
 }
 
-export function getPrevTrialLicense(): NewActionFuncAsync {
+export function getPrevTrialLicense(): ActionFuncAsync {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -403,7 +403,7 @@ export function getPrevTrialLicense(): NewActionFuncAsync {
     };
 }
 
-export function getAnalytics(name: string, teamId = ''): NewActionFuncAsync {
+export function getAnalytics(name: string, teamId = ''): ActionFuncAsync {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -444,7 +444,7 @@ export function getUsersPerDayAnalytics(teamId = '') {
     return getAnalytics('user_counts_with_posts_day', teamId);
 }
 
-export function uploadPlugin(fileData: File, force = false): NewActionFuncAsync {
+export function uploadPlugin(fileData: File, force = false): ActionFuncAsync {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -459,7 +459,7 @@ export function uploadPlugin(fileData: File, force = false): NewActionFuncAsync 
     };
 }
 
-export function installPluginFromUrl(url: string, force = false): NewActionFuncAsync {
+export function installPluginFromUrl(url: string, force = false): ActionFuncAsync {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -488,7 +488,7 @@ export function getPluginStatuses() {
     });
 }
 
-export function removePlugin(pluginId: string): NewActionFuncAsync {
+export function removePlugin(pluginId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.removePlugin(pluginId);
@@ -507,7 +507,7 @@ export function removePlugin(pluginId: string): NewActionFuncAsync {
     };
 }
 
-export function enablePlugin(pluginId: string): NewActionFuncAsync {
+export function enablePlugin(pluginId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.enablePlugin(pluginId);
@@ -523,7 +523,7 @@ export function enablePlugin(pluginId: string): NewActionFuncAsync {
     };
 }
 
-export function disablePlugin(pluginId: string): NewActionFuncAsync {
+export function disablePlugin(pluginId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         dispatch({type: AdminTypes.DISABLE_PLUGIN_REQUEST, data: pluginId});
 
@@ -560,7 +560,7 @@ export function setSamlIdpCertificateFromMetadata(certData: string) {
     });
 }
 
-export function sendWarnMetricAck(warnMetricId: string, forceAck: boolean): NewActionFuncAsync {
+export function sendWarnMetricAck(warnMetricId: string, forceAck: boolean): ActionFuncAsync {
     return async (dispatch) => {
         try {
             Client4.trackEvent('api', 'api_request_send_metric_ack', {warnMetricId});
@@ -573,7 +573,7 @@ export function sendWarnMetricAck(warnMetricId: string, forceAck: boolean): NewA
     };
 }
 
-export function getDataRetentionCustomPolicies(page = 0, perPage = 10): NewActionFuncAsync<GetDataRetentionCustomPoliciesRequest> {
+export function getDataRetentionCustomPolicies(page = 0, perPage = 10): ActionFuncAsync<GetDataRetentionCustomPoliciesRequest> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -597,7 +597,7 @@ export function getDataRetentionCustomPolicies(page = 0, perPage = 10): NewActio
     };
 }
 
-export function getDataRetentionCustomPolicy(id: string): NewActionFuncAsync<DataRetentionCustomPolicies> {
+export function getDataRetentionCustomPolicy(id: string): ActionFuncAsync<DataRetentionCustomPolicies> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -621,7 +621,7 @@ export function getDataRetentionCustomPolicy(id: string): NewActionFuncAsync<Dat
     };
 }
 
-export function deleteDataRetentionCustomPolicy(id: string): NewActionFuncAsync<{id: string}> {
+export function deleteDataRetentionCustomPolicy(id: string): ActionFuncAsync<{id: string}> {
     return async (dispatch, getState) => {
         try {
             await Client4.deleteDataRetentionCustomPolicy(id);
@@ -646,7 +646,7 @@ export function deleteDataRetentionCustomPolicy(id: string): NewActionFuncAsync<
     };
 }
 
-export function getDataRetentionCustomPolicyTeams(id: string, page = 0, perPage: number = General.TEAMS_CHUNK_SIZE): NewActionFuncAsync<Team[]> {
+export function getDataRetentionCustomPolicyTeams(id: string, page = 0, perPage: number = General.TEAMS_CHUNK_SIZE): ActionFuncAsync<Team[]> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -670,7 +670,7 @@ export function getDataRetentionCustomPolicyTeams(id: string, page = 0, perPage:
     };
 }
 
-export function getDataRetentionCustomPolicyChannels(id: string, page = 0, perPage: number = General.TEAMS_CHUNK_SIZE): NewActionFuncAsync<{channels: Channel[]; total_count: number}> {
+export function getDataRetentionCustomPolicyChannels(id: string, page = 0, perPage: number = General.TEAMS_CHUNK_SIZE): ActionFuncAsync<{channels: Channel[]; total_count: number}> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -694,7 +694,7 @@ export function getDataRetentionCustomPolicyChannels(id: string, page = 0, perPa
     };
 }
 
-export function searchDataRetentionCustomPolicyTeams(id: string, term: string, opts: TeamSearchOpts): NewActionFuncAsync<DataRetentionCustomPolicies> {
+export function searchDataRetentionCustomPolicyTeams(id: string, term: string, opts: TeamSearchOpts): ActionFuncAsync<DataRetentionCustomPolicies> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -718,7 +718,7 @@ export function searchDataRetentionCustomPolicyTeams(id: string, term: string, o
     };
 }
 
-export function searchDataRetentionCustomPolicyChannels(id: string, term: string, opts: ChannelSearchOpts): NewActionFuncAsync<DataRetentionCustomPolicies> {
+export function searchDataRetentionCustomPolicyChannels(id: string, term: string, opts: ChannelSearchOpts): ActionFuncAsync<DataRetentionCustomPolicies> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -742,7 +742,7 @@ export function searchDataRetentionCustomPolicyChannels(id: string, term: string
     };
 }
 
-export function createDataRetentionCustomPolicy(policy: CreateDataRetentionCustomPolicy): NewActionFuncAsync<DataRetentionCustomPolicies> {
+export function createDataRetentionCustomPolicy(policy: CreateDataRetentionCustomPolicy): ActionFuncAsync<DataRetentionCustomPolicies> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -760,7 +760,7 @@ export function createDataRetentionCustomPolicy(policy: CreateDataRetentionCusto
     };
 }
 
-export function updateDataRetentionCustomPolicy(id: string, policy: PatchDataRetentionCustomPolicy): NewActionFuncAsync<DataRetentionCustomPolicies> {
+export function updateDataRetentionCustomPolicy(id: string, policy: PatchDataRetentionCustomPolicy): ActionFuncAsync<DataRetentionCustomPolicies> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -789,7 +789,7 @@ export function addDataRetentionCustomPolicyTeams(id: string, teams: string[]) {
     });
 }
 
-export function removeDataRetentionCustomPolicyTeams(id: string, teams: string[]): NewActionFuncAsync<{teams: string[]}> {
+export function removeDataRetentionCustomPolicyTeams(id: string, teams: string[]): ActionFuncAsync<{teams: string[]}> {
     return async (dispatch, getState) => {
         try {
             await Client4.removeDataRetentionPolicyTeams(id, teams);
@@ -825,7 +825,7 @@ export function addDataRetentionCustomPolicyChannels(id: string, channels: strin
     });
 }
 
-export function removeDataRetentionCustomPolicyChannels(id: string, channels: string[]): NewActionFuncAsync<{channels: string[]}> {
+export function removeDataRetentionCustomPolicyChannels(id: string, channels: string[]): ActionFuncAsync<{channels: string[]}> {
     return async (dispatch, getState) => {
         try {
             await Client4.removeDataRetentionPolicyChannels(id, channels);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/apps.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/apps.ts
@@ -7,11 +7,11 @@ import {AppsTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
 import {getChannel, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {bindClientFunc} from './helpers';
 
-export function fetchAppBindings(channelID: string): NewActionFuncAsync<true | AppBinding[]> {
+export function fetchAppBindings(channelID: string): ActionFuncAsync<true | AppBinding[]> {
     return async (dispatch, getState) => {
         if (!channelID) {
             return {data: true};
@@ -29,7 +29,7 @@ export function fetchAppBindings(channelID: string): NewActionFuncAsync<true | A
     };
 }
 
-export function fetchRHSAppsBindings(channelID: string): NewActionFuncAsync {
+export function fetchRHSAppsBindings(channelID: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
 

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/boards.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/boards.ts
@@ -4,13 +4,13 @@
 import type {PreferenceType} from '@mattermost/types/preferences';
 
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {savePreferences} from './preferences';
 
 import {Preferences} from '../constants';
 
-export function setNewChannelWithBoardPreference(initializationState: Record<string, boolean>): NewActionFuncAsync {
+export function setNewChannelWithBoardPreference(initializationState: Record<string, boolean>): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/channel_categories.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/channel_categories.ts
@@ -21,7 +21,7 @@ import {
 } from 'mattermost-redux/selectors/entities/channel_categories';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import type {
-    NewActionFuncAsync,
+    ActionFuncAsync,
     ThunkActionFunc,
 } from 'mattermost-redux/types/actions';
 import {insertMultipleWithoutDuplicates, insertWithoutDuplicates, removeItem} from 'mattermost-redux/utils/array_utils';
@@ -40,7 +40,7 @@ export function setCategorySorting(categoryId: string, sorting: CategorySorting)
     });
 }
 
-export function patchCategory(categoryId: string, patch: Partial<ChannelCategory>): NewActionFuncAsync {
+export function patchCategory(categoryId: string, patch: Partial<ChannelCategory>): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
@@ -73,7 +73,7 @@ export function patchCategory(categoryId: string, patch: Partial<ChannelCategory
     };
 }
 
-export function setCategoryMuted(categoryId: string, muted: boolean): NewActionFuncAsync {
+export function setCategoryMuted(categoryId: string, muted: boolean): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const category = getCategory(state, categoryId);
@@ -107,7 +107,7 @@ export function setCategoryMuted(categoryId: string, muted: boolean): NewActionF
     };
 }
 
-function updateCategory(category: ChannelCategory): NewActionFuncAsync {
+function updateCategory(category: ChannelCategory): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
@@ -163,7 +163,7 @@ export function fetchMyCategories(teamId: string, isWebSocket?: boolean): ThunkA
 //
 // Unless setOnServer is true, this only affects the categories on this client. If it is set to true, this updates
 // categories on the server too.
-export function addChannelToInitialCategory(channel: Channel, setOnServer = false): NewActionFuncAsync {
+export function addChannelToInitialCategory(channel: Channel, setOnServer = false): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const categories = Object.values(getAllCategoriesByIds(state));
@@ -220,14 +220,14 @@ export function addChannelToInitialCategory(channel: Channel, setOnServer = fals
 // addChannelToCategory returns an action that can be dispatched to add a channel to a given category without specifying
 // its order. The channel will be removed from its previous category (if any) on the given category's team and it will be
 // placed first in its new category.
-export function addChannelToCategory(categoryId: string, channelId: string): NewActionFuncAsync {
+export function addChannelToCategory(categoryId: string, channelId: string): ActionFuncAsync {
     return moveChannelToCategory(categoryId, channelId, 0, false);
 }
 
 // moveChannelToCategory returns an action that moves a channel into a category and puts it at the given index at the
 // category. The channel will also be removed from its previous category (if any) on that category's team. The category's
 // order will also be set to manual by default.
-export function moveChannelToCategory(categoryId: string, channelId: string, newIndex: number, setManualSorting = true): NewActionFuncAsync {
+export function moveChannelToCategory(categoryId: string, channelId: string, newIndex: number, setManualSorting = true): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const targetCategory = getCategory(state, categoryId);
@@ -285,7 +285,7 @@ export function moveChannelToCategory(categoryId: string, channelId: string, new
     };
 }
 
-export function moveChannelsToCategory(categoryId: string, channelIds: string[], newIndex: number, setManualSorting = true): NewActionFuncAsync {
+export function moveChannelsToCategory(categoryId: string, channelIds: string[], newIndex: number, setManualSorting = true): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const targetCategory = getCategory(state, categoryId);
@@ -364,7 +364,7 @@ export function moveChannelsToCategory(categoryId: string, channelIds: string[],
     };
 }
 
-export function moveCategory(teamId: string, categoryId: string, newIndex: number): NewActionFuncAsync {
+export function moveCategory(teamId: string, categoryId: string, newIndex: number): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const order = getCategoryIdsForTeam(state, teamId)!;
@@ -413,7 +413,7 @@ export function receivedCategoryOrder(teamId: string, order: string[]) {
     };
 }
 
-export function createCategory(teamId: string, displayName: string, channelIds: Array<Channel['id']> = []): NewActionFuncAsync<ChannelCategory> {
+export function createCategory(teamId: string, displayName: string, channelIds: Array<Channel['id']> = []): ActionFuncAsync<ChannelCategory> {
     return async (dispatch, getState) => {
         const currentUserId = getCurrentUserId(getState());
 
@@ -443,7 +443,7 @@ export function renameCategory(categoryId: string, displayName: string) {
     });
 }
 
-export function deleteCategory(categoryId: string): NewActionFuncAsync {
+export function deleteCategory(categoryId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const category = getCategory(state, categoryId);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/channels.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/channels.ts
@@ -32,7 +32,7 @@ import {
 } from 'mattermost-redux/selectors/entities/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
-import type {GetStateFunc, NewActionFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {GetStateFunc, ActionFunc, ActionFuncAsync} from 'mattermost-redux/types/actions';
 import {getChannelByName} from 'mattermost-redux/utils/channel_utils';
 
 import {addChannelToInitialCategory, addChannelToCategory} from './channel_categories';
@@ -51,7 +51,7 @@ export function selectChannel(channelId: string) {
     };
 }
 
-export function createChannel(channel: Channel, userId: string): NewActionFuncAsync<Channel> {
+export function createChannel(channel: Channel, userId: string): ActionFuncAsync<Channel> {
     return async (dispatch, getState) => {
         let created;
         try {
@@ -102,7 +102,7 @@ export function createChannel(channel: Channel, userId: string): NewActionFuncAs
     };
 }
 
-export function createDirectChannel(userId: string, otherUserId: string): NewActionFuncAsync<Channel> {
+export function createDirectChannel(userId: string, otherUserId: string): ActionFuncAsync<Channel> {
     return async (dispatch, getState) => {
         dispatch({type: ChannelTypes.CREATE_CHANNEL_REQUEST, data: null});
 
@@ -165,7 +165,7 @@ export function createDirectChannel(userId: string, otherUserId: string): NewAct
     };
 }
 
-export function markGroupChannelOpen(channelId: string): NewActionFuncAsync {
+export function markGroupChannelOpen(channelId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const {currentUserId} = getState().entities.users;
 
@@ -178,7 +178,7 @@ export function markGroupChannelOpen(channelId: string): NewActionFuncAsync {
     };
 }
 
-export function createGroupChannel(userIds: string[]): NewActionFuncAsync<Channel> {
+export function createGroupChannel(userIds: string[]): ActionFuncAsync<Channel> {
     return async (dispatch, getState) => {
         dispatch({type: ChannelTypes.CREATE_CHANNEL_REQUEST, data: null});
 
@@ -255,7 +255,7 @@ export function createGroupChannel(userIds: string[]): NewActionFuncAsync<Channe
     };
 }
 
-export function patchChannel(channelId: string, patch: Partial<Channel>): NewActionFuncAsync<Channel> {
+export function patchChannel(channelId: string, patch: Partial<Channel>): ActionFuncAsync<Channel> {
     return bindClientFunc({
         clientFunc: Client4.patchChannel,
         onSuccess: [ChannelTypes.RECEIVED_CHANNEL],
@@ -263,7 +263,7 @@ export function patchChannel(channelId: string, patch: Partial<Channel>): NewAct
     });
 }
 
-export function updateChannelPrivacy(channelId: string, privacy: string): NewActionFuncAsync<Channel> {
+export function updateChannelPrivacy(channelId: string, privacy: string): ActionFuncAsync<Channel> {
     return bindClientFunc({
         clientFunc: Client4.updateChannelPrivacy,
         onSuccess: [ChannelTypes.RECEIVED_CHANNEL],
@@ -271,7 +271,7 @@ export function updateChannelPrivacy(channelId: string, privacy: string): NewAct
     });
 }
 
-export function convertGroupMessageToPrivateChannel(channelID: string, teamID: string, displayName: string, name: string): NewActionFuncAsync {
+export function convertGroupMessageToPrivateChannel(channelID: string, teamID: string, displayName: string, name: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         let updatedChannel;
         try {
@@ -297,7 +297,7 @@ export function convertGroupMessageToPrivateChannel(channelID: string, teamID: s
     };
 }
 
-export function updateChannelNotifyProps(userId: string, channelId: string, props: Partial<ChannelNotifyProps>): NewActionFuncAsync {
+export function updateChannelNotifyProps(userId: string, channelId: string, props: Partial<ChannelNotifyProps>): ActionFuncAsync {
     return async (dispatch, getState) => {
         const notifyProps = {
             user_id: userId,
@@ -329,7 +329,7 @@ export function updateChannelNotifyProps(userId: string, channelId: string, prop
     };
 }
 
-export function getChannelByNameAndTeamName(teamName: string, channelName: string, includeDeleted = false): NewActionFuncAsync<Channel> {
+export function getChannelByNameAndTeamName(teamName: string, channelName: string, includeDeleted = false): ActionFuncAsync<Channel> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -350,7 +350,7 @@ export function getChannelByNameAndTeamName(teamName: string, channelName: strin
     };
 }
 
-export function getChannel(channelId: string): NewActionFuncAsync<Channel> {
+export function getChannel(channelId: string): ActionFuncAsync<Channel> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -371,7 +371,7 @@ export function getChannel(channelId: string): NewActionFuncAsync<Channel> {
     };
 }
 
-export function getChannelAndMyMember(channelId: string): NewActionFuncAsync<{channel: Channel; member: ChannelMembership}> {
+export function getChannelAndMyMember(channelId: string): ActionFuncAsync<{channel: Channel; member: ChannelMembership}> {
     return async (dispatch, getState) => {
         let channel;
         let member;
@@ -404,7 +404,7 @@ export function getChannelAndMyMember(channelId: string): NewActionFuncAsync<{ch
     };
 }
 
-export function getChannelTimezones(channelId: string): NewActionFuncAsync<string[]> {
+export function getChannelTimezones(channelId: string): ActionFuncAsync<string[]> {
     return async (dispatch, getState) => {
         let channelTimezones;
         try {
@@ -421,7 +421,7 @@ export function getChannelTimezones(channelId: string): NewActionFuncAsync<strin
     };
 }
 
-export function fetchChannelsAndMembers(teamId: string): NewActionFuncAsync<{channels: ServerChannel[]; channelMembers: ChannelMembership[]}> {
+export function fetchChannelsAndMembers(teamId: string): ActionFuncAsync<{channels: ServerChannel[]; channelMembers: ChannelMembership[]}> {
     return async (dispatch, getState) => {
         let channels;
         let channelMembers;
@@ -462,7 +462,7 @@ export function fetchChannelsAndMembers(teamId: string): NewActionFuncAsync<{cha
     };
 }
 
-export function fetchAllMyTeamsChannelsAndChannelMembersREST(): NewActionFuncAsync {
+export function fetchAllMyTeamsChannelsAndChannelMembersREST(): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const {currentUserId} = state.entities.users;
@@ -511,7 +511,7 @@ export function fetchAllMyTeamsChannelsAndChannelMembersREST(): NewActionFuncAsy
     };
 }
 
-export function getChannelMembers(channelId: string, page = 0, perPage: number = General.CHANNELS_CHUNK_SIZE): NewActionFuncAsync<ChannelMembership[]> {
+export function getChannelMembers(channelId: string, page = 0, perPage: number = General.CHANNELS_CHUNK_SIZE): ActionFuncAsync<ChannelMembership[]> {
     return async (dispatch, getState) => {
         let channelMembers: ChannelMembership[];
 
@@ -537,7 +537,7 @@ export function getChannelMembers(channelId: string, page = 0, perPage: number =
     };
 }
 
-export function leaveChannel(channelId: string): NewActionFuncAsync {
+export function leaveChannel(channelId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const {currentUserId} = state.entities.users;
@@ -583,7 +583,7 @@ export function leaveChannel(channelId: string): NewActionFuncAsync {
     };
 }
 
-export function joinChannel(userId: string, teamId: string, channelId: string, channelName?: string): NewActionFuncAsync<{channel: Channel; member: ChannelMembership} | null> {
+export function joinChannel(userId: string, teamId: string, channelId: string, channelName?: string): ActionFuncAsync<{channel: Channel; member: ChannelMembership} | null> {
     return async (dispatch, getState) => {
         if (!channelId && !channelName) {
             return {data: null};
@@ -632,7 +632,7 @@ export function joinChannel(userId: string, teamId: string, channelId: string, c
     };
 }
 
-export function deleteChannel(channelId: string): NewActionFuncAsync {
+export function deleteChannel(channelId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         let state = getState();
         const viewArchivedChannels = state.entities.general.config.ExperimentalViewArchivedChannels === 'true';
@@ -662,7 +662,7 @@ export function deleteChannel(channelId: string): NewActionFuncAsync {
     };
 }
 
-export function unarchiveChannel(channelId: string): NewActionFuncAsync {
+export function unarchiveChannel(channelId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.unarchiveChannel(channelId);
@@ -681,7 +681,7 @@ export function unarchiveChannel(channelId: string): NewActionFuncAsync {
     };
 }
 
-export function updateApproximateViewTime(channelId: string): NewActionFuncAsync {
+export function updateApproximateViewTime(channelId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const {currentUserId} = getState().entities.users;
 
@@ -699,7 +699,7 @@ export function updateApproximateViewTime(channelId: string): NewActionFuncAsync
     };
 }
 
-export function readMultipleChannels(channelIds: string[]): NewActionFuncAsync {
+export function readMultipleChannels(channelIds: string[]): ActionFuncAsync {
     return async (dispatch, getState) => {
         let response;
         try {
@@ -716,7 +716,7 @@ export function readMultipleChannels(channelIds: string[]): NewActionFuncAsync {
     };
 }
 
-export function getChannels(teamId: string, page = 0, perPage: number = General.CHANNELS_CHUNK_SIZE): NewActionFuncAsync<Channel[]> {
+export function getChannels(teamId: string, page = 0, perPage: number = General.CHANNELS_CHUNK_SIZE): ActionFuncAsync<Channel[]> {
     return async (dispatch, getState) => {
         dispatch({type: ChannelTypes.GET_CHANNELS_REQUEST, data: null});
 
@@ -745,7 +745,7 @@ export function getChannels(teamId: string, page = 0, perPage: number = General.
     };
 }
 
-export function getArchivedChannels(teamId: string, page = 0, perPage: number = General.CHANNELS_CHUNK_SIZE): NewActionFuncAsync<Channel[]> {
+export function getArchivedChannels(teamId: string, page = 0, perPage: number = General.CHANNELS_CHUNK_SIZE): ActionFuncAsync<Channel[]> {
     return async (dispatch, getState) => {
         let channels;
         try {
@@ -765,7 +765,7 @@ export function getArchivedChannels(teamId: string, page = 0, perPage: number = 
     };
 }
 
-export function getAllChannelsWithCount(page = 0, perPage: number = General.CHANNELS_CHUNK_SIZE, notAssociatedToGroup = '', excludeDefaultChannels = false, includeDeleted = false, excludePolicyConstrained = false): NewActionFuncAsync<ChannelsWithTotalCount> {
+export function getAllChannelsWithCount(page = 0, perPage: number = General.CHANNELS_CHUNK_SIZE, notAssociatedToGroup = '', excludeDefaultChannels = false, includeDeleted = false, excludePolicyConstrained = false): ActionFuncAsync<ChannelsWithTotalCount> {
     return async (dispatch, getState) => {
         dispatch({type: ChannelTypes.GET_ALL_CHANNELS_REQUEST, data: null});
 
@@ -797,7 +797,7 @@ export function getAllChannelsWithCount(page = 0, perPage: number = General.CHAN
     };
 }
 
-export function getAllChannels(page = 0, perPage: number = General.CHANNELS_CHUNK_SIZE, notAssociatedToGroup = '', excludeDefaultChannels = false, excludePolicyConstrained = false): NewActionFuncAsync<ChannelWithTeamData[]> {
+export function getAllChannels(page = 0, perPage: number = General.CHANNELS_CHUNK_SIZE, notAssociatedToGroup = '', excludeDefaultChannels = false, excludePolicyConstrained = false): ActionFuncAsync<ChannelWithTeamData[]> {
     return async (dispatch, getState) => {
         dispatch({type: ChannelTypes.GET_ALL_CHANNELS_REQUEST, data: null});
 
@@ -825,7 +825,7 @@ export function getAllChannels(page = 0, perPage: number = General.CHANNELS_CHUN
     };
 }
 
-export function autocompleteChannels(teamId: string, term: string): NewActionFuncAsync<Channel[]> {
+export function autocompleteChannels(teamId: string, term: string): ActionFuncAsync<Channel[]> {
     return async (dispatch, getState) => {
         dispatch({type: ChannelTypes.GET_CHANNELS_REQUEST, data: null});
 
@@ -854,7 +854,7 @@ export function autocompleteChannels(teamId: string, term: string): NewActionFun
     };
 }
 
-export function autocompleteChannelsForSearch(teamId: string, term: string): NewActionFuncAsync<Channel[]> {
+export function autocompleteChannelsForSearch(teamId: string, term: string): ActionFuncAsync<Channel[]> {
     return async (dispatch, getState) => {
         dispatch({type: ChannelTypes.GET_CHANNELS_REQUEST, data: null});
 
@@ -883,7 +883,7 @@ export function autocompleteChannelsForSearch(teamId: string, term: string): New
     };
 }
 
-export function searchChannels(teamId: string, term: string, archived?: boolean): NewActionFuncAsync<Channel[]> {
+export function searchChannels(teamId: string, term: string, archived?: boolean): ActionFuncAsync<Channel[]> {
     return async (dispatch, getState) => {
         dispatch({type: ChannelTypes.GET_CHANNELS_REQUEST, data: null});
 
@@ -916,9 +916,9 @@ export function searchChannels(teamId: string, term: string, archived?: boolean)
     };
 }
 
-export function searchAllChannels(term: string, opts: {page: number; per_page: number} & ChannelSearchOpts): NewActionFuncAsync<ChannelsWithTotalCount>;
-export function searchAllChannels(term: string, opts: Omit<ChannelSearchOpts, 'page' | 'per_page'> | undefined): NewActionFuncAsync<ChannelWithTeamData[]>;
-export function searchAllChannels(term: string, opts: ChannelSearchOpts = {}): NewActionFuncAsync<Channel[] | ChannelsWithTotalCount> {
+export function searchAllChannels(term: string, opts: {page: number; per_page: number} & ChannelSearchOpts): ActionFuncAsync<ChannelsWithTotalCount>;
+export function searchAllChannels(term: string, opts: Omit<ChannelSearchOpts, 'page' | 'per_page'> | undefined): ActionFuncAsync<ChannelWithTeamData[]>;
+export function searchAllChannels(term: string, opts: ChannelSearchOpts = {}): ActionFuncAsync<Channel[] | ChannelsWithTotalCount> {
     return async (dispatch, getState) => {
         dispatch({type: ChannelTypes.GET_ALL_CHANNELS_REQUEST, data: null});
 
@@ -955,7 +955,7 @@ export function searchGroupChannels(term: string) {
     });
 }
 
-export function getChannelStats(channelId: string, includeFileCount?: boolean): NewActionFuncAsync<ChannelStats> {
+export function getChannelStats(channelId: string, includeFileCount?: boolean): ActionFuncAsync<ChannelStats> {
     return async (dispatch, getState) => {
         let stat;
         try {
@@ -975,7 +975,7 @@ export function getChannelStats(channelId: string, includeFileCount?: boolean): 
     };
 }
 
-export function getChannelsMemberCount(channelIds: string[]): NewActionFuncAsync<Record<string, number>> {
+export function getChannelsMemberCount(channelIds: string[]): ActionFuncAsync<Record<string, number>> {
     return async (dispatch, getState) => {
         let channelsMemberCount;
 
@@ -996,7 +996,7 @@ export function getChannelsMemberCount(channelIds: string[]): NewActionFuncAsync
     };
 }
 
-export function addChannelMember(channelId: string, userId: string, postRootId = ''): NewActionFuncAsync<ChannelMembership> {
+export function addChannelMember(channelId: string, userId: string, postRootId = ''): ActionFuncAsync<ChannelMembership> {
     return async (dispatch, getState) => {
         let member;
         try {
@@ -1031,7 +1031,7 @@ export function addChannelMember(channelId: string, userId: string, postRootId =
     };
 }
 
-export function removeChannelMember(channelId: string, userId: string): NewActionFuncAsync {
+export function removeChannelMember(channelId: string, userId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.removeFromChannel(userId, channelId);
@@ -1058,7 +1058,7 @@ export function removeChannelMember(channelId: string, userId: string): NewActio
     };
 }
 
-export function markChannelAsRead(channelId: string, skipUpdateViewTime = false): NewActionFunc {
+export function markChannelAsRead(channelId: string, skipUpdateViewTime = false): ActionFunc {
     return (dispatch, getState) => {
         if (skipUpdateViewTime) {
             dispatch(updateApproximateViewTime(channelId));
@@ -1074,7 +1074,7 @@ export function markChannelAsRead(channelId: string, skipUpdateViewTime = false)
     };
 }
 
-export function markMultipleChannelsAsRead(channelTimes: Record<string, number>): NewActionFunc {
+export function markMultipleChannelsAsRead(channelTimes: Record<string, number>): ActionFunc {
     return (dispatch, getState) => {
         const actions: AnyAction[] = [];
         for (const id of Object.keys(channelTimes)) {
@@ -1089,7 +1089,7 @@ export function markMultipleChannelsAsRead(channelTimes: Record<string, number>)
     };
 }
 
-export function markChannelAsViewedOnServer(channelId: string): NewActionFuncAsync {
+export function markChannelAsViewedOnServer(channelId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.viewMyChannel(channelId);
@@ -1246,7 +1246,7 @@ export function getMyChannelMember(channelId: string) {
     });
 }
 
-export function loadMyChannelMemberAndRole(channelId: string): NewActionFuncAsync {
+export function loadMyChannelMemberAndRole(channelId: string): ActionFuncAsync {
     return async (dispatch) => {
         const result = await dispatch(getMyChannelMember(channelId));
         const roles = result.data?.roles.split(' ');
@@ -1258,7 +1258,7 @@ export function loadMyChannelMemberAndRole(channelId: string): NewActionFuncAsyn
 }
 
 // favoriteChannel moves the provided channel into the current team's Favorites category.
-export function favoriteChannel(channelId: string): NewActionFuncAsync {
+export function favoriteChannel(channelId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const channel = getChannelSelector(state, channelId);
@@ -1275,7 +1275,7 @@ export function favoriteChannel(channelId: string): NewActionFuncAsync {
 }
 
 // unfavoriteChannel moves the provided channel into the current team's Channels/DMs category.
-export function unfavoriteChannel(channelId: string): NewActionFuncAsync {
+export function unfavoriteChannel(channelId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const channel = getChannelSelector(state, channelId);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/emojis.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/emojis.ts
@@ -10,7 +10,7 @@ import type {GlobalState} from '@mattermost/types/store';
 import {EmojiTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
 import {getCustomEmojisByName as selectCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 import {parseEmojiNamesFromText} from 'mattermost-redux/utils/emoji_utils';
 
 import {logError} from './errors';
@@ -45,7 +45,7 @@ export function getCustomEmoji(emojiId: string) {
     });
 }
 
-export function getCustomEmojiByName(name: string): NewActionFuncAsync {
+export function getCustomEmojiByName(name: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         let data;
 
@@ -72,7 +72,7 @@ export function getCustomEmojiByName(name: string): NewActionFuncAsync {
     };
 }
 
-export function getCustomEmojisByName(names: string[]): NewActionFuncAsync {
+export function getCustomEmojisByName(names: string[]): ActionFuncAsync {
     return async (dispatch, getState) => {
         const neededNames = filterNeededCustomEmojis(getState(), names);
 
@@ -135,7 +135,7 @@ function filterNeededCustomEmojis(state: GlobalState, names: string[]) {
     });
 }
 
-export function getCustomEmojisInText(text: string): NewActionFuncAsync {
+export function getCustomEmojisInText(text: string): ActionFuncAsync {
     return async (dispatch) => {
         if (!text) {
             return {data: true};
@@ -150,7 +150,7 @@ export function getCustomEmojis(
     perPage: number = General.PAGE_SIZE_DEFAULT,
     sort: string = Emoji.SORT_BY_NAME,
     loadUsers = false,
-): NewActionFuncAsync<CustomEmoji[]> {
+): ActionFuncAsync<CustomEmoji[]> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -175,7 +175,7 @@ export function getCustomEmojis(
     };
 }
 
-export function loadProfilesForCustomEmojis(emojis: CustomEmoji[]): NewActionFuncAsync {
+export function loadProfilesForCustomEmojis(emojis: CustomEmoji[]): ActionFuncAsync {
     return async (dispatch, getState) => {
         const usersToLoad: Record<string, boolean> = {};
         emojis.forEach((emoji: CustomEmoji) => {
@@ -194,7 +194,7 @@ export function loadProfilesForCustomEmojis(emojis: CustomEmoji[]): NewActionFun
     };
 }
 
-export function deleteCustomEmoji(emojiId: string): NewActionFuncAsync {
+export function deleteCustomEmoji(emojiId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.deleteCustomEmoji(emojiId);
@@ -214,7 +214,7 @@ export function deleteCustomEmoji(emojiId: string): NewActionFuncAsync {
     };
 }
 
-export function searchCustomEmojis(term: string, options: any = {}, loadUsers = false): NewActionFuncAsync<CustomEmoji[]> {
+export function searchCustomEmojis(term: string, options: any = {}, loadUsers = false): ActionFuncAsync<CustomEmoji[]> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -239,7 +239,7 @@ export function searchCustomEmojis(term: string, options: any = {}, loadUsers = 
     };
 }
 
-export function autocompleteCustomEmojis(name: string): NewActionFuncAsync {
+export function autocompleteCustomEmojis(name: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         let data;
         try {

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/errors.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/errors.ts
@@ -9,7 +9,7 @@ import type {ServerError} from '@mattermost/types/errors';
 
 import {ErrorTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 export function dismissError(index: number) {
     return {
@@ -28,7 +28,7 @@ export function getLogErrorAction(error: ErrorObject, displayable = false) {
     };
 }
 
-export function logError(error: ServerError, displayable = false, consoleError = false): NewActionFuncAsync<boolean> {
+export function logError(error: ServerError, displayable = false, consoleError = false): ActionFuncAsync<boolean> {
     return async (dispatch, getState) => {
         if (error.server_error_id === 'api.context.session_expired.app_error') {
             return {data: true};

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/files.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/files.ts
@@ -6,7 +6,7 @@ import type {Post} from '@mattermost/types/posts';
 
 import {FileTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
@@ -18,7 +18,7 @@ export function receivedFiles(files: Map<string, FileSearchResultItem>) {
     };
 }
 
-export function getMissingFilesByPosts(posts: Post[]): NewActionFuncAsync {
+export function getMissingFilesByPosts(posts: Post[]): ActionFuncAsync {
     return async (dispatch, getState) => {
         const {files} = getState().entities.files;
         const postIds = posts.reduce((curr: Array<Post['id']>, post: Post) => {
@@ -39,7 +39,7 @@ export function getMissingFilesByPosts(posts: Post[]): NewActionFuncAsync {
     };
 }
 
-export function getFilesForPost(postId: string): NewActionFuncAsync {
+export function getFilesForPost(postId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         let files;
 

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/general.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/general.ts
@@ -6,13 +6,13 @@ import type {SystemSetting} from '@mattermost/types/general';
 
 import {GeneralTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
 import {loadRolesIfNeeded} from './roles';
 
-export function getClientConfig(): NewActionFuncAsync {
+export function getClientConfig(): ActionFuncAsync {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -51,7 +51,7 @@ export function logClientError(message: string, level = LogLevel.Error) {
     });
 }
 
-export function setServerVersion(serverVersion: string): NewActionFuncAsync {
+export function setServerVersion(serverVersion: string): ActionFuncAsync {
     return async (dispatch) => {
         dispatch({type: GeneralTypes.RECEIVED_SERVER_VERSION, data: serverVersion});
         dispatch(loadRolesIfNeeded([]));
@@ -65,7 +65,7 @@ export function setUrl(url: string) {
     return true;
 }
 
-export function setFirstAdminVisitMarketplaceStatus(): NewActionFuncAsync {
+export function setFirstAdminVisitMarketplaceStatus(): ActionFuncAsync {
     return async (dispatch) => {
         try {
             await Client4.setFirstAdminVisitMarketplaceStatus();
@@ -79,7 +79,7 @@ export function setFirstAdminVisitMarketplaceStatus(): NewActionFuncAsync {
 }
 
 // accompanying "set" happens as part of Client4.completeSetup
-export function getFirstAdminSetupComplete(): NewActionFuncAsync<SystemSetting> {
+export function getFirstAdminSetupComplete(): ActionFuncAsync<SystemSetting> {
     return async (dispatch, getState) => {
         let data;
         try {

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/groups.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/groups.ts
@@ -11,12 +11,12 @@ import type {UserProfile} from '@mattermost/types/users';
 import {ChannelTypes, GroupTypes, UserTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
 import {General} from 'mattermost-redux/constants';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
 
-export function linkGroupSyncable(groupID: string, syncableID: string, syncableType: SyncableType, patch: Partial<SyncablePatch>): NewActionFuncAsync {
+export function linkGroupSyncable(groupID: string, syncableID: string, syncableType: SyncableType, patch: Partial<SyncablePatch>): ActionFuncAsync {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -48,7 +48,7 @@ export function linkGroupSyncable(groupID: string, syncableID: string, syncableT
     };
 }
 
-export function unlinkGroupSyncable(groupID: string, syncableID: string, syncableType: SyncableType): NewActionFuncAsync {
+export function unlinkGroupSyncable(groupID: string, syncableID: string, syncableType: SyncableType): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.unlinkGroupSyncable(groupID, syncableID, syncableType);
@@ -83,7 +83,7 @@ export function unlinkGroupSyncable(groupID: string, syncableID: string, syncabl
     };
 }
 
-export function getGroupSyncables(groupID: string, syncableType: SyncableType): NewActionFuncAsync {
+export function getGroupSyncables(groupID: string, syncableType: SyncableType): ActionFuncAsync {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -114,7 +114,7 @@ export function getGroupSyncables(groupID: string, syncableType: SyncableType): 
     };
 }
 
-export function patchGroupSyncable(groupID: string, syncableID: string, syncableType: SyncableType, patch: Partial<SyncablePatch>): NewActionFuncAsync {
+export function patchGroupSyncable(groupID: string, syncableID: string, syncableType: SyncableType, patch: Partial<SyncablePatch>): ActionFuncAsync {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -324,7 +324,7 @@ export function getGroupStats(groupID: string) {
     });
 }
 
-export function createGroupWithUserIds(group: GroupCreateWithUserIds): NewActionFuncAsync<Group> {
+export function createGroupWithUserIds(group: GroupCreateWithUserIds): ActionFuncAsync<Group> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -342,7 +342,7 @@ export function createGroupWithUserIds(group: GroupCreateWithUserIds): NewAction
     };
 }
 
-export function addUsersToGroup(groupId: string, userIds: string[]): NewActionFuncAsync<UserProfile[]> {
+export function addUsersToGroup(groupId: string, userIds: string[]): ActionFuncAsync<UserProfile[]> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -364,7 +364,7 @@ export function addUsersToGroup(groupId: string, userIds: string[]): NewActionFu
     };
 }
 
-export function removeUsersFromGroup(groupId: string, userIds: string[]): NewActionFuncAsync<UserProfile[]> {
+export function removeUsersFromGroup(groupId: string, userIds: string[]): ActionFuncAsync<UserProfile[]> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -386,7 +386,7 @@ export function removeUsersFromGroup(groupId: string, userIds: string[]): NewAct
     };
 }
 
-export function searchGroups(params: GroupSearchParams): NewActionFuncAsync {
+export function searchGroups(params: GroupSearchParams): ActionFuncAsync {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -411,7 +411,7 @@ export function searchGroups(params: GroupSearchParams): NewActionFuncAsync {
     };
 }
 
-export function archiveGroup(groupId: string): NewActionFuncAsync<Group> {
+export function archiveGroup(groupId: string): ActionFuncAsync<Group> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -433,7 +433,7 @@ export function archiveGroup(groupId: string): NewActionFuncAsync<Group> {
     };
 }
 
-export function restoreGroup(groupId: string): NewActionFuncAsync<Group> {
+export function restoreGroup(groupId: string): ActionFuncAsync<Group> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -455,7 +455,7 @@ export function restoreGroup(groupId: string): NewActionFuncAsync<Group> {
     };
 }
 
-export function createGroupTeamsAndChannels(userID: string): NewActionFuncAsync<{user_id: string}> {
+export function createGroupTeamsAndChannels(userID: string): ActionFuncAsync<{user_id: string}> {
     return async (dispatch, getState) => {
         try {
             await Client4.createGroupTeamsAndChannels(userID);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/helpers.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/helpers.ts
@@ -5,7 +5,7 @@ import type {ServerError} from '@mattermost/types/errors';
 
 import {UserTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
-import type {DispatchFunc, GetStateFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {DispatchFunc, GetStateFunc, ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {logError} from './errors';
 
@@ -75,7 +75,7 @@ export function bindClientFunc<Func extends(...args: any[]) => Promise<any>>({
     onSuccess?: ActionType | ActionType[];
     onFailure?: ActionType;
     params?: Parameters<Func>;
-}): NewActionFuncAsync<Awaited<ReturnType<Func>>> {
+}): ActionFuncAsync<Awaited<ReturnType<Func>>> {
     return async (dispatch, getState) => {
         if (onRequest) {
             dispatch(requestData(onRequest));

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/integrations.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/integrations.ts
@@ -10,7 +10,7 @@ import {Client4} from 'mattermost-redux/client';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
@@ -49,7 +49,7 @@ export function getIncomingHooks(teamId = '', page = 0, perPage: number = Genera
     });
 }
 
-export function removeIncomingHook(hookId: string): NewActionFuncAsync {
+export function removeIncomingHook(hookId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.removeIncomingWebhook(hookId);
@@ -114,7 +114,7 @@ export function getOutgoingHooks(channelId = '', teamId = '', page = 0, perPage:
     });
 }
 
-export function removeOutgoingHook(hookId: string): NewActionFuncAsync {
+export function removeOutgoingHook(hookId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.removeOutgoingWebhook(hookId);
@@ -218,7 +218,7 @@ export function executeCommand(command: string, args: CommandArgs) {
     });
 }
 
-export function regenCommandToken(id: string): NewActionFuncAsync {
+export function regenCommandToken(id: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         let res;
         try {
@@ -244,7 +244,7 @@ export function regenCommandToken(id: string): NewActionFuncAsync {
     };
 }
 
-export function deleteCommand(id: string): NewActionFuncAsync {
+export function deleteCommand(id: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.deleteCommand(id);
@@ -321,7 +321,7 @@ export function getOAuthApp(appId: string) {
     });
 }
 
-export function getAuthorizedOAuthApps(): NewActionFuncAsync<OAuthApp[]> {
+export function getAuthorizedOAuthApps(): ActionFuncAsync<OAuthApp[]> {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
@@ -348,7 +348,7 @@ export function deauthorizeOAuthApp(clientId: string) {
     });
 }
 
-export function deleteOAuthApp(id: string): NewActionFuncAsync {
+export function deleteOAuthApp(id: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.deleteOAuthApp(id);
@@ -380,7 +380,7 @@ export function regenOAuthAppSecret(appId: string) {
     });
 }
 
-export function submitInteractiveDialog(submission: DialogSubmission): NewActionFuncAsync<SubmitDialogResponse> {
+export function submitInteractiveDialog(submission: DialogSubmission): ActionFuncAsync<SubmitDialogResponse> {
     return async (dispatch, getState) => {
         const state = getState();
         submission.channel_id = getCurrentChannelId(state);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/limits.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/limits.ts
@@ -9,10 +9,10 @@ import {logError} from 'mattermost-redux/actions/errors';
 import {forceLogoutIfNecessary} from 'mattermost-redux/actions/helpers';
 import {Client4} from 'mattermost-redux/client';
 import {getCurrentUserRoles} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 import {isAdmin} from 'mattermost-redux/utils/user_utils';
 
-export function getUsersLimits(): NewActionFuncAsync<UsersLimits> {
+export function getUsersLimits(): ActionFuncAsync<UsersLimits> {
     return async (dispatch, getState) => {
         const roles = getCurrentUserRoles(getState());
         const amIAdmin = isAdmin(roles);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/posts.ts
@@ -30,7 +30,7 @@ import {getAllGroupsByName} from 'mattermost-redux/selectors/entities/groups';
 import * as PostSelectors from 'mattermost-redux/selectors/entities/posts';
 import {getUnreadScrollPositionPreference, isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId, getUsersByUsername} from 'mattermost-redux/selectors/entities/users';
-import type {ActionResult, DispatchFunc, GetStateFunc, NewActionFunc, NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionResult, DispatchFunc, GetStateFunc, ActionFunc, ActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 import {isCombinedUserActivityPost} from 'mattermost-redux/utils/post_list';
 
 import {logError} from './errors';
@@ -136,7 +136,7 @@ export function postRemoved(post: Post) {
     };
 }
 
-export function getPost(postId: string): NewActionFuncAsync<Post> {
+export function getPost(postId: string): ActionFuncAsync<Post> {
     return async (dispatch, getState) => {
         let post;
         const crtEnabled = isCollapsedThreadsEnabled(getState());
@@ -162,7 +162,7 @@ export function getPost(postId: string): NewActionFuncAsync<Post> {
     };
 }
 
-export function createPost(post: Post, files: any[] = []): NewActionFuncAsync {
+export function createPost(post: Post, files: any[] = []): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = state.entities.users.currentUserId;
@@ -289,7 +289,7 @@ export function createPost(post: Post, files: any[] = []): NewActionFuncAsync {
     };
 }
 
-export function createPostImmediately(post: Post, files: any[] = []): NewActionFuncAsync<Post> {
+export function createPostImmediately(post: Post, files: any[] = []): ActionFuncAsync<Post> {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = state.entities.users.currentUserId;
@@ -390,7 +390,7 @@ export function resetCreatePostRequest() {
     return {type: PostTypes.CREATE_POST_RESET_REQUEST};
 }
 
-export function deletePost(post: ExtendedPost): NewActionFuncAsync {
+export function deletePost(post: ExtendedPost): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const delPost = {...post};
@@ -461,7 +461,7 @@ function getUnreadPostData(unreadChan: ChannelUnread, state: GlobalState) {
     return data;
 }
 
-export function setUnreadPost(userId: string, postId: string): NewActionFuncAsync {
+export function setUnreadPost(userId: string, postId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         let state = getState();
         const post = PostSelectors.getPost(state, postId);
@@ -500,7 +500,7 @@ export function setUnreadPost(userId: string, postId: string): NewActionFuncAsyn
     };
 }
 
-export function pinPost(postId: string): NewActionFuncAsync {
+export function pinPost(postId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         dispatch({type: PostTypes.EDIT_POST_REQUEST});
         let posts;
@@ -552,7 +552,7 @@ export function decrementPinnedPostCount(channelId: Channel['id']) {
     };
 }
 
-export function unpinPost(postId: string): NewActionFuncAsync {
+export function unpinPost(postId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         dispatch({type: PostTypes.EDIT_POST_REQUEST});
         let posts;
@@ -591,7 +591,7 @@ export function unpinPost(postId: string): NewActionFuncAsync {
     };
 }
 
-export function addReaction(postId: string, emojiName: string): NewActionFuncAsync {
+export function addReaction(postId: string, emojiName: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const currentUserId = getState().entities.users.currentUserId;
 
@@ -613,7 +613,7 @@ export function addReaction(postId: string, emojiName: string): NewActionFuncAsy
     };
 }
 
-export function removeReaction(postId: string, emojiName: string): NewActionFuncAsync {
+export function removeReaction(postId: string, emojiName: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const currentUserId = getState().entities.users.currentUserId;
 
@@ -634,7 +634,7 @@ export function removeReaction(postId: string, emojiName: string): NewActionFunc
     };
 }
 
-export function getCustomEmojiForReaction(name: string): NewActionFuncAsync {
+export function getCustomEmojiForReaction(name: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const nonExistentEmoji = getState().entities.emojis.nonExistentEmoji;
         const customEmojisByName = selectCustomEmojisByName(getState());
@@ -655,7 +655,7 @@ export function getCustomEmojiForReaction(name: string): NewActionFuncAsync {
     };
 }
 
-export function flagPost(postId: string): NewActionFuncAsync {
+export function flagPost(postId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const {currentUserId} = getState().entities.users;
         const preference = {
@@ -705,7 +705,7 @@ async function getPaginatedPostThread(rootId: string, options: FetchPaginatedThr
     return list;
 }
 
-export function getPostThread(rootId: string, fetchThreads = true): NewActionFuncAsync<PostList> {
+export function getPostThread(rootId: string, fetchThreads = true): ActionFuncAsync<PostList> {
     return async (dispatch, getState) => {
         dispatch({type: PostTypes.GET_POST_THREAD_REQUEST});
         const collapsedThreadsEnabled = isCollapsedThreadsEnabled(getState());
@@ -733,7 +733,7 @@ export function getPostThread(rootId: string, fetchThreads = true): NewActionFun
     };
 }
 
-export function getNewestPostThread(rootId: string): NewActionFuncAsync {
+export function getNewestPostThread(rootId: string): ActionFuncAsync {
     const getPostsForThread = PostSelectors.makeGetPostsForThread();
 
     return async (dispatch, getState) => {
@@ -774,7 +774,7 @@ export function getNewestPostThread(rootId: string): NewActionFuncAsync {
     };
 }
 
-export function getPosts(channelId: string, page = 0, perPage = Posts.POST_CHUNK_SIZE, fetchThreads = true, collapsedThreadsExtended = false): NewActionFuncAsync<PostList> {
+export function getPosts(channelId: string, page = 0, perPage = Posts.POST_CHUNK_SIZE, fetchThreads = true, collapsedThreadsExtended = false): ActionFuncAsync<PostList> {
     return async (dispatch, getState) => {
         let posts;
         const collapsedThreadsEnabled = isCollapsedThreadsEnabled(getState());
@@ -796,7 +796,7 @@ export function getPosts(channelId: string, page = 0, perPage = Posts.POST_CHUNK
     };
 }
 
-export function getPostsUnread(channelId: string, fetchThreads = true, collapsedThreadsExtended = false): NewActionFuncAsync<PostList> {
+export function getPostsUnread(channelId: string, fetchThreads = true, collapsedThreadsExtended = false): ActionFuncAsync<PostList> {
     return async (dispatch, getState) => {
         const shouldLoadRecent = getUnreadScrollPositionPreference(getState()) === Preferences.UNREAD_SCROLL_POSITION_START_FROM_NEWEST;
         const collapsedThreadsEnabled = isCollapsedThreadsEnabled(getState());
@@ -837,7 +837,7 @@ export function getPostsUnread(channelId: string, fetchThreads = true, collapsed
     };
 }
 
-export function getPostsSince(channelId: string, since: number, fetchThreads = true, collapsedThreadsExtended = false): NewActionFuncAsync<PostList> {
+export function getPostsSince(channelId: string, since: number, fetchThreads = true, collapsedThreadsExtended = false): ActionFuncAsync<PostList> {
     return async (dispatch, getState) => {
         let posts;
         try {
@@ -862,7 +862,7 @@ export function getPostsSince(channelId: string, since: number, fetchThreads = t
     };
 }
 
-export function getPostsBefore(channelId: string, postId: string, page = 0, perPage = Posts.POST_CHUNK_SIZE, fetchThreads = true, collapsedThreadsExtended = false): NewActionFuncAsync<PostList> {
+export function getPostsBefore(channelId: string, postId: string, page = 0, perPage = Posts.POST_CHUNK_SIZE, fetchThreads = true, collapsedThreadsExtended = false): ActionFuncAsync<PostList> {
     return async (dispatch, getState) => {
         let posts;
         try {
@@ -884,7 +884,7 @@ export function getPostsBefore(channelId: string, postId: string, page = 0, perP
     };
 }
 
-export function getPostsAfter(channelId: string, postId: string, page = 0, perPage = Posts.POST_CHUNK_SIZE, fetchThreads = true, collapsedThreadsExtended = false): NewActionFuncAsync<PostList> {
+export function getPostsAfter(channelId: string, postId: string, page = 0, perPage = Posts.POST_CHUNK_SIZE, fetchThreads = true, collapsedThreadsExtended = false): ActionFuncAsync<PostList> {
     return async (dispatch, getState) => {
         let posts;
         try {
@@ -906,7 +906,7 @@ export function getPostsAfter(channelId: string, postId: string, page = 0, perPa
     };
 }
 
-export function getPostsAround(channelId: string, postId: string, perPage = Posts.POST_CHUNK_SIZE / 2, fetchThreads = true, collapsedThreadsExtended = false): NewActionFuncAsync<PostList> {
+export function getPostsAround(channelId: string, postId: string, perPage = Posts.POST_CHUNK_SIZE / 2, fetchThreads = true, collapsedThreadsExtended = false): ActionFuncAsync<PostList> {
     return async (dispatch, getState) => {
         let after;
         let thread;
@@ -1085,7 +1085,7 @@ export async function getMentionsAndStatusesForPosts(postsArrayOrMap: Post[]|Pos
     return Promise.all(promises);
 }
 
-export function getPostsByIds(ids: string[]): NewActionFuncAsync {
+export function getPostsByIds(ids: string[]): ActionFuncAsync {
     return async (dispatch, getState) => {
         let posts;
 
@@ -1176,7 +1176,7 @@ export function getNeededAtMentionedUsernamesAndGroups(state: GlobalState, posts
 
 export type ExtendedPost = Post & { system_post_ids?: string[] };
 
-export function removePost(post: ExtendedPost): NewActionFunc<boolean> {
+export function removePost(post: ExtendedPost): ActionFunc<boolean> {
     return (dispatch, getState) => {
         if (post.type === Posts.POST_TYPES.COMBINED_USER_ACTIVITY && post.system_post_ids) {
             const state = getState();
@@ -1197,7 +1197,7 @@ export function removePost(post: ExtendedPost): NewActionFunc<boolean> {
     };
 }
 
-export function moveThread(postId: string, channelId: string): NewActionFuncAsync {
+export function moveThread(postId: string, channelId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.moveThread(postId, channelId);
@@ -1221,7 +1221,7 @@ export function selectFocusedPostId(postId: string) {
     };
 }
 
-export function unflagPost(postId: string): NewActionFuncAsync {
+export function unflagPost(postId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const {currentUserId} = getState().entities.users;
         const preference = {
@@ -1236,7 +1236,7 @@ export function unflagPost(postId: string): NewActionFuncAsync {
     };
 }
 
-export function addPostReminder(userId: string, postId: string, timestamp: number): NewActionFuncAsync {
+export function addPostReminder(userId: string, postId: string, timestamp: number): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.addPostReminder(userId, postId, timestamp);
@@ -1253,7 +1253,7 @@ export function doPostAction(postId: string, actionId: string, selectedOption = 
     return doPostActionWithCookie(postId, actionId, '', selectedOption);
 }
 
-export function doPostActionWithCookie(postId: string, actionId: string, actionCookie: string, selectedOption = ''): NewActionFuncAsync {
+export function doPostActionWithCookie(postId: string, actionId: string, actionCookie: string, selectedOption = ''): ActionFuncAsync {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -1289,7 +1289,7 @@ export function resetHistoryIndex(index: string) {
     };
 }
 
-export function moveHistoryIndexBack(index: string): NewActionFuncAsync {
+export function moveHistoryIndexBack(index: string): ActionFuncAsync {
     return async (dispatch) => {
         dispatch({
             type: PostTypes.MOVE_HISTORY_INDEX_BACK,
@@ -1300,7 +1300,7 @@ export function moveHistoryIndexBack(index: string): NewActionFuncAsync {
     };
 }
 
-export function moveHistoryIndexForward(index: string): NewActionFuncAsync {
+export function moveHistoryIndexForward(index: string): ActionFuncAsync {
     return async (dispatch) => {
         dispatch({
             type: PostTypes.MOVE_HISTORY_INDEX_FORWARD,
@@ -1314,7 +1314,7 @@ export function moveHistoryIndexForward(index: string): NewActionFuncAsync {
 /**
  * Ensures thread-replies in channels correctly follow CRT:ON/OFF
  */
-export function resetReloadPostsInChannel(): NewActionFuncAsync {
+export function resetReloadPostsInChannel(): ActionFuncAsync {
     return async (dispatch, getState) => {
         dispatch({
             type: PostTypes.RESET_POSTS_IN_CHANNEL,
@@ -1331,7 +1331,7 @@ export function resetReloadPostsInChannel(): NewActionFuncAsync {
     };
 }
 
-export function acknowledgePost(postId: string): NewActionFuncAsync {
+export function acknowledgePost(postId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const userId = getCurrentUserId(getState());
 
@@ -1353,7 +1353,7 @@ export function acknowledgePost(postId: string): NewActionFuncAsync {
     };
 }
 
-export function unacknowledgePost(postId: string): NewActionFuncAsync {
+export function unacknowledgePost(postId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const userId = getCurrentUserId(getState());
 

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/preferences.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/preferences.ts
@@ -8,14 +8,14 @@ import {Client4} from 'mattermost-redux/client';
 import {getMyPreferences as getMyPreferencesSelector, makeGetCategory} from 'mattermost-redux/selectors/entities/preferences';
 import type {Theme} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 import {getPreferenceKey} from 'mattermost-redux/utils/preference_utils';
 
 import {bindClientFunc} from './helpers';
 
 import {Preferences} from '../constants';
 
-export function deletePreferences(userId: string, preferences: PreferenceType[]): NewActionFuncAsync {
+export function deletePreferences(userId: string, preferences: PreferenceType[]): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const myPreferences = getMyPreferencesSelector(state);
@@ -76,7 +76,7 @@ export function setCustomStatusInitialisationState(initializationState: Record<s
     };
 }
 
-export function savePreferences(userId: string, preferences: PreferenceType[]): NewActionFuncAsync {
+export function savePreferences(userId: string, preferences: PreferenceType[]): ActionFuncAsync {
     return async (dispatch) => {
         (async function savePreferencesWrapper() {
             try {
@@ -98,7 +98,7 @@ export function savePreferences(userId: string, preferences: PreferenceType[]): 
     };
 }
 
-export function saveTheme(teamId: string, theme: Theme): NewActionFuncAsync {
+export function saveTheme(teamId: string, theme: Theme): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
@@ -114,7 +114,7 @@ export function saveTheme(teamId: string, theme: Theme): NewActionFuncAsync {
     };
 }
 
-export function deleteTeamSpecificThemes(): NewActionFuncAsync {
+export function deleteTeamSpecificThemes(): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
 

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/roles.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/roles.ts
@@ -6,7 +6,7 @@ import type {Role} from '@mattermost/types/roles';
 import {RoleTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
 import {getRoles} from 'mattermost-redux/selectors/entities/roles_helpers';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {bindClientFunc} from './helpers';
 
@@ -68,7 +68,7 @@ export function setPendingRoles(roles: string[]) {
     };
 }
 
-export function loadRolesIfNeeded(roles: Iterable<string>): NewActionFuncAsync<Record<string, Role>> {
+export function loadRolesIfNeeded(roles: Iterable<string>): ActionFuncAsync<Record<string, Role>> {
     return async (dispatch, getState) => {
         const state = getState();
         let pendingRoles = new Set<string>();

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/schemes.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/schemes.ts
@@ -5,7 +5,7 @@ import type {Scheme, SchemeScope, SchemePatch} from '@mattermost/types/schemes';
 
 import {SchemeTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
@@ -44,7 +44,7 @@ export function createScheme(scheme: Scheme) {
     });
 }
 
-export function deleteScheme(schemeId: string): NewActionFuncAsync {
+export function deleteScheme(schemeId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         let data = null;
         try {

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/search.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/search.ts
@@ -11,7 +11,7 @@ import {SearchTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {ActionResult, NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionResult, ActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 import {getChannelAndMyMember, getChannelMembers} from './channels';
 import {logError} from './errors';
@@ -67,7 +67,7 @@ export function getMissingChannelsFromFiles(files: Map<string, FileSearchResultI
     };
 }
 
-export function searchPostsWithParams(teamId: string, params: SearchParameter): NewActionFuncAsync<PostSearchResults> {
+export function searchPostsWithParams(teamId: string, params: SearchParameter): ActionFuncAsync<PostSearchResults> {
     return async (dispatch, getState) => {
         const isGettingMore = params.page > 0;
         dispatch({
@@ -117,7 +117,7 @@ export function searchPosts(teamId: string, terms: string, isOrSearch: boolean, 
     return searchPostsWithParams(teamId, {terms, is_or_search: isOrSearch, include_deleted_channels: includeDeletedChannels, page: 0, per_page: WEBAPP_SEARCH_PER_PAGE});
 }
 
-export function getMorePostsForSearch(): NewActionFuncAsync {
+export function getMorePostsForSearch(): ActionFuncAsync {
     return async (dispatch, getState) => {
         const teamId = getCurrentTeamId(getState());
         const {params, isEnd} = getState().entities.search.current[teamId];
@@ -130,7 +130,7 @@ export function getMorePostsForSearch(): NewActionFuncAsync {
     };
 }
 
-export function clearSearch(): NewActionFuncAsync {
+export function clearSearch(): ActionFuncAsync {
     return async (dispatch) => {
         dispatch({type: SearchTypes.REMOVE_SEARCH_POSTS});
         dispatch({type: SearchTypes.REMOVE_SEARCH_FILES});
@@ -139,7 +139,7 @@ export function clearSearch(): NewActionFuncAsync {
     };
 }
 
-export function searchFilesWithParams(teamId: string, params: SearchParameter): NewActionFuncAsync {
+export function searchFilesWithParams(teamId: string, params: SearchParameter): ActionFuncAsync {
     return async (dispatch, getState) => {
         const isGettingMore = params.page > 0;
         dispatch({
@@ -182,7 +182,7 @@ export function searchFilesWithParams(teamId: string, params: SearchParameter): 
     };
 }
 
-export function getMoreFilesForSearch(): NewActionFuncAsync {
+export function getMoreFilesForSearch(): ActionFuncAsync {
     return async (dispatch, getState) => {
         const teamId = getCurrentTeamId(getState());
         const {params, isFilesEnd} = getState().entities.search.current[teamId];
@@ -195,7 +195,7 @@ export function getMoreFilesForSearch(): NewActionFuncAsync {
     };
 }
 
-export function getFlaggedPosts(): NewActionFuncAsync<PostList> {
+export function getFlaggedPosts(): ActionFuncAsync<PostList> {
     return async (dispatch, getState) => {
         const state = getState();
         const userId = getCurrentUserId(state);
@@ -229,7 +229,7 @@ export function getFlaggedPosts(): NewActionFuncAsync<PostList> {
     };
 }
 
-export function getPinnedPosts(channelId: string): NewActionFuncAsync {
+export function getPinnedPosts(channelId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         dispatch({type: SearchTypes.SEARCH_PINNED_POSTS_REQUEST});
 

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/teams.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/teams.ts
@@ -18,7 +18,7 @@ import {Client4} from 'mattermost-redux/client';
 import {General} from 'mattermost-redux/constants';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {ActionResult, DispatchFunc, GetStateFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionResult, DispatchFunc, GetStateFunc, ActionFuncAsync} from 'mattermost-redux/types/actions';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 async function getProfilesAndStatusesForMembers(userIds: string[], dispatch: DispatchFunc, getState: GetStateFunc) {
@@ -71,7 +71,7 @@ export function getMyTeams() {
 // The argument skipCurrentTeam is a (not ideal) workaround for CRT mention counts. Unread mentions are stored in the reducer per
 // team but we do not track unread mentions for DMs/GMs independently. This results in a bit of funky logic and edge case bugs
 // that need workarounds like this. In the future we should fix the root cause with better APIs and redux state.
-export function getMyTeamUnreads(collapsedThreads: boolean, skipCurrentTeam = false): NewActionFuncAsync {
+export function getMyTeamUnreads(collapsedThreads: boolean, skipCurrentTeam = false): ActionFuncAsync {
     return async (dispatch, getState) => {
         let unreads;
         try {
@@ -123,7 +123,7 @@ export function getTeamByName(teamName: string) {
     });
 }
 
-export function getTeams(page = 0, perPage: number = General.TEAMS_CHUNK_SIZE, includeTotalCount = false, excludePolicyConstrained = false): NewActionFuncAsync {
+export function getTeams(page = 0, perPage: number = General.TEAMS_CHUNK_SIZE, includeTotalCount = false, excludePolicyConstrained = false): ActionFuncAsync {
     return async (dispatch, getState) => {
         let data;
 
@@ -162,9 +162,9 @@ export function getTeams(page = 0, perPage: number = General.TEAMS_CHUNK_SIZE, i
     };
 }
 
-export function searchTeams(term: string, opts: PagedTeamSearchOpts): NewActionFuncAsync<Team[]>;
-export function searchTeams(term: string, opts?: NotPagedTeamSearchOpts): NewActionFuncAsync<TeamsWithCount>;
-export function searchTeams(term: string, opts: TeamSearchOpts = {}): NewActionFuncAsync {
+export function searchTeams(term: string, opts: PagedTeamSearchOpts): ActionFuncAsync<Team[]>;
+export function searchTeams(term: string, opts?: NotPagedTeamSearchOpts): ActionFuncAsync<TeamsWithCount>;
+export function searchTeams(term: string, opts: TeamSearchOpts = {}): ActionFuncAsync {
     return async (dispatch, getState) => {
         dispatch({type: TeamTypes.GET_TEAMS_REQUEST, data: null});
 
@@ -200,7 +200,7 @@ export function searchTeams(term: string, opts: TeamSearchOpts = {}): NewActionF
     };
 }
 
-export function createTeam(team: Team): NewActionFuncAsync<Team> {
+export function createTeam(team: Team): ActionFuncAsync<Team> {
     return async (dispatch, getState) => {
         let created;
         try {
@@ -240,7 +240,7 @@ export function createTeam(team: Team): NewActionFuncAsync<Team> {
     };
 }
 
-export function deleteTeam(teamId: string): NewActionFuncAsync {
+export function deleteTeam(teamId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.deleteTeam(teamId);
@@ -273,7 +273,7 @@ export function deleteTeam(teamId: string): NewActionFuncAsync {
     };
 }
 
-export function unarchiveTeam(teamId: string): NewActionFuncAsync {
+export function unarchiveTeam(teamId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         let team: Team;
         try {
@@ -323,7 +323,7 @@ export function regenerateTeamInviteId(teamId: string) {
     });
 }
 
-export function getMyTeamMembers(): NewActionFuncAsync<TeamMembership[]> {
+export function getMyTeamMembers(): ActionFuncAsync<TeamMembership[]> {
     return async (dispatch) => {
         const getMyTeamMembersFunc = bindClientFunc({
             clientFunc: Client4.getMyTeamMembers,
@@ -363,7 +363,7 @@ export function getTeamMembers(teamId: string, page = 0, perPage: number = Gener
     });
 }
 
-export function getTeamMember(teamId: string, userId: string): NewActionFuncAsync {
+export function getTeamMember(teamId: string, userId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         let member;
         try {
@@ -387,7 +387,7 @@ export function getTeamMember(teamId: string, userId: string): NewActionFuncAsyn
     };
 }
 
-export function getTeamMembersByIds(teamId: string, userIds: string[]): NewActionFuncAsync<TeamMembership[]> {
+export function getTeamMembersByIds(teamId: string, userIds: string[]): ActionFuncAsync<TeamMembership[]> {
     return async (dispatch, getState) => {
         let members;
         try {
@@ -456,7 +456,7 @@ export function addUserToTeamFromInvite(token: string, inviteId: string) {
     });
 }
 
-export function addUserToTeam(teamId: string, userId: string): NewActionFuncAsync<TeamMembership> {
+export function addUserToTeam(teamId: string, userId: string): ActionFuncAsync<TeamMembership> {
     return async (dispatch, getState) => {
         let member;
         try {
@@ -482,7 +482,7 @@ export function addUserToTeam(teamId: string, userId: string): NewActionFuncAsyn
     };
 }
 
-export function addUsersToTeamGracefully(teamId: string, userIds: string[]): NewActionFuncAsync<TeamMemberWithError[]> {
+export function addUsersToTeamGracefully(teamId: string, userIds: string[]): ActionFuncAsync<TeamMemberWithError[]> {
     return async (dispatch, getState) => {
         let result: TeamMemberWithError[];
         try {
@@ -512,7 +512,7 @@ export function addUsersToTeamGracefully(teamId: string, userIds: string[]): New
     };
 }
 
-export function removeUserFromTeam(teamId: string, userId: string): NewActionFuncAsync {
+export function removeUserFromTeam(teamId: string, userId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.removeFromTeam(teamId, userId);
@@ -638,7 +638,7 @@ export function getTeamInviteInfo(inviteId: string) {
     });
 }
 
-export function checkIfTeamExists(teamName: string): NewActionFuncAsync<boolean> {
+export function checkIfTeamExists(teamName: string): ActionFuncAsync<boolean> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -653,7 +653,7 @@ export function checkIfTeamExists(teamName: string): NewActionFuncAsync<boolean>
     };
 }
 
-export function setTeamIcon(teamId: string, imageData: File): NewActionFuncAsync {
+export function setTeamIcon(teamId: string, imageData: File): ActionFuncAsync {
     return async (dispatch) => {
         await Client4.setTeamIcon(teamId, imageData);
         const team = await Client4.getTeam(teamId);
@@ -665,7 +665,7 @@ export function setTeamIcon(teamId: string, imageData: File): NewActionFuncAsync
     };
 }
 
-export function removeTeamIcon(teamId: string): NewActionFuncAsync {
+export function removeTeamIcon(teamId: string): ActionFuncAsync {
     return async (dispatch) => {
         await Client4.removeTeamIcon(teamId);
         const team = await Client4.getTeam(teamId);
@@ -677,7 +677,7 @@ export function removeTeamIcon(teamId: string): NewActionFuncAsync {
     };
 }
 
-export function updateTeamScheme(teamId: string, schemeId: string): NewActionFuncAsync<{teamId: string; schemeId: string}> {
+export function updateTeamScheme(teamId: string, schemeId: string): ActionFuncAsync<{teamId: string; schemeId: string}> {
     return bindClientFunc({
         clientFunc: async () => {
             await Client4.updateTeamScheme(teamId, schemeId);
@@ -692,7 +692,7 @@ export function updateTeamMemberSchemeRoles(
     userId: string,
     isSchemeUser: boolean,
     isSchemeAdmin: boolean,
-): NewActionFuncAsync {
+): ActionFuncAsync {
     return bindClientFunc({
         clientFunc: async () => {
             await Client4.updateTeamMemberSchemeRoles(teamId, userId, isSchemeUser, isSchemeAdmin);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/threads.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/threads.ts
@@ -18,7 +18,7 @@ import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/pre
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getThread as getThreadSelector, getThreadItemsInChannel} from 'mattermost-redux/selectors/entities/threads';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {DispatchFunc, GetStateFunc, NewActionFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {DispatchFunc, GetStateFunc, ActionFunc, ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {logError} from './errors';
 import {forceLogoutIfNecessary} from './helpers';
@@ -26,7 +26,7 @@ import {getPostThread} from './posts';
 
 type ExtendedPost = Post & { system_post_ids?: string[] };
 
-export function fetchThreads(userId: string, teamId: string, {before = '', after = '', perPage = ThreadConstants.THREADS_CHUNK_SIZE, unread = false, totalsOnly = false, threadsOnly = false, extended = false, since = 0} = {}): NewActionFuncAsync<UserThreadList> {
+export function fetchThreads(userId: string, teamId: string, {before = '', after = '', perPage = ThreadConstants.THREADS_CHUNK_SIZE, unread = false, totalsOnly = false, threadsOnly = false, extended = false, since = 0} = {}): ActionFuncAsync<UserThreadList> {
     return async (dispatch, getState) => {
         let data: undefined | UserThreadList;
 
@@ -42,7 +42,7 @@ export function fetchThreads(userId: string, teamId: string, {before = '', after
     };
 }
 
-export function getThreads(userId: string, teamId: string, {before = '', after = '', perPage = ThreadConstants.THREADS_CHUNK_SIZE, unread = false, extended = true} = {}): NewActionFuncAsync<UserThreadList> {
+export function getThreads(userId: string, teamId: string, {before = '', after = '', perPage = ThreadConstants.THREADS_CHUNK_SIZE, unread = false, extended = true} = {}): ActionFuncAsync<UserThreadList> {
     return async (dispatch) => {
         const response = await dispatch(fetchThreads(userId, teamId, {before, after, perPage, unread, totalsOnly: false, threadsOnly: true, extended}));
 
@@ -79,7 +79,7 @@ export function getThreads(userId: string, teamId: string, {before = '', after =
     };
 }
 
-export function getThreadCounts(userId: string, teamId: string): NewActionFuncAsync {
+export function getThreadCounts(userId: string, teamId: string): ActionFuncAsync {
     return async (dispatch) => {
         const response = await dispatch(fetchThreads(userId, teamId, {totalsOnly: true, threadsOnly: false}));
 
@@ -111,7 +111,7 @@ export function getThreadCounts(userId: string, teamId: string): NewActionFuncAs
     };
 }
 
-export function getCountsAndThreadsSince(userId: string, teamId: string, since?: number): NewActionFuncAsync {
+export function getCountsAndThreadsSince(userId: string, teamId: string, since?: number): ActionFuncAsync {
     return async (dispatch) => {
         const response = await dispatch(fetchThreads(userId, teamId, {since, totalsOnly: false, threadsOnly: false, extended: true}));
 
@@ -218,7 +218,7 @@ export function handleThreadArrived(dispatch: DispatchFunc, getState: GetStateFu
     return thread;
 }
 
-export function getThread(userId: string, teamId: string, threadId: string, extended = true): NewActionFuncAsync {
+export function getThread(userId: string, teamId: string, threadId: string, extended = true): ActionFuncAsync {
     return async (dispatch, getState) => {
         let thread;
         try {
@@ -246,7 +246,7 @@ export function handleAllMarkedRead(dispatch: DispatchFunc, teamId: string) {
     });
 }
 
-export function markAllThreadsInTeamRead(userId: string, teamId: string): NewActionFuncAsync {
+export function markAllThreadsInTeamRead(userId: string, teamId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.updateThreadsReadForUser(userId, teamId);
@@ -262,7 +262,7 @@ export function markAllThreadsInTeamRead(userId: string, teamId: string): NewAct
     };
 }
 
-export function markThreadAsUnread(userId: string, teamId: string, threadId: string, postId: string): NewActionFuncAsync {
+export function markThreadAsUnread(userId: string, teamId: string, threadId: string, postId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.markThreadAsUnreadForUser(userId, teamId, threadId, postId);
@@ -276,7 +276,7 @@ export function markThreadAsUnread(userId: string, teamId: string, threadId: str
     };
 }
 
-export function markLastPostInThreadAsUnread(userId: string, teamId: string, threadId: string): NewActionFuncAsync {
+export function markLastPostInThreadAsUnread(userId: string, teamId: string, threadId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const getPostsForThread = makeGetPostsForThread();
         let posts = getPostsForThread(getState(), threadId);
@@ -303,7 +303,7 @@ export function markLastPostInThreadAsUnread(userId: string, teamId: string, thr
     };
 }
 
-export function updateThreadRead(userId: string, teamId: string, threadId: string, timestamp: number): NewActionFuncAsync {
+export function updateThreadRead(userId: string, teamId: string, threadId: string, timestamp: number): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.updateThreadReadForUser(userId, teamId, threadId, timestamp);
@@ -334,7 +334,7 @@ export function handleReadChanged(
         prevUnreadReplies: number;
         newUnreadReplies: number;
     },
-): NewActionFunc {
+): ActionFunc {
     return (dispatch, getState) => {
         const state = getState();
         const channel = getChannel(state, channelId);
@@ -369,7 +369,7 @@ export function handleFollowChanged(dispatch: DispatchFunc, threadId: string, te
     });
 }
 
-export function setThreadFollow(userId: string, teamId: string, threadId: string, newState: boolean): NewActionFuncAsync {
+export function setThreadFollow(userId: string, teamId: string, threadId: string, newState: boolean): ActionFuncAsync {
     return async (dispatch, getState) => {
         handleFollowChanged(dispatch, threadId, teamId, newState);
 
@@ -412,7 +412,7 @@ export function handleAllThreadsInChannelMarkedRead(dispatch: DispatchFunc, getS
     dispatch(batchActions(actions));
 }
 
-export function decrementThreadCounts(post: ExtendedPost): NewActionFunc {
+export function decrementThreadCounts(post: ExtendedPost): ActionFunc {
     return (dispatch, getState) => {
         const state = getState();
         const thread = getThreadSelector(state, post.id);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/timezone.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/timezone.ts
@@ -3,11 +3,11 @@
 
 import {getCurrentTimezoneFull} from 'mattermost-redux/selectors/entities/timezone';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {updateMe} from './users';
 
-export function autoUpdateTimezone(deviceTimezone: string): NewActionFuncAsync {
+export function autoUpdateTimezone(deviceTimezone: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         const currentUser = getCurrentUser(getState());
         const currentTimezone = getCurrentTimezoneFull(getState());

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
@@ -21,7 +21,7 @@ import {General} from 'mattermost-redux/constants';
 import {getServerVersion} from 'mattermost-redux/selectors/entities/general';
 import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId, getUsers} from 'mattermost-redux/selectors/entities/users';
-import type {DispatchFunc, NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {DispatchFunc, ActionFuncAsync} from 'mattermost-redux/types/actions';
 import {isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
 
 export function generateMfaSecret(userId: string) {
@@ -33,7 +33,7 @@ export function generateMfaSecret(userId: string) {
     });
 }
 
-export function createUser(user: UserProfile, token: string, inviteId: string, redirect: string): NewActionFuncAsync<UserProfile> {
+export function createUser(user: UserProfile, token: string, inviteId: string, redirect: string): ActionFuncAsync<UserProfile> {
     return async (dispatch, getState) => {
         let created;
 
@@ -56,7 +56,7 @@ export function createUser(user: UserProfile, token: string, inviteId: string, r
     };
 }
 
-export function loadMe(): NewActionFuncAsync<boolean> {
+export function loadMe(): ActionFuncAsync<boolean> {
     return async (dispatch, getState) => {
         // Sometimes the server version is set in one or the other
         const serverVersion = getState().entities.general.serverVersion || Client4.getServerVersion();
@@ -85,7 +85,7 @@ export function loadMe(): NewActionFuncAsync<boolean> {
     };
 }
 
-export function logout(): NewActionFuncAsync {
+export function logout(): ActionFuncAsync {
     return async (dispatch) => {
         dispatch({type: UserTypes.LOGOUT_REQUEST, data: null});
 
@@ -108,7 +108,7 @@ export function getTotalUsersStats() {
     });
 }
 
-export function getFilteredUsersStats(options: GetFilteredUsersStatsOpts = {}, updateGlobalState = true): NewActionFuncAsync<UsersStats> {
+export function getFilteredUsersStats(options: GetFilteredUsersStatsOpts = {}, updateGlobalState = true): ActionFuncAsync<UsersStats> {
     return async (dispatch, getState) => {
         let stats: UsersStats;
         try {
@@ -130,7 +130,7 @@ export function getFilteredUsersStats(options: GetFilteredUsersStatsOpts = {}, u
     };
 }
 
-export function getProfiles(page = 0, perPage: number = General.PROFILE_CHUNK_SIZE, options: any = {}): NewActionFuncAsync<UserProfile[]> {
+export function getProfiles(page = 0, perPage: number = General.PROFILE_CHUNK_SIZE, options: any = {}): ActionFuncAsync<UserProfile[]> {
     return async (dispatch, getState) => {
         let profiles: UserProfile[];
 
@@ -151,7 +151,7 @@ export function getProfiles(page = 0, perPage: number = General.PROFILE_CHUNK_SI
     };
 }
 
-export function getMissingProfilesByIds(userIds: string[]): NewActionFuncAsync<UserProfile[]> {
+export function getMissingProfilesByIds(userIds: string[]): ActionFuncAsync<UserProfile[]> {
     return async (dispatch, getState) => {
         const {profiles} = getState().entities.users;
         const missingIds: string[] = [];
@@ -170,7 +170,7 @@ export function getMissingProfilesByIds(userIds: string[]): NewActionFuncAsync<U
     };
 }
 
-export function getMissingProfilesByUsernames(usernames: string[]): NewActionFuncAsync<UserProfile[]> {
+export function getMissingProfilesByUsernames(usernames: string[]): ActionFuncAsync<UserProfile[]> {
     return async (dispatch, getState) => {
         const {profiles} = getState().entities.users;
 
@@ -193,7 +193,7 @@ export function getMissingProfilesByUsernames(usernames: string[]): NewActionFun
     };
 }
 
-export function getProfilesByIds(userIds: string[], options?: any): NewActionFuncAsync<UserProfile[]> {
+export function getProfilesByIds(userIds: string[], options?: any): ActionFuncAsync<UserProfile[]> {
     return async (dispatch, getState) => {
         let profiles: UserProfile[];
 
@@ -214,7 +214,7 @@ export function getProfilesByIds(userIds: string[], options?: any): NewActionFun
     };
 }
 
-export function getProfilesByUsernames(usernames: string[]): NewActionFuncAsync<UserProfile[]> {
+export function getProfilesByUsernames(usernames: string[]): ActionFuncAsync<UserProfile[]> {
     return async (dispatch, getState) => {
         let profiles;
 
@@ -235,7 +235,7 @@ export function getProfilesByUsernames(usernames: string[]): NewActionFuncAsync<
     };
 }
 
-export function getProfilesInTeam(teamId: string, page: number, perPage: number = General.PROFILE_CHUNK_SIZE, sort = '', options: any = {}): NewActionFuncAsync<UserProfile[]> {
+export function getProfilesInTeam(teamId: string, page: number, perPage: number = General.PROFILE_CHUNK_SIZE, sort = '', options: any = {}): ActionFuncAsync<UserProfile[]> {
     return async (dispatch, getState) => {
         let profiles;
 
@@ -263,7 +263,7 @@ export function getProfilesInTeam(teamId: string, page: number, perPage: number 
     };
 }
 
-export function getProfilesNotInTeam(teamId: string, groupConstrained: boolean, page: number, perPage: number = General.PROFILE_CHUNK_SIZE): NewActionFuncAsync<UserProfile[]> {
+export function getProfilesNotInTeam(teamId: string, groupConstrained: boolean, page: number, perPage: number = General.PROFILE_CHUNK_SIZE): ActionFuncAsync<UserProfile[]> {
     return async (dispatch, getState) => {
         let profiles;
         try {
@@ -292,7 +292,7 @@ export function getProfilesNotInTeam(teamId: string, groupConstrained: boolean, 
     };
 }
 
-export function getProfilesWithoutTeam(page: number, perPage: number = General.PROFILE_CHUNK_SIZE, options: any = {}): NewActionFuncAsync<UserProfile[]> {
+export function getProfilesWithoutTeam(page: number, perPage: number = General.PROFILE_CHUNK_SIZE, options: any = {}): ActionFuncAsync<UserProfile[]> {
     return async (dispatch, getState) => {
         let profiles = null;
         try {
@@ -323,7 +323,7 @@ export enum ProfilesInChannelSortBy {
     Admin = 'admin',
 }
 
-export function getProfilesInChannel(channelId: string, page: number, perPage: number = General.PROFILE_CHUNK_SIZE, sort = '', options: {active?: boolean} = {}): NewActionFuncAsync<UserProfile[]> {
+export function getProfilesInChannel(channelId: string, page: number, perPage: number = General.PROFILE_CHUNK_SIZE, sort = '', options: {active?: boolean} = {}): ActionFuncAsync<UserProfile[]> {
     return async (dispatch, getState) => {
         let profiles;
 
@@ -351,7 +351,7 @@ export function getProfilesInChannel(channelId: string, page: number, perPage: n
     };
 }
 
-export function getProfilesInGroupChannels(channelsIds: string[]): NewActionFuncAsync {
+export function getProfilesInGroupChannels(channelsIds: string[]): ActionFuncAsync {
     return async (dispatch, getState) => {
         let channelProfiles;
 
@@ -388,7 +388,7 @@ export function getProfilesInGroupChannels(channelsIds: string[]): NewActionFunc
     };
 }
 
-export function getProfilesNotInChannel(teamId: string, channelId: string, groupConstrained: boolean, page: number, perPage: number = General.PROFILE_CHUNK_SIZE): NewActionFuncAsync<UserProfile[]> {
+export function getProfilesNotInChannel(teamId: string, channelId: string, groupConstrained: boolean, page: number, perPage: number = General.PROFILE_CHUNK_SIZE): ActionFuncAsync<UserProfile[]> {
     return async (dispatch, getState) => {
         let profiles;
 
@@ -418,7 +418,7 @@ export function getProfilesNotInChannel(teamId: string, channelId: string, group
     };
 }
 
-export function getMe(): NewActionFuncAsync<UserProfile> {
+export function getMe(): ActionFuncAsync<UserProfile> {
     return async (dispatch) => {
         const getMeFunc = bindClientFunc({
             clientFunc: Client4.getMe,
@@ -436,7 +436,7 @@ export function getMe(): NewActionFuncAsync<UserProfile> {
     };
 }
 
-export function updateMyTermsOfServiceStatus(termsOfServiceId: string, accepted: boolean): NewActionFuncAsync {
+export function updateMyTermsOfServiceStatus(termsOfServiceId: string, accepted: boolean): ActionFuncAsync {
     return async (dispatch, getState) => {
         const response = await dispatch(bindClientFunc({
             clientFunc: Client4.updateMyTermsOfServiceStatus,
@@ -469,7 +469,7 @@ export function updateMyTermsOfServiceStatus(termsOfServiceId: string, accepted:
     };
 }
 
-export function getProfilesInGroup(groupId: string, page = 0, perPage: number = General.PROFILE_CHUNK_SIZE, sort = ''): NewActionFuncAsync<UserProfile[]> {
+export function getProfilesInGroup(groupId: string, page = 0, perPage: number = General.PROFILE_CHUNK_SIZE, sort = ''): ActionFuncAsync<UserProfile[]> {
     return async (dispatch, getState) => {
         let profiles;
 
@@ -497,7 +497,7 @@ export function getProfilesInGroup(groupId: string, page = 0, perPage: number = 
     };
 }
 
-export function getProfilesNotInGroup(groupId: string, page = 0, perPage: number = General.PROFILE_CHUNK_SIZE): NewActionFuncAsync<UserProfile[]> {
+export function getProfilesNotInGroup(groupId: string, page = 0, perPage: number = General.PROFILE_CHUNK_SIZE): ActionFuncAsync<UserProfile[]> {
     return async (dispatch, getState) => {
         let profiles;
 
@@ -621,7 +621,7 @@ export function getStatus(userId: string) {
     });
 }
 
-export function setStatus(status: UserStatus): NewActionFuncAsync {
+export function setStatus(status: UserStatus): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.updateStatus(status);
@@ -674,7 +674,7 @@ export function getSessions(userId: string) {
     });
 }
 
-export function revokeSession(userId: string, sessionId: string): NewActionFuncAsync {
+export function revokeSession(userId: string, sessionId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.revokeSession(userId, sessionId);
@@ -694,7 +694,7 @@ export function revokeSession(userId: string, sessionId: string): NewActionFuncA
     };
 }
 
-export function revokeAllSessionsForUser(userId: string): NewActionFuncAsync<boolean> {
+export function revokeAllSessionsForUser(userId: string): ActionFuncAsync<boolean> {
     return async (dispatch, getState) => {
         try {
             await Client4.revokeAllSessionsForUser(userId);
@@ -715,7 +715,7 @@ export function revokeAllSessionsForUser(userId: string): NewActionFuncAsync<boo
     };
 }
 
-export function revokeSessionsForAllUsers(): NewActionFuncAsync<boolean> {
+export function revokeSessionsForAllUsers(): ActionFuncAsync<boolean> {
     return async (dispatch, getState) => {
         try {
             await Client4.revokeSessionsForAllUsers();
@@ -748,7 +748,7 @@ export function getUserAudits(userId: string, page = 0, perPage: number = Genera
 
 export function autocompleteUsers(term: string, teamId = '', channelId = '', options?: {
     limit: number;
-}): NewActionFuncAsync<UserAutocomplete> {
+}): ActionFuncAsync<UserAutocomplete> {
     return async (dispatch, getState) => {
         dispatch({type: UserTypes.AUTOCOMPLETE_USERS_REQUEST, data: null});
         let data;
@@ -805,7 +805,7 @@ export function autocompleteUsers(term: string, teamId = '', channelId = '', opt
     };
 }
 
-export function searchProfiles(term: string, options: any = {}): NewActionFuncAsync<UserProfile[]> {
+export function searchProfiles(term: string, options: any = {}): ActionFuncAsync<UserProfile[]> {
     return async (dispatch, getState) => {
         let profiles;
         try {
@@ -872,7 +872,7 @@ export function searchProfiles(term: string, options: any = {}): NewActionFuncAs
     };
 }
 
-export function updateMe(user: Partial<UserProfile>): NewActionFuncAsync<UserProfile> {
+export function updateMe(user: Partial<UserProfile>): ActionFuncAsync<UserProfile> {
     return async (dispatch) => {
         dispatch({type: UserTypes.UPDATE_ME_REQUEST, data: null});
 
@@ -895,7 +895,7 @@ export function updateMe(user: Partial<UserProfile>): NewActionFuncAsync<UserPro
     };
 }
 
-export function patchUser(user: UserProfile): NewActionFuncAsync<UserProfile> {
+export function patchUser(user: UserProfile): ActionFuncAsync<UserProfile> {
     return async (dispatch) => {
         let data: UserProfile;
         try {
@@ -911,7 +911,7 @@ export function patchUser(user: UserProfile): NewActionFuncAsync<UserProfile> {
     };
 }
 
-export function updateUserRoles(userId: string, roles: string): NewActionFuncAsync {
+export function updateUserRoles(userId: string, roles: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.updateUserRoles(userId, roles);
@@ -928,7 +928,7 @@ export function updateUserRoles(userId: string, roles: string): NewActionFuncAsy
     };
 }
 
-export function updateUserMfa(userId: string, activate: boolean, code = ''): NewActionFuncAsync {
+export function updateUserMfa(userId: string, activate: boolean, code = ''): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.updateUserMfa(userId, activate, code);
@@ -946,7 +946,7 @@ export function updateUserMfa(userId: string, activate: boolean, code = ''): New
     };
 }
 
-export function updateUserPassword(userId: string, currentPassword: string, newPassword: string): NewActionFuncAsync {
+export function updateUserPassword(userId: string, currentPassword: string, newPassword: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.updateUserPassword(userId, currentPassword, newPassword);
@@ -964,7 +964,7 @@ export function updateUserPassword(userId: string, currentPassword: string, newP
     };
 }
 
-export function updateUserActive(userId: string, active: boolean): NewActionFuncAsync<true> {
+export function updateUserActive(userId: string, active: boolean): ActionFuncAsync<true> {
     return async (dispatch, getState) => {
         try {
             await Client4.updateUserActive(userId, active);
@@ -1020,7 +1020,7 @@ export function sendPasswordResetEmail(email: string) {
     });
 }
 
-export function setDefaultProfileImage(userId: string): NewActionFuncAsync {
+export function setDefaultProfileImage(userId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.setDefaultProfileImage(userId);
@@ -1038,7 +1038,7 @@ export function setDefaultProfileImage(userId: string): NewActionFuncAsync {
     };
 }
 
-export function uploadProfileImage(userId: string, imageData: any): NewActionFuncAsync {
+export function uploadProfileImage(userId: string, imageData: any): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.uploadProfileImage(userId, imageData);
@@ -1103,7 +1103,7 @@ export function switchLdapToEmail(ldapPassword: string, email: string, emailPass
     });
 }
 
-export function createUserAccessToken(userId: string, description: string): NewActionFuncAsync<UserAccessToken> {
+export function createUserAccessToken(userId: string, description: string): ActionFuncAsync<UserAccessToken> {
     return async (dispatch, getState) => {
         let data;
 
@@ -1138,7 +1138,7 @@ export function createUserAccessToken(userId: string, description: string): NewA
     };
 }
 
-export function getUserAccessToken(tokenId: string): NewActionFuncAsync<UserAccessToken> {
+export function getUserAccessToken(tokenId: string): ActionFuncAsync<UserAccessToken> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -1170,7 +1170,7 @@ export function getUserAccessToken(tokenId: string): NewActionFuncAsync<UserAcce
     };
 }
 
-export function getUserAccessTokensForUser(userId: string, page = 0, perPage: number = General.PROFILE_CHUNK_SIZE): NewActionFuncAsync<UserAccessToken[]> {
+export function getUserAccessTokensForUser(userId: string, page = 0, perPage: number = General.PROFILE_CHUNK_SIZE): ActionFuncAsync<UserAccessToken[]> {
     return async (dispatch, getState) => {
         let data;
         try {
@@ -1203,7 +1203,7 @@ export function getUserAccessTokensForUser(userId: string, page = 0, perPage: nu
     };
 }
 
-export function revokeUserAccessToken(tokenId: string): NewActionFuncAsync {
+export function revokeUserAccessToken(tokenId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.revokeUserAccessToken(tokenId);
@@ -1222,7 +1222,7 @@ export function revokeUserAccessToken(tokenId: string): NewActionFuncAsync {
     };
 }
 
-export function disableUserAccessToken(tokenId: string): NewActionFuncAsync {
+export function disableUserAccessToken(tokenId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.disableUserAccessToken(tokenId);
@@ -1241,7 +1241,7 @@ export function disableUserAccessToken(tokenId: string): NewActionFuncAsync {
     };
 }
 
-export function enableUserAccessToken(tokenId: string): NewActionFuncAsync {
+export function enableUserAccessToken(tokenId: string): ActionFuncAsync {
     return async (dispatch, getState) => {
         try {
             await Client4.enableUserAccessToken(tokenId);
@@ -1266,14 +1266,14 @@ export function getKnownUsers() {
     });
 }
 
-export function clearUserAccessTokens(): NewActionFuncAsync {
+export function clearUserAccessTokens(): ActionFuncAsync {
     return async (dispatch) => {
         dispatch({type: UserTypes.CLEAR_MY_USER_ACCESS_TOKENS, data: null});
         return {data: true};
     };
 }
 
-export function checkForModifiedUsers(): NewActionFuncAsync {
+export function checkForModifiedUsers(): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         const users = getUsers(state);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/websocket.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/websocket.ts
@@ -5,11 +5,11 @@ import {batchActions} from 'redux-batched-actions';
 
 import {UserTypes} from 'mattermost-redux/action_types';
 import {getCurrentUserId, getUsers} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {getKnownUsers} from './users';
 
-export function removeNotVisibleUsers(): NewActionFuncAsync {
+export function removeNotVisibleUsers(): ActionFuncAsync {
     return async (dispatch, getState) => {
         const state = getState();
         let knownUsers: Set<string>;

--- a/webapp/channels/src/packages/mattermost-redux/src/types/actions.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/types/actions.ts
@@ -1,16 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {Action as ReduxAction, AnyAction, Dispatch} from 'redux';
-import type {ThunkAction as BaseThunkAction} from 'redux-thunk';
+import type {Action, AnyAction, Dispatch} from 'redux';
+import type {ThunkAction} from 'redux-thunk';
 
 import type {GlobalState} from '@mattermost/types/store';
 
 /**
  * This file extends Redux's Dispatch type and bindActionCreators function to support Thunk actions by default.
  *
- * It specifically requires those action creators to return ThunkAction-derived types which are not compatible with
- * our existing ActionFunc and Thunk types, and it requires NewActionFunc*
+ * It specifically requires those action creators to return ThunkAction-derived types.
  */
 import 'redux-thunk/extend-redux';
 
@@ -26,21 +25,21 @@ export type ActionResult<Data = any, Error = any> = {
 };
 
 /**
- * NewActionFunc should be the return type of most non-async Thunk action creators. If that action requires web app
- * state, the second type parameter should be used to pass the version of GlobalState from 'types/store'.
+ * ActionFunc should be the return type of most non-async Thunk action creators. If that action requires web app state,
+ * the second type parameter should be used to pass the version of GlobalState from 'types/store'.
  */
-export type NewActionFunc<Data = unknown, State extends GlobalState = GlobalState> = BaseThunkAction<ActionResult<Data>, State, unknown, ReduxAction>;
+export type ActionFunc<Data = unknown, State extends GlobalState = GlobalState> = ThunkAction<ActionResult<Data>, State, unknown, Action>;
 
 /**
- * NewActionFunc should be the return type of most async Thunk action creators. If that action requires web app
- * state, the second type parameter should be used to pass the version of GlobalState from 'types/store'.
+ * ActionFuncAsync should be the return type of most async Thunk action creators. If that action requires web app state,
+ * the second type parameter should be used to pass the version of GlobalState from 'types/store'.
  */
-export type NewActionFuncAsync<Data = unknown, State extends GlobalState = GlobalState> = BaseThunkAction<Promise<ActionResult<Data>>, State, unknown, ReduxAction>;
+export type ActionFuncAsync<Data = unknown, State extends GlobalState = GlobalState> = ThunkAction<Promise<ActionResult<Data>>, State, unknown, Action>;
 
 /**
  * ThunkActionFunc is a type that extends ActionFunc with defaults that match our other ActionFunc variants to save
  * users from having to manually specify GlobalState and other arguments.
  *
- * NewActionFunc or NewActionFuncAsync should generally be preferred, but this type is available for legacy code.
+ * ActionFunc or ActionFuncAsync should generally be preferred, but this type is available for legacy code.
  */
-export type ThunkActionFunc<ReturnType, State extends GlobalState = GlobalState> = BaseThunkAction<ReturnType, State, unknown, AnyAction>;
+export type ThunkActionFunc<ReturnType, State extends GlobalState = GlobalState> = ThunkAction<ReturnType, State, unknown, AnyAction>;

--- a/webapp/channels/src/plugins/products.ts
+++ b/webapp/channels/src/plugins/products.ts
@@ -3,7 +3,7 @@
 
 import type {Store} from 'redux';
 
-import type {NewActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 import store from 'stores/redux_store';
 
@@ -23,14 +23,14 @@ export function initializeProducts(): ThunkActionFunc<Promise<unknown>> {
     };
 }
 
-function configureClient(): NewActionFuncAsync {
+function configureClient(): ActionFuncAsync {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     return (dispatch, getState) => {
         return Promise.resolve({data: true});
     };
 }
 
-function loadRemoteModules(): NewActionFuncAsync {
+function loadRemoteModules(): ActionFuncAsync {
     /* eslint-disable no-console */
     return async (/*dispatch, getState*/) => {
         // const config = getConfig(getState());

--- a/webapp/channels/src/utils/channel_utils.tsx
+++ b/webapp/channels/src/utils/channel_utils.tsx
@@ -10,7 +10,7 @@ import Permissions from 'mattermost-redux/constants/permissions';
 import {getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
 import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import type {NewActionFuncAsync} from 'mattermost-redux/types/actions';
+import type {ActionFuncAsync} from 'mattermost-redux/types/actions';
 
 import {openModal} from 'actions/views/modals';
 import LocalStorageStore from 'stores/local_storage_store';
@@ -71,7 +71,7 @@ type JoinPrivateChannelPromptResult = {
     };
 };
 
-export function joinPrivateChannelPrompt(team: Team, channelDisplayName: string, handleOnCancel = true): NewActionFuncAsync<JoinPrivateChannelPromptResult['data']> {
+export function joinPrivateChannelPrompt(team: Team, channelDisplayName: string, handleOnCancel = true): ActionFuncAsync<JoinPrivateChannelPromptResult['data']> {
     return async (dispatch, getState) => {
         const result: JoinPrivateChannelPromptResult = await new Promise((resolve) => {
             const modalData = {


### PR DESCRIPTION
#### Summary
Based on https://github.com/mattermost/mattermost/pull/26006

This is the last of these. Now that all the TODOs and such are gone and everything is using the new types, this gets rid of the `New` prefix on all these type names

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56619

#### Release Note
```release-note
NONE
```
