### PR TITLE
 [GH-26022] [MM-55632] Updated getPerPageFromQuery to output warning if page req > 200

### DIFF
--- a/server/channels/web/params.go
+++ b/server/channels/web/params.go
@@ -12,6 +12,8 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/mattermost/mattermost/server/public/model"
+
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
 )
 
 const (
@@ -257,6 +259,7 @@ func getPerPageFromQuery(query url.Values) int {
 	if err != nil || val < 0 {
 		return PerPageDefault
 	} else if val > PerPageMaximum {
+		mlog.Warn("Per page value is greater than the maximum allowed.", mlog.Int("value", val), mlog.Int("maximum", PerPageMaximum))
 		return PerPageMaximum
 	}
 	return val


### PR DESCRIPTION
#### Summary

Updated getPerPageFromQuery to log and output warning if user inputted per page value is greater than 200. 

QA: 
None


#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/26022
Jira https://mattermost.atlassian.net/browse/MM-56632

#### Screenshots

|  before  |  after  |
|----|----|
| ![before](https://github.com/mattermost/mattermost/assets/122504006/afa5d33d-b516-47f8-ae5f-a9c9aeb1d9a0)| ![Screenshot 2024-01-26 at 7 43 31 PM](https://github.com/mattermost/mattermost/assets/122504006/d5f7f64f-1e66-4794-90b7-94da4e597ca6) |

#### Release Note

Added and logged output warning if user inputted page request value is greater than per page max.
