### PR TITLE
Update default nginx client_max_body_size configuration

### DIFF
--- a/server/build/docker/nginx/default.conf
+++ b/server/build/docker/nginx/default.conf
@@ -24,7 +24,7 @@ server {
   }
 
   location / {
-    client_max_body_size 50M;
+    client_max_body_size 100M;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
 	proxy_http_version 1.1;


### PR DESCRIPTION


#### Summary
Plugins are generally larger than 50mb

#### Release Note

```release-note
NONE
```
