### PR TITLE
[MM-57966]Document the 200 maximum page size cap for the per_page parameter in a central location in the documentation

### DIFF
--- a/api/v4/source/bots.yaml
+++ b/api/v4/source/bots.yaml
@@ -60,8 +60,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of users per page. There is a maximum limit of 200 users
-            per page.
+          description: The number of users per page.
           schema:
             type: integer
             default: 60

--- a/api/v4/source/channels.yaml
+++ b/api/v4/source/channels.yaml
@@ -1307,7 +1307,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of members per page. There is a maximum limit of 200 members.
+          description: The number of members per page.
           schema:
             type: integer
             default: 60

--- a/api/v4/source/dataretention.yaml
+++ b/api/v4/source/dataretention.yaml
@@ -93,7 +93,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of policies per page. There is a maximum limit of 200 per page.
+          description: The number of policies per page.
           schema:
             type: integer
             default: 60
@@ -301,7 +301,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of teams per page. There is a maximum limit of 200 per page.
+          description: The number of teams per page.
           schema:
             type: integer
             default: 60
@@ -495,7 +495,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of channels per page. There is a maximum limit of 200 per page.
+          description: The number of channels per page.
           schema:
             type: integer
             default: 60

--- a/api/v4/source/introduction.yaml
+++ b/api/v4/source/introduction.yaml
@@ -49,6 +49,9 @@ tags:
 
 
       When using endpoints that require a user id, the string `me` can be used in place of the user id to indicate the action is to be taken for the logged in user.
+
+
+      For all endpoints that implement pagination via the `per_page` parameter, the maximum number of items returned per request is capped at 200. If `per_page` exceeds 200, the list will be silently truncated to 200 items.
   - name: drivers
     description: >
       The easiest way to interact with the Mattermost Web Service API is through

--- a/api/v4/source/ldap.yaml
+++ b/api/v4/source/ldap.yaml
@@ -71,7 +71,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of users per page. There is a maximum limit of 200 users
+          description: The number of users per page.
             per page.
           schema:
             type: integer

--- a/api/v4/source/users.yaml
+++ b/api/v4/source/users.yaml
@@ -195,8 +195,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of users per page. There is a maximum limit of 200 users
-            per page.
+          description: The number of users per page.
           schema:
             type: integer
             default: 60
@@ -3140,7 +3139,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of policies per page. There is a maximum limit of 200 per page.
+          description: The number of policies per page.
           schema:
             type: integer
             default: 60
@@ -3190,7 +3189,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of policies per page. There is a maximum limit of 200 per page.
+          description: The number of policies per page.
           schema:
             type: integer
             default: 60
@@ -3233,8 +3232,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of users per page. There is a maximum limit of 200 users
-            per page.
+          description: The number of users per page.
           schema:
             type: integer
             default: 60


### PR DESCRIPTION
#### Summary
This PR includes two changes:

1. It documents the 200 maximum page size cap for the per_page parameter in a common place within the documentation.
2. It eliminates specific mentions of the 200 cap at individual API endpoints to avoid future inconsistencies, ensuring that this limit is consistently referenced from a single common location.

Related Issue: https://github.com/mattermost/mattermost/issues/26830

cc: @agnivade @amyblais @connorkuehl

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57966

