### PR TITLE
MM-58252 Ensure remotes cannot update users belonging to different remotes

### DIFF
--- a/server/platform/services/sharedchannel/util.go
+++ b/server/platform/services/sharedchannel/util.go
@@ -148,3 +148,10 @@ func reducePostsSliceInCache(posts []*model.Post, cache map[string]*model.Post) 
 	}
 	return reduced
 }
+
+func SafeString(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}


### PR DESCRIPTION
#### Summary
This PR addresses an issue where a check is needed to ensure that a user update comes from the remote that owns the user.  The ensures remotes cannot update users from other remotes, including setting the user's remoteID so that the user appears to originate from somewhere else.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58253


#### Release Note
```release-note
Ensures remotes cannot update users belonging to different remotes.
```
