### PR TITLE
Passed actual channel data to action instead of HTTP response

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/actions/channels.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/channels.ts
@@ -275,7 +275,8 @@ export function convertGroupMessageToPrivateChannel(channelID: string, teamID: s
     return async (dispatch, getState) => {
         let updatedChannel;
         try {
-            updatedChannel = await Client4.convertGroupMessageToPrivateChannel(channelID, teamID, displayName, name);
+            const response = await Client4.convertGroupMessageToPrivateChannel(channelID, teamID, displayName, name);
+            updatedChannel = response.data;
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));


### PR DESCRIPTION
#### Summary
Passed channel data instead of client response to Redux action.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-56946

#### Release Note
```release-note
Fixed a bug causing empty channel switcher after converting a GM to a private channel.
```
