### PR TITLE
Fix thread icon size and color

### DIFF
--- a/webapp/channels/src/components/threading/global_threads_link/global_threads_link.scss
+++ b/webapp/channels/src/components/threading/global_threads_link/global_threads_link.scss
@@ -11,12 +11,18 @@
 
         .icon {
             padding: 3px;
-            margin-right: 8px;
-            margin-left: 1px;
+            margin-right: 7px;
+            margin-left: -1px;
 
             svg {
-                fill: rgba(var(--sidebar-text-rgb), 0.75);
+                fill: rgba(var(--sidebar-text-rgb), 0.64);
                 vertical-align: middle;
+            }
+        }
+
+        &.unread-title {
+            svg {
+                fill: var(--sidebar-text);
             }
         }
 

--- a/webapp/channels/src/components/threading/global_threads_link/threads_icon.tsx
+++ b/webapp/channels/src/components/threading/global_threads_link/threads_icon.tsx
@@ -7,8 +7,8 @@ import type {HTMLAttributes} from 'react';
 const ThreadsIcon = (attrs: HTMLAttributes<SVGElement>) => {
     return (
         <svg
-            width='14'
-            height='13'
+            width='18'
+            height='18'
             viewBox='0 0 14 13'
             fill='none'
             xmlns='http://www.w3.org/2000/svg'


### PR DESCRIPTION
#### Summary
Fixes a minor inconsistency in icon size with the LHS Threads item compared to icons in other LHS items.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-56971

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="238" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/fe209f1c-375b-4be7-83fc-03390f29e79a"> | <img width="241" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/09fc0386-214f-4a35-a147-a40a1719a17c"> |

#### Release Note
```release-note
NONE
```
