### PR TITLE
MM-57320 Fix autocomplete occasionally erasing all text after caret

### DIFF
--- a/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.jsx
+++ b/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.jsx
@@ -668,16 +668,11 @@ export default class SuggestionBox extends React.PureComponent {
     makeHandleReceivedSuggestionsAndComplete = () => {
         let firstComplete = true;
         return (suggestions) => {
-
             const {selection, matchedPretext} = this.handleReceivedSuggestions(suggestions);
 
-            if (!firstComplete) {
-                return;
-            }
-            firstComplete = false;
-
-            if (selection) {
+            if (selection && firstComplete) {
                 this.handleCompleteWord(selection, matchedPretext);
+                firstComplete = false;
             }
         };
     };

--- a/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.jsx
+++ b/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.jsx
@@ -666,15 +666,16 @@ export default class SuggestionBox extends React.PureComponent {
     };
 
     makeHandleReceivedSuggestionsAndComplete = () => {
-        let firstCall = true;
+        let firstComplete = true;
         return (suggestions) => {
-            if (!firstCall) {
-                return;
-            }
-
-            firstCall = false;
 
             const {selection, matchedPretext} = this.handleReceivedSuggestions(suggestions);
+
+            if (!firstComplete) {
+                return;
+            }
+            firstComplete = false;
+
             if (selection) {
                 this.handleCompleteWord(selection, matchedPretext);
             }

--- a/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.jsx
+++ b/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.jsx
@@ -248,6 +248,10 @@ export default class SuggestionBox extends React.PureComponent {
         }
     }
 
+    componentWillUnmount() {
+        clearTimeout(this.timeoutId);
+    }
+
     getTextbox = () => {
         if (!this.inputRef.current) {
             return null;
@@ -387,15 +391,14 @@ export default class SuggestionBox extends React.PureComponent {
             prefix = pretext.substring(0, pretext.length - overlap.length - matchedPretext.length);
         }
 
-        const suffix = text.substring(caret);
-
-        let newValue;
         if (keepPretext) {
-            newValue = pretext;
-        } else {
-            newValue = prefix + term + ' ' + suffix;
+            // The term no longer fits the pretext, so don't change anything or else we might erase something
+            return;
         }
 
+        const suffix = text.substring(caret);
+
+        const newValue = prefix + term + ' ' + suffix;
         textbox.value = newValue;
 
         if (this.props.onChange) {
@@ -565,29 +568,6 @@ export default class SuggestionBox extends React.PureComponent {
         return this.state.items.some((item) => !item.loading);
     };
 
-    confirmPretext = () => {
-        const textbox = this.getTextbox();
-        const pretext = textbox.value.substring(0, textbox.selectionEnd).toLowerCase();
-
-        if (this.pretext !== pretext) {
-            this.handlePretextChanged(pretext);
-        }
-    };
-
-    handleKeyUp = (e) => {
-        this.confirmPretext();
-        if (this.props.onKeyUp) {
-            this.props.onKeyUp(e);
-        }
-    };
-
-    handleMouseUp = (e) => {
-        this.confirmPretext();
-        if (this.props.onMouseUp) {
-            this.props.onMouseUp(e);
-        }
-    };
-
     handleKeyDown = (e) => {
         if ((this.props.openWhenEmpty || this.props.value) && this.hasSuggestions()) {
             const ctrlOrMetaKeyPressed = e.ctrlKey || e.metaKey;
@@ -685,11 +665,20 @@ export default class SuggestionBox extends React.PureComponent {
         return {selection, matchedPretext: suggestions.matchedPretext};
     };
 
-    handleReceivedSuggestionsAndComplete = (suggestions) => {
-        const {selection, matchedPretext} = this.handleReceivedSuggestions(suggestions);
-        if (selection) {
-            this.handleCompleteWord(selection, matchedPretext);
-        }
+    makeHandleReceivedSuggestionsAndComplete = () => {
+        let firstCall = true;
+        return (suggestions) => {
+            if (!firstCall) {
+                return;
+            }
+
+            firstCall = false;
+
+            const {selection, matchedPretext} = this.handleReceivedSuggestions(suggestions);
+            if (selection) {
+                this.handleCompleteWord(selection, matchedPretext);
+            }
+        };
     };
 
     nonDebouncedPretextChanged = (pretext, complete = false) => {
@@ -698,7 +687,7 @@ export default class SuggestionBox extends React.PureComponent {
         let handled = false;
         let callback = this.handleReceivedSuggestions;
         if (complete) {
-            callback = this.handleReceivedSuggestionsAndComplete;
+            callback = this.makeHandleReceivedSuggestionsAndComplete();
         }
         for (const provider of this.props.providers) {
             handled = provider.handlePretextChanged(pretext, callback) || handled;
@@ -840,8 +829,6 @@ export default class SuggestionBox extends React.PureComponent {
                     onCompositionUpdate={this.handleCompositionUpdate}
                     onCompositionEnd={this.handleCompositionEnd}
                     onKeyDown={this.handleKeyDown}
-                    onKeyUp={this.handleKeyUp}
-                    onMouseUp={this.handleMouseUp}
                 />
                 {(this.props.openWhenEmpty || this.props.value.length >= this.props.requiredCharacters) && this.state.presentationType === 'text' && (
                     <SuggestionListComponent

--- a/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.test.tsx
+++ b/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.test.tsx
@@ -1,0 +1,244 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useCallback, useState} from 'react';
+
+import {renderWithContext, screen, userEvent, waitFor} from 'tests/react_testing_utils';
+
+import SuggestionBox from './suggestion_box';
+
+import type {ResultsCallback} from '../provider';
+import Provider from '../provider';
+import SuggestionList from '../suggestion_list';
+
+function TestWrapper(props: React.ComponentPropsWithoutRef<typeof SuggestionBox>) {
+    // eslint-disable-next-line react/prop-types
+    const [value, setValue] = useState(props.value);
+
+    const handleChange = useCallback((e) => setValue(e.target.value), []);
+
+    return (
+        <SuggestionBox
+            {...props}
+            onChange={handleChange}
+            value={value}
+        />
+    );
+}
+
+const TestSuggestion = React.forwardRef<HTMLDivElement, {term: string}>((props, ref) => {
+    return <div ref={ref}>{'Suggestion: ' + props.term}</div>;
+});
+
+class TestProvider extends Provider {
+    private repeatResults: boolean;
+
+    constructor(repeatResults = false) {
+        super();
+
+        this.repeatResults = repeatResults;
+    }
+
+    handlePretextChanged(pretext: string, resultCallback: ResultsCallback<string>) {
+        if (pretext.trim().length === 0) {
+            return false;
+        }
+
+        const terms = [pretext + pretext];
+        resultCallback({
+            matchedPretext: pretext,
+            terms,
+            items: terms,
+            component: TestSuggestion,
+        });
+
+        if (this.repeatResults) {
+            setTimeout(() => {
+                resultCallback({
+                    matchedPretext: pretext,
+                    terms,
+                    items: terms,
+                    component: TestSuggestion,
+                });
+            }, 10);
+        }
+
+        return true;
+    }
+}
+
+describe('SuggestionBox', () => {
+    function makeBaseProps(): React.ComponentProps<typeof SuggestionBox> {
+        return {
+            listComponent: SuggestionList,
+            value: '',
+            providers: [],
+            actions: {
+                addMessageIntoHistory: jest.fn(),
+            },
+            placeholder: 'test input',
+        };
+    }
+
+    test('should list suggestions based on typed text', async () => {
+        const provider = new TestProvider();
+        const providerSpy = jest.spyOn(provider, 'handlePretextChanged');
+
+        renderWithContext(
+            <TestWrapper
+                {...makeBaseProps()}
+                providers={[provider]}
+            />,
+        );
+
+        // Start with no suggestions rendered
+        expect(screen.queryByRole('list')).not.toBeInTheDocument();
+
+        // Typing some text should cause a suggestion to be shown
+        userEvent.click(screen.getByPlaceholderText('test input'));
+        await userEvent.keyboard('test');
+
+        await waitFor(() => {
+            // Note that debouncing causes the provider to only be called once when the user stops typing
+            expect(providerSpy).toHaveBeenCalledTimes(1);
+        });
+
+        expect(screen.queryByRole('list')).toBeVisible();
+
+        expect(screen.queryByRole('list')).toBeVisible();
+        expect(screen.getByText('Suggestion: testtest')).toBeVisible();
+
+        // Typing more text should cause the suggestion to be updaetd
+        await userEvent.keyboard('words');
+
+        await waitFor(() => {
+            expect(providerSpy).toHaveBeenCalledTimes(2);
+        });
+
+        expect(screen.queryByRole('list')).toBeVisible();
+        expect(screen.getByText('Suggestion: testwordstestwords')).toBeVisible();
+
+        // Clearing the textbox hides all suggestions
+        await userEvent.clear(screen.getByPlaceholderText('test input'));
+
+        expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+
+    test('should hide suggestions on pressing escape', async () => {
+        const provider = new TestProvider();
+
+        renderWithContext(
+            <TestWrapper
+                {...makeBaseProps()}
+                providers={[provider]}
+            />,
+        );
+
+        // Start with no suggestions rendered
+        expect(screen.queryByRole('list')).not.toBeInTheDocument();
+
+        // Typing some text should cause a suggestion to be shown
+        userEvent.click(screen.getByPlaceholderText('test input'));
+        await userEvent.keyboard('test');
+
+        await waitFor(() => {
+            expect(screen.getByRole('list')).toBeVisible();
+        });
+
+        // Pressing escape hides all suggestions
+        await userEvent.keyboard('{escape}');
+
+        expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+
+    test('should autocomplete suggestions by pressing enter', async () => {
+        const provider = new TestProvider();
+
+        renderWithContext(
+            <TestWrapper
+                {...makeBaseProps()}
+                providers={[provider]}
+            />,
+        );
+
+        // Typing some text should cause a suggestion to be shown
+        userEvent.click(screen.getByPlaceholderText('test input'));
+        await userEvent.keyboard('test');
+
+        await waitFor(() => {
+            expect(screen.queryByRole('list')).toBeVisible();
+            expect(screen.getByText('Suggestion: testtest')).toBeVisible();
+        });
+
+        // Pressing enter should update the textbox value and hide the suggestion list
+        await userEvent.keyboard('{enter}');
+
+        await waitFor(() => {
+            expect(screen.getByPlaceholderText('test input')).toHaveValue('testtest ');
+        });
+
+        expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+
+    test('MM-57320 completing text with enter and calling resultCallback twice should not erase text following caret', async () => {
+        const provider = new TestProvider(true);
+        const onSuggestionsReceived = jest.fn();
+
+        renderWithContext(
+            <TestWrapper
+                {...makeBaseProps()}
+                providers={[provider]}
+                onSuggestionsReceived={onSuggestionsReceived}
+            />,
+        );
+
+        userEvent.click(screen.getByPlaceholderText('test input'));
+        await userEvent.keyboard('This is important');
+
+        // The provider will send results to the SuggestionBox twice to simulate loading results from the server
+        await waitFor(() => {
+            expect(onSuggestionsReceived).toHaveBeenCalledTimes(2);
+        });
+
+        onSuggestionsReceived.mockClear();
+
+        expect(screen.getByPlaceholderText('test input')).toHaveValue('This is important');
+        expect(screen.getByRole('list')).toBeVisible();
+        expect(screen.getByText('Suggestion: This is importantThis is important')).toBeVisible();
+
+        // Move the caret back to the start of the textbox and then use escape to clear the suggestions because
+        // we don't support moving the caret with the autocomplete open yet
+        await userEvent.keyboard('{home}{escape}');
+
+        expect(screen.queryByRole('list')).not.toBeInTheDocument();
+
+        // Type a space and then start typing something again to show results
+        onSuggestionsReceived.mockClear();
+
+        await userEvent.keyboard('@us');
+
+        await waitFor(() => {
+            expect(onSuggestionsReceived).toHaveBeenCalledTimes(2);
+        });
+
+        expect(screen.getByRole('list')).toBeVisible();
+        expect(screen.getByText('Suggestion: @us@us')).toBeVisible();
+
+        onSuggestionsReceived.mockClear();
+
+        // Type some more and then hit enter before the second set of results is received
+        await userEvent.keyboard('e{enter}');
+
+        await waitFor(() => {
+            expect(onSuggestionsReceived).toHaveBeenCalledTimes(1);
+        });
+
+        expect(screen.getByPlaceholderText('test input')).toHaveValue('@use@use This is important');
+
+        // Wait for the second set of results has been received to ensure the contents of the textbox aren't lost
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        // expect(onSuggestionsReceived).toHaveBeenCalledTimes(1);
+        expect(screen.getByPlaceholderText('test input')).toHaveValue('@use@use This is important');
+    });
+});


### PR DESCRIPTION
#### Summary
I think I've finally tracked down the cause of this nasty bug where autocompleting something earlier in the post textbox will occasionally wipe out everything after the autocompleted text. If I understand correctly, the issue is because
1. https://github.com/mattermost/mattermost-webapp/pull/2078 added the ability to press enter while results are loading and then have the autocomplete wait to trigger until those results are loaded. The important part of this is that, the `SuggestionBox` passes a `resultCallback` into the `Provider` which calls `SuggestionBox.handleCompleteWord` whenever results are received.
2. Providers can call their `resultCallback` multiple times so that they can return a mix of local data and data from the server. When the above logic triggers, this means that it can call `SuggestionBox.handleCompleteWord` multiple times.
3. Calling `SuggestionBox.handleCompleteWord` multiple times should only mess up the text a bit by repeating part of the suggestion like `@userser`, but in an attempt to prevent that, https://github.com/mattermost/mattermost-webapp/pull/442 accidentally made it so that, if this triggers, the contents of the post textbox are replaced by the "pretext" which is just the text before the caret. That erases everything after the caret.

I'm still not 100% confident that this is the only issue going on, but to be safe:
1. For point 1 above, the `resultCallback` passed into the `Provider` can only trigger `SuggestionBox.handleCompleteWord` once.
2. Point 2 above is unchanged
3. For point 3, I changed the fix from the old PR to just return early if we're unable to determine what to replace with the suggestion. Ideally, we might be able to prevent this from even being possible by changing how we track the state of the textbox and what text should be replaced, but that's a big task.

@larkox I ended up reverting that previous fix you made for this issue as well because it was making some of the new tests behave funny. I've also got some other followup misc fixes to make.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57320

#### Release Note
```release-note
Fixed a longstanding bug where the at-mention autocomplete could erase post text following the autocompleted at-mention
```
