### PR TITLE
Improve isolation of PerformanceReporter tests to increase their stability

### DIFF
--- a/webapp/channels/src/utils/performance_telemetry/reporter.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.ts
@@ -67,6 +67,8 @@ export default class PerformanceReporter {
     private observer: PerformanceObserver;
     private reportTimeout: number | undefined;
 
+    // These values are protected instead of private so that they can be modified by unit tests
+    protected sendBeacon = navigator.sendBeacon;
     protected reportPeriodBase = 60 * 1000;
     protected reportPeriodJitter = 15 * 1000;
 
@@ -298,7 +300,7 @@ export default class PerformanceReporter {
         const url = this.client.getClientMetricsRoute();
         const data = JSON.stringify(report);
 
-        const beaconSent = navigator.sendBeacon(url, data);
+        const beaconSent = this.sendBeacon(url, data);
 
         if (!beaconSent) {
             // The data couldn't be queued as a beacon for some reason, so fall back to sending an immediate fetch

--- a/webapp/channels/src/utils/performance_telemetry/reporter.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.ts
@@ -68,7 +68,6 @@ export default class PerformanceReporter {
     private reportTimeout: number | undefined;
 
     // These values are protected instead of private so that they can be modified by unit tests
-    protected sendBeacon = navigator.sendBeacon;
     protected reportPeriodBase = 60 * 1000;
     protected reportPeriodJitter = 15 * 1000;
 
@@ -306,6 +305,10 @@ export default class PerformanceReporter {
             // The data couldn't be queued as a beacon for some reason, so fall back to sending an immediate fetch
             fetch(url, {method: 'POST', body: data});
         }
+    }
+
+    protected sendBeacon(url: string | URL, data?: BodyInit | null | undefined): boolean {
+        return navigator.sendBeacon(url, data);
     }
 }
 


### PR DESCRIPTION
#### Summary
These tests seem to fail randomly sometimes such as in https://github.com/mattermost/mattermost/actions/runs/9355062430/job/25749374384#step:4:1125. I thought that was due to other tests failing, but that doesn't seem to be the case based on the log I linked there.

I can't get these to fail reliably, but I think the issue is that the tests are affecting each other because of all the async stuff they have happening, so I changed this to better isolate them from each other which should hopefully fix this issue

#### Release Note
```release-note
NONE
```
