### PR TITLE
Fix Ctrl-up when changing the value on different inputs

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/use_key_handler.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_key_handler.tsx
@@ -371,6 +371,10 @@ const useKeyHandler = (
         }
     }, [draft.message]);
 
+    useEffect(() => {
+        messageHistoryIndex.current = messageHistory.length;
+    }, [messageHistory]);
+
     // Update last channel switch at
     useEffect(() => {
         lastChannelSwitchAt.current = Date.now();


### PR DESCRIPTION
#### Summary
When the message history is changed from a different input (RHS), we were not resetting the index. This would cause that messages written in the RHS won't apparently appear in the history when using CTRL-UP.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-60290

#### Release Note
Caught before release
```release-note
NONE
```
