### PR TITLE
CLD-5704 Fix concurrency for daily tests

### DIFF
--- a/.github/workflows/e2e-fulltests-ci.yml
+++ b/.github/workflows/e2e-fulltests-ci.yml
@@ -30,7 +30,7 @@ on:
         default: NONE
 
 concurrency:
-  group: "${{ github.workflow }}-${{ inputs.PR_NUMBER || inputs.ref }}-${{ inputs.MM_ENV }}"
+  group: "${{ github.workflow }}-${{ inputs.REPORT_TYPE }}-${{ inputs.PR_NUMBER || inputs.ref }}-${{ inputs.MM_ENV }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
#### Summary

Today's daily test all ran correctly, but [one of them](https://github.com/mattermost/mattermost/actions/runs/9689742488) (`CLOUD_UNSTABLE`) ran before [its previous one](https://github.com/mattermost/mattermost/actions/runs/9689475883) could be finished (`MASTER_UNSTABLE`). The current configuration of our `concurrency` directive in the workflow meant that the previously running job was canceled.

This PR configures it so that only workflows of the same  `REPORT_TYPE` can cancel each other, so that master-unstable and cloud-unstable tests can have a small overlap time as well.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-5704

#### Release Note
```release-note
NONE
```
