### PR TITLE
Remove mysql from Docker-based development environment by default

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -201,6 +201,12 @@ ifeq ($(ARM_BASED_MAC),true)
   DOCKER_COMPOSE_OVERRIDE := -f docker-compose.makefile.m1.yml $(DOCKER_COMPOSE_OVERRIDE)
 endif
 
+ifeq ($(ENABLED_MYSQL),true)
+  $(info MySQL is enabled, running MySQL services)
+  ENABLED_DOCKER_SERVICES:= $(ENABLED_DOCKER_SERVICES) mysql
+  DOCKER_COMPOSE_OVERRIDE := -f docker-compose.mysql.yaml $(DOCKER_COMPOSE_OVERRIDE)
+endif
+
 ifneq ($(DOCKER_SERVICES_OVERRIDE),true)
   ifeq (,$(findstring minio,$(ENABLED_DOCKER_SERVICES)))
     TEMP_DOCKER_SERVICES:=$(TEMP_DOCKER_SERVICES) minio

--- a/server/config.mk
+++ b/server/config.mk
@@ -9,8 +9,11 @@
 #
 # Must be space separated names.
 #
-# Example: mysql postgres elasticsearch
-ENABLED_DOCKER_SERVICES ?= mysql postgres inbucket
+# Example: postgres elasticsearch
+ENABLED_DOCKER_SERVICES ?= postgres inbucket
+
+# Enable MySQL service to be run in docker.
+ENABLED_MYSQL ?= false
 
 # Disable entirely the use of docker
 MM_NO_DOCKER ?= false

--- a/server/docker-compose.mysql.yaml
+++ b/server/docker-compose.mysql.yaml
@@ -1,0 +1,33 @@
+services:
+  mysql:
+    container_name: mattermost-mysql
+    ports:
+      - "3306:3306"
+    extends:
+        file: build/docker-compose.common.yml
+        service: mysql
+  mysql-read-replica:
+    container_name: mattermost-mysql-read-replica
+    ports:
+      - "3307:3306"
+    extends:
+        file: build/docker-compose.common.yml
+        service: mysql-read-replica
+
+  start_dependencies:
+    image: mattermost/mattermost-wait-for-dep:latest
+    networks:
+      - mm-test
+    depends_on:
+      - mysql
+      - postgres
+      - minio
+      - inbucket
+      - openldap
+      - elasticsearch
+      - opensearch
+      - prometheus
+      - grafana
+      - loki
+      - promtail
+    command: postgres:5432 mysql:3306 minio:9000 inbucket:9001 openldap:389 elasticsearch:9200 opensearch:9201 prometheus:9090 grafana:3000 loki:3100 promtail:3180

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -1,19 +1,5 @@
 version: '2.4'
 services:
-  mysql:
-    container_name: mattermost-mysql
-    ports:
-      - "3306:3306"
-    extends:
-        file: build/docker-compose.common.yml
-        service: mysql
-  mysql-read-replica:
-    container_name: mattermost-mysql-read-replica
-    ports:
-      - "3307:3306"
-    extends:
-        file: build/docker-compose.common.yml
-        service: mysql-read-replica
   postgres:
     container_name: mattermost-postgres
     ports:
@@ -108,7 +94,6 @@ services:
     networks:
       - mm-test
     depends_on:
-      - mysql
       - postgres
       - minio
       - inbucket
@@ -119,7 +104,7 @@ services:
       - grafana
       - loki
       - promtail
-    command: postgres:5432 mysql:3306 minio:9000 inbucket:9001 openldap:389 elasticsearch:9200 opensearch:9201 prometheus:9090 grafana:3000 loki:3100 promtail:3180
+    command: postgres:5432 minio:9000 inbucket:9001 openldap:389 elasticsearch:9200 opensearch:9201 prometheus:9090 grafana:3000 loki:3100 promtail:3180
 
   leader:
     build:


### PR DESCRIPTION
#### Summary

This change removes MySQL from the Docker-based development environment, but it can be enabled bysetting `ENABLED_MYSQL=true` at runtime.
For example, to run the development environment with MySQL enabled, run the following command:

```sh
cd server && ENABLED_MYSQL=true make run
```

Same as before, the following command would run only PostgreSQL service without MySQL:

```sh
cd server && make run
```

#### Ticket Link

- Fixes #27909

#### Screenshots

n/a

#### Release Note

```release-note
NONE
```
