### PR TITLE
[MM-60429] server/Makefile: add metrics-plugin to the prepackaged plugins

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -160,6 +160,7 @@ PLUGIN_PACKAGES += mattermost-plugin-msteams-v2.0.3
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.3.4
 PLUGIN_PACKAGES += mattermost-plugin-msteams-meetings-v2.2.0
+PLUGIN_PACKAGES += mattermost-plugin-metrics-v0.5.1
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)
 


### PR DESCRIPTION

#### Summary
Title says it all.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60429

#### Release Note

```release-note
Added metrics-plugin to the prepackaged plugins.
```
