### PR TITLE
MM-57037 Upgrade web app and pacakges to TypeScript 5.3.3

### DIFF
--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -98,7 +98,7 @@
     "timezones.json": "1.6.1",
     "tinycolor2": "1.4.2",
     "turndown": "7.1.1",
-    "typescript": "4.9.5",
+    "typescript": "5.3.3",
     "zen-observable": "0.9.0"
   },
   "devDependencies": {
@@ -183,6 +183,11 @@
     "webpack-bundle-analyzer": "4.7.0",
     "webpack-pwa-manifest": "4.3.0",
     "yargs": "16.2.0"
+  },
+  "overrides": {
+    "@mattermost/desktop-api": {
+      "typescript": "$typescript"
+    }
   },
   "scripts": {
     "check": "eslint --ext .js,.jsx,.tsx,.ts ./src --quiet --cache && stylelint \"**/*.{css,scss}\" --cache",

--- a/webapp/channels/src/components/channel_header/channel_header.tsx
+++ b/webapp/channels/src/components/channel_header/channel_header.tsx
@@ -495,7 +495,7 @@ class ChannelHeader extends React.PureComponent<Props, State> {
                             placement='bottom'
                             rootClose={true}
                             target={this.headerDescriptionRef.current as React.ReactInstance}
-                            ref={this.headerOverlayRef}
+                            ref={this.headerOverlayRef as any}
                             onHide={() => this.setState({showChannelHeaderPopover: false})}
                         >
                             {popoverContent}

--- a/webapp/channels/src/components/suggestion/switch_channel_provider.test.tsx
+++ b/webapp/channels/src/components/suggestion/switch_channel_provider.test.tsx
@@ -151,6 +151,7 @@ describe('components/SwitchChannelProvider', () => {
             type: 'O',
             name: 'other_user',
             display_name: 'other_user',
+            update_at: 0,
             delete_at: 0,
         },
         {
@@ -158,6 +159,7 @@ describe('components/SwitchChannelProvider', () => {
             type: 'D',
             name: 'current_user_id__other_user',
             display_name: 'other_user',
+            update_at: 0,
             delete_at: 0,
         }];
         const searchText = 'other';
@@ -194,6 +196,7 @@ describe('components/SwitchChannelProvider', () => {
             type: 'O',
             name: 'other_user',
             display_name: 'other_user',
+            update_at: 0,
             delete_at: 0,
         }];
         const searchText = 'other';
@@ -226,6 +229,7 @@ describe('components/SwitchChannelProvider', () => {
             type: 'O',
             name: 'other_user',
             display_name: 'other_user',
+            update_at: 0,
             delete_at: 0,
         },
         {
@@ -233,6 +237,7 @@ describe('components/SwitchChannelProvider', () => {
             type: 'D',
             name: 'current_user_id__other_user',
             display_name: 'other_user',
+            update_at: 0,
             delete_at: 0,
         }];
         const searchText = 'something else';
@@ -833,6 +838,7 @@ describe('components/SwitchChannelProvider', () => {
             type: 'G',
             name: 'other_gm_channel',
             delete_at: 0,
+            update_at: 0,
             display_name: 'other_user1, current_user_id',
         }];
 

--- a/webapp/channels/src/components/suggestion/switch_channel_provider.tsx
+++ b/webapp/channels/src/components/suggestion/switch_channel_provider.tsx
@@ -74,10 +74,11 @@ const ThreadsChannel: FakeChannel = {
     name: 'threads',
     display_name: 'Threads',
     type: Constants.THREADS,
+    update_at: 0,
     delete_at: 0,
 };
 
-type FakeChannel = Pick<Channel, 'id' | 'name' | 'display_name' | 'delete_at'> & {
+type FakeChannel = Pick<Channel, 'id' | 'name' | 'display_name' | 'update_at' | 'delete_at'> & {
     type: string;
 }
 

--- a/webapp/channels/src/packages/mattermost-redux/src/utils/file_utils.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/utils/file_utils.ts
@@ -14,7 +14,7 @@ export function getFormattedFileSize(file: FileInfo): string {
         ['GB', 1024 * 1024 * 1024],
         ['MB', 1024 * 1024],
         ['KB', 1024],
-    ];
+    ] as const;
     const size = fileSizes.find((unitAndMinBytes) => {
         const minBytes = unitAndMinBytes[1];
         return bytes > minBytes;

--- a/webapp/channels/src/types/external/react-bootstrap.d.ts
+++ b/webapp/channels/src/types/external/react-bootstrap.d.ts
@@ -11,6 +11,7 @@ import type {OverlayTriggerProps} from 'react-bootstrap';
 export interface AdditionalOverlayTriggerProps extends React.ComponentPropsWithRef<typeof OverlayTriggerProps> {
 
     className?: string;
+    overlay: any;
 }
 
 declare class OverlayTrigger extends React.Component<AdditionalOverlayTriggerProps> {}

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -14,7 +14,7 @@
         "platform/types"
       ],
       "dependencies": {
-        "react-intl": "6.5.5"
+        "react-intl": "6.6.2"
       },
       "devDependencies": {
         "@babel/core": "7.21.8",
@@ -33,7 +33,7 @@
         "css-loader": "6.7.3",
         "eslint": "8.37.0",
         "eslint-import-resolver-webpack": "0.13.2",
-        "eslint-plugin-formatjs": "4.9.1",
+        "eslint-plugin-formatjs": "4.12.2",
         "mini-css-extract-plugin": "2.7.5",
         "sass": "1.62.1",
         "sass-loader": "13.2.2",
@@ -144,7 +144,7 @@
         "timezones.json": "1.6.1",
         "tinycolor2": "1.4.2",
         "turndown": "7.1.1",
-        "typescript": "4.9.5",
+        "typescript": "5.3.3",
         "zen-observable": "0.9.0"
       },
       "devDependencies": {
@@ -2420,7 +2420,8 @@
     },
     "node_modules/@formatjs/fast-memoize": {
       "version": "2.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.0.tgz",
+      "integrity": "sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2445,19 +2446,20 @@
       }
     },
     "node_modules/@formatjs/intl": {
-      "version": "2.9.9",
-      "license": "MIT",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.10.0.tgz",
+      "integrity": "sha512-X3xT9guVkKDS86EKV80lS0KxoazUglkJTGZO66sKY7otgl0VeStPA8B3u8UkKT47PexVV98fUzjpkchYmbe9nw==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.0",
+        "@formatjs/ecma402-abstract": "1.18.2",
         "@formatjs/fast-memoize": "2.2.0",
-        "@formatjs/icu-messageformat-parser": "2.7.3",
-        "@formatjs/intl-displaynames": "6.6.4",
-        "@formatjs/intl-listformat": "7.5.3",
-        "intl-messageformat": "10.5.8",
+        "@formatjs/icu-messageformat-parser": "2.7.6",
+        "@formatjs/intl-displaynames": "6.6.6",
+        "@formatjs/intl-listformat": "7.5.5",
+        "intl-messageformat": "10.5.11",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
-        "typescript": "5"
+        "typescript": "^4.7 || 5"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2466,49 +2468,55 @@
       }
     },
     "node_modules/@formatjs/intl-displaynames": {
-      "version": "6.6.4",
-      "license": "MIT",
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.6.6.tgz",
+      "integrity": "sha512-Dg5URSjx0uzF8VZXtHb6KYZ6LFEEhCbAbKoYChYHEOnMFTw/ZU3jIo/NrujzQD2EfKPgQzIq73LOUvW6Z/LpFA==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.0",
-        "@formatjs/intl-localematcher": "0.5.2",
+        "@formatjs/ecma402-abstract": "1.18.2",
+        "@formatjs/intl-localematcher": "0.5.4",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@formatjs/intl-displaynames/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.18.0",
-      "license": "MIT",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.2.tgz",
+      "integrity": "sha512-+QoPW4csYALsQIl8GbN14igZzDbuwzcpWrku9nyMXlaqAlwRBgl5V+p0vWMGFqHOw37czNXaP/lEk4wbLgcmtA==",
       "dependencies": {
-        "@formatjs/intl-localematcher": "0.5.2",
+        "@formatjs/intl-localematcher": "0.5.4",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@formatjs/intl-displaynames/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.2",
-      "license": "MIT",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.4.tgz",
+      "integrity": "sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@formatjs/intl-listformat": {
-      "version": "7.5.3",
-      "license": "MIT",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.5.5.tgz",
+      "integrity": "sha512-XoI52qrU6aBGJC9KJddqnacuBbPlb/bXFN+lIFVFhQ1RnFHpzuFrlFdjD9am2O7ZSYsyqzYRpkVcXeT1GHkwDQ==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.0",
-        "@formatjs/intl-localematcher": "0.5.2",
+        "@formatjs/ecma402-abstract": "1.18.2",
+        "@formatjs/intl-localematcher": "0.5.4",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@formatjs/intl-listformat/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.18.0",
-      "license": "MIT",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.2.tgz",
+      "integrity": "sha512-+QoPW4csYALsQIl8GbN14igZzDbuwzcpWrku9nyMXlaqAlwRBgl5V+p0vWMGFqHOw37czNXaP/lEk4wbLgcmtA==",
       "dependencies": {
-        "@formatjs/intl-localematcher": "0.5.2",
+        "@formatjs/intl-localematcher": "0.5.4",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@formatjs/intl-listformat/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.2",
-      "license": "MIT",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.4.tgz",
+      "integrity": "sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2522,33 +2530,37 @@
       }
     },
     "node_modules/@formatjs/intl/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.18.0",
-      "license": "MIT",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.2.tgz",
+      "integrity": "sha512-+QoPW4csYALsQIl8GbN14igZzDbuwzcpWrku9nyMXlaqAlwRBgl5V+p0vWMGFqHOw37czNXaP/lEk4wbLgcmtA==",
       "dependencies": {
-        "@formatjs/intl-localematcher": "0.5.2",
+        "@formatjs/intl-localematcher": "0.5.4",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@formatjs/intl/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.7.3",
-      "license": "MIT",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.6.tgz",
+      "integrity": "sha512-etVau26po9+eewJKYoiBKP6743I1br0/Ie00Pb/S/PtmYfmjTcOn2YCh2yNkSZI12h6Rg+BOgQYborXk46BvkA==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.0",
-        "@formatjs/icu-skeleton-parser": "1.7.0",
+        "@formatjs/ecma402-abstract": "1.18.2",
+        "@formatjs/icu-skeleton-parser": "1.8.0",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@formatjs/intl/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.7.0",
-      "license": "MIT",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.0.tgz",
+      "integrity": "sha512-QWLAYvM0n8hv7Nq5BEs4LKIjevpVpbGLAJgOaYzg9wABEoX1j0JO1q2/jVkO6CVlq0dbsxZCngS5aXbysYueqA==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.0",
+        "@formatjs/ecma402-abstract": "1.18.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@formatjs/intl/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.2",
-      "license": "MIT",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.4.tgz",
+      "integrity": "sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -4113,11 +4125,6 @@
       "resolved": "platform/types",
       "link": true
     },
-    "node_modules/@mdn/browser-compat-data": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
     "node_modules/@mui/base": {
       "version": "5.0.0-alpha.127",
       "license": "MIT",
@@ -4532,23 +4539,49 @@
       }
     },
     "node_modules/@rollup/plugin-typescript": {
-      "version": "8.5.0",
+      "version": "11.1.6",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.6.tgz",
+      "integrity": "sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
-        "resolve": "^1.17.0"
+        "@rollup/pluginutils": "^5.1.0",
+        "resolve": "^1.22.1"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^2.14.0",
+        "rollup": "^2.14.0||^3.0.0||^4.0.0",
         "tslib": "*",
         "typescript": ">=3.7.0"
       },
       "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
         "tslib": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-typescript/node_modules/@rollup/pluginutils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
           "optional": true
         }
       }
@@ -5201,11 +5234,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/object-path": {
-      "version": "0.11.4",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "license": "MIT"
@@ -5494,11 +5522,6 @@
     },
     "node_modules/@types/turndown": {
       "version": "5.0.1",
-      "license": "MIT"
-    },
-    "node_modules/@types/ua-parser-js": {
-      "version": "0.7.39",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/unist": {
@@ -5929,14 +5952,6 @@
         "webpack-dev-server": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@wessberg/stringutil": {
-      "version": "1.0.19",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@xobotyi/scrollbar-width": {
@@ -7458,72 +7473,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/browserslist-generator": {
-      "version": "1.0.66",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mdn/browser-compat-data": "^4.1.16",
-        "@types/object-path": "^0.11.1",
-        "@types/semver": "^7.3.9",
-        "@types/ua-parser-js": "^0.7.36",
-        "browserslist": "4.20.2",
-        "caniuse-lite": "^1.0.30001328",
-        "isbot": "3.4.5",
-        "object-path": "^0.11.8",
-        "semver": "^7.3.7",
-        "ua-parser-js": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/wessberg/browserslist-generator?sponsor=1"
-      }
-    },
-    "node_modules/browserslist-generator/node_modules/browserslist": {
-      "version": "4.20.2",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001317",
-        "electron-to-chromium": "^1.4.84",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.2",
-        "picocolors": "^1.0.0"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/browserslist-generator/node_modules/semver": {
-      "version": "7.5.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/bser": {
       "version": "2.1.1",
       "dev": true,
@@ -8088,20 +8037,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/compatfactory": {
-      "version": "0.0.13",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "helpertypes": "^0.0.18"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=3.x || >= 4.x"
-      }
-    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "dev": true,
@@ -8495,22 +8430,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crosspath": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^16.11.7"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/crosspath/node_modules/@types/node": {
-      "version": "16.18.65",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/crypto-browserify": {
       "version": "3.12.0",
@@ -10059,66 +9978,80 @@
       }
     },
     "node_modules/eslint-plugin-formatjs": {
-      "version": "4.9.1",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-formatjs/-/eslint-plugin-formatjs-4.12.2.tgz",
+      "integrity": "sha512-b4iEsi0Y3zy7J6xjxlhrIaDFJa27OiLwardvCRBRHALoZs8rNJ0oQIW6ymUgELLEMeFuEMAd2837M+n5SHJutg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@formatjs/icu-messageformat-parser": "2.3.0",
-        "@formatjs/ts-transformer": "3.12.0",
+        "@formatjs/icu-messageformat-parser": "2.7.6",
+        "@formatjs/ts-transformer": "3.13.12",
         "@types/eslint": "7 || 8",
         "@types/picomatch": "^2.3.0",
-        "@typescript-eslint/typescript-estree": "5.45.0",
+        "@typescript-eslint/utils": "^6.18.1",
         "emoji-regex": "^10.2.1",
-        "magic-string": "^0.29.0",
+        "magic-string": "^0.30.0",
         "picomatch": "^2.3.1",
-        "tslib": "2.4.0",
-        "typescript": "^4.7",
-        "unicode-emoji-utils": "^1.1.1"
+        "tslib": "2.6.2",
+        "typescript": "5",
+        "unicode-emoji-utils": "^1.2.0"
       },
       "peerDependencies": {
         "eslint": "7 || 8"
       }
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.14.3",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.2.tgz",
+      "integrity": "sha512-+QoPW4csYALsQIl8GbN14igZzDbuwzcpWrku9nyMXlaqAlwRBgl5V+p0vWMGFqHOw37czNXaP/lEk4wbLgcmtA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@formatjs/intl-localematcher": "0.2.32",
+        "@formatjs/intl-localematcher": "0.5.4",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.3.0",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.6.tgz",
+      "integrity": "sha512-etVau26po9+eewJKYoiBKP6743I1br0/Ie00Pb/S/PtmYfmjTcOn2YCh2yNkSZI12h6Rg+BOgQYborXk46BvkA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.14.3",
-        "@formatjs/icu-skeleton-parser": "1.3.18",
+        "@formatjs/ecma402-abstract": "1.18.2",
+        "@formatjs/icu-skeleton-parser": "1.8.0",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.3.18",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.0.tgz",
+      "integrity": "sha512-QWLAYvM0n8hv7Nq5BEs4LKIjevpVpbGLAJgOaYzg9wABEoX1j0JO1q2/jVkO6CVlq0dbsxZCngS5aXbysYueqA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/ecma402-abstract": "1.18.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.4.tgz",
+      "integrity": "sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/ts-transformer": {
-      "version": "3.12.0",
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.13.12.tgz",
+      "integrity": "sha512-uf1+DgbsCrzHAg7uIf0QlzpIkHYxRSRig5iJa9FaoUNIDZzNEE2oW/uLLLq7I9Z2FLIPhbmgq8hbW40FoQv+Fg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@formatjs/icu-messageformat-parser": "2.3.0",
+        "@formatjs/icu-messageformat-parser": "2.7.6",
         "@types/json-stable-stringify": "^1.0.32",
         "@types/node": "14 || 16 || 17",
         "chalk": "^4.0.0",
         "json-stable-stringify": "^1.0.1",
         "tslib": "^2.4.0",
-        "typescript": "^4.7"
+        "typescript": "5"
       },
       "peerDependencies": {
         "ts-jest": ">=27"
@@ -10131,15 +10064,40 @@
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@types/node": {
       "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/types": {
-      "version": "5.45.0",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10147,20 +10105,22 @@
       }
     },
     "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.45.0",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "5.45.0",
-        "@typescript-eslint/visitor-keys": "5.45.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10172,26 +10132,77 @@
         }
       }
     },
-    "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.45.0",
+    "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "5.45.0",
-        "eslint-visitor-keys": "^3.3.0"
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/eslint-plugin-formatjs/node_modules/semver": {
-      "version": "7.5.4",
+    "node_modules/eslint-plugin-formatjs/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
-      "license": "ISC",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -10201,11 +10212,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/eslint-plugin-formatjs/node_modules/tslib": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/eslint-plugin-header": {
       "version": "3.1.1",
@@ -11980,14 +11986,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/helpertypes": {
-      "version": "0.0.18",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/highlight.js": {
       "version": "11.6.0",
       "license": "BSD-3-Clause",
@@ -12847,43 +12845,48 @@
       "license": "Apache-2.0"
     },
     "node_modules/intl-messageformat": {
-      "version": "10.5.8",
-      "license": "BSD-3-Clause",
+      "version": "10.5.11",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.11.tgz",
+      "integrity": "sha512-eYq5fkFBVxc7GIFDzpFQkDOZgNayNTQn4Oufe8jw6YY6OHVw70/4pA3FyCsQ0Gb2DnvEJEMmN2tOaXUGByM+kg==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.0",
+        "@formatjs/ecma402-abstract": "1.18.2",
         "@formatjs/fast-memoize": "2.2.0",
-        "@formatjs/icu-messageformat-parser": "2.7.3",
+        "@formatjs/icu-messageformat-parser": "2.7.6",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/intl-messageformat/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.18.0",
-      "license": "MIT",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.2.tgz",
+      "integrity": "sha512-+QoPW4csYALsQIl8GbN14igZzDbuwzcpWrku9nyMXlaqAlwRBgl5V+p0vWMGFqHOw37czNXaP/lEk4wbLgcmtA==",
       "dependencies": {
-        "@formatjs/intl-localematcher": "0.5.2",
+        "@formatjs/intl-localematcher": "0.5.4",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/intl-messageformat/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.7.3",
-      "license": "MIT",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.6.tgz",
+      "integrity": "sha512-etVau26po9+eewJKYoiBKP6743I1br0/Ie00Pb/S/PtmYfmjTcOn2YCh2yNkSZI12h6Rg+BOgQYborXk46BvkA==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.0",
-        "@formatjs/icu-skeleton-parser": "1.7.0",
+        "@formatjs/ecma402-abstract": "1.18.2",
+        "@formatjs/icu-skeleton-parser": "1.8.0",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/intl-messageformat/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.7.0",
-      "license": "MIT",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.0.tgz",
+      "integrity": "sha512-QWLAYvM0n8hv7Nq5BEs4LKIjevpVpbGLAJgOaYzg9wABEoX1j0JO1q2/jVkO6CVlq0dbsxZCngS5aXbysYueqA==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.0",
+        "@formatjs/ecma402-abstract": "1.18.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/intl-messageformat/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.2",
-      "license": "MIT",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.4.tgz",
+      "integrity": "sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -13501,14 +13504,6 @@
     "node_modules/isarray": {
       "version": "2.0.5",
       "license": "MIT"
-    },
-    "node_modules/isbot": {
-      "version": "3.4.5",
-      "dev": true,
-      "license": "Unlicense",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -16470,11 +16465,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.29.0",
+      "version": "0.30.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.7.tgz",
+      "integrity": "sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       },
       "engines": {
         "node": ">=12"
@@ -17516,14 +17512,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/object-path": {
-      "version": "0.11.8",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.12.0"
       }
     },
     "node_modules/object.assign": {
@@ -19286,23 +19274,24 @@
       }
     },
     "node_modules/react-intl": {
-      "version": "6.5.5",
-      "license": "BSD-3-Clause",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.6.2.tgz",
+      "integrity": "sha512-IpW2IkLtGENSFlX3vfH11rjuCIsW0VyjT0Q1pPKMZPtT2z1FxLt4weFT5Ezti2TScT1xiyb3aQBFth9EB7jzAg==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.0",
-        "@formatjs/icu-messageformat-parser": "2.7.3",
-        "@formatjs/intl": "2.9.9",
-        "@formatjs/intl-displaynames": "6.6.4",
-        "@formatjs/intl-listformat": "7.5.3",
+        "@formatjs/ecma402-abstract": "1.18.2",
+        "@formatjs/icu-messageformat-parser": "2.7.6",
+        "@formatjs/intl": "2.10.0",
+        "@formatjs/intl-displaynames": "6.6.6",
+        "@formatjs/intl-listformat": "7.5.5",
         "@types/hoist-non-react-statics": "^3.3.1",
         "@types/react": "16 || 17 || 18",
         "hoist-non-react-statics": "^3.3.2",
-        "intl-messageformat": "10.5.8",
+        "intl-messageformat": "10.5.11",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
         "react": "^16.6.0 || 17 || 18",
-        "typescript": "5"
+        "typescript": "^4.7 || 5"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -19311,33 +19300,37 @@
       }
     },
     "node_modules/react-intl/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.18.0",
-      "license": "MIT",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.2.tgz",
+      "integrity": "sha512-+QoPW4csYALsQIl8GbN14igZzDbuwzcpWrku9nyMXlaqAlwRBgl5V+p0vWMGFqHOw37czNXaP/lEk4wbLgcmtA==",
       "dependencies": {
-        "@formatjs/intl-localematcher": "0.5.2",
+        "@formatjs/intl-localematcher": "0.5.4",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/react-intl/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.7.3",
-      "license": "MIT",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.6.tgz",
+      "integrity": "sha512-etVau26po9+eewJKYoiBKP6743I1br0/Ie00Pb/S/PtmYfmjTcOn2YCh2yNkSZI12h6Rg+BOgQYborXk46BvkA==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.0",
-        "@formatjs/icu-skeleton-parser": "1.7.0",
+        "@formatjs/ecma402-abstract": "1.18.2",
+        "@formatjs/icu-skeleton-parser": "1.8.0",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/react-intl/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.7.0",
-      "license": "MIT",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.0.tgz",
+      "integrity": "sha512-QWLAYvM0n8hv7Nq5BEs4LKIjevpVpbGLAJgOaYzg9wABEoX1j0JO1q2/jVkO6CVlq0dbsxZCngS5aXbysYueqA==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.0",
+        "@formatjs/ecma402-abstract": "1.18.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/react-intl/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.2",
-      "license": "MIT",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.4.tgz",
+      "integrity": "sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -20387,86 +20380,6 @@
       "license": "MIT",
       "dependencies": {
         "rollup-pluginutils": "^2.3.3"
-      }
-    },
-    "node_modules/rollup-plugin-ts": {
-      "version": "2.0.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^4.2.0",
-        "@wessberg/stringutil": "^1.0.19",
-        "browserslist": "^4.20.2",
-        "browserslist-generator": "^1.0.66",
-        "chalk": "4.1.2",
-        "compatfactory": "^0.0.13",
-        "crosspath": "1.0.0",
-        "magic-string": "^0.26.1",
-        "ts-clone-node": "^0.3.32",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=7.0.0",
-        "pnpm": ">=3.2.0",
-        "yarn": ">=1.13"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/wessberg/rollup-plugin-ts?sponsor=1"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=6.x || >=7.x",
-        "@babel/plugin-transform-runtime": ">=6.x || >=7.x",
-        "@babel/preset-env": ">=6.x || >=7.x",
-        "@babel/runtime": ">=6.x || >=7.x",
-        "@swc/core": ">=1.x",
-        "@swc/helpers": ">=0.2",
-        "rollup": ">=1.x || >=2.x",
-        "typescript": ">=3.2.x || >= 4.x"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@babel/plugin-transform-runtime": {
-          "optional": true
-        },
-        "@babel/preset-env": {
-          "optional": true
-        },
-        "@babel/runtime": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/helpers": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/rollup-plugin-ts/node_modules/@rollup/pluginutils": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "estree-walker": "^2.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/rollup-plugin-ts/node_modules/magic-string": {
-      "version": "0.26.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/rollup-pluginutils": {
@@ -22634,22 +22547,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/ts-clone-node": {
-      "version": "0.3.32",
+    "node_modules/ts-api-utils": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
+      "integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "compatfactory": "^0.0.13"
-      },
       "engines": {
-        "node": ">=10.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/wessberg/ts-clone-node?sponsor=1"
+        "node": ">=16"
       },
       "peerDependencies": {
-        "typescript": "^3.x || ^4.x"
+        "typescript": ">=4.2.0"
       }
     },
     "node_modules/ts-easing": {
@@ -22835,36 +22742,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "license": "Apache-2.0",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/ua-parser-js": {
-      "version": "1.0.37",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": "*"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -24021,11 +23907,12 @@
         "form-data": "^4.0.0"
       },
       "devDependencies": {
-        "jest": "27.1.0"
+        "jest": "27.1.0",
+        "typescript": "^5.0.0"
       },
       "peerDependencies": {
-        "@mattermost/types": "*",
-        "typescript": "^4.3"
+        "@mattermost/types": "9.3.0",
+        "typescript": "^4.3.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -25367,7 +25254,7 @@
         "@rollup/plugin-babel": "^5.3.1",
         "@rollup/plugin-commonjs": "^21.0.2",
         "@rollup/plugin-node-resolve": "^13.1.3",
-        "@rollup/plugin-typescript": "^8.3.1",
+        "@rollup/plugin-typescript": "11.1.6",
         "@testing-library/jest-dom": "5.16.4",
         "@types/lodash": "^4.14.178",
         "@types/react": "^17.0.71",
@@ -25380,8 +25267,7 @@
         "rollup-plugin-auto-external": "^2.0.0",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-scss": "^3.0.0",
-        "rollup-plugin-ts": "^2.0.5",
-        "typescript": "^4.3.4"
+        "typescript": "^5.0.0"
       },
       "peerDependencies": {
         "@babel/runtime-corejs3": "^7.17.8",
@@ -25394,7 +25280,7 @@
         "react": "^17.0.2",
         "react-bootstrap": "github:mattermost/react-bootstrap#d821e2b1db1059bd36112d7587fd1b0912b27626",
         "react-dom": "^17.0.2",
-        "react-intl": "^6.3.2",
+        "react-intl": "*",
         "shallow-equals": "^1.0.0",
         "styled-components": "^5.3.5",
         "tippy.js": "^6.3.7"
@@ -25423,8 +25309,11 @@
       "name": "@mattermost/types",
       "version": "9.3.0",
       "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.0.0"
+      },
       "peerDependencies": {
-        "typescript": "^4.3"
+        "typescript": "^4.3.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -19,7 +19,7 @@
     "clean": "npm run clean --workspaces --if-present"
   },
   "dependencies": {
-    "react-intl": "6.5.5"
+    "react-intl": "6.6.2"
   },
   "devDependencies": {
     "@babel/core": "7.21.8",
@@ -38,7 +38,7 @@
     "css-loader": "6.7.3",
     "eslint": "8.37.0",
     "eslint-import-resolver-webpack": "0.13.2",
-    "eslint-plugin-formatjs": "4.9.1",
+    "eslint-plugin-formatjs": "4.12.2",
     "mini-css-extract-plugin": "2.7.5",
     "sass": "1.62.1",
     "sass-loader": "13.2.2",

--- a/webapp/platform/client/package.json
+++ b/webapp/platform/client/package.json
@@ -20,9 +20,13 @@
   "dependencies": {
     "form-data": "^4.0.0"
   },
+  "devDependencies": {
+    "jest": "27.1.0",
+    "typescript": "^5.0.0"
+  },
   "peerDependencies": {
-    "@mattermost/types": "*",
-    "typescript": "^4.3"
+    "@mattermost/types": "9.3.0",
+    "typescript": "^4.3.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {
@@ -35,8 +39,5 @@
     "test": "jest",
     "test-ci": "jest --ci --forceExit --detectOpenHandles --maxWorkers=100%",
     "clean": "rm -rf lib node_modules tsconfig.tsbuildinfo"
-  },
-  "devDependencies": {
-    "jest": "27.1.0"
   }
 }

--- a/webapp/platform/components/package.json
+++ b/webapp/platform/components/package.json
@@ -18,7 +18,7 @@
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^21.0.2",
     "@rollup/plugin-node-resolve": "^13.1.3",
-    "@rollup/plugin-typescript": "^8.3.1",
+    "@rollup/plugin-typescript": "11.1.6",
     "@testing-library/jest-dom": "5.16.4",
     "@types/lodash": "^4.14.178",
     "@types/react": "^17.0.71",
@@ -31,8 +31,7 @@
     "rollup-plugin-auto-external": "^2.0.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-scss": "^3.0.0",
-    "rollup-plugin-ts": "^2.0.5",
-    "typescript": "^4.3.4"
+    "typescript": "^5.0.0"
   },
   "peerDependencies": {
     "@babel/runtime-corejs3": "^7.17.8",
@@ -45,7 +44,7 @@
     "react": "^17.0.2",
     "react-bootstrap": "github:mattermost/react-bootstrap#d821e2b1db1059bd36112d7587fd1b0912b27626",
     "react-dom": "^17.0.2",
-    "react-intl": "^6.3.2",
+    "react-intl": "*",
     "shallow-equals": "^1.0.0",
     "styled-components": "^5.3.5",
     "tippy.js": "^6.3.7"

--- a/webapp/platform/types/package.json
+++ b/webapp/platform/types/package.json
@@ -25,8 +25,11 @@
     "url": "github:mattermost/mattermost-server",
     "directory": "webapp/platform/types"
   },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  },
   "peerDependencies": {
-    "typescript": "^4.3"
+    "typescript": "^4.3.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {


### PR DESCRIPTION
#### Summary
This was a straightforward enough upgrade. There's a couple places where TS is slightly stricter which I needed to update, but none of them seem particularly notable.

I haven't really looked at all the new features from this, but I see that they made improvements to enums and have at least started work on `using`, so those will be neat to play with eventually.

#### Ticket Link
MM-57037

#### Release Note
```release-note
Upgraded `@mattermost/client` and `@mattermost/types` to support TypeScript 5.x
```
