### PR TITLE
Fix drafts not being synced with the server

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -184,7 +184,7 @@ const AdvanceTextEditor = ({
             }
 
             if (options.show) {
-                dispatch(updateDraft(key, {...draftToChange, show: true}, draftToChange.rootId));
+                dispatch(updateDraft(key, {...draftToChange, show: true}, draftToChange.rootId, true));
                 return;
             }
 


### PR DESCRIPTION
#### Summary
On https://github.com/mattermost/mattermost/pull/26419 we introduced a bug where the drafts were not being saved in the server.

That is because we never passed the save argument, which now we are doing whenever we leave the channel or close the app.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59563

#### Release Note
```release-note
NONE
```
Bug never released to production