### PR TITLE
Fix scroll on user settings

### DIFF
--- a/webapp/channels/src/components/setting_item.tsx
+++ b/webapp/channels/src/components/setting_item.tsx
@@ -2,10 +2,12 @@
 // See LICENSE.txt for license information.
 
 import type {ReactNode} from 'react';
-import React, {useEffect, useRef} from 'react';
+import React, {useRef} from 'react';
 
 import type SettingItemMinComponent from 'components/setting_item_min';
 import SettingItemMin from 'components/setting_item_min';
+
+import useDidUpdate from './common/hooks/useDidUpdate';
 
 type Props = {
 
@@ -54,7 +56,7 @@ const SettingItem = ({
 }: Props) => {
     const minRef = useRef<SettingItemMinComponent>(null);
 
-    useEffect(() => {
+    useDidUpdate(() => {
         // We want to bring back focus to the edit button when the section is opened and then closed along with all sections are closed
 
         if (!active && areAllSectionsInactive) {


### PR DESCRIPTION
#### Summary
During the [change of this component from class to function component](https://github.com/mattermost/mattermost/commit/c582f497391611715761530f8e0b99f0bf41e07f), we made a small behavior change.

We use to focus the edit button on update if we change from active to inactive. But when migrating, we used a `useEffect`, which also runs on mount. So all edit buttons where trying to get the focus, and in the end, the last one got the focus. Therefore, the scroll there.

Changing to use the `useDidUpdate` hook solves it.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-60238

#### Release Note
Catched before it made it into production
```release-note
NONE
```
