### PR TITLE
[MM-59037] Prepackage calls v0.28.2 for v9.10

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -144,7 +144,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v0.28.1
+PLUGIN_PACKAGES += mattermost-plugin-calls-v0.28.2
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.2.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.9.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.1.1


### PR DESCRIPTION
#### Summary
- Dot release to fixe a bug: https://github.com/mattermost/mattermost-plugin-calls/pull/792

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-59037

#### Release Note

```release-note
Prepackage Calls version [v0.28.2](https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.28.2)
```

Calls [v0.28.2](https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.28.2)