### PR TITLE
Allows invites to be sent to offline remotes

### DIFF
--- a/server/channels/store/sqlstore/shared_channel_store.go
+++ b/server/channels/store/sqlstore/shared_channel_store.go
@@ -495,7 +495,11 @@ func (s SqlSharedChannelStore) GetRemotes(offset, limit int, opts model.SharedCh
 		query = query.Where(sq.Eq{"scr.RemoteId": opts.RemoteId})
 	}
 
-	if !opts.InclUnconfirmed {
+	if opts.OnlyUnconfirmed {
+		query = query.Where(sq.Eq{"scr.IsInviteConfirmed": false})
+	}
+
+	if !opts.OnlyUnconfirmed && !opts.IncludeUnconfirmed {
 		query = query.Where(sq.Eq{"scr.IsInviteConfirmed": true})
 	}
 

--- a/server/channels/store/sqlstore/shared_channel_store.go
+++ b/server/channels/store/sqlstore/shared_channel_store.go
@@ -495,11 +495,9 @@ func (s SqlSharedChannelStore) GetRemotes(offset, limit int, opts model.SharedCh
 		query = query.Where(sq.Eq{"scr.RemoteId": opts.RemoteId})
 	}
 
-	if opts.OnlyUnconfirmed {
+	if opts.ExcludeConfirmed {
 		query = query.Where(sq.Eq{"scr.IsInviteConfirmed": false})
-	}
-
-	if !opts.OnlyUnconfirmed && !opts.IncludeUnconfirmed {
+	} else if !opts.IncludeUnconfirmed {
 		query = query.Where(sq.Eq{"scr.IsInviteConfirmed": true})
 	}
 

--- a/server/channels/store/storetest/shared_channel_store.go
+++ b/server/channels/store/storetest/shared_channel_store.go
@@ -688,14 +688,27 @@ func testGetSharedChannelRemotes(t *testing.T, rctx request.CTX, ss store.Store)
 
 	t.Run("Get shared channel remotes by remote_id including unconfirmed", func(t *testing.T) {
 		opts := model.SharedChannelRemoteFilterOpts{
-			RemoteId:        remoteId,
-			InclUnconfirmed: true,
+			RemoteId:           remoteId,
+			IncludeUnconfirmed: true,
 		}
 		remotes, err := ss.SharedChannel().GetRemotes(0, 999999, opts)
 		require.NoError(t, err, "should not error", err)
 		require.Len(t, remotes, 3)
 		for _, r := range remotes {
 			require.Equal(t, remoteId, r.RemoteId)
+		}
+	})
+
+	t.Run("Get only unconfirmed shared channel remotes for remote", func(t *testing.T) {
+		opts := model.SharedChannelRemoteFilterOpts{
+			RemoteId:        remoteId,
+			OnlyUnconfirmed: true,
+		}
+		remotes, err := ss.SharedChannel().GetRemotes(0, 999999, opts)
+		require.NoError(t, err, "should not error", err)
+		require.Len(t, remotes, 1)
+		for _, r := range remotes {
+			require.False(t, r.IsInviteConfirmed)
 		}
 	})
 
@@ -739,8 +752,8 @@ func testGetSharedChannelRemotes(t *testing.T, rctx request.CTX, ss store.Store)
 
 	t.Run("Get shared channel remotes excluding shared from home including unconfirmed", func(t *testing.T) {
 		opts := model.SharedChannelRemoteFilterOpts{
-			ExcludeHome:     true,
-			InclUnconfirmed: true,
+			ExcludeHome:        true,
+			IncludeUnconfirmed: true,
 		}
 		remotes, err := ss.SharedChannel().GetRemotes(0, 999999, opts)
 		require.NoError(t, err, "should not error", err)

--- a/server/channels/store/storetest/shared_channel_store.go
+++ b/server/channels/store/storetest/shared_channel_store.go
@@ -393,7 +393,7 @@ func testDeleteSharedChannel(t *testing.T, rctx request.CTX, ss store.Store) {
 			ChannelId:         channel.Id,
 			CreatorId:         model.NewId(),
 			RemoteId:          model.NewId(),
-			IsInviteConfirmed: true, // to avoid adding the InclUnconfirmed filter
+			IsInviteConfirmed: true, // to avoid adding the IncludeUnconfirmed filter
 		}
 		_, err := ss.SharedChannel().SaveRemote(remote)
 		require.NoError(t, err, "couldn't add remote", err)
@@ -701,8 +701,8 @@ func testGetSharedChannelRemotes(t *testing.T, rctx request.CTX, ss store.Store)
 
 	t.Run("Get only unconfirmed shared channel remotes for remote", func(t *testing.T) {
 		opts := model.SharedChannelRemoteFilterOpts{
-			RemoteId:        remoteId,
-			OnlyUnconfirmed: true,
+			RemoteId:         remoteId,
+			ExcludeConfirmed: true,
 		}
 		remotes, err := ss.SharedChannel().GetRemotes(0, 999999, opts)
 		require.NoError(t, err, "should not error", err)

--- a/server/platform/services/sharedchannel/service.go
+++ b/server/platform/services/sharedchannel/service.go
@@ -245,6 +245,7 @@ func (scs *Service) makeChannelReadOnly(channel *model.Channel) *model.AppError 
 func (scs *Service) onConnectionStateChange(rc *model.RemoteCluster, online bool) {
 	if online {
 		// when a previously offline remote comes back online force a sync.
+		scs.SendPendingInvitesForRemote(rc)
 		scs.ForceSyncForRemote(rc)
 	}
 

--- a/server/platform/services/sharedchannel/sync_send.go
+++ b/server/platform/services/sharedchannel/sync_send.go
@@ -161,8 +161,8 @@ func (scs *Service) SendPendingInvitesForRemote(rc *model.RemoteCluster) {
 	)
 
 	opts := model.SharedChannelRemoteFilterOpts{
-		RemoteId:        rc.RemoteId,
-		OnlyUnconfirmed: true,
+		RemoteId:         rc.RemoteId,
+		ExcludeConfirmed: true,
 	}
 	scrs, err := scs.server.GetStore().SharedChannel().GetRemotes(0, 999999, opts)
 	if err != nil {

--- a/server/platform/services/sharedchannel/sync_send.go
+++ b/server/platform/services/sharedchannel/sync_send.go
@@ -150,6 +150,61 @@ func (scs *Service) NotifyUserStatusChanged(status *model.Status) {
 	}
 }
 
+func (scs *Service) SendPendingInvitesForRemote(rc *model.RemoteCluster) {
+	if rcs := scs.server.GetRemoteClusterService(); rcs == nil {
+		return
+	}
+
+	scs.server.Log().Log(mlog.LvlSharedChannelServiceDebug, "Processing pending invites for remote after reconnection",
+		mlog.String("remote", rc.DisplayName),
+		mlog.String("remoteId", rc.RemoteId),
+	)
+
+	opts := model.SharedChannelRemoteFilterOpts{
+		RemoteId:        rc.RemoteId,
+		OnlyUnconfirmed: true,
+	}
+	scrs, err := scs.server.GetStore().SharedChannel().GetRemotes(0, 999999, opts)
+	if err != nil {
+		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to fetch shared channel remotes for pending invites",
+			mlog.String("remote", rc.DisplayName),
+			mlog.String("remoteId", rc.RemoteId),
+			mlog.Err(err),
+		)
+		return
+	}
+
+	for _, scr := range scrs {
+		channel, err := scs.server.GetStore().Channel().Get(scr.ChannelId, true)
+		if err != nil {
+			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to fetch channel for pending invite",
+				mlog.String("remote_id", scr.RemoteId),
+				mlog.String("channel_id", scr.ChannelId),
+				mlog.String("sharedchannelremote_id", scr.Id),
+				mlog.Err(err),
+			)
+			continue
+		}
+
+		if err := scs.SendChannelInvite(channel, scr.CreatorId, rc); err != nil {
+			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to send pending invite",
+				mlog.String("remote_id", scr.RemoteId),
+				mlog.String("channel_id", scr.ChannelId),
+				mlog.String("sharedchannelremote_id", scr.Id),
+				mlog.Err(err),
+			)
+			continue
+		}
+
+		scs.server.Log().Log(mlog.LvlSharedChannelServiceDebug, "Pending invite sent",
+			mlog.String("remote", rc.DisplayName),
+			mlog.String("remoteId", rc.RemoteId),
+			mlog.String("channel_id", scr.ChannelId),
+			mlog.String("sharedchannelremote_id", scr.Id),
+		)
+	}
+}
+
 // ForceSyncForRemote causes all channels shared with the remote to be synchronized.
 func (scs *Service) ForceSyncForRemote(rc *model.RemoteCluster) {
 	if rcs := scs.server.GetRemoteClusterService(); rcs == nil {
@@ -327,9 +382,10 @@ func (scs *Service) processTask(task syncTask) error {
 			remotesMap[r.RemoteId] = r
 		}
 
-		// add all remotes that have the autoinvited option.
+		// add all confirmed remotes that have the autoinvited option.
 		filter = model.RemoteClusterQueryFilter{
 			RequireOptions: model.BitflagOptionAutoInvited,
+			OnlyConfirmed:  true,
 		}
 		remotesAutoInvited, err := scs.server.GetStore().RemoteCluster().GetAll(0, 999999, filter)
 		if err != nil {

--- a/server/public/model/remote_cluster.go
+++ b/server/public/model/remote_cluster.go
@@ -33,6 +33,8 @@ const (
 
 var (
 	validRemoteNameChars = regexp.MustCompile(`^[a-zA-Z0-9\.\-\_]+$`)
+
+	ErrOfflineRemote = errors.New("remote is offline")
 )
 
 type Bitmask uint32

--- a/server/public/model/shared_channel.go
+++ b/server/public/model/shared_channel.go
@@ -261,12 +261,13 @@ type SharedChannelFilterOpts struct {
 }
 
 type SharedChannelRemoteFilterOpts struct {
-	ChannelId       string
-	RemoteId        string
-	InclUnconfirmed bool
-	ExcludeHome     bool
-	ExcludeRemote   bool
-	IncludeDeleted  bool
+	ChannelId          string
+	RemoteId           string
+	IncludeUnconfirmed bool
+	OnlyUnconfirmed    bool
+	ExcludeHome        bool
+	ExcludeRemote      bool
+	IncludeDeleted     bool
 }
 
 // SyncMsg represents a change in content (post add/edit/delete, reaction add/remove, users).

--- a/server/public/model/shared_channel.go
+++ b/server/public/model/shared_channel.go
@@ -264,7 +264,7 @@ type SharedChannelRemoteFilterOpts struct {
 	ChannelId          string
 	RemoteId           string
 	IncludeUnconfirmed bool
-	OnlyUnconfirmed    bool
+	ExcludeConfirmed   bool
 	ExcludeHome        bool
 	ExcludeRemote      bool
 	IncludeDeleted     bool


### PR DESCRIPTION
#### Summary
Invites sent to remotes marked as offline will be stored as pending, and when the remote comes back online, it will fetch and process the pending invites as part of the synchronization process.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58800

#### Release Note
```release-note
* Adds support for sending channel invites to offline remotes in Shared Channels
```
