### PR TITLE
MM 57068 - remove export button from log item viewer.

### DIFF
--- a/webapp/channels/src/components/admin_console/full_log_event_modal/full_log_event_modal.tsx
+++ b/webapp/channels/src/components/admin_console/full_log_event_modal/full_log_event_modal.tsx
@@ -15,7 +15,6 @@ type Props = {
 
 type State = {
     copySuccess: boolean;
-    exportSuccess: boolean;
 }
 
 export default class FullLogEventModal extends React.PureComponent<Props, State> {
@@ -24,7 +23,6 @@ export default class FullLogEventModal extends React.PureComponent<Props, State>
 
         this.state = {
             copySuccess: false,
-            exportSuccess: false,
         };
     }
 
@@ -49,14 +47,6 @@ export default class FullLogEventModal extends React.PureComponent<Props, State>
         this.showCopySuccess();
     };
 
-    exportToCsv = () => {
-        const file = JSON.stringify(this.props.log, undefined, 2);
-        const csvContent = 'data:text/csv;charset=utf-8,' + file;
-        const encodedUri = encodeURI(csvContent);
-        window.open(encodedUri);
-        this.showExportSuccess();
-    };
-
     showCopySuccess = () => {
         this.setState({
             copySuccess: true,
@@ -65,18 +55,6 @@ export default class FullLogEventModal extends React.PureComponent<Props, State>
         setTimeout(() => {
             this.setState({
                 copySuccess: false,
-            });
-        }, 3000);
-    };
-
-    showExportSuccess = () => {
-        this.setState({
-            exportSuccess: true,
-        });
-
-        setTimeout(() => {
-            this.setState({
-                exportSuccess: false,
             });
         }, 3000);
     };
@@ -128,21 +106,6 @@ export default class FullLogEventModal extends React.PureComponent<Props, State>
                             defaultMessage='Cancel'
                         />
                     </button>
-                    {this.state.exportSuccess ? (
-                        <Button>
-                            <FormattedMessage
-                                id='admin.server_logs.Exported'
-                                defaultMessage='Exported'
-                            />
-                        </Button>
-                    ) : (
-                        <Button onClick={this.exportToCsv}>
-                            <FormattedMessage
-                                id='admin.server_logs.Export'
-                                defaultMessage='Export'
-                            />
-                        </Button>
-                    )}
                 </Modal.Footer>
             </Modal>
         );

--- a/webapp/channels/src/components/admin_console/full_log_event_modal/full_log_event_modal.tsx
+++ b/webapp/channels/src/components/admin_console/full_log_event_modal/full_log_event_modal.tsx
@@ -50,7 +50,7 @@ export default class FullLogEventModal extends React.PureComponent<Props, State>
     };
 
     exportToCsv = () => {
-        const file = navigator.clipboard.writeText(JSON.stringify(this.props.log, undefined, 2));
+        const file = JSON.stringify(this.props.log, undefined, 2);
         const csvContent = 'data:text/csv;charset=utf-8,' + file;
         const encodedUri = encodeURI(csvContent);
         window.open(encodedUri);
@@ -129,10 +129,12 @@ export default class FullLogEventModal extends React.PureComponent<Props, State>
                         />
                     </button>
                     {this.state.exportSuccess ? (
-                        <FormattedMessage
-                            id='admin.server_logs.Exported'
-                            defaultMessage='Exported'
-                        />
+                        <Button>
+                            <FormattedMessage
+                                id='admin.server_logs.Exported'
+                                defaultMessage='Exported'
+                            />
+                        </Button>
                     ) : (
                         <Button onClick={this.exportToCsv}>
                             <FormattedMessage

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -2237,8 +2237,6 @@
   "admin.security.password": "Password",
   "admin.server_logs.CopyLog": "Copy log",
   "admin.server_logs.DataCopied": "Data copied",
-  "admin.server_logs.Export": "Export",
-  "admin.server_logs.Exported": "Exported",
   "admin.server_logs.LogEvent": "Log Event",
   "admin.service.attemptDescription": "Number of login attempts allowed before a user is locked out and required to reset their password via email.",
   "admin.service.attemptExample": "E.g.: \"10\"",


### PR DESCRIPTION

#### Summary
This functionality has never worked and really isn't useful as is. It only exports a single log item at a time. Its been implemented a year and this is the first report, therefore it isn't being used.

Remove the export button from the log item viewer.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-57068

#### Screenshots
![Screenshot 2024-03-04 at 4 06 43 PM](https://github.com/mattermost/mattermost/assets/12704875/93b9d4c1-b943-49dc-9c28-30aefe6ca070)


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
