### PR TITLE
avoid segfault in TestDeleteChannelBookmark

### DIFF
--- a/server/channels/api4/channel_bookmark_test.go
+++ b/server/channels/api4/channel_bookmark_test.go
@@ -1310,8 +1310,7 @@ func TestDeleteChannelBookmark(t *testing.T) {
 
 		var b *model.ChannelBookmarkWithFileInfo
 		require.Eventuallyf(t, func() bool {
-			event := <-webSocketClient.EventChannel
-			if event.EventType() == model.WebsocketEventChannelBookmarkDeleted {
+			if event, ok := <-webSocketClient.EventChannel; ok && event.EventType() == model.WebsocketEventChannelBookmarkDeleted {
 				err := json.Unmarshal([]byte(event.GetData()["bookmark"].(string)), &b)
 				require.NoError(t, err)
 				return true


### PR DESCRIPTION
#### Summary
If the websocket is closed before we receive the expected message, this test fails spuriously with a panic. (This doesn't resolve the root cause of why the websocket event doesn't get delivered during some test runs, but pushing this for now to focus the test report.)

#### Ticket Link
None.

#### Screenshots
None.

#### Release Note
```release-note
NONE
```
