### PR TITLE
MM-60533 Object to accept function

### DIFF
--- a/webapp/channels/src/components/admin_console/schema_text.tsx
+++ b/webapp/channels/src/components/admin_console/schema_text.tsx
@@ -11,7 +11,7 @@ import FormattedMarkdownMessage, {CustomRenderer} from 'components/formatted_mar
 type Props = {
     isMarkdown?: boolean;
     text: string | MessageDescriptor | JSX.Element;
-    textValues?: Record<string, React.ReactNode>;
+    textValues?: Record<string, string | (() => React.ReactNode)>;
 }
 
 const SchemaText = ({


### PR DESCRIPTION

#### Summary
Anytime you navigate to a page in the system console that use help_text_values to create <ExternalLinks>. You get the Javascript error. Surprisingly, the error didn't seem to cause any functionality issues.

This PR updates the `textValue` field to either a string or a function that returns a ReactNode, rather than accepting a ReactNode.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-60533

#### Release Note
```release-note
Fixes issue causing Javascript errors in System Console.
```
