### PR TITLE
Ignore performance counts if notifications are blocked by the device

### DIFF
--- a/server/channels/api4/system.go
+++ b/server/channels/api4/system.go
@@ -673,7 +673,16 @@ func pushNotificationAck(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if ack.NotificationType == model.PushTypeMessage {
-		c.App.CountNotificationAck(model.NotificationTypePush, ack.ClientPlatform)
+		session := c.AppContext.Session()
+		ignoreNotificationACK := session.Props[model.SessionPropIgnoreNotificationACK] == "true"
+		if ignoreNotificationACK && ack.ClientPlatform == "ios" {
+			// iOS doesn't send ack when the notificications are disabled
+			// so we restore the value the moment we receive an ack
+			c.App.SetIgnoreNotificationACK(session, false)
+		}
+		if !ignoreNotificationACK {
+			c.App.CountNotificationAck(model.NotificationTypePush, ack.ClientPlatform)
+		}
 	}
 
 	err := c.App.SendAckToPushProxy(&ack)

--- a/server/channels/app/app_iface.go
+++ b/server/channels/app/app_iface.go
@@ -1115,6 +1115,7 @@ type AppIface interface {
 	SetCustomStatus(c request.CTX, userID string, cs *model.CustomStatus) *model.AppError
 	SetDefaultProfileImage(c request.CTX, user *model.User) *model.AppError
 	SetFileSearchableContent(rctx request.CTX, fileID string, data string) *model.AppError
+	SetIgnoreNotificationACK(session *model.Session, value bool) *model.AppError
 	SetPhase2PermissionsMigrationStatus(isComplete bool) error
 	SetPluginKey(pluginID string, key string, value []byte) *model.AppError
 	SetPluginKeyWithExpiry(pluginID string, key string, value []byte, expireInSeconds int64) *model.AppError

--- a/server/channels/app/notification_push.go
+++ b/server/channels/app/notification_push.go
@@ -212,7 +212,10 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 		}
 
 		if msg.Type == model.PushTypeMessage {
-			a.CountNotification(model.NotificationTypePush, tmpMessage.Platform)
+			// If we are ignoring the ack, we don't count the send
+			if session.Props[model.SessionPropIgnoreNotificationACK] != "true" {
+				a.CountNotification(model.NotificationTypePush, tmpMessage.Platform)
+			}
 		}
 	}
 

--- a/server/channels/app/opentracing/opentracing_layer.go
+++ b/server/channels/app/opentracing/opentracing_layer.go
@@ -16663,6 +16663,28 @@ func (a *OpenTracingAppLayer) SetFileSearchableContent(rctx request.CTX, fileID 
 	return resultVar0
 }
 
+func (a *OpenTracingAppLayer) SetIgnoreNotificationACK(session *model.Session, value bool) *model.AppError {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.SetIgnoreNotificationACK")
+
+	a.ctx = newCtx
+	a.app.Srv().Store().SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store().SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0 := a.app.SetIgnoreNotificationACK(session, value)
+
+	if resultVar0 != nil {
+		span.LogFields(spanlog.Error(resultVar0))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0
+}
+
 func (a *OpenTracingAppLayer) SetPhase2PermissionsMigrationStatus(isComplete bool) error {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.SetPhase2PermissionsMigrationStatus")

--- a/server/channels/app/session.go
+++ b/server/channels/app/session.go
@@ -291,6 +291,20 @@ func (a *App) AttachDeviceId(sessionID string, deviceID string, expiresAt int64)
 	return nil
 }
 
+func (a *App) SetIgnoreNotificationACK(session *model.Session, value bool) *model.AppError {
+	stringValue := "false"
+	if value {
+		stringValue = "true"
+	}
+	session.AddProp(model.SessionPropIgnoreNotificationACK, stringValue)
+	err := a.Srv().Store().Session().UpdateProps(session)
+	if err != nil {
+		return model.NewAppError("SetIgnoreNotificationACK", "app.session.ignore_ack.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+
+	return nil
+}
+
 // ExtendSessionExpiryIfNeeded extends Session.ExpiresAt based on session lengths in config.
 // A new ExpiresAt is only written if enough time has elapsed since last update.
 // Returns true only if the session was extended.

--- a/server/public/model/session.go
+++ b/server/public/model/session.go
@@ -26,6 +26,7 @@ const (
 	SessionPropIsBotValue             = "true"
 	SessionPropOAuthAppID             = "oauth_app_id"
 	SessionPropMattermostAppID        = "mattermost_app_id"
+	SessionPropIgnoreNotificationACK  = "ignore_notification_ack"
 	SessionTypeUserAccessToken        = "UserAccessToken"
 	SessionTypeCloudKey               = "CloudKey"
 	SessionTypeRemoteclusterToken     = "RemoteClusterToken"


### PR DESCRIPTION
#### Summary
When a mobile device sets the notification blocked, there are two different behaviors that we have seen happening.
- Android: The notification seems to reach the app, and gets acked, but is never shown
- iOS: The notification seems to reach ok the APNs, but never acked

Specially to count for the gap that phones that don't allow notification may create in our metrics, specially on iOS, we added these changes.

We mainly stop tracking the notification count if the session is marked as "ignore acks". The session is marked as "ignore acks" if the phone says so.

The phone will check on every startup, similar to when the phone sets the device id.

For iOS, since we know acks only arrive if the phone is receiving notifications, we can reset the value the moment we receive an ACK. This is not possible on Android.

This is the first draft. We could consider some changes, like piggybacking on other API, to avoid conditional code in the mobile app and adding yet another API, but wanted to verify with you before going that path.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-59096

#### Related PRs
Mobile: TBD

#### Release Note
```release-note
Improve metrics around notifications
```
