### PR TITLE
[MM-60284] Desktop app doesnt stop the initial loading indicator

### DIFF
--- a/webapp/channels/src/components/initial_loading_screen/initial_loading_screen_class.ts
+++ b/webapp/channels/src/components/initial_loading_screen/initial_loading_screen_class.ts
@@ -42,6 +42,8 @@ export class InitialLoadingScreenClass {
 
         this.addAnimationEndListener();
 
+        // Starting automatically in the constructor instead of waiting for call from the code base
+        // as per the latest UX recommendation
         this.start();
     }
 

--- a/webapp/channels/src/components/initial_loading_screen/initial_loading_screen_class.ts
+++ b/webapp/channels/src/components/initial_loading_screen/initial_loading_screen_class.ts
@@ -26,10 +26,23 @@ export class InitialLoadingScreenClass {
     constructor() {
         this.loadingScreenElement = document.getElementById('initialPageLoadingScreen');
         this.loadingAnimationElement = document.getElementById('initialPageLoadingAnimation');
-
         this.initialLoadingScreenCSS = document.getElementById('initialLoadingScreenCSS') as HTMLLinkElement | null;
 
         this.handleAnimationEndEvent = this.handleAnimationEndEvent.bind(this);
+
+        this.init();
+    }
+
+    private init() {
+        if (isDesktopApp()) {
+            // Let Mattermost desktop handle the loading screen
+            this.destroy();
+            return;
+        }
+
+        this.addAnimationEndListener();
+
+        this.start();
     }
 
     private handleAnimationEndEvent(event: AnimationEvent) {
@@ -88,14 +101,6 @@ export class InitialLoadingScreenClass {
      * If we do want to do that then we should remove the set timeout destroy call doing above.
      */
     public start() {
-        if (isDesktopApp()) {
-            // Let Mattermost desktop handle the loading screen
-            this.destroy();
-            return;
-        }
-
-        this.addAnimationEndListener();
-
         if (!this.loadingScreenElement || !this.loadingAnimationElement) {
             // eslint-disable-next-line no-console
             console.error('InitialLoadingScreen: No loading screen or animation element found');


### PR DESCRIPTION
#### Summary
This fixes the issue where the loading indicator doesnt get cleaned up after the loading is complete. It also fixes the issue where the desktop renders the initial loading indicator where it should not have had.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60284

#### Screenshots
none

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
