### PR TITLE
MM-56596 Fix username style in profile popover

### DIFF
--- a/webapp/channels/src/components/profile_popover/profile_popover_name/user_name.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover_name/user_name.tsx
@@ -13,7 +13,7 @@ const UserName = ({
     hasFullName,
     username,
 }: Props) => {
-    const userNameClass = classNames('overflow--ellipsis pb-1', {'user-profile-popover__heading': hasFullName});
+    const userNameClass = classNames('overflow--ellipsis pb-1', {'user-profile-popover__heading': !hasFullName});
     return (
         <div
             id='userPopoverUsername'


### PR DESCRIPTION
#### Summary
In https://github.com/mattermost/mattermost/pull/25608 , when refactoring the profile popover, I missed one negation in the code, so the username was showing as a header when there was already a full name, and not showing as a header when there was no full name.

This PR fixes that.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-56596

#### Release Note
I think this will be in the same release as the mentioned PR, so there should be no need for release notes.
```release-note
NONE
```
