### PR TITLE
MM-56948 Fix flaky TestUserHasJoinedChannel

### DIFF
--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -2018,12 +2018,21 @@ func TestUserHasJoinedChannel(t *testing.T) {
 		})
 		require.Nil(t, appErr)
 
-		assert.EventuallyWithT(t, func(t *assert.CollectT) {
-			posts, appErr := th.App.GetPosts(channel.Id, 0, 1)
+		expectedMessage := fmt.Sprintf("Test: User %s added to %s by %s", user2.Id, channel.Id, user1.Id)
+		assert.Eventually(t, func() bool {
+			posts, appErr := th.App.GetPosts(channel.Id, 0, 10)
 
 			require.Nil(t, appErr)
 
-			assert.Equal(t, fmt.Sprintf("Test: User %s added to %s by %s", user2.Id, channel.Id, user1.Id), posts.Posts[posts.Order[0]].Message)
+			for _, postId := range posts.Order {
+				post := posts.Posts[postId]
+
+				if post.Message == expectedMessage {
+					return true
+				}
+			}
+
+			return false
 		}, 1*time.Second, 10*time.Millisecond)
 	})
 


### PR DESCRIPTION
#### Summary
One time, the "User has joined the channel" message appeared after the plugin post which caused this to fail. Checking more than just the last post prevents this from failing that way.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56948

#### Release Note
```release-note
NONE
```
