### PR TITLE
fix(webapp/Makefile): Drop quotes around appended cppflags

### DIFF
--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -8,12 +8,12 @@ CI ?= false
 # please see optipng-bin Linux arm64 support issue (https://github.com/imagemin/optipng-bin/issues/118) for details:
 ifeq ($(shell uname)/$(shell uname -m),Linux/aarch64)
   LINUX_ARM64 = true
-  CPPFLAGS += " -DPNG_ARM_NEON_OPT=0"
+  CPPFLAGS += -DPNG_ARM_NEON_OPT=0
 endif
 # Exact same issue but for Linux/PPC64
 ifeq ($(findstring Linux/ppc64,$(shell uname)/$(shell uname -m)),Linux/ppc64)
   LINUX_PPC64 = true
-  CPPFLAGS += " -DPNG_POWERPC_VSX_OPT=0"
+  CPPFLAGS += -DPNG_POWERPC_VSX_OPT=0
 endif
 
 .PHONY: run


### PR DESCRIPTION
Currently, if you're building under aarch64 and have cppflags set in your environment as such:

```
CPPFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv8-a -mtune=neoverse-n1 -Wp,-D_FORTIFY_SOURCE=3"
```

This will result in `-DPNG_ARM_NEON_OPT=0` being improperly applied:

```
CPPFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv8-a -mtune=neoverse-n1 -Wp,-D_FORTIFY_SOURCE=3 " -DPNG_ARM_NEON_OPT=0""
```

As a result, when npm install is ran, it will fail. To fix this, we remove the quotes around the appended cppflags

```release-note
NONE
```