### PR TITLE
MM-52570 Prevent pasteHandler from having any effect when shift is held

### DIFF
--- a/webapp/channels/src/utils/paste.test.tsx
+++ b/webapp/channels/src/utils/paste.test.tsx
@@ -287,6 +287,36 @@ describe('pasteHandler', () => {
             },
             expectedMarkdown: "```\n// a javascript codeblock example\nif (1 > 0) {\n  return 'condition is true';\n}\n```",
         },
+        {
+            testName: 'should paste table as plain text when shift is held',
+            isNonFormattedPaste: true,
+            clipboardData: {
+                items: [1],
+                types: ['text/plain', 'text/html'],
+                getData: (dataType: string) => {
+                    if (dataType === 'text/plain') {
+                        return 'test \ttest\ntest \ttest';
+                    }
+                    return '<table><tr><th>test</th>\n<th>test</th>\n</tr>\n<tr>\n<td>test</td>\n<td>test</td></tr></table>';
+                },
+            },
+            expectedMarkdown: 'test \ttest\ntest \ttest',
+        },
+        {
+            testName: 'should paste github code as plain text when shift is held',
+            isNonFormattedPaste: true,
+            clipboardData: {
+                items: [1],
+                types: ['text/plain', 'text/html'],
+                getData: (type: string) => {
+                    if (type === 'text/plain') {
+                        return '// a javascript codeblock example\nif (1 > 0) {\n  return \'condition is true\';\n}';
+                    }
+                    return '<table class="highlight tab-size js-file-line-container" data-tab-size="8"><tbody><tr><td id="LC1" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">//</span> a javascript codeblock example</span></td></tr><tr><td id="L2" class="blob-num js-line-number" data-line-number="2">&nbsp;</td><td id="LC2" class="blob-code blob-code-inner js-file-line"><span class="pl-k">if</span> (<span class="pl-c1">1</span> <span class="pl-k">&gt;</span> <span class="pl-c1">0</span>) {</td></tr><tr><td id="L3" class="blob-num js-line-number" data-line-number="3">&nbsp;</td><td id="LC3" class="blob-code blob-code-inner js-file-line"><span class="pl-en">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">\'</span>condition is true<span class="pl-pds">\'</span></span>);</td></tr><tr><td id="L4" class="blob-num js-line-number" data-line-number="4">&nbsp;</td><td id="LC4" class="blob-code blob-code-inner js-file-line">}</td></tr></tbody></table>';
+                },
+            },
+            expectedMarkdown: '// a javascript codeblock example\nif (1 > 0) {\n  return \'condition is true\';\n}',
+        },
     ];
 
     for (const tc of testCases) {
@@ -300,9 +330,13 @@ describe('pasteHandler', () => {
                 clipboardData: tc.clipboardData,
             };
 
-            pasteHandler(event, location, '', false, 0);
+            pasteHandler(event, location, '', tc.isNonFormattedPaste ?? false, 0);
 
-            expect(execCommandInsertText).toHaveBeenCalledWith(tc.expectedMarkdown);
+            if (tc.isNonFormattedPaste) {
+                expect(execCommandInsertText).not.toHaveBeenCalled();
+            } else {
+                expect(execCommandInsertText).toHaveBeenCalledWith(tc.expectedMarkdown);
+            }
         });
     }
 });

--- a/webapp/channels/src/utils/paste.tsx
+++ b/webapp/channels/src/utils/paste.tsx
@@ -160,7 +160,7 @@ export function formatMarkdownLinkMessage({message, clipboardData, selectionStar
     return markdownLink;
 }
 
-export function pasteHandler(event: ClipboardEvent, location: string, message: string, isNonFormattedPaste?: boolean, caretPosition?: number) {
+export function pasteHandler(event: ClipboardEvent, location: string, message: string, isNonFormattedPaste: boolean, caretPosition?: number) {
     const {clipboardData, target} = event;
 
     const textboxId = location === Locations.RHS_COMMENT ? 'reply_textbox' : 'post_textbox';
@@ -169,11 +169,15 @@ export function pasteHandler(event: ClipboardEvent, location: string, message: s
         return;
     }
 
+    if (isNonFormattedPaste) {
+        return;
+    }
+
     const {selectionStart, selectionEnd} = target as TextboxElement;
 
     const hasSelection = !isNil(selectionStart) && !isNil(selectionEnd) && selectionStart < selectionEnd;
     const hasTextUrl = isTextUrl(clipboardData);
-    const hasHTMLLinks = !isNonFormattedPaste && hasHtmlLink(clipboardData);
+    const hasHTMLLinks = hasHtmlLink(clipboardData);
     const htmlTable = getHtmlTable(clipboardData);
     const shouldApplyLinkMarkdown = hasSelection && hasTextUrl;
     const shouldApplyGithubCodeBlock = htmlTable && isGitHubCodeBlock(htmlTable.className);


### PR DESCRIPTION
#### Summary
Previously, we made it so that ctrl+shift+v would make it so that text with links would be pasted without the links. Now, we want it to prevent any special formatting.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52570

#### Release Note
```release-note
Ensured that pasting in the post textbox can always paste without formatting
```
