### PR TITLE
MM-58252 cherry-pick into release 9.5

### DIFF
--- a/server/platform/services/sharedchannel/util.go
+++ b/server/platform/services/sharedchannel/util.go
@@ -130,3 +130,28 @@ func isNotFoundError(err error) bool {
 	var errNotFound *store.ErrNotFound
 	return errors.As(err, &errNotFound)
 }
+
+func postsSliceToMap(posts []*model.Post) map[string]*model.Post {
+	m := make(map[string]*model.Post, len(posts))
+	for _, p := range posts {
+		m[p.Id] = p
+	}
+	return m
+}
+
+func reducePostsSliceInCache(posts []*model.Post, cache map[string]*model.Post) []*model.Post {
+	reduced := make([]*model.Post, 0, len(posts))
+	for _, p := range posts {
+		if _, ok := cache[p.Id]; !ok {
+			reduced = append(reduced, p)
+		}
+	}
+	return reduced
+}
+
+func SafeString(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}

--- a/server/platform/services/sharedchannel/util.go
+++ b/server/platform/services/sharedchannel/util.go
@@ -131,24 +131,6 @@ func isNotFoundError(err error) bool {
 	return errors.As(err, &errNotFound)
 }
 
-func postsSliceToMap(posts []*model.Post) map[string]*model.Post {
-	m := make(map[string]*model.Post, len(posts))
-	for _, p := range posts {
-		m[p.Id] = p
-	}
-	return m
-}
-
-func reducePostsSliceInCache(posts []*model.Post, cache map[string]*model.Post) []*model.Post {
-	reduced := make([]*model.Post, 0, len(posts))
-	for _, p := range posts {
-		if _, ok := cache[p.Id]; !ok {
-			reduced = append(reduced, p)
-		}
-	}
-	return reduced
-}
-
 func SafeString(p *string) string {
 	if p == nil {
 		return ""


### PR DESCRIPTION
#### Summary
Cherry-pick https://github.com/mattermost/mattermost/pull/27203 into release-9.5

This PR addresses an issue where a check is needed to ensure that a user update comes from the remote that owns the user.  This ensures remotes cannot update users from other remotes, including setting the user's remoteID so that the user appears to originate from somewhere else.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58253
https://mattermost.atlassian.net/browse/MM-58249


#### Release Note
```release-note
Ensures remotes cannot update users belonging to different remotes.
```
