### PR TITLE
MM-59254 Fix EnableClientMetrics setting being hidden

### DIFF
--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -1815,7 +1815,6 @@ const AdminDefinition: AdminDefinitionType = {
                                 it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.ENVIRONMENT.PERFORMANCE_MONITORING)),
                                 it.configIsFalse('MetricsSettings', 'Enable'),
                             ),
-                            isHidden: it.configIsFalse('FeatureFlags', 'ClientMetrics'),
                         },
                         {
                             type: 'text',


### PR DESCRIPTION
#### Summary
When I removed the feature flag, I forgot to remove the one place it's used in the system console, so the setting is currently never shown to the user

#### Ticket Link
MM-59254

#### Release Note
```release-note
Fix EnableClientMetrics setting not being available in the system console
```
