### PR TITLE
Update Copilot plugin prepackaged version to 0.8.3

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -152,7 +152,7 @@ PLUGIN_PACKAGES += mattermost-plugin-playbooks-v1.39.3
 PLUGIN_PACKAGES += mattermost-plugin-nps-v1.3.3
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.3.4
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.8.0
-PLUGIN_PACKAGES += mattermost-plugin-ai-v0.8.1
+PLUGIN_PACKAGES += mattermost-plugin-ai-v0.8.3
 PLUGIN_PACKAGES += focalboard-v8.0.0
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)


### PR DESCRIPTION
#### Summary
Updating copilot plugin to 0.8.3

#### Release Note
```release-note
Updating copilot plugin prepackaged version [v0.8.3](https://github.com/mattermost/mattermost-plugin-ai/releases/tag/v0.8.3).
```

Mattermost Copilot [v0.8.3](https://github.com/mattermost/mattermost-plugin-ai/releases/tag/v0.8.1).