### PR TITLE
[MM-56683] Auto select first emoji in emoji picker

### DIFF
--- a/webapp/channels/src/components/emoji_picker/__snapshots__/emoji_picker.test.tsx.snap
+++ b/webapp/channels/src/components/emoji_picker/__snapshots__/emoji_picker.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
       aria-live="assertive"
       class="sr-only"
     >
-       emoji
+      grinning emoji
     </div>
     <div
       class="emoji-picker__search-container"
@@ -159,9 +159,9 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
       class="emoji-picker__footer"
     >
       <div
-        class="emoji-picker__preview emoji-picker__preview-placeholder"
+        class="emoji-picker__preview"
       >
-        Select an Emoji
+        Preview for grinning emoji
       </div>
     </div>
   </div>

--- a/webapp/channels/src/components/emoji_picker/emoji_picker.test.tsx
+++ b/webapp/channels/src/components/emoji_picker/emoji_picker.test.tsx
@@ -4,6 +4,8 @@
 import React from 'react';
 import {IntlProvider} from 'react-intl';
 
+import type {SystemEmoji} from '@mattermost/types/emojis';
+
 import {render, screen} from 'tests/react_testing_utils';
 import EmojiMap from 'utils/emoji_map';
 
@@ -11,6 +13,9 @@ import EmojiPicker from './emoji_picker';
 
 jest.mock('components/emoji_picker/components/emoji_picker_skin', () => () => (
     <div/>
+));
+jest.mock('components/emoji_picker/components/emoji_picker_preview', () => ({emoji}: {emoji?: SystemEmoji}) => (
+    <div className='emoji-picker__preview'>{`Preview for ${emoji?.short_name} emoji`}</div>
 ));
 
 describe('components/emoji_picker/EmojiPicker', () => {
@@ -72,5 +77,20 @@ describe('components/emoji_picker/EmojiPicker', () => {
         );
 
         expect(screen.queryByLabelText('emoji_picker.recent')).not.toBeNull();
+    });
+
+    test('First emoji should be selected on search', () => {
+        const props = {
+            ...baseProps,
+            filter: 'wave',
+        };
+
+        render(
+            <IntlProvider {...intlProviderProps}>
+                <EmojiPicker {...props}/>
+            </IntlProvider>,
+        );
+
+        expect(screen.queryByText('Preview for wave emoji')).not.toBeNull();
     });
 });

--- a/webapp/channels/src/components/emoji_picker/emoji_picker.tsx
+++ b/webapp/channels/src/components/emoji_picker/emoji_picker.tsx
@@ -120,6 +120,7 @@ const EmojiPicker = ({
 
         const [updatedCategoryOrEmojisRows, updatedEmojiPositions] = createCategoryAndEmojiRows(allEmojis, categories, filter, userSkinTone);
 
+        selectFirstEmoji(updatedEmojiPositions);
         setCategoryOrEmojisRows(updatedCategoryOrEmojisRows);
         setEmojiPositionsArray(updatedEmojiPositions);
         throttledSearchCustomEmoji.current(filter, customEmojisEnabled);
@@ -157,6 +158,22 @@ const EmojiPicker = ({
         }
         const emoji = allEmojis[emojiId] || allEmojis[emojiId.toUpperCase()] || allEmojis[emojiId.toLowerCase()];
         return emoji;
+    };
+
+    const selectFirstEmoji = (emojiPositions: EmojiPosition[]) => {
+        if (!emojiPositions[0]) {
+            return;
+        }
+
+        const {rowIndex, emojiId} = emojiPositions[0];
+        const cursorEmoji = getEmojiById(emojiId);
+        if (cursorEmoji) {
+            setCursor({
+                rowIndex,
+                emojiId,
+                emoji: cursorEmoji,
+            });
+        }
     };
 
     const handleCategoryClick = useCallback((categoryRowIndex: CategoryOrEmojiRow['index'], categoryName: EmojiCategory, emojiId: string) => {


### PR DESCRIPTION
#### Summary
- Auto selects the first emoji in the emoji picker so the user can press enter to insert the first emoji without navigating with the arrow keys

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/26119

#### Screenshots
![Screenshot 2024-02-09 at 12 29 12 am](https://github.com/mattermost/mattermost/assets/8002179/ad056af7-5fad-4d2a-9a36-7d89b76dbfdb)
![Screenshot 2024-02-09 at 12 29 31 am](https://github.com/mattermost/mattermost/assets/8002179/2cf4d97a-056a-4637-a332-ed8846e44e68)


#### Release Note
```
First emoji is auto selected in the emoji picker
```
