### PR TITLE
[CLD-7724] Allow admin-set announcement banners to stack below system ones

### DIFF
--- a/webapp/channels/src/components/announcement_bar/__snapshots__/announcement_bar.test.tsx.snap
+++ b/webapp/channels/src/components/announcement_bar/__snapshots__/announcement_bar.test.tsx.snap
@@ -1,5 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/AnnouncementBar should match snapshot, admin configured bar 1`] = `
+<div>
+  <AnnouncementBar
+    actions={
+      Object {
+        "decrementAnnouncementBarCount": [MockFunction],
+        "incrementAnnouncementBarCount": [MockFunction],
+        "sendVerificationEmail": [MockFunction],
+      }
+    }
+    allowBannerDismissal={true}
+    announcementBarCount={0}
+    bannerColor="green"
+    bannerText="Banner text"
+    bannerTextColor="black"
+    canViewAPIv3Banner={false}
+    canViewSystemErrors={false}
+    color=""
+    enableBanner={true}
+    enablePreviewMode={false}
+    enableSignUpWithGitLab={false}
+    isLoggedIn={true}
+    isTallBanner={false}
+    license={
+      Object {
+        "id": "",
+      }
+    }
+    message="text"
+    sendEmailNotifications={true}
+    showCTA={true}
+    showCloseButton={false}
+    showLinkAsButton={false}
+    siteURL=""
+    textColor=""
+    type="critical"
+  />
+  <AnnouncementBar
+    actions={
+      Object {
+        "decrementAnnouncementBarCount": [MockFunction],
+        "incrementAnnouncementBarCount": [MockFunction],
+        "sendVerificationEmail": [MockFunction],
+      }
+    }
+    allowBannerDismissal={true}
+    announcementBarCount={0}
+    bannerColor="green"
+    bannerText="Banner text"
+    bannerTextColor="black"
+    canViewAPIv3Banner={false}
+    canViewSystemErrors={false}
+    className="admin-announcement"
+    color=""
+    enableBanner={true}
+    enablePreviewMode={false}
+    enableSignUpWithGitLab={false}
+    isLoggedIn={true}
+    isTallBanner={false}
+    license={
+      Object {
+        "id": "",
+      }
+    }
+    message="text"
+    sendEmailNotifications={true}
+    showCTA={true}
+    showCloseButton={false}
+    showLinkAsButton={false}
+    siteURL=""
+    textColor=""
+    type="critical"
+  />
+</div>
+`;
+
 exports[`components/AnnouncementBar should match snapshot, bar not showing 1`] = `
 <_StyledDiv
   className="announcement-bar announcement-bar-critical"

--- a/webapp/channels/src/components/announcement_bar/announcement_bar.test.tsx
+++ b/webapp/channels/src/components/announcement_bar/announcement_bar.test.tsx
@@ -101,4 +101,16 @@ describe('components/AnnouncementBar', () => {
         wrapper.setProps(newProps as any);
         expect(wrapper).toMatchSnapshot();
     });
+
+    test('should match snapshot, admin configured bar', () => {
+        const props = { ...baseProps, enableBanner: true, bannerText: 'Banner text' };
+        const wrapper = shallow(
+            <div>
+                <AnnouncementBar {...props} />
+                <AnnouncementBar {...props} className="admin-announcement" />
+            </div>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/webapp/channels/src/components/announcement_bar/announcement_bar.test.tsx
+++ b/webapp/channels/src/components/announcement_bar/announcement_bar.test.tsx
@@ -103,11 +103,14 @@ describe('components/AnnouncementBar', () => {
     });
 
     test('should match snapshot, admin configured bar', () => {
-        const props = { ...baseProps, enableBanner: true, bannerText: 'Banner text' };
+        const props = {...baseProps, enableBanner: true, bannerText: 'Banner text'};
         const wrapper = shallow(
             <div>
-                <AnnouncementBar {...props} />
-                <AnnouncementBar {...props} className="admin-announcement" />
+                <AnnouncementBar {...props}/>
+                <AnnouncementBar
+                    {...props}
+                    className='admin-announcement'
+                />
             </div>,
         );
 

--- a/webapp/channels/src/components/announcement_bar/announcement_bar_controller.tsx
+++ b/webapp/channels/src/components/announcement_bar/announcement_bar_controller.tsx
@@ -43,6 +43,7 @@ class AnnouncementBarController extends React.PureComponent<Props> {
         if (this.props.config?.EnableBanner === 'true' && this.props.config.BannerText?.trim()) {
             adminConfiguredAnnouncementBar = (
                 <TextDismissableBar
+                    className='admin-announcement'
                     color={this.props.config.BannerColor}
                     textColor={this.props.config.BannerTextColor}
                     allowDismissal={this.props.config.AllowBannerDismissal === 'true'}
@@ -98,6 +99,8 @@ class AnnouncementBarController extends React.PureComponent<Props> {
         //    Baz
         // }
         // Even if all Foo, Bar and Baz render, only Baz is visible as it's further down.
+        // One exception to this rule is for admin configured announcement banners
+        // If set with class 'admin-announcement', they will always be visible, stacked vertically.
         return (
             <>
                 <NotificationPermissionBar/>

--- a/webapp/channels/src/components/announcement_bar/default_announcement_bar/announcement_bar.tsx
+++ b/webapp/channels/src/components/announcement_bar/default_announcement_bar/announcement_bar.tsx
@@ -16,6 +16,7 @@ import {isStringContainingUrl} from 'utils/url';
 type Props = {
     id?: string;
     showCloseButton: boolean;
+    className?: string;
     color: string;
     textColor: string;
     type: string;
@@ -129,6 +130,10 @@ export default class AnnouncementBar extends React.PureComponent<Props, State> {
             barClass = 'announcement-bar announcement-bar-advisor-ack';
         } else if (this.props.type === AnnouncementBarTypes.GENERAL) {
             barClass = 'announcement-bar announcement-bar-general';
+        }
+
+        if (this.props.className) {
+            barClass += ` ${this.props.className}`;
         }
 
         let closeButton;

--- a/webapp/channels/src/components/announcement_bar/text_dismissable_bar.tsx
+++ b/webapp/channels/src/components/announcement_bar/text_dismissable_bar.tsx
@@ -17,6 +17,7 @@ interface Props extends Partial<AnnouncementBarProps> {
     allowDismissal: boolean;
     text: React.ReactNode;
     onDismissal?: () => void;
+    className?: string;
 }
 
 type State = {

--- a/webapp/channels/src/sass/base/_structure.scss
+++ b/webapp/channels/src/sass/base/_structure.scss
@@ -116,6 +116,7 @@ body.app__body #root {
     --columns: min-content minmax(385px, 1fr) min-content;
     grid-template:
         "announcement announcement announcement" min-content
+        "admin-announcement admin-announcement admin-announcement" min-content
         "header header header" min-content
         "team-sidebar main app-sidebar"
         "footer footer footer" min-content / var(--columns);
@@ -131,6 +132,7 @@ body.app__body #root {
         padding-right: 0;
         grid-template:
             'announcement announcement' min-content
+            'admin-announcement admin-announcement' min-content
             'header header' min-content
             'lhs center'
             'footer footer' min-content
@@ -145,6 +147,10 @@ body.app__body #root {
 
     .announcement-bar {
         grid-area: announcement;
+    }
+
+    .announcement-bar.admin-announcement {
+        grid-area: admin-announcement;
     }
 
     #global-header {

--- a/webapp/channels/src/sass/components/_announcement-bar.scss
+++ b/webapp/channels/src/sass/components/_announcement-bar.scss
@@ -63,7 +63,6 @@
         }
 
         &.announcement-bar__close {
-            position: absolute;
             top: 5px;
             right: 0;
             padding: 0 10px;


### PR DESCRIPTION
#### Summary
Some users have a requirement to always display an admin-created banner to all users, at all times. This was problematic when a system banner was displayed to administrators, as those would take precedence over the administrator-set ones. This PR makes it so that any banners set by the administrators have their own placement, below that of any system banners. 

Note: this PR makes no changes to the behaviour of existing banners - they will still be displayed in the order of the announcement_bar_controller, it just added a special section to the CSS grid to display the administrator-configured announcements. 

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

https://mattermost.atlassian.net/browse/CLD-7724

#### Screenshots
Before:
(An admin banner is configured, it's just not visible because it's behind the 3 days left in trial banner)
![image](https://github.com/mattermost/mattermost/assets/12176405/865e3165-6622-475e-baa2-4cc051891b33)

After
![image](https://github.com/mattermost/mattermost/assets/12176405/1d310806-1b2c-46b0-acea-2da91ba59455)

Without a system banner:
![image](https://github.com/mattermost/mattermost/assets/12176405/2d902a77-ee47-4173-ae13-de9c3ef7041f)


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Banners set by system administrators will now stack below system banners, rather than appear underneath them. Existing system banners have remained unchanged.
```
