### PR TITLE
Added customer and license ID to Support Packet

### DIFF
--- a/server/channels/app/support_packet.go
+++ b/server/channels/app/support_packet.go
@@ -71,6 +71,8 @@ func (a *App) GenerateSupportPacket(c request.CTX) []model.FileData {
 func (a *App) generateSupportPacketYaml(c request.CTX) (*model.FileData, error) {
 	var rErr error
 
+	generatedAt := model.GetMillis()
+
 	/* DB */
 
 	databaseType, databaseSchemaVersion := a.Srv().DatabaseTypeAndSchemaVersion()
@@ -162,6 +164,9 @@ func (a *App) generateSupportPacketYaml(c request.CTX) (*model.FileData, error) 
 
 	// Creating the struct for support packet yaml file
 	supportPacket := model.SupportPacket{
+
+		GeneratedAt: generatedAt,
+
 		/* Build information */
 		ServerOS:           runtime.GOOS,
 		ServerArchitecture: runtime.GOARCH,

--- a/server/channels/app/support_packet.go
+++ b/server/channels/app/support_packet.go
@@ -123,7 +123,7 @@ func (a *App) generateSupportPacketYaml(c request.CTX) (*model.FileData, error) 
 		customerID = license.Customer.Id
 	}
 
-	diagnosticID := a.TelemetryId()
+	serverID := a.TelemetryId()
 	/* Jobs  */
 
 	uniqueUserCount, err := a.Srv().Store().User().Count(model.UserCountOptions{})
@@ -194,7 +194,7 @@ func (a *App) generateSupportPacketYaml(c request.CTX) (*model.FileData, error) 
 		LicenseIsTrial:        strconv.FormatBool(isTrial),
 		CustomerID:            customerID,
 		LicenseID:             licenseID,
-		DiagnosticID:          diagnosticID,
+		ServerID:              serverID,
 
 		/* Server stats */
 		ActiveUsers: int(uniqueUserCount),

--- a/server/channels/app/support_packet.go
+++ b/server/channels/app/support_packet.go
@@ -111,12 +111,16 @@ func (a *App) generateSupportPacketYaml(c request.CTX) (*model.FileData, error) 
 	/* License */
 
 	licenseTo := ""
+	customerID := ""
+	licenseID := ""
 	supportedUsers := 0
 	var isTrial bool
 	if license := a.Srv().License(); license != nil {
 		supportedUsers = *license.Features.Users
 		licenseTo = license.Customer.Company
 		isTrial = license.IsTrial
+		licenseID = license.Id
+		customerID = license.Customer.Id
 	}
 
 	/* Jobs  */
@@ -187,6 +191,8 @@ func (a *App) generateSupportPacketYaml(c request.CTX) (*model.FileData, error) 
 		LicenseTo:             licenseTo,
 		LicenseSupportedUsers: supportedUsers,
 		LicenseIsTrial:        strconv.FormatBool(isTrial),
+		CustomerID:            customerID,
+		LicenseID:             licenseID,
 
 		/* Server stats */
 		ActiveUsers: int(uniqueUserCount),

--- a/server/channels/app/support_packet.go
+++ b/server/channels/app/support_packet.go
@@ -123,6 +123,7 @@ func (a *App) generateSupportPacketYaml(c request.CTX) (*model.FileData, error) 
 		customerID = license.Customer.Id
 	}
 
+	diagnosticID := a.TelemetryId()
 	/* Jobs  */
 
 	uniqueUserCount, err := a.Srv().Store().User().Count(model.UserCountOptions{})
@@ -193,6 +194,7 @@ func (a *App) generateSupportPacketYaml(c request.CTX) (*model.FileData, error) 
 		LicenseIsTrial:        strconv.FormatBool(isTrial),
 		CustomerID:            customerID,
 		LicenseID:             licenseID,
+		DiagnosticID:          diagnosticID,
 
 		/* Server stats */
 		ActiveUsers: int(uniqueUserCount),

--- a/server/channels/app/support_packet_test.go
+++ b/server/channels/app/support_packet_test.go
@@ -61,6 +61,9 @@ func TestGenerateSupportPacketYaml(t *testing.T) {
 
 		assert.Equal(t, 3, packet.ActiveUsers) // from InitBasic.
 		assert.Equal(t, licenseUsers, packet.LicenseSupportedUsers)
+		assert.Equal(t, license.Id, packet.LicenseID)
+		assert.Equal(t, license.Customer.Id, packet.CustomerID)
+
 		assert.Empty(t, packet.ClusterID)
 		assert.Equal(t, "local", packet.FileDriver)
 		assert.Equal(t, "OK", packet.FileStatus)

--- a/server/channels/app/support_packet_test.go
+++ b/server/channels/app/support_packet_test.go
@@ -47,6 +47,8 @@ func TestGenerateSupportPacketYaml(t *testing.T) {
 	license := model.NewTestLicense()
 	license.Features.Users = model.NewInt(licenseUsers)
 	th.App.Srv().SetLicense(license)
+	license.Id = "test-license-id"
+	license.Customer.Id = "test-customer-id"
 
 	t.Run("Happy path", func(t *testing.T) {
 		// Happy path where we have a support packet yaml file without any warnings

--- a/server/channels/app/support_packet_test.go
+++ b/server/channels/app/support_packet_test.go
@@ -51,6 +51,7 @@ func TestGenerateSupportPacketYaml(t *testing.T) {
 	license.Customer.Id = "test-customer-id"
 
 	t.Run("Happy path", func(t *testing.T) {
+		currentTime := model.GetMillis()
 		// Happy path where we have a support packet yaml file without any warnings
 
 		fileData, err := th.App.generateSupportPacketYaml(th.Context)
@@ -61,6 +62,7 @@ func TestGenerateSupportPacketYaml(t *testing.T) {
 		var packet model.SupportPacket
 		require.NoError(t, yaml.Unmarshal(fileData.Body, &packet))
 
+		assert.True(t, packet.GeneratedAt >= currentTime)
 		assert.Equal(t, 3, packet.ActiveUsers) // from InitBasic.
 		assert.Equal(t, licenseUsers, packet.LicenseSupportedUsers)
 		assert.Equal(t, license.Id, packet.LicenseID)

--- a/server/channels/app/support_packet_test.go
+++ b/server/channels/app/support_packet_test.go
@@ -65,7 +65,7 @@ func TestGenerateSupportPacketYaml(t *testing.T) {
 		assert.Equal(t, licenseUsers, packet.LicenseSupportedUsers)
 		assert.Equal(t, license.Id, packet.LicenseID)
 		assert.Equal(t, license.Customer.Id, packet.CustomerID)
-		assert.Equal(t, th.App.TelemetryId(), packet.DiagnosticID)
+		assert.Equal(t, th.App.TelemetryId(), packet.ServerID)
 
 		assert.Empty(t, packet.ClusterID)
 		assert.Equal(t, "local", packet.FileDriver)

--- a/server/channels/app/support_packet_test.go
+++ b/server/channels/app/support_packet_test.go
@@ -65,6 +65,7 @@ func TestGenerateSupportPacketYaml(t *testing.T) {
 		assert.Equal(t, licenseUsers, packet.LicenseSupportedUsers)
 		assert.Equal(t, license.Id, packet.LicenseID)
 		assert.Equal(t, license.Customer.Id, packet.CustomerID)
+		assert.Equal(t, th.App.TelemetryId(), packet.DiagnosticID)
 
 		assert.Empty(t, packet.ClusterID)
 		assert.Equal(t, "local", packet.FileDriver)

--- a/server/public/model/system.go
+++ b/server/public/model/system.go
@@ -121,6 +121,7 @@ type SupportPacket struct {
 	LicenseIsTrial        string `yaml:"license_is_trial,omitempty"`
 	CustomerID            string `yaml:"customer_id"`
 	LicenseID             string `yaml:"license_id"`
+	DiagnosticID          string `yaml:"diagnostic_id"`
 
 	/* Server stats */
 

--- a/server/public/model/system.go
+++ b/server/public/model/system.go
@@ -79,6 +79,8 @@ type ServerBusyState struct {
 }
 
 type SupportPacket struct {
+	GeneratedAt int64 `json:"generated_at"`
+
 	/* Build information */
 
 	ServerOS           string `yaml:"server_os"`

--- a/server/public/model/system.go
+++ b/server/public/model/system.go
@@ -121,7 +121,7 @@ type SupportPacket struct {
 	LicenseIsTrial        string `yaml:"license_is_trial,omitempty"`
 	CustomerID            string `yaml:"customer_id"`
 	LicenseID             string `yaml:"license_id"`
-	DiagnosticID          string `yaml:"diagnostic_id"`
+	ServerID              string `yaml:"server_id"`
 
 	/* Server stats */
 

--- a/server/public/model/system.go
+++ b/server/public/model/system.go
@@ -119,6 +119,8 @@ type SupportPacket struct {
 	LicenseTo             string `yaml:"license_to"`
 	LicenseSupportedUsers int    `yaml:"license_supported_users,omitempty"`
 	LicenseIsTrial        string `yaml:"license_is_trial,omitempty"`
+	CustomerID            string `yaml:"customer_id"`
+	LicenseID             string `yaml:"license_id"`
 
 	/* Server stats */
 


### PR DESCRIPTION
#### Summary
Simply adds some identifying data to the support packet. 

```
customer_id: hz7q68ye4tnixc3uge5rsmbmoy
license_id: b6urayxd1j8mjbri5cy65jb5te
diagnostic_id: nphtznrn4fbuxmwr3sz1oqauxa
generated_at: 1706295838690
```

```release-notes
Added customer id, license id, server id, and generated time to the Support Packet. 
```