### PR TITLE
[MM-57379] Still generate support_packet.yaml even if an error occurs

### DIFF
--- a/server/channels/app/support_packet.go
+++ b/server/channels/app/support_packet.go
@@ -50,7 +50,9 @@ func (a *App) GenerateSupportPacket(c request.CTX) []model.FileData {
 		if err != nil {
 			c.Logger().Error("Failed to generate file for support package", mlog.Err(err), mlog.String("file", name))
 			warnings = append(warnings, err.Error())
-		} else if fileData != nil {
+		}
+
+		if fileData != nil {
 			fileDatas = append(fileDatas, *fileData)
 		}
 	}

--- a/server/channels/app/support_packet_test.go
+++ b/server/channels/app/support_packet_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/v8/channels/app/platform"
+	smocks "github.com/mattermost/mattermost/server/v8/channels/store/storetest/mocks"
 	fmocks "github.com/mattermost/mattermost/server/v8/platform/shared/filestore/mocks"
 )
 
@@ -139,6 +140,42 @@ func TestGenerateSupportPacket(t *testing.T) {
 		rFileNames = append(rFileNames, fileData.Filename)
 	}
 	assert.ElementsMatch(t, testFiles, rFileNames)
+
+	t.Run("steps that generated an error should still return file data", func(t *testing.T) {
+		mockStore := smocks.Store{}
+
+		// Mock the post store to trigger an error
+		ps := &smocks.PostStore{}
+		ps.On("AnalyticsPostCount", &model.PostCountOptions{}).Return(int64(0), errors.New("all broken"))
+		ps.On("ClearCaches")
+		mockStore.On("Post").Return(ps)
+
+		mockStore.On("User").Return(th.App.Srv().Store().User())
+		mockStore.On("Channel").Return(th.App.Srv().Store().Channel())
+		mockStore.On("Post").Return(th.App.Srv().Store().Post())
+		mockStore.On("Team").Return(th.App.Srv().Store().Team())
+		mockStore.On("Job").Return(th.App.Srv().Store().Job())
+		mockStore.On("FileInfo").Return(th.App.Srv().Store().FileInfo())
+		mockStore.On("Webhook").Return(th.App.Srv().Store().Webhook())
+		mockStore.On("System").Return(th.App.Srv().Store().System())
+		mockStore.On("License").Return(th.App.Srv().Store().License())
+		mockStore.On("Close").Return(nil)
+		mockStore.On("GetDBSchemaVersion").Return(1, nil)
+		mockStore.On("GetDbVersion", false).Return("1.0.0", nil)
+		th.App.Srv().SetStore(&mockStore)
+
+		fileDatas := th.App.GenerateSupportPacket(th.Context)
+
+		var rFileNames []string
+		for _, fileData := range fileDatas {
+			require.NotNil(t, fileData)
+			assert.Positive(t, len(fileData.Body))
+
+			rFileNames = append(rFileNames, fileData.Filename)
+		}
+		assert.Contains(t, rFileNames, "warning.txt")
+		assert.Contains(t, rFileNames, "support_packet.yaml")
+	})
 }
 
 func TestGetNotificationsLog(t *testing.T) {


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57379

#### Release Note
```release-note
Still generate `support_packet.yaml` even if an error occurs
```
