### PR TITLE
MM-58245  Don't allow patching real email or username for remote users

### DIFF
--- a/server/platform/services/sharedchannel/sync_recv.go
+++ b/server/platform/services/sharedchannel/sync_recv.go
@@ -209,12 +209,14 @@ func (scs *Service) upsertSyncUser(c request.CTX, user *model.User, channel *mod
 			)
 			return nil, fmt.Errorf("error updating user: %w", ErrRemoteIDMismatch)
 		}
+		// save the updated username and email in props
+		user.SetProp(model.UserPropsKeyRemoteUsername, user.Username)
+		user.SetProp(model.UserPropsKeyRemoteEmail, user.Email)
+
 		patch := &model.UserPatch{
-			Username:  &user.Username,
 			Nickname:  &user.Nickname,
 			FirstName: &user.FirstName,
 			LastName:  &user.LastName,
-			Email:     &user.Email,
 			Props:     user.Props,
 			Position:  &user.Position,
 			Locale:    &user.Locale,

--- a/server/platform/services/sharedchannel/sync_recv.go
+++ b/server/platform/services/sharedchannel/sync_recv.go
@@ -212,6 +212,7 @@ func (scs *Service) upsertSyncUser(c request.CTX, user *model.User, channel *mod
 		// save the updated username and email in props
 		user.SetProp(model.UserPropsKeyRemoteUsername, user.Username)
 		user.SetProp(model.UserPropsKeyRemoteEmail, user.Email)
+		// TODO:  MM-59398:  allow patching username with munged, unique name
 
 		patch := &model.UserPatch{
 			Nickname:  &user.Nickname,


### PR DESCRIPTION
#### Summary
This PR prevents a username or email to be update sync'ed from a remote.  The real (updated) username and email are stored in props for display purposes.

**Release note is covered by a previous PR.**

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58245

#### Release Note
```release-note
NONE
```
