### PR TITLE
MM-59835: Prevent unnecessary channel bookmarks request causing console 404

### DIFF
--- a/webapp/channels/src/components/channel_bookmarks/channel_bookmarks.tsx
+++ b/webapp/channels/src/components/channel_bookmarks/channel_bookmarks.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 
 import BookmarkItem from './bookmark_item';
 import PlusMenu from './channel_bookmarks_plus_menu';
-import {useChannelBookmarkPermission, useChannelBookmarks, useIsChannelBookmarksEnabled, MAX_BOOKMARKS_PER_CHANNEL, useCanUploadFiles} from './utils';
+import {useChannelBookmarkPermission, useChannelBookmarks, MAX_BOOKMARKS_PER_CHANNEL, useCanUploadFiles} from './utils';
 
 import './channel_bookmarks.scss';
 
@@ -17,13 +17,12 @@ type Props = {
 const ChannelBookmarks = ({
     channelId,
 }: Props) => {
-    const show = useIsChannelBookmarksEnabled();
     const {order, bookmarks} = useChannelBookmarks(channelId);
     const canUploadFiles = useCanUploadFiles();
     const canAdd = useChannelBookmarkPermission(channelId, 'add');
     const hasBookmarks = Boolean(order?.length);
 
-    if (!show || (!hasBookmarks && !canAdd)) {
+    if (!hasBookmarks && !canAdd) {
         return null;
     }
 

--- a/webapp/channels/src/components/channel_bookmarks/utils.ts
+++ b/webapp/channels/src/components/channel_bookmarks/utils.ts
@@ -22,10 +22,6 @@ import {canUploadFiles, isPublicLinksEnabled} from 'utils/file_utils';
 
 export const MAX_BOOKMARKS_PER_CHANNEL = 50;
 
-export const useIsChannelBookmarksEnabled = () => {
-    return useSelector(getIsChannelBookmarksEnabled);
-};
-
 const {OPEN_CHANNEL, PRIVATE_CHANNEL, GM_CHANNEL, DM_CHANNEL} = Constants as {OPEN_CHANNEL: 'O'; PRIVATE_CHANNEL: 'P'; GM_CHANNEL: 'G'; DM_CHANNEL: 'D'};
 
 type TAction = 'add' | 'edit' | 'delete' | 'order';

--- a/webapp/channels/src/components/channel_view/__snapshots__/channel_view.test.tsx.snap
+++ b/webapp/channels/src/components/channel_view/__snapshots__/channel_view.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`components/channel_view Should match snapshot if channel is archived 1`
     enableWebSocketEventScope={false}
     goToLastViewedChannel={[MockFunction]}
     history={Object {}}
+    isChannelBookmarksEnabled={false}
     isCloud={false}
     isFirstAdmin={false}
     location={Object {}}
@@ -73,6 +74,7 @@ exports[`components/channel_view Should match snapshot if channel is deactivated
     enableWebSocketEventScope={false}
     goToLastViewedChannel={[MockFunction]}
     history={Object {}}
+    isChannelBookmarksEnabled={false}
     isCloud={false}
     isFirstAdmin={false}
     location={Object {}}
@@ -129,6 +131,7 @@ exports[`components/channel_view Should match snapshot with base props 1`] = `
     enableWebSocketEventScope={false}
     goToLastViewedChannel={[MockFunction]}
     history={Object {}}
+    isChannelBookmarksEnabled={false}
     isCloud={false}
     isFirstAdmin={false}
     location={Object {}}

--- a/webapp/channels/src/components/channel_view/__snapshots__/channel_view.test.tsx.snap
+++ b/webapp/channels/src/components/channel_view/__snapshots__/channel_view.test.tsx.snap
@@ -28,9 +28,6 @@ exports[`components/channel_view Should match snapshot if channel is archived 1`
     teamUrl="/team"
     viewArchivedChannels={false}
   />
-  <ChannelBookmarks
-    channelId="channelId"
-  />
   <DeferredRenderWrapper
     channelId="channelId"
   />
@@ -88,9 +85,6 @@ exports[`components/channel_view Should match snapshot if channel is deactivated
     teamUrl="/team"
     viewArchivedChannels={false}
   />
-  <ChannelBookmarks
-    channelId="channelId"
-  />
   <DeferredRenderWrapper
     channelId="channelId"
   />
@@ -146,9 +140,6 @@ exports[`components/channel_view Should match snapshot with base props 1`] = `
     }
     teamUrl="/team"
     viewArchivedChannels={false}
-  />
-  <ChannelBookmarks
-    channelId="channelId"
   />
   <DeferredRenderWrapper
     channelId="channelId"

--- a/webapp/channels/src/components/channel_view/channel_view.test.tsx
+++ b/webapp/channels/src/components/channel_view/channel_view.test.tsx
@@ -25,6 +25,7 @@ describe('components/channel_view', () => {
         goToLastViewedChannel: jest.fn(),
         isFirstAdmin: false,
         enableWebSocketEventScope: false,
+        isChannelBookmarksEnabled: false,
     };
 
     it('Should match snapshot with base props', () => {

--- a/webapp/channels/src/components/channel_view/channel_view.tsx
+++ b/webapp/channels/src/components/channel_view/channel_view.tsx
@@ -171,7 +171,7 @@ export default class ChannelView extends React.PureComponent<Props, State> {
             >
                 <FileUploadOverlay overlayType='center'/>
                 <ChannelHeader {...this.props}/>
-                <ChannelBookmarks channelId={this.props.channelId}/>
+                {this.props.isChannelBookmarksEnabled && <ChannelBookmarks channelId={this.props.channelId}/>}
                 <DeferredPostView
                     channelId={this.props.channelId}
                     focusedPostId={this.state.focusedPostId}

--- a/webapp/channels/src/components/channel_view/index.ts
+++ b/webapp/channels/src/components/channel_view/index.ts
@@ -12,6 +12,8 @@ import {isFirstAdmin} from 'mattermost-redux/selectors/entities/users';
 
 import {goToLastViewedChannel} from 'actions/views/channel';
 
+import {getIsChannelBookmarksEnabled} from 'components/channel_bookmarks/utils';
+
 import type {GlobalState} from 'types/store';
 
 import ChannelView from './channel_view';
@@ -41,6 +43,7 @@ function mapStateToProps(state: GlobalState) {
         teamUrl: getCurrentRelativeTeamUrl(state),
         isFirstAdmin: isFirstAdmin(state),
         enableWebSocketEventScope,
+        isChannelBookmarksEnabled: getIsChannelBookmarksEnabled(state),
     };
 }
 


### PR DESCRIPTION
#### Summary
Hoists feature flag check to prevent mounting `<ChannelBookmarks/>` when feature flag is off, so an extraneous request is not made.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59835

#### Screenshots
|  before  |  after  |
|----|----|
| ![CleanShot 2024-07-23 at 16 06 21](https://github.com/user-attachments/assets/b9771035-fc87-4ec7-b5dd-7921fb27a7f6) | ![CleanShot 2024-07-23 at 16 05 43](https://github.com/user-attachments/assets/59134f44-3fe4-4233-bd9e-ab287fd5d19b) |

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
