### PR TITLE
MM-57221 - Adding formattedMessage to reply count

### DIFF
--- a/webapp/channels/src/components/threading/virtualized_thread_viewer/thread_viewer_row.tsx
+++ b/webapp/channels/src/components/threading/virtualized_thread_viewer/thread_viewer_row.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {memo} from 'react';
+import {FormattedMessage} from 'react-intl';
 
 import type {Post} from '@mattermost/types/posts';
 
@@ -79,7 +80,13 @@ function ThreadViewerRow({
                 />
                 {replyCount > 0 && (
                     <div className='root-post__divider'>
-                        <div>{`${replyCount} Replies`}</div>
+                        <div>
+                            <FormattedMessage
+                                id='threading.numReplies'
+                                defaultMessage='{replyCount, plural, =0 {Reply} =1 {# reply} other {# replies}}'
+                                values={{replyCount}}
+                            />
+                        </div>
                     </div>
                 )}
             </>


### PR DESCRIPTION
#### Summary
MM-57221 - Adding formattedMessage to reply count
Looks like I missed adding the formatted message

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-57221

#### Screenshots
![CleanShot 2024-03-14 at 01 38 33@2x](https://github.com/mattermost/mattermost/assets/11034289/eb1a68eb-142a-42ae-ac3d-cd65b217fb6c)
![CleanShot 2024-03-14 at 01 38 29@2x](https://github.com/mattermost/mattermost/assets/11034289/45c8b0ac-ccc2-4a77-b21e-9fb99f6454f0)



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
