### PR TITLE
Orders results of the GetAll remote clusters store method

### DIFF
--- a/server/channels/api4/remote_cluster_test.go
+++ b/server/channels/api4/remote_cluster_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestGetRemoteClusters(t *testing.T) {
-	t.Skip("MM-59324")
-
 	t.Run("Should not work if the remote cluster service is not enabled", func(t *testing.T) {
 		th := Setup(t)
 		defer th.TearDown()

--- a/server/channels/store/sqlstore/remote_cluster_store.go
+++ b/server/channels/store/sqlstore/remote_cluster_store.go
@@ -172,7 +172,8 @@ func (s sqlRemoteClusterStore) GetAll(offset, limit int, filter model.RemoteClus
 
 	query := s.getQueryBuilder().
 		Select(remoteClusterFields("rc")...).
-		From("RemoteClusters rc")
+		From("RemoteClusters rc").
+		OrderBy("rc.DisplayName, rc.Name")
 
 	if filter.InChannel != "" {
 		query = query.Where("rc.RemoteId IN (SELECT scr.RemoteId FROM SharedChannelRemotes scr WHERE scr.ChannelId = ?)", filter.InChannel)


### PR DESCRIPTION
#### Release Note
```release-note
NONE
```
