### PR TITLE
Updated minimum supported Edge and Chrome versions

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10004,11 +10004,11 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "Version 122+"
+    "translation": "Version 126+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "Version 122+"
+    "translation": "Version 126+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",


### PR DESCRIPTION
Desktop app v5.9 will include Electron 31.2 which supports Chrome 126+.

```release-note
Updated minimum Edge and Chrome versions to 126+.
```