### PR TITLE
[MM-56266] Use ListTeamChannels for member count permission for public channels

### DIFF
--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -732,8 +732,8 @@ func getChannelsMemberCount(c *Context, w http.ResponseWriter, r *http.Request) 
 	}
 
 	for _, channel := range channels {
-		if !c.App.HasPermissionToReadChannel(c.AppContext, c.AppContext.Session().UserId, channel) {
-			c.SetPermissionError(model.PermissionReadChannel)
+		if !c.App.HasPermissionToChannelMemberCount(c.AppContext, c.AppContext.Session().UserId, channel) {
+			c.SetPermissionError(model.PermissionListTeamChannels)
 			return
 		}
 	}

--- a/server/channels/app/app_iface.go
+++ b/server/channels/app/app_iface.go
@@ -909,6 +909,7 @@ type AppIface interface {
 	HasPermissionTo(askingUserId string, permission *model.Permission) bool
 	HasPermissionToChannel(c request.CTX, askingUserId string, channelID string, permission *model.Permission) bool
 	HasPermissionToChannelByPost(c request.CTX, askingUserId string, postID string, permission *model.Permission) bool
+	HasPermissionToChannelMemberCount(c request.CTX, userID string, channel *model.Channel) bool
 	HasPermissionToReadChannel(c request.CTX, userID string, channel *model.Channel) bool
 	HasPermissionToTeam(c request.CTX, askingUserId string, teamID string, permission *model.Permission) bool
 	HasPermissionToUser(askingUserId string, userID string) bool

--- a/server/channels/app/authorization.go
+++ b/server/channels/app/authorization.go
@@ -385,3 +385,18 @@ func (a *App) HasPermissionToReadChannel(c request.CTX, userID string, channel *
 
 	return false
 }
+
+func (a *App) HasPermissionToChannelMemberCount(c request.CTX, userID string, channel *model.Channel) bool {
+	if !*a.Config().TeamSettings.ExperimentalViewArchivedChannels && channel.DeleteAt != 0 {
+		return false
+	}
+	if a.HasPermissionToChannel(c, userID, channel.Id, model.PermissionReadChannelContent) {
+		return true
+	}
+
+	if channel.Type == model.ChannelTypeOpen {
+		return a.HasPermissionToTeam(c, userID, channel.TeamId, model.PermissionListTeamChannels)
+	}
+
+	return false
+}

--- a/server/channels/app/opentracing/opentracing_layer.go
+++ b/server/channels/app/opentracing/opentracing_layer.go
@@ -11776,6 +11776,23 @@ func (a *OpenTracingAppLayer) HasPermissionToChannelByPost(c request.CTX, asking
 	return resultVar0
 }
 
+func (a *OpenTracingAppLayer) HasPermissionToChannelMemberCount(c request.CTX, userID string, channel *model.Channel) bool {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.HasPermissionToChannelMemberCount")
+
+	a.ctx = newCtx
+	a.app.Srv().Store().SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store().SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0 := a.app.HasPermissionToChannelMemberCount(c, userID, channel)
+
+	return resultVar0
+}
+
 func (a *OpenTracingAppLayer) HasPermissionToReadChannel(c request.CTX, userID string, channel *model.Channel) bool {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.HasPermissionToReadChannel")


### PR DESCRIPTION
#### Summary
We made a fix to allow users that had the permission to read public channels to also be able to see the member count. This worked fine except for servers with compliance turned on, which wouldn't make sense to allow for channel read without explicitly being in the channel.

This PR adds a different permission check for the member count specifically, checking for the `ListTeamChannels` permissions which is already used when listing the available public channel objects.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56266

```release-note
Fixed an issue where on some server you cannot see the member count in the Browse Channels dialog
```
