### PR TITLE
MM-59947: Get rid of special casing of **model.User in cache

### DIFF
--- a/server/platform/services/cache/lru.go
+++ b/server/platform/services/cache/lru.go
@@ -196,27 +196,6 @@ func (l *LRU) get(key string, value any) error {
 		return err
 	}
 
-	// This is ugly and makes the cache package aware of the model package.
-	// But this is due to 2 things.
-	// 1. The msgp package works on methods on structs rather than functions.
-	// 2. Our cache interface passes pointers to empty pointers, and not pointers
-	// to values. This is mainly how all our model structs are passed around.
-	// It might be technically possible to use values _just_ for hot structs
-	// like these and then return a pointer while returning from the cache function,
-	// but it will make the codebase inconsistent, and has some edge-cases to take care of.
-	switch v := value.(type) {
-	case **model.User:
-		var u model.User
-		_, err := u.UnmarshalMsg(val)
-		*v = &u
-		return err
-	case *map[string]*model.User:
-		var u model.UserMap
-		_, err := u.UnmarshalMsg(val)
-		*v = u
-		return err
-	}
-
 	// Slow path for other structs.
 	return msgpack.Unmarshal(val, value)
 }


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/MM-59947

```release-note
NONE
```
