### PR TITLE
Automated cherry pick of #26070

### DIFF
--- a/server/channels/api4/cloud.go
+++ b/server/channels/api4/cloud.go
@@ -65,8 +65,13 @@ func (api *API) InitCloud() {
 
 func ensureCloudInterface(c *Context, where string) bool {
 	cloud := c.App.Cloud()
+	disabled := c.App.Config().CloudSettings.Disable != nil && *c.App.Config().CloudSettings.Disable
 	if cloud == nil {
 		c.Err = model.NewAppError(where, "api.server.cws.needs_enterprise_edition", nil, "", http.StatusBadRequest)
+		return false
+	}
+	if disabled {
+		c.Err = model.NewAppError(where, "api.server.cws.disabled", nil, "", http.StatusUnprocessableEntity)
 		return false
 	}
 	return true

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -2739,6 +2739,10 @@
     "translation": "CWS Server failed to delete workspace."
   },
   {
+    "id": "api.server.cws.disabled",
+    "translation": "Interactions with the Mattermost Customer Portal have been disabled by the system admin."
+  },
+  {
     "id": "api.server.cws.health_check.app_error",
     "translation": "CWS Server is not available."
   },

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -3026,6 +3026,7 @@ type CloudSettings struct {
 	CWSURL    *string `access:"write_restrictable"`
 	CWSAPIURL *string `access:"write_restrictable"`
 	CWSMock   *bool   `access:"write_restrictable"`
+	Disable   *bool   `access:"write_restrictable,cloud_restrictable"`
 }
 
 func (s *CloudSettings) SetDefaults() {
@@ -3050,6 +3051,10 @@ func (s *CloudSettings) SetDefaults() {
 	if s.CWSMock == nil {
 		isMockCws := MockCWS == "true"
 		s.CWSMock = &isMockCws
+	}
+
+	if s.Disable == nil {
+		s.Disable = NewBool(false)
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #26070 on release-9.5.

/cc  @nickmisasi

```release-note
NONE
```