### PR TITLE
chore: update package metadata for API reference

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -19,12 +19,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mattermost/mattermost-api-reference.git"
+    "url": "https://github.com/mattermost/mattermost.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/mattermost/mattermost-api-reference/issues"
+    "url": "https://github.com/mattermost/mattermost/issues"
   },
-  "homepage": "https://github.com/mattermost/mattermost-api-reference#readme"
+  "homepage": "https://api.mattermost.com/"
 }


### PR DESCRIPTION
#### Summary

In accordance with https://github.com/mattermost/mattermost-api-reference/pull/735, this updates metadata information in terms of `mattermost-api-reference` npm package.

#### Ticket Link

n/a

#### Screenshots

n/a

#### Release Note

```release-note
NONE
```