### PR TITLE
[MM-58159] Add admin setting for notification monitoring alongside feature flag

### DIFF
--- a/server/channels/app/notification.go
+++ b/server/channels/app/notification.go
@@ -1740,7 +1740,7 @@ func (a *App) CountNotification(notificationType model.NotificationType) {
 		return
 	}
 
-	if !a.Config().FeatureFlags.NotificationMonitoring {
+	if !(a.Config().FeatureFlags.NotificationMonitoring && *a.Config().MetricsSettings.EnableNotificationMetrics) {
 		return
 	}
 
@@ -1752,7 +1752,7 @@ func (a *App) CountNotificationAck(notificationType model.NotificationType) {
 		return
 	}
 
-	if !a.Config().FeatureFlags.NotificationMonitoring {
+	if !(a.Config().FeatureFlags.NotificationMonitoring && *a.Config().MetricsSettings.EnableNotificationMetrics) {
 		return
 	}
 
@@ -1768,7 +1768,7 @@ func (a *App) CountNotificationReason(
 		return
 	}
 
-	if !a.Config().FeatureFlags.NotificationMonitoring {
+	if !(a.Config().FeatureFlags.NotificationMonitoring && *a.Config().MetricsSettings.EnableNotificationMetrics) {
 		return
 	}
 

--- a/server/channels/app/notification.go
+++ b/server/channels/app/notification.go
@@ -1736,11 +1736,7 @@ func ShouldAckWebsocketNotification(channelType model.ChannelType, userNotificat
 }
 
 func (a *App) CountNotification(notificationType model.NotificationType) {
-	if a.Metrics() == nil {
-		return
-	}
-
-	if !(a.Config().FeatureFlags.NotificationMonitoring && *a.Config().MetricsSettings.EnableNotificationMetrics) {
+	if a.notificationMetricsDisabled() {
 		return
 	}
 
@@ -1748,11 +1744,7 @@ func (a *App) CountNotification(notificationType model.NotificationType) {
 }
 
 func (a *App) CountNotificationAck(notificationType model.NotificationType) {
-	if a.Metrics() == nil {
-		return
-	}
-
-	if !(a.Config().FeatureFlags.NotificationMonitoring && *a.Config().MetricsSettings.EnableNotificationMetrics) {
+	if a.notificationMetricsDisabled() {
 		return
 	}
 
@@ -1764,11 +1756,7 @@ func (a *App) CountNotificationReason(
 	notificationType model.NotificationType,
 	notificationReason model.NotificationReason,
 ) {
-	if a.Metrics() == nil {
-		return
-	}
-
-	if !(a.Config().FeatureFlags.NotificationMonitoring && *a.Config().MetricsSettings.EnableNotificationMetrics) {
+	if a.notificationMetricsDisabled() {
 		return
 	}
 
@@ -1782,4 +1770,16 @@ func (a *App) CountNotificationReason(
 	case model.NotificationStatusUnsupported:
 		a.Metrics().IncrementNotificationUnsupportedCounter(notificationType, notificationReason)
 	}
+}
+
+func (a *App) notificationMetricsDisabled() bool {
+	if a.Metrics() == nil {
+		return true
+	}
+
+	if a.Config().FeatureFlags.NotificationMonitoring && *a.Config().MetricsSettings.EnableNotificationMetrics {
+		return false
+	}
+
+	return true
 }

--- a/server/channels/app/web_broadcast_hooks.go
+++ b/server/channels/app/web_broadcast_hooks.go
@@ -135,7 +135,7 @@ func incrementWebsocketCounter(wc *platform.WebConn) {
 		return
 	}
 
-	if !wc.Platform.Config().FeatureFlags.NotificationMonitoring {
+	if !(wc.Platform.Config().FeatureFlags.NotificationMonitoring && *wc.Platform.Config().MetricsSettings.EnableNotificationMetrics) {
 		return
 	}
 

--- a/server/config/client.go
+++ b/server/config/client.go
@@ -188,6 +188,7 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 		if *license.Features.Cluster {
 			props["EnableMetrics"] = strconv.FormatBool(*c.MetricsSettings.Enable)
 			props["EnableClientMetrics"] = strconv.FormatBool(c.FeatureFlags.ClientMetrics && *c.MetricsSettings.EnableClientMetrics)
+			props["EnableNotificationMetrics"] = strconv.FormatBool(c.FeatureFlags.NotificationMonitoring && *c.MetricsSettings.EnableNotificationMetrics)
 		}
 
 		if *license.Features.Announcement {

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -980,10 +980,11 @@ func (s *ClusterSettings) SetDefaults() {
 }
 
 type MetricsSettings struct {
-	Enable              *bool   `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"`
-	BlockProfileRate    *int    `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"`
-	ListenAddress       *string `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"` // telemetry: none
-	EnableClientMetrics *bool   `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"`
+	Enable                    *bool   `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"`
+	BlockProfileRate          *int    `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"`
+	ListenAddress             *string `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"` // telemetry: none
+	EnableClientMetrics       *bool   `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"`
+	EnableNotificationMetrics *bool   `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"`
 }
 
 func (s *MetricsSettings) SetDefaults() {
@@ -1001,6 +1002,10 @@ func (s *MetricsSettings) SetDefaults() {
 
 	if s.EnableClientMetrics == nil {
 		s.EnableClientMetrics = NewBool(true)
+	}
+
+	if s.EnableNotificationMetrics == nil {
+		s.EnableNotificationMetrics = NewBool(true)
 	}
 }
 

--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -2376,6 +2376,16 @@ const AdminDefinition: AdminDefinitionType = {
                             isHidden: it.not(it.licensedForFeature('IDLoadedPushNotifications')),
                             isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.SITE.NOTIFICATIONS)),
                         },
+                        {
+                            type: 'bool',
+                            key: 'MetricsSettings.EnableNotificationMetrics',
+                            label: defineMessage({id: 'admin.metrics.enableNotificationMetricsTitle', defaultMessage: 'Enable Notification Monitoring:'}),
+                            help_text: defineMessage({id: 'admin.metrics.enableNotificationMetricsDescription', defaultMessage: 'When true, Mattermost will enable notification data collection for web and Desktop App users.'}),
+                            isDisabled: it.any(
+                                it.configIsFalse('MetricsSettings', 'Enable'),
+                            ),
+                            isHidden: it.configIsFalse('FeatureFlags', 'NotificationMonitoring'),
+                        },
                     ],
                 },
             },

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -1489,6 +1489,8 @@
   "admin.metrics.enableClientMetricsDescription": "When true, Mattermost will enable performance monitoring collection for web and desktop app users. Please see <link>documentation</link> to learn more about configuring performance monitoring for Mattermost.",
   "admin.metrics.enableClientMetricsTitle": "Enable Client Performance Monitoring:",
   "admin.metrics.enableDescription": "When true, Mattermost will enable performance monitoring collection and profiling. Please see <link>documentation</link> to learn more about configuring performance monitoring for Mattermost.",
+  "admin.metrics.enableNotificationMetricsDescription": "When true, Mattermost will enable notification data collection for web and Desktop App users.",
+  "admin.metrics.enableNotificationMetricsTitle": "Enable Notification Monitoring:",
   "admin.metrics.enableTitle": "Enable Performance Monitoring:",
   "admin.metrics.listenAddressDesc": "The address the server will listen on to expose performance metrics.",
   "admin.metrics.listenAddressEx": "E.g.: \":8067\"",


### PR DESCRIPTION
#### Summary
Adding a setting to accompany the feature for Notification Metrics, so that admins can turn it off via the System Console if they choose. Setting is default-on.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58159

```release-note
Added a setting for Notification Metrics `MetricsSettings.EnableNotificationMetrics`
```
