### PR TITLE
[Draft] Outgoing OAuth Connections: Team Scope connections

### DIFF
--- a/server/channels/api4/outgoing_oauth_connection.go
+++ b/server/channels/api4/outgoing_oauth_connection.go
@@ -37,7 +37,7 @@ func (api *API) InitOutgoingOAuthConnection() {
 // This is made in this way so only users with the management permission can setup the outgoing oauth connections and then
 // other users can use them in their outgoing webhooks and slash commands if they have permissions to manage those.
 func checkOutgoingOAuthConnectionReadPermissions(c *Context, teamId string) bool {
-	if c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), teamId, model.PermissionManageOutgoingOAuthConnections) ||
+	if c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageOutgoingOAuthConnections) ||
 		c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), teamId, model.PermissionManageOutgoingWebhooks) ||
 		c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), teamId, model.PermissionManageSlashCommands) {
 		return true

--- a/server/channels/api4/outgoing_oauth_connection.go
+++ b/server/channels/api4/outgoing_oauth_connection.go
@@ -207,11 +207,6 @@ func getOutgoingOAuthConnection(c *Context, w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if !c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), connection.TeamId, model.PermissionManageOutgoingOAuthConnections) {
-		c.Err = model.NewAppError(whereOutgoingOAuthConnection, "api.context.outgoing_oauth_connection.get_connection.permission_error", nil, "", http.StatusForbidden)
-		return
-	}
-
 	service.SanitizeConnection(connection)
 
 	if err := json.NewEncoder(w).Encode(connection); err != nil {

--- a/server/channels/api4/outgoing_oauth_connection.go
+++ b/server/channels/api4/outgoing_oauth_connection.go
@@ -49,7 +49,7 @@ func checkOutgoingOAuthConnectionReadPermissions(c *Context, teamId string) bool
 
 // checkOutgoingOAuthConnectionWritePermissions checks if the user has the permissions to write outgoing oauth connections.
 // This is a more granular permissions intended for system admins to manage (setup) outgoing oauth connections.
-func checkOutgoingOAuthConnectionWritePermissions(c *Context, _ string) bool {
+func checkOutgoingOAuthConnectionWritePermissions(c *Context) bool {
 	if c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageOutgoingOAuthConnections) {
 		return true
 	}
@@ -186,11 +186,10 @@ func listOutgoingOAuthConnections(c *Context, w http.ResponseWriter, r *http.Req
 }
 
 func getOutgoingOAuthConnection(c *Context, w http.ResponseWriter, r *http.Request) {
-	teamID := r.URL.Query().Get("team_id")
 	// We check for write permissions because the user needs to have the permissions to manage outgoing oauth connections
 	// and the read permissions are only used on the listOutgoingOAuthConnections function to search
 	// by audience.
-	if !checkOutgoingOAuthConnectionWritePermissions(c, teamID) {
+	if !checkOutgoingOAuthConnectionWritePermissions(c) {
 		return
 	}
 
@@ -216,12 +215,11 @@ func getOutgoingOAuthConnection(c *Context, w http.ResponseWriter, r *http.Reque
 }
 
 func createOutgoingOAuthConnection(c *Context, w http.ResponseWriter, r *http.Request) {
-	teamID := r.URL.Query().Get("team_id")
 	auditRec := c.MakeAuditRecord("createOutgoingOauthConnection", audit.Fail)
 	defer c.LogAuditRec(auditRec)
 	c.LogAudit("attempt")
 
-	if !checkOutgoingOAuthConnectionWritePermissions(c, teamID) {
+	if !checkOutgoingOAuthConnectionWritePermissions(c) {
 		return
 	}
 
@@ -262,13 +260,12 @@ func createOutgoingOAuthConnection(c *Context, w http.ResponseWriter, r *http.Re
 }
 
 func updateOutgoingOAuthConnection(c *Context, w http.ResponseWriter, r *http.Request) {
-	teamID := r.URL.Query().Get("team_id")
 	auditRec := c.MakeAuditRecord("updateOutgoingOAuthConnection", audit.Fail)
 	defer c.LogAuditRec(auditRec)
 	audit.AddEventParameter(auditRec, "outgoing_oauth_connection_id", c.Params.OutgoingOAuthConnectionID)
 	c.LogAudit("attempt")
 
-	if !checkOutgoingOAuthConnectionWritePermissions(c, teamID) {
+	if !checkOutgoingOAuthConnectionWritePermissions(c) {
 		return
 	}
 
@@ -330,14 +327,12 @@ func updateOutgoingOAuthConnection(c *Context, w http.ResponseWriter, r *http.Re
 }
 
 func deleteOutgoingOAuthConnection(c *Context, w http.ResponseWriter, r *http.Request) {
-	teamID := r.URL.Query().Get("team_id")
-
 	auditRec := c.MakeAuditRecord("deleteOutgoingOAuthConnection", audit.Fail)
 	defer c.LogAuditRec(auditRec)
 	audit.AddEventParameter(auditRec, "outgoing_oauth_connection_id", c.Params.OutgoingOAuthConnectionID)
 	c.LogAudit("attempt")
 
-	if !checkOutgoingOAuthConnectionWritePermissions(c, teamID) {
+	if !checkOutgoingOAuthConnectionWritePermissions(c) {
 		return
 	}
 
@@ -373,12 +368,11 @@ func deleteOutgoingOAuthConnection(c *Context, w http.ResponseWriter, r *http.Re
 // with the provided connection configuration. If the credentials are valid, the request will return a 200 status code and
 // if the credentials are invalid, the request will return a 400 status code.
 func validateOutgoingOAuthConnectionCredentials(c *Context, w http.ResponseWriter, r *http.Request) {
-	teamID := r.URL.Query().Get("team_id")
 	auditRec := c.MakeAuditRecord("validateOutgoingOAuthConnectionCredentials", audit.Fail)
 	defer c.LogAuditRec(auditRec)
 	c.LogAudit("attempt")
 
-	if !checkOutgoingOAuthConnectionWritePermissions(c, teamID) {
+	if !checkOutgoingOAuthConnectionWritePermissions(c) {
 		return
 	}
 

--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -236,6 +236,8 @@ channels/db/migrations/mysql/000118_create_index_poststats.down.sql
 channels/db/migrations/mysql/000118_create_index_poststats.up.sql
 channels/db/migrations/mysql/000119_msteams_shared_channels_opts.down.sql
 channels/db/migrations/mysql/000119_msteams_shared_channels_opts.up.sql
+channels/db/migrations/mysql/000120_add_teamid_outgoing_oauth_connection.down.sql
+channels/db/migrations/mysql/000120_add_teamid_outgoing_oauth_connection.up.sql
 channels/db/migrations/postgres/000001_create_teams.down.sql
 channels/db/migrations/postgres/000001_create_teams.up.sql
 channels/db/migrations/postgres/000002_create_team_members.down.sql
@@ -472,3 +474,5 @@ channels/db/migrations/postgres/000118_create_index_poststats.down.sql
 channels/db/migrations/postgres/000118_create_index_poststats.up.sql
 channels/db/migrations/postgres/000119_msteams_shared_channels_opts.down.sql
 channels/db/migrations/postgres/000119_msteams_shared_channels_opts.up.sql
+channels/db/migrations/postgres/000120_add_teamid_outgoing_oauth_connection.down.sql
+channels/db/migrations/postgres/000120_add_teamid_outgoing_oauth_connection.up.sql

--- a/server/channels/db/migrations/mysql/000120_add_teamid_outgoing_oauth_connection.down.sql
+++ b/server/channels/db/migrations/mysql/000120_add_teamid_outgoing_oauth_connection.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE OutgoingOAuthConnections DROP COLUMN TeamId;

--- a/server/channels/db/migrations/mysql/000120_add_teamid_outgoing_oauth_connection.up.sql
+++ b/server/channels/db/migrations/mysql/000120_add_teamid_outgoing_oauth_connection.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE OutgoingOAuthConnections
+    ADD COLUMN TeamId varchar(26) DEFAULT NULL;

--- a/server/channels/db/migrations/postgres/000120_add_teamid_outgoing_oauth_connection.down.sql
+++ b/server/channels/db/migrations/postgres/000120_add_teamid_outgoing_oauth_connection.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE outgoingoauthconnections DROP COLUMN teamid;

--- a/server/channels/db/migrations/postgres/000120_add_teamid_outgoing_oauth_connection.up.sql
+++ b/server/channels/db/migrations/postgres/000120_add_teamid_outgoing_oauth_connection.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE outgoingoauthconnections
+    ADD COLUMN teamid VARCHAR(26) DEFAULT NULL;

--- a/server/channels/store/sqlstore/outgoing_oauth_connection_store.go
+++ b/server/channels/store/sqlstore/outgoing_oauth_connection_store.go
@@ -34,9 +34,9 @@ func (s *SqlOutgoingOAuthConnectionStore) SaveConnection(c request.CTX, conn *mo
 	}
 
 	if _, err := s.GetMasterX().NamedExec(`INSERT INTO OutgoingOAuthConnections
-	(Id, Name, ClientId, ClientSecret, CreateAt, UpdateAt, CreatorId, OAuthTokenURL, GrantType, Audiences)
+	(Id, TeamId, Name, ClientId, ClientSecret, CreateAt, UpdateAt, CreatorId, OAuthTokenURL, GrantType, Audiences)
 	VALUES
-	(:Id, :Name, :ClientId, :ClientSecret, :CreateAt, :UpdateAt, :CreatorId, :OAuthTokenURL, :GrantType, :Audiences)`, conn); err != nil {
+	(:Id, :TeamId, :Name, :ClientId, :ClientSecret, :CreateAt, :UpdateAt, :CreatorId, :OAuthTokenURL, :GrantType, :Audiences)`, conn); err != nil {
 		return nil, errors.Wrap(err, "failed to save OutgoingOAuthConnection")
 	}
 	return conn, nil
@@ -104,6 +104,10 @@ func (s *SqlOutgoingOAuthConnectionStore) GetConnections(c request.CTX, filters 
 		From("OutgoingOAuthConnections").
 		OrderBy("Id").
 		Limit(uint64(filters.Limit))
+
+	if filters.TeamId != "" {
+		query = query.Where(sq.Eq{"TeamId": filters.TeamId})
+	}
 
 	if filters.OffsetId != "" {
 		query = query.Where("Id > ?", filters.OffsetId)

--- a/server/public/model/outgoing_oauth_connection.go
+++ b/server/public/model/outgoing_oauth_connection.go
@@ -25,6 +25,7 @@ const (
 
 type OutgoingOAuthConnection struct {
 	Id                  string                           `json:"id"`
+	TeamId              string                           `json:"team_id"`
 	CreatorId           string                           `json:"creator_id"`
 	CreateAt            int64                            `json:"create_at"`
 	UpdateAt            int64                            `json:"update_at"`
@@ -91,6 +92,10 @@ func (oa *OutgoingOAuthConnection) Patch(conn *OutgoingOAuthConnection) {
 func (oa *OutgoingOAuthConnection) IsValid() *AppError {
 	if !IsValidId(oa.Id) {
 		return NewAppError("OutgoingOAuthConnection.IsValid", "model.outgoing_oauth_connection.is_valid.id.error", nil, "", http.StatusBadRequest)
+	}
+
+	if !IsValidId(oa.TeamId) {
+		return NewAppError("OutgoingOAuthConnection.IsValid", "model.outgoing_oauth_connection.is_valid.team_id.error", nil, "id="+oa.Id, http.StatusBadRequest)
 	}
 
 	if oa.CreateAt == 0 {
@@ -182,11 +187,7 @@ type OutgoingOAuthConnectionGetConnectionsFilter struct {
 	OffsetId string
 	Limit    int
 	Audience string
-
-	// TeamId is not used as a filter but as a way to check if the current user has permission to
-	// access the outgoing oauth connection for the given team in order to use them in the slash
-	// commands and outgoing webhooks.
-	TeamId string
+	TeamId   string
 }
 
 // SetDefaults sets the default values for the filter

--- a/webapp/channels/src/components/integrations/outgoing_oauth_connections/abstract_outgoing_oauth_connection.test.tsx
+++ b/webapp/channels/src/components/integrations/outgoing_oauth_connections/abstract_outgoing_oauth_connection.test.tsx
@@ -22,6 +22,7 @@ describe('components/integrations/AbstractOutgoingOAuthConnection', () => {
     const loading = {id: 'Loading', defaultMessage: 'Loading'};
     const initialConnection: OutgoingOAuthConnection = {
         id: 'facxd9wpzpbpfp8pad78xj75pr',
+        team_id: '88oybd1dwfdoxpkpw1h5kpbyca',
         name: 'testConnection',
         client_secret: '',
         client_id: 'clientid',

--- a/webapp/channels/src/components/integrations/outgoing_oauth_connections/abstract_outgoing_oauth_connection.tsx
+++ b/webapp/channels/src/components/integrations/outgoing_oauth_connections/abstract_outgoing_oauth_connection.tsx
@@ -69,6 +69,7 @@ const useOutgoingOAuthForm = (connection: OutgoingOAuthConnection): [State, (sta
 
 const initialState: OutgoingOAuthConnection = {
     id: '',
+    team_id: '',
     name: '',
     creator_id: '',
     create_at: 0,
@@ -224,6 +225,8 @@ export default function AbstractOutgoingOAuthConnection(props: Props) {
         }
 
         setIsSubmitting(true);
+
+        connection.team_id = props.team.id;
 
         const res = props.submitAction(connection);
         res.then(() => setIsSubmitting(false));

--- a/webapp/channels/src/components/integrations/outgoing_oauth_connections/installed_outgoing_oauth_connection.test.tsx
+++ b/webapp/channels/src/components/integrations/outgoing_oauth_connections/installed_outgoing_oauth_connection.test.tsx
@@ -14,6 +14,7 @@ describe('components/integrations/InstalledOutgoingOAuthConnection', () => {
     const team = {name: 'team_name'};
     const outgoingOAuthConnection: OutgoingOAuthConnection = {
         id: 'someid',
+        team_id: 'someteamid',
         create_at: 1501365458934,
         creator_id: 'someuserid',
         update_at: 1501365458934,

--- a/webapp/platform/types/src/integrations.ts
+++ b/webapp/platform/types/src/integrations.ts
@@ -106,6 +106,7 @@ export type OAuthApp = {
 
 export type OutgoingOAuthConnection = {
     'id': string;
+    'team_id': string;
     'name': string;
     'creator_id': string;
     'create_at': number;


### PR DESCRIPTION
#### Summary
This PR made necessary modification to move the connections from outgoing oauth connections to a team scope, including:
- Database migrations to create the column
- Model representation new field, along with validation
- Modified logic to require a team for lists. Create/Update already requires it via validation.
- Updated tests to reflect the logic changes