### PR TITLE
Fix shortcuts alignment on tooltips

### DIFF
--- a/webapp/channels/src/components/keyboard_shortcuts/keyboard_shortcuts_sequence/keyboard_shortcuts_sequence.scss
+++ b/webapp/channels/src/components/keyboard_shortcuts/keyboard_shortcuts_sequence/keyboard_shortcuts_sequence.scss
@@ -2,8 +2,6 @@
 // See LICENSE.txt for license information.
 
 .shortcut-line {
-    display: flex;
-    align-items: center;
     margin: 16px 0;
 
     span {


### PR DESCRIPTION
#### Summary
In https://github.com/mattermost/mattermost/pull/25622 we added some styles that are (apparently) not needed, and were messing with the alignment on tooltips.

This PRs removes those unneeded styles.

#### Ticket Link
NONE

#### Release Note
```release-note
Fix shortcuts alignment on tooltips
```
