### PR TITLE
MM-58262 Remove payload from RemoteClusterFrame audit

### DIFF
--- a/server/public/model/remote_cluster.go
+++ b/server/public/model/remote_cluster.go
@@ -251,7 +251,8 @@ type RemoteClusterFrame struct {
 func (f *RemoteClusterFrame) Auditable() map[string]interface{} {
 	return map[string]interface{}{
 		"remote_id": f.RemoteId,
-		"msg":       f.Msg,
+		"msg_id":    f.Msg.Id,
+		"topic":     f.Msg.Topic,
 	}
 }
 


### PR DESCRIPTION
#### Summary
This PR removes message payloads from RemoteClusterFrame audit logs.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58262

#### Release Note
```release-note
Removes message payloads from RemoteClusterFrame audit logs.
```
