### PR TITLE
Fix flaky TestCreateZipFileAndAddFiles/write_one_file

### DIFF
--- a/server/channels/app/file_test.go
+++ b/server/channels/app/file_test.go
@@ -321,13 +321,14 @@ func TestCreateZipFileAndAddFiles(t *testing.T) {
 	t.Run("write one file", func(t *testing.T) {
 		mockBackend := filesStoreMocks.FileBackend{}
 		mockBackend.On("WriteFile", mock.Anything, path.Join(directory, zipName)).Return(int64(666), nil).Run(func(args mock.Arguments) {
+			now := time.Now()
 			r, err := zip.OpenReader(zipName)
 			require.NoError(t, err)
 			require.Len(t, r.File, 1)
 
 			file := r.File[0]
 			assert.Equal(t, "file1", file.Name)
-			assert.GreaterOrEqual(t, file.Modified, time.Now().Add(-1*time.Second))
+			assert.GreaterOrEqual(t, file.Modified, now.Truncate(time.Second)) // Files are stored with a second precision
 
 			fr, err := file.Open()
 			require.NoError(t, err)


### PR DESCRIPTION
#### Summary
Unix systems store files with a second precision timestamp. That is one part of the flaky test. The other issue was that the test checked if the file had been generated in the last second, which might not be enough time for CI.

#### Ticket Link
https://community.mattermost.com/core/pl/m8gifco657g6mxmr64y6wte8kh

#### Release Note
```release-note
NONE
```
