### PR TITLE
Gh 26025 add request context to userstore permanentdelete

### DIFF
--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -2744,7 +2744,7 @@ func TestGetUsersWithoutTeam(t *testing.T) {
 	})
 	require.NoError(t, err)
 	th.LinkUserToTeam(user, th.BasicTeam)
-	defer th.App.Srv().Store().User().PermanentDelete(user.Id)
+	defer th.App.Srv().Store().User().PermanentDelete(th.Context, user.Id)
 
 	user2, _, err := th.Client.CreateUser(context.Background(), &model.User{
 		Username: "a000000001" + model.NewId(),
@@ -2752,7 +2752,7 @@ func TestGetUsersWithoutTeam(t *testing.T) {
 		Password: "Password1",
 	})
 	require.NoError(t, err)
-	defer th.App.Srv().Store().User().PermanentDelete(user2.Id)
+	defer th.App.Srv().Store().User().PermanentDelete(th.Context, user2.Id)
 
 	rusers, _, err := th.SystemAdminClient.GetUsersWithoutTeam(context.Background(), 0, 100, "")
 	require.NoError(t, err)

--- a/server/channels/app/bot.go
+++ b/server/channels/app/bot.go
@@ -124,7 +124,7 @@ func (a *App) CreateBot(rctx request.CTX, bot *model.Bot) (*model.Bot, *model.Ap
 
 	savedBot, nErr := a.Srv().Store().Bot().Save(bot)
 	if nErr != nil {
-		a.Srv().Store().User().PermanentDelete(bot.UserId)
+		a.Srv().Store().User().PermanentDelete(rctx, bot.UserId)
 		var appErr *model.AppError
 		switch {
 		case errors.As(nErr, &appErr): // in case we haven't converted to plain error.
@@ -227,7 +227,7 @@ func (a *App) getOrCreateBot(rctx request.CTX, botDef *model.Bot) (*model.Bot, *
 		//save the bot
 		savedBot, nErr := a.Srv().Store().Bot().Save(botDef)
 		if nErr != nil {
-			a.Srv().Store().User().PermanentDelete(savedBot.UserId)
+			a.Srv().Store().User().PermanentDelete(rctx, savedBot.UserId)
 			var nAppErr *model.AppError
 			switch {
 			case errors.As(nErr, &nAppErr): // in case we haven't converted to plain error.
@@ -414,7 +414,7 @@ func (a *App) PermanentDeleteBot(rctx request.CTX, botUserId string) *model.AppE
 		}
 	}
 
-	if err := a.Srv().Store().User().PermanentDelete(botUserId); err != nil {
+	if err := a.Srv().Store().User().PermanentDelete(rctx, botUserId); err != nil {
 		return model.NewAppError("PermanentDeleteBot", "app.user.permanent_delete.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 

--- a/server/channels/app/bot_test.go
+++ b/server/channels/app/bot_test.go
@@ -169,7 +169,7 @@ func TestEnsureBot(t *testing.T) {
 		assert.Equal(t, "username", bot.Username)
 		assert.Equal(t, "a bot", bot.Description)
 
-		err = th.App.Srv().Store().User().PermanentDelete(initialBot.UserId)
+		err = th.App.Srv().Store().User().PermanentDelete(th.Context, initialBot.UserId)
 		require.NoError(t, err)
 		botID2, err := th.App.EnsureBot(th.Context, pluginId, &model.Bot{
 			Username:    "another_username",

--- a/server/channels/app/channel_category_test.go
+++ b/server/channels/app/channel_category_test.go
@@ -19,7 +19,7 @@ func TestSidebarCategory(t *testing.T) {
 	basicChannel2 := th.CreateChannel(th.Context, th.BasicTeam)
 	defer th.App.PermanentDeleteChannel(th.Context, basicChannel2)
 	user := th.CreateUser()
-	defer th.App.Srv().Store().User().PermanentDelete(user.Id)
+	defer th.App.Srv().Store().User().PermanentDelete(th.Context, user.Id)
 	th.LinkUserToTeam(user, th.BasicTeam)
 	th.AddUserToChannel(user, basicChannel2)
 

--- a/server/channels/app/teams/helper_test.go
+++ b/server/channels/app/teams/helper_test.go
@@ -122,7 +122,7 @@ func (th *TestHelper) CreateUser(u *model.User) *model.User {
 }
 
 func (th *TestHelper) DeleteUser(u *model.User) {
-	err := th.dbStore.User().PermanentDelete(u.Id)
+	err := th.dbStore.User().PermanentDelete(th.Context, u.Id)
 	if err != nil {
 		panic(err)
 	}

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -1847,7 +1847,7 @@ func (a *App) PermanentDeleteUser(c request.CTX, user *model.User) *model.AppErr
 		return model.NewAppError("PermanentDeleteUser", "app.file_info.permanent_delete_by_user.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
-	if err := a.Srv().Store().User().PermanentDelete(user.Id); err != nil {
+	if err := a.Srv().Store().User().PermanentDelete(c, user.Id); err != nil {
 		return model.NewAppError("PermanentDeleteUser", "app.user.permanent_delete.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 

--- a/server/channels/app/users/users_test.go
+++ b/server/channels/app/users/users_test.go
@@ -56,7 +56,7 @@ func TestFirstUserPromoted(t *testing.T) {
 
 	require.Equal(t, model.SystemUserRoleId, user2.Roles)
 
-	th.dbStore.User().PermanentDelete(user.Id)
+	th.dbStore.User().PermanentDelete(th.Context, user.Id)
 
 	b := &model.Bot{
 		UserId:   user2.Id,

--- a/server/channels/store/opentracinglayer/opentracinglayer.go
+++ b/server/channels/store/opentracinglayer/opentracinglayer.go
@@ -12252,7 +12252,7 @@ func (s *OpenTracingLayerUserStore) IsEmpty(excludeBots bool) (bool, error) {
 	return result, err
 }
 
-func (s *OpenTracingLayerUserStore) PermanentDelete(userID string) error {
+func (s *OpenTracingLayerUserStore) PermanentDelete(rctx request.CTX, userID string) error {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "UserStore.PermanentDelete")
 	s.Root.Store.SetContext(newCtx)
@@ -12261,7 +12261,7 @@ func (s *OpenTracingLayerUserStore) PermanentDelete(userID string) error {
 	}()
 
 	defer span.Finish()
-	err := s.UserStore.PermanentDelete(userID)
+	err := s.UserStore.PermanentDelete(rctx, userID)
 	if err != nil {
 		span.LogFields(spanlog.Error(err))
 		ext.Error.Set(span, true)

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -13977,11 +13977,11 @@ func (s *RetryLayerUserStore) IsEmpty(excludeBots bool) (bool, error) {
 
 }
 
-func (s *RetryLayerUserStore) PermanentDelete(userID string) error {
+func (s *RetryLayerUserStore) PermanentDelete(rctx request.CTX, userID string) error {
 
 	tries := 0
 	for {
-		err := s.UserStore.PermanentDelete(userID)
+		err := s.UserStore.PermanentDelete(rctx, userID)
 		if err == nil {
 			return nil
 		}

--- a/server/channels/store/searchlayer/user_layer.go
+++ b/server/channels/store/searchlayer/user_layer.go
@@ -90,15 +90,12 @@ func (s *SearchUserStore) Save(rctx request.CTX, user *model.User) (*model.User,
 	return nuser, err
 }
 
-func (s *SearchUserStore) PermanentDelete(userId string) error {
-	// TODO: Use the actuall request context from the App layer
-	// https://mattermost.atlassian.net/browse/MM-55738
-	rctx := request.EmptyContext(s.rootStore.Logger())
+func (s *SearchUserStore) PermanentDelete(rctx request.CTX, userId string) error {
 	user, userErr := s.UserStore.Get(context.Background(), userId)
 	if userErr != nil {
 		rctx.Logger().Warn("Encountered error deleting user", mlog.String("user_id", userId), mlog.Err(userErr))
 	}
-	err := s.UserStore.PermanentDelete(userId)
+	err := s.UserStore.PermanentDelete(rctx, userId)
 	if err == nil && userErr == nil {
 		s.deleteUserIndex(rctx, user)
 	}

--- a/server/channels/store/searchtest/helper.go
+++ b/server/channels/store/searchtest/helper.go
@@ -192,14 +192,14 @@ func (th *SearchTestHelper) createGuest(username, nickname, firstName, lastName 
 }
 
 func (th *SearchTestHelper) deleteUser(user *model.User) error {
-	return th.Store.User().PermanentDelete(user.Id)
+	return th.Store.User().PermanentDelete(th.Context, user.Id)
 }
 
 func (th *SearchTestHelper) deleteBotUser(botID string) error {
 	if err := th.deleteBot(botID); err != nil {
 		return err
 	}
-	return th.Store.User().PermanentDelete(botID)
+	return th.Store.User().PermanentDelete(th.Context, botID)
 }
 
 func (th *SearchTestHelper) cleanAllUsers() error {
@@ -233,7 +233,7 @@ func (th *SearchTestHelper) createBot(username, displayName, ownerID string) (*m
 	botModel.UserId = user.Id
 	bot, err := th.Store.Bot().Save(botModel)
 	if err != nil {
-		th.Store.User().PermanentDelete(bot.UserId)
+		th.Store.User().PermanentDelete(th.Context, bot.UserId)
 		return nil, errors.New(err.Error())
 	}
 

--- a/server/channels/store/sqlstore/user_store.go
+++ b/server/channels/store/sqlstore/user_store.go
@@ -1337,7 +1337,7 @@ func (us SqlUserStore) VerifyEmail(userId, email string) (string, error) {
 	return userId, nil
 }
 
-func (us SqlUserStore) PermanentDelete(userId string) error {
+func (us SqlUserStore) PermanentDelete(rctx request.CTX, userId string) error {
 	if _, err := us.GetMasterX().Exec("DELETE FROM Users WHERE Id = ?", userId); err != nil {
 		return errors.Wrapf(err, "failed to delete User with userId=%s", userId)
 	}

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -444,7 +444,7 @@ type UserStore interface {
 	GetEtagForProfiles(teamID string) string
 	UpdateFailedPasswordAttempts(userID string, attempts int) error
 	GetSystemAdminProfiles() (map[string]*model.User, error)
-	PermanentDelete(userID string) error
+	PermanentDelete(rctx request.CTX, userID string) error
 	AnalyticsActiveCount(timestamp int64, options model.UserCountOptions) (int64, error)
 	AnalyticsActiveCountForPeriod(startTime int64, endTime int64, options model.UserCountOptions) (int64, error)
 	GetUnreadCount(userID string, isCRTEnabled bool) (int64, error)

--- a/server/channels/store/storetest/bot_store.go
+++ b/server/channels/store/storetest/bot_store.go
@@ -44,7 +44,7 @@ func testBotStoreGet(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore)
 	deletedBot, err := ss.Bot().Update(deletedBot)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, ss.Bot().PermanentDelete(deletedBot.UserId)) }()
-	defer func() { require.NoError(t, ss.User().PermanentDelete(deletedBot.UserId)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, deletedBot.UserId)) }()
 
 	permanentlyDeletedBot, _ := makeBotWithUser(t, rctx, ss, &model.Bot{
 		Username:       "permanently_deleted_bot",
@@ -54,7 +54,7 @@ func testBotStoreGet(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore)
 		DeleteAt:       0,
 	})
 	require.NoError(t, ss.Bot().PermanentDelete(permanentlyDeletedBot.UserId))
-	defer func() { require.NoError(t, ss.User().PermanentDelete(permanentlyDeletedBot.UserId)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, permanentlyDeletedBot.UserId)) }()
 
 	b1, _ := makeBotWithUser(t, rctx, ss, &model.Bot{
 		Username:       "b1",
@@ -63,7 +63,7 @@ func testBotStoreGet(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore)
 		LastIconUpdate: model.GetMillis(),
 	})
 	defer func() { require.NoError(t, ss.Bot().PermanentDelete(b1.UserId)) }()
-	defer func() { require.NoError(t, ss.User().PermanentDelete(b1.UserId)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, b1.UserId)) }()
 
 	b2, _ := makeBotWithUser(t, rctx, ss, &model.Bot{
 		Username:       "b2",
@@ -72,7 +72,7 @@ func testBotStoreGet(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore)
 		LastIconUpdate: 0,
 	})
 	defer func() { require.NoError(t, ss.Bot().PermanentDelete(b2.UserId)) }()
-	defer func() { require.NoError(t, ss.User().PermanentDelete(b2.UserId)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, b2.UserId)) }()
 
 	// Artificially set b2.LastIconUpdate to NULL to verify handling of same.
 	_, sqlErr := s.GetMasterX().Exec("UPDATE Bots SET LastIconUpdate = NULL WHERE UserId = '" + b2.UserId + "'")
@@ -132,7 +132,7 @@ func testBotStoreGetAll(t *testing.T, rctx request.CTX, ss store.Store, s SqlSto
 	deletedBot, err := ss.Bot().Update(deletedBot)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, ss.Bot().PermanentDelete(deletedBot.UserId)) }()
-	defer func() { require.NoError(t, ss.User().PermanentDelete(deletedBot.UserId)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, deletedBot.UserId)) }()
 
 	permanentlyDeletedBot, _ := makeBotWithUser(t, rctx, ss, &model.Bot{
 		Username:       "permanently_deleted_bot",
@@ -142,7 +142,7 @@ func testBotStoreGetAll(t *testing.T, rctx request.CTX, ss store.Store, s SqlSto
 		DeleteAt:       0,
 	})
 	require.NoError(t, ss.Bot().PermanentDelete(permanentlyDeletedBot.UserId))
-	defer func() { require.NoError(t, ss.User().PermanentDelete(permanentlyDeletedBot.UserId)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, permanentlyDeletedBot.UserId)) }()
 
 	b1, _ := makeBotWithUser(t, rctx, ss, &model.Bot{
 		Username:       "b1",
@@ -151,7 +151,7 @@ func testBotStoreGetAll(t *testing.T, rctx request.CTX, ss store.Store, s SqlSto
 		LastIconUpdate: model.GetMillis(),
 	})
 	defer func() { require.NoError(t, ss.Bot().PermanentDelete(b1.UserId)) }()
-	defer func() { require.NoError(t, ss.User().PermanentDelete(b1.UserId)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, b1.UserId)) }()
 
 	b2, _ := makeBotWithUser(t, rctx, ss, &model.Bot{
 		Username:       "b2",
@@ -160,7 +160,7 @@ func testBotStoreGetAll(t *testing.T, rctx request.CTX, ss store.Store, s SqlSto
 		LastIconUpdate: 0,
 	})
 	defer func() { require.NoError(t, ss.Bot().PermanentDelete(b2.UserId)) }()
-	defer func() { require.NoError(t, ss.User().PermanentDelete(b2.UserId)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, b2.UserId)) }()
 
 	// Artificially set b2.LastIconUpdate to NULL to verify handling of same.
 	_, sqlErr := s.GetMasterX().Exec("UPDATE Bots SET LastIconUpdate = NULL WHERE UserId = '" + b2.UserId + "'")
@@ -181,7 +181,7 @@ func testBotStoreGetAll(t *testing.T, rctx request.CTX, ss store.Store, s SqlSto
 		OwnerId:     OwnerId1,
 	})
 	defer func() { require.NoError(t, ss.Bot().PermanentDelete(b3.UserId)) }()
-	defer func() { require.NoError(t, ss.User().PermanentDelete(b3.UserId)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, b3.UserId)) }()
 
 	b4, _ := makeBotWithUser(t, rctx, ss, &model.Bot{
 		Username:    "b4",
@@ -189,7 +189,7 @@ func testBotStoreGetAll(t *testing.T, rctx request.CTX, ss store.Store, s SqlSto
 		OwnerId:     OwnerId2,
 	})
 	defer func() { require.NoError(t, ss.Bot().PermanentDelete(b4.UserId)) }()
-	defer func() { require.NoError(t, ss.User().PermanentDelete(b4.UserId)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, b4.UserId)) }()
 
 	deletedUser := model.User{
 		Email:    MakeEmail(),
@@ -202,14 +202,14 @@ func testBotStoreGetAll(t *testing.T, rctx request.CTX, ss store.Store, s SqlSto
 	_, err2 := ss.User().Update(rctx, &deletedUser, true)
 	require.NoError(t, err2, "couldn't delete user")
 
-	defer func() { require.NoError(t, ss.User().PermanentDelete(deletedUser.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, deletedUser.Id)) }()
 	ob5, _ := makeBotWithUser(t, rctx, ss, &model.Bot{
 		Username:    "ob5",
 		Description: "Orphaned bot 5",
 		OwnerId:     deletedUser.Id,
 	})
 	defer func() { require.NoError(t, ss.Bot().PermanentDelete(b4.UserId)) }()
-	defer func() { require.NoError(t, ss.User().PermanentDelete(b4.UserId)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, b4.UserId)) }()
 
 	t.Run("get newly created bot stoo", func(t *testing.T) {
 		bots, err := ss.Bot().GetAll(&model.BotGetOptions{Page: 0, PerPage: 10})
@@ -335,7 +335,7 @@ func testBotStoreSave(t *testing.T, rctx request.CTX, ss store.Store) {
 
 		user, err := ss.User().Save(rctx, model.UserFromBot(bot))
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 		bot.UserId = user.Id
 
 		returnedNewBot, nErr := ss.Bot().Save(bot)
@@ -366,7 +366,7 @@ func testBotStoreUpdate(t *testing.T, rctx request.CTX, ss store.Store) {
 			OwnerId:  model.NewId(),
 		})
 		defer func() { require.NoError(t, ss.Bot().PermanentDelete(existingBot.UserId)) }()
-		defer func() { require.NoError(t, ss.User().PermanentDelete(existingBot.UserId)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, existingBot.UserId)) }()
 
 		bot := existingBot.Clone()
 		bot.Username = "invalid username"
@@ -383,7 +383,7 @@ func testBotStoreUpdate(t *testing.T, rctx request.CTX, ss store.Store) {
 			OwnerId:  model.NewId(),
 		})
 		defer func() { require.NoError(t, ss.Bot().PermanentDelete(existingBot.UserId)) }()
-		defer func() { require.NoError(t, ss.User().PermanentDelete(existingBot.UserId)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, existingBot.UserId)) }()
 
 		bot := existingBot.Clone()
 		bot.OwnerId = model.NewId()
@@ -418,7 +418,7 @@ func testBotStoreUpdate(t *testing.T, rctx request.CTX, ss store.Store) {
 			OwnerId:  model.NewId(),
 		})
 		defer func() { require.NoError(t, ss.Bot().PermanentDelete(existingBot.UserId)) }()
-		defer func() { require.NoError(t, ss.User().PermanentDelete(existingBot.UserId)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, existingBot.UserId)) }()
 
 		existingBot.DeleteAt = 100000
 		existingBot, err := ss.Bot().Update(existingBot)
@@ -447,14 +447,14 @@ func testBotStorePermanentDelete(t *testing.T, rctx request.CTX, ss store.Store)
 		OwnerId:  model.NewId(),
 	})
 	defer func() { require.NoError(t, ss.Bot().PermanentDelete(b1.UserId)) }()
-	defer func() { require.NoError(t, ss.User().PermanentDelete(b1.UserId)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, b1.UserId)) }()
 
 	b2, _ := makeBotWithUser(t, rctx, ss, &model.Bot{
 		Username: "b2",
 		OwnerId:  model.NewId(),
 	})
 	defer func() { require.NoError(t, ss.Bot().PermanentDelete(b2.UserId)) }()
-	defer func() { require.NoError(t, ss.User().PermanentDelete(b2.UserId)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, b2.UserId)) }()
 
 	t.Run("permanently delete a non-existent bot", func(t *testing.T) {
 		err := ss.Bot().PermanentDelete("unknown")

--- a/server/channels/store/storetest/channel_store_categories.go
+++ b/server/channels/store/storetest/channel_store_categories.go
@@ -2182,7 +2182,7 @@ func testClearSidebarOnTeamLeave(t *testing.T, rctx request.CTX, ss store.Store,
 func testDeleteSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
 	t.Run("should correctly remove an empty category", func(t *testing.T) {
 		userId, teamId := setupInitialSidebarCategories(t, rctx, ss)
-		defer ss.User().PermanentDelete(userId)
+		defer ss.User().PermanentDelete(rctx, userId)
 
 		newCategory, err := ss.Channel().CreateSidebarCategory(userId, teamId, &model.SidebarCategoryWithChannels{})
 		require.NoError(t, err)
@@ -2204,7 +2204,7 @@ func testDeleteSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store, s
 
 	t.Run("should correctly remove a category and its channels", func(t *testing.T) {
 		userId, teamId := setupInitialSidebarCategories(t, rctx, ss)
-		defer ss.User().PermanentDelete(userId)
+		defer ss.User().PermanentDelete(rctx, userId)
 
 		user := &model.User{
 			Id: userId,
@@ -2272,7 +2272,7 @@ func testDeleteSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store, s
 
 	t.Run("should not allow you to remove non-custom categories", func(t *testing.T) {
 		userId, teamId := setupInitialSidebarCategories(t, rctx, ss)
-		defer ss.User().PermanentDelete(userId)
+		defer ss.User().PermanentDelete(rctx, userId)
 		res, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userId, teamId)
 		require.NoError(t, err)
 		require.Len(t, res.Categories, 3)

--- a/server/channels/store/storetest/compliance_store.go
+++ b/server/channels/store/storetest/compliance_store.go
@@ -21,7 +21,7 @@ func cleanupStoreState(t *testing.T, rctx request.CTX, ss store.Store) {
 	allUsers, err := ss.User().GetAll()
 	require.NoError(t, err, "error cleaning all test users", err)
 	for _, u := range allUsers {
-		err = ss.User().PermanentDelete(u.Id)
+		err = ss.User().PermanentDelete(rctx, u.Id)
 		require.NoError(t, err, "failed cleaning up test user %s", u.Username)
 
 		//remove all posts by this user

--- a/server/channels/store/storetest/group_store.go
+++ b/server/channels/store/storetest/group_store.go
@@ -5350,8 +5350,8 @@ func groupTestDistinctGroupMemberCountForSource(t *testing.T, rctx request.CTX, 
 		ss.Group().Delete(customGroup.Id)
 		ss.Group().Delete(ldapGroup.Id)
 
-		ss.User().PermanentDelete(user1.Id)
-		ss.User().PermanentDelete(user2.Id)
+		ss.User().PermanentDelete(rctx, user1.Id)
+		ss.User().PermanentDelete(rctx, user2.Id)
 	}()
 
 	customGroupCount, err := ss.Group().DistinctGroupMemberCountForSource(model.GroupSourceCustom)

--- a/server/channels/store/storetest/mocks/UserStore.go
+++ b/server/channels/store/storetest/mocks/UserStore.go
@@ -1332,13 +1332,13 @@ func (_m *UserStore) IsEmpty(excludeBots bool) (bool, error) {
 	return r0, r1
 }
 
-// PermanentDelete provides a mock function with given fields: userID
-func (_m *UserStore) PermanentDelete(userID string) error {
-	ret := _m.Called(userID)
+// PermanentDelete provides a mock function with given fields: rctx, userID
+func (_m *UserStore) PermanentDelete(rctx request.CTX, userID string) error {
+	ret := _m.Called(rctx, userID)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(userID)
+	if rf, ok := ret.Get(0).(func(request.CTX, string) error); ok {
+		r0 = rf(rctx, userID)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/server/channels/store/storetest/team_store.go
+++ b/server/channels/store/storetest/team_store.go
@@ -2895,7 +2895,7 @@ func testSaveTeamMemberMaxMembers(t *testing.T, rctx request.CTX, ss store.Store
 		userIds[i] = user.Id
 
 		defer func(userId string) {
-			ss.User().PermanentDelete(userId)
+			ss.User().PermanentDelete(rctx, userId)
 		}(userIds[i])
 
 		_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{
@@ -2920,7 +2920,7 @@ func testSaveTeamMemberMaxMembers(t *testing.T, rctx request.CTX, ss store.Store
 	require.NoError(t, nErr)
 	newUserId := user.Id
 	defer func() {
-		ss.User().PermanentDelete(newUserId)
+		ss.User().PermanentDelete(rctx, newUserId)
 	}()
 
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{

--- a/server/channels/store/storetest/user_store.go
+++ b/server/channels/store/storetest/user_store.go
@@ -35,7 +35,7 @@ func TestUserStore(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
 	require.NoError(t, err, "failed cleaning up test users")
 
 	for _, u := range users {
-		err := ss.User().PermanentDelete(u.Id)
+		err := ss.User().PermanentDelete(rctx, u.Id)
 		require.NoError(t, err, "failed cleaning up test user %s", u.Username)
 	}
 
@@ -113,7 +113,7 @@ func testUserStoreSave(t *testing.T, rctx request.CTX, ss store.Store) {
 	_, err := ss.User().Save(rctx, &u1)
 	require.NoError(t, err, "couldn't save user")
 
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, maxUsersPerTeam)
 	require.NoError(t, nErr)
@@ -155,7 +155,7 @@ func testUserStoreSave(t *testing.T, rctx request.CTX, ss store.Store) {
 		_, err = ss.User().Save(rctx, &u)
 		require.NoError(t, err, "couldn't save item")
 
-		defer func() { require.NoError(t, ss.User().PermanentDelete(u.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u.Id)) }()
 
 		_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u.Id}, maxUsersPerTeam)
 		require.NoError(t, nErr)
@@ -167,7 +167,7 @@ func testUserStoreSave(t *testing.T, rctx request.CTX, ss store.Store) {
 	_, err = ss.User().Save(rctx, &u2)
 	require.NoError(t, err, "couldn't save item")
 
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, maxUsersPerTeam)
 	require.Error(t, nErr, "should be the limit")
@@ -179,7 +179,7 @@ func testUserStoreUpdate(t *testing.T, rctx request.CTX, ss store.Store) {
 	}
 	_, err := ss.User().Save(rctx, u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -189,7 +189,7 @@ func testUserStoreUpdate(t *testing.T, rctx request.CTX, ss store.Store) {
 	}
 	_, err = ss.User().Save(rctx, u2)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: model.NewId(), UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -217,7 +217,7 @@ func testUserStoreUpdate(t *testing.T, rctx request.CTX, ss store.Store) {
 	oldEmail := u3.Email
 	_, err = ss.User().Save(rctx, u3)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: model.NewId(), UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -268,7 +268,7 @@ func testUserStoreUpdateUpdateAt(t *testing.T, rctx request.CTX, ss store.Store)
 	u1.Email = MakeEmail()
 	_, err := ss.User().Save(rctx, u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -288,7 +288,7 @@ func testUserStoreUpdateFailedPasswordAttempts(t *testing.T, rctx request.CTX, s
 	u1.Email = MakeEmail()
 	_, err := ss.User().Save(rctx, u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -306,7 +306,7 @@ func testUserStoreGet(t *testing.T, rctx request.CTX, ss store.Store) {
 	}
 	_, err := ss.User().Save(rctx, u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	u2, _ := ss.User().Save(rctx, &model.User{
 		Email:    MakeEmail(),
@@ -322,7 +322,7 @@ func testUserStoreGet(t *testing.T, rctx request.CTX, ss store.Store) {
 	u2.IsBot = true
 	u2.BotDescription = "bot description"
 	defer func() { require.NoError(t, ss.Bot().PermanentDelete(u2.Id)) }()
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
@@ -357,7 +357,7 @@ func testGetAllUsingAuthService(t *testing.T, rctx request.CTX, ss store.Store) 
 		AuthService: "service",
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -367,7 +367,7 @@ func testGetAllUsingAuthService(t *testing.T, rctx request.CTX, ss store.Store) 
 		AuthService: "service",
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -377,7 +377,7 @@ func testGetAllUsingAuthService(t *testing.T, rctx request.CTX, ss store.Store) 
 		AuthService: "service2",
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Bot().Save(&model.Bot{
@@ -388,7 +388,7 @@ func testGetAllUsingAuthService(t *testing.T, rctx request.CTX, ss store.Store) 
 	require.NoError(t, nErr)
 	u3.IsBot = true
 	defer func() { require.NoError(t, ss.Bot().PermanentDelete(u3.Id)) }()
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 
 	t.Run("get by unknown auth service", func(t *testing.T) {
 		users, err := ss.User().GetAllUsingAuthService("unknown")
@@ -423,7 +423,7 @@ func testUserStoreGetAllProfiles(t *testing.T, rctx request.CTX, ss store.Store)
 		Roles:    model.SystemUserRoleId,
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	u2, err := ss.User().Save(rctx, &model.User{
 		Email:    MakeEmail(),
@@ -431,7 +431,7 @@ func testUserStoreGetAllProfiles(t *testing.T, rctx request.CTX, ss store.Store)
 		Roles:    model.SystemUserRoleId,
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 
 	u3, err := ss.User().Save(rctx, &model.User{
 		Email:    MakeEmail(),
@@ -446,7 +446,7 @@ func testUserStoreGetAllProfiles(t *testing.T, rctx request.CTX, ss store.Store)
 	require.NoError(t, nErr)
 	u3.IsBot = true
 	defer func() { require.NoError(t, ss.Bot().PermanentDelete(u3.Id)) }()
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 
 	u4, err := ss.User().Save(rctx, &model.User{
 		Email:    MakeEmail(),
@@ -454,7 +454,7 @@ func testUserStoreGetAllProfiles(t *testing.T, rctx request.CTX, ss store.Store)
 		Roles:    "system_user some-other-role",
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u4.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u4.Id)) }()
 
 	u5, err := ss.User().Save(rctx, &model.User{
 		Email:    MakeEmail(),
@@ -462,7 +462,7 @@ func testUserStoreGetAllProfiles(t *testing.T, rctx request.CTX, ss store.Store)
 		Roles:    "system_admin",
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u5.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u5.Id)) }()
 
 	u6, err := ss.User().Save(rctx, &model.User{
 		Email:    MakeEmail(),
@@ -471,7 +471,7 @@ func testUserStoreGetAllProfiles(t *testing.T, rctx request.CTX, ss store.Store)
 		Roles:    "system_admin",
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u6.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u6.Id)) }()
 
 	u7, err := ss.User().Save(rctx, &model.User{
 		Email:    MakeEmail(),
@@ -480,7 +480,7 @@ func testUserStoreGetAllProfiles(t *testing.T, rctx request.CTX, ss store.Store)
 		Roles:    model.SystemUserRoleId,
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u7.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u7.Id)) }()
 
 	t.Run("get offset 0, limit 100", func(t *testing.T) {
 		options := &model.UserGetOptions{Page: 0, PerPage: 100}
@@ -531,7 +531,7 @@ func testUserStoreGetAllProfiles(t *testing.T, rctx request.CTX, ss store.Store)
 		uNew.Email = MakeEmail()
 		_, userErr := ss.User().Save(rctx, uNew)
 		require.NoError(t, userErr)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(uNew.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, uNew.Id)) }()
 
 		updatedEtag := ss.User().GetEtagForAllProfiles()
 		require.NotEqual(t, etag, updatedEtag)
@@ -613,7 +613,7 @@ func testUserStoreGetAllProfiles(t *testing.T, rctx request.CTX, ss store.Store)
 		Roles:    "system_user_manager system_user",
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u8.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u8.Id)) }()
 
 	u9, err := ss.User().Save(rctx, &model.User{
 		Email:    MakeEmail(),
@@ -622,7 +622,7 @@ func testUserStoreGetAllProfiles(t *testing.T, rctx request.CTX, ss store.Store)
 		Roles:    "system_manager system_user",
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u9.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u9.Id)) }()
 
 	u10, err := ss.User().Save(rctx, &model.User{
 		Email:    MakeEmail(),
@@ -631,7 +631,7 @@ func testUserStoreGetAllProfiles(t *testing.T, rctx request.CTX, ss store.Store)
 		Roles:    "system_read_only_admin system_user",
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u10.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u10.Id)) }()
 
 	t.Run("filter by system_user_manager role", func(t *testing.T) {
 		actual, userErr := ss.User().GetAllProfiles(&model.UserGetOptions{
@@ -684,7 +684,7 @@ func testUserStoreGetProfiles(t *testing.T, rctx request.CTX, ss store.Store) {
 		Username: "u1" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -693,7 +693,7 @@ func testUserStoreGetProfiles(t *testing.T, rctx request.CTX, ss store.Store) {
 		Username: "u2" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -710,7 +710,7 @@ func testUserStoreGetProfiles(t *testing.T, rctx request.CTX, ss store.Store) {
 	require.NoError(t, nErr)
 	u3.IsBot = true
 	defer func() { require.NoError(t, ss.Bot().PermanentDelete(u3.Id)) }()
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -720,7 +720,7 @@ func testUserStoreGetProfiles(t *testing.T, rctx request.CTX, ss store.Store) {
 		Roles:    "system_admin",
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u4.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u4.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u4.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -730,7 +730,7 @@ func testUserStoreGetProfiles(t *testing.T, rctx request.CTX, ss store.Store) {
 		DeleteAt: model.GetMillis(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u5.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u5.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u5.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -780,7 +780,7 @@ func testUserStoreGetProfiles(t *testing.T, rctx request.CTX, ss store.Store) {
 		uNew.Email = MakeEmail()
 		_, err := ss.User().Save(rctx, uNew)
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(uNew.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, uNew.Id)) }()
 		_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: uNew.Id}, -1)
 		require.NoError(t, nErr)
 
@@ -853,7 +853,7 @@ func testUserStoreGetProfilesInChannel(t *testing.T, rctx request.CTX, ss store.
 		Username: "u1" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -862,7 +862,7 @@ func testUserStoreGetProfilesInChannel(t *testing.T, rctx request.CTX, ss store.
 		Username: "u2" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -871,7 +871,7 @@ func testUserStoreGetProfilesInChannel(t *testing.T, rctx request.CTX, ss store.
 		Username: "u3" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Bot().Save(&model.Bot{
@@ -888,7 +888,7 @@ func testUserStoreGetProfilesInChannel(t *testing.T, rctx request.CTX, ss store.
 		Username: "u4" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u4.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u4.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u4.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1015,7 +1015,7 @@ func testUserStoreGetProfilesInChannel(t *testing.T, rctx request.CTX, ss store.
 			Username: "bbb" + model.NewId(),
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user2Admin.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user2Admin.Id)) }()
 		_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: user2Admin.Id}, -1)
 		require.NoError(t, nErr)
 
@@ -1049,7 +1049,7 @@ func testUserStoreGetProfilesInChannelByAdmin(t *testing.T, rctx request.CTX, ss
 		Username: "aaa" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(user1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: user1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1058,7 +1058,7 @@ func testUserStoreGetProfilesInChannelByAdmin(t *testing.T, rctx request.CTX, ss
 		Username: "bbb" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(user2Admin.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user2Admin.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: user2Admin.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1067,7 +1067,7 @@ func testUserStoreGetProfilesInChannelByAdmin(t *testing.T, rctx request.CTX, ss
 		Username: "ccc" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(user3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: user3.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1127,7 +1127,7 @@ func testUserStoreGetProfilesInChannelByStatus(t *testing.T, rctx request.CTX, s
 		Username: "u1" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1136,7 +1136,7 @@ func testUserStoreGetProfilesInChannelByStatus(t *testing.T, rctx request.CTX, s
 		Username: "u2" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1145,7 +1145,7 @@ func testUserStoreGetProfilesInChannelByStatus(t *testing.T, rctx request.CTX, s
 		Username: "u3" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Bot().Save(&model.Bot{
@@ -1162,7 +1162,7 @@ func testUserStoreGetProfilesInChannelByStatus(t *testing.T, rctx request.CTX, s
 		Username: "u4" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u4.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u4.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u4.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1286,7 +1286,7 @@ func testUserStoreGetProfilesWithoutTeam(t *testing.T, rctx request.CTX, ss stor
 		Username: "u1" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1295,7 +1295,7 @@ func testUserStoreGetProfilesWithoutTeam(t *testing.T, rctx request.CTX, ss stor
 		Username: "u2" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 
 	u3, err := ss.User().Save(rctx, &model.User{
 		Email:    MakeEmail(),
@@ -1304,7 +1304,7 @@ func testUserStoreGetProfilesWithoutTeam(t *testing.T, rctx request.CTX, ss stor
 		Roles:    "system_admin",
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Bot().Save(&model.Bot{
 		UserId:   u3.Id,
 		Username: u3.Username,
@@ -1353,7 +1353,7 @@ func testUserStoreGetAllProfilesInChannel(t *testing.T, rctx request.CTX, ss sto
 		Username: "u1" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1362,7 +1362,7 @@ func testUserStoreGetAllProfilesInChannel(t *testing.T, rctx request.CTX, ss sto
 		Username: "u2" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1371,7 +1371,7 @@ func testUserStoreGetAllProfilesInChannel(t *testing.T, rctx request.CTX, ss sto
 		Username: "u3" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Bot().Save(&model.Bot{
@@ -1479,7 +1479,7 @@ func testUserStoreGetProfilesNotInChannel(t *testing.T, rctx request.CTX, ss sto
 		Username: "u1" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1488,7 +1488,7 @@ func testUserStoreGetProfilesNotInChannel(t *testing.T, rctx request.CTX, ss sto
 		Username: "u2" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1497,7 +1497,7 @@ func testUserStoreGetProfilesNotInChannel(t *testing.T, rctx request.CTX, ss sto
 		Username: "u3" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Bot().Save(&model.Bot{
@@ -1641,7 +1641,7 @@ func testUserStoreGetProfilesByIds(t *testing.T, rctx request.CTX, ss store.Stor
 		Username: "u1" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1650,7 +1650,7 @@ func testUserStoreGetProfilesByIds(t *testing.T, rctx request.CTX, ss store.Stor
 		Username: "u2" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1660,7 +1660,7 @@ func testUserStoreGetProfilesByIds(t *testing.T, rctx request.CTX, ss store.Stor
 		Username: "u3" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Bot().Save(&model.Bot{
@@ -1677,7 +1677,7 @@ func testUserStoreGetProfilesByIds(t *testing.T, rctx request.CTX, ss store.Stor
 		Username: "u4" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u4.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u4.Id)) }()
 
 	t.Run("get u1 by id, no caching", func(t *testing.T) {
 		users, err := ss.User().GetProfileByIds(context.Background(), []string{u1.Id}, nil, false)
@@ -1726,28 +1726,28 @@ func testUserStoreGetProfileByGroupChannelIdsForUser(t *testing.T, rctx request.
 		Username: "u1" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	u2, err := ss.User().Save(rctx, &model.User{
 		Email:    MakeEmail(),
 		Username: "u2" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 
 	u3, err := ss.User().Save(rctx, &model.User{
 		Email:    MakeEmail(),
 		Username: "u3" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 
 	u4, err := ss.User().Save(rctx, &model.User{
 		Email:    MakeEmail(),
 		Username: "u4" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u4.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u4.Id)) }()
 
 	gc1, nErr := ss.Channel().Save(rctx, &model.Channel{
 		DisplayName: "Profiles in private",
@@ -1851,7 +1851,7 @@ func testUserStoreGetProfilesByUsernames(t *testing.T, rctx request.CTX, ss stor
 		Username: "u1" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1860,7 +1860,7 @@ func testUserStoreGetProfilesByUsernames(t *testing.T, rctx request.CTX, ss stor
 		Username: "u2" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1869,7 +1869,7 @@ func testUserStoreGetProfilesByUsernames(t *testing.T, rctx request.CTX, ss stor
 		Username: "u3" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: team2Id, UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Bot().Save(&model.Bot{
@@ -1921,7 +1921,7 @@ func testUserStoreGetSystemAdminProfiles(t *testing.T, rctx request.CTX, ss stor
 		Username: "u1" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1930,7 +1930,7 @@ func testUserStoreGetSystemAdminProfiles(t *testing.T, rctx request.CTX, ss stor
 		Username: "u2" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1940,7 +1940,7 @@ func testUserStoreGetSystemAdminProfiles(t *testing.T, rctx request.CTX, ss stor
 		Username: "u3" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Bot().Save(&model.Bot{
@@ -1970,7 +1970,7 @@ func testUserStoreGetByEmail(t *testing.T, rctx request.CTX, ss store.Store) {
 		Username: "u1" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1979,7 +1979,7 @@ func testUserStoreGetByEmail(t *testing.T, rctx request.CTX, ss store.Store) {
 		Username: "u2" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -1988,7 +1988,7 @@ func testUserStoreGetByEmail(t *testing.T, rctx request.CTX, ss store.Store) {
 		Username: "u3" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Bot().Save(&model.Bot{
@@ -2041,7 +2041,7 @@ func testUserStoreGetByAuthData(t *testing.T, rctx request.CTX, ss store.Store) 
 		AuthService: "service",
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -2050,7 +2050,7 @@ func testUserStoreGetByAuthData(t *testing.T, rctx request.CTX, ss store.Store) 
 		Username: "u2" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -2061,7 +2061,7 @@ func testUserStoreGetByAuthData(t *testing.T, rctx request.CTX, ss store.Store) 
 		AuthService: "service2",
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Bot().Save(&model.Bot{
@@ -2117,7 +2117,7 @@ func testUserStoreGetByUsername(t *testing.T, rctx request.CTX, ss store.Store) 
 		Username: "u1" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -2126,7 +2126,7 @@ func testUserStoreGetByUsername(t *testing.T, rctx request.CTX, ss store.Store) 
 		Username: "u2" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -2135,7 +2135,7 @@ func testUserStoreGetByUsername(t *testing.T, rctx request.CTX, ss store.Store) 
 		Username: "u3" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Bot().Save(&model.Bot{
@@ -2194,7 +2194,7 @@ func testUserStoreGetForLogin(t *testing.T, rctx request.CTX, ss store.Store) {
 	})
 
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -2205,7 +2205,7 @@ func testUserStoreGetForLogin(t *testing.T, rctx request.CTX, ss store.Store) {
 		AuthData:    &auth2,
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -2216,7 +2216,7 @@ func testUserStoreGetForLogin(t *testing.T, rctx request.CTX, ss store.Store) {
 		AuthData:    &auth3,
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Bot().Save(&model.Bot{
@@ -2290,7 +2290,7 @@ func testUserStoreUpdatePassword(t *testing.T, rctx request.CTX, ss store.Store)
 	u1.Email = MakeEmail()
 	_, err := ss.User().Save(rctx, u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -2309,11 +2309,11 @@ func testUserStoreDelete(t *testing.T, rctx request.CTX, ss store.Store) {
 	u1.Email = MakeEmail()
 	_, err := ss.User().Save(rctx, u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
-	err = ss.User().PermanentDelete(u1.Id)
+	err = ss.User().PermanentDelete(rctx, u1.Id)
 	require.NoError(t, err)
 }
 
@@ -2324,7 +2324,7 @@ func testUserStoreUpdateAuthData(t *testing.T, rctx request.CTX, ss store.Store)
 	u1.Email = MakeEmail()
 	_, err := ss.User().Save(rctx, u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -2347,7 +2347,7 @@ func testUserStoreResetAuthDataToEmailForUsers(t *testing.T, rctx request.CTX, s
 	user.Email = MakeEmail()
 	_, err := ss.User().Save(rctx, user)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(user.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 
 	resetAuthDataToID := func() {
 		_, err = ss.User().UpdateAuthData(
@@ -2410,7 +2410,7 @@ func testUserUnreadCount(t *testing.T, rctx request.CTX, ss store.Store) {
 	u1.Email = MakeEmail()
 	_, err := ss.User().Save(rctx, u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -2419,7 +2419,7 @@ func testUserUnreadCount(t *testing.T, rctx request.CTX, ss store.Store) {
 	u2.Username = "user2" + model.NewId()
 	_, err = ss.User().Save(rctx, u2)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -2428,7 +2428,7 @@ func testUserUnreadCount(t *testing.T, rctx request.CTX, ss store.Store) {
 	u3.Username = "user3" + model.NewId()
 	_, err = ss.User().Save(rctx, u3)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -2525,7 +2525,7 @@ func testUserStoreUpdateMfaSecret(t *testing.T, rctx request.CTX, ss store.Store
 	u1.Email = MakeEmail()
 	_, err := ss.User().Save(rctx, &u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	err = ss.User().UpdateMfaSecret(u1.Id, "12345")
 	require.NoError(t, err)
@@ -2540,7 +2540,7 @@ func testUserStoreUpdateMfaActive(t *testing.T, rctx request.CTX, ss store.Store
 	u1.Email = MakeEmail()
 	_, err := ss.User().Save(rctx, &u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	time.Sleep(time.Millisecond)
 
@@ -2565,7 +2565,7 @@ func testUserStoreGetRecentlyActiveUsersForTeam(t *testing.T, rctx request.CTX, 
 		Username: "u1" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -2574,7 +2574,7 @@ func testUserStoreGetRecentlyActiveUsersForTeam(t *testing.T, rctx request.CTX, 
 		Username: "u2" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -2583,7 +2583,7 @@ func testUserStoreGetRecentlyActiveUsersForTeam(t *testing.T, rctx request.CTX, 
 		Username: "u3" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Bot().Save(&model.Bot{
@@ -2640,7 +2640,7 @@ func testUserStoreGetNewUsersForTeam(t *testing.T, rctx request.CTX, ss store.St
 		Username: "Yuka",
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -2649,7 +2649,7 @@ func testUserStoreGetNewUsersForTeam(t *testing.T, rctx request.CTX, ss store.St
 		Username: "Leia",
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -2658,7 +2658,7 @@ func testUserStoreGetNewUsersForTeam(t *testing.T, rctx request.CTX, ss store.St
 		Username: "Ali",
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Bot().Save(&model.Bot{
@@ -2675,7 +2675,7 @@ func testUserStoreGetNewUsersForTeam(t *testing.T, rctx request.CTX, ss store.St
 		Username: "u4" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u4.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u4.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId2, UserId: u4.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -2741,7 +2741,7 @@ func testUserStoreSearch(t *testing.T, rctx request.CTX, ss store.Store) {
 	}
 	_, err := ss.User().Save(rctx, u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	u2 := &model.User{
 		Username: "jim2-bobby" + NewTestId(),
@@ -2750,7 +2750,7 @@ func testUserStoreSearch(t *testing.T, rctx request.CTX, ss store.Store) {
 	}
 	_, err = ss.User().Save(rctx, u2)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 
 	u3 := &model.User{
 		Username: "jimbo3" + NewTestId(),
@@ -2759,7 +2759,7 @@ func testUserStoreSearch(t *testing.T, rctx request.CTX, ss store.Store) {
 	}
 	_, err = ss.User().Save(rctx, u3)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 
 	// The users returned from the database will have AuthData as an empty string.
 	nilAuthData := new(string)
@@ -2912,7 +2912,7 @@ func testUserStoreSearchNotInChannel(t *testing.T, rctx request.CTX, ss store.St
 	}
 	_, err := ss.User().Save(rctx, u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	u2 := &model.User{
 		Username: "jim2-bobby" + NewTestId(),
@@ -2920,7 +2920,7 @@ func testUserStoreSearchNotInChannel(t *testing.T, rctx request.CTX, ss store.St
 	}
 	_, err = ss.User().Save(rctx, u2)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 
 	u3 := &model.User{
 		Username: "jimbo3" + NewTestId(),
@@ -2929,7 +2929,7 @@ func testUserStoreSearchNotInChannel(t *testing.T, rctx request.CTX, ss store.St
 	}
 	_, err = ss.User().Save(rctx, u3)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr := ss.Bot().Save(&model.Bot{
 		UserId:   u3.Id,
 		Username: u3.Username,
@@ -3139,7 +3139,7 @@ func testUserStoreSearchInChannel(t *testing.T, rctx request.CTX, ss store.Store
 	}
 	_, err := ss.User().Save(rctx, u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	u2 := &model.User{
 		Username: "jim-bobby" + NewTestId(),
@@ -3148,7 +3148,7 @@ func testUserStoreSearchInChannel(t *testing.T, rctx request.CTX, ss store.Store
 	}
 	_, err = ss.User().Save(rctx, u2)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 
 	u3 := &model.User{
 		Username: "jimbo3" + NewTestId(),
@@ -3158,7 +3158,7 @@ func testUserStoreSearchInChannel(t *testing.T, rctx request.CTX, ss store.Store
 	}
 	_, err = ss.User().Save(rctx, u3)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr := ss.Bot().Save(&model.Bot{
 		UserId:   u3.Id,
 		Username: u3.Username,
@@ -3372,7 +3372,7 @@ func testUserStoreSearchNotInTeam(t *testing.T, rctx request.CTX, ss store.Store
 	}
 	_, err := ss.User().Save(rctx, u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	u2 := &model.User{
 		Username: "jim-bobby" + NewTestId(),
@@ -3380,7 +3380,7 @@ func testUserStoreSearchNotInTeam(t *testing.T, rctx request.CTX, ss store.Store
 	}
 	_, err = ss.User().Save(rctx, u2)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 
 	u3 := &model.User{
 		Username: "jimbo3" + NewTestId(),
@@ -3389,7 +3389,7 @@ func testUserStoreSearchNotInTeam(t *testing.T, rctx request.CTX, ss store.Store
 	}
 	_, err = ss.User().Save(rctx, u3)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr := ss.Bot().Save(&model.Bot{
 		UserId:   u3.Id,
 		Username: u3.Username,
@@ -3406,7 +3406,7 @@ func testUserStoreSearchNotInTeam(t *testing.T, rctx request.CTX, ss store.Store
 	}
 	_, err = ss.User().Save(rctx, u4)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u4.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u4.Id)) }()
 
 	u5 := &model.User{
 		Username:  "yu" + NewTestId(),
@@ -3417,7 +3417,7 @@ func testUserStoreSearchNotInTeam(t *testing.T, rctx request.CTX, ss store.Store
 	}
 	_, err = ss.User().Save(rctx, u5)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u5.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u5.Id)) }()
 
 	u6 := &model.User{
 		Username:  "underscore" + NewTestId(),
@@ -3428,7 +3428,7 @@ func testUserStoreSearchNotInTeam(t *testing.T, rctx request.CTX, ss store.Store
 	}
 	_, err = ss.User().Save(rctx, u6)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u6.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u6.Id)) }()
 
 	teamId1 := model.NewId()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId1, UserId: u1.Id}, -1)
@@ -3564,7 +3564,7 @@ func testUserStoreSearchWithoutTeam(t *testing.T, rctx request.CTX, ss store.Sto
 	}
 	_, err := ss.User().Save(rctx, u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	u2 := &model.User{
 		Username: "jim2-bobby" + NewTestId(),
@@ -3572,7 +3572,7 @@ func testUserStoreSearchWithoutTeam(t *testing.T, rctx request.CTX, ss store.Sto
 	}
 	_, err = ss.User().Save(rctx, u2)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 
 	u3 := &model.User{
 		Username: "jimbo3" + NewTestId(),
@@ -3581,7 +3581,7 @@ func testUserStoreSearchWithoutTeam(t *testing.T, rctx request.CTX, ss store.Sto
 	}
 	_, err = ss.User().Save(rctx, u3)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr := ss.Bot().Save(&model.Bot{
 		UserId:   u3.Id,
 		Username: u3.Username,
@@ -3669,7 +3669,7 @@ func testUserStoreSearchInGroup(t *testing.T, rctx request.CTX, ss store.Store) 
 	}
 	_, err := ss.User().Save(rctx, u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	u2 := &model.User{
 		Username: "jim-bobby" + NewTestId(),
@@ -3677,7 +3677,7 @@ func testUserStoreSearchInGroup(t *testing.T, rctx request.CTX, ss store.Store) 
 	}
 	_, err = ss.User().Save(rctx, u2)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 
 	u3 := &model.User{
 		Username: "jimbo3" + NewTestId(),
@@ -3685,7 +3685,7 @@ func testUserStoreSearchInGroup(t *testing.T, rctx request.CTX, ss store.Store) 
 	}
 	_, err = ss.User().Save(rctx, u3)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 
 	// The users returned from the database will have AuthData as an empty string.
 	nilAuthData := model.NewString("")
@@ -3812,7 +3812,7 @@ func testUserStoreSearchNotInGroup(t *testing.T, rctx request.CTX, ss store.Stor
 	}
 	_, err := ss.User().Save(rctx, u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	u2 := &model.User{
 		Username: "jim-bobby" + NewTestId(),
@@ -3820,7 +3820,7 @@ func testUserStoreSearchNotInGroup(t *testing.T, rctx request.CTX, ss store.Stor
 	}
 	_, err = ss.User().Save(rctx, u2)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 
 	u3 := &model.User{
 		Username: "jimbo3" + NewTestId(),
@@ -3828,7 +3828,7 @@ func testUserStoreSearchNotInGroup(t *testing.T, rctx request.CTX, ss store.Stor
 	}
 	_, err = ss.User().Save(rctx, u3)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 
 	// The users returned from the database will have AuthData as an empty string.
 	nilAuthData := model.NewString("")
@@ -3943,7 +3943,7 @@ func testCount(t *testing.T, rctx request.CTX, ss store.Store) {
 	regularUser.Roles = model.SystemUserRoleId
 	_, err := ss.User().Save(rctx, regularUser)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(regularUser.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, regularUser.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: regularUser.Id, SchemeAdmin: false, SchemeUser: true}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{UserId: regularUser.Id, ChannelId: channelId, SchemeAdmin: false, SchemeUser: true, NotifyProps: model.GetDefaultChannelNotifyProps()})
@@ -3954,7 +3954,7 @@ func testCount(t *testing.T, rctx request.CTX, ss store.Store) {
 	guestUser.Roles = model.SystemGuestRoleId
 	_, err = ss.User().Save(rctx, guestUser)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(guestUser.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, guestUser.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: guestUser.Id, SchemeAdmin: false, SchemeUser: false, SchemeGuest: true}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{UserId: guestUser.Id, ChannelId: channelId, SchemeAdmin: false, SchemeUser: false, SchemeGuest: true, NotifyProps: model.GetDefaultChannelNotifyProps()})
@@ -3965,7 +3965,7 @@ func testCount(t *testing.T, rctx request.CTX, ss store.Store) {
 	teamAdmin.Roles = model.SystemUserRoleId
 	_, err = ss.User().Save(rctx, teamAdmin)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(teamAdmin.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, teamAdmin.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: teamAdmin.Id, SchemeAdmin: true, SchemeUser: true}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{UserId: teamAdmin.Id, ChannelId: channelId, SchemeAdmin: true, SchemeUser: true, NotifyProps: model.GetDefaultChannelNotifyProps()})
@@ -3976,7 +3976,7 @@ func testCount(t *testing.T, rctx request.CTX, ss store.Store) {
 	sysAdmin.Roles = model.SystemAdminRoleId + " " + model.SystemUserRoleId
 	_, err = ss.User().Save(rctx, sysAdmin)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(sysAdmin.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, sysAdmin.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: sysAdmin.Id, SchemeAdmin: false, SchemeUser: true}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{UserId: sysAdmin.Id, ChannelId: channelId, SchemeAdmin: true, SchemeUser: true, NotifyProps: model.GetDefaultChannelNotifyProps()})
@@ -3988,7 +3988,7 @@ func testCount(t *testing.T, rctx request.CTX, ss store.Store) {
 	deletedUser.DeleteAt = model.GetMillis()
 	_, err = ss.User().Save(rctx, deletedUser)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(deletedUser.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, deletedUser.Id)) }()
 
 	// Remote User
 	remoteId := "remote-id"
@@ -3997,14 +3997,14 @@ func testCount(t *testing.T, rctx request.CTX, ss store.Store) {
 		RemoteId: &remoteId,
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(remoteUser.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, remoteUser.Id)) }()
 
 	// Bot
 	botUser, err := ss.User().Save(rctx, &model.User{
 		Email: MakeEmail(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(botUser.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, botUser.Id)) }()
 	_, nErr = ss.Bot().Save(&model.Bot{
 		UserId:   botUser.Id,
 		Username: botUser.Username,
@@ -4325,11 +4325,11 @@ func testUserStoreAnalyticsActiveCount(t *testing.T, rctx request.CTX, ss store.
 	})
 	require.NoError(t, err)
 	defer func() {
-		require.NoError(t, ss.User().PermanentDelete(u0.Id))
-		require.NoError(t, ss.User().PermanentDelete(u1.Id))
-		require.NoError(t, ss.User().PermanentDelete(u2.Id))
-		require.NoError(t, ss.User().PermanentDelete(u3.Id))
-		require.NoError(t, ss.User().PermanentDelete(u4.Id))
+		require.NoError(t, ss.User().PermanentDelete(rctx, u0.Id))
+		require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id))
+		require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id))
+		require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id))
+		require.NoError(t, ss.User().PermanentDelete(rctx, u4.Id))
 	}()
 
 	_, nErr := ss.Bot().Save(&model.Bot{
@@ -4409,11 +4409,11 @@ func testUserStoreAnalyticsActiveCountForPeriod(t *testing.T, rctx request.CTX, 
 	})
 	require.NoError(t, err)
 	defer func() {
-		require.NoError(t, ss.User().PermanentDelete(u0.Id))
-		require.NoError(t, ss.User().PermanentDelete(u1.Id))
-		require.NoError(t, ss.User().PermanentDelete(u2.Id))
-		require.NoError(t, ss.User().PermanentDelete(u3.Id))
-		require.NoError(t, ss.User().PermanentDelete(u4.Id))
+		require.NoError(t, ss.User().PermanentDelete(rctx, u0.Id))
+		require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id))
+		require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id))
+		require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id))
+		require.NoError(t, ss.User().PermanentDelete(rctx, u4.Id))
 	}()
 
 	_, nErr := ss.Bot().Save(&model.Bot{
@@ -4465,7 +4465,7 @@ func testUserStoreAnalyticsGetInactiveUsersCount(t *testing.T, rctx request.CTX,
 	u1.Email = MakeEmail()
 	_, err := ss.User().Save(rctx, u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	count, err := ss.User().AnalyticsGetInactiveUsersCount()
 	require.NoError(t, err)
@@ -4475,7 +4475,7 @@ func testUserStoreAnalyticsGetInactiveUsersCount(t *testing.T, rctx request.CTX,
 	u2.DeleteAt = model.GetMillis()
 	_, err = ss.User().Save(rctx, u2)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 
 	newCount, err := ss.User().AnalyticsGetInactiveUsersCount()
 	require.NoError(t, err)
@@ -4497,12 +4497,12 @@ func testUserStoreAnalyticsGetSystemAdminCount(t *testing.T, rctx request.CTX, s
 
 	_, nErr := ss.User().Save(rctx, &u1)
 	require.NoError(t, nErr, "couldn't save user")
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	_, nErr = ss.User().Save(rctx, &u2)
 	require.NoError(t, nErr, "couldn't save user")
 
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 
 	result, err := ss.User().AnalyticsGetSystemAdminCount()
 	require.NoError(t, err)
@@ -4530,15 +4530,15 @@ func testUserStoreAnalyticsGetGuestCount(t *testing.T, rctx request.CTX, ss stor
 
 	_, nErr := ss.User().Save(rctx, &u1)
 	require.NoError(t, nErr, "couldn't save user")
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	_, nErr = ss.User().Save(rctx, &u2)
 	require.NoError(t, nErr, "couldn't save user")
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 
 	_, nErr = ss.User().Save(rctx, &u3)
 	require.NoError(t, nErr, "couldn't save user")
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 
 	result, err := ss.User().AnalyticsGetGuestCount()
 	require.NoError(t, err)
@@ -4568,15 +4568,15 @@ func testUserStoreAnalyticsGetExternalUsers(t *testing.T, rctx request.CTX, ss s
 
 	_, err = ss.User().Save(rctx, &u1)
 	require.NoError(t, err, "couldn't save user")
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	_, err = ss.User().Save(rctx, &u2)
 	require.NoError(t, err, "couldn't save user")
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 
 	_, err = ss.User().Save(rctx, &u3)
 	require.NoError(t, err, "couldn't save user")
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 
 	result, err = ss.User().AnalyticsGetExternalUsers(localHostDomain)
 	require.NoError(t, err)
@@ -4599,7 +4599,7 @@ func testUserStoreGetProfilesNotInTeam(t *testing.T, rctx request.CTX, ss store.
 		Username: "u1" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -4611,7 +4611,7 @@ func testUserStoreGetProfilesNotInTeam(t *testing.T, rctx request.CTX, ss store.
 		Username: "u2" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId2, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -4623,7 +4623,7 @@ func testUserStoreGetProfilesNotInTeam(t *testing.T, rctx request.CTX, ss store.
 		Username: "u3" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Bot().Save(&model.Bot{
 		UserId:   u3.Id,
 		Username: u3.Username,
@@ -4724,7 +4724,7 @@ func testUserStoreGetProfilesNotInTeam(t *testing.T, rctx request.CTX, ss store.
 		Username: "u4" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u4.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u4.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u4.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -4813,16 +4813,16 @@ func testUserStoreClearAllCustomRoleAssignments(t *testing.T, rctx request.CTX, 
 
 	_, err := ss.User().Save(rctx, &u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, err = ss.User().Save(rctx, &u2)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, err = ss.User().Save(rctx, &u3)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, err = ss.User().Save(rctx, &u4)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u4.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u4.Id)) }()
 
 	require.NoError(t, ss.User().ClearAllCustomRoleAssignments())
 
@@ -4850,14 +4850,14 @@ func testUserStoreGetAllAfter(t *testing.T, rctx request.CTX, ss store.Store) {
 		Roles:    "system_user system_admin system_post_all",
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	u2, err := ss.User().Save(rctx, &model.User{
 		Email:    MakeEmail(),
 		Username: "u2" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr := ss.Bot().Save(&model.Bot{
 		UserId:   u2.Id,
 		Username: u2.Username,
@@ -4931,7 +4931,7 @@ func testUserStoreGetUsersBatchForIndexing(t *testing.T, rctx request.CTX, ss st
 		CreateAt: model.GetMillis(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	time.Sleep(time.Millisecond)
 
@@ -4941,7 +4941,7 @@ func testUserStoreGetUsersBatchForIndexing(t *testing.T, rctx request.CTX, ss st
 		CreateAt: model.GetMillis(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{
 		UserId: u2.Id,
 		TeamId: t1.Id,
@@ -4968,7 +4968,7 @@ func testUserStoreGetUsersBatchForIndexing(t *testing.T, rctx request.CTX, ss st
 		CreateAt: model.GetMillis(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{
 		UserId:   u3.Id,
 		TeamId:   t1.Id,
@@ -5059,7 +5059,7 @@ func testUserStoreGetTeamGroupUsers(t *testing.T, rctx request.CTX, ss store.Sto
 		require.NoError(t, userErr)
 		require.NotNil(t, user)
 		testUsers = append(testUsers, user)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 	}
 	require.Len(t, testUsers, 3, "testUsers length doesn't meet required length")
 	userGroupA, userGroupB, userNoGroup := testUsers[0], testUsers[1], testUsers[2]
@@ -5180,7 +5180,7 @@ func testUserStoreGetChannelGroupUsers(t *testing.T, rctx request.CTX, ss store.
 		require.NoError(t, userErr)
 		require.NotNil(t, user)
 		testUsers = append(testUsers, user)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 	}
 	require.Len(t, testUsers, 3, "testUsers length doesn't meet required length")
 	userGroupA, userGroupB, userNoGroup := testUsers[0], testUsers[1], testUsers[2]
@@ -5290,7 +5290,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 			Roles:     "system_user",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 
 		teamId := model.NewId()
 		_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: user.Id, SchemeGuest: true, SchemeUser: false}, 999)
@@ -5336,7 +5336,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 			Roles:     "system_user system_admin",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 
 		teamId := model.NewId()
 		_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: user.Id, SchemeGuest: true, SchemeUser: false}, 999)
@@ -5381,7 +5381,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 			Roles:     "system_guest",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 
 		err = ss.User().PromoteGuestToUser(user.Id)
 		require.NoError(t, err)
@@ -5402,7 +5402,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 			Roles:     "system_guest",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 
 		teamId := model.NewId()
 		_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: user.Id, SchemeGuest: true, SchemeUser: false}, 999)
@@ -5432,7 +5432,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 			Roles:     "system_guest",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 
 		teamId := model.NewId()
 		_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: user.Id, SchemeGuest: true, SchemeUser: false}, 999)
@@ -5477,7 +5477,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 			Roles:     "system_guest custom_role",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 
 		teamId := model.NewId()
 		_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: user.Id, SchemeGuest: true, SchemeUser: false}, 999)
@@ -5522,7 +5522,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 			Roles:     "system_guest",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user1.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user1.Id)) }()
 
 		teamId1 := model.NewId()
 		_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId1, UserId: user1.Id, SchemeGuest: true, SchemeUser: false}, 999)
@@ -5550,7 +5550,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 			Roles:     "system_guest",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user2.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user2.Id)) }()
 
 		teamId2 := model.NewId()
 		_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId2, UserId: user2.Id, SchemeGuest: true, SchemeUser: false}, 999)
@@ -5605,7 +5605,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 			Roles:     "system_guest",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 
 		teamId := model.NewId()
 		_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: user.Id, SchemeGuest: false, SchemeUser: true}, 999)
@@ -5649,7 +5649,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 			Roles:     "system_user system_admin",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 
 		teamId := model.NewId()
 		_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: user.Id, SchemeGuest: true, SchemeUser: false}, 999)
@@ -5692,7 +5692,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 			Roles:     "system_user",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 
 		updatedUser, err := ss.User().DemoteUserToGuest(user.Id)
 		require.NoError(t, err)
@@ -5711,7 +5711,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 			Roles:     "system_user",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 
 		teamId := model.NewId()
 		_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: user.Id, SchemeGuest: false, SchemeUser: true}, 999)
@@ -5739,7 +5739,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 			Roles:     "system_user",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 
 		teamId := model.NewId()
 		_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: user.Id, SchemeGuest: false, SchemeUser: true}, 999)
@@ -5782,7 +5782,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 			Roles:     "system_user custom_role",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 
 		teamId := model.NewId()
 		_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: user.Id, SchemeGuest: false, SchemeUser: true}, 999)
@@ -5825,7 +5825,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 			Roles:     "system_user",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user1.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user1.Id)) }()
 
 		teamId1 := model.NewId()
 		_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId1, UserId: user1.Id, SchemeGuest: false, SchemeUser: true}, 999)
@@ -5853,7 +5853,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 			Roles:     "system_user",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(user2.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user2.Id)) }()
 
 		teamId2 := model.NewId()
 		_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId2, UserId: user2.Id, SchemeGuest: false, SchemeUser: true}, 999)
@@ -5906,7 +5906,7 @@ func testDeactivateGuests(t *testing.T, rctx request.CTX, ss store.Store) {
 			Roles:     "system_guest",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(guest1.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, guest1.Id)) }()
 
 		guest2Random := model.NewId()
 		guest2, err := ss.User().Save(rctx, &model.User{
@@ -5919,7 +5919,7 @@ func testDeactivateGuests(t *testing.T, rctx request.CTX, ss store.Store) {
 			Roles:     "system_guest",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(guest2.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, guest2.Id)) }()
 
 		guest3Random := model.NewId()
 		guest3, err := ss.User().Save(rctx, &model.User{
@@ -5933,7 +5933,7 @@ func testDeactivateGuests(t *testing.T, rctx request.CTX, ss store.Store) {
 			DeleteAt:  10,
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(guest3.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, guest3.Id)) }()
 
 		regularUserRandom := model.NewId()
 		regularUser, err := ss.User().Save(rctx, &model.User{
@@ -5946,7 +5946,7 @@ func testDeactivateGuests(t *testing.T, rctx request.CTX, ss store.Store) {
 			Roles:     "system_user",
 		})
 		require.NoError(t, err)
-		defer func() { require.NoError(t, ss.User().PermanentDelete(regularUser.Id)) }()
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, regularUser.Id)) }()
 
 		ids, err := ss.User().DeactivateGuests()
 		require.NoError(t, err)
@@ -5976,7 +5976,7 @@ func testUserStoreResetLastPictureUpdate(t *testing.T, rctx request.CTX, ss stor
 	u1.Email = MakeEmail()
 	_, err := ss.User().Save(rctx, u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -6011,7 +6011,7 @@ func testGetKnownUsers(t *testing.T, rctx request.CTX, ss store.Store) {
 		Username: "u1" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -6020,7 +6020,7 @@ func testGetKnownUsers(t *testing.T, rctx request.CTX, ss store.Store) {
 		Username: "u2" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u2.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u2.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -6029,7 +6029,7 @@ func testGetKnownUsers(t *testing.T, rctx request.CTX, ss store.Store) {
 		Username: "u3" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u3.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u3.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1)
 	require.NoError(t, nErr)
 	_, nErr = ss.Bot().Save(&model.Bot{
@@ -6047,7 +6047,7 @@ func testGetKnownUsers(t *testing.T, rctx request.CTX, ss store.Store) {
 		Username: "u4" + model.NewId(),
 	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u4.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u4.Id)) }()
 	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamId, UserId: u4.Id}, -1)
 	require.NoError(t, nErr)
 
@@ -6176,7 +6176,7 @@ func testIsEmpty(t *testing.T, rctx request.CTX, ss store.Store) {
 	require.NoError(t, err)
 	require.True(t, ok)
 
-	err = ss.User().PermanentDelete(u.Id)
+	err = ss.User().PermanentDelete(rctx, u.Id)
 	require.NoError(t, err)
 
 	ok, err = ss.User().IsEmpty(false)
@@ -6191,7 +6191,7 @@ func testGetUsersWithInvalidEmails(t *testing.T, rctx request.CTX, ss store.Stor
 	})
 
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	users, err := ss.User().GetUsersWithInvalidEmails(0, 50, "localhost,simulator.amazonses.com")
 	require.NoError(t, err)
@@ -6203,7 +6203,7 @@ func testUpdateLastLogin(t *testing.T, rctx request.CTX, ss store.Store) {
 	u1.Email = MakeEmail()
 	_, err := ss.User().Save(rctx, &u1)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
 
 	err = ss.User().UpdateLastLogin(u1.Id, 1234567890)
 	require.NoError(t, err)
@@ -6248,7 +6248,7 @@ func testGetUserReport(t *testing.T, rctx request.CTX, ss store.Store, s SqlStor
 	// cleanup users after the test
 	defer func() {
 		for _, user := range users {
-			require.NoError(t, ss.User().PermanentDelete(user.Id))
+			require.NoError(t, ss.User().PermanentDelete(rctx, user.Id))
 		}
 	}()
 

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -11036,10 +11036,10 @@ func (s *TimerLayerUserStore) IsEmpty(excludeBots bool) (bool, error) {
 	return result, err
 }
 
-func (s *TimerLayerUserStore) PermanentDelete(userID string) error {
+func (s *TimerLayerUserStore) PermanentDelete(rctx request.CTX, userID string) error {
 	start := time.Now()
 
-	err := s.UserStore.PermanentDelete(userID)
+	err := s.UserStore.PermanentDelete(rctx, userID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
- Added request context as a parameter to UserStore.PermanentDelete
- Added request context parameter to functions that call PermanentDelete method 

<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
Fixes [#26025](https://github.com/mattermost/mattermost/issues/26025)
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

<!--
#### Screenshots

If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
