### PR TITLE
[MM-56478] Only clear the suggestion pretext when the suggestion is completed and not when the list is cleared

### DIFF
--- a/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.jsx
+++ b/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.jsx
@@ -259,6 +259,7 @@ export default class SuggestionBox extends React.PureComponent {
     handleEmitClearSuggestions = (delay = 0) => {
         setTimeout(() => {
             this.clear();
+            this.handlePretextChanged('');
         }, delay);
     };
 

--- a/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.jsx
+++ b/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.jsx
@@ -465,6 +465,7 @@ export default class SuggestionBox extends React.PureComponent {
         }
 
         this.clear();
+        this.handlePretextChanged('');
 
         if (openCommandInModal) {
             const appProvider = this.props.providers.find((p) => p.openAppsModalFromCommand);
@@ -556,7 +557,6 @@ export default class SuggestionBox extends React.PureComponent {
                 selection: '',
                 suggestionBoxAlgn: undefined,
             });
-            this.handlePretextChanged('');
         }
     };
 

--- a/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.test.jsx
+++ b/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.test.jsx
@@ -293,4 +293,12 @@ describe('components/SuggestionBox', () => {
         instance.componentDidMount();
         expect(instance.handlePretextChanged).toHaveBeenCalledTimes(1);
     });
+
+    test('should not clear pretext when clearing the suggestion list', () => {
+        const wrapper = shallow(<SuggestionBox {...baseProps}/>);
+        const instance = wrapper.instance();
+        instance.handlePretextChanged = jest.fn();
+        instance.clear();
+        expect(instance.handlePretextChanged).not.toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
#### Summary
A [previous change](https://github.com/mattermost/mattermost-webapp/pull/5913) that fixed an issue with the suggestion list made it so that on every clear of the list (which is what happens when the user presses ESC, OR if they select an item), the pretext would be cleared. Unfortunately though that doesn't clear the actual pretext in the textbox, which causes the list to then refresh since the pretext "changed" and needs to be refetched. The symptom of this was that a user would press ESC and the list would simply re-open.

To fix this, we want to avoid running `handlePretextChanged` for the ESC case since we're still actively using the suggestion box, meaning that we at least want to keep typing. We can also remove it for the debounced version since that will likely just loop as well.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56748

```release-note
NONE
```
