### PR TITLE
MM-57885: Do not mark channel as read on tab unload

### DIFF
--- a/webapp/channels/src/components/logged_in/index.ts
+++ b/webapp/channels/src/components/logged_in/index.ts
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import {markChannelAsViewedOnServer, updateApproximateViewTime} from 'mattermost-redux/actions/channels';
+import {updateApproximateViewTime} from 'mattermost-redux/actions/channels';
 import {autoUpdateTimezone} from 'mattermost-redux/actions/timezone';
 import {getChannel, getCurrentChannelId, isManuallyUnread} from 'mattermost-redux/selectors/entities/channels';
 import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
@@ -60,7 +60,6 @@ function mapDispatchToProps(dispatch: Dispatch) {
         actions: bindActionCreators({
             autoUpdateTimezone,
             getChannelURLAction,
-            markChannelAsViewedOnServer,
             updateApproximateViewTime,
         }, dispatch),
     };

--- a/webapp/channels/src/components/logged_in/logged_in.test.tsx
+++ b/webapp/channels/src/components/logged_in/logged_in.test.tsx
@@ -12,9 +12,20 @@ import BrowserStore from 'stores/browser_store';
 import LoggedIn from 'components/logged_in/logged_in';
 import type {Props} from 'components/logged_in/logged_in';
 
+import {fireEvent, renderWithContext, screen} from 'tests/react_testing_utils';
+
 jest.mock('actions/websocket_actions.jsx', () => ({
     initialize: jest.fn(),
+    close: jest.fn(),
 }));
+
+const originalFetch = global.fetch;
+beforeAll(() => {
+    global.fetch = jest.fn();
+});
+afterAll(() => {
+    global.fetch = originalFetch;
+});
 
 BrowserStore.signalLogin = jest.fn();
 
@@ -178,5 +189,20 @@ describe('components/logged_in/LoggedIn', () => {
 
         shallow(<LoggedIn {...props}>{children}</LoggedIn>);
         expect(obj.emitBrowserFocus).toBeCalledTimes(1);
+    });
+
+    it('should not make viewChannel call on unload', () => {
+        const props = {
+            ...baseProps,
+            mfaRequired: false,
+            showTermsOfService: false,
+        };
+
+        renderWithContext(<LoggedIn {...props}>{children}</LoggedIn>);
+        fireEvent(window, new Event('beforeunload'));
+
+        expect(fetch).not.toHaveBeenCalledWith('/api/v4/channels/members/me/view');
+
+        expect(screen.getByText('Test')).toBeInTheDocument();
     });
 });

--- a/webapp/channels/src/components/logged_in/logged_in.test.tsx
+++ b/webapp/channels/src/components/logged_in/logged_in.test.tsx
@@ -19,17 +19,17 @@ jest.mock('actions/websocket_actions.jsx', () => ({
     close: jest.fn(),
 }));
 
-const originalFetch = global.fetch;
-beforeAll(() => {
-    global.fetch = jest.fn();
-});
-afterAll(() => {
-    global.fetch = originalFetch;
-});
-
 BrowserStore.signalLogin = jest.fn();
 
 describe('components/logged_in/LoggedIn', () => {
+    const originalFetch = global.fetch;
+    beforeAll(() => {
+        global.fetch = jest.fn();
+    });
+    afterAll(() => {
+        global.fetch = originalFetch;
+    });
+
     const children = <span>{'Test'}</span>;
     const baseProps: Props = {
         currentUser: {} as UserProfile,
@@ -199,9 +199,9 @@ describe('components/logged_in/LoggedIn', () => {
         };
 
         renderWithContext(<LoggedIn {...props}>{children}</LoggedIn>);
-        fireEvent(window, new Event('beforeunload'));
-
-        expect(fetch).not.toHaveBeenCalledWith('/api/v4/channels/members/me/view');
         expect(screen.getByText('Test')).toBeInTheDocument();
+
+        fireEvent(window, new Event('beforeunload'));
+        expect(fetch).not.toHaveBeenCalledWith('/api/v4/channels/members/me/view');
     });
 });

--- a/webapp/channels/src/components/logged_in/logged_in.test.tsx
+++ b/webapp/channels/src/components/logged_in/logged_in.test.tsx
@@ -26,7 +26,6 @@ describe('components/logged_in/LoggedIn', () => {
         actions: {
             autoUpdateTimezone: jest.fn(),
             getChannelURLAction: jest.fn(),
-            markChannelAsViewedOnServer: jest.fn(),
             updateApproximateViewTime: jest.fn(),
         },
         isCurrentChannelManuallyUnread: false,

--- a/webapp/channels/src/components/logged_in/logged_in.test.tsx
+++ b/webapp/channels/src/components/logged_in/logged_in.test.tsx
@@ -202,7 +202,6 @@ describe('components/logged_in/LoggedIn', () => {
         fireEvent(window, new Event('beforeunload'));
 
         expect(fetch).not.toHaveBeenCalledWith('/api/v4/channels/members/me/view');
-
         expect(screen.getByText('Test')).toBeInTheDocument();
     });
 });

--- a/webapp/channels/src/components/logged_in/logged_in.tsx
+++ b/webapp/channels/src/components/logged_in/logged_in.tsx
@@ -36,7 +36,6 @@ export type Props = {
     actions: {
         autoUpdateTimezone: (deviceTimezone: string) => void;
         getChannelURLAction: (channelId: string, teamId: string, url: string) => void;
-        markChannelAsViewedOnServer: (channelId: string) => void;
         updateApproximateViewTime: (channelId: string) => void;
     };
     showTermsOfService: boolean;
@@ -192,7 +191,6 @@ export default class LoggedIn extends React.PureComponent<Props> {
         window.removeEventListener('beforeunload', this.handleBeforeUnload);
         if (document.cookie.indexOf('MMUSERID=') > -1 && this.props.currentChannelId && !this.props.isCurrentChannelManuallyUnread) {
             this.props.actions.updateApproximateViewTime(this.props.currentChannelId);
-            this.props.actions.markChannelAsViewedOnServer(this.props.currentChannelId);
         }
         WebSocketActions.close();
     };


### PR DESCRIPTION
This was spurious code left from old times. It's not
needed now, and it was causing a race condition with the server
side where we were setting the status to offline on
websocket disconnect. So if this request reached the server
after the status was set to offline, the status would
reset to online.

https://mattermost.atlassian.net/browse/MM-57885

```release-note
Fixed a bug where status would incorrectly get stuck to online
after user closes the tab.
```
