### PR TITLE
Automated cherry pick of #26172

### DIFF
--- a/server/cmd/mmctl/commands/user_e2e_test.go
+++ b/server/cmd/mmctl/commands/user_e2e_test.go
@@ -1076,6 +1076,10 @@ func (s *MmctlE2ETestSuite) cleanUpPreferences(userID string) {
 	preferences, _, err := s.th.SystemAdminClient.GetPreferences(context.Background(), userID)
 	s.NoError(err)
 
+	if len(preferences) == 0 {
+		return
+	}
+
 	_, err = s.th.SystemAdminClient.DeletePreferences(context.Background(), userID, preferences)
 	s.NoError(err)
 }


### PR DESCRIPTION
Cherry pick of #26172 on release-9.6.

/cc  @lieut-data

```release-note
NONE
```