### PR TITLE
Using correct type for websocket events

### DIFF
--- a/server/channels/wsapi/system.go
+++ b/server/channels/wsapi/system.go
@@ -10,7 +10,7 @@ import (
 
 func (api *API) InitSystem() {
 	api.Router.Handle("ping", api.APIWebSocketHandler(ping))
-	api.Router.Handle(model.WebsocketPostedNotifyAck, api.APIWebSocketHandler(api.websocketNotificationAck))
+	api.Router.Handle(string(model.WebsocketPostedNotifyAck), api.APIWebSocketHandler(api.websocketNotificationAck))
 }
 
 func ping(req *model.WebSocketRequest) (map[string]any, *model.AppError) {

--- a/server/public/model/websocket_message.go
+++ b/server/public/model/websocket_message.go
@@ -87,12 +87,12 @@ const (
 	WebsocketEventAcknowledgementRemoved              WebsocketEventType = "post_acknowledgement_removed"
 	WebsocketEventPersistentNotificationTriggered     WebsocketEventType = "persistent_notification_triggered"
 	WebsocketEventHostedCustomerSignupProgressUpdated WebsocketEventType = "hosted_customer_signup_progress_updated"
-	WebsocketEventChannelBookmarkCreated                                 = "channel_bookmark_created"
-	WebsocketEventChannelBookmarkUpdated                                 = "channel_bookmark_updated"
-	WebsocketEventChannelBookmarkDeleted                                 = "channel_bookmark_deleted"
-	WebsocketEventChannelBookmarkSorted                                  = "channel_bookmark_sorted"
+	WebsocketEventChannelBookmarkCreated              WebsocketEventType = "channel_bookmark_created"
+	WebsocketEventChannelBookmarkUpdated              WebsocketEventType = "channel_bookmark_updated"
+	WebsocketEventChannelBookmarkDeleted              WebsocketEventType = "channel_bookmark_deleted"
+	WebsocketEventChannelBookmarkSorted               WebsocketEventType = "channel_bookmark_sorted"
 	WebsocketPresenceIndicator                        WebsocketEventType = "presence"
-	WebsocketPostedNotifyAck                                             = "posted_notify_ack"
+	WebsocketPostedNotifyAck                          WebsocketEventType = "posted_notify_ack"
 )
 
 type WebSocketMessage interface {


### PR DESCRIPTION
#### Summary
All websocket events should use the type `WebsocketEventType` as a uniform type. Some recently added events are missing that type.

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
