### PR TITLE
Automated cherry pick of #27308

### DIFF
--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -1351,6 +1351,10 @@ func (s *Server) doLicenseExpirationCheck() {
 		return
 	}
 
+	if license.IsCloud() {
+		return
+	}
+
 	users, err := s.Store().User().GetSystemAdminProfiles()
 	if err != nil {
 		mlog.Error("Failed to get system admins for license expired message from Mattermost.")


### PR DESCRIPTION
Cherry pick of #27308 on release-9.9.

/cc  @nickmisasi

```release-note
NONE
```