### PR TITLE
MM-59095: Properly implement IsIndexingSync

### DIFF
--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -202,7 +202,7 @@ const (
 	ElasticsearchSettingsDefaultAggregatePostsAfterDays     = 365
 	ElasticsearchSettingsDefaultPostsAggregatorJobStartTime = "03:00"
 	ElasticsearchSettingsDefaultIndexPrefix                 = ""
-	ElasticsearchSettingsDefaultLiveIndexingBatchSize       = 1
+	ElasticsearchSettingsDefaultLiveIndexingBatchSize       = 10
 	ElasticsearchSettingsDefaultRequestTimeoutSeconds       = 30
 	ElasticsearchSettingsDefaultBatchSize                   = 10000
 	ElasticsearchSettingsESBackend                          = "elasticsearch"


### PR DESCRIPTION
Here we change the default liveIndexing size.

https://mattermost.atlassian.net/browse/MM-59095
```release-note
Fix a bug where indexing would always be done async
even after setting LiveIndexingBatchSize to 1. Now
we respect the config and index synchronously if the
value is set to 1.
```
