### PR TITLE
MM-56776 Call ChannelHasBeenCreated plugin hook for GMs

### DIFF
--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -668,6 +668,14 @@ func (a *App) createGroupChannel(c request.CTX, userIDs []string) (*model.Channe
 		}
 	}
 
+	a.Srv().Go(func() {
+		pluginContext := pluginContext(c)
+		a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
+			hooks.ChannelHasBeenCreated(pluginContext, channel)
+			return true
+		}, plugin.ChannelHasBeenCreatedID)
+	})
+
 	return channel, nil
 }
 

--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -1887,8 +1887,6 @@ func TestChannelHasBeenCreated(t *testing.T) {
 	})
 
 	t.Run("should call hook when a GM is created", func(t *testing.T) {
-		t.Skip("Currently broken due to MM-56776")
-
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
 


### PR DESCRIPTION
#### Summary
Somehow, we forgot to call this hook for GM channels even though it's called for both regular channels and DMs

#### Ticket Link
MM-56776

#### Release Note
```release-note
Fixed ChannelHasBeenCreated plugin hook not being called when a group channel is created
```
