### PR TITLE
MM-53919 Add imagemin-gifsicle and imagemin-mozjpeg as required dependencies

### DIFF
--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -158,6 +158,8 @@
     "html-webpack-plugin": "5.5.0",
     "identity-obj-proxy": "3.0.0",
     "image-webpack-loader": "8.1.0",
+    "imagemin-gifsicle": "7.0.0",
+    "imagemin-mozjpeg": "9.0.0",
     "isomorphic-fetch": "3.0.0",
     "jest": "29.7.0",
     "jest-canvas-mock": "2.5.0",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -204,6 +204,8 @@
         "html-webpack-plugin": "5.5.0",
         "identity-obj-proxy": "3.0.0",
         "image-webpack-loader": "8.1.0",
+        "imagemin-gifsicle": "7.0.0",
+        "imagemin-mozjpeg": "9.0.0",
         "isomorphic-fetch": "3.0.0",
         "jest": "29.7.0",
         "jest-canvas-mock": "2.5.0",
@@ -4587,7 +4589,6 @@
       "version": "0.7.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -6196,14 +6197,12 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/archive-type": {
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "file-type": "^4.2.0"
       },
@@ -6215,7 +6214,6 @@
       "version": "4.4.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -6823,7 +6821,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "decompress": "^4.0.0",
         "download": "^6.2.2",
@@ -6839,7 +6836,6 @@
       "version": "5.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
@@ -6850,7 +6846,6 @@
       "version": "0.7.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "cross-spawn": "^5.0.1",
         "get-stream": "^3.0.0",
@@ -6868,7 +6863,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -6877,7 +6871,6 @@
       "version": "4.1.5",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -6887,7 +6880,6 @@
       "version": "1.2.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "shebang-regex": "^1.0.0"
       },
@@ -6899,7 +6891,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6908,7 +6899,6 @@
       "version": "1.3.1",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -6919,14 +6909,12 @@
     "node_modules/bin-build/node_modules/yallist": {
       "version": "2.1.2",
       "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/bin-check": {
       "version": "4.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "execa": "^0.7.0",
         "executable": "^4.1.0"
@@ -6939,7 +6927,6 @@
       "version": "5.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
@@ -6950,7 +6937,6 @@
       "version": "0.7.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "cross-spawn": "^5.0.1",
         "get-stream": "^3.0.0",
@@ -6968,7 +6954,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -6977,7 +6962,6 @@
       "version": "4.1.5",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -6987,7 +6971,6 @@
       "version": "1.2.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "shebang-regex": "^1.0.0"
       },
@@ -6999,7 +6982,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7008,7 +6990,6 @@
       "version": "1.3.1",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -7019,14 +7000,12 @@
     "node_modules/bin-check/node_modules/yallist": {
       "version": "2.1.2",
       "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/bin-version": {
       "version": "3.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "execa": "^1.0.0",
         "find-versions": "^3.0.0"
@@ -7039,7 +7018,6 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bin-version": "^3.0.0",
         "semver": "^5.6.0",
@@ -7053,7 +7031,6 @@
       "version": "5.7.2",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -7062,7 +7039,6 @@
       "version": "4.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bin-check": "^4.1.0",
         "bin-version-check": "^4.0.0",
@@ -7079,7 +7055,6 @@
       "version": "7.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "archive-type": "^4.0.0",
         "caw": "^2.0.1",
@@ -7102,7 +7077,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -7111,7 +7085,6 @@
       "version": "8.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -7120,7 +7093,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -7129,7 +7101,6 @@
       "version": "8.3.2",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@sindresorhus/is": "^0.7.0",
         "cacheable-request": "^2.1.1",
@@ -7157,7 +7128,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -7166,7 +7136,6 @@
       "version": "1.3.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "pify": "^3.0.0"
       },
@@ -7178,7 +7147,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -7187,7 +7155,6 @@
       "version": "0.4.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -7196,7 +7163,6 @@
       "version": "2.3.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "p-timeout": "^2.0.1"
       },
@@ -7208,7 +7174,6 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "p-finally": "^1.0.0"
       },
@@ -7220,7 +7185,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -7229,7 +7193,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "prepend-http": "^2.0.0"
       },
@@ -7249,7 +7212,6 @@
       "version": "1.2.3",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -7258,14 +7220,12 @@
     "node_modules/bl/node_modules/isarray": {
       "version": "1.0.0",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/bl/node_modules/readable-stream": {
       "version": "2.3.8",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -7279,14 +7239,12 @@
     "node_modules/bl/node_modules/safe-buffer": {
       "version": "5.1.2",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/bl/node_modules/string_decoder": {
       "version": "1.1.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -7613,7 +7571,6 @@
       "version": "1.2.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -7622,14 +7579,12 @@
     "node_modules/buffer-alloc-unsafe": {
       "version": "1.1.0",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -7645,8 +7600,7 @@
     "node_modules/buffer-fill": {
       "version": "1.0.0",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -7688,7 +7642,6 @@
       "version": "2.1.4",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "clone-response": "1.0.2",
         "get-stream": "3.0.0",
@@ -7703,7 +7656,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -7711,14 +7663,12 @@
     "node_modules/cacheable-request/node_modules/json-buffer": {
       "version": "3.0.0",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/cacheable-request/node_modules/keyv": {
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "json-buffer": "3.0.0"
       }
@@ -7727,7 +7677,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7828,7 +7777,6 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "get-proxy": "^2.0.0",
         "isurl": "^1.0.0-alpha5",
@@ -8062,7 +8010,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "mimic-response": "^1.0.0"
       }
@@ -8304,7 +8251,6 @@
       "version": "1.1.13",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -8900,7 +8846,6 @@
       "version": "4.2.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "decompress-tar": "^4.0.0",
         "decompress-tarbz2": "^4.0.0",
@@ -8919,7 +8864,6 @@
       "version": "3.3.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "mimic-response": "^1.0.0"
       },
@@ -8931,7 +8875,6 @@
       "version": "4.1.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "file-type": "^5.2.0",
         "is-stream": "^1.1.0",
@@ -8945,7 +8888,6 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -8954,7 +8896,6 @@
       "version": "4.1.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "decompress-tar": "^4.1.0",
         "file-type": "^6.1.0",
@@ -8970,7 +8911,6 @@
       "version": "6.2.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -8979,7 +8919,6 @@
       "version": "4.1.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "decompress-tar": "^4.1.1",
         "file-type": "^5.2.0",
@@ -8993,7 +8932,6 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -9002,7 +8940,6 @@
       "version": "4.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "file-type": "^3.8.0",
         "get-stream": "^2.2.0",
@@ -9017,7 +8954,6 @@
       "version": "3.9.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9026,7 +8962,6 @@
       "version": "2.3.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "object-assign": "^4.0.1",
         "pinkie-promise": "^2.0.0"
@@ -9039,7 +8974,6 @@
       "version": "2.3.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9048,7 +8982,6 @@
       "version": "1.3.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "pify": "^3.0.0"
       },
@@ -9060,7 +8993,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -9069,7 +9001,6 @@
       "version": "2.3.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9480,7 +9411,6 @@
       "version": "6.2.5",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "caw": "^2.0.0",
         "content-disposition": "^0.5.2",
@@ -9502,7 +9432,6 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -9511,7 +9440,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -9520,7 +9448,6 @@
       "version": "1.3.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "pify": "^3.0.0"
       },
@@ -9532,7 +9459,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -9545,8 +9471,7 @@
     "node_modules/duplexer3": {
       "version": "0.1.5",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dynamic-virtualized-list": {
       "version": "1.0.0-beta",
@@ -9645,7 +9570,6 @@
       "version": "1.4.4",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -10784,7 +10708,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "cross-spawn": "^6.0.0",
         "get-stream": "^4.0.0",
@@ -10802,7 +10725,6 @@
       "version": "6.0.5",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -10818,7 +10740,6 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -10827,7 +10748,6 @@
       "version": "5.7.2",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -10836,7 +10756,6 @@
       "version": "1.2.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "shebang-regex": "^1.0.0"
       },
@@ -10848,7 +10767,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10857,7 +10775,6 @@
       "version": "1.3.1",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -10880,7 +10797,6 @@
       "version": "4.1.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "pify": "^2.2.0"
       },
@@ -10892,7 +10808,6 @@
       "version": "2.3.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11009,7 +10924,6 @@
       "version": "2.2.2",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "mime-db": "^1.28.0"
       },
@@ -11021,7 +10935,6 @@
       "version": "5.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ext-list": "^2.0.0",
         "sort-keys-length": "^1.0.0"
@@ -11156,7 +11069,6 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -11226,7 +11138,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -11235,7 +11146,6 @@
       "version": "2.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "filename-reserved-regex": "^2.0.0",
         "strip-outer": "^1.0.0",
@@ -11325,7 +11235,6 @@
       "version": "3.2.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "semver-regex": "^2.0.0"
       },
@@ -11427,7 +11336,6 @@
       "version": "2.3.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -11436,14 +11344,12 @@
     "node_modules/from2/node_modules/isarray": {
       "version": "1.0.0",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/from2/node_modules/readable-stream": {
       "version": "2.3.8",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -11457,14 +11363,12 @@
     "node_modules/from2/node_modules/safe-buffer": {
       "version": "5.1.2",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/from2/node_modules/string_decoder": {
       "version": "1.1.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -11472,8 +11376,7 @@
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
@@ -11615,7 +11518,6 @@
       "version": "2.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "npm-conf": "^1.1.0"
       },
@@ -11638,7 +11540,6 @@
       "version": "4.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -11665,7 +11566,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bin-build": "^3.0.0",
         "bin-wrapper": "^4.0.0",
@@ -11685,7 +11585,6 @@
       "version": "5.1.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
@@ -11708,7 +11607,6 @@
       "version": "6.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -11720,7 +11618,6 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       },
@@ -11732,7 +11629,6 @@
       "version": "4.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -11899,7 +11795,6 @@
       "version": "7.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "decompress-response": "^3.2.0",
         "duplexer3": "^0.1.4",
@@ -11924,7 +11819,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -12018,7 +11912,6 @@
       "version": "1.4.2",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -12037,7 +11930,6 @@
       "version": "1.4.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "has-symbol-support-x": "^1.4.1"
       },
@@ -12338,8 +12230,7 @@
     "node_modules/http-cache-semantics": {
       "version": "3.8.1",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
@@ -12605,9 +12496,9 @@
     },
     "node_modules/imagemin-gifsicle": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/imagemin-gifsicle/-/imagemin-gifsicle-7.0.0.tgz",
+      "integrity": "sha512-LaP38xhxAwS3W8PFh4y5iQ6feoTSF+dTAXFRUEYQWYst6Xd+9L/iPk34QGgK/VO/objmIlmq9TStGfVY2IcHIA==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "execa": "^1.0.0",
         "gifsicle": "^5.0.0",
@@ -12622,9 +12513,9 @@
     },
     "node_modules/imagemin-mozjpeg": {
       "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/imagemin-mozjpeg/-/imagemin-mozjpeg-9.0.0.tgz",
+      "integrity": "sha512-TwOjTzYqCFRgROTWpVSt5UTT0JeCuzF1jswPLKALDd89+PmrJ2PdMMYeDLYZ1fs9cTovI9GJd68mRSnuVt691w==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "execa": "^4.0.0",
         "is-jpg": "^2.0.0",
@@ -12638,7 +12529,6 @@
       "version": "4.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
@@ -12661,7 +12551,6 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -12676,7 +12565,6 @@
       "version": "1.1.1",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8.12.0"
       }
@@ -12685,7 +12573,6 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       },
@@ -12697,7 +12584,6 @@
       "version": "4.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -12881,7 +12767,6 @@
       "version": "3.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -13020,7 +12905,6 @@
       "version": "3.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "from2": "^2.1.1",
         "p-is-promise": "^1.1.0"
@@ -13310,7 +13194,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "file-type": "^10.4.0"
       },
@@ -13322,7 +13205,6 @@
       "version": "10.11.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -13351,7 +13233,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -13371,8 +13252,7 @@
     "node_modules/is-natural-number": {
       "version": "4.0.1",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
@@ -13409,7 +13289,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -13489,7 +13368,6 @@
       "version": "1.2.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13515,7 +13393,6 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13775,7 +13652,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "has-to-string-tag-x": "^1.2.0",
         "is-object": "^1.0.1"
@@ -16577,7 +16453,6 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16912,7 +16787,6 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -17224,7 +17098,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bin-build": "^3.0.0",
         "bin-wrapper": "^4.0.0"
@@ -17355,8 +17228,7 @@
     "node_modules/nice-try": {
       "version": "1.0.5",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -17524,7 +17396,6 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "prepend-http": "^2.0.0",
         "query-string": "^5.0.1",
@@ -17538,7 +17409,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -17547,7 +17417,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-plain-obj": "^1.0.0"
       },
@@ -17559,7 +17428,6 @@
       "version": "1.1.3",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "config-chain": "^1.1.11",
         "pify": "^3.0.0"
@@ -17572,7 +17440,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -17581,7 +17448,6 @@
       "version": "2.0.2",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "path-key": "^2.0.0"
       },
@@ -17593,7 +17459,6 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -17856,7 +17721,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "arch": "^2.1.0"
       },
@@ -17895,7 +17759,6 @@
       "version": "0.3.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -17904,7 +17767,6 @@
       "version": "1.3.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "p-timeout": "^1.1.1"
       },
@@ -17916,7 +17778,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -17925,7 +17786,6 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -17962,7 +17822,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "p-reduce": "^1.0.0"
       },
@@ -18009,7 +17868,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -18038,7 +17896,6 @@
       "version": "1.2.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "p-finally": "^1.0.0"
       },
@@ -18280,8 +18137,7 @@
     "node_modules/pend": {
       "version": "1.2.0",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -18310,7 +18166,6 @@
       "version": "4.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -18319,7 +18174,6 @@
       "version": "2.0.4",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18328,7 +18182,6 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "pinkie": "^2.0.0"
       },
@@ -18889,7 +18742,6 @@
       "version": "1.0.4",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19029,8 +18881,7 @@
     "node_modules/proto-list": {
       "version": "1.2.4",
       "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -19055,8 +18906,7 @@
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/psl": {
       "version": "1.9.0",
@@ -19083,7 +18933,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -19129,7 +18978,6 @@
       "version": "5.1.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "decode-uri-component": "^0.2.0",
         "object-assign": "^4.1.0",
@@ -20405,7 +20253,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "lowercase-keys": "^1.0.0"
       }
@@ -20874,7 +20721,6 @@
       "version": "1.0.6",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "commander": "^2.8.1"
       },
@@ -20886,8 +20732,7 @@
     "node_modules/seek-bzip/node_modules/commander": {
       "version": "2.20.3",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -20918,7 +20763,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -20927,7 +20771,6 @@
       "version": "1.1.2",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "semver": "^5.3.0"
       },
@@ -20939,7 +20782,6 @@
       "version": "5.7.2",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -21367,7 +21209,6 @@
       "version": "1.1.2",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-plain-obj": "^1.0.0"
       },
@@ -21379,7 +21220,6 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "sort-keys": "^1.0.0"
       },
@@ -21594,7 +21434,6 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21717,7 +21556,6 @@
       "version": "2.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-natural-number": "^4.0.1"
       }
@@ -21726,7 +21564,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21765,7 +21602,6 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.2"
       },
@@ -21777,7 +21613,6 @@
       "version": "1.0.5",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -22363,7 +22198,6 @@
       "version": "1.6.2",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bl": "^1.0.0",
         "buffer-alloc": "^1.2.0",
@@ -22380,14 +22214,12 @@
     "node_modules/tar-stream/node_modules/isarray": {
       "version": "1.0.0",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/tar-stream/node_modules/readable-stream": {
       "version": "2.3.8",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -22401,14 +22233,12 @@
     "node_modules/tar-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/tar-stream/node_modules/string_decoder": {
       "version": "1.1.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -22417,7 +22247,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -22426,7 +22255,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "temp-dir": "^1.0.0",
         "uuid": "^3.0.1"
@@ -22439,7 +22267,6 @@
       "version": "3.4.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -22628,8 +22455,7 @@
     "node_modules/through": {
       "version": "2.3.8",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/thunky": {
       "version": "1.1.0",
@@ -22640,7 +22466,6 @@
       "version": "4.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -22684,8 +22509,7 @@
     "node_modules/to-buffer": {
       "version": "1.1.1",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/to-camel-case": {
       "version": "1.0.0",
@@ -22804,7 +22628,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.2"
       },
@@ -22816,7 +22639,6 @@
       "version": "1.0.5",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -22909,7 +22731,6 @@
       "version": "0.6.0",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -23081,7 +22902,6 @@
       "version": "1.4.3",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -23105,7 +22925,6 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -23307,7 +23126,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "prepend-http": "^1.0.1"
       },
@@ -23319,7 +23137,6 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 4"
       }
@@ -24185,7 +24002,6 @@
       "version": "2.10.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"


### PR DESCRIPTION
#### Summary
Based on a suggestion from https://github.com/mattermost/mattermost/issues/24155, adding these as required dependencies might help solve some issues where they're not downloaded by NPM automatically for whatever reason. These libraries tend to cause problems for many contributors, so hopefully this reduces the chances of those problems happening.

#### Ticket Link
Fixes #24155
https://mattermost.atlassian.net/browse/MM-53919

#### Release Note
```release-note
NONE
```
