### PR TITLE
[MM-58463] Remove defer for main/entry JS scripts

### DIFF
--- a/webapp/channels/src/entry.tsx
+++ b/webapp/channels/src/entry.tsx
@@ -30,7 +30,7 @@ declare global {
 // This runs before we start to render anything.
 function preRenderSetup(callwhendone: () => void) {
     window.onerror = (msg, url, line, column, error) => {
-        if (msg === 'ResizeObserver loop limit exceededs') {
+        if (msg === 'ResizeObserver loop limit exceeded') {
             return;
         }
 

--- a/webapp/channels/src/entry.tsx
+++ b/webapp/channels/src/entry.tsx
@@ -30,7 +30,7 @@ declare global {
 // This runs before we start to render anything.
 function preRenderSetup(callwhendone: () => void) {
     window.onerror = (msg, url, line, column, error) => {
-        if (msg === 'ResizeObserver loop limit exceeded') {
+        if (msg === 'ResizeObserver loop limit exceededs') {
             return;
         }
 

--- a/webapp/channels/webpack.config.js
+++ b/webapp/channels/webpack.config.js
@@ -159,6 +159,7 @@ var config = {
             filename: 'root.html',
             inject: 'head',
             template: 'src/root.html',
+            scriptLoading: 'blocking',
             meta: {
                 csp: {
                     'http-equiv': 'Content-Security-Policy',


### PR DESCRIPTION
#### Summary
The initial JS should have high priority regardless of other chunks. So only the initial chunk along with remote entry are not defered with HTMLWebpackPlugin as this plugin is responsible for rending the initial HTML page, rest other chunks are loaded by webpack in deferred without any changes as they should be loaded. This should marginally improve and parsing the initial scripts.

After
```html
        <script src="/static/main.2ef0b4d9e5e308934fe0.js"></script>
        <script src="/static/remote_entry.js?bt=1717453929387"></script>
```

Before
```html
<script defer="defer" src="/static/main.4bfd7c2a87a6b0a05c35.js"></script>
<script defer="defer" src="/static/remote_entry.js?bt=1717212713679"></script>
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58463

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
