### PR TITLE
Add saml private key to gitignore, remove unused constants

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -12,6 +12,7 @@ mattermost.mattermost-license
 config/mattermost.mattermost-license
 config/config.json
 config/*.crt
+config/*.key
 
 web/static/js/bundle*.js
 web/static/js/bundle*.js.map

--- a/server/channels/app/license.go
+++ b/server/channels/app/license.go
@@ -4,9 +4,10 @@
 package app
 
 import (
+	"net/http"
+
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/pkg/errors"
-	"net/http"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/v8/channels/store"

--- a/server/channels/app/license.go
+++ b/server/channels/app/license.go
@@ -4,18 +4,12 @@
 package app
 
 import (
-	"net/http"
-	"time"
-
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/pkg/errors"
+	"net/http"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
-)
-
-const (
-	JWTDefaultTokenExpiration = 7 * 24 * time.Hour // 7 days of expiration
 )
 
 func (ch *Channels) License() *model.License {

--- a/server/channels/app/platform/license.go
+++ b/server/channels/app/platform/license.go
@@ -7,12 +7,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"os"
-	"time"
-
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/pkg/errors"
+	"net/http"
+	"os"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
@@ -24,8 +22,7 @@ import (
 )
 
 const (
-	LicenseEnv                = "MM_LICENSE"
-	JWTDefaultTokenExpiration = 7 * 24 * time.Hour // 7 days of expiration
+	LicenseEnv = "MM_LICENSE"
 )
 
 // JWTClaims custom JWT claims with the needed information for the

--- a/server/channels/app/platform/license.go
+++ b/server/channels/app/platform/license.go
@@ -7,10 +7,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/golang-jwt/jwt/v5"
-	"github.com/pkg/errors"
 	"net/http"
 	"os"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"


### PR DESCRIPTION
#### Summary
- Add SAML private key to `.gitignore`
- Remove unused constants

#### Ticket Link
N/A

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```
