### PR TITLE
Automated cherry pick of #28155

### DIFF
--- a/server/channels/api4/channel_bookmark_test.go
+++ b/server/channels/api4/channel_bookmark_test.go
@@ -959,6 +959,8 @@ func TestUpdateChannelBookmarkSortOrder(t *testing.T) {
 	})
 
 	t.Run("a websockets event should be fired as part of editing a bookmark's sort order", func(t *testing.T) {
+		t.Skip("MM-60499")
+
 		webSocketClient, err := th.CreateWebSocketClient()
 		require.NoError(t, err)
 		webSocketClient.Listen()


### PR DESCRIPTION
Cherry pick of #28155 on release-10.1.

/cc  @mgdelacroix

```release-note
NONE
```