### PR TITLE
[MM-57121] Remove remote_id if necessary when merging user profile

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.test.ts
@@ -746,6 +746,26 @@ describe('Reducers.users', () => {
                 });
             });
 
+            test(`should remove remote_id when not set anymore (${actionType})`, () => {
+                const user1 = TestHelper.getUserMock({id: 'user_id1', remote_id: 'abcdef'});
+                const user1WithoutRemoteId = TestHelper.getUserMock({id: 'user_id1'});
+
+                const state = deepFreezeAndThrowOnMutation({
+                    profiles: {
+                        [user1.id]: user1,
+                    },
+                });
+
+                const nextState = reducer(state, {
+                    type: actionType,
+                    data: user1WithoutRemoteId,
+                });
+
+                expect(nextState.profiles).toEqual({
+                    [user1.id]: user1WithoutRemoteId,
+                });
+            });
+
             test(`should not overwrite unsanitized data with sanitized data (${actionType})`, () => {
                 const user1 = TestHelper.getUserMock({
                     id: 'user_id1',

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.ts
@@ -169,6 +169,11 @@ function receiveUserProfile(state: IDMappedObjects<UserProfile>, received: UserP
         ...received,
     };
 
+    // If there was a remote_id but not anymore, remove it
+    if (existing.remote_id && !received.remote_id) {
+        delete merged.remote_id;
+    }
+
     // MM-53377:
     // For non-admin users, certain API responses don't return details for the current user that would be sanitized
     // out for others. This currently includes:


### PR DESCRIPTION
#### Summary
With the MSTeams plugin, we promote a user by removing their `remote_id` and changing their username. The username update was reflected by the webapp but the user still appeared as remote until a refresh was done

I found that the merge did not take into consideration the fact that the `remote_id` field can disappear: it's set to NULL in the DB and [the go model has an omitempty](https://github.com/mattermost/mattermost/blob/446c763fa8933e8262e71b0a0dd71a479ca0afd9/server/public/model/user.go#L101). The PR fixes this by deleting the field if the received user does not have it anymore.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57121

#### Release Note
```release-note
NONE
```
