### PR TITLE
MM-58802 Fix overlapping back button

### DIFF
--- a/webapp/channels/src/components/header_footer_route/header.scss
+++ b/webapp/channels/src/components/header_footer_route/header.scss
@@ -24,7 +24,6 @@
             @include link;
 
             display: flex;
-            margin-top: 12px;
             color: rgba(var(--center-channel-color-rgb), 0.75);
             font-family: 'Metropolis';
             font-size: 20px;
@@ -70,6 +69,12 @@
 
         a {
             @include link;
+        }
+    }
+
+    &.has-custom-site-name {
+        .header-logo-link ~ .header-logo-link {
+            margin-top: 12px;
         }
     }
 

--- a/webapp/channels/src/components/header_footer_route/header.scss
+++ b/webapp/channels/src/components/header_footer_route/header.scss
@@ -63,13 +63,19 @@
     .header-back-button {
         position: absolute;
         top: unset;
-        bottom: 0;
+        bottom: -8px;
         width: auto;
         padding: 0 0 0 40px;
         background: none;
 
         a {
             @include link;
+        }
+    }
+
+    &.has-free-banner.has-custom-site-name {
+        .header-back-button {
+            bottom: -20px;
         }
     }
 }

--- a/webapp/channels/src/components/header_footer_route/header.tsx
+++ b/webapp/channels/src/components/header_footer_route/header.tsx
@@ -11,6 +11,7 @@ import BackButton from 'components/common/back_button';
 import Logo from 'components/common/svg_images_components/logo_dark_blue_svg';
 
 import './header.scss';
+import classNames from 'classnames';
 
 export type HeaderProps = {
     alternateLink?: React.ReactElement;
@@ -39,7 +40,7 @@ const Header = ({alternateLink, backButtonURL, onBackButtonClick}: HeaderProps) 
     }
 
     return (
-        <div className={'hfroute-header' + (freeBanner ? ' has-free-banner' : '') + (title ? ' has-custom-site-name' : '')}>
+        <div className={classNames('hfroute-header', {'has-free-banner': freeBanner, 'has-custom-site-name': title})}>
             <div className='header-main'>
                 <div>
                     {freeBanner &&

--- a/webapp/channels/src/components/header_footer_route/header.tsx
+++ b/webapp/channels/src/components/header_footer_route/header.tsx
@@ -39,7 +39,7 @@ const Header = ({alternateLink, backButtonURL, onBackButtonClick}: HeaderProps) 
     }
 
     return (
-        <div className='hfroute-header'>
+        <div className={'hfroute-header' + (freeBanner ? ' has-free-banner' : '') + (title ? ' has-custom-site-name' : '')}>
             <div className='header-main'>
                 <div>
                     {freeBanner &&

--- a/webapp/channels/src/components/header_footer_route/header.tsx
+++ b/webapp/channels/src/components/header_footer_route/header.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import classNames from 'classnames';
 import React from 'react';
 import {useSelector} from 'react-redux';
 import {Link} from 'react-router-dom';
@@ -11,7 +12,6 @@ import BackButton from 'components/common/back_button';
 import Logo from 'components/common/svg_images_components/logo_dark_blue_svg';
 
 import './header.scss';
-import classNames from 'classnames';
 
 export type HeaderProps = {
     alternateLink?: React.ReactElement;

--- a/webapp/channels/src/components/signup/signup.scss
+++ b/webapp/channels/src/components/signup/signup.scss
@@ -403,7 +403,6 @@
                 padding: 24px;
 
                 .signup-body-message-title {
-                    max-width: 271px;
                     padding-right: 0;
                     font-size: 45px;
                     line-height: 56px;


### PR DESCRIPTION
#### Summary
Fixes an issue with the positioning of the back button on the signup screen when the free edition and custom site name display.

Also fixes an issue with the title wrapping unnecessarily on to 2 lines on mobile screens

**Testing notes**
The following cases need to be considered when testing:
- free edition, no custom site name
- free edition, with custom site name
- licensed edition, no custom site name
- licensed edition, with custom site name

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/MM-58802

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="458" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/ae082646-a71d-4ded-b73b-d83d1ad227dd"> | <img width="465" alt="image" src="https://github.com/mattermost/mattermost/assets/2040554/0e2a1ef7-5509-4b53-be00-5517b9d9cfae"> |


#### Release Note
```release-note
NONE
```
