### PR TITLE
Fix flaky TestCreateZipFileAndAddFiles/write_one_file - 2nd round

### DIFF
--- a/server/channels/app/file_test.go
+++ b/server/channels/app/file_test.go
@@ -321,14 +321,16 @@ func TestCreateZipFileAndAddFiles(t *testing.T) {
 	t.Run("write one file", func(t *testing.T) {
 		mockBackend := filesStoreMocks.FileBackend{}
 		mockBackend.On("WriteFile", mock.Anything, path.Join(directory, zipName)).Return(int64(666), nil).Run(func(args mock.Arguments) {
-			now := time.Now()
 			r, err := zip.OpenReader(zipName)
 			require.NoError(t, err)
 			require.Len(t, r.File, 1)
 
 			file := r.File[0]
 			assert.Equal(t, "file1", file.Name)
-			assert.GreaterOrEqual(t, file.Modified, now.Truncate(time.Second)) // Files are stored with a second precision
+			now := time.Now().Truncate(time.Second) // Files are stored with a second precision
+			// Confirm that the file was created in the last 10 seconds
+			assert.GreaterOrEqual(t, file.Modified, now.Add(-10*time.Second))
+			assert.GreaterOrEqual(t, now, file.Modified)
 
 			fr, err := file.Open()
 			require.NoError(t, err)


### PR DESCRIPTION
#### Summary
The fix in https://github.com/mattermost/mattermost/pull/27737 was incorrect. The test file's timestamp is created before the mocked implementation of `WriteFile` runs. Therefore, it's possible that some time passes before the time stamp checks are executed.

I've relaxed the check a bit. It now confirms that the file was created in the last 10 seconds. To summarize, the initial implementation of the test was fine, but the 1-second timeframe was too short for CI. 10 seconds should do the trick. 

TODO: Enable test once https://github.com/mattermost/mattermost/pull/27881 is merged

#### Ticket Link
https://community.mattermost.com/core/pl/jbqqhqtwhjf15corwifsfbk1sc

#### Release Note
```release-note
NONE
```
