### PR TITLE
[MM-58091] Fix tracking websocket connections

### DIFF
--- a/server/channels/app/platform/web_conn.go
+++ b/server/channels/app/platform/web_conn.go
@@ -417,8 +417,15 @@ func (wc *WebConn) Pump() {
 
 func (wc *WebConn) readPump() {
 	defer func() {
+		if metrics := wc.Platform.metricsIFace; metrics != nil {
+			metrics.DecrementHTTPWebSockets(wc.originClient)
+		}
 		wc.WebSocket.Close()
 	}()
+	if metrics := wc.Platform.metricsIFace; metrics != nil {
+		metrics.IncrementHTTPWebSockets(wc.originClient)
+	}
+
 	wc.WebSocket.SetReadLimit(model.SocketMaxMessageSizeKb)
 	wc.WebSocket.SetReadDeadline(time.Now().Add(pongWaitTime))
 	wc.WebSocket.SetPongHandler(func(string) error {

--- a/server/channels/app/platform/web_hub.go
+++ b/server/channels/app/platform/web_hub.go
@@ -423,9 +423,6 @@ func (h *Hub) Start() {
 
 				connIndex.Add(webConn)
 				atomic.StoreInt64(&h.connectionCount, int64(connIndex.AllActive()))
-				if metrics := h.platform.metricsIFace; metrics != nil {
-					metrics.IncrementHTTPWebSockets(webConn.originClient)
-				}
 
 				if webConn.IsAuthenticated() && webConn.reuseCount == 0 {
 					// The hello message should only be sent when the reuseCount is 0.
@@ -440,9 +437,6 @@ func (h *Hub) Start() {
 				webConn.active.Store(false)
 
 				atomic.StoreInt64(&h.connectionCount, int64(connIndex.AllActive()))
-				if metrics := h.platform.metricsIFace; metrics != nil {
-					metrics.DecrementHTTPWebSockets(webConn.originClient)
-				}
 
 				if webConn.UserId == "" {
 					continue


### PR DESCRIPTION
#### Summary

PR fixes an issue that can cause the websocket connection gauges to go negative. Here's how Community is looking today:

![image](https://github.com/mattermost/mattermost/assets/1832946/653da7a1-1d7b-4de8-940a-aed26c671534)

In https://github.com/mattermost/mattermost/pull/26763 I made a wrong assumption that webconn registrations will always match unregistrations. This is not the case, in fact, if the session is not authenticated we could end up unregistering only:


https://github.com/mattermost/mattermost/blob/f1019d076edd5b7b42f2c61c630c3ad4620383f0/server/channels/api4/websocket.go#L77-L82

https://github.com/mattermost/mattermost/blob/f1019d076edd5b7b42f2c61c630c3ad4620383f0/server/channels/app/platform/web_conn.go#L406


I am adding the inc/dec operations to the webconn read pump function as I think it's more realistic than tracking registrations. This means that the counter will show unauthenticated connections as well (for the short time they live that is), which I find reasonable for this sort of metric. Please let me know if you have concerns about this choice.

Still, it's not clear to me why we would be [opening so many unauthenticated connections on Community](https://grafana.internal.mattermost.com/goto/GMrx_eBIg?orgId=1), something that may deserve a separate investigation. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-58091

#### Release Note

```release-note
Changed the semantics of the `mattermost_http_websockets_total` metric to track all open WebSocket connections, regardless of whether they are authenticated.
```
