### PR TITLE
Update client and types npm packages to link to monorepo directly

### DIFF
--- a/webapp/platform/client/package.json
+++ b/webapp/platform/client/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "mattermost"
   ],
-  "homepage": "https://github.com/mattermost/mattermost-server/tree/master/webapp/platform/client#readme",
+  "homepage": "https://github.com/mattermost/mattermost/tree/master/webapp/platform/client#readme",
   "license": "MIT",
   "files": [
     "lib"
@@ -14,7 +14,7 @@
   "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "github:mattermost/mattermost-server",
+    "url": "github:mattermost/mattermost",
     "directory": "webapp/platform/client"
   },
   "dependencies": {

--- a/webapp/platform/types/package.json
+++ b/webapp/platform/types/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "mattermost"
   ],
-  "homepage": "https://github.com/mattermost/mattermost-server/tree/master/webapp/platform/types#readme",
+  "homepage": "https://github.com/mattermost/mattermost/tree/master/webapp/platform/types#readme",
   "license": "MIT",
   "files": [
     "lib"
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "github:mattermost/mattermost-server",
+    "url": "github:mattermost/mattermost",
     "directory": "webapp/platform/types"
   },
   "peerDependencies": {


### PR DESCRIPTION
#### Summary

A customer was confused as to why `mattermost-server` was in the link for the npm packages. This cleans it up a bit so that we directly link to the monorepo instead of using the redirect.

#### Ticket Link
n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
