### PR TITLE
MM-58479 - Revert text changes on channel archive.

### DIFF
--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost/server/public/model"
-	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 	"github.com/mattermost/mattermost/server/v8/einterfaces"
@@ -2330,17 +2329,18 @@ func (s SqlChannelStore) GetMemberCountsByGroup(ctx context.Context, channelID s
 	query := s.getQueryBuilder().
 		Select(selectStr).
 		From("ChannelMembers").
-		Join("GroupMembers ON GroupMembers.UserId = ChannelMembers.UserId AND GroupMembers.DeleteAt = 0").
-		Join("Users ON Users.Id = GroupMembers.UserId")
+		Join("GroupMembers ON GroupMembers.UserId = ChannelMembers.UserId AND GroupMembers.DeleteAt = 0")
 
-	query = query.Where(sq.Eq{"ChannelMembers.ChannelId": channelID}).Where("Users.DeleteAt = 0").GroupBy("GroupMembers.GroupId")
+	if includeTimezones {
+		query = query.Join("Users ON Users.Id = GroupMembers.UserId")
+	}
+
+	query = query.Where(sq.Eq{"ChannelMembers.ChannelId": channelID}).GroupBy("GroupMembers.GroupId")
 
 	queryString, args, err := query.ToSql()
 	if err != nil {
 		return nil, errors.Wrap(err, "channel_tosql")
 	}
-	mlog.Debug("Hello")
-	mlog.Debug(queryString)
 
 	data := []*model.ChannelMemberCountByGroup{}
 	if err := s.DBXFromContext(ctx).Select(&data, queryString, args...); err != nil {

--- a/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/__snapshots__/channel_details.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/__snapshots__/channel_details.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
         }
         message={
           <Memo(MemoizedFormattedMessage)
-            defaultMessage="Archiving will remove the team from the user interface but it's contents remain in the database and may still be accessible with the API. Are you sure you wish to save and archive this channel?"
+            defaultMessage="Saving will archive the channel from the team and make it's contents inaccessible for all users. Are you sure you wish to save and archive this channel?"
             id="admin.channel_settings.channel_detail.archive_confirm.message"
           />
         }
@@ -260,7 +260,7 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
         }
         message={
           <Memo(MemoizedFormattedMessage)
-            defaultMessage="Archiving will remove the team from the user interface but it's contents remain in the database and may still be accessible with the API. Are you sure you wish to save and archive this channel?"
+            defaultMessage="Saving will archive the channel from the team and make it's contents inaccessible for all users. Are you sure you wish to save and archive this channel?"
             id="admin.channel_settings.channel_detail.archive_confirm.message"
           />
         }
@@ -461,7 +461,7 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
         }
         message={
           <Memo(MemoizedFormattedMessage)
-            defaultMessage="Archiving will remove the team from the user interface but it's contents remain in the database and may still be accessible with the API. Are you sure you wish to save and archive this channel?"
+            defaultMessage="Saving will archive the channel from the team and make it's contents inaccessible for all users. Are you sure you wish to save and archive this channel?"
             id="admin.channel_settings.channel_detail.archive_confirm.message"
           />
         }
@@ -595,7 +595,7 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
         }
         message={
           <Memo(MemoizedFormattedMessage)
-            defaultMessage="Archiving will remove the team from the user interface but it's contents remain in the database and may still be accessible with the API. Are you sure you wish to save and archive this channel?"
+            defaultMessage="Saving will archive the channel from the team and make it's contents inaccessible for all users. Are you sure you wish to save and archive this channel?"
             id="admin.channel_settings.channel_detail.archive_confirm.message"
           />
         }
@@ -748,7 +748,7 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
         }
         message={
           <Memo(MemoizedFormattedMessage)
-            defaultMessage="Archiving will remove the team from the user interface but it's contents remain in the database and may still be accessible with the API. Are you sure you wish to save and archive this channel?"
+            defaultMessage="Saving will archive the channel from the team and make it's contents inaccessible for all users. Are you sure you wish to save and archive this channel?"
             id="admin.channel_settings.channel_detail.archive_confirm.message"
           />
         }
@@ -882,7 +882,7 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
         }
         message={
           <Memo(MemoizedFormattedMessage)
-            defaultMessage="Archiving will remove the team from the user interface but it's contents remain in the database and may still be accessible with the API. Are you sure you wish to save and archive this channel?"
+            defaultMessage="Saving will archive the channel from the team and make it's contents inaccessible for all users. Are you sure you wish to save and archive this channel?"
             id="admin.channel_settings.channel_detail.archive_confirm.message"
           />
         }

--- a/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/channel_details.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/channel_details.tsx
@@ -824,7 +824,7 @@ export default class ChannelDetails extends React.PureComponent<ChannelDetailsPr
                             message={
                                 <FormattedMessage
                                     id='admin.channel_settings.channel_detail.archive_confirm.message'
-                                    defaultMessage={'Archiving will remove the team from the user interface but it\'s contents remain in the database and may still be accessible with the API. Are you sure you wish to save and archive this channel?'}
+                                    defaultMessage={'Saving will archive the channel from the team and make it\'s contents inaccessible for all users. Are you sure you wish to save and archive this channel?'}
                                 />
                             }
                             confirmButtonText={

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -445,7 +445,7 @@
   "admin.channel_list.private": "Private",
   "admin.channel_list.public": "Public",
   "admin.channel_settings.channel_detail.archive_confirm.button": "Save and Archive Channel",
-  "admin.channel_settings.channel_detail.archive_confirm.message": "Archiving will remove the team from the user interface but it's contents remain in the database and may still be accessible with the API. Are you sure you wish to save and archive this channel?",
+  "admin.channel_settings.channel_detail.archive_confirm.message": "Saving will archive the channel from the team and make it's contents inaccessible for all users. Are you sure you wish to save and archive this channel?",
   "admin.channel_settings.channel_detail.archive_confirm.title": "Save and Archive Channel",
   "admin.channel_settings.channel_detail.channel_configuration": "Channel Configuration",
   "admin.channel_settings.channel_detail.channelName": "**Name**",


### PR DESCRIPTION
#### Summary
Previously both Teams and Channels had the same text…so it all got updated…only the Teams text should have been changed.

This PR reverts the changes to the channels text.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-58479

#### Screenshots
![Screenshot 2024-05-29 at 8 56 47 AM](https://github.com/mattermost/mattermost/assets/12704875/7489e2ca-2ce3-4112-bdc2-617b7ed06571)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```
NONE
```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
