### PR TITLE
Adds includeDeleted flag to get remote cluster app and store methods

### DIFF
--- a/server/channels/api4/remote_cluster.go
+++ b/server/channels/api4/remote_cluster.go
@@ -57,7 +57,7 @@ func remoteClusterPing(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rc, appErr := c.App.GetRemoteCluster(frame.RemoteId)
+	rc, appErr := c.App.GetRemoteCluster(frame.RemoteId, false)
 	if appErr != nil {
 		c.SetInvalidRemoteIdError(frame.RemoteId)
 		return
@@ -110,7 +110,7 @@ func remoteClusterAcceptMessage(c *Context, w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	rc, appErr := c.App.GetRemoteCluster(frame.RemoteId)
+	rc, appErr := c.App.GetRemoteCluster(frame.RemoteId, false)
 	if appErr != nil {
 		c.SetInvalidRemoteIdError(frame.RemoteId)
 		return
@@ -158,7 +158,7 @@ func remoteClusterConfirmInvite(c *Context, w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	rc, err := c.App.GetRemoteCluster(frame.RemoteId)
+	rc, err := c.App.GetRemoteCluster(frame.RemoteId, false)
 	if err != nil {
 		c.SetInvalidRemoteIdError(frame.RemoteId)
 		return
@@ -527,7 +527,7 @@ func generateRemoteClusterInvite(c *Context, w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	rc, appErr := c.App.GetRemoteCluster(c.Params.RemoteId)
+	rc, appErr := c.App.GetRemoteCluster(c.Params.RemoteId, false)
 	if appErr != nil {
 		c.Err = appErr
 		return
@@ -561,7 +561,7 @@ func getRemoteCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rc, err := c.App.GetRemoteCluster(c.Params.RemoteId)
+	rc, err := c.App.GetRemoteCluster(c.Params.RemoteId, true)
 	if err != nil {
 		c.Err = err
 		return
@@ -601,7 +601,7 @@ func patchRemoteCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 	audit.AddEventParameterAuditable(auditRec, "remotecluster_patch", &patch)
 	defer c.LogAuditRec(auditRec)
 
-	orc, err := c.App.GetRemoteCluster(c.Params.RemoteId)
+	orc, err := c.App.GetRemoteCluster(c.Params.RemoteId, false)
 	if err != nil {
 		c.Err = err
 		return
@@ -645,7 +645,7 @@ func deleteRemoteCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 	audit.AddEventParameter(auditRec, "remote_id", c.Params.RemoteId)
 	defer c.LogAuditRec(auditRec)
 
-	orc, err := c.App.GetRemoteCluster(c.Params.RemoteId)
+	orc, err := c.App.GetRemoteCluster(c.Params.RemoteId, false)
 	if err != nil {
 		c.Err = err
 		return

--- a/server/channels/api4/remote_cluster_test.go
+++ b/server/channels/api4/remote_cluster_test.go
@@ -242,7 +242,7 @@ func TestCreateRemoteCluster(t *testing.T) {
 		require.NotZero(t, rcWithInvite.Password)
 		require.Len(t, rcWithInvite.Password, 16)
 
-		rc, appErr := th.App.GetRemoteCluster(rcWithInvite.RemoteCluster.RemoteId)
+		rc, appErr := th.App.GetRemoteCluster(rcWithInvite.RemoteCluster.RemoteId, false)
 		require.Nil(t, appErr)
 		require.Equal(t, rcWithTeamNoPassword.Name, rc.Name)
 
@@ -266,7 +266,7 @@ func TestCreateRemoteCluster(t *testing.T) {
 		// by the endpoint
 		require.Zero(t, rcWithInvite.Password)
 
-		rc, appErr := th.App.GetRemoteCluster(rcWithInvite.RemoteCluster.RemoteId)
+		rc, appErr := th.App.GetRemoteCluster(rcWithInvite.RemoteCluster.RemoteId, false)
 		require.Nil(t, appErr)
 		require.Equal(t, rcWithTeamAndPassword.Name, rc.Name)
 
@@ -599,7 +599,7 @@ func TestDeleteRemoteCluster(t *testing.T) {
 
 	t.Run("should correctly delete the remote cluster", func(t *testing.T) {
 		// ensure the remote cluster is not deleted
-		initialRC, appErr := th.App.GetRemoteCluster(rc.RemoteId)
+		initialRC, appErr := th.App.GetRemoteCluster(rc.RemoteId, false)
 		require.Nil(t, appErr)
 		require.NotEmpty(t, initialRC)
 		require.Zero(t, initialRC.DeleteAt)
@@ -608,7 +608,7 @@ func TestDeleteRemoteCluster(t *testing.T) {
 		CheckOKStatus(t, resp)
 		require.NoError(t, err)
 
-		deletedRC, appErr := th.App.GetRemoteCluster(rc.RemoteId)
+		deletedRC, appErr := th.App.GetRemoteCluster(rc.RemoteId, true)
 		require.Nil(t, appErr)
 		require.NotEmpty(t, deletedRC)
 		require.NotZero(t, deletedRC.DeleteAt)

--- a/server/channels/api4/shared_channel.go
+++ b/server/channels/api4/shared_channel.go
@@ -110,7 +110,7 @@ func getSharedChannelRemotesByRemoteCluster(c *Context, w http.ResponseWriter, r
 		return
 	}
 
-	if _, appErr := c.App.GetRemoteCluster(c.Params.RemoteId); appErr != nil {
+	if _, appErr := c.App.GetRemoteCluster(c.Params.RemoteId, true); appErr != nil {
 		c.Err = appErr
 		return
 	}
@@ -154,7 +154,7 @@ func inviteRemoteClusterToChannel(c *Context, w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if rc, appErr := c.App.GetRemoteCluster(c.Params.RemoteId); appErr != nil || rc.DeleteAt != 0 {
+	if _, appErr := c.App.GetRemoteCluster(c.Params.RemoteId, false); appErr != nil {
 		c.SetInvalidRemoteIdError(c.Params.RemoteId)
 		return
 	}
@@ -201,7 +201,7 @@ func uninviteRemoteClusterToChannel(c *Context, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	if rc, appErr := c.App.GetRemoteCluster(c.Params.RemoteId); appErr != nil || rc.DeleteAt != 0 {
+	if _, appErr := c.App.GetRemoteCluster(c.Params.RemoteId, false); appErr != nil {
 		c.SetInvalidRemoteIdError(c.Params.RemoteId)
 		return
 	}

--- a/server/channels/app/app_iface.go
+++ b/server/channels/app/app_iface.go
@@ -792,7 +792,7 @@ type AppIface interface {
 	GetReactionsForPost(postID string) ([]*model.Reaction, *model.AppError)
 	GetRecentlyActiveUsersForTeam(rctx request.CTX, teamID string) (map[string]*model.User, *model.AppError)
 	GetRecentlyActiveUsersForTeamPage(rctx request.CTX, teamID string, page, perPage int, asAdmin bool, viewRestrictions *model.ViewUsersRestrictions) ([]*model.User, *model.AppError)
-	GetRemoteCluster(remoteClusterId string) (*model.RemoteCluster, *model.AppError)
+	GetRemoteCluster(remoteClusterId string, includeDeleted bool) (*model.RemoteCluster, *model.AppError)
 	GetRemoteClusterForUser(remoteID string, userID string) (*model.RemoteCluster, *model.AppError)
 	GetRemoteClusterService() (remotecluster.RemoteClusterServiceIFace, *model.AppError)
 	GetRemoteClusterSession(token string, remoteId string) (*model.Session, *model.AppError)

--- a/server/channels/app/opentracing/opentracing_layer.go
+++ b/server/channels/app/opentracing/opentracing_layer.go
@@ -9104,7 +9104,7 @@ func (a *OpenTracingAppLayer) GetRecentlyActiveUsersForTeamPage(rctx request.CTX
 	return resultVar0, resultVar1
 }
 
-func (a *OpenTracingAppLayer) GetRemoteCluster(remoteClusterId string) (*model.RemoteCluster, *model.AppError) {
+func (a *OpenTracingAppLayer) GetRemoteCluster(remoteClusterId string, includeDeleted bool) (*model.RemoteCluster, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetRemoteCluster")
 
@@ -9116,7 +9116,7 @@ func (a *OpenTracingAppLayer) GetRemoteCluster(remoteClusterId string) (*model.R
 	}()
 
 	defer span.Finish()
-	resultVar0, resultVar1 := a.app.GetRemoteCluster(remoteClusterId)
+	resultVar0, resultVar1 := a.app.GetRemoteCluster(remoteClusterId, includeDeleted)
 
 	if resultVar1 != nil {
 		span.LogFields(spanlog.Error(resultVar1))

--- a/server/channels/app/platform/shared_channel_notifier.go
+++ b/server/channels/app/platform/shared_channel_notifier.go
@@ -140,7 +140,7 @@ func handleInvitation(ps *PlatformService, syncService SharedChannelServiceIFace
 		return nil
 	}
 
-	rc, err := ps.Store.RemoteCluster().Get(*participant.RemoteId)
+	rc, err := ps.Store.RemoteCluster().Get(*participant.RemoteId, false)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("couldn't find remote cluster %s, for creating shared channel invitation for a DM", *participant.RemoteId))
 	}

--- a/server/channels/app/remote_cluster.go
+++ b/server/channels/app/remote_cluster.go
@@ -117,7 +117,7 @@ func (a *App) AddRemoteCluster(rc *model.RemoteCluster) (*model.RemoteCluster, *
 }
 
 func (a *App) PatchRemoteCluster(rcId string, patch *model.RemoteClusterPatch) (*model.RemoteCluster, *model.AppError) {
-	rc, err := a.GetRemoteCluster(rcId)
+	rc, err := a.GetRemoteCluster(rcId, false)
 	if err != nil {
 		return nil, err
 	}
@@ -152,8 +152,8 @@ func (a *App) DeleteRemoteCluster(remoteClusterId string) (bool, *model.AppError
 	return deleted, nil
 }
 
-func (a *App) GetRemoteCluster(remoteClusterId string) (*model.RemoteCluster, *model.AppError) {
-	rc, err := a.Srv().Store().RemoteCluster().Get(remoteClusterId)
+func (a *App) GetRemoteCluster(remoteClusterId string, includeDeleted bool) (*model.RemoteCluster, *model.AppError) {
+	rc, err := a.Srv().Store().RemoteCluster().Get(remoteClusterId, includeDeleted)
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/server/channels/app/session.go
+++ b/server/channels/app/session.go
@@ -68,8 +68,8 @@ func (a *App) GetCloudSession(token string) (*model.Session, *model.AppError) {
 }
 
 func (a *App) GetRemoteClusterSession(token string, remoteId string) (*model.Session, *model.AppError) {
-	rc, appErr := a.GetRemoteCluster(remoteId)
-	if appErr == nil && rc.DeleteAt == 0 && subtle.ConstantTimeCompare([]byte(rc.Token), []byte(token)) == 1 {
+	rc, appErr := a.GetRemoteCluster(remoteId, false)
+	if appErr == nil && subtle.ConstantTimeCompare([]byte(rc.Token), []byte(token)) == 1 {
 		// Need a bare-bones session object for later checks
 		session := &model.Session{
 			Token:   token,

--- a/server/channels/app/slashcommands/command_share.go
+++ b/server/channels/app/slashcommands/command_share.go
@@ -248,12 +248,9 @@ func (sp *ShareProvider) doInviteRemote(a *app.App, c request.CTX, args *model.C
 		}()
 	}
 
-	rc, appErr := a.GetRemoteCluster(remoteID)
+	rc, appErr := a.GetRemoteCluster(remoteID, false)
 	if appErr != nil {
 		return responsef(args.T("api.command_share.remote_id_invalid.error", map[string]any{"Error": appErr.Error()}))
-	}
-	if rc.DeleteAt != 0 {
-		return responsef(args.T("api.command_share.remote_id_invalid.error", map[string]any{"Error": "entity is deleted"}))
 	}
 
 	if err = a.InviteRemoteToChannel(args.ChannelId, remoteID, args.UserId, true); err != nil {

--- a/server/channels/store/opentracinglayer/opentracinglayer.go
+++ b/server/channels/store/opentracinglayer/opentracinglayer.go
@@ -7828,7 +7828,7 @@ func (s *OpenTracingLayerRemoteClusterStore) Delete(remoteClusterId string) (boo
 	return result, err
 }
 
-func (s *OpenTracingLayerRemoteClusterStore) Get(remoteClusterId string) (*model.RemoteCluster, error) {
+func (s *OpenTracingLayerRemoteClusterStore) Get(remoteClusterId string, includeDeleted bool) (*model.RemoteCluster, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "RemoteClusterStore.Get")
 	s.Root.Store.SetContext(newCtx)
@@ -7837,7 +7837,7 @@ func (s *OpenTracingLayerRemoteClusterStore) Get(remoteClusterId string) (*model
 	}()
 
 	defer span.Finish()
-	result, err := s.RemoteClusterStore.Get(remoteClusterId)
+	result, err := s.RemoteClusterStore.Get(remoteClusterId, includeDeleted)
 	if err != nil {
 		span.LogFields(spanlog.Error(err))
 		ext.Error.Set(span, true)

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -8909,11 +8909,11 @@ func (s *RetryLayerRemoteClusterStore) Delete(remoteClusterId string) (bool, err
 
 }
 
-func (s *RetryLayerRemoteClusterStore) Get(remoteClusterId string) (*model.RemoteCluster, error) {
+func (s *RetryLayerRemoteClusterStore) Get(remoteClusterId string, includeDeleted bool) (*model.RemoteCluster, error) {
 
 	tries := 0
 	for {
-		result, err := s.RemoteClusterStore.Get(remoteClusterId)
+		result, err := s.RemoteClusterStore.Get(remoteClusterId, includeDeleted)
 		if err == nil {
 			return result, nil
 		}

--- a/server/channels/store/sqlstore/remote_cluster_store.go
+++ b/server/channels/store/sqlstore/remote_cluster_store.go
@@ -159,11 +159,15 @@ func (s sqlRemoteClusterStore) Delete(remoteId string) (bool, error) {
 	return count > 0, nil
 }
 
-func (s sqlRemoteClusterStore) Get(remoteId string) (*model.RemoteCluster, error) {
+func (s sqlRemoteClusterStore) Get(remoteId string, includeDeleted bool) (*model.RemoteCluster, error) {
 	query := s.getQueryBuilder().
 		Select(remoteClusterFields("")...).
 		From("RemoteClusters").
 		Where(sq.Eq{"RemoteId": remoteId})
+
+	if !includeDeleted {
+		query = query.Where(sq.Eq{"DeleteAt": 0})
+	}
 
 	queryString, args, err := query.ToSql()
 	if err != nil {
@@ -272,7 +276,7 @@ func (s sqlRemoteClusterStore) GetAll(offset, limit int, filter model.RemoteClus
 }
 
 func (s sqlRemoteClusterStore) UpdateTopics(remoteClusterid string, topics string) (*model.RemoteCluster, error) {
-	rc, err := s.Get(remoteClusterid)
+	rc, err := s.Get(remoteClusterid, false)
 	if err != nil {
 		return nil, err
 	}

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -535,7 +535,7 @@ type RemoteClusterStore interface {
 	Save(rc *model.RemoteCluster) (*model.RemoteCluster, error)
 	Update(rc *model.RemoteCluster) (*model.RemoteCluster, error)
 	Delete(remoteClusterId string) (bool, error)
-	Get(remoteClusterId string) (*model.RemoteCluster, error)
+	Get(remoteClusterId string, includeDeleted bool) (*model.RemoteCluster, error)
 	GetByPluginID(pluginID string) (*model.RemoteCluster, error)
 	GetAll(offset, limit int, filter model.RemoteClusterQueryFilter) ([]*model.RemoteCluster, error)
 	UpdateTopics(remoteClusterId string, topics string) (*model.RemoteCluster, error)

--- a/server/channels/store/storetest/mocks/RemoteClusterStore.go
+++ b/server/channels/store/storetest/mocks/RemoteClusterStore.go
@@ -42,9 +42,9 @@ func (_m *RemoteClusterStore) Delete(remoteClusterId string) (bool, error) {
 	return r0, r1
 }
 
-// Get provides a mock function with given fields: remoteClusterId
-func (_m *RemoteClusterStore) Get(remoteClusterId string) (*model.RemoteCluster, error) {
-	ret := _m.Called(remoteClusterId)
+// Get provides a mock function with given fields: remoteClusterId, includeDeleted
+func (_m *RemoteClusterStore) Get(remoteClusterId string, includeDeleted bool) (*model.RemoteCluster, error) {
+	ret := _m.Called(remoteClusterId, includeDeleted)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Get")
@@ -52,19 +52,19 @@ func (_m *RemoteClusterStore) Get(remoteClusterId string) (*model.RemoteCluster,
 
 	var r0 *model.RemoteCluster
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (*model.RemoteCluster, error)); ok {
-		return rf(remoteClusterId)
+	if rf, ok := ret.Get(0).(func(string, bool) (*model.RemoteCluster, error)); ok {
+		return rf(remoteClusterId, includeDeleted)
 	}
-	if rf, ok := ret.Get(0).(func(string) *model.RemoteCluster); ok {
-		r0 = rf(remoteClusterId)
+	if rf, ok := ret.Get(0).(func(string, bool) *model.RemoteCluster); ok {
+		r0 = rf(remoteClusterId, includeDeleted)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.RemoteCluster)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(remoteClusterId)
+	if rf, ok := ret.Get(1).(func(string, bool) error); ok {
+		r1 = rf(remoteClusterId, includeDeleted)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -7065,10 +7065,10 @@ func (s *TimerLayerRemoteClusterStore) Delete(remoteClusterId string) (bool, err
 	return result, err
 }
 
-func (s *TimerLayerRemoteClusterStore) Get(remoteClusterId string) (*model.RemoteCluster, error) {
+func (s *TimerLayerRemoteClusterStore) Get(remoteClusterId string, includeDeleted bool) (*model.RemoteCluster, error) {
 	start := time.Now()
 
-	result, err := s.RemoteClusterStore.Get(remoteClusterId)
+	result, err := s.RemoteClusterStore.Get(remoteClusterId, includeDeleted)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {

--- a/server/platform/services/remotecluster/recv.go
+++ b/server/platform/services/remotecluster/recv.go
@@ -57,7 +57,7 @@ func callback(listener TopicListener, msg model.RemoteClusterMsg, rc *model.Remo
 func (rcs *Service) ReceiveInviteConfirmation(confirm model.RemoteClusterInvite) (*model.RemoteCluster, error) {
 	store := rcs.server.GetStore().RemoteCluster()
 
-	rc, err := store.Get(confirm.RemoteId)
+	rc, err := store.Get(confirm.RemoteId, false)
 	if err != nil {
 		return nil, fmt.Errorf("cannot accept invite confirmation for remote %s: %w", confirm.RemoteId, err)
 	}

--- a/server/platform/services/sharedchannel/service_api.go
+++ b/server/platform/services/sharedchannel/service_api.go
@@ -134,7 +134,7 @@ func (scs *Service) InviteRemoteToChannel(channelID, remoteID, userID string, sh
 		}
 	}
 
-	rc, err := rcStore.Get(remoteID)
+	rc, err := rcStore.Get(remoteID, false)
 	if err != nil {
 		return model.NewAppError("InviteRemoteToChannel", "api.command_share.remote_id_invalid.error",
 			map[string]any{"Error": err.Error()}, "", http.StatusInternalServerError).Wrap(err)

--- a/server/platform/services/sharedchannel/sync_send.go
+++ b/server/platform/services/sharedchannel/sync_send.go
@@ -339,12 +339,9 @@ func (scs *Service) processTask(task syncTask) error {
 			remotesMap[r.RemoteId] = r
 		}
 	} else {
-		rc, err := scs.server.GetStore().RemoteCluster().Get(task.remoteID)
+		rc, err := scs.server.GetStore().RemoteCluster().Get(task.remoteID, false)
 		if err != nil {
 			return err
-		}
-		if rc.DeleteAt != 0 {
-			return fmt.Errorf("Processing task for a deleted remote cluster '%s'", task.remoteID)
 		}
 		if !rc.IsOnline() {
 			return fmt.Errorf("Failed updating shared channel '%s' for offline remote cluster '%s'", task.channelID, rc.DisplayName)


### PR DESCRIPTION
#### Summary
This is done for improving code safety and readability, as the caller now needs to explicitly state if they allow deleted remote clusters to be fetched instead of having to control those cases after each call.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60535

#### Release Note
```release-note
NONE
```
