### PR TITLE
[MM-56589] Validating the site URL before entering login information through mmctl auth login

### DIFF
--- a/server/cmd/mmctl/commands/auth.go
+++ b/server/cmd/mmctl/commands/auth.go
@@ -165,9 +165,14 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 	allowInsecureTLS := viper.GetBool("insecure-tls-version")
 
 	url := strings.TrimRight(args[0], "/")
-	method := MethodPassword
-
 	ctx := context.TODO()
+
+	err = validateSiteURL(ctx, url)
+	if err != nil {
+		return err
+	}
+
+	method := MethodPassword
 
 	if name == "" {
 		reader := bufio.NewReader(os.Stdin)

--- a/server/cmd/mmctl/commands/init.go
+++ b/server/cmd/mmctl/commands/init.go
@@ -234,3 +234,14 @@ func checkInsecureTLSError(err error, allowInsecureTLS bool) error {
 	}
 	return err
 }
+
+func validateSiteURL(ctx context.Context, siteURL string) error {
+	client := model.NewAPIv4Client(siteURL)
+
+	_, appErr := client.TestSiteURL(ctx, siteURL)
+	if appErr != nil {
+		return appErr
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Added new function `validateSiteURL` which validates the site URL before asking the user for a connection name.



#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/25995
Jira https://mattermost.atlassian.net/browse/MM-56612


#### Screenshots

|  before  |

> If the URL provided to mmctl auth login contains a typo, users will only realize the error after entering all their login information.

<img width="1393" alt="Screenshot 2024-01-24 at 12 29 24 AM" src="https://github.com/mattermost/mattermost/assets/16017648/b681b61d-40b1-4cca-b0d6-6798030b5e4a">


|  after  |

> Validating the site URL before entering login information through mmctl auth login enables users to promptly identify any typos or errors in the URL.

<img width="1146" alt="Screenshot 2024-01-24 at 12 31 34 AM" src="https://github.com/mattermost/mattermost/assets/16017648/794f01c0-83c4-404b-842c-d39dd26d7c2a">


#### Release Note
```release-note
NONE
```
