### PR TITLE
Automated cherry pick of #27035

### DIFF
--- a/webapp/channels/src/components/root/__snapshots__/root.test.tsx.snap
+++ b/webapp/channels/src/components/root/__snapshots__/root.test.tsx.snap
@@ -126,11 +126,11 @@ exports[`components/Root Routes Should mount public product routes 1`] = `
           />
           <Connect(RootRedirect) />
         </Switch>
-        <Connect(Pluggable)
-          pluggableName="Global"
-        />
         <withRouter(Connect(SidebarRight)) />
       </div>
+      <Connect(Pluggable)
+        pluggableName="Global"
+      />
       <AppBar />
       <Connect(Component) />
     </CompassThemeProvider>

--- a/webapp/channels/src/components/root/root.tsx
+++ b/webapp/channels/src/components/root/root.tsx
@@ -619,9 +619,9 @@ export default class Root extends React.PureComponent<Props, State> {
                                 />
                                 <RootRedirect/>
                             </Switch>
-                            <Pluggable pluggableName='Global'/>
                             <SidebarRight/>
                         </div>
+                        <Pluggable pluggableName='Global'/>
                         <AppBar/>
                         <SidebarRightMenu/>
                     </CompassThemeProvider>


### PR DESCRIPTION
Cherry pick of #27035 on release-9.9.

/cc  @cpoile

```release-note
NONE
```