### PR TITLE
[MM-51514] Allow plugins to open user settings modal

### DIFF
--- a/webapp/channels/src/components/user_settings/modal/user_settings_modal.test.tsx
+++ b/webapp/channels/src/components/user_settings/modal/user_settings_modal.test.tsx
@@ -173,12 +173,12 @@ describe('plugin tabs use the correct icon', () => {
         const element = screen.queryByTitle(uiName);
         expect(element).toBeInTheDocument();
         expect(element!.nodeName).toBe('I');
-        expect(element?.className).toBe('icon-power-plug-outline');
+        expect(element?.className).toBe('icon icon-power-plug-outline');
     });
 
-    it('use image when icon provided', () => {
+    it('use image when icon URL provided', () => {
         const uiName = 'plugin_a';
-        const icon = 'icon_url';
+        const icon = 'http://localhost:8065/plugins/com.mattermost.plugin_a/public/icon.svg';
         const state: DeepPartial<GlobalState> = {
             plugins: {
                 userSettings: {
@@ -197,5 +197,52 @@ describe('plugin tabs use the correct icon', () => {
         expect(element).toBeInTheDocument();
         expect(element!.nodeName).toBe('IMG');
         expect(element!.getAttribute('src')).toBe(icon);
+    });
+
+    it('use image when icon path provided', () => {
+        const uiName = 'plugin_a';
+        const icon = '/plugins/com.mattermost.plugin_a/public/icon.svg';
+        const state: DeepPartial<GlobalState> = {
+            plugins: {
+                userSettings: {
+                    plugin_a: {
+                        id: 'plugin_a',
+                        sections: [],
+                        uiName,
+                        icon,
+                    },
+                },
+            },
+        };
+        renderWithContext(<UserSettingsModal {...baseProps}/>, mergeObjects(baseState, state));
+
+        const element = screen.queryByAltText(uiName);
+        expect(element).toBeInTheDocument();
+        expect(element!.nodeName).toBe('IMG');
+        expect(element!.getAttribute('src')).toBe(icon);
+    });
+
+    it('use class name when icon name provided', () => {
+        const uiName = 'plugin_a';
+        const icon = 'icon-phone-in-talk';
+        const state: DeepPartial<GlobalState> = {
+            plugins: {
+                userSettings: {
+                    plugin_a: {
+                        id: 'plugin_a',
+                        sections: [],
+                        uiName,
+                        icon,
+                    },
+                },
+            },
+        };
+
+        renderWithContext(<UserSettingsModal {...baseProps}/>, mergeObjects(baseState, state));
+
+        const element = screen.queryByTitle(uiName);
+        expect(element).toBeInTheDocument();
+        expect(element!.nodeName).toBe('I');
+        expect(element?.className).toBe('icon icon-phone-in-talk');
     });
 });

--- a/webapp/channels/src/components/user_settings/modal/user_settings_modal.test.tsx
+++ b/webapp/channels/src/components/user_settings/modal/user_settings_modal.test.tsx
@@ -99,6 +99,58 @@ describe('tabs are properly rendered', () => {
         expect(screen.queryByText(uiName1)).toBeInTheDocument();
         expect(screen.queryByText(uiName2)).toBeInTheDocument();
     });
+
+    it('plugin settings tabs can be selected', async () => {
+        const uiName1 = 'plugin A';
+        const uiName2 = 'plugin B';
+        const state: DeepPartial<GlobalState> = {
+            plugins: {
+                userSettings: {
+                    plugin_a: {
+                        id: 'plugin_a',
+                        sections: [
+                            {
+                                title: 'plugin A section',
+                                settings: [
+                                    {
+                                        name: 'plugin A setting',
+                                    },
+                                ],
+                            },
+                        ],
+                        uiName: uiName1,
+                    },
+                    plugin_b: {
+                        id: 'plugin_b',
+                        sections: [
+                            {
+                                title: 'plugin B section',
+                                settings: [
+                                    {
+                                        name: 'plugin B setting',
+                                    },
+                                ],
+                            },
+                        ],
+                        uiName: uiName2,
+                    },
+                },
+            },
+        };
+
+        renderWithContext(
+            <UserSettingsModal
+                {...baseProps}
+                activeTab='plugin_b'
+            />,
+            mergeObjects(baseState, state),
+        );
+
+        expect(screen.queryByText(uiName1)).toBeInTheDocument();
+        expect(screen.queryByText(uiName2)).toBeInTheDocument();
+        expect(screen.queryAllByText('plugin B Settings')).toHaveLength(2);
+        expect(screen.queryByText('plugin A Settings')).not.toBeInTheDocument();
+    });
 });
 
 describe('plugin tabs use the correct icon', () => {

--- a/webapp/channels/src/components/user_settings/modal/user_settings_modal.tsx
+++ b/webapp/channels/src/components/user_settings/modal/user_settings_modal.tsx
@@ -30,6 +30,7 @@ export type OwnProps = {
     adminMode?: boolean;
     isContentProductSettings: boolean;
     userPreferences?: PreferencesType;
+    activeTab?: string;
 }
 
 export type Props = OwnProps & {
@@ -64,7 +65,7 @@ class UserSettingsModal extends React.PureComponent<Props, State> {
         super(props);
 
         this.state = {
-            active_tab: props.isContentProductSettings ? 'notifications' : 'profile',
+            active_tab: props.activeTab ?? (props.isContentProductSettings ? 'notifications' : 'profile'),
             active_section: '',
             showConfirmModal: false,
             enforceFocus: true,

--- a/webapp/channels/src/components/user_settings/modal/user_settings_modal.tsx
+++ b/webapp/channels/src/components/user_settings/modal/user_settings_modal.tsx
@@ -21,6 +21,7 @@ import SmartLoader from 'components/widgets/smart_loader';
 import Constants from 'utils/constants';
 import {cmdOrCtrlPressed, isKeyPressed} from 'utils/keyboard';
 import {stopTryNotificationRing} from 'utils/notification_sounds';
+import {isValidUrl} from 'utils/url';
 import {getDisplayName} from 'utils/utils';
 
 import type {PluginConfiguration} from 'types/plugins/user_settings';
@@ -300,12 +301,16 @@ class UserSettingsModal extends React.PureComponent<Props, State> {
     };
 
     getPluginsSettingsTab = () => {
-        return Object.values(this.props.pluginSettings).map((v) => ({
-            name: v.id,
-            uiName: v.uiName,
-            icon: v.icon ? {url: v.icon} : 'icon-power-plug-outline',
-            iconTitle: v.uiName,
-        }));
+        return Object.values(this.props.pluginSettings).map((v) => {
+            const className = v.icon ? `icon ${v.icon}` : 'icon icon-power-plug-outline';
+            const useURL = v.icon && (isValidUrl(v.icon) || v.icon.startsWith('/'));
+            return {
+                name: v.id,
+                uiName: v.uiName,
+                icon: useURL ? {url: v.icon!} : className,
+                iconTitle: v.uiName,
+            };
+        });
     };
 
     render() {

--- a/webapp/channels/src/components/user_settings/plugin/plugin_setting.tsx
+++ b/webapp/channels/src/components/user_settings/plugin/plugin_setting.tsx
@@ -96,7 +96,7 @@ const PluginSetting = ({
                     pluginId={pluginId}
                     hideRefresh={true}
                 >
-                    <CustomComponent/>
+                    <CustomComponent informChange={onSettingChanged}/>
                 </PluggableErrorBoundary>
             );
             inputs.push(inputEl);

--- a/webapp/channels/src/plugins/export.js
+++ b/webapp/channels/src/plugins/export.js
@@ -14,6 +14,7 @@ import PostMessagePreview from 'components/post_view/post_message_preview';
 import StartTrialFormModal from 'components/start_trial_form_modal';
 import ThreadViewer from 'components/threading/thread_viewer';
 import Timestamp from 'components/timestamp';
+import UserSettingsModal from 'components/user_settings/modal';
 import BotTag from 'components/widgets/tag/bot_tag';
 import Avatar from 'components/widgets/users/avatar';
 
@@ -65,6 +66,11 @@ window.WebappUtils = {
     modals: {openModal, ModalIdentifiers},
     notificationSounds: {ring: NotificationSounds.ring, stopRing: NotificationSounds.stopRing},
     sendDesktopNotificationToMe: notifyMe,
+    openUserSettings: (dialogProps) => openModal({
+        modalId: ModalIdentifiers.USER_SETTINGS,
+        dialogType: UserSettingsModal,
+        dialogProps,
+    }),
 };
 Object.defineProperty(window.WebappUtils, 'browserHistory', {
     get: () => getHistory(),

--- a/webapp/channels/src/types/plugins/user_settings.ts
+++ b/webapp/channels/src/types/plugins/user_settings.ts
@@ -85,11 +85,13 @@ export type PluginConfigurationRadioSetting = BasePluginConfigurationSetting & {
     options: PluginConfigurationRadioSettingOption[];
 }
 
+export type PluginCustomSettingComponent = React.ComponentType<{informChange: (name: string, value: string) => void}>;
+
 export type PluginConfigurationCustomSetting = BasePluginConfigurationSetting & {
     type: 'custom';
 
     /** A React component used to render the custom setting. */
-    component: React.ComponentType;
+    component: PluginCustomSettingComponent;
 }
 
 export type PluginConfigurationRadioSettingOption = {

--- a/webapp/channels/src/utils/plugins/plugin_setting_extraction.tsx
+++ b/webapp/channels/src/utils/plugins/plugin_setting_extraction.tsx
@@ -11,6 +11,7 @@ import type {
     PluginConfigurationRadioSettingOption,
     PluginConfigurationSection,
     PluginConfigurationCustomSetting,
+    PluginCustomSettingComponent,
 } from 'types/plugins/user_settings';
 
 export function extractPluginConfiguration(pluginConfiguration: unknown, pluginId: string) {
@@ -267,7 +268,7 @@ function extractPluginConfigurationCustomSetting(setting: unknown, base: BasePlu
     const res: PluginConfigurationCustomSetting = {
         ...base,
         type: 'custom',
-        component: setting.component as React.ComponentType,
+        component: setting.component as PluginCustomSettingComponent,
     };
 
     return res;


### PR DESCRIPTION
#### Summary

On top of the changes in https://github.com/mattermost/mattermost/pull/27535, we'd like a way to programmatically open the user settings modal from a plugin (e.g. from the Calls widget).

PR adds a new `openUserSettings` method to the globally exported `WebappUtils`. To be used as such:

```js
store.dispatch(WebappUtils.openUserSettings({activeTab: 'com.mattermost.calls', isContentProductSettings: true}));
```

Alternatively, we could expose the `UserSettingsModal` component and use the existing `openModal` function. I am also open to stricter solutions but the above offered some flexibility for more use cases as well without exposing too many implementation details.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51514

#### Release Note

```release-note
NONE
```
