### PR TITLE
[MM-58045] Enable errcheck linter for enterprise/cloud package

### DIFF
--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -59,4 +59,4 @@ issues:
 
     - linters:
         - errcheck
-      path: "channels|platform|cmd/mattermost|public/model|public/plugin|public/shared/mlog|enterprise/cloud|enterprise/ldap"
+      path: "channels|platform|cmd/mattermost|public/model|public/plugin|public/shared/mlog|enterprise/ldap"


### PR DESCRIPTION
#### Summary
See https://github.com/mattermost/enterprise/pull/1707

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58045

#### Release Note
```release-note
NONE
```
