### PR TITLE
[MM-60307] Fix racy use of session in NewWebConn

### DIFF
--- a/server/channels/app/platform/session.go
+++ b/server/channels/app/platform/session.go
@@ -20,6 +20,8 @@ func (ps *PlatformService) ReturnSessionToPool(session *model.Session) {
 		// Once the session is retrieved from the pool, all existing prop fields are cleared.
 		// To avoid a race between clearing the props and accessing it, clear the props maps before returning it to the pool.
 		clear(session.Props)
+		// Also clear the team members slice to avoid a similar race condition.
+		clear(session.TeamMembers)
 		ps.sessionPool.Put(session)
 	}
 }

--- a/server/channels/app/platform/session.go
+++ b/server/channels/app/platform/session.go
@@ -17,6 +17,9 @@ import (
 func (ps *PlatformService) ReturnSessionToPool(session *model.Session) {
 	if session != nil {
 		session.Id = ""
+		// Once the session is retrieved from the pool, all existing prop fields are cleared.
+		// To avoid a race between clearing the props and accessing it, clear the props maps before returning it to the pool.
+		clear(session.Props)
 		ps.sessionPool.Put(session)
 	}
 }

--- a/server/channels/app/platform/web_conn.go
+++ b/server/channels/app/platform/web_conn.go
@@ -194,15 +194,6 @@ func (ps *PlatformService) PopulateWebConnConfig(s *model.Session, cfg *WebConnC
 
 // NewWebConn returns a new WebConn instance.
 func (ps *PlatformService) NewWebConn(cfg *WebConnConfig, suite SuiteIFace, runner HookRunner) *WebConn {
-	userID := cfg.Session.UserId
-	session := cfg.Session
-	if cfg.Session.UserId != "" {
-		ps.Go(func() {
-			ps.SetStatusOnline(userID, false)
-			ps.UpdateLastActivityAtIfNeeded(session)
-		})
-	}
-
 	// Disable TCP_NO_DELAY for higher throughput
 	var tcpConn *net.TCPConn
 	switch conn := cfg.WebSocket.UnderlyingConn().(type) {
@@ -254,9 +245,18 @@ func (ps *PlatformService) NewWebConn(cfg *WebConnConfig, suite SuiteIFace, runn
 		remoteAddress:      cfg.RemoteAddress,
 		xForwardedFor:      cfg.XForwardedFor,
 	}
-	wc.Active.Store(cfg.Active)
 
 	wc.SetSession(&cfg.Session)
+	userID := cfg.Session.UserId
+	if userID != "" {
+		ps.Go(func() {
+			ps.SetStatusOnline(userID, false)
+			ps.UpdateLastActivityAtIfNeeded(*wc.GetSession())
+		})
+	}
+
+	wc.Active.Store(cfg.Active)
+
 	wc.SetSessionToken(cfg.Session.Token)
 	wc.SetSessionExpiresAt(cfg.Session.ExpiresAt)
 	wc.SetConnectionID(cfg.ConnectionID)
@@ -388,6 +388,8 @@ func (wc *WebConn) GetSession() *model.Session {
 
 // SetSession sets the session of the connection.
 func (wc *WebConn) SetSession(v *model.Session) {
+	// Clone the session first as WebConn takes ownership of the object
+	// and the web.Hub will return it to the [sync.Poll] once the WebConn gets removed.
 	if v != nil {
 		v = v.DeepCopy()
 	}

--- a/server/channels/app/platform/web_conn.go
+++ b/server/channels/app/platform/web_conn.go
@@ -389,7 +389,7 @@ func (wc *WebConn) GetSession() *model.Session {
 // SetSession sets the session of the connection.
 func (wc *WebConn) SetSession(v *model.Session) {
 	// Clone the session first as WebConn takes ownership of the object
-	// and the web.Hub will return it to the [sync.Poll] once the WebConn gets removed.
+	// and the web.Hub will return it to the [sync.Pool] once the WebConn gets removed.
 	if v != nil {
 		v = v.DeepCopy()
 	}

--- a/server/channels/app/platform/web_conn.go
+++ b/server/channels/app/platform/web_conn.go
@@ -249,6 +249,8 @@ func (ps *PlatformService) NewWebConn(cfg *WebConnConfig, suite SuiteIFace, runn
 	wc.SetSession(&cfg.Session)
 	userID := cfg.Session.UserId
 	if userID != "" {
+		// UpdateLastActivityAtIfNeeded might block if the Hub is busy.
+		// Create a goroutine to avoid blocking the creation of the websocket connection.
 		ps.Go(func() {
 			ps.SetStatusOnline(userID, false)
 			ps.UpdateLastActivityAtIfNeeded(*wc.GetSession())

--- a/server/channels/app/platform/web_conn_test.go
+++ b/server/channels/app/platform/web_conn_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
+	"github.com/mattermost/mattermost/server/public/shared/i18n"
 )
 
 type hookRunner struct {
@@ -240,4 +242,40 @@ func TestWebConnDrainDeadQueue(t *testing.T) {
 		t.Run("Cycled End", func(t *testing.T) { run(int64(137), deadQueueSize+10) })
 		t.Run("Overwritten First", func(t *testing.T) { run(int64(128), deadQueueSize+10) })
 	})
+}
+
+// TestWebConnSessionRace guards against https://mattermost.atlassian.net/browse/MM-60307. It need to be run with the -race flag.
+func TestWebConnSessionRace(t *testing.T) {
+	th := Setup(t).InitBasic()
+	t.Cleanup(th.TearDown)
+
+	s := httptest.NewServer(dummyWebsocketHandler(t))
+	t.Cleanup(s.Close)
+	d := websocket.Dialer{}
+	c, _, err := d.Dial("ws://"+s.Listener.Addr().String()+"/ws", nil)
+	require.NoError(t, err)
+
+	err = th.Service.Start(nil)
+	require.NoError(t, err)
+
+	session, err := th.Service.CreateSession(th.Context, &model.Session{
+		UserId: th.BasicUser.Id,
+	})
+	require.NoError(t, err)
+	// Ensure LastActivityAt needs to get updated in the session store
+	session.LastActivityAt = session.LastActivityAt - model.SessionActivityTimeout - 1
+
+	cfg := &WebConnConfig{
+		WebSocket: c,
+		Session:   *session,
+		TFunc:     i18n.IdentityTfunc(),
+		Locale:    "en",
+	}
+	wc := th.Service.NewWebConn(cfg, th.Suite, &hookRunner{})
+	t.Cleanup(wc.Close)
+
+	session.AddProp(model.SessionPropPlatform, "chrome")
+
+	// Wait a bit of the race checker to catch any
+	time.Sleep(100 * time.Millisecond)
 }

--- a/server/channels/app/platform/web_conn_test.go
+++ b/server/channels/app/platform/web_conn_test.go
@@ -271,8 +271,7 @@ func TestWebConnSessionRace(t *testing.T) {
 		TFunc:     i18n.IdentityTfunc(),
 		Locale:    "en",
 	}
-	wc := th.Service.NewWebConn(cfg, th.Suite, &hookRunner{})
-	t.Cleanup(wc.Close)
+	_ = th.Service.NewWebConn(cfg, th.Suite, &hookRunner{})
 
 	session.AddProp(model.SessionPropPlatform, "chrome")
 


### PR DESCRIPTION
#### Summary

This Pr is another race fix for `WebConn` similar to https://github.com/mattermost/mattermost/pull/20996.

1. A request for `/api/v4/websocket` comes in.
2. `web.Handler.ServeHTTP` get the corresponding session `S`
3. `connectWebSocket` is called. It handles the request, calling `PlatformService.NewWebConn` in the process and starts to `Pump()` the websocket connection.
4. The connection is terminated, e.g. through a bad mobile connection.
5. The deferred statement in `web.Handler.ServeHTTP` returns `S` to the `sync.Pool`.
6. Another request comes in, gets `S` from the pool and calls `UnmarshalMsg`. As part of that method, all existing props get deleted 
https://github.com/mattermost/mattermost/blob/e8de27b043b2971472f30cb2e6c77bf4f8978486/server/public/model/session_serial_gen.go#L348-L352
7. Simultaneously, the go routine created by `PlatformService.NewWebConn` runs and calls `PlatformService.UpdateLastActivityAtIfNeeded`. It adds `S` to the session cache, which involves iterating over `S.Props`. That panics because `S.Props` gets modified by `Session.UnmarshalMsg`.

It is unclear to me why this race is happening now and didn't before. It might have existed for quite some time.

The fix is to first copy the session via `WebConn.Store` and then start the go routine that calls `UpdateLastActivityAtIfNeeded`.


The newly added test `TestWebConnSessionRace` guards against a regression. However, it must be run with the `-race` flag, which we currently don't do.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60307

#### Release Note
```release-note
Fix racy use of session in NewWebConn
```
