### PR TITLE
Update link preview URL in test-search.md

### DIFF
--- a/server/tests/test-search.md
+++ b/server/tests/test-search.md
@@ -11,7 +11,7 @@ This post is used by the core team to test search. It should be returned for the
 您好吗  
 您好  
 **Email search:** person@domain.org  
-**Link search:** www.dropbox.com  
+**Link search:** www.github.com/mattermost  
 **Markdown search:**  
 ##### Hello  
 ```  


### PR DESCRIPTION
Updated link preview test URL from www.dropbox.com to www.github.com/mattermost, as the dropbox link no longer shows a preview and the github link still does. The github link is likely going to be more stable for us to use in testing over time.