### PR TITLE
Remove t from actions/invite_actions and components/invitation_modal

### DIFF
--- a/webapp/channels/src/actions/invite_actions.ts
+++ b/webapp/channels/src/actions/invite_actions.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {defineMessage} from 'react-intl';
+
 import type {Channel, ChannelMembership} from '@mattermost/types/channels';
 import type {TeamMemberWithError, TeamInviteWithError} from '@mattermost/types/teams';
 import type {UserProfile} from '@mattermost/types/users';
@@ -16,11 +18,10 @@ import {isGuest} from 'mattermost-redux/utils/user_utils';
 
 import {addUsersToTeam} from 'actions/team_actions';
 
+import type {InviteResult} from 'components/invitation_modal/result_table';
 import type {InviteResults} from 'components/invitation_modal/result_view';
 
 import {ConsolePages} from 'utils/constants';
-import {t} from 'utils/i18n';
-import {localizeMessage} from 'utils/utils';
 
 export function sendMembersInvites(teamId: string, users: UserProfile[], emails: string[]): ActionFuncAsync<InviteResults> {
     return async (dispatch, getState) => {
@@ -34,9 +35,9 @@ export function sendMembersInvites(teamId: string, users: UserProfile[], emails:
         for (const user of users) {
             const member = getTeamMember(state, teamId, user.id);
             if (isGuest(user.roles)) {
-                notSent.push({user, reason: localizeMessage('invite.members.user-is-guest', 'Contact your admin to make this guest a full member.')});
+                notSent.push({user, reason: defineMessage({id: 'invite.members.user-is-guest', defaultMessage: 'Contact your admin to make this guest a full member.'})});
             } else if (member) {
-                notSent.push({user, reason: localizeMessage('invite.members.already-member', 'This person is already a team member.')});
+                notSent.push({user, reason: defineMessage({id: 'invite.members.already-member', defaultMessage: 'This person is already a team member.'})});
             } else {
                 usersToAdd.push(user);
             }
@@ -54,7 +55,7 @@ export function sendMembersInvites(teamId: string, users: UserProfile[], emails:
                     if (memberWithError) {
                         notSent.push({user: userToAdd, reason: memberWithError.error.message});
                     } else {
-                        sent.push({user: userToAdd, reason: localizeMessage('invite.members.added-to-team', 'This member has been added to the team.')});
+                        sent.push({user: userToAdd, reason: defineMessage({id: 'invite.members.added-to-team', defaultMessage: 'This member has been added to the team.'})});
                     }
                 }
             }
@@ -67,14 +68,14 @@ export function sendMembersInvites(teamId: string, users: UserProfile[], emails:
                 response = {
                     data: emails.map((email) => ({
                         email,
-                        error: {error: localizeMessage('invite.members.unable-to-add-the-user-to-the-team', 'Unable to add the user to the team.')},
+                        error: {error: defineMessage({id: 'invite.members.unable-to-add-the-user-to-the-team', defaultMessage: 'Unable to add the user to the team.'})},
                     })) as unknown as TeamInviteWithError[],
                 };
             }
             const invitesWithErrors = response.data || [];
             if (response.error) {
                 if (response.error.server_error_id === 'app.email.rate_limit_exceeded.app_error') {
-                    response.error.message = localizeMessage('invite.rate-limit-exceeded', 'Invite emails rate limit exceeded.');
+                    response.error.message = defineMessage({id: 'invite.rate-limit-exceeded', defaultMessage: 'Invite emails rate limit exceeded.'});
                 }
                 for (const email of emails) {
                     notSent.push({email, reason: response.error.message});
@@ -85,16 +86,16 @@ export function sendMembersInvites(teamId: string, users: UserProfile[], emails:
                     if (inviteWithError && inviteWithError.error.id === 'api.team.invite_members.unable_to_send_email_with_defaults.app_error' && isCurrentUserSystemAdmin(state)) {
                         notSent.push({
                             email,
-                            reason: {
-                                id: t('admin.environment.smtp.smtpFailure'),
-                                message: 'SMTP is not configured in System Console. Can be configured <a>here</a>.',
-                            },
+                            reason: defineMessage({
+                                id: 'admin.environment.smtp.smtpFailure',
+                                defaultMessage: 'SMTP is not configured in System Console. Can be configured <a>here</a>.',
+                            }),
                             path: ConsolePages.SMTP,
                         });
                     } else if (inviteWithError) {
                         notSent.push({email, reason: inviteWithError.error.message});
                     } else {
-                        sent.push({email, reason: localizeMessage('invite.members.invite-sent', 'An invitation email has been sent.')});
+                        sent.push({email, reason: defineMessage({id: 'invite.members.invite-sent', defaultMessage: 'An invitation email has been sent.'})});
                     }
                 }
             }
@@ -114,9 +115,9 @@ export async function sendGuestInviteForUser(
     teamId: string,
     channels: Channel[],
     members: RelationOneToOne<Channel, Record<string, ChannelMembership>>,
-) {
+): Promise<({sent: InviteResult} | {notSent: InviteResult})> {
     if (!isGuest(user.roles)) {
-        return {notSent: {user, reason: localizeMessage('invite.members.user-is-not-guest', 'This person is already a member.')}};
+        return {notSent: {user, reason: defineMessage({id: 'invite.members.user-is-not-guest', defaultMessage: 'This person is already a member.'})}};
     }
     let memberOfAll = true;
     let memberOfAny = false;
@@ -131,7 +132,7 @@ export async function sendGuestInviteForUser(
     }
 
     if (memberOfAll) {
-        return {notSent: {user, reason: localizeMessage('invite.guests.already-all-channels-member', 'This person is already a member of all the channels.')}};
+        return {notSent: {user, reason: defineMessage({id: 'invite.guests.already-all-channels-member', defaultMessage: 'This person is already a member of all the channels.'})}};
     }
 
     try {
@@ -143,13 +144,13 @@ export async function sendGuestInviteForUser(
             }
         }
     } catch (e) {
-        return {notSent: {user, reason: localizeMessage('invite.guests.unable-to-add-the-user-to-the-channels', 'Unable to add the guest to the channels.')}};
+        return {notSent: {user, reason: defineMessage({id: 'invite.guests.unable-to-add-the-user-to-the-channels', defaultMessage: 'Unable to add the guest to the channels.'})}};
     }
 
     if (memberOfAny) {
-        return {notSent: {user, reason: localizeMessage('invite.guests.already-some-channels-member', 'This person is already a member of some of the channels.')}};
+        return {notSent: {user, reason: defineMessage({id: 'invite.guests.already-some-channels-member', defaultMessage: 'This person is already a member of some of the channels.'})}};
     }
-    return {sent: {user, reason: {id: t('invite.guests.new-member'), message: 'This guest has been added to the team and {count, plural, one {channel} other {channels}}.', values: {count: channels.length}}}};
+    return {sent: {user, reason: defineMessage({id: 'invite.guests.new-member', defaultMessage: 'This guest has been added to the team and {count, plural, one {channel} other {channels}}.', values: {count: channels.length}})}};
 }
 
 export function sendGuestsInvites(
@@ -167,10 +168,10 @@ export function sendGuestsInvites(
         const results = await Promise.all(users.map((user) => sendGuestInviteForUser(dispatch, user, teamId, channels, members)));
 
         for (const result of results) {
-            if (result.sent) {
+            if ('sent' in result) {
                 sent.push(result.sent);
             }
-            if (result.notSent) {
+            if ('notSent' in result) {
                 notSent.push(result.notSent);
             }
         }
@@ -183,14 +184,14 @@ export function sendGuestsInvites(
                 response = {
                     data: emails.map((email) => ({
                         email,
-                        error: {error: localizeMessage('invite.guests.unable-to-add-the-user-to-the-channels', 'Unable to add the guest to the channels.')},
+                        error: {error: defineMessage({id: 'invite.guests.unable-to-add-the-user-to-the-channels', defaultMessage: 'Unable to add the guest to the channels.'})},
                     })) as unknown as TeamInviteWithError[],
                 };
             }
 
             if (response.error) {
                 if (response.error.server_error_id === 'app.email.rate_limit_exceeded.app_error') {
-                    response.error.message = localizeMessage('invite.rate-limit-exceeded', 'Invite emails rate limit exceeded.');
+                    response.error.message = defineMessage({id: 'invite.rate-limit-exceeded', defaultMessage: 'Invite emails rate limit exceeded.'});
                 }
                 for (const email of emails) {
                     notSent.push({email, reason: response.error.message});
@@ -201,17 +202,17 @@ export function sendGuestsInvites(
                         if (res.error.id === 'api.team.invite_members.unable_to_send_email_with_defaults.app_error' && isCurrentUserSystemAdmin(state)) {
                             notSent.push({
                                 email: res.email,
-                                reason: {
-                                    id: t('admin.environment.smtp.smtpFailure'),
-                                    message: 'SMTP is not configured in System Console. Can be configured <a>here</a>.',
-                                },
+                                reason: defineMessage({
+                                    id: 'admin.environment.smtp.smtpFailure',
+                                    defaultMessage: 'SMTP is not configured in System Console. Can be configured <a>here</a>.',
+                                }),
                                 path: ConsolePages.SMTP,
                             });
                         } else {
                             notSent.push({email: res.email, reason: res.error.message});
                         }
                     } else {
-                        sent.push({email: res.email, reason: localizeMessage('invite.guests.added-to-channel', 'An invitation email has been sent.')});
+                        sent.push({email: res.email, reason: defineMessage({id: 'invite.guests.added-to-channel', defaultMessage: 'An invitation email has been sent.'})});
                     }
                 }
             }
@@ -240,9 +241,9 @@ export function sendMembersInvitesToChannels(
         for (const user of users) {
             const member = getTeamMember(state, teamId, user.id);
             if (isGuest(user.roles)) {
-                notSent.push({user, reason: localizeMessage('invite.members.user-is-guest', 'Contact your admin to make this guest a full member.')});
+                notSent.push({user, reason: defineMessage({id: 'invite.members.user-is-guest', defaultMessage: 'Contact your admin to make this guest a full member.'})});
             } else if (member) {
-                notSent.push({user, reason: localizeMessage('invite.members.already-member', 'This person is already a team member.')});
+                notSent.push({user, reason: defineMessage({id: 'invite.members.already-member', defaultMessage: 'This person is already a team member.'})});
             } else {
                 usersToAdd.push(user);
             }
@@ -260,7 +261,7 @@ export function sendMembersInvitesToChannels(
                     if (memberWithError) {
                         notSent.push({user: userToAdd, reason: memberWithError.error.message});
                     } else {
-                        sent.push({user: userToAdd, reason: localizeMessage('invite.members.added-to-team', 'This member has been added to the team.')});
+                        sent.push({user: userToAdd, reason: defineMessage({id: 'invite.members.added-to-team', defaultMessage: 'This member has been added to the team.'})});
                     }
                 }
             }
@@ -280,14 +281,14 @@ export function sendMembersInvitesToChannels(
                 response = {
                     data: emails.map((email) => ({
                         email,
-                        error: {error: localizeMessage('invite.members.unable-to-add-the-user-to-the-team', 'Unable to add the user to the team.')},
+                        error: {error: defineMessage({id: 'invite.members.unable-to-add-the-user-to-the-team', defaultMessage: 'Unable to add the user to the team.'})},
                     })) as unknown as TeamInviteWithError[],
                 };
             }
             const invitesWithErrors = response.data || [];
             if (response.error) {
                 if (response.error.server_error_id === 'app.email.rate_limit_exceeded.app_error') {
-                    response.error.message = localizeMessage('invite.rate-limit-exceeded', 'Invite emails rate limit exceeded.');
+                    response.error.message = defineMessage({id: 'invite.rate-limit-exceeded', defaultMessage: 'Invite emails rate limit exceeded.'});
                 }
                 for (const email of emails) {
                     notSent.push({email, reason: response.error.message});
@@ -299,17 +300,17 @@ export function sendMembersInvitesToChannels(
                         if (inviteWithError.error.id === 'api.team.invite_members.unable_to_send_email_with_defaults.app_error' && isCurrentUserSystemAdmin(state)) {
                             notSent.push({
                                 email,
-                                reason: {
-                                    id: t('admin.environment.smtp.smtpFailure'),
-                                    message: 'SMTP is not configured in System Console. Can be configured <a>here</a>.',
-                                },
+                                reason: defineMessage({
+                                    id: 'admin.environment.smtp.smtpFailure',
+                                    defaultMessage: 'SMTP is not configured in System Console. Can be configured <a>here</a>.',
+                                }),
                                 path: ConsolePages.SMTP,
                             });
                         } else {
                             notSent.push({email, reason: inviteWithError.error.message});
                         }
                     } else {
-                        sent.push({email, reason: localizeMessage('invite.members.invite-sent', 'An invitation email has been sent.')});
+                        sent.push({email, reason: defineMessage({id: 'invite.members.invite-sent', defaultMessage: 'An invitation email has been sent.'})});
                     }
                 }
             }

--- a/webapp/channels/src/components/invitation_modal/invitation_modal.test.tsx
+++ b/webapp/channels/src/components/invitation_modal/invitation_modal.test.tsx
@@ -16,7 +16,7 @@ import {SelfHostedProducts} from 'utils/constants';
 import {TestHelper} from 'utils/test_helper';
 import {generateId} from 'utils/utils';
 
-import InvitationModal, {View, InvitationModal as BaseInvitationModal} from './invitation_modal';
+import InvitationModal, {View} from './invitation_modal';
 import type {Props} from './invitation_modal';
 import InviteView from './invite_view';
 import NoPermissionsView from './no_permissions_view';
@@ -129,7 +129,7 @@ describe('InvitationModal', () => {
                 <InvitationModal {...props}/>
             </Provider>,
         );
-        wrapper.find(BaseInvitationModal).at(0).setState({view: View.RESULT});
+        wrapper.find(InvitationModal).at(0).setState({view: View.RESULT});
 
         wrapper.update();
         expect(wrapper.find(ResultView).length).toBe(1);

--- a/webapp/channels/src/components/invitation_modal/invitation_modal.tsx
+++ b/webapp/channels/src/components/invitation_modal/invitation_modal.tsx
@@ -3,8 +3,7 @@
 
 import React from 'react';
 import {Modal} from 'react-bootstrap';
-import {injectIntl} from 'react-intl';
-import type {IntlShape} from 'react-intl';
+import {defineMessages} from 'react-intl';
 
 import type {Channel} from '@mattermost/types/channels';
 import type {Team} from '@mattermost/types/teams';
@@ -30,6 +29,17 @@ import './invitation_modal.scss';
 // true means backdrop clicks do close
 // false means no backdrop
 type Backdrop = 'static' | boolean
+
+const messages = defineMessages({
+    notValidChannel: {
+        id: 'invitation-modal.confirm.not-valid-channel',
+        defaultMessage: 'Does not match a valid channel name.',
+    },
+    notValidUserOrEmail: {
+        id: 'invitation-modal.confirm.not-valid-user-or-email',
+        defaultMessage: 'Does not match a valid user or email.',
+    },
+});
 
 export type Props = {
     actions: {
@@ -66,7 +76,6 @@ export type Props = {
     isCloud: boolean;
     canAddUsers: boolean;
     canInviteGuests: boolean;
-    intl: IntlShape;
     onExited: () => void;
     channelToInvite?: Channel;
     initialValue?: string;
@@ -89,7 +98,7 @@ type State = {
     show: boolean;
 };
 
-export class InvitationModal extends React.PureComponent<Props, State> {
+export default class InvitationModal extends React.PureComponent<Props, State> {
     defaultState: State = deepFreeze({
         view: View.INVITE,
         termWithoutResults: null,
@@ -206,20 +215,14 @@ export class InvitationModal extends React.PureComponent<Props, State> {
         if (this.state.invite.usersEmailsSearch !== '') {
             invites.notSent.push({
                 text: this.state.invite.usersEmailsSearch,
-                reason: this.props.intl.formatMessage({
-                    id: 'invitation-modal.confirm.not-valid-user-or-email',
-                    defaultMessage: 'Does not match a valid user or email.',
-                }),
+                reason: messages.notValidUserOrEmail,
             });
         }
 
         if (inviteAs === InviteType.GUEST && this.state.invite.inviteChannels.search !== '') {
             invites.notSent.push({
                 text: this.state.invite.inviteChannels.search,
-                reason: this.props.intl.formatMessage({
-                    id: 'invitation-modal.confirm.not-valid-channel',
-                    defaultMessage: 'Does not match a valid channel name.',
-                }),
+                reason: messages.notValidChannel,
             });
         }
 
@@ -431,5 +434,3 @@ export class InvitationModal extends React.PureComponent<Props, State> {
         );
     }
 }
-
-export default injectIntl(InvitationModal);

--- a/webapp/channels/src/components/invitation_modal/invite_view.tsx
+++ b/webapp/channels/src/components/invitation_modal/invite_view.tsx
@@ -4,7 +4,7 @@
 import classNames from 'classnames';
 import React, {useEffect, useMemo} from 'react';
 import {Modal} from 'react-bootstrap';
-import {FormattedMessage, useIntl} from 'react-intl';
+import {FormattedMessage, defineMessages, useIntl} from 'react-intl';
 import {useSelector} from 'react-redux';
 
 import type {Channel} from '@mattermost/types/channels';
@@ -20,7 +20,6 @@ import {getAnalyticsCategory} from 'components/onboarding_tasks';
 import UsersEmailsInput from 'components/widgets/inputs/users_emails_input';
 
 import {Constants} from 'utils/constants';
-import {t} from 'utils/i18n';
 import {getSiteURL} from 'utils/url';
 import {getTrackFlowRole, getRoleForTrackFlow, getSourceForTrackFlow} from 'utils/utils';
 
@@ -133,42 +132,37 @@ export default function InviteView(props: Props) {
 
     const errorProperties = {
         showError: false,
-        errorMessageId: '',
-        errorMessageDefault: '',
+        errorMessage: messages.exceededMaxBatch,
         errorMessageValues: {
-            text: '',
+            text: Constants.MAX_ADD_MEMBERS_BATCH.toString(),
         },
-        extraErrorText: '',
     };
 
     if (props.usersEmails.length > Constants.MAX_ADD_MEMBERS_BATCH) {
         errorProperties.showError = true;
-        errorProperties.errorMessageId = t(
-            'invitation_modal.invite_members.exceeded_max_add_members_batch',
-        );
-        errorProperties.errorMessageDefault = 'No more than **{text}** people can be invited at once';
-        errorProperties.errorMessageValues.text = Constants.MAX_ADD_MEMBERS_BATCH.toString();
     }
 
-    let placeholder = formatMessage({
-        id: 'invite_modal.add_invites',
-        defaultMessage: 'Enter a name or email address',
-    });
-    let noMatchMessageId = t(
-        'invitation_modal.members.users_emails_input.no_user_found_matching',
-    );
-    let noMatchMessageDefault =
-        'No one found matching **{text}**. Enter their email to invite them.';
-
-    if (!props.emailInvitationsEnabled) {
+    let placeholder;
+    let noMatchMessage;
+    if (props.emailInvitationsEnabled) {
+        placeholder = formatMessage({
+            id: 'invite_modal.add_invites',
+            defaultMessage: 'Enter a name or email address',
+        });
+        noMatchMessage = messages.noUserFound;
+    } else {
         placeholder = formatMessage({
             id: 'invitation_modal.members.search-and-add.placeholder-email-disabled',
             defaultMessage: 'Add members',
         });
-        noMatchMessageId = t(
-            'invitation_modal.members.users_emails_input.no_user_found_matching-email-disabled',
-        );
-        noMatchMessageDefault = 'No one found matching **{text}**';
+        noMatchMessage = messages.noUserFoundEmailDisabled;
+    }
+
+    let validAddressMessage;
+    if (props.inviteType === InviteType.MEMBER) {
+        validAddressMessage = messages.validAddressMember;
+    } else {
+        validAddressMessage = messages.validAddressGuest;
     }
 
     const isInviteValid = useMemo(() => {
@@ -233,12 +227,8 @@ export default function InviteView(props: Props) {
                         props.onChangeUsersEmails(usersEmails);
                     }}
                     value={props.usersEmails}
-                    validAddressMessageId={props.inviteType === InviteType.MEMBER ? t(
-                        'invitation_modal.members.users_emails_input.valid_email',
-                    ) : t('invitation_modal.guests.users_emails_input.valid_email')}
-                    validAddressMessageDefault={props.inviteType === InviteType.MEMBER ? 'Invite **{email}** as a team member' : 'Invite **{email}** as a guest'}
-                    noMatchMessageId={noMatchMessageId}
-                    noMatchMessageDefault={noMatchMessageDefault}
+                    validAddressMessage={validAddressMessage}
+                    noMatchMessage={noMatchMessage}
                     onInputChange={props.onUsersInputChange}
                     inputValue={props.usersEmailsSearch}
                     emailInvitationsEnabled={props.emailInvitationsEnabled}
@@ -287,3 +277,26 @@ export default function InviteView(props: Props) {
         </>
     );
 }
+
+const messages = defineMessages({
+    exceededMaxBatch: {
+        id: 'invitation_modal.invite_members.exceeded_max_add_members_batch',
+        defaultMessage: 'No more than **{text}** people can be invited at once',
+    },
+    noUserFound: {
+        id: 'invitation_modal.members.users_emails_input.no_user_found_matching',
+        defaultMessage: 'No one found matching **{text}**. Enter their email to invite them.',
+    },
+    noUserFoundEmailDisabled: {
+        id: 'invitation_modal.members.users_emails_input.no_user_found_matching-email-disabled',
+        defaultMessage: 'No one found matching **{text}**',
+    },
+    validAddressGuest: {
+        id: 'invitation_modal.guests.users_emails_input.valid_email',
+        defaultMessage: 'Invite **{email}** as a guest',
+    },
+    validAddressMember: {
+        id: 'invitation_modal.members.users_emails_input.valid_email',
+        defaultMessage: 'Invite **{email}** as a team member',
+    },
+});

--- a/webapp/channels/src/components/invitation_modal/result_table.test.tsx
+++ b/webapp/channels/src/components/invitation_modal/result_table.test.tsx
@@ -73,7 +73,7 @@ describe('ResultTable', () => {
     test('emails render as email', () => {
         props.rows = [{
             email: 'aa@aa.aa',
-            reason: 'some reason',
+            reason: {id: 'some_reason', defaultMessage: 'some reason'},
         }];
         const wrapper = shallow(<ResultTable {...props}/>);
         expect(wrapper.find(EmailIcon).length).toBe(1);
@@ -82,7 +82,7 @@ describe('ResultTable', () => {
     test('unsent invites render as unsent invites', () => {
         props.rows = [{
             text: '@incomplete_userna',
-            reason: 'This was not a complete user',
+            reason: {id: 'incomplete_user', defaultMessage: 'This was not a complete user'},
         }];
         const wrapper = shallow(<ResultTable {...props}/>);
         expect(wrapper.find(AlertIcon).length).toBe(1);
@@ -91,7 +91,7 @@ describe('ResultTable', () => {
     test('user invites render as users', () => {
         props.rows = [{
             user: defaultUser,
-            reason: 'added successfuly',
+            reason: {id: 'success', defaultMessage: 'added successfully'},
         }];
         const wrapper = shallow(<ResultTable {...props}/>);
         expect(wrapper.find(Avatar).length).toBe(1);
@@ -105,7 +105,7 @@ describe('ResultTable', () => {
                 ...defaultUser,
                 is_bot: true,
             },
-            reason: 'added successfuly',
+            reason: {id: 'success', defaultMessage: 'added successfully'},
         }];
         const wrapper = shallow(<ResultTable {...props}/>);
         expect(wrapper.find(Avatar).length).toBe(1);
@@ -119,7 +119,7 @@ describe('ResultTable', () => {
                 ...defaultUser,
                 roles: 'system_guest',
             },
-            reason: 'added successfuly',
+            reason: {id: 'success', defaultMessage: 'added successfully'},
         }];
         const wrapper = shallow(<ResultTable {...props}/>);
         expect(wrapper.find(Avatar).length).toBe(1);

--- a/webapp/channels/src/components/invitation_modal/result_table.tsx
+++ b/webapp/channels/src/components/invitation_modal/result_table.tsx
@@ -32,12 +32,12 @@ type InviteUser = {
 
 type I18nLike = {
     id: string;
-    message: string;
+    defaultMessage: string;
     values?: Record<string, React.ReactNode>;
 }
 
 export type InviteResult = (InviteNotSent | InviteEmail | InviteUser) & {
-    reason: string | I18nLike;
+    reason: I18nLike;
     path?: string;
 }
 
@@ -69,12 +69,9 @@ export default function ResultTable(props: Props) {
         );
     }
 
-    function messageWithLink(reason: any, link: any) {
+    function messageWithLink(reason: I18nLike, link: string) {
         return intl.formatMessage(
-            {
-                id: reason.id,
-                defaultMessage: reason.message,
-            },
+            reason,
             {
                 a: (chunks: React.ReactNode | React.ReactNodeArray) => (
                     <a
@@ -150,21 +147,17 @@ export default function ResultTable(props: Props) {
                             username = text;
                         }
 
-                        let reason: React.ReactNode = invitation.reason;
-                        if (typeof invitation?.reason !== 'string' &&
-                                invitation.reason?.id &&
-                                    invitation.reason?.message &&
-                                        invitation.reason?.values
-                        ) {
+                        let reason;
+                        if (invitation.path) {
+                            reason = messageWithLink(invitation.reason, invitation.path);
+                        } else {
                             reason = (
                                 <FormattedMessage
                                     id={invitation.reason.id}
-                                    defaultMessage={invitation.reason.message}
+                                    defaultMessage={invitation.reason.defaultMessage}
                                     values={invitation.reason.values}
                                 />
                             );
-                        } else if (invitation.path && invitation.reason) {
-                            reason = messageWithLink(invitation.reason, invitation.path);
                         }
 
                         return (

--- a/webapp/channels/src/components/invitation_modal/result_view.tsx
+++ b/webapp/channels/src/components/invitation_modal/result_view.tsx
@@ -3,11 +3,9 @@
 
 import React from 'react';
 import {Modal} from 'react-bootstrap';
-import {FormattedMessage, useIntl} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 
 import deepFreeze from 'mattermost-redux/utils/deep_freeze';
-
-import {t} from 'utils/i18n';
 
 import {InviteType} from './invite_as';
 import ResultTable from './result_table';
@@ -40,7 +38,23 @@ type Props = {
 } & ResultState;
 
 export default function ResultView(props: Props) {
-    const {formatMessage} = useIntl();
+    let inviteType;
+    if (props.inviteType === InviteType.MEMBER) {
+        inviteType = (
+            <FormattedMessage
+                id='invite_modal.invited_members'
+                defaultMessage='Members'
+            />
+        );
+    } else {
+        inviteType = (
+            <FormattedMessage
+                id='invite_modal.invited_guests'
+                defaultMessage='Guests'
+            />
+        );
+    }
+
     return (
         <>
             <Modal.Header className={props.headerClass}>
@@ -52,10 +66,7 @@ export default function ResultView(props: Props) {
                         id='invite_modal.invited'
                         defaultMessage='{inviteType} invited to {team_name}'
                         values={{
-                            inviteType: formatMessage({
-                                id: props.inviteType === InviteType.MEMBER ? t('invite_modal.invited_members') : t('invite_modal.invited_guests'),
-                                defaultMessage: props.inviteType === InviteType.MEMBER ? 'Members' : 'Guests',
-                            }),
+                            inviteType,
                             team_name: props.currentTeamName,
                         }}
                     />

--- a/webapp/channels/src/components/preparing_workspace/invite_members.tsx
+++ b/webapp/channels/src/components/preparing_workspace/invite_members.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useState, useMemo, useEffect} from 'react';
-import {FormattedMessage, useIntl} from 'react-intl';
+import {FormattedMessage, defineMessages, useIntl} from 'react-intl';
 import {CSSTransition} from 'react-transition-group';
 
 import type {UserProfile} from '@mattermost/types/users';
@@ -10,7 +10,6 @@ import type {UserProfile} from '@mattermost/types/users';
 import UsersEmailsInput from 'components/widgets/inputs/users_emails_input';
 
 import {Constants} from 'utils/constants';
-import {t} from 'utils/i18n';
 
 import Description from './description';
 import InviteMembersLink from './invite_members_link';
@@ -64,10 +63,7 @@ const InviteMembers = (props: Props) => {
     });
     const errorProperties = {
         showError: false,
-        errorMessageId: t(
-            'invitation_modal.invite_members.exceeded_max_add_members_batch',
-        ),
-        errorMessageDefault: 'No more than **{text}** people can be invited at once',
+        errorMessage: messages.exceededMaxBatch,
         errorMessageValues: {
             text: Constants.MAX_ADD_MEMBERS_BATCH.toString(),
         },
@@ -115,8 +111,7 @@ const InviteMembers = (props: Props) => {
             inputValue={email}
             emailInvitationsEnabled={true}
             autoFocus={true}
-            validAddressMessageId={t('invitation_modal.members.users_emails_input.valid_email')}
-            validAddressMessageDefault={'Invite **{email}** as a team member'}
+            validAddressMessage={messages.validAddress}
             suppressNoOptionsMessage={suppressNoOptionsMessage}
         />
     );
@@ -241,5 +236,16 @@ const InviteMembers = (props: Props) => {
         </CSSTransition>
     );
 };
+
+const messages = defineMessages({
+    exceededMaxBatch: {
+        id: 'invitation_modal.invite_members.exceeded_max_add_members_batch',
+        defaultMessage: 'No more than **{text}** people can be invited at once',
+    },
+    validAddress: {
+        id: 'invitation_modal.members.users_emails_input.valid_email',
+        defaultMessage: 'Invite **{email}** as a team member',
+    },
+});
 
 export default InviteMembers;

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.test.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.test.tsx
@@ -25,8 +25,10 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
                         last_name: 'user',
                     } as UserProfile,
                 ]}
-                errorMessageId='errorMessageId'
-                errorMessageDefault='errorMessageDefault'
+                errorMessage={{
+                    id: 'errorMessageId',
+                    defaultMessage: 'errorMessageDefault',
+                }}
                 onInputChange={jest.fn()}
                 inputValue=''
                 emailInvitationsEnabled={false}

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
@@ -4,7 +4,8 @@
 import classNames from 'classnames';
 import React from 'react';
 import type {RefObject} from 'react';
-import {FormattedMessage} from 'react-intl';
+import type {MessageDescriptor} from 'react-intl';
+import {FormattedMessage, defineMessages} from 'react-intl';
 import {components} from 'react-select';
 import type {FormatOptionLabelMeta, InputActionMeta, InputProps, OptionsType, Styles, ValueType} from 'react-select';
 import AsyncCreatable from 'react-select/async-creatable';
@@ -24,7 +25,6 @@ import BotTag from 'components/widgets/tag/bot_tag';
 import GuestTag from 'components/widgets/tag/guest_tag';
 import Avatar from 'components/widgets/users/avatar';
 
-import {t} from 'utils/i18n';
 import {getDisplayName, getLongDisplayNameParts, imageURLForUser} from 'utils/utils';
 
 import './users_emails_input.scss';
@@ -37,18 +37,14 @@ type Props = {
     onBlur?: () => void;
     onChange: (change: Array<UserProfile | string>) => void;
     showError?: boolean;
-    errorMessageId: string;
-    errorMessageDefault: string;
+    errorMessage?: MessageDescriptor;
     errorMessageValues?: Record<string, React.ReactNode>;
     value: Array<UserProfile | string>;
     onInputChange: (change: string) => void;
     inputValue: string;
-    noMatchMessageId?: string;
-    noMatchMessageDefault?: string;
-    validAddressMessageId?: string;
-    validAddressMessageDefault?: string;
-    loadingMessageId?: string;
-    loadingMessageDefault?: string;
+    noMatchMessage?: MessageDescriptor;
+    validAddressMessage?: MessageDescriptor;
+    loadingMessage?: MessageDescriptor;
     emailInvitationsEnabled: boolean;
     extraErrorText?: React.ReactNode;
     autoFocus?: boolean;
@@ -67,14 +63,26 @@ type State = {
 
 const multipleValuesDelimiter = /[\s,;]+/;
 
+const messages = defineMessages({
+    loadingDefault: {
+        id: 'widgets.users_emails_input.loading',
+        defaultMessage: 'Loading',
+    },
+    noMatchDefault: {
+        id: 'widgets.users_emails_input.no_user_found_matching',
+        defaultMessage: 'No one found matching **{text}**. Enter their email to invite them.',
+    },
+    validAddressDefault: {
+        id: 'widgets.users_emails_input.valid_email',
+        defaultMessage: 'Add **{email}**',
+    },
+});
+
 export default class UsersEmailsInput extends React.PureComponent<Props, State> {
     static defaultProps = {
-        noMatchMessageId: t('widgets.users_emails_input.no_user_found_matching'),
-        noMatchMessageDefault: 'No one found matching **{text}**. Enter their email to invite them.',
-        validAddressMessageId: t('widgets.users_emails_input.valid_email'),
-        validAddressMessageDefault: 'Add **{email}**',
-        loadingMessageId: t('widgets.users_emails_input.loading'),
-        loadingMessageDefault: 'Loading',
+        noMatchMessage: messages.noMatchDefault,
+        validAddress: messages.validAddressDefault,
+        loadingMessage: messages.loadingDefault,
         showError: false,
     };
     private selectRef: RefObject<AsyncCreatable<UserProfile | EmailInvite> & { handleInputChange: (newValue: string, actionMeta: InputActionMeta | { action: 'custom' }) => string }>;
@@ -110,8 +118,7 @@ export default class UsersEmailsInput extends React.PureComponent<Props, State> 
     loadingMessage = (): string => {
         const text = (
             <FormattedMessage
-                id={this.props.loadingMessageId}
-                defaultMessage={this.props.loadingMessageDefault}
+                {...this.props.loadingMessage}
             />
         );
 
@@ -200,8 +207,7 @@ export default class UsersEmailsInput extends React.PureComponent<Props, State> 
             <MailPlusIcon className='mail-plus-icon'/>
             <FormattedMarkdownMessage
                 key='widgets.users_emails_input.valid_email'
-                id={this.props.validAddressMessageId}
-                defaultMessage={this.props.validAddressMessageDefault}
+                {...this.props.validAddressMessage}
                 values={{email: value}}
                 disableLinks={true}
             />
@@ -242,8 +248,7 @@ export default class UsersEmailsInput extends React.PureComponent<Props, State> 
             <div className='users-emails-input__option users-emails-input__option--no-matches'>
                 <Msg {...props}>
                     <FormattedMarkdownMessage
-                        id={this.props.noMatchMessageId}
-                        defaultMessage={this.props.noMatchMessageDefault}
+                        {...this.props.noMatchMessage}
                         values={{text: inputValue}}
                         disableLinks={true}
                     />
@@ -518,8 +523,7 @@ export default class UsersEmailsInput extends React.PureComponent<Props, State> 
                     <div className='InputErrorBox'>
                         <Msg>
                             <FormattedMarkdownMessage
-                                id={this.props.errorMessageId}
-                                defaultMessage={this.props.errorMessageDefault}
+                                {...this.props.errorMessage}
                                 values={this.props.errorMessageValues}
                                 disableLinks={true}
                             />


### PR DESCRIPTION
#### Summary
I decided to spend some time this afternoon on getting rid of `t`.

As much as I generally prefer `defineMessages` and having all the strings in one place, it really makes it difficult to read the diff when migrating existing code. I'm not sure if I'm going to keep using it when migrating busier files like `actions/invite_actions` in the future since it's much easier to follow a diff when using `defineMessage` instead like in https://github.com/mattermost/mattermost/commit/65205bbd8e82e66c383d53525636c4509d0b3408

#### Release Note
```release-note
NONE
```
