### PR TITLE
Adding unsupported text into the team/e0 edition menu

### DIFF
--- a/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss
+++ b/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss
@@ -333,13 +333,12 @@
             }
         }
 
-        .start_trial_content {
+        .editionText {
             position: relative;
             width: 100%;
-        }
-
-        .editionName {
-            text-transform: capitalize;
+            a {
+                color: var(--link-color);
+            }
         }
     }
 }

--- a/webapp/channels/src/components/widgets/menu/menu_items/menu_start_trial.tsx
+++ b/webapp/channels/src/components/widgets/menu/menu_items/menu_start_trial.tsx
@@ -13,12 +13,15 @@ import {Permissions} from 'mattermost-redux/constants';
 import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
 import {haveISystemPermission} from 'mattermost-redux/selectors/entities/roles';
 
+
 import {trackEvent} from 'actions/telemetry_actions';
 import {openModal} from 'actions/views/modals';
 
+import ExternalLink from 'components/external_link';
 import {makeAsyncComponent} from 'components/async_load';
 
-import {ModalIdentifiers, TELEMETRY_CATEGORIES} from 'utils/constants';
+import {ModalIdentifiers, LicenseLinks, TELEMETRY_CATEGORIES} from 'utils/constants';
+
 
 import './menu_item.scss';
 
@@ -84,20 +87,24 @@ const MenuStartTrial = (props: Props): JSX.Element | null => {
             id={props.id}
         >
             <FreeVersionBadge>{'FREE EDITION'}</FreeVersionBadge>
-            {isE0 &&
-                <div className='start_trial_content'>
-                    {formatMessage({
-                        id: 'navbar_dropdown.versionTextE0',
-                        defaultMessage: 'This is the free edition of Mattermost, ideal for evaluation and small teams.',
-                    })}
-                </div>}
-            {!isE0 &&
-                <div className='start_trial_content'>
-                    {formatMessage({
-                        id: 'navbar_dropdown.versionTextTeamEdition',
-                        defaultMessage: 'This is the free open source edition of Mattermost, ideal for evaluation and small teams.',
-                    })}
-                </div>}
+            <div className='editionText'>
+                {formatMessage(
+                    {
+                        id: 'navbar_dropdown.versionText',
+                        defaultMessage: 'This is the free <link>unsupported</link> edition of Mattermost.',
+                    },
+                    {
+                        link: (msg: React.ReactNode) => (
+                            <ExternalLink
+                                location='unsupported-link'
+                                href={LicenseLinks.UNSUPPORTED}
+                            >
+                                {msg}
+                            </ExternalLink>
+                        ),
+                    }
+                )}
+            </div>
             {showTrialButton &&
                 <button onClick={openLearnMoreTrialModal}>
                     {formatMessage({id: 'navbar_dropdown.startAnEnterpriseTrial', defaultMessage: 'Start an Enterprise trial'})}

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -1114,6 +1114,7 @@ export const LicenseLinks = {
     EMBARGOED_COUNTRIES: 'https://mattermost.com/pl/limitations-for-embargoed-countries',
     SOFTWARE_SERVICES_LICENSE_AGREEMENT: 'https://mattermost.com/pl/software-and-services-license-agreement',
     SOFTWARE_SERVICES_LICENSE_AGREEMENT_TEXT: 'Software Services and License Agreement',
+    UNSUPPORTED: 'https://mattermost.com/pricing/',
 };
 
 export const MattermostLink = 'https://mattermost.com/';


### PR DESCRIPTION
#### Summary
Changing the text for the free/e0 edition to show in the product menu a text that clarifies that the edition is unsupported.

#### Ticket Link
Not Yet

#### Screenshots

#### Release Note

```release-note
Added unsupported label to the Team/E0 editions in the product menu.
```