### PR TITLE
MM-56987: Improve cache API

### DIFF
--- a/server/channels/app/platform/session.go
+++ b/server/channels/app/platform/session.go
@@ -45,13 +45,6 @@ func (ps *PlatformService) AddSessionToCache(session *model.Session) {
 	ps.sessionCache.SetWithExpiry(session.Token, session, time.Duration(int64(*ps.Config().ServiceSettings.SessionCacheInMinutes))*time.Minute)
 }
 
-func (ps *PlatformService) SessionCacheLength() int {
-	if l, err := ps.sessionCache.Len(); err == nil {
-		return l
-	}
-	return 0
-}
-
 func (ps *PlatformService) ClearUserSessionCacheLocal(userID string) {
 	if keys, err := ps.sessionCache.Keys(); err == nil {
 		var session *model.Session

--- a/server/channels/store/localcachelayer/terms_of_service_layer.go
+++ b/server/channels/store/localcachelayer/terms_of_service_layer.go
@@ -47,11 +47,9 @@ func (s LocalCacheTermsOfServiceStore) Save(termsOfService *model.TermsOfService
 
 func (s LocalCacheTermsOfServiceStore) GetLatest(allowFromCache bool) (*model.TermsOfService, error) {
 	if allowFromCache {
-		if l, err := s.rootStore.termsOfServiceCache.Len(); err == nil && l != 0 {
-			var cacheItem *model.TermsOfService
-			if err := s.rootStore.doStandardReadCache(s.rootStore.termsOfServiceCache, LatestKey, &cacheItem); err == nil {
-				return cacheItem, nil
-			}
+		var cacheItem *model.TermsOfService
+		if err := s.rootStore.doStandardReadCache(s.rootStore.termsOfServiceCache, LatestKey, &cacheItem); err == nil {
+			return cacheItem, nil
 		}
 	}
 

--- a/server/platform/services/cache/cache.go
+++ b/server/platform/services/cache/cache.go
@@ -40,9 +40,6 @@ type Cache interface {
 	// Keys returns a slice of the keys in the cache.
 	Keys() ([]string, error)
 
-	// Len returns the number of items in the cache.
-	Len() (int, error)
-
 	// GetInvalidateClusterEvent returns the cluster event configured when this cache was created.
 	GetInvalidateClusterEvent() model.ClusterEvent
 

--- a/server/platform/services/cache/lru_test.go
+++ b/server/platform/services/cache/lru_test.go
@@ -26,9 +26,6 @@ func TestLRU(t *testing.T) {
 		err := l.Set(fmt.Sprintf("%d", i), i)
 		require.NoError(t, err)
 	}
-	size, err := l.Len()
-	require.NoError(t, err)
-	require.Equalf(t, size, 128, "bad len: %v", size)
 
 	keys, err := l.Keys()
 	require.NoError(t, err)
@@ -69,9 +66,6 @@ func TestLRU(t *testing.T) {
 	}
 
 	l.Purge()
-	size, err = l.Len()
-	require.NoError(t, err)
-	require.Equalf(t, size, 0, "bad len: %v", size)
 	err = l.Get("200", &v)
 	require.Equal(t, err, ErrKeyNotFound, "should contain nothing")
 

--- a/server/platform/services/cache/lru_test.go
+++ b/server/platform/services/cache/lru_test.go
@@ -27,6 +27,11 @@ func TestLRU(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	lru, ok := l.(*LRU)
+	require.True(t, ok)
+	size := lru.len
+	require.Equalf(t, size, 128, "bad len: %v", size)
+
 	keys, err := l.Keys()
 	require.NoError(t, err)
 	for i, k := range keys {
@@ -66,6 +71,8 @@ func TestLRU(t *testing.T) {
 	}
 
 	l.Purge()
+	size = lru.len
+	require.Equalf(t, size, 0, "bad len: %v", size)
 	err = l.Get("200", &v)
 	require.Equal(t, err, ErrKeyNotFound, "should contain nothing")
 

--- a/server/platform/services/cache/provider_test.go
+++ b/server/platform/services/cache/provider_test.go
@@ -28,9 +28,6 @@ func TestNewCache(t *testing.T) {
 		require.NoError(t, err)
 		err = c.Set("key3", "val3")
 		require.NoError(t, err)
-		l, err := c.Len()
-		require.NoError(t, err)
-		require.Equal(t, size, l)
 	})
 
 	t.Run("with only size option given", func(t *testing.T) {
@@ -48,9 +45,6 @@ func TestNewCache(t *testing.T) {
 		require.NoError(t, err)
 		err = c.Set("key3", "val3")
 		require.NoError(t, err)
-		l, err := c.Len()
-		require.NoError(t, err)
-		require.Equal(t, size, l)
 	})
 
 	t.Run("with all options specified", func(t *testing.T) {
@@ -75,9 +69,6 @@ func TestNewCache(t *testing.T) {
 		require.NoError(t, err)
 		err = c.SetWithDefaultExpiry("key3", "val3")
 		require.NoError(t, err)
-		l, err := c.Len()
-		require.NoError(t, err)
-		require.Equal(t, size, l)
 
 		time.Sleep(expiry + 1*time.Second)
 
@@ -109,9 +100,6 @@ func TestNewCache_Striped(t *testing.T) {
 		require.NoError(t, err)
 		err = c.Set("key3", "val3")
 		require.NoError(t, err)
-		l, err := c.Len()
-		require.NoError(t, err)
-		require.Equal(t, size+1, l) // +10% from striping
 	})
 
 	t.Run("with only size option given", func(t *testing.T) {
@@ -131,9 +119,6 @@ func TestNewCache_Striped(t *testing.T) {
 		require.NoError(t, err)
 		err = c.Set("key3", "val3")
 		require.NoError(t, err)
-		l, err := c.Len()
-		require.NoError(t, err)
-		require.Equal(t, size+1, l) // +10% rounded up from striped lru
 	})
 
 	t.Run("with all options specified", func(t *testing.T) {
@@ -160,9 +145,6 @@ func TestNewCache_Striped(t *testing.T) {
 		require.NoError(t, err)
 		err = c.SetWithDefaultExpiry("key3", "val3")
 		require.NoError(t, err)
-		l, err := c.Len()
-		require.NoError(t, err)
-		require.Equal(t, size+1, l) // +10% from striping
 
 		time.Sleep(expiry + 1*time.Second)
 


### PR DESCRIPTION
This is in preparation to make the codebase
ready to use Redis. In Redis, iterating all
the keys at once is an expensive operation.
It is recommended to work on batches of keys.

Remove the Len method as it was unused.

I tried to repurpose the Keys method to iterate
on keys rather than returning all keys at once, but
it has other complicacies because the code calls
other cache functions on those keys, so to handle
the LRU cache properly, it becomes slightly more
painful.

For now, we keep it like this and rather collect
all keys from Redis and then return.

https://mattermost.atlassian.net/browse/MM-56987

```release-note
NONE
```
