### PR TITLE
MM-58329: Update /api/v4/cluster/status docs

### DIFF
--- a/api/v4/source/cluster.yaml
+++ b/api/v4/source/cluster.yaml
@@ -4,8 +4,9 @@
         - cluster
       summary: Get cluster status
       description: >
-        Get a set of information for each node in the cluster, useful for
-        checking the status and health of each node.
+        Get a list of all healthy nodes, including local information and
+        status of each one. If a node is not present, it means it is not
+        healthy.
 
         ##### Permissions
 

--- a/api/v4/source/definitions.yaml
+++ b/api/v4/source/definitions.yaml
@@ -2205,29 +2205,29 @@ components:
         emails:
           type: string
     ClusterInfo:
-      type: object
+      type: array
       properties:
-        id:
-          description: The unique ID for the node
-          type: string
-        version:
-          description: The server version the node is on
-          type: string
-        config_hash:
-          description: The hash of the configuartion file the node is using
-          type: string
-        internode_url:
-          description: The URL used to communicate with those node from other nodes
-          type: string
-        hostname:
-          description: The hostname for this node
-          type: string
-        last_ping:
-          description: The time of the last ping to this node
-          type: integer
-        is_alive:
-          description: Whether or not the node is alive and well
-          type: boolean
+        items:
+          type: object
+          properties:
+            id:
+              description: The unique ID for the node
+              type: string
+            version:
+              description: The server version the node is on
+              type: string
+            schema_version:
+              description: The number of the latest DB migration successfully executed for the node
+              type: string
+            config_hash:
+              description: The hash of the configuration file the node is using
+              type: string
+            ipaddress:
+              description: The IP address of the node
+              type: string
+            hostname:
+              description: The hostname for this node
+              type: string
     AppError:
       type: object
       properties:


### PR DESCRIPTION
#### Summary
Update API docs on the object returned by `/api/v4/cluster/status`. The corresponding code is in https://github.com/mattermost/enterprise/blob/2fc261a71adbf637cab3d47abe920f978ae0fd03/cluster/cluster.go#L451-L468 and https://github.com/mattermost/mattermost/blob/6cece9faa6eae10b97e319e8cdeab5477708a570/server/public/model/cluster_info.go#L6-L13

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58329

#### Screenshots
--

#### Release Note
```release-note
NONE
```