### PR TITLE
Automated cherry pick of #28132

### DIFF
--- a/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/__snapshots__/channel_profile.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/__snapshots__/channel_profile.test.tsx.snap
@@ -114,7 +114,6 @@ exports[`admin_console/team_channel_settings/channel/ChannelProfile should match
         />
         <br />
         <SharedChannelIndicator
-          channelType="O"
           className="shared-channel-icon"
         />
         <MemoizedFormattedMessage

--- a/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/channel_profile.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/channel_profile.tsx
@@ -39,7 +39,6 @@ export const ChannelProfile = (props: ChannelProfileProps): JSX.Element => {
                 <br/>
                 <SharedChannelIndicator
                     className='shared-channel-icon'
-                    channelType={channel.type}
                 />
                 <FormattedMessage
                     id='admin.channel_settings.channel_detail.channelOrganizationsMessage'

--- a/webapp/channels/src/components/admin_console/team_channel_settings/channel/list/__snapshots__/channel_list.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/channel/list/__snapshots__/channel_list.test.tsx.snap
@@ -988,7 +988,6 @@ exports[`admin_console/team_channel_settings/channel/ChannelList should match sn
                 DN
               </span>
               <SharedChannelIndicator
-                channelType="O"
                 className="channel-icon"
                 withTooltip={true}
               />

--- a/webapp/channels/src/components/admin_console/team_channel_settings/channel/list/channel_list.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/channel/list/channel_list.tsx
@@ -206,7 +206,6 @@ export default class ChannelList extends React.PureComponent<ChannelListProps, C
             const sharedChannelIcon = channel.shared ? (
                 <SharedChannelIndicator
                     className='channel-icon'
-                    channelType={channel.type}
                     withTooltip={true}
                 />
             ) : null;

--- a/webapp/channels/src/components/channel_header/channel_header_title.tsx
+++ b/webapp/channels/src/components/channel_header/channel_header_title.tsx
@@ -79,7 +79,6 @@ const ChannelHeaderTitle = ({
         sharedIcon = (
             <SharedChannelIndicator
                 className='shared-channel-icon'
-                channelType={channel.type}
                 withTooltip={true}
             />
         );

--- a/webapp/channels/src/components/channel_members_rhs/member.tsx
+++ b/webapp/channels/src/components/channel_members_rhs/member.tsx
@@ -139,7 +139,6 @@ const Member = ({className, channel, member, index, totalUsers, editing, actions
                         (
                             <SharedIcon>
                                 <SharedChannelIndicator
-                                    channelType={'O'}
                                     withTooltip={true}
                                 />
                             </SharedIcon>

--- a/webapp/channels/src/components/forward_post_modal/forward_post_channel_select.tsx
+++ b/webapp/channels/src/components/forward_post_modal/forward_post_channel_select.tsx
@@ -144,7 +144,6 @@ const FormattedOption = (props: ChannelOption & {className: string; isSingleValu
     const sharedIcon = details.shared ? (
         <SharedChannelIndicator
             className='shared-channel-icon'
-            channelType={details.type}
         />
     ) : null;
 

--- a/webapp/channels/src/components/searchable_channel_list.tsx
+++ b/webapp/channels/src/components/searchable_channel_list.tsx
@@ -201,7 +201,6 @@ export class SearchableChannelList extends React.PureComponent<Props, State> {
         const sharedChannelIcon = channel.shared ? (
             <SharedChannelIndicator
                 className='shared-channel-icon'
-                channelType={channel.type}
                 withTooltip={true}
             />
         ) : null;

--- a/webapp/channels/src/components/shared_channel_indicator.tsx
+++ b/webapp/channels/src/components/shared_channel_indicator.tsx
@@ -4,25 +4,15 @@
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import type {ChannelType} from '@mattermost/types/channels';
-
 import WithTooltip from 'components/with_tooltip';
-
-import {Constants} from 'utils/constants';
 
 type Props = {
     className?: string;
-    channelType: ChannelType;
     withTooltip?: boolean;
 };
 
 const SharedChannelIndicator: React.FC<Props> = (props: Props): JSX.Element => {
-    let sharedIcon;
-    if (props.channelType === Constants.PRIVATE_CHANNEL) {
-        sharedIcon = (<i className={`${props.className || ''} icon-circle-multiple-outline-lock`}/>);
-    } else {
-        sharedIcon = (<i className={`${props.className || ''} icon-circle-multiple-outline`}/>);
-    }
+    const sharedIcon = (<i className={`${props.className || ''} icon-circle-multiple-outline`}/>);
 
     if (!props.withTooltip) {
         return sharedIcon;

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -228,7 +228,6 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
         const sharedChannelIcon = this.props.isSharedChannel ? (
             <SharedChannelIndicator
                 className='icon'
-                channelType={channel.type}
                 withTooltip={true}
             />
         ) : null;

--- a/webapp/channels/src/components/suggestion/switch_channel_provider.tsx
+++ b/webapp/channels/src/components/suggestion/switch_channel_provider.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import {defineMessages} from 'react-intl';
 import {connect, useSelector} from 'react-redux';
 
-import type {Channel, ChannelMembership, ChannelType} from '@mattermost/types/channels';
+import type {Channel, ChannelMembership} from '@mattermost/types/channels';
 import type {PreferenceType} from '@mattermost/types/preferences';
 import type {Team} from '@mattermost/types/teams';
 import type {UserProfile} from '@mattermost/types/users';
@@ -243,7 +243,6 @@ const SwitchChannelSuggestion = React.forwardRef<HTMLDivElement, Props>((props, 
         sharedIcon = (
             <SharedChannelIndicator
                 className='shared-channel-icon'
-                channelType={channel.type as ChannelType}
             />
         );
     }


### PR DESCRIPTION
Cherry pick of #28132 on release-10.1.

/cc  @sbishel

```release-note
NONE
```