### PR TITLE
[MM-59059] Re enable markdown preview for channel header in user advanced settings

### DIFF
--- a/webapp/channels/src/components/edit_channel_header_modal/__snapshots__/edit_channel_header_modal.test.tsx.snap
+++ b/webapp/channels/src/components/edit_channel_header_modal/__snapshots__/edit_channel_header_modal.test.tsx.snap
@@ -84,7 +84,6 @@ exports[`components/EditChannelHeaderModal edit direct message channel 1`] = `
         <TextboxLinks
           hasExceededCharacterLimit={false}
           hasText={true}
-          isMarkdownPreviewEnabled={false}
           previewMessageLink={
             <Memo(MemoizedFormattedMessage)
               defaultMessage="Edit"
@@ -215,7 +214,6 @@ exports[`components/EditChannelHeaderModal error with intl message 1`] = `
         <TextboxLinks
           hasExceededCharacterLimit={false}
           hasText={true}
-          isMarkdownPreviewEnabled={false}
           previewMessageLink={
             <Memo(MemoizedFormattedMessage)
               defaultMessage="Edit"
@@ -364,7 +362,6 @@ exports[`components/EditChannelHeaderModal error without intl message 1`] = `
         <TextboxLinks
           hasExceededCharacterLimit={false}
           hasText={true}
-          isMarkdownPreviewEnabled={false}
           previewMessageLink={
             <Memo(MemoizedFormattedMessage)
               defaultMessage="Edit"
@@ -505,7 +502,6 @@ exports[`components/EditChannelHeaderModal should match snapshot, init 1`] = `
         <TextboxLinks
           hasExceededCharacterLimit={false}
           hasText={true}
-          isMarkdownPreviewEnabled={false}
           previewMessageLink={
             <Memo(MemoizedFormattedMessage)
               defaultMessage="Edit"
@@ -636,7 +632,6 @@ exports[`components/EditChannelHeaderModal submitted 1`] = `
         <TextboxLinks
           hasExceededCharacterLimit={false}
           hasText={true}
-          isMarkdownPreviewEnabled={false}
           previewMessageLink={
             <Memo(MemoizedFormattedMessage)
               defaultMessage="Edit"

--- a/webapp/channels/src/components/edit_channel_header_modal/edit_channel_header_modal.tsx
+++ b/webapp/channels/src/components/edit_channel_header_modal/edit_channel_header_modal.tsx
@@ -253,7 +253,6 @@ export class EditChannelHeaderModal extends React.PureComponent<Props, State> {
                         </div>
                         <div className='post-create-footer'>
                             <TextboxLinks
-                                isMarkdownPreviewEnabled={this.props.markdownPreviewFeatureIsEnabled}
                                 showPreview={this.props.shouldShowPreview}
                                 updatePreview={this.setShowPreview}
                                 hasText={this.state.header ? this.state.header.length > 0 : false}

--- a/webapp/channels/src/components/edit_channel_header_modal/index.ts
+++ b/webapp/channels/src/components/edit_channel_header_modal/index.ts
@@ -13,16 +13,12 @@ import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {setShowPreviewOnEditChannelHeaderModal} from 'actions/views/textbox';
 import {showPreviewOnEditChannelHeaderModal} from 'selectors/views/textbox';
 
-import {Constants} from 'utils/constants';
-import {isFeatureEnabled} from 'utils/utils';
-
 import type {GlobalState} from 'types/store';
 
 import EditChannelHeaderModal from './edit_channel_header_modal';
 
 function mapStateToProps(state: GlobalState) {
     return {
-        markdownPreviewFeatureIsEnabled: isFeatureEnabled(Constants.PRE_RELEASE_FEATURES.MARKDOWN_PREVIEW, state),
         shouldShowPreview: showPreviewOnEditChannelHeaderModal(state),
         ctrlSend: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
     };

--- a/webapp/channels/src/components/textbox/textbox_links.tsx
+++ b/webapp/channels/src/components/textbox/textbox_links.tsx
@@ -12,7 +12,6 @@ type Props = {
     previewMessageLink?: ReactNode;
     hasText?: boolean;
     hasExceededCharacterLimit?: boolean;
-    isMarkdownPreviewEnabled: boolean;
     updatePreview?: (showPreview: boolean) => void;
 };
 
@@ -21,7 +20,6 @@ function TextboxLinks({
     previewMessageLink,
     hasText = false,
     hasExceededCharacterLimit = false,
-    isMarkdownPreviewEnabled,
     updatePreview,
 }: Props) {
     const togglePreview = (e: MouseEvent) => {
@@ -48,25 +46,22 @@ function TextboxLinks({
         );
     }
 
-    let previewLink = null;
-    if (isMarkdownPreviewEnabled) {
-        previewLink = (
-            <button
-                id='previewLink'
-                onClick={togglePreview}
-                className='style--none textbox-preview-link color--link'
-            >
-                {showPreview ? (
-                    editHeader
-                ) : (
-                    <FormattedMessage
-                        id='textbox.preview'
-                        defaultMessage='Preview'
-                    />
-                )}
-            </button>
-        );
-    }
+    const previewLink = (
+        <button
+            id='previewLink'
+            onClick={togglePreview}
+            className='style--none textbox-preview-link color--link'
+        >
+            {showPreview ? (
+                editHeader
+            ) : (
+                <FormattedMessage
+                    id='textbox.preview'
+                    defaultMessage='Preview'
+                />
+            )}
+        </button>
+    );
 
     const helpText = (
         <div

--- a/webapp/channels/src/components/user_settings/advanced/user_settings_advanced.tsx
+++ b/webapp/channels/src/components/user_settings/advanced/user_settings_advanced.tsx
@@ -92,7 +92,6 @@ export default class AdvancedSettingsDisplay extends React.PureComponent<Props, 
         };
 
         const PreReleaseFeaturesLocal = JSON.parse(JSON.stringify(PreReleaseFeatures));
-        delete PreReleaseFeaturesLocal.MARKDOWN_PREVIEW;
         const preReleaseFeaturesKeys = Object.keys(PreReleaseFeaturesLocal);
 
         let enabledFeatures = 0;

--- a/webapp/channels/src/components/user_settings/advanced/user_settings_advanced.tsx
+++ b/webapp/channels/src/components/user_settings/advanced/user_settings_advanced.tsx
@@ -28,7 +28,8 @@ import PerformanceDebuggingSection from './performance_debugging_section';
 import SettingDesktopHeader from '../headers/setting_desktop_header';
 import SettingMobileHeader from '../headers/setting_mobile_header';
 
-const PreReleaseFeatures = Constants.PRE_RELEASE_FEATURES;
+type PreReleaseFeaturesType = Record<string, {label: string; description: string}>;
+const PreReleaseFeatures: PreReleaseFeaturesType = Constants.PRE_RELEASE_FEATURES;
 
 type Settings = {
     [key: string]: string | undefined;
@@ -63,7 +64,7 @@ export type Props = {
 };
 
 type State = {
-    preReleaseFeatures: typeof PreReleaseFeatures;
+    preReleaseFeatures: PreReleaseFeaturesType;
     settings: Settings;
     enabledFeatures: number;
     isSaving: boolean;
@@ -708,7 +709,7 @@ export default class AdvancedSettingsDisplay extends React.PureComponent<Props, 
             const inputs = [];
 
             this.state.preReleaseFeaturesKeys.forEach((key) => {
-                const feature = this.state.preReleaseFeatures[key as keyof typeof PreReleaseFeatures];
+                const feature = this.state.preReleaseFeatures[key as keyof PreReleaseFeaturesType];
                 inputs.push(
                     <div key={'advancedPreviewFeatures_' + feature.label}>
                         <div className='checkbox'>

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -1971,12 +1971,7 @@ export const Constants = {
         COMMAND_SUGGESTION_USER: 'user',
     },
     FeatureTogglePrefix: 'feature_enabled_',
-    PRE_RELEASE_FEATURES: {
-        MARKDOWN_PREVIEW: {
-            label: 'markdown_preview', // github issue: https://github.com/mattermost/platform/pull/1389
-            description: 'Show markdown preview option in message input box',
-        },
-    },
+    PRE_RELEASE_FEATURES: {},
     OVERLAY_TIME_DELAY_SMALL: 100,
     OVERLAY_TIME_DELAY: 400,
     OVERLAY_DEFAULT_TRIGGER: ['hover', 'focus'],


### PR DESCRIPTION
#### Summary
This should have been deleted when we were cleaning up flags for advanced text editor in https://github.com/mattermost/mattermost-webapp/pull/11031 And this flag is currently only used to preview channel header. So i cleaned up this flag and removed it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59059

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
