### PR TITLE
MM-58275 Ensure image proxy site URL is updated when that changes

### DIFF
--- a/server/platform/services/imageproxy/atmos_camo_test.go
+++ b/server/platform/services/imageproxy/atmos_camo_test.go
@@ -66,14 +66,13 @@ func TestAtmosCamoBackend_GetImageDirect(t *testing.T) {
 	defer mock.Close()
 
 	proxy := makeTestAtmosCamoProxy()
-	parsedURL, err := url.Parse(*proxy.ConfigService.Config().ServiceSettings.SiteURL)
+	parsedURL, err := url.Parse("https://mattermost.example.com")
 	require.NoError(t, err)
 
 	remoteURL, err := url.Parse(mock.URL)
 	require.NoError(t, err)
 
 	backend := &AtmosCamoBackend{
-		proxy:     proxy,
 		siteURL:   parsedURL,
 		remoteURL: remoteURL,
 		client:    proxy.HTTPService.MakeClient(false),
@@ -177,9 +176,9 @@ func TestGetAtmosCamoImageURL(t *testing.T) {
 			require.NoError(t, err)
 
 			backend := &AtmosCamoBackend{
-				proxy:     makeTestAtmosCamoProxy(),
-				siteURL:   parsedURL,
-				remoteURL: remoteURL,
+				siteURL:       parsedURL,
+				remoteURL:     remoteURL,
+				remoteOptions: *makeTestAtmosCamoProxy().ConfigService.Config().ImageProxySettings.RemoteImageProxyOptions,
 			}
 
 			assert.Equal(t, test.Expected, backend.getAtmosCamoImageURL(test.Input))

--- a/server/platform/services/imageproxy/imageproxy.go
+++ b/server/platform/services/imageproxy/imageproxy.go
@@ -59,21 +59,21 @@ func MakeImageProxy(configService configservice.ConfigService, httpService https
 	proxy.configListenerID = proxy.ConfigService.AddConfigListener(proxy.OnConfigChange)
 
 	config := proxy.ConfigService.Config()
-	proxy.backend = proxy.makeBackend(*config.ImageProxySettings.Enable, *config.ImageProxySettings.ImageProxyType)
+	proxy.backend = proxy.makeBackend(config.ImageProxySettings)
 
 	return proxy
 }
 
-func (proxy *ImageProxy) makeBackend(enable bool, proxyType string) ImageProxyBackend {
-	if !enable {
+func (proxy *ImageProxy) makeBackend(proxySettings model.ImageProxySettings) ImageProxyBackend {
+	if !*proxySettings.Enable {
 		return nil
 	}
 
-	switch proxyType {
+	switch *proxySettings.ImageProxyType {
 	case model.ImageProxyTypeLocal:
 		return makeLocalBackend(proxy)
 	case model.ImageProxyTypeAtmosCamo:
-		return makeAtmosCamoBackend(proxy)
+		return makeAtmosCamoBackend(proxy, proxySettings)
 	default:
 		return nil
 	}
@@ -87,12 +87,18 @@ func (proxy *ImageProxy) Close() {
 }
 
 func (proxy *ImageProxy) OnConfigChange(oldConfig, newConfig *model.Config) {
-	if *oldConfig.ImageProxySettings.Enable != *newConfig.ImageProxySettings.Enable ||
-		*oldConfig.ImageProxySettings.ImageProxyType != *newConfig.ImageProxySettings.ImageProxyType {
+	if model.AreReferencedValuesEqual(oldConfig.ImageProxySettings.Enable, newConfig.ImageProxySettings.Enable) ||
+		model.AreReferencedValuesEqual(oldConfig.ImageProxySettings.ImageProxyType, newConfig.ImageProxySettings.ImageProxyType) ||
+		model.AreReferencedValuesEqual(oldConfig.ImageProxySettings.RemoteImageProxyURL, newConfig.ImageProxySettings.RemoteImageProxyURL) ||
+		model.AreReferencedValuesEqual(oldConfig.ImageProxySettings.RemoteImageProxyOptions, newConfig.ImageProxySettings.RemoteImageProxyOptions) ||
+		model.AreReferencedValuesEqual(oldConfig.ServiceSettings.SiteURL, newConfig.ServiceSettings.SiteURL) {
 		proxy.lock.Lock()
 		defer proxy.lock.Unlock()
 
-		proxy.backend = proxy.makeBackend(*newConfig.ImageProxySettings.Enable, *newConfig.ImageProxySettings.ImageProxyType)
+		siteURL, _ := url.Parse(*newConfig.ServiceSettings.SiteURL)
+		proxy.siteURL = siteURL
+
+		proxy.backend = proxy.makeBackend(newConfig.ImageProxySettings)
 	}
 }
 

--- a/server/platform/services/imageproxy/imageproxy.go
+++ b/server/platform/services/imageproxy/imageproxy.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -87,11 +88,8 @@ func (proxy *ImageProxy) Close() {
 }
 
 func (proxy *ImageProxy) OnConfigChange(oldConfig, newConfig *model.Config) {
-	if model.AreReferencedValuesEqual(oldConfig.ImageProxySettings.Enable, newConfig.ImageProxySettings.Enable) ||
-		model.AreReferencedValuesEqual(oldConfig.ImageProxySettings.ImageProxyType, newConfig.ImageProxySettings.ImageProxyType) ||
-		model.AreReferencedValuesEqual(oldConfig.ImageProxySettings.RemoteImageProxyURL, newConfig.ImageProxySettings.RemoteImageProxyURL) ||
-		model.AreReferencedValuesEqual(oldConfig.ImageProxySettings.RemoteImageProxyOptions, newConfig.ImageProxySettings.RemoteImageProxyOptions) ||
-		model.AreReferencedValuesEqual(oldConfig.ServiceSettings.SiteURL, newConfig.ServiceSettings.SiteURL) {
+	if *oldConfig.ServiceSettings.SiteURL != *newConfig.ServiceSettings.SiteURL ||
+		!reflect.DeepEqual(oldConfig.ImageProxySettings, newConfig.ImageProxySettings) {
 		proxy.lock.Lock()
 		defer proxy.lock.Unlock()
 

--- a/server/platform/services/imageproxy/imageproxy_test.go
+++ b/server/platform/services/imageproxy/imageproxy_test.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/v8/channels/utils/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -114,4 +116,72 @@ func TestGetUnproxiedImageURL(t *testing.T) {
 			assert.Equal(t, test.Expected, getUnproxiedImageURL(test.Input, siteURL))
 		})
 	}
+}
+
+func TestOnConfigChange(t *testing.T) {
+	t.Run("should switch between backends", func(t *testing.T) {
+		proxy := makeTestAtmosCamoProxy()
+
+		require.Equal(t, "https://mattermost.example.com", proxy.backend.(*AtmosCamoBackend).siteURL.String())
+
+		newConfig := proxy.ConfigService.Config().Clone()
+		newConfig.ImageProxySettings.ImageProxyType = model.NewString(model.ImageProxyTypeLocal)
+
+		proxy.ConfigService.(*testutils.StaticConfigService).UpdateConfig(newConfig)
+
+		require.Equal(t, "https://mattermost.example.com", proxy.backend.(*LocalBackend).baseURL.String())
+
+		newConfig = proxy.ConfigService.Config().Clone()
+		newConfig.ImageProxySettings.ImageProxyType = model.NewString(model.ImageProxyTypeAtmosCamo)
+
+		proxy.ConfigService.(*testutils.StaticConfigService).UpdateConfig(newConfig)
+
+		require.Equal(t, "https://mattermost.example.com", proxy.backend.(*AtmosCamoBackend).siteURL.String())
+	})
+
+	t.Run("for local proxy, should update site URL when that changes", func(t *testing.T) {
+		proxy := makeTestLocalProxy()
+
+		require.Equal(t, "https://mattermost.example.com", proxy.siteURL.String())
+		require.Equal(t, "https://mattermost.example.com", proxy.backend.(*LocalBackend).baseURL.String())
+
+		newConfig := proxy.ConfigService.Config().Clone()
+		newConfig.ServiceSettings.SiteURL = model.NewString("https://new.example.com")
+
+		proxy.ConfigService.(*testutils.StaticConfigService).UpdateConfig(newConfig)
+
+		require.Equal(t, "https://new.example.com", proxy.siteURL.String())
+		require.Equal(t, "https://new.example.com", proxy.backend.(*LocalBackend).baseURL.String())
+	})
+
+	t.Run("for atmos/camo proxy, should update site URL when that changes", func(t *testing.T) {
+		proxy := makeTestAtmosCamoProxy()
+
+		require.Equal(t, "https://mattermost.example.com", proxy.siteURL.String())
+		require.Equal(t, "https://mattermost.example.com", proxy.backend.(*AtmosCamoBackend).siteURL.String())
+
+		newConfig := proxy.ConfigService.Config().Clone()
+		newConfig.ServiceSettings.SiteURL = model.NewString("https://new.example.com")
+
+		proxy.ConfigService.(*testutils.StaticConfigService).UpdateConfig(newConfig)
+
+		require.Equal(t, "https://new.example.com", proxy.siteURL.String())
+		require.Equal(t, "https://new.example.com", proxy.backend.(*AtmosCamoBackend).siteURL.String())
+	})
+
+	t.Run("for atmos/camo proxy, should update additional options when those change", func(t *testing.T) {
+		proxy := makeTestAtmosCamoProxy()
+
+		require.Equal(t, "http://images.example.com", proxy.backend.(*AtmosCamoBackend).remoteURL.String())
+		// require.Equal(t, "7e5f3fab20b94782b43cdb022a66985ef28ba355df2c5d5da3c9a05e4b697bac", proxy.backend.(*AtmosCamoBackend).remoteOptions)
+
+		newConfig := proxy.ConfigService.Config().Clone()
+		newConfig.ImageProxySettings.RemoteImageProxyURL = model.NewString("https://new.example.com")
+		newConfig.ImageProxySettings.RemoteImageProxyOptions = model.NewString("some other random hash")
+
+		proxy.ConfigService.(*testutils.StaticConfigService).UpdateConfig(newConfig)
+
+		require.Equal(t, "https://new.example.com", proxy.backend.(*AtmosCamoBackend).remoteURL.String())
+		// require.Equal(t, "some other random hash", proxy.backend.(*AtmosCamoBackend).remoteOptions)
+	})
 }

--- a/server/platform/services/imageproxy/local.go
+++ b/server/platform/services/imageproxy/local.go
@@ -40,8 +40,6 @@ var msgNotAllowed = "requested URL is not allowed"
 var ErrLocalRequestFailed = Error{errors.New("imageproxy.LocalBackend: failed to request proxied image")}
 
 type LocalBackend struct {
-	proxy *ImageProxy
-
 	client  *http.Client
 	baseURL *url.URL
 }
@@ -57,15 +55,14 @@ func (e URLError) Error() string {
 }
 
 func makeLocalBackend(proxy *ImageProxy) *LocalBackend {
-	baseURL, err := url.Parse(*proxy.ConfigService.Config().ServiceSettings.SiteURL)
-	if err != nil {
-		mlog.Warn("Failed to set base URL for image proxy. Relative image links may not work.", mlog.Err(err))
+	baseURL := proxy.siteURL
+	if baseURL == nil {
+		mlog.Warn("Failed to set base URL for image proxy. Relative image links may not work.")
 	}
 
 	client := proxy.HTTPService.MakeClient(false)
 
 	return &LocalBackend{
-		proxy:   proxy,
 		client:  client,
 		baseURL: baseURL,
 	}

--- a/server/public/model/builtin.go
+++ b/server/public/model/builtin.go
@@ -7,15 +7,3 @@ func NewBool(b bool) *bool       { return &b }
 func NewInt(n int) *int          { return &n }
 func NewInt64(n int64) *int64    { return &n }
 func NewString(s string) *string { return &s }
-
-func AreReferencedValuesEqual[T comparable](a, b *T) bool {
-	if a == b {
-		return true
-	}
-
-	if a == nil || b == nil {
-		return false
-	}
-
-	return *a == *b
-}

--- a/server/public/model/builtin.go
+++ b/server/public/model/builtin.go
@@ -7,3 +7,15 @@ func NewBool(b bool) *bool       { return &b }
 func NewInt(n int) *int          { return &n }
 func NewInt64(n int64) *int64    { return &n }
 func NewString(s string) *string { return &s }
+
+func AreReferencedValuesEqual[T comparable](a, b *T) bool {
+	if a == b {
+		return true
+	}
+
+	if a == nil || b == nil {
+		return false
+	}
+
+	return *a == *b
+}


### PR DESCRIPTION
#### Summary
At some point, we changed the image proxy to store a parsed URL instead of getting the site URL directly from the config each time, but it didn't update that stored URL correctly when the config is updated which leads to some double proxying if a server's site URL is changed without restarting the server. This fixes that, and I also fixed a related bug where the options for the atmos/camo proxy aren't always updated. Hopefully, this solves the rare double proxying bugs that get reported occasionally.

I also made it so that neither of the image proxy backends directly reference `proxy.ConfigService` any more to reduce the chance that this sort of bug might happen again. I would've removed `proxy.ConfigService` entirely, but we needed it to remove remove the image proxy's config listener.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58275

#### Release Note
```release-note
Fixed incorrect behaviour of image proxy when site URL is changed
```
