### PR TITLE
[MM-57489] Check for StatusCode when receiving responses from the push proxy

### DIFF
--- a/server/channels/app/notification_push.go
+++ b/server/channels/app/notification_push.go
@@ -490,6 +490,10 @@ func (a *App) rawSendToPushProxy(msg *model.PushNotification) (model.PushRespons
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("response returned error code: %d", resp.StatusCode)
+	}
+
 	var pushResponse model.PushResponse
 	if err := json.NewDecoder(resp.Body).Decode(&pushResponse); err != nil {
 		return nil, fmt.Errorf("failed to decode from JSON: %w", err)
@@ -561,6 +565,10 @@ func (a *App) SendAckToPushProxy(ack *model.PushNotificationAck) error {
 		return fmt.Errorf("failed to send: %w", err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("response returned error code: %d", resp.StatusCode)
+	}
 
 	// Reading the body to completion.
 	_, err = io.Copy(io.Discard, resp.Body)


### PR DESCRIPTION
#### Summary
When sending requests to the push proxy, we automatically assume that we receive the correct status code from the push proxy, which is not always the case if the push proxy experiences an internal server error (500) or if it's down (404). 

This PR adds that check so that we handle that error separately.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57489

```release-note
NONE
```
