### PR TITLE
GH-28034 fix http status code, return 400 (Bad Request)

### DIFF
--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -1642,7 +1642,7 @@ func (a *App) AddChannelMember(c request.CTX, userID string, channel *model.Chan
 	}
 
 	if user.DeleteAt > 0 {
-		return nil, model.NewAppError("AddChannelMember", "app.channel.add_member.deleted_user.app_error", nil, "", http.StatusForbidden)
+		return nil, model.NewAppError("AddChannelMember", "app.channel.add_member.deleted_user.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	var userRequestor *model.User


### PR DESCRIPTION
#### Summary
Return 400 HTTP status code in  [POST] /api/v4/channels/{channel_id}/members method when user is deleted.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/28034

#### Release Note
```release-note
Fixes  HTTP status code in  [POST] /api/v4/channels/{channel_id}/members method when user is deleted.
```
