### PR TITLE
Fix flaky IP Filtering test

### DIFF
--- a/server/channels/api4/ip_filtering_test.go
+++ b/server/channels/api4/ip_filtering_test.go
@@ -233,10 +233,6 @@ func Test_applyIPFilters(t *testing.T) {
 			CloudCustomerInfo: model.CloudCustomerInfo{Email: "test@localhost"},
 		}, nil)
 
-		cloudImpl := th.App.Srv().Cloud
-		defer func() {
-			th.App.Srv().Cloud = cloudImpl
-		}()
 		th.App.Srv().Cloud = cloud
 
 		th.Client.Login(context.Background(), th.SystemAdminUser.Email, th.SystemAdminUser.Password)


### PR DESCRIPTION
#### Summary
This line was brought over from another test - it resets the cloud mock back to whatever it was set to before the test run (a pattern that is needed elsewhere in cloud tests) - this causes a race because the cloud interface is removed before the Go routine that's sending the emails can finish. There are no subsequent actions that would actually require this to be reset so the line isn't necessary.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
