### PR TITLE
Add css variables for border radius

### DIFF
--- a/webapp/channels/src/components/widgets/admin_console/admin_panel.scss
+++ b/webapp/channels/src/components/widgets/admin_console/admin_panel.scss
@@ -1,6 +1,7 @@
 @import 'utils/module';
 
 .AdminPanel {
+    overflow: hidden;
     padding: 0;
     border: solid 1px rgba(var(--center-channel-color-rgb), 0.12);
     border-radius: var(--radius-s);

--- a/webapp/channels/src/components/widgets/admin_console/admin_panel.scss
+++ b/webapp/channels/src/components/widgets/admin_console/admin_panel.scss
@@ -2,10 +2,10 @@
 
 .AdminPanel {
     padding: 0;
-    background-color: var(--center-channel-bg);
     border: solid 1px rgba(var(--center-channel-color-rgb), 0.12);
     border-radius: var(--radius-s);
     margin: 2em 0 1em;
+    background-color: var(--center-channel-bg);
     box-shadow: var(--elevation-1);
     font-size: 0.95em;
 
@@ -36,8 +36,8 @@
         align-items: center;
         justify-content: space-between;
         padding: 20px;
-        background: $white;
         border-radius: var(--radius-s) var(--radius-s) 0 0;
+        background: $white;
 
         h3 {
             padding: 0;

--- a/webapp/channels/src/components/widgets/admin_console/admin_panel.scss
+++ b/webapp/channels/src/components/widgets/admin_console/admin_panel.scss
@@ -3,7 +3,7 @@
 .AdminPanel {
     padding: 0;
     border: solid 1px alpha-color($black, 0.1);
-    border-radius: $border-rad;
+    border-radius: var(--radius-xs);
     margin: 2em 0 1em;
     box-shadow: 0 1px 2px 0 alpha-color($black, 0.5);
     font-size: 0.95em;

--- a/webapp/channels/src/components/widgets/admin_console/admin_panel.scss
+++ b/webapp/channels/src/components/widgets/admin_console/admin_panel.scss
@@ -2,10 +2,11 @@
 
 .AdminPanel {
     padding: 0;
-    border: solid 1px alpha-color($black, 0.1);
-    border-radius: var(--radius-xs);
+    background-color: var(--center-channel-bg);
+    border: solid 1px rgba(var(--center-channel-color-rgb), 0.12);
+    border-radius: var(--radius-s);
     margin: 2em 0 1em;
-    box-shadow: 0 1px 2px 0 alpha-color($black, 0.5);
+    box-shadow: var(--elevation-1);
     font-size: 0.95em;
 
     .AdminPanel__content {
@@ -36,6 +37,7 @@
         justify-content: space-between;
         padding: 20px;
         background: $white;
+        border-radius: var(--radius-s) var(--radius-s) 0 0;
 
         h3 {
             padding: 0;

--- a/webapp/channels/src/sass/base/_css_variables.scss
+++ b/webapp/channels/src/sass/base/_css_variables.scss
@@ -78,6 +78,14 @@
     --elevation-5: 0 12px 32px 0 rgba(0, 0, 0, 0.12);
     --elevation-6: 0 20px 32px 0 rgba(0, 0, 0, 0.12);
 
+    //Corner Radius variables
+    --radius-xs: 2px;
+    --radius-s: 4px;
+    --radius-m: 8px;
+    --radius-l: 12px;
+    --radius-xl: 16px;
+    --radius-full: 50%;
+
     // Global Header variables
     --global-header-background: var(--sidebar-teambar-bg);
     --global-header-text: var(--sidebar-header-text-color);

--- a/webapp/channels/src/sass/components/_alerts.scss
+++ b/webapp/channels/src/sass/components/_alerts.scss
@@ -2,7 +2,7 @@
 
 .alert {
     padding: 8px 12px;
-    border-radius: $border-rad;
+    border-radius: var(--radius-s);
 
     .alert-transparent {
         border-color: rgba(var(--center-channel-color-rgb), 0.12);

--- a/webapp/channels/src/sass/components/_buttons.scss
+++ b/webapp/channels/src/sass/components/_buttons.scss
@@ -26,7 +26,7 @@ button {
         display: inline-block;
         width: 8px;
         height: 8px;
-        border-radius: 50%;
+        border-radius: var(--radius-full);
         margin: 0 0 0 40px;
         background: #f74343;
     }
@@ -40,7 +40,7 @@ button {
     justify-content: center;
     padding: 0 20px;
     border: none;
-    border-radius: $border-rad * 2;
+    border-radius: var(--radius-s);
     font-size: 14px;
     font-weight: 600;
     gap: 8px;

--- a/webapp/channels/src/sass/components/_dnd-pickers-dropdown-menu.scss
+++ b/webapp/channels/src/sass/components/_dnd-pickers-dropdown-menu.scss
@@ -16,7 +16,7 @@
     .btn {
         height: 4rem;
         padding: 0 2rem;
-        border-radius: $border-rad * 2;
+        border-radius: var(--radius-s);
         font-size: 14px;
         font-weight: 600;
     }

--- a/webapp/channels/src/sass/components/_edit-post-time-limit-button.scss
+++ b/webapp/channels/src/sass/components/_edit-post-time-limit-button.scss
@@ -2,7 +2,7 @@
     height: 26px;
     padding: 0 8px;
     border-color: #5b6672;
-    border-radius: $border-rad * 2;
+    border-radius: var(--radius-s);
     background: transparent;
     color: #5b6672;
     transition: all 0.15s ease;

--- a/webapp/channels/src/sass/components/_emoticons.scss
+++ b/webapp/channels/src/sass/components/_emoticons.scss
@@ -90,8 +90,7 @@
     width: 350px;
     flex-direction: column;
     border: 1px solid;
-    border-radius: $border-rad;
-    border-radius: 4px;
+    border-radius: var(--radius-s);
     margin-right: 3px;
     background: var(--center-channel-bg);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);

--- a/webapp/channels/src/sass/components/_inputs.scss
+++ b/webapp/channels/src/sass/components/_inputs.scss
@@ -30,7 +30,7 @@
 }
 
 .form-control {
-    border-radius: $border-rad;
+    border-radius: var(--radius-xs);
     text-align: left;
 
     &:focus {

--- a/webapp/channels/src/sass/components/_popover.scss
+++ b/webapp/channels/src/sass/components/_popover.scss
@@ -14,7 +14,7 @@
 
 .popover {
     padding: 0;
-    border-radius: $border-rad * 2;
+    border-radius: var(--radius-s);
     background: var(--center-channel-bg);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
     color: var(--center-channel-color);

--- a/webapp/channels/src/sass/components/_scrollbar.scss
+++ b/webapp/channels/src/sass/components/_scrollbar.scss
@@ -10,7 +10,7 @@
 }
 
 ::-webkit-scrollbar-thumb {
-    border-radius: $border-rad * 2;
+    border-radius: var(--radius-s);
     background: rgba(var(--center-channel-color-rgb), 0.4);
 }
 

--- a/webapp/channels/src/sass/routes/_about-modal.scss
+++ b/webapp/channels/src/sass/routes/_about-modal.scss
@@ -2,7 +2,7 @@
 
 .modal {
     .modal-content {
-        border-radius: $border-rad;
+        border-radius: var(--radius-s);
         box-shadow: 0 0 10px rgba($black, 0.5);
     }
 

--- a/webapp/channels/src/sass/routes/_admin-console.scss
+++ b/webapp/channels/src/sass/routes/_admin-console.scss
@@ -491,7 +491,7 @@
             height: 34px;
             align-items: center;
             justify-content: center;
-            border-radius: $border-rad;
+            border-radius: var(--radius-s);
             margin: 0 10px 0 0;
             text-decoration: none;
             transition: all 0.15s ease;

--- a/webapp/channels/src/sass/utils/_variables.scss
+++ b/webapp/channels/src/sass/utils/_variables.scss
@@ -26,7 +26,6 @@ $announcement-bar-height: 40px;
 $backstage-bar-height: 43px;
 
 // Random variables
-$border-rad: 2px;
 $emoji-per-row: 9; // needs to match variable `EMOJI_PER_ROW` in emoji_picker.jsx
 
 // Transition timing defaults


### PR DESCRIPTION
#### Summary
This PR adds css variables for border radius and applies them in a few select areas (mainly where the sass variable `$border-rad` was being used. Also includes a few minor fixes to CSS in the admin panel CSS to fix how the border radius looks.

Future PRs are in the works that would like to take advantage of these variables.

#### Screenshots
The only place where a visible change occurs is where admin panels are used in the system console (fixes the corner radiuses and shadow)

| Before | After |
| --- | --- |
| <img width="2032" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/26d36ee0-0088-4d93-be2b-ffd2868678ad"> | <img width="2032" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/210ecb95-3bea-4e70-98ae-76e9c78d57ff"> |


#### Release Note
```release-note
NONE
```
