### PR TITLE
MM-58359 Add page_load to Prometheus metrics

### DIFF
--- a/server/channels/app/metrics.go
+++ b/server/channels/app/metrics.go
@@ -36,6 +36,8 @@ func (a *App) RegisterPerformanceReport(rctx request.CTX, report *model.Performa
 			a.Metrics().ObserveClientInteractionToNextPaint(commonLabels["platform"], commonLabels["agent"], h.Value/1000)
 		case model.ClientCumulativeLayoutShift:
 			a.Metrics().ObserveClientCumulativeLayoutShift(commonLabels["platform"], commonLabels["agent"], h.Value)
+		case model.ClientPageLoadDuration:
+			a.Metrics().ObserveClientPageLoadDuration(commonLabels["platform"], commonLabels["agent"], h.Value/1000)
 		case model.ClientChannelSwitchDuration:
 			a.Metrics().ObserveClientChannelSwitchDuration(commonLabels["platform"], commonLabels["agent"], h.Value/1000)
 		case model.ClientTeamSwitchDuration:

--- a/server/einterfaces/metrics.go
+++ b/server/einterfaces/metrics.go
@@ -109,6 +109,7 @@ type MetricsInterface interface {
 	ObserveClientInteractionToNextPaint(platform, agent string, elapsed float64)
 	ObserveClientCumulativeLayoutShift(platform, agent string, elapsed float64)
 	IncrementClientLongTasks(platform, agent string, inc float64)
+	ObserveClientPageLoadDuration(platform, agent string, elapsed float64)
 	ObserveClientChannelSwitchDuration(platform, agent string, elapsed float64)
 	ObserveClientTeamSwitchDuration(platform, agent string, elapsed float64)
 	ObserveClientRHSLoadDuration(platform, agent string, elapsed float64)

--- a/server/einterfaces/mocks/MetricsInterface.go
+++ b/server/einterfaces/mocks/MetricsInterface.go
@@ -323,6 +323,11 @@ func (_m *MetricsInterface) ObserveClientLargestContentfulPaint(platform string,
 	_m.Called(platform, agent, elapsed)
 }
 
+// ObserveClientPageLoadDuration provides a mock function with given fields: platform, agent, elapsed
+func (_m *MetricsInterface) ObserveClientPageLoadDuration(platform string, agent string, elapsed float64) {
+	_m.Called(platform, agent, elapsed)
+}
+
 // ObserveClientRHSLoadDuration provides a mock function with given fields: platform, agent, elapsed
 func (_m *MetricsInterface) ObserveClientRHSLoadDuration(platform string, agent string, elapsed float64) {
 	_m.Called(platform, agent, elapsed)

--- a/server/enterprise/metrics/metrics.go
+++ b/server/enterprise/metrics/metrics.go
@@ -217,6 +217,7 @@ type MetricsInterfaceImpl struct {
 	ClientInteractionToNextPaint    *prometheus.HistogramVec
 	ClientCumulativeLayoutShift     *prometheus.HistogramVec
 	ClientLongTasks                 *prometheus.CounterVec
+	ClientPageLoadDuration          *prometheus.HistogramVec
 	ClientChannelSwitchDuration     *prometheus.HistogramVec
 	ClientTeamSwitchDuration        *prometheus.HistogramVec
 	ClientRHSLoadDuration           *prometheus.HistogramVec
@@ -1200,6 +1201,17 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 	)
 	m.Registry.MustRegister(m.ClientLongTasks)
 
+	m.ClientPageLoadDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: MetricsNamespace,
+			Subsystem: MetricsSubsystemClientsWeb,
+			Name:      "page_load",
+			Help:      "The amount of time from when the browser starts loading the web app until when the web app's load event has finished (seconds)",
+		},
+		[]string{"platform", "agent"},
+	)
+	m.Registry.MustRegister(m.ClientPageLoadDuration)
+
 	m.ClientChannelSwitchDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: MetricsNamespace,
@@ -1724,6 +1736,10 @@ func (mi *MetricsInterfaceImpl) ObserveClientCumulativeLayoutShift(platform, age
 
 func (mi *MetricsInterfaceImpl) IncrementClientLongTasks(platform, agent string, inc float64) {
 	mi.ClientLongTasks.With(prometheus.Labels{"platform": platform, "agent": agent}).Add(inc)
+}
+
+func (mi *MetricsInterfaceImpl) ObserveClientPageLoadDuration(platform, agent string, elapsed float64) {
+	mi.ClientPageLoadDuration.With(prometheus.Labels{"platform": platform, "agent": agent}).Observe(elapsed)
 }
 
 func (mi *MetricsInterfaceImpl) ObserveClientChannelSwitchDuration(platform, agent string, elapsed float64) {

--- a/server/public/model/metrics.go
+++ b/server/public/model/metrics.go
@@ -20,6 +20,7 @@ const (
 	ClientInteractionToNextPaint    MetricType = "INP"
 	ClientCumulativeLayoutShift     MetricType = "CLS"
 	ClientLongTasks                 MetricType = "long_tasks"
+	ClientPageLoadDuration          MetricType = "page_load"
 	ClientChannelSwitchDuration     MetricType = "channel_switch"
 	ClientTeamSwitchDuration        MetricType = "team_switch"
 	ClientRHSLoadDuration           MetricType = "rhs_load"

--- a/webapp/channels/src/utils/performance_telemetry/index.ts
+++ b/webapp/channels/src/utils/performance_telemetry/index.ts
@@ -12,6 +12,7 @@ export const enum Mark {
 export const enum Measure {
     ChannelSwitch = 'channel_switch',
     GlobalThreadsLoad = 'global_threads_load',
+    PageLoad = 'page_load',
     RhsLoad = 'rhs_load',
     TeamSwitch = 'team_switch',
 }


### PR DESCRIPTION
#### Summary
This value is sort of reflected by the FCP and LCP metrics (both of which will happen after this), but I decided to this to Prometheus since it lets us compare to the existing `page_load` metrics that we've collected with the Rudder/Looker stack

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58359

#### Release Note
```release-note
Add page load time to client performance metrics
```
