### PR TITLE
fix build: do not delete an empty set of preferences

### DIFF
--- a/server/cmd/mmctl/commands/user_e2e_test.go
+++ b/server/cmd/mmctl/commands/user_e2e_test.go
@@ -1076,6 +1076,10 @@ func (s *MmctlE2ETestSuite) cleanUpPreferences(userID string) {
 	preferences, _, err := s.th.SystemAdminClient.GetPreferences(context.Background(), userID)
 	s.NoError(err)
 
+	if len(preferences) == 0 {
+		return
+	}
+
 	_, err = s.th.SystemAdminClient.DeletePreferences(context.Background(), userID, preferences)
 	s.NoError(err)
 }


### PR DESCRIPTION
#### Summary
Address testing issues introduced by https://github.com/mattermost/mattermost/pull/25721, avoiding a call to `DeletePreferences` without any preferences to delete.

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
