### PR TITLE
MM-60241 Ensure RHS post list always fills available space

### DIFF
--- a/webapp/channels/src/components/threading/thread_viewer/thread_viewer.scss
+++ b/webapp/channels/src/components/threading/thread_viewer/thread_viewer.scss
@@ -9,9 +9,16 @@
     }
 
     .post-list__dynamic--RHS {
+        display: flex;
+        height: 100%;
+        flex-direction: column;
         padding-bottom: 8px;
         scrollbar-color: var(--center-channel-color-32) #fff0;
         scrollbar-width: thin;
+
+        & > div[role="list"]:nth-child(1) {
+            margin-top: auto;
+        }
     }
 
     > div {


### PR DESCRIPTION
#### Summary
This fixes the post actions menu being cut off because it overflowed outside of the div that contains the RHS post list by ensuring that that div always fills the whole RHS height even if it doesn't have enough posts to take up the whole height of the screen. Thanks to @harshilsharma63 for this fix since it's much easier than migrating the menu to use a portal like I originally tried to do!

@AshishDhama This relates back to the changes to the RHS scrolling, so I added you as an extra reviewer in case you happen to know any case where this might not work

#### Ticket Link
MM-60241

#### Release Note
None needed since this hasn't shipped yet
```release-note
NONE
```
