### PR TITLE
Prepackage plugins mscalender and msteams meetings

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -158,6 +158,8 @@ PLUGIN_PACKAGES += mattermost-plugin-ai-v1.0.0
 PLUGIN_PACKAGES += focalboard-v8.0.0
 PLUGIN_PACKAGES += mattermost-plugin-msteams-v2.0.3
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
+PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.3.4
+PLUGIN_PACKAGES += com.mattermost.msteamsmeetings-2.2.0
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -159,7 +159,7 @@ PLUGIN_PACKAGES += focalboard-v8.0.0
 PLUGIN_PACKAGES += mattermost-plugin-msteams-v2.0.3
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.3.4
-PLUGIN_PACKAGES += com.mattermost.msteamsmeetings-2.2.0
+PLUGIN_PACKAGES += mattermost-plugin-msteams-meetings-v2.2.0
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)
 


### PR DESCRIPTION
#### Summary
This PR adds two plugins to the prepackaged plugins list:

- [MS Calendar](https://github.com/mattermost/mattermost-plugin-mscalendar)
- [MS Teams Meetings](https://github.com/mattermost-community/mattermost-plugin-msteams-meetings)

**Note:**  Moving the [MS Teams Meetings plugin](https://github.com/mattermost-community/mattermost-plugin-msteams-meetings) to the Mattermost Github org is still pending. Therefore some manual intervention may be need to get the [release binary](https://github.com/mattermost-community/mattermost-plugin-msteams-meetings/releases/tag/v2.2.0) to the right place.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59878

#### Release Note
```release-note
Prepackage MS Calendar and MS Teams Meetings plugins
```
