### PR TITLE
MM-58777 Confirm that sendBeacon exists before trying to use it

### DIFF
--- a/webapp/channels/src/utils/performance_telemetry/reporter.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.ts
@@ -308,6 +308,11 @@ export default class PerformanceReporter {
     }
 
     protected sendBeacon(url: string | URL, data?: BodyInit | null | undefined): boolean {
+        // Confirm that sendBeacon exists because it doesn't on Firefox with certain settings enabled
+        if (!navigator.sendBeacon) {
+            return false;
+        }
+
         return navigator.sendBeacon(url, data);
     }
 }


### PR DESCRIPTION
#### Summary
Certain browser settings can cause this API to be disabled. For whatever reason, instead of just returning false to say that nothing was sent which the API is already supposed to do, Firefox decides to just blank it out so that an error occurs if you try to call it. Thanks, Firefox!

#### Ticket Link
MM-58777

#### Release Note
```release-note
Fix an error caused by performance telemetry when using Firefox with `beacon.enabled` set to false
```
