### PR TITLE
Automated cherry pick of #28183

### DIFF
--- a/server/channels/app/slashcommands/command_share_test.go
+++ b/server/channels/app/slashcommands/command_share_test.go
@@ -26,7 +26,7 @@ func setupForSharedChannels(tb testing.TB) *TestHelper {
 }
 
 func TestShareProviderDoCommand(t *testing.T) {
-	t.Run("share command sends a websocket channel converted event", func(t *testing.T) {
+	t.Run("share command sends a websocket channel updated event", func(t *testing.T) {
 		th := setupForSharedChannels(t).initBasic()
 		defer th.tearDown()
 
@@ -52,14 +52,14 @@ func TestShareProviderDoCommand(t *testing.T) {
 		response := commandProvider.DoCommand(th.App, th.Context, args, "")
 		require.Equal(t, "##### "+args.T("api.command_share.channel_shared"), response.Text)
 
-		channelConvertedMessages := testCluster.SelectMessages(func(msg *model.ClusterMessage) bool {
+		channelUpdatedMessages := testCluster.SelectMessages(func(msg *model.ClusterMessage) bool {
 			event, err := model.WebSocketEventFromJSON(bytes.NewReader(msg.Data))
-			return err == nil && event.EventType() == model.WebsocketEventChannelConverted
+			return err == nil && event.EventType() == model.WebsocketEventChannelUpdated
 		})
-		assert.Len(t, channelConvertedMessages, 1) // one msg for share creation
+		assert.Len(t, channelUpdatedMessages, 1) // one msg for share creation
 	})
 
-	t.Run("unshare command sends a websocket channel converted event", func(t *testing.T) {
+	t.Run("unshare command sends a websocket channel updated event", func(t *testing.T) {
 		th := setupForSharedChannels(t).initBasic()
 		defer th.tearDown()
 
@@ -84,11 +84,11 @@ func TestShareProviderDoCommand(t *testing.T) {
 		response := commandProvider.DoCommand(th.App, th.Context, args, "")
 		require.Equal(t, "##### "+args.T("api.command_share.shared_channel_unavailable"), response.Text)
 
-		channelConvertedMessages := testCluster.SelectMessages(func(msg *model.ClusterMessage) bool {
+		channelUpdatedMessages := testCluster.SelectMessages(func(msg *model.ClusterMessage) bool {
 			event, err := model.WebSocketEventFromJSON(bytes.NewReader(msg.Data))
-			return err == nil && event.EventType() == model.WebsocketEventChannelConverted
+			return err == nil && event.EventType() == model.WebsocketEventChannelUpdated
 		})
-		require.Len(t, channelConvertedMessages, 2) // one msg for share creation, one for unshare.
+		require.Len(t, channelUpdatedMessages, 2) // one msg for share creation, one for unshare.
 	})
 
 	t.Run("invite remote to channel shared with us", func(t *testing.T) {

--- a/server/platform/services/sharedchannel/service_api.go
+++ b/server/platform/services/sharedchannel/service_api.go
@@ -59,6 +59,9 @@ func (scs *Service) ShareChannel(sc *model.SharedChannel) (*model.SharedChannel,
 	if err != nil {
 		return nil, err
 	}
+	// to avoid fetching the channel again, we manually set the shared
+	// flag before notifying the clients
+	channel.Shared = model.NewPointer(true)
 
 	scs.notifyClientsForSharedChannelConverted(channel)
 	return scNew, nil
@@ -93,6 +96,9 @@ func (scs *Service) UnshareChannel(channelID string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	// to avoid fetching the channel again, we manually set the shared
+	// flag before notifying the clients
+	channel.Shared = model.NewPointer(false)
 
 	scs.notifyClientsForSharedChannelConverted(channel)
 	return deleted, nil


### PR DESCRIPTION
Cherry pick of #28183 on release-10.1.

/cc  @mgdelacroix

```release-note
NONE
```