### PR TITLE
CLD-7553 Implement per-MM_ENV runs, post the E2E test links back to user

### DIFF
--- a/.github/workflows/e2e-fulltests-ci.yml
+++ b/.github/workflows/e2e-fulltests-ci.yml
@@ -30,8 +30,11 @@ on:
         default: NONE
 
 concurrency:
-  group: "${{ github.workflow }}-${{ inputs.PR_NUMBER || inputs.ref }}"
+  group: "${{ github.workflow }}-${{ inputs.PR_NUMBER || inputs.ref }}-${{ inputs.MM_ENV }}"
   cancel-in-progress: true
+
+permissions:
+  issues: write
 
 jobs:
   resolve-ref:
@@ -63,6 +66,7 @@ jobs:
             echo "commit_sha=$(git rev-parse --verify HEAD)" >> $GITHUB_OUTPUT
             echo "BRANCH=${{ inputs.ref || github.sha }}" >> $GITHUB_OUTPUT
           fi
+
   generate-test-variables:
     runs-on: ubuntu-22.04
     needs:
@@ -77,12 +81,15 @@ jobs:
       TEST_FILTER: "${{ steps.generate.outputs.TEST_FILTER }}"
       BUILD_ID: "${{ steps.generate.outputs.BUILD_ID }}"
     env:
+      GH_TOKEN: "${{ github.token }}"
+      PR_NUMBER: "${{ inputs.PR_NUMBER || '' }}"
       # We could exclude the @smoke group for PRs, but then we wouldn't have it in the report
       TEST_FILTER_PR: >-
         --stage="@prod"
         --excludeGroup="@te_only,@cloud_only,@high_availability"
         --sortFirst="@compliance_export,@elasticsearch,@ldap_group,@ldap"
         --sortLast="@saml,@keycloak,@plugin,@plugins_uninstall,@mfa,@license_removal"
+      MM_ENV: "${{ inputs.MM_ENV || '' }}"
     steps:
       - name: ci/generate-test-variables
         id: generate
@@ -91,9 +98,10 @@ jobs:
           # BUILD_ID format: $pipelineID-$imageTag-$testType-$serverType-$serverEdition
           # Reference on BUILD_ID parsing: https://github.com/saturninoabril/automation-dashboard/blob/175891781bf1072c162c58c6ec0abfc5bcb3520e/lib/common_utils.ts#L3-L23
           BUILD_ID_PREFIX="${{ github.run_id }}_${{ github.run_attempt }}-${COMMIT_SHA::7}"
+          MM_ENV_HASH=$(md5sum -z <<<"$MM_ENV" | cut -c-8)
           case "${{ inputs.REPORT_TYPE }}" in
             NONE | PR)
-              echo "status_check_context=E2E Tests/test" >> $GITHUB_OUTPUT
+              echo "status_check_context=E2E Tests/test${MM_ENV:+/$MM_ENV_HASH}" >> $GITHUB_OUTPUT
               echo "workers_number=20" >> $GITHUB_OUTPUT
               echo "ENABLED_DOCKER_SERVICES=postgres inbucket minio openldap elasticsearch keycloak" >> $GITHUB_OUTPUT
               echo "TEST_FILTER=$TEST_FILTER_PR" >> $GITHUB_OUTPUT
@@ -104,6 +112,19 @@ jobs:
               echo "Fatal: unimplemented test type. Aborting."
               exit 1
           esac
+      - name: ci/notify-user
+        run: |
+          if [ -n "$PR_NUMBER" ]; then
+            WORKFLOW_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            CYCLE_URL="https://automation-dashboard.vercel.app/cycle/${{ github.run_id }}"
+            gh issue -R "${{ github.repository }}" comment "$PR_NUMBER" --body-file - <<EOF
+          E2E test run is starting for commit \`${{ needs.resolve-ref.outputs.commit_sha }}\`${MM_ENV:+, with \`MM_ENV=$MM_ENV\`}.
+          You can check its progress by either:
+          - Looking at the corresponding commit status, which will be available in a few moments: \`${{ steps.generate.outputs.status_check_context }}\`.
+          - Looking at the [E2E test's Workflow Run]($WORKFLOW_RUN_URL), with Run ID \`${{ github.run_id }}\`.
+          - Looking at the [E2E test's Cycle on the Automation Dashboard]($CYCLE_URL).
+          EOF
+          fi
 
   e2e-fulltest:
     needs:

--- a/.github/workflows/e2e-fulltests-ci.yml
+++ b/.github/workflows/e2e-fulltests-ci.yml
@@ -33,9 +33,6 @@ concurrency:
   group: "${{ github.workflow }}-${{ inputs.PR_NUMBER || inputs.ref }}-${{ inputs.MM_ENV }}"
   cancel-in-progress: true
 
-permissions:
-  issues: write
-
 jobs:
   resolve-ref:
     runs-on: ubuntu-22.04
@@ -71,6 +68,9 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
       - resolve-ref
+    permissions:
+      issues: write
+      pull-requests: write
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
#### Summary

Support running multiple E2E Tests per-PR, one per `MM_ENV` specification.
Also post back the Workflow and Automation Dashboard URLs as soon as possible in the run.

Tested by running with the following settings:
- Leaving `MM_ENV` empty
- Setting `MM_ENV` to `MM_SUPPORTSETTINGS_HELPLINK=https://about.mattermost.com/default-help/?dummy`

Note that in the future, the `E2E Tests/test` status check (created by runs that leave `MM_ENV` empty) will be the only one required for PR mergeability.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7553
https://mattermost.atlassian.net/browse/CLD-7647

#### Release Note
```release-note
NONE
```
