### PR TITLE
removed an incorretc return that caused missing API timing metrics for 4xx and 5xx errors

### DIFF
--- a/server/channels/api4/metrics_test.go
+++ b/server/channels/api4/metrics_test.go
@@ -155,4 +155,67 @@ func TestSubmitMetrics(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 	})
+
+	t.Run("metrics recorded for API errors", func(t *testing.T) {
+		metricsMock := setupMetricsMock()
+		metricsMock.On("IncrementClientLongTasks", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("float64")).Return()
+
+		platform.RegisterMetricsInterface(func(_ *platform.PlatformService, _, _ string) einterfaces.MetricsInterface {
+			return metricsMock
+		})
+		t.Cleanup(func() {
+			platform.RegisterMetricsInterface(func(_ *platform.PlatformService, _, _ string) einterfaces.MetricsInterface {
+				return nil
+			})
+		})
+
+		th := SetupEnterpriseWithServerOptions(t, []app.Option{app.StartMetrics})
+		defer th.TearDown()
+
+		// enable metrics and add the license
+		th.App.Srv().SetLicense(model.NewTestLicense())
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.MetricsSettings.Enable = true })
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.MetricsSettings.ListenAddress = ":0" })
+
+		_, resp, err := th.Client.CreatePost(th.Context.Context(), &model.Post{
+			ChannelId: model.NewId(),
+		})
+
+		require.Error(t, err)
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+		metricsMock.AssertCalled(t, "IncrementHTTPRequest")
+		metricsMock.AssertCalled(t, "IncrementHTTPError")
+	})
+
+	t.Run("metrics recorded for URL length limit errors", func(t *testing.T) {
+		metricsMock := setupMetricsMock()
+		metricsMock.On("IncrementClientLongTasks", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("float64")).Return()
+
+		platform.RegisterMetricsInterface(func(_ *platform.PlatformService, _, _ string) einterfaces.MetricsInterface {
+			return metricsMock
+		})
+		t.Cleanup(func() {
+			platform.RegisterMetricsInterface(func(_ *platform.PlatformService, _, _ string) einterfaces.MetricsInterface {
+				return nil
+			})
+		})
+
+		th := SetupEnterpriseWithServerOptions(t, []app.Option{app.StartMetrics})
+		defer th.TearDown()
+
+		// enable metrics and add the license
+		th.App.Srv().SetLicense(model.NewTestLicense())
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.MetricsSettings.Enable = true })
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.MetricsSettings.ListenAddress = ":0" })
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.MaximumURLLength = 1 })
+
+		_, resp, err := th.Client.CreatePost(th.Context.Context(), &model.Post{
+			ChannelId: model.NewId(),
+		})
+
+		require.Error(t, err)
+		require.Equal(t, http.StatusRequestURITooLong, resp.StatusCode)
+		metricsMock.AssertCalled(t, "IncrementHTTPRequest")
+		metricsMock.AssertCalled(t, "IncrementHTTPError")
+	})
 }

--- a/server/channels/web/handlers.go
+++ b/server/channels/web/handlers.go
@@ -380,7 +380,8 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Handle errors that have occurred
 	if c.Err != nil {
 		h.handleContextError(c, w, r)
-		return
+		// intentionally not returning here as we need the code block below to report
+		// the Mattermost API time metrics.
 	}
 
 	statusCode = strconv.Itoa(w.(*responseWriterWrapper).StatusCode())


### PR DESCRIPTION
#### Summary
Removed an incorrect return statement that caused missed timing metrics for API calls that resulted in 4xx and 5xx errors.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-60269

#### Release Note
```release-note
None
```
