### PR TITLE
Add login/logout signal to Desktop App API

### DIFF
--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -13,7 +13,7 @@
     "@mattermost/client": "*",
     "@mattermost/compass-components": "^0.2.12",
     "@mattermost/compass-icons": "0.1.39",
-    "@mattermost/desktop-api": "5.7.0-1",
+    "@mattermost/desktop-api": "5.8.0-4",
     "@mattermost/types": "*",
     "@mui/base": "5.0.0-alpha.127",
     "@mui/material": "5.11.16",

--- a/webapp/channels/src/actions/global_actions.tsx
+++ b/webapp/channels/src/actions/global_actions.tsx
@@ -44,6 +44,7 @@ import SubMenuModal from 'components/widgets/menu/menu_modals/submenu_modal/subm
 import WebSocketClient from 'client/web_websocket_client';
 import {getHistory} from 'utils/browser_history';
 import {ActionTypes, PostTypes, RHSStates, ModalIdentifiers, PreviousViewedTypes} from 'utils/constants';
+import DesktopApp from 'utils/desktop_api';
 import {filterAndSortTeamsByDisplayName} from 'utils/team_utils';
 import * as Utils from 'utils/utils';
 
@@ -249,6 +250,7 @@ export function emitUserLoggedOutEvent(redirectTo = '/', shouldSignalLogout = tr
     dispatch(logout()).then(() => {
         if (shouldSignalLogout) {
             BrowserStore.signalLogout();
+            DesktopApp.signalLogout();
         }
 
         WebsocketActions.close();

--- a/webapp/channels/src/components/logged_in/logged_in.tsx
+++ b/webapp/channels/src/components/logged_in/logged_in.tsx
@@ -106,6 +106,7 @@ export default class LoggedIn extends React.PureComponent<Props> {
 
         if (this.isValidState() && !this.props.mfaRequired) {
             BrowserStore.signalLogin();
+            DesktopApp.signalLogin();
         }
     }
 

--- a/webapp/channels/src/utils/desktop_api.ts
+++ b/webapp/channels/src/utils/desktop_api.ts
@@ -206,6 +206,8 @@ class DesktopAppAPI {
     updateUnreadsAndMentions = (isUnread: boolean, mentionCount: number) =>
         window.desktopAPI?.setUnreadsAndMentions && window.desktopAPI.setUnreadsAndMentions(isUnread, mentionCount);
     setSessionExpired = (expired: boolean) => window.desktopAPI?.setSessionExpired && window.desktopAPI.setSessionExpired(expired);
+    signalLogin = () => window.desktopAPI?.onLogin && window.desktopAPI?.onLogin();
+    signalLogout = () => window.desktopAPI?.onLogout && window.desktopAPI?.onLogout();
 
     /*********************************************************************
      * Helper functions for legacy code

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -62,7 +62,7 @@
         "@mattermost/client": "*",
         "@mattermost/compass-components": "^0.2.12",
         "@mattermost/compass-icons": "0.1.39",
-        "@mattermost/desktop-api": "5.7.0-1",
+        "@mattermost/desktop-api": "5.8.0-4",
         "@mattermost/types": "*",
         "@mui/base": "5.0.0-alpha.127",
         "@mui/material": "5.11.16",
@@ -4290,11 +4290,11 @@
       "link": true
     },
     "node_modules/@mattermost/desktop-api": {
-      "version": "5.7.0-1",
-      "resolved": "https://registry.npmjs.org/@mattermost/desktop-api/-/desktop-api-5.7.0-1.tgz",
-      "integrity": "sha512-3VdmrdiGwqXpLGomRWiDt8L2LMlOyeAP+S9uKm82JpRt8HoVFeSe9fu39VV9pbnA8O6u6wfnwGUXFeasmmIIkQ==",
+      "version": "5.8.0-4",
+      "resolved": "https://registry.npmjs.org/@mattermost/desktop-api/-/desktop-api-5.8.0-4.tgz",
+      "integrity": "sha512-oEbh3ByDgM432LrjO9JsRnIwqBIAkF6bJaQkHjYeQAYwkI4/s4CSQ4kZcfMiO9hE0MjfF1VeXnGTBv9wyWsbAw==",
       "peerDependencies": {
-        "typescript": "^4.3"
+        "typescript": "^4.3.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {


### PR DESCRIPTION
#### Summary
This PR is the complement to https://github.com/mattermost/desktop/pull/2999 where we now have the server notify the Desktop App directly when it has logged in or logged out.

```release-note
NONE
```
