### PR TITLE
Skips flaky test on the remote cluster API

### DIFF
--- a/server/channels/api4/remote_cluster_test.go
+++ b/server/channels/api4/remote_cluster_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestGetRemoteClusters(t *testing.T) {
+	t.Skip("Flaky test")
+
 	t.Run("Should not work if the remote cluster service is not enabled", func(t *testing.T) {
 		th := Setup(t)
 		defer th.TearDown()

--- a/server/channels/api4/remote_cluster_test.go
+++ b/server/channels/api4/remote_cluster_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestGetRemoteClusters(t *testing.T) {
-	t.Skip("Flaky test")
+	t.Skip("MM-59324")
 
 	t.Run("Should not work if the remote cluster service is not enabled", func(t *testing.T) {
 		th := Setup(t)


### PR DESCRIPTION
#### Summary
Skips flaky test on the remote cluster API

#### Release Note
```release-note
NONE
```
