### PR TITLE
Automated cherry pick of #28154

### DIFF
--- a/server/platform/services/sharedchannel/service.go
+++ b/server/platform/services/sharedchannel/service.go
@@ -24,7 +24,6 @@ const (
 	TopicChannelInvite           = "sharedchannel_invite"
 	TopicUploadCreate            = "sharedchannel_upload"
 	MaxRetries                   = 3
-	MaxPostsPerSync              = 50 // a bit more than 4 typical screenfulls of posts
 	MaxUsersPerSync              = 25
 	NotifyRemoteOfflineThreshold = time.Second * 10
 	NotifyMinimumDelay           = time.Second * 2

--- a/server/platform/services/sharedchannel/sync_send_remote.go
+++ b/server/platform/services/sharedchannel/sync_send_remote.go
@@ -280,12 +280,13 @@ func (scs *Service) fetchPostsForSync(sd *syncData) error {
 		LastPostCreateAt: sd.scr.LastPostCreateAt,
 		LastPostCreateID: sd.scr.LastPostCreateID,
 	}
+	maxPostsPerSync := *scs.server.Config().ConnectedWorkspacesSettings.MaxPostsPerSync
 
 	// Fetch all newly created posts first. This is to ensure that post order is preserved for sync targets
 	// that cannot set the CreateAt timestamp for incoming posts (e.g. MS Teams).  If we simply used UpdateAt
 	// then posts could get out of order. For example: p1 created, p2 created, p1 updated... sync'ing on UpdateAt
 	// would order the posts p2, p1.
-	posts, nextCursor, err := scs.server.GetStore().Post().GetPostsSinceForSync(options, cursor, MaxPostsPerSync)
+	posts, nextCursor, err := scs.server.GetStore().Post().GetPostsSinceForSync(options, cursor, maxPostsPerSync)
 	if err != nil {
 		return fmt.Errorf("could not fetch new posts for sync: %w", err)
 	}
@@ -295,10 +296,10 @@ func (scs *Service) fetchPostsForSync(sd *syncData) error {
 	cache := postsSliceToMap(posts)
 
 	// Fill remaining batch capacity with updated posts.
-	if len(posts) < MaxPostsPerSync {
+	if len(posts) < maxPostsPerSync {
 		options.SinceCreateAt = false
 		// use 'nextcursor' as it has the correct xxxUpdateAt values, and the updsted xxxCreateAt values.
-		posts, nextCursor, err = scs.server.GetStore().Post().GetPostsSinceForSync(options, nextCursor, MaxPostsPerSync-len(posts))
+		posts, nextCursor, err = scs.server.GetStore().Post().GetPostsSinceForSync(options, nextCursor, maxPostsPerSync-len(posts))
 		if err != nil {
 			return fmt.Errorf("could not fetch modified posts for sync: %w", err)
 		}
@@ -308,7 +309,7 @@ func (scs *Service) fetchPostsForSync(sd *syncData) error {
 	}
 
 	sd.resultNextCursor = nextCursor
-	sd.resultRepeat = count >= MaxPostsPerSync
+	sd.resultRepeat = count >= maxPostsPerSync
 
 	return nil
 }

--- a/server/platform/services/telemetry/telemetry.go
+++ b/server/platform/services/telemetry/telemetry.go
@@ -894,6 +894,7 @@ func (ts *TelemetryService) trackConfig() {
 		"enable_shared_channels":              *cfg.ConnectedWorkspacesSettings.EnableSharedChannels,
 		"enable_remote_cluster_service":       *cfg.ConnectedWorkspacesSettings.EnableRemoteClusterService && cfg.FeatureFlags.EnableRemoteClusterService,
 		"disable_shared_channels_status_sync": *cfg.ConnectedWorkspacesSettings.DisableSharedChannelsStatusSync,
+		"max_posts_per_sync":                  *cfg.ConnectedWorkspacesSettings.MaxPostsPerSync,
 	})
 
 	// Convert feature flags to map[string]any for sending

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -265,6 +265,8 @@ const (
 	OpenidSettingsDefaultScope = "profile openid email"
 
 	LocalModeSocketPath = "/var/tmp/mattermost_local.socket"
+
+	ConnectedWorkspacesSettingsDefaultMaxPostsPerSync = 50 // a bit more than 4 typical screenfulls of posts
 )
 
 func GetDefaultAppCustomURLSchemes() []string {
@@ -3278,6 +3280,7 @@ type ConnectedWorkspacesSettings struct {
 	EnableSharedChannels            *bool
 	EnableRemoteClusterService      *bool
 	DisableSharedChannelsStatusSync *bool
+	MaxPostsPerSync                 *int
 }
 
 func (c *ConnectedWorkspacesSettings) SetDefaults(isUpdate bool, e ExperimentalSettings) {
@@ -3299,6 +3302,10 @@ func (c *ConnectedWorkspacesSettings) SetDefaults(isUpdate bool, e ExperimentalS
 
 	if c.DisableSharedChannelsStatusSync == nil {
 		c.DisableSharedChannelsStatusSync = NewPointer(false)
+	}
+
+	if c.MaxPostsPerSync == nil {
+		c.MaxPostsPerSync = NewPointer(ConnectedWorkspacesSettingsDefaultMaxPostsPerSync)
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #28154 on release-10.1.

/cc  @mgdelacroix

```release-note
NONE
```