### PR TITLE
Updated the user limit to make it easier for community forks

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -193,6 +193,7 @@ include public/Makefile
 
 LDFLAGS += -X "github.com/mattermost/mattermost/server/public/model.MockCWS=$(MM_ENABLE_CWS_MOCK)"
 LDFLAGS += -X "github.com/mattermost/mattermost/server/public/model.MattermostGiphySdkKey=$(MM_GIPHY_SDK_KEY)"
+LDFLAGS += -X "github.com/mattermost/mattermost/server/v8/channels/app.MaxUsersLimit=$(USER_LIMIT)"
 
 RUN_IN_BACKGROUND ?=
 ifeq ($(RUN_SERVER_IN_BACKGROUND),true)

--- a/server/channels/app/limits_test.go
+++ b/server/channels/app/limits_test.go
@@ -14,6 +14,11 @@ func TestGetUserLimits(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
+	MaxUsersLimit = "10000"
+	defer func() {
+		MaxUsersLimit = ""
+	}()
+
 	t.Run("base case", func(t *testing.T) {
 		userLimits, appErr := th.App.GetUserLimits()
 		require.Nil(t, appErr)


### PR DESCRIPTION
#### Summary
Updated the user limit logic to not have limits by default, making it easier for community forks to stay updated with upstream.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-56551

#### Release Note
```release-note
None
```
