### PR TITLE
[MM-59061] Remove redundant index route for Root.tsx

### DIFF
--- a/webapp/channels/src/components/app.tsx
+++ b/webapp/channels/src/components/app.tsx
@@ -4,12 +4,11 @@
 import React from 'react';
 import {hot} from 'react-hot-loader/root';
 import {Provider} from 'react-redux';
-import {Router, Route} from 'react-router-dom';
+import {Router} from 'react-router-dom';
 
 import store from 'stores/redux_store';
 
 import {makeAsyncComponent} from 'components/async_load';
-import CRTPostsChannelResetWatcher from 'components/threading/channel_threads/posts_channel_reset_watcher';
 
 import {getHistory} from 'utils/browser_history';
 const LazyRoot = React.lazy(() => import('components/root'));
@@ -19,12 +18,8 @@ const Root = makeAsyncComponent('Root', LazyRoot);
 const App = () => {
     return (
         <Provider store={store}>
-            <CRTPostsChannelResetWatcher/>
             <Router history={getHistory()}>
-                <Route
-                    path='/'
-                    component={Root}
-                />
+                <Root/>
             </Router>
         </Provider>
     );

--- a/webapp/channels/src/components/channel_layout/channel_controller.test.tsx
+++ b/webapp/channels/src/components/channel_layout/channel_controller.test.tsx
@@ -9,6 +9,7 @@ import * as actions from 'actions/status_actions';
 
 import mockStore from 'tests/test_store';
 import Constants from 'utils/constants';
+import {TestHelper} from 'utils/test_helper';
 
 import type {GlobalState} from 'types/store';
 
@@ -40,6 +41,9 @@ describe('ChannelController', () => {
                     config: {
                         EnableUserStatuses: 'false',
                     },
+                },
+                preferences: {
+                    myPreferences: TestHelper.getPreferencesMock(),
                 },
             },
         } as unknown as GlobalState;

--- a/webapp/channels/src/components/channel_layout/channel_controller.tsx
+++ b/webapp/channels/src/components/channel_layout/channel_controller.tsx
@@ -15,6 +15,7 @@ import LoadingScreen from 'components/loading_screen';
 import ProductNoticesModal from 'components/product_notices_modal';
 import ResetStatusModal from 'components/reset_status_modal';
 import Sidebar from 'components/sidebar';
+import CRTPostsChannelResetWatcher from 'components/threading/channel_threads/posts_channel_reset_watcher';
 import UnreadsStatusHandler from 'components/unreads_status_handler';
 
 import Pluggable from 'plugins/pluggable';
@@ -63,6 +64,7 @@ export default function ChannelController(props: Props) {
 
     return (
         <>
+            <CRTPostsChannelResetWatcher/>
             <Sidebar/>
             <div
                 id='channel_view'

--- a/webapp/channels/src/components/root/index.ts
+++ b/webapp/channels/src/components/root/index.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
+import {withRouter} from 'react-router-dom';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
@@ -78,4 +79,4 @@ function mapDispatchToProps(dispatch: Dispatch) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Root);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Root));


### PR DESCRIPTION
#### Summary
- Removed redundant index route for Root.tsx
- Moves CRT watcher to deeper component

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59061

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
