### PR TITLE
[MM-60025][MM-59522] Add playbooks v2 to prepackaged plugins

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -148,7 +148,7 @@ PLUGIN_PACKAGES += mattermost-plugin-calls-v0.29.1
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.3.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.9.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.1.1
-# We need to prepackage both versions of playbooks and install the correct one based on the server license.
+# We need to prepackage both versions of playbooks and install the correct one based on the server license. See MM-60025.
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v1.39.3
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.0.0
 PLUGIN_PACKAGES += mattermost-plugin-nps-v1.3.3

--- a/server/Makefile
+++ b/server/Makefile
@@ -148,7 +148,9 @@ PLUGIN_PACKAGES += mattermost-plugin-calls-v0.29.1
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.3.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.9.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.1.1
+# We need to prepackage both versions of playbooks and install the correct one based on the server license.
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v1.39.3
+PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.0.0
 PLUGIN_PACKAGES += mattermost-plugin-nps-v1.3.3
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.3.4
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.8.0

--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -997,13 +997,19 @@ func (ch *Channels) processPrepackagedPlugin(pluginPath *pluginSignaturePath) (*
 		if err != nil {
 			return nil, errors.Wrapf(err, "Unable to verify prepackaged playbooks version")
 		}
-		if version.GTE(SemVerV2) {
-			license := ch.License()
-			canUsePlaybookv2 := license != nil && license.IsE20OrEnterprise()
-			if !canUsePlaybookv2 {
-				logger.Info("Skip installing prepackaged playbooks because the license does not allow it")
-				return plugin, nil
-			}
+		license := ch.License()
+		hasEnterpriseLicense := license != nil && license.IsE20OrEnterprise()
+
+		// Do not install playbooks >=v2 if we do not have an enterprise license
+		if version.GTE(SemVerV2) && !hasEnterpriseLicense {
+			logger.Info("Skip installing prepackaged playbooks >=v2 because the license does not allow it")
+			return plugin, nil
+		}
+
+		// Do not install playbooks <v2 if we have an enterprise license
+		if version.LT(SemVerV2) && hasEnterpriseLicense {
+			logger.Info("Skip installing prepackaged playbooks <v2 because the license allows v2")
+			return plugin, nil
 		}
 	}
 


### PR DESCRIPTION
#### Summary
This PR adds Playbooks v2 to the prepackaged plugins and maintains Playbooks v1.39.3 for servers without an enterprise license.

A [ticket has been created](https://mattermost.atlassian.net/browse/MM-60026) to add Playbooks 1.39.3 to the transitionally prepackaged plugin list for Mattermost installations without an enterprise license, so in the future we will be able to remove playbooks 1.39.3 from the prepackaged plugins.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59522
https://mattermost.atlassian.net/browse/MM-60025

#### Screenshots
N/A

#### Release Note
```release-note
Added Playbooks v2.0.0 to the prepackaged plugins.
```
