### PR TITLE
MM-58823 Remove feature flag from client metrics

### DIFF
--- a/server/config/client.go
+++ b/server/config/client.go
@@ -188,7 +188,7 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 
 		if *license.Features.Cluster {
 			props["EnableMetrics"] = strconv.FormatBool(*c.MetricsSettings.Enable)
-			props["EnableClientMetrics"] = strconv.FormatBool(c.FeatureFlags.ClientMetrics && *c.MetricsSettings.EnableClientMetrics)
+			props["EnableClientMetrics"] = strconv.FormatBool(*c.MetricsSettings.Enable && *c.MetricsSettings.EnableClientMetrics)
 			props["EnableNotificationMetrics"] = strconv.FormatBool(c.FeatureFlags.NotificationMonitoring && *c.MetricsSettings.EnableNotificationMetrics)
 		}
 

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -57,8 +57,6 @@ type FeatureFlags struct {
 	NotificationMonitoring bool
 
 	ExperimentalAuditSettingsSystemConsoleUI bool
-
-	ClientMetrics bool
 }
 
 func (f *FeatureFlags) SetDefaults() {
@@ -83,7 +81,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.WebSocketEventScope = false
 	f.NotificationMonitoring = true
 	f.ExperimentalAuditSettingsSystemConsoleUI = false
-	f.ClientMetrics = false
 }
 
 // ToMap returns the feature flags as a map[string]string


### PR DESCRIPTION
#### Summary
This has soaked for long enough that we're confident that this can be enabled for everyone with Prometheus metrics enabled. I've also made sure that the client doesn't report results to the server if the Prometheus metrics themselves are disabled since I forgot to do that previously.

#### Ticket Link
MM-58823

#### Release Note
```release-note
Removed feature flag which prevented enabling MetricsSettings.EnableClientMetrics
```
