### PR TITLE
fix: Enable scrolling and visible scrollbar in post textbox

### DIFF
--- a/webapp/channels/src/components/autosize_textarea.tsx
+++ b/webapp/channels/src/components/autosize_textarea.tsx
@@ -41,7 +41,6 @@ const styles = {
     },
     textArea: {
         overflowY: 'auto',
-        maxHeight:'200px'
     } as CSSProperties,
 };
 

--- a/webapp/channels/src/components/autosize_textarea.tsx
+++ b/webapp/channels/src/components/autosize_textarea.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {ChangeEvent, FormEvent, HTMLProps} from 'react';
+import type {CSSProperties, ChangeEvent, FormEvent, HTMLProps} from 'react';
 import React, {useRef, useEffect, useCallback} from 'react';
 
 import type {Intersection} from '@mattermost/types/utilities';
@@ -39,6 +39,10 @@ const styles = {
         background: 'none',
         borderColor: 'transparent',
     },
+    textArea: {
+        overflowY: 'auto',
+        maxHeight:'200px'
+    } as CSSProperties,
 };
 
 const AutosizeTextarea = React.forwardRef<HTMLTextAreaElement, Props>(({
@@ -168,6 +172,7 @@ const AutosizeTextarea = React.forwardRef<HTMLTextAreaElement, Props>(({
                 onInput={onInput}
                 value={value}
                 defaultValue={defaultValue}
+                style={styles.textArea}
             />
             <div style={styles.container}>
                 <div


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

This update enhances the user experience by allowing scrolling in the post textbox using the mouse wheel. A visible scrollbar is also added to the textbox when it contains sufficient content, ensuring users can easily navigate through longer texts.

fixes: #24841

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/24841
Jira https://mattermost.atlassian.net/browse/MM-54561

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->
![image](https://github.com/mattermost/mattermost/assets/92169163/97457062-e67b-4a6d-944d-092c9b2365f0)
| 
![image](https://github.com/mattermost/mattermost/assets/92169163/62d0a0c7-f9e9-4971-aabc-9661bc026125)


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```


NONE

-->
```release-note

```
