### PR TITLE
MM-56402: Initialize replica conn pool on-demand

### DIFF
--- a/server/public/pluginapi/store.go
+++ b/server/public/pluginapi/store.go
@@ -112,6 +112,7 @@ func (s *StoreService) initializeReplica() error {
 	if s.initializedReplica {
 		return nil
 	}
+
 	config := s.api.GetUnsanitizedConfig()
 	// Set up replica db
 	if len(config.SqlSettings.DataSourceReplicas) > 0 {

--- a/server/public/pluginapi/store.go
+++ b/server/public/pluginapi/store.go
@@ -63,20 +63,16 @@ func (s *StoreService) Close() error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	// replicaDB will be nil if it's not initialized, so no need
-	// to check for initialization again.
 	if s.replicaDB != nil {
 		if err := s.replicaDB.Close(); err != nil {
 			return err
 		}
 	}
 
-	if !s.initializedMaster {
-		return nil
-	}
-
-	if err := s.masterDB.Close(); err != nil {
-		return err
+	if s.masterDB != nil {
+		if err := s.masterDB.Close(); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/server/public/pluginapi/store_test.go
+++ b/server/public/pluginapi/store_test.go
@@ -12,18 +12,10 @@ import (
 
 func TestStore(t *testing.T) {
 	t.Run("master db singleton", func(t *testing.T) {
-		config := &model.Config{
-			SqlSettings: model.SqlSettings{
-				DriverName: model.NewString("test"),
-				DataSource: model.NewString("TestStore-master-db"),
-			},
-		}
-
 		api := &plugintest.API{}
-		defer api.AssertExpectations(t)
-		api.On("GetUnsanitizedConfig").Return(config)
 
 		driver := &plugintest.Driver{}
+		defer driver.AssertExpectations(t)
 		driver.On("Conn", true).Return("test", nil)
 		driver.On("ConnPing", "test").Return(nil)
 		driver.On("ConnClose", "test").Return(nil)
@@ -52,6 +44,7 @@ func TestStore(t *testing.T) {
 		}
 
 		driver := &plugintest.Driver{}
+		defer driver.AssertExpectations(t)
 		driver.On("Conn", true).Return("test", nil)
 		driver.On("ConnPing", "test").Return(nil)
 		driver.On("ConnClose", "test").Return(nil)
@@ -88,7 +81,7 @@ func TestStore(t *testing.T) {
 		api.On("GetUnsanitizedConfig").Return(config)
 
 		driver := &plugintest.Driver{}
-		driver.On("Conn", true).Return("test", nil)
+		defer driver.AssertExpectations(t)
 		driver.On("Conn", false).Return("test", nil)
 		driver.On("ConnPing", "test").Return(nil)
 		driver.On("ConnClose", "test").Return(nil)


### PR DESCRIPTION
Previously, we would setup both pools only when
GetMasterDB was called. This was inefficient and
would waste open connections if the replica wasn't used
at all.

We fix it to initialize the pools as they are called.

https://mattermost.atlassian.net/browse/MM-56402
```release-note
NONE
```
