### PR TITLE
[MM-55272] Accessibility: Team Icon requires tabbing twice

### DIFF
--- a/webapp/channels/src/components/team_sidebar/components/team_button.tsx
+++ b/webapp/channels/src/components/team_sidebar/components/team_button.tsx
@@ -192,10 +192,12 @@ export default function TeamButton({
                         ref={provided.innerRef}
                         {...provided.draggableProps}
                         {...provided.dragHandleProps}
+                        tabIndex={-1}
                     >
                         <div
 
                             className={classNames([`team-container ${teamClass}`, {isDragging: snapshot.isDragging}])}
+                            tabIndex={-1}
                         >
                             {teamButton}
                             {orderIndicator}
@@ -205,7 +207,10 @@ export default function TeamButton({
             }}
         </Draggable>
     ) : (
-        <div className={`team-container ${teamClass}`}>
+        <div
+            className={`team-container ${teamClass}`}
+            tabIndex={-1}
+        >
             {teamButton}
             {orderIndicator}
         </div>

--- a/webapp/channels/src/components/team_sidebar/components/team_button.tsx
+++ b/webapp/channels/src/components/team_sidebar/components/team_button.tsx
@@ -195,9 +195,7 @@ export default function TeamButton({
                         tabIndex={-1}
                     >
                         <div
-
                             className={classNames([`team-container ${teamClass}`, {isDragging: snapshot.isDragging}])}
-                            tabIndex={-1}
                         >
                             {teamButton}
                             {orderIndicator}
@@ -209,7 +207,6 @@ export default function TeamButton({
     ) : (
         <div
             className={`team-container ${teamClass}`}
-            tabIndex={-1}
         >
             {teamButton}
             {orderIndicator}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

-  Only one `Tab` is needed to switch team buttons now 
- Did not add in functionality for `Space` to activate a team button because it is currently used for selecting and swapping the position of team buttons (see GIF below)
- I can add in functionality for `Space` to activate button (i.e same behavior as `Enter`) if that's something we still want to do

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
GH: https://github.com/mattermost/mattermost/issues/26489
JIRA: https://mattermost.atlassian.net/browse/MM-55272
#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->
|  Before  |  After  |
|----|----|
|<img src="https://github.com/mattermost/mattermost/assets/112513258/fff3f6d4-4dba-48e9-91f9-a5db94fe3cca" width="250" height="350"/>|<img src="https://github.com/mattermost/mattermost/assets/112513258/d394fd2b-ed72-4bf5-ab1c-48593dd99ee0" width="250" height="350"/>|

| Using `Space` To Switch Icons |
|----|   
|<img src="https://github.com/mattermost/mattermost/assets/112513258/6d87c9a2-204b-4622-afb6-cc753e058cfd" width="250" height="350"/>|

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
