### PR TITLE
MM-58528 Fixed wrapping button label for followed threads

### DIFF
--- a/webapp/channels/src/components/threading/global_threads/thread_list/thread_list.scss
+++ b/webapp/channels/src/components/threading/global_threads/thread_list/thread_list.scss
@@ -23,12 +23,23 @@
             + .tab-button-wrapper {
                 margin-left: 4px;
             }
+
+            Button {
+                display: flex;
+                max-width: 100%;
+
+                .Button_label {
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                }
+            }
         }
 
         .left {
-            display: flex;
+            display: grid;
             height: 100%;
-            align-items: center;
+            grid-template-columns: minmax(0, auto) minmax(0, auto);
         }
 
         .right-anchor {


### PR DESCRIPTION
#### Summary
Fixes the 'followed threads' label and prevents it from wrapping on 2 lines.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-58528

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="275" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/72a8b3bd-3b66-45d8-9610-e0969715ed40"> | <img width="295" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/8a03a1e9-840c-4fd1-b307-ebfe2c3a6787"> |

#### Release Note
```release-note
NONE
```
