### PR TITLE
fix plugin request auth

### DIFF
--- a/server/channels/app/plugin_requests.go
+++ b/server/channels/app/plugin_requests.go
@@ -161,6 +161,12 @@ func (ch *Channels) servePluginRequest(w http.ResponseWriter, r *http.Request, h
 				r.ParseForm()
 				sentToken = r.FormValue("csrf")
 				r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+				if sentToken == "" {
+					if csrfCookie, _ := r.Cookie(model.SessionCookieCsrf); csrfCookie != nil {
+						sentToken = csrfCookie.Value
+					}
+				}
 			} else {
 				sentToken = r.Header.Get(model.HeaderCsrfToken)
 			}


### PR DESCRIPTION
This is a fix for https://github.com/mattermost/mattermost/issues/26745

Requests from plugin webapps to plugin server code contain a CSRF token that should be used to validate who the current user is. However Mattermost doesn't currently use the CSRF token that is sent in the request, and so authentication always fails and there is no current user available in the plugin server code. This pulls the CSRF token and does the comparison. More details in the linked issue.