### PR TITLE
MM-59846: Removing some deprecated ws events for v10

### DIFF
--- a/server/public/model/websocket_message.go
+++ b/server/public/model/websocket_message.go
@@ -72,8 +72,6 @@ const (
 	WebsocketEventSidebarCategoryUpdated              WebsocketEventType = "sidebar_category_updated"
 	WebsocketEventSidebarCategoryDeleted              WebsocketEventType = "sidebar_category_deleted"
 	WebsocketEventSidebarCategoryOrderUpdated         WebsocketEventType = "sidebar_category_order_updated"
-	WebsocketWarnMetricStatusReceived                 WebsocketEventType = "warn_metric_status_received"
-	WebsocketWarnMetricStatusRemoved                  WebsocketEventType = "warn_metric_status_removed"
 	WebsocketEventCloudPaymentStatusUpdated           WebsocketEventType = "cloud_payment_status_updated"
 	WebsocketEventCloudSubscriptionChanged            WebsocketEventType = "cloud_subscription_changed"
 	WebsocketEventThreadUpdated                       WebsocketEventType = "thread_updated"


### PR DESCRIPTION
These WS events are no longer used in the code. Can be
removed as part of v10.

https://mattermost.atlassian.net/browse/MM-59846
```release-note
NONE
```
