### PR TITLE
MM-58116 Increase width of profile picture setting

### DIFF
--- a/webapp/channels/src/components/__snapshots__/setting_picture.test.tsx.snap
+++ b/webapp/channels/src/components/__snapshots__/setting_picture.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`components/SettingItemMin should match snapshot with active Save button
     Profile Picture
   </h4>
   <div
-    className="col-xs-offset-3 col-xs-8"
+    className="col-sm-10 col-sm-offset-2"
   >
     <div
       aria-describedby="setting-picture__helptext"
@@ -125,7 +125,7 @@ exports[`components/SettingItemMin should match snapshot with active Save button
     Profile Picture
   </h4>
   <div
-    className="col-xs-offset-3 col-xs-8"
+    className="col-sm-10 col-sm-offset-2"
   >
     <div
       aria-describedby="setting-picture__helptext"
@@ -230,7 +230,7 @@ exports[`components/SettingItemMin should match snapshot, on loading picture 1`]
     Profile Picture
   </h4>
   <div
-    className="col-xs-offset-3 col-xs-8"
+    className="col-sm-10 col-sm-offset-2"
   >
     <div
       aria-describedby="setting-picture__helptext"
@@ -345,7 +345,7 @@ exports[`components/SettingItemMin should match snapshot, profile picture on fil
     Profile Picture
   </h4>
   <div
-    className="col-xs-offset-3 col-xs-8"
+    className="col-sm-10 col-sm-offset-2"
   >
     <div
       aria-describedby="setting-picture__helptext"
@@ -472,7 +472,7 @@ exports[`components/SettingItemMin should match snapshot, profile picture on sou
     Profile Picture
   </h4>
   <div
-    className="col-xs-offset-3 col-xs-8"
+    className="col-sm-10 col-sm-offset-2"
   >
     <div
       aria-describedby="setting-picture__helptext"
@@ -587,7 +587,7 @@ exports[`components/SettingItemMin should match snapshot, team icon on file 1`] 
     Profile Picture
   </h4>
   <div
-    className="col-xs-offset-3 col-xs-8"
+    className="col-sm-10 col-sm-offset-2"
   >
     <div
       aria-describedby="setting-picture__helptext"
@@ -714,7 +714,7 @@ exports[`components/SettingItemMin should match snapshot, team icon on source 1`
     Profile Picture
   </h4>
   <div
-    className="col-xs-offset-3 col-xs-8"
+    className="col-sm-10 col-sm-offset-2"
   >
     <div
       aria-describedby="setting-picture__helptext"
@@ -883,7 +883,7 @@ exports[`components/SettingItemMin should match snapshot, user icon on source 1`
     Profile Picture
   </h4>
   <div
-    className="col-xs-offset-3 col-xs-8"
+    className="col-sm-10 col-sm-offset-2"
   >
     <div
       aria-describedby="setting-picture__helptext"

--- a/webapp/channels/src/components/setting_picture.tsx
+++ b/webapp/channels/src/components/setting_picture.tsx
@@ -335,7 +335,7 @@ export default class SettingPicture extends Component<Props, State> {
                 <h4 className='col-xs-12 section-title'>
                     {this.props.title}
                 </h4>
-                <div className='col-xs-offset-3 col-xs-8'>
+                <div className='col-sm-10 col-sm-offset-2'>
                     <div
                         className='setting-list'
                         ref={this.settingList}


### PR DESCRIPTION
#### Summary
This setting was narrower than other settings which meant there was not enough space for the three buttons in it which caused them to stack up. It's now the same width as any other setting which uses `SettingItemMax`

#### Ticket Link
MM-58116

#### Screenshots
![Screenshot 2024-05-28 at 10 46 14 AM](https://github.com/mattermost/mattermost/assets/3277310/68a1e82c-5119-4331-bcd1-51d29432b6c1)

#### Release Note
```release-note
Increased the width of the profile picture setting to match other user settings
```
