### PR TITLE
[MM-57065] Remove markdown from LDAP page size error

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -7924,7 +7924,7 @@
   },
   {
     "id": "ent.ldap.syncronize.search_failure_size_exceeded.app_error",
-    "translation": "Size Limit Exceeded. Try checking your [max page size](https://docs.mattermost.com/deployment/sso-ldap.html#i-see-the-log-error-ldap-result-code-4-size-limit-exceeded)."
+    "translation": "Size Limit Exceeded. Try increasing your Maximum page size setting. Check out https://docs.mattermost.com/onboard/ad-ldap.html#i-see-the-log-error-ldap-result-code-4-size-limit-exceeded for more details."
   },
   {
     "id": "ent.ldap.validate_admin_filter.app_error",


### PR DESCRIPTION
#### Summary
I did consider parsing the markdown instead of removing it. Given that the error is thrown by a third-party library and it's not well-defined which data ends up in the error, I do consider it a security risk to parse arbitrary markdown in the webapp.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57065

#### Screenshots
|  before  |  after  |
|----|----|
| ![image-20240301-190138](https://github.com/mattermost/mattermost/assets/16541325/947a3f3e-467c-4879-b00a-1c485e1b4751)| ![Screenshot from 2024-03-04 12-32-11](https://github.com/mattermost/mattermost/assets/16541325/81567534-bc16-4401-983b-cd877081f86b) |


#### Release Note
```release-note
Remove markdown from AD page size error
```
