### PR TITLE
[CLD-7375] Fix z index in stat trial form modal

### DIFF
--- a/webapp/channels/src/components/start_trial_form_modal/start_trial_form_modal.scss
+++ b/webapp/channels/src/components/start_trial_form_modal/start_trial_form_modal.scss
@@ -111,13 +111,12 @@
         .DropdownInput {
             margin-top: 36px;
 
+
             .DropDown__menu {
-                z-index: 999;
                 max-height: 124px;
             }
 
             .DropDown__menu-list {
-                z-index: 999;
                 max-height: 124px;
             }
         }
@@ -136,7 +135,6 @@
         }
 
         .countries-section {
-            z-index: 999;
             max-height: 164px;
         }
 


### PR DESCRIPTION
#### Summary
Fixes z-indexes to prevent weirdness in the UI 

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-7375

#### Screenshots
|  before  |  after  |
|----|----|
| ![image](https://github.com/mattermost/mattermost/assets/12176405/9d9f248b-a40b-40ed-a4c7-e5c2763e1155) | ![image](https://github.com/mattermost/mattermost/assets/12176405/3de94906-f1a3-4f4e-ba60-ed9473ade993) |



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
