### PR TITLE
[MM-56931] Date separator shows repeated when Saved RHS is open while in Threads view

### DIFF
--- a/webapp/channels/src/components/post/post_component.test.tsx
+++ b/webapp/channels/src/components/post/post_component.test.tsx
@@ -331,12 +331,12 @@ describe('PostComponent', () => {
             const props = {
                 ...baseProps,
                 isConsecutivePost: true,
-                location: Locations.RHS_ROOT
-            }
+                location: Locations.RHS_ROOT,
+            };
 
             renderWithContext(<PostComponent {...props} />);
 
             expect(screen.queryByTestId('basicSeparator')).not.toBeInTheDocument();
-        })
-    })
+        });
+    });
 });

--- a/webapp/channels/src/components/post/post_component.test.tsx
+++ b/webapp/channels/src/components/post/post_component.test.tsx
@@ -334,7 +334,7 @@ describe('PostComponent', () => {
                 location: Locations.RHS_ROOT,
             };
 
-            renderWithContext(<PostComponent {...props} />);
+            renderWithContext(<PostComponent {...props}/>);
 
             expect(screen.queryByTestId('basicSeparator')).not.toBeInTheDocument();
         });

--- a/webapp/channels/src/components/post/post_component.test.tsx
+++ b/webapp/channels/src/components/post/post_component.test.tsx
@@ -7,7 +7,6 @@ import type {DeepPartial} from '@mattermost/types/utilities';
 
 import mergeObjects from 'packages/mattermost-redux/test/merge_objects';
 import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
-import {getHistory} from 'utils/browser_history';
 import {Locations} from 'utils/constants';
 import {TestHelper} from 'utils/test_helper';
 
@@ -250,79 +249,31 @@ describe('PostComponent', () => {
 
             expect(screen.queryByText(/Follow|Following/)).not.toBeInTheDocument();
         });
-
-        describe('reply/X replies link', () => {
-            const rootPost = TestHelper.getPostMock({
-                id: 'rootPost',
-                channel_id: channel.id,
-                reply_count: 1,
-            });
-            const state: DeepPartial<GlobalState> = {
-                entities: {
-                    posts: {
-                        posts: {
-                            rootPost,
-                        },
-                    },
-                },
-            };
-
-            const propsForRootPost = {
-                ...baseProps,
-                hasReplies: true,
-                post: rootPost,
-                replyCount: 1,
-            };
-
-            test('should select post in RHS when clicked in center channel', () => {
-                renderWithContext(<PostComponent {...propsForRootPost}/>, state);
-
-                userEvent.click(screen.getByText('1 reply'));
-
-                // Yes, this action has a different name than the one you'd expect
-                expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).toHaveBeenCalledWith(rootPost);
-            });
-
-            test('should select post in RHS when clicked in center channel in a DM/GM', () => {
-                const props = {
-                    ...propsForRootPost,
-                    team: undefined,
-                };
-                renderWithContext(<PostComponent {...props}/>, state);
-
-                userEvent.click(screen.getByText('1 reply'));
-
-                // Yes, this action has a different name than the one you'd expect
-                expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).toHaveBeenCalledWith(rootPost);
-                expect(getHistory().push).not.toHaveBeenCalled();
-            });
-
-            test('should select post in RHS when clicked in a search result on the current team', () => {
-                const props = {
-                    ...propsForRootPost,
-                    location: Locations.SEARCH,
-                };
-                renderWithContext(<PostComponent {...props}/>, state);
-
-                userEvent.click(screen.getByText('1 reply'));
-
-                expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).toHaveBeenCalledWith(rootPost);
-                expect(getHistory().push).not.toHaveBeenCalled();
-            });
-
-            test('should jump to post when clicked in a search result on another team', () => {
-                const props = {
-                    ...propsForRootPost,
-                    location: Locations.SEARCH,
-                    team: TestHelper.getTeamMock({id: 'another_team'}),
-                };
-                renderWithContext(<PostComponent {...props}/>, state);
-
-                userEvent.click(screen.getByText('1 reply'));
-
-                expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).not.toHaveBeenCalled();
-                expect(getHistory().push).toHaveBeenCalled();
-            });
-        });
     });
+
+    describe('date seperator', () => {
+        // const baseState: DeepPartial<GlobalState> = {
+        //     entities: {
+        //         posts: {
+        //             reactions: {
+        //                 [baseProps.post.id]: {
+        //                     [`${baseProps.currentUserId}-taco`]: TestHelper.getReactionMock({emoji_name: 'taco'}),
+        //                 },
+        //             },
+        //         },
+        //     },
+        // };
+
+        test('should not show date seperator on consecutive posts when RHS is open.', () => {
+            const props = {
+                ...baseProps,
+                isConsecutivePost: true,
+                location: Locations.RHS_ROOT
+            }
+
+            renderWithContext(<PostComponent {...props} />);
+
+            expect(screen.queryByTestId('basicSeparator')).not.toBeInTheDocument();
+        })
+    })
 });

--- a/webapp/channels/src/components/post/post_component.test.tsx
+++ b/webapp/channels/src/components/post/post_component.test.tsx
@@ -250,79 +250,79 @@ describe('PostComponent', () => {
 
             expect(screen.queryByText(/Follow|Following/)).not.toBeInTheDocument();
         });
-    });
 
-    describe('reply/X replies link', () => {
-        const rootPost = TestHelper.getPostMock({
-            id: 'rootPost',
-            channel_id: channel.id,
-            reply_count: 1,
-        });
-        const state: DeepPartial<GlobalState> = {
-            entities: {
-                posts: {
+        describe('reply/X replies link', () => {
+            const rootPost = TestHelper.getPostMock({
+                id: 'rootPost',
+                channel_id: channel.id,
+                reply_count: 1,
+            });
+            const state: DeepPartial<GlobalState> = {
+                entities: {
                     posts: {
-                        rootPost,
+                        posts: {
+                            rootPost,
+                        },
                     },
                 },
-            },
-        };
-
-        const propsForRootPost = {
-            ...baseProps,
-            hasReplies: true,
-            post: rootPost,
-            replyCount: 1,
-        };
-
-        test('should select post in RHS when clicked in center channel', () => {
-            renderWithContext(<PostComponent {...propsForRootPost}/>, state);
-
-            userEvent.click(screen.getByText('1 reply'));
-
-            // Yes, this action has a different name than the one you'd expect
-            expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).toHaveBeenCalledWith(rootPost);
-        });
-
-        test('should select post in RHS when clicked in center channel in a DM/GM', () => {
-            const props = {
-                ...propsForRootPost,
-                team: undefined,
             };
-            renderWithContext(<PostComponent {...props}/>, state);
 
-            userEvent.click(screen.getByText('1 reply'));
-
-            // Yes, this action has a different name than the one you'd expect
-            expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).toHaveBeenCalledWith(rootPost);
-            expect(getHistory().push).not.toHaveBeenCalled();
-        });
-
-        test('should select post in RHS when clicked in a search result on the current team', () => {
-            const props = {
-                ...propsForRootPost,
-                location: Locations.SEARCH,
+            const propsForRootPost = {
+                ...baseProps,
+                hasReplies: true,
+                post: rootPost,
+                replyCount: 1,
             };
-            renderWithContext(<PostComponent {...props}/>, state);
 
-            userEvent.click(screen.getByText('1 reply'));
+            test('should select post in RHS when clicked in center channel', () => {
+                renderWithContext(<PostComponent {...propsForRootPost}/>, state);
 
-            expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).toHaveBeenCalledWith(rootPost);
-            expect(getHistory().push).not.toHaveBeenCalled();
-        });
+                userEvent.click(screen.getByText('1 reply'));
 
-        test('should jump to post when clicked in a search result on another team', () => {
-            const props = {
-                ...propsForRootPost,
-                location: Locations.SEARCH,
-                team: TestHelper.getTeamMock({id: 'another_team'}),
-            };
-            renderWithContext(<PostComponent {...props}/>, state);
+                // Yes, this action has a different name than the one you'd expect
+                expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).toHaveBeenCalledWith(rootPost);
+            });
 
-            userEvent.click(screen.getByText('1 reply'));
+            test('should select post in RHS when clicked in center channel in a DM/GM', () => {
+                const props = {
+                    ...propsForRootPost,
+                    team: undefined,
+                };
+                renderWithContext(<PostComponent {...props}/>, state);
 
-            expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).not.toHaveBeenCalled();
-            expect(getHistory().push).toHaveBeenCalled();
+                userEvent.click(screen.getByText('1 reply'));
+
+                // Yes, this action has a different name than the one you'd expect
+                expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).toHaveBeenCalledWith(rootPost);
+                expect(getHistory().push).not.toHaveBeenCalled();
+            });
+
+            test('should select post in RHS when clicked in a search result on the current team', () => {
+                const props = {
+                    ...propsForRootPost,
+                    location: Locations.SEARCH,
+                };
+                renderWithContext(<PostComponent {...props}/>, state);
+
+                userEvent.click(screen.getByText('1 reply'));
+
+                expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).toHaveBeenCalledWith(rootPost);
+                expect(getHistory().push).not.toHaveBeenCalled();
+            });
+
+            test('should jump to post when clicked in a search result on another team', () => {
+                const props = {
+                    ...propsForRootPost,
+                    location: Locations.SEARCH,
+                    team: TestHelper.getTeamMock({id: 'another_team'}),
+                };
+                renderWithContext(<PostComponent {...props}/>, state);
+
+                userEvent.click(screen.getByText('1 reply'));
+
+                expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).not.toHaveBeenCalled();
+                expect(getHistory().push).toHaveBeenCalled();
+            });
         });
     });
 

--- a/webapp/channels/src/components/post/post_component.tsx
+++ b/webapp/channels/src/components/post/post_component.tsx
@@ -518,7 +518,7 @@ const PostComponent = (props: Props): JSX.Element => {
 
     return (
         <>
-            {(isSearchResultItem || (props.location !== Locations.CENTER && (props.isPinnedPosts || props.isFlaggedPosts))) && <DateSeparator date={currentPostDay}/>}
+            {(isSearchResultItem || (props.location !== Locations.CENTER && props.isConsecutivePost !== true && (props.isPinnedPosts || props.isFlaggedPosts))) && <DateSeparator date={currentPostDay}/>}
             <PostAriaLabelDiv
                 ref={postRef}
                 id={getTestId()}


### PR DESCRIPTION
#### Summary
- Adds logic to `PostComponent` that will prevent duplicate `DateSeperator` tags when RHS is open the replies are consecutive posts.
- Adds unit test for the above logic

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/26591
Jira https://mattermost.atlassian.net/browse/MM-56931

#### Screenshots

|  before  |  after  |
|----|----|
| ![mm-56999-before](https://github.com/mattermost/mattermost/assets/18295079/faaaf7b2-9216-485d-8702-da9d1c19c62d)  | ![mm-56999-after](https://github.com/mattermost/mattermost/assets/18295079/520c9062-8571-4627-8499-dcc86a399a8f) |

#### Release Note

```release-note
Fixes duplicate Date Separator bug on threads panel.
```

