### PR TITLE
[MM-58496] Change post messages font size

### DIFF
--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -1048,7 +1048,7 @@
     p {
         width: 100%;
         margin: 0;
-        font-size: 13.5px;
+        font-size: 14px;
         line-height: 1.6em;
         white-space: pre-wrap;
         word-break: break-word;


### PR DESCRIPTION
#### Summary
Previously on firefox 125.0.2 (linux), the font aspect was distorted and overall harder to read because a decimal number was used as font-size. This PR uses a round number which fixes this issue.

#### Ticket Link
[https://mattermost.atlassian.net/browse/MM-58496](https://mattermost.atlassian.net/browse/MM-58496)

Fixes #27181 