### PR TITLE
MM-58772 Change PerformanceReporter to use Date.now for timestamps

### DIFF
--- a/webapp/channels/src/utils/performance_telemetry/reporter.test.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.test.ts
@@ -33,9 +33,15 @@ describe('PerformanceReporter', () => {
 
         const testMarkA = performance.mark('testMarkA');
         const testMarkB = performance.mark('testMarkB');
+
+        const timeA = Date.now();
         measureAndReport('testMeasureA', 'testMarkA', 'testMarkB');
 
+        await waitForObservations();
+
         const testMarkC = performance.mark('testMarkC');
+
+        const timeBC = Date.now();
         measureAndReport('testMeasureB', 'testMarkA', 'testMarkC');
         measureAndReport('testMeasureC', 'testMarkB', 'testMarkC');
 
@@ -49,26 +55,27 @@ describe('PerformanceReporter', () => {
         expect(sendBeacon.mock.calls[0][0]).toEqual(siteUrl + '/api/v4/client_perf');
         const report = JSON.parse(sendBeacon.mock.calls[0][1]);
         expect(report).toMatchObject({
-            start: performance.timeOrigin + testMarkA.startTime,
-            end: performance.timeOrigin + testMarkB.startTime,
             histograms: [
                 {
                     metric: 'testMeasureA',
                     value: testMarkB.startTime - testMarkA.startTime,
-                    timestamp: performance.timeOrigin + testMarkA.startTime,
                 },
                 {
                     metric: 'testMeasureB',
                     value: testMarkC.startTime - testMarkA.startTime,
-                    timestamp: performance.timeOrigin + testMarkA.startTime,
                 },
                 {
                     metric: 'testMeasureC',
                     value: testMarkC.startTime - testMarkB.startTime,
-                    timestamp: performance.timeOrigin + testMarkB.startTime,
                 },
             ],
         });
+        expect(report.start).toEqual(report.histograms[0].timestamp);
+        expect(report.end).toEqual(report.histograms[2].timestamp);
+        expect(report.histograms[0].timestamp).toBeGreaterThan(timeA);
+        expect(report.histograms[0].timestamp).toBeLessThan(timeBC);
+        expect(report.histograms[1].timestamp).toBeGreaterThan(timeBC);
+        expect(report.histograms[2].timestamp).toBeGreaterThan(timeBC);
 
         reporter.disconnect();
     });

--- a/webapp/channels/src/utils/performance_telemetry/reporter.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.ts
@@ -126,7 +126,7 @@ export default class PerformanceReporter {
         this.histogramMeasures.push({
             metric: Measure.PageLoad,
             value: entries[0].duration,
-            timestamp: performance.timeOrigin + entries[0].startTime,
+            timestamp: Date.now(),
         });
     }
 
@@ -162,7 +162,7 @@ export default class PerformanceReporter {
         this.histogramMeasures.push({
             metric: entry.name,
             value: entry.duration,
-            timestamp: performance.timeOrigin + entry.startTime,
+            timestamp: Date.now(),
         });
     }
 
@@ -187,7 +187,7 @@ export default class PerformanceReporter {
         this.histogramMeasures.push({
             metric: metric.name,
             value: metric.value,
-            timestamp: performance.timeOrigin + performance.now(),
+            timestamp: Date.now(),
         });
     }
 


### PR DESCRIPTION
#### Summary
As I learned yesterday and noted in the ticket, the clock used by the browser's performance API (`performance.now()`) doesn't tick up while the computer is asleep which leads performance reports to be treated by the server as "outdated" after the computer sleeps for more than 5 minutes. Using `Date.now()` is technically less accurate than `performance.now()`, but we don't even store these timestamps anywhere, so we certainly don't care if they're sub-millisecond accurate

#### Ticket Link
MM-58772

#### Release Note
```release-note
Fixed web app performance reports being marked as outdated after the user's computer wakes up from sleep
```
