### PR TITLE
Fix racy unit tests by protecting Shared Channels service ref with a mutex

### DIFF
--- a/server/channels/app/platform/service.go
+++ b/server/channels/app/platform/service.go
@@ -98,7 +98,9 @@ type PlatformService struct {
 	goroutineBuffered   chan struct{}
 
 	additionalClusterHandlers map[model.ClusterEvent]einterfaces.ClusterMessageHandler
-	sharedChannelService      SharedChannelServiceIFace
+
+	shareChannelServiceMux sync.RWMutex
+	sharedChannelService   SharedChannelServiceIFace
 
 	pluginEnv HookRunner
 }
@@ -471,7 +473,15 @@ func (ps *PlatformService) SetSqlStore(s *sqlstore.SqlStore) {
 }
 
 func (ps *PlatformService) SetSharedChannelService(s SharedChannelServiceIFace) {
+	ps.shareChannelServiceMux.Lock()
+	defer ps.shareChannelServiceMux.Unlock()
 	ps.sharedChannelService = s
+}
+
+func (ps *PlatformService) GetSharedChannelService() SharedChannelServiceIFace {
+	ps.shareChannelServiceMux.RLock()
+	defer ps.shareChannelServiceMux.RUnlock()
+	return ps.sharedChannelService
 }
 
 func (ps *PlatformService) SetPluginsEnvironment(runner HookRunner) {

--- a/server/channels/app/platform/shared_channel_notifier.go
+++ b/server/channels/app/platform/shared_channel_notifier.go
@@ -31,7 +31,7 @@ var sharedChannelEventsForInvitation = []model.WebsocketEventType{
 // Only on the leader node it will notify the sync service to perform necessary updates to the remote for the given
 // shared channel.
 func (ps *PlatformService) SharedChannelSyncHandler(event *model.WebSocketEvent) {
-	syncService := ps.sharedChannelService
+	syncService := ps.GetSharedChannelService()
 	if syncService == nil {
 		return
 	}


### PR DESCRIPTION
#### Summary
CI is failing with racy unit test for Shared Channels due to setting and reading the `Platform.sharedChannelsService` ref.  

A recent change to remove Shared Channels service mock and use real service uncovered this race condition.

This PR fixes the issue by protecting access to the service ref with a RWMutex.

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
