### PR TITLE
Use RPC for message actions

### DIFF
--- a/server/channels/app/integration_action.go
+++ b/server/channels/app/integration_action.go
@@ -228,28 +228,69 @@ func (a *App) DoPostActionWithCookie(c request.CTX, postID, actionId, userID, se
 		return "", appErr
 	}
 
-	requestJSON, err := json.Marshal(upstreamRequest)
-	if err != nil {
-		return "", model.NewAppError("DoPostActionWithCookie", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*a.Config().ServiceSettings.OutgoingIntegrationRequestsTimeout)*time.Second)
-	defer cancel()
-	resp, appErr := a.DoActionRequest(c.WithContext(ctx), upstreamURL, requestJSON)
-	if appErr != nil {
-		return "", appErr
-	}
-	defer resp.Body.Close()
-
 	var response model.PostActionIntegrationResponse
-	respBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", model.NewAppError("DoPostActionWithCookie", "api.post.do_action.action_integration.app_error", nil, "", http.StatusBadRequest).Wrap(err)
-	}
+	if strings.HasPrefix(upstreamURL, "rpc://") {
+		u := strings.TrimPrefix(upstreamURL, "rpc://")
+		// format is <plugin_id>/<handleName>
+		parts := strings.Split(u, "/")
+		if len(parts) != 2 {
+			return "", model.NewAppError("DoPostActionWithCookie", "api.post.do_action.action_integration.app_error", nil, "invalid plugin handle", http.StatusBadRequest)
+		}
+		pluginID := parts[0]
+		handleName := parts[1]
 
-	if len(respBytes) > 0 {
-		if err = json.Unmarshal(respBytes, &response); err != nil {
+		pluginsEnvironment := a.GetPluginsEnvironment()
+		if pluginsEnvironment == nil {
+			return "", model.NewAppError("DoPostActionWithCookie", "model.plugin_postactionr.error.app_error", nil, "err=Plugins are not enabled", http.StatusInternalServerError)
+		}
+
+		// Checking if plugin is working or not
+		if err := pluginsEnvironment.PerformHealthCheck(pluginID); err != nil {
+			return "", model.NewAppError("DoPostActionWithCookie", "model.plugin_postaction.error.app_error", nil, "err= Plugin has recently crashed: "+pluginID, http.StatusInternalServerError)
+		}
+
+		pluginHooks, err := pluginsEnvironment.HooksForPlugin(pluginID)
+		if err != nil {
+			return "", model.NewAppError("DoPostActionWithCookie", "model.plugin_postaction.error.app_error", nil, "err="+err.Error(), http.StatusInternalServerError)
+		}
+
+		var appErr *model.AppError
+		response, appErr = pluginHooks.ExecutePostAction(pluginContext(c), handleName, upstreamRequest)
+
+		// Checking if plugin crashed after running the command
+		if err := pluginsEnvironment.PerformHealthCheck(pluginID); err != nil {
+			errMessage := fmt.Sprintf("err= Plugin %s crashed due to the post action", pluginID)
+			return "", model.NewAppError("ExecutePluginCommand", "model.plugin_postaction.error.app_error", map[string]any{"PluginId": pluginID}, errMessage, http.StatusInternalServerError)
+		}
+		if appErr != nil && (appErr.StatusCode < 100 || appErr.StatusCode > 999) {
+			c.Logger().Warn("Invalid status code returned from plugin. Converting to internal server error.", mlog.String("plugin_id", pluginID), mlog.Int("status_code", appErr.StatusCode))
+			appErr.StatusCode = http.StatusInternalServerError
+		}
+
+		return clientTriggerId, nil
+	} else {
+		requestJSON, err := json.Marshal(upstreamRequest)
+		if err != nil {
+			return "", model.NewAppError("DoPostActionWithCookie", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*a.Config().ServiceSettings.OutgoingIntegrationRequestsTimeout)*time.Second)
+		defer cancel()
+		resp, appErr := a.DoActionRequest(c.WithContext(ctx), upstreamURL, requestJSON)
+		if appErr != nil {
+			return "", appErr
+		}
+		defer resp.Body.Close()
+
+		respBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
 			return "", model.NewAppError("DoPostActionWithCookie", "api.post.do_action.action_integration.app_error", nil, "", http.StatusBadRequest).Wrap(err)
+		}
+
+		if len(respBytes) > 0 {
+			if err = json.Unmarshal(respBytes, &response); err != nil {
+				return "", model.NewAppError("DoPostActionWithCookie", "api.post.do_action.action_integration.app_error", nil, "", http.StatusBadRequest).Wrap(err)
+			}
 		}
 	}
 

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -119,6 +119,43 @@ func (s *hooksRPCServer) ExecuteCommand(args *Z_ExecuteCommandArgs, returns *Z_E
 }
 
 func init() {
+	hookNameToId["ExecutePostAction"] = ExecutePostActionID
+}
+
+type Z_ExecutePostActionArgs struct {
+	A *Context
+	B string
+	C *model.PostActionIntegrationRequest
+}
+
+type Z_ExecutePostActionReturns struct {
+	A model.PostActionIntegrationResponse
+	B *model.AppError
+}
+
+func (g *hooksRPCClient) ExecutePostAction(c *Context, handle string, actionRequest *model.PostActionIntegrationRequest) (model.PostActionIntegrationResponse, *model.AppError) {
+	_args := &Z_ExecutePostActionArgs{c, handle, actionRequest}
+	_returns := &Z_ExecutePostActionReturns{}
+	if g.implemented[ExecutePostActionID] {
+		if err := g.client.Call("Plugin.ExecutePostAction", _args, _returns); err != nil {
+			g.log.Error("RPC call ExecutePostAction to plugin failed.", mlog.Err(err))
+		}
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *hooksRPCServer) ExecutePostAction(args *Z_ExecutePostActionArgs, returns *Z_ExecutePostActionReturns) error {
+	if hook, ok := s.impl.(interface {
+		ExecutePostAction(c *Context, handle string, actionRequest *model.PostActionIntegrationRequest) (model.PostActionIntegrationResponse, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.ExecutePostAction(args.A, args.B, args.C)
+	} else {
+		return encodableError(fmt.Errorf("Hook ExecutePostAction called but not implemented."))
+	}
+	return nil
+}
+
+func init() {
 	hookNameToId["UserHasBeenCreated"] = UserHasBeenCreatedID
 }
 

--- a/server/public/plugin/hooks.go
+++ b/server/public/plugin/hooks.go
@@ -61,6 +61,7 @@ const (
 	OnSharedChannelsAttachmentSyncMsgID       = 43
 	OnSharedChannelsProfileImageSyncMsgID     = 44
 	GenerateSupportDataID                     = 45
+	ExecutePostActionID                       = 46
 	TotalHooksID                              = iota
 )
 
@@ -116,6 +117,11 @@ type Hooks interface {
 	//
 	// Minimum server version: 5.2
 	ExecuteCommand(c *Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError)
+
+	// ExecutePostAction executes a post action on the plugin
+	//
+	// Minimum server version: TBD
+	ExecutePostAction(c *Context, handle string, actionRequest *model.PostActionIntegrationRequest) (model.PostActionIntegrationResponse, *model.AppError)
 
 	// UserHasBeenCreated is invoked after a user was created.
 	//

--- a/server/public/plugin/hooks_timer_layer_generated.go
+++ b/server/public/plugin/hooks_timer_layer_generated.go
@@ -68,6 +68,13 @@ func (hooks *hooksTimerLayer) ExecuteCommand(c *Context, args *model.CommandArgs
 	return _returnsA, _returnsB
 }
 
+func (hooks *hooksTimerLayer) ExecutePostAction(c *Context, handle string, actionRequest *model.PostActionIntegrationRequest) (model.PostActionIntegrationResponse, *model.AppError) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := hooks.hooksImpl.ExecutePostAction(c, handle, actionRequest)
+	hooks.recordTime(startTime, "ExecutePostAction", _returnsB == nil)
+	return _returnsA, _returnsB
+}
+
 func (hooks *hooksTimerLayer) UserHasBeenCreated(c *Context, user *model.User) {
 	startTime := timePkg.Now()
 	hooks.hooksImpl.UserHasBeenCreated(c, user)


### PR DESCRIPTION
#### Summary
This PR allows plugin devs to use `rpc://{pluginid}/{someHandlerName}` for message actions instead of having to declare and create an HTTP endpoint.

TODO:
- [ ] Take the temperature during dev meeting
- [ ] Add tests
- [ ] Eventually: add an example in our demo plugin
- [ ] Docs

#### Ticket Link
N/A - OSF Project

#### Release Note
```release-note
Added an option for plugins to use RPC to handle message actions
```
