### PR TITLE
Change PerformanceReporter tests to not check exact values for timestamps

### DIFF
--- a/webapp/channels/src/utils/performance_telemetry/reporter.test.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.test.ts
@@ -31,17 +31,15 @@ describe('PerformanceReporter', () => {
 
         expect(sendBeacon).not.toHaveBeenCalled();
 
-        const testMarkA = performance.mark('testMarkA');
-        const testMarkB = performance.mark('testMarkB');
+        performance.mark('testMarkA');
+        performance.mark('testMarkB');
 
-        const timeA = Date.now();
         measureAndReport('testMeasureA', 'testMarkA', 'testMarkB');
 
         await waitForObservations();
 
-        const testMarkC = performance.mark('testMarkC');
+        performance.mark('testMarkC');
 
-        const timeBC = Date.now();
         measureAndReport('testMeasureB', 'testMarkA', 'testMarkC');
         measureAndReport('testMeasureC', 'testMarkB', 'testMarkC');
 
@@ -58,24 +56,20 @@ describe('PerformanceReporter', () => {
             histograms: [
                 {
                     metric: 'testMeasureA',
-                    value: testMarkB.startTime - testMarkA.startTime,
                 },
                 {
                     metric: 'testMeasureB',
-                    value: testMarkC.startTime - testMarkA.startTime,
                 },
                 {
                     metric: 'testMeasureC',
-                    value: testMarkC.startTime - testMarkB.startTime,
                 },
             ],
         });
-        expect(report.start).toEqual(report.histograms[0].timestamp);
-        expect(report.end).toEqual(report.histograms[2].timestamp);
-        expect(report.histograms[0].timestamp).toBeGreaterThanOrEqual(timeA);
-        expect(report.histograms[0].timestamp).toBeLessThanOrEqual(timeBC);
-        expect(report.histograms[1].timestamp).toBeGreaterThanOrEqual(timeBC);
-        expect(report.histograms[2].timestamp).toBeGreaterThanOrEqual(timeBC);
+        expect(report.start).toEqual(Math.min(report.histograms[0].timestamp, report.histograms[1].timestamp, report.histograms[2].timestamp));
+        expect(report.end).toEqual(Math.max(report.histograms[0].timestamp, report.histograms[1].timestamp, report.histograms[2].timestamp));
+        expect(report.histograms[0].timestamp).toBeDefined();
+        expect(report.histograms[1].timestamp).toBeDefined();
+        expect(report.histograms[2].timestamp).toBeDefined();
 
         reporter.disconnect();
     });


### PR DESCRIPTION
#### Summary
I've already fought with these tests being flaky twice before, so I've given up trying to check the exact values of these because they keep causing CI to periodically fail

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
