### PR TITLE
Fixed horizontal alignment of no draft graphic

### DIFF
--- a/webapp/channels/src/components/drafts/drafts.scss
+++ b/webapp/channels/src/components/drafts/drafts.scss
@@ -17,6 +17,7 @@
         display: flex;
         overflow: auto;
         height: 100%;
+        width: 100%;
         flex-flow: column nowrap;
         padding: 24px;
         grid-area: list;

--- a/webapp/channels/src/components/drafts/drafts.scss
+++ b/webapp/channels/src/components/drafts/drafts.scss
@@ -16,8 +16,8 @@
         position: absolute;
         display: flex;
         overflow: auto;
-        height: 100%;
         width: 100%;
+        height: 100%;
         flex-flow: column nowrap;
         padding: 24px;
         grid-area: list;


### PR DESCRIPTION
#### Summary
Fixed a bug where horizontal alignment of "no draft" graphic was broken.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-60581

#### Screenshots
Before-
<img width="807" alt="Screenshot 2024-09-18 at 9 23 43 AM" src="https://github.com/user-attachments/assets/042be085-fbd4-44dc-ae39-4fca3050d4d8">

After-
<img width="805" alt="Screenshot 2024-09-18 at 9 24 03 AM" src="https://github.com/user-attachments/assets/b65221f6-feb9-49d0-873b-e267a647dfe4">


#### Release Note
```release-note
none
```
