### PR TITLE
MM-59404 Stop automatically dismissing desktop notifications

### DIFF
--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -2043,7 +2043,6 @@ export const Constants = {
     MENTION_RECENT_CHANNELS: 'mention.recent.channels',
     MENTION_SPECIAL: 'mention.special',
     MENTION_GROUPS: 'search.group',
-    DEFAULT_NOTIFICATION_DURATION: 5000,
     STATUS_INTERVAL: 60000,
     AUTOCOMPLETE_TIMEOUT: 100,
     AUTOCOMPLETE_SPLIT_CHARACTERS: ['.', '-', '_'],

--- a/webapp/channels/src/utils/notifications.ts
+++ b/webapp/channels/src/utils/notifications.ts
@@ -5,7 +5,6 @@ import type {ThunkActionFunc} from 'mattermost-redux/types/actions';
 
 import icon50 from 'images/icon50x50.png';
 import iconWS from 'images/icon_WS.png';
-import Constants from 'utils/constants';
 import * as UserAgent from 'utils/user_agent';
 
 export type NotificationResult = {
@@ -20,8 +19,7 @@ let requestedNotificationPermission = false;
 //
 // If successful in showing a notification, it resolves with a callback to manually close the
 // notification. If no error occurred but the user did not grant permission to show notifications, it
-// resolves with a no-op callback. Notifications that do not require interaction will be closed automatically after
-// the Constants.DEFAULT_NOTIFICATION_DURATION. Not all platforms support all features, and may
+// resolves with a no-op callback. Not all platforms support all features, and may
 // choose different semantics for the notifications.
 
 export interface ShowNotificationParams {
@@ -95,13 +93,6 @@ export function showNotification(
         notification.onerror = () => {
             throw new Error('Notification failed to show.');
         };
-
-        // Mac desktop app notification dismissal is handled by the OS
-        if (!requireInteraction && !UserAgent.isMacApp()) {
-            setTimeout(() => {
-                notification.close();
-            }, Constants.DEFAULT_NOTIFICATION_DURATION);
-        }
 
         return {
             status: 'success',


### PR DESCRIPTION
#### Summary
This is a leftover part of an old setting for automatically dismissing desktop notifications from back before OSes properly supported notifications themselves. Manually closing the notification prevents it from being shown in the Notification Center on Windows or Mac

#### Ticket Link
MM-59404

#### Release Note
```release-note
Fixed web app notifications not being shown in the Notification Center on Windows or Mac
```
