### PR TITLE
MM-57738 - Added GetPluginID function across multiple files

### DIFF
--- a/server/channels/app/plugin_api.go
+++ b/server/channels/app/plugin_api.go
@@ -1343,3 +1343,7 @@ func (api *PluginAPI) InviteRemoteToChannel(channelID string, remoteID, userID s
 func (api *PluginAPI) UninviteRemoteFromChannel(channelID string, remoteID string) error {
 	return api.app.UninviteRemoteFromChannel(channelID, remoteID)
 }
+
+func (api *PluginAPI) GetPluginID() string {
+	return api.id
+}

--- a/server/public/plugin/api.go
+++ b/server/public/plugin/api.go
@@ -1309,9 +1309,8 @@ type API interface {
 
 	// GetPluginID returns the plugin ID.
 	//
-	// @tag ID
 	// @tag Plugin
-	// Minimum server version: 9.12
+	// Minimum server version: 10.1
 	GetPluginID() string
 }
 

--- a/server/public/plugin/api.go
+++ b/server/public/plugin/api.go
@@ -1306,6 +1306,13 @@ type API interface {
 	// @tag User
 	// Minimum server version: 9.8
 	UpdateUserRoles(userID, newRoles string) (*model.User, *model.AppError)
+
+	// GetPluginID returns the plugin ID.
+	//
+	// @tag ID
+	// @tag Plugin
+	// Minimum server version: 9.12
+	GetPluginID() string
 }
 
 var handshake = plugin.HandshakeConfig{

--- a/server/public/plugin/api_timer_layer_generated.go
+++ b/server/public/plugin/api_timer_layer_generated.go
@@ -1378,3 +1378,10 @@ func (api *apiTimerLayer) UpdateUserRoles(userID, newRoles string) (*model.User,
 	api.recordTime(startTime, "UpdateUserRoles", _returnsB == nil)
 	return _returnsA, _returnsB
 }
+
+func (api *apiTimerLayer) GetPluginID() string {
+	startTime := timePkg.Now()
+	_returnsA := api.apiImpl.GetPluginID()
+	api.recordTime(startTime, "GetPluginID", true)
+	return _returnsA
+}

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -6630,3 +6630,30 @@ func (s *apiRPCServer) UpdateUserRoles(args *Z_UpdateUserRolesArgs, returns *Z_U
 	}
 	return nil
 }
+
+type Z_GetPluginIDArgs struct {
+}
+
+type Z_GetPluginIDReturns struct {
+	A string
+}
+
+func (g *apiRPCClient) GetPluginID() string {
+	_args := &Z_GetPluginIDArgs{}
+	_returns := &Z_GetPluginIDReturns{}
+	if err := g.client.Call("Plugin.GetPluginID", _args, _returns); err != nil {
+		log.Printf("RPC call to GetPluginID API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) GetPluginID(args *Z_GetPluginIDArgs, returns *Z_GetPluginIDReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetPluginID() string
+	}); ok {
+		returns.A = hook.GetPluginID()
+	} else {
+		return encodableError(fmt.Errorf("API GetPluginID called but not implemented."))
+	}
+	return nil
+}

--- a/server/public/plugin/plugintest/api.go
+++ b/server/public/plugin/plugintest/api.go
@@ -1990,6 +1990,24 @@ func (_m *API) GetPluginConfig() map[string]interface{} {
 	return r0
 }
 
+// GetPluginID provides a mock function with given fields:
+func (_m *API) GetPluginID() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPluginID")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // GetPluginStatus provides a mock function with given fields: id
 func (_m *API) GetPluginStatus(id string) (*model.PluginStatus, *model.AppError) {
 	ret := _m.Called(id)


### PR DESCRIPTION
#### Summary
The new function, GetPluginID, has been added to various server and plugin related files. This function returns the ID of a plugin. The changes include:
- Addition of the GetPluginID method in the PluginAPI interface.
- Implementation of this method in apiTimerLayer and client_rpc_generated files.
- Mocking of this method for testing purposes in plugintest/api.go file.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/26710

#### Release Note
```release-note
NONE
```
