### PR TITLE
Differentiate remove device error from push proxy

### DIFF
--- a/server/channels/app/expirynotify.go
+++ b/server/channels/app/expirynotify.go
@@ -48,7 +48,7 @@ func (a *App) NotifySessionsExpired() error {
 		errPush := a.sendToPushProxy(tmpMessage, session)
 		if errPush != nil {
 			reason := model.NotificationReasonPushProxySendError
-			if err.Error() == notificationErrorRemoveDevice {
+			if errPush.Error() == notificationErrorRemoveDevice {
 				reason = model.NotificationReasonPushProxyRemoveDevice
 			}
 			a.CountNotificationReason(model.NotificationStatusError, model.NotificationTypePush, reason, tmpMessage.Platform)

--- a/server/channels/app/expirynotify.go
+++ b/server/channels/app/expirynotify.go
@@ -47,11 +47,15 @@ func (a *App) NotifySessionsExpired() error {
 
 		errPush := a.sendToPushProxy(tmpMessage, session)
 		if errPush != nil {
-			a.CountNotificationReason(model.NotificationStatusError, model.NotificationTypePush, model.NotificationReasonPushProxySendError, tmpMessage.Platform)
+			reason := model.NotificationReasonPushProxySendError
+			if err.Error() == notificationErrorRemoveDevice {
+				reason = model.NotificationReasonPushProxyRemoveDevice
+			}
+			a.CountNotificationReason(model.NotificationStatusError, model.NotificationTypePush, reason, tmpMessage.Platform)
 			a.NotificationsLog().Error("Failed to send to push proxy",
 				mlog.String("type", model.NotificationTypePush),
 				mlog.String("status", model.NotificationStatusNotSent),
-				mlog.String("reason", model.NotificationReasonPushProxySendError),
+				mlog.String("reason", reason),
 				mlog.String("ack_id", tmpMessage.AckId),
 				mlog.String("push_type", tmpMessage.Type),
 				mlog.String("user_id", session.UserId),

--- a/server/public/model/notification.go
+++ b/server/public/model/notification.go
@@ -24,6 +24,7 @@ const (
 	NotificationReasonParseError                         NotificationReason = "json_parse_error"
 	NotificationReasonPushProxyError                     NotificationReason = "push_proxy_error"
 	NotificationReasonPushProxySendError                 NotificationReason = "push_proxy_send_error"
+	NotificationReasonPushProxyRemoveDevice              NotificationReason = "push_proxy_remove_device"
 	NotificationReasonRejectedByPlugin                   NotificationReason = "rejected_by_plugin"
 	NotificationReasonSessionExpired                     NotificationReason = "session_expired"
 	NotificationReasonChannelMuted                       NotificationReason = "channel_muted"


### PR DESCRIPTION
#### Summary
The `sendToPushProxy` returns an specific error when the device token is removed. This is an expected error, so we added a new reason to differentiate from other generic push proxy errors that may imply problems in the delivery metrics.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58592

#### Release Note
```release-note
Improve metrics related to push proxy errors
```
