### PR TITLE
MM-57738/Added GetPluginID method to PluginAPI

### DIFF
--- a/server/channels/app/plugin_api.go
+++ b/server/channels/app/plugin_api.go
@@ -1343,3 +1343,7 @@ func (api *PluginAPI) InviteRemoteToChannel(channelID string, remoteID, userID s
 func (api *PluginAPI) UninviteRemoteFromChannel(channelID string, remoteID string) error {
 	return api.app.UninviteRemoteFromChannel(channelID, remoteID)
 }
+
+func (api *PluginAPI) GetPluginID() string {
+	return api.id
+}

--- a/server/public/plugin/api.go
+++ b/server/public/plugin/api.go
@@ -1306,6 +1306,12 @@ type API interface {
 	// @tag User
 	// Minimum server version: 9.8
 	UpdateUserRoles(userID, newRoles string) (*model.User, *model.AppError)
+
+	// GetPluginId returns the plugin's ID.
+	//
+	// @tag ID
+	// Minimum server version: 9.12
+	GetPluginId() string
 }
 
 var handshake = plugin.HandshakeConfig{

--- a/server/public/plugin/api_timer_layer_generated.go
+++ b/server/public/plugin/api_timer_layer_generated.go
@@ -1378,3 +1378,10 @@ func (api *apiTimerLayer) UpdateUserRoles(userID, newRoles string) (*model.User,
 	api.recordTime(startTime, "UpdateUserRoles", _returnsB == nil)
 	return _returnsA, _returnsB
 }
+
+func (api *apiTimerLayer) GetPluginId() string {
+	startTime := timePkg.Now()
+	_returnsA := api.apiImpl.GetPluginId()
+	api.recordTime(startTime, "GetPluginId", true)
+	return _returnsA
+}

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -6630,3 +6630,30 @@ func (s *apiRPCServer) UpdateUserRoles(args *Z_UpdateUserRolesArgs, returns *Z_U
 	}
 	return nil
 }
+
+type Z_GetPluginIdArgs struct {
+}
+
+type Z_GetPluginIdReturns struct {
+	A string
+}
+
+func (g *apiRPCClient) GetPluginId() string {
+	_args := &Z_GetPluginIdArgs{}
+	_returns := &Z_GetPluginIdReturns{}
+	if err := g.client.Call("Plugin.GetPluginId", _args, _returns); err != nil {
+		log.Printf("RPC call to GetPluginId API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) GetPluginId(args *Z_GetPluginIdArgs, returns *Z_GetPluginIdReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetPluginId() string
+	}); ok {
+		returns.A = hook.GetPluginId()
+	} else {
+		return encodableError(fmt.Errorf("API GetPluginId called but not implemented."))
+	}
+	return nil
+}

--- a/server/public/plugin/plugintest/api.go
+++ b/server/public/plugin/plugintest/api.go
@@ -1990,6 +1990,24 @@ func (_m *API) GetPluginConfig() map[string]interface{} {
 	return r0
 }
 
+// GetPluginId provides a mock function with given fields:
+func (_m *API) GetPluginId() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPluginId")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // GetPluginStatus provides a mock function with given fields: id
 func (_m *API) GetPluginStatus(id string) (*model.PluginStatus, *model.AppError) {
 	ret := _m.Called(id)


### PR DESCRIPTION
#### Summary
This update introduces a new method, GetPluginID, to the PluginAPI. This function returns the ID of the plugin. The change is reflected across multiple files including api.go, api_timer_layer_generated.go and client_rpc_generated.go where necessary adjustments have been made for this new addition. Also, a mock function for GetPluginId has been added in plugintest/api.go for testing purposes.

#### Ticket Link
https://github.com/mattermost/mattermost/issues/26710

#### Release Note
```release-note
NONE
```

