### PR TITLE
Remove the unnecessary attributes from headerLabels.

### DIFF
--- a/webapp/channels/src/components/admin_console/system_user_detail/team_list/team_list.tsx
+++ b/webapp/channels/src/components/admin_console/system_user_detail/team_list/team_list.tsx
@@ -45,11 +45,6 @@ const headerLabels = [
             width: '150px',
         },
     },
-    {
-        style: {
-            width: '150px',
-        },
-    },
 ];
 
 type Props = {


### PR DESCRIPTION
 remove 
```
 {
        style: {
            width: '150px',
        },
    },

```

cause : 

```
team_list.tsx:108 
 The above error occurred in the <FormattedMessage> component:

    at FormattedMessage (webpack-internal:///../node_modules/react-intl/lib/src/components/message.js:26:68)
    at div
    at div
    at div
    at AbstractList (webpack-internal:///./src/components/admin_console/system_user_detail/team_list/abstract_list.tsx:43:5)
    at TeamList (webpack-internal:///./src/components/admin_console/system_user_detail/team_list/team_list.tsx:79:5)
    at ConnectFunction (webpack-internal:///../node_modules/react-redux/es/components/connectAdvanced.js:232:68)
    at div
    at AdminPanel (webpack-internal:///./src/components/widgets/admin_console/admin_panel.tsx:32:5)
    at div
    at div
    at div
    at SystemUserDetail (webpack-internal:///./src/components/admin_console/system_user_detail/system_user_detail.tsx:89:5)
    at injectIntl(SystemUserDetail)
    at ConnectFunction (webpack-internal:///../node_modules/react-redux/es/components/connectAdvanced.js:232:68)
    at SchemaAdminSettings (webpack-internal:///./src/components/admin_console/schema_admin_settings.tsx:136:5)
    at injectIntl(SchemaAdminSettings)
    at Route (webpack-internal:///../node_modules/react-router/esm/react-router.js:649:29)
    at Switch (webpack-internal:///../node_modules/react-router/esm/react-router.js:851:29)
    at div
    at SearchKeywordMarking (webpack-internal:///./src/components/admin_console/search_keyword_marking.tsx:28:5)
    at div
    at AdminConsole (webpack-internal:///./src/components/admin_console/admin_console.tsx:77:5)
    at ConnectFunction (webpack-internal:///../node_modules/react-redux/es/components/connectAdvanced.js:232:68)
    at Suspense
    at AdminConsole
    at LoggedIn (webpack-internal:///./src/components/logged_in/logged_in.tsx:62:5)
    at ConnectFunction (webpack-internal:///../node_modules/react-redux/es/components/connectAdvanced.js:232:68)
    at Suspense
    at LoggedIn
    at Route (webpack-internal:///../node_modules/react-router/esm/react-router.js:649:29)
    at LoggedInRoute (webpack-internal:///./src/components/root/root.tsx:207:18)
    at Switch (webpack-internal:///../node_modules/react-router/esm/react-router.js:851:29)
    at Route (webpack-internal:///../node_modules/react-router/esm/react-router.js:649:29)
    at Switch (webpack-internal:///../node_modules/react-router/esm/react-router.js:851:29)
    at IntlProvider (webpack-internal:///../node_modules/react-intl/lib/src/components/provider.js:42:47)
    at IntlProvider (webpack-internal:///./src/components/intl_provider/intl_provider.tsx:41:5)
    at ConnectFunction (webpack-internal:///../node_modules/react-redux/es/components/connectAdvanced.js:232:68)
    at RootProvider (webpack-internal:///./src/components/root/root_provider.tsx:31:12)
    at Root (webpack-internal:///./src/components/root/root.tsx:226:5)
    at ConnectFunction (webpack-internal:///../node_modules/react-redux/es/components/connectAdvanced.js:232:68)
    at Suspense
    at Root
    at Route (webpack-internal:///../node_modules/react-router/esm/react-router.js:649:29)
    at Router (webpack-internal:///../node_modules/react-router/esm/react-router.js:268:30)
    at Provider (webpack-internal:///../node_modules/react-redux/es/components/Provider.js:19:20)
    at App

Consider adding an error boundary to your tree to customize error handling behavior.
Visit https://reactjs.org/link/error-boundaries to learn more about error boundaries.
performance_reporter_controller.tsx:23 
 PerformanceReporterController - Component unmounted or store changed
utils.js:76 
 Uncaught (in promise) 
Error: [@formatjs/intl] An `id` must be provided to format a message. You can either:
1. Configure your build toolchain with [babel-plugin-formatjs](https://formatjs.io/docs/tooling/babel-plugin)
or [@formatjs/ts-transformer](https://formatjs.io/docs/tooling/ts-transformer) OR
2. Configure your `eslint` config to include [eslint-plugin-formatjs](https://formatjs.io/docs/tooling/linter#enforce-id)
to autofix this issue
    at invariant (utils.js:76:1)
    at formatMessage (message.js:31:1)
    at formatMessage (createIntl.js:29:1)
    at FormattedMessage (message.js:21:1)
    at renderWithHooks (react-dom.development.js:14985:1)
    at mountIndeterminateComponent (react-dom.development.js:17811:1)
    at beginWork (react-dom.development.js:19049:1)
    at HTMLUnknownElement.callCallback (react-dom.development.js:3945:1)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:3994:1)
    at invokeGuardedCallback (react-dom.development.js:4056:1)


```

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
 This code:
```
 
{
    style: {
        width: '150px',
    },
}
```
will cause an issue in abstract_list.tsx in the following code segment:

```
<div className='AbstractList__header'>
    {this.props.headerLabels.map((headerLabel, id) => (
        <div
            key={id}
            className='AbstractList__header-label'
            style={headerLabel.style}
        >
            <FormattedMessage {...headerLabel.label}/>
        </div>
    ))}
</div>


```


#### Screenshots

![image](https://github.com/mattermost/mattermost/assets/6021724/3c792c7f-1ff6-4f49-9084-e28174ec4f0a)

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| ![image](https://github.com/mattermost/mattermost/assets/6021724/6f63ce4f-3e92-4ec1-b4b0-3bb8cdc66606) | ![image](https://github.com/mattermost/mattermost/assets/6021724/f6361f49-0662-4c20-aca1-f3b2e1532c11) |



