### PR TITLE
Log warning when plugin using Shared Channels APIs is uninstalled

### DIFF
--- a/server/channels/app/shared_channel.go
+++ b/server/channels/app/shared_channel.go
@@ -248,8 +248,8 @@ func (a *App) OnSharedChannelsPing(rc *model.RemoteCluster) bool {
 		// plugin was likely uninstalled. Issue a warning once per hour, with instructions how to clean up if this is
 		// intentional.
 		if time.Now().Minute() == 0 {
-			msg := "Cannot find plugin for shared channels ping; if the plugin was intentionally uninstalled, stop this warning using "
-			msg = msg + "`/secure-connection remove --connectionID %s`"
+			msg := "Cannot find plugin for shared channels ping; if the plugin was intentionally uninstalled, "
+			msg = msg + "stop this warning using  `/secure-connection remove --connectionID %s`"
 			a.Log().Warn(fmt.Sprintf(msg, rc.RemoteId),
 				mlog.String("plugin_id", rc.PluginID),
 				mlog.Err(err),


### PR DESCRIPTION
#### Summary
A plugin using the Shared Channels plugin APIs that is uninstalled will log errors every minute as the shared channels service tries to ping it to ensure sync messages should continue to be generated for it.  Uninstalled plugins are not given a chance to cleanup, and this cannot unregister with the service.

Plugins are continually checked by the service to ensure they are accepting calls to their sync hooks, since sync messages can be expensive to generate and should not be done for plugins that are no longer accepting calls.  

This PR changes that error to a warning that is emitted only once per hour, and includes instructions on how to clean up the plugin's registration.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56912


#### Release Note
```release-note
NONE
```
