### PR TITLE
MM-58499 Fix bolded icon issue in LHS

### DIFF
--- a/webapp/channels/src/sass/layout/_sidebar-left.scss
+++ b/webapp/channels/src/sass/layout/_sidebar-left.scss
@@ -214,10 +214,6 @@ $sidebarOpacityAnimationDuration: 0.15s;
             &--untouched {
                 color: var(--sidebar-unread-text);
                 font-weight: $font-weight--semibold;
-
-                i::before {
-                    font-weight: $font-weight--semibold;
-                }
             }
         }
 
@@ -1282,10 +1278,13 @@ $sidebarOpacityAnimationDuration: 0.15s;
     }
 
     .SidebarChannel.unread .SidebarChannelLinkLabel,
-    .SidebarChannel.unread .SidebarLink > i,
     .SidebarChannel.unread .SidebarLink:hover .SidebarChannelLinkLabel {
         color: var(--sidebar-unread-text);
         font-weight: 600;
+    }
+
+    .SidebarChannel.unread .SidebarLink > i {
+        color: var(--sidebar-unread-text);
     }
 
     .SidebarChannel .SidebarLink > i {


### PR DESCRIPTION
#### Summary
Icons in the LHS are being improperly bolded in unread or untouched states. This removes the unneeded bold style for icons in the LHS to prevent rendering issues (primarily noticeable in Safari).

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-58499

#### Screenshots
Notice the difference with the plus icon for the 'Add channels' item in the LHS
|  before  |  after  |
|----|----|
| <img width="329" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/8d8c822b-b9ee-4f64-92fc-99ba9b65d55b"> | <img width="330" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/5d48aab0-7070-4f53-95d3-ab5bd1d010ac"> |

#### Release Note
```release-note
NONE
```
