### PR TITLE
MM-58772 Fix counter metrics not using Date.now

### DIFF
--- a/webapp/channels/src/utils/performance_telemetry/reporter.test.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.test.ts
@@ -94,7 +94,7 @@ describe('PerformanceReporter', () => {
 
         expect(reporter.handleObservations).toHaveBeenCalled();
 
-        const timestamp = performance.timeOrigin + performance.now();
+        const timestamp = Date.now();
 
         await waitForReport();
 
@@ -113,8 +113,8 @@ describe('PerformanceReporter', () => {
                 },
             ],
         });
-        expect(report.start).toBeGreaterThan(timestamp);
-        expect(report.end).toBeGreaterThan(timestamp);
+        expect(report.start).toBeGreaterThanOrEqual(timestamp);
+        expect(report.end).toBeGreaterThanOrEqual(timestamp);
         expect(report.start).toEqual(report.end);
 
         reporter.disconnect();

--- a/webapp/channels/src/utils/performance_telemetry/reporter.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.ts
@@ -268,7 +268,7 @@ export default class PerformanceReporter {
     }
 
     private generateReport(histogramMeasures: PerformanceReportMeasure[], counters: Map<string, number>): PerformanceReport {
-        const now = performance.timeOrigin + performance.now();
+        const now = Date.now();
 
         const counterMeasures = this.countersToMeasures(now, counters);
 
@@ -289,7 +289,7 @@ export default class PerformanceReporter {
 
     private getReportStartEnd(now: number, histogramMeasures: PerformanceReportMeasure[], counterMeasures: PerformanceReportMeasure[]): {start: number; end: number} {
         let start = now;
-        let end = performance.timeOrigin;
+        let end = 0;
 
         for (const measure of histogramMeasures) {
             start = Math.min(start, measure.timestamp);


### PR DESCRIPTION
#### Summary
In #27396, I made it so that histogram metrics always used `Date.now()` to fix the fact that `performance.now()` stops counting while the device is asleep. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58772

#### Release Note
```release-note
Fixed more web app performance reports being marked as outdated after the user's computer wakes up from sleep
```
