### PR TITLE
MM-56611: Move license expiration check to be synchronous

### DIFF
--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -529,9 +529,9 @@ func NewServer(options ...Option) (*Server, error) {
 }
 
 func (s *Server) runJobs() {
+	s.runLicenseExpirationCheckJob()
 	s.Go(func() {
 		appInstance := New(ServerConnector(s.Channels()))
-		s.runLicenseExpirationCheckJob()
 		runDNDStatusExpireJob(appInstance)
 		runPostReminderJob(appInstance)
 	})


### PR DESCRIPTION
During server start, runLicenseExpirationCheckJob was being called
from a goroutine which would eventually call SetLicense and iterate
through the ps.licenseListeners.

But at the same time doElasticsearchFixChannelIndex would also
call AddLicenseListener and try to edit the ps.licenseListeners map,
leading to a race condition.

To fix this, we simply move the runLicenseExpirationCheckJob
to be synchronous. This fixes the race, and also improves
the correctness because after https://github.com/mattermost/mattermost/commit/1f431bf72276b98edd35fc5e130d08d2491c2c39
there was no license check being done synchronously during server boot.

So theoretically, the server might go on doing some stuff
until the Go runtime decides to run the license check goroutine.

https://mattermost.atlassian.net/browse/MM-56611

```release-note
NONE
```
