### PR TITLE
MM-57873 Check user visibility when accepting channel invites for DMs

### DIFF
--- a/server/platform/services/sharedchannel/channelinvite.go
+++ b/server/platform/services/sharedchannel/channelinvite.go
@@ -226,7 +226,7 @@ func (scs *Service) onReceiveChannelInvite(msg model.RemoteClusterMsg, rc *model
 
 func (scs *Service) handleChannelCreation(invite channelInviteMsg, rc *model.RemoteCluster) (*model.Channel, error) {
 	if invite.Type == model.ChannelTypeDirect {
-		return scs.createDirectChannel(invite)
+		return scs.createDirectChannel(invite, rc)
 	}
 
 	channelNew := &model.Channel{
@@ -250,7 +250,7 @@ func (scs *Service) handleChannelCreation(invite channelInviteMsg, rc *model.Rem
 	return channel, nil
 }
 
-func (scs *Service) createDirectChannel(invite channelInviteMsg) (*model.Channel, error) {
+func (scs *Service) createDirectChannel(invite channelInviteMsg, rc *model.RemoteCluster) (*model.Channel, error) {
 	if len(invite.DirectParticipantIDs) != 2 {
 		return nil, fmt.Errorf("cannot create direct channel `%s` insufficient participant count `%d`", invite.ChannelId, len(invite.DirectParticipantIDs))
 	}
@@ -282,6 +282,10 @@ func (scs *Service) createDirectChannel(invite channelInviteMsg) (*model.Channel
 
 	if userLocal.IsRemote() {
 		return nil, fmt.Errorf("cannot create direct channel `%s` local user is not local (%s)", invite.ChannelId, userLocal.Id)
+	}
+
+	if userRemote.GetRemoteID() != rc.RemoteId {
+		return nil, fmt.Errorf("cannot create direct channel `%s`: %w", invite.ChannelId, ErrRemoteIDMismatch)
 	}
 
 	// ensure remote user is allowed to DM the local user

--- a/server/platform/services/sharedchannel/channelinvite_test.go
+++ b/server/platform/services/sharedchannel/channelinvite_test.go
@@ -160,6 +160,7 @@ func TestOnReceiveChannelInvite(t *testing.T) {
 	})
 
 	t.Run("DM channels", func(t *testing.T) {
+		var testRemoteID = model.NewId()
 		testCases := []struct {
 			desc          string
 			user1         *model.User
@@ -167,11 +168,12 @@ func TestOnReceiveChannelInvite(t *testing.T) {
 			canSee        bool
 			expectSuccess bool
 		}{
-			{"valid users", &model.User{Id: model.NewId(), RemoteId: model.NewString(model.NewId())}, &model.User{Id: model.NewId()}, true, true},
-			{"swapped users", &model.User{Id: model.NewId()}, &model.User{Id: model.NewId(), RemoteId: model.NewString(model.NewId())}, true, true},
-			{"two remotes", &model.User{Id: model.NewId(), RemoteId: model.NewString(model.NewId())}, &model.User{Id: model.NewId(), RemoteId: model.NewString(model.NewId())}, true, false},
+			{"valid users", &model.User{Id: model.NewId(), RemoteId: &testRemoteID}, &model.User{Id: model.NewId()}, true, true},
+			{"swapped users", &model.User{Id: model.NewId()}, &model.User{Id: model.NewId(), RemoteId: &testRemoteID}, true, true},
+			{"two remotes", &model.User{Id: model.NewId(), RemoteId: &testRemoteID}, &model.User{Id: model.NewId(), RemoteId: &testRemoteID}, true, false},
 			{"two locals", &model.User{Id: model.NewId()}, &model.User{Id: model.NewId()}, true, false},
-			{"can't see", &model.User{Id: model.NewId(), RemoteId: model.NewString(model.NewId())}, &model.User{Id: model.NewId()}, false, false},
+			{"can't see", &model.User{Id: model.NewId(), RemoteId: &testRemoteID}, &model.User{Id: model.NewId()}, false, false},
+			{"invalid remoteid", &model.User{Id: model.NewId(), RemoteId: model.NewString("bogus")}, &model.User{Id: model.NewId()}, true, false},
 		}
 
 		for _, tc := range testCases {
@@ -186,7 +188,7 @@ func TestOnReceiveChannelInvite(t *testing.T) {
 				}
 
 				mockStore := &mocks.Store{}
-				remoteCluster := &model.RemoteCluster{Name: "test3", CreatorId: model.NewId()}
+				remoteCluster := &model.RemoteCluster{Name: "test3", CreatorId: model.NewId(), RemoteId: testRemoteID}
 				invitation := channelInviteMsg{
 					ChannelId:            model.NewId(),
 					TeamId:               model.NewId(),

--- a/server/platform/services/sharedchannel/channelinvite_test.go
+++ b/server/platform/services/sharedchannel/channelinvite_test.go
@@ -4,6 +4,7 @@
 package sharedchannel
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,6 +25,7 @@ var (
 	mockTypeChannel    = mock.AnythingOfType("*model.Channel")
 	mockTypeString     = mock.AnythingOfType("string")
 	mockTypeReqContext = mock.AnythingOfType("*request.Context")
+	mockTypeContext    = mock.MatchedBy(func(ctx context.Context) bool { return true })
 )
 
 func TestOnReceiveChannelInvite(t *testing.T) {
@@ -157,48 +159,76 @@ func TestOnReceiveChannelInvite(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("cannot make channel readonly `%s`: foo: bar, boom", invitation.ChannelId), err.Error())
 	})
 
-	t.Run("when invitation prescribes a direct channel, it does create a direct channel", func(t *testing.T) {
-		mockServer := &MockServerIface{}
-		logger := mlog.CreateConsoleTestLogger(t)
-		mockServer.On("Log").Return(logger)
-		mockApp := &MockAppIface{}
-		scs := &Service{
-			server: mockServer,
-			app:    mockApp,
+	t.Run("DM channels", func(t *testing.T) {
+		testCases := []struct {
+			desc          string
+			user1         *model.User
+			user2         *model.User
+			canSee        bool
+			expectSuccess bool
+		}{
+			{"valid users", &model.User{Id: model.NewId(), RemoteId: model.NewString(model.NewId())}, &model.User{Id: model.NewId()}, true, true},
+			{"swapped users", &model.User{Id: model.NewId()}, &model.User{Id: model.NewId(), RemoteId: model.NewString(model.NewId())}, true, true},
+			{"two remotes", &model.User{Id: model.NewId(), RemoteId: model.NewString(model.NewId())}, &model.User{Id: model.NewId(), RemoteId: model.NewString(model.NewId())}, true, false},
+			{"two locals", &model.User{Id: model.NewId()}, &model.User{Id: model.NewId()}, true, false},
+			{"can't see", &model.User{Id: model.NewId(), RemoteId: model.NewString(model.NewId())}, &model.User{Id: model.NewId()}, false, false},
 		}
 
-		mockStore := &mocks.Store{}
-		remoteCluster := &model.RemoteCluster{Name: "test3", CreatorId: model.NewId()}
-		invitation := channelInviteMsg{
-			ChannelId:            model.NewId(),
-			TeamId:               model.NewId(),
-			ReadOnly:             false,
-			Type:                 model.ChannelTypeDirect,
-			DirectParticipantIDs: []string{model.NewId(), model.NewId()},
+		for _, tc := range testCases {
+			t.Run(tc.desc, func(t *testing.T) {
+				mockServer := &MockServerIface{}
+				logger := mlog.CreateConsoleTestLogger(t)
+				mockServer.On("Log").Return(logger)
+				mockApp := &MockAppIface{}
+				scs := &Service{
+					server: mockServer,
+					app:    mockApp,
+				}
+
+				mockStore := &mocks.Store{}
+				remoteCluster := &model.RemoteCluster{Name: "test3", CreatorId: model.NewId()}
+				invitation := channelInviteMsg{
+					ChannelId:            model.NewId(),
+					TeamId:               model.NewId(),
+					ReadOnly:             false,
+					Type:                 model.ChannelTypeDirect,
+					DirectParticipantIDs: []string{tc.user1.Id, tc.user2.Id},
+				}
+				payload, err := json.Marshal(invitation)
+				require.NoError(t, err)
+
+				msg := model.RemoteClusterMsg{
+					Payload: payload,
+				}
+				mockChannelStore := mocks.ChannelStore{}
+				mockSharedChannelStore := mocks.SharedChannelStore{}
+				channel := &model.Channel{}
+
+				mockUserStore := mocks.UserStore{}
+				mockUserStore.On("Get", mockTypeContext, tc.user1.Id).
+					Return(tc.user1, nil)
+				mockUserStore.On("Get", mockTypeContext, tc.user2.Id).
+					Return(tc.user2, nil)
+
+				mockChannelStore.On("Get", invitation.ChannelId, true).Return(nil, errors.New("boom"))
+				mockSharedChannelStore.On("Save", mock.Anything).Return(nil, nil)
+				mockSharedChannelStore.On("SaveRemote", mock.Anything).Return(nil, nil)
+				mockStore.On("Channel").Return(&mockChannelStore)
+				mockStore.On("SharedChannel").Return(&mockSharedChannelStore)
+				mockStore.On("User").Return(&mockUserStore)
+
+				mockServer = scs.server.(*MockServerIface)
+				mockServer.On("GetStore").Return(mockStore)
+
+				mockApp.On("GetOrCreateDirectChannel", mockTypeReqContext, mockTypeString, mockTypeString, mock.AnythingOfType("model.ChannelOption")).
+					Return(channel, nil).Maybe()
+				mockApp.On("UserCanSeeOtherUser", mockTypeReqContext, mockTypeString, mockTypeString).Return(tc.canSee, nil).Maybe()
+
+				defer mockApp.AssertExpectations(t)
+
+				err = scs.onReceiveChannelInvite(msg, remoteCluster, nil)
+				require.Equal(t, tc.expectSuccess, err == nil)
+			})
 		}
-		payload, err := json.Marshal(invitation)
-		require.NoError(t, err)
-
-		msg := model.RemoteClusterMsg{
-			Payload: payload,
-		}
-		mockChannelStore := mocks.ChannelStore{}
-		mockSharedChannelStore := mocks.SharedChannelStore{}
-		channel := &model.Channel{}
-
-		mockChannelStore.On("Get", invitation.ChannelId, true).Return(nil, errors.New("boom"))
-		mockSharedChannelStore.On("Save", mock.Anything).Return(nil, nil)
-		mockSharedChannelStore.On("SaveRemote", mock.Anything).Return(nil, nil)
-		mockStore.On("Channel").Return(&mockChannelStore)
-		mockStore.On("SharedChannel").Return(&mockSharedChannelStore)
-
-		mockServer = scs.server.(*MockServerIface)
-		mockServer.On("GetStore").Return(mockStore)
-
-		mockApp.On("GetOrCreateDirectChannel", mock.AnythingOfType("*request.Context"), invitation.DirectParticipantIDs[0], invitation.DirectParticipantIDs[1], mock.AnythingOfType("model.ChannelOption")).Return(channel, nil)
-		defer mockApp.AssertExpectations(t)
-
-		err = scs.onReceiveChannelInvite(msg, remoteCluster, nil)
-		require.NoError(t, err)
 	})
 }

--- a/server/platform/services/sharedchannel/mock_AppIface_test.go
+++ b/server/platform/services/sharedchannel/mock_AppIface_test.go
@@ -558,6 +558,36 @@ func (_m *MockAppIface) UpdatePost(c request.CTX, post *model.Post, safeUpdate b
 	return r0, r1
 }
 
+// UserCanSeeOtherUser provides a mock function with given fields: c, userID, otherUserId
+func (_m *MockAppIface) UserCanSeeOtherUser(c request.CTX, userID string, otherUserId string) (bool, *model.AppError) {
+	ret := _m.Called(c, userID, otherUserId)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UserCanSeeOtherUser")
+	}
+
+	var r0 bool
+	var r1 *model.AppError
+	if rf, ok := ret.Get(0).(func(request.CTX, string, string) (bool, *model.AppError)); ok {
+		return rf(c, userID, otherUserId)
+	}
+	if rf, ok := ret.Get(0).(func(request.CTX, string, string) bool); ok {
+		r0 = rf(c, userID, otherUserId)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(request.CTX, string, string) *model.AppError); ok {
+		r1 = rf(c, userID, otherUserId)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // NewMockAppIface creates a new instance of MockAppIface. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockAppIface(t interface {

--- a/server/platform/services/sharedchannel/service.go
+++ b/server/platform/services/sharedchannel/service.go
@@ -55,6 +55,7 @@ type AppIface interface {
 	SendEphemeralPost(c request.CTX, userId string, post *model.Post) *model.Post
 	CreateChannelWithUser(c request.CTX, channel *model.Channel, userId string) (*model.Channel, *model.AppError)
 	GetOrCreateDirectChannel(c request.CTX, userId, otherUserId string, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError)
+	UserCanSeeOtherUser(c request.CTX, userID string, otherUserId string) (bool, *model.AppError)
 	AddUserToChannel(c request.CTX, user *model.User, channel *model.Channel, skipTeamMemberIntegrityCheck bool) (*model.ChannelMember, *model.AppError)
 	AddUserToTeamByTeamId(c request.CTX, teamId string, user *model.User) *model.AppError
 	PermanentDeleteChannel(c request.CTX, channel *model.Channel) *model.AppError

--- a/server/platform/services/sharedchannel/sync_recv.go
+++ b/server/platform/services/sharedchannel/sync_recv.go
@@ -20,6 +20,7 @@ import (
 var (
 	ErrRemoteIDMismatch  = errors.New("remoteID mismatch")
 	ErrChannelIDMismatch = errors.New("channelID mismatch")
+	ErrUserDMPermission  = errors.New("users cannot DM each other")
 )
 
 func (scs *Service) onReceiveSyncMessage(msg model.RemoteClusterMsg, rc *model.RemoteCluster, response *remotecluster.Response) error {
@@ -224,20 +225,23 @@ func (scs *Service) upsertSyncUser(c request.CTX, user *model.User, channel *mod
 		}
 	}
 
-	// Add user to team. We do this here regardless of whether the user was
+	// Add user to team and channel. We do this here regardless of whether the user was
 	// just created or patched since there are three steps to adding a user
 	// (insert rec, add to team, add to channel) and any one could fail.
 	// Instead of undoing what succeeded on any failure we simply do all steps each
 	// time. AddUserToChannel & AddUserToTeamByTeamId do not error if user was already
-	// added and exit quickly.
-	if err := scs.app.AddUserToTeamByTeamId(request.EmptyContext(scs.server.Log()), channel.TeamId, userSaved); err != nil {
-		return nil, fmt.Errorf("error adding sync user to Team: %w", err)
+	// added and exit quickly.  Not needed for DMs where teamId is empty.
+	if channel.TeamId != "" {
+		// add user to team
+		if err := scs.app.AddUserToTeamByTeamId(request.EmptyContext(scs.server.Log()), channel.TeamId, userSaved); err != nil {
+			return nil, fmt.Errorf("error adding sync user to Team: %w", err)
+		}
+		// add user to channel
+		if _, err := scs.app.AddUserToChannel(c, userSaved, channel, false); err != nil {
+			return nil, fmt.Errorf("error adding sync user to ChannelMembers: %w", err)
+		}
 	}
 
-	// add user to channel
-	if _, err := scs.app.AddUserToChannel(c, userSaved, channel, false); err != nil {
-		return nil, fmt.Errorf("error adding sync user to ChannelMembers: %w", err)
-	}
 	return userSaved, nil
 }
 


### PR DESCRIPTION
#### Summary
This PR ensures that when accepting DM channel invites for Shared Channels, a check is made to ensure the users can see each other (allowed to DM).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57873

```release-note
Check user visibility when accepting DM channel invites for Shared Channels.
```
