### PR TITLE
MM-58525 Fix upload file permissions (#27298)

### DIFF
--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -240,6 +240,8 @@ channels/db/migrations/mysql/000120_create_channelbookmarks_table.down.sql
 channels/db/migrations/mysql/000120_create_channelbookmarks_table.up.sql
 channels/db/migrations/mysql/000121_remove_true_up_review_history.down.sql
 channels/db/migrations/mysql/000121_remove_true_up_review_history.up.sql
+channels/db/migrations/mysql/000123_remove_upload_file_permission.down.sql
+channels/db/migrations/mysql/000123_remove_upload_file_permission.up.sql
 channels/db/migrations/postgres/000001_create_teams.down.sql
 channels/db/migrations/postgres/000001_create_teams.up.sql
 channels/db/migrations/postgres/000002_create_team_members.down.sql
@@ -480,3 +482,5 @@ channels/db/migrations/postgres/000120_create_channelbookmarks_table.down.sql
 channels/db/migrations/postgres/000120_create_channelbookmarks_table.up.sql
 channels/db/migrations/postgres/000121_remove_true_up_review_history.down.sql
 channels/db/migrations/postgres/000121_remove_true_up_review_history.up.sql
+channels/db/migrations/postgres/000123_remove_upload_file_permission.down.sql
+channels/db/migrations/postgres/000123_remove_upload_file_permission.up.sql

--- a/server/channels/db/migrations/mysql/000123_remove_upload_file_permission.down.sql
+++ b/server/channels/db/migrations/mysql/000123_remove_upload_file_permission.down.sql
@@ -1,0 +1,1 @@
+-- Skipping it because the forward migrations are destructive

--- a/server/channels/db/migrations/mysql/000123_remove_upload_file_permission.up.sql
+++ b/server/channels/db/migrations/mysql/000123_remove_upload_file_permission.up.sql
@@ -1,0 +1,18 @@
+CREATE PROCEDURE RemoveUuploadFilePermission()
+BEGIN
+    updateRoles: LOOP
+        -- update affected rows
+        UPDATE Roles 
+            SET Permissions = REGEXP_REPLACE(Permissions, 'upload_file([[:space:]]|$)', '')
+            WHERE Permissions like '%upload_file%' and Permissions not REGEXP 'create_post([[:space:]]|$)'
+            LIMIT 100;
+
+          -- check if the loop has completed    
+          IF  ROW_COUNT() < 100 THEN
+              LEAVE updateRoles;
+          END IF;    
+    END LOOP updateRoles;
+END;
+
+CALL RemoveUuploadFilePermission();
+DROP PROCEDURE IF EXISTS RemoveUuploadFilePermission;

--- a/server/channels/db/migrations/postgres/000123_remove_upload_file_permission.down.sql
+++ b/server/channels/db/migrations/postgres/000123_remove_upload_file_permission.down.sql
@@ -1,0 +1,1 @@
+-- Skipping it because the forward migrations are destructive

--- a/server/channels/db/migrations/postgres/000123_remove_upload_file_permission.up.sql
+++ b/server/channels/db/migrations/postgres/000123_remove_upload_file_permission.up.sql
@@ -1,0 +1,18 @@
+DO $$
+<<remove_upload_file_permission>>
+DECLARE
+  rows_updated integer;
+BEGIN
+  LOOP
+    WITH table_holder AS (
+      SELECT id FROM roles
+          WHERE permissions ~~ '%upload_file%' AND permissions !~ 'create_post($|\s)'
+          ORDER BY id ASC limit 100
+    )
+
+    UPDATE Roles r set permissions = REGEXP_REPLACE(permissions, 'upload_file($|\s)', '') 
+        WHERE r.id in (SELECT id FROM table_holder);
+    GET DIAGNOSTICS rows_updated = ROW_COUNT;
+    EXIT WHEN rows_updated < 100;
+  END LOOP;
+END remove_upload_file_permission $$;

--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/guest_permissions_tree/__snapshots__/guest_permissions_tree.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/guest_permissions_tree/__snapshots__/guest_permissions_tree.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
             "id": "guest_create_post",
             "permissions": Array [
               "create_post",
+              "upload_file",
             ],
           },
           Object {
@@ -194,6 +195,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
             "id": "guest_create_post",
             "permissions": Array [
               "create_post",
+              "upload_file",
             ],
           },
           Object {
@@ -311,6 +313,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
             "id": "guest_create_post",
             "permissions": Array [
               "create_post",
+              "upload_file",
             ],
           },
           Object {
@@ -435,6 +438,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
             "id": "guest_create_post",
             "permissions": Array [
               "create_post",
+              "upload_file",
             ],
           },
           Object {
@@ -559,6 +563,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
             "id": "guest_create_post",
             "permissions": Array [
               "create_post",
+              "upload_file",
             ],
           },
           Object {
@@ -699,6 +704,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
             "id": "guest_create_post",
             "permissions": Array [
               "create_post",
+              "upload_file",
             ],
           },
           Object {

--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/guest_permissions_tree/guest_permissions_tree.tsx
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/guest_permissions_tree/guest_permissions_tree.tsx
@@ -31,7 +31,14 @@ const GuestPermissionsTree = ({license, onToggle, readOnly, scope, selectRow, pa
             Permissions.CREATE_PRIVATE_CHANNEL,
             Permissions.EDIT_POST,
             Permissions.DELETE_POST,
-            Permissions.CREATE_POST,
+            {
+                id: 'guest_' + Permissions.CREATE_POST,
+                combined: true,
+                permissions: [
+                    Permissions.CREATE_POST,
+                    Permissions.UPLOAD_FILE,
+                ],
+            },
             {
                 id: 'guest_reactions',
                 combined: true,

--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/permissions_tree/__snapshots__/permissions_tree.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/permissions_tree/__snapshots__/permissions_tree.test.tsx.snap
@@ -151,7 +151,14 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
                 ],
               },
               "use_channel_mentions",
-              "create_post",
+              Object {
+                "combined": true,
+                "id": "create_post",
+                "permissions": Array [
+                  "create_post",
+                  "upload_file",
+                ],
+              },
             ],
           },
           Object {
@@ -345,7 +352,14 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
                 ],
               },
               "use_channel_mentions",
-              "create_post",
+              Object {
+                "combined": true,
+                "id": "create_post",
+                "permissions": Array [
+                  "create_post",
+                  "upload_file",
+                ],
+              },
             ],
           },
           Object {
@@ -536,7 +550,14 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
                 ],
               },
               "use_channel_mentions",
-              "create_post",
+              Object {
+                "combined": true,
+                "id": "create_post",
+                "permissions": Array [
+                  "create_post",
+                  "upload_file",
+                ],
+              },
             ],
           },
           Object {
@@ -738,7 +759,14 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
                 ],
               },
               "use_channel_mentions",
-              "create_post",
+              Object {
+                "combined": true,
+                "id": "create_post",
+                "permissions": Array [
+                  "create_post",
+                  "upload_file",
+                ],
+              },
             ],
           },
           Object {
@@ -940,7 +968,14 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
                 ],
               },
               "use_channel_mentions",
-              "create_post",
+              Object {
+                "combined": true,
+                "id": "create_post",
+                "permissions": Array [
+                  "create_post",
+                  "upload_file",
+                ],
+              },
             ],
           },
           Object {
@@ -1142,7 +1177,14 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
                 ],
               },
               "use_channel_mentions",
-              "create_post",
+              Object {
+                "combined": true,
+                "id": "create_post",
+                "permissions": Array [
+                  "create_post",
+                  "upload_file",
+                ],
+              },
             ],
           },
           Object {
@@ -1351,7 +1393,14 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
                 ],
               },
               "use_channel_mentions",
-              "create_post",
+              Object {
+                "combined": true,
+                "id": "create_post",
+                "permissions": Array [
+                  "create_post",
+                  "upload_file",
+                ],
+              },
             ],
           },
           Object {

--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree.tsx
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree.tsx
@@ -249,8 +249,14 @@ export default class PermissionsTree extends React.PureComponent<Props, State> {
         if (license?.IsLicensed === 'true' && license?.LDAPGroups === 'true' && !postsGroup.permissions.includes(Permissions.USE_GROUP_MENTIONS)) {
             postsGroup.permissions.push(Permissions.USE_GROUP_MENTIONS);
         }
-        postsGroup.permissions.push(Permissions.CREATE_POST);
-
+        postsGroup.permissions.push({
+            id: Permissions.CREATE_POST,
+            combined: true,
+            permissions: [
+                Permissions.CREATE_POST,
+                Permissions.UPLOAD_FILE,
+            ],
+        });
         if (config.ExperimentalSharedChannels === 'true') {
             sharedChannelsGroup.permissions.push(Permissions.MANAGE_SHARED_CHANNELS);
             sharedChannelsGroup.permissions.push(Permissions.MANAGE_SECURE_CONNECTIONS);

--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/strings/groups.tsx
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/strings/groups.tsx
@@ -35,6 +35,16 @@ export const groupRolesStrings: Record<string, Record<string, MessageDescriptor>
             defaultMessage: 'Write, edit and delete posts.',
         },
     }),
+    create_post: defineMessages({
+        name: {
+            id: 'admin.permissions.permission.create_post.name',
+            defaultMessage: 'Create Posts',
+        },
+        description: {
+            id: 'admin.permissions.permission.create_post.description',
+            defaultMessage: 'Allow users to create posts.',
+        },
+    }),
     private_channel: defineMessages({
         name: {
             id: 'admin.permissions.group.private_channel.name',


### PR DESCRIPTION
* tie create_post and upload_file permissions together

* update tests

* update file name

* update migration to do in batches

* Update 000122_remove_upload_file_permission.up.sql

* fix formatting

* simplify migrations, fix regex issue

* update file names for recent merge

---------

Co-authored-by: Mattermost Build <build@mattermost.com>
(cherry picked from commit 71c25fb316cfcda9b9af09df9318e153d5e7e66a)

```release-note
NONE
```
