### PR TITLE
MM-58771 - Make manage_server permission, non updatable

### DIFF
--- a/server/channels/api4/role.go
+++ b/server/channels/api4/role.go
@@ -18,6 +18,7 @@ var notAllowedPermissions = []string{
 	model.PermissionSysconsoleWriteUserManagementSystemRoles.Id,
 	model.PermissionSysconsoleReadUserManagementSystemRoles.Id,
 	model.PermissionManageRoles.Id,
+	model.PermissionManageSystem.Id,
 }
 
 func (api *API) InitRole() {

--- a/server/channels/api4/role_test.go
+++ b/server/channels/api4/role_test.go
@@ -265,7 +265,6 @@ func TestPatchRole(t *testing.T) {
 		_, resp, err = client.PatchRole(context.Background(), systemManager.Id, patchManageSystem)
 		require.Error(t, err)
 		CheckNotImplementedStatus(t, resp)
-
 	})
 
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {

--- a/server/channels/api4/role_test.go
+++ b/server/channels/api4/role_test.go
@@ -46,7 +46,7 @@ func TestGetRole(t *testing.T) {
 		Name:          model.NewId(),
 		DisplayName:   model.NewId(),
 		Description:   model.NewId(),
-		Permissions:   []string{"manage_system", "create_public_channel"},
+		Permissions:   []string{"create_direct_channel", "create_public_channel"},
 		SchemeManaged: true,
 	}
 
@@ -85,7 +85,7 @@ func TestGetRoleByName(t *testing.T) {
 		Name:          model.NewId(),
 		DisplayName:   model.NewId(),
 		Description:   model.NewId(),
-		Permissions:   []string{"manage_system", "create_public_channel"},
+		Permissions:   []string{"create_direct_channel", "create_public_channel"},
 		SchemeManaged: true,
 	}
 
@@ -124,21 +124,21 @@ func TestGetRolesByNames(t *testing.T) {
 		Name:          model.NewId(),
 		DisplayName:   model.NewId(),
 		Description:   model.NewId(),
-		Permissions:   []string{"manage_system", "create_public_channel"},
+		Permissions:   []string{"create_direct_channel", "create_public_channel"},
 		SchemeManaged: true,
 	}
 	role2 := &model.Role{
 		Name:          model.NewId(),
 		DisplayName:   model.NewId(),
 		Description:   model.NewId(),
-		Permissions:   []string{"manage_system", "delete_private_channel"},
+		Permissions:   []string{"create_direct_channel", "delete_private_channel"},
 		SchemeManaged: true,
 	}
 	role3 := &model.Role{
 		Name:          model.NewId(),
 		DisplayName:   model.NewId(),
 		Description:   model.NewId(),
-		Permissions:   []string{"manage_system", "manage_public_channel_properties"},
+		Permissions:   []string{"create_direct_channel", "manage_public_channel_properties"},
 		SchemeManaged: true,
 	}
 
@@ -207,7 +207,7 @@ func TestPatchRole(t *testing.T) {
 		Name:          model.NewId(),
 		DisplayName:   model.NewId(),
 		Description:   model.NewId(),
-		Permissions:   []string{"manage_system", "create_public_channel", "manage_slash_commands"},
+		Permissions:   []string{"create_direct_channel", "create_public_channel", "manage_slash_commands"},
 		SchemeManaged: true,
 	}
 
@@ -216,7 +216,7 @@ func TestPatchRole(t *testing.T) {
 	defer th.App.Srv().Store().Job().Delete(role.Id)
 
 	patch := &model.RolePatch{
-		Permissions: &[]string{"manage_system", "create_public_channel", "manage_incoming_webhooks", "manage_outgoing_webhooks"},
+		Permissions: &[]string{"create_direct_channel", "create_public_channel", "manage_incoming_webhooks", "manage_outgoing_webhooks"},
 	}
 
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
@@ -257,6 +257,15 @@ func TestPatchRole(t *testing.T) {
 		_, resp, err = client.PatchRole(context.Background(), systemManager.Id, patchManageRoles)
 		require.Error(t, err)
 		CheckNotImplementedStatus(t, resp)
+
+		patchManageSystem := &model.RolePatch{
+			Permissions: &[]string{model.PermissionManageSystem.Id},
+		}
+
+		_, resp, err = client.PatchRole(context.Background(), systemManager.Id, patchManageSystem)
+		require.Error(t, err)
+		CheckNotImplementedStatus(t, resp)
+
 	})
 
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
@@ -267,7 +276,7 @@ func TestPatchRole(t *testing.T) {
 		assert.Equal(t, received.Name, role.Name)
 		assert.Equal(t, received.DisplayName, role.DisplayName)
 		assert.Equal(t, received.Description, role.Description)
-		perms := []string{"manage_system", "create_public_channel", "manage_incoming_webhooks", "manage_outgoing_webhooks"}
+		perms := []string{"create_direct_channel", "create_public_channel", "manage_incoming_webhooks", "manage_outgoing_webhooks"}
 		sort.Strings(perms)
 		assert.EqualValues(t, received.Permissions, perms)
 		assert.Equal(t, received.SchemeManaged, role.SchemeManaged)
@@ -290,7 +299,7 @@ func TestPatchRole(t *testing.T) {
 	CheckForbiddenStatus(t, resp)
 
 	patch = &model.RolePatch{
-		Permissions: &[]string{"manage_system", "manage_incoming_webhooks", "manage_outgoing_webhooks"},
+		Permissions: &[]string{"create_direct_channel", "manage_incoming_webhooks", "manage_outgoing_webhooks"},
 	}
 
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
@@ -301,7 +310,7 @@ func TestPatchRole(t *testing.T) {
 		assert.Equal(t, received.Name, role.Name)
 		assert.Equal(t, received.DisplayName, role.DisplayName)
 		assert.Equal(t, received.Description, role.Description)
-		perms := []string{"manage_system", "manage_incoming_webhooks", "manage_outgoing_webhooks"}
+		perms := []string{"create_direct_channel", "manage_incoming_webhooks", "manage_outgoing_webhooks"}
 		sort.Strings(perms)
 		assert.EqualValues(t, received.Permissions, perms)
 		assert.Equal(t, received.SchemeManaged, role.SchemeManaged)


### PR DESCRIPTION

#### Summary
There is a set of 3 "role" permissions that cannot be assigned or removed from roles. Making them only available to System Administrators. They are `PermissionSysconsoleWriteUserManagementSystemRoles.Id`, `PermissionSysconsoleReadUserManagementSystemRoles.Id`, `PermissionManageRoles.Id`. This allows only System Admins to Manage Roles, that permission cannot be given to any other Role. 

This PR adds the `manage_system` permission to that list. The only way a user should be able to obtain the permission is be made a system admin.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-58771

#### Screenshots

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
