### PR TITLE
[MM-56900] Reduce the number of statuses we are loading on page load and at each interval

### DIFF
--- a/webapp/channels/src/actions/status_actions.test.ts
+++ b/webapp/channels/src/actions/status_actions.test.ts
@@ -45,12 +45,12 @@ describe('actions/status_actions', () => {
             channelCategories: {
                 byId: {
                     category_id1: {
-                        id: 'category_id1', 
+                        id: 'category_id1',
                         team_id: 'team_id1',
-                        sort_order:20,
-                        sorting: "alpha",
-                        type: "direct_messages",
-                        display_name: "Direct Messages",
+                        sort_order: 20,
+                        sorting: 'alpha',
+                        type: 'direct_messages',
+                        display_name: 'Direct Messages',
                         muted: false,
                         collapsed: false,
                         channel_ids: ['channel_id3'],

--- a/webapp/channels/src/actions/status_actions.test.ts
+++ b/webapp/channels/src/actions/status_actions.test.ts
@@ -3,10 +3,12 @@
 
 import cloneDeep from 'lodash/cloneDeep';
 
+import {CategorySorting} from '@mattermost/types/channel_categories';
 import type {UserProfile} from '@mattermost/types/users';
 
 import {getStatusesByIds} from 'mattermost-redux/actions/users';
-import {Preferences} from 'mattermost-redux/constants';
+import {General, Preferences} from 'mattermost-redux/constants';
+import {CategoryTypes} from 'mattermost-redux/constants/channel_categories';
 
 import * as Actions from 'actions/status_actions';
 
@@ -37,7 +39,7 @@ describe('actions/status_actions', () => {
         entities: {
             channels: {
                 currentChannelId: 'channel_id1',
-                channels: {channel_id1: {id: 'channel_id1', name: 'channel1', team_id: 'team_id1'}, channel_id2: {id: 'channel_id2', name: 'channel2', team_id: 'team_id1'}, channel_id3: {id: 'channel_id3', name: 'current_user_id__user_id2', team_id: '', type: 'D', delete_at: 0}},
+                channels: {channel_id1: {id: 'channel_id1', name: 'channel1', team_id: 'team_id1'}, channel_id2: {id: 'channel_id2', name: 'channel2', team_id: 'team_id1'}, channel_id3: {id: 'channel_id3', name: 'current_user_id__user_id2', team_id: '', type: General.DM_CHANNEL, delete_at: 0}},
                 myMembers: {channel_id1: {channel_id: 'channel_id1', user_id: 'current_user_id'}},
                 channelsInTeam: {team_id1: new Set(['channel_id1'])},
                 messageCounts: {},
@@ -48,8 +50,8 @@ describe('actions/status_actions', () => {
                         id: 'category_id1',
                         team_id: 'team_id1',
                         sort_order: 20,
-                        sorting: 'alpha',
-                        type: 'direct_messages',
+                        sorting: CategorySorting.Default,
+                        type: CategoryTypes.DIRECT_MESSAGES,
                         display_name: 'Direct Messages',
                         muted: false,
                         collapsed: false,

--- a/webapp/channels/src/actions/status_actions.test.ts
+++ b/webapp/channels/src/actions/status_actions.test.ts
@@ -30,13 +30,35 @@ describe('actions/status_actions', () => {
             channel: {
                 postVisibility: {channel_id1: 100, channel_id2: 100},
             },
+            channelSidebar: {
+                unreadFilterEnabled: false,
+            },
         },
         entities: {
             channels: {
                 currentChannelId: 'channel_id1',
-                channels: {channel_id1: {id: 'channel_id1', name: 'channel1', team_id: 'team_id1'}, channel_id2: {id: 'channel_id2', name: 'channel2', team_id: 'team_id1'}},
+                channels: {channel_id1: {id: 'channel_id1', name: 'channel1', team_id: 'team_id1'}, channel_id2: {id: 'channel_id2', name: 'channel2', team_id: 'team_id1'}, channel_id3: {id: 'channel_id3', name: 'current_user_id__user_id2', team_id: '', type: 'D', delete_at: 0}},
                 myMembers: {channel_id1: {channel_id: 'channel_id1', user_id: 'current_user_id'}},
                 channelsInTeam: {team_id1: new Set(['channel_id1'])},
+                messageCounts: {},
+            },
+            channelCategories: {
+                byId: {
+                    category_id1: {
+                        id: 'category_id1', 
+                        team_id: 'team_id1',
+                        sort_order:20,
+                        sorting: "alpha",
+                        type: "direct_messages",
+                        display_name: "Direct Messages",
+                        muted: false,
+                        collapsed: false,
+                        channel_ids: ['channel_id3'],
+                    },
+                },
+                orderByTeam: {
+                    team_id1: ['category_id1'],
+                },
             },
             general: {
                 config: {
@@ -71,6 +93,7 @@ describe('actions/status_actions', () => {
                 myPreferences: {
                     [Preferences.CATEGORY_DIRECT_CHANNEL_SHOW + '--user_id3']: {category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, name: 'user_id3', value: 'true', user_id: 'current_user_id'},
                     [Preferences.CATEGORY_DIRECT_CHANNEL_SHOW + '--user_id1']: {category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, name: 'user_id1', value: 'false', user_id: 'current_user_id'},
+                    [Preferences.CATEGORY_DIRECT_CHANNEL_SHOW + '--user_id2']: {category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, name: 'user_id2', value: 'true', user_id: 'current_user_id'},
                 },
             },
         },
@@ -81,7 +104,7 @@ describe('actions/status_actions', () => {
             const state = cloneDeep(initialState);
             const testStore = mockStore(state);
             testStore.dispatch(Actions.loadStatusesForChannelAndSidebar());
-            expect(getStatusesByIds).toHaveBeenCalledWith((expect as GreatExpectations).arrayContainingExactly(['current_user_id', 'user_id2', 'user_id3']));
+            expect(getStatusesByIds).toHaveBeenCalledWith((expect as GreatExpectations).arrayContainingExactly(['current_user_id', 'user_id2']));
         });
 
         test('load statuses with empty channel and user in sidebar', () => {
@@ -89,7 +112,7 @@ describe('actions/status_actions', () => {
             state.entities.channels.currentChannelId = 'channel_id2';
             const testStore = mockStore(state);
             testStore.dispatch(Actions.loadStatusesForChannelAndSidebar());
-            expect(getStatusesByIds).toHaveBeenCalledWith((expect as GreatExpectations).arrayContainingExactly(['current_user_id', 'user_id3']));
+            expect(getStatusesByIds).toHaveBeenCalledWith((expect as GreatExpectations).arrayContainingExactly(['current_user_id', 'user_id2']));
         });
 
         test('load statuses with empty channel and no users in sidebar', () => {

--- a/webapp/channels/src/actions/status_actions.ts
+++ b/webapp/channels/src/actions/status_actions.ts
@@ -4,7 +4,6 @@
 import type {UserProfile} from '@mattermost/types/users';
 
 import {getStatusesByIds} from 'mattermost-redux/actions/users';
-import {getDMsForLoading} from './user_actions';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getIsUserStatusesConfigEnabled} from 'mattermost-redux/selectors/entities/common';
 import {getPostsInCurrentChannel} from 'mattermost-redux/selectors/entities/posts';
@@ -13,9 +12,11 @@ import type {ActionFunc} from 'mattermost-redux/types/actions';
 
 import {loadCustomEmojisForCustomStatusesByUserIds} from 'actions/emoji_actions';
 
+import * as Utils from 'utils/utils';
+
 import type {GlobalState} from 'types/store';
 
-import * as Utils from 'utils/utils';
+import {getDMsForLoading} from './user_actions';
 
 export function loadStatusesForChannelAndSidebar(): ActionFunc<boolean, GlobalState> {
     return (dispatch, getState) => {

--- a/webapp/channels/src/actions/user_actions.ts
+++ b/webapp/channels/src/actions/user_actions.ts
@@ -18,7 +18,6 @@ import {
     getChannelMessageCount,
     getCurrentChannelId,
     getMyChannelMember,
-    getMyChannels,
 } from 'mattermost-redux/selectors/entities/channels';
 import {getIsUserStatusesConfigEnabled} from 'mattermost-redux/selectors/entities/common';
 import {getBool, isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';

--- a/webapp/channels/src/actions/user_actions.ts
+++ b/webapp/channels/src/actions/user_actions.ts
@@ -304,6 +304,16 @@ export const getGMsForLoading = (state: GlobalState) => {
     return channels;
 };
 
+export const getDMsForLoading = (state: GlobalState) => {
+    // Get all channels visible on the current team which doesn't include hidden GMs/DMs
+    let channels = getDisplayedChannels(state);
+
+    // Make sure we only have DMs
+    channels = channels.filter((channel) => channel.type === General.DM_CHANNEL);
+
+    return channels;
+};
+
 export async function loadProfilesForGM() {
     const state = getState();
     const newPreferences = [];
@@ -357,19 +367,14 @@ export async function loadProfilesForGM() {
 
 export async function loadProfilesForDM() {
     const state = getState();
-    const channels = getMyChannels(state);
     const newPreferences = [];
     const profilesToLoad = [];
     const profileIds = [];
     const currentUserId = Selectors.getCurrentUserId(state);
     const collapsedThreads = isCollapsedThreadsEnabled(state);
+    const dmChannels = getDMsForLoading(state);
 
-    for (let i = 0; i < channels.length; i++) {
-        const channel = channels[i];
-        if (channel.type !== Constants.DM_CHANNEL) {
-            continue;
-        }
-
+    for (const channel of dmChannels) {
         const teammateId = channel.name.replace(currentUserId, '').replace('__', '');
         const isVisible = getBool(state, Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, teammateId);
 


### PR DESCRIPTION
#### Summary
We only need to load the statuses for visible DMs, previously we were doing it for every DM in our preferences which could be a lot for certain power users.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56900

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Reduce the number of statuses we are loading on page load and at each interval
```
