### PR TITLE
Prepackage Calls v0.29.2 in 9.11

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -144,7 +144,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v0.29.1
+PLUGIN_PACKAGES += mattermost-plugin-calls-v0.29.2
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.3.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.9.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.1.1


### PR DESCRIPTION
#### Summary

Prepackaging the latest Calls v0.29 release to be included in the upcoming 9.11 dot release.

#### Release Note

```release-note
Pre-packaged Calls v0.29.2
```

