### PR TITLE
Add MobileExternalBrowser to client config

### DIFF
--- a/server/config/client.go
+++ b/server/config/client.go
@@ -294,7 +294,7 @@ func GenerateLimitedClientConfig(c *model.Config, telemetryID string, license *m
 	props["AppDownloadLink"] = *c.NativeAppSettings.AppDownloadLink
 	props["AndroidAppDownloadLink"] = *c.NativeAppSettings.AndroidAppDownloadLink
 	props["IosAppDownloadLink"] = *c.NativeAppSettings.IosAppDownloadLink
-	props["MobileExternalBrowser"] = strconv.FormatBool(c.NativeAppSettings.MobileExternalBrowser)
+	props["MobileExternalBrowser"] = strconv.FormatBool(*c.NativeAppSettings.MobileExternalBrowser)
 
 	props["DiagnosticId"] = telemetryID
 	props["TelemetryId"] = telemetryID

--- a/server/config/client.go
+++ b/server/config/client.go
@@ -294,6 +294,7 @@ func GenerateLimitedClientConfig(c *model.Config, telemetryID string, license *m
 	props["AppDownloadLink"] = *c.NativeAppSettings.AppDownloadLink
 	props["AndroidAppDownloadLink"] = *c.NativeAppSettings.AndroidAppDownloadLink
 	props["IosAppDownloadLink"] = *c.NativeAppSettings.IosAppDownloadLink
+	props["MobileExternalBrowser"] = strconv.FormatBool(c.NativeAppSettings.MobileExternalBrowser)
 
 	props["DiagnosticId"] = telemetryID
 	props["TelemetryId"] = telemetryID

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -2764,7 +2764,7 @@ type NativeAppSettings struct {
 	AppDownloadLink        *string  `access:"site_customization,write_restrictable,cloud_restrictable"`
 	AndroidAppDownloadLink *string  `access:"site_customization,write_restrictable,cloud_restrictable"`
 	IosAppDownloadLink     *string  `access:"site_customization,write_restrictable,cloud_restrictable"`
-	MobileExternalBrowser  bool     `access:"site_customization,write_restrictable,cloud_restrictable"`
+	MobileExternalBrowser  *bool    `access:"site_customization,write_restrictable,cloud_restrictable"`
 }
 
 func (s *NativeAppSettings) SetDefaults() {
@@ -2782,6 +2782,10 @@ func (s *NativeAppSettings) SetDefaults() {
 
 	if s.AppCustomURLSchemes == nil {
 		s.AppCustomURLSchemes = GetDefaultAppCustomURLSchemes()
+	}
+
+	if s.MobileExternalBrowser == nil {
+		s.MobileExternalBrowser = NewPointer(false)
 	}
 }
 

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -2762,6 +2762,7 @@ type NativeAppSettings struct {
 	AppDownloadLink        *string  `access:"site_customization,write_restrictable,cloud_restrictable"`
 	AndroidAppDownloadLink *string  `access:"site_customization,write_restrictable,cloud_restrictable"`
 	IosAppDownloadLink     *string  `access:"site_customization,write_restrictable,cloud_restrictable"`
+	MobileExternalBrowser  bool     `access:"site_customization,write_restrictable,cloud_restrictable"`
 }
 
 func (s *NativeAppSettings) SetDefaults() {


### PR DESCRIPTION
#### Summary
Introducing a client config property that determines if the mobile app should use the default external browser to perform SSO Authentication instead of the internal one.

Value defaults to **false**.

Note: It does not include an admin console UI.

Important: We want to include this in the latest ESR as will mostly be used by certain enterprise customers.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60332

#### Release Note
```release-note
Added config setting NativeAppSettings -> MobileExternalBrowser that tells the mobile app to perform the SSO Authentication using the external default browser
```
