### PR TITLE
[MM-58043] Enable errcheck linter for enterprise/data_retention package

### DIFF
--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -59,4 +59,4 @@ issues:
 
     - linters:
         - errcheck
-      path: "channels|platform|cmd/mattermost|public/model|public/plugin|public/shared/mlog|enterprise/data_retention|enterprise/saml|enterprise/cloud|enterprise/ldap"
+      path: "channels|platform|cmd/mattermost|public/model|public/plugin|public/shared/mlog|enterprise/saml|enterprise/cloud|enterprise/ldap"


### PR DESCRIPTION
#### Summary
See https://github.com/mattermost/enterprise/pull/1674

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58043

#### Release Note
```release-note
NONE
```
