### PR TITLE
MM-58459 Fix unread threads not always being loaded correctly

### DIFF
--- a/webapp/channels/src/components/threading/global_threads/global_threads.tsx
+++ b/webapp/channels/src/components/threading/global_threads/global_threads.tsx
@@ -110,7 +110,7 @@ const GlobalThreads = () => {
         }
 
         if (filter === ThreadFilter.unread && shouldLoadUnreadThreads) {
-            promises.push(dispatch(getThreadsForCurrentTeam({unread: false})));
+            promises.push(dispatch(getThreadsForCurrentTeam({unread: true})));
         }
 
         Promise.all(promises).then(() => {


### PR DESCRIPTION
#### Summary
This fixes an issue I introduced because of a copy-paste typo in https://github.com/mattermost/mattermost/pull/26984 where switching to the Unreads tab in the Threads view wouldn't load anything unless you first selected a thread in the list to view.

I would've liked to add a unit test for this, but unfortunately, the threads code is extremely unfriendly to being tested, so I gave up after an hour or so fighting with that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58459

#### Release Note
No release note for this since the previous PR hasn't shipped yet
```release-note
NONE
```
