### PR TITLE
[MM-60154] Migrate tooltips of components/advanced_text_editor/formatting_bar/formatting_icon.tsx' to WithTooltip

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_icon.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_icon.tsx
@@ -24,10 +24,8 @@ import KeyboardShortcutSequence, {
 } from 'components/keyboard_shortcuts/keyboard_shortcuts_sequence';
 import type {
     KeyboardShortcutDescriptor} from 'components/keyboard_shortcuts/keyboard_shortcuts_sequence';
-import OverlayTrigger from 'components/overlay_trigger';
-import Tooltip from 'components/tooltip';
+import WithTooltip from 'components/with_tooltip';
 
-import Constants from 'utils/constants';
 import type {MarkdownMode} from 'utils/markdown/apply_markdown';
 
 export const IconContainer = styled.button`
@@ -146,25 +144,21 @@ const FormattingIcon = (props: FormattingIconProps): JSX.Element => {
 
     /* get the correct tooltip from the ShortcutsMap */
     const shortcut = MAP_MARKDOWN_MODE_TO_KEYBOARD_SHORTCUTS[mode];
-    const tooltip = (
-        <Tooltip id='upload-tooltip'>
-            <KeyboardShortcutSequence
-                shortcut={shortcut}
-                hoistDescription={true}
-                isInsideTooltip={true}
-            />
-        </Tooltip>
-    );
 
     return (
-        <OverlayTrigger
-            delayShow={Constants.OVERLAY_TIME_DELAY}
+        <WithTooltip
+            id='formatting-icon-tooltip'
             placement='top'
-            trigger={['hover', 'focus']}
-            overlay={tooltip}
+            title={
+                <KeyboardShortcutSequence
+                    shortcut={shortcut}
+                    hoistDescription={true}
+                    isInsideTooltip={true}
+                />
+            }
         >
             {bodyAction}
-        </OverlayTrigger>
+        </WithTooltip>
     );
 };
 


### PR DESCRIPTION
#### Summary
The changes ensure that the tooltip in "components/advanced_text_editor/formatting_bar/formatting_icon.tsx" now utilizes the WithTooltip component, replacing the previous usage of OverlayTrigger and Tooltip.

#### Ticket Link
Fixes #27942
Jira: [MM-60154](https://mattermost.atlassian.net/browse/MM-60154)

### Screenshot
<a href="https://imgbb.com/"><img src="https://i.ibb.co/KwhRCmr/formatting-icon.png" alt="formatting-icon" border="0"></a>

#### Release Note

```release-note
NONE
```

[MM-60154]: https://mattermost.atlassian.net/browse/MM-60154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ