### PR TITLE
Update minimum supported Safari version

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9956,7 +9956,7 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.safari",
-    "translation": "Version 16.2+"
+    "translation": "Version 17.0+"
   },
   {
     "id": "web.error.unsupported_browser.min_os_version.mac",


### PR DESCRIPTION
macOS minimum supported version was recently updated to 12+ https://github.com/mattermost/mattermost/pull/26748 , so I'm updating the Safari version to 17+ https://en.wikipedia.org/wiki/Safari_(web_browser)#History_and_development.

```release-note
Updated minimum Safari version to 17+.
```
