### PR TITLE
Fix incorrect translation string

### DIFF
--- a/webapp/channels/src/components/threading/virtualized_thread_viewer/thread_viewer_row.tsx
+++ b/webapp/channels/src/components/threading/virtualized_thread_viewer/thread_viewer_row.tsx
@@ -83,8 +83,10 @@ function ThreadViewerRow({
                         <div>
                             <FormattedMessage
                                 id='threading.numReplies'
-                                defaultMessage='{replyCount, plural, =0 {Reply} =1 {# reply} other {# replies}}'
-                                values={{replyCount}}
+                                defaultMessage='{totalReplies, plural, =0 {Reply} =1 {# reply} other {# replies}}'
+                                values={{
+                                    totalReplies: replyCount,
+                                }}
                             />
                         </div>
                     </div>


### PR DESCRIPTION
#### Summary
Apparently our i18n tooling silently ignores when two components have different `defaultMessage`s for the same `id` since this wasn't caught be CI

#### Release Note
```release-note
NONE
```
