### PR TITLE
[MM-57851] Add WebP to MediaFormats #26628

### DIFF
--- a/server/channels/app/imaging/decode.go
+++ b/server/channels/app/imaging/decode.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/oov/psd"
 	_ "golang.org/x/image/bmp"
 	_ "golang.org/x/image/tiff"
+	_ "golang.org/x/image/webp"
 )
 
 // DecoderOptions holds configuration options for an image decoder.

--- a/server/platform/shared/web/files.go
+++ b/server/platform/shared/web/files.go
@@ -27,6 +27,7 @@ var MediaContentTypes = [...]string{
 	"image/bmp",
 	"image/gif",
 	"image/tiff",
+	"image/webp",
 	"video/avi",
 	"video/mpeg",
 	"video/mp4",


### PR DESCRIPTION
Changes the default content disposition for WebP attachments from *download* to *inline*.

Add WebP codec support side-effect to decode.go. To prevent future issues caused by possible changes in emoji.go.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR adds WebP to MediaFormats on the server side. This changes behaviour related to WebP attachments.
Currently WebP Attachments are downloaded when accessed by the `Public Link` Feature. After this change those files all displayed inline in the browser as one might expect. This aligns with other image formats that are supported by the preview feature. It adds a most likely overseen (required) change related to [MM-11777].

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/26628
Jira https://mattermost.atlassian.net/browse/MM-57851

#### Release Note

```release-note
Added inline display of WebP images accessed through the public-link feature
```

### EDIT
I forgot to sign the commit, so I had to force-push the same change

[MM-11777]: https://mattermost.atlassian.net/browse/MM-11777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ