### PR TITLE
[MM-57392] Skip flaky TestEditChannelBookmark test

### DIFF
--- a/server/channels/api4/channel_bookmark_test.go
+++ b/server/channels/api4/channel_bookmark_test.go
@@ -257,6 +257,7 @@ func TestCreateChannelBookmark(t *testing.T) {
 }
 
 func TestEditChannelBookmark(t *testing.T) {
+	t.Skip("https://mattermost.atlassian.net/browse/MM-57392")
 	os.Setenv("MM_FEATUREFLAGS_ChannelBookmarks", "true")
 	defer os.Unsetenv("MM_FEATUREFLAGS_ChannelBookmarks")
 

--- a/server/channels/api4/channel_bookmark_test.go
+++ b/server/channels/api4/channel_bookmark_test.go
@@ -220,6 +220,7 @@ func TestCreateChannelBookmark(t *testing.T) {
 	})
 
 	t.Run("a websockets event should be fired as part of creating a bookmark", func(t *testing.T) {
+		t.Skip("https://mattermost.atlassian.net/browse/MM-57393")
 		webSocketClient, err := th.CreateWebSocketClient()
 		require.NoError(t, err)
 		webSocketClient.Listen()
@@ -257,7 +258,6 @@ func TestCreateChannelBookmark(t *testing.T) {
 }
 
 func TestEditChannelBookmark(t *testing.T) {
-	t.Skip("https://mattermost.atlassian.net/browse/MM-57392")
 	os.Setenv("MM_FEATUREFLAGS_ChannelBookmarks", "true")
 	defer os.Unsetenv("MM_FEATUREFLAGS_ChannelBookmarks")
 
@@ -587,6 +587,7 @@ func TestEditChannelBookmark(t *testing.T) {
 	})
 
 	t.Run("a websockets event should be fired as part of editing a bookmark", func(t *testing.T) {
+		t.Skip("https://mattermost.atlassian.net/browse/MM-57392")
 		webSocketClient, err := th.CreateWebSocketClient()
 		require.NoError(t, err)
 		webSocketClient.Listen()


### PR DESCRIPTION
#### Summary
`TestEditChannelBookmark` and `TestCreateChannelBookmark` are both flaky. Skip them until they are fixed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57392
https://mattermost.atlassian.net/browse/MM-57393

#### Release Note
```release-note
NONE
```
