### PR TITLE
[MM-56602] Clicking outside the file preview area doesn't close the modal

### DIFF
--- a/webapp/channels/src/sass/components/_modal.scss
+++ b/webapp/channels/src/sass/components/_modal.scss
@@ -425,7 +425,7 @@
 
             .code-preview {
                 display: flex;
-                height: calc(100vh - 168px);
+                max-height: calc(100vh - 168px);
                 flex-direction: column;
                 border-radius: 8px;
 


### PR DESCRIPTION
#### Summary
As a user, I want to quit the preview mode by clicking outside the doc preview. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56602
#### Screenshots
|  before  |  after  |
|----|----|
| ![image](https://github.com/mattermost/mattermost/assets/39456891/23c647d8-9a18-45c8-9c46-66a0eee13231)| ![image](https://github.com/mattermost/mattermost/assets/39456891/629fbf23-91eb-4f73-bd9b-19c16fd03989)|

