### PR TITLE
[MM-58271] User Profile pop up | Make Call button appear Disabled when user is on active call

### DIFF
--- a/webapp/channels/src/components/profile_popover/profile_popover.scss
+++ b/webapp/channels/src/components/profile_popover/profile_popover.scss
@@ -223,5 +223,12 @@
                 row-gap: 4px;
             }
         }
+
+        button#startCallButton {
+            &.disabledStyleButton {
+                cursor: not-allowed;
+                opacity: 0.65;
+            }
+        }
     }
 }

--- a/webapp/channels/src/components/profile_popover/profile_popover.scss
+++ b/webapp/channels/src/components/profile_popover/profile_popover.scss
@@ -225,7 +225,7 @@
         }
 
         button#startCallButton {
-            &.disabledStyleButton {
+            &.icon-btn-disabled {
                 cursor: not-allowed;
                 opacity: 0.65;
             }

--- a/webapp/channels/src/components/profile_popover/profile_popover_call_button_wrapper/index.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover_call_button_wrapper/index.tsx
@@ -6,21 +6,18 @@ import React, {useCallback, useEffect, useState} from 'react';
 import {useIntl} from 'react-intl';
 import {useSelector} from 'react-redux';
 
-import {PhoneInTalkIcon} from '@mattermost/compass-icons/components';
-
 import {Client4} from 'mattermost-redux/client';
 import {getChannelByName} from 'mattermost-redux/selectors/entities/channels';
 
 import {isCallsEnabled as getIsCallsEnabled, getSessionsInCalls} from 'selectors/calls';
 
-import OverlayTrigger from 'components/overlay_trigger';
 import ProfilePopoverCallButton from 'components/profile_popover/profile_popover_calls_button';
-import Tooltip from 'components/tooltip';
+import WithTooltip from 'components/with_tooltip';
 
-import Constants from 'utils/constants';
 import {getDirectChannelName} from 'utils/utils';
 
 import type {GlobalState} from 'types/store';
+
 type Props = {
     userId: string;
     currentUserId: string;
@@ -98,29 +95,26 @@ const CallButton = ({
         id: 'webapp.mattermost.feature.start_call',
         defaultMessage: 'Start Call',
     });
-    const iconButtonClassname = classNames('style--none btn btn-icon btn-sm', {'icon-btn-disabled': disabled});
+    const iconButtonClassName = classNames('btn btn-icon btn-sm style--none', {disabledStyleButton: disabled});
     const callButton = (
-        <OverlayTrigger
-            delayShow={Constants.OVERLAY_TIME_DELAY}
+        <WithTooltip
+            id='startCallButtonTooltip'
+            title={startCallMessage}
             placement='top'
-            overlay={
-                <Tooltip id='startCallTooltip'>
-                    {startCallMessage}
-                </Tooltip>
-            }
         >
             <button
                 id='startCallButton'
                 type='button'
                 aria-disabled={disabled}
-                className={iconButtonClassname}
+                className={iconButtonClassName}
+                aria-label={startCallMessage}
             >
-                <PhoneInTalkIcon
-                    size={18}
-                    aria-label={startCallMessage}
+                <span
+                    className='icon icon-phone'
+                    aria-hidden='true'
                 />
             </button>
-        </OverlayTrigger>
+        </WithTooltip>
     );
 
     if (disabled) {

--- a/webapp/channels/src/components/profile_popover/profile_popover_call_button_wrapper/index.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover_call_button_wrapper/index.tsx
@@ -95,10 +95,10 @@ const CallButton = ({
         id: 'webapp.mattermost.feature.start_call',
         defaultMessage: 'Start Call',
     });
-    const iconButtonClassName = classNames('btn btn-icon btn-sm style--none', {disabledStyleButton: disabled});
+    const iconButtonClassName = classNames('btn btn-icon btn-sm style--none', {'icon-btn-disabled': disabled});
     const callButton = (
         <WithTooltip
-            id='startCallButtonTooltip'
+            id='startCallTooltip'
             title={startCallMessage}
             placement='top'
         >

--- a/webapp/channels/src/components/profile_popover/profile_popover_call_button_wrapper/profile_popover_call_button_wrapper.scss
+++ b/webapp/channels/src/components/profile_popover/profile_popover_call_button_wrapper/profile_popover_call_button_wrapper.scss
@@ -1,6 +1,0 @@
-button#startCallButton {
-    &.btn-disabled-styled {
-        cursor: not-allowed;
-        opacity: 0.65;
-    }
-}


### PR DESCRIPTION
#### Summary
- Added disabled styling to the calls button
- Wrapped it in WithTooltip component
- Will be adding e2e in calls repo

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58271

#### Screenshots
![CleanShot 2024-05-16 at 14 08 53](https://github.com/mattermost/mattermost/assets/17708702/b06d2cf2-1fb1-49ef-930b-536bd2b9a5e7)

#### Release Note
<!--
Add a release note for each of the f

ollowing conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
