### PR TITLE
Allow plugins to specify all props for create comment.

### DIFF
--- a/webapp/channels/src/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/webapp/channels/src/components/advanced_create_comment/advanced_create_comment.tsx
@@ -28,11 +28,11 @@ import PostDeletedModal from 'components/post_deleted_modal';
 import type {TextboxClass, TextboxElement} from 'components/textbox';
 
 import Constants, {AdvancedTextEditor as AdvancedTextEditorConst, Locations, ModalIdentifiers, Preferences} from 'utils/constants';
+import type {
+    ApplyMarkdownOptions} from 'utils/markdown/apply_markdown';
 import {
     applyMarkdown,
 } from 'utils/markdown/apply_markdown';
-import type {
-    ApplyMarkdownOptions} from 'utils/markdown/apply_markdown';
 import {
     specialMentionsInText,
     postMessageOnKeyPress,
@@ -182,6 +182,7 @@ export type Props = {
     searchAssociatedGroupsForReference: (prefix: string, teamId: string, channelId: string | undefined) => Promise<ActionResult>;
     postEditorActions: PluginComponent[];
     placeholder?: string;
+    isPlugin: boolean;
 }
 
 type State = {

--- a/webapp/channels/src/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/webapp/channels/src/components/advanced_create_comment/advanced_create_comment.tsx
@@ -28,11 +28,11 @@ import PostDeletedModal from 'components/post_deleted_modal';
 import type {TextboxClass, TextboxElement} from 'components/textbox';
 
 import Constants, {AdvancedTextEditor as AdvancedTextEditorConst, Locations, ModalIdentifiers, Preferences} from 'utils/constants';
-import type {
-    ApplyMarkdownOptions} from 'utils/markdown/apply_markdown';
 import {
     applyMarkdown,
 } from 'utils/markdown/apply_markdown';
+import type {
+    ApplyMarkdownOptions} from 'utils/markdown/apply_markdown';
 import {
     specialMentionsInText,
     postMessageOnKeyPress,
@@ -182,7 +182,7 @@ export type Props = {
     searchAssociatedGroupsForReference: (prefix: string, teamId: string, channelId: string | undefined) => Promise<ActionResult>;
     postEditorActions: PluginComponent[];
     placeholder?: string;
-    isPlugin: boolean;
+    isPlugin?: boolean;
 }
 
 type State = {

--- a/webapp/channels/src/components/advanced_create_comment/index.ts
+++ b/webapp/channels/src/components/advanced_create_comment/index.ts
@@ -45,6 +45,7 @@ type OwnProps = {
     rootId: string;
     channelId: string;
     latestPostId: string;
+    isPlugin: boolean;
 };
 
 function makeMapStateToProps() {
@@ -134,20 +135,22 @@ function makeMapDispatchToProps() {
     let latestPostId: string;
 
     return (dispatch: Dispatch, ownProps: OwnProps) => {
-        if (rootId !== ownProps.rootId) {
-            onUpdateCommentDraft = makeOnUpdateCommentDraft(ownProps.rootId, ownProps.channelId);
-        }
+        if (!ownProps.isPlugin) {
+            if (rootId !== ownProps.rootId) {
+                onUpdateCommentDraft = makeOnUpdateCommentDraft(ownProps.rootId, ownProps.channelId);
+            }
 
-        if (channelId !== ownProps.channelId) {
-            updateCommentDraftWithRootId = makeUpdateCommentDraftWithRootId(ownProps.channelId);
-        }
+            if (channelId !== ownProps.channelId) {
+                updateCommentDraftWithRootId = makeUpdateCommentDraftWithRootId(ownProps.channelId);
+            }
 
-        if (rootId !== ownProps.rootId) {
-            onEditLatestPost = makeOnEditLatestPost(ownProps.rootId);
-        }
+            if (rootId !== ownProps.rootId) {
+                onEditLatestPost = makeOnEditLatestPost(ownProps.rootId);
+            }
 
-        if (rootId !== ownProps.rootId || channelId !== ownProps.channelId || latestPostId !== ownProps.latestPostId) {
-            onSubmit = makeOnSubmit(ownProps.channelId, ownProps.rootId, ownProps.latestPostId);
+            if (rootId !== ownProps.rootId || channelId !== ownProps.channelId || latestPostId !== ownProps.latestPostId) {
+                onSubmit = makeOnSubmit(ownProps.channelId, ownProps.rootId, ownProps.latestPostId);
+            }
         }
 
         rootId = ownProps.rootId;

--- a/webapp/channels/src/components/advanced_create_comment/index.ts
+++ b/webapp/channels/src/components/advanced_create_comment/index.ts
@@ -45,7 +45,7 @@ type OwnProps = {
     rootId: string;
     channelId: string;
     latestPostId: string;
-    isPlugin: boolean;
+    isPlugin?: boolean;
 };
 
 function makeMapStateToProps() {

--- a/webapp/channels/src/plugins/exported_create_post.tsx
+++ b/webapp/channels/src/plugins/exported_create_post.tsx
@@ -4,30 +4,25 @@
 import React from 'react';
 
 import AdvancedCreateComment from 'components/advanced_create_comment';
+import type {Props} from 'components/advanced_create_comment/advanced_create_comment';
 
-import type {PostDraft} from 'types/store/draft';
-
-type Props = {
-    placeholder?: string;
-    onSubmit: (draft: PostDraft) => void;
-}
-
-const ExportedCreatePost = ({placeholder, onSubmit}: Props) => {
+const ExportedCreatePost = (props: Partial<Props>) => {
     const Component = AdvancedCreateComment as any;
 
     return (
         <Component
-            placeholder={placeholder}
+            placeholder={''}
             rootDeleted={false}
             channelId={undefined}
             rootId={undefined}
             latestPostId={undefined}
-            onSubmit={onSubmit}
             onUpdateCommentDraft={() => null}
             updateCommentDraftWithRootId={() => null}
             onMoveHistoryIndexBack={() => null}
             onMoveHistoryIndexForward={() => null}
             onEditLatestPost={() => ({data: true})}
+            isPlugin={true}
+            {...props}
         />
     );
 };


### PR DESCRIPTION
#### Summary
Follow up to https://github.com/mattermost/mattermost/pull/24972 that exposed the AdvancedCreateComment to the LLM plugin.
The original PR restricted plugins from specifying all props. This caused the LLM plugin to use a nasty workaround to fix a bug where the component would disable itself for non system admins if a channelID was not spcified. 
This PR exposes all the props to prevent further issues. Also works around some code by specifying that a plugin is using the component. 


#### Release Note

```release-note
NONE
```
