### PR TITLE
[CLD-7742] Make location prop on ExternalLink component required

### DIFF
--- a/webapp/channels/src/components/admin_console/group_settings/group_settings.tsx
+++ b/webapp/channels/src/components/admin_console/group_settings/group_settings.tsx
@@ -54,6 +54,7 @@ const GroupSettings = ({isDisabled}: Props) => {
                         subtitleValues={{
                             link: (msg: React.ReactNode) => (
                                 <ExternalLink
+                                    location='group_settings.ldap_groups'
                                     href={`${siteURL}/admin_console/authentication/ldap`}
                                 >
                                     {msg}

--- a/webapp/channels/src/components/admin_console/ip_filtering/save_confirmation_modal.tsx
+++ b/webapp/channels/src/components/admin_console/ip_filtering/save_confirmation_modal.tsx
@@ -52,6 +52,7 @@ export default function SaveConfirmationModal({onExited, onConfirm, title, subti
                                     values={{
                                         customerportal: (msg) => (
                                             <ExternalLink
+                                                location='save_confirmation_modal'
                                                 href='https://customers.mattermost.com/console/ip_filtering'
                                             >
                                                 {msg}

--- a/webapp/channels/src/components/admin_console/jobs/job_download_link.tsx
+++ b/webapp/channels/src/components/admin_console/jobs/job_download_link.tsx
@@ -17,6 +17,7 @@ const JobDownloadLink = React.memo(({job}: {job: Job}): JSX.Element => {
         return (
             <ExternalLink
                 key={job.id}
+                location='job_download_link'
                 href={`${Client4.getJobsRoute()}/${job.id}/download`}
                 className='JobDownloadLink'
             >

--- a/webapp/channels/src/components/analytics/activated_users_card/title.tsx
+++ b/webapp/channels/src/components/analytics/activated_users_card/title.tsx
@@ -23,7 +23,7 @@ const Title = () => {
             placement='top'
         >
             <span>
-                <ExternalLink href='https://mattermost.com/pl/site-statistics-definitions'>
+                <ExternalLink location='activated_users_card.title' href='https://mattermost.com/pl/site-statistics-definitions'>
                     {intl.formatMessage(messages.totalUsers)}
                     <InformationOutlineIcon size='16'/>
                 </ExternalLink>

--- a/webapp/channels/src/components/analytics/activated_users_card/title.tsx
+++ b/webapp/channels/src/components/analytics/activated_users_card/title.tsx
@@ -23,7 +23,10 @@ const Title = () => {
             placement='top'
         >
             <span>
-                <ExternalLink location='activated_users_card.title' href='https://mattermost.com/pl/site-statistics-definitions'>
+                <ExternalLink
+                    location='activated_users_card.title'
+                    href='https://mattermost.com/pl/site-statistics-definitions'
+                >
                     {intl.formatMessage(messages.totalUsers)}
                     <InformationOutlineIcon size='16'/>
                 </ExternalLink>

--- a/webapp/channels/src/components/external_link/__snapshots__/external_link.test.tsx.snap
+++ b/webapp/channels/src/components/external_link/__snapshots__/external_link.test.tsx.snap
@@ -15,9 +15,11 @@ exports[`components/external_link should match snapshot 1`] = `
 >
   <ExternalLink
     href="https://mattermost.com"
+    location="test"
   >
     <a
-      href="https://mattermost.com?utm_source=mattermost&utm_medium=in-product-cloud&utm_content=&uid=currentUserId&sid="
+      href="https://mattermost.com?utm_source=mattermost&utm_medium=in-product-cloud&utm_content=test&uid=currentUserId&sid="
+      location="test"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"

--- a/webapp/channels/src/components/external_link/external_link.test.tsx
+++ b/webapp/channels/src/components/external_link/external_link.test.tsx
@@ -58,7 +58,10 @@ describe('components/external_link', () => {
             },
         };
         renderWithContext(
-            <ExternalLink location='test' href='https://mattermost.com'>
+            <ExternalLink
+                location='test'
+                href='https://mattermost.com'
+            >
                 {'Click Me'}
             </ExternalLink>,
             state,
@@ -84,7 +87,10 @@ describe('components/external_link', () => {
             },
         };
         renderWithContext(
-            <ExternalLink location='test' href='https://mattermost.com?test=true'>
+            <ExternalLink
+                location='test'
+                href='https://mattermost.com?test=true'
+            >
                 {'Click Me'}
             </ExternalLink>,
             state,
@@ -110,7 +116,10 @@ describe('components/external_link', () => {
             },
         };
         renderWithContext(
-            <ExternalLink location='test' href='https://google.com'>
+            <ExternalLink
+                location='test'
+                href='https://google.com'
+            >
                 {'Click Me'}
             </ExternalLink>,
             state,

--- a/webapp/channels/src/components/external_link/external_link.test.tsx
+++ b/webapp/channels/src/components/external_link/external_link.test.tsx
@@ -34,6 +34,7 @@ describe('components/external_link', () => {
         const wrapper = mount(
             <Provider store={store}>
                 <ExternalLink
+                    location='test'
                     href='https://mattermost.com'
 
                 >{'Click Me'}</ExternalLink>
@@ -57,7 +58,7 @@ describe('components/external_link', () => {
             },
         };
         renderWithContext(
-            <ExternalLink href='https://mattermost.com'>
+            <ExternalLink location='test' href='https://mattermost.com'>
                 {'Click Me'}
             </ExternalLink>,
             state,
@@ -83,7 +84,7 @@ describe('components/external_link', () => {
             },
         };
         renderWithContext(
-            <ExternalLink href='https://mattermost.com?test=true'>
+            <ExternalLink location='test' href='https://mattermost.com?test=true'>
                 {'Click Me'}
             </ExternalLink>,
             state,
@@ -109,7 +110,7 @@ describe('components/external_link', () => {
             },
         };
         renderWithContext(
-            <ExternalLink href='https://google.com'>
+            <ExternalLink location='test' href='https://google.com'>
                 {'Click Me'}
             </ExternalLink>,
             state,
@@ -139,6 +140,7 @@ describe('components/external_link', () => {
                 target='test'
                 rel='test'
                 href='https://google.com'
+                location='test'
             >{'Click Me'}</ExternalLink>,
             state,
         );
@@ -170,6 +172,7 @@ describe('components/external_link', () => {
         };
         renderWithContext(
             <ExternalLink
+                location='test'
                 href='https://mattermost.com#desktop'
             >
                 {'Click Me'}

--- a/webapp/channels/src/components/external_link/external_link.test.tsx
+++ b/webapp/channels/src/components/external_link/external_link.test.tsx
@@ -69,7 +69,7 @@ describe('components/external_link', () => {
 
         expect(screen.queryByText('Click Me')).toHaveAttribute(
             'href',
-            expect.stringMatching('utm_source=mattermost&utm_medium=in-product-cloud&utm_content=&uid=currentUserId&sid='),
+            expect.stringMatching('utm_source=mattermost&utm_medium=in-product-cloud&utm_content=test&uid=currentUserId&sid='),
         );
     });
 
@@ -98,7 +98,7 @@ describe('components/external_link', () => {
 
         expect(screen.queryByText('Click Me')).toHaveAttribute(
             'href',
-            'https://mattermost.com?utm_source=mattermost&utm_medium=in-product-cloud&utm_content=&uid=currentUserId&sid=&test=true',
+            'https://mattermost.com?utm_source=mattermost&utm_medium=in-product-cloud&utm_content=test&uid=currentUserId&sid=&test=true',
         );
     });
 
@@ -191,7 +191,7 @@ describe('components/external_link', () => {
 
         expect(screen.queryByText('Click Me')).toHaveAttribute(
             'href',
-            'https://mattermost.com?utm_source=mattermost&utm_medium=in-product-cloud&utm_content=&uid=currentUserId&sid=#desktop',
+            'https://mattermost.com?utm_source=mattermost&utm_medium=in-product-cloud&utm_content=test&uid=currentUserId&sid=#desktop',
         );
     });
 });

--- a/webapp/channels/src/components/external_link/index.tsx
+++ b/webapp/channels/src/components/external_link/index.tsx
@@ -25,7 +25,7 @@ type Props = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
     rel?: string;
     onClick?: (event: React.MouseEvent<HTMLElement>) => void;
     queryParams?: ExternalLinkQueryParams;
-    location?: string;
+    location: string;
     children: React.ReactNode;
 };
 

--- a/webapp/channels/src/components/invitation_modal/overage_users_banner_notice/index.tsx
+++ b/webapp/channels/src/components/invitation_modal/overage_users_banner_notice/index.tsx
@@ -97,6 +97,7 @@ const OverageUsersBannerNotice = () => {
 
                         return (
                             <ExternalLink
+                                location='overage_users_banner'
                                 className='overage_users_banner__button'
                                 href={LicenseLinks.CONTACT_SALES}
                                 onClick={handleClick}

--- a/webapp/channels/src/components/invitation_modal/overage_users_banner_notice/overage_users_banner_notice.test.tsx
+++ b/webapp/channels/src/components/invitation_modal/overage_users_banner_notice/overage_users_banner_notice.test.tsx
@@ -231,7 +231,7 @@ describe('components/invitation_modal/overage_users_banner_notice', () => {
         expect(screen.getByRole('link')).toHaveAttribute(
             'href',
             LicenseLinks.CONTACT_SALES +
-                '?utm_source=mattermost&utm_medium=in-product&utm_content=&uid=current_user&sid=',
+                '?utm_source=mattermost&utm_medium=in-product&utm_content=overage_users_banner&uid=current_user&sid=',
         );
         expect(trackEvent).toBeCalledTimes(2);
         expect(trackEvent).toBeCalledWith('insights', 'click_true_up_warning', {
@@ -337,7 +337,7 @@ describe('components/invitation_modal/overage_users_banner_notice', () => {
         expect(screen.getByRole('link')).toHaveAttribute(
             'href',
             LicenseLinks.CONTACT_SALES +
-                '?utm_source=mattermost&utm_medium=in-product&utm_content=&uid=current_user&sid=',
+                '?utm_source=mattermost&utm_medium=in-product&utm_content=overage_users_banner&uid=current_user&sid=',
         );
         expect(trackEvent).toBeCalledTimes(2);
         expect(trackEvent).toBeCalledWith('insights', 'click_true_up_error', {

--- a/webapp/channels/src/components/login/login.tsx
+++ b/webapp/channels/src/components/login/login.tsx
@@ -745,7 +745,7 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
         if (ForgotPasswordLink) {
             return (
                 <div className='login-body-card-form-link'>
-                    <ExternalLink href={ForgotPasswordLink}>
+                    <ExternalLink location='login_page' href={ForgotPasswordLink}>
                         {formatMessage({id: 'login.forgot', defaultMessage: 'Forgot your password?'})}
                     </ExternalLink>
                 </div>

--- a/webapp/channels/src/components/login/login.tsx
+++ b/webapp/channels/src/components/login/login.tsx
@@ -745,7 +745,10 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
         if (ForgotPasswordLink) {
             return (
                 <div className='login-body-card-form-link'>
-                    <ExternalLink location='login_page' href={ForgotPasswordLink}>
+                    <ExternalLink
+                        location='login_page'
+                        href={ForgotPasswordLink}
+                    >
                         {formatMessage({id: 'login.forgot', defaultMessage: 'Forgot your password?'})}
                     </ExternalLink>
                 </div>

--- a/webapp/channels/src/components/main_menu/learn_about_teams_link.tsx
+++ b/webapp/channels/src/components/main_menu/learn_about_teams_link.tsx
@@ -16,6 +16,7 @@ const LearnAboutTeamsLink = () => {
                 values={{
                     a: (chunks) => (
                         <ExternalLink
+                            location='learn_about_teams'
                             href='https://mattermost.com/pl/mattermost-academy-team-training'
                         >
                             <i className='icon icon-lightbulb-outline'/>

--- a/webapp/channels/src/components/preparing_workspace/organization_status.tsx
+++ b/webapp/channels/src/components/preparing_workspace/organization_status.tsx
@@ -55,9 +55,8 @@ const OrganizationStatus = (props: {error: (UrlValidationCheck['error'] | typeof
                     values={{
                         a: (chunks: React.ReactNode | React.ReactNodeArray) => (
                             <ExternalLink
+                                location='organization_status'
                                 href={DocLinks.ABOUT_TEAMS}
-                                target='_blank'
-                                rel='noreferrer'
                             >
                                 {chunks}
                             </ExternalLink>

--- a/webapp/channels/src/components/reaction_limit_reached_modal.tsx
+++ b/webapp/channels/src/components/reaction_limit_reached_modal.tsx
@@ -17,6 +17,7 @@ export default function ReactionLimitReachedModal(props: {isAdmin: boolean; onEx
             values={{
                 link: (msg: React.ReactNode) => (
                     <ExternalLink
+                        location='reaction_limit_reached_modal'
                         href='https://mattermost.com/pl/configure-unique-emoji-reaction-limit'
                     >
                         {msg}

--- a/webapp/channels/src/components/search_hint/search_hint.tsx
+++ b/webapp/channels/src/components/search_hint/search_hint.tsx
@@ -59,6 +59,7 @@ const SearchHint = (props: Props): JSX.Element => {
                             values={{
                                 a: (chunks) => (
                                     <ExternalLink
+                                        location='search_hint'
                                         className='search-hint_learn-search'
                                         href='https://mattermost.com/pl/mattermost-academy-search-training'
                                     >

--- a/webapp/channels/src/components/seats_calculator/consequences.tsx
+++ b/webapp/channels/src/components/seats_calculator/consequences.tsx
@@ -86,6 +86,7 @@ export default function Consequences(props: Props) {
                 values={{
                     a: (chunks: React.ReactNode) => (
                         <ExternalLink
+                            location='seats_calculator_consequences'
                             onClick={telemetryHandler}
                             href={props.isCloud ? CloudLinks.BILLING_DOCS : HostedCustomerLinks.BILLING_DOCS}
                         >

--- a/webapp/channels/src/components/user_settings/notifications/__snapshots__/user_settings_notifications.test.tsx.snap
+++ b/webapp/channels/src/components/user_settings/notifications/__snapshots__/user_settings_notifications.test.tsx.snap
@@ -54,7 +54,8 @@ Object {
             >
               <a
                 class="btn btn-link"
-                href="https://mattermost.com/pl/about-notifications?utm_source=mattermost&utm_medium=in-product&utm_content=&uid=&sid="
+                href="https://mattermost.com/pl/about-notifications?utm_source=mattermost&utm_medium=in-product&utm_content=user_settings_notifications&uid=&sid="
+                location="user_settings_notifications"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -312,7 +313,8 @@ Object {
           >
             <a
               class="btn btn-link"
-              href="https://mattermost.com/pl/about-notifications?utm_source=mattermost&utm_medium=in-product&utm_content=&uid=&sid="
+              href="https://mattermost.com/pl/about-notifications?utm_source=mattermost&utm_medium=in-product&utm_content=user_settings_notifications&uid=&sid="
+              location="user_settings_notifications"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -629,7 +631,8 @@ Object {
             >
               <a
                 class="btn btn-link"
-                href="https://mattermost.com/pl/about-notifications?utm_source=mattermost&utm_medium=in-product&utm_content=&uid=&sid="
+                href="https://mattermost.com/pl/about-notifications?utm_source=mattermost&utm_medium=in-product&utm_content=user_settings_notifications&uid=&sid="
+                location="user_settings_notifications"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -890,7 +893,8 @@ Object {
           >
             <a
               class="btn btn-link"
-              href="https://mattermost.com/pl/about-notifications?utm_source=mattermost&utm_medium=in-product&utm_content=&uid=&sid="
+              href="https://mattermost.com/pl/about-notifications?utm_source=mattermost&utm_medium=in-product&utm_content=user_settings_notifications&uid=&sid="
+              location="user_settings_notifications"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1210,7 +1214,8 @@ Object {
             >
               <a
                 class="btn btn-link"
-                href="https://mattermost.com/pl/about-notifications?utm_source=mattermost&utm_medium=in-product&utm_content=&uid=&sid="
+                href="https://mattermost.com/pl/about-notifications?utm_source=mattermost&utm_medium=in-product&utm_content=user_settings_notifications&uid=&sid="
+                location="user_settings_notifications"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -1433,7 +1438,8 @@ Object {
           >
             <a
               class="btn btn-link"
-              href="https://mattermost.com/pl/about-notifications?utm_source=mattermost&utm_medium=in-product&utm_content=&uid=&sid="
+              href="https://mattermost.com/pl/about-notifications?utm_source=mattermost&utm_medium=in-product&utm_content=user_settings_notifications&uid=&sid="
+              location="user_settings_notifications"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.tsx
+++ b/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.tsx
@@ -985,6 +985,7 @@ class NotificationsTab extends React.PureComponent<Props, State> {
                                 values={{
                                     a: (chunks: string) => ((
                                         <ExternalLink
+                                            location='user_settings_notifications'
                                             href='https://mattermost.com/pl/about-notifications'
                                             className='btn btn-link'
                                         >


### PR DESCRIPTION
#### Summary
Marketing has requested that the `utm_content` parameter not be empty - it's driven by the `location` prop on the `ExternalLink` component. This PR removes the optionality of that prop so that it must be passed. This PR also updates existing occurrences of the ExternalLink that were missing the `location` prop. 

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-7742

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
