### PR TITLE
Simplify page size in mmctl

### DIFF
--- a/server/cmd/mmctl/commands/bot.go
+++ b/server/cmd/mmctl/commands/bot.go
@@ -160,7 +160,7 @@ func botListCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	all, _ := cmd.Flags().GetBool("all")
 
 	page := 0
-	perPage := 200
+	perPage := DefaultPageSize
 	tpl := `{{.UserId}}: {{.Username}}`
 	for {
 		var bots []*model.Bot
@@ -206,7 +206,7 @@ func botListCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 			printer.PrintT(tpl+tplExtraText, bot)
 		}
 
-		if len(bots) < 200 {
+		if len(bots) < perPage {
 			break
 		}
 

--- a/server/cmd/mmctl/commands/channel.go
+++ b/server/cmd/mmctl/commands/channel.go
@@ -12,7 +12,6 @@ import (
 	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/printer"
 
 	"github.com/mattermost/mattermost/server/public/model"
-	"github.com/mattermost/mattermost/server/v8/channels/web"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
@@ -284,7 +283,7 @@ func getAllPublicChannelsForTeam(c client.Client, teamID string) ([]*model.Chann
 	page := 0
 
 	for {
-		channelsPage, _, err := c.GetPublicChannelsForTeam(context.TODO(), teamID, page, web.PerPageMaximum, "")
+		channelsPage, _, err := c.GetPublicChannelsForTeam(context.TODO(), teamID, page, DefaultPageSize, "")
 		if err != nil {
 			return nil, err
 		}
@@ -305,7 +304,7 @@ func getAllDeletedChannelsForTeam(c client.Client, teamID string) ([]*model.Chan
 	page := 0
 
 	for {
-		channelsPage, _, err := c.GetDeletedChannelsForTeam(context.TODO(), teamID, page, web.PerPageMaximum, "")
+		channelsPage, _, err := c.GetDeletedChannelsForTeam(context.TODO(), teamID, page, DefaultPageSize, "")
 		if err != nil {
 			return nil, err
 		}
@@ -561,7 +560,7 @@ func getPrivateChannels(c client.Client, teamID string) ([]*model.Channel, error
 	withoutError := true
 
 	for {
-		channelsPage, _, err := c.GetPrivateChannelsForTeam(context.TODO(), teamID, page, web.PerPageMaximum, "")
+		channelsPage, _, err := c.GetPrivateChannelsForTeam(context.TODO(), teamID, page, DefaultPageSize, "")
 		if err != nil && viper.GetBool("local") {
 			return nil, err
 		} else if err != nil {

--- a/server/cmd/mmctl/commands/completion.go
+++ b/server/cmd/mmctl/commands/completion.go
@@ -240,7 +240,7 @@ func fetchAndComplete[T any](f fetcher[T], m matcher[T]) validateArgsFn {
 
 		var page int
 		for {
-			entities, _, err := f(ctx, c, page, perPage)
+			entities, _, err := f(ctx, c, page, DefaultPageSize)
 			if err != nil {
 				// Return what we got so far
 				return res, cobra.ShellCompDirectiveNoFileComp
@@ -262,7 +262,7 @@ func fetchAndComplete[T any](f fetcher[T], m matcher[T]) validateArgsFn {
 				break
 			}
 
-			if len(entities) < perPage {
+			if len(entities) < DefaultPageSize {
 				break
 			}
 

--- a/server/cmd/mmctl/commands/export.go
+++ b/server/cmd/mmctl/commands/export.go
@@ -112,7 +112,7 @@ func init() {
 	ExportDownloadCmd.Flags().Int("num-retries", 5, "Number of retries to do to resume a download.")
 
 	ExportJobListCmd.Flags().Int("page", 0, "Page number to fetch for the list of export jobs")
-	ExportJobListCmd.Flags().Int("per-page", 200, "Number of export jobs to be fetched")
+	ExportJobListCmd.Flags().Int("per-page", DefaultPageSize, "Number of export jobs to be fetched")
 	ExportJobListCmd.Flags().Bool("all", false, "Fetch all export jobs. --page flag will be ignore if provided")
 
 	ExportJobCmd.AddCommand(

--- a/server/cmd/mmctl/commands/extract.go
+++ b/server/cmd/mmctl/commands/extract.go
@@ -55,7 +55,7 @@ func init() {
 	ExtractRunCmd.Flags().Int64("from", 0, "The timestamp of the earliest file to extract, expressed in seconds since the unix epoch.")
 	ExtractRunCmd.Flags().Int64("to", 0, "The timestamp of the latest file to extract, expressed in seconds since the unix epoch. Defaults to the current time.")
 	ExtractJobListCmd.Flags().Int("page", 0, "Page number to fetch for the list of extract jobs")
-	ExtractJobListCmd.Flags().Int("per-page", 200, "Number of extract jobs to be fetched")
+	ExtractJobListCmd.Flags().Int("per-page", DefaultPageSize, "Number of extract jobs to be fetched")
 	ExtractJobListCmd.Flags().Bool("all", false, "Fetch all extract jobs. --page flag will be ignore if provided")
 	ExtractJobCmd.AddCommand(
 		ExtractJobListCmd,

--- a/server/cmd/mmctl/commands/import.go
+++ b/server/cmd/mmctl/commands/import.go
@@ -103,7 +103,7 @@ func init() {
 	ImportUploadCmd.Flags().String("upload", "", "The ID of the import upload to resume.")
 
 	ImportJobListCmd.Flags().Int("page", 0, "Page number to fetch for the list of import jobs")
-	ImportJobListCmd.Flags().Int("per-page", 200, "Number of import jobs to be fetched")
+	ImportJobListCmd.Flags().Int("per-page", DefaultPageSize, "Number of import jobs to be fetched")
 	ImportJobListCmd.Flags().Bool("all", false, "Fetch all import jobs. --page flag will be ignore if provided")
 
 	ImportValidateCmd.Flags().StringArray("team", nil, "Predefined team[s] to assume as already present on the destination server. Implies --check-missing-teams. The flag can be repeated")

--- a/server/cmd/mmctl/commands/init.go
+++ b/server/cmd/mmctl/commands/init.go
@@ -26,8 +26,6 @@ import (
 )
 
 const (
-	perPage = 200
-
 	shellCompletionMaxItems = 50 // Maximum number of items that will be loaded and shown in shell completion.
 	shellCompleteTimeout    = 5 * time.Second
 )

--- a/server/cmd/mmctl/commands/logs.go
+++ b/server/cmd/mmctl/commands/logs.go
@@ -27,7 +27,7 @@ var LogsCmd = &cobra.Command{
 }
 
 func init() {
-	LogsCmd.Flags().IntP("number", "n", 200, "Number of log lines to retrieve.")
+	LogsCmd.Flags().IntP("number", "n", DefaultPageSize, "Number of log lines to retrieve.")
 	LogsCmd.Flags().BoolP("logrus", "l", false, "Use logrus for formatting.")
 	RootCmd.AddCommand(LogsCmd)
 }

--- a/server/cmd/mmctl/commands/oauth.go
+++ b/server/cmd/mmctl/commands/oauth.go
@@ -73,7 +73,7 @@ func listOAuthAppsCmdF(c client.Client, command *cobra.Command, args []string) e
 
 func init() {
 	ListOAuthAppsCmd.Flags().Int("page", 0, "Page number to fetch for the list of OAuth2 apps")
-	ListOAuthAppsCmd.Flags().Int("per-page", 200, "Number of OAuth2 apps to be fetched")
+	ListOAuthAppsCmd.Flags().Int("per-page", DefaultPageSize, "Number of OAuth2 apps to be fetched")
 
 	OAuthCmd.AddCommand(
 		ListOAuthAppsCmd,

--- a/server/cmd/mmctl/commands/plugin_marketplace.go
+++ b/server/cmd/mmctl/commands/plugin_marketplace.go
@@ -50,7 +50,7 @@ var PluginMarketplaceListCmd = &cobra.Command{
 
 func init() {
 	PluginMarketplaceListCmd.Flags().Int("page", 0, "Page number to fetch for the list of users")
-	PluginMarketplaceListCmd.Flags().Int("per-page", 200, "Number of users to be fetched")
+	PluginMarketplaceListCmd.Flags().Int("per-page", DefaultPageSize, "Number of users to be fetched")
 	PluginMarketplaceListCmd.Flags().Bool("all", false, "Fetch all plugins. --page flag will be ignore if provided")
 	PluginMarketplaceListCmd.Flags().String("filter", "", "Filter plugins by ID, name or description")
 	PluginMarketplaceListCmd.Flags().Bool("local-only", false, "Only retrieve local plugins")

--- a/server/cmd/mmctl/commands/team.go
+++ b/server/cmd/mmctl/commands/team.go
@@ -18,8 +18,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const APILimitMaximum = 200
-
 var TeamCmd = &cobra.Command{
 	Use:   "team",
 	Short: "Management of teams",
@@ -206,7 +204,7 @@ func archiveTeamsCmdF(c client.Client, cmd *cobra.Command, args []string) error 
 func listTeamsCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	page := 0
 	for {
-		teams, _, err := c.GetAllTeams(context.TODO(), "", page, APILimitMaximum)
+		teams, _, err := c.GetAllTeams(context.TODO(), "", page, DefaultPageSize)
 		if err != nil {
 			return err
 		}
@@ -219,7 +217,7 @@ func listTeamsCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		if len(teams) < APILimitMaximum {
+		if len(teams) < DefaultPageSize {
 			break
 		}
 

--- a/server/cmd/mmctl/commands/team_test.go
+++ b/server/cmd/mmctl/commands/team_test.go
@@ -248,7 +248,7 @@ func (s *MmctlUnitTestSuite) TestListTeamsCmdF() {
 
 		s.client.
 			EXPECT().
-			GetAllTeams(context.TODO(), "", 0, APILimitMaximum).
+			GetAllTeams(context.TODO(), "", 0, DefaultPageSize).
 			Return(nil, &model.Response{}, mockError).
 			Times(1)
 
@@ -266,7 +266,7 @@ func (s *MmctlUnitTestSuite) TestListTeamsCmdF() {
 
 		s.client.
 			EXPECT().
-			GetAllTeams(context.TODO(), "", 0, APILimitMaximum).
+			GetAllTeams(context.TODO(), "", 0, DefaultPageSize).
 			Return([]*model.Team{&mockTeam}, &model.Response{}, nil).
 			Times(2)
 
@@ -300,7 +300,7 @@ func (s *MmctlUnitTestSuite) TestListTeamsCmdF() {
 
 		s.client.
 			EXPECT().
-			GetAllTeams(context.TODO(), "", 0, APILimitMaximum).
+			GetAllTeams(context.TODO(), "", 0, DefaultPageSize).
 			Return([]*model.Team{&mockTeam}, &model.Response{}, nil).
 			Times(2)
 
@@ -347,7 +347,7 @@ func (s *MmctlUnitTestSuite) TestListTeamsCmdF() {
 
 		s.client.
 			EXPECT().
-			GetAllTeams(context.TODO(), "", 0, APILimitMaximum).
+			GetAllTeams(context.TODO(), "", 0, DefaultPageSize).
 			Return(mockTeams, &model.Response{}, nil).
 			Times(2)
 
@@ -383,28 +383,28 @@ func (s *MmctlUnitTestSuite) TestListTeamsCmdF() {
 	s.Run("Multiple team pages", func() {
 		printer.Clean()
 
-		mockTeamsPage1 := make([]*model.Team, APILimitMaximum)
-		for i := 0; i < APILimitMaximum; i++ {
+		mockTeamsPage1 := make([]*model.Team, DefaultPageSize)
+		for i := 0; i < DefaultPageSize; i++ {
 			mockTeamsPage1[i] = &model.Team{Name: fmt.Sprintf("Team%d", i)}
 		}
-		mockTeamsPage2 := []*model.Team{{Name: fmt.Sprintf("Team%d", APILimitMaximum)}}
+		mockTeamsPage2 := []*model.Team{{Name: fmt.Sprintf("Team%d", DefaultPageSize)}}
 
 		s.client.
 			EXPECT().
-			GetAllTeams(context.TODO(), "", 0, APILimitMaximum).
+			GetAllTeams(context.TODO(), "", 0, DefaultPageSize).
 			Return(mockTeamsPage1, &model.Response{}, nil).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetAllTeams(context.TODO(), "", 1, APILimitMaximum).
+			GetAllTeams(context.TODO(), "", 1, DefaultPageSize).
 			Return(mockTeamsPage2, &model.Response{}, nil).
 			Times(1)
 
 		err := listTeamsCmdF(s.client, &cobra.Command{}, []string{})
 		s.Require().NoError(err)
-		s.Require().Len(printer.GetLines(), APILimitMaximum+1)
-		for i := 0; i < APILimitMaximum+1; i++ {
+		s.Require().Len(printer.GetLines(), DefaultPageSize+1)
+		for i := 0; i < DefaultPageSize+1; i++ {
 			s.Require().Equal(printer.GetLines()[i].(*model.Team).Name, fmt.Sprintf("Team%d", i))
 		}
 		s.Require().Len(printer.GetErrorLines(), 0)

--- a/server/cmd/mmctl/commands/token.go
+++ b/server/cmd/mmctl/commands/token.go
@@ -48,7 +48,7 @@ var ListUserTokensCmd = &cobra.Command{
 
 func init() {
 	ListUserTokensCmd.Flags().Int("page", 0, "Page number to fetch for the list of users")
-	ListUserTokensCmd.Flags().Int("per-page", 200, "Number of users to be fetched")
+	ListUserTokensCmd.Flags().Int("per-page", DefaultPageSize, "Number of users to be fetched")
 	ListUserTokensCmd.Flags().Bool("all", false, "Fetch all tokens. --page flag will be ignore if provided")
 	ListUserTokensCmd.Flags().Bool("active", true, "List only active tokens")
 	ListUserTokensCmd.Flags().Bool("inactive", false, "List only inactive tokens")

--- a/server/cmd/mmctl/commands/user.go
+++ b/server/cmd/mmctl/commands/user.go
@@ -315,7 +315,7 @@ func init() {
 	DeleteAllUsersCmd.Flags().Bool("confirm", false, "Confirm you really want to delete the user and a DB backup has been performed")
 
 	ListUsersCmd.Flags().Int("page", 0, "Page number to fetch for the list of users")
-	ListUsersCmd.Flags().Int("per-page", 200, "Number of users to be fetched")
+	ListUsersCmd.Flags().Int("per-page", DefaultPageSize, "Number of users to be fetched")
 	ListUsersCmd.Flags().Bool("all", false, "Fetch all users. --page flag will be ignore if provided")
 	ListUsersCmd.Flags().String("team", "", "If supplied, only users belonging to this team will be listed")
 

--- a/server/cmd/mmctl/commands/utils.go
+++ b/server/cmd/mmctl/commands/utils.go
@@ -14,7 +14,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-const DefaultPageSize = 200
+const (
+	DefaultPageSize = 200
+)
 
 func checkInteractiveTerminal() error {
 	fileInfo, err := os.Stdout.Stat()


### PR DESCRIPTION
#### Summary
The `mmctl` code has a lot of different ways to select the page size for requests. The PR unifies that to using `DefaultPageSize`, which is 200.

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
