### PR TITLE
[MM-58326] Remove aria-disabled for disabled tooltip in calls button following WithTooltip integration

### DIFF
--- a/webapp/channels/src/components/profile_popover/profile_popover.scss
+++ b/webapp/channels/src/components/profile_popover/profile_popover.scss
@@ -223,12 +223,5 @@
                 row-gap: 4px;
             }
         }
-
-        button#startCallButton {
-            &.icon-btn-disabled {
-                cursor: not-allowed;
-                opacity: 0.65;
-            }
-        }
     }
 }

--- a/webapp/channels/src/components/profile_popover/profile_popover.test.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover.test.tsx
@@ -315,7 +315,7 @@ describe('components/ProfilePopover', () => {
 
         renderWithPluginReducers(<ProfilePopover {...props}/>, initialState);
         const button = (await screen.findByLabelText('Call with user is ongoing')).closest('button');
-        expect(button?.getAttribute('aria-disabled')).toBe('true');
+        expect(button).toBeDisabled();
     });
 
     test('should not show the start call button when callsChannelState.enabled is false', async () => {

--- a/webapp/channels/src/components/profile_popover/profile_popover_call_button_wrapper/index.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover_call_button_wrapper/index.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import classNames from 'classnames';
 import React, {useCallback, useEffect, useState} from 'react';
 import {useIntl} from 'react-intl';
 import {useSelector} from 'react-redux';
@@ -95,7 +94,6 @@ const CallButton = ({
         id: 'webapp.mattermost.feature.start_call',
         defaultMessage: 'Start Call',
     });
-    const iconButtonClassName = classNames('btn btn-icon btn-sm style--none', {'icon-btn-disabled': disabled});
     const callButton = (
         <WithTooltip
             id='startCallTooltip'
@@ -105,8 +103,8 @@ const CallButton = ({
             <button
                 id='startCallButton'
                 type='button'
-                aria-disabled={disabled}
-                className={iconButtonClassName}
+                disabled={disabled}
+                className='btn btn-icon btn-sm style--none'
                 aria-label={startCallMessage}
             >
                 <span


### PR DESCRIPTION
#### Summary
Withtooltip component supports the element with disabled attribute as well so i just removed the hack we did to make it work previously with aria-disabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58326

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
