### PR TITLE
MM-58281 Change performance timestamps to be floats

### DIFF
--- a/server/channels/api4/metrics_test.go
+++ b/server/channels/api4/metrics_test.go
@@ -111,8 +111,8 @@ func TestSubmitMetrics(t *testing.T) {
 
 		resp, err := th.Client.SubmitClientMetrics(th.Context.Context(), &model.PerformanceReport{
 			Version: "0.1",
-			Start:   time.Now().Add(-1 * time.Minute).UnixMilli(),
-			End:     time.Now().UnixMilli(),
+			Start:   float64(time.Now().Add(-1 * time.Minute).UnixMilli()),
+			End:     float64(time.Now().UnixMilli()),
 			Counters: []*model.MetricSample{
 				{Metric: model.ClientLongTasks, Value: 1},
 			},
@@ -145,8 +145,8 @@ func TestSubmitMetrics(t *testing.T) {
 
 		resp, err := th.Client.SubmitClientMetrics(th.Context.Context(), &model.PerformanceReport{
 			Version: "0.1",
-			Start:   time.Now().Add(-1 * time.Minute).UnixMilli(),
-			End:     time.Now().UnixMilli(),
+			Start:   float64(time.Now().Add(-1 * time.Minute).UnixMilli()),
+			End:     float64(time.Now().UnixMilli()),
 			Counters: []*model.MetricSample{
 				{Metric: model.ClientLongTasks, Value: 1},
 			},

--- a/server/public/model/metrics.go
+++ b/server/public/model/metrics.go
@@ -36,7 +36,7 @@ var (
 type MetricSample struct {
 	Metric    MetricType        `json:"metric"`
 	Value     float64           `json:"value"`
-	Timestamp int64             `json:"timestamp,omitempty"`
+	Timestamp float64           `json:"timestamp,omitempty"`
 	Labels    map[string]string `json:"labels,omitempty"`
 }
 
@@ -45,8 +45,8 @@ type PerformanceReport struct {
 	Version    string            `json:"version"`
 	ClientID   string            `json:"client_id"`
 	Labels     map[string]string `json:"labels"`
-	Start      int64             `json:"start"`
-	End        int64             `json:"end"`
+	Start      float64           `json:"start"`
+	End        float64           `json:"end"`
 	Counters   []*MetricSample   `json:"counters"`
 	Histograms []*MetricSample   `json:"histograms"`
 }
@@ -70,7 +70,7 @@ func (r *PerformanceReport) IsValid() error {
 	}
 
 	now := time.Now().UnixMilli()
-	if r.End < now-performanceReportTTLMilliseconds {
+	if r.End < float64(now-performanceReportTTLMilliseconds) {
 		return fmt.Errorf("report is outdated: %d", r.End)
 	}
 

--- a/server/public/model/metrics.go
+++ b/server/public/model/metrics.go
@@ -71,7 +71,7 @@ func (r *PerformanceReport) IsValid() error {
 
 	now := time.Now().UnixMilli()
 	if r.End < float64(now-performanceReportTTLMilliseconds) {
-		return fmt.Errorf("report is outdated: %d", r.End)
+		return fmt.Errorf("report is outdated: %f", r.End)
 	}
 
 	return nil

--- a/server/public/model/metrics_test.go
+++ b/server/public/model/metrics_test.go
@@ -23,8 +23,8 @@ func TestPerformanceReport_IsValid(t *testing.T) {
 			report: &PerformanceReport{
 				Version: "0.1.0",
 				Labels:  map[string]string{"platform": "linux"},
-				Start:   time.Now().UnixMilli() - 10000,
-				End:     time.Now().UnixMilli(),
+				Start:   float64(time.Now().UnixMilli() - 10000),
+				End:     float64(time.Now().UnixMilli()),
 			},
 			expected: nil,
 		},
@@ -38,8 +38,8 @@ func TestPerformanceReport_IsValid(t *testing.T) {
 			report: &PerformanceReport{
 				Version: "2.0.0",
 				Labels:  map[string]string{"platform": "linux"},
-				Start:   time.Now().UnixMilli() - 10000,
-				End:     time.Now().UnixMilli(),
+				Start:   float64(time.Now().UnixMilli() - 10000),
+				End:     float64(time.Now().UnixMilli()),
 			},
 			expected: fmt.Errorf("report version is not supported: server version: 0.1.0, report version: 2.0.0"),
 		},
@@ -48,8 +48,8 @@ func TestPerformanceReport_IsValid(t *testing.T) {
 			report: &PerformanceReport{
 				Version: "0.1.0",
 				Labels:  map[string]string{"platform": "linux"},
-				Start:   time.Now().UnixMilli(),
-				End:     time.Now().Add(-1 * time.Hour).UnixMilli(),
+				Start:   float64(time.Now().UnixMilli()),
+				End:     float64(time.Now().Add(-1 * time.Hour).UnixMilli()),
 			},
 			expected: fmt.Errorf("report timestamps are erroneous"),
 		},
@@ -58,10 +58,10 @@ func TestPerformanceReport_IsValid(t *testing.T) {
 			report: &PerformanceReport{
 				Version: "0.1.0",
 				Labels:  map[string]string{"platform": "linux"},
-				Start:   time.Now().Add(-7 * time.Minute).UnixMilli(),
-				End:     outdatedTimestamp,
+				Start:   float64(time.Now().Add(-7 * time.Minute).UnixMilli()),
+				End:     float64(outdatedTimestamp),
 			},
-			expected: fmt.Errorf("report is outdated: %d", outdatedTimestamp),
+			expected: fmt.Errorf("report is outdated: %f", float64(outdatedTimestamp)),
 		},
 	}
 

--- a/webapp/channels/src/utils/performance_telemetry/reporter.test.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.test.ts
@@ -52,23 +52,23 @@ describe('PerformanceReporter', () => {
         expect(sendBeacon.mock.calls[0][0]).toEqual(siteUrl + '/api/v4/client_perf');
         const report = JSON.parse(sendBeacon.mock.calls[0][1]);
         expect(report).toMatchObject({
-            start: Math.round(performance.timeOrigin + testMarkA.startTime),
-            end: Math.round(performance.timeOrigin + testMarkB.startTime),
+            start: performance.timeOrigin + testMarkA.startTime,
+            end: performance.timeOrigin + testMarkB.startTime,
             histograms: [
                 {
                     metric: 'testMeasureA',
                     value: testMarkB.startTime - testMarkA.startTime,
-                    timestamp: Math.round(performance.timeOrigin + testMarkA.startTime),
+                    timestamp: performance.timeOrigin + testMarkA.startTime,
                 },
                 {
                     metric: 'testMeasureB',
                     value: testMarkC.startTime - testMarkA.startTime,
-                    timestamp: Math.round(performance.timeOrigin + testMarkA.startTime),
+                    timestamp: performance.timeOrigin + testMarkA.startTime,
                 },
                 {
                     metric: 'testMeasureC',
                     value: testMarkC.startTime - testMarkB.startTime,
-                    timestamp: Math.round(performance.timeOrigin + testMarkB.startTime),
+                    timestamp: performance.timeOrigin + testMarkB.startTime,
                 },
             ],
         });
@@ -94,7 +94,7 @@ describe('PerformanceReporter', () => {
 
         expect(reporter.handleObservations).toHaveBeenCalled();
 
-        const timestamp = Math.round(performance.timeOrigin + performance.now());
+        const timestamp = performance.timeOrigin + performance.now();
 
         await waitForReport();
 

--- a/webapp/channels/src/utils/performance_telemetry/reporter.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.ts
@@ -141,7 +141,7 @@ export default class PerformanceReporter {
         this.histogramMeasures.push({
             metric: entry.name,
             value: entry.duration,
-            timestamp: Math.round(performance.timeOrigin + entry.startTime),
+            timestamp: performance.timeOrigin + entry.startTime,
         });
     }
 
@@ -166,7 +166,7 @@ export default class PerformanceReporter {
         this.histogramMeasures.push({
             metric: metric.name,
             value: metric.value,
-            timestamp: Math.round(performance.timeOrigin + performance.now()),
+            timestamp: performance.timeOrigin + performance.now(),
         });
     }
 
@@ -267,7 +267,7 @@ export default class PerformanceReporter {
             counterMeasures.push({
                 metric: name,
                 value,
-                timestamp: Math.round(now),
+                timestamp: now,
             });
         }
 


### PR DESCRIPTION
#### Summary
I missed a case in https://github.com/mattermost/mattermost/pull/27027 where I forgot to round a timestamp. Because there's so many places in the web app code where we need to remember to convert these into floats, I've decided that it'd be better to do this on the server because Go's static typing properly differentiates floats and ints which we can't do in TypeScript.

#### Ticket Link
[MM-58281](https://mattermost.atlassian.net/browse/MM-58281)

#### Release Note
```release-note
NONE
```


[MM-58281]: https://mattermost.atlassian.net/browse/MM-58281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ