### PR TITLE
Adds a make target and a database for a shared channels node

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build package run stop run-client run-server run-haserver stop-haserver stop-client stop-server restart restart-server restart-client restart-haserver start-docker update-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-windows package-prep package-linux package-osx package-windows internal-test-web-client vet run-server-for-web-client-tests diff-config prepackaged-plugins prepackaged-binaries test-server test-server-ee test-server-quick test-server-race test-mmctl-unit test-mmctl-e2e test-mmctl test-mmctl-coverage mmctl-build mmctl-docs new-migration migrations-extract test-public mocks-public
+.PHONY: build package run stop run-client run-server run-node run-haserver stop-haserver stop-client stop-server restart restart-server restart-client restart-haserver start-docker update-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-windows package-prep package-linux package-osx package-windows internal-test-web-client vet run-server-for-web-client-tests diff-config prepackaged-plugins prepackaged-binaries test-server test-server-ee test-server-quick test-server-race test-mmctl-unit test-mmctl-e2e test-mmctl test-mmctl-coverage mmctl-build mmctl-docs new-migration migrations-extract test-public mocks-public
 
 ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
@@ -590,6 +590,18 @@ debug-server-headless: start-docker ## Debug server from within an IDE like VSCo
 		-X github.com/mattermost/mattermost/server/public/model.BuildHashEnterprise=$(BUILD_HASH_ENTERPRISE)\
 		-X github.com/mattermost/mattermost/server/public/model.BuildEnterpriseReady=$(BUILD_ENTERPRISE_READY)'\
 		-tags '$(BUILD_TAGS)'"
+
+run-node: export MM_SERVICESETTINGS_SITEURL=http://localhost:8066
+run-node: export MM_SERVICESETTINGS_LISTENADDRESS=:8066
+run-node: export MM_SERVICESETTINGS_ENABLELOCALMODE=true
+run-node: export MM_SERVICESETTINGS_LOCALMODESOCKETLOCATION=/var/tmp/mattermost_local_node.socket
+run-node: export MM_SQLSETTINGS_DRIVERNAME=postgres
+run-node: export MM_SQLSETTINGS_DATASOURCE=postgres://mmuser:mostest@localhost/mattermost_node_test?sslmode=disable&sslmode=disable&connect_timeout=10&binary_parameters=yes
+
+run-node: start-docker ## Runs a shared channel node.
+	@echo Running mattermost node
+
+	$(GO) run $(GOFLAGS) -ldflags '$(LDFLAGS)' -tags '$(BUILD_TAGS)' $(PLATFORM_FILES) $(RUN_IN_BACKGROUND)
 
 run-cli: start-docker ## Runs CLI.
 	@echo Running mattermost for development

--- a/server/build/docker-compose.common.yml
+++ b/server/build/docker-compose.common.yml
@@ -53,6 +53,7 @@ services:
     command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'
     volumes:
      - "./docker/postgres.conf:/etc/postgresql/postgresql.conf"
+     - "./docker/postgres_node_database.sql:/docker-entrypoint-initdb.d/postgres_node_database.sql"
     healthcheck:
       test: [ "CMD", "pg_isready", "-h", "localhost" ]
       interval: 5s

--- a/server/build/docker/postgres_node_database.sql
+++ b/server/build/docker/postgres_node_database.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE mattermost_node_test;
+GRANT ALL PRIVILEGES ON DATABASE mattermost_node_test TO mmuser;


### PR DESCRIPTION
#### Summary
This PR allows to run a different Mattermost instance in port :8066 using the `make run-node` target. This instance reuses the frontend files compiled for the main development instance, has its own database and local mode enabled through environment variables, and for the rest of the configuration simply takes whatever properties are set in the `config.json` file.

This target is specially useful to run a Shared Channels development environment, compiling first the frontend and then running `make run-server` and `make run-node` side by side, later connecting both and testing Shared Channels features.

#### Release Note
```release-note
NONE
```
