### PR TITLE
Bubble up parsing error from en.json

### DIFF
--- a/tools/mmgotool/commands/i18n.go
+++ b/tools/mmgotool/commands/i18n.go
@@ -113,8 +113,8 @@ func getBaseFileSrcStrings(mattermostDir string) ([]Translation, error) {
 		return nil, err
 	}
 	var translations []Translation
-	_ = json.Unmarshal(jsonFile, &translations)
-	return translations, nil
+	err = json.Unmarshal(jsonFile, &translations)
+	return translations, err
 }
 
 func extractSrcStrings(enterpriseDir, mattermostDir, modelDir, pluginDir, portalDir string) map[string]bool {


### PR DESCRIPTION
Running `make i18n-extract` on a en.json file
with bad JSON will just wipe off all keys instead
of throwing the error. This is very confusing
and can lead to a lot of time wasted because
there's no indication that the JSON is incorrect.

Fixing this.

```release-note
NONE
```
