### PR TITLE
MM-56571 - Update prepackaged calls to v0.24.0

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -147,7 +147,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v0.23.1
+PLUGIN_PACKAGES += mattermost-plugin-calls-v0.24.0
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.1.7
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.8.0
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v1.39.1


### PR DESCRIPTION
#### Summary
- Prepackage Calls v0.24.0

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-56571

#### Release Note

```release-note
Prepackage Calls version v0.24.0
```