### PR TITLE
[MM-59350] Include LDAP vendor errors in Support Packet

### DIFF
--- a/server/channels/app/support_packet.go
+++ b/server/channels/app/support_packet.go
@@ -123,8 +123,16 @@ func (a *App) generateSupportPacketYaml(c request.CTX) (*model.FileData, error) 
 	/* LDAP */
 
 	var vendorName, vendorVersion string
-	if ldapInterface := a.Ldap(); ldapInterface != nil {
-		vendorName, vendorVersion = ldapInterface.GetVendorNameAndVendorVersion(c)
+	ldap := a.Ldap()
+	if ldap != nil {
+		vendorName, vendorVersion, err = ldap.GetVendorNameAndVendorVersion(c)
+		if err != nil {
+			rErr = multierror.Append(errors.Wrap(err, "error while getting LDAP vendor info"))
+		}
+		if vendorName == "" && vendorVersion == "" {
+			vendorName = "unknown"
+			vendorVersion = "unknown"
+		}
 	}
 
 	/* Elastic Search */

--- a/server/channels/app/support_packet.go
+++ b/server/channels/app/support_packet.go
@@ -129,8 +129,11 @@ func (a *App) generateSupportPacketYaml(c request.CTX) (*model.FileData, error) 
 		if err != nil {
 			rErr = multierror.Append(errors.Wrap(err, "error while getting LDAP vendor info"))
 		}
-		if vendorName == "" && vendorVersion == "" {
+
+		if vendorName == "" {
 			vendorName = "unknown"
+		}
+		if vendorVersion == "" {
 			vendorVersion = "unknown"
 		}
 	}

--- a/server/einterfaces/ldap.go
+++ b/server/einterfaces/ldap.go
@@ -26,5 +26,5 @@ type LdapInterface interface {
 	UpdateProfilePictureIfNecessary(request.CTX, model.User, model.Session)
 	GetADLdapIdFromSAMLId(c request.CTX, authData string) string
 	GetSAMLIdFromADLdapId(c request.CTX, authData string) string
-	GetVendorNameAndVendorVersion(rctx request.CTX) (string, string)
+	GetVendorNameAndVendorVersion(rctx request.CTX) (string, string, error)
 }

--- a/server/einterfaces/mocks/LdapInterface.go
+++ b/server/einterfaces/mocks/LdapInterface.go
@@ -329,7 +329,7 @@ func (_m *LdapInterface) GetUserAttributes(rctx request.CTX, id string, attribut
 }
 
 // GetVendorNameAndVendorVersion provides a mock function with given fields: rctx
-func (_m *LdapInterface) GetVendorNameAndVendorVersion(rctx request.CTX) (string, string) {
+func (_m *LdapInterface) GetVendorNameAndVendorVersion(rctx request.CTX) (string, string, error) {
 	ret := _m.Called(rctx)
 
 	if len(ret) == 0 {
@@ -338,7 +338,8 @@ func (_m *LdapInterface) GetVendorNameAndVendorVersion(rctx request.CTX) (string
 
 	var r0 string
 	var r1 string
-	if rf, ok := ret.Get(0).(func(request.CTX) (string, string)); ok {
+	var r2 error
+	if rf, ok := ret.Get(0).(func(request.CTX) (string, string, error)); ok {
 		return rf(rctx)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX) string); ok {
@@ -353,7 +354,13 @@ func (_m *LdapInterface) GetVendorNameAndVendorVersion(rctx request.CTX) (string
 		r1 = ret.Get(1).(string)
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(request.CTX) error); ok {
+		r2 = rf(rctx)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // MigrateIDAttribute provides a mock function with given fields: c, toAttribute


### PR DESCRIPTION
#### Summary
If fetching the LDAP vendor name fails, the Support Packet generation now correctly includes the error in `warning.txt`. If no vendor name is found, the Support Packet lists them as `unknown`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59350

#### Release Note
```release-note
Include LDAP vendor errors in Support Packet
```
