### PR TITLE
MM-57193: Standardize the cache names

### DIFF
--- a/server/channels/app/platform/service.go
+++ b/server/channels/app/platform/service.go
@@ -275,6 +275,7 @@ func New(sc ServiceConfig, options ...Option) (*PlatformService, error) {
 
 	// Needed before loading license
 	ps.statusCache, err = ps.cacheProvider.NewCache(&cache.CacheOptions{
+		Name:           "Status",
 		Size:           model.StatusCacheSize,
 		Striped:        true,
 		StripedBuckets: maxInt(runtime.NumCPU()-1, 1),

--- a/server/channels/app/platform/status.go
+++ b/server/channels/app/platform/status.go
@@ -65,12 +65,12 @@ func (ps *PlatformService) GetStatusesByIds(userIDs []string) (map[string]any, *
 		if err := ps.statusCache.Get(userID, &status); err == nil {
 			statusMap[userID] = status.Status
 			if metrics != nil {
-				metrics.IncrementMemCacheHitCounter("Status")
+				metrics.IncrementMemCacheHitCounter(ps.statusCache.Name())
 			}
 		} else {
 			missingUserIds = append(missingUserIds, userID)
 			if metrics != nil {
-				metrics.IncrementMemCacheMissCounter("Status")
+				metrics.IncrementMemCacheMissCounter(ps.statusCache.Name())
 			}
 		}
 	}
@@ -112,12 +112,12 @@ func (ps *PlatformService) GetUserStatusesByIds(userIDs []string) ([]*model.Stat
 		if err := ps.statusCache.Get(userID, &status); err == nil {
 			statusMap = append(statusMap, status)
 			if metrics != nil {
-				metrics.IncrementMemCacheHitCounter("Status")
+				metrics.IncrementMemCacheHitCounter(ps.statusCache.Name())
 			}
 		} else {
 			missingUserIds = append(missingUserIds, userID)
 			if metrics != nil {
-				metrics.IncrementMemCacheMissCounter("Status")
+				metrics.IncrementMemCacheMissCounter(ps.statusCache.Name())
 			}
 		}
 	}

--- a/server/channels/store/localcachelayer/channel_layer.go
+++ b/server/channels/store/localcachelayer/channel_layer.go
@@ -112,14 +112,14 @@ func (s LocalCacheChannelStore) InvalidateMemberCount(channelId string) {
 func (s LocalCacheChannelStore) InvalidateGuestCount(channelId string) {
 	s.rootStore.doInvalidateCacheCluster(s.rootStore.channelGuestCountCache, channelId, nil)
 	if s.rootStore.metrics != nil {
-		s.rootStore.metrics.IncrementMemCacheInvalidationCounter("Channel Guests Count - Remove by channelId")
+		s.rootStore.metrics.IncrementMemCacheInvalidationCounter(s.rootStore.channelGuestCountCache.Name())
 	}
 }
 
 func (s LocalCacheChannelStore) InvalidateChannel(channelId string) {
 	s.rootStore.doInvalidateCacheCluster(s.rootStore.channelByIdCache, channelId, nil)
 	if s.rootStore.metrics != nil {
-		s.rootStore.metrics.IncrementMemCacheInvalidationCounter("Channel - Remove by ChannelId")
+		s.rootStore.metrics.IncrementMemCacheInvalidationCounter(s.rootStore.channelByIdCache.Name())
 	}
 }
 

--- a/server/channels/store/localcachelayer/file_info_layer.go
+++ b/server/channels/store/localcachelayer/file_info_layer.go
@@ -53,7 +53,7 @@ func (s LocalCacheFileInfoStore) GetForPost(postId string, readFromMaster, inclu
 func (s LocalCacheFileInfoStore) ClearCaches() {
 	s.rootStore.fileInfoCache.Purge()
 	if s.rootStore.metrics != nil {
-		s.rootStore.metrics.IncrementMemCacheInvalidationCounter("File Info Cache - Purge")
+		s.rootStore.metrics.IncrementMemCacheInvalidationCounter(s.rootStore.fileInfoCache.Name())
 	}
 }
 
@@ -64,7 +64,7 @@ func (s LocalCacheFileInfoStore) InvalidateFileInfosForPostCache(postId string, 
 	}
 	s.rootStore.doInvalidateCacheCluster(s.rootStore.fileInfoCache, cacheKey, nil)
 	if s.rootStore.metrics != nil {
-		s.rootStore.metrics.IncrementMemCacheInvalidationCounter("File Info Cache - Remove by PostId")
+		s.rootStore.metrics.IncrementMemCacheInvalidationCounter(s.rootStore.fileInfoCache.Name())
 	}
 }
 

--- a/server/channels/store/localcachelayer/post_layer.go
+++ b/server/channels/store/localcachelayer/post_layer.go
@@ -49,9 +49,9 @@ func (s LocalCachePostStore) ClearCaches() {
 	s.PostStore.ClearCaches()
 
 	if s.rootStore.metrics != nil {
-		s.rootStore.metrics.IncrementMemCacheInvalidationCounter("Last Post Time - Purge")
-		s.rootStore.metrics.IncrementMemCacheInvalidationCounter("Last Posts Cache - Purge")
-		s.rootStore.metrics.IncrementMemCacheInvalidationCounter("Posts Usage Cache - Purge")
+		s.rootStore.metrics.IncrementMemCacheInvalidationCounter(s.rootStore.lastPostTimeCache.Name())
+		s.rootStore.metrics.IncrementMemCacheInvalidationCounter(s.rootStore.postLastPostsCache.Name())
+		s.rootStore.metrics.IncrementMemCacheInvalidationCounter(s.rootStore.postsUsageCache.Name())
 	}
 }
 
@@ -65,8 +65,8 @@ func (s LocalCachePostStore) InvalidateLastPostTimeCache(channelId string) {
 	s.PostStore.InvalidateLastPostTimeCache(channelId)
 
 	if s.rootStore.metrics != nil {
-		s.rootStore.metrics.IncrementMemCacheInvalidationCounter("Last Post Time - Remove by Channel Id")
-		s.rootStore.metrics.IncrementMemCacheInvalidationCounter("Last Posts Cache - Remove by Channel Id")
+		s.rootStore.metrics.IncrementMemCacheInvalidationCounter(s.rootStore.lastPostTimeCache.Name())
+		s.rootStore.metrics.IncrementMemCacheInvalidationCounter(s.rootStore.postLastPostsCache.Name())
 	}
 }
 

--- a/server/channels/store/localcachelayer/team_layer.go
+++ b/server/channels/store/localcachelayer/team_layer.go
@@ -26,14 +26,14 @@ func (s *LocalCacheTeamStore) handleClusterInvalidateTeam(msg *model.ClusterMess
 func (s LocalCacheTeamStore) ClearCaches() {
 	s.rootStore.teamAllTeamIdsForUserCache.Purge()
 	if s.rootStore.metrics != nil {
-		s.rootStore.metrics.IncrementMemCacheInvalidationCounter("All Team Ids for User - Purge")
+		s.rootStore.metrics.IncrementMemCacheInvalidationCounter(s.rootStore.teamAllTeamIdsForUserCache.Name())
 	}
 }
 
 func (s LocalCacheTeamStore) InvalidateAllTeamIdsForUser(userId string) {
 	s.rootStore.doInvalidateCacheCluster(s.rootStore.teamAllTeamIdsForUserCache, userId, nil)
 	if s.rootStore.metrics != nil {
-		s.rootStore.metrics.IncrementMemCacheInvalidationCounter("All Team Ids for User - Remove by UserId")
+		s.rootStore.metrics.IncrementMemCacheInvalidationCounter(s.rootStore.teamAllTeamIdsForUserCache.Name())
 	}
 }
 

--- a/server/channels/store/localcachelayer/terms_of_service_layer.go
+++ b/server/channels/store/localcachelayer/terms_of_service_layer.go
@@ -31,7 +31,7 @@ func (s LocalCacheTermsOfServiceStore) ClearCaches() {
 	s.rootStore.doClearCacheCluster(s.rootStore.termsOfServiceCache)
 
 	if s.rootStore.metrics != nil {
-		s.rootStore.metrics.IncrementMemCacheInvalidationCounter("Terms Of Service - Purge")
+		s.rootStore.metrics.IncrementMemCacheInvalidationCounter(s.rootStore.termsOfServiceCache.Name())
 	}
 }
 

--- a/server/channels/store/localcachelayer/webhook_layer.go
+++ b/server/channels/store/localcachelayer/webhook_layer.go
@@ -27,14 +27,14 @@ func (s LocalCacheWebhookStore) ClearCaches() {
 	s.rootStore.doClearCacheCluster(s.rootStore.webhookCache)
 
 	if s.rootStore.metrics != nil {
-		s.rootStore.metrics.IncrementMemCacheInvalidationCounter("Webhook - Purge")
+		s.rootStore.metrics.IncrementMemCacheInvalidationCounter(s.rootStore.webhookCache.Name())
 	}
 }
 
 func (s LocalCacheWebhookStore) InvalidateWebhookCache(webhookId string) {
 	s.rootStore.doInvalidateCacheCluster(s.rootStore.webhookCache, webhookId, nil)
 	if s.rootStore.metrics != nil {
-		s.rootStore.metrics.IncrementMemCacheInvalidationCounter("Webhook - Remove by WebhookId")
+		s.rootStore.metrics.IncrementMemCacheInvalidationCounter(s.rootStore.webhookCache.Name())
 	}
 }
 


### PR DESCRIPTION
We use the same name for hit/miss/invalidation metrics.

The downside is that now we have conflated a full cache purge
and a single cache key invalidation into a single label, but
the advantage is that it's easier to monitor the usage of a single
cache.

And moreover, duplicating the same string across multiple places
increases the chances of making a mistake. Centralizing the cache
name only at instantiation simplifies the code.

After this, we would be ready to use Redis.

https://mattermost.atlassian.net/browse/MM-57193

```release-note
NONE
```
