### PR TITLE
MM-60188 Stop rendering EmojiPickerOverlay inside of EditBox

### DIFF
--- a/webapp/channels/src/components/edit_post/edit_post.tsx
+++ b/webapp/channels/src/components/edit_post/edit_post.tsx
@@ -463,7 +463,6 @@ const EditPost = ({editingPost, actions, canEditPost, config, channelId, draft, 
         }
     };
 
-    const getEmojiContainerRef = useCallback(() => textboxRef.current, [textboxRef]);
     const getEmojiTargetRef = useCallback(() => emojiButtonRef.current, [emojiButtonRef]);
 
     let emojiPicker = null;
@@ -473,7 +472,6 @@ const EditPost = ({editingPost, actions, canEditPost, config, channelId, draft, 
             <>
                 <EmojiPickerOverlay
                     show={showEmojiPicker}
-                    container={getEmojiContainerRef}
                     target={getEmojiTargetRef}
                     onHide={hideEmojiPicker}
                     onEmojiClick={handleEmojiClick}

--- a/webapp/channels/src/components/emoji_picker/emoji_picker_overlay/emoji_picker_overlay.tsx
+++ b/webapp/channels/src/components/emoji_picker/emoji_picker_overlay/emoji_picker_overlay.tsx
@@ -16,7 +16,6 @@ import EmojiPickerTabs from '../emoji_picker_tabs';
 import type {PropsFromRedux} from './index';
 
 export interface Props extends PropsFromRedux {
-    container?: () => ReactNode;
     target: () => ReactNode;
     onEmojiClick: (emoji: Emoji) => void;
     onGifClick?: (gif: string) => void;
@@ -93,7 +92,6 @@ export default class EmojiPickerOverlay extends React.PureComponent<Props> {
                 show={show}
                 placement={this.props.placement ?? placement}
                 rootClose={!isMobileView}
-                container={this.props.container}
                 onHide={this.props.onHide}
                 target={target}
                 animation={false}


### PR DESCRIPTION
#### Summary
The `container` prop of React Bootstrap's `Overlay` and `OverlayTrigger` components is used to control where in the DOM the overlaid component is rendered (like a React Portal), and we used to do that for the emoji picker in some places so that it would move with the surrounding content when that was scrolled. Without it, the component is rendered at the root of the document.

We no longer let users scroll content behind the emoji picker, so we don't need to use a `container` here. By moving it to the root of the document, it'll render on top of everything, and it'll no longer get cut off by the a container that has overflow hidden.

#### Ticket Link
MM-60188

#### Release Note
This never shipped, so no release not is needed
```release-note
NONE
```
