### PR TITLE
 [MM-58500] Turn off PostedAck when the connection is no longer registered

### DIFF
--- a/server/channels/app/platform/web_conn.go
+++ b/server/channels/app/platform/web_conn.go
@@ -107,7 +107,7 @@ type WebConn struct {
 	deadQueuePointer int
 	// active indicates whether there is an open websocket connection attached
 	// to this webConn or not.
-	active atomic.Bool
+	Active atomic.Bool
 	// reuseCount indicates how many times this connection has been reused.
 	// This is used to differentiate between a fresh connection and
 	// a reused connection.
@@ -245,7 +245,7 @@ func (ps *PlatformService) NewWebConn(cfg *WebConnConfig, suite SuiteIFace, runn
 		lastLogTimeFull:    time.Now(),
 		originClient:       cfg.OriginClient,
 	}
-	wc.active.Store(cfg.Active)
+	wc.Active.Store(cfg.Active)
 
 	wc.SetSession(&cfg.Session)
 	wc.SetSessionToken(cfg.Session.Token)
@@ -555,7 +555,7 @@ func (wc *WebConn) writePump() {
 				continue
 			}
 
-			if wc.active.Load() && len(wc.send) >= sendFullWarn && time.Since(wc.lastLogTimeFull) > websocketSuppressWarnThreshold {
+			if wc.Active.Load() && len(wc.send) >= sendFullWarn && time.Since(wc.lastLogTimeFull) > websocketSuppressWarnThreshold {
 				logData := []mlog.Field{
 					mlog.String("user_id", wc.UserId),
 					mlog.String("conn_id", wc.GetConnectionID()),
@@ -812,7 +812,7 @@ func (wc *WebConn) ShouldSendEvent(msg *model.WebSocketEvent) bool {
 		case model.WebsocketEventTyping,
 			model.WebsocketEventStatusChange,
 			model.WebsocketEventMultipleChannelsViewed:
-			if wc.active.Load() && time.Since(wc.lastLogTimeSlow) > websocketSuppressWarnThreshold {
+			if wc.Active.Load() && time.Since(wc.lastLogTimeSlow) > websocketSuppressWarnThreshold {
 				mlog.Warn(
 					"websocket.slow: dropping message",
 					mlog.String("user_id", wc.UserId),

--- a/server/channels/app/platform/web_hub.go
+++ b/server/channels/app/platform/web_hub.go
@@ -435,6 +435,7 @@ func (h *Hub) Start() {
 				// If already removed (via queue full), then removing again becomes a noop.
 				// But if not removed, mark inactive.
 				webConn.active.Store(false)
+				webConn.PostedAck = false
 
 				atomic.StoreInt64(&h.connectionCount, int64(connIndex.AllActive()))
 

--- a/server/channels/app/platform/web_hub.go
+++ b/server/channels/app/platform/web_hub.go
@@ -389,7 +389,7 @@ func (h *Hub) Start() {
 				conns := connIndex.ForUser(webSessionMessage.userID)
 				var isRegistered bool
 				for _, conn := range conns {
-					if !conn.active.Load() {
+					if !conn.Active.Load() {
 						continue
 					}
 					if conn.GetSessionToken() == webSessionMessage.sessionToken {
@@ -419,7 +419,7 @@ func (h *Hub) Start() {
 				// Mark the current one as active.
 				// There is no need to check if it was inactive or not,
 				// we will anyways need to make it active.
-				webConn.active.Store(true)
+				webConn.Active.Store(true)
 
 				connIndex.Add(webConn)
 				atomic.StoreInt64(&h.connectionCount, int64(connIndex.AllActive()))
@@ -434,8 +434,7 @@ func (h *Hub) Start() {
 			case webConn := <-h.unregister:
 				// If already removed (via queue full), then removing again becomes a noop.
 				// But if not removed, mark inactive.
-				webConn.active.Store(false)
-				webConn.PostedAck = false
+				webConn.Active.Store(false)
 
 				atomic.StoreInt64(&h.connectionCount, int64(connIndex.AllActive()))
 
@@ -472,7 +471,7 @@ func (h *Hub) Start() {
 				}
 				var latestActivity int64
 				for _, conn := range conns {
-					if !conn.active.Load() {
+					if !conn.Active.Load() {
 						continue
 					}
 					if conn.lastUserActivityAt > latestActivity {
@@ -492,7 +491,7 @@ func (h *Hub) Start() {
 				}
 			case activity := <-h.activity:
 				for _, webConn := range connIndex.ForUser(activity.userID) {
-					if !webConn.active.Load() {
+					if !webConn.Active.Load() {
 						continue
 					}
 					if webConn.GetSessionToken() == activity.sessionToken {
@@ -507,7 +506,7 @@ func (h *Hub) Start() {
 				case directMsg.conn.send <- directMsg.msg:
 				default:
 					// Don't log the warning if it's an inactive connection.
-					if directMsg.conn.active.Load() {
+					if directMsg.conn.Active.Load() {
 						mlog.Error("webhub.broadcast: cannot send, closing websocket for user",
 							mlog.String("user_id", directMsg.conn.UserId),
 							mlog.String("conn_id", directMsg.conn.GetConnectionID()))
@@ -534,7 +533,7 @@ func (h *Hub) Start() {
 						case webConn.send <- h.runBroadcastHooks(msg, webConn, broadcastHooks, broadcastHookArgs):
 						default:
 							// Don't log the warning if it's an inactive connection.
-							if webConn.active.Load() {
+							if webConn.Active.Load() {
 								mlog.Error("webhub.broadcast: cannot send, closing websocket for user",
 									mlog.String("user_id", webConn.UserId),
 									mlog.String("conn_id", webConn.GetConnectionID()))
@@ -602,7 +601,7 @@ func (h *Hub) Start() {
 // are inactive or not.
 func areAllInactive(conns []*WebConn) bool {
 	for _, conn := range conns {
-		if conn.active.Load() {
+		if conn.Active.Load() {
 			return false
 		}
 	}
@@ -690,7 +689,7 @@ func (i *hubConnectionIndex) ForUser(id string) []*WebConn {
 func (i *hubConnectionIndex) ForUserActiveCount(id string) int {
 	cnt := 0
 	for _, conn := range i.ForUser(id) {
-		if conn.active.Load() {
+		if conn.Active.Load() {
 			cnt++
 		}
 	}
@@ -715,7 +714,7 @@ func (i *hubConnectionIndex) RemoveInactiveByConnectionID(userID, connectionID s
 		return nil
 	}
 	for _, conn := range i.ForUser(userID) {
-		if conn.GetConnectionID() == connectionID && !conn.active.Load() {
+		if conn.GetConnectionID() == connectionID && !conn.Active.Load() {
 			i.Remove(conn)
 			return conn
 		}
@@ -728,7 +727,7 @@ func (i *hubConnectionIndex) RemoveInactiveByConnectionID(userID, connectionID s
 func (i *hubConnectionIndex) RemoveInactiveConnections() {
 	now := model.GetMillis()
 	for conn := range i.byConnection {
-		if !conn.active.Load() && now-conn.lastUserActivityAt > i.staleThreshold.Milliseconds() {
+		if !conn.Active.Load() && now-conn.lastUserActivityAt > i.staleThreshold.Milliseconds() {
 			i.Remove(conn)
 		}
 	}
@@ -740,7 +739,7 @@ func (i *hubConnectionIndex) RemoveInactiveConnections() {
 func (i *hubConnectionIndex) AllActive() int {
 	cnt := 0
 	for conn := range i.byConnection {
-		if conn.active.Load() {
+		if conn.Active.Load() {
 			cnt++
 		}
 	}

--- a/server/channels/app/platform/web_hub_test.go
+++ b/server/channels/app/platform/web_hub_test.go
@@ -429,7 +429,7 @@ func TestHubConnIndexInactive(t *testing.T) {
 		Platform: th.Service,
 		UserId:   model.NewId(),
 	}
-	wc1.active.Store(true)
+	wc1.Active.Store(true)
 	wc1.SetConnectionID("conn1")
 	wc1.SetSession(&model.Session{})
 
@@ -438,7 +438,7 @@ func TestHubConnIndexInactive(t *testing.T) {
 		Platform: th.Service,
 		UserId:   model.NewId(),
 	}
-	wc2.active.Store(true)
+	wc2.Active.Store(true)
 	wc2.SetConnectionID("conn2")
 	wc2.SetSession(&model.Session{})
 
@@ -446,7 +446,7 @@ func TestHubConnIndexInactive(t *testing.T) {
 		Platform: th.Service,
 		UserId:   wc2.UserId,
 	}
-	wc3.active.Store(false)
+	wc3.Active.Store(false)
 	wc3.SetConnectionID("conn3")
 	wc3.SetSession(&model.Session{})
 

--- a/server/channels/app/web_broadcast_hooks.go
+++ b/server/channels/app/web_broadcast_hooks.go
@@ -83,7 +83,7 @@ func usePostedAckHook(message *model.WebSocketEvent, postedUserId string, channe
 
 func (h *postedAckBroadcastHook) Process(msg *platform.HookedWebSocketEvent, webConn *platform.WebConn, args map[string]any) error {
 	// Don't ACK unless we say to explicitly
-	if !webConn.PostedAck {
+	if !(webConn.PostedAck && webConn.Active.Load()) {
 		return nil
 	}
 


### PR DESCRIPTION
#### Summary
When the websocket connection is closed at the client, the server still keeps the connection object alive and will process `POSTED` events for that connection, even if they go nowhere. We cleanup the connections eventually, but in that time we are counting notifiable events still that will never get an ACK.

This PR flips the `PostedAck` flag off on the connection at unregistry so that we don't expect ACKs back for the POSTED events that we send. This should improve the metrics a bit since we were adding measuring errors here.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58500

```release-note
NONE
```
