### PR TITLE
Automated cherry pick of #27871

### DIFF
--- a/webapp/channels/src/components/threading/virtualized_thread_viewer/virtualized_thread_viewer.tsx
+++ b/webapp/channels/src/components/threading/virtualized_thread_viewer/virtualized_thread_viewer.tsx
@@ -451,6 +451,7 @@ class ThreadViewerVirtualized extends PureComponent<Props, State> {
                                     style={virtListStyles}
                                     width={width}
                                     className={'post-list__dynamic--RHS'}
+                                    correctScrollToBottom={true}
                                 >
                                     {this.renderRow}
                                 </DynamicSizeList>


### PR DESCRIPTION
Cherry pick of #27871 on release-10.0.

/cc  @crspeller

```release-note
NONE
```