### PR TITLE
updated modifyTeamsCmdF to return error instead of nil when encounting error

### DIFF
--- a/server/cmd/mmctl/commands/team.go
+++ b/server/cmd/mmctl/commands/team.go
@@ -336,7 +336,7 @@ func modifyTeamsCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 		return errors.New("must specify one of --private or --public")
 	}
 
-	var errs error
+	var errs *multierror.Error
 
 	// I = invite only (private)
 	// O = open (public)
@@ -362,11 +362,7 @@ func modifyTeamsCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if errs != nil {
-		return errs
-	}
-
-	return nil
+	return errs.ErrorOrNil()
 }
 
 func restoreTeamsCmdF(c client.Client, cmd *cobra.Command, args []string) error {

--- a/server/cmd/mmctl/commands/team.go
+++ b/server/cmd/mmctl/commands/team.go
@@ -348,18 +348,21 @@ func modifyTeamsCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	teams := getTeamsFromTeamArgs(c, args)
 	for i, team := range teams {
 		if team == nil {
-			errText := "Unable to find team '" + args[i] + "'"
-			printer.PrintError(errText)
-			errs = multierror.Append(errs, errors.New(errText))
+			errs = multierror.Append(errs, errors.New("Unable to find team '"+args[i]+"'"))
 			continue
 		}
-		if updatedTeam, _, err := c.UpdateTeamPrivacy(context.TODO(), team.Id, privacy); err != nil {
-			errText := "Unable to modify team '" + team.Name + "' error: " + err.Error()
-			printer.PrintError(errText)
-			errs = multierror.Append(errs, errors.New(errText))
-		} else {
-			printer.PrintT("Modified team '{{.Name}}'", updatedTeam)
+
+		updatedTeam, _, err := c.UpdateTeamPrivacy(context.TODO(), team.Id, privacy)
+		if err != nil {
+			errs = multierror.Append(errs, errors.New("Unable to modify team '"+team.Name+"' error: "+err.Error()))
+			continue
 		}
+
+		printer.PrintT("Modified team '{{.Name}}'", updatedTeam)
+	}
+
+	for _, err := range errs.WrappedErrors() {
+		printer.PrintError(err.Error())
 	}
 
 	return errs.ErrorOrNil()

--- a/server/cmd/mmctl/commands/team_e2e_test.go
+++ b/server/cmd/mmctl/commands/team_e2e_test.go
@@ -184,7 +184,7 @@ func (s *MmctlE2ETestSuite) TestModifyTeamsCmdF() {
 		err := modifyTeamsCmdF(s.th.Client, cmd, []string{teamID})
 
 		expectedError := fmt.Sprintf("Unable to modify team '%s' error: You do not have the appropriate permissions.", s.th.BasicTeam.Name)
-		s.Require().Equal(expectedError, err.(*multierror.Error).Unwrap().Error())
+		s.Require().ErrorContains(err, expectedError)
 		s.Require().Contains(
 			printer.GetErrorLines()[0],
 			expectedError,
@@ -203,7 +203,7 @@ func (s *MmctlE2ETestSuite) TestModifyTeamsCmdF() {
 		err := modifyTeamsCmdF(s.th.Client, cmd, []string{teamID})
 
 		expectedError := fmt.Sprintf("Unable to modify team '%s' error: You do not have the appropriate permissions.", s.th.BasicTeam.Name)
-		s.Require().Equal(expectedError, err.(*multierror.Error).Unwrap().Error())
+		s.Require().ErrorContains(err, expectedError)
 		s.Require().Contains(
 			printer.GetErrorLines()[0],
 			expectedError,

--- a/server/cmd/mmctl/commands/team_e2e_test.go
+++ b/server/cmd/mmctl/commands/team_e2e_test.go
@@ -182,10 +182,12 @@ func (s *MmctlE2ETestSuite) TestModifyTeamsCmdF() {
 		cmd := &cobra.Command{}
 		cmd.Flags().Bool("private", true, "")
 		err := modifyTeamsCmdF(s.th.Client, cmd, []string{teamID})
-		s.Require().NoError(err)
+
+		expectedError := fmt.Sprintf("Unable to modify team '%s' error: You do not have the appropriate permissions.", s.th.BasicTeam.Name)
+		s.Require().Equal(expectedError, err.(*multierror.Error).Unwrap().Error())
 		s.Require().Contains(
 			printer.GetErrorLines()[0],
-			fmt.Sprintf("Unable to modify team '%s' error: You do not have the appropriate permissions.", s.th.BasicTeam.Name),
+			expectedError,
 		)
 		t, appErr := s.th.App.GetTeam(teamID)
 		s.Require().Nil(appErr)
@@ -199,10 +201,12 @@ func (s *MmctlE2ETestSuite) TestModifyTeamsCmdF() {
 		cmd.Flags().Bool("private", true, "")
 		s.th.LoginBasic2()
 		err := modifyTeamsCmdF(s.th.Client, cmd, []string{teamID})
-		s.Require().NoError(err)
+
+		expectedError := fmt.Sprintf("Unable to modify team '%s' error: You do not have the appropriate permissions.", s.th.BasicTeam.Name)
+		s.Require().Equal(expectedError, err.(*multierror.Error).Unwrap().Error())
 		s.Require().Contains(
 			printer.GetErrorLines()[0],
-			fmt.Sprintf("Unable to modify team '%s' error: You do not have the appropriate permissions.", s.th.BasicTeam.Name),
+			expectedError,
 		)
 		t, appErr := s.th.App.GetTeam(teamID)
 		s.Require().Nil(appErr)

--- a/server/cmd/mmctl/commands/team_test.go
+++ b/server/cmd/mmctl/commands/team_test.go
@@ -736,7 +736,7 @@ func (s *MmctlUnitTestSuite) TestModifyTeamsCmd() {
 		err := modifyTeamsCmdF(s.client, cmd, []string{"team1"})
 
 		expectedError := "Unable to find team 'team1'"
-		s.Require().Equal(expectedError, err.(*multierror.Error).Unwrap().Error())
+		s.Require().ErrorContains(err, expectedError)
 		s.Require().Equal(expectedError, printer.GetErrorLines()[0])
 	})
 
@@ -827,7 +827,7 @@ func (s *MmctlUnitTestSuite) TestModifyTeamsCmd() {
 		err := modifyTeamsCmdF(s.client, cmd, []string{"team1"})
 
 		expectedError := "Unable to modify team 'team1' error: an error occurred modifying a team"
-		s.Require().Equal(expectedError, err.(*multierror.Error).Unwrap().Error())
+		s.Require().ErrorContains(err, expectedError)
 		s.Require().Equal(expectedError,
 			printer.GetErrorLines()[0])
 	})

--- a/server/cmd/mmctl/commands/team_test.go
+++ b/server/cmd/mmctl/commands/team_test.go
@@ -734,8 +734,10 @@ func (s *MmctlUnitTestSuite) TestModifyTeamsCmd() {
 		cmd.Flags().Bool("private", true, "")
 
 		err := modifyTeamsCmdF(s.client, cmd, []string{"team1"})
-		s.Require().Nil(err)
-		s.Require().Equal("Unable to find team 'team1'", printer.GetErrorLines()[0])
+
+		expectedError := "Unable to find team 'team1'"
+		s.Require().Equal(expectedError, err.(*multierror.Error).Unwrap().Error())
+		s.Require().Equal(expectedError, printer.GetErrorLines()[0])
 	})
 
 	s.Run("Modify teams, set to private", func() {
@@ -823,8 +825,10 @@ func (s *MmctlUnitTestSuite) TestModifyTeamsCmd() {
 		cmd.Flags().Bool("public", true, "")
 
 		err := modifyTeamsCmdF(s.client, cmd, []string{"team1"})
-		s.Require().Nil(err)
-		s.Require().Equal("Unable to modify team 'team1' error: an error occurred modifying a team",
+
+		expectedError := "Unable to modify team 'team1' error: an error occurred modifying a team"
+		s.Require().Equal(expectedError, err.(*multierror.Error).Unwrap().Error())
+		s.Require().Equal(expectedError,
 			printer.GetErrorLines()[0])
 	})
 }


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
- Return error instead of nil for modifyTeamsCmdF when encountering error 
- Error is returned using go-multierror
#### Ticket Link

Fixes [#21571](https://github.com/mattermost/mattermost/issues/21471)
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

<!--
#### Screenshots

If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
