### PR TITLE
[MM-59912] Update unread threads in team when threads are received

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/threadsInTeam.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/threadsInTeam.test.ts
@@ -1,10 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {Team} from '@mattermost/types/teams';
+import type {UserThread} from '@mattermost/types/threads';
+import type {RelationOneToMany} from '@mattermost/types/utilities';
+
 import {ThreadTypes} from 'mattermost-redux/action_types';
 import deepFreeze from 'mattermost-redux/utils/deep_freeze';
 
-import {handleFollowChanged} from './threadsInTeam';
+import {handleFollowChanged, unreadThreadsInTeamReducer} from './threadsInTeam';
 import type {ExtraData} from './types';
 
 describe('handleFollowChanged', () => {
@@ -72,5 +76,25 @@ describe('handleFollowChanged', () => {
             team_id1: expected,
             team_id2: ['id2_1', 'id2_2'],
         });
+    });
+});
+
+describe('unreadThreadsInTeam', () => {
+    test('RECEIVED_THREADS should update the state if there are unread threads', () => {
+        const state = deepFreeze({});
+        const nextState: RelationOneToMany<Team, UserThread> = unreadThreadsInTeamReducer(state, {
+            type: ThreadTypes.RECEIVED_THREADS,
+            data: {
+                team_id: 'a',
+                threads: [
+                    {id: 't1', unread_replies: 1},
+                    {id: 't2', unread_mentions: 1},
+                    {id: 't3'},
+                ],
+            },
+        }, {threads: {}});
+
+        expect(nextState).not.toBe(state);
+        expect(nextState.a).toEqual(['t1', 't2']);
     });
 });

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/threadsInTeam.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/threadsInTeam.ts
@@ -4,7 +4,7 @@
 import type {AnyAction} from 'redux';
 
 import type {Team} from '@mattermost/types/teams';
-import type {ThreadsState, UserThread} from '@mattermost/types/threads';
+import type {ThreadsState, UserThread, UserThreadWithPost} from '@mattermost/types/threads';
 import type {IDMappedObjects, RelationOneToMany} from '@mattermost/types/utilities';
 
 import {ChannelTypes, PostTypes, TeamTypes, ThreadTypes, UserTypes} from 'mattermost-redux/action_types';
@@ -283,6 +283,14 @@ export const unreadThreadsInTeamReducer = (state: ThreadsState['unreadThreadsInT
             return handleReceivedThread(state, action, extra);
         }
         return state;
+    case ThreadTypes.RECEIVED_THREADS:
+        return handleReceiveThreads(state, {
+            ...action,
+            data: {
+                ...action.data,
+                threads: action.data.threads.filter((thread: UserThreadWithPost) => thread.unread_replies > 0 || thread.unread_mentions > 0),
+            },
+        });
     case PostTypes.POST_REMOVED:
         return handlePostRemoved(state, action);
     case ThreadTypes.RECEIVED_UNREAD_THREADS:


### PR DESCRIPTION
#### Summary
There are cases when the application receives threads, for example via `getCountsAndThreadsSince` when the websocket reconnects after a user has been inactive, where we receive threads that are unread. Where this may be reflected is the Unreads tab of Threads view where we list our unread threads. We show that they are marked unread in the Threads view as the information is available on the thread, but we were not updating the reducers that also track the thread IDs.

This PR adds that update to the reducer for `unreadThreadsInTeam` so that we can be assured that the latest unread thread information is available widespread. Definitely worth reading the JIRA ticket to understand how the issue can arise.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59912

```release-note
Fixed an issue where the Unreads tab would not update correctly after the websocket reconnects.
```
