### PR TITLE
MM-58755 - Fixing inproduct notices spacing

### DIFF
--- a/webapp/channels/src/components/product_notices_modal/__snapshots__/product_notices.test.tsx.snap
+++ b/webapp/channels/src/components/product_notices_modal/__snapshots__/product_notices.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`ProductNoticesModal Match snapshot for single notice 1`] = `
   bodyPadding={true}
   cancelButtonText={null}
   className="productNotices"
+  compassDesign={true}
   confirmButtonText={
     <span>
       Download
@@ -56,6 +57,7 @@ exports[`ProductNoticesModal Match snapshot for user notice 1`] = `
     </React.Fragment>
   }
   className="productNotices"
+  compassDesign={true}
   confirmButtonText={
     <Memo(MemoizedFormattedMessage)
       defaultMessage="Done"
@@ -125,6 +127,7 @@ exports[`ProductNoticesModal Should match snapshot for system admin notice 1`] =
   bodyPadding={true}
   cancelButtonText={null}
   className="productNotices"
+  compassDesign={true}
   confirmButtonText={
     <React.Fragment>
       <Memo(MemoizedFormattedMessage)

--- a/webapp/channels/src/components/product_notices_modal/product_notices_modal.tsx
+++ b/webapp/channels/src/components/product_notices_modal/product_notices_modal.tsx
@@ -28,40 +28,19 @@ type State = {
     noticesData: ProductNotices;
 }
 
-const noticesData = [
-    {
-        id: 1231,
-        "title": "Mattermost 9.9 is here!",
-        "description": "Mattermost v9.9 includes multiple new improvements and bug fixes, including new client-side performance metrics. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
-        "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
-        "actionText": "Learn more",
-        "actionParam": "https://docs.mattermost.com/deploy/mattermost-changelog.html",
-        sysAdminOnly: false,
-        teamAdminonly: false,
-    },
-    {
-        id: 12313,
-        "title": "Mattermost 9.9 is here!",
-        "description": "Mattermost v9.9 includes multiple new improvements and bug fixes, including new client-side performance metrics. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
-        "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
-        "actionText": "Learn more",
-        "actionParam": "https://docs.mattermost.com/deploy/mattermost-changelog.html",
-    }
-]
-
 export default class ProductNoticesModal extends React.PureComponent<Props, State> {
     clearDataTimer?: number;
     constructor(props: Props) {
         super(props);
         this.state = {
             presentNoticeIndex: 0,
-            noticesData: noticesData,
+            noticesData: [],
         };
         this.clearDataTimer = undefined;
     }
 
     public componentDidMount() {
-        // this.fetchNoticesData();
+        this.fetchNoticesData();
     }
 
     public componentDidUpdate(prevProps: Props) {
@@ -96,16 +75,16 @@ export default class ProductNoticesModal extends React.PureComponent<Props, Stat
             clientVersion = getDesktopVersion();
         }
 
-        // const {data} = await this.props.actions.getInProductNotices(currentTeamId, client, clientVersion);
-        // if (data) {
-        //     this.setState({
-        //         noticesData: data,
-        //     });
-        //     if (data.length) {
-        //         const presentNoticeInfo = this.state.noticesData[this.state.presentNoticeIndex];
-        //         this.props.actions.updateNoticesAsViewed([presentNoticeInfo.id]);
-        //     }
-        // }
+        const {data} = await this.props.actions.getInProductNotices(currentTeamId, client, clientVersion);
+        if (data) {
+            this.setState({
+                noticesData: data,
+            });
+            if (data.length) {
+                const presentNoticeInfo = this.state.noticesData[this.state.presentNoticeIndex];
+                this.props.actions.updateNoticesAsViewed([presentNoticeInfo.id]);
+            }
+        }
     }
 
     private confirmButtonText(presentNoticeInfo: ProductNotice) {

--- a/webapp/channels/src/components/product_notices_modal/product_notices_modal.tsx
+++ b/webapp/channels/src/components/product_notices_modal/product_notices_modal.tsx
@@ -28,19 +28,40 @@ type State = {
     noticesData: ProductNotices;
 }
 
+const noticesData = [
+    {
+        id: 1231,
+        "title": "Mattermost 9.9 is here!",
+        "description": "Mattermost v9.9 includes multiple new improvements and bug fixes, including new client-side performance metrics. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
+        "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
+        "actionText": "Learn more",
+        "actionParam": "https://docs.mattermost.com/deploy/mattermost-changelog.html",
+        sysAdminOnly: false,
+        teamAdminonly: false,
+    },
+    {
+        id: 12313,
+        "title": "Mattermost 9.9 is here!",
+        "description": "Mattermost v9.9 includes multiple new improvements and bug fixes, including new client-side performance metrics. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) only takes a few minutes.",
+        "image": "https://raw.githubusercontent.com/mattermost/notices/master/images/server_upgrade.png",
+        "actionText": "Learn more",
+        "actionParam": "https://docs.mattermost.com/deploy/mattermost-changelog.html",
+    }
+]
+
 export default class ProductNoticesModal extends React.PureComponent<Props, State> {
     clearDataTimer?: number;
     constructor(props: Props) {
         super(props);
         this.state = {
             presentNoticeIndex: 0,
-            noticesData: [],
+            noticesData: noticesData,
         };
         this.clearDataTimer = undefined;
     }
 
     public componentDidMount() {
-        this.fetchNoticesData();
+        // this.fetchNoticesData();
     }
 
     public componentDidUpdate(prevProps: Props) {
@@ -75,16 +96,16 @@ export default class ProductNoticesModal extends React.PureComponent<Props, Stat
             clientVersion = getDesktopVersion();
         }
 
-        const {data} = await this.props.actions.getInProductNotices(currentTeamId, client, clientVersion);
-        if (data) {
-            this.setState({
-                noticesData: data,
-            });
-            if (data.length) {
-                const presentNoticeInfo = this.state.noticesData[this.state.presentNoticeIndex];
-                this.props.actions.updateNoticesAsViewed([presentNoticeInfo.id]);
-            }
-        }
+        // const {data} = await this.props.actions.getInProductNotices(currentTeamId, client, clientVersion);
+        // if (data) {
+        //     this.setState({
+        //         noticesData: data,
+        //     });
+        //     if (data.length) {
+        //         const presentNoticeInfo = this.state.noticesData[this.state.presentNoticeIndex];
+        //         this.props.actions.updateNoticesAsViewed([presentNoticeInfo.id]);
+        //     }
+        // }
     }
 
     private confirmButtonText(presentNoticeInfo: ProductNotice) {
@@ -255,6 +276,7 @@ export default class ProductNoticesModal extends React.PureComponent<Props, Stat
 
         return (
             <GenericModal
+                compassDesign={true}
                 onExited={this.onModalDismiss}
                 handleConfirm={this.handleNextButton}
                 handleEnterKeyPress={this.handleNextButton}


### PR DESCRIPTION
#### Summary
MM-58755 - Fixing inproduct notices spacing
MM-58449 - Fixing CRT modal

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-58755
Jira https://mattermost.atlassian.net/browse/MM-58449

#### Screenshots
![CleanShot 2024-06-24 at 19 20 44@2x](https://github.com/mattermost/mattermost/assets/11034289/d25b136e-3ba7-4471-a434-0d071d15e61d)
![CleanShot 2024-06-24 at 21 28 05@2x](https://github.com/mattermost/mattermost/assets/11034289/3029ea69-16c9-4d02-b7f4-65983e8be9c5)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
