### PR TITLE
[MM-57517] Add exact user ID lookup to the search query for Users

### DIFF
--- a/server/channels/store/sqlstore/user_store.go
+++ b/server/channels/store/sqlstore/user_store.go
@@ -1613,6 +1613,8 @@ func generateSearchQuery(query sq.SelectBuilder, terms []string, fields []string
 			}
 			termArgs = append(termArgs, fmt.Sprintf("%%%s%%", strings.TrimLeft(term, "@")))
 		}
+		searchFields = append(searchFields, "Id = ?")
+		termArgs = append(termArgs, fmt.Sprintf("%s", strings.TrimLeft(term, "@")))
 		query = query.Where(fmt.Sprintf("(%s)", strings.Join(searchFields, " OR ")), termArgs...)
 	}
 

--- a/server/channels/store/sqlstore/user_store.go
+++ b/server/channels/store/sqlstore/user_store.go
@@ -1614,7 +1614,7 @@ func generateSearchQuery(query sq.SelectBuilder, terms []string, fields []string
 			termArgs = append(termArgs, fmt.Sprintf("%%%s%%", strings.TrimLeft(term, "@")))
 		}
 		searchFields = append(searchFields, "Id = ?")
-		termArgs = append(termArgs, fmt.Sprintf("%s", strings.TrimLeft(term, "@")))
+		termArgs = append(termArgs, strings.TrimLeft(term, "@"))
 		query = query.Where(fmt.Sprintf("(%s)", strings.Join(searchFields, " OR ")), termArgs...)
 	}
 

--- a/server/channels/store/storetest/user_store.go
+++ b/server/channels/store/storetest/user_store.go
@@ -2862,6 +2862,30 @@ func testUserStoreSearch(t *testing.T, rctx request.CTX, ss store.Store) {
 			},
 			[]*model.User{u3},
 		},
+		{
+			"search for Id of u1",
+			t1id,
+			u1.Id,
+			&model.UserSearchOptions{
+				AllowFullNames: true,
+				Limit:          model.UserSearchDefaultLimit,
+				Roles:          []string{},
+				TeamRoles:      []string{},
+			},
+			[]*model.User{u1},
+		},
+		{
+			"search for partial Id of u1",
+			t1id,
+			u1.Id[:len(u1.Id)-1],
+			&model.UserSearchOptions{
+				AllowFullNames: true,
+				Limit:          model.UserSearchDefaultLimit,
+				Roles:          []string{},
+				TeamRoles:      []string{},
+			},
+			[]*model.User{},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
#### Summary
When the new User Admin Reporting screen was added, we removed the extra logic to go lookup a user by their ID if an ID was supplied. We were unable to keep it in its current state since that would require a separate endpoint to look up by ID that also provided the extra reporting data points.

This PR insteads adds the exact ID lookup to the server, where now any searching done using the user store will allow the exact ID to be matched as part of the user lookup.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57517

```release-note
Fixed an issue where you couldn't look up a user by their ID in the System Console anymore
```
