### PR TITLE
Updated minimum supported Edge, Chrome and macOS versions

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10280,11 +10280,11 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "Version 120+"
+    "translation": "Version 122+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "Version 120+"
+    "translation": "Version 122+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",
@@ -10296,7 +10296,7 @@
   },
   {
     "id": "web.error.unsupported_browser.min_os_version.mac",
-    "translation": "macOS 11+"
+    "translation": "macOS 12+"
   },
   {
     "id": "web.error.unsupported_browser.min_os_version.windows",


### PR DESCRIPTION
Desktop app v5.8 will include Electron 29.0 which supports Chrome 122+. macOS 11 went out of support last year.

```release-note
Updated minimum Edge and Chrome versions to 122+, and updated minimum macOS version to 12+.
```