### PR TITLE
[MM-58796] Print panic message when mmctl panics

### DIFF
--- a/server/cmd/mmctl/commands/root.go
+++ b/server/cmd/mmctl/commands/root.go
@@ -4,6 +4,8 @@
 package commands
 
 import (
+	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -56,15 +58,31 @@ func Run(args []string) error {
 
 	defer func() {
 		if x := recover(); x != nil {
-			printer.PrintError("Uh oh! Something unexpected happened :( Would you mind reporting it?\n")
-			printer.PrintError(`https://github.com/mattermost/mmctl/issues/new?title=%5Bbug%5D%20panic%20on%20mmctl%20v` + Version + "&body=%3C!---%20Please%20provide%20the%20stack%20trace%20--%3E\n")
-			printer.PrintError(string(debug.Stack()))
+			printPanic(x)
 
+			_ = printer.Flush()
 			os.Exit(1)
 		}
 	}()
 
 	return RootCmd.Execute()
+}
+
+func printPanic(x any) {
+	u, err := url.Parse("https://github.com/mattermost/mattermost/issues/new")
+	if err != nil {
+		panic(err)
+	}
+
+	q := u.Query()
+	q.Add("title", "[mmctl] [bug] panic on v"+Version)
+	q.Add("body", "<!--- Please provide the stack trace -->\n")
+	u.RawQuery = q.Encode()
+
+	printer.PrintError("Uh oh! Something unexpected happened :( Would you mind reporting it?")
+	printer.PrintError(u.String() + "\n")
+	printer.PrintError(fmt.Sprintf("%s", x))
+	printer.PrintError(string(debug.Stack()))
 }
 
 var RootCmd = &cobra.Command{

--- a/server/cmd/mmctl/commands/root_test.go
+++ b/server/cmd/mmctl/commands/root_test.go
@@ -7,8 +7,11 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"testing"
 
+	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/printer"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 )
 
 func executeRawCommand(root *cobra.Command, args string) (c *cobra.Command, output string, err error) {
@@ -18,6 +21,16 @@ func executeRawCommand(root *cobra.Command, args string) (c *cobra.Command, outp
 	RootCmd.SetArgs(strings.Split(args, " "))
 	c, err = RootCmd.ExecuteC()
 	return c, actual.String(), err
+}
+
+func TestRootRecover(t *testing.T) {
+	printPanic("some panic")
+
+	lines := printer.GetErrorLines()
+	assert.Equal(t, "Uh oh! Something unexpected happened :( Would you mind reporting it?", lines[0])
+	assert.True(t, strings.HasPrefix(lines[1], "https://github.com/mattermost/mattermost/issues/new?body="))
+	assert.Equal(t, "some panic", lines[2])
+	assert.True(t, strings.HasPrefix(lines[3], "goroutine "))
 }
 
 func (s *MmctlUnitTestSuite) TestArgumentsHaveWhitespaceTrimmed() {

--- a/server/cmd/mmctl/printer/printer.go
+++ b/server/cmd/mmctl/printer/printer.go
@@ -33,7 +33,7 @@ type Printer struct { //nolint
 	pager         bool
 	Quiet         bool
 	Lines         []interface{}
-	ErrorLines    []interface{}
+	ErrorLines    []string
 
 	cmd        *cobra.Command
 	serverAddr string
@@ -193,7 +193,7 @@ func Flush() error {
 
 	defer func() {
 		printer.Lines = []interface{}{}
-		printer.ErrorLines = []interface{}{}
+		printer.ErrorLines = []string{}
 	}()
 
 	if cmd == nil || cmd.Name() != "list" || printer.cmd.Parent().Name() == "auth" {
@@ -232,7 +232,7 @@ func Flush() error {
 // Clean resets the printer's accumulated lines
 func Clean() {
 	printer.Lines = []interface{}{}
-	printer.ErrorLines = []interface{}{}
+	printer.ErrorLines = []string{}
 }
 
 // GetLines returns the printer's accumulated lines
@@ -241,7 +241,7 @@ func GetLines() []interface{} {
 }
 
 // GetErrorLines returns the printer's accumulated error lines
-func GetErrorLines() []interface{} {
+func GetErrorLines() []string {
 	return printer.ErrorLines
 }
 


### PR DESCRIPTION
#### Summary
When `mmctl` panics, the panic message and the stack trace should be output. However, these lines never printed because the printer was not flushed. This PR fixes that.

I also took the time to add a test that covers the printer output.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58796

#### Release Note
```release-note
Print panic message when mmctl panics
```
