### PR TITLE
[MM-58567] Added `window.isActive` check for marking threads as active when they're open, mark the threads as read when the window becomes active again

### DIFF
--- a/webapp/channels/src/actions/new_post.ts
+++ b/webapp/channels/src/actions/new_post.ts
@@ -148,7 +148,7 @@ export function setThreadRead(post: Post): ActionFunc<boolean, GlobalState> {
         const thread = getThread(state, post.root_id);
 
         // mark a thread as read (when the user is viewing the thread)
-        if (thread && isThreadOpen(state, thread.id)) {
+        if (thread && isThreadOpen(state, thread.id) && window.isActive) {
             // update the new messages line (when there are no previous unreads)
             if (thread.last_reply_at < getThreadLastViewedAt(state, thread.id)) {
                 dispatch(updateThreadLastOpened(thread.id, post.create_at));

--- a/webapp/channels/src/actions/views/channel.test.js
+++ b/webapp/channels/src/actions/views/channel.test.js
@@ -8,6 +8,7 @@ import {General, Posts, RequestStatus} from 'mattermost-redux/constants';
 
 import * as Actions from 'actions/views/channel';
 import {closeRightHandSide} from 'actions/views/rhs';
+import {markThreadAsRead} from 'actions/views/threads';
 
 import mockStore from 'tests/test_store';
 import {getHistory} from 'utils/browser_history';
@@ -37,6 +38,11 @@ jest.mock('mattermost-redux/actions/channels', () => ({
 jest.mock('actions/views/rhs', () => ({
     ...jest.requireActual('actions/views/rhs'),
     closeRightHandSide: jest.fn(() => ({type: ''})),
+}));
+
+jest.mock('actions/views/threads', () => ({
+    ...jest.requireActual('actions/views/threads'),
+    markThreadAsRead: jest.fn(() => ({type: ''})),
 }));
 
 jest.mock('mattermost-redux/actions/posts');
@@ -110,6 +116,7 @@ describe('channel view actions', () => {
             rhs: {
                 selectedPostId: '',
             },
+            threads: {},
         },
     };
 
@@ -589,11 +596,11 @@ describe('channel view actions', () => {
         });
     });
 
-    describe('markChannelAsReadOnFocus', () => {
+    describe('markAsReadOnFocus', () => {
         test('should mark channel as read when channel is not manually unread', async () => {
             store = mockStore(initialState);
 
-            await store.dispatch(Actions.markChannelAsReadOnFocus(channel1.id));
+            await store.dispatch(Actions.markAsReadOnFocus());
 
             expect(markChannelAsRead).toHaveBeenCalledWith(channel1.id);
         });
@@ -612,9 +619,34 @@ describe('channel view actions', () => {
                 },
             });
 
-            await store.dispatch(Actions.markChannelAsReadOnFocus(channel1.id));
+            await store.dispatch(Actions.markAsReadOnFocus());
 
             expect(markChannelAsRead).not.toHaveBeenCalled();
+        });
+
+        test('should dispatch markThreadAsRead when threads are selected', async () => {
+            store = mockStore({
+                ...initialState,
+                views: {
+                    ...initialState.views,
+                    rhs: {
+                        ...initialState.views.rhs,
+                        selectedPostId: 'post_id',
+                    },
+                    threads: {
+                        ...initialState.views.threads,
+                        selectedThreadIdInTeam: {
+                            teamid1: 'thread_id',
+                        },
+                    },
+                },
+            });
+
+            await store.dispatch(Actions.markAsReadOnFocus());
+
+            expect(markThreadAsRead).toHaveBeenCalledTimes(2);
+            expect(markThreadAsRead).toHaveBeenCalledWith('thread_id');
+            expect(markThreadAsRead).toHaveBeenCalledWith('post_id');
         });
 
         test('should match actions for PREFETCH_POSTS_FOR_CHANNEL when prefetch argument and getPostsSince sucess', async () => {

--- a/webapp/channels/src/actions/views/channel.ts
+++ b/webapp/channels/src/actions/views/channel.ts
@@ -49,9 +49,11 @@ import EventEmitter from 'mattermost-redux/utils/event_emitter';
 import {openDirectChannelToUserId} from 'actions/channel_actions';
 import {loadCustomStatusEmojisForPostList} from 'actions/emoji_actions';
 import {closeRightHandSide} from 'actions/views/rhs';
+import {markThreadAsRead} from 'actions/views/threads';
 import {getLastViewedChannelName} from 'selectors/local_storage';
 import {getSelectedPost, getSelectedPostId} from 'selectors/rhs';
 import {getLastPostsApiTimeForChannel} from 'selectors/views/channel';
+import {getSelectedThreadIdInCurrentTeam} from 'selectors/views/threads';
 import {getSocketStatus} from 'selectors/views/websocket';
 import LocalStorageStore from 'stores/local_storage_store';
 
@@ -493,13 +495,24 @@ export function scrollPostListToBottom() {
     };
 }
 
-export function markChannelAsReadOnFocus(channelId: string): ThunkActionFunc<void> {
+export function markAsReadOnFocus(): ThunkActionFunc<void, GlobalState> {
     return (dispatch, getState) => {
-        if (isManuallyUnread(getState(), channelId)) {
-            return;
+        const state = getState();
+        const currentChannelId = getCurrentChannelId(state);
+        const selectedThreadId = getSelectedThreadIdInCurrentTeam(state);
+        const selectedPostId = getSelectedPostId(state);
+
+        if (!isManuallyUnread(getState(), currentChannelId)) {
+            dispatch(markChannelAsRead(currentChannelId));
         }
 
-        dispatch(markChannelAsRead(channelId));
+        if (selectedThreadId) {
+            dispatch(markThreadAsRead(selectedThreadId));
+        }
+
+        if (currentChannelId && selectedPostId) {
+            dispatch(markThreadAsRead(selectedPostId));
+        }
     };
 }
 

--- a/webapp/channels/src/actions/views/threads.ts
+++ b/webapp/channels/src/actions/views/threads.ts
@@ -3,7 +3,16 @@
 
 import {batchActions} from 'redux-batched-actions';
 
+import {updateThreadRead} from 'mattermost-redux/actions/threads';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import type {ThunkActionFunc} from 'mattermost-redux/types/actions';
+
+import {isThreadManuallyUnread, isThreadOpen} from 'selectors/views/threads';
+
 import {ActionTypes, Threads} from 'utils/constants';
+
+import type {GlobalState} from 'types/store';
 
 export function updateThreadLastOpened(threadId: string, lastViewedAt: number) {
     return {
@@ -39,5 +48,18 @@ export function updateThreadToastStatus(status: boolean) {
     return {
         type: ActionTypes.UPDATE_THREAD_TOAST_STATUS,
         data: status,
+    };
+}
+
+export function markThreadAsRead(threadId: string): ThunkActionFunc<void, GlobalState> {
+    return (dispatch, getState) => {
+        const state = getState();
+        const currentUserId = getCurrentUserId(state);
+        const currentTeamId = getCurrentTeamId(state);
+
+        if (isThreadOpen(state, threadId) && window.isActive && !isThreadManuallyUnread(state, threadId)) {
+            // mark thread as read on the server
+            dispatch(updateThreadRead(currentUserId, currentTeamId, threadId, Date.now()));
+        }
     };
 }

--- a/webapp/channels/src/actions/websocket_actions.jsx
+++ b/webapp/channels/src/actions/websocket_actions.jsx
@@ -1680,7 +1680,7 @@ function handleThreadUpdated(msg) {
             threadData.is_following = true;
         }
 
-        if (isThreadOpen(state, threadData.id) && !isThreadManuallyUnread(state, threadData.id)) {
+        if (isThreadOpen(state, threadData.id) && window.isActive && !isThreadManuallyUnread(state, threadData.id)) {
             lastViewedAt = Date.now();
 
             // Sometimes `Date.now()` was generating a timestamp before the

--- a/webapp/channels/src/components/team_controller/index.ts
+++ b/webapp/channels/src/components/team_controller/index.ts
@@ -11,8 +11,7 @@ import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general
 import {getCurrentTeamId, getMyTeams} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
-import {markChannelAsReadOnFocus} from 'actions/views/channel';
-import {markThreadAsRead} from 'actions/views/threads';
+import {markAsReadOnFocus} from 'actions/views/channel';
 import {getSelectedPostId} from 'selectors/rhs';
 import {getSelectedThreadIdInCurrentTeam} from 'selectors/views/threads';
 
@@ -55,8 +54,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
 const mapDispatchToProps = {
     fetchChannelsAndMembers,
     fetchAllMyTeamsChannelsAndChannelMembersREST,
-    markChannelAsReadOnFocus,
-    markThreadAsRead,
+    markAsReadOnFocus,
     initializeTeam,
     joinTeam,
     unsetActiveChannelOnServer,

--- a/webapp/channels/src/components/team_controller/index.ts
+++ b/webapp/channels/src/components/team_controller/index.ts
@@ -12,6 +12,8 @@ import {getCurrentTeamId, getMyTeams} from 'mattermost-redux/selectors/entities/
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import {markChannelAsReadOnFocus} from 'actions/views/channel';
+import {markThreadAsRead} from 'actions/views/threads';
+import {getSelectedPostId} from 'selectors/rhs';
 import {getSelectedThreadIdInCurrentTeam} from 'selectors/views/threads';
 
 import {initializeTeam, joinTeam} from 'components/team_controller/actions';
@@ -43,6 +45,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
         teamsList: getMyTeams(state),
         plugins,
         selectedThreadId: getSelectedThreadIdInCurrentTeam(state),
+        selectedPostId: getSelectedPostId(state),
         mfaRequired: checkIfMFARequired(currentUser, license, config, ownProps.match.url),
         disableRefetchingOnBrowserFocus,
         disableWakeUpReconnectHandler,
@@ -53,6 +56,7 @@ const mapDispatchToProps = {
     fetchChannelsAndMembers,
     fetchAllMyTeamsChannelsAndChannelMembersREST,
     markChannelAsReadOnFocus,
+    markThreadAsRead,
     initializeTeam,
     joinTeam,
     unsetActiveChannelOnServer,

--- a/webapp/channels/src/components/team_controller/team_controller.tsx
+++ b/webapp/channels/src/components/team_controller/team_controller.tsx
@@ -86,10 +86,15 @@ function TeamController(props: Props) {
         function handleFocus() {
             if (props.selectedThreadId) {
                 window.isActive = true;
+                props.markThreadAsRead(props.selectedThreadId);
             }
             if (props.currentChannelId) {
                 window.isActive = true;
                 props.markChannelAsReadOnFocus(props.currentChannelId);
+
+                if (props.selectedPostId) {
+                    props.markThreadAsRead(props.selectedPostId);
+                }
             }
 
             // Temporary flag to disable refetching of channel members on browser focus
@@ -130,7 +135,7 @@ function TeamController(props: Props) {
             window.removeEventListener('blur', handleBlur);
             window.removeEventListener('keydown', handleKeydown);
         };
-    }, [props.selectedThreadId, props.currentChannelId, props.currentTeamId]);
+    }, [props.selectedThreadId, props.currentChannelId, props.currentTeamId, props.selectedPostId]);
 
     // Effect runs on mount, adds active state to window
     useEffect(() => {

--- a/webapp/channels/src/components/team_controller/team_controller.tsx
+++ b/webapp/channels/src/components/team_controller/team_controller.tsx
@@ -84,18 +84,8 @@ function TeamController(props: Props) {
     // Effect runs on mount, add event listeners on windows object
     useEffect(() => {
         function handleFocus() {
-            if (props.selectedThreadId) {
-                window.isActive = true;
-                props.markThreadAsRead(props.selectedThreadId);
-            }
-            if (props.currentChannelId) {
-                window.isActive = true;
-                props.markChannelAsReadOnFocus(props.currentChannelId);
-
-                if (props.selectedPostId) {
-                    props.markThreadAsRead(props.selectedPostId);
-                }
-            }
+            window.isActive = true;
+            props.markAsReadOnFocus();
 
             // Temporary flag to disable refetching of channel members on browser focus
             if (!props.disableRefetchingOnBrowserFocus) {
@@ -135,7 +125,7 @@ function TeamController(props: Props) {
             window.removeEventListener('blur', handleBlur);
             window.removeEventListener('keydown', handleKeydown);
         };
-    }, [props.selectedThreadId, props.currentChannelId, props.currentTeamId, props.selectedPostId]);
+    }, [props.currentTeamId]);
 
     // Effect runs on mount, adds active state to window
     useEffect(() => {


### PR DESCRIPTION
#### Summary
When you leave a thread open on your app, and then put the app in the background, if you received a new message the message would automatically be marked as read. This is because we weren't checking for `window.isActive` when the new message arrived and when we checked if the thread is open, we would mark it read from there (and sync it with the server).

This fixed the missed message issue, but then when we refocus the app the thread would still be marked as unread and that wouldn't change unless you went to another thread or page and then came back (or marked it as read manually). To fix this, on focus we will mark the currently open thread as read, similar to how we do for channels.

As a side note, we didn't have any test coverage for any of this logic beforehand and it would make sense to add some, but I'm going to address that separately.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58567

```release-note
Fixed an issue where threads would be marked read when open in the background.
```
