### PR TITLE
MM-58257 - Use ConstantTimeCompare when comparing token.

### DIFF
--- a/server/channels/app/session.go
+++ b/server/channels/app/session.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"crypto/subtle"
 	"errors"
 	"math"
 	"net/http"
@@ -57,7 +58,7 @@ func (a *App) GetCloudSession(token string) (*model.Session, *model.AppError) {
 
 func (a *App) GetRemoteClusterSession(token string, remoteId string) (*model.Session, *model.AppError) {
 	rc, appErr := a.GetRemoteCluster(remoteId)
-	if appErr == nil && rc.Token == token {
+	if appErr == nil && subtle.ConstantTimeCompare([]byte(rc.Token), []byte(token)) == 1 {
 		// Need a bare-bones session object for later checks
 		session := &model.Session{
 			Token:   token,


### PR DESCRIPTION
#### Summary
This PR replaces a token comparison with `cryto/subtle.ConstantTimeCompare` to guard against timing attacks.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58257

#### Release Note
```release-note
Use `ConstantTimeCompare` when comparing tokens for Shared Channels
```
