### PR TITLE
Add support for global custom themes

### DIFF
--- a/server/config/client.go
+++ b/server/config/client.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"encoding/json"
 	"strconv"
 	"strings"
 
@@ -124,6 +125,7 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 	props["DefaultTheme"] = ""
 	props["AllowCustomThemes"] = "true"
 	props["AllowedThemes"] = ""
+	props["CustomThemes"] = ""
 	props["DataRetentionEnableMessageDeletion"] = "false"
 	props["DataRetentionMessageRetentionHours"] = "0"
 	props["DataRetentionEnableFileDeletion"] = "false"
@@ -205,6 +207,8 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 			props["DefaultTheme"] = *c.ThemeSettings.DefaultTheme
 			props["AllowCustomThemes"] = strconv.FormatBool(*c.ThemeSettings.AllowCustomThemes)
 			props["AllowedThemes"] = strings.Join(c.ThemeSettings.AllowedThemes, ",")
+			customThemes, _ := json.Marshal(c.ThemeSettings.CustomThemes)
+			props["CustomThemes"] = string(customThemes)
 		}
 
 		if *license.Features.DataRetention {

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -2146,11 +2146,18 @@ func (s *AnnouncementSettings) SetDefaults() {
 	}
 }
 
+type CustomTheme struct {
+	ID    string
+	Name  string
+	Theme string
+}
+
 type ThemeSettings struct {
 	EnableThemeSelection *bool   `access:"experimental_features"`
 	DefaultTheme         *string `access:"experimental_features"`
 	AllowCustomThemes    *bool   `access:"experimental_features"`
 	AllowedThemes        []string
+	CustomThemes         []CustomTheme `access:"experimental_features"`
 }
 
 func (s *ThemeSettings) SetDefaults() {

--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -54,6 +54,7 @@ import {messages as customTermsOfServiceMessages, searchableStrings as customTer
 import CustomURLSchemesSetting from './custom_url_schemes_setting';
 import CustomThemesSetting from './custom_themes_setting';
 import AllowedThemesSetting from './allowed_themes_setting';
+import DefaultThemeSetting from './default_theme_setting';
 import DataRetentionSettings from './data_retention_settings';
 import CustomDataRetentionForm from './data_retention_settings/custom_policy_form';
 import {searchableStrings as dataRetentionSearchableStrings} from './data_retention_settings/data_retention_settings';
@@ -1952,6 +1953,45 @@ const AdminDefinition: AdminDefinitionType = {
                             component: AllowedThemesSetting,
                             key: 'ThemeSettings.AllowedThemes',
                             isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.ABOUT.EDITION_AND_LICENSE)),
+                        },
+                        {
+                            type: 'bool',
+                            key: 'ThemeSettings.EnableThemeSelection',
+                            label: defineMessage({id: 'admin.experimental.enableThemeSelection.title', defaultMessage: 'Enable Theme Selection:'}),
+                            help_text: defineMessage({id: 'admin.experimental.enableThemeSelection.desc', defaultMessage: 'Enables the **Display > Theme** tab in Settings so users can select their theme.'}),
+                            help_text_markdown: true,
+                            isHidden: it.any(
+                                it.not(it.licensed),
+                                it.licensedForSku('starter'),
+                            ),
+                            isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.EXPERIMENTAL.FEATURES)),
+                        },
+                        {
+                            type: 'bool',
+                            key: 'ThemeSettings.AllowCustomThemes',
+                            label: defineMessage({id: 'admin.experimental.allowCustomThemes.title', defaultMessage: 'Allow Custom Themes:'}),
+                            help_text: defineMessage({id: 'admin.experimental.allowCustomThemes.desc', defaultMessage: 'Enables the **Display > Theme > Custom Theme** section in Settings.'}),
+                            help_text_markdown: true,
+                            isHidden: it.any(
+                                it.not(it.licensed),
+                                it.licensedForSku('starter'),
+                            ),
+                            isDisabled: it.any(
+                                it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.EXPERIMENTAL.FEATURES)),
+                                it.stateIsFalse('ThemeSettings.EnableThemeSelection'),
+                            ),
+                        },
+                        {
+                            // TODO: Add translations here for support search in the admin console
+                            // TODO: Ensure disabled field is correctly set here
+                            type: 'custom',
+                            key: 'ThemeSettings.DefaultTheme',
+                            component: DefaultThemeSetting,
+                            // isHidden: it.any(
+                            //     it.not(it.licensed),
+                            //     it.licensedForSku('starter'),
+                            // ),
+                            // isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.EXPERIMENTAL.FEATURES)),
                         },
                         {
                             type: 'longtext',
@@ -6072,67 +6112,6 @@ const AdminDefinition: AdminDefinitionType = {
                             label: defineMessage({id: 'admin.experimental.enablePreviewFeatures.title', defaultMessage: 'Enable Preview Features:'}),
                             help_text: defineMessage({id: 'admin.experimental.enablePreviewFeatures.desc', defaultMessage: 'When true, preview features can be enabled from **Settings > Advanced > Preview pre-release features**. When false, disables and hides preview features from **Settings > Advanced > Preview pre-release features**.'}),
                             help_text_markdown: true,
-                            isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.EXPERIMENTAL.FEATURES)),
-                        },
-                        {
-                            type: 'bool',
-                            key: 'ThemeSettings.EnableThemeSelection',
-                            label: defineMessage({id: 'admin.experimental.enableThemeSelection.title', defaultMessage: 'Enable Theme Selection:'}),
-                            help_text: defineMessage({id: 'admin.experimental.enableThemeSelection.desc', defaultMessage: 'Enables the **Display > Theme** tab in Settings so users can select their theme.'}),
-                            help_text_markdown: true,
-                            isHidden: it.any(
-                                it.not(it.licensed),
-                                it.licensedForSku('starter'),
-                            ),
-                            isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.EXPERIMENTAL.FEATURES)),
-                        },
-                        {
-                            type: 'bool',
-                            key: 'ThemeSettings.AllowCustomThemes',
-                            label: defineMessage({id: 'admin.experimental.allowCustomThemes.title', defaultMessage: 'Allow Custom Themes:'}),
-                            help_text: defineMessage({id: 'admin.experimental.allowCustomThemes.desc', defaultMessage: 'Enables the **Display > Theme > Custom Theme** section in Settings.'}),
-                            help_text_markdown: true,
-                            isHidden: it.any(
-                                it.not(it.licensed),
-                                it.licensedForSku('starter'),
-                            ),
-                            isDisabled: it.any(
-                                it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.EXPERIMENTAL.FEATURES)),
-                                it.stateIsFalse('ThemeSettings.EnableThemeSelection'),
-                            ),
-                        },
-                        {
-                            type: 'dropdown',
-                            key: 'ThemeSettings.DefaultTheme',
-                            label: defineMessage({id: 'admin.experimental.defaultTheme.title', defaultMessage: 'Default Theme:'}),
-                            help_text: defineMessage({id: 'admin.experimental.defaultTheme.desc', defaultMessage: 'Set a default theme that applies to all new users on the system.'}),
-                            help_text_markdown: true,
-                            options: [
-                                {
-                                    value: 'denim',
-                                    display_name: defineMessage({id: 'admin.experimental.defaultTheme.options.denim', defaultMessage: 'Denim'}),
-                                },
-                                {
-                                    value: 'sapphire',
-                                    display_name: defineMessage({id: 'admin.experimental.defaultTheme.options.sapphire', defaultMessage: 'Sapphire'}),
-                                },
-                                {
-                                    value: 'quartz',
-                                    display_name: defineMessage({id: 'admin.experimental.defaultTheme.options.quartz', defaultMessage: 'Quartz'}),
-                                },
-                                {
-                                    value: 'indigo',
-                                    display_name: defineMessage({id: 'admin.experimental.defaultTheme.options.indigo', defaultMessage: 'Indigo'}),
-                                },
-                                {
-                                    value: 'onyx',
-                                    display_name: defineMessage({id: 'admin.experimental.defaultTheme.options.onyx', defaultMessage: 'Onyx'}),
-                                },
-                            ],
-                            isHidden: it.any(
-                                it.not(it.licensed),
-                                it.licensedForSku('starter'),
-                            ),
                             isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.EXPERIMENTAL.FEATURES)),
                         },
                         {

--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -52,6 +52,7 @@ import CustomEnableDisableGuestAccountsSetting from './custom_enable_disable_gue
 import CustomTermsOfServiceSettings from './custom_terms_of_service_settings';
 import {messages as customTermsOfServiceMessages, searchableStrings as customTermsOfServiceSearchableStrings} from './custom_terms_of_service_settings/custom_terms_of_service_settings';
 import CustomURLSchemesSetting from './custom_url_schemes_setting';
+import CustomThemesSetting from './custom_themes_setting';
 import DataRetentionSettings from './data_retention_settings';
 import CustomDataRetentionForm from './data_retention_settings/custom_policy_form';
 import {searchableStrings as dataRetentionSearchableStrings} from './data_retention_settings/data_retention_settings';
@@ -1934,6 +1935,12 @@ const AdminDefinition: AdminDefinitionType = {
                                 it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.SITE.CUSTOMIZATION)),
                                 it.stateIsFalse('TeamSettings.EnableCustomBrand'),
                             ),
+                        },
+                        {
+                            type: 'custom',
+                            component: CustomThemesSetting,
+                            key: 'ThemeSettings.CustomThemes',
+                            isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.ABOUT.EDITION_AND_LICENSE)),
                         },
                         {
                             type: 'longtext',

--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -53,6 +53,7 @@ import CustomTermsOfServiceSettings from './custom_terms_of_service_settings';
 import {messages as customTermsOfServiceMessages, searchableStrings as customTermsOfServiceSearchableStrings} from './custom_terms_of_service_settings/custom_terms_of_service_settings';
 import CustomURLSchemesSetting from './custom_url_schemes_setting';
 import CustomThemesSetting from './custom_themes_setting';
+import AllowedThemesSetting from './allowed_themes_setting';
 import DataRetentionSettings from './data_retention_settings';
 import CustomDataRetentionForm from './data_retention_settings/custom_policy_form';
 import {searchableStrings as dataRetentionSearchableStrings} from './data_retention_settings/data_retention_settings';
@@ -1937,9 +1938,19 @@ const AdminDefinition: AdminDefinitionType = {
                             ),
                         },
                         {
+                            // TODO: Add translations here for support search in the admin console
+                            // TODO: Ensure disabled field is correctly set here
                             type: 'custom',
                             component: CustomThemesSetting,
                             key: 'ThemeSettings.CustomThemes',
+                            isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.ABOUT.EDITION_AND_LICENSE)),
+                        },
+                        {
+                            // TODO: Add translations here for support search in the admin console
+                            // TODO: Ensure disabled field is correctly set here
+                            type: 'custom',
+                            component: AllowedThemesSetting,
+                            key: 'ThemeSettings.AllowedThemes',
                             isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.ABOUT.EDITION_AND_LICENSE)),
                         },
                         {

--- a/webapp/channels/src/components/admin_console/allowed_themes_setting.tsx
+++ b/webapp/channels/src/components/admin_console/allowed_themes_setting.tsx
@@ -1,0 +1,90 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useCallback} from 'react';
+import {useIntl} from 'react-intl';
+import ReactSelect from 'react-select';
+import type {ValueType} from 'react-select';
+
+import {toTitleCase} from 'utils/utils';
+
+import {Preferences} from 'mattermost-redux/constants';
+
+import Setting from './setting';
+
+type CustomTheme = {
+    ID: string;
+    Name: string;
+    Theme: string;
+}
+
+type Option = {
+    value: string;
+    text: string;
+}
+
+type Props = {
+    id: string;
+    value: string[];
+    state: any;
+    onChange?: (id: string, themes: string[]) => void;
+    disabled?: boolean;
+    setByEnv?: boolean;
+}
+
+const AllowedThemesSetting = (props: Props) => {
+    const intl = useIntl();
+
+    const allThemes: {[key: string]: string} = {}
+    const options: Option[] = []
+    Object.keys(Preferences.THEMES).forEach((theme) => {
+        allThemes[theme] = toTitleCase(theme);;
+        options.push({value: theme, text: toTitleCase(theme)})
+    })
+    props.state['ThemeSettings.CustomThemes'].forEach((theme: CustomTheme) => {
+        allThemes[theme.ID] = theme.Name;
+        options.push({value: theme.ID, text: theme.Name})
+    })
+
+    const getOptionLabel = ({text}: { text: string}) => text;
+
+    const handleChange = useCallback((newValue: ValueType<Option>) => {
+        const values = newValue ? (newValue as Option[]).map((n) => {
+            return n.value;
+        }) : [];
+
+        if (props.onChange) {
+            props.onChange(props.id, values);
+        }
+    }, [props.id, props.onChange]);
+
+    return (
+        <Setting
+            label={intl.formatMessage({
+                id: 'admin.themes.allowed_themes.title',
+                defaultMessage: 'Allowed Themes',
+            })}
+            inputId={props.id}
+        >
+            <ReactSelect
+                id={props.id}
+                isMulti={true}
+                options={options}
+                getOptionLabel={getOptionLabel}
+                delimiter={','}
+                clearable={false}
+                isDisabled={props.disabled || props.setByEnv}
+                noResultsText={intl.formatMessage({
+                    id: 'admin.themes.allowed_themes.no_themes_found',
+                    defaultMessage: 'No themes found',
+                })}
+                onChange={handleChange}
+                value={props.value.map((theme) => {
+                    return {value: theme, text: allThemes[theme]}
+                })}
+            />
+        </Setting>
+    );
+};
+
+export default React.memo(AllowedThemesSetting);

--- a/webapp/channels/src/components/admin_console/allowed_themes_setting.tsx
+++ b/webapp/channels/src/components/admin_console/allowed_themes_setting.tsx
@@ -10,6 +10,8 @@ import {toTitleCase} from 'utils/utils';
 
 import {Preferences} from 'mattermost-redux/constants';
 
+import SchemaText from 'components/admin_console/schema_text';
+
 import Setting from './setting';
 
 type CustomTheme = {
@@ -83,6 +85,9 @@ const AllowedThemesSetting = (props: Props) => {
                     return {value: theme, text: allThemes[theme]}
                 })}
             />
+            <div className='help-text'>
+                <SchemaText text={intl.formatMessage({id: 'admin.themes.allowed_themes.help_text', defaultMessage: 'Choose the themes you’d like to make available to users on the server. If left empty, there will bo no limits on available themes.'})} />
+            </div>
         </Setting>
     );
 };

--- a/webapp/channels/src/components/admin_console/custom_themes_setting.tsx
+++ b/webapp/channels/src/components/admin_console/custom_themes_setting.tsx
@@ -1,0 +1,98 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useCallback} from 'react';
+import {useIntl} from 'react-intl';
+
+import {Preferences} from 'mattermost-redux/constants';
+import {changeOpacity} from 'mattermost-redux/utils/theme_utils';
+
+import ThemeThumbnail from 'components/user_settings/display/user_settings_theme/theme_thumbnail';
+import CustomThemeChooser from 'components/user_settings/display/user_settings_theme/custom_theme_chooser/custom_theme_chooser';
+
+import {generateId} from 'utils/utils';
+
+import Setting from './setting';
+
+type CustomTheme = {
+    ID: string;
+    Name: string;
+    Theme: string;
+}
+
+type Props = {
+    id: string;
+    value: CustomTheme[];
+    onChange?: (id: string, themes: CustomTheme[]) => void;
+    disabled?: boolean;
+}
+
+// TODO: Add i18n
+
+const CustomThemesSetting = (props: Props) => {
+    const [openTheme, setOpenTheme] = React.useState<string | null>(null);
+
+    const handleChange = useCallback((themes: CustomTheme[]) => {
+        if (props.onChange) {
+            props.onChange(props.id, themes);
+        }
+    }, [props.id, props.onChange]);
+
+    const newTheme: CustomTheme = {ID: generateId(), Name: 'New', Theme: '{}'};
+
+    return (
+        <Setting
+            label={'Brand themes'}
+            inputId={props.id}
+        >
+            {props.value.map((theme: CustomTheme) => {
+                const data = {...Object.values(Preferences.THEMES)[0], ...JSON.parse(theme.Theme)}
+                data.type = theme.ID
+                return (
+                    <div className='settings-table settings-content' onClick={() => openTheme === theme.ID ? setOpenTheme(null) : setOpenTheme(theme.ID)}>
+                        <ThemeThumbnail
+                            themeKey={theme.ID}
+                            themeName={data.type}
+                            sidebarBg={data.sidebarBg}
+                            sidebarText={changeOpacity(data.sidebarText, 0.48)}
+                            sidebarUnreadText={data.sidebarUnreadText}
+                            onlineIndicator={data.onlineIndicator}
+                            awayIndicator={data.awayIndicator}
+                            dndIndicator={data.dndIndicator}
+                            centerChannelColor={changeOpacity(data.centerChannelColor, 0.16)}
+                            centerChannelBg={data.centerChannelBg}
+                            newMessageSeparator={data.newMessageSeparator}
+                            buttonBg={data.buttonBg}
+                        />
+                        {openTheme !== theme.ID &&
+                            <div className='theme-label'>{theme.Name}</div>}
+                        {openTheme === theme.ID &&
+                            <div onClick={(e) => e.stopPropagation()}>
+                                <input
+                                    value={theme.Name}
+                                    onChange={(e) => handleChange(props.value.map((t) => t.ID === openTheme ? {ID: t.ID, Name: e.target.value, Theme: t.Theme} : t))}
+                                />
+                                <CustomThemeChooser
+                                    theme={data}
+                                    updateTheme={(theme: any) => {
+                                        handleChange(props.value.map((t) => t.ID === openTheme ? {ID: t.ID, Name: t.Name, Theme: JSON.stringify(theme)} : t));
+                                    }}
+                                />
+                                <button onClick={() => { handleChange(props.value.filter((t) => t.ID !== openTheme)); setOpenTheme(null)}}>{'Delete'}</button>
+                            </div>}
+                    </div>
+                );
+            })}
+
+            <button onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleChange([...props.value, newTheme]); setOpenTheme(newTheme.ID)}}>{'+ Add custom theme'}</button>
+        </Setting>
+    );
+            // <ColorInput
+            //     id={props.id}
+            //     value={props.value}
+            //     onChange={handleChange}
+            //     isDisabled={props.disabled}
+            // />
+};
+
+export default React.memo(CustomThemesSetting);

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
@@ -971,6 +971,7 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
                 label={this.renderLabel(setting)}
                 helpText={this.renderSettingHelpText(setting)}
                 value={this.state[setting.key]}
+                state={this.state}
                 disabled={this.isDisabled(setting)}
                 config={this.props.config}
                 license={this.props.license}

--- a/webapp/channels/src/components/user_settings/display/user_settings_theme/custom_theme_chooser/custom_theme_chooser.tsx
+++ b/webapp/channels/src/components/user_settings/display/user_settings_theme/custom_theme_chooser/custom_theme_chooser.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {createRef} from 'react';
+import styled from 'styled-components';
 import type {ChangeEvent, ClipboardEvent, MouseEvent, RefObject} from 'react';
 import {defineMessages, FormattedMessage, injectIntl} from 'react-intl';
 import type {IntlShape, MessageDescriptor} from 'react-intl';
@@ -16,6 +17,52 @@ import Popover from 'components/widgets/popover';
 import Constants from 'utils/constants';
 
 import ColorChooser from '../color_chooser/color_chooser';
+
+const ThemeElementsHeader = styled.div`
+    padding: 1px 0 10px;
+    border-bottom: 1px solid;
+    margin: 10px 20px 0 0;
+    cursor: pointer;
+    font-size: em(13.5px);
+    font-weight: 600;
+
+    .fa-minus {
+        display: none;
+    }
+
+    &.open {
+        .fa-minus {
+            display: inline-block;
+        }
+
+        .fa-plus {
+            display: none;
+        }
+    }
+
+    .header__icon {
+        float: right;
+        opacity: 0.5;
+    }
+`
+
+const ThemeElementsBody = styled.div`
+    max-height: 0;
+    padding: 0 0 0 24px;
+    border-radius: 0 0 3px 3px;
+    margin: 0 20px 0 0;
+    background-color: rgba(255, 255, 255, 0.05);
+    overflow-y: hidden;
+    transition: all 0.4s ease-out;
+
+    @include pie-clearfix;
+
+    &.open {
+        max-height: 1200px;
+        padding: 24px 0 0 24px;
+        margin: 0 20px 0 0;
+    }
+`
 
 const COPY_SUCCESS_INTERVAL = 3000;
 
@@ -456,10 +503,9 @@ export class CustomThemeChooser extends React.PureComponent<Props, State> {
         return (
             <div className='appearance-section pt-2'>
                 <div className='theme-elements row'>
-                    <div
+                    <ThemeElementsHeader
                         ref={this.sidebarStylesHeaderRef}
                         id='sidebarStyles'
-                        className='theme-elements__header'
                         onClick={this.toggleSidebarStyles}
                     >
                         <FormattedMessage
@@ -476,19 +522,17 @@ export class CustomThemeChooser extends React.PureComponent<Props, State> {
                                 title={intl.formatMessage({id: 'generic_icons.collapse', defaultMessage: 'Collapse Icon'})}
                             />
                         </div>
-                    </div>
-                    <div
+                    </ThemeElementsHeader>
+                    <ThemeElementsBody
                         ref={this.sidebarStylesRef}
-                        className='theme-elements__body'
                     >
                         {sidebarElements}
-                    </div>
+                    </ThemeElementsBody>
                 </div>
                 <div className='theme-elements row'>
-                    <div
+                    <ThemeElementsHeader
                         ref={this.centerChannelStylesHeaderRef}
                         id='centerChannelStyles'
-                        className='theme-elements__header'
                         onClick={this.toggleCenterChannelStyles}
                     >
                         <FormattedMessage
@@ -505,20 +549,18 @@ export class CustomThemeChooser extends React.PureComponent<Props, State> {
                                 title={intl.formatMessage({id: 'generic_icons.collapse', defaultMessage: 'Collapse Icon'})}
                             />
                         </div>
-                    </div>
-                    <div
+                    </ThemeElementsHeader>
+                    <ThemeElementsBody
                         ref={this.centerChannelStylesRef}
                         id='centerChannelStyles'
-                        className='theme-elements__body'
                     >
                         {centerChannelElements}
-                    </div>
+                    </ThemeElementsBody>
                 </div>
                 <div className='theme-elements row'>
-                    <div
+                    <ThemeElementsHeader
                         ref={this.linkAndButtonStylesHeaderRef}
                         id='linkAndButtonsStyles'
-                        className='theme-elements__header'
                         onClick={this.toggleLinkAndButtonStyles}
                     >
                         <FormattedMessage
@@ -535,13 +577,10 @@ export class CustomThemeChooser extends React.PureComponent<Props, State> {
                                 title={intl.formatMessage({id: 'generic_icons.collapse', defaultMessage: 'Collapse Icon'})}
                             />
                         </div>
-                    </div>
-                    <div
-                        ref={this.linkAndButtonStylesRef}
-                        className='theme-elements__body'
-                    >
+                    </ThemeElementsHeader>
+                    <ThemeElementsBody ref={this.linkAndButtonStylesRef}>
                         {linkAndButtonElements}
-                    </div>
+                    </ThemeElementsBody>
                 </div>
                 <div className='row mt-3'>
                     {pasteBox}

--- a/webapp/channels/src/components/user_settings/display/user_settings_theme/premade_theme_chooser/premade_theme_chooser.tsx
+++ b/webapp/channels/src/components/user_settings/display/user_settings_theme/premade_theme_chooser/premade_theme_chooser.tsx
@@ -55,6 +55,8 @@ const PremadeThemeChooser = ({theme, updateTheme, allowedThemes = []}: Props) =>
                             sidebarBg={data.sidebarBg}
                             sidebarText={changeOpacity(data.sidebarText, 0.48)}
                             sidebarUnreadText={data.sidebarUnreadText}
+                            sidebarHeaderBg={data.sidebarHeaderBg}
+                            sidebarHeaderTextColor={changeOpacity(data.sidebarHeaderTextColor, 0.48)}
                             onlineIndicator={data.onlineIndicator}
                             awayIndicator={data.awayIndicator}
                             dndIndicator={data.dndIndicator}
@@ -101,6 +103,8 @@ const PremadeThemeChooser = ({theme, updateTheme, allowedThemes = []}: Props) =>
                                 sidebarBg={premadeTheme.sidebarBg}
                                 sidebarText={changeOpacity(premadeTheme.sidebarText, 0.48)}
                                 sidebarUnreadText={premadeTheme.sidebarUnreadText}
+                                sidebarHeaderBg={premadeTheme.sidebarHeaderBg}
+                                sidebarHeaderTextColor={changeOpacity(premadeTheme.sidebarHeaderTextColor, 0.48)}
                                 onlineIndicator={premadeTheme.onlineIndicator}
                                 awayIndicator={premadeTheme.awayIndicator}
                                 dndIndicator={premadeTheme.dndIndicator}

--- a/webapp/channels/src/components/user_settings/display/user_settings_theme/premade_theme_chooser/premade_theme_chooser.tsx
+++ b/webapp/channels/src/components/user_settings/display/user_settings_theme/premade_theme_chooser/premade_theme_chooser.tsx
@@ -2,10 +2,12 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {useSelector} from 'react-redux';
 
 import {Preferences} from 'mattermost-redux/constants';
 import type {Theme, ThemeKey} from 'mattermost-redux/selectors/entities/preferences';
 import {changeOpacity} from 'mattermost-redux/utils/theme_utils';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {toTitleCase} from 'utils/utils';
 
@@ -20,6 +22,54 @@ type Props = {
 const PremadeThemeChooser = ({theme, updateTheme, allowedThemes = []}: Props) => {
     const premadeThemes = [];
     const hasAllowedThemes = allowedThemes.length > 1 || (allowedThemes[0] && allowedThemes[0].trim().length > 0);
+
+    const config = useSelector(getConfig)
+
+    const customThemes = JSON.parse(config.CustomThemes)
+    customThemes.forEach((customTheme: any) => {
+        if (hasAllowedThemes && allowedThemes.indexOf(customTheme.ID) < 0) {
+            return
+        }
+        const data = {...Object.values(Preferences.THEMES)[0], ...JSON.parse(customTheme.Theme)}
+        data.type = customTheme.ID
+
+        let activeClass = '';
+        if (data.ID === theme.type) {
+            activeClass = 'active';
+        }
+
+        premadeThemes.push(
+            <div
+                className='col-xs-6 col-sm-3 premade-themes'
+                key={'premade-theme-key' + customTheme.ID}
+            >
+                <div
+                    id={`premadeTheme${data.type?.replace(' ', '')}`}
+                    className={activeClass}
+                    onClick={() => updateTheme(data)}
+                >
+                    <label>
+                        <ThemeThumbnail
+                            themeKey={customTheme.ID}
+                            themeName={data.type}
+                            sidebarBg={data.sidebarBg}
+                            sidebarText={changeOpacity(data.sidebarText, 0.48)}
+                            sidebarUnreadText={data.sidebarUnreadText}
+                            onlineIndicator={data.onlineIndicator}
+                            awayIndicator={data.awayIndicator}
+                            dndIndicator={data.dndIndicator}
+                            centerChannelColor={changeOpacity(data.centerChannelColor, 0.16)}
+                            centerChannelBg={data.centerChannelBg}
+                            newMessageSeparator={data.newMessageSeparator}
+                            buttonBg={data.buttonBg}
+                        />
+                        <div className='theme-label'>{customTheme.Name}</div>
+                    </label>
+                </div>
+            </div>,
+        );
+    })
+
 
     for (const k in Preferences.THEMES) {
         if (Preferences.THEMES.hasOwnProperty(k)) {

--- a/webapp/channels/src/components/user_settings/display/user_settings_theme/theme_thumbnail.tsx
+++ b/webapp/channels/src/components/user_settings/display/user_settings_theme/theme_thumbnail.tsx
@@ -10,6 +10,8 @@ type ThemeThumbnailProps = {
     themeKey: string;
     sidebarBg: string;
     sidebarText: string;
+    sidebarHeaderBg: string;
+    sidebarHeaderTextColor: string;
     sidebarUnreadText: string;
     onlineIndicator: string;
     awayIndicator: string;
@@ -25,6 +27,8 @@ function ThemeThumbnail({
     themeKey,
     sidebarBg = '#174AB5',
     sidebarText = '#86A1D9',
+    sidebarHeaderBg = '#192a4d',
+    sidebarHeaderTextColor = '#ffffff',
     sidebarUnreadText = 'white',
     onlineIndicator = '#3DB887',
     awayIndicator = '#FFBC1F',
@@ -81,6 +85,8 @@ function ThemeThumbnail({
                     <rect x='11' y='23' width='28' height='4' rx='2'/>
                 </g>
             </g>
+            <rect style={{fill: sidebarHeaderBg}} x='0' y='0' width='112' height='10'/>
+            <rect style={{fill: sidebarHeaderTextColor}} x='4' y='3' width='25' height='4' rx='2'/>
         </svg>
     );
 }

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/preferences.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/preferences.ts
@@ -150,6 +150,17 @@ const getDefaultTheme = createSelector('getDefaultTheme', getConfig, (config): T
         }
     }
 
+    if (config.DefaultTheme) {
+        const customThemes = JSON.parse(config.CustomThemes);
+        for (const theme of customThemes) {
+            if (config.DefaultTheme === theme.ID) {
+                const data = JSON.parse(theme.Theme);
+                data.type = theme.ID
+                return data;
+            }
+        }
+    }
+
     // If no config.DefaultTheme or value doesn't refer to a valid theme name...
     return Preferences.THEMES.denim;
 });

--- a/webapp/channels/src/sass/routes/_settings.scss
+++ b/webapp/channels/src/sass/routes/_settings.scss
@@ -366,52 +366,6 @@
                         }
                     }
 
-                    .theme-elements__header {
-                        padding: 1px 0 10px;
-                        border-bottom: 1px solid;
-                        margin: 10px 20px 0 0;
-                        cursor: pointer;
-                        font-size: em(13.5px);
-                        font-weight: 600;
-
-                        .fa-minus {
-                            display: none;
-                        }
-
-                        &.open {
-                            .fa-minus {
-                                display: inline-block;
-                            }
-
-                            .fa-plus {
-                                display: none;
-                            }
-                        }
-
-                        .header__icon {
-                            float: right;
-                            opacity: 0.5;
-                        }
-                    }
-
-                    .theme-elements__body {
-                        max-height: 0;
-                        padding: 0 0 0 24px;
-                        border-radius: 0 0 3px 3px;
-                        margin: 0 20px 0 0;
-                        background-color: rgba(255, 255, 255, 0.05);
-                        overflow-y: hidden;
-                        transition: all 0.4s ease-out;
-
-                        @include pie-clearfix;
-
-                        &.open {
-                            max-height: 1200px;
-                            padding: 24px 0 0 24px;
-                            margin: 0 20px 0 0;
-                        }
-                    }
-
                     .custom-label {
                         overflow: hidden;
                         width: 100%;


### PR DESCRIPTION
#### Summary
This changes add support for global custom themes, allowing theme to be selected in the interface, and also be restricted in usage from the admin console.

#### Ticket Link
Not Yet

#### Screenshots

#### Release Note
```release-note
New global custom themes support
```