### PR TITLE
Fix breaking change in Docker 25 by using long form port definition

### DIFF
--- a/server/build/docker-compose.common.yml
+++ b/server/build/docker-compose.common.yml
@@ -24,7 +24,10 @@ services:
     networks:
       - mm-test
     ports:
-      - 3307:3306
+      - target: 3306
+        published: 3307
+        protocol: tcp
+        mode: host
     environment:
       MYSQL_ROOT_HOST: "%"
       MYSQL_ROOT_PASSWORD: mostest


### PR DESCRIPTION
#### Summary
Ubuntu recently upgraded Docker compose packages to v25.0 which broke short-form `ports` syntax in some cases.  This PR fixes it by switching to long form syntax. 

This only affects development environments using docker compose.  Error happened even when mysql was excluded from the services list.

Symptoms were an error on `make run-server`:
```
Starting docker containers
docker compose rm start_dependencies
No stopped containers
go run ./build/docker-compose-generator/main.go mysql postgres inbucket  minio openldap elasticsearch | docker compose -f docker-compose.makefile.yml -f /dev/stdin  run -T --rm start_dependencies
service ports services.mysql-read-replica.ports.[0] is missing a target port
make: *** [Makefile:235: start-docker] Error 15
```

Ref:  https://forums.docker.com/t/ports-short-syntax-no-longer-works/139155

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
