### PR TITLE
Quote CPPFLAGS in webapp Makefile, add corresponding optipng fix for PPC

### DIFF
--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -8,7 +8,12 @@ CI ?= false
 # please see optipng-bin Linux arm64 support issue (https://github.com/imagemin/optipng-bin/issues/118) for details:
 ifeq ($(shell uname)/$(shell uname -m),Linux/aarch64)
   LINUX_ARM64 = true
-  CPPFLAGS = "-DPNG_ARM_NEON_OPT=0"
+  CPPFLAGS += " -DPNG_ARM_NEON_OPT=0"
+endif
+# Exact same issue but for Linux/PPC64
+ifeq ($(findstring Linux/ppc64,$(shell uname)/$(shell uname -m)),Linux/ppc64)
+  LINUX_PPC64 = true
+  CPPFLAGS += " -DPNG_POWERPC_VSX_OPT=0"
 endif
 
 .PHONY: run
@@ -68,7 +73,7 @@ node_modules: package.json $(wildcard package-lock.json)
 	@echo Getting dependencies using npm
 
 ifeq ($(CI),false)
-	CPPFLAGS=$(CPPFLAGS) npm install
+	CPPFLAGS="$(CPPFLAGS)" npm install
 else
 	# This runs in CI with NODE_ENV=production which skips devDependencies without this flag
 	npm ci --include=dev


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
The optipng issue that the CPPFLAGS fix here was working around may have already been fixed in downstream packaging by overriding CPPFLAGS, so it should be appended to rather than replaced, this also respects any existing CPPFLAGS the user has configured.

Also, an identical issue exists on PPC with its corresponding SIMD extensions (VSX), so add the same workaround there in the upstream Makefile.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.
* 
```release-note
NONE
```
