### PR TITLE
[MM-59825] Fix linter error found by updated govet

### DIFF
--- a/server/channels/app/channel_bookmark_test.go
+++ b/server/channels/app/channel_bookmark_test.go
@@ -486,13 +486,13 @@ func TestUpdateChannelBookmarkSortOrder(t *testing.T) {
 
 	t.Run("change order of bookmarks error when new index is out of bounds", func(t *testing.T) {
 		_, appErr = th.App.UpdateChannelBookmarkSortOrder(bookmark3.Id, channelId, int64(-1), "")
-		assert.Error(t, appErr)
+		assert.NotNil(t, appErr)
 		_, appErr = th.App.UpdateChannelBookmarkSortOrder(bookmark3.Id, channelId, int64(5), "")
-		assert.Error(t, appErr)
+		assert.NotNil(t, appErr)
 	})
 
 	t.Run("change order of bookmarks error when bookmark not found", func(t *testing.T) {
 		_, appErr = th.App.UpdateChannelBookmarkSortOrder(model.NewId(), channelId, int64(0), "")
-		assert.Error(t, appErr)
+		assert.NotNil(t, appErr)
 	})
 }

--- a/server/channels/app/integration_action_test.go
+++ b/server/channels/app/integration_action_test.go
@@ -167,7 +167,7 @@ func TestPostActionEmptyResponse(t *testing.T) {
 		})
 
 		_, err = th.App.DoPostActionWithCookie(th.Context, post.Id, attachments[0].Actions[0].Id, th.BasicUser.Id, "", nil)
-		require.Error(t, err)
+		require.NotNil(t, err)
 		assert.Contains(t, err.DetailedError, "context deadline exceeded")
 	})
 }

--- a/server/channels/app/user_test.go
+++ b/server/channels/app/user_test.go
@@ -1242,7 +1242,7 @@ func TestPasswordChangeSessionTermination(t *testing.T) {
 		require.False(t, session.IsExpired())
 
 		session2, err = th.App.GetSession(session2.Token)
-		require.Error(t, err)
+		require.NotNil(t, err)
 		require.Nil(t, session2)
 
 		// Cleanup
@@ -1311,11 +1311,11 @@ func TestPasswordChangeSessionTermination(t *testing.T) {
 		require.Nil(t, err)
 
 		session, err = th.App.GetSession(session.Token)
-		require.Error(t, err)
+		require.NotNil(t, err)
 		require.Nil(t, session)
 
 		session2, err = th.App.GetSession(session2.Token)
-		require.Error(t, err)
+		require.NotNil(t, err)
 		require.Nil(t, session2)
 
 		// Cleanup
@@ -2136,7 +2136,7 @@ func TestGetUsersForReporting(t *testing.T) {
 				EndAt:      500,
 			},
 		})
-		require.Error(t, err)
+		require.NotNil(t, err)
 		require.Nil(t, userReports)
 	})
 
@@ -2150,7 +2150,7 @@ func TestGetUsersForReporting(t *testing.T) {
 				PageSize:   50,
 			},
 		})
-		require.Error(t, err)
+		require.NotNil(t, err)
 		require.Nil(t, userReports)
 	})
 


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost-govet/pull/40 fixes a bug in `govet` that blocked most linter from running. Since that bug exists, some linter errors have crept into the code base. This PR fixes them.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59825

#### Release Note
```release-note
NONE
```
