### PR TITLE
WIP: Test elasticsearch enterprise tests with OpenSearch docker image

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -156,7 +156,9 @@ PLUGIN_PACKAGES += mattermost-plugin-nps-v1.3.3
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.3.4
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.6.2
 
-EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)
+EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/elasticsearch)
+export MM_ELASTICSEARCHSETTINGS_USERNAME := admin
+export MM_ELASTICSEARCHSETTINGS_PASSWORD := admin
 
 ifeq ($(BUILD_ENTERPRISE_READY),true)
   ALL_PACKAGES=$(TE_PACKAGES) $(EE_PACKAGES)

--- a/server/build/Dockerfile.opensearch
+++ b/server/build/Dockerfile.opensearch
@@ -1,0 +1,3 @@
+FROM opensearchproject/opensearch:2.7.0
+
+RUN /usr/share/opensearch/bin/opensearch-plugin install analysis-icu

--- a/server/build/docker-compose.common.yml
+++ b/server/build/docker-compose.common.yml
@@ -102,7 +102,7 @@ services:
       transport.host: "127.0.0.1"
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
       discovery.type: single-node
-      plugins.security.disabled: true
+      plugins.security.disabled: "true"
   dejavu:
     image: "appbaseio/dejavu:3.4.2"
     networks:

--- a/server/build/docker-compose.common.yml
+++ b/server/build/docker-compose.common.yml
@@ -87,7 +87,9 @@ services:
       LDAP_DOMAIN: "mm.test.com"
       LDAP_ADMIN_PASSWORD: "mostest"
   elasticsearch:
-    image: "mattermostdevelopment/mattermost-elasticsearch:7.17.10"
+    build:
+      context: .
+      dockerfile: ./Dockerfile.opensearch
     networks:
       - mm-test
     environment:
@@ -99,6 +101,8 @@ services:
       http.cors.allow-credentials: "true"
       transport.host: "127.0.0.1"
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      discovery.type: single-node
+      plugins.security.disabled: true
   dejavu:
     image: "appbaseio/dejavu:3.4.2"
     networks:

--- a/server/docker-compose.makefile.m1.yml
+++ b/server/docker-compose.makefile.m1.yml
@@ -1,7 +1,6 @@
 version: '2.4'
 services:
   elasticsearch:
-    image: "mattermostdevelopment/mattermost-elasticsearch:7.17.10"
     platform: linux/arm64/v8
     restart: 'no'
     container_name: mattermost-elasticsearch


### PR DESCRIPTION
#### Summary

This PR aims to show Mattermost's compatibility with Open Search, by running the enterprise unit tests with an Open Search container.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-56546

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Mattermost server has been unit-tested with Open Search
```
