### PR TITLE
[Mm-56931] Resolved the date separation issue #26591

### DIFF
--- a/my_changes.patch
+++ b/my_changes.patch
@@ -1,0 +1,2 @@
+this is what i have changed:
+{(isSearchResultItem || (props.location === Locations.CENTER && (props.isPinnedPosts || props.isFlaggedPosts))) && <DateSeparator date={currentPostDay}/>}

--- a/webapp/channels/src/components/post/post_component.test.tsx
+++ b/webapp/channels/src/components/post/post_component.test.tsx
@@ -325,4 +325,17 @@ describe('PostComponent', () => {
             });
         });
     });
+
+    describe('date separator', ()=> {
+        test('should not show date separator on consecutive posts when RHS is open', ()=> {
+            const props = {
+                ...baseProps,
+                isConsecutivePost: true,
+                location: Locations.RHS_ROOT,
+            };
+            renderWithContext(<PostComponent {...props}/>)
+
+            expect(screen.queryByTestId('basicSeparator')).not.toBeInTheDocument();
+        });
+    });
 });

--- a/webapp/channels/src/components/post/post_component.test.tsx
+++ b/webapp/channels/src/components/post/post_component.test.tsx
@@ -325,17 +325,4 @@ describe('PostComponent', () => {
             });
         });
     });
-
-    describe('date separator', ()=> {
-        test('should not show date separator on consecutive posts when RHS is open', ()=> {
-            const props = {
-                ...baseProps,
-                isConsecutivePost: true,
-                location: Locations.RHS_ROOT,
-            };
-            renderWithContext(<PostComponent {...props}/>)
-
-            expect(screen.queryByTestId('basicSeparator')).not.toBeInTheDocument();
-        });
-    });
 });

--- a/webapp/channels/src/components/post/post_component.tsx
+++ b/webapp/channels/src/components/post/post_component.tsx
@@ -518,7 +518,7 @@ const PostComponent = (props: Props): JSX.Element => {
 
     return (
         <>
-            {(isSearchResultItem || (props.location === Locations.CENTER && props.isConsecutivePost !== true && (props.isPinnedPosts || props.isFlaggedPosts))) && <DateSeparator date={currentPostDay}/>}
+            {(isSearchResultItem || (props.location === Locations.CENTER && (props.isPinnedPosts || props.isFlaggedPosts))) && <DateSeparator date={currentPostDay}/>}
             <PostAriaLabelDiv
                 ref={postRef}
                 id={getTestId()}

--- a/webapp/channels/src/components/post/post_component.tsx
+++ b/webapp/channels/src/components/post/post_component.tsx
@@ -518,7 +518,7 @@ const PostComponent = (props: Props): JSX.Element => {
 
     return (
         <>
-            {(isSearchResultItem || (props.location !== Locations.CENTER && (props.isPinnedPosts || props.isFlaggedPosts))) && <DateSeparator date={currentPostDay}/>}
+            {(isSearchResultItem || (props.location === Locations.CENTER && props.isConsecutivePost !== true && (props.isPinnedPosts || props.isFlaggedPosts))) && <DateSeparator date={currentPostDay}/>}
             <PostAriaLabelDiv
                 ref={postRef}
                 id={getTestId()}


### PR DESCRIPTION
#### Summary

Folowing the instructions in the comment section:
- the date seperation dupicate and multi user date repeating was fixed by changing the condition of props.location 


#### Ticket Link
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/26591
Jira https://mattermost.atlassian.net/browse/MM-56931


#### Screenshots

|  before  |  after  |
|----|----|
| <![Screenshot_51](https://github.com/mattermost/mattermost/assets/171164513/98c5d996-3f8d-4543-bf92-b8cf74f92008)> | <![Screenshot_20240605_165234](https://github.com/mattermost/mattermost/assets/171164513/7dcd3208-6d08-44ed-8b5a-8c5e2c25cde0)> |


#### Release Note



```release-note
Additional date-separator has been removed and not shown in the Thread context
```
