### PR TITLE
[MM-60164] Migrate tooltips of 'components/post_view/post_time/post_time.tsx' to WithTooltip

### DIFF
--- a/webapp/channels/src/components/post_view/post_time/post_time.tsx
+++ b/webapp/channels/src/components/post_view/post_time/post_time.tsx
@@ -7,9 +7,8 @@ import {Link} from 'react-router-dom';
 
 import * as GlobalActions from 'actions/global_actions';
 
-import OverlayTrigger from 'components/overlay_trigger';
 import Timestamp, {RelativeRanges} from 'components/timestamp';
-import Tooltip from 'components/tooltip';
+import WithTooltip from 'components/with_tooltip';
 
 import {Locations} from 'utils/constants';
 import {isMobile} from 'utils/user_agent';
@@ -94,25 +93,20 @@ export default class PostTime extends React.PureComponent<Props> {
         );
 
         return (
-            <OverlayTrigger
-                delayShow={500}
+            <WithTooltip
                 placement='top'
-                overlay={
-                    <Tooltip
-                        id={eventTime.toString()}
-                        className='hidden-xs'
-                    >
-                        <Timestamp
-                            value={eventTime}
-                            ranges={POST_TOOLTIP_RANGES}
-                            useSemanticOutput={false}
-                            useTime={getTimeFormat}
-                        />
-                    </Tooltip>
+                id={eventTime.toString()}
+                title={
+                    <Timestamp
+                        value={eventTime}
+                        ranges={POST_TOOLTIP_RANGES}
+                        useSemanticOutput={false}
+                        useTime={getTimeFormat}
+                    />
                 }
             >
                 {content}
-            </OverlayTrigger>
+            </WithTooltip>
         );
     }
 }


### PR DESCRIPTION
#### Summary
The changes ensure that the tooltip in "components/post_view/post_time/post_time.tsx" now utilizes the WithTooltip component, replacing the previous usage of OverlayTrigger and Tooltip.

#### Ticket Link
Fixes #27932
Jira: [MM-60164](https://mattermost.atlassian.net/browse/MM-60164)

### Screenshot
<a href="https://imgbb.com/"><img src="https://i.ibb.co/MCB8t2x/post-time.png" alt="post-time" border="0"></a>
#### Release Note

```release-note
NONE
```

[MM-60164]: https://mattermost.atlassian.net/browse/MM-60164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ