### PR TITLE
[MM-59274] Potential for panic in app migrations

### DIFF
--- a/server/channels/app/migrations.go
+++ b/server/channels/app/migrations.go
@@ -598,7 +598,7 @@ func (s *Server) doCloudS3PathMigrations(c request.CTX) error {
 	}
 
 	if _, appErr := s.Jobs.CreateJobOnce(c, model.JobTypeS3PathMigration, nil); appErr != nil {
-		return fmt.Errorf("failed to start job for migrating s3 file paths: %w", err)
+		return fmt.Errorf("failed to start job for migrating s3 file paths: %w", appErr)
 	}
 
 	return nil
@@ -619,7 +619,7 @@ func (s *Server) doDeleteEmptyDraftsMigration(c request.CTX) error {
 	}
 
 	if _, appErr := s.Jobs.CreateJobOnce(c, model.JobTypeDeleteEmptyDraftsMigration, nil); appErr != nil {
-		return fmt.Errorf("failed to start job for deleting empty drafts: %w", err)
+		return fmt.Errorf("failed to start job for deleting empty drafts: %w", appErr)
 	}
 
 	return nil
@@ -640,7 +640,7 @@ func (s *Server) doDeleteOrphanDraftsMigration(c request.CTX) error {
 	}
 
 	if _, appErr := s.Jobs.CreateJobOnce(c, model.JobTypeDeleteOrphanDraftsMigration, nil); appErr != nil {
-		return fmt.Errorf("failed to start job for deleting orphan drafts: %w", err)
+		return fmt.Errorf("failed to start job for deleting orphan drafts: %w", appErr)
 	}
 
 	return nil


### PR DESCRIPTION
#### Summary
Fix potential for panic in app migrations

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59274

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
