### PR TITLE
Use GetMasterX() to ensure writeability for the RefreshPostStats job

### DIFF
--- a/server/channels/store/sqlstore/user_store.go
+++ b/server/channels/store/sqlstore/user_store.go
@@ -2260,7 +2260,7 @@ func (us SqlUserStore) GetUsersWithInvalidEmails(page int, perPage int, restrict
 
 func (us SqlUserStore) RefreshPostStatsForUsers() error {
 	if us.DriverName() == model.DatabaseDriverPostgres {
-		if _, err := us.GetReplicaX().Exec("REFRESH MATERIALIZED VIEW poststats"); err != nil {
+		if _, err := us.GetMasterX().Exec("REFRESH MATERIALIZED VIEW poststats"); err != nil {
 			return errors.Wrap(err, "users_refresh_post_stats_exec")
 		}
 	} else {


### PR DESCRIPTION
#### Summary
We noticed errors on the `RefreshPostStats` job where we had read-only transaction, where we need to guarantee a write. This PR switches to using `GetMasterX()`

```release-note
Fix an issue where the `RefreshPostStats` job could fail
```
