### PR TITLE
MM-57860 - Check user belongs to remote when Shared Channels updates a user profile image

### DIFF
--- a/server/channels/api4/remote_cluster.go
+++ b/server/channels/api4/remote_cluster.go
@@ -271,6 +271,15 @@ func remoteSetProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.SetInvalidURLParam("user_id")
 		return
 	}
+
+	// ensure the user being modified belongs to the remote requesting the change.
+	requesterRemoteID := c.GetRemoteID(r)
+	if user.GetRemoteID() != requesterRemoteID {
+		c.Err = model.NewAppError("remoteSetProfileImage", "api.context.remote_id_mismatch.app_error",
+			nil, "", http.StatusUnauthorized)
+		return
+	}
+
 	audit.AddEventParameterAuditable(auditRec, "user", user)
 
 	imageData := imageArray[0]


### PR DESCRIPTION
#### Summary
This PR adds a check when updating remote user profile images to ensure the user belongs to the remote making the request.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57860

#### Release Note
```release-note
Check user belongs to remote when Shared Channels updates a user profile image
```
