### PR TITLE
MM-59855 Fix layout issue on smaller screens when rhs is expanded

### DIFF
--- a/webapp/channels/src/sass/base/_structure.scss
+++ b/webapp/channels/src/sass/base/_structure.scss
@@ -281,6 +281,7 @@ body.app__body #root {
                 width: 100%;
                 grid-area: center;
                 transition: width .25s ease-in-out;
+                border-radius: var(--radius-l);
             }
 
             --columns: min-content 1fr min-content;

--- a/webapp/channels/src/sass/base/_structure.scss
+++ b/webapp/channels/src/sass/base/_structure.scss
@@ -283,7 +283,7 @@ body.app__body #root {
                 transition: width .25s ease-in-out;
             }
 
-            --columns: min-content auto min-content;
+            --columns: min-content 1fr min-content;
         }
 
         #sidebar-right {


### PR DESCRIPTION
#### Summary
Fixes a layout issue when view the expanded RHS on screens between 768px and < 1200px

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/MM-59855

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="1107" alt="image" src="https://github.com/user-attachments/assets/49ee73f6-4f55-42a4-ad8b-41dbcc558a80"> | <img width="1107" alt="image" src="https://github.com/user-attachments/assets/ea63cf7d-dafc-4e02-81bb-84039ff0b5c2">|
| <img width="1156" alt="image" src="https://github.com/user-attachments/assets/082cf40b-256d-4603-8fd4-c3f22e29995b"> | <img width="568" alt="image" src="https://github.com/user-attachments/assets/e5c062b7-2830-42cc-ae38-bc38b3e5998f"> |


#### Release Note
```release-note
NONE
```