### PR TITLE
MM-58263 Remove CSRF check from /api/v4/client_perf

### DIFF
--- a/server/channels/api4/metrics.go
+++ b/server/channels/api4/metrics.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (api *API) InitClientPerformanceMetrics() {
-	api.BaseRoutes.APIRoot.Handle("/client_perf", api.APISessionRequired(submitPerformanceReport)).Methods("POST")
+	api.BaseRoutes.APIRoot.Handle("/client_perf", api.APISessionRequiredTrustRequester(submitPerformanceReport)).Methods("POST")
 }
 
 func submitPerformanceReport(c *Context, w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
#### Summary
We use navigator.sendBeacon to send the new metrics since it's recommended for that, but it doesn't let us set custom headers which means that we can't set the CSRF token header that we'd need to pass that check

#### Ticket Link
MM-58263

#### Release Note
```release-note
NONE
```
