### PR TITLE
MM-52219 Add announcement bar to prompt users for notification permission

### DIFF
--- a/webapp/channels/src/components/announcement_bar/announcement_bar_controller.tsx
+++ b/webapp/channels/src/components/announcement_bar/announcement_bar_controller.tsx
@@ -15,6 +15,7 @@ import CloudTrialAnnouncementBar from './cloud_trial_announcement_bar';
 import CloudTrialEndAnnouncementBar from './cloud_trial_ended_announcement_bar';
 import ConfigurationAnnouncementBar from './configuration_bar';
 import AnnouncementBar from './default_announcement_bar';
+import NotificationPermissionBar from './notification_permission_bar';
 import OverageUsersBanner from './overage_users_banner';
 import PaymentAnnouncementBar from './payment_announcement_bar';
 import AutoStartTrialModal from './show_start_trial_modal/show_start_trial_modal';
@@ -109,6 +110,7 @@ class AnnouncementBarController extends React.PureComponent<Props> {
         // Even if all Foo, Bar and Baz render, only Baz is visible as it's further down.
         return (
             <>
+                <NotificationPermissionBar/>
                 {adminConfiguredAnnouncementBar}
                 {errorBar}
                 <PostLimitsAnnouncementBar

--- a/webapp/channels/src/components/announcement_bar/notification_permission_bar/index.tsx
+++ b/webapp/channels/src/components/announcement_bar/notification_permission_bar/index.tsx
@@ -1,0 +1,52 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useCallback, useState} from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import AnnouncementBar from 'components/announcement_bar/default_announcement_bar';
+
+import {AnnouncementBarTypes} from 'utils/constants';
+
+export default function NotificationPermissionBar() {
+    const [show, setShow] = useState(Notification.permission === 'default');
+
+    const handleClose = useCallback(() => {
+        // If the user closes the bar, don't show the notification bar any more for the rest of the session, but
+        // show it again after refresh.
+        setShow(false);
+    }, []);
+
+    const handleClick = useCallback(() => {
+        Notification.requestPermission().then(() => {
+            setShow(false);
+        });
+    }, []);
+
+    if (!show) {
+        return null;
+    }
+
+    return (
+        <AnnouncementBar
+            showCloseButton={true}
+            handleClose={handleClose}
+            type={AnnouncementBarTypes.ANNOUNCEMENT}
+            message={
+                <FormattedMessage
+                    id='announcement_bar.notification.needs_permisson'
+                    defaultMessage='Mattermost needs your permission to show desktop notifications.'
+                />
+            }
+            ctaText={
+                <FormattedMessage
+                    id='announcement_bar.notification.give_permission'
+                    defaultMessage='Give Permission'
+                />
+            }
+            showCTA={true}
+            showLinkAsButton={true}
+            onButtonClick={handleClick}
+        />
+    );
+}


### PR DESCRIPTION
#### Summary
This is a fix for the issue where some browsers prevent us from prompting for notification permission because the app tries to notify the user when the browser isn't focused.

My original plan was for something fancier where we'd wait until the user could've received a notification and then we prompt them for permission when the app next gets focus, but that ended up getting overly complicated, and it changed the existing code which had me worried that something might break.

Instead, I went for the super simple solution of just showing a "give us permission" banner as soon as the app opens like other apps do. This might be mildly annoying to people, but it's simple and hopefully effective enough to do the trick. It also leaves the existing code path in place so, if someone ignores the banner, they'll still get the same permission prompt that we previously trigger.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
