### PR TITLE
Kaoski/MM-56819 mmctl user preference local mode support

### DIFF
--- a/api/v4/source/bots.yaml
+++ b/api/v4/source/bots.yaml
@@ -60,8 +60,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of users per page. There is a maximum limit of 200 users
-            per page.
+          description: The number of users per page.
           schema:
             type: integer
             default: 60

--- a/api/v4/source/channels.yaml
+++ b/api/v4/source/channels.yaml
@@ -1307,7 +1307,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of members per page. There is a maximum limit of 200 members.
+          description: The number of members per page.
           schema:
             type: integer
             default: 60

--- a/api/v4/source/dataretention.yaml
+++ b/api/v4/source/dataretention.yaml
@@ -93,7 +93,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of policies per page. There is a maximum limit of 200 per page.
+          description: The number of policies per page.
           schema:
             type: integer
             default: 60
@@ -301,7 +301,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of teams per page. There is a maximum limit of 200 per page.
+          description: The number of teams per page.
           schema:
             type: integer
             default: 60
@@ -495,7 +495,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of channels per page. There is a maximum limit of 200 per page.
+          description: The number of channels per page.
           schema:
             type: integer
             default: 60

--- a/api/v4/source/introduction.yaml
+++ b/api/v4/source/introduction.yaml
@@ -49,6 +49,9 @@ tags:
 
 
       When using endpoints that require a user id, the string `me` can be used in place of the user id to indicate the action is to be taken for the logged in user.
+
+
+      For all endpoints that implement pagination via the `per_page` parameter, the maximum number of items returned per request is capped at 200. If `per_page` exceeds 200, the list will be silently truncated to 200 items.
   - name: drivers
     description: >
       The easiest way to interact with the Mattermost Web Service API is through

--- a/api/v4/source/ldap.yaml
+++ b/api/v4/source/ldap.yaml
@@ -71,7 +71,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of users per page. There is a maximum limit of 200 users
+          description: The number of users per page.
             per page.
           schema:
             type: integer

--- a/api/v4/source/users.yaml
+++ b/api/v4/source/users.yaml
@@ -195,8 +195,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of users per page. There is a maximum limit of 200 users
-            per page.
+          description: The number of users per page.
           schema:
             type: integer
             default: 60
@@ -3140,7 +3139,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of policies per page. There is a maximum limit of 200 per page.
+          description: The number of policies per page.
           schema:
             type: integer
             default: 60
@@ -3190,7 +3189,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of policies per page. There is a maximum limit of 200 per page.
+          description: The number of policies per page.
           schema:
             type: integer
             default: 60
@@ -3233,8 +3232,7 @@
             default: 0
         - name: per_page
           in: query
-          description: The number of users per page. There is a maximum limit of 200 users
-            per page.
+          description: The number of users per page.
           schema:
             type: integer
             default: 60

--- a/server/channels/api4/api.go
+++ b/server/channels/api4/api.go
@@ -390,6 +390,7 @@ func InitLocal(srv *app.Server) *API {
 
 	api.BaseRoutes.LDAP = api.BaseRoutes.APIRoot.PathPrefix("/ldap").Subrouter()
 	api.BaseRoutes.System = api.BaseRoutes.APIRoot.PathPrefix("/system").Subrouter()
+	api.BaseRoutes.Preferences = api.BaseRoutes.User.PathPrefix("/preferences").Subrouter()
 	api.BaseRoutes.Posts = api.BaseRoutes.APIRoot.PathPrefix("/posts").Subrouter()
 	api.BaseRoutes.Post = api.BaseRoutes.Posts.PathPrefix("/{post_id:[A-Za-z0-9]+}").Subrouter()
 	api.BaseRoutes.PostsForChannel = api.BaseRoutes.Channel.PathPrefix("/posts").Subrouter()
@@ -420,6 +421,7 @@ func InitLocal(srv *app.Server) *API {
 	api.InitLdapLocal()
 	api.InitSystemLocal()
 	api.InitPostLocal()
+	api.InitPreferenceLocal()
 	api.InitRoleLocal()
 	api.InitUploadLocal()
 	api.InitImportLocal()

--- a/server/channels/api4/preference_local.go
+++ b/server/channels/api4/preference_local.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package api4
+
+func (api *API) InitPreferenceLocal() {
+	api.BaseRoutes.Preferences.Handle("", api.APILocal(getPreferences)).Methods("GET")
+	api.BaseRoutes.Preferences.Handle("", api.APILocal(updatePreferences)).Methods("PUT")
+	api.BaseRoutes.Preferences.Handle("/delete", api.APILocal(deletePreferences)).Methods("POST")
+	api.BaseRoutes.Preferences.Handle("/{category:[A-Za-z0-9_]+}", api.APILocal(getPreferencesByCategory)).Methods("GET")
+	api.BaseRoutes.Preferences.Handle("/{category:[A-Za-z0-9_]+}/name/{preference_name:[A-Za-z0-9_]+}", api.APILocal(getPreferenceByCategoryAndName)).Methods("GET")
+}

--- a/server/channels/api4/preference_test.go
+++ b/server/channels/api4/preference_test.go
@@ -74,6 +74,14 @@ func TestGetPreferences(t *testing.T) {
 	_, resp, err = client.GetPreferences(context.Background(), th.BasicUser2.Id)
 	require.Error(t, err)
 	CheckUnauthorizedStatus(t, resp)
+
+	//GetPreferences API from System Admin and Local Client
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, c *model.Client4) {
+		prefs, resp, err := c.GetPreferences(context.Background(), user1.Id)
+		require.NotNil(t, prefs)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+	})
 }
 
 func TestGetPreferencesByCategory(t *testing.T) {
@@ -134,6 +142,14 @@ func TestGetPreferencesByCategory(t *testing.T) {
 	_, resp, err = client.GetPreferencesByCategory(context.Background(), th.BasicUser2.Id, category)
 	require.Error(t, err)
 	CheckUnauthorizedStatus(t, resp)
+
+	//GetPreferencesByCategory API from System Admin and Local Client
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, c *model.Client4) {
+		prefs, resp, err := c.GetPreferencesByCategory(context.Background(), user1.Id, category)
+		require.NotNil(t, prefs)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+	})
 }
 
 func TestGetPreferenceByCategoryAndName(t *testing.T) {
@@ -192,6 +208,14 @@ func TestGetPreferenceByCategoryAndName(t *testing.T) {
 	_, resp, err = client.GetPreferenceByCategoryAndName(context.Background(), user.Id, preferences[0].Category, preferences[0].Name)
 	require.Error(t, err)
 	CheckUnauthorizedStatus(t, resp)
+
+	//GetPreferenceByCategoryAndName API from System Admin and Local Client
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, c *model.Client4) {
+		pref, resp, err := c.GetPreferenceByCategoryAndName(context.Background(), user.Id, preferences[0].Category, preferences[0].Name)
+		require.NotNil(t, pref)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+	})
 }
 
 func TestUpdatePreferences(t *testing.T) {
@@ -255,6 +279,21 @@ func TestUpdatePreferences(t *testing.T) {
 	resp, err = client.UpdatePreferences(context.Background(), user1.Id, preferences1)
 	require.Error(t, err)
 	CheckUnauthorizedStatus(t, resp)
+
+	//UpdatePreferences API from System Admin and Local Client
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, c *model.Client4) {
+		preferences := model.Preferences{
+			{
+				UserId:   user1.Id,
+				Category: category,
+				Name:     model.NewId(),
+				Value:    "true",
+			},
+		}
+		resp, err := c.UpdatePreferences(context.Background(), user1.Id, preferences)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+	})
 }
 
 func TestUpdatePreferencesOverload(t *testing.T) {
@@ -623,6 +662,28 @@ func TestDeletePreferences(t *testing.T) {
 	resp, err = client.DeletePreferences(context.Background(), th.BasicUser.Id, preferences)
 	require.Error(t, err)
 	CheckUnauthorizedStatus(t, resp)
+
+	//DeletePreferences API from System Admin and Local Client
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, c *model.Client4) {
+
+		//Creating Test Data
+		var preferences model.Preferences
+		preference := model.Preference{
+			UserId:   th.BasicUser.Id,
+			Category: model.PreferenceCategoryCustomStatus,
+			Name:     model.NewId(),
+			Value:    "true",
+		}
+		preferences = append(preferences, preference)
+		c.UpdatePreferences(context.Background(), th.BasicUser.Id, preferences)
+
+		//Delete Prefrerences Operation
+		resp, err = c.DeletePreferences(context.Background(), th.BasicUser.Id, preferences)
+
+		//Validations
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+	})
 }
 
 func TestDeletePreferencesOverload(t *testing.T) {


### PR DESCRIPTION
#### Summary
This commit introduces support for --local mode in MMCTL for managing user preferences. The following changes have been added:
1. API endpoints for user preferences are registered with the local router.
2. Test cases have been added to ensure functionality for both System Admins and --local mode.


**Note**: As there is no authentication/authorization required in --local mode, @mattermod suggested omitting session checks from the API handlers. But we are already bypassing session checks for local mode requests as detailed [here](https://github.com/mattermost/mattermost/blob/master/server/channels/app/authorization.go#L205). Hence, I have retained the existing session checks in place.

#### Ticket Link
Github Issue: https://github.com/mattermost/mattermost/issues/26864 
Jira Ticket: https://mattermost.atlassian.net/browse/MM-56819

#### Release Note
1. Added --local mode support in MMCTL to handle user preferences.
