### PR TITLE
[MM-58200] Pass remote address in `WebSocketMessageHasBeenPosted` plugin hook

### DIFF
--- a/server/channels/api4/websocket.go
+++ b/server/channels/api4/websocket.go
@@ -44,12 +44,14 @@ func connectWebSocket(c *Context, w http.ResponseWriter, r *http.Request) {
 	// We initialize webconn with all the necessary data.
 	// If the queues are empty, they are initialized in the constructor.
 	cfg := &platform.WebConnConfig{
-		WebSocket: ws,
-		Session:   *c.AppContext.Session(),
-		TFunc:     c.AppContext.T,
-		Locale:    "",
-		Active:    true,
-		PostedAck: r.URL.Query().Get(postedAckParam) == "true",
+		WebSocket:     ws,
+		Session:       *c.AppContext.Session(),
+		TFunc:         c.AppContext.T,
+		Locale:        "",
+		Active:        true,
+		PostedAck:     r.URL.Query().Get(postedAckParam) == "true",
+		RemoteAddress: c.AppContext.IPAddress(),
+		XForwardedFor: c.AppContext.XForwardedFor(),
 	}
 	// The WebSocket upgrade request coming from mobile is missing the
 	// user agent so we need to fallback on the session's metadata.

--- a/server/channels/app/plugin_api_tests/manual.test_websocket_remote_address/main.go
+++ b/server/channels/app/plugin_api_tests/manual.test_websocket_remote_address/main.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+)
+
+type Plugin struct {
+	plugin.MattermostPlugin
+	addrCh chan string
+}
+
+func (p *Plugin) MessageWillBePosted(_ *plugin.Context, _ *model.Post) (*model.Post, string) {
+	return nil, <-p.addrCh
+}
+
+func (p *Plugin) WebSocketMessageHasBeenPosted(connID, userID string, req *model.WebSocketRequest) {
+	p.addrCh <- req.Data[model.WebSocketRemoteAddr].(string)
+}
+
+func main() {
+	plugin.ClientMain(&Plugin{
+		addrCh: make(chan string, 1),
+	})
+}

--- a/server/public/model/websocket_request.go
+++ b/server/public/model/websocket_request.go
@@ -9,6 +9,11 @@ import (
 	"github.com/vmihailenco/msgpack/v5"
 )
 
+const (
+	WebSocketRemoteAddr    = "remote_addr"
+	WebSocketXForwardedFor = "x_forwarded_for"
+)
+
 // WebSocketRequest represents a request made to the server through a websocket.
 type WebSocketRequest struct {
 	// Client-provided fields


### PR DESCRIPTION
#### Summary

For auditing purposes, we need an easy way to correlate users joining calls with their remote addresses. This information is missing on the plugin side as we don't manage the underlying WebSocket connections directly. 

PR uses the `WebSocketRequest.Data` map to pass through the required information.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-58200

#### Release Note

```release-note
NONE
```
