### PR TITLE
MM-54264: Unblock TestCheckValidSocket

### DIFF
--- a/server/cmd/mmctl/commands/utils_unix_test.go
+++ b/server/cmd/mmctl/commands/utils_unix_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestCheckValidSocket(t *testing.T) {
-	t.Skip("https://mattermost.atlassian.net/browse/MM-54264")
 	t.Run("should return error if the file is not a socket", func(t *testing.T) {
 		f, err := os.CreateTemp(os.TempDir(), "mmctl_socket_")
 		require.NoError(t, err)


### PR DESCRIPTION
The failure seemed to be due to incorect detection from gotestsum
itself rather than any failure in the test.

I note that from that time onwards, gotestsum has had a new release
and we are using that.

I also ran the test several times with gotestsum and could not
repro this. Let's hope that the new version of gotestsum has fixed
the issue. Otherwise, there isn't much we can do.

https://mattermost.atlassian.net/browse/MM-54264

```release-note
NONE
```
