### PR TITLE
Create proper SharedChannel record for InviteRemoteToChannel

### DIFF
--- a/server/channels/app/platform/shared_channel_notifier.go
+++ b/server/channels/app/platform/shared_channel_notifier.go
@@ -95,7 +95,7 @@ func handleContentSync(ps *PlatformService, syncService SharedChannelServiceIFac
 		for _, remote := range remotes {
 			// invite remote to channel (will share the channel if not already shared)
 			if err := syncService.InviteRemoteToChannel(channel.Id, remote.RemoteId, remote.CreatorId, true); err != nil {
-				return fmt.Errorf("cannot invite remote to channel %s: %w", channel.Id, err)
+				return fmt.Errorf("cannot invite remote %s to channel %s: %w", remote.RemoteId, channel.Id, err)
 			}
 			shouldNotify = true
 		}

--- a/server/platform/services/sharedchannel/service_api.go
+++ b/server/platform/services/sharedchannel/service_api.go
@@ -117,7 +117,13 @@ func (scs *Service) InviteRemoteToChannel(channelID, remoteID, userID string, sh
 
 	// set the channel `shared` flag if needed
 	if shareIfNotShared {
-		if _, err = scs.ShareChannel(&model.SharedChannel{ChannelId: channelID, CreatorId: userID}); err != nil {
+		sc := &model.SharedChannel{
+			ChannelId: channelID,
+			CreatorId: userID,
+			Home:      true,
+			RemoteId:  remoteID,
+		}
+		if _, err = scs.ShareChannel(sc); err != nil {
 			return model.NewAppError("InviteRemoteToChannel", "api.command_share.share_channel.error",
 				map[string]any{"Error": err.Error()}, "", http.StatusBadRequest)
 		}


### PR DESCRIPTION
#### Summary
The new/recent auto-share feature changes the code path to get channels automatically shared.  One code path wasn't creating a proper ShareChannels record.  This PR addresses that issue.

This only affects MS Teams plugin since normal Shared Channels does not auto subscibe.

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
