### PR TITLE
Clarify meaning of 'channel_id' field in `posts` and `channels` API endpoints

### DIFF
--- a/api/v4/source/channels.yaml
+++ b/api/v4/source/channels.yaml
@@ -441,7 +441,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: &channel_id The machine-generated, unique, 26-character-long alphanumeric string identifying the channel.
           required: true
           schema:
             type: string
@@ -473,7 +473,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -505,7 +505,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -575,7 +575,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -610,7 +610,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -673,7 +673,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -721,7 +721,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -755,7 +755,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -801,7 +801,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -828,7 +828,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -1295,7 +1295,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -1381,7 +1381,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -1424,7 +1424,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -1466,7 +1466,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -1502,7 +1502,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -1557,7 +1557,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -1613,7 +1613,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -1873,7 +1873,7 @@
             type: string
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -1912,7 +1912,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -1968,7 +1968,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -2018,7 +2018,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -2053,7 +2053,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string
@@ -2095,7 +2095,7 @@
       parameters:
         - name: channel_id
           in: path
-          description: Channel GUID
+          description: *channel_id
           required: true
           schema:
             type: string

--- a/api/v4/source/definitions.yaml
+++ b/api/v4/source/definitions.yaml
@@ -186,6 +186,7 @@ components:
       type: object
       properties:
         id:
+          description: The machine-generated, unique, 26-character-long alphanumeric string identifying the channel.
           type: string
         create_at:
           description: The time in milliseconds a channel was created

--- a/api/v4/source/posts.yaml
+++ b/api/v4/source/posts.yaml
@@ -29,7 +29,11 @@
               properties:
                 channel_id:
                   type: string
-                  description: The channel ID to post in
+                  description: &channel_id The machine-generated, unique, 26-character-long
+                    alphanumeric string identifying the channel to post in.
+                    Given a human-readable channel name, to find the `channel_id`,
+                    use [the API](/#tag/channels/operation/GetChannelByName) or
+                    [the `mmctl channel search` command](https://docs.mattermost.com/manage/mmctl-command-line-tool.html#mmctl-channel-search).
                 message:
                   type: string
                   description: The message contents, can be formatted with Markdown
@@ -108,7 +112,7 @@
                   properties:
                     channel_id:
                       type: string
-                      description: The channel ID to post in
+                      description: *channel_id
                     message:
                       type: string
                       description: The message contents, can be formatted with Markdown


### PR DESCRIPTION
#### Summary
As someone who's new to the Mattermost `/api/v4/posts` API, it took me a while to figure out what to put in the `channel_id` field.

On https://api.mattermost.com/#tag/posts/operation/CreatePost, it says just "The channel ID to post in".  At first, I assumed this would be the channel's URL slug, e.g. `town-square`, but that fails with this misleading error message:

> You do not have the appropriate permissions.

I therefore spent a while trying different combinations of permissions, without success.

I eventually happened to find https://github.com/mattermost/docs/pull/4892/files which says "Channel IDs can be obtained via … the `mattermost channel search` command".  If I understand correctly, that's out-of-date, and the current recommended command is `mmctl channel search`.

This PR updates the API documentation to include a little more information about the expected value of the `channel_id` field, which I think might help newcomers more quickly figure out how to use the API.

I tested this change by building the documentation and viewing the results locally:
```sh
cd api
make build
open v4/html/index.html
```

#### Ticket Link
n/a

#### Screenshots
|  before  |  after  |
|----|----|
| ![Screenshot 2024-02-15 at 20 26 53](https://github.com/mattermost/mattermost/assets/190164/9506ae7e-70cf-4218-9806-22541d880195) | ![Screenshot 2024-02-15 at 20 26 35](https://github.com/mattermost/mattermost/assets/190164/690b8756-d129-43a0-b079-142266bf0a22) |

#### Release Note
```release-note
Clarified meaning of 'channel_id' field in `POST /api/v4/posts` and `POST /api/v4/channels` endpoints.
```
