### PR TITLE
fix: enable preview for all image types without initial or mini preview

### DIFF
--- a/webapp/channels/src/components/threading/global_threads/thread_item/attachments/file_card/file_card.tsx
+++ b/webapp/channels/src/components/threading/global_threads/thread_item/attachments/file_card/file_card.tsx
@@ -8,7 +8,7 @@ import type {FileInfo} from '@mattermost/types/files';
 
 import {getFileThumbnailUrl, getFileUrl} from 'mattermost-redux/utils/file_utils';
 
-import {FileTypes} from 'utils/constants';
+import Constants, {FileTypes} from 'utils/constants';
 import {fileSizeToString, getCompassIconClassName, getFileType} from 'utils/utils';
 
 import './file_card.scss';
@@ -37,6 +37,10 @@ function File({
     enableSVGs,
 }: FileProps) {
     const imgSrc = useMemo(() => {
+        // all images type from constants.IMAGE_TYPES can preview if they have not initial image preview and mini preview.
+        if (Constants.IMAGE_TYPES.includes(extension.toLowerCase()) && !hasPreviewImage && !miniPreview) {
+            return getFileUrl(id);
+        }
         if (!hasPreviewImage) {
             return undefined;
         }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
- This pr aims to update the logic for generating file previews to ensure that all image types specified in Constants.IMAGE_TYPES can have a preview, even if they not have an initial or mini preview. Previously, only images with a predefined preview or mini preview were displayed, which excluded certain image types like PSD files.

- the issues appeared when the file was the first message in a thread (GIF when upload via fileUpload / WEBP)
 
- Modified the preview generation logic in File component to check if an image type is supported and does not have initial or mini previews.

- Ensured that all image types listed in Constants.IMAGE_TYPES are eligible for preview by fetching the full file URL.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots

|  before  |  after  |
|----|----|
|<img width="580" alt="Capture d’écran 2024-09-04 à 14 22 11" src="https://github.com/user-attachments/assets/75ef38a8-8857-40e1-88fb-240057e402eb"> | <img width="546" alt="Capture d’écran 2024-09-04 à 14 02 03" src="https://github.com/user-attachments/assets/c5751474-44d8-4a23-aa41-ce9866cf72ca">|


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
fix: enable preview for all image types without initial or mini preview
```