### PR TITLE
[CLD-7344] CD. Revisiting image registry for mattermostdevelopment/mirrored-keycloak

### DIFF
--- a/server/scripts/mirror-docker-images.json
+++ b/server/scripts/mirror-docker-images.json
@@ -16,7 +16,7 @@
     "1.4.0": "osixia/openldap:1.4.0@sha256:d5b2f2b816b25a1b57033b34f5d48c91cc3161a7d041811a9032604030bad9db"
   },
   "keycloak": {
-    "10.0.2": "jboss/keycloak:10.0.2@sha256:3720b5ace316b5790a58ce838f46e8cd44cedbdb7e35d3866311ddc5a5e71466"
+    "10.0.2": "quay.io/keycloak/keycloak:10.0.2@sha256:fa434fd4e96f03242295febb37fb648b9ee271315ba7380d06003b43a42b5195"
   },
   "dejavu": {
     "3.4.2": "appbaseio/dejavu:3.4.2@sha256:8f2f4d45565da53c4235495737fff3921d302955daeb2f53a433c7b0e2044951"


### PR DESCRIPTION






<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Switching to quay.io for keycloak. Used for CD Process on providing a mirror of keyclock image under  `mattermostdevelopment/mirrored-keycloak` 



Local DRY RUNs follow
Before: 
```
[2024-03-14T15:07:36+02:00] Pushing image: cypress/browsers:node-18.16.1-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1@sha256:f798d6cc25d724210be3660e95f63ae75d052ef392e3fc5ae728d02da7e52df8 ---> mattermostdevelopment/mirrored-cypress-browsers-public:node-18.16.1-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:07:36+02:00] Pushing image: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge@sha256:f8459ee677ce356eff64698095fbdf48eb9ab018fc5eb0d30c07ba23884edace ---> mattermostdevelopment/mirrored-cypress-browsers-public:node16.14.2-slim-chrome100-ff99-edge (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:07:36+02:00] Pushing image: appbaseio/dejavu:3.4.2@sha256:8f2f4d45565da53c4235495737fff3921d302955daeb2f53a433c7b0e2044951 ---> mattermostdevelopment/mirrored-dejavu:3.4.2 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:07:36+02:00] Pushing image: grafana/grafana:8.0.1@sha256:1c3e2fc7896adf9e33be5d062c08066087cb556f63b0a95f8aefe92bd37a6f38 ---> mattermostdevelopment/mirrored-grafana:8.0.1 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:07:37+02:00] Pushing image: inbucket/inbucket:3.0.0@sha256:1f10a0efea694592c06799c729aee1d6d71c9a4f72b73031d4a426ef5f26dfc1 ---> mattermostdevelopment/mirrored-inbucket:3.0.0 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:07:37+02:00] Pushing image: jboss/keycloak:10.0.2@sha256:3720b5ace316b5790a58ce838f46e8cd44cedbdb7e35d3866311ddc5a5e71466 ---> mattermostdevelopment/mirrored-keycloak:10.0.2 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:07:37+02:00] Pushing image: minio/minio:RELEASE.2019-10-11T00-38-09Z@sha256:0d02f16a1662653f9b961211b21ed7de04bf04492f44c2b7594bacbfcc519eb5 ---> mattermostdevelopment/mirrored-minio:RELEASE.2019-10-11T00-38-09Z-1 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:07:37+02:00] Pushing image: mysql/mysql-server:5.7.12@sha256:3f0d90736a3298bb04965db697a3a85f1df1480da49eafd256be1ea2b9b5337e ---> mattermostdevelopment/mirrored-mysql:5.7.12 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:07:37+02:00] Pushing image: node:16.10.0 ---> mattermostdevelopment/mirrored-node:16.10.0 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:07:37+02:00] Pushing image: node:16.17.0 ---> mattermostdevelopment/mirrored-node:16.17.0 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:07:37+02:00] Pushing image: node:18@sha256:11e9c297fc51f6f65f7d0c7c8a8581e5721f2f16de43ceff1a199fd3ef609f95 ---> mattermostdevelopment/mirrored-node:18 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:07:37+02:00] Pushing image: node:18.17@sha256:11e9c297fc51f6f65f7d0c7c8a8581e5721f2f16de43ceff1a199fd3ef609f95 ---> mattermostdevelopment/mirrored-node:18.17 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:07:37+02:00] Pushing image: node:18.17.1@sha256:11e9c297fc51f6f65f7d0c7c8a8581e5721f2f16de43ceff1a199fd3ef609f95 ---> mattermostdevelopment/mirrored-node:18.17.1 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:07:37+02:00] Pushing image: node:20.11.1@sha256:e06aae17c40c7a6b5296ca6f942a02e6737ae61bbbf3e2158624bb0f887991b5 ---> mattermostdevelopment/mirrored-node:20.11.1 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:07:37+02:00] Pushing image: osixia/openldap:1.4.0@sha256:d5b2f2b816b25a1b57033b34f5d48c91cc3161a7d041811a9032604030bad9db ---> mattermostdevelopment/mirrored-openldap:1.4.0 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:07:37+02:00] Pushing image: postgres:10@sha256:7a484b11fcabd39596b1bf08780cdb61fa9b0d8bfad0844dbdce3a6922df95d1 ---> mattermostdevelopment/mirrored-postgres:10 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:07:37+02:00] Pushing image: postgres:12@sha256:cc7a021d9aff3aa02788d35c27a5cc32d4790ad92d72232a6be75b76ab7d79db ---> mattermostdevelopment/mirrored-postgres:12 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:07:37+02:00] Pushing image: prom/prometheus:v2.27.1@sha256:5accb68b56ba452e449a5e552411acaeabbbe0f087acf19a1157ce3dd10a8bed ---> mattermostdevelopment/mirrored-prometheus:v2.27.1 (dry run mode, set the DRY_RUN=no env var to disable)
```

After: 
```
[2024-03-14T15:08:34+02:00] Pushing image: cypress/browsers:node-18.16.1-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1@sha256:f798d6cc25d724210be3660e95f63ae75d052ef392e3fc5ae728d02da7e52df8 ---> mattermostdevelopment/mirrored-cypress-browsers-public:node-18.16.1-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:08:34+02:00] Pushing image: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge@sha256:f8459ee677ce356eff64698095fbdf48eb9ab018fc5eb0d30c07ba23884edace ---> mattermostdevelopment/mirrored-cypress-browsers-public:node16.14.2-slim-chrome100-ff99-edge (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:08:34+02:00] Pushing image: appbaseio/dejavu:3.4.2@sha256:8f2f4d45565da53c4235495737fff3921d302955daeb2f53a433c7b0e2044951 ---> mattermostdevelopment/mirrored-dejavu:3.4.2 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:08:34+02:00] Pushing image: grafana/grafana:8.0.1@sha256:1c3e2fc7896adf9e33be5d062c08066087cb556f63b0a95f8aefe92bd37a6f38 ---> mattermostdevelopment/mirrored-grafana:8.0.1 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:08:34+02:00] Pushing image: inbucket/inbucket:3.0.0@sha256:1f10a0efea694592c06799c729aee1d6d71c9a4f72b73031d4a426ef5f26dfc1 ---> mattermostdevelopment/mirrored-inbucket:3.0.0 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:08:34+02:00] Pushing image: quay.io/keycloak/keycloak:10.0.2@sha256:fa434fd4e96f03242295febb37fb648b9ee271315ba7380d06003b43a42b5195 ---> mattermostdevelopment/mirrored-keycloak:10.0.2 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:08:34+02:00] Pushing image: minio/minio:RELEASE.2019-10-11T00-38-09Z@sha256:0d02f16a1662653f9b961211b21ed7de04bf04492f44c2b7594bacbfcc519eb5 ---> mattermostdevelopment/mirrored-minio:RELEASE.2019-10-11T00-38-09Z-1 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:08:34+02:00] Pushing image: mysql/mysql-server:5.7.12@sha256:3f0d90736a3298bb04965db697a3a85f1df1480da49eafd256be1ea2b9b5337e ---> mattermostdevelopment/mirrored-mysql:5.7.12 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:08:34+02:00] Pushing image: node:16.10.0 ---> mattermostdevelopment/mirrored-node:16.10.0 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:08:34+02:00] Pushing image: node:16.17.0 ---> mattermostdevelopment/mirrored-node:16.17.0 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:08:34+02:00] Pushing image: node:18@sha256:11e9c297fc51f6f65f7d0c7c8a8581e5721f2f16de43ceff1a199fd3ef609f95 ---> mattermostdevelopment/mirrored-node:18 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:08:34+02:00] Pushing image: node:18.17@sha256:11e9c297fc51f6f65f7d0c7c8a8581e5721f2f16de43ceff1a199fd3ef609f95 ---> mattermostdevelopment/mirrored-node:18.17 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:08:34+02:00] Pushing image: node:18.17.1@sha256:11e9c297fc51f6f65f7d0c7c8a8581e5721f2f16de43ceff1a199fd3ef609f95 ---> mattermostdevelopment/mirrored-node:18.17.1 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:08:34+02:00] Pushing image: node:20.11.1@sha256:e06aae17c40c7a6b5296ca6f942a02e6737ae61bbbf3e2158624bb0f887991b5 ---> mattermostdevelopment/mirrored-node:20.11.1 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:08:34+02:00] Pushing image: osixia/openldap:1.4.0@sha256:d5b2f2b816b25a1b57033b34f5d48c91cc3161a7d041811a9032604030bad9db ---> mattermostdevelopment/mirrored-openldap:1.4.0 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:08:34+02:00] Pushing image: postgres:10@sha256:7a484b11fcabd39596b1bf08780cdb61fa9b0d8bfad0844dbdce3a6922df95d1 ---> mattermostdevelopment/mirrored-postgres:10 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:08:34+02:00] Pushing image: postgres:12@sha256:cc7a021d9aff3aa02788d35c27a5cc32d4790ad92d72232a6be75b76ab7d79db ---> mattermostdevelopment/mirrored-postgres:12 (dry run mode, set the DRY_RUN=no env var to disable)
[2024-03-14T15:08:34+02:00] Pushing image: prom/prometheus:v2.27.1@sha256:5accb68b56ba452e449a5e552411acaeabbbe0f087acf19a1157ce3dd10a8bed ---> mattermostdevelopment/mirrored-prometheus:v2.27.1 (dry run mode, set the DRY_RUN=no env var to disable)
```






#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Ticket: https://mattermost.atlassian.net/browse/CLD-7344


#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
