### PR TITLE
Improvements to logging start-up.

### DIFF
--- a/server/channels/app/platform/config.go
+++ b/server/channels/app/platform/config.go
@@ -135,6 +135,8 @@ func (ps *PlatformService) ConfigureLogger(name string, logger *mlog.Logger, log
 	// Advanced logging is E20 only, however logging must be initialized before the license
 	// file is loaded.  If no valid E20 license exists then advanced logging will be
 	// shutdown once license is loaded/checked.
+	var resultLevel = mlog.LvlInfo
+	var resultMsg string
 	var err error
 	var logConfigSrc config.LogConfigSrc
 	dsn := logSettings.GetAdvancedLoggingConfig()
@@ -143,9 +145,10 @@ func (ps *PlatformService) ConfigureLogger(name string, logger *mlog.Logger, log
 		if err != nil {
 			return fmt.Errorf("invalid config source for %s, %w", name, err)
 		}
-		ps.logger.Info("Loaded configuration for "+name, mlog.String("source", dsn))
+		resultMsg = fmt.Sprintf("Loaded advanced logging configuration for %s: %s", name, string(dsn))
 	} else {
-		ps.logger.Debug("Advanced logging config not provided for " + name)
+		resultLevel = mlog.LvlDebug
+		resultMsg = fmt.Sprintf("Advanced logging config not provided for %s", name)
 	}
 
 	cfg, err := config.MloggerConfigFromLoggerConfig(logSettings, logConfigSrc, getPath)
@@ -153,9 +156,15 @@ func (ps *PlatformService) ConfigureLogger(name string, logger *mlog.Logger, log
 		return fmt.Errorf("invalid config source for %s, %w", name, err)
 	}
 
+	// this will remove any existing targets and replace with those defined in cfg.
 	if err := logger.ConfigureTargets(cfg, nil); err != nil {
 		return fmt.Errorf("invalid config for %s, %w", name, err)
 	}
+
+	if resultMsg != "" {
+		ps.logger.Log(resultLevel, resultMsg)
+	}
+
 	return nil
 }
 

--- a/server/channels/app/platform/config.go
+++ b/server/channels/app/platform/config.go
@@ -162,7 +162,7 @@ func (ps *PlatformService) ConfigureLogger(name string, logger *mlog.Logger, log
 	}
 
 	if resultMsg != "" {
-		ps.logger.Log(resultLevel, resultMsg)
+		ps.Log().Log(resultLevel, resultMsg)
 	}
 
 	return nil

--- a/server/channels/app/platform/config.go
+++ b/server/channels/app/platform/config.go
@@ -145,7 +145,7 @@ func (ps *PlatformService) ConfigureLogger(name string, logger *mlog.Logger, log
 		if err != nil {
 			return fmt.Errorf("invalid config source for %s, %w", name, err)
 		}
-		resultMsg = fmt.Sprintf("Loaded advanced logging configuration for %s: %s", name, string(dsn))
+		resultMsg = fmt.Sprintf("Loaded Advanced Logging configuration for %s: %s", name, string(dsn))
 	} else {
 		resultLevel = mlog.LvlDebug
 		resultMsg = fmt.Sprintf("Advanced logging config not provided for %s", name)


### PR DESCRIPTION
#### Summary
This PR makes minor improvements to logging start-up.
- comments have been added
- order of configuration is adjusted to allow the main logger to capture errors in notification logger
- redundant logger initialization removed; no need to configure the logger just to replace the configuration immediately after

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57569

#### Release Note
```release-note
NONE
```
