### PR TITLE
Fix user group not being properly potitioned

### DIFF
--- a/webapp/channels/src/components/user_group_popover/user_group_popover.tsx
+++ b/webapp/channels/src/components/user_group_popover/user_group_popover.tsx
@@ -71,7 +71,11 @@ const UserGroupPopover = ({
     returnFocus,
     searchTerm,
     showUserOverlay,
-    ...popoverProps // Props are not passed explictly to this component, but they exist.
+
+    // These props are not passed explictly to this component, but
+    // they are added when this component is passed as a child to Overlay.
+    // They are not typed in the component because they will cause more confusion.
+    ...popoverProps
 }: Props) => {
     const {formatMessage} = useIntl();
 

--- a/webapp/channels/src/components/user_group_popover/user_group_popover.tsx
+++ b/webapp/channels/src/components/user_group_popover/user_group_popover.tsx
@@ -71,6 +71,7 @@ const UserGroupPopover = ({
     returnFocus,
     searchTerm,
     showUserOverlay,
+    ...popoverProps // Props are not passed explictly to this component, but they exist.
 }: Props) => {
     const {formatMessage} = useIntl();
 
@@ -182,6 +183,7 @@ const UserGroupPopover = ({
     return (
         <Popover
             id='user-group-popover'
+            {...popoverProps}
         >
             {tabCatcher}
             <Body


### PR DESCRIPTION
#### Summary
In https://github.com/mattermost/mattermost/pull/26476 I did some cleanup, and removed the extra props that were apparently not being used. But that broke the popover.

~~Looking deeper, the component is receiving some props without nobody explicitly passing them. I guess is some kind of weird behavior of the Popover, but no idea. Either way, passing the props to the popover fixes the issue.~~

The reason is because the component is passed as a child to `Overlay` which fill up the missing props. I don't think there is a good way to type this without being more confusing.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-57482

#### Release Note
```release-note
NONE
```
This just fixes a bug introduced in 9.7, so there should be no need for release notes.
