### PR TITLE
[MM-52675] Use message_source in copy text action (#26674)

### DIFF
--- a/webapp/channels/src/components/dot_menu/dot_menu.tsx
+++ b/webapp/channels/src/components/dot_menu/dot_menu.tsx
@@ -221,7 +221,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
     };
 
     copyText = (e: ChangeEvent) => {
-        Utils.copyToClipboard(this.props.post.message);
+        Utils.copyToClipboard(this.props.post.message_source || this.props.post.message);
         trackDotMenuEvent(e, TELEMETRY_LABELS.COPY_TEXT);
     };
 


### PR DESCRIPTION
Fixes https://github.com/mattermost/mattermost/issues/26674
Fixes Jira https://mattermost.atlassian.net/browse/MM-52675

```release-note
When clicking on the "Copy Text" list item in a channel post dot menu (accessed by clicking the three dots) for a post that includes embedded images using markdown, the clipboard now receives the markdown as was entered into the original post instead of one that includes a proxy link.
```