### PR TITLE
[MM-38131] Remove deprecated pageSize query parameter

### DIFF
--- a/api/v4/source/users.yaml
+++ b/api/v4/source/users.yaml
@@ -2618,16 +2618,16 @@
             type: string
         - name: page
           in: query
-          description: Page specifies which part of the results to return, by PageSize.
+          description: Page specifies which part of the results to return, by perPage.
           required: false
           schema:
             type: integer
-        - name: pageSize
+        - name: per_page
           in: query
-          description: PageSize specifies the size of the returned chunk of results.
-          required: false
+          description: The size of the returned chunk of results.
           schema:
-           type: integer
+            type: integer
+            default: 60
       responses:
         "200":
           description: User's uploads retrieval successful
@@ -2787,18 +2787,17 @@
           default: false
       - name: page
         in: query
-        description: Page specifies which part of the results to return, by PageSize.
+        description: Page specifies which part of the results to return, by per_page.
         required: false
         schema:
           type: integer
           default: 0
-      - name: pageSize
+      - name: per_page
         in: query
-        description: PageSize specifies the size of the returned chunk of results.
-        required: false
+        description: The size of the returned chunk of results.
         schema:
-         default: 30
-         type: integer
+          type: integer
+          default: 60
       - name: totalsOnly
         in: query
         description: Setting this to true will only return the total counts.

--- a/server/channels/web/params.go
+++ b/server/channels/web/params.go
@@ -5,7 +5,6 @@ package web
 
 import (
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 
@@ -187,7 +186,15 @@ func ParamsFromRequest(r *http.Request) *Params {
 
 	params.TimeRange = query.Get("time_range")
 	params.Permanent, _ = strconv.ParseBool(query.Get("permanent"))
-	params.PerPage = getPerPageFromQuery(query)
+
+	val, err := strconv.Atoi(query.Get("per_page"))
+	if err != nil || val < 0 {
+		params.PerPage = PerPageDefault
+	} else if val > PerPageMaximum {
+		params.PerPage = PerPageMaximum
+	} else {
+		params.PerPage = val
+	}
 
 	if val, err := strconv.Atoi(query.Get("logs_per_page")); err != nil || val < 0 {
 		params.LogsPerPage = LogsPerPageDefault
@@ -272,21 +279,4 @@ func ParamsFromRequest(r *http.Request) *Params {
 	}
 
 	return params
-}
-
-// getPerPageFromQuery returns the PerPage value from the given query.
-// This function should be removed and the support for `pageSize`
-// should be dropped after v1.46 of the mobile app is no longer supported
-// https://mattermost.atlassian.net/browse/MM-38131
-func getPerPageFromQuery(query url.Values) int {
-	val, err := strconv.Atoi(query.Get("per_page"))
-	if err != nil {
-		val, err = strconv.Atoi(query.Get("pageSize"))
-	}
-	if err != nil || val < 0 {
-		return PerPageDefault
-	} else if val > PerPageMaximum {
-		return PerPageMaximum
-	}
-	return val
 }

--- a/server/channels/web/params_test.go
+++ b/server/channels/web/params_test.go
@@ -13,30 +13,6 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
-func TestGetPerPageFromQuery(t *testing.T) {
-	t.Run("defaults should be set", func(t *testing.T) {
-		query := make(url.Values)
-		perPage := getPerPageFromQuery(query)
-		require.Equal(t, PerPageDefault, perPage)
-	})
-
-	t.Run("per_page should take priority", func(t *testing.T) {
-		query := make(url.Values)
-		query.Add("pageSize", "100")
-		query.Add("per_page", "50")
-		perPage := getPerPageFromQuery(query)
-		require.Equal(t, 50, perPage)
-	})
-
-	t.Run("pageSize should be used only if per_page is incorrectly set", func(t *testing.T) {
-		query := make(url.Values)
-		query.Add("pageSize", "100")
-		query.Add("per_page", "BAD VALUE")
-		perPage := getPerPageFromQuery(query)
-		require.Equal(t, 100, perPage)
-	})
-}
-
 func TestParamsFromRequest(t *testing.T) {
 	testCases := []struct {
 		Description string


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost/pull/18260 standardized the query parameter, so all client calls use `pageSize`. It has been three years since `pageSize` was no longer used by clients, so it's time to remove it. The last mobile version to use it is v1.46, which is no longer supported.

I also updated some docs pointing towards `PageSize` for unknown reasons.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38131

#### Release Note
```release-note
Remove deprecated pageSize query parameter
```
