### PR TITLE
Better handle some defaults and setting keys

### DIFF
--- a/webapp/channels/src/actions/admin_actions.test.js
+++ b/webapp/channels/src/actions/admin_actions.test.js
@@ -45,7 +45,7 @@ describe('Actions.Admin', () => {
         store.dispatch(Actions.registerAdminConsoleCustomSetting('plugin-id', 'settingA', React.Component, {showTitle: true}));
         expect(store.getState().plugins.adminConsoleCustomComponents).toEqual(
             {'plugin-id': {
-                settinga: {
+                settingA: {
                     key: 'settingA',
                     pluginId: 'plugin-id',
                     component: React.Component,

--- a/webapp/channels/src/components/admin_console/custom_plugin_settings/__snapshots__/custom_plugin_settings.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/custom_plugin_settings/__snapshots__/custom_plugin_settings.test.tsx.snap
@@ -80,8 +80,8 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
                 text="This is some help text for the dropdown field."
               />
             }
-            id="settingc"
-            key="testplugin_dropdown_settingc"
+            id="settingC"
+            key="testplugin_dropdown_settingC"
             label="Setting Three"
             onChange={[Function]}
             setByEnv={false}
@@ -380,8 +380,8 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
                 text="This is some help text for the dropdown field."
               />
             }
-            id="PluginSettings.Plugins.testplugin.settingc"
-            key="testplugin_dropdown_PluginSettings.Plugins.testplugin.settingc"
+            id="PluginSettings.Plugins.testplugin.settingC"
+            key="testplugin_dropdown_PluginSettings.Plugins.testplugin.settingC"
             label="Setting Three"
             onChange={[Function]}
             setByEnv={false}

--- a/webapp/channels/src/components/admin_console/custom_plugin_settings/custom_plugin_settings.test.tsx
+++ b/webapp/channels/src/components/admin_console/custom_plugin_settings/custom_plugin_settings.test.tsx
@@ -61,7 +61,7 @@ describe('components/admin_console/CustomPluginSettings', () => {
                         placeholder: 'e.g. some setting',
                     },
                     {
-                        key: 'settingc',
+                        key: 'settingC',
                         display_name: 'Setting Three',
                         type: 'dropdown',
                         default: 'option1',
@@ -113,7 +113,7 @@ describe('components/admin_console/CustomPluginSettings', () => {
                     testplugin: {
                         settinga: 'fsdsdg',
                         settingb: false,
-                        settingc: 'option3',
+                        settingC: 'option3',
                         settingd: 'option1',
                         settinge: 'Q6DHXrFLOIS5sOI5JNF4PyDLqWm7vh23',
                         settingf: '3xz3r6n7dtbbmgref3yw4zg7sr',
@@ -128,7 +128,7 @@ describe('components/admin_console/CustomPluginSettings', () => {
             const escapedPluginId = escapePathPart(plugin.id);
             return {
                 ...setting,
-                key: 'PluginSettings.Plugins.' + escapedPluginId + '.' + setting.key.toLowerCase(),
+                key: 'PluginSettings.Plugins.' + escapedPluginId + '.' + setting.key,
                 label: setting.display_name,
             } as AdminDefinitionSetting;
         });

--- a/webapp/channels/src/components/admin_console/custom_plugin_settings/index.ts
+++ b/webapp/channels/src/components/admin_console/custom_plugin_settings/index.ts
@@ -47,7 +47,7 @@ function makeGetPluginSchema() {
             let settings: Array<Partial<AdminDefinitionSetting>> = [];
             if (plugin.settings_schema && plugin.settings_schema.settings) {
                 settings = plugin.settings_schema.settings.map((setting) => {
-                    const key = setting.key.toLowerCase();
+                    const key = setting.key;
                     let component = null;
                     let bannerType = '';
                     let type = setting.type;

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
@@ -323,6 +323,10 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
             return setting.dynamic_value(this.state[setting.key], this.props.config, this.state);
         }
 
+        if (this.state[setting.key] === undefined && 'default' in setting) {
+            return setting.default;
+        }
+
         return this.state[setting.key];
     }
 
@@ -505,8 +509,10 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
         }
 
         let inputType: 'text' | 'number' | 'textarea' = 'text';
+        let defaultValue: string | number = '';
         if (setting.type === Constants.SettingsTypes.TYPE_NUMBER) {
             inputType = 'number';
+            defaultValue = 0;
         } else if (setting.type === Constants.SettingsTypes.TYPE_LONG_TEXT) {
             inputType = 'textarea';
         }
@@ -517,7 +523,7 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
         } else if (setting.multiple) {
             value = this.state[setting.key] ? this.state[setting.key].join(',') : '';
         } else {
-            value = this.state[setting.key] ?? (setting.default || '');
+            value = this.state[setting.key] ?? (setting.default ?? defaultValue);
         }
 
         let footer = null;
@@ -578,7 +584,7 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
                 id={setting.key}
                 label={this.renderLabel(setting)}
                 helpText={this.renderSettingHelpText(setting)}
-                value={this.state[setting.key] ?? (setting.default || false)}
+                value={this.state[setting.key] ?? (setting.default ?? false)}
                 disabled={this.isDisabled(setting)}
                 setByEnv={this.isSetByEnv(setting.key)}
                 onChange={this.handleChange}
@@ -803,7 +809,7 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
                 helpText={this.renderSettingHelpText(setting)}
                 regenerateHelpText={setting.regenerate_help_text}
                 placeholder={descriptorOrStringToString(setting.placeholder, this.props.intl)}
-                value={this.state[setting.key] ?? (setting.default || '')}
+                value={this.state[setting.key] ?? (setting.default ?? '')}
                 disabled={this.isDisabled(setting)}
                 setByEnv={this.isSetByEnv(setting.key)}
                 onChange={this.handleGeneratedChange}
@@ -870,7 +876,7 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
                 label={this.renderLabel(setting)}
                 helpText={this.renderSettingHelpText(setting)}
                 placeholder={setting.placeholder}
-                value={this.state[setting.key] ?? (setting.default || '')}
+                value={this.state[setting.key] ?? (setting.default ?? '')}
                 disabled={this.isDisabled(setting)}
                 onChange={this.handleChange}
             />

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
@@ -509,10 +509,10 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
         }
 
         let inputType: 'text' | 'number' | 'textarea' = 'text';
-        let defaultValue: string | number = '';
+        let zeroValue: string | number = '';
         if (setting.type === Constants.SettingsTypes.TYPE_NUMBER) {
             inputType = 'number';
-            defaultValue = 0;
+            zeroValue = 0;
         } else if (setting.type === Constants.SettingsTypes.TYPE_LONG_TEXT) {
             inputType = 'textarea';
         }
@@ -523,7 +523,7 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
         } else if (setting.multiple) {
             value = this.state[setting.key] ? this.state[setting.key].join(',') : '';
         } else {
-            value = this.state[setting.key] ?? (setting.default ?? defaultValue);
+            value = this.state[setting.key] ?? (setting.default ?? zeroValue);
         }
 
         let footer = null;

--- a/webapp/channels/src/reducers/plugins/index.ts
+++ b/webapp/channels/src/reducers/plugins/index.ts
@@ -331,7 +331,7 @@ function adminConsoleCustomComponents(state: {[pluginId: string]: Record<string,
         }
 
         const pluginId = action.data.pluginId;
-        const key = action.data.key.toLowerCase();
+        const key = action.data.key;
 
         const nextState = {...state};
         let nextArray: Record<string, AdminConsolePluginComponent> = {};


### PR DESCRIPTION
#### Summary
During my initial PR, I changed how many settings we send on save, so we only send the modified settings.

I changed this so we send all the settings, with the default sets.

I also removed a couple of `toLowerCase` that were creating issues with setting keys with camelCase notation.

Finally, I also changed how we deal with some falsy defaults, specially on number fields.

#### Ticket Link
NONE

#### Release Note
```release-note
Fix minor issues with plugin settings in the admin console
```
