### PR TITLE
MM-59033 Increase maximum bucket size for Load Event End metric

### DIFF
--- a/server/enterprise/metrics/metrics.go
+++ b/server/enterprise/metrics/metrics.go
@@ -1218,6 +1218,7 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 			Subsystem: MetricsSubsystemClientsWeb,
 			Name:      "page_load",
 			Help:      "The amount of time from when the browser starts loading the web app until when the web app's load event has finished (seconds)",
+			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 40},
 		},
 		[]string{"platform", "agent"},
 	)


### PR DESCRIPTION
#### Summary
Bumping this up since we've had 30 or more second times as the P99 for this reported using the Rudder/Looker telemetry.

This change will also be made in 9.9.1 by https://github.com/mattermost/mattermost/pull/27415

#### Ticket Link
MM-59033

#### Release Note
```release-note
Increased range of Load Event End metrics that can be measured
```
