### PR TITLE
MM-59276 Don't update channel stats state unnecessarily

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channels.test.js
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channels.test.js
@@ -114,6 +114,94 @@ describe('channels', () => {
         });
     });
 
+    describe('RECEIVED_CHANNEL_STATS', () => {
+        test("should store a channel's stats", () => {
+            const state = deepFreeze(channelsReducer({}, {}));
+            const nextState = channelsReducer(state, {
+                type: ChannelTypes.RECEIVED_CHANNEL_STATS,
+                data: {
+                    channel_id: 'channel1',
+                    member_count: 2,
+                    guest_count: 3,
+                    pinnedpost_count: 4,
+                    files_count: 5,
+                },
+            });
+
+            expect(state).not.toBe(nextState);
+            expect(nextState.stats).toEqual({
+                channel1: {
+                    channel_id: 'channel1',
+                    member_count: 2,
+                    guest_count: 3,
+                    pinnedpost_count: 4,
+                    files_count: 5,
+                },
+            });
+        });
+
+        test("should update a channel's stats", () => {
+            const state = deepFreeze(channelsReducer({
+                stats: {
+                    channel1: {
+                        channel_id: 'channel1',
+                        member_count: 1,
+                        guest_count: 1,
+                        pinnedpost_count: 1,
+                        files_count: 1,
+                    },
+                },
+            }, {}));
+            const nextState = channelsReducer(state, {
+                type: ChannelTypes.RECEIVED_CHANNEL_STATS,
+                data: {
+                    channel_id: 'channel1',
+                    member_count: 2,
+                    guest_count: 3,
+                    pinnedpost_count: 4,
+                    files_count: 5,
+                },
+            });
+
+            expect(state).not.toBe(nextState);
+            expect(nextState.stats).toEqual({
+                channel1: {
+                    channel_id: 'channel1',
+                    member_count: 2,
+                    guest_count: 3,
+                    pinnedpost_count: 4,
+                    files_count: 5,
+                },
+            });
+        });
+
+        test("should return the same object when a channel's stats are unchanged", () => {
+            const state = deepFreeze(channelsReducer({
+                stats: {
+                    channel1: {
+                        channel_id: 'channel1',
+                        member_count: 2,
+                        guest_count: 3,
+                        pinnedpost_count: 4,
+                        files_count: 5,
+                    },
+                },
+            }, {}));
+            const nextState = channelsReducer(state, {
+                type: ChannelTypes.RECEIVED_CHANNEL_STATS,
+                data: {
+                    channel_id: 'channel1',
+                    member_count: 2,
+                    guest_count: 3,
+                    pinnedpost_count: 4,
+                    files_count: 5,
+                },
+            });
+
+            expect(state).toBe(nextState);
+        });
+    });
+
     describe('INCREMENT_FILE_COUNT', () => {
         test('should change channel file count stats', () => {
             const state = deepFreeze(channelsReducer({

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channels.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channels.ts
@@ -583,11 +583,16 @@ function membersInChannel(state: RelationOneToOne<Channel, Record<string, Channe
 function stats(state: RelationOneToOne<Channel, ChannelStats> = {}, action: AnyAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL_STATS: {
-        const nextState = {...state};
-        const stat = action.data;
-        nextState[stat.channel_id] = stat;
+        const stat: ChannelStats = action.data;
 
-        return nextState;
+        if (isEqual(state[stat.channel_id], stat)) {
+            return state;
+        }
+
+        return {
+            ...state,
+            [stat.channel_id]: stat,
+        };
     }
     case ChannelTypes.ADD_CHANNEL_MEMBER_SUCCESS: {
         const nextState = {...state};


### PR DESCRIPTION
#### Summary
If I remember right, we don't sync some of the data in the channel stats object in real time, so we request a channel's stats any time that we switch to it. While that might be worth spending some more time on, it's a pretty quick improvement to just make sure that that request doesn't cause the Redux state to change.

#### Ticket Link
MM-59276

#### Release Note
```release-note
Removed a re-render on channel change
```
