### PR TITLE
[MM-57521] Profile button on hover shouldn't be red

### DIFF
--- a/webapp/channels/src/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
+++ b/webapp/channels/src/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
@@ -215,7 +215,6 @@ exports[`components/StatusDropdown should match snapshot in default state 1`] = 
         }
         icon={
           <AccountOutlineIcon
-            className="profile__icon"
             color="rgba(var(--center-channel-color-rgb), 0.56)"
             size={16}
           />
@@ -543,7 +542,6 @@ exports[`components/StatusDropdown should match snapshot with custom status and 
         }
         icon={
           <AccountOutlineIcon
-            className="profile__icon"
             color="rgba(var(--center-channel-color-rgb), 0.56)"
             size={16}
           />
@@ -823,7 +821,6 @@ exports[`components/StatusDropdown should match snapshot with custom status enab
         }
         icon={
           <AccountOutlineIcon
-            className="profile__icon"
             color="rgba(var(--center-channel-color-rgb), 0.56)"
             size={16}
           />
@@ -1103,7 +1100,6 @@ exports[`components/StatusDropdown should match snapshot with custom status expi
         }
         icon={
           <AccountOutlineIcon
-            className="profile__icon"
             color="rgba(var(--center-channel-color-rgb), 0.56)"
             size={16}
           />
@@ -1384,7 +1380,6 @@ exports[`components/StatusDropdown should match snapshot with custom status puls
         }
         icon={
           <AccountOutlineIcon
-            className="profile__icon"
             color="rgba(var(--center-channel-color-rgb), 0.56)"
             size={16}
           />
@@ -1640,7 +1635,6 @@ exports[`components/StatusDropdown should match snapshot with profile picture UR
         }
         icon={
           <AccountOutlineIcon
-            className="profile__icon"
             color="rgba(var(--center-channel-color-rgb), 0.56)"
             size={16}
           />
@@ -1888,7 +1882,6 @@ exports[`components/StatusDropdown should match snapshot with status dropdown op
         }
         icon={
           <AccountOutlineIcon
-            className="profile__icon"
             color="rgba(var(--center-channel-color-rgb), 0.56)"
             size={16}
           />
@@ -2168,7 +2161,6 @@ exports[`components/StatusDropdown should not show clear status button when cust
         }
         icon={
           <AccountOutlineIcon
-            className="profile__icon"
             color="rgba(var(--center-channel-color-rgb), 0.56)"
             size={16}
           />
@@ -2495,8 +2487,7 @@ exports[`components/StatusDropdown should show clear status button when custom s
           }
         }
         icon={
-          <AccountOutlineIcon
-            className="profile__icon"
+          <AccountOutlineIcon          
             color="rgba(var(--center-channel-color-rgb), 0.56)"
             size={16}
           />

--- a/webapp/channels/src/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
+++ b/webapp/channels/src/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
@@ -2487,7 +2487,7 @@ exports[`components/StatusDropdown should show clear status button when custom s
           }
         }
         icon={
-          <AccountOutlineIcon          
+          <AccountOutlineIcon
             color="rgba(var(--center-channel-color-rgb), 0.56)"
             size={16}
           />

--- a/webapp/channels/src/components/status_dropdown/status_dropdown.scss
+++ b/webapp/channels/src/components/status_dropdown/status_dropdown.scss
@@ -1,9 +1,3 @@
-.profile__icon {
-    &:hover {
-        fill: rgba(255, 0, 0, 0.75);
-    }
-}
-
 .logout__icon {
     &:hover {
         fill: rgba(255, 0, 0, 0.75);

--- a/webapp/channels/src/components/status_dropdown/status_dropdown.tsx
+++ b/webapp/channels/src/components/status_dropdown/status_dropdown.tsx
@@ -665,7 +665,6 @@ export class StatusDropdown extends React.PureComponent<Props, State> {
                                 <AccountOutlineIcon
                                     size={16}
                                     color={'rgba(var(--center-channel-color-rgb), 0.56)'}
-                                    className={'profile__icon'}
                                 />
                             }
                         >


### PR DESCRIPTION
#### Summary

When clicking your profile photo > then hovering over the profile button it isn't red anymore. Now there isn't any style on hover for the profile button. 

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/26915
Jira https://mattermost.atlassian.net/browse/MM-57521

#### Screenshots

|  before  |  after  |
|----|----|
| ![mattermost-old](https://github.com/mattermost/mattermost/assets/92564081/6846c735-14ed-47c8-a5c6-f723fbdf928d) | ![mattermost-new](https://github.com/mattermost/mattermost/assets/92564081/a050ed74-096e-44a1-be2f-bb3681ed8b1c) |

#### Release Note

```release-note
NONE
```
