### PR TITLE
MM-56759 Fix crash caused by joinPrivateChannelPrompt

### DIFF
--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -1397,7 +1397,7 @@ export async function handleFormattedTextClick(e: React.MouseEvent, currentRelat
                                 }
                             }
                             if (!member) {
-                                const {data} = await store.dispatch(joinPrivateChannelPrompt(team, channel, false));
+                                const {data} = await store.dispatch(joinPrivateChannelPrompt(team, channel.display_name, false));
                                 if (data.join) {
                                     let error = false;
                                     if (!getTeamMemberships(state)[team.id]) {


### PR DESCRIPTION
#### Summary
When an admin clicks on a link to a private channel they're not a member of, this crashed the app by incorrectly trying to render a Channel object instead of its name.

There's no test included with this PR because I did this as part of migrating `stores/index.js` to TS which caught this automatically. I'm just submitting it separately because it's small and self-contained.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56759

#### Release Note
```release-note
Fixed a web app crash when a system admin clicks on a link to a private channel that they're not a member of
```
