### PR TITLE
Add posted event

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/actions/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/posts.ts
@@ -24,7 +24,7 @@ import {batchFetchStatusesProfilesGroupsFromPosts} from 'mattermost-redux/action
 import {decrementThreadCounts} from 'mattermost-redux/actions/threads';
 import {getProfilesByIds, getProfilesByUsernames, getStatusesByIds} from 'mattermost-redux/actions/users';
 import {Client4, DEFAULT_LIMIT_AFTER, DEFAULT_LIMIT_BEFORE} from 'mattermost-redux/client';
-import {General, Preferences, Posts} from 'mattermost-redux/constants';
+import {General, Preferences, Posts, Events} from 'mattermost-redux/constants';
 import {getCurrentChannelId, getMyChannelMember as getMyChannelMemberSelector} from 'mattermost-redux/selectors/entities/channels';
 import {getIsUserStatusesConfigEnabled} from 'mattermost-redux/selectors/entities/common';
 import {getCustomEmojisByName as selectCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
@@ -266,6 +266,9 @@ export function createPost(post: Post, files: any[] = []): ActionFuncAsync {
                 }
 
                 dispatch(batchActions(actions, 'BATCH_CREATE_POST'));
+
+                // Dispatch event for plugins to see when a post is posted
+                document.dispatchEvent(new Event(Events.POST_POSTED));
             } catch (error) {
                 const data = {
                     ...newPost,

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/posts.ts
@@ -268,7 +268,7 @@ export function createPost(post: Post, files: any[] = []): ActionFuncAsync {
                 dispatch(batchActions(actions, 'BATCH_CREATE_POST'));
 
                 // Dispatch event for plugins to see when a post is posted
-                document.dispatchEvent(new Event(Events.POST_POSTED));
+                document.dispatchEvent(new CustomEvent(Events.POST_POSTED, {detail: {post: created}}));
             } catch (error) {
                 const data = {
                     ...newPost,

--- a/webapp/channels/src/packages/mattermost-redux/src/constants/events.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/constants/events.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+const Events = {
+    POST_POSTED: 'post_posted',
+};
+
+export default Events;

--- a/webapp/channels/src/packages/mattermost-redux/src/constants/index.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/constants/index.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import Emoji from './emoji';
+import Events from './events';
 import Files from './files';
 import General from './general';
 import Permissions from './permissions';
@@ -16,4 +17,20 @@ import Threads from './threads';
 import Users from './users';
 import WebsocketEvents from './websocket';
 
-export {General, Preferences, Posts, Files, RequestStatus, WebsocketEvents, Teams, Stats, Permissions, Emoji, Plugins, Users, Roles, Threads};
+export {
+    Emoji,
+    Events,
+    Files,
+    General,
+    Permissions,
+    Plugins,
+    Posts,
+    Preferences,
+    RequestStatus,
+    Roles,
+    Stats,
+    Teams,
+    Threads,
+    Users,
+    WebsocketEvents,
+};


### PR DESCRIPTION
#### Summary
There has been an issue with the AI plugin due to the unification of the post input. More details here: https://hub.mattermost.com/private-core/pl/rqi6egtn7frozqgkibdhnawmir

After some fixes done in the plugin to circumvent this, there is still one detail that had to be solved. The plugin needed to know the post that has been posted.

This approach is just adding a posted event, and let the plugins listen to that.

Other alternatives that we could consider are:
- Add a new hook "message has been posted"
- Add the post information to the `CREATE_POST_SUCCESS` redux action and let the plugins use that action

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
The change has not yet gone into production.