### PR TITLE
[MM-56631] Clarify that LDAP profile picture setting is optional

### DIFF
--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -3434,7 +3434,7 @@ const AdminDefinition: AdminDefinitionType = {
                                     key: 'LdapSettings.PictureAttribute',
                                     label: defineMessage({id: 'admin.ldap.pictureAttrTitle', defaultMessage: 'Profile Picture Attribute:'}),
                                     placeholder: defineMessage({id: 'admin.ldap.pictureAttrEx', defaultMessage: 'E.g.: "thumbnailPhoto" or "jpegPhoto"'}),
-                                    help_text: defineMessage({id: 'admin.ldap.pictureAttrDesc', defaultMessage: 'The attribute in the AD/LDAP server used to populate the profile picture in Mattermost.'}),
+                                    help_text: defineMessage({id: 'admin.ldap.pictureAttrDesc', defaultMessage: '(Optional) The attribute in the AD/LDAP server used to populate the profile picture in Mattermost.'}),
                                     isDisabled: it.any(
                                         it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
                                         it.all(

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -1312,7 +1312,7 @@
   "admin.ldap.nicknameAttrDesc": "(Optional) The attribute in the AD/LDAP server used to populate the nickname of users in Mattermost. When set, users cannot edit their nickname, since it is synchronized with the LDAP server. When left blank, users can set their nickname in <strong>Profile > Profile Settings</strong>.",
   "admin.ldap.nicknameAttrEx": "E.g.: \"nickname\"",
   "admin.ldap.nicknameAttrTitle": "Nickname Attribute:",
-  "admin.ldap.pictureAttrDesc": "The attribute in the AD/LDAP server used to populate the profile picture in Mattermost.",
+  "admin.ldap.pictureAttrDesc": "(Optional) The attribute in the AD/LDAP server used to populate the profile picture in Mattermost.",
   "admin.ldap.pictureAttrEx": "E.g.: \"thumbnailPhoto\" or \"jpegPhoto\"",
   "admin.ldap.pictureAttrTitle": "Profile Picture Attribute:",
   "admin.ldap.portDesc": "The port Mattermost will use to connect to the AD/LDAP server. Default is 389.",


### PR DESCRIPTION
#### Summary
![Screenshot from 2024-01-23 17-32-20](https://github.com/mattermost/mattermost/assets/16541325/af5343bd-a62a-4f06-92c8-dfea2f6051e9)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56631

#### Release Note
```release-note
Clarify that LDAP profile picture setting is optional
```
