### PR TITLE
MM-58323 - sanitize more sensitive values from config

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -8927,6 +8927,14 @@
     "translation": "Invalid value for write timeout."
   },
   {
+    "id": "model.config.sanitize.marshal.app_error",
+    "translation": "Failed to encode field to JSON."
+  },
+  {
+    "id": "model.config.sanitize.unmarshal_to_map.app_error",
+    "translation": "Failed to unmarshal."
+  },
+  {
     "id": "model.draft.is_valid.channel_id.app_error",
     "translation": "Invalid channel id."
   },

--- a/server/public/model/config_test.go
+++ b/server/public/model/config_test.go
@@ -1376,6 +1376,152 @@ func TestLogSettingsIsValid(t *testing.T) {
 	}
 }
 
+func TestShouldSanitize(t *testing.T) {
+	rules := SanitizeConfigRules{
+		Contains:   []string{"password", "secret", "key", "keyid"},
+		StartsWith: []string{"key", "password"},
+		EndsWith:   []string{"key", "keyid", "id"},
+	}
+
+	tests := map[string]struct {
+		Key         string
+		ExpectMatch bool
+	}{
+		"contains password":      {Key: "userPassword", ExpectMatch: true},
+		"contains secret":        {Key: "clientSecret", ExpectMatch: true},
+		"starts with key":        {Key: "keyName", ExpectMatch: true},
+		"ends with id":           {Key: "clientId", ExpectMatch: true},
+		"does not match":         {Key: "username", ExpectMatch: false},
+		"case insensitive match": {Key: "SeCrEtKeY", ExpectMatch: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.ExpectMatch, shouldSanitize(test.Key, rules))
+		})
+	}
+}
+
+func TestSanitizeMap(t *testing.T) {
+	rules := SanitizeConfigRules{
+		Contains:   []string{"password", "secret", "key", "keyid", "email"},
+		StartsWith: []string{"key", "password", "email"},
+		EndsWith:   []string{"key", "keyid", "id", "email"},
+	}
+
+	tests := map[string]struct {
+		Config    map[string]interface{}
+		Expect    map[string]interface{}
+		ExpectErr bool
+	}{
+		"sanitize simple map": {
+			Config: map[string]interface{}{
+				"userPassword": "mypassword",
+				"username":     "user1",
+			},
+			Expect: map[string]interface{}{
+				"userPassword": FakeSetting,
+				"username":     "user1",
+			},
+			ExpectErr: false,
+		},
+		"sanitize nested map": {
+			Config: map[string]interface{}{
+				"userPassword": "mypassword",
+				"nested": map[string]interface{}{
+					"clientSecret": "mysecret",
+					"clientId":     "myclientid",
+				},
+			},
+			Expect: map[string]interface{}{
+				"userPassword": FakeSetting,
+				"nested": map[string]interface{}{
+					"clientSecret": FakeSetting,
+					"clientId":     FakeSetting,
+				},
+			},
+			ExpectErr: false,
+		},
+		"sanitize array of maps": {
+			Config: map[string]interface{}{
+				"userPassword": "mypassword",
+				"services": []interface{}{
+					map[string]interface{}{
+						"apiKey": "myapikey",
+						"name":   "service1",
+					},
+					map[string]interface{}{
+						"keyName": "mykeyname",
+					},
+				},
+			},
+			Expect: map[string]interface{}{
+				"userPassword": FakeSetting,
+				"services": []interface{}{
+					map[string]interface{}{
+						"apiKey": FakeSetting,
+						"name":   "service1",
+					},
+					map[string]interface{}{
+						"keyName": FakeSetting,
+					},
+				},
+			},
+			ExpectErr: false,
+		},
+		"sanitize email fields": {
+			Config: map[string]interface{}{
+				"userEmail": "user@example.com",
+				"emails": []interface{}{
+					"user1@example.com",
+					"user2@example.com",
+				},
+			},
+			Expect: map[string]interface{}{
+				"userEmail": FakeSetting,
+				"emails": []interface{}{
+					FakeSetting,
+					FakeSetting,
+				},
+			},
+			ExpectErr: false,
+		},
+		"do not sanitize non-string or non-array of strings": {
+			Config: map[string]interface{}{
+				"userPassword": "mypassword",
+				"isActive":     true,
+				"retryCount":   5,
+				"config": map[string]interface{}{
+					"enableFeature": true,
+					"maxRetries":    3,
+				},
+			},
+			Expect: map[string]interface{}{
+				"userPassword": FakeSetting,
+				"isActive":     true,
+				"retryCount":   5,
+				"config": map[string]interface{}{
+					"enableFeature": true,
+					"maxRetries":    3,
+				},
+			},
+			ExpectErr: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := sanitizeConfigMap(test.Config, rules)
+			if test.ExpectErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, test.Expect, test.Config)
+			}
+		})
+	}
+}
+
 func TestConfigSanitize(t *testing.T) {
 	c := Config{}
 	c.SetDefaults()
@@ -1385,6 +1531,10 @@ func TestConfigSanitize(t *testing.T) {
 	*c.EmailSettings.SMTPPassword = "baz"
 	*c.GitLabSettings.Secret = "bingo"
 	*c.OpenIdSettings.Secret = "secret"
+	*c.SqlSettings.AtRestEncryptKey = "foo"
+	*c.ServiceSettings.EnableEmailInvitations = true
+	*c.SamlSettings.PrivateKeyFile = ""
+	*c.EmailSettings.FeedbackEmail = "feedback@email.com"
 	c.SqlSettings.DataSourceReplicas = []string{"stuff"}
 	c.SqlSettings.DataSourceSearchReplicas = []string{"stuff"}
 	c.SqlSettings.ReplicaLagSettings = []*ReplicaLagSettings{{
@@ -1411,6 +1561,9 @@ func TestConfigSanitize(t *testing.T) {
 	assert.Equal(t, FakeSetting, *c.SqlSettings.ReplicaLagSettings[0].DataSource)
 	assert.Equal(t, "QueryAbsoluteLag", *c.SqlSettings.ReplicaLagSettings[0].QueryAbsoluteLag)
 	assert.Equal(t, "QueryTimeLag", *c.SqlSettings.ReplicaLagSettings[0].QueryTimeLag)
+	assert.Equal(t, true, *c.ServiceSettings.EnableEmailInvitations)
+	assert.Equal(t, FakeSetting, *c.EmailSettings.FeedbackEmail)
+	assert.Equal(t, "", *c.SamlSettings.PrivateKeyFile)
 
 	t.Run("with default config", func(t *testing.T) {
 		c := Config{}


### PR DESCRIPTION

#### Summary
This PR enhances the logic to sanitize the sensitive config values contained in the config file. The idea is to cover most common use cases where the config should be sanitized. Those rules are based on the config names when it contains/starts/ends with common sensitive named values as "secret", "password", "key", "keyid", "id", "email".

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58323

#### Release Note
```release-note
NONE
```
