### PR TITLE
[MM-57711] Convert ./components/latex_inline/latex_inline.tsx from Class Component to Function Component

### DIFF
--- a/webapp/channels/src/components/latex_inline/__snapshots__/latex_inline.test.tsx.snap
+++ b/webapp/channels/src/components/latex_inline/__snapshots__/latex_inline.test.tsx.snap
@@ -1,31 +1,502 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/LatexBlock error in katex 1`] = `
+exports[`components/LatexInline error in katex 1`] = `
 <span
-  className="post-body--code inline-tex"
-  dangerouslySetInnerHTML={
-    Object {
-      "__html": "<span class=\\"katex-error\\" title=\\"ParseError: KaTeX parse error: Expected &#x27;}&#x27;, got &#x27;EOF&#x27; at end of input: e^{i\\\\pi + 1 = 0\\" style=\\"color:#cc0000\\">e^{i\\\\pi + 1 = 0</span>",
-    }
-  }
-/>
-`;
-
-exports[`components/LatexBlock latex is disabled 1`] = `
-<span
-  className="post-body--code inline-tex"
+  class="post-body--code inline-tex"
+  data-testid="latex-enabled"
 >
-  $e^{i\\pi} + 1 = 0$
+  <span
+    class="katex-error"
+    style="color:#cc0000"
+    title="ParseError: KaTeX parse error: Expected '}', got 'EOF' at end of input: …i\\\\pi + 1 = 0\`\`\`"
+  >
+    \`\`\`latex e^{i\\pi + 1 = 0\`\`\`
+  </span>
 </span>
 `;
 
-exports[`components/LatexBlock should match snapshot 1`] = `
+exports[`components/LatexInline latex is disabled 1`] = `
 <span
-  className="post-body--code inline-tex"
-  dangerouslySetInnerHTML={
-    Object {
-      "__html": "<span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\"><semantics><mrow><msup><mi>e</mi><mrow><mi>i</mi><mi>π</mi></mrow></msup><mo>+</mo><mn>1</mn><mo>=</mo><mn>0</mn></mrow><annotation encoding=\\"application/x-tex\\">e^{i\\\\pi} + 1 = 0</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.908em;vertical-align:-0.0833em;\\"></span><span class=\\"mord\\"><span class=\\"mord mathnormal\\">e</span><span class=\\"msupsub\\"><span class=\\"vlist-t\\"><span class=\\"vlist-r\\"><span class=\\"vlist\\" style=\\"height:0.8247em;\\"><span style=\\"top:-3.063em;margin-right:0.05em;\\"><span class=\\"pstrut\\" style=\\"height:2.7em;\\"></span><span class=\\"sizing reset-size6 size3 mtight\\"><span class=\\"mord mtight\\"><span class=\\"mord mathnormal mtight\\" style=\\"margin-right:0.03588em;\\">iπ</span></span></span></span></span></span></span></span></span><span class=\\"mspace\\" style=\\"margin-right:0.2222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.6444em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.6444em;\\"></span><span class=\\"mord\\">0</span></span></span></span>",
-    }
-  }
-/>
+  class="post-body--code inline-tex"
+  data-testid="latex-enabled"
+>
+  <span
+    class="katex"
+  >
+    <span
+      class="katex-mathml"
+    >
+      <math
+        xmlns="http://www.w3.org/1998/Math/MathML"
+      >
+        <semantics>
+          <mrow>
+            <mi
+              mathvariant="normal"
+            >
+              ‘
+            </mi>
+            <mi
+              mathvariant="normal"
+            >
+              ‘
+            </mi>
+            <mi
+              mathvariant="normal"
+            >
+              ‘
+            </mi>
+            <mi>
+              l
+            </mi>
+            <mi>
+              a
+            </mi>
+            <mi>
+              t
+            </mi>
+            <mi>
+              e
+            </mi>
+            <mi>
+              x
+            </mi>
+            <msup>
+              <mi>
+                e
+              </mi>
+              <mrow>
+                <mi>
+                  i
+                </mi>
+                <mi>
+                  π
+                </mi>
+              </mrow>
+            </msup>
+            <mo>
+              +
+            </mo>
+            <mn>
+              1
+            </mn>
+            <mo>
+              =
+            </mo>
+            <mn>
+              0
+            </mn>
+            <mi
+              mathvariant="normal"
+            >
+              ‘
+            </mi>
+            <mi
+              mathvariant="normal"
+            >
+              ‘
+            </mi>
+            <mi
+              mathvariant="normal"
+            >
+              ‘
+            </mi>
+          </mrow>
+          <annotation
+            encoding="application/x-tex"
+          >
+            \`\`\`latex e^{i\\pi} + 1 = 0\`\`\`
+          </annotation>
+        </semantics>
+      </math>
+    </span>
+    <span
+      aria-hidden="true"
+      class="katex-html"
+    >
+      <span
+        class="base"
+      >
+        <span
+          class="strut"
+          style="height:0.908em;vertical-align:-0.0833em;"
+        />
+        <span
+          class="mord"
+        >
+          ‘‘‘
+        </span>
+        <span
+          class="mord mathnormal"
+          style="margin-right:0.01968em;"
+        >
+          l
+        </span>
+        <span
+          class="mord mathnormal"
+        >
+          a
+        </span>
+        <span
+          class="mord mathnormal"
+        >
+          t
+        </span>
+        <span
+          class="mord mathnormal"
+        >
+          e
+        </span>
+        <span
+          class="mord mathnormal"
+        >
+          x
+        </span>
+        <span
+          class="mord"
+        >
+          <span
+            class="mord mathnormal"
+          >
+            e
+          </span>
+          <span
+            class="msupsub"
+          >
+            <span
+              class="vlist-t"
+            >
+              <span
+                class="vlist-r"
+              >
+                <span
+                  class="vlist"
+                  style="height:0.8247em;"
+                >
+                  <span
+                    style="top:-3.063em;margin-right:0.05em;"
+                  >
+                    <span
+                      class="pstrut"
+                      style="height:2.7em;"
+                    />
+                    <span
+                      class="sizing reset-size6 size3 mtight"
+                    >
+                      <span
+                        class="mord mtight"
+                      >
+                        <span
+                          class="mord mathnormal mtight"
+                          style="margin-right:0.03588em;"
+                        >
+                          iπ
+                        </span>
+                      </span>
+                    </span>
+                  </span>
+                </span>
+              </span>
+            </span>
+          </span>
+        </span>
+        <span
+          class="mspace"
+          style="margin-right:0.2222em;"
+        />
+        <span
+          class="mbin"
+        >
+          +
+        </span>
+        <span
+          class="mspace"
+          style="margin-right:0.2222em;"
+        />
+      </span>
+      <span
+        class="base"
+      >
+        <span
+          class="strut"
+          style="height:0.6444em;"
+        />
+        <span
+          class="mord"
+        >
+          1
+        </span>
+        <span
+          class="mspace"
+          style="margin-right:0.2778em;"
+        />
+        <span
+          class="mrel"
+        >
+          =
+        </span>
+        <span
+          class="mspace"
+          style="margin-right:0.2778em;"
+        />
+      </span>
+      <span
+        class="base"
+      >
+        <span
+          class="strut"
+          style="height:0.6944em;"
+        />
+        <span
+          class="mord"
+        >
+          0‘‘‘
+        </span>
+      </span>
+    </span>
+  </span>
+</span>
+`;
+
+exports[`components/LatexInline should match snapshot 1`] = `
+<span
+  class="post-body--code inline-tex"
+  data-testid="latex-enabled"
+>
+  <span
+    class="katex"
+  >
+    <span
+      class="katex-mathml"
+    >
+      <math
+        xmlns="http://www.w3.org/1998/Math/MathML"
+      >
+        <semantics>
+          <mrow>
+            <mi
+              mathvariant="normal"
+            >
+              ‘
+            </mi>
+            <mi
+              mathvariant="normal"
+            >
+              ‘
+            </mi>
+            <mi
+              mathvariant="normal"
+            >
+              ‘
+            </mi>
+            <mi>
+              l
+            </mi>
+            <mi>
+              a
+            </mi>
+            <mi>
+              t
+            </mi>
+            <mi>
+              e
+            </mi>
+            <mi>
+              x
+            </mi>
+            <msup>
+              <mi>
+                e
+              </mi>
+              <mrow>
+                <mi>
+                  i
+                </mi>
+                <mi>
+                  π
+                </mi>
+              </mrow>
+            </msup>
+            <mo>
+              +
+            </mo>
+            <mn>
+              1
+            </mn>
+            <mo>
+              =
+            </mo>
+            <mn>
+              0
+            </mn>
+            <mi
+              mathvariant="normal"
+            >
+              ‘
+            </mi>
+            <mi
+              mathvariant="normal"
+            >
+              ‘
+            </mi>
+            <mi
+              mathvariant="normal"
+            >
+              ‘
+            </mi>
+          </mrow>
+          <annotation
+            encoding="application/x-tex"
+          >
+            \`\`\`latex e^{i\\pi} + 1 = 0\`\`\`
+          </annotation>
+        </semantics>
+      </math>
+    </span>
+    <span
+      aria-hidden="true"
+      class="katex-html"
+    >
+      <span
+        class="base"
+      >
+        <span
+          class="strut"
+          style="height:0.908em;vertical-align:-0.0833em;"
+        />
+        <span
+          class="mord"
+        >
+          ‘‘‘
+        </span>
+        <span
+          class="mord mathnormal"
+          style="margin-right:0.01968em;"
+        >
+          l
+        </span>
+        <span
+          class="mord mathnormal"
+        >
+          a
+        </span>
+        <span
+          class="mord mathnormal"
+        >
+          t
+        </span>
+        <span
+          class="mord mathnormal"
+        >
+          e
+        </span>
+        <span
+          class="mord mathnormal"
+        >
+          x
+        </span>
+        <span
+          class="mord"
+        >
+          <span
+            class="mord mathnormal"
+          >
+            e
+          </span>
+          <span
+            class="msupsub"
+          >
+            <span
+              class="vlist-t"
+            >
+              <span
+                class="vlist-r"
+              >
+                <span
+                  class="vlist"
+                  style="height:0.8247em;"
+                >
+                  <span
+                    style="top:-3.063em;margin-right:0.05em;"
+                  >
+                    <span
+                      class="pstrut"
+                      style="height:2.7em;"
+                    />
+                    <span
+                      class="sizing reset-size6 size3 mtight"
+                    >
+                      <span
+                        class="mord mtight"
+                      >
+                        <span
+                          class="mord mathnormal mtight"
+                          style="margin-right:0.03588em;"
+                        >
+                          iπ
+                        </span>
+                      </span>
+                    </span>
+                  </span>
+                </span>
+              </span>
+            </span>
+          </span>
+        </span>
+        <span
+          class="mspace"
+          style="margin-right:0.2222em;"
+        />
+        <span
+          class="mbin"
+        >
+          +
+        </span>
+        <span
+          class="mspace"
+          style="margin-right:0.2222em;"
+        />
+      </span>
+      <span
+        class="base"
+      >
+        <span
+          class="strut"
+          style="height:0.6444em;"
+        />
+        <span
+          class="mord"
+        >
+          1
+        </span>
+        <span
+          class="mspace"
+          style="margin-right:0.2778em;"
+        />
+        <span
+          class="mrel"
+        >
+          =
+        </span>
+        <span
+          class="mspace"
+          style="margin-right:0.2778em;"
+        />
+      </span>
+      <span
+        class="base"
+      >
+        <span
+          class="strut"
+          style="height:0.6944em;"
+        />
+        <span
+          class="mord"
+        >
+          0‘‘‘
+        </span>
+      </span>
+    </span>
+  </span>
+</span>
 `;

--- a/webapp/channels/src/components/latex_inline/latex_inline.test.tsx
+++ b/webapp/channels/src/components/latex_inline/latex_inline.test.tsx
@@ -27,7 +27,7 @@ describe('components/LatexInline', () => {
             enableInlineLatex: false,
         };
 
-        render(<LatexInline {...defaultProps}/>);
+        render(<LatexInline {...props}/>);
         const wrapper = await screen.findAllByTestId('latex-disabled');
         expect(wrapper.length).toBe(1);
         expect(wrapper.at(0)).toMatchSnapshot();

--- a/webapp/channels/src/components/latex_inline/latex_inline.test.tsx
+++ b/webapp/channels/src/components/latex_inline/latex_inline.test.tsx
@@ -1,20 +1,24 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import { shallow } from 'enzyme';
+import {render, screen} from '@testing-library/react';
 import React from 'react';
 
 import LatexInline from 'components/latex_inline/latex_inline';
 
+import {withIntl} from 'tests/helpers/intl-test-helper';
+
 describe('components/LatexInline', () => {
     const defaultProps = {
-        content: 'e^{i\\pi} + 1 = 0',
+        content: '```latex e^{i\\pi} + 1 = 0```',
         enableInlineLatex: true,
     };
 
     test('should match snapshot', async () => {
-        const wrapper = shallow(<LatexInline {...defaultProps} />);
-        expect(wrapper).toMatchSnapshot();
+        render(<LatexInline {...defaultProps}/>);
+        const wrapper = await screen.findAllByTestId('latex-enabled');
+        expect(wrapper.length).toBe(1);
+        expect(wrapper.at(0)).toMatchSnapshot();
     });
 
     test('latex is disabled', async () => {
@@ -23,17 +27,21 @@ describe('components/LatexInline', () => {
             enableInlineLatex: false,
         };
 
-        const wrapper = shallow(<LatexInline {...props} />);
-        expect(wrapper).toMatchSnapshot();
+        render(<LatexInline {...defaultProps}/>);
+        const wrapper = await screen.findAllByTestId('latex-disabled');
+        expect(wrapper.length).toBe(1);
+        expect(wrapper.at(0)).toMatchSnapshot();
     });
 
     test('error in katex', async () => {
         const props = {
-            content: 'e^{i\\pi + 1 = 0',
+            content: '```latex e^{i\\pi + 1 = 0```',
             enableInlineLatex: true,
         };
 
-        const wrapper = shallow(<LatexInline {...props} />);
-        expect(wrapper).toMatchSnapshot();
+        render(withIntl(<LatexInline {...props}/>));
+        const wrapper = await screen.findAllByTestId('latex-enabled');
+        expect(wrapper.length).toBe(1);
+        expect(wrapper.at(0)).toMatchSnapshot();
     });
 });

--- a/webapp/channels/src/components/latex_inline/latex_inline.test.tsx
+++ b/webapp/channels/src/components/latex_inline/latex_inline.test.tsx
@@ -1,20 +1,19 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {shallow} from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 
 import LatexInline from 'components/latex_inline/latex_inline';
 
-describe('components/LatexBlock', () => {
+describe('components/LatexInline', () => {
     const defaultProps = {
         content: 'e^{i\\pi} + 1 = 0',
         enableInlineLatex: true,
     };
 
     test('should match snapshot', async () => {
-        const wrapper = shallow(<LatexInline {...defaultProps}/>);
-        await import('katex'); //manually import katex
+        const wrapper = shallow(<LatexInline {...defaultProps} />);
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -24,8 +23,7 @@ describe('components/LatexBlock', () => {
             enableInlineLatex: false,
         };
 
-        const wrapper = shallow(<LatexInline {...props}/>);
-        await import('katex'); //manually import katex
+        const wrapper = shallow(<LatexInline {...props} />);
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -35,8 +33,7 @@ describe('components/LatexBlock', () => {
             enableInlineLatex: true,
         };
 
-        const wrapper = shallow(<LatexInline {...props}/>);
-        await import('katex'); //manually import katex
+        const wrapper = shallow(<LatexInline {...props} />);
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/webapp/channels/src/components/latex_inline/latex_inline.tsx
+++ b/webapp/channels/src/components/latex_inline/latex_inline.tsx
@@ -1,11 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-
-import type { KatexOptions } from 'katex';
-import { flatMap } from 'lodash';
-import React, { useEffect, useState } from 'react';
-import { FormattedMessage } from 'react-intl';
+import type {KatexOptions} from 'katex';
+import {flatMap} from 'lodash';
+import React, {useEffect, useState} from 'react';
+import {FormattedMessage} from 'react-intl';
 
 type Katex = typeof import('katex');
 
@@ -51,7 +50,7 @@ const LatexInline = ({
         return (
             <span
                 className='post-body--code inline-tex'
-                dangerouslySetInnerHTML={{ __html: html }}
+                dangerouslySetInnerHTML={{__html: html}}
                 data-testid='latex-enabled'
             />
         );
@@ -68,7 +67,6 @@ const LatexInline = ({
             </span>
         );
     }
-
-}
+};
 
 export default React.memo(LatexInline);

--- a/webapp/channels/src/components/latex_inline/latex_inline.tsx
+++ b/webapp/channels/src/components/latex_inline/latex_inline.tsx
@@ -3,6 +3,7 @@
 
 
 import type { KatexOptions } from 'katex';
+import { flatMap } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
@@ -17,7 +18,7 @@ const LatexInline = ({
     content,
     enableInlineLatex,
 }: Props) => {
-    const [katex, setKatex] = useState<Katex | undefined>(undefined);
+    const [katex, setKatex] = useState<Katex | undefined>();
 
     useEffect(() => {
         import('katex').then((katex) => {
@@ -29,6 +30,7 @@ const LatexInline = ({
         return (
             <span
                 className='post-body--code inline-tex'
+                data-testid='latex-disabled'
             >
                 {'$' + content + '$'}
             </span>
@@ -50,12 +52,14 @@ const LatexInline = ({
             <span
                 className='post-body--code inline-tex'
                 dangerouslySetInnerHTML={{ __html: html }}
+                data-testid='latex-enabled'
             />
         );
     } catch (e) {
         return (
             <span
                 className='post-body--code inline-tex'
+                data-testid='latex-error'
             >
                 <FormattedMessage
                     id='katex.error'

--- a/webapp/channels/src/components/latex_inline/latex_inline.tsx
+++ b/webapp/channels/src/components/latex_inline/latex_inline.tsx
@@ -13,7 +13,10 @@ type Props = {
     enableInlineLatex: boolean;
 };
 
-const LatexInline = ({ content, enableInlineLatex }: Props) => {
+const LatexInline = ({
+    content,
+    enableInlineLatex,
+}: Props) => {
     const [katex, setKatex] = useState<Katex | undefined>(undefined);
 
     useEffect(() => {
@@ -24,7 +27,6 @@ const LatexInline = ({ content, enableInlineLatex }: Props) => {
 
     if (!enableInlineLatex || katex === undefined) {
         return (
-            // returns latex code as plain test wrapped in $
             <span
                 className='post-body--code inline-tex'
             >

--- a/webapp/channels/src/components/latex_inline/latex_inline.tsx
+++ b/webapp/channels/src/components/latex_inline/latex_inline.tsx
@@ -1,9 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {KatexOptions} from 'katex';
-import React from 'react';
-import {FormattedMessage} from 'react-intl';
+
+import type { KatexOptions } from 'katex';
+import React, { useEffect, useState } from 'react';
+import { FormattedMessage } from 'react-intl';
 
 type Katex = typeof import('katex');
 
@@ -12,64 +13,56 @@ type Props = {
     enableInlineLatex: boolean;
 };
 
-type State = {
-    katex?: Katex;
-}
+const LatexInline = ({ content, enableInlineLatex }: Props) => {
+    const [katex, setKatex] = useState<Katex | undefined>(undefined);
 
-export default class LatexInline extends React.PureComponent<Props, State> {
-    constructor(props: Props) {
-        super(props);
-
-        this.state = {
-            katex: undefined,
-        };
-    }
-
-    componentDidMount(): void {
+    useEffect(() => {
         import('katex').then((katex) => {
-            this.setState({katex: katex.default});
+            setKatex(katex.default);
         });
+    }, []);
+
+    if (!enableInlineLatex || katex === undefined) {
+        return (
+            // returns latex code as plain test wrapped in $
+            <span
+                className='post-body--code inline-tex'
+            >
+                {'$' + content + '$'}
+            </span>
+        );
     }
 
-    render(): React.ReactNode {
-        if (!this.props.enableInlineLatex || this.state.katex === undefined) {
-            return (
-                <span
-                    className='post-body--code inline-tex'
-                >
-                    {'$' + this.props.content + '$'}
-                </span>
-            );
-        }
+    try {
+        const katexOptions: KatexOptions = {
+            throwOnError: false,
+            displayMode: false,
+            maxSize: 200,
+            maxExpand: 100,
+            fleqn: true,
+        };
 
-        try {
-            const katexOptions: KatexOptions = {
-                throwOnError: false,
-                displayMode: false,
-                maxSize: 200,
-                maxExpand: 100,
-                fleqn: true,
-            };
+        const html = katex.renderToString(content, katexOptions);
 
-            const html = this.state.katex.renderToString(this.props.content, katexOptions);
-
-            return (
-                <span
-                    className='post-body--code inline-tex'
-                    dangerouslySetInnerHTML={{__html: html}}
+        return (
+            <span
+                className='post-body--code inline-tex'
+                dangerouslySetInnerHTML={{ __html: html }}
+            />
+        );
+    } catch (e) {
+        return (
+            <span
+                className='post-body--code inline-tex'
+            >
+                <FormattedMessage
+                    id='katex.error'
+                    defaultMessage="Couldn't compile your Latex code. Please review the syntax and try again."
                 />
-            );
-        } catch (e) {
-            return (
-                <span
-                    className='post-body--code inline-tex'
-                >
-                    <FormattedMessage
-                        id='katex.error'
-                        defaultMessage="Couldn't compile your Latex code. Please review the syntax and try again."
-                    />
-                </span>
-            );
-        }
+            </span>
+        );
     }
+
 }
+
+export default React.memo(LatexInline);


### PR DESCRIPTION
#### Summary

Migrated latex_inline.tsx from Class Component to Function Component.

QA Test Steps: 
Paste: e^{i\\pi} + 1 = 0 wrapped by $ into the textarea. The latex inline component will render.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/26679
Jira https://mattermost.atlassian.net/browse/MM-57711

#### Release Note

None
