### PR TITLE
MM-59099 Show invalid emoji text with its original case (9.5)

### DIFF
--- a/webapp/channels/src/components/post_emoji/post_emoji.test.tsx
+++ b/webapp/channels/src/components/post_emoji/post_emoji.test.tsx
@@ -9,6 +9,7 @@ import PostEmoji from './post_emoji';
 
 describe('PostEmoji', () => {
     const baseProps = {
+        children: ':emoji:',
         imageUrl: '/api/v4/emoji/1234/image',
         name: 'emoji',
     };
@@ -26,7 +27,7 @@ describe('PostEmoji', () => {
         expect(screen.getByTitle(':' + baseProps.name + ':')).toHaveTextContent(`:${baseProps.name}:`);
     });
 
-    test('should render original text when imageUrl is empty', () => {
+    test('should render children as fallback when imageUrl is empty', () => {
         const props = {
             ...baseProps,
             imageUrl: '',

--- a/webapp/channels/src/components/post_emoji/post_emoji.tsx
+++ b/webapp/channels/src/components/post_emoji/post_emoji.tsx
@@ -3,7 +3,8 @@
 
 import React from 'react';
 
-interface Props {
+export interface Props {
+    children: React.ReactNode;
     name: string;
     imageUrl: string;
 }
@@ -13,12 +14,12 @@ declare module 'react' {
     }
 }
 
-const PostEmoji = ({name, imageUrl}: Props) => {
+const PostEmoji = ({children, name, imageUrl}: Props) => {
     const emojiText = `:${name}:`;
     const backgroundImageUrl = `url(${imageUrl})`;
 
     if (!imageUrl) {
-        return <>{emojiText}</>;
+        return <>{children}</>;
     }
 
     return (
@@ -28,7 +29,7 @@ const PostEmoji = ({name, imageUrl}: Props) => {
             title={emojiText}
             style={{backgroundImage: backgroundImageUrl}}
         >
-            {emojiText}
+            {children}
         </span>
     );
 };

--- a/webapp/channels/src/utils/emoticons.tsx
+++ b/webapp/channels/src/utils/emoticons.tsx
@@ -90,5 +90,5 @@ export function handleEmoticons(
 }
 
 export function renderEmoji(name: string, matchText: string): string {
-    return `<span data-emoticon="${name.toLowerCase()}">${matchText.toLowerCase()}</span>`;
+    return `<span data-emoticon="${name.toLowerCase()}">${matchText}</span>`;
 }

--- a/webapp/channels/src/utils/message_html_to_component.test.tsx
+++ b/webapp/channels/src/utils/message_html_to_component.test.tsx
@@ -6,6 +6,7 @@ import {shallow} from 'enzyme';
 import AtMention from 'components/at_mention';
 import MarkdownImage from 'components/markdown_image';
 
+import {renderWithContext, screen} from 'tests/react_testing_utils';
 import Constants from 'utils/constants';
 import EmojiMap from 'utils/emoji_map';
 import messageHtmlToComponent from 'utils/message_html_to_component';
@@ -145,5 +146,44 @@ const myFunction = () => {
         const html = TextFormatting.formatText(input, {}, emptyEmojiMap);
 
         expect(messageHtmlToComponent(html)).toMatchSnapshot();
+    });
+
+    describe('emojis', () => {
+        test('should render valid named emojis as spans with background images', () => {
+            const input = 'These are emojis: :taco: :astronaut:';
+
+            const {container} = renderWithContext(messageHtmlToComponent(TextFormatting.formatText(input, {}, emptyEmojiMap)));
+
+            expect(screen.getByTitle(':taco:')).toBeInTheDocument();
+            expect(screen.getByTitle(':taco:').getAttribute('style')).toContain('background-image');
+            expect(screen.getByTitle(':astronaut:')).toBeInTheDocument();
+            expect(screen.getByTitle(':astronaut:').getAttribute('style')).toContain('background-image');
+
+            expect(container).toHaveTextContent('These are emojis: :taco: :astronaut:');
+        });
+
+        test('should render invalid named emojis as spans with background images', () => {
+            const input = 'These are emojis: :fake: :notAnEmoji:';
+
+            const {container} = renderWithContext(messageHtmlToComponent(TextFormatting.formatText(input, {}, emptyEmojiMap)));
+
+            expect(screen.queryByTitle(':taco:')).not.toBeInTheDocument();
+            expect(screen.queryByTitle(':astronaut:')).not.toBeInTheDocument();
+
+            expect(container).toHaveTextContent('These are emojis: :fake: :notAnEmoji:');
+        });
+
+        test('should render supported unicode emojis as spans with background images', () => {
+            const input = 'These are emojis: 🌮 🧑‍🚀';
+
+            const {container} = renderWithContext(messageHtmlToComponent(TextFormatting.formatText(input, {}, emptyEmojiMap)));
+
+            expect(screen.getByTitle(':taco:')).toBeInTheDocument();
+            expect(screen.getByTitle(':taco:').getAttribute('style')).toContain('background-image');
+            expect(screen.getByTitle(':astronaut:')).toBeInTheDocument();
+            expect(screen.getByTitle(':astronaut:').getAttribute('style')).toContain('background-image');
+
+            expect(container).toHaveTextContent('These are emojis: 🌮 🧑‍🚀');
+        });
     });
 });

--- a/webapp/channels/src/utils/message_html_to_component.tsx
+++ b/webapp/channels/src/utils/message_html_to_component.tsx
@@ -182,10 +182,10 @@ export function messageHtmlToComponent(html: string, options: Options = {}) {
         processingInstructions.push({
             replaceChildren: true,
             shouldProcessNode: (node: any) => node.attribs && node.attribs[emojiAttrib],
-            processNode: (node: any) => {
+            processNode: (node: any, children: any) => {
                 const emojiName = node.attribs[emojiAttrib];
 
-                return <PostEmoji name={emojiName}/>;
+                return <PostEmoji name={emojiName}>{children}</PostEmoji>;
             },
         });
     }


### PR DESCRIPTION
#### Summary
The emoji code passes a lower cased version of the emoji's name into `PostEmoji` for lookup, so I changed it to also pass the original text into `PostEmoji` as a fallback for when the emoji can't be found.

master version: https://github.com/mattermost/mattermost/pull/27603

#### Ticket Link
MM-59099

#### Release Note
```release-note
Ensured text that looks like an emoji but isn't renders in its original case
```
