### PR TITLE
MM-58351 Fix showing LHS scrollbar when moving mouse over on chrome and safari

### DIFF
--- a/webapp/channels/src/components/sidebar/sidebar_list/__snapshots__/sidebar_list.test.tsx.snap
+++ b/webapp/channels/src/components/sidebar/sidebar_list/__snapshots__/sidebar_list.test.tsx.snap
@@ -37,50 +37,55 @@ exports[`SidebarList should match snapshot 1`] = `
       onClick={[Function]}
       show={false}
     />
-    <Scrollbars
-      autoHeight={false}
-      autoHeightMax={200}
-      autoHeightMin={0}
-      autoHide={true}
-      autoHideDuration={500}
-      autoHideTimeout={500}
-      hideTracksWhenNotNeeded={false}
-      onScroll={[Function]}
-      renderThumbHorizontal={[Function]}
-      renderThumbVertical={[Function]}
-      renderTrackHorizontal={[Function]}
-      renderTrackVertical={[Function]}
-      renderView={[Function]}
-      style={
-        Object {
-          "position": "absolute",
-        }
-      }
-      tagName="div"
-      thumbMinSize={30}
-      universal={false}
+    <div
+      onPointerLeave={[Function]}
+      onPointerOver={[Function]}
     >
-      <DragDropContext
-        onBeforeCapture={[Function]}
-        onBeforeDragStart={[Function]}
-        onDragEnd={[Function]}
-        onDragStart={[Function]}
+      <Scrollbars
+        autoHeight={false}
+        autoHeightMax={200}
+        autoHeightMin={0}
+        autoHide={true}
+        autoHideDuration={200}
+        autoHideTimeout={1000}
+        hideTracksWhenNotNeeded={false}
+        onScroll={[Function]}
+        renderThumbHorizontal={[Function]}
+        renderThumbVertical={[Function]}
+        renderTrackHorizontal={[Function]}
+        renderTrackVertical={[Function]}
+        renderView={[Function]}
+        style={
+          Object {
+            "position": "absolute",
+          }
+        }
+        tagName="div"
+        thumbMinSize={30}
+        universal={false}
       >
-        <Connect(Droppable)
-          direction="vertical"
-          droppableId="droppable-categories"
-          getContainerForClone={[Function]}
-          ignoreContainerClipping={false}
-          isCombineEnabled={false}
-          isDropDisabled={false}
-          mode="standard"
-          renderClone={null}
-          type="SIDEBAR_CATEGORY"
+        <DragDropContext
+          onBeforeCapture={[Function]}
+          onBeforeDragStart={[Function]}
+          onDragEnd={[Function]}
+          onDragStart={[Function]}
         >
-          <Component />
-        </Connect(Droppable)>
-      </DragDropContext>
-    </Scrollbars>
+          <Connect(Droppable)
+            direction="vertical"
+            droppableId="droppable-categories"
+            getContainerForClone={[Function]}
+            ignoreContainerClipping={false}
+            isCombineEnabled={false}
+            isDropDisabled={false}
+            mode="standard"
+            renderClone={null}
+            type="SIDEBAR_CATEGORY"
+          >
+            <Component />
+          </Connect(Droppable)>
+        </DragDropContext>
+      </Scrollbars>
+    </div>
   </div>
 </Fragment>
 `;

--- a/webapp/channels/src/components/sidebar/sidebar_list/sidebar_list.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_list/sidebar_list.tsx
@@ -111,8 +111,6 @@ type State = {
     autoHide: boolean;
 };
 
-let mouseMoveTimeout: NodeJS.Timeout;
-
 // scrollMargin is the margin at the edge of the channel list that we leave when scrolling to a channel.
 const scrollMargin = 10;
 
@@ -128,6 +126,7 @@ export default class SidebarList extends React.PureComponent<Props, State> {
     scrollbar: React.RefObject<Scrollbars>;
     animate: SpringSystem;
     scrollAnimation: Spring;
+    channelsListScrollTimeout: NodeJS.Timeout | null = null;
 
     constructor(props: Props) {
         super(props);
@@ -136,7 +135,7 @@ export default class SidebarList extends React.PureComponent<Props, State> {
         this.state = {
             showTopUnread: false,
             showBottomUnread: false,
-            autoHide: false,
+            autoHide: true,
         };
         this.scrollbar = React.createRef();
 
@@ -466,14 +465,18 @@ export default class SidebarList extends React.PureComponent<Props, State> {
         this.props.actions.stopDragging();
     };
 
-    showScrollbarOnMouseMove = () => {
-        clearTimeout(mouseMoveTimeout);
+    showChannelListScrollbar = () => {
+        if (this.channelsListScrollTimeout !== null) {
+            clearTimeout(this.channelsListScrollTimeout);
+        }
 
         this.setState({autoHide: false});
+    };
 
-        mouseMoveTimeout = setTimeout(() => {
+    hideChannelListScrollbar = () => {
+        this.channelsListScrollTimeout = setTimeout(() => {
             this.setState({autoHide: true});
-        }, 500);
+        }, 300);
     };
 
     render() {
@@ -577,7 +580,8 @@ export default class SidebarList extends React.PureComponent<Props, State> {
                         content={below}
                     />
                     <div
-                        onMouseMove={this.showScrollbarOnMouseMove}
+                        onPointerLeave={this.hideChannelListScrollbar}
+                        onPointerOver={this.showChannelListScrollbar}
                     >
                         <Scrollbars
                             ref={this.scrollbar}

--- a/webapp/channels/src/components/sidebar/sidebar_list/sidebar_list.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_list/sidebar_list.tsx
@@ -108,7 +108,10 @@ type Props = {
 type State = {
     showTopUnread: boolean;
     showBottomUnread: boolean;
+    autoHide: boolean;
 };
+
+let mouseMoveTimeout: NodeJS.Timeout;
 
 // scrollMargin is the margin at the edge of the channel list that we leave when scrolling to a channel.
 const scrollMargin = 10;
@@ -133,6 +136,7 @@ export default class SidebarList extends React.PureComponent<Props, State> {
         this.state = {
             showTopUnread: false,
             showBottomUnread: false,
+            autoHide: false,
         };
         this.scrollbar = React.createRef();
 
@@ -462,6 +466,16 @@ export default class SidebarList extends React.PureComponent<Props, State> {
         this.props.actions.stopDragging();
     };
 
+    showScrollbarOnMouseMove = () => {
+        clearTimeout(mouseMoveTimeout);
+
+        this.setState({autoHide: false});
+
+        mouseMoveTimeout = setTimeout(() => {
+            this.setState({autoHide: true});
+        }, 500);
+    };
+
     render() {
         const {categories} = this.props;
 
@@ -562,20 +576,22 @@ export default class SidebarList extends React.PureComponent<Props, State> {
                         extraClass='nav-pills__unread-indicator-bottom'
                         content={below}
                     />
-                    <Scrollbars
-                        ref={this.scrollbar}
-                        autoHide={true}
-                        autoHideTimeout={500}
-                        autoHideDuration={500}
-                        renderThumbHorizontal={renderThumbHorizontal}
-                        renderThumbVertical={renderThumbVertical}
-                        renderTrackVertical={renderTrackVertical}
-                        renderView={renderView}
-                        onScroll={this.onScroll}
-                        style={scrollbarStyles}
+                    <div
+                        onMouseMove={this.showScrollbarOnMouseMove}
                     >
-                        {channelList}
-                    </Scrollbars>
+                        <Scrollbars
+                            ref={this.scrollbar}
+                            autoHide={this.state.autoHide}
+                            renderThumbHorizontal={renderThumbHorizontal}
+                            renderThumbVertical={renderThumbVertical}
+                            renderTrackVertical={renderTrackVertical}
+                            renderView={renderView}
+                            onScroll={this.onScroll}
+                            style={scrollbarStyles}
+                        >
+                            {channelList}
+                        </Scrollbars>
+                    </div>
                 </div>
             </>
         );


### PR DESCRIPTION
#### Summary
The problem was, the `react-custom-scrollbars` seems to not work consistent across browsers with `auto-hide` feature. I added my own event that does the same effect as on firefox, but is also working now for others in the same way. I did not found other solutions that would have same effect by just using `Scrollbar` component interface.

Please test on safari as I don't have mac at home :) But I'm pretty sure that should work.

Small note: The lib itself is super old and not maintained for over 7 years. There is forked version called `react-custom-scrollbars-2` I checked it quickly and seems like it does not break anything, if you are up for it I could do other PR with update. Newer version last publish is 2y ago but it fixes some bugs.

#### Ticket Link
[https://mattermost.atlassian.net/browse/MM-58351](https://mattermost.atlassian.net/browse/MM-58351)
Fixes https://github.com/mattermost/mattermost/issues/27093

#### Screenshots

For an easier comparison of UI changes a table (template below) can be used.

GIfs from chrome
|  before  |  after  |
|----|----|
| ![before](https://github.com/mattermost/mattermost/assets/45789222/c0ba82b2-ff54-497b-822e-6bb8037d8936) | ![after](https://github.com/mattermost/mattermost/assets/45789222/73d4183c-9e84-4d2f-85a9-4f2caab51afc) |


#### Release Note
```release-note
Fix LHS scrollbar autohide functionality, for chrome and safari.
```
