### PR TITLE
[MM-58304] Move global pluggable outside of new main-wrapper div

### DIFF
--- a/webapp/channels/src/components/root/root.tsx
+++ b/webapp/channels/src/components/root/root.tsx
@@ -619,9 +619,9 @@ export default class Root extends React.PureComponent<Props, State> {
                                 />
                                 <RootRedirect/>
                             </Switch>
-                            <Pluggable pluggableName='Global'/>
                             <SidebarRight/>
                         </div>
+                        <Pluggable pluggableName='Global'/>
                         <AppBar/>
                         <SidebarRightMenu/>
                     </CompassThemeProvider>


### PR DESCRIPTION
#### Summary
- #26407 introduced a new main-wrapped div on the root component, and this wrapped the `Global` pluggable. That changed the dom hierarchy for the global pluggable. I imagine this will affect other plugins as well, which might have relied on being in the previous dom level.
- For calls:

| before | after fix |
|--|--|
| <img width="517" alt="image" src="https://github.com/mattermost/mattermost/assets/1490756/7188786d-0415-42af-81bc-433b5cd7d546"> | <img width="476" alt="image" src="https://github.com/mattermost/mattermost/assets/1490756/d56ffb71-f564-4e07-b5be-7532eef39895"> |

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-58304

#### Release Note

```release-note
NONE
```
