### PR TITLE
[MM-60157] Migrate tooltips of 'components/advanced_text_editor/use_emoji_picker.tsx' to WithTooltip

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/use_emoji_picker.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_emoji_picker.tsx
@@ -15,10 +15,8 @@ import {getEmojiName} from 'mattermost-redux/utils/emoji_utils';
 import useDidUpdate from 'components/common/hooks/useDidUpdate';
 import EmojiPickerOverlay from 'components/emoji_picker/emoji_picker_overlay';
 import KeyboardShortcutSequence, {KEYBOARD_SHORTCUTS} from 'components/keyboard_shortcuts/keyboard_shortcuts_sequence';
-import OverlayTrigger from 'components/overlay_trigger';
-import Tooltip from 'components/tooltip';
+import WithTooltip from 'components/with_tooltip';
 
-import Constants from 'utils/constants';
 import {splitMessageBasedOnCaretPosition} from 'utils/post_utils';
 
 import type {GlobalState} from 'types/store';
@@ -119,15 +117,6 @@ const useEmojiPicker = (
     let emojiPicker = null;
 
     if (enableEmojiPicker && !readOnlyChannel) {
-        const emojiPickerTooltip = (
-            <Tooltip id='upload-tooltip'>
-                <KeyboardShortcutSequence
-                    shortcut={KEYBOARD_SHORTCUTS.msgShowEmojiPicker}
-                    hoistDescription={true}
-                    isInsideTooltip={true}
-                />
-            </Tooltip>
-        );
         emojiPicker = (
             <>
                 <EmojiPickerOverlay
@@ -139,11 +128,16 @@ const useEmojiPicker = (
                     enableGifPicker={enableGifPicker}
                     topOffset={-7}
                 />
-                <OverlayTrigger
+                <WithTooltip
+                    id='upload-tooltip'
                     placement='top'
-                    delayShow={Constants.OVERLAY_TIME_DELAY}
-                    trigger={Constants.OVERLAY_DEFAULT_TRIGGER}
-                    overlay={emojiPickerTooltip}
+                    title={
+                        <KeyboardShortcutSequence
+                            shortcut={KEYBOARD_SHORTCUTS.msgShowEmojiPicker}
+                            hoistDescription={true}
+                            isInsideTooltip={true}
+                        />
+                    }
                 >
                     <IconContainer
                         id={'emojiPickerButton'}
@@ -159,7 +153,7 @@ const useEmojiPicker = (
                             size={18}
                         />
                     </IconContainer>
-                </OverlayTrigger>
+                </WithTooltip>
             </>
         );
     }


### PR DESCRIPTION
#### Summary
The changes ensure that the tooltip in "components/advanced_text_editor/use_emoji_picker.tsx" now utilizes the WithTooltip component, replacing the previous usage of OverlayTrigger and Tooltip.

#### Ticket Link
Fixes #27939
Jira: [MM-60157](https://mattermost.atlassian.net/browse/MM-60157)

### Screenshot
<a href="https://imgbb.com/"><img src="https://i.ibb.co/5F6g0gX/emoji-picker.png" alt="emoji-picker" border="0"></a>

#### Release Note

```release-note
NONE
```

[MM-60157]: https://mattermost.atlassian.net/browse/MM-60157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ