### PR TITLE
MM-58777 Confirm that sendBeacon exists before trying to use it (9.9)

### DIFF
--- a/webapp/channels/src/utils/performance_telemetry/reporter.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.ts
@@ -298,12 +298,21 @@ export default class PerformanceReporter {
         const url = this.client.getClientMetricsRoute();
         const data = JSON.stringify(report);
 
-        const beaconSent = navigator.sendBeacon(url, data);
+        const beaconSent = this.sendBeacon(url, data);
 
         if (!beaconSent) {
             // The data couldn't be queued as a beacon for some reason, so fall back to sending an immediate fetch
             fetch(url, {method: 'POST', body: data});
         }
+    }
+
+    protected sendBeacon(url: string | URL, data?: BodyInit | null | undefined): boolean {
+        // Confirm that sendBeacon exists because it doesn't on Firefox with certain settings enabled
+        if (!navigator.sendBeacon) {
+            return false;
+        }
+
+        return navigator.sendBeacon(url, data);
     }
 }
 


### PR DESCRIPTION
#### Summary
Cherry-pick of https://github.com/mattermost/mattermost/pull/27458 to 9.9

#### Release Note
```release-note
Fix an error caused by performance telemetry when using Firefox with `beacon.enabled` set to false
```
