### PR TITLE
Add some tests for plugin hooks used by MS Teams plugin automute

### DIFF
--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -2058,7 +2058,8 @@ func TestUserHasJoinedChannel(t *testing.T) {
 			post := posts.Posts[postID]
 
 			if strings.HasPrefix(post.Message, "Test: ") {
-				t.Fatal("Plugin message found:", post.Message)
+				t.Log("Plugin message found:", post.Message)
+				t.FailNow()
 			}
 		}
 	})
@@ -2088,7 +2089,8 @@ func TestUserHasJoinedChannel(t *testing.T) {
 			post := posts.Posts[postID]
 
 			if strings.HasPrefix(post.Message, "Test: ") {
-				t.Fatal("Plugin message found:", post.Message)
+				t.Log("Plugin message found:", post.Message)
+				t.FailNow()
 			}
 		}
 	})
@@ -2119,7 +2121,8 @@ func TestUserHasJoinedChannel(t *testing.T) {
 			post := posts.Posts[postID]
 
 			if strings.HasPrefix(post.Message, "Test: ") {
-				t.Fatal("Plugin message found:", post.Message)
+				t.Log("Plugin message found:", post.Message)
+				t.FailNow()
 			}
 		}
 	})

--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -1785,13 +1785,12 @@ func TestHookPreferencesHaveChanged(t *testing.T) {
 		})
 		require.Nil(t, appErr)
 
-		// Hooks are run in a goroutine, so wait for those to complete
-		time.Sleep(1 * time.Second)
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			preference, appErr := th.App.GetPreferenceByCategoryAndNameForUser(th.Context, th.BasicUser.Id, "test_category", "test_name")
 
-		preference, appErr := th.App.GetPreferenceByCategoryAndNameForUser(th.Context, th.BasicUser.Id, "test_category", "test_name")
-
-		require.Nil(t, appErr)
-		assert.Equal(t, "test_value_third", preference.Value)
+			require.Nil(t, appErr)
+			assert.Equal(t, "test_value_third", preference.Value)
+		}, 1*time.Second, 10*time.Millisecond)
 	})
 }
 
@@ -1849,16 +1848,14 @@ func TestChannelHasBeenCreated(t *testing.T) {
 		require.Nil(t, appErr)
 		require.NotNil(t, channel)
 
-		assert.Eventually(t, func() bool {
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
 			posts, appErr := th.App.GetPosts(channel.Id, 0, 1)
+
 			require.Nil(t, appErr)
 
-			if len(posts.Posts) == 0 {
-				return false
-			}
-
 			post := posts.Posts[posts.Order[0]]
-			return post.ChannelId == channel.Id && post.Message == "ChannelHasBeenCreated has been called for "+channel.Id
+			assert.Equal(t, channel.Id, post.ChannelId)
+			assert.Equal(t, "ChannelHasBeenCreated has been called for "+channel.Id, post.Message)
 		}, 1*time.Second, 10*time.Millisecond)
 	})
 
@@ -1876,16 +1873,14 @@ func TestChannelHasBeenCreated(t *testing.T) {
 		require.Nil(t, appErr)
 		require.NotNil(t, channel)
 
-		assert.Eventually(t, func() bool {
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
 			posts, appErr := th.App.GetPosts(channel.Id, 0, 1)
+
 			require.Nil(t, appErr)
 
-			if len(posts.Posts) == 0 {
-				return false
-			}
-
 			post := posts.Posts[posts.Order[0]]
-			return post.ChannelId == channel.Id && post.Message == "ChannelHasBeenCreated has been called for "+channel.Id
+			assert.Equal(t, channel.Id, post.ChannelId)
+			assert.Equal(t, "ChannelHasBeenCreated has been called for "+channel.Id, post.Message)
 		}, 1*time.Second, 10*time.Millisecond)
 	})
 
@@ -1906,16 +1901,14 @@ func TestChannelHasBeenCreated(t *testing.T) {
 		require.Nil(t, appErr)
 		require.NotNil(t, channel)
 
-		assert.Eventually(t, func() bool {
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
 			posts, appErr := th.App.GetPosts(channel.Id, 0, 1)
+
 			require.Nil(t, appErr)
 
-			if len(posts.Posts) == 0 {
-				return false
-			}
-
 			post := posts.Posts[posts.Order[0]]
-			return post.ChannelId == channel.Id && post.Message == "ChannelHasBeenCreated has been called for "+channel.Id
+			assert.Equal(t, channel.Id, post.ChannelId)
+			assert.Equal(t, "ChannelHasBeenCreated has been called for "+channel.Id, post.Message)
 		}, 1*time.Second, 10*time.Millisecond)
 	})
 }

--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1842,6 +1843,7 @@ func TestChannelHasBeenCreated(t *testing.T) {
 
 		channel, appErr := th.App.CreateChannel(th.Context, &model.Channel{
 			CreatorId: user1.Id,
+			TeamId:    th.BasicTeam.Id,
 			Name:      "test_channel",
 			Type:      model.ChannelTypeOpen,
 		}, false)
@@ -1910,5 +1912,215 @@ func TestChannelHasBeenCreated(t *testing.T) {
 			assert.Equal(t, channel.Id, post.ChannelId)
 			assert.Equal(t, "ChannelHasBeenCreated has been called for "+channel.Id, post.Message)
 		}, 1*time.Second, 10*time.Millisecond)
+	})
+}
+
+func TestUserHasJoinedChannel(t *testing.T) {
+	getPluginCode := func(th *TestHelper) string {
+		return `
+			package main
+
+			import (
+				"fmt"
+
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			const (
+				adminUserID = "` + th.SystemAdminUser.Id + `"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.ChannelMember, actor *model.User) {
+				message := fmt.Sprintf("Test: User %s joined %s", channelMember.UserId, channelMember.ChannelId)
+				if actor != nil && actor.Id != channelMember.UserId {
+					message = fmt.Sprintf("Test: User %s added to %s by %s", channelMember.UserId, channelMember.ChannelId, actor.Id)
+				}
+
+				_, appErr := p.API.CreatePost(&model.Post{
+					UserId: adminUserID,
+					ChannelId: channelMember.ChannelId,
+					Message: message,
+				})
+				if appErr != nil {
+					panic(appErr)
+				}
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+		`
+	}
+	pluginID := "testplugin"
+	pluginManifest := `{"id": "testplugin", "server": {"executable": "backend.exe"}}`
+
+	t.Run("should call hook when a user joins an existing channel", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		user1 := th.CreateUser()
+		th.LinkUserToTeam(user1, th.BasicTeam)
+		user2 := th.CreateUser()
+		th.LinkUserToTeam(user2, th.BasicTeam)
+
+		channel, appErr := th.App.CreateChannel(th.Context, &model.Channel{
+			CreatorId: user1.Id,
+			TeamId:    th.BasicTeam.Id,
+			Name:      "test_channel",
+			Type:      model.ChannelTypeOpen,
+		}, false)
+		require.Nil(t, appErr)
+		require.NotNil(t, channel)
+
+		// Setup plugin after creating the channel
+		setupPluginAPITest(t, getPluginCode(th), pluginManifest, pluginID, th.App, th.Context)
+
+		_, appErr = th.App.AddChannelMember(th.Context, user2.Id, channel, ChannelMemberOpts{
+			UserRequestorID: user2.Id,
+		})
+		require.Nil(t, appErr)
+
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			posts, appErr := th.App.GetPosts(channel.Id, 0, 1)
+
+			require.Nil(t, appErr)
+
+			assert.Equal(t, fmt.Sprintf("Test: User %s joined %s", user2.Id, channel.Id), posts.Posts[posts.Order[0]].Message)
+		}, 1*time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("should call hook when a user is added to an existing channel", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		user1 := th.CreateUser()
+		th.LinkUserToTeam(user1, th.BasicTeam)
+		user2 := th.CreateUser()
+		th.LinkUserToTeam(user2, th.BasicTeam)
+
+		channel, appErr := th.App.CreateChannel(th.Context, &model.Channel{
+			CreatorId: user1.Id,
+			TeamId:    th.BasicTeam.Id,
+			Name:      "test_channel",
+			Type:      model.ChannelTypeOpen,
+		}, false)
+		require.Nil(t, appErr)
+		require.NotNil(t, channel)
+
+		// Setup plugin after creating the channel
+		setupPluginAPITest(t, getPluginCode(th), pluginManifest, pluginID, th.App, th.Context)
+
+		_, appErr = th.App.AddChannelMember(th.Context, user2.Id, channel, ChannelMemberOpts{
+			UserRequestorID: user1.Id,
+		})
+		require.Nil(t, appErr)
+
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			posts, appErr := th.App.GetPosts(channel.Id, 0, 1)
+
+			require.Nil(t, appErr)
+
+			assert.Equal(t, fmt.Sprintf("Test: User %s added to %s by %s", user2.Id, channel.Id, user1.Id), posts.Posts[posts.Order[0]].Message)
+		}, 1*time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("should not call hook when a regular channel is created", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		// Setup plugin
+		setupPluginAPITest(t, getPluginCode(th), pluginManifest, pluginID, th.App, th.Context)
+
+		user1 := th.CreateUser()
+
+		channel, appErr := th.App.CreateChannel(th.Context, &model.Channel{
+			CreatorId: user1.Id,
+			TeamId:    th.BasicTeam.Id,
+			Name:      "test_channel",
+			Type:      model.ChannelTypeOpen,
+		}, false)
+		require.Nil(t, appErr)
+		require.NotNil(t, channel)
+
+		// Wait for async plugin hooks to be run
+		time.Sleep(time.Second / 2)
+
+		posts, appErr := th.App.GetPosts(channel.Id, 0, 10)
+
+		require.Nil(t, appErr)
+
+		for _, postID := range posts.Order {
+			post := posts.Posts[postID]
+
+			if strings.HasPrefix(post.Message, "Test: ") {
+				t.Fatal("Plugin message found:", post.Message)
+			}
+		}
+	})
+
+	t.Run("should not call hook when a DM is created", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		// Setup plugin
+		setupPluginAPITest(t, getPluginCode(th), pluginManifest, pluginID, th.App, th.Context)
+
+		user1 := th.CreateUser()
+		user2 := th.CreateUser()
+
+		channel, appErr := th.App.GetOrCreateDirectChannel(th.Context, user1.Id, user2.Id)
+		require.Nil(t, appErr)
+		require.NotNil(t, channel)
+
+		// Wait for async plugin hooks to be run
+		time.Sleep(time.Second / 2)
+
+		posts, appErr := th.App.GetPosts(channel.Id, 0, 10)
+
+		require.Nil(t, appErr)
+
+		for _, postID := range posts.Order {
+			post := posts.Posts[postID]
+
+			if strings.HasPrefix(post.Message, "Test: ") {
+				t.Fatal("Plugin message found:", post.Message)
+			}
+		}
+	})
+
+	t.Run("should not call hook when a GM is created", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		// Setup plugin
+		setupPluginAPITest(t, getPluginCode(th), pluginManifest, pluginID, th.App, th.Context)
+
+		user1 := th.CreateUser()
+		user2 := th.CreateUser()
+		user3 := th.CreateUser()
+
+		channel, appErr := th.App.CreateGroupChannel(th.Context, []string{user1.Id, user2.Id, user3.Id}, user1.Id)
+		require.Nil(t, appErr)
+		require.NotNil(t, channel)
+
+		// Wait for async plugin hooks to be run
+		time.Sleep(time.Second / 2)
+
+		posts, appErr := th.App.GetPosts(channel.Id, 0, 10)
+
+		require.Nil(t, appErr)
+
+		for _, postID := range posts.Order {
+			post := posts.Posts[postID]
+
+			if strings.HasPrefix(post.Message, "Test: ") {
+				t.Fatal("Plugin message found:", post.Message)
+			}
+		}
 	})
 }


### PR DESCRIPTION
#### Summary
Continuing from #26057 there's a few plugin hooks that I wanted to ensure worked the way I expected to. Unfortunately they don't work in one case (which is how I found MM-56776), but it's better for us to know that before we shipped the MS Teams plugin feature that relies on it.

#### Release Note
```release-note
NONE
```
