### PR TITLE
[CLD-6430] Remove telemetry check from true_up_review

### DIFF
--- a/server/channels/api4/license.go
+++ b/server/channels/api4/license.go
@@ -351,10 +351,8 @@ func requestTrueUpReview(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// True-up is only enabled when telemetry is disabled.
-	// When telemetry is enabled, we already have all the data necessary for true-up reviews to be completed.
-	telemetryEnabled := c.App.Config().LogSettings.EnableDiagnostics
-	if telemetryEnabled != nil && !*telemetryEnabled {
+	// Only report the true up review to CWS if the connection is available.
+	if err := c.App.Cloud().CheckCWSConnection(c.AppContext.Session().UserId); err == nil {
 		err = c.App.Cloud().SubmitTrueUpReview(c.AppContext.Session().UserId, profileMap)
 		if err != nil {
 			c.Err = model.NewAppError("requestTrueUpReview", "api.license.true_up_review.failed_to_submit", nil, err.Error(), http.StatusInternalServerError)

--- a/server/channels/api4/license_test.go
+++ b/server/channels/api4/license_test.go
@@ -487,6 +487,7 @@ func TestRequestTrueUpReview(t *testing.T) {
 
 		cloud := mocks.CloudInterface{}
 		cloud.Mock.On("SubmitTrueUpReview", mock.Anything, mock.Anything).Return(nil)
+		cloud.Mock.On("CheckCWSConnection", mock.Anything).Return(nil)
 
 		cloudImpl := th.App.Srv().Cloud
 		defer func() {

--- a/webapp/channels/src/components/analytics/true_up_review.test.tsx
+++ b/webapp/channels/src/components/analytics/true_up_review.test.tsx
@@ -25,7 +25,7 @@ describe('TrueUpReview', () => {
                     IsLicensed: 'true',
                 }),
                 config: {
-                    EnableDiagnostics: 'false',
+                    EnableDiagnostics: 'true',
                 },
             },
             users: {
@@ -55,10 +55,28 @@ describe('TrueUpReview', () => {
         },
 
     };
-    it('regular self hosted license in the true up window sees content', () => {
+
+    it('regular self hosted license (NOT air-gapped) in the true up window sees content', () => {
         jest.spyOn(useCWSAvailabilityCheckAll, 'default').mockImplementation(() => useCWSAvailabilityCheckAll.CSWAvailabilityCheckTypes.Available);
 
         renderWithContext(<TrueUpReview/>, showsTrueUpReviewState);
+        screen.getByText('Share to Mattermost');
+    });
+
+    it('regular self hosted license thats air gapped sees download button only', () => {
+        jest.spyOn(useCWSAvailabilityCheckAll, 'default').mockImplementation(() => useCWSAvailabilityCheckAll.CSWAvailabilityCheckTypes.Unavailable);
+
+        renderWithContext(<TrueUpReview/>, showsTrueUpReviewState);
+        screen.getByText('Download Data');
+        expect(screen.queryByText('Share to Mattermost')).not.toBeInTheDocument();
+    });
+
+    it('displays the panel regardless of the config value for EnableDiagnostic', () => {
+        const store = JSON.parse(JSON.stringify(showsTrueUpReviewState));
+        store.entities.general.config.EnableDiagnostics = 'false';
+        jest.spyOn(useCWSAvailabilityCheckAll, 'default').mockImplementation(() => useCWSAvailabilityCheckAll.CSWAvailabilityCheckTypes.Available);
+
+        renderWithContext(<TrueUpReview/>, store);
         screen.getByText('Share to Mattermost');
     });
 

--- a/webapp/channels/src/components/analytics/true_up_review.tsx
+++ b/webapp/channels/src/components/analytics/true_up_review.tsx
@@ -10,7 +10,7 @@ import {useDispatch, useSelector} from 'react-redux';
 import type {GlobalState} from '@mattermost/types/store';
 
 import {isCurrentLicenseCloud} from 'mattermost-redux/selectors/entities/cloud';
-import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
+import {getLicense} from 'mattermost-redux/selectors/entities/general';
 import {
     getSelfHostedErrors,
     getTrueUpReviewProfile as trueUpReviewProfileSelector,
@@ -50,7 +50,6 @@ const TrueUpReview: React.FC = () => {
     // * are not on starter/free
     // * are not a government sku
     const licenseIsTrueUpEligible = isLicensed && !isCloud && !isStarter && !isGovSku;
-    const telemetryEnabled = useSelector(getConfig).EnableDiagnostics === 'true';
     const trueUpReviewError = useSelector((state: GlobalState) => {
         const errors = getSelfHostedErrors(state);
         return Boolean(errors.trueUpReview);
@@ -218,10 +217,6 @@ const TrueUpReview: React.FC = () => {
 
     // If the review has already been submitted, don't show anything.
     if (reviewStatus.complete) {
-        return null;
-    }
-
-    if (telemetryEnabled) {
         return null;
     }
 

--- a/webapp/channels/src/components/analytics/true_up_review.tsx
+++ b/webapp/channels/src/components/analytics/true_up_review.tsx
@@ -3,7 +3,7 @@
 
 import classNames from 'classnames';
 import moment from 'moment';
-import React, {useEffect} from 'react';
+import React, {useEffect, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 
@@ -30,6 +30,7 @@ import {DocLinks, TELEMETRY_CATEGORIES} from 'utils/constants';
 import {getIsStarterLicense, getIsGovSku} from 'utils/license_utils';
 
 import './true_up_review.scss';
+import { HostedCustomerTypes } from 'mattermost-redux/action_types';
 
 const TrueUpReview: React.FC = () => {
     const dispatch = useDispatch();
@@ -69,7 +70,7 @@ const TrueUpReview: React.FC = () => {
             return;
         }
 
-        if (reviewProfile.getRequestState === 'OK' && isAirGapped && !trueUpReviewError && reviewProfile.content.length > 0) {
+        if (reviewProfile.getRequestState === 'OK' && !reviewStatus.complete && isAirGapped && !trueUpReviewError && reviewProfile.content.length > 0) {
             // Create the bundle as a blob containing base64 encoded json data and assign it to a link element.
             const blob = new Blob([reviewProfile.content], {type: 'application/text'});
             const href = URL.createObjectURL(blob);
@@ -84,6 +85,7 @@ const TrueUpReview: React.FC = () => {
             // Remove link and revoke object url to avoid memory leaks.
             document.body.removeChild(link);
             URL.revokeObjectURL(href);
+            dispatch(getTrueUpReviewStatus());
         }
     }, [isAirGapped, reviewProfile, reviewProfile.getRequestState, trueUpReviewError]);
 

--- a/webapp/channels/src/components/analytics/true_up_review.tsx
+++ b/webapp/channels/src/components/analytics/true_up_review.tsx
@@ -3,7 +3,7 @@
 
 import classNames from 'classnames';
 import moment from 'moment';
-import React, {useEffect, useState} from 'react';
+import React, {useEffect} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 
@@ -30,7 +30,6 @@ import {DocLinks, TELEMETRY_CATEGORIES} from 'utils/constants';
 import {getIsStarterLicense, getIsGovSku} from 'utils/license_utils';
 
 import './true_up_review.scss';
-import { HostedCustomerTypes } from 'mattermost-redux/action_types';
 
 const TrueUpReview: React.FC = () => {
     const dispatch = useDispatch();


### PR DESCRIPTION
#### Summary
The true-up review card was not rendering in the event of telemetry being disabled. This meant that instances that currently send telemetry and are asked for true-up information are not able to send via the button in the true-up review card

This PR removes the telemetry config from the picture, meaning the card will always show to those eligible. 

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-6430

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
