### PR TITLE
Fix typo

### DIFF
--- a/server/channels/app/import_functions_test.go
+++ b/server/channels/app/import_functions_test.go
@@ -1588,7 +1588,7 @@ func TestImportUserTeams(t *testing.T) {
 			expectedUserChannels: 0,
 		},
 		{
-			name: "Should fail if one of the roles doesn't exists",
+			name: "Should fail if one of the roles doesn't exist",
 			data: &[]imports.UserTeamImportData{
 				{
 					Name:  &th.BasicTeam.Name,
@@ -1810,7 +1810,7 @@ func TestImportUserChannels(t *testing.T) {
 			expectedUserChannels: 0,
 		},
 		{
-			name: "Should fail if one of the roles doesn't exists",
+			name: "Should fail if one of the roles doesn't exist",
 			data: &[]imports.UserChannelImportData{
 				{
 					Name:  &th.BasicChannel.Name,

--- a/server/cmd/mmctl/commands/config_e2e_test.go
+++ b/server/cmd/mmctl/commands/config_e2e_test.go
@@ -144,7 +144,7 @@ func (s *MmctlE2ETestSuite) TestConfigSetCmd() {
 		s.Require().Equal("mysql", *(config.SqlSettings.DriverName))
 	})
 
-	s.RunForSystemAdminAndLocal("Get error if the key doesn't exists", func(c client.Client) {
+	s.RunForSystemAdminAndLocal("Get error if the key doesn't exist", func(c client.Client) {
 		printer.Clean()
 
 		args := []string{"SqlSettings.WrongKey", "mysql"}

--- a/server/cmd/mmctl/commands/config_test.go
+++ b/server/cmd/mmctl/commands/config_test.go
@@ -140,7 +140,7 @@ func (s *MmctlUnitTestSuite) TestConfigGetCmd() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
-	s.Run("Get error if the key doesn't exists", func() {
+	s.Run("Get error if the key doesn't exist", func() {
 		printer.Clean()
 		args := []string{"SqlSettings.WrongKey"}
 		outputConfig := &model.Config{}
@@ -443,7 +443,7 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 		s.Require().Len(printer.GetLines(), 0)
 	})
 
-	s.Run("Get error if the key doesn't exists", func() {
+	s.Run("Get error if the key doesn't exist", func() {
 		printer.Clean()
 		defaultConfig := &model.Config{}
 		defaultConfig.SetDefaults()
@@ -713,7 +713,7 @@ func (s *MmctlUnitTestSuite) TestConfigResetCmd() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
-	s.Run("Should fail if the key doesn't exists", func() {
+	s.Run("Should fail if the key doesn't exist", func() {
 		printer.Clean()
 		args := []string{"WrongKey"}
 		defaultConfig := &model.Config{}

--- a/server/cmd/mmctl/commands/utils_unix.go
+++ b/server/cmd/mmctl/commands/utils_unix.go
@@ -21,7 +21,7 @@ func checkValidSocket(socketPath string) error {
 	// check file mode and permissions
 	fi, err := os.Stat(socketPath)
 	if err != nil && os.IsNotExist(err) {
-		return fmt.Errorf("socket file %q doesn't exists, please check the server configuration for local mode", socketPath)
+		return fmt.Errorf("socket file %q doesn't exist, please check the server configuration for local mode", socketPath)
 	} else if err != nil {
 		return err
 	}

--- a/server/cmd/mmctl/commands/utils_windows.go
+++ b/server/cmd/mmctl/commands/utils_windows.go
@@ -13,7 +13,7 @@ func checkValidSocket(socketPath string) error {
 	// check file mode and permissions
 	fi, err := os.Stat(socketPath)
 	if err != nil && os.IsNotExist(err) {
-		return fmt.Errorf("socket file %q doesn't exists, please check the server configuration for local mode", socketPath)
+		return fmt.Errorf("socket file %q doesn't exist, please check the server configuration for local mode", socketPath)
 	} else if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Summary
I've seen this typo many times when trying to use mmctl in local mode having the server misconfigured, but only today decided to fix it once and for all :muscle: When I searched for it it showed up in a couple more places in some tests, so there they go.

#### Ticket Link
--
#### Screenshots
--
#### Release Note
```release-note
NONE
```
