### PR TITLE
Allow shared channel remotes endpoint to be filtered by confirmation status

### DIFF
--- a/api/v4/source/sharedchannels.yaml
+++ b/api/v4/source/sharedchannels.yaml
@@ -65,6 +65,16 @@
           required: true
           schema:
             type: string
+        - name: include_unconfirmed
+          in: query
+          description: Include those Shared channel remotes that are unconfirmed
+          schema:
+            type: boolean
+        - name: exclude_confirmed
+          in: query
+          description: Show only those Shared channel remotes that are not confirmed yet
+          schema:
+            type: boolean
         - name: exclude_home
           in: query
           description: Show only those Shared channel remotes that were shared with this server

--- a/server/channels/api4/shared_channel.go
+++ b/server/channels/api4/shared_channel.go
@@ -116,10 +116,12 @@ func getSharedChannelRemotesByRemoteCluster(c *Context, w http.ResponseWriter, r
 	}
 
 	filter := model.SharedChannelRemoteFilterOpts{
-		RemoteId:       c.Params.RemoteId,
-		ExcludeHome:    c.Params.ExcludeHome,
-		ExcludeRemote:  c.Params.ExcludeRemote,
-		IncludeDeleted: c.Params.IncludeDeleted,
+		RemoteId:           c.Params.RemoteId,
+		IncludeUnconfirmed: c.Params.IncludeUnconfirmed,
+		ExcludeConfirmed:   c.Params.ExcludeConfirmed,
+		ExcludeHome:        c.Params.ExcludeHome,
+		ExcludeRemote:      c.Params.ExcludeRemote,
+		IncludeDeleted:     c.Params.IncludeDeleted,
 	}
 	sharedChannelRemotes, err := c.App.GetSharedChannelRemotes(c.Params.Page, c.Params.PerPage, filter)
 	if err != nil {

--- a/server/channels/api4/shared_channel_test.go
+++ b/server/channels/api4/shared_channel_test.go
@@ -355,9 +355,7 @@ func TestGetSharedChannelRemotesByRemoteCluster(t *testing.T) {
 			Name               string
 			Client             *model.Client4
 			RemoteId           string
-			ExcludeHome        bool
-			ExcludeRemote      bool
-			IncludeDeleted     bool
+			Filter             model.SharedChannelRemoteFilterOpts
 			Page               int
 			PerPage            int
 			ExpectedStatusCode int
@@ -396,7 +394,7 @@ func TestGetSharedChannelRemotesByRemoteCluster(t *testing.T) {
 				Name:               "should return the complete list of shared channel remotes for a remote cluster, including deleted",
 				Client:             th.SystemAdminClient,
 				RemoteId:           rc1.RemoteId,
-				IncludeDeleted:     true,
+				Filter:             model.SharedChannelRemoteFilterOpts{IncludeDeleted: true},
 				Page:               0,
 				PerPage:            100,
 				ExpectedStatusCode: http.StatusOK,
@@ -407,7 +405,7 @@ func TestGetSharedChannelRemotesByRemoteCluster(t *testing.T) {
 				Name:               "should return only the shared channel remotes homed localy",
 				Client:             th.SystemAdminClient,
 				RemoteId:           rc1.RemoteId,
-				ExcludeRemote:      true,
+				Filter:             model.SharedChannelRemoteFilterOpts{ExcludeRemote: true},
 				Page:               0,
 				PerPage:            100,
 				ExpectedStatusCode: http.StatusOK,
@@ -418,7 +416,7 @@ func TestGetSharedChannelRemotesByRemoteCluster(t *testing.T) {
 				Name:               "should return only the shared channel remotes homed remotely",
 				Client:             th.SystemAdminClient,
 				RemoteId:           rc1.RemoteId,
-				ExcludeHome:        true,
+				Filter:             model.SharedChannelRemoteFilterOpts{ExcludeHome: true},
 				Page:               0,
 				PerPage:            100,
 				ExpectedStatusCode: http.StatusOK,
@@ -429,7 +427,7 @@ func TestGetSharedChannelRemotesByRemoteCluster(t *testing.T) {
 				Name:               "should correctly paginate the results",
 				Client:             th.SystemAdminClient,
 				RemoteId:           rc1.RemoteId,
-				IncludeDeleted:     true,
+				Filter:             model.SharedChannelRemoteFilterOpts{IncludeDeleted: true},
 				Page:               1,
 				PerPage:            1,
 				ExpectedStatusCode: http.StatusOK,
@@ -440,7 +438,7 @@ func TestGetSharedChannelRemotesByRemoteCluster(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.Name, func(t *testing.T) {
-				scrs, resp, err := tc.Client.GetSharedChannelRemotesByRemoteCluster(context.Background(), tc.RemoteId, tc.ExcludeHome, tc.ExcludeRemote, tc.IncludeDeleted, tc.Page, tc.PerPage)
+				scrs, resp, err := tc.Client.GetSharedChannelRemotesByRemoteCluster(context.Background(), tc.RemoteId, tc.Filter, tc.Page, tc.PerPage)
 				checkHTTPStatus(t, resp, tc.ExpectedStatusCode)
 				if tc.ExpectedError {
 					require.Error(t, err)

--- a/server/channels/web/params.go
+++ b/server/channels/web/params.go
@@ -99,6 +99,8 @@ type Params struct {
 	CreatorId                 string
 	OnlyConfirmed             bool
 	OnlyPlugins               bool
+	IncludeUnconfirmed        bool
+	ExcludeConfirmed          bool
 	ExcludePlugins            bool
 	ExcludeHome               bool
 	ExcludeRemote             bool
@@ -170,6 +172,8 @@ func ParamsFromRequest(r *http.Request) *Params {
 	params.CreatorId = query.Get("creator_id")
 	params.OnlyConfirmed, _ = strconv.ParseBool(query.Get("only_confirmed"))
 	params.OnlyPlugins, _ = strconv.ParseBool(query.Get("only_plugins"))
+	params.IncludeUnconfirmed, _ = strconv.ParseBool(query.Get("include_unconfirmed"))
+	params.ExcludeConfirmed, _ = strconv.ParseBool(query.Get("exclude_confirmed"))
 	params.ExcludePlugins, _ = strconv.ParseBool(query.Get("exclude_plugins"))
 	params.ExcludeHome, _ = strconv.ParseBool(query.Get("exclude_home"))
 	params.ExcludeRemote, _ = strconv.ParseBool(query.Get("exclude_remote"))

--- a/server/public/model/client4.go
+++ b/server/public/model/client4.go
@@ -8900,15 +8900,21 @@ func (c *Client4) DeleteRemoteCluster(ctx context.Context, remoteClusterId strin
 	return BuildResponse(r), nil
 }
 
-func (c *Client4) GetSharedChannelRemotesByRemoteCluster(ctx context.Context, remoteId string, excludeHome, excludeRemote, includeDeleted bool, page, perPage int) ([]*SharedChannelRemote, *Response, error) {
+func (c *Client4) GetSharedChannelRemotesByRemoteCluster(ctx context.Context, remoteId string, filter SharedChannelRemoteFilterOpts, page, perPage int) ([]*SharedChannelRemote, *Response, error) {
 	v := url.Values{}
-	if excludeHome {
+	if filter.IncludeUnconfirmed {
+		v.Set("include_unconfirmed", "true")
+	}
+	if filter.ExcludeConfirmed {
+		v.Set("exclude_confirmed", "true")
+	}
+	if filter.ExcludeHome {
 		v.Set("exclude_home", "true")
 	}
-	if excludeRemote {
+	if filter.ExcludeRemote {
 		v.Set("exclude_remote", "true")
 	}
-	if includeDeleted {
+	if filter.IncludeDeleted {
 		v.Set("include_deleted", "true")
 	}
 	if page != 0 {


### PR DESCRIPTION
#### Summary
This is necessary to show the pending invites that a server has sent and have not been accepted yet in the system console.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60571

#### Release Note
```release-note
NONE
```
