### PR TITLE
Profile image from bytes

### DIFF
--- a/server/public/pluginapi/bot.go
+++ b/server/public/pluginapi/bot.go
@@ -118,6 +118,9 @@ type ensureBotOptions struct {
 
 type EnsureBotOption func(*ensureBotOptions)
 
+// ProfileImagePath configures EnsureBot to set a profile image from the given path.
+//
+// Using this option overrides any previously set ProfileImageBytes option.
 func ProfileImagePath(path string) EnsureBotOption {
 	return func(args *ensureBotOptions) {
 		args.ProfileImagePath = path
@@ -125,6 +128,9 @@ func ProfileImagePath(path string) EnsureBotOption {
 	}
 }
 
+// ProfileImageBytes configures EnsureBot to set a profile image from the given bytes.
+//
+// Using this option overrides any previously set ProfileImagePath option.
 func ProfileImageBytes(bytes []byte) EnsureBotOption {
 	return func(args *ensureBotOptions) {
 		args.ProfileImageBytes = bytes

--- a/server/public/pluginapi/bot.go
+++ b/server/public/pluginapi/bot.go
@@ -112,7 +112,8 @@ func (b *BotService) DeletePermanently(botUserID string) error {
 }
 
 type ensureBotOptions struct {
-	ProfileImagePath string
+	ProfileImagePath  string
+	ProfileImageBytes []byte
 }
 
 type EnsureBotOption func(*ensureBotOptions)
@@ -120,6 +121,14 @@ type EnsureBotOption func(*ensureBotOptions)
 func ProfileImagePath(path string) EnsureBotOption {
 	return func(args *ensureBotOptions) {
 		args.ProfileImagePath = path
+		args.ProfileImageBytes = nil
+	}
+}
+
+func ProfileImageBytes(bytes []byte) EnsureBotOption {
+	return func(args *ensureBotOptions) {
+		args.ProfileImageBytes = bytes
+		args.ProfileImagePath = ""
 	}
 }
 
@@ -169,6 +178,11 @@ func (b *BotService) ensureBot(m mutex, bot *model.Bot, options ...EnsureBotOpti
 			return "", errors.Wrap(err, "failed to read profile image")
 		}
 		appErr := b.api.SetProfileImage(botID, imageBytes)
+		if appErr != nil {
+			return "", errors.Wrap(appErr, "failed to set profile image")
+		}
+	} else if len(o.ProfileImageBytes) > 0 {
+		appErr := b.api.SetProfileImage(botID, o.ProfileImageBytes)
 		if appErr != nil {
 			return "", errors.Wrap(appErr, "failed to set profile image")
 		}

--- a/server/public/pluginapi/bot_test.go
+++ b/server/public/pluginapi/bot_test.go
@@ -185,7 +185,6 @@ func TestListBot(t *testing.T) {
 				require.NoError(t, err, test.name)
 			}
 			require.Equal(t, test.bots, bots, test.name)
-
 		})
 	}
 }

--- a/server/public/pluginapi/bot_test.go
+++ b/server/public/pluginapi/bot_test.go
@@ -263,7 +263,7 @@ func TestEnsureBot(t *testing.T) {
 			assert.Equal(t, expectedBotID, botID)
 		})
 
-		t.Run("should set the bot profile image when specified", func(t *testing.T) {
+		t.Run("should set the bot profile image when specified from a file", func(t *testing.T) {
 			api := &plugintest.API{}
 			defer api.AssertExpectations(t)
 			client := NewClient(api, &plugintest.Driver{})
@@ -283,6 +283,42 @@ func TestEnsureBot(t *testing.T) {
 			api.On("GetServerVersion").Return("5.10.0")
 
 			botID, err := client.Bot.ensureBot(m, testbot, ProfileImagePath(profileImageFile.Name()))
+			require.NoError(t, err)
+			assert.Equal(t, expectedBotID, botID)
+		})
+
+		t.Run("should set the bot profile image when specified from bytes", func(t *testing.T) {
+			api := &plugintest.API{}
+			defer api.AssertExpectations(t)
+			client := NewClient(api, &plugintest.Driver{})
+
+			expectedBotID := model.NewId()
+
+			profileImageBytes := []byte("profile image")
+
+			api.On("EnsureBotUser", testbot).Return(expectedBotID, nil)
+			api.On("SetProfileImage", expectedBotID, profileImageBytes).Return(nil)
+			api.On("GetServerVersion").Return("5.10.0")
+
+			botID, err := client.Bot.ensureBot(m, testbot, ProfileImageBytes(profileImageBytes))
+			require.NoError(t, err)
+			assert.Equal(t, expectedBotID, botID)
+		})
+
+		t.Run("the last bot profile image configuration should take precedence", func(t *testing.T) {
+			api := &plugintest.API{}
+			defer api.AssertExpectations(t)
+			client := NewClient(api, &plugintest.Driver{})
+
+			expectedBotID := model.NewId()
+
+			profileImageBytes := []byte("profile image")
+
+			api.On("EnsureBotUser", testbot).Return(expectedBotID, nil)
+			api.On("SetProfileImage", expectedBotID, profileImageBytes).Return(nil)
+			api.On("GetServerVersion").Return("5.10.0")
+
+			botID, err := client.Bot.ensureBot(m, testbot, ProfileImagePath("does not exist"), ProfileImageBytes(profileImageBytes))
 			require.NoError(t, err)
 			assert.Equal(t, expectedBotID, botID)
 		})

--- a/server/public/pluginapi/bot_test.go
+++ b/server/public/pluginapi/bot_test.go
@@ -14,8 +14,7 @@ import (
 
 func TestCreateBot(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		api := &plugintest.API{}
-		defer api.AssertExpectations(t)
+		api := plugintest.NewAPI(t)
 		client := NewClient(api, &plugintest.Driver{})
 
 		api.On("CreateBot", &model.Bot{Username: "1"}).Return(&model.Bot{Username: "1", UserId: "2"}, nil)
@@ -27,8 +26,7 @@ func TestCreateBot(t *testing.T) {
 	})
 
 	t.Run("failure", func(t *testing.T) {
-		api := &plugintest.API{}
-		defer api.AssertExpectations(t)
+		api := plugintest.NewAPI(t)
 		client := NewClient(api, &plugintest.Driver{})
 
 		appErr := newAppError()
@@ -44,8 +42,7 @@ func TestCreateBot(t *testing.T) {
 
 func TestUpdateBotStatus(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		api := &plugintest.API{}
-		defer api.AssertExpectations(t)
+		api := plugintest.NewAPI(t)
 		client := NewClient(api, &plugintest.Driver{})
 
 		api.On("UpdateBotActive", "1", true).Return(&model.Bot{UserId: "2"}, nil)
@@ -56,8 +53,7 @@ func TestUpdateBotStatus(t *testing.T) {
 	})
 
 	t.Run("failure", func(t *testing.T) {
-		api := &plugintest.API{}
-		defer api.AssertExpectations(t)
+		api := plugintest.NewAPI(t)
 		client := NewClient(api, &plugintest.Driver{})
 
 		appErr := newAppError()
@@ -72,8 +68,7 @@ func TestUpdateBotStatus(t *testing.T) {
 
 func TestGetBot(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		api := &plugintest.API{}
-		defer api.AssertExpectations(t)
+		api := plugintest.NewAPI(t)
 		client := NewClient(api, &plugintest.Driver{})
 
 		api.On("GetBot", "1", true).Return(&model.Bot{UserId: "2"}, nil)
@@ -84,8 +79,7 @@ func TestGetBot(t *testing.T) {
 	})
 
 	t.Run("failure", func(t *testing.T) {
-		api := &plugintest.API{}
-		defer api.AssertExpectations(t)
+		api := plugintest.NewAPI(t)
 		client := NewClient(api, &plugintest.Driver{})
 
 		appErr := newAppError()
@@ -179,7 +173,7 @@ func TestListBot(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			api := &plugintest.API{}
+			api := plugintest.NewAPI(t)
 			client := NewClient(api, &plugintest.Driver{})
 
 			api.On("GetBots", test.expectedOptions).Return(test.bots, test.err)
@@ -192,15 +186,13 @@ func TestListBot(t *testing.T) {
 			}
 			require.Equal(t, test.bots, bots, test.name)
 
-			api.AssertExpectations(t)
 		})
 	}
 }
 
 func TestDeleteBotPermanently(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		api := &plugintest.API{}
-		defer api.AssertExpectations(t)
+		api := plugintest.NewAPI(t)
 		client := NewClient(api, &plugintest.Driver{})
 
 		api.On("PermanentDeleteBot", "1").Return(nil)
@@ -210,8 +202,7 @@ func TestDeleteBotPermanently(t *testing.T) {
 	})
 
 	t.Run("failure", func(t *testing.T) {
-		api := &plugintest.API{}
-		defer api.AssertExpectations(t)
+		api := plugintest.NewAPI(t)
 		client := NewClient(api, &plugintest.Driver{})
 
 		appErr := newAppError()
@@ -233,8 +224,7 @@ func TestEnsureBot(t *testing.T) {
 	m := testMutex{}
 
 	t.Run("server version incompatible", func(t *testing.T) {
-		api := &plugintest.API{}
-		defer api.AssertExpectations(t)
+		api := plugintest.NewAPI(t)
 		client := NewClient(api, &plugintest.Driver{})
 
 		api.On("GetServerVersion").Return("5.9.0")
@@ -249,8 +239,7 @@ func TestEnsureBot(t *testing.T) {
 
 	t.Run("if bot already exists", func(t *testing.T) {
 		t.Run("should find and return the existing bot ID", func(t *testing.T) {
-			api := &plugintest.API{}
-			defer api.AssertExpectations(t)
+			api := plugintest.NewAPI(t)
 			client := NewClient(api, &plugintest.Driver{})
 
 			expectedBotID := model.NewId()
@@ -264,8 +253,7 @@ func TestEnsureBot(t *testing.T) {
 		})
 
 		t.Run("should set the bot profile image when specified from a file", func(t *testing.T) {
-			api := &plugintest.API{}
-			defer api.AssertExpectations(t)
+			api := plugintest.NewAPI(t)
 			client := NewClient(api, &plugintest.Driver{})
 
 			expectedBotID := model.NewId()
@@ -288,8 +276,7 @@ func TestEnsureBot(t *testing.T) {
 		})
 
 		t.Run("should set the bot profile image when specified from bytes", func(t *testing.T) {
-			api := &plugintest.API{}
-			defer api.AssertExpectations(t)
+			api := plugintest.NewAPI(t)
 			client := NewClient(api, &plugintest.Driver{})
 
 			expectedBotID := model.NewId()
@@ -306,8 +293,7 @@ func TestEnsureBot(t *testing.T) {
 		})
 
 		t.Run("the last bot profile image configuration should take precedence", func(t *testing.T) {
-			api := &plugintest.API{}
-			defer api.AssertExpectations(t)
+			api := plugintest.NewAPI(t)
 			client := NewClient(api, &plugintest.Driver{})
 
 			expectedBotID := model.NewId()
@@ -324,8 +310,7 @@ func TestEnsureBot(t *testing.T) {
 		})
 
 		t.Run("should find and update the bot with new bot details", func(t *testing.T) {
-			api := &plugintest.API{}
-			defer api.AssertExpectations(t)
+			api := plugintest.NewAPI(t)
 			client := NewClient(api, &plugintest.Driver{})
 
 			expectedBotID := model.NewId()
@@ -368,8 +353,7 @@ func TestEnsureBot(t *testing.T) {
 
 	t.Run("if bot doesn't exist", func(t *testing.T) {
 		t.Run("should create bot and set the bot profile image when specified", func(t *testing.T) {
-			api := &plugintest.API{}
-			defer api.AssertExpectations(t)
+			api := plugintest.NewAPI(t)
 			client := NewClient(api, &plugintest.Driver{})
 
 			expectedBotID := model.NewId()


### PR DESCRIPTION
#### Summary
Extend the `EnsureBot` functionality with a `ProfileImageFromBytes` option that doesn't require an on-disk file but can instead be supplied with `embed` or some other means.

At the same time, switch to `plugintest.NewAPI` in the affected tests based on the conversation in https://community.mattermost.com/core/pl/hzc71rikdjrztq97t3frf95hxw.

#### Ticket Link
None.

#### Release Note
```release-note
Expose `pluginapi.ProfileImageBytes` to simplify bot setup from a plugin.
```
