### PR TITLE
MM-56780: Ensure p.Integration is not nil

### DIFF
--- a/server/public/model/integration_action.go
+++ b/server/public/model/integration_action.go
@@ -122,6 +122,11 @@ func (p *PostAction) Equals(input *PostAction) bool {
 		return p.Integration == nil
 	}
 
+	// At this point, input is not nil, so return false if original is.
+	if p.Integration == nil {
+		return false
+	}
+
 	// Both are unequal and not nil.
 	if p.Integration.URL != input.Integration.URL {
 		return false

--- a/server/public/model/integration_action_test.go
+++ b/server/public/model/integration_action_test.go
@@ -144,7 +144,7 @@ func TestPostActionIntegrationEquals(t *testing.T) {
 		require.False(t, pa1.Equals(pa2))
 	})
 
-	t.Run("nil check", func(t *testing.T) {
+	t.Run("nil check in input integration", func(t *testing.T) {
 		pa1 := &PostAction{
 			Integration: &PostActionIntegration{},
 		}
@@ -154,5 +154,29 @@ func TestPostActionIntegrationEquals(t *testing.T) {
 		}
 
 		require.False(t, pa1.Equals(pa2))
+	})
+
+	t.Run("nil check in original integration", func(t *testing.T) {
+		pa1 := &PostAction{
+			Integration: nil,
+		}
+
+		pa2 := &PostAction{
+			Integration: &PostActionIntegration{},
+		}
+
+		require.False(t, pa1.Equals(pa2))
+	})
+
+	t.Run("both nil", func(t *testing.T) {
+		pa1 := &PostAction{
+			Integration: nil,
+		}
+
+		pa2 := &PostAction{
+			Integration: nil,
+		}
+
+		require.True(t, pa1.Equals(pa2))
 	})
 }


### PR DESCRIPTION
#### Summary
A Sentry crash report showed that the check `p.Integration.URL != input.integration.URL` was dereferencing a nil pointer. At that point in the code, `input.Integration` is known to be non-nil, but we still need to check whether the original, `p.Integration`, is.

Crash report: https://mattermost-mr.sentry.io/issues/4918263046/events/5738b67edcee4c9c883d40f7d26563a6

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56780

#### Screenshots
--

#### Release Note
```release-note
NONE
```
