### PR TITLE
[MM-56680] Use Golang UnixMilli instead of UnixNano in Milli helpers

### DIFF
--- a/server/public/model/utils.go
+++ b/server/public/model/utils.go
@@ -397,17 +397,17 @@ func NewRandomString(length int) string {
 
 // GetMillis is a convenience method to get milliseconds since epoch.
 func GetMillis() int64 {
-	return time.Now().UnixNano() / int64(time.Millisecond)
+	return GetMillisForTime(time.Now())
 }
 
 // GetMillisForTime is a convenience method to get milliseconds since epoch for provided Time.
 func GetMillisForTime(thisTime time.Time) int64 {
-	return thisTime.UnixNano() / int64(time.Millisecond)
+	return thisTime.UnixMilli()
 }
 
 // GetTimeForMillis is a convenience method to get time.Time for milliseconds since epoch.
 func GetTimeForMillis(millis int64) time.Time {
-	return time.Unix(0, millis*int64(time.Millisecond))
+	return time.UnixMilli(millis)
 }
 
 // PadDateStringZeros is a convenience method to pad 2 digit date parts with zeros to meet ISO 8601 format


### PR DESCRIPTION
#### Summary
Small refacto to use Golang's 1.17 UnixMilli instead of the current `UnixNano/time.Milli` approach.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56680

#### Release Note
```release-note
NONE
```
