### PR TITLE
Restrict post metadata to allow for potentially unsafe links

### DIFF
--- a/server/channels/app/post_metadata.go
+++ b/server/channels/app/post_metadata.go
@@ -35,6 +35,8 @@ type linkMetadataCache struct {
 
 const MaxMetadataImageSize = MaxOpenGraphResponseSize
 
+const UnsafeLinksPostProp = "unsafe_links"
+
 func (s *Server) initPostMetadata() {
 	// Dump any cached links if the proxy settings have changed so image URLs can be updated
 	s.platform.AddConfigListener(func(before, after *model.Config) {
@@ -169,12 +171,16 @@ func (a *App) getEmbedsAndImages(c request.CTX, post *model.Post, isNewPost bool
 		post.Metadata = &model.PostMetadata{}
 	}
 
-	// Embeds and image dimensions
-	firstLink, images := a.getFirstLinkAndImages(post.Message)
-
 	if post.Metadata.Embeds == nil {
 		post.Metadata.Embeds = []*model.PostEmbed{}
 	}
+
+	if post.GetProp(UnsafeLinksPostProp) != nil {
+		return post
+	}
+
+	// Embeds and image dimensions
+	firstLink, images := a.getFirstLinkAndImages(post.Message)
 
 	if embed, err := a.getEmbedForPost(c, post, firstLink, isNewPost); err != nil {
 		appErr, ok := err.(*model.AppError)


### PR DESCRIPTION
#### Summary
Unsafe links can potentially be generated by LLMs in the Mattermost AI plugin. For example a prompt injection could occour that tells the AI to create a malicious link that contains private data in the query paramenter: http://badserver.com/all/my?private=data
This is part of the effort to prevent this by restricting the post metadata system from making requests to servers using potentially unsafe links.
The AI plugin will be modified to add the `UnsafeLinksPostProp` to all its posts that potentially have unsafe links.

#### Release Note

```release-note
NONE
```
