### PR TITLE
[MM-60152] Fix notifications log file location for Support Packet

### DIFF
--- a/server/channels/app/platform/log.go
+++ b/server/channels/app/platform/log.go
@@ -230,7 +230,7 @@ func (ps *PlatformService) GetNotificationLogFile(_ request.CTX) (*model.FileDat
 		return nil, errors.New("Unable to retrieve notifications logs because NotificationLogSettings.EnableFile is set to false")
 	}
 
-	notificationsLog := config.GetNotificationsLogFileLocation(*ps.Config().LogSettings.FileLocation)
+	notificationsLog := config.GetNotificationsLogFileLocation(*ps.Config().NotificationLogSettings.FileLocation)
 	notificationsLogFileData, err := os.ReadFile(notificationsLog)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed read notifcation log file at path %s", notificationsLog)

--- a/server/channels/app/platform/log_test.go
+++ b/server/channels/app/platform/log_test.go
@@ -81,7 +81,7 @@ func TestGetNotificationLogFile(t *testing.T) {
 	// Enable notifications file but point to an empty directory to get an error trying to read the file
 	th.Service.UpdateConfig(func(cfg *model.Config) {
 		*cfg.NotificationLogSettings.EnableFile = true
-		*cfg.LogSettings.FileLocation = dir
+		*cfg.NotificationLogSettings.FileLocation = dir
 	})
 
 	logLocation := config.GetNotificationsLogFileLocation(dir)

--- a/server/channels/app/support_packet_test.go
+++ b/server/channels/app/support_packet_test.go
@@ -193,6 +193,7 @@ func TestGenerateSupportPacket(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.LogSettings.FileLocation = dir
+		*cfg.NotificationLogSettings.FileLocation = dir
 	})
 
 	logLocation := config.GetLogFileLocation(dir)


### PR DESCRIPTION
#### Summary
~~In https://github.com/mattermost/mattermost/pull/27598, I moved `GetNotificationLogFile` from the `app`  package to `platform`. During that process, I made a copy-and-paste mistake and picked the wrong sub-setting. Unfortunately, this also affected the corresponding test :disappointed. The mistake was only caught by a race condition that was introduced accidentally. ~~

Turns out, the notifications log file location was broken for quite some time. https://github.com/mattermost/mattermost/pull/27598 didn't break it, it copied the broken code. But due to a bug in the tests, they didn't caught it.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60152
https://community.mattermost.com/core/pl/h5bwzootni8atp5g9kk4ffpc4e

#### Release Note
```release-note
NONE
```
