### PR TITLE
[MM-56651] fix: set cache duration

### DIFF
--- a/server/platform/shared/web/files.go
+++ b/server/platform/shared/web/files.go
@@ -35,7 +35,7 @@ var MediaContentTypes = [...]string{
 }
 
 func WriteFileResponse(filename string, contentType string, contentSize int64, lastModification time.Time, webserverMode string, fileReader io.ReadSeeker, forceDownload bool, w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Cache-Control", "private, no-cache")
+	w.Header().Set("Cache-Control", "private, max-age=864000")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 
 	if contentSize > 0 {

--- a/server/platform/shared/web/files.go
+++ b/server/platform/shared/web/files.go
@@ -35,7 +35,7 @@ var MediaContentTypes = [...]string{
 }
 
 func WriteFileResponse(filename string, contentType string, contentSize int64, lastModification time.Time, webserverMode string, fileReader io.ReadSeeker, forceDownload bool, w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Cache-Control", "private, max-age=864000")
+	w.Header().Set("Cache-Control", "private, max-age=86400")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 
 	if contentSize > 0 {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This pull request changes the `Cache-Control` header to have a `max-age=86400` instead of `no-cache`

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/26020
Jira https://mattermost.atlassian.net/browse/MM-56651


#### Release Note

```release-note
Changed the cache headers for file endpoints to cache privately for 24 hours, instead of not caching at all.
```
