### PR TITLE
Support for additional audit config via env var

### DIFF
--- a/server/channels/app/audit.go
+++ b/server/channels/app/audit.go
@@ -136,7 +136,7 @@ func (s *Server) configureAudit(adt *audit.Audit, bAllowAdvancedLogging bool) er
 	}
 
 	// Append additional config from env var; any target name collisions will be overwritten.
-	additionalJSON := strings.TrimSpace(os.Getenv("MM_EXPERIMENTALAUDITSETTINGS_ADVANCEDLOGGINGJSON_2"))
+	additionalJSON := strings.TrimSpace(os.Getenv("MM_EXPERIMENTALAUDITSETTINGS_ADDITIONAL"))
 	if additionalJSON != "" {
 		cfgAdditional := make(mlog.LoggerConfiguration)
 		if err := json.Unmarshal([]byte(additionalJSON), &cfgAdditional); err != nil {

--- a/server/channels/app/audit.go
+++ b/server/channels/app/audit.go
@@ -4,10 +4,13 @@
 package app
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"os/user"
+	"strings"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
@@ -130,6 +133,16 @@ func (s *Server) configureAudit(adt *audit.Audit, bAllowAdvancedLogging bool) er
 	cfg, err := config.MloggerConfigFromAuditConfig(s.platform.Config().ExperimentalAuditSettings, logConfigSrc)
 	if err != nil {
 		return fmt.Errorf("invalid config for audit, %w", err)
+	}
+
+	// Append additional config from env var; any target name collisions will be overwritten.
+	additionalJSON := strings.TrimSpace(os.Getenv("MM_EXPERIMENTALAUDITSETTINGS_ADVANCEDLOGGINGJSON_2"))
+	if additionalJSON != "" {
+		cfgAdditional := make(mlog.LoggerConfiguration)
+		if err := json.Unmarshal([]byte(additionalJSON), &cfgAdditional); err != nil {
+			return fmt.Errorf("invalid additional config for audit, %w", err)
+		}
+		cfg.Append(cfgAdditional)
 	}
 
 	return adt.Configure(cfg)

--- a/server/public/shared/mlog/mlog.go
+++ b/server/public/shared/mlog/mlog.go
@@ -248,7 +248,7 @@ func (l *Logger) Configure(cfgFile string, cfgEscaped string, factories *Factori
 }
 
 // ConfigureTargets provides a new configuration for this logger via a `LoggerConfig` map.
-// Typically `mlog.Configure` is used instead which accepts JSON formatted configuration.
+// `Logger.Configure` can be used instead which accepts JSON formatted configuration.
 // An optional set of factories can be provided which will be called to create any target
 // types or formatters not built-in.
 func (l *Logger) ConfigureTargets(cfg LoggerConfiguration, factories *Factories) error {


### PR DESCRIPTION
#### Summary
Cloud team requested the ability to have a secondary source of configuration for audit logging.  This is available only via env var.   In the case of a target name colliding with one in config.json, this config will take precedence. 

Example:
```bash
export MM_EXPERIMENTALAUDITSETTINGS_ADDITIONAL=$(jq -n -c '{
        "additional_audit_file_1": {
                "Type": "file",
                "Format": "json",
                "Levels": [
                        {"ID": 100, "Name": "audit-api"},
                        {"ID": 101, "Name": "audit-content"},
                        {"ID": 102, "Name": "audit-permissions"},
                        {"ID": 103, "Name": "audit-cli"}
                ],
                "Options": {
                        "Compress": true,
                        "Filename": "additional_mattermost_audit.log",
                        "MaxAgeDays": 1,
                        "MaxBackups": 10,
                        "MaxSizeMB": 500
                },
                "MaxQueueSize": 1000
        }
}')
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57823

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
```release-note
NONE
```
