### PR TITLE
Fix test that is not using context

### DIFF
--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -244,7 +244,7 @@ func TestCreatePost(t *testing.T) {
 		CheckCreatedStatus(t, resp)
 		require.Zero(t, *respPost.RemoteId)
 
-		createdPost, appErr := th.App.GetSinglePost(respPost.Id, false)
+		createdPost, appErr := th.App.GetSinglePost(th.Context, respPost.Id, false)
 		require.Nil(t, appErr)
 		require.Zero(t, *createdPost.RemoteId)
 	})


### PR DESCRIPTION
#### Summary
Fixes a post test that is not using the context parameter in an app call

#### Release Note
```release-note
NONE
```
