### PR TITLE
Simplify how GlobalThreads fetches threads

### DIFF
--- a/webapp/channels/src/components/threading/global_threads/global_threads.tsx
+++ b/webapp/channels/src/components/threading/global_threads/global_threads.tsx
@@ -9,7 +9,7 @@ import {useIntl} from 'react-intl';
 import {useSelector, useDispatch, shallowEqual} from 'react-redux';
 import {Link, useRouteMatch} from 'react-router-dom';
 
-import {getThreadCounts, getThreads} from 'mattermost-redux/actions/threads';
+import {getThreadCounts, getThreadsForCurrentTeam} from 'mattermost-redux/actions/threads';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {
     getThreadOrderInCurrentTeam,
@@ -30,7 +30,7 @@ import LocalStorageStore from 'stores/local_storage_store';
 import LoadingScreen from 'components/loading_screen';
 import NoResultsIndicator from 'components/no_results_indicator';
 
-import {Constants, PreviousViewedTypes} from 'utils/constants';
+import {PreviousViewedTypes} from 'utils/constants';
 
 import type {GlobalState} from 'types/store/index';
 import {LhsItemType, LhsPage} from 'types/store/lhs';
@@ -93,19 +93,6 @@ const GlobalThreads = () => {
 
     const [isLoading, setLoading] = useState(isEmptyList);
 
-    const fetchThreads = useCallback(async (unread): Promise<{data: any}> => {
-        await dispatch(getThreads(
-            currentUserId,
-            currentTeamId,
-            {
-                unread,
-                perPage: Constants.THREADS_PAGE_SIZE,
-            },
-        ));
-
-        return {data: true};
-    }, [currentUserId, currentTeamId]);
-
     const isOnlySelectedThreadInList = (list: string[]) => {
         return selectedThreadId && list.length === 1 && list[0] === selectedThreadId;
     };
@@ -118,17 +105,17 @@ const GlobalThreads = () => {
 
         // this is needed to jump start threads fetching
         if (shouldLoadThreads) {
-            promises.push(fetchThreads(false));
+            promises.push(dispatch(getThreadsForCurrentTeam({unread: false})));
         }
 
         if (filter === ThreadFilter.unread && shouldLoadUnreadThreads) {
-            promises.push(fetchThreads(true));
+            promises.push(dispatch(getThreadsForCurrentTeam({unread: false})));
         }
 
         Promise.all(promises).then(() => {
             setLoading(false);
         });
-    }, [fetchThreads, filter, threadIds, unreadThreadIds]);
+    }, [filter, threadIds, unreadThreadIds]);
 
     useEffect(() => {
         if (!selectedThread && !selectedPost && !isLoading) {

--- a/webapp/channels/src/components/threading/global_threads/thread_list/thread_list.test.tsx
+++ b/webapp/channels/src/components/threading/global_threads/thread_list/thread_list.test.tsx
@@ -5,13 +5,13 @@ import {shallow} from 'enzyme';
 import React from 'react';
 import type {ComponentProps} from 'react';
 
-import {getThreads} from 'mattermost-redux/actions/threads';
+import {getThreadsForCurrentTeam} from 'mattermost-redux/actions/threads';
 
 import {openModal} from 'actions/views/modals';
 
 import Header from 'components/widgets/header';
 
-import {Constants, WindowSizes} from 'utils/constants';
+import {WindowSizes} from 'utils/constants';
 import {TestHelper} from 'utils/test_helper';
 
 import ThreadList, {ThreadFilter} from './thread_list';
@@ -136,7 +136,7 @@ describe('components/threading/global_threads/thread_list', () => {
         const loadMoreItems = await handleLoadMoreItems(2, 3);
 
         expect(loadMoreItems).toEqual({data: true});
-        expect(getThreads).toHaveBeenCalledWith('uid', 'tid', {unread: false, perPage: Constants.THREADS_PAGE_SIZE, before: '2'});
+        expect(getThreadsForCurrentTeam).toHaveBeenCalledWith({unread: false, before: '2'});
         expect(setState.mock.calls).toEqual([[true], [false], [true]]);
     });
 });

--- a/webapp/channels/src/components/threading/global_threads/thread_list/thread_list.tsx
+++ b/webapp/channels/src/components/threading/global_threads/thread_list/thread_list.tsx
@@ -10,7 +10,7 @@ import {useDispatch, useSelector} from 'react-redux';
 import {PlaylistCheckIcon} from '@mattermost/compass-icons/components';
 import type {UserThread} from '@mattermost/types/threads';
 
-import {getThreads, markAllThreadsInTeamRead} from 'mattermost-redux/actions/threads';
+import {getThreadsForCurrentTeam, markAllThreadsInTeamRead} from 'mattermost-redux/actions/threads';
 import {getInt} from 'mattermost-redux/selectors/entities/preferences';
 import {getThreadCountsInCurrentTeam} from 'mattermost-redux/selectors/entities/threads';
 
@@ -149,7 +149,7 @@ const ThreadList = ({
             before = data[startIndex - 2];
         }
 
-        await dispatch(getThreads(currentUserId, currentTeamId, {unread, perPage: Constants.THREADS_PAGE_SIZE, before}));
+        await dispatch(getThreadsForCurrentTeam({unread, before}));
 
         setLoading(false);
         setHasLoaded(true);

--- a/webapp/channels/src/components/threading/global_threads/thread_list/virtualized_thread_list.tsx
+++ b/webapp/channels/src/components/threading/global_threads/thread_list/virtualized_thread_list.tsx
@@ -8,6 +8,8 @@ import InfiniteLoader from 'react-window-infinite-loader';
 
 import type {UserThread} from '@mattermost/types/threads';
 
+import ThreadsConstants from 'mattermost-redux/constants/threads';
+
 import {Constants} from 'utils/constants';
 
 import Row from './virtualized_thread_list_row';
@@ -77,7 +79,7 @@ function VirtualizedThreadList({
                     itemCount={total}
                     loadMoreItems={loadMoreItems}
                     isItemLoaded={isItemLoaded}
-                    minimumBatchSize={Constants.THREADS_PAGE_SIZE}
+                    minimumBatchSize={ThreadsConstants.THREADS_PAGE_SIZE}
                 >
                     {({onItemsRendered, ref}) => {
                         return (

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/threads.test.js
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/threads.test.js
@@ -5,7 +5,7 @@ import nock from 'nock';
 
 import {
     getThread as fetchThread,
-    getThreads as fetchThreads,
+    getThreadsForCurrentTeam,
     getThreadCounts as fetchThreadCounts,
 } from 'mattermost-redux/actions/threads';
 import {Client4} from 'mattermost-redux/client';
@@ -123,7 +123,7 @@ describe('Actions.Threads', () => {
         expect(thread).toEqual({...mockThread, is_following: true});
     });
 
-    test('getThreads', async () => {
+    test('getThreadsForCurrentTeam', async () => {
         const [mockThread0, {threadId: threadId0}] = mockUserThread({uniq: 0});
         const [mockThread1, {threadId: threadId1}] = mockUserThread({uniq: 1});
         const [mockThread2, {threadId: threadId2}] = mockUserThread({uniq: 2});
@@ -139,7 +139,7 @@ describe('Actions.Threads', () => {
             get((uri) => uri.includes(`/users/${currentUserId}/teams/${currentTeamId}/threads`)).
             reply(200, mockResponse);
 
-        const {error, data} = await store.dispatch(fetchThreads(currentUserId, currentTeamId));
+        const {error, data} = await store.dispatch(getThreadsForCurrentTeam());
         const state = store.getState();
         const threads = getThreadsInCurrentTeam(state);
         expect(error).toBeUndefined();

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/threads.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/threads.ts
@@ -42,9 +42,20 @@ export function fetchThreads(userId: string, teamId: string, {before = '', after
     };
 }
 
-export function getThreads(userId: string, teamId: string, {before = '', after = '', perPage = ThreadConstants.THREADS_CHUNK_SIZE, unread = false, extended = true} = {}): ActionFuncAsync<UserThreadList> {
-    return async (dispatch) => {
-        const response = await dispatch(fetchThreads(userId, teamId, {before, after, perPage, unread, totalsOnly: false, threadsOnly: true, extended}));
+export function getThreadsForCurrentTeam({before = '', after = '', unread = false} = {}): ActionFuncAsync<UserThreadList> {
+    return async (dispatch, getState) => {
+        const userId = getCurrentUserId(getState());
+        const teamId = getCurrentTeamId(getState());
+
+        const response = await dispatch(fetchThreads(userId, teamId, {
+            before,
+            after,
+            perPage: ThreadConstants.THREADS_PAGE_SIZE,
+            unread,
+            totalsOnly: false,
+            threadsOnly: true,
+            extended: true,
+        }));
 
         if (response.error) {
             return response;

--- a/webapp/channels/src/packages/mattermost-redux/src/constants/threads.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/constants/threads.ts
@@ -3,4 +3,5 @@
 
 export default {
     THREADS_CHUNK_SIZE: 20,
+    THREADS_PAGE_SIZE: 25,
 };

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -2023,7 +2023,6 @@ export const Constants = {
     MAX_ATTACHMENT_FOOTER_LENGTH: 300,
     ACCEPT_STATIC_IMAGE: '.jpeg,.jpg,.png,.bmp',
     ACCEPT_EMOJI_IMAGE: '.jpeg,.jpg,.png,.gif',
-    THREADS_PAGE_SIZE: 25,
     THREADS_LOADING_INDICATOR_ITEM_ID: 'threads_loading_indicator_item_id',
     THREADS_NO_RESULTS_ITEM_ID: 'threads_no_results_item_id',
     TRIAL_MODAL_AUTO_SHOWN: 'trial_modal_auto_shown',


### PR DESCRIPTION
#### Summary
I originally made these changes as part of #26983, but I changed where we took that measurement from a previous version, so these changes were no longer needed for it. Still, I think these are good to include since the extra parameters of `getThreads` made calling it kind of annoying when we always called it with the same values for `perPage`, `userId`, and `teamId`.

#### Release Note
```release-note
NONE
```
