### PR TITLE
MM-58032 Fix "Hide Joined" checkbox in "Browse channels" modal

### DIFF
--- a/webapp/channels/src/components/browse_channels/browse_channels.scss
+++ b/webapp/channels/src/components/browse_channels/browse_channels.scss
@@ -66,11 +66,28 @@
             justify-content: center;
 
             .get-app__checkbox {
+                position: relative;
                 display: flex;
                 width: 16px;
                 height: 16px;
                 align-items: center;
                 border: 1px solid rgba(var(--center-channel-color-rgb), 0.24);
+                border-radius: var(--radius-xs);
+                margin-right: 6px;
+                background-color: var(--center-channel-bg);
+
+                &.checked {
+                    border: none;
+                }
+
+                svg {
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    width: 16px;
+                    height: 16px;
+                    fill: var(--button-bg);
+                }
             }
 
             #hideJoinedPreferenceCheckbox {


### PR DESCRIPTION
#### Summary
This PR fixes a styling issue with the checkbox on the Browse Channels Modal.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-58032

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="624" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/57e87ca7-9c04-46af-b69a-cab12f0bf7b3"> | <img width="629" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/455bf1b3-8a66-4ca7-8eae-9462ecea2c71"> |
| <img width="626" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/46b64d3c-c5e5-4ebb-a471-231e9291e076"> | <img width="627" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/dfc7d427-6646-429d-8106-4b4636abb899"> |
#### Release Note

```release-note
NONE
```
