### PR TITLE
Automated cherry pick of #28176

### DIFF
--- a/server/channels/store/sqlstore/shared_channel_store.go
+++ b/server/channels/store/sqlstore/shared_channel_store.go
@@ -495,7 +495,9 @@ func (s SqlSharedChannelStore) GetRemotes(offset, limit int, opts model.SharedCh
 		query = query.Where(sq.Eq{"scr.RemoteId": opts.RemoteId})
 	}
 
-	if !opts.InclUnconfirmed {
+	if opts.ExcludeConfirmed {
+		query = query.Where(sq.Eq{"scr.IsInviteConfirmed": false})
+	} else if !opts.IncludeUnconfirmed {
 		query = query.Where(sq.Eq{"scr.IsInviteConfirmed": true})
 	}
 

--- a/server/platform/services/sharedchannel/service.go
+++ b/server/platform/services/sharedchannel/service.go
@@ -244,6 +244,7 @@ func (scs *Service) makeChannelReadOnly(channel *model.Channel) *model.AppError 
 func (scs *Service) onConnectionStateChange(rc *model.RemoteCluster, online bool) {
 	if online {
 		// when a previously offline remote comes back online force a sync.
+		scs.SendPendingInvitesForRemote(rc)
 		scs.ForceSyncForRemote(rc)
 	}
 

--- a/server/platform/services/sharedchannel/sync_send.go
+++ b/server/platform/services/sharedchannel/sync_send.go
@@ -150,6 +150,61 @@ func (scs *Service) NotifyUserStatusChanged(status *model.Status) {
 	}
 }
 
+func (scs *Service) SendPendingInvitesForRemote(rc *model.RemoteCluster) {
+	if rcs := scs.server.GetRemoteClusterService(); rcs == nil {
+		return
+	}
+
+	scs.server.Log().Log(mlog.LvlSharedChannelServiceDebug, "Processing pending invites for remote after reconnection",
+		mlog.String("remote", rc.DisplayName),
+		mlog.String("remoteId", rc.RemoteId),
+	)
+
+	opts := model.SharedChannelRemoteFilterOpts{
+		RemoteId:         rc.RemoteId,
+		ExcludeConfirmed: true,
+	}
+	scrs, err := scs.server.GetStore().SharedChannel().GetRemotes(0, 999999, opts)
+	if err != nil {
+		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to fetch shared channel remotes for pending invites",
+			mlog.String("remote", rc.DisplayName),
+			mlog.String("remoteId", rc.RemoteId),
+			mlog.Err(err),
+		)
+		return
+	}
+
+	for _, scr := range scrs {
+		channel, err := scs.server.GetStore().Channel().Get(scr.ChannelId, true)
+		if err != nil {
+			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to fetch channel for pending invite",
+				mlog.String("remote_id", scr.RemoteId),
+				mlog.String("channel_id", scr.ChannelId),
+				mlog.String("sharedchannelremote_id", scr.Id),
+				mlog.Err(err),
+			)
+			continue
+		}
+
+		if err := scs.SendChannelInvite(channel, scr.CreatorId, rc); err != nil {
+			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to send pending invite",
+				mlog.String("remote_id", scr.RemoteId),
+				mlog.String("channel_id", scr.ChannelId),
+				mlog.String("sharedchannelremote_id", scr.Id),
+				mlog.Err(err),
+			)
+			continue
+		}
+
+		scs.server.Log().Log(mlog.LvlSharedChannelServiceDebug, "Pending invite sent",
+			mlog.String("remote", rc.DisplayName),
+			mlog.String("remoteId", rc.RemoteId),
+			mlog.String("channel_id", scr.ChannelId),
+			mlog.String("sharedchannelremote_id", scr.Id),
+		)
+	}
+}
+
 // ForceSyncForRemote causes all channels shared with the remote to be synchronized.
 func (scs *Service) ForceSyncForRemote(rc *model.RemoteCluster) {
 	if rcs := scs.server.GetRemoteClusterService(); rcs == nil {
@@ -327,9 +382,10 @@ func (scs *Service) processTask(task syncTask) error {
 			remotesMap[r.RemoteId] = r
 		}
 
-		// add all remotes that have the autoinvited option.
+		// add all confirmed remotes that have the autoinvited option.
 		filter = model.RemoteClusterQueryFilter{
 			RequireOptions: model.BitflagOptionAutoInvited,
+			OnlyConfirmed:  true,
 		}
 		remotesAutoInvited, err := scs.server.GetStore().RemoteCluster().GetAll(0, 999999, filter)
 		if err != nil {

--- a/server/public/model/remote_cluster.go
+++ b/server/public/model/remote_cluster.go
@@ -33,6 +33,8 @@ const (
 
 var (
 	validRemoteNameChars = regexp.MustCompile(`^[a-zA-Z0-9\.\-\_]+$`)
+
+	ErrOfflineRemote = errors.New("remote is offline")
 )
 
 type Bitmask uint32

--- a/server/public/model/shared_channel.go
+++ b/server/public/model/shared_channel.go
@@ -261,12 +261,13 @@ type SharedChannelFilterOpts struct {
 }
 
 type SharedChannelRemoteFilterOpts struct {
-	ChannelId       string
-	RemoteId        string
-	InclUnconfirmed bool
-	ExcludeHome     bool
-	ExcludeRemote   bool
-	IncludeDeleted  bool
+	ChannelId          string
+	RemoteId           string
+	IncludeUnconfirmed bool
+	ExcludeConfirmed   bool
+	ExcludeHome        bool
+	ExcludeRemote      bool
+	IncludeDeleted     bool
 }
 
 // SyncMsg represents a change in content (post add/edit/delete, reaction add/remove, users).


### PR DESCRIPTION
Cherry pick of #28176 on release-10.1.

/cc  @mgdelacroix

```release-note
NONE
```