### PR TITLE
[MM-60163] Migrate tooltips of 'components/post_view/post_flag_icon' to WithTooltip

### DIFF
--- a/webapp/channels/src/components/post_view/post_edited_indicator/post_edited_indicator.tsx
+++ b/webapp/channels/src/components/post_view/post_edited_indicator/post_edited_indicator.tsx
@@ -9,8 +9,7 @@ import {PencilOutlineIcon} from '@mattermost/compass-icons/components';
 
 import {getDateForTimezone} from 'mattermost-redux/utils/timezone_utils';
 
-import OverlayTrigger from 'components/overlay_trigger';
-import Tooltip from 'components/tooltip';
+import WithTooltip from 'components/with_tooltip';
 
 import {isSameDay, isWithinLastWeek, isYesterday} from 'utils/datetime';
 
@@ -65,16 +64,6 @@ const PostEditedIndicator = ({postId, isMilitaryTime, timeZone, editedAt = 0, po
         <span className='view-history__text'>{viewHistoryText}</span>
     ) : null;
 
-    const tooltip = (
-        <Tooltip
-            id={`edited-post-tooltip_${postId}`}
-            className='hidden-xs'
-        >
-            {`${editedText} ${formattedTime}`}
-            {postOwnerTooltipInfo}
-        </Tooltip>
-    );
-
     const showPostEditHistory = (e: MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();
         if (post?.id) {
@@ -105,13 +94,18 @@ const PostEditedIndicator = ({postId, isMilitaryTime, timeZone, editedAt = 0, po
     ) : editedIndicatorContent;
 
     return !postId || editedAt === 0 ? null : (
-        <OverlayTrigger
-            delayShow={250}
+        <WithTooltip
             placement='top'
-            overlay={tooltip}
+            id={`edited-post-tooltip_${postId}`}
+            title={
+                <>
+                    {`${editedText} ${formattedTime}`}
+                    {postOwnerTooltipInfo}
+                </>
+            }
         >
             {editedIndicator}
-        </OverlayTrigger>
+        </WithTooltip>
     );
 };
 


### PR DESCRIPTION
#### Summary
The changes ensure that the tooltip in "components/post_view/post_edited_indicator/post_edited_indicator.tsx" now utilizes the WithTooltip component, replacing the previous usage of OverlayTrigger and Tooltip.

#### Ticket Link
Fixes #27933
Jira: [60163](https://mattermost.atlassian.net/browse/MM-60163)

### Screenshot
<a href="https://imgbb.com/"><img src="https://i.ibb.co/9HZ4QZc/post-edit.png" alt="post-edit" border="0"></a>
#### Release Note

```release-note
NONE
```