### PR TITLE
[MM-51514] Improvements to custom plugin user settings

### DIFF
--- a/webapp/channels/src/components/user_settings/modal/user_settings_modal.test.tsx
+++ b/webapp/channels/src/components/user_settings/modal/user_settings_modal.test.tsx
@@ -173,12 +173,12 @@ describe('plugin tabs use the correct icon', () => {
         const element = screen.queryByTitle(uiName);
         expect(element).toBeInTheDocument();
         expect(element!.nodeName).toBe('I');
-        expect(element?.className).toBe('icon-power-plug-outline');
+        expect(element?.className).toBe('icon icon-power-plug-outline');
     });
 
-    it('use image when icon provided', () => {
+    it('use image when icon URL provided', () => {
         const uiName = 'plugin_a';
-        const icon = 'icon_url';
+        const icon = 'http://localhost:8065/plugins/com.mattermost.plugin_a/public/icon.svg';
         const state: DeepPartial<GlobalState> = {
             plugins: {
                 userSettings: {
@@ -197,5 +197,52 @@ describe('plugin tabs use the correct icon', () => {
         expect(element).toBeInTheDocument();
         expect(element!.nodeName).toBe('IMG');
         expect(element!.getAttribute('src')).toBe(icon);
+    });
+
+    it('use image when icon path provided', () => {
+        const uiName = 'plugin_a';
+        const icon = '/plugins/com.mattermost.plugin_a/public/icon.svg';
+        const state: DeepPartial<GlobalState> = {
+            plugins: {
+                userSettings: {
+                    plugin_a: {
+                        id: 'plugin_a',
+                        sections: [],
+                        uiName,
+                        icon,
+                    },
+                },
+            },
+        };
+        renderWithContext(<UserSettingsModal {...baseProps}/>, mergeObjects(baseState, state));
+
+        const element = screen.queryByAltText(uiName);
+        expect(element).toBeInTheDocument();
+        expect(element!.nodeName).toBe('IMG');
+        expect(element!.getAttribute('src')).toBe(icon);
+    });
+
+    it('use class name when icon name provided', () => {
+        const uiName = 'plugin_a';
+        const icon = 'icon-phone-in-talk';
+        const state: DeepPartial<GlobalState> = {
+            plugins: {
+                userSettings: {
+                    plugin_a: {
+                        id: 'plugin_a',
+                        sections: [],
+                        uiName,
+                        icon,
+                    },
+                },
+            },
+        };
+
+        renderWithContext(<UserSettingsModal {...baseProps}/>, mergeObjects(baseState, state));
+
+        const element = screen.queryByTitle(uiName);
+        expect(element).toBeInTheDocument();
+        expect(element!.nodeName).toBe('I');
+        expect(element?.className).toBe('icon icon-phone-in-talk');
     });
 });

--- a/webapp/channels/src/components/user_settings/modal/user_settings_modal.tsx
+++ b/webapp/channels/src/components/user_settings/modal/user_settings_modal.tsx
@@ -21,6 +21,7 @@ import SmartLoader from 'components/widgets/smart_loader';
 import Constants from 'utils/constants';
 import {cmdOrCtrlPressed, isKeyPressed} from 'utils/keyboard';
 import {stopTryNotificationRing} from 'utils/notification_sounds';
+import {isValidUrl} from 'utils/url';
 import {getDisplayName} from 'utils/utils';
 
 import type {PluginConfiguration} from 'types/plugins/user_settings';
@@ -300,12 +301,16 @@ class UserSettingsModal extends React.PureComponent<Props, State> {
     };
 
     getPluginsSettingsTab = () => {
-        return Object.values(this.props.pluginSettings).map((v) => ({
-            name: v.id,
-            uiName: v.uiName,
-            icon: v.icon ? {url: v.icon} : 'icon-power-plug-outline',
-            iconTitle: v.uiName,
-        }));
+        return Object.values(this.props.pluginSettings).map((v) => {
+            const className = v.icon ? `icon ${v.icon}` : 'icon icon-power-plug-outline';
+            const useURL = v.icon && (isValidUrl(v.icon) || v.icon.startsWith('/'));
+            return {
+                name: v.id,
+                uiName: v.uiName,
+                icon: useURL ? {url: v.icon!} : className,
+                iconTitle: v.uiName,
+            };
+        });
     };
 
     render() {

--- a/webapp/channels/src/components/user_settings/plugin/plugin_setting.tsx
+++ b/webapp/channels/src/components/user_settings/plugin/plugin_setting.tsx
@@ -96,7 +96,7 @@ const PluginSetting = ({
                     pluginId={pluginId}
                     hideRefresh={true}
                 >
-                    <CustomComponent/>
+                    <CustomComponent informChange={onSettingChanged}/>
                 </PluggableErrorBoundary>
             );
             inputs.push(inputEl);

--- a/webapp/channels/src/plugins/export.js
+++ b/webapp/channels/src/plugins/export.js
@@ -42,6 +42,7 @@ window.ReactRouterDom = require('react-router-dom');
 window.PropTypes = require('prop-types');
 window.Luxon = require('luxon');
 window.StyledComponents = require('styled-components');
+window.ReactSelect = require('react-select');
 
 // Functions exposed on window for plugins to use.
 window.PostUtils = {

--- a/webapp/channels/src/plugins/export.js
+++ b/webapp/channels/src/plugins/export.js
@@ -42,7 +42,6 @@ window.ReactRouterDom = require('react-router-dom');
 window.PropTypes = require('prop-types');
 window.Luxon = require('luxon');
 window.StyledComponents = require('styled-components');
-window.ReactSelect = require('react-select');
 
 // Functions exposed on window for plugins to use.
 window.PostUtils = {

--- a/webapp/channels/src/types/plugins/user_settings.ts
+++ b/webapp/channels/src/types/plugins/user_settings.ts
@@ -85,11 +85,13 @@ export type PluginConfigurationRadioSetting = BasePluginConfigurationSetting & {
     options: PluginConfigurationRadioSettingOption[];
 }
 
+export type PluginCustomSettingComponent = React.ComponentType<{informChange: (name: string, value: string) => void}>;
+
 export type PluginConfigurationCustomSetting = BasePluginConfigurationSetting & {
     type: 'custom';
 
     /** A React component used to render the custom setting. */
-    component: React.ComponentType;
+    component: PluginCustomSettingComponent;
 }
 
 export type PluginConfigurationRadioSettingOption = {

--- a/webapp/channels/src/utils/plugins/plugin_setting_extraction.tsx
+++ b/webapp/channels/src/utils/plugins/plugin_setting_extraction.tsx
@@ -11,6 +11,7 @@ import type {
     PluginConfigurationRadioSettingOption,
     PluginConfigurationSection,
     PluginConfigurationCustomSetting,
+    PluginCustomSettingComponent,
 } from 'types/plugins/user_settings';
 
 export function extractPluginConfiguration(pluginConfiguration: unknown, pluginId: string) {
@@ -267,7 +268,7 @@ function extractPluginConfigurationCustomSetting(setting: unknown, base: BasePlu
     const res: PluginConfigurationCustomSetting = {
         ...base,
         type: 'custom',
-        component: setting.component as React.ComponentType,
+        component: setting.component as PluginCustomSettingComponent,
     };
 
     return res;


### PR DESCRIPTION
#### Summary

While implementing the actual thing, I found a couple of issues I am addressing here:

1. Support an icon class in addition to a URL/path to the icon file. This makes it possible to use compass icons and make the style consistent with other sections.
2. Pass the `informChange` prop to custom components so they can properly set the preference that needs updating.
3. Export the `react-select` package so we can conveniently reuse it on the plugin side.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51514

#### Release Note

```release-note
NONE
```
