### PR TITLE
Update AI Plugin prepackaged version

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -155,7 +155,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v4.1.0
 PLUGIN_PACKAGES += mattermost-plugin-nps-v1.3.3
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.3.4
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.6.2
-PLUGIN_PACKAGES += mattermost-plugin-ai-v0.6.2
+PLUGIN_PACKAGES += mattermost-plugin-ai-v0.6.3
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)
 


### PR DESCRIPTION
#### Summary
Updating AI plugin to 0.6.3


#### Release Note

```release-note
NONE
```
(note this is a NONE release note since the previous PR introducing the AI plugin in this version is still valid)
