### PR TITLE
Fix several re-renders on init

### DIFF
--- a/webapp/channels/src/components/advanced_create_post/advanced_create_post.tsx
+++ b/webapp/channels/src/components/advanced_create_post/advanced_create_post.tsx
@@ -83,7 +83,7 @@ export type Props = {
     currentChannelMembersCount: number;
 
     // Data used in multiple places of the component
-    currentChannel: Channel;
+    currentChannel?: Channel;
 
     //Data used for DM prewritten messages
     currentChannelTeammateUsername?: string;
@@ -238,7 +238,7 @@ type State = {
     uploadsProgressPercent: {[clientID: string]: FilePreviewInfo};
     renderScrollbar: boolean;
     scrollbarWidth: number;
-    currentChannel: Channel;
+    currentChannel?: Channel;
     errorClass: string | null;
     serverError: (ServerError & {submittedMessage?: string}) | null;
     postError?: React.ReactNode;
@@ -270,7 +270,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             currentChannel: props.currentChannel,
         };
         if (
-            props.currentChannel.id !== state.currentChannel.id ||
+            props.currentChannel?.id !== state.currentChannel?.id ||
             (props.isRemoteDraft && props.draft.message !== state.message)
         ) {
             updatedState = {
@@ -320,14 +320,14 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
 
     componentDidUpdate(prevProps: Props, prevState: State) {
         const {currentChannel, actions} = this.props;
-        if (prevProps.currentChannel.id !== currentChannel.id) {
+        if (prevProps.currentChannel?.id !== currentChannel?.id) {
             this.lastChannelSwitchAt = Date.now();
             this.focusTextbox();
             this.saveDraftWithShow(prevProps);
             this.getChannelMemberCountsByGroup();
         }
 
-        if (currentChannel.id !== prevProps.currentChannel.id) {
+        if (currentChannel?.id !== prevProps.currentChannel?.id) {
             actions.setShowPreview(false);
         }
 
@@ -355,7 +355,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
     getChannelMemberCountsByGroup = () => {
         const {useLDAPGroupMentions, useCustomGroupMentions, currentChannel, actions, draft} = this.props;
 
-        if ((useLDAPGroupMentions || useCustomGroupMentions) && currentChannel.id) {
+        if ((useLDAPGroupMentions || useCustomGroupMentions) && currentChannel?.id) {
             const mentions = mentionsMinusSpecialMentionsInText(draft.message);
 
             if (mentions.length === 1) {
@@ -457,7 +457,11 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
     };
 
     doSubmit = async (e?: React.FormEvent) => {
-        const channelId = this.props.currentChannel.id;
+        const channelId = this.props.currentChannel?.id;
+        if (!channelId) {
+            return;
+        }
+
         if (e) {
             e.preventDefault();
         }
@@ -627,6 +631,10 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             useCustomGroupMentions,
         } = this.props;
 
+        if (!updateChannel) {
+            return;
+        }
+
         this.setShowPreview(false);
         this.isDraftSubmitting = true;
 
@@ -670,7 +678,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
                 }
             }
 
-            const {data} = await this.props.actions.getChannelTimezones(this.props.currentChannel.id);
+            const {data} = await this.props.actions.getChannelTimezones(updateChannel.id);
             channelTimezoneCount = data ? data.length : 0;
         }
 
@@ -746,6 +754,10 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             groupsWithAllowReference,
             useCustomGroupMentions,
         } = this.props;
+
+        if (!currentChannel) {
+            return {data: false};
+        }
 
         let post = originalPost;
 
@@ -863,6 +875,9 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
     };
 
     emitTypingEvent = () => {
+        if (!this.props.currentChannel) {
+            return;
+        }
         const channelId = this.props.currentChannel.id;
         GlobalActions.emitLocalUserTypingEvent(channelId, '');
     };
@@ -888,7 +903,11 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
         this.handleDraftChange(draft);
     };
 
-    handleDraftChange = (draft: PostDraft, channelId = this.props.currentChannel.id, instant = false) => {
+    handleDraftChange = (draft: PostDraft, channelId = this.props.currentChannel?.id, instant = false) => {
+        if (!channelId) {
+            return;
+        }
+
         if (this.saveDraftFrame) {
             clearTimeout(this.saveDraftFrame);
         }
@@ -904,7 +923,10 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
         this.draftsForChannel[channelId] = draft;
     };
 
-    removeDraft = (channelId = this.props.currentChannel.id) => {
+    removeDraft = (channelId = this.props.currentChannel?.id) => {
+        if (!channelId) {
+            return;
+        }
         this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, null, channelId);
         this.draftsForChannel[channelId] = null;
     };
@@ -1017,7 +1039,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             };
         }
 
-        this.handleDraftChange(modifiedDraft, this.props.currentChannel.id, true);
+        this.handleDraftChange(modifiedDraft, this.props.currentChannel?.id, true);
         this.handleFileUploadChange();
 
         if (this.saveDraftFrame) {
@@ -1279,7 +1301,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             updatedDraft.metadata = {};
         }
 
-        this.handleDraftChange(updatedDraft, this.props.currentChannel.id, true);
+        this.handleDraftChange(updatedDraft, this.props.currentChannel?.id, true);
         this.focusTextbox();
     };
 
@@ -1308,7 +1330,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             return true;
         }
 
-        if (currentChannel.type === Constants.DM_CHANNEL) {
+        if (currentChannel?.type === Constants.DM_CHANNEL) {
             return true;
         }
 

--- a/webapp/channels/src/components/advanced_create_post/index.ts
+++ b/webapp/channels/src/components/advanced_create_post/index.ts
@@ -65,10 +65,10 @@ function makeMapStateToProps() {
     return (state: GlobalState) => {
         const config = getConfig(state);
         const license = getLicense(state);
-        const currentChannel = getCurrentChannel(state) || {};
-        const currentChannelTeammateUsername = getUser(state, currentChannel.teammate_id || '')?.username;
-        const draft = getChannelDraft(state, currentChannel.id);
-        const isRemoteDraft = state.views.drafts.remotes[`${StoragePrefixes.DRAFT}${currentChannel.id}`] || false;
+        const currentChannel = getCurrentChannel(state);
+        const currentChannelTeammateUsername = getUser(state, currentChannel?.teammate_id || '')?.username;
+        const draft = getChannelDraft(state, currentChannel?.id);
+        const isRemoteDraft = state.views.drafts.remotes[`${StoragePrefixes.DRAFT}${currentChannel?.id}`] || false;
         const latestReplyablePostId = getLatestReplyablePostId(state);
         const currentChannelMembersCount = getCurrentChannelStats(state) ? getCurrentChannelStats(state).member_count : 1;
         const enableEmojiPicker = config.EnableEmojiPicker === 'true';
@@ -82,9 +82,9 @@ function makeMapStateToProps() {
         const isLDAPEnabled = license?.IsLicensed === 'true' && license?.LDAPGroups === 'true';
         const useCustomGroupMentions = isCustomGroupsEnabled(state) && haveICurrentChannelPermission(state, Permissions.USE_GROUP_MENTIONS);
         const useLDAPGroupMentions = isLDAPEnabled && haveICurrentChannelPermission(state, Permissions.USE_GROUP_MENTIONS);
-        const channelMemberCountsByGroup = selectChannelMemberCountsByGroup(state, currentChannel.id);
+        const channelMemberCountsByGroup = selectChannelMemberCountsByGroup(state, currentChannel?.id);
         const currentTeamId = getCurrentTeamId(state);
-        const groupsWithAllowReference = useLDAPGroupMentions || useCustomGroupMentions ? getAssociatedGroupsForReferenceByMention(state, currentTeamId, currentChannel.id) : null;
+        const groupsWithAllowReference = useLDAPGroupMentions || useCustomGroupMentions ? getAssociatedGroupsForReferenceByMention(state, currentTeamId, currentChannel?.id) : null;
         const enableTutorial = config.EnableTutorial === 'true';
         const tutorialStep = getInt(state, TutorialTourName.ONBOARDING_TUTORIAL_STEP, currentUserId, 0);
 

--- a/webapp/channels/src/components/common/hooks/useExpandOverageUsersCheck.ts
+++ b/webapp/channels/src/components/common/hooks/useExpandOverageUsersCheck.ts
@@ -31,7 +31,10 @@ export const useExpandOverageUsersCheck = ({
 }: UseExpandOverageUsersCheckArgs) => {
     const {formatMessage} = useIntl();
     const dispatch = useDispatch();
-    const {getRequestState, is_expandable: isExpandable}: LicenseSelfServeStatusReducer = useSelector((state: GlobalState) => state.entities.cloud.subscriptionStats || {is_expandable: false, getRequestState: 'IDLE'});
+    const {getRequestState, is_expandable: isExpandable}: LicenseSelfServeStatusReducer = useSelector(
+        (state: GlobalState) => state.entities.cloud.subscriptionStats || {is_expandable: false, getRequestState: 'IDLE'},
+        (a, b) => a.is_expandable === b.is_expandable && a.getRequestState === b.getRequestState,
+    );
     const expandableLink = useSelector(getExpandSeatsLink);
 
     const cta = useMemo(() => {

--- a/webapp/channels/src/components/common/hooks/useGetSelfHostedProducts.ts
+++ b/webapp/channels/src/components/common/hooks/useGetSelfHostedProducts.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useState, useEffect, useMemo} from 'react';
+import {useEffect, useMemo, useRef} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
 import type {Product} from '@mattermost/types/cloud';
@@ -19,14 +19,15 @@ export default function useGetSelfHostedProducts(): [Record<string, Product>, bo
     const products = useSelector(getSelfHostedProducts);
     const productsReceived = useSelector(getSelfHostedProductsLoaded);
     const dispatch = useDispatch();
-    const [requested, setRequested] = useState(false);
+    const requested = useRef(false);
 
     useEffect(() => {
-        if (isLoggedIn && !isCloud && !requested && !productsReceived) {
+        if (isLoggedIn && !isCloud && !requested.current && !productsReceived) {
             dispatch(getSelfHostedProductsAction());
-            setRequested(true);
+            requested.current = true;
         }
-    }, [isLoggedIn, isCloud, requested, productsReceived]);
+    }, [isLoggedIn, isCloud, productsReceived]);
+
     const result: [Record<string, Product>, boolean] = useMemo(() => {
         return [products, productsReceived];
     }, [products, productsReceived]);

--- a/webapp/channels/src/components/compass_theme_provider/compass_theme_provider.tsx
+++ b/webapp/channels/src/components/compass_theme_provider/compass_theme_provider.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useState, useEffect} from 'react';
+import React, {useMemo} from 'react';
 
 import ThemeProvider, {lightTheme} from '@mattermost/compass-components/utilities/theme'; // eslint-disable-line no-restricted-imports
 
@@ -12,45 +12,48 @@ type Props = {
     children?: React.ReactNode;
 }
 
-const CompassThemeProvider = ({theme, children}: Props): JSX.Element | null => {
-    const [compassTheme, setCompassTheme] = useState({
-        ...lightTheme,
-        noStyleReset: true,
-        noDefaultStyle: true,
-        noFontFaces: true,
-    });
+const CompassThemeProvider = ({
+    theme,
+    children,
+}: Props) => {
+    const compassTheme = useMemo(() => {
+        const base = {
+            ...lightTheme,
+            noStyleReset: true,
+            noDefaultStyle: true,
+            noFontFaces: true,
+        };
 
-    useEffect(() => {
-        setCompassTheme({
-            ...compassTheme,
+        return {
+            ...base,
             palette: {
-                ...compassTheme.palette,
+                ...base.palette,
                 primary: {
-                    ...compassTheme.palette.primary,
+                    ...base.palette.primary,
                     main: theme.sidebarHeaderBg,
                     contrast: theme.sidebarHeaderTextColor,
                 },
                 alert: {
-                    ...compassTheme.palette.alert,
+                    ...base.palette.alert,
                     main: theme.dndIndicator,
                 },
             },
             action: {
-                ...compassTheme.action,
+                ...base.action,
                 hover: theme.sidebarHeaderTextColor,
                 disabled: theme.sidebarHeaderTextColor,
             },
             badges: {
-                ...compassTheme.badges,
+                ...base.badges,
                 online: theme.onlineIndicator,
                 away: theme.awayIndicator,
                 dnd: theme.dndIndicator,
             },
             text: {
-                ...compassTheme.text,
+                ...base.text,
                 primary: theme.sidebarHeaderTextColor,
             },
-        });
+        };
     }, [theme]);
 
     return (

--- a/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist.tsx
+++ b/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist.tsx
@@ -161,11 +161,11 @@ const Skeleton = styled.div`
 `;
 
 const OnBoardingTaskList = (): JSX.Element | null => {
-    const myPreferences = useSelector((state: GlobalState) => getMyPreferencesSelector(state));
+    const hasPreferences = useSelector((state: GlobalState) => Object.keys(getMyPreferencesSelector(state)).length !== 0);
 
     useEffect(() => {
         dispatch(getPrevTrialLicense());
-        if (Object.keys(myPreferences).length === 0) {
+        if (!hasPreferences) {
             dispatch(getMyPreferences());
         }
     }, []);
@@ -182,7 +182,10 @@ const OnBoardingTaskList = (): JSX.Element | null => {
     const isCurrentUserSystemAdmin = useIsCurrentUserSystemAdmin();
     const isFirstAdmin = useFirstAdminUser();
     const isEnableOnboardingFlow = useSelector((state: GlobalState) => getConfig(state).EnableOnboardingFlow === 'true');
-    const [showTaskList, firstTimeOnboarding] = useSelector(getShowTaskListBool);
+    const [showTaskList, firstTimeOnboarding] = useSelector(
+        getShowTaskListBool,
+        (a, b) => a[0] === b[0] && a[1] === b[1],
+    );
     const theme = useSelector(getTheme);
 
     const startTask = (taskName: string) => {
@@ -284,7 +287,7 @@ const OnBoardingTaskList = (): JSX.Element | null => {
         }));
     }, []);
 
-    if (Object.keys(myPreferences).length === 0 || !showTaskList || !isEnableOnboardingFlow) {
+    if (!hasPreferences || !showTaskList || !isEnableOnboardingFlow) {
         return null;
     }
 

--- a/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist_popover.tsx
+++ b/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist_popover.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import type {Placement} from 'popper.js';
-import React from 'react';
+import React, {useRef} from 'react';
 import type {RefObject} from 'react';
 import {usePopper} from 'react-popper';
 import {CSSTransition} from 'react-transition-group';
@@ -65,13 +65,12 @@ export const TaskListPopover = ({
     children,
     onClick,
 }: TaskListPopoverProps): JSX.Element | null => {
-    const [popperElement, setPopperElement] =
-        React.useState<HTMLDivElement | null>(null);
+    const popperElement = useRef<HTMLDivElement>(null);
 
     const {
         styles: {popper},
         attributes,
-    } = usePopper(trigger.current, popperElement, {
+    } = usePopper(trigger.current, popperElement.current, {
         placement,
         modifiers: [
             {
@@ -100,7 +99,7 @@ export const TaskListPopover = ({
                 />
             </CSSTransition>
             <div
-                ref={setPopperElement}
+                ref={popperElement}
                 style={style}
                 {...attributes.popper}
             >

--- a/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category_menu/index.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category_menu/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {memo, useCallback} from 'react';
+import React, {memo, useCallback, useMemo} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 
@@ -42,13 +42,12 @@ type Props = {
     category: ChannelCategory;
 };
 
-const getUnreadsIdsForCategory = makeGetUnreadIdsForCategory();
-
 const SidebarCategoryMenu = ({
     category,
 }: Props) => {
     const dispatch = useDispatch();
     const showUnreadsCategory = useSelector(shouldShowUnreadsCategory);
+    const getUnreadsIdsForCategory = useMemo(makeGetUnreadIdsForCategory, [category]);
     const unreadsIds = useSelector((state: GlobalState) => getUnreadsIdsForCategory(state, category));
 
     const {formatMessage} = useIntl();

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/index.ts
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/index.ts
@@ -8,7 +8,6 @@ import type {Channel} from '@mattermost/types/channels';
 
 import {favoriteChannel, unfavoriteChannel, markChannelAsRead} from 'mattermost-redux/actions/channels';
 import Permissions from 'mattermost-redux/constants/permissions';
-import {getCategoryInTeamWithChannel} from 'mattermost-redux/selectors/entities/channel_categories';
 import {isFavoriteChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getMyChannelMemberships, getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
@@ -17,9 +16,7 @@ import {isChannelMuted} from 'mattermost-redux/utils/channel_utils';
 
 import {unmuteChannel, muteChannel} from 'actions/channel_actions';
 import {markMostRecentPostInChannelAsUnread} from 'actions/post_actions';
-import {addChannelsInSidebar} from 'actions/views/channel_sidebar';
 import {openModal} from 'actions/views/modals';
-import {getCategoriesForCurrentTeam, getDisplayedChannels} from 'selectors/views/channel_sidebar';
 
 import {getSiteURL} from 'utils/url';
 
@@ -41,28 +38,19 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
 
     let managePublicChannelMembers = false;
     let managePrivateChannelMembers = false;
-    let categories;
-    let currentCategory;
 
     if (currentTeam) {
         managePublicChannelMembers = haveIChannelPermission(state, currentTeam.id, ownProps.channel.id, Permissions.MANAGE_PUBLIC_CHANNEL_MEMBERS);
         managePrivateChannelMembers = haveIChannelPermission(state, currentTeam.id, ownProps.channel.id, Permissions.MANAGE_PRIVATE_CHANNEL_MEMBERS);
-        categories = getCategoriesForCurrentTeam(state);
-        currentCategory = getCategoryInTeamWithChannel(state, currentTeam.id, ownProps.channel.id);
     }
 
     return {
-        currentTeamId: currentTeam.id,
         currentUserId: getCurrentUserId(state),
-        categories,
-        currentCategory,
         isFavorite: isFavoriteChannel(state, ownProps.channel.id),
         isMuted: isChannelMuted(member),
         channelLink: `${getSiteURL()}${ownProps.channelLink}`,
         managePublicChannelMembers,
         managePrivateChannelMembers,
-        displayedChannels: getDisplayedChannels(state),
-        multiSelectedChannelIds: state.views.channelSidebar.multiSelectedChannelIds,
     };
 }
 
@@ -74,7 +62,6 @@ const mapDispatchToProps = {
     muteChannel,
     unmuteChannel,
     openModal,
-    addChannelsInSidebar,
 };
 
 const connector = connect(mapStateToProps, mapDispatchToProps);

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
@@ -29,21 +29,39 @@ import type {PropsFromRedux, OwnProps} from './index';
 
 type Props = PropsFromRedux & OwnProps;
 
-const SidebarChannelMenu = (props: Props) => {
+const SidebarChannelMenu = ({
+    channel,
+    channelLink,
+    currentUserId,
+    favoriteChannel,
+    isFavorite,
+    isMuted,
+    isUnread,
+    managePrivateChannelMembers,
+    managePublicChannelMembers,
+    markChannelAsRead,
+    markMostRecentPostInChannelAsUnread,
+    muteChannel,
+    onMenuToggle,
+    openModal,
+    unfavoriteChannel,
+    unmuteChannel,
+    channelLeaveHandler,
+}: Props) => {
     const isLeaving = useRef(false);
 
     const {formatMessage} = useIntl();
 
     let markAsReadUnreadMenuItem: JSX.Element | null = null;
-    if (props.isUnread) {
+    if (isUnread) {
         function handleMarkAsRead() {
-            props.markChannelAsRead(props.channel.id, true);
+            markChannelAsRead(channel.id, true);
             trackEvent('ui', 'ui_sidebar_channel_menu_markAsRead');
         }
 
         markAsReadUnreadMenuItem = (
             <Menu.Item
-                id={`markAsRead-${props.channel.id}`}
+                id={`markAsRead-${channel.id}`}
                 onClick={handleMarkAsRead}
                 leadingElement={<MarkAsUnreadIcon size={18}/>}
                 labels={(
@@ -57,13 +75,13 @@ const SidebarChannelMenu = (props: Props) => {
         );
     } else {
         function handleMarkAsUnread() {
-            props.markMostRecentPostInChannelAsUnread(props.channel.id);
+            markMostRecentPostInChannelAsUnread(channel.id);
             trackEvent('ui', 'ui_sidebar_channel_menu_markAsUnread');
         }
 
         markAsReadUnreadMenuItem = (
             <Menu.Item
-                id={`markAsUnread-${props.channel.id}`}
+                id={`markAsUnread-${channel.id}`}
                 onClick={handleMarkAsUnread}
                 leadingElement={<MarkAsUnreadIcon size={18}/>}
                 labels={(
@@ -77,15 +95,15 @@ const SidebarChannelMenu = (props: Props) => {
     }
 
     let favoriteUnfavoriteMenuItem: JSX.Element | null = null;
-    if (props.isFavorite) {
+    if (isFavorite) {
         function handleUnfavoriteChannel() {
-            props.unfavoriteChannel(props.channel.id);
+            unfavoriteChannel(channel.id);
             trackEvent('ui', 'ui_sidebar_channel_menu_unfavorite');
         }
 
         favoriteUnfavoriteMenuItem = (
             <Menu.Item
-                id={`unfavorite-${props.channel.id}`}
+                id={`unfavorite-${channel.id}`}
                 onClick={handleUnfavoriteChannel}
                 leadingElement={<StarIcon size={18}/>}
                 labels={(
@@ -98,14 +116,14 @@ const SidebarChannelMenu = (props: Props) => {
         );
     } else {
         function handleFavoriteChannel() {
-            props.favoriteChannel(props.channel.id);
+            favoriteChannel(channel.id);
             trackEvent('ui', 'ui_sidebar_channel_menu_favorite');
         }
 
         favoriteUnfavoriteMenuItem = (
 
             <Menu.Item
-                id={`favorite-${props.channel.id}`}
+                id={`favorite-${channel.id}`}
                 onClick={handleFavoriteChannel}
                 leadingElement={<StarOutlineIcon size={18}/>}
                 labels={(
@@ -119,14 +137,14 @@ const SidebarChannelMenu = (props: Props) => {
     }
 
     let muteUnmuteChannelMenuItem: JSX.Element | null = null;
-    if (props.isMuted) {
+    if (isMuted) {
         let muteChannelText = (
             <FormattedMessage
                 id='sidebar_left.sidebar_channel_menu.unmuteChannel'
                 defaultMessage='Unmute Channel'
             />
         );
-        if (props.channel.type === Constants.DM_CHANNEL || props.channel.type === Constants.GM_CHANNEL) {
+        if (channel.type === Constants.DM_CHANNEL || channel.type === Constants.GM_CHANNEL) {
             muteChannelText = (
                 <FormattedMessage
                     id='sidebar_left.sidebar_channel_menu.unmuteConversation'
@@ -136,12 +154,12 @@ const SidebarChannelMenu = (props: Props) => {
         }
 
         function handleUnmuteChannel() {
-            props.unmuteChannel(props.currentUserId, props.channel.id);
+            unmuteChannel(currentUserId, channel.id);
         }
 
         muteUnmuteChannelMenuItem = (
             <Menu.Item
-                id={`unmute-${props.channel.id}`}
+                id={`unmute-${channel.id}`}
                 onClick={handleUnmuteChannel}
                 leadingElement={<BellOffOutlineIcon size={18}/>}
                 labels={muteChannelText}
@@ -154,7 +172,7 @@ const SidebarChannelMenu = (props: Props) => {
                 defaultMessage='Mute Channel'
             />
         );
-        if (props.channel.type === Constants.DM_CHANNEL || props.channel.type === Constants.GM_CHANNEL) {
+        if (channel.type === Constants.DM_CHANNEL || channel.type === Constants.GM_CHANNEL) {
             muteChannelText = (
                 <FormattedMessage
                     id='sidebar_left.sidebar_channel_menu.muteConversation'
@@ -164,12 +182,12 @@ const SidebarChannelMenu = (props: Props) => {
         }
 
         function handleMuteChannel() {
-            props.muteChannel(props.currentUserId, props.channel.id);
+            muteChannel(currentUserId, channel.id);
         }
 
         muteUnmuteChannelMenuItem = (
             <Menu.Item
-                id={`mute-${props.channel.id}`}
+                id={`mute-${channel.id}`}
                 onClick={handleMuteChannel}
                 leadingElement={<BellOutlineIcon size={18}/>}
                 labels={muteChannelText}
@@ -178,14 +196,14 @@ const SidebarChannelMenu = (props: Props) => {
     }
 
     let copyLinkMenuItem: JSX.Element | null = null;
-    if (props.channel.type === Constants.OPEN_CHANNEL || props.channel.type === Constants.PRIVATE_CHANNEL) {
+    if (channel.type === Constants.OPEN_CHANNEL || channel.type === Constants.PRIVATE_CHANNEL) {
         function handleCopyLink() {
-            copyToClipboard(props.channelLink);
+            copyToClipboard(channelLink);
         }
 
         copyLinkMenuItem = (
             <Menu.Item
-                id={`copyLink-${props.channel.id}`}
+                id={`copyLink-${channel.id}`}
                 onClick={handleCopyLink}
                 leadingElement={<LinkVariantIcon size={18}/>}
                 labels={(
@@ -199,19 +217,19 @@ const SidebarChannelMenu = (props: Props) => {
     }
 
     let addMembersMenuItem: JSX.Element | null = null;
-    if ((props.channel.type === Constants.PRIVATE_CHANNEL && props.managePrivateChannelMembers) || (props.channel.type === Constants.OPEN_CHANNEL && props.managePublicChannelMembers)) {
+    if ((channel.type === Constants.PRIVATE_CHANNEL && managePrivateChannelMembers) || (channel.type === Constants.OPEN_CHANNEL && managePublicChannelMembers)) {
         function handleAddMembers() {
-            props.openModal({
+            openModal({
                 modalId: ModalIdentifiers.CHANNEL_INVITE,
                 dialogType: ChannelInviteModal,
-                dialogProps: {channel: props.channel},
+                dialogProps: {channel},
             });
             trackEvent('ui', 'ui_sidebar_channel_menu_addMembers');
         }
 
         addMembersMenuItem = (
             <Menu.Item
-                id={`addMembers-${props.channel.id}`}
+                id={`addMembers-${channel.id}`}
                 onClick={handleAddMembers}
                 aria-haspopup='true'
                 leadingElement={<AccountPlusOutlineIcon size={18}/>}
@@ -226,14 +244,14 @@ const SidebarChannelMenu = (props: Props) => {
     }
 
     let leaveChannelMenuItem: JSX.Element | null = null;
-    if (props.channel.name !== Constants.DEFAULT_CHANNEL) {
+    if (channel.name !== Constants.DEFAULT_CHANNEL) {
         let leaveChannelText = (
             <FormattedMessage
                 id='sidebar_left.sidebar_channel_menu.leaveChannel'
                 defaultMessage='Leave Channel'
             />
         );
-        if (props.channel.type === Constants.DM_CHANNEL || props.channel.type === Constants.GM_CHANNEL) {
+        if (channel.type === Constants.DM_CHANNEL || channel.type === Constants.GM_CHANNEL) {
             leaveChannelText = (
                 <FormattedMessage
                     id='sidebar_left.sidebar_channel_menu.leaveConversation'
@@ -243,13 +261,13 @@ const SidebarChannelMenu = (props: Props) => {
         }
 
         function handleLeaveChannel() {
-            if (isLeaving.current || !props.channelLeaveHandler) {
+            if (isLeaving.current || !channelLeaveHandler) {
                 return;
             }
 
             isLeaving.current = true;
 
-            props.channelLeaveHandler(() => {
+            channelLeaveHandler(() => {
                 isLeaving.current = false;
             });
             trackEvent('ui', 'ui_sidebar_channel_menu_leave');
@@ -257,7 +275,7 @@ const SidebarChannelMenu = (props: Props) => {
 
         leaveChannelMenuItem = (
             <Menu.Item
-                id={`leave-${props.channel.id}`}
+                id={`leave-${channel.id}`}
                 onClick={handleLeaveChannel}
                 leadingElement={<ExitToAppIcon size={18}/>}
                 labels={leaveChannelText}
@@ -269,27 +287,27 @@ const SidebarChannelMenu = (props: Props) => {
     return (
         <Menu.Container
             menuButton={{
-                id: `SidebarChannelMenu-Button-${props.channel.id}`,
+                id: `SidebarChannelMenu-Button-${channel.id}`,
                 class: 'SidebarMenu_menuButton',
                 'aria-label': formatMessage({id: 'sidebar_left.sidebar_channel_menu.editChannel', defaultMessage: 'Channel options'}),
                 children: <DotsVerticalIcon size={16}/>,
             }}
             menuButtonTooltip={{
-                id: `SidebarChannelMenu-ButtonTooltip-${props.channel.id}`,
+                id: `SidebarChannelMenu-ButtonTooltip-${channel.id}`,
                 class: 'hidden-xs',
                 text: formatMessage({id: 'sidebar_left.sidebar_channel_menu.editChannel', defaultMessage: 'Channel options'}),
             }}
             menu={{
-                id: `SidebarChannelMenu-MenuList-${props.channel.id}`,
+                id: `SidebarChannelMenu-MenuList-${channel.id}`,
                 'aria-label': formatMessage({id: 'sidebar_left.sidebar_channel_menu.dropdownAriaLabel', defaultMessage: 'Edit channel menu'}),
-                onToggle: props.onMenuToggle,
+                onToggle: onMenuToggle,
             }}
         >
             {markAsReadUnreadMenuItem}
             {favoriteUnfavoriteMenuItem}
             {muteUnmuteChannelMenuItem}
             <Menu.Separator/>
-            <ChannelMoveToSubmenu channel={props.channel}/>
+            <ChannelMoveToSubmenu channel={channel}/>
             {(copyLinkMenuItem || addMembersMenuItem) && <Menu.Separator/>}
             {copyLinkMenuItem}
             {addMembersMenuItem}

--- a/webapp/channels/src/components/sidebar/sidebar_list/sidebar_list.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_list/sidebar_list.tsx
@@ -35,7 +35,7 @@ import SidebarCategory from '../sidebar_category';
 import UnreadChannelIndicator from '../unread_channel_indicator';
 import UnreadChannels from '../unread_channels';
 
-export function renderView(props: any) {
+export function renderView(props: React.HTMLProps<HTMLDivElement>) {
     return (
         <div
             {...props}
@@ -44,7 +44,7 @@ export function renderView(props: any) {
     );
 }
 
-export function renderThumbHorizontal(props: any) {
+export function renderThumbHorizontal(props: React.HTMLProps<HTMLDivElement>) {
     return (
         <div
             {...props}
@@ -53,7 +53,7 @@ export function renderThumbHorizontal(props: any) {
     );
 }
 
-export function renderTrackVertical(props: any) {
+export function renderTrackVertical(props: React.HTMLProps<HTMLDivElement>) {
     return (
         <div
             {...props}
@@ -62,7 +62,7 @@ export function renderTrackVertical(props: any) {
     );
 }
 
-export function renderThumbVertical(props: any) {
+export function renderThumbVertical(props: React.HTMLProps<HTMLDivElement>) {
     return (
         <div
             {...props}

--- a/webapp/channels/src/components/threading/global_threads_link/global_threads_link.tsx
+++ b/webapp/channels/src/components/threading/global_threads_link/global_threads_link.tsx
@@ -61,10 +61,9 @@ const GlobalThreadsLink = () => {
     const crtTutorialTrigger = useSelector((state: GlobalState) => getInt(state, Preferences.CRT_TUTORIAL_TRIGGERED, currentUserId, Constants.CrtTutorialTriggerSteps.START));
     const threads = useSelector(getThreadsInCurrentTeam);
     const showTutorialTip = crtTutorialTrigger === CrtTutorialTriggerSteps.STARTED && tipStep === CrtTutorialSteps.WELCOME_POPOVER && threads.length >= 1;
-    const threadsCount = useSelector(getThreadCountsInCurrentTeam);
     const rhsOpen = useSelector(getIsRhsOpen);
     const rhsState = useSelector(getRhsState);
-    const showTutorialTrigger = isFeatureEnabled && crtTutorialTrigger === Constants.CrtTutorialTriggerSteps.START && !appHaveOpenModal && Boolean(threadsCount) && threadsCount.total >= 1;
+    const showTutorialTrigger = isFeatureEnabled && crtTutorialTrigger === Constants.CrtTutorialTriggerSteps.START && !appHaveOpenModal && Boolean(counts) && counts.total >= 1;
     const openThreads = useCallback((e) => {
         e.stopPropagation();
         trackEvent('crt', 'go_to_global_threads');
@@ -74,7 +73,7 @@ const GlobalThreadsLink = () => {
         if (rhsOpen && rhsState === RHSStates.EDIT_HISTORY) {
             dispatch(closeRightHandSide());
         }
-    }, [showTutorialTrigger, threadsCount, threads, rhsOpen, rhsState]);
+    }, [showTutorialTrigger, counts, threads, rhsOpen, rhsState]);
 
     useEffect(() => {
         // load counts if necessary

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channel_categories.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channel_categories.ts
@@ -447,13 +447,18 @@ export function makeGetChannelsByCategory() {
 
         const channelsByCategory: RelationOneToOne<ChannelCategory, Channel[]> = {};
 
+        // TODO: This avoids some rendering, but there is a bigger issue underneath
+        // Every time myPreferences or myChannels change (which can happen for many
+        // unrelated reasons) the whole list of channels gets reordered and re-filtered.
+        let allEquals = categoryIds === lastCategoryIds;
         for (const category of categories) {
             const channels = getChannels[category.id](state, category.channel_ids);
             channelsByCategory[category.id] = filterAndSortChannels[category.id](state, channels, category);
+            allEquals = allEquals && shallowEquals(channelsByCategory[category.id], lastChannelsByCategory[category.id]);
         }
 
         // Do a shallow equality check of channelsByCategory to avoid returning a new object containing the same data
-        if (shallowEquals(channelsByCategory, lastChannelsByCategory)) {
+        if (allEquals) {
             return lastChannelsByCategory;
         }
 

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channels.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channels.ts
@@ -152,7 +152,7 @@ export function getChannelMember(state: GlobalState, channelId: string, userId: 
 // - The display_name set to the other user(s) names, following the Teammate Name Display setting
 // - The teammate_id for DM channels
 // - The status of the other user in a DM channel
-export function makeGetChannel(): (state: GlobalState, props: {id: string}) => Channel {
+export function makeGetChannel(): (state: GlobalState, props: {id: string}) => Channel | undefined {
     return createSelector(
         'makeGetChannel',
         getCurrentUserId,
@@ -184,7 +184,7 @@ export function makeGetChannel(): (state: GlobalState, props: {id: string}) => C
 
 // getChannel returns a channel as it exists in the store without filling in any additional details such as the
 // display_name for DM/GM channels.
-export function getChannel(state: GlobalState, id: string) {
+export function getChannel(state: GlobalState, id: string): Channel | undefined {
     return getAllChannels(state)[id];
 }
 
@@ -206,7 +206,7 @@ export function makeGetChannelsForIds(): (state: GlobalState, ids: string[]) => 
     );
 }
 
-export const getCurrentChannel: (state: GlobalState) => Channel = createSelector(
+export const getCurrentChannel: (state: GlobalState) => Channel | undefined = createSelector(
     'getCurrentChannel',
     getAllChannels,
     getCurrentChannelId,
@@ -297,7 +297,7 @@ export const isMutedChannel: (state: GlobalState, channelId: string) => boolean 
 export const isCurrentChannelArchived: (state: GlobalState) => boolean = createSelector(
     'isCurrentChannelArchived',
     getCurrentChannel,
-    (channel) => channel.delete_at !== 0,
+    (channel) => channel?.delete_at !== 0,
 );
 
 export const isCurrentChannelDefault: (state: GlobalState) => boolean = createSelector(
@@ -314,8 +314,8 @@ export function isChannelReadOnlyById(state: GlobalState, channelId: string): bo
     return isChannelReadOnly(state, getChannel(state, channelId));
 }
 
-export function isChannelReadOnly(state: GlobalState, channel: Channel): boolean {
-    return channel && channel.name === General.DEFAULT_CHANNEL && !isCurrentUserSystemAdmin(state);
+export function isChannelReadOnly(state: GlobalState, channel?: Channel): boolean {
+    return Boolean(channel && channel.name === General.DEFAULT_CHANNEL && !isCurrentUserSystemAdmin(state));
 }
 
 export function getChannelMessageCounts(state: GlobalState): RelationOneToOne<Channel, ChannelMessageCount> {
@@ -879,7 +879,7 @@ export const canManageChannelMembers: (state: GlobalState) => boolean = createSe
         Permissions.MANAGE_PUBLIC_CHANNEL_MEMBERS,
     ),
     (
-        channel: Channel,
+        channel: Channel | undefined,
         managePrivateMembers: boolean,
         managePublicMembers: boolean,
     ): boolean => {
@@ -1264,7 +1264,10 @@ export function getChannelModerations(state: GlobalState, channelId: string): Ch
 }
 
 const EMPTY_OBJECT = {};
-export function getChannelMemberCountsByGroup(state: GlobalState, channelId: string): ChannelMemberCountsByGroup {
+export function getChannelMemberCountsByGroup(state: GlobalState, channelId?: string): ChannelMemberCountsByGroup {
+    if (!channelId) {
+        return EMPTY_OBJECT;
+    }
     return state.entities.channels.channelMemberCountsByGroup[channelId] || EMPTY_OBJECT;
 }
 

--- a/webapp/channels/src/packages/mattermost-redux/src/utils/channel_utils.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/utils/channel_utils.ts
@@ -151,8 +151,8 @@ export function getGroupDisplayNameFromUserIds(userIds: Set<string>, profiles: I
     return names.sort(sortUsernames).join(', ');
 }
 
-export function isDefault(channel: Channel): boolean {
-    return channel.name === General.DEFAULT_CHANNEL;
+export function isDefault(channel?: Channel): boolean {
+    return channel?.name === General.DEFAULT_CHANNEL;
 }
 
 export function completeDirectGroupInfo(usersState: UsersState, teammateNameDisplay: string, channel: Channel, omitCurrentUser = true) {

--- a/webapp/channels/src/selectors/rhs.ts
+++ b/webapp/channels/src/selectors/rhs.ts
@@ -141,7 +141,11 @@ export function makeGetChannelDraft() {
     const defaultDraft = Object.freeze({message: '', fileInfos: [], uploadsInProgress: [], createAt: 0, updateAt: 0, channelId: '', rootId: ''});
     const getDraft = makeGetGlobalItemWithDefault(defaultDraft);
 
-    return (state: GlobalState, channelId: string): PostDraft => {
+    return (state: GlobalState, channelId?: string): PostDraft => {
+        if (!channelId) {
+            return defaultDraft;
+        }
+
         const draft = getDraft(state, StoragePrefixes.DRAFT + channelId);
         if (
             typeof draft.message !== 'undefined' &&


### PR DESCRIPTION
#### Summary
I have made some improvements to reduce the number of re-renders on init.

Number of profiler commits:
- Before: 122
- After: 79


Regarding time, there doesn't seem to be any relevant difference on my machine.

#### Ticket Link
NONE

#### Release Note
```release-note
Minor performance improvements on init
```
