### PR TITLE
MM-56994 Used false as default for useMilitaryTime

### DIFF
--- a/server/channels/app/notification_email.go
+++ b/server/channels/app/notification_email.go
@@ -71,7 +71,7 @@ func (a *App) sendNotificationEmail(c request.CTX, notification *PostNotificatio
 
 	var useMilitaryTime bool
 	if data, err := a.Srv().Store().Preference().Get(user.Id, model.PreferenceCategoryDisplaySettings, model.PreferenceNameUseMilitaryTime); err != nil {
-		useMilitaryTime = true
+		useMilitaryTime = false
 	} else {
 		useMilitaryTime = data.Value == "true"
 	}


### PR DESCRIPTION
GitHub issue: https://github.com/mattermost/mattermost/issues/26309
https://mattermost.atlassian.net/browse/MM-56994

```
Description: Changed the logic of useMilitaryTime to false to default to 12-hour time format unless the user's preference from data.Value is "true".

Field affected: When a notification mail is sent to a user, the time should now default to the 12-hour format except otherwise stated by the user.
```

```release-note
Fixed email notifications using 24 hour timestamps by default
```