### PR TITLE
MM-59260: allowed group channels to be deleted

### DIFF
--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -1320,7 +1320,7 @@ func deleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.AddEventPriorState(channel)
 	defer c.LogAuditRec(auditRec)
 
-	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
+	if channel.Type == model.ChannelTypeDirect {
 		c.Err = model.NewAppError("deleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
#### Summary
Deleted the validation on deletion on ‘group channel is it a group channel’ 

QA cases: try to delete a group channel with access to delete it

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/27489
Jira https://mattermost.atlassian.net/browse/MM-59260
