### PR TITLE
Fix test for invite modal error

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/enterprise/guest_accounts/guest_invitation_ui_more_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/enterprise/guest_accounts/guest_invitation_ui_more_spec.ts
@@ -54,7 +54,7 @@ describe('Guest Account - Guest User Invitation Flow', () => {
                 invitePeople(newUser.username, 1, newUser.username);
 
                 // * Verify the content and message in next screen
-                verifyInvitationError(newUser.username, testTeam, 'This person is already a member.');
+                verifyInvitationError(newUser.username, testTeam, 'This person is not a guest. Invite them as a regular user.');
             });
         });
     });
@@ -83,7 +83,7 @@ describe('Guest Account - Guest User Invitation Flow', () => {
             invitePeople(regularUser.email, 1, regularUser.username);
 
             // * Verify the content and message in next screen
-            verifyInvitationError(regularUser.username, testTeam, 'This person is already a member.');
+            verifyInvitationError(regularUser.username, testTeam, 'This person is not a guest. Invite them as a regular user.');
         });
     });
 

--- a/e2e-tests/cypress/tests/integration/channels/enterprise/guest_accounts/guest_invitation_ui_more_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/enterprise/guest_accounts/guest_invitation_ui_more_spec.ts
@@ -54,7 +54,7 @@ describe('Guest Account - Guest User Invitation Flow', () => {
                 invitePeople(newUser.username, 1, newUser.username);
 
                 // * Verify the content and message in next screen
-                verifyInvitationError(newUser.username, testTeam, 'This person is not a guest. Invite them as a regular user.');
+                verifyInvitationError(newUser.username, testTeam, 'This person is already a member of the workspace. Invite them as a member instead of a guest.');
             });
         });
     });
@@ -83,7 +83,7 @@ describe('Guest Account - Guest User Invitation Flow', () => {
             invitePeople(regularUser.email, 1, regularUser.username);
 
             // * Verify the content and message in next screen
-            verifyInvitationError(regularUser.username, testTeam, 'This person is not a guest. Invite them as a regular user.');
+            verifyInvitationError(regularUser.username, testTeam, 'This person is already a member of the workspace. Invite them as a member instead of a guest.');
         });
     });
 

--- a/e2e-tests/cypress/tests/integration/channels/enterprise/guest_accounts/guest_invitation_ui_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/enterprise/guest_accounts/guest_invitation_ui_spec.ts
@@ -198,7 +198,7 @@ describe('Guest Account - Guest User Invitation Flow', () => {
         invitePeople(newUser.username, 1, newUser.username);
 
         // * Verify the content and message in next screen
-        cy.findByText('This person is already a member.').should('be.visible');
+        cy.findByText('This person is not a guest. Invite them as a regular user.').should('be.visible');
 
         // # Click on invite more button
         cy.findByTestId('invite-more').click();

--- a/e2e-tests/cypress/tests/integration/channels/enterprise/guest_accounts/guest_invitation_ui_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/enterprise/guest_accounts/guest_invitation_ui_spec.ts
@@ -198,7 +198,7 @@ describe('Guest Account - Guest User Invitation Flow', () => {
         invitePeople(newUser.username, 1, newUser.username);
 
         // * Verify the content and message in next screen
-        cy.findByText('This person is not a guest. Invite them as a regular user.').should('be.visible');
+        cy.findByText('This person is already a member of the workspace. Invite them as a member instead of a guest.').should('be.visible');
 
         // # Click on invite more button
         cy.findByTestId('invite-more').click();

--- a/webapp/channels/src/actions/invite_actions.test.ts
+++ b/webapp/channels/src/actions/invite_actions.test.ts
@@ -401,14 +401,14 @@ describe('actions/invite_actions', () => {
                     ],
                     notSent: [
                         {
-                            reason: 'This person is already a member.',
+                            reason: 'This person is not a guest. Invite them as a regular user.',
                             user: {
                                 id: 'user1',
                                 roles: 'system_user',
                             },
                         },
                         {
-                            reason: 'This person is already a member.',
+                            reason: 'This person is not a guest. Invite them as a regular user.',
                             user: {
                                 id: 'other-user',
                                 roles: 'system_user',
@@ -489,14 +489,14 @@ describe('actions/invite_actions', () => {
                     ],
                     notSent: [
                         {
-                            reason: 'This person is already a member.',
+                            reason: 'This person is not a guest. Invite them as a regular user.',
                             user: {
                                 id: 'user1',
                                 roles: 'system_user',
                             },
                         },
                         {
-                            reason: 'This person is already a member.',
+                            reason: 'This person is not a guest. Invite them as a regular user.',
                             user: {
                                 id: 'other-user',
                                 roles: 'system_user',
@@ -520,7 +520,7 @@ describe('actions/invite_actions', () => {
                     sent: [],
                     notSent: [
                         {
-                            reason: 'This person is already a member.',
+                            reason: 'This person is not a guest. Invite them as a regular user.',
                             user: {
                                 id: 'user1',
                                 roles: 'system_user',
@@ -534,7 +534,7 @@ describe('actions/invite_actions', () => {
                             },
                         },
                         {
-                            reason: 'This person is already a member.',
+                            reason: 'This person is not a guest. Invite them as a regular user.',
                             user: {
                                 id: 'other-user',
                                 roles: 'system_user',

--- a/webapp/channels/src/actions/invite_actions.test.ts
+++ b/webapp/channels/src/actions/invite_actions.test.ts
@@ -401,14 +401,14 @@ describe('actions/invite_actions', () => {
                     ],
                     notSent: [
                         {
-                            reason: 'This person is not a guest. Invite them as a regular user.',
+                            reason: 'This person is already a member of the workspace. Invite them as a member instead of a guest.',
                             user: {
                                 id: 'user1',
                                 roles: 'system_user',
                             },
                         },
                         {
-                            reason: 'This person is not a guest. Invite them as a regular user.',
+                            reason: 'This person is already a member of the workspace. Invite them as a member instead of a guest.',
                             user: {
                                 id: 'other-user',
                                 roles: 'system_user',
@@ -489,14 +489,14 @@ describe('actions/invite_actions', () => {
                     ],
                     notSent: [
                         {
-                            reason: 'This person is not a guest. Invite them as a regular user.',
+                            reason: 'This person is already a member of the workspace. Invite them as a member instead of a guest.',
                             user: {
                                 id: 'user1',
                                 roles: 'system_user',
                             },
                         },
                         {
-                            reason: 'This person is not a guest. Invite them as a regular user.',
+                            reason: 'This person is already a member of the workspace. Invite them as a member instead of a guest.',
                             user: {
                                 id: 'other-user',
                                 roles: 'system_user',
@@ -520,7 +520,7 @@ describe('actions/invite_actions', () => {
                     sent: [],
                     notSent: [
                         {
-                            reason: 'This person is not a guest. Invite them as a regular user.',
+                            reason: 'This person is already a member of the workspace. Invite them as a member instead of a guest.',
                             user: {
                                 id: 'user1',
                                 roles: 'system_user',
@@ -534,7 +534,7 @@ describe('actions/invite_actions', () => {
                             },
                         },
                         {
-                            reason: 'This person is not a guest. Invite them as a regular user.',
+                            reason: 'This person is already a member of the workspace. Invite them as a member instead of a guest.',
                             user: {
                                 id: 'other-user',
                                 roles: 'system_user',

--- a/webapp/channels/src/actions/invite_actions.ts
+++ b/webapp/channels/src/actions/invite_actions.ts
@@ -116,7 +116,7 @@ export async function sendGuestInviteForUser(
     members: RelationOneToOne<Channel, Record<string, ChannelMembership>>,
 ) {
     if (!isGuest(user.roles)) {
-        return {notSent: {user, reason: localizeMessage('invite.members.user-is-not-guest', 'This person is already a member.')}};
+        return {notSent: {user, reason: localizeMessage('invite.members.user-is-not-guest', 'This person is not a guest. Invite them as a regular user.')}};
     }
     let memberOfAll = true;
     let memberOfAny = false;

--- a/webapp/channels/src/actions/invite_actions.ts
+++ b/webapp/channels/src/actions/invite_actions.ts
@@ -116,7 +116,7 @@ export async function sendGuestInviteForUser(
     members: RelationOneToOne<Channel, Record<string, ChannelMembership>>,
 ) {
     if (!isGuest(user.roles)) {
-        return {notSent: {user, reason: localizeMessage('invite.members.user-is-not-guest', 'This person is not a guest. Invite them as a regular user.')}};
+        return {notSent: {user, reason: localizeMessage('invite.members.user-is-not-guest', 'This person is already a member of the workspace. Invite them as a member instead of a guest.')}};
     }
     let memberOfAll = true;
     let memberOfAny = false;

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -3939,7 +3939,7 @@
   "invite.members.invite-sent": "An invitation email has been sent.",
   "invite.members.unable-to-add-the-user-to-the-team": "Unable to add the user to the team.",
   "invite.members.user-is-guest": "Contact your admin to make this guest a full member.",
-  "invite.members.user-is-not-guest": "This person is already a member.",
+  "invite.members.user-is-not-guest": "This person is not a guest. Invite them as a regular user.",
   "invite.rate-limit-exceeded": "Invite emails rate limit exceeded.",
   "join_team_group_constrained_denied": "You need to be a member of a linked group to join this team.",
   "join_team_group_constrained_denied_admin": "You need to be a member of a linked group to join this team. You can add a group to this team [here]({siteURL}/admin_console/user_management/groups).",

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -3939,7 +3939,7 @@
   "invite.members.invite-sent": "An invitation email has been sent.",
   "invite.members.unable-to-add-the-user-to-the-team": "Unable to add the user to the team.",
   "invite.members.user-is-guest": "Contact your admin to make this guest a full member.",
-  "invite.members.user-is-not-guest": "This person is not a guest. Invite them as a regular user.",
+  "invite.members.user-is-not-guest": "This person is already a member of the workspace. Invite them as a member instead of a guest.",
   "invite.rate-limit-exceeded": "Invite emails rate limit exceeded.",
   "join_team_group_constrained_denied": "You need to be a member of a linked group to join this team.",
   "join_team_group_constrained_denied_admin": "You need to be a member of a linked group to join this team. You can add a group to this team [here]({siteURL}/admin_console/user_management/groups).",


### PR DESCRIPTION
#### Summary
The error string for when a user is not a guest was wrong. Updated the string to show the correct copy.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-57861

#### Screenshots
![Screenshot from 2024-05-03 12-57-15](https://github.com/mattermost/mattermost/assets/1933730/8bfc18f1-302b-4b50-a26f-e63f6c7dd87e)

#### Release Note
```release-note
Improve error text when inviting guests to a team.
```
