### PR TITLE
MM-58855 Cherry pick client metrics fixes

### DIFF
--- a/server/channels/app/metrics.go
+++ b/server/channels/app/metrics.go
@@ -36,6 +36,8 @@ func (a *App) RegisterPerformanceReport(rctx request.CTX, report *model.Performa
 			a.Metrics().ObserveClientInteractionToNextPaint(commonLabels["platform"], commonLabels["agent"], h.Value/1000)
 		case model.ClientCumulativeLayoutShift:
 			a.Metrics().ObserveClientCumulativeLayoutShift(commonLabels["platform"], commonLabels["agent"], h.Value)
+		case model.ClientPageLoadDuration:
+			a.Metrics().ObserveClientPageLoadDuration(commonLabels["platform"], commonLabels["agent"], h.Value/1000)
 		case model.ClientChannelSwitchDuration:
 			a.Metrics().ObserveClientChannelSwitchDuration(commonLabels["platform"], commonLabels["agent"], h.Value/1000)
 		case model.ClientTeamSwitchDuration:

--- a/server/einterfaces/metrics.go
+++ b/server/einterfaces/metrics.go
@@ -109,6 +109,7 @@ type MetricsInterface interface {
 	ObserveClientInteractionToNextPaint(platform, agent string, elapsed float64)
 	ObserveClientCumulativeLayoutShift(platform, agent string, elapsed float64)
 	IncrementClientLongTasks(platform, agent string, inc float64)
+	ObserveClientPageLoadDuration(platform, agent string, elapsed float64)
 	ObserveClientChannelSwitchDuration(platform, agent string, elapsed float64)
 	ObserveClientTeamSwitchDuration(platform, agent string, elapsed float64)
 	ObserveClientRHSLoadDuration(platform, agent string, elapsed float64)

--- a/server/einterfaces/mocks/MetricsInterface.go
+++ b/server/einterfaces/mocks/MetricsInterface.go
@@ -323,6 +323,11 @@ func (_m *MetricsInterface) ObserveClientLargestContentfulPaint(platform string,
 	_m.Called(platform, agent, elapsed)
 }
 
+// ObserveClientPageLoadDuration provides a mock function with given fields: platform, agent, elapsed
+func (_m *MetricsInterface) ObserveClientPageLoadDuration(platform string, agent string, elapsed float64) {
+	_m.Called(platform, agent, elapsed)
+}
+
 // ObserveClientRHSLoadDuration provides a mock function with given fields: platform, agent, elapsed
 func (_m *MetricsInterface) ObserveClientRHSLoadDuration(platform string, agent string, elapsed float64) {
 	_m.Called(platform, agent, elapsed)

--- a/server/enterprise/metrics/metrics.go
+++ b/server/enterprise/metrics/metrics.go
@@ -217,6 +217,7 @@ type MetricsInterfaceImpl struct {
 	ClientInteractionToNextPaint *prometheus.HistogramVec
 	ClientCumulativeLayoutShift  *prometheus.HistogramVec
 	ClientLongTasks              *prometheus.CounterVec
+	ClientPageLoadDuration       *prometheus.HistogramVec
 	ClientChannelSwitchDuration  *prometheus.HistogramVec
 	ClientTeamSwitchDuration     *prometheus.HistogramVec
 	ClientRHSLoadDuration        *prometheus.HistogramVec
@@ -1199,6 +1200,17 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 	)
 	m.Registry.MustRegister(m.ClientLongTasks)
 
+	m.ClientPageLoadDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: MetricsNamespace,
+			Subsystem: MetricsSubsystemClientsWeb,
+			Name:      "page_load",
+			Help:      "The amount of time from when the browser starts loading the web app until when the web app's load event has finished (seconds)",
+		},
+		[]string{"platform", "agent"},
+	)
+	m.Registry.MustRegister(m.ClientPageLoadDuration)
+
 	m.ClientChannelSwitchDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: MetricsNamespace,
@@ -1712,6 +1724,10 @@ func (mi *MetricsInterfaceImpl) ObserveClientCumulativeLayoutShift(platform, age
 
 func (mi *MetricsInterfaceImpl) IncrementClientLongTasks(platform, agent string, inc float64) {
 	mi.ClientLongTasks.With(prometheus.Labels{"platform": platform, "agent": agent}).Add(inc)
+}
+
+func (mi *MetricsInterfaceImpl) ObserveClientPageLoadDuration(platform, agent string, elapsed float64) {
+	mi.ClientPageLoadDuration.With(prometheus.Labels{"platform": platform, "agent": agent}).Observe(elapsed)
 }
 
 func (mi *MetricsInterfaceImpl) ObserveClientChannelSwitchDuration(platform, agent string, elapsed float64) {

--- a/server/enterprise/metrics/metrics.go
+++ b/server/enterprise/metrics/metrics.go
@@ -1151,6 +1151,9 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 			Subsystem: MetricsSubsystemClientsWeb,
 			Name:      "first_contentful_paint",
 			Help:      "Duration of how long it takes for any content to be displayed on screen to a user (seconds)",
+
+			// Extend the range of buckets for this while we get a better idea of the expected range of this metric is
+			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 15, 20},
 		},
 		[]string{"platform", "agent"},
 	)
@@ -1162,6 +1165,9 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 			Subsystem: MetricsSubsystemClientsWeb,
 			Name:      "largest_contentful_paint",
 			Help:      "Duration of how long it takes for large content to be displayed on screen to a user (seconds)",
+
+			// Extend the range of buckets for this while we get a better idea of the expected range of this metric is
+			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 15, 20},
 		},
 		[]string{"platform", "agent"},
 	)

--- a/server/enterprise/metrics/metrics.go
+++ b/server/enterprise/metrics/metrics.go
@@ -1212,6 +1212,7 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 			Subsystem: MetricsSubsystemClientsWeb,
 			Name:      "page_load",
 			Help:      "The amount of time from when the browser starts loading the web app until when the web app's load event has finished (seconds)",
+			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 40},
 		},
 		[]string{"platform", "agent"},
 	)

--- a/server/public/model/metrics.go
+++ b/server/public/model/metrics.go
@@ -20,6 +20,7 @@ const (
 	ClientInteractionToNextPaint MetricType = "INP"
 	ClientCumulativeLayoutShift  MetricType = "CLS"
 	ClientLongTasks              MetricType = "long_tasks"
+	ClientPageLoadDuration       MetricType = "page_load"
 	ClientChannelSwitchDuration  MetricType = "channel_switch"
 	ClientTeamSwitchDuration     MetricType = "team_switch"
 	ClientRHSLoadDuration        MetricType = "rhs_load"

--- a/webapp/channels/src/utils/performance_telemetry/index.ts
+++ b/webapp/channels/src/utils/performance_telemetry/index.ts
@@ -10,6 +10,7 @@ export const enum Mark {
 
 export const enum Measure {
     ChannelSwitch = 'channel_switch',
+    PageLoad = 'page_load',
     RhsLoad = 'rhs_load',
     TeamSwitch = 'team_switch',
 }

--- a/webapp/channels/src/utils/performance_telemetry/reporter.test.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.test.ts
@@ -36,9 +36,15 @@ describe('PerformanceReporter', () => {
 
         const testMarkA = performance.mark('testMarkA');
         const testMarkB = performance.mark('testMarkB');
+
+        const timeA = Date.now();
         measureAndReport('testMeasureA', 'testMarkA', 'testMarkB');
 
+        await waitForObservations();
+
         const testMarkC = performance.mark('testMarkC');
+
+        const timeBC = Date.now();
         measureAndReport('testMeasureB', 'testMarkA', 'testMarkC');
         measureAndReport('testMeasureC', 'testMarkB', 'testMarkC');
 
@@ -52,26 +58,27 @@ describe('PerformanceReporter', () => {
         expect(sendBeacon.mock.calls[0][0]).toEqual(siteUrl + '/api/v4/client_perf');
         const report = JSON.parse(sendBeacon.mock.calls[0][1]);
         expect(report).toMatchObject({
-            start: performance.timeOrigin + testMarkA.startTime,
-            end: performance.timeOrigin + testMarkB.startTime,
             histograms: [
                 {
                     metric: 'testMeasureA',
                     value: testMarkB.startTime - testMarkA.startTime,
-                    timestamp: performance.timeOrigin + testMarkA.startTime,
                 },
                 {
                     metric: 'testMeasureB',
                     value: testMarkC.startTime - testMarkA.startTime,
-                    timestamp: performance.timeOrigin + testMarkA.startTime,
                 },
                 {
                     metric: 'testMeasureC',
                     value: testMarkC.startTime - testMarkB.startTime,
-                    timestamp: performance.timeOrigin + testMarkB.startTime,
                 },
             ],
         });
+        expect(report.start).toEqual(report.histograms[0].timestamp);
+        expect(report.end).toEqual(report.histograms[2].timestamp);
+        expect(report.histograms[0].timestamp).toBeGreaterThanOrEqual(timeA);
+        expect(report.histograms[0].timestamp).toBeLessThanOrEqual(timeBC);
+        expect(report.histograms[1].timestamp).toBeGreaterThanOrEqual(timeBC);
+        expect(report.histograms[2].timestamp).toBeGreaterThanOrEqual(timeBC);
 
         reporter.disconnect();
     });

--- a/webapp/channels/src/utils/performance_telemetry/reporter.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.ts
@@ -125,7 +125,7 @@ export default class PerformanceReporter {
         this.histogramMeasures.push({
             metric: Measure.PageLoad,
             value: entries[0].duration,
-            timestamp: performance.timeOrigin + entries[0].startTime,
+            timestamp: Date.now(),
         });
     }
 
@@ -161,7 +161,7 @@ export default class PerformanceReporter {
         this.histogramMeasures.push({
             metric: entry.name,
             value: entry.duration,
-            timestamp: performance.timeOrigin + entry.startTime,
+            timestamp: Date.now(),
         });
     }
 
@@ -186,7 +186,7 @@ export default class PerformanceReporter {
         this.histogramMeasures.push({
             metric: metric.name,
             value: metric.value,
-            timestamp: performance.timeOrigin + performance.now(),
+            timestamp: Date.now(),
         });
     }
 


### PR DESCRIPTION
#### Summary
This cherry-picks both #27159 to re-add the Load Event End/page_load metric to the client metrics and #27396 to fix metric reports being rejected for being outdated

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58855

#### Release Note
```release-note
Added page load time to client performance metrics
Fixed web app performance reports being marked as outdated after the user's computer wakes up from sleep
Increased range of LCP metrics that can be measured
Increased range of Load Event End metrics that can be measured
```
