### PR TITLE
listen on unix socket support

### DIFF
--- a/server/channels/api4/apitestlib.go
+++ b/server/channels/api4/apitestlib.go
@@ -513,7 +513,7 @@ func (th *TestHelper) DeleteBots() *TestHelper {
 
 func (th *TestHelper) waitForConnectivity() {
 	for i := 0; i < 1000; i++ {
-		conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%v", th.App.Srv().ListenAddr.Port))
+		conn, err := net.Dial("tcp", th.App.Srv().ListenAddr.String())
 		if err == nil {
 			conn.Close()
 			return
@@ -524,7 +524,7 @@ func (th *TestHelper) waitForConnectivity() {
 }
 
 func (th *TestHelper) CreateClient() *model.Client4 {
-	return model.NewAPIv4Client(fmt.Sprintf("http://localhost:%v", th.App.Srv().ListenAddr.Port))
+	return model.NewAPIv4Client(fmt.Sprint("http://", th.App.Srv().ListenAddr.String()))
 }
 
 // ToDo: maybe move this to NewAPIv4SocketClient and reuse it in mmctl
@@ -544,19 +544,19 @@ func (th *TestHelper) CreateLocalClient(socketPath string) *model.Client4 {
 }
 
 func (th *TestHelper) CreateWebSocketClient() (*model.WebSocketClient, error) {
-	return model.NewWebSocketClient4(fmt.Sprintf("ws://localhost:%v", th.App.Srv().ListenAddr.Port), th.Client.AuthToken)
+	return model.NewWebSocketClient4(fmt.Sprint("ws://", th.App.Srv().ListenAddr.String()), th.Client.AuthToken)
 }
 
 func (th *TestHelper) CreateReliableWebSocketClient(connID string, seqNo int) (*model.WebSocketClient, error) {
-	return model.NewReliableWebSocketClientWithDialer(websocket.DefaultDialer, fmt.Sprintf("ws://localhost:%v", th.App.Srv().ListenAddr.Port), th.Client.AuthToken, connID, seqNo, true)
+	return model.NewReliableWebSocketClientWithDialer(websocket.DefaultDialer, fmt.Sprint("ws://localhost:", th.App.Srv().ListenAddr.String()), th.Client.AuthToken, connID, seqNo, true)
 }
 
 func (th *TestHelper) CreateWebSocketSystemAdminClient() (*model.WebSocketClient, error) {
-	return model.NewWebSocketClient4(fmt.Sprintf("ws://localhost:%v", th.App.Srv().ListenAddr.Port), th.SystemAdminClient.AuthToken)
+	return model.NewWebSocketClient4(fmt.Sprint("ws://localhost:", th.App.Srv().ListenAddr.String()), th.SystemAdminClient.AuthToken)
 }
 
 func (th *TestHelper) CreateWebSocketClientWithClient(client *model.Client4) (*model.WebSocketClient, error) {
-	return model.NewWebSocketClient4(fmt.Sprintf("ws://localhost:%v", th.App.Srv().ListenAddr.Port), client.AuthToken)
+	return model.NewWebSocketClient4(fmt.Sprint("ws://localhost:", th.App.Srv().ListenAddr.String()), client.AuthToken)
 }
 
 func (th *TestHelper) CreateBotWithSystemAdminClient() *model.Bot {

--- a/server/channels/api4/apitestlib.go
+++ b/server/channels/api4/apitestlib.go
@@ -548,15 +548,15 @@ func (th *TestHelper) CreateWebSocketClient() (*model.WebSocketClient, error) {
 }
 
 func (th *TestHelper) CreateReliableWebSocketClient(connID string, seqNo int) (*model.WebSocketClient, error) {
-	return model.NewReliableWebSocketClientWithDialer(websocket.DefaultDialer, fmt.Sprint("ws://localhost:", th.App.Srv().ListenAddr.String()), th.Client.AuthToken, connID, seqNo, true)
+	return model.NewReliableWebSocketClientWithDialer(websocket.DefaultDialer, fmt.Sprint("ws://", th.App.Srv().ListenAddr.String()), th.Client.AuthToken, connID, seqNo, true)
 }
 
 func (th *TestHelper) CreateWebSocketSystemAdminClient() (*model.WebSocketClient, error) {
-	return model.NewWebSocketClient4(fmt.Sprint("ws://localhost:", th.App.Srv().ListenAddr.String()), th.SystemAdminClient.AuthToken)
+	return model.NewWebSocketClient4(fmt.Sprint("ws://", th.App.Srv().ListenAddr.String()), th.SystemAdminClient.AuthToken)
 }
 
 func (th *TestHelper) CreateWebSocketClientWithClient(client *model.Client4) (*model.WebSocketClient, error) {
-	return model.NewWebSocketClient4(fmt.Sprint("ws://localhost:", th.App.Srv().ListenAddr.String()), client.AuthToken)
+	return model.NewWebSocketClient4(fmt.Sprint("ws://", th.App.Srv().ListenAddr.String()), client.AuthToken)
 }
 
 func (th *TestHelper) CreateBotWithSystemAdminClient() *model.Bot {

--- a/server/channels/api4/cors_test.go
+++ b/server/channels/api4/cors_test.go
@@ -131,8 +131,7 @@ func TestCORSRequestHandling(t *testing.T) {
 			licenseStore.On("Get", "").Return(&model.LicenseRecord{}, nil)
 			th.App.Srv().Store().(*mocks.Store).On("License").Return(&licenseStore)
 
-			port := th.App.Srv().ListenAddr.Port
-			host := fmt.Sprintf("http://localhost:%v", port)
+			host := fmt.Sprintf("http://%v", th.App.Srv().ListenAddr.String())
 			url := fmt.Sprintf("%v/api/v4/system/ping", host)
 
 			req, err := http.NewRequest("GET", url, nil)

--- a/server/channels/api4/plugin_test.go
+++ b/server/channels/api4/plugin_test.go
@@ -2024,7 +2024,7 @@ func TestPluginWebSocketSession(t *testing.T) {
 	require.True(t, activated)
 
 	// Connect through WebSocket and send a message
-	reqURL := fmt.Sprintf("ws://localhost:%d", th.Server.ListenAddr.Port)
+	reqURL := fmt.Sprintf("ws://%s", th.Server.ListenAddr.String())
 	wsc, err := model.NewWebSocketClient4(reqURL, th.Client.AuthToken)
 	require.NoError(t, err)
 	require.NotNil(t, wsc)
@@ -2075,7 +2075,7 @@ func TestPluginWebSocketRemoteAddress(t *testing.T) {
 	require.True(t, activated)
 
 	// Connect through WebSocket and send a message
-	reqURL := fmt.Sprintf("ws://localhost:%d", th.Server.ListenAddr.Port)
+	reqURL := fmt.Sprintf("ws://%s", th.Server.ListenAddr.String())
 	wsc, err := model.NewWebSocketClient4(reqURL, th.Client.AuthToken)
 	require.NoError(t, err)
 	require.NotNil(t, wsc)

--- a/server/channels/api4/shared_channel_test.go
+++ b/server/channels/api4/shared_channel_test.go
@@ -29,7 +29,7 @@ func setupForSharedChannels(tb testing.TB) *TestHelper {
 	})
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
-		*cfg.ServiceSettings.SiteURL = fmt.Sprintf("http://localhost:%d", th.Server.ListenAddr.Port)
+		*cfg.ServiceSettings.SiteURL = fmt.Sprintf("http://%s", th.Server.ListenAddr.String())
 	})
 
 	return th

--- a/server/channels/api4/websocket_test.go
+++ b/server/channels/api4/websocket_test.go
@@ -24,7 +24,7 @@ func TestWebSocketTrailingSlash(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()
 
-	url := fmt.Sprintf("ws://localhost:%v", th.App.Srv().ListenAddr.Port)
+	url := fmt.Sprintf("ws://%s", th.App.Srv().ListenAddr.String())
 	_, _, err := websocket.DefaultDialer.Dial(url+model.APIURLSuffix+"/websocket/", nil)
 	require.NoError(t, err)
 }
@@ -157,7 +157,7 @@ func TestWebsocketOriginSecurity(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()
 
-	url := fmt.Sprintf("ws://localhost:%v", th.App.Srv().ListenAddr.Port)
+	url := fmt.Sprintf("ws://%s", th.App.Srv().ListenAddr.String())
 
 	// Should fail because origin doesn't match
 	_, _, err := websocket.DefaultDialer.Dial(url+model.APIURLSuffix+"/websocket", http.Header{
@@ -168,7 +168,7 @@ func TestWebsocketOriginSecurity(t *testing.T) {
 
 	// We are not a browser so we can spoof this just fine
 	_, _, err = websocket.DefaultDialer.Dial(url+model.APIURLSuffix+"/websocket", http.Header{
-		"Origin": []string{fmt.Sprintf("http://localhost:%v", th.App.Srv().ListenAddr.Port)},
+		"Origin": []string{fmt.Sprintf("http://%s", th.App.Srv().ListenAddr.String())},
 	})
 	require.NoError(t, err, err)
 
@@ -460,7 +460,7 @@ func TestWebSocketUpgrade(t *testing.T) {
 	err := mlog.AddWriterTarget(th.TestLogger, buffer, true, mlog.StdAll...)
 	require.NoError(t, err)
 
-	url := fmt.Sprintf("http://localhost:%v", th.App.Srv().ListenAddr.Port) + model.APIURLSuffix + "/websocket"
+	url := fmt.Sprintf("http://%s", th.App.Srv().ListenAddr.String()) + model.APIURLSuffix + "/websocket"
 	resp, err := http.Get(url)
 	require.NoError(t, err)
 	require.Equal(t, resp.StatusCode, http.StatusBadRequest)

--- a/server/channels/app/plugin_api_test.go
+++ b/server/channels/app/plugin_api_test.go
@@ -1850,7 +1850,7 @@ func TestPluginHTTPConnHijack(t *testing.T) {
 	pluginID := ids[0]
 	require.NotEmpty(t, pluginID)
 
-	reqURL := fmt.Sprintf("http://localhost:%d/plugins/%s", th.Server.ListenAddr.Port, pluginID)
+	reqURL := fmt.Sprintf("http://%s/plugins/%s", th.Server.ListenAddr.String(), pluginID)
 	req, err := http.NewRequest("GET", reqURL, nil)
 	require.NoError(t, err)
 
@@ -1883,7 +1883,7 @@ func TestPluginHTTPUpgradeWebSocket(t *testing.T) {
 	pluginID := ids[0]
 	require.NotEmpty(t, pluginID)
 
-	reqURL := fmt.Sprintf("ws://localhost:%d/plugins/%s", th.Server.ListenAddr.Port, pluginID)
+	reqURL := fmt.Sprintf("ws://%s/plugins/%s", th.Server.ListenAddr.String(), pluginID)
 	wsc, err := model.NewWebSocketClient(reqURL, "")
 	require.NoError(t, err)
 	require.NotNil(t, wsc)

--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -100,7 +100,7 @@ type Server struct {
 	Router *mux.Router
 
 	Server      *http.Server
-	ListenAddr  *net.TCPAddr
+	ListenAddr  net.Addr
 	RateLimiter *RateLimiter
 
 	localModeServer *http.Server
@@ -952,11 +952,15 @@ func (s *Server) Start() error {
 		}
 	}
 
-	listener, err := net.Listen("tcp", addr)
+	protocol := "tcp"
+	if strings.HasPrefix(addr, "/") {
+		protocol = "unix"
+	}
+	listener, err := net.Listen(protocol, addr)
 	if err != nil {
 		return errors.Wrapf(err, i18n.T("api.server.start_server.starting.critical"), err)
 	}
-	s.ListenAddr = listener.Addr().(*net.TCPAddr)
+	s.ListenAddr = listener.Addr()
 
 	logListeningPort := fmt.Sprintf("Server is listening on %v", listener.Addr().String())
 	mlog.Info(logListeningPort, mlog.String("address", listener.Addr().String()))

--- a/server/channels/app/server_test.go
+++ b/server/channels/app/server_test.go
@@ -480,7 +480,7 @@ func TestSentry(t *testing.T) {
 		require.NoError(t, s.Start())
 		defer s.Shutdown()
 
-		resp, err := client.Get("https://localhost:" + s.ListenAddr.String() + "/panic")
+		resp, err := client.Get("https://" + s.ListenAddr.String() + "/panic")
 		require.Nil(t, resp)
 		require.True(t, errors.Is(err, io.EOF), fmt.Sprintf("unexpected error: %s", err))
 

--- a/server/channels/web/web_test.go
+++ b/server/channels/web/web_test.go
@@ -127,7 +127,7 @@ func setupTestHelper(tb testing.TB, includeCacheLayer bool, options []app.Option
 	})
 
 	web := New(s)
-	URL = fmt.Sprintf("http://localhost:%v", s.ListenAddr.Port)
+	URL = fmt.Sprintf("http://%s", s.ListenAddr.String())
 	apiClient = model.NewAPIv4Client(URL)
 
 	s.Store().MarkSystemRanUnitTests()

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -4132,7 +4132,11 @@ func (s *ServiceSettings) isValid() *AppError {
 
 	host, port, _ := net.SplitHostPort(*s.ListenAddress)
 	var isValidHost bool
-	if host == "" {
+	if strings.HasPrefix(*s.ListenAddress, "/") {
+		host = *s.ListenAddress
+		port = "0"
+		isValidHost = true
+	} else if host == "" {
 		isValidHost = true
 	} else {
 		isValidHost = (net.ParseIP(host) != nil) || isDomainName(host)


### PR DESCRIPTION
Listen on unix socket support. I need this for Syncloud self hosting platform (https://github.com/syncloud/platform) where I try to avoid any additional tcp port config to reduce potential conflicts as users run varios apps together on a single box.
This is just a bare minimum which works for me, I am ready to spend some reasonable time on refactoring and unit/e2e testing if I am pointed at right direction.


Example:
```
"ListenAddress" : "/path/to/socket"
```

#### Release Note
```release-note
ListenAddress also supports unix socket paths now, example: "ListenAddress" : "/path/to/socket"
```