### PR TITLE
MM-56985 Remove babel-plugin-lodash

### DIFF
--- a/webapp/channels/.eslintrc.json
+++ b/webapp/channels/.eslintrc.json
@@ -128,6 +128,10 @@
             "name": "redux",
             "importNames": ["DeepPartial"],
             "message": "Use DeepPartial from '@mattermost/types/utilities instead."
+          },
+          {
+            "name": "lodash",
+            "message": "Import individual functions from lodash/<function> instead."
           }
         ]
       }

--- a/webapp/channels/babel.config.js
+++ b/webapp/channels/babel.config.js
@@ -23,7 +23,6 @@ const config = {
         }],
     ],
     plugins: [
-        'lodash',
         'react-hot-loader/babel',
         'babel-plugin-typescript-to-proptypes',
         [

--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -141,7 +141,6 @@
     "@types/tinycolor2": "1.4.3",
     "@typescript-eslint/eslint-plugin": "5.57.1",
     "@typescript-eslint/parser": "5.57.1",
-    "babel-plugin-lodash": "3.3.4",
     "copy-webpack-plugin": "11.0.0",
     "emoji-datasource": "6.1.1",
     "emoji-datasource-apple": "6.1.1",

--- a/webapp/channels/src/actions/status_actions.test.ts
+++ b/webapp/channels/src/actions/status_actions.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {cloneDeep} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import type {UserProfile} from '@mattermost/types/users';
 

--- a/webapp/channels/src/actions/views/rhs.test.ts
+++ b/webapp/channels/src/actions/views/rhs.test.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {cloneDeep, set} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import set from 'lodash/set';
 import type {Dispatch} from 'redux';
 import {batchActions} from 'redux-batched-actions';
 import type {MockStoreEnhanced} from 'redux-mock-store';

--- a/webapp/channels/src/components/admin_console/data_retention_settings/channel_list/channel_list.tsx
+++ b/webapp/channels/src/components/admin_console/data_retention_settings/channel_list/channel_list.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {debounce, isEqual} from 'lodash';
+import debounce from 'lodash/debounce';
+import isEqual from 'lodash/isEqual';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 

--- a/webapp/channels/src/components/admin_console/data_retention_settings/team_list/team_list.tsx
+++ b/webapp/channels/src/components/admin_console/data_retention_settings/team_list/team_list.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {debounce} from 'lodash';
+import debounce from 'lodash/debounce';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 

--- a/webapp/channels/src/components/admin_console/group_settings/group_details/group_teams_and_channels_row.tsx
+++ b/webapp/channels/src/components/admin_console/group_settings/group_details/group_teams_and_channels_row.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import classNames from 'classnames';
-import {isNil} from 'lodash';
+import isNil from 'lodash/isNil';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 

--- a/webapp/channels/src/components/admin_console/group_settings/group_details/group_users.test.tsx
+++ b/webapp/channels/src/components/admin_console/group_settings/group_details/group_users.test.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {shallow} from 'enzyme';
-import {range} from 'lodash';
+import range from 'lodash/range';
 import React from 'react';
 
 import type {UserProfile} from '@mattermost/types/users';

--- a/webapp/channels/src/components/admin_console/member_list_group/member_list_group.test.tsx
+++ b/webapp/channels/src/components/admin_console/member_list_group/member_list_group.test.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {shallow} from 'enzyme';
-import {range} from 'lodash';
+import range from 'lodash/range';
 import React from 'react';
 
 import {TestHelper} from 'utils/test_helper';

--- a/webapp/channels/src/components/admin_console/server_logs/logs.tsx
+++ b/webapp/channels/src/components/admin_console/server_logs/logs.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {debounce} from 'lodash';
+import debounce from 'lodash/debounce';
 import React from 'react';
 import {FormattedMessage, defineMessages} from 'react-intl';
 

--- a/webapp/channels/src/components/admin_console/system_roles/system_role/system_role.tsx
+++ b/webapp/channels/src/components/admin_console/system_roles/system_role/system_role.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {uniq, difference} from 'lodash';
+import difference from 'lodash/difference';
+import uniq from 'lodash/uniq';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 

--- a/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/channel_details.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/channel_details.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {cloneDeep} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 

--- a/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/channel_moderation.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/channel_moderation.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import classNames from 'classnames';
-import {isNil} from 'lodash';
+import isNil from 'lodash/isNil';
 import React from 'react';
 import {FormattedMessage, defineMessages} from 'react-intl';
 import type {MessageDescriptor} from 'react-intl';

--- a/webapp/channels/src/components/admin_console/team_channel_settings/team/details/team_details.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/team/details/team_details.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {cloneDeep} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 

--- a/webapp/channels/src/components/admin_console/team_channel_settings/team/details/team_profile.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/team/details/team_profile.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import classNames from 'classnames';
-import {noop} from 'lodash';
+import noop from 'lodash/noop';
 import React, {useEffect, useState} from 'react';
 import {FormattedMessage, defineMessage, useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';

--- a/webapp/channels/src/components/advanced_text_editor/formatting_bar/hooks.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/formatting_bar/hooks.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import type {Instance} from '@popperjs/core';
-import {debounce} from 'lodash';
+import debounce from 'lodash/debounce';
 import type React from 'react';
 import {useCallback, useEffect, useLayoutEffect, useState} from 'react';
 

--- a/webapp/channels/src/components/announcement_bar/cloud_trial_announcement_bar/cloud_trial_announcement_bar.tsx
+++ b/webapp/channels/src/components/announcement_bar/cloud_trial_announcement_bar/cloud_trial_announcement_bar.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {isEmpty} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 

--- a/webapp/channels/src/components/announcement_bar/payment_announcement_bar/index.tsx
+++ b/webapp/channels/src/components/announcement_bar/payment_announcement_bar/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {isEmpty} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import React, {useEffect, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useSelector, useDispatch} from 'react-redux';

--- a/webapp/channels/src/components/app_bar/app_bar.tsx
+++ b/webapp/channels/src/components/app_bar/app_bar.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {partition} from 'lodash';
+import partition from 'lodash/partition';
 import React from 'react';
 import type {ReactNode} from 'react';
 import {useSelector} from 'react-redux';

--- a/webapp/channels/src/components/channel_invite_modal/channel_invite_modal.tsx
+++ b/webapp/channels/src/components/channel_invite_modal/channel_invite_modal.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {isEqual} from 'lodash';
+import isEqual from 'lodash/isEqual';
 import React from 'react';
 import {Modal} from 'react-bootstrap';
 import type {IntlShape} from 'react-intl';

--- a/webapp/channels/src/components/channel_members_rhs/channel_members_rhs.tsx
+++ b/webapp/channels/src/components/channel_members_rhs/channel_members_rhs.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {debounce} from 'lodash';
+import debounce from 'lodash/debounce';
 import React, {useCallback, useEffect, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useHistory} from 'react-router-dom';

--- a/webapp/channels/src/components/cloud_start_trial/request_business_email_modal.tsx
+++ b/webapp/channels/src/components/cloud_start_trial/request_business_email_modal.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {debounce} from 'lodash';
+import debounce from 'lodash/debounce';
 import React, {useCallback, useEffect, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useDispatch} from 'react-redux';

--- a/webapp/channels/src/components/common/hocs/cloud/with_get_cloud_subscription.tsx
+++ b/webapp/channels/src/components/common/hocs/cloud/with_get_cloud_subscription.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {isEmpty} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import React from 'react';
 import type {ComponentType} from 'react';
 

--- a/webapp/channels/src/components/custom_open_plugin_install_post_renderer/index.tsx
+++ b/webapp/channels/src/components/custom_open_plugin_install_post_renderer/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {uniqWith} from 'lodash';
+import uniqWith from 'lodash/uniqWith';
 import React, {useEffect, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useSelector, useDispatch} from 'react-redux';

--- a/webapp/channels/src/components/integrations/outgoing_oauth_connections/oauth_connection_audience_input.tsx
+++ b/webapp/channels/src/components/integrations/outgoing_oauth_connections/oauth_connection_audience_input.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {debounce} from 'lodash';
+import debounce from 'lodash/debounce';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';

--- a/webapp/channels/src/components/menu/menu_item.tsx
+++ b/webapp/channels/src/components/menu/menu_item.tsx
@@ -4,7 +4,7 @@
 import MuiMenuItem from '@mui/material/MenuItem';
 import type {MenuItemProps as MuiMenuItemProps} from '@mui/material/MenuItem';
 import {styled} from '@mui/material/styles';
-import {cloneDeep} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import React, {
     Children,
     useContext,

--- a/webapp/channels/src/components/more_direct_channels/more_direct_channels.tsx
+++ b/webapp/channels/src/components/more_direct_channels/more_direct_channels.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {debounce} from 'lodash';
+import debounce from 'lodash/debounce';
 import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';

--- a/webapp/channels/src/components/post_view/post_attachment_opengraph/post_attachment_opengraph.test.tsx
+++ b/webapp/channels/src/components/post_view/post_attachment_opengraph/post_attachment_opengraph.test.tsx
@@ -2,7 +2,8 @@
 // See LICENSE.txt for license information.
 
 import {mount} from 'enzyme';
-import {cloneDeep, set} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import set from 'lodash/set';
 import React from 'react';
 import {Provider} from 'react-redux';
 

--- a/webapp/channels/src/components/purchase_modal/purchase_modal.tsx
+++ b/webapp/channels/src/components/purchase_modal/purchase_modal.tsx
@@ -7,7 +7,7 @@ import {Elements} from '@stripe/react-stripe-js';
 import type {Stripe, StripeCardElementChangeEvent} from '@stripe/stripe-js';
 import {loadStripe} from '@stripe/stripe-js/pure'; // https://github.com/stripe/stripe-js#importing-loadstripe-without-side-effects
 import classnames from 'classnames';
-import {isEmpty} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import React from 'react';
 import type {ReactNode} from 'react';
 import {FormattedMessage, injectIntl} from 'react-intl';

--- a/webapp/channels/src/components/suggestion/suggestion_list.tsx
+++ b/webapp/channels/src/components/suggestion/suggestion_list.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {cloneDeep} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {FormattedMessage} from 'react-intl';

--- a/webapp/channels/src/components/threading/global_threads/global_threads.tsx
+++ b/webapp/channels/src/components/threading/global_threads/global_threads.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import classNames from 'classnames';
-import {isEmpty} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import React, {memo, useCallback, useEffect, useState} from 'react';
 import type {ReactNode} from 'react';
 import {useIntl} from 'react-intl';

--- a/webapp/channels/src/components/threading/global_threads/thread_list/thread_list.tsx
+++ b/webapp/channels/src/components/threading/global_threads/thread_list/thread_list.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {isEmpty} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import React, {memo, useCallback, useEffect} from 'react';
 import type {PropsWithChildren} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';

--- a/webapp/channels/src/components/threading/global_threads/thread_menu/thread_menu.test.tsx
+++ b/webapp/channels/src/components/threading/global_threads/thread_menu/thread_menu.test.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {shallow} from 'enzyme';
-import {set} from 'lodash';
+import set from 'lodash/set';
 import React from 'react';
 import type {ComponentProps} from 'react';
 

--- a/webapp/channels/src/components/timestamp/timestamp.tsx
+++ b/webapp/channels/src/components/timestamp/timestamp.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {capitalize as caps, isArray} from 'lodash';
+import caps from 'lodash/capitalize';
+import isArray from 'lodash/isArray';
 import type {Moment} from 'moment-timezone';
 import moment from 'moment-timezone';
 import React, {PureComponent} from 'react';

--- a/webapp/channels/src/components/user_group_popover/user_group_popover.tsx
+++ b/webapp/channels/src/components/user_group_popover/user_group_popover.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {debounce} from 'lodash';
+import debounce from 'lodash/debounce';
 import React, {useEffect, useCallback, useState, useRef} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import styled from 'styled-components';

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/threads.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/threads.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {uniq} from 'lodash';
+import uniq from 'lodash/uniq';
 import {batchActions} from 'redux-batched-actions';
 
 import type {Post} from '@mattermost/types/posts';

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channels.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channels.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {isEqual} from 'lodash';
+import isEqual from 'lodash/isEqual';
 import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channels.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channels.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {max} from 'lodash';
+import max from 'lodash/max';
 
 import type {
     Channel,

--- a/webapp/channels/src/reducers/views/threads.ts
+++ b/webapp/channels/src/reducers/views/threads.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {findKey} from 'lodash';
+import findKey from 'lodash/findKey';
 import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 

--- a/webapp/channels/src/selectors/admin_console.jsx
+++ b/webapp/channels/src/selectors/admin_console.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {cloneDeep} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {ResourceToSysConsolePermissionsTable, RESOURCE_KEYS} from 'mattermost-redux/constants/permissions_sysconsole';
 import {createSelector} from 'mattermost-redux/selectors/create_selector';

--- a/webapp/channels/src/utils/func.ts
+++ b/webapp/channels/src/utils/func.ts
@@ -1,7 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {intersection, isPlainObject, zipObject} from 'lodash';
+import intersection from 'lodash/intersection';
+import isPlainObject from 'lodash/isPlainObject';
+import zipObject from 'lodash/zipObject';
 
 /**
  * Transform a function with multiple args into one that receives a normalized args object.

--- a/webapp/channels/src/utils/paste.tsx
+++ b/webapp/channels/src/utils/paste.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {isNil} from 'lodash';
+import isNil from 'lodash/isNil';
 
 import type {TextboxElement} from 'components/textbox';
 

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -5,7 +5,7 @@ import {getName} from 'country-list';
 import crypto from 'crypto';
 import cssVars from 'css-vars-ponyfill';
 import type {Locale} from 'date-fns';
-import {isNil} from 'lodash';
+import isNil from 'lodash/isNil';
 import moment from 'moment';
 import React from 'react';
 import type {LinkHTMLAttributes} from 'react';

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -187,7 +187,6 @@
         "@types/tinycolor2": "1.4.3",
         "@typescript-eslint/eslint-plugin": "5.57.1",
         "@typescript-eslint/parser": "5.57.1",
-        "babel-plugin-lodash": "3.3.4",
         "copy-webpack-plugin": "11.0.0",
         "emoji-datasource": "6.1.1",
         "emoji-datasource-apple": "6.1.1",
@@ -6642,18 +6641,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/babel-plugin-lodash": {
-      "version": "3.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0-beta.49",
-        "@babel/types": "^7.0.0-beta.49",
-        "glob": "^7.1.1",
-        "lodash": "^4.17.10",
-        "require-package-name": "^2.0.1"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -20181,11 +20168,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/require-package-name": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/requires-port": {
       "version": "1.0.0",


### PR DESCRIPTION
#### Summary
https://github.com/lodash/babel-plugin-lodash is no longer supported, and since all it does is splitting imports `from 'lodash'` into individual imports to allow for tree shaking, it's easy enough to do manually. I also added an ESLint rule to prevent people from importing the index of Lodash as well to ensure that we don't import parts of Lodash that we don't need accidentally

I'm definitely wondering if we do actually need lodash seeing as we're mostly using it for simple enough things (like `isNil` which is just `arg == null`), but I decided to leave it for now since it's standard enough.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56985

#### Release Note
```release-note
NONE
```
