### PR TITLE
[MM-59520] Prepackage Calls v1.0.1

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -144,7 +144,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.0.0
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.0.1
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.3.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.9.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.1.1


### PR DESCRIPTION
#### Summary

PR prepackages a dot release of Calls v1 that fixes a regression we caught on Community this week.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-59520

#### Release Note

```release-note
Prepackaged Calls [v1.0.1](https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v1.0.1) - This includes breaking changes such as allowing calls in direct message channels only on unlicensed servers.
```

