### PR TITLE
Promote/downgrade some languages

### DIFF
--- a/webapp/channels/src/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/webapp/channels/src/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -406,7 +406,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 19,
-                  "text": "中文 (简体)",
+                  "text": "中文 (简体) (Beta)",
                   "value": "zh-CN",
                 },
                 Object {
@@ -535,7 +535,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 19,
-                  "text": "中文 (简体)",
+                  "text": "中文 (简体) (Beta)",
                   "value": "zh-CN",
                 },
                 Object {

--- a/webapp/channels/src/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/webapp/channels/src/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -326,7 +326,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 3,
-                  "text": "Español",
+                  "text": "Español (Beta)",
                   "value": "es",
                 },
                 Object {
@@ -341,7 +341,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 6,
-                  "text": "Magyar",
+                  "text": "Magyar (Beta)",
                   "value": "hu",
                 },
                 Object {
@@ -406,7 +406,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 19,
-                  "text": "中文 (简体) (Alpha)",
+                  "text": "中文 (简体)",
                   "value": "zh-CN",
                 },
                 Object {
@@ -455,7 +455,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 3,
-                  "text": "Español",
+                  "text": "Español (Beta)",
                   "value": "es",
                 },
                 Object {
@@ -470,7 +470,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 6,
-                  "text": "Magyar",
+                  "text": "Magyar (Beta)",
                   "value": "hu",
                 },
                 Object {
@@ -535,7 +535,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 19,
-                  "text": "中文 (简体) (Alpha)",
+                  "text": "中文 (简体)",
                   "value": "zh-CN",
                 },
                 Object {

--- a/webapp/channels/src/i18n/i18n.jsx
+++ b/webapp/channels/src/i18n/i18n.jsx
@@ -146,7 +146,7 @@ const languages = {
     },
     'zh-CN': {
         value: 'zh-CN',
-        name: '中文 (简体)',
+        name: '中文 (简体) (Beta)',
         order: 19,
         url: zhCN,
     },

--- a/webapp/channels/src/i18n/i18n.jsx
+++ b/webapp/channels/src/i18n/i18n.jsx
@@ -50,7 +50,7 @@ const languages = {
     },
     es: {
         value: 'es',
-        name: 'Español',
+        name: 'Español (Beta)',
         order: 3,
         url: es,
     },
@@ -68,7 +68,7 @@ const languages = {
     },
     hu: {
         value: 'hu',
-        name: 'Magyar',
+        name: 'Magyar (Beta)',
         order: 6,
         url: hu,
     },
@@ -146,7 +146,7 @@ const languages = {
     },
     'zh-CN': {
         value: 'zh-CN',
-        name: '中文 (简体) (Alpha)',
+        name: '中文 (简体)',
         order: 19,
         url: zhCN,
     },


### PR DESCRIPTION
Simplified Chinese has been above 90% quality level for at least the past three months, and Hungarian and Spanish languages have been below 85% quality level for at least the past three months.

```release-note
Promoted Simplified Chinese to Beta, and downgraded Hungarian and Spanish languages to Beta.
```