### PR TITLE
Prominent payload limit error and configurable URL length limit

### DIFF
--- a/server/channels/web/context.go
+++ b/server/channels/web/context.go
@@ -4,7 +4,6 @@
 package web
 
 import (
-	"errors"
 	"net/http"
 	"path"
 	"regexp"
@@ -233,12 +232,6 @@ func (c *Context) SetInvalidParamWithDetails(parameter string, details string) {
 }
 
 func (c *Context) SetInvalidParamWithErr(parameter string, err error) {
-	var maxBytesErr *http.MaxBytesError
-	if ok := errors.As(err, &maxBytesErr); ok {
-		c.HandlePayloadTooLargeError(err)
-		return
-	}
-
 	c.Err = NewInvalidParamError(parameter).Wrap(err)
 }
 

--- a/server/channels/web/context.go
+++ b/server/channels/web/context.go
@@ -236,7 +236,6 @@ func (c *Context) SetInvalidParamWithErr(parameter string, err error) {
 }
 
 func (c *Context) HandlePayloadTooLargeError(err error) {
-	//err := model.NewAppError("Context", "api.context.invalid_body_param.app_error", map[string]any{"Name": parameter}, "", http.StatusBadRequest)
 	c.Err = model.NewAppError("Context", "api.context.request_body_too_large.app_error", nil, "", http.StatusRequestEntityTooLarge)
 }
 

--- a/server/channels/web/context.go
+++ b/server/channels/web/context.go
@@ -235,10 +235,6 @@ func (c *Context) SetInvalidParamWithErr(parameter string, err error) {
 	c.Err = NewInvalidParamError(parameter).Wrap(err)
 }
 
-func (c *Context) HandlePayloadTooLargeError(err error) {
-	c.Err = model.NewAppError("Context", "api.context.request_body_too_large.app_error", nil, "", http.StatusRequestEntityTooLarge)
-}
-
 func (c *Context) SetInvalidURLParam(parameter string) {
 	c.Err = NewInvalidURLParamError(parameter)
 }

--- a/server/channels/web/context.go
+++ b/server/channels/web/context.go
@@ -4,6 +4,7 @@
 package web
 
 import (
+	"errors"
 	"net/http"
 	"path"
 	"regexp"
@@ -232,7 +233,18 @@ func (c *Context) SetInvalidParamWithDetails(parameter string, details string) {
 }
 
 func (c *Context) SetInvalidParamWithErr(parameter string, err error) {
+	var maxBytesErr *http.MaxBytesError
+	if ok := errors.As(err, &maxBytesErr); ok {
+		c.HandlePayloadTooLargeError(err)
+		return
+	}
+
 	c.Err = NewInvalidParamError(parameter).Wrap(err)
+}
+
+func (c *Context) HandlePayloadTooLargeError(err error) {
+	//err := model.NewAppError("Context", "api.context.invalid_body_param.app_error", map[string]any{"Name": parameter}, "", http.StatusBadRequest)
+	c.Err = model.NewAppError("Context", "api.context.request_body_too_large.app_error", nil, "", http.StatusRequestEntityTooLarge)
 }
 
 func (c *Context) SetInvalidURLParam(parameter string) {

--- a/server/channels/web/handlers_test.go
+++ b/server/channels/web/handlers_test.go
@@ -950,7 +950,7 @@ func TestHandlerServeHTTPBasicSecurityChecks(t *testing.T) {
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
 
-	t.Run("Should cause 414 error if url is smaller than configured limit", func(t *testing.T) {
+	t.Run("Should cause 414 error if url is longer than configured limit", func(t *testing.T) {
 		th := SetupWithStoreMock(t)
 		defer th.TearDown()
 

--- a/server/channels/web/handlers_test.go
+++ b/server/channels/web/handlers_test.go
@@ -4,8 +4,11 @@
 package web
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -926,4 +929,157 @@ func TestGetOriginClient(t *testing.T) {
 
 		require.Equal(t, tc.expectedClient, actualClient)
 	}
+}
+
+func noOpHandler(_ *Context, _ http.ResponseWriter, _ *http.Request) {
+	// no op
+}
+
+func TestHandlerServeHTTPBasicSecurityChecks(t *testing.T) {
+	t.Run("Should not cause 414 error if url is smaller than configured limit", func(t *testing.T) {
+		th := SetupWithStoreMock(t)
+		defer th.TearDown()
+
+		web := New(th.Server)
+		handler := web.NewHandler(noOpHandler)
+
+		// using the default URL length
+		request := httptest.NewRequest("GET", "/api/v4/test?with=not&many=query_params", nil)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	t.Run("Should cause 414 error if url is smaller than configured limit", func(t *testing.T) {
+		th := SetupWithStoreMock(t)
+		defer th.TearDown()
+
+		mockStore := th.App.Srv().Store().(*mocks.Store)
+		mockUserStore := mocks.UserStore{}
+		mockUserStore.On("Count", mock.Anything).Return(int64(10), nil)
+		mockPostStore := mocks.PostStore{}
+		mockPostStore.On("GetMaxPostSize").Return(65535, nil)
+		mockSystemStore := mocks.SystemStore{}
+		mockSystemStore.On("GetByName", "UpgradedFromTE").Return(&model.System{Name: "UpgradedFromTE", Value: "false"}, nil)
+		mockSystemStore.On("GetByName", "InstallationDate").Return(&model.System{Name: "InstallationDate", Value: "10"}, nil)
+		mockSystemStore.On("GetByName", "FirstServerRunTimestamp").Return(&model.System{Name: "FirstServerRunTimestamp", Value: "10"}, nil)
+
+		mockStore.On("User").Return(&mockUserStore)
+		mockStore.On("Post").Return(&mockPostStore)
+		mockStore.On("System").Return(&mockSystemStore)
+		mockStore.On("GetDBSchemaVersion").Return(1, nil)
+
+		th.App.UpdateConfig(func(config *model.Config) {
+			config.ServiceSettings.MaximumURLLength = model.NewInt(10)
+		})
+
+		web := New(th.Server)
+		handler := web.NewHandler(noOpHandler)
+
+		request := httptest.NewRequest("GET", "/api/v4/test?a_url_longer_than_10_characters_including_query_params", nil)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+		assert.Equal(t, http.StatusRequestURITooLong, response.Code)
+	})
+
+	t.Run("414 error should include query params in computing URL length", func(t *testing.T) {
+		th := SetupWithStoreMock(t)
+		defer th.TearDown()
+
+		mockStore := th.App.Srv().Store().(*mocks.Store)
+		mockUserStore := mocks.UserStore{}
+		mockUserStore.On("Count", mock.Anything).Return(int64(10), nil)
+		mockPostStore := mocks.PostStore{}
+		mockPostStore.On("GetMaxPostSize").Return(65535, nil)
+		mockSystemStore := mocks.SystemStore{}
+		mockSystemStore.On("GetByName", "UpgradedFromTE").Return(&model.System{Name: "UpgradedFromTE", Value: "false"}, nil)
+		mockSystemStore.On("GetByName", "InstallationDate").Return(&model.System{Name: "InstallationDate", Value: "10"}, nil)
+		mockSystemStore.On("GetByName", "FirstServerRunTimestamp").Return(&model.System{Name: "FirstServerRunTimestamp", Value: "10"}, nil)
+
+		mockStore.On("User").Return(&mockUserStore)
+		mockStore.On("Post").Return(&mockPostStore)
+		mockStore.On("System").Return(&mockSystemStore)
+		mockStore.On("GetDBSchemaVersion").Return(1, nil)
+
+		th.App.UpdateConfig(func(config *model.Config) {
+			config.ServiceSettings.MaximumURLLength = model.NewInt(20)
+		})
+
+		web := New(th.Server)
+		handler := web.NewHandler(noOpHandler)
+
+		// this URL is within the 20 characters limit excluding query params.
+		// but this should still fail as URL length includes query params
+		request := httptest.NewRequest("GET", "/api/v4/test?a_url_longer_than_10_characters_including_query_params", nil)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+		assert.Equal(t, http.StatusRequestURITooLong, response.Code)
+	})
+}
+
+func TestHandlerServeHTTPRequestPayloadLimit(t *testing.T) {
+	jsonReaderHandler := func(context *Context, writer http.ResponseWriter, request *http.Request) {
+		// read request body into a string
+		var body *string
+		err := json.NewDecoder(request.Body).Decode(&body)
+		if err != nil {
+			fmt.Printf("Error occurred reading request body, error: %s", err.Error())
+			context.Err = model.NewAppError("TestHandlerServeHTTPRequestPayloadLimit", "", nil, "", http.StatusBadRequest).Wrap(err)
+		} else {
+			fmt.Printf("Received body- '%s'", *body)
+			writer.WriteHeader(http.StatusOK)
+		}
+	}
+
+	t.Run("should allow payload smaller than set limit", func(t *testing.T) {
+		th := SetupWithStoreMock(t)
+		defer th.TearDown()
+
+		web := New(th.Server)
+		handler := web.NewHandler(jsonReaderHandler)
+
+		body := strings.NewReader("\"a very small request body\"")
+		request := httptest.NewRequest("POST", "/api/v4/test", body)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	t.Run("Should error out when request body is larger than set limit", func(t *testing.T) {
+		th := SetupWithStoreMock(t)
+		defer th.TearDown()
+
+		mockStore := th.App.Srv().Store().(*mocks.Store)
+		mockUserStore := mocks.UserStore{}
+		mockUserStore.On("Count", mock.Anything).Return(int64(10), nil)
+		mockPostStore := mocks.PostStore{}
+		mockPostStore.On("GetMaxPostSize").Return(65535, nil)
+		mockSystemStore := mocks.SystemStore{}
+		mockSystemStore.On("GetByName", "UpgradedFromTE").Return(&model.System{Name: "UpgradedFromTE", Value: "false"}, nil)
+		mockSystemStore.On("GetByName", "InstallationDate").Return(&model.System{Name: "InstallationDate", Value: "10"}, nil)
+		mockSystemStore.On("GetByName", "FirstServerRunTimestamp").Return(&model.System{Name: "FirstServerRunTimestamp", Value: "10"}, nil)
+
+		mockStore.On("User").Return(&mockUserStore)
+		mockStore.On("Post").Return(&mockPostStore)
+		mockStore.On("System").Return(&mockSystemStore)
+		mockStore.On("GetDBSchemaVersion").Return(1, nil)
+
+		th.App.UpdateConfig(func(config *model.Config) {
+			config.ServiceSettings.MaximumPayloadSizeBytes = model.NewInt64(1)
+		})
+
+		web := New(th.Server)
+		handler := web.NewHandler(jsonReaderHandler)
+
+		// this is a 600 character long string.
+		// Even though we have set the max payload size to be 1, we still need at least 513 bytes (1 byte configured + bytes.MinRead = 1 + 512 = 513) bytes.
+		// This is because the buffer will always be at least bytes.MinRead bytes large, so the effective payload limit is bytes.MinRead + the configured value.
+		body := strings.NewReader("\"weunfrwghyajuaqqkrecexurpmrmgpimjieymiwfhfrrrgiqpqrznkjtubwcuybyixyxwtwddpytukritccyugyeuvdtzjkkyiwhquzqkrqkhgyyfqnquzchjqkrkzfrxthduzizqtdxzqirxhzihbivmkdwpbeddepdanzuuzqxbdqfvgkwumervhghywexitbjdnvxcniuamwmqdecbbqbgnjjqwkdcucvnpwynuruztpdtmmvbpkevurpjdwdhpayaindzmnkmyybudfkjdkqwuiviriudtqytybuwfkkwpepwhpekfewnxgpkfctdqjmemngvntnizvfznaiqpbumgtcxidvawtgcdyqijbxzrgezvjmcwikiabbpqabrwfgncrmvqththepffatnhchhnmrhkuqvgrzfugzhuwicaemhcacrazmgzmrgrkuhwucfydhwxfhzfukzjhvdxkuhzjrxwippxadvwzigndxwdxvganxggjjxwdqtgqgnpqqygndviadvttwfntcreitijaqrpfygdehbcftyfcjvrfwvjmbtdptutjgtbyhbyddfecyyujgrxyujzmryymj\"")
+		request := httptest.NewRequest("POST", "/api/v4/test", body)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+
+		assert.Equal(t, http.StatusRequestEntityTooLarge, response.Code)
+	})
 }

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10085,5 +10085,9 @@
   {
     "id": "web.incoming_webhook.user.app_error",
     "translation": "Couldn't find the user."
+  },
+  {
+    "id": "api.context.request_body_too_large.app_error",
+    "translation": "Unable to process request. Request body too large."
   }
 ]

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -1786,6 +1786,10 @@
     "translation": "Secure connection ID missing."
   },
   {
+    "id": "api.context.request_body_too_large.app_error",
+    "translation": "Unable to process request. Request body too large."
+  },
+  {
     "id": "api.context.server_busy.app_error",
     "translation": "Server is busy, non-critical services are temporarily unavailable."
   },
@@ -8763,6 +8767,10 @@
     "translation": "Invalid max payload size for service settings. Must be a whole number greater than zero."
   },
   {
+    "id": "model.config.is_valid.max_url_length.app_error",
+    "translation": "Invalid max URL length for service settings. Must be a whole number greater than zero."
+  },
+  {
     "id": "model.config.is_valid.max_users.app_error",
     "translation": "Invalid maximum users per team for team settings. Must be a positive number."
   },
@@ -10085,9 +10093,5 @@
   {
     "id": "web.incoming_webhook.user.app_error",
     "translation": "Couldn't find the user."
-  },
-  {
-    "id": "api.context.request_body_too_large.app_error",
-    "translation": "Unable to process request. Request body too large."
   }
 ]

--- a/server/platform/services/telemetry/telemetry.go
+++ b/server/platform/services/telemetry/telemetry.go
@@ -493,6 +493,7 @@ func (ts *TelemetryService) trackConfig() {
 		"allow_synced_drafts":                                     *cfg.ServiceSettings.AllowSyncedDrafts,
 		"refresh_post_stats_run_time":                             *cfg.ServiceSettings.RefreshPostStatsRunTime,
 		"maximum_payload_size":                                    *cfg.ServiceSettings.MaximumPayloadSizeBytes,
+		"maximum_url_length":                                      *cfg.ServiceSettings.MaximumURLLength,
 	})
 
 	ts.SendTelemetry(TrackConfigTeam, map[string]any{

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -112,6 +112,7 @@ const (
 	ServiceSettingsDefaultGiphySdkKeyTest        = "s0glxvzVg9azvPipKxcPLpXV0q1x1fVP"
 	ServiceSettingsDefaultDeveloperFlags         = ""
 	ServiceSettingsDefaultUniqueReactionsPerPost = 50
+	ServiceSettingsDefaultMaxURLLength           = 2048
 	ServiceSettingsMaxUniqueReactionsPerPost     = 500
 
 	TeamSettingsDefaultSiteName              = "Mattermost"
@@ -410,6 +411,7 @@ type ServiceSettings struct {
 	UniqueEmojiReactionLimitPerPost                   *int    `access:"site_posts"`
 	RefreshPostStatsRunTime                           *string `access:"site_users_and_teams"`
 	MaximumPayloadSizeBytes                           *int64  `access:"environment_file_storage,write_restrictable,cloud_restrictable"`
+	MaximumURLLength                                  *int    `access:"environment_file_storage,write_restrictable,cloud_restrictable"`
 }
 
 var MattermostGiphySdkKey string
@@ -920,6 +922,10 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 
 	if s.MaximumPayloadSizeBytes == nil {
 		s.MaximumPayloadSizeBytes = NewInt64(300000)
+	}
+
+	if s.MaximumURLLength == nil {
+		s.MaximumURLLength = NewInt(ServiceSettingsDefaultMaxURLLength)
 	}
 }
 
@@ -4029,6 +4035,10 @@ func (s *ServiceSettings) isValid() *AppError {
 
 	if *s.MaximumPayloadSizeBytes <= 0 {
 		return NewAppError("Config.IsValid", "model.config.is_valid.max_payload_size.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	if *s.MaximumURLLength <= 0 {
+		return NewAppError("Config.IsValid", "model.config.is_valid.max_url_length.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if *s.ReadTimeout <= 0 {


### PR DESCRIPTION
#### Summary
Made following changes to HTTP handler security logic-
1. Made payload size limit error more prominent by adding the following line in API error response-

```json
{
  "id": "api.context.request_body_too_large.app_error",
  "message": "Unable to process request. Request body too large.",
  "detailed_error": "",
  "request_id": "k51a683tdtdrtq6chwog9zw53o",
  "status_code": 413
}
```

and following error log on server side-

```json
{
  "timestamp": "2024-07-24 12:57:58.425 +05:30",
  "level": "debug",
  "msg": "Unable to process request. Request body too large.",
  "caller": "web/context.go:120",
  "path": "/api/v4/posts",
  "request_id": "9w39umwc1tnm7xyouz843jehjo",
  "ip_addr": "::1",
  "user_id": "f8ama5so7bnaix5z94zj4x77sr",
  "method": "POST",
  "err_where": "Context",
  "http_code": 413,
  "error": "Context: Unable to process request. Request body too large. Use the setting `MaximumPayloadSizeBytes` in Mattermost config to configure allowed payload limit. Learn more about this setting in Mattermost docs at https://docs.mattermost.com/configure/environment-configuration-settings.html#maximum-payload-size"
}
```

2. Made URL length limit configurable via a new `MaximumURLLength` service settings config.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-59352

#### Release Note
```release-note
Made payload size limit error more clearly visible and recognisable i API response and server error logs.
Added a new setting `MaximumURLLength` to remove the hardcoded URL length limit.
```
