### PR TITLE
Allows remote users to change their username

### DIFF
--- a/server/platform/services/sharedchannel/sync_recv.go
+++ b/server/platform/services/sharedchannel/sync_recv.go
@@ -212,9 +212,9 @@ func (scs *Service) upsertSyncUser(c request.CTX, user *model.User, channel *mod
 		// save the updated username and email in props
 		user.SetProp(model.UserPropsKeyRemoteUsername, user.Username)
 		user.SetProp(model.UserPropsKeyRemoteEmail, user.Email)
-		// TODO:  MM-59398:  allow patching username with munged, unique name
 
 		patch := &model.UserPatch{
+			Username:  &user.Username,
 			Nickname:  &user.Nickname,
 			FirstName: &user.FirstName,
 			LastName:  &user.LastName,


### PR DESCRIPTION
#### Summary
Although we had systems in place to munge a patched username and update the internal props, we were not accepting usernames from updated users, so this change adds those into the patch applied when a user is updated.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59398

#### Release Note
```release-note
NONE
```
