### PR TITLE
[MM-57076] Stop removing local drafts when calling `removeDraft` for servers with synced drafts

### DIFF
--- a/webapp/channels/src/actions/views/drafts.test.ts
+++ b/webapp/channels/src/actions/views/drafts.test.ts
@@ -164,6 +164,19 @@ describe('draft actions', () => {
 
     describe('removeDraft', () => {
         it('calls setGlobalItem action correctly', async () => {
+            store = mockStore({
+                ...initialState,
+                entities: {
+                    ...initialState.entities,
+                    general: {
+                        ...initialState.entities.general,
+                        config: {
+                            ...initialState.entities.general.config,
+                            AllowSyncedDrafts: 'false',
+                        },
+                    },
+                },
+            });
             await store.dispatch(removeDraft(key, channelId));
 
             const testStore = mockStore(initialState);

--- a/webapp/channels/src/actions/views/drafts.ts
+++ b/webapp/channels/src/actions/views/drafts.ts
@@ -105,9 +105,6 @@ export function removeDraft(key: string, channelId: string, rootId = ''): Action
         // set draft to empty to re-render the component
         await dispatch(setGlobalItem(key, {message: '', fileInfos: [], uploadsInProgress: []}));
 
-        // remove draft from storage
-        await dispatch(removeGlobalItem(key));
-
         if (syncedDraftsAreAllowedAndEnabled(state)) {
             const connectionId = getConnectionId(getState());
 
@@ -119,6 +116,9 @@ export function removeDraft(key: string, channelId: string, rootId = ''): Action
                     error,
                 };
             }
+        } else {
+            // only remove draft from storage for local drafts
+            await dispatch(removeGlobalItem(key));
         }
         return {data: true};
     };


### PR DESCRIPTION
#### Summary
When calling `removeDraft` (ie. after clicking delete on a draft or posting a message that had a draft), we were explicitly calling `removeGlobalitem` to delete the local draft, before other tabs were synced up. This would cause rehydration to sync drafts from other tabs (if open) back to the original tab, thus leaving the orphaned draft still in storage.

This PR defers that call to only do this when synced drafts are disabled, which should stop the bug from happening with server-synced drafts, and reduce it for local drafts (or at least only make it happen ephemerally).

The better solution going forward might be to rework the way we handle drafts when server syncing is turned on. It's unfortunately very hard to reproduce since it relies on the rehydration completing before the server can successfully delete the draft and send a websocket connection.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57076
Closes https://github.com/mattermost/mattermost/issues/26373

```release-note
NONE
```
