### PR TITLE
Example of logging client performance events above threshold

### DIFF
--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -987,11 +987,12 @@ func (s *ClusterSettings) SetDefaults() {
 }
 
 type MetricsSettings struct {
-	Enable                    *bool   `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"`
-	BlockProfileRate          *int    `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"`
-	ListenAddress             *string `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"` // telemetry: none
-	EnableClientMetrics       *bool   `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"`
-	EnableNotificationMetrics *bool   `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"`
+	Enable                      *bool   `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"`
+	BlockProfileRate            *int    `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"`
+	ListenAddress               *string `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"` // telemetry: none
+	EnableClientMetrics         *bool   `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"`
+	EnableNotificationMetrics   *bool   `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"`
+	ExperimentalClientDebugLogs *bool   `access:"environment_performance_monitoring,write_restrictable,cloud_restrictable"`
 }
 
 func (s *MetricsSettings) SetDefaults() {
@@ -1013,6 +1014,10 @@ func (s *MetricsSettings) SetDefaults() {
 
 	if s.EnableNotificationMetrics == nil {
 		s.EnableNotificationMetrics = NewBool(true)
+	}
+
+	if s.ExperimentalClientDebugLogs == nil {
+		s.ExperimentalClientDebugLogs = NewBool(false)
 	}
 }
 


### PR DESCRIPTION
#### Summary

This isn't meant to be merged but to illustrate a possible way we could get more details on client performance events that are beyond a threshold, allowing us to dig deeper.

This results in a log message like:

```
debug [2024-07-02 15:18:01.733 -04:00] client performance event above threshold      caller="app/metrics.go:50" path=/api/v4/client_perf request_id=kxmc7ty4jfnpxxubk6by85wh3a ip_addr="::1" user_id=rbszsjkho7fz38sniba95eb9cc method=POST name=page_load duration=32.4513
```

#### Ticket Link
n/a

#### Release Note
```release-note
NONE
```
