### PR TITLE
Update minimum supported Edge and Chrome versions

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10292,11 +10292,11 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "Version 118+"
+    "translation": "Version 120+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "Version 118+"
+    "translation": "Version 120+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",


### PR DESCRIPTION
Desktop app v5.7 will include Electron v28.2.2, which includes Chrome v120+. Edge versions follow the Chromium versions.

```release-note
Updated minimum required Edge and Chrome versions to 120+.
```