### PR TITLE
[GH-26831] fix modal suggestion list position

### DIFF
--- a/webapp/channels/src/components/suggestion/modal_suggestion_list.tsx
+++ b/webapp/channels/src/components/suggestion/modal_suggestion_list.tsx
@@ -204,7 +204,7 @@ export default class ModalSuggestionList extends React.PureComponent<Props, Stat
 
         return (
             <div
-                style={{position: 'fixed', zIndex: 101, width: this.state.inputBounds.width, ...position}}
+                style={{position: 'absolute', zIndex: 101, width: this.state.inputBounds.width, ...position}}
                 ref={this.container}
             >
                 <SuggestionList


### PR DESCRIPTION
#### Summary
The dropdown of select field in the modal has an absolute position (instead of fixed).


#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/26831

#### Release Note
```release-note
NONE
```
