### PR TITLE
MM-58354 Fix numbered Markdown lists not wrapping long words

### DIFF
--- a/webapp/channels/src/sass/layout/_markdown.scss
+++ b/webapp/channels/src/sass/layout/_markdown.scss
@@ -397,12 +397,14 @@ ol.markdown__list {
     >li {
         display: table-row;
         counter-increment: list;
+        word-break: break-word;
 
         &::before {
             display: table-cell;
             padding-right: 8px;
             content: counter(list) ".";
             text-align: right;
+            word-break: keep-all;
         }
     }
 }


### PR DESCRIPTION
#### Summary
A few years ago, we changed the CSS of numbered lists so that the numbers for each item were right aligned and always showed each digit of the number properly. We did that by making each row render as a row of a table and then adding our own number using `:before` which then rendered as a column of the table.

For whatever reason, tables seem to have different behaviour for breaking words when wrapping text, so long words with no spaces (or long lines of CSV data like in the ticket) wouldn't be broken in the middle. Manually specifying the `word-break` behaviour on the text in the row (but not the fake item number) fixes that.

#### Ticket Link
MM-58354
Fixes #27104 

#### Release Note
```release-note
Fixed incorrect wrapping of long words in numbered lists
```
