### PR TITLE
MM-59865: Set WebsocketEventScope FF to true

### DIFF
--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -78,7 +78,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.CloudAnnualRenewals = false
 	f.CloudDedicatedExportUI = false
 	f.ChannelBookmarks = false
-	f.WebSocketEventScope = false
+	f.WebSocketEventScope = true
 	f.NotificationMonitoring = true
 	f.ExperimentalAuditSettingsSystemConsoleUI = false
 }


### PR DESCRIPTION
This has been set to true for a while on Community.
Setting it to true now for it to soak in cloud.

https://mattermost.atlassian.net/browse/MM-59865
```release-note
NONE
```
