### PR TITLE
[MM-60280] api4/license.go: add err check to JSON unmarshal

### DIFF
--- a/server/channels/api4/license.go
+++ b/server/channels/api4/license.go
@@ -212,7 +212,12 @@ func requestTrialLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = model.NewAppError("requestTrialLicense", "api.license.request-trial.bad-request", nil, "", http.StatusBadRequest)
 		return
 	}
-	json.Unmarshal(b, &trialRequest)
+
+	err = json.Unmarshal(b, &trialRequest)
+	if err != nil {
+		c.Err = model.NewAppError("requestTrialLicense", "api.license.request-trial.bad-request", nil, "", http.StatusBadRequest).Wrap(err)
+		return
+	}
 
 	var appErr *model.AppError
 	// If any of the newly supported trial request fields are set (ie, not a legacy request), process this as a new trial request (requiring the new fields) otherwise fall back on the old method.

--- a/server/channels/api4/license_test.go
+++ b/server/channels/api4/license_test.go
@@ -386,6 +386,18 @@ func TestRequestTrialLicense(t *testing.T) {
 		CheckForbiddenStatus(t, resp)
 	})
 
+	t.Run("trial license invalid JSON", func(t *testing.T) {
+		// the JSON is invalid because it is missing a closing brace
+
+		licenseManagerMock := &mocks.LicenseInterface{}
+		licenseManagerMock.On("CanStartTrial").Return(true, nil).Once()
+		th.App.Srv().Platform().SetLicenseManager(licenseManagerMock)
+
+		resp, err := th.SystemAdminClient.DoAPIPost(context.Background(), "/trial-license", `{"users": 5`)
+		CheckErrorID(t, err, "api.license.request-trial.bad-request")
+		CheckBadRequestStatus(t, model.BuildResponse(resp))
+	})
+
 	t.Run("trial license user count less than current users", func(t *testing.T) {
 		nUsers := 1
 		license := model.NewTestLicense()
@@ -450,13 +462,6 @@ func TestRequestTrialLicense(t *testing.T) {
 		resp, err := th.SystemAdminClient.RequestTrialLicense(context.Background(), nUsers)
 		require.Error(t, err)
 		require.Equal(t, resp.StatusCode, 451)
-	})
-
-	t.Run("trial license invalid JSON", func(t *testing.T) {
-		// the JSON is invalid because it is missing a closing brace
-		resp, err := th.SystemAdminClient.DoAPIPost(context.Background(), "/trial-license", `{"users": 5`)
-		CheckErrorID(t, err, "api.license.request-trial.bad-request")
-		CheckBadRequestStatus(t, model.BuildResponse(resp))
 	})
 
 	th.App.Srv().Platform().SetLicenseManager(nil)

--- a/server/channels/api4/license_test.go
+++ b/server/channels/api4/license_test.go
@@ -465,5 +465,4 @@ func TestRequestTrialLicense(t *testing.T) {
 		CheckErrorID(t, err, "api.license.upgrade_needed.app_error")
 		CheckForbiddenStatus(t, resp)
 	})
-
 }

--- a/server/channels/api4/license_test.go
+++ b/server/channels/api4/license_test.go
@@ -452,10 +452,18 @@ func TestRequestTrialLicense(t *testing.T) {
 		require.Equal(t, resp.StatusCode, 451)
 	})
 
+	t.Run("trial license invalid JSON", func(t *testing.T) {
+		// the JSON is invalid because it is missing a closing brace
+		resp, err := th.SystemAdminClient.DoAPIPost(context.Background(), "/trial-license", `{"users": 5`)
+		CheckErrorID(t, err, "api.license.request-trial.bad-request")
+		CheckBadRequestStatus(t, model.BuildResponse(resp))
+	})
+
 	th.App.Srv().Platform().SetLicenseManager(nil)
 	t.Run("trial license should fail if LicenseManager is nil", func(t *testing.T) {
 		resp, err := th.SystemAdminClient.RequestTrialLicense(context.Background(), 1)
 		CheckErrorID(t, err, "api.license.upgrade_needed.app_error")
 		CheckForbiddenStatus(t, resp)
 	})
+
 }


### PR DESCRIPTION


#### Summary
Looks like the error check was forgotten, this leading to a `nil` struct method to be invoked.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60280

#### Release Note

```release-note
NONE
```
