### PR TITLE
Change client metrics api path to client_perf

### DIFF
--- a/server/channels/api4/metrics.go
+++ b/server/channels/api4/metrics.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (api *API) InitClientPerformanceMetrics() {
-	api.BaseRoutes.APIRoot.Handle("/perf", api.APISessionRequired(submitPerformanceReport)).Methods("POST")
+	api.BaseRoutes.APIRoot.Handle("/client_perf", api.APISessionRequired(submitPerformanceReport)).Methods("POST")
 }
 
 func submitPerformanceReport(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/server/enterprise/metrics/metrics.go
+++ b/server/enterprise/metrics/metrics.go
@@ -1140,7 +1140,7 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 			Name:      "time_to_first_byte",
 			Help:      "Duration from when a browser starts to request a page from a server until when it starts to receive data in response (milliseconds)",
 		},
-		[]string{"platform", "user_agent"},
+		[]string{"platform", "agent"},
 	)
 	m.Registry.MustRegister(m.ClientTimeToFirstByte)
 
@@ -1151,7 +1151,7 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 			Name:      "first_contentful_paint",
 			Help:      "Duration of how long it takes for any content to be displayed on screen to a user (milliseconds)",
 		},
-		[]string{"platform", "user_agent"},
+		[]string{"platform", "agent"},
 	)
 	m.Registry.MustRegister(m.ClientFirstContentfulPaint)
 
@@ -1162,7 +1162,7 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 			Name:      "largest_contentful_paint",
 			Help:      "Duration of how long it takes for large content to be displayed on screen to a user (milliseconds)",
 		},
-		[]string{"platform", "user_agent"},
+		[]string{"platform", "agent"},
 	)
 	m.Registry.MustRegister(m.ClientLargestContentfulPaint)
 
@@ -1173,7 +1173,7 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 			Name:      "interaction_to_next_paint",
 			Help:      "Measure of how long it takes for a user to see the effects of clicking with a mouse, tapping with a touchscreen, or pressing a key on the keyboard (milliseconds)",
 		},
-		[]string{"platform", "user_agent"},
+		[]string{"platform", "agent"},
 	)
 	m.Registry.MustRegister(m.ClientInteractionToNextPaint)
 
@@ -1184,7 +1184,7 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 			Name:      "cumulative_layout_shift",
 			Help:      "Measure of how much a page's content shifts unexpectedly",
 		},
-		[]string{"platform", "user_agent"},
+		[]string{"platform", "agent"},
 	)
 	m.Registry.MustRegister(m.ClientCumulativeLayoutShift)
 
@@ -1195,7 +1195,7 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 			Name:      "long_tasks",
 			Help:      "Counter of the number of times that the browser's main UI thread is blocked for more than 50ms by a single task",
 		},
-		[]string{"platform", "user_agent"},
+		[]string{"platform", "agent"},
 	)
 	m.Registry.MustRegister(m.ClientLongTasks)
 
@@ -1206,7 +1206,7 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 			Name:      "channel_switch",
 			Help:      "Duration of the time taken from when a user clicks on a channel in the LHS to when posts in that channel become visible (milliseconds)",
 		},
-		[]string{"platform", "user_agent"},
+		[]string{"platform", "agent"},
 	)
 	m.Registry.MustRegister(m.ClientChannelSwitchDuration)
 
@@ -1217,7 +1217,7 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 			Name:      "team_switch",
 			Help:      "Duration of the time taken from when a user clicks on a team in the LHS to when posts in that team become visible (milliseconds)",
 		},
-		[]string{"platform", "user_agent"},
+		[]string{"platform", "agent"},
 	)
 	m.Registry.MustRegister(m.ClientTeamSwitchDuration)
 
@@ -1228,7 +1228,7 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 			Name:      "rhs_load",
 			Help:      "Duration of the time taken from when a user clicks to open a thread in the RHS until when posts in that thread become visible (milliseconds)",
 		},
-		[]string{"platform", "user_agent"},
+		[]string{"platform", "agent"},
 	)
 	m.Registry.MustRegister(m.ClientRHSLoadDuration)
 

--- a/server/public/model/client4.go
+++ b/server/public/model/client4.go
@@ -588,8 +588,8 @@ func (c *Client4) bookmarkRoute(channelId, bookmarkId string) string {
 	return fmt.Sprintf(c.bookmarksRoute(channelId)+"/%v", bookmarkId)
 }
 
-func (c *Client4) perfMetricsRoute() string {
-	return "/perf"
+func (c *Client4) clientPerfMetricsRoute() string {
+	return "/client_perf"
 }
 
 func (c *Client4) DoAPIGet(ctx context.Context, url string, etag string) (*http.Response, error) {
@@ -8858,7 +8858,7 @@ func (c *Client4) SubmitClientMetrics(ctx context.Context, report *PerformanceRe
 	if err != nil {
 		return nil, NewAppError("SubmitClientMetrics", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
-	res, err := c.DoAPIPostBytes(ctx, c.perfMetricsRoute(), buf)
+	res, err := c.DoAPIPostBytes(ctx, c.clientPerfMetricsRoute(), buf)
 	if err != nil {
 		return BuildResponse(res), err
 	}

--- a/server/scripts/vet-api-check.sh
+++ b/server/scripts/vet-api-check.sh
@@ -43,7 +43,7 @@ OUTPUT_EXCLUDING_IGNORED=$(echo "$OUTPUT" | grep -Fv \
     -e 'Cannot find /api/v4/hosted_customer/subscribe-newsletter method: POST in OpenAPI 3 spec.' \
     -e 'Cannot find /api/v4/license/review method: POST in OpenAPI 3 spec.' \
     -e 'Cannot find /api/v4/license/review/status method: GET in OpenAPI 3 spec.' \
-    -e 'Cannot find /api/v4/perf method: POST in OpenAPI 3 spec.' \
+    -e 'Cannot find /api/v4/client_perf method: POST in OpenAPI 3 spec.' \
     -e 'Cannot find /api/v4/posts/{post_id}/edit_history method: GET in OpenAPI 3 spec.' \
     -e 'Cannot find /api/v4/posts/{post_id}/info method: GET in OpenAPI 3 spec.' \
     -e 'Cannot find /api/v4/posts/search method: POST in OpenAPI 3 spec.' \

--- a/server/scripts/vet-api-check.sh
+++ b/server/scripts/vet-api-check.sh
@@ -21,6 +21,7 @@ OUTPUT_EXCLUDING_IGNORED=$(echo "$OUTPUT" | grep -Fv \
     -e 'Cannot find /api/v4/channels/stats/member_count method: POST in OpenAPI 3 spec.' \
     -e 'Cannot find /api/v4/channels/{channel_id}/common_teams method: GET in OpenAPI 3 spec.' \
     -e 'Cannot find /api/v4/channels/{channel_id}/convert_to_channel method: POST in OpenAPI 3 spec.' \
+    -e 'Cannot find /api/v4/client_perf method: POST in OpenAPI 3 spec.' \
     -e 'Cannot find /api/v4/cloud/products/selfhosted method: GET in OpenAPI 3 spec.' \
     -e 'Cannot find /api/v4/cloud/subscription/self-serve-status method: GET in OpenAPI 3 spec.' \
     -e 'Cannot find /api/v4/cloud/request-trial method: PUT in OpenAPI 3 spec.' \
@@ -43,7 +44,6 @@ OUTPUT_EXCLUDING_IGNORED=$(echo "$OUTPUT" | grep -Fv \
     -e 'Cannot find /api/v4/hosted_customer/subscribe-newsletter method: POST in OpenAPI 3 spec.' \
     -e 'Cannot find /api/v4/license/review method: POST in OpenAPI 3 spec.' \
     -e 'Cannot find /api/v4/license/review/status method: GET in OpenAPI 3 spec.' \
-    -e 'Cannot find /api/v4/client_perf method: POST in OpenAPI 3 spec.' \
     -e 'Cannot find /api/v4/posts/{post_id}/edit_history method: GET in OpenAPI 3 spec.' \
     -e 'Cannot find /api/v4/posts/{post_id}/info method: GET in OpenAPI 3 spec.' \
     -e 'Cannot find /api/v4/posts/search method: POST in OpenAPI 3 spec.' \

--- a/webapp/channels/src/utils/performance_telemetry/reporter.test.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.test.ts
@@ -49,7 +49,7 @@ describe('PerformanceReporter', () => {
         await waitForReport();
 
         expect(sendBeacon).toHaveBeenCalled();
-        expect(sendBeacon.mock.calls[0][0]).toEqual(siteUrl + '/api/v4/perf');
+        expect(sendBeacon.mock.calls[0][0]).toEqual(siteUrl + '/api/v4/client_perf');
         const report = JSON.parse(sendBeacon.mock.calls[0][1]);
         expect(report).toMatchObject({
             start: performance.timeOrigin + testMarkA.startTime,
@@ -99,7 +99,7 @@ describe('PerformanceReporter', () => {
         await waitForReport();
 
         expect(sendBeacon).toHaveBeenCalled();
-        expect(sendBeacon.mock.calls[0][0]).toEqual(siteUrl + '/api/v4/perf');
+        expect(sendBeacon.mock.calls[0][0]).toEqual(siteUrl + '/api/v4/client_perf');
         const report = JSON.parse(sendBeacon.mock.calls[0][1]);
         expect(report).toMatchObject({
             counters: [
@@ -151,7 +151,7 @@ describe('PerformanceReporter', () => {
         await waitForReport();
 
         expect(sendBeacon).toHaveBeenCalled();
-        expect(sendBeacon.mock.calls[0][0]).toEqual(siteUrl + '/api/v4/perf');
+        expect(sendBeacon.mock.calls[0][0]).toEqual(siteUrl + '/api/v4/client_perf');
         const report = JSON.parse(sendBeacon.mock.calls[0][1]);
         expect(report).toMatchObject({
             counters: [
@@ -179,7 +179,7 @@ describe('PerformanceReporter', () => {
         await waitForReport();
 
         expect(sendBeacon).toHaveBeenCalled();
-        expect(sendBeacon.mock.calls[0][0]).toEqual(siteUrl + '/api/v4/perf');
+        expect(sendBeacon.mock.calls[0][0]).toEqual(siteUrl + '/api/v4/client_perf');
         let report = JSON.parse(sendBeacon.mock.calls[0][1]);
         expect(report).toMatchObject({
             histograms: [
@@ -206,7 +206,7 @@ describe('PerformanceReporter', () => {
         await waitForReport();
 
         expect(sendBeacon).toHaveBeenCalled();
-        expect(sendBeacon.mock.calls[0][0]).toEqual(siteUrl + '/api/v4/perf');
+        expect(sendBeacon.mock.calls[0][0]).toEqual(siteUrl + '/api/v4/client_perf');
         report = JSON.parse(sendBeacon.mock.calls[0][1]);
         expect(report).toMatchObject({
             histograms: [
@@ -302,7 +302,7 @@ describe('PerformanceReporter', () => {
         await waitForReport();
 
         expect(sendBeacon).toHaveBeenCalled();
-        expect(sendBeacon.mock.calls[0][0]).toEqual(siteUrl + '/api/v4/perf');
+        expect(sendBeacon.mock.calls[0][0]).toEqual(siteUrl + '/api/v4/client_perf');
         const report = JSON.parse(sendBeacon.mock.calls[0][1]);
         expect(report).toMatchObject({
             labels: {
@@ -322,7 +322,7 @@ describe('PerformanceReporter', () => {
 
         sendBeacon.mockReturnValue(false);
         const mock = nock(client.getBaseRoute()).
-            post('/perf').
+            post('/client_perf').
             reply(200);
 
         expect(sendBeacon).not.toHaveBeenCalled();

--- a/webapp/platform/client/src/client4.ts
+++ b/webapp/platform/client/src/client4.ts
@@ -492,7 +492,7 @@ export default class Client4 {
     }
 
     getClientMetricsRoute() {
-        return `${this.getBaseRoute()}/perf`;
+        return `${this.getBaseRoute()}/client_perf`;
     }
 
     getCSRFFromCookie() {


### PR DESCRIPTION

#### Summary
As discussed in a PR review comment: https://github.com/mattermost/mattermost/pull/26919#discussion_r1592959738 changing the API path to `client_perf`.

Since we are here, fixing the Prometheus labels as we are using `agent` everywhere else for the user agent label.

#### Release Note

```release-note
NONE
```
