### PR TITLE
[MM-58317]: disable plugin if skip market place if prepackage flg is set

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -153,7 +153,6 @@ PLUGIN_PACKAGES += mattermost-plugin-nps-v1.3.3
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.3.4
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.8.0
 PLUGIN_PACKAGES += mattermost-plugin-ai-v0.6.3
-PLUGIN_PACKAGES += mattermost-plugin-focalboard-v8.0.0
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -153,6 +153,7 @@ PLUGIN_PACKAGES += mattermost-plugin-nps-v1.3.3
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.3.4
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.8.0
 PLUGIN_PACKAGES += mattermost-plugin-ai-v0.6.3
+PLUGIN_PACKAGES += mattermost-plugin-focalboard-v8.0.0
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)
 

--- a/server/channels/api4/plugin_test.go
+++ b/server/channels/api4/plugin_test.go
@@ -1297,6 +1297,25 @@ func TestGetPrepackagedPluginInMarketplace(t *testing.T) {
 		require.Len(t, plugins, 1)
 		require.Equal(t, newerPrepackagePlugin.Manifest, plugins[0].Manifest)
 	})
+
+	t.Run("hide prepackaged plugins from marketplace if skip_marketplace_if_prepackaged is set", func(t *testing.T) {
+		manifest := &model.Manifest{
+			Version:                      "0.1.2",
+			Id:                           "prepackaged.id.test",
+			SkipMarketplaceIfPrepackaged: true,
+		}
+
+		prepackagedPlugins := &plugin.PrepackagedPlugin{
+			Manifest: manifest,
+		}
+
+		env := th.App.GetPluginsEnvironment()
+		env.SetPrepackagedPlugins([]*plugin.PrepackagedPlugin{prepackagedPlugins}, nil)
+
+		plugins, _, err := th.SystemAdminClient.GetMarketplacePlugins(context.Background(), &model.MarketplacePluginFilter{})
+		require.NoError(t, err)
+		require.Len(t, plugins, 1)
+	})
 }
 
 func TestInstallMarketplacePlugin(t *testing.T) {

--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -953,8 +953,6 @@ func (ch *Channels) processPrepackagedPlugins(prepackagedPluginsDir string) erro
 		if ch.pluginIsTransitionallyPrepackaged(p.Manifest.Id) {
 			if ch.shouldPersistTransitionallyPrepackagedPlugin(availablePluginsMap, p) {
 				transitionallyPrepackagedPlugins = append(transitionallyPrepackagedPlugins, p)
-			} else {
-				prepackagedPlugins = append(prepackagedPlugins, p)
 			}
 		} else {
 			prepackagedPlugins = append(prepackagedPlugins, p)

--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -652,7 +652,7 @@ func (a *App) mergePrepackagedPlugins(remoteMarketplacePlugins map[string]*model
 	}
 
 	for _, prepackaged := range pluginsEnvironment.PrepackagedPlugins() {
-		if prepackaged.Manifest == nil || prepackaged.Manifest.DisableInMarketPlace {
+		if prepackaged.Manifest == nil || prepackaged.Manifest.SkipMarketplaceIfPrepackaged {
 			continue
 		}
 

--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -652,7 +652,7 @@ func (a *App) mergePrepackagedPlugins(remoteMarketplacePlugins map[string]*model
 	}
 
 	for _, prepackaged := range pluginsEnvironment.PrepackagedPlugins() {
-		if prepackaged.Manifest == nil {
+		if prepackaged.Manifest == nil || prepackaged.Manifest.DisableInMarketPlace {
 			continue
 		}
 
@@ -953,6 +953,8 @@ func (ch *Channels) processPrepackagedPlugins(prepackagedPluginsDir string) erro
 		if ch.pluginIsTransitionallyPrepackaged(p.Manifest.Id) {
 			if ch.shouldPersistTransitionallyPrepackagedPlugin(availablePluginsMap, p) {
 				transitionallyPrepackagedPlugins = append(transitionallyPrepackagedPlugins, p)
+			} else {
+				prepackagedPlugins = append(prepackagedPlugins, p)
 			}
 		} else {
 			prepackagedPlugins = append(prepackagedPlugins, p)

--- a/server/public/model/manifest.go
+++ b/server/public/model/manifest.go
@@ -188,6 +188,9 @@ type Manifest struct {
 
 	// Plugins can store any kind of data in Props to allow other plugins to use it.
 	Props map[string]any `json:"props,omitempty" yaml:"props,omitempty"`
+
+	// To show the plugin in market place, if set to true then hide the plugin from market place plugin list
+	DisableInMarketPlace bool `json:"disable_in_marketplace,omitempty" yaml:"disable_in_marketplace,omitempty"`
 }
 
 type ManifestServer struct {

--- a/server/public/model/manifest.go
+++ b/server/public/model/manifest.go
@@ -190,7 +190,7 @@ type Manifest struct {
 	Props map[string]any `json:"props,omitempty" yaml:"props,omitempty"`
 
 	// To show the plugin in market place, if set to true then hide the plugin from market place plugin list
-	DisableInMarketPlace bool `json:"disable_in_marketplace,omitempty" yaml:"disable_in_marketplace,omitempty"`
+	SkipMarketplaceIfPrepackaged bool `json:"skip_marketplace_if_prepackaged,omitempty" yaml:"skip_marketplace_if_prepackaged,omitempty"`
 }
 
 type ManifestServer struct {


### PR DESCRIPTION
Fixes: https://mattermost.atlassian.net/browse/MM-58317

This PR adds support for a flag named `skip_marketplace_if_prepackaged`, if set then the prepackaged plugin will not be shown up in the marketplace plugin. 

#### Release Note

```release-note
NONE
```