### PR TITLE
MM-59345 add hover states expandable containers in workspace optimization page

### DIFF
--- a/webapp/channels/src/components/admin_console/workspace-optimization/dashboard.scss
+++ b/webapp/channels/src/components/admin_console/workspace-optimization/dashboard.scss
@@ -24,7 +24,6 @@
 }
 
 .WorkspaceOptimizationDashboard {
-    background-color: #fff;
 
     button[class*=' StyledChip'],
     button[class^='StyledChip'] {
@@ -146,7 +145,8 @@
             &__title {
                 margin-bottom: 8px;
                 color: var(--sys-denim-center-channel-text);
-                font-size: 22px;
+                font-family: Metropolis, sans-serif;
+                font-size: 20px;
                 font-weight: 700;
                 line-height: 28px;
             }
@@ -179,10 +179,19 @@
         margin-left: 4px;
 
         li.accordion-card {
+            overflow: hidden;
             box-sizing: border-box;
-            border: 1px solid rgba(63, 67, 80, 0.08) !important;
+            border: var(--border-light);
+            border-radius: var(--radius-s);
             margin-top: 16px;
             background-color: var(--sys-center-channel-bg);
+
+            &:has(.accordion-card-header[role="button"]){
+                &:hover {
+                    border: var(--border-dark);
+                    box-shadow: var(--elevation-2);
+                }
+            }
 
             .accordion-card-header {
                 max-height: 92px;


### PR DESCRIPTION
#### Summary
Adds hover states for expandable cards in the Workspace Optimization page for better affordance when they are interactive. Also tweaked a few styles:
- Updated font for 'Overall Score' to better match styles for headings.
- Removed white background to be more consistent with other views in the console.
- Add hover state to expandable cards.

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/MM-59345

#### Screenshots
|  before  |  after  |
|----|----|
| ![2024-07-05 16 35 29](https://github.com/mattermost/mattermost/assets/2040554/7cee15ac-1882-44e5-9c78-e2ffdd98c669) | ![2024-07-05 16 34 56](https://github.com/mattermost/mattermost/assets/2040554/430bd1f3-1285-4cc0-9f6d-326105b136e5) |

#### Release Note
```release-note
NONE
```
