### PR TITLE
Fix default text setting on admin console not getting cleared

### DIFF
--- a/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
@@ -517,7 +517,7 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
         } else if (setting.multiple) {
             value = this.state[setting.key] ? this.state[setting.key].join(',') : '';
         } else {
-            value = this.state[setting.key] || setting.default || '';
+            value = this.state[setting.key] ?? (setting.default || '');
         }
 
         let footer = null;


### PR DESCRIPTION
#### Summary
While refactoring the admin console in https://github.com/mattermost/mattermost/pull/25406 we added a bug where the default value of a setting will override the visible setting if we remove the whole string.

This was due to using the `||` operator when the first member (the value stored in the state) could valid when falsy (empty string).

Changing to the `??` operator solves the issue.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-57570

#### Release Note
```release-note
Fix issue where it was not possible to clear plugin settings with a default value in the admin console
```
