### PR TITLE
Increased default payload limit from 100 kB to 300 kB

### DIFF
--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -918,7 +918,7 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 	}
 
 	if s.MaximumPayloadSizeBytes == nil {
-		s.MaximumPayloadSizeBytes = NewInt64(100000)
+		s.MaximumPayloadSizeBytes = NewInt64(300000)
 	}
 }
 


### PR DESCRIPTION
#### Summary
Increased default payload limit from 100 kB to 300 kB

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-57572

#### Release Note
```release-note
Increased default payload size limit (setting `MaximumPayloadSizeBytes`) from 100 kB to 300 kB
```
