### PR TITLE
MM-55252 Update RHS Thread View to Use Relative Timestamps

### DIFF
--- a/webapp/channels/src/components/rhs_thread/__snapshots__/rhs_thread.test.tsx.snap
+++ b/webapp/channels/src/components/rhs_thread/__snapshots__/rhs_thread.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`components/RhsThread should match snapshot 1`] = `
     fromSuppressed={false}
     isThreadView={false}
     rootPostId="id"
-    useRelativeTimestamp={false}
+    useRelativeTimestamp={true}
   />
 </div>
 `;

--- a/webapp/channels/src/components/rhs_thread/rhs_thread.tsx
+++ b/webapp/channels/src/components/rhs_thread/rhs_thread.tsx
@@ -59,7 +59,7 @@ const RhsThread = ({
             />
             <ThreadViewer
                 rootPostId={selected.id}
-                useRelativeTimestamp={false}
+                useRelativeTimestamp={true}
                 isThreadView={false}
                 fromSuppressed={fromSuppressed}
             />

--- a/webapp/channels/src/sass/components/_post-right.scss
+++ b/webapp/channels/src/sass/components/_post-right.scss
@@ -67,7 +67,8 @@
     }
 
     .post {
-        &.post--root {
+        &.post--root,
+        &.other--root {
             padding-top: 16px;
 
             .post__body {


### PR DESCRIPTION
#### Summary
This PR cleans up the RHS thread view by removing the date separators and uses relative timestamps instead. This makes the RHS thread view consistent with the Global Threads view. Before this PR, the two views used different time stamp methods.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-55252

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="571" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/1e4d8379-6c46-4e8a-8fd9-b66ea01f104b"> | <img width="570" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/5a462f2b-439d-4e42-bdb3-8ec4814cb3f3"> |

#### Release Note
```release-note
Updated the RHS Thread view to use relative time stamps to be more consistent with the global Threads view.
```
