### PR TITLE
fix issue when a line is selected one by one the numbering was always…

### DIFF
--- a/webapp/channels/src/utils/markdown/apply_markdown.ts
+++ b/webapp/channels/src/utils/markdown/apply_markdown.ts
@@ -155,6 +155,16 @@ const applyOlMarkdown = ({selectionEnd, selectionStart, message}: ApplySpecificM
         newEnd = Math.max(selectionEnd - (delimiterLength * count), 0);
     } else {
         let count = 0;
+
+        const getLastNumberedLine = (text: string): number => {
+            const match = text.match(/(\d+)\.\s/g);
+            if (match) {
+                return parseInt(match[match.length - 1], 10);
+            }
+            return 0;
+        };
+        getDelimiter.counter = getLastNumberedLine(newPrefix) + 1;
+
         if (isFirstLineSelected) {
             multilineSelection = getDelimiter() + multilineSelection;
             count++;


### PR DESCRIPTION
… one

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary


- When a line is selected one by one, the numbering was always 1
- To solve the problem, I added getLastNumberedLine function that extracts the last numbering in the text before adding the new numbering


#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
|  
<img width="108" alt="Capture d’écran 2024-08-28 à 13 52 47" src="https://github.com/user-attachments/assets/f742fecb-1605-49fd-81d9-487a5b54accc">
|
<img width="87" alt="Capture d’écran 2024-08-28 à 13 53 28" src="https://github.com/user-attachments/assets/2253a795-f8cb-42bd-a56c-643155fdf1d6">
  |



-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
fix issue when a line is selected one by one the numbering was always…
```
