### PR TITLE
Fix the problem that YouTube preview didn't shows Youtube Shorts & add layout for it

### DIFF
--- a/webapp/channels/src/components/youtube_video/__snapshots__/youtube_video.test.tsx.snap
+++ b/webapp/channels/src/components/youtube_video/__snapshots__/youtube_video.test.tsx.snap
@@ -1,91 +1,113 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`YoutubeVideo should match init snapshot (Shorts) 1`] = `
-<Provider
-  store={
-    Object {
-      "clearActions": [Function],
-      "dispatch": [Function],
-      "getActions": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-    }
-  }
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en"
+  fallbackOnEmptyString={true}
+  formats={Object {}}
+  locale="en"
+  messages={Object {}}
+  onError={[Function]}
+  onWarn={[Function]}
+  textComponent={Symbol(react.fragment)}
 >
-  <YoutubeVideo
-    googleDeveloperKey="googledevkey"
-    hasImageProxy={false}
-    link="https://www.youtube.com/shorts/2oa5WCUpwD8"
-    metadata={
+  <Provider
+    store={
       Object {
-        "images": Array [
-          Object {
-            "secure_url": "linkForThumbnail",
-            "url": "linkForThumbnail",
-          },
-        ],
-        "title": "Youtube title",
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
       }
     }
-    postId="post_id_1"
-    show={true}
-    youtubeReferrerPolicy={false}
   >
-    <div
-      className="post__embed-container"
+    <YoutubeVideo
+      googleDeveloperKey="googledevkey"
+      hasImageProxy={false}
+      link="https://www.youtube.com/shorts/2oa5WCUpwD8"
+      metadata={
+        Object {
+          "images": Array [
+            Object {
+              "secure_url": "linkForThumbnail",
+              "url": "linkForThumbnail",
+            },
+          ],
+          "title": "Youtube title",
+        }
+      }
+      postId="post_id_1"
+      show={true}
+      youtubeReferrerPolicy={false}
     >
-      <div>
-        <h4>
-          <span
-            className="video-type"
-          >
-            YouTube Shorts - 
-          </span>
-          <span
-            className="video-title"
-          >
-            <ForwardRef
-              href="https://www.youtube.com/shorts/2oa5WCUpwD8"
-              location="youtube_video"
+      <div
+        className="post__embed-container"
+      >
+        <div>
+          <h4>
+            <FormattedMessage
+              defaultMessage="<type>YouTube Shorts - </type>{title}"
+              id="youtube_video.type.shorts"
+              values={
+                Object {
+                  "title": <span
+                    className="video-title"
+                  >
+                    <ForwardRef
+                      href="https://www.youtube.com/shorts/2oa5WCUpwD8"
+                      location="youtube_video"
+                    >
+                      Youtube title
+                    </ForwardRef>
+                  </span>,
+                  "type": [Function],
+                }
+              }
             >
-              <a
-                href="https://www.youtube.com/shorts/2oa5WCUpwD8"
-                location="youtube_video"
-                onClick={[Function]}
-                rel="noopener noreferrer"
-                target="_blank"
+              <span
+                className="video-type"
+                key=".$.0"
               >
-                Youtube title
-              </a>
-            </ForwardRef>
-          </span>
-          <WithTooltip
-            id="post_id_1_expand_shorts"
-            placement="right"
-            title="Expand Horizontally"
-          >
-            <OverlayTrigger
-              defaultOverlayShown={false}
-              delay={400}
-              disabled={false}
-              overlay={<Unknown />}
+                YouTube Shorts - 
+              </span>
+              <span
+                className="video-title"
+                key=".$.1"
+              >
+                <ForwardRef
+                  href="https://www.youtube.com/shorts/2oa5WCUpwD8"
+                  location="youtube_video"
+                >
+                  <a
+                    href="https://www.youtube.com/shorts/2oa5WCUpwD8"
+                    location="youtube_video"
+                    onClick={[Function]}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Youtube title
+                  </a>
+                </ForwardRef>
+              </span>
+            </FormattedMessage>
+            <WithTooltip
+              id="post_id_1_expand_shorts"
               placement="right"
-              trigger={
-                Array [
-                  "hover",
-                  "focus",
-                ]
+              title={
+                Object {
+                  "defaultMessage": "Expand Horizontally",
+                  "id": "youtube_video.shorts.expand",
+                }
               }
             >
               <OverlayTrigger
                 defaultOverlayShown={false}
                 delay={400}
-                overlay={
-                  <OverlayWrapper
-                    intl={null}
-                  />
-                }
+                disabled={false}
+                overlay={<Unknown />}
                 placement="right"
                 trigger={
                   Array [
@@ -94,234 +116,272 @@ exports[`YoutubeVideo should match init snapshot (Shorts) 1`] = `
                   ]
                 }
               >
-                <i
-                  className="video-expand-shorts"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onMouseOut={[Function]}
-                  onMouseOver={[Function]}
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delay={400}
+                  overlay={
+                    <OverlayWrapper
+                      intl={
+                        Object {
+                          "$t": [Function],
+                          "defaultFormats": Object {},
+                          "defaultLocale": "en",
+                          "defaultRichTextElements": undefined,
+                          "fallbackOnEmptyString": true,
+                          "formatDate": [Function],
+                          "formatDateTimeRange": [Function],
+                          "formatDateToParts": [Function],
+                          "formatDisplayName": [Function],
+                          "formatList": [Function],
+                          "formatListToParts": [Function],
+                          "formatMessage": [Function],
+                          "formatNumber": [Function],
+                          "formatNumberToParts": [Function],
+                          "formatPlural": [Function],
+                          "formatRelativeTime": [Function],
+                          "formatTime": [Function],
+                          "formatTimeToParts": [Function],
+                          "formats": Object {},
+                          "formatters": Object {
+                            "getDateTimeFormat": [Function],
+                            "getDisplayNames": [Function],
+                            "getListFormat": [Function],
+                            "getMessageFormat": [Function],
+                            "getNumberFormat": [Function],
+                            "getPluralRules": [Function],
+                            "getRelativeTimeFormat": [Function],
+                          },
+                          "locale": "en",
+                          "messages": Object {},
+                          "onError": [Function],
+                          "onWarn": [Function],
+                          "textComponent": Symbol(react.fragment),
+                          "timeZone": undefined,
+                          "wrapRichTextChunksInFragment": undefined,
+                        }
+                      }
+                    />
+                  }
+                  placement="right"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
                 >
-                  <ArrowExpandIcon>
-                    <svg
-                      fill="currentColor"
-                      height="1em"
-                      version="1.1"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M10,21V19H6.41L10.91,14.5L9.5,13.09L5,17.59V14H3V21H10M14.5,10.91L19,6.41V10H21V3H14V5H17.59L13.09,9.5L14.5,10.91Z"
-                      />
-                    </svg>
-                  </ArrowExpandIcon>
-                </i>
+                  <i
+                    className="video-expand-shorts"
+                    data-testid="youtube-expand-shorts"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <ArrowExpandIcon>
+                      <svg
+                        fill="currentColor"
+                        height="1em"
+                        version="1.1"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M10,21V19H6.41L10.91,14.5L9.5,13.09L5,17.59V14H3V21H10M14.5,10.91L19,6.41V10H21V3H14V5H17.59L13.09,9.5L14.5,10.91Z"
+                        />
+                      </svg>
+                    </ArrowExpandIcon>
+                  </i>
+                </OverlayTrigger>
               </OverlayTrigger>
-            </OverlayTrigger>
-          </WithTooltip>
-        </h4>
-        <div
-          className="video-div embed-responsive-item video-shorts"
-          onClick={[Function]}
-        >
+            </WithTooltip>
+          </h4>
           <div
-            className="embed-responsive video-div__placeholder"
+            className="video-div embed-responsive-item video-shorts"
+            data-testid="youtube-video"
+            onClick={[Function]}
           >
             <div
-              className="video-thumbnail__container"
+              className="embed-responsive video-div__placeholder"
             >
-              <Connect(Component)
-                src="linkForThumbnail"
+              <div
+                className="video-thumbnail__container"
               >
-                <Memo(ExternalImage)
-                  dispatch={[Function]}
-                  enableSVGs={false}
-                  hasImageProxy={false}
+                <Connect(Component)
                   src="linkForThumbnail"
                 >
-                  <img
-                    alt="youtube video thumbnail"
-                    className="video-thumbnail"
+                  <Memo(ExternalImage)
+                    dispatch={[Function]}
+                    enableSVGs={false}
+                    hasImageProxy={false}
                     src="linkForThumbnail"
-                  />
-                </Memo(ExternalImage)>
-              </Connect(Component)>
-              <div
-                className="block"
-              >
-                <span
-                  className="play-button"
+                  >
+                    <img
+                      alt="youtube video thumbnail"
+                      className="video-thumbnail"
+                      src="linkForThumbnail"
+                    />
+                  </Memo(ExternalImage)>
+                </Connect(Component)>
+                <div
+                  className="block"
                 >
-                  <span />
-                </span>
+                  <span
+                    className="play-button"
+                  >
+                    <span />
+                  </span>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </YoutubeVideo>
-</Provider>
+    </YoutubeVideo>
+  </Provider>
+</IntlProvider>
 `;
 
 exports[`YoutubeVideo should match init snapshot 1`] = `
-<Provider
-  store={
-    Object {
-      "clearActions": [Function],
-      "dispatch": [Function],
-      "getActions": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-    }
-  }
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en"
+  fallbackOnEmptyString={true}
+  formats={Object {}}
+  locale="en"
+  messages={Object {}}
+  onError={[Function]}
+  onWarn={[Function]}
+  textComponent={Symbol(react.fragment)}
 >
-  <YoutubeVideo
-    googleDeveloperKey="googledevkey"
-    hasImageProxy={false}
-    link="https://www.youtube.com/watch?v=xqCoNej8Zxo"
-    metadata={
+  <Provider
+    store={
       Object {
-        "images": Array [
-          Object {
-            "secure_url": "linkForThumbnail",
-            "url": "linkForThumbnail",
-          },
-        ],
-        "title": "Youtube title",
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
       }
     }
-    postId="post_id_1"
-    show={true}
-    youtubeReferrerPolicy={false}
   >
-    <div
-      className="post__embed-container"
+    <YoutubeVideo
+      googleDeveloperKey="googledevkey"
+      hasImageProxy={false}
+      link="https://www.youtube.com/watch?v=xqCoNej8Zxo"
+      metadata={
+        Object {
+          "images": Array [
+            Object {
+              "secure_url": "linkForThumbnail",
+              "url": "linkForThumbnail",
+            },
+          ],
+          "title": "Youtube title",
+        }
+      }
+      postId="post_id_1"
+      show={true}
+      youtubeReferrerPolicy={false}
     >
-      <div>
-        <h4>
-          <span
-            className="video-type"
-          >
-            YouTube - 
-          </span>
-          <span
-            className="video-title"
-          >
-            <ForwardRef
-              href="https://www.youtube.com/watch?v=xqCoNej8Zxo"
-              location="youtube_video"
+      <div
+        className="post__embed-container"
+      >
+        <div>
+          <h4>
+            <FormattedMessage
+              defaultMessage="<type>YouTube - </type>{title}"
+              id="youtube_video.type.youtube"
+              values={
+                Object {
+                  "title": <span
+                    className="video-title"
+                  >
+                    <ForwardRef
+                      href="https://www.youtube.com/watch?v=xqCoNej8Zxo"
+                      location="youtube_video"
+                    >
+                      Youtube title
+                    </ForwardRef>
+                  </span>,
+                  "type": [Function],
+                }
+              }
             >
-              <a
-                href="https://www.youtube.com/watch?v=xqCoNej8Zxo"
-                location="youtube_video"
-                onClick={[Function]}
-                rel="noopener noreferrer"
-                target="_blank"
+              <span
+                className="video-type"
+                key=".$.0"
               >
-                Youtube title
-              </a>
-            </ForwardRef>
-          </span>
-        </h4>
-        <div
-          className="video-div embed-responsive-item"
-          onClick={[Function]}
-        >
+                YouTube - 
+              </span>
+              <span
+                className="video-title"
+                key=".$.1"
+              >
+                <ForwardRef
+                  href="https://www.youtube.com/watch?v=xqCoNej8Zxo"
+                  location="youtube_video"
+                >
+                  <a
+                    href="https://www.youtube.com/watch?v=xqCoNej8Zxo"
+                    location="youtube_video"
+                    onClick={[Function]}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Youtube title
+                  </a>
+                </ForwardRef>
+              </span>
+            </FormattedMessage>
+          </h4>
           <div
-            className="embed-responsive video-div__placeholder"
+            className="video-div embed-responsive-item"
+            data-testid="youtube-video"
+            onClick={[Function]}
           >
             <div
-              className="video-thumbnail__container"
+              className="embed-responsive video-div__placeholder"
             >
-              <Connect(Component)
-                src="linkForThumbnail"
+              <div
+                className="video-thumbnail__container"
               >
-                <Memo(ExternalImage)
-                  dispatch={[Function]}
-                  enableSVGs={false}
-                  hasImageProxy={false}
+                <Connect(Component)
                   src="linkForThumbnail"
                 >
-                  <img
-                    alt="youtube video thumbnail"
-                    className="video-thumbnail"
+                  <Memo(ExternalImage)
+                    dispatch={[Function]}
+                    enableSVGs={false}
+                    hasImageProxy={false}
                     src="linkForThumbnail"
-                  />
-                </Memo(ExternalImage)>
-              </Connect(Component)>
-              <div
-                className="block"
-              >
-                <span
-                  className="play-button"
+                  >
+                    <img
+                      alt="youtube video thumbnail"
+                      className="video-thumbnail"
+                      src="linkForThumbnail"
+                    />
+                  </Memo(ExternalImage)>
+                </Connect(Component)>
+                <div
+                  className="block"
                 >
-                  <span />
-                </span>
+                  <span
+                    className="play-button"
+                  >
+                    <span />
+                  </span>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </YoutubeVideo>
-</Provider>
-`;
-
-exports[`YoutubeVideo should match snapshot for playing state (Shorts) 1`] = `
-<div
-  className="post__embed-container"
->
-  <div>
-    <h4>
-      <span
-        className="video-type"
-      >
-        YouTube Shorts - 
-      </span>
-      <span
-        className="video-title"
-      >
-        <ForwardRef
-          href="https://www.youtube.com/shorts/2oa5WCUpwD8"
-          location="youtube_video"
-        >
-          Youtube title
-        </ForwardRef>
-      </span>
-      <WithTooltip
-        id="post_id_1_expand_shorts"
-        placement="right"
-        title="Expand Horizontally"
-      >
-        <i
-          className="video-expand-shorts"
-          onClick={[Function]}
-        >
-          <ArrowExpandIcon />
-        </i>
-      </WithTooltip>
-    </h4>
-    <div
-      className="video-div embed-responsive-item video-shorts"
-      onClick={[Function]}
-    >
-      <iframe
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        allowFullScreen={true}
-        frameBorder="0"
-        height="360px"
-        referrerPolicy="no-referrer"
-        sandbox="allow-scripts allow-same-origin allow-popups allow-presentation"
-        src="https://www.youtube.com/embed/2oa5WCUpwD8?autoplay=1&autohide=1&border=0&wmode=opaque&fs=1&enablejsapi=1"
-        title="Youtube title"
-        width="480px"
-      />
-    </div>
-  </div>
-</div>
+    </YoutubeVideo>
+  </Provider>
+</IntlProvider>
 `;
 
 exports[`YoutubeVideo should match snapshot for playing state 1`] = `
@@ -330,24 +390,29 @@ exports[`YoutubeVideo should match snapshot for playing state 1`] = `
 >
   <div>
     <h4>
-      <span
-        className="video-type"
-      >
-        YouTube - 
-      </span>
-      <span
-        className="video-title"
-      >
-        <ForwardRef
-          href="https://www.youtube.com/watch?v=xqCoNej8Zxo"
-          location="youtube_video"
-        >
-          Youtube title
-        </ForwardRef>
-      </span>
+      <MemoizedFormattedMessage
+        defaultMessage="<type>YouTube - </type>{title}"
+        id="youtube_video.type.youtube"
+        values={
+          Object {
+            "title": <span
+              className="video-title"
+            >
+              <ForwardRef
+                href="https://www.youtube.com/watch?v=xqCoNej8Zxo"
+                location="youtube_video"
+              >
+                Youtube title
+              </ForwardRef>
+            </span>,
+            "type": [Function],
+          }
+        }
+      />
     </h4>
     <div
       className="video-div embed-responsive-item"
+      data-testid="youtube-video"
       onClick={[Function]}
     >
       <iframe
@@ -372,24 +437,29 @@ exports[`YoutubeVideo should match snapshot for playing state and \`youtubeRefer
 >
   <div>
     <h4>
-      <span
-        className="video-type"
-      >
-        YouTube - 
-      </span>
-      <span
-        className="video-title"
-      >
-        <ForwardRef
-          href="https://www.youtube.com/watch?v=xqCoNej8Zxo"
-          location="youtube_video"
-        >
-          Youtube title
-        </ForwardRef>
-      </span>
+      <MemoizedFormattedMessage
+        defaultMessage="<type>YouTube - </type>{title}"
+        id="youtube_video.type.youtube"
+        values={
+          Object {
+            "title": <span
+              className="video-title"
+            >
+              <ForwardRef
+                href="https://www.youtube.com/watch?v=xqCoNej8Zxo"
+                location="youtube_video"
+              >
+                Youtube title
+              </ForwardRef>
+            </span>,
+            "type": [Function],
+          }
+        }
+      />
     </h4>
     <div
       className="video-div embed-responsive-item"
+      data-testid="youtube-video"
       onClick={[Function]}
     >
       <iframe
@@ -400,60 +470,6 @@ exports[`YoutubeVideo should match snapshot for playing state and \`youtubeRefer
         referrerPolicy="strict-origin-when-cross-origin"
         sandbox="allow-scripts allow-same-origin allow-popups allow-presentation"
         src="https://www.youtube.com/embed/xqCoNej8Zxo?autoplay=1&autohide=1&border=0&wmode=opaque&fs=1&enablejsapi=1"
-        title="Youtube title"
-        width="480px"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`YoutubeVideo should match snapshot for playing state and shortsExpanded state (Shorts) 1`] = `
-<div
-  className="post__embed-container"
->
-  <div>
-    <h4>
-      <span
-        className="video-type"
-      >
-        YouTube Shorts - 
-      </span>
-      <span
-        className="video-title"
-      >
-        <ForwardRef
-          href="https://www.youtube.com/shorts/2oa5WCUpwD8"
-          location="youtube_video"
-        >
-          Youtube title
-        </ForwardRef>
-      </span>
-      <WithTooltip
-        id="post_id_1_expand_shorts"
-        placement="right"
-        title="Shrink"
-      >
-        <i
-          className="video-expand-shorts"
-          onClick={[Function]}
-        >
-          <ArrowCollapseIcon />
-        </i>
-      </WithTooltip>
-    </h4>
-    <div
-      className="video-div embed-responsive-item video-shorts-expanded"
-      onClick={[Function]}
-    >
-      <iframe
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        allowFullScreen={true}
-        frameBorder="0"
-        height="360px"
-        referrerPolicy="no-referrer"
-        sandbox="allow-scripts allow-same-origin allow-popups allow-presentation"
-        src="https://www.youtube.com/embed/2oa5WCUpwD8?autoplay=1&autohide=1&border=0&wmode=opaque&fs=1&enablejsapi=1"
         title="Youtube title"
         width="480px"
       />

--- a/webapp/channels/src/components/youtube_video/__snapshots__/youtube_video.test.tsx.snap
+++ b/webapp/channels/src/components/youtube_video/__snapshots__/youtube_video.test.tsx.snap
@@ -1,5 +1,170 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`YoutubeVideo should match init snapshot (Shorts) 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <YoutubeVideo
+    googleDeveloperKey="googledevkey"
+    hasImageProxy={false}
+    link="https://www.youtube.com/shorts/2oa5WCUpwD8"
+    metadata={
+      Object {
+        "images": Array [
+          Object {
+            "secure_url": "linkForThumbnail",
+            "url": "linkForThumbnail",
+          },
+        ],
+        "title": "Youtube title",
+      }
+    }
+    postId="post_id_1"
+    show={true}
+    youtubeReferrerPolicy={false}
+  >
+    <div
+      className="post__embed-container"
+    >
+      <div>
+        <h4>
+          <span
+            className="video-type"
+          >
+            YouTube Shorts - 
+          </span>
+          <span
+            className="video-title"
+          >
+            <ForwardRef
+              href="https://www.youtube.com/shorts/2oa5WCUpwD8"
+              location="youtube_video"
+            >
+              <a
+                href="https://www.youtube.com/shorts/2oa5WCUpwD8"
+                location="youtube_video"
+                onClick={[Function]}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Youtube title
+              </a>
+            </ForwardRef>
+          </span>
+          <WithTooltip
+            id="post_id_1_expand_shorts"
+            placement="right"
+            title="Expand Horizontally"
+          >
+            <OverlayTrigger
+              defaultOverlayShown={false}
+              delay={400}
+              disabled={false}
+              overlay={<Unknown />}
+              placement="right"
+              trigger={
+                Array [
+                  "hover",
+                  "focus",
+                ]
+              }
+            >
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delay={400}
+                overlay={
+                  <OverlayWrapper
+                    intl={null}
+                  />
+                }
+                placement="right"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <i
+                  className="video-expand-shorts"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <ArrowExpandIcon>
+                    <svg
+                      fill="currentColor"
+                      height="1em"
+                      version="1.1"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M10,21V19H6.41L10.91,14.5L9.5,13.09L5,17.59V14H3V21H10M14.5,10.91L19,6.41V10H21V3H14V5H17.59L13.09,9.5L14.5,10.91Z"
+                      />
+                    </svg>
+                  </ArrowExpandIcon>
+                </i>
+              </OverlayTrigger>
+            </OverlayTrigger>
+          </WithTooltip>
+        </h4>
+        <div
+          className="video-div embed-responsive-item video-shorts"
+          onClick={[Function]}
+        >
+          <div
+            className="embed-responsive video-div__placeholder"
+          >
+            <div
+              className="video-thumbnail__container"
+            >
+              <Connect(Component)
+                src="linkForThumbnail"
+              >
+                <Memo(ExternalImage)
+                  dispatch={[Function]}
+                  enableSVGs={false}
+                  hasImageProxy={false}
+                  src="linkForThumbnail"
+                >
+                  <img
+                    alt="youtube video thumbnail"
+                    className="video-thumbnail"
+                    src="linkForThumbnail"
+                  />
+                </Memo(ExternalImage)>
+              </Connect(Component)>
+              <div
+                className="block"
+              >
+                <span
+                  className="play-button"
+                >
+                  <span />
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </YoutubeVideo>
+</Provider>
+`;
+
 exports[`YoutubeVideo should match init snapshot 1`] = `
 <Provider
   store={
@@ -105,6 +270,60 @@ exports[`YoutubeVideo should match init snapshot 1`] = `
 </Provider>
 `;
 
+exports[`YoutubeVideo should match snapshot for playing state (Shorts) 1`] = `
+<div
+  className="post__embed-container"
+>
+  <div>
+    <h4>
+      <span
+        className="video-type"
+      >
+        YouTube Shorts - 
+      </span>
+      <span
+        className="video-title"
+      >
+        <ForwardRef
+          href="https://www.youtube.com/shorts/2oa5WCUpwD8"
+          location="youtube_video"
+        >
+          Youtube title
+        </ForwardRef>
+      </span>
+      <WithTooltip
+        id="post_id_1_expand_shorts"
+        placement="right"
+        title="Expand Horizontally"
+      >
+        <i
+          className="video-expand-shorts"
+          onClick={[Function]}
+        >
+          <ArrowExpandIcon />
+        </i>
+      </WithTooltip>
+    </h4>
+    <div
+      className="video-div embed-responsive-item video-shorts"
+      onClick={[Function]}
+    >
+      <iframe
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowFullScreen={true}
+        frameBorder="0"
+        height="360px"
+        referrerPolicy="no-referrer"
+        sandbox="allow-scripts allow-same-origin allow-popups allow-presentation"
+        src="https://www.youtube.com/embed/2oa5WCUpwD8?autoplay=1&autohide=1&border=0&wmode=opaque&fs=1&enablejsapi=1"
+        title="Youtube title"
+        width="480px"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`YoutubeVideo should match snapshot for playing state 1`] = `
 <div
   className="post__embed-container"
@@ -181,6 +400,60 @@ exports[`YoutubeVideo should match snapshot for playing state and \`youtubeRefer
         referrerPolicy="strict-origin-when-cross-origin"
         sandbox="allow-scripts allow-same-origin allow-popups allow-presentation"
         src="https://www.youtube.com/embed/xqCoNej8Zxo?autoplay=1&autohide=1&border=0&wmode=opaque&fs=1&enablejsapi=1"
+        title="Youtube title"
+        width="480px"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`YoutubeVideo should match snapshot for playing state and shortsExpanded state (Shorts) 1`] = `
+<div
+  className="post__embed-container"
+>
+  <div>
+    <h4>
+      <span
+        className="video-type"
+      >
+        YouTube Shorts - 
+      </span>
+      <span
+        className="video-title"
+      >
+        <ForwardRef
+          href="https://www.youtube.com/shorts/2oa5WCUpwD8"
+          location="youtube_video"
+        >
+          Youtube title
+        </ForwardRef>
+      </span>
+      <WithTooltip
+        id="post_id_1_expand_shorts"
+        placement="right"
+        title="Shrink"
+      >
+        <i
+          className="video-expand-shorts"
+          onClick={[Function]}
+        >
+          <ArrowCollapseIcon />
+        </i>
+      </WithTooltip>
+    </h4>
+    <div
+      className="video-div embed-responsive-item video-shorts-expanded"
+      onClick={[Function]}
+    >
+      <iframe
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowFullScreen={true}
+        frameBorder="0"
+        height="360px"
+        referrerPolicy="no-referrer"
+        sandbox="allow-scripts allow-same-origin allow-popups allow-presentation"
+        src="https://www.youtube.com/embed/2oa5WCUpwD8?autoplay=1&autohide=1&border=0&wmode=opaque&fs=1&enablejsapi=1"
         title="Youtube title"
         width="480px"
       />

--- a/webapp/channels/src/components/youtube_video/youtube_video.test.tsx
+++ b/webapp/channels/src/components/youtube_video/youtube_video.test.tsx
@@ -3,12 +3,14 @@
 
 import {mount, shallow} from 'enzyme';
 import React from 'react';
+import {IntlProvider} from 'react-intl';
 import {Provider} from 'react-redux';
 
 import type {DeepPartial} from '@mattermost/types/utilities';
 
 import ExternalImage from 'components/external_image';
 
+import {renderWithContext, screen} from 'tests/react_testing_utils';
 import mockStore from 'tests/test_store';
 
 import type {GlobalState} from 'types/store';
@@ -51,9 +53,11 @@ describe('YoutubeVideo', () => {
     test('should match init snapshot', () => {
         const store = mockStore(initialState);
         const wrapper = mount(
-            <Provider store={store}>
-                <YoutubeVideo {...baseProps}/>
-            </Provider>,
+            <IntlProvider locale='en'>
+                <Provider store={store}>
+                    <YoutubeVideo {...baseProps}/>
+                </Provider>
+            </IntlProvider>,
         );
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.find(ExternalImage).prop('src')).toEqual('linkForThumbnail');
@@ -99,9 +103,11 @@ describe('YoutubeVideo', () => {
             link: 'https://www.youtube.com/shorts/2oa5WCUpwD8',
         };
         const wrapper = mount(
-            <Provider store={store}>
-                <YoutubeVideo {...props}/>
-            </Provider>,
+            <IntlProvider locale='en'>
+                <Provider store={store}>
+                    <YoutubeVideo {...props}/>
+                </Provider>
+            </IntlProvider>,
         );
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.find(ExternalImage).prop('src')).toEqual('linkForThumbnail');
@@ -111,28 +117,28 @@ describe('YoutubeVideo', () => {
     });
 
     test('should match snapshot for playing state (Shorts)', () => {
-        const wrapper = shallow(
+        renderWithContext(
             <YoutubeVideo
                 {...baseProps}
                 link={'https://www.youtube.com/shorts/2oa5WCUpwD8'}
             />,
+            initialState,
         );
-        wrapper.setState({playing: true, shortsExpanded: false});
-        expect(wrapper).toMatchSnapshot();
-        expect(wrapper.find('.video-shorts').exists()).toBe(true);
-        expect(wrapper.find('.video-shorts-expanded').exists()).toBe(false);
+
+        expect(screen.getByTestId('youtube-video')).toHaveClass('video-shorts');
     });
 
     test('should match snapshot for playing state and shortsExpanded state (Shorts)', () => {
-        const wrapper = shallow(
+        renderWithContext(
             <YoutubeVideo
                 {...baseProps}
                 link={'https://www.youtube.com/shorts/2oa5WCUpwD8'}
             />,
+            initialState,
         );
-        wrapper.setState({playing: true, shortsExpanded: true});
-        expect(wrapper).toMatchSnapshot();
-        expect(wrapper.find('.video-shorts').exists()).toBe(false);
-        expect(wrapper.find('.video-shorts-expanded').exists()).toBe(true);
+
+        screen.getByTestId('youtube-expand-shorts').click();
+
+        expect(screen.getByTestId('youtube-video')).toHaveClass('video-shorts-expanded');
     });
 });

--- a/webapp/channels/src/components/youtube_video/youtube_video.test.tsx
+++ b/webapp/channels/src/components/youtube_video/youtube_video.test.tsx
@@ -91,4 +91,48 @@ describe('YoutubeVideo', () => {
 
         expect(wrapper.find(ExternalImage).prop('src')).toEqual('linkUrl');
     });
+
+    test('should match init snapshot (Shorts)', () => {
+        const store = mockStore(initialState);
+        const props = {
+            ...baseProps,
+            link: 'https://www.youtube.com/shorts/2oa5WCUpwD8',
+        };
+        const wrapper = mount(
+            <Provider store={store}>
+                <YoutubeVideo {...props}/>
+            </Provider>,
+        );
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find(ExternalImage).prop('src')).toEqual('linkForThumbnail');
+        expect(wrapper.find('a').text()).toEqual('Youtube title');
+        expect(wrapper.find('.video-shorts').exists()).toBe(true);
+        expect(wrapper.find('.video-shorts-expanded').exists()).toBe(false);
+    });
+
+    test('should match snapshot for playing state (Shorts)', () => {
+        const wrapper = shallow(
+            <YoutubeVideo
+                {...baseProps}
+                link={'https://www.youtube.com/shorts/2oa5WCUpwD8'}
+            />,
+        );
+        wrapper.setState({playing: true, shortsExpanded: false});
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find('.video-shorts').exists()).toBe(true);
+        expect(wrapper.find('.video-shorts-expanded').exists()).toBe(false);
+    });
+
+    test('should match snapshot for playing state and shortsExpanded state (Shorts)', () => {
+        const wrapper = shallow(
+            <YoutubeVideo
+                {...baseProps}
+                link={'https://www.youtube.com/shorts/2oa5WCUpwD8'}
+            />,
+        );
+        wrapper.setState({playing: true, shortsExpanded: true});
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find('.video-shorts').exists()).toBe(false);
+        expect(wrapper.find('.video-shorts-expanded').exists()).toBe(true);
+    });
 });

--- a/webapp/channels/src/components/youtube_video/youtube_video.tsx
+++ b/webapp/channels/src/components/youtube_video/youtube_video.tsx
@@ -144,7 +144,14 @@ export default class YoutubeVideo extends React.PureComponent<Props, State> {
                 <div>
                     {header}
                     <div
-                        className={classNames('video-div', 'embed-responsive-item', this.state.shortsExpanded ? 'video-shorts-expanded' : (isShorts && 'video-shorts'))}
+                        className={classNames(
+                            'video-div',
+                            'embed-responsive-item',
+                            {
+                                'video-shorts-expanded': this.state.shortsExpanded,
+                                'video-shorts': isShorts && !this.state.shortsExpanded,
+                            },
+                        )}
                         onClick={this.play}
                     >
                         {content}

--- a/webapp/channels/src/components/youtube_video/youtube_video.tsx
+++ b/webapp/channels/src/components/youtube_video/youtube_video.tsx
@@ -44,15 +44,15 @@ export default class YoutubeVideo extends React.PureComponent<Props, State> {
     }
 
     play = () => {
-        this.setState({...this.state, playing: true});
+        this.setState({playing: true});
     };
 
     stop = () => {
-        this.setState({...this.state, playing: false});
+        this.setState({playing: false});
     };
 
     toggleShortsExpanded = () => {
-        this.setState({...this.state, shortsExpanded: !this.state.shortsExpanded});
+        this.setState({shortsExpanded: !this.state.shortsExpanded});
     };
 
     render() {

--- a/webapp/channels/src/components/youtube_video/youtube_video.tsx
+++ b/webapp/channels/src/components/youtube_video/youtube_video.tsx
@@ -90,6 +90,7 @@ export default class YoutubeVideo extends React.PureComponent<Props, State> {
                         placement='right'
                     >
                         <i
+                            data-testid='youtube-expand-shorts'
                             className='video-expand-shorts'
                             onClick={this.toggleShortsExpanded}
                         >
@@ -146,6 +147,7 @@ export default class YoutubeVideo extends React.PureComponent<Props, State> {
                 <div>
                     {header}
                     <div
+                        data-testid='youtube-video'
                         className={classNames(
                             'video-div',
                             'embed-responsive-item',

--- a/webapp/channels/src/components/youtube_video/youtube_video.tsx
+++ b/webapp/channels/src/components/youtube_video/youtube_video.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import cn from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 
 import {ArrowCollapseIcon, ArrowExpandIcon} from '@mattermost/compass-icons/components';
@@ -137,7 +137,7 @@ export default class YoutubeVideo extends React.PureComponent<Props, State> {
                 <div>
                     {header}
                     <div
-                        className={cn('video-div', 'embed-responsive-item', this.state.shortsExpanded ? 'video-shorts-expanded' : (isShorts && 'video-shorts'))}
+                        className={classNames('video-div', 'embed-responsive-item', this.state.shortsExpanded ? 'video-shorts-expanded' : (isShorts && 'video-shorts'))}
                         onClick={this.play}
                     >
                         {content}

--- a/webapp/channels/src/components/youtube_video/youtube_video.tsx
+++ b/webapp/channels/src/components/youtube_video/youtube_video.tsx
@@ -3,6 +3,7 @@
 
 import classNames from 'classnames';
 import React from 'react';
+import {defineMessages, FormattedMessage} from 'react-intl';
 
 import {ArrowCollapseIcon, ArrowExpandIcon} from '@mattermost/compass-icons/components';
 import type {OpenGraphMetadata} from '@mattermost/types/posts';
@@ -60,12 +61,18 @@ export default class YoutubeVideo extends React.PureComponent<Props, State> {
 
         const videoId = getVideoId(link);
         const isShorts = getIsShortsVideoLink(link);
+        const videoType = isShorts ? messages.shorts : messages.youtube;
         const videoTitle = metadata?.title || 'unknown';
         const time = handleYoutubeTime(link);
 
         const header = (
             <h4>
-                <span className='video-type'>{`YouTube ${isShorts ? 'Shorts ' : ''}- `}</span>
+                <span className='video-type'>
+                    <FormattedMessage
+                        {...videoType}
+                        values={{type: videoType}}
+                    />
+                </span>
                 <span className='video-title'>
                     <ExternalLink
                         href={this.props.link}
@@ -77,7 +84,7 @@ export default class YoutubeVideo extends React.PureComponent<Props, State> {
                 {isShorts && (
                     <WithTooltip
                         id={`${this.props.postId}_expand_shorts`}
-                        title={this.state.shortsExpanded ? 'Shrink' : 'Expand Horizontally'}
+                        title={this.state.shortsExpanded ? messages.shrink : messages.expand}
                         placement='right'
                     >
                         <i
@@ -151,3 +158,23 @@ export default class YoutubeVideo extends React.PureComponent<Props, State> {
         return Boolean(link.trim().match(ytRegex));
     }
 }
+
+const messages = defineMessages({
+    youtube: {
+        id: 'youtube_video.type.youtube',
+        defaultMessage: 'YouTube - ',
+    },
+    shorts: {
+        id: 'youtube_video.type.shorts',
+        defaultMessage: 'YouTube Shorts - ',
+    },
+
+    shrink: {
+        id: 'youtube_video.shorts.shrink',
+        defaultMessage: 'Shrink',
+    },
+    expand: {
+        id: 'youtube_video.shorts.expand',
+        defaultMessage: 'Expand Horizontally',
+    },
+});

--- a/webapp/channels/src/components/youtube_video/youtube_video.tsx
+++ b/webapp/channels/src/components/youtube_video/youtube_video.tsx
@@ -67,20 +67,22 @@ export default class YoutubeVideo extends React.PureComponent<Props, State> {
 
         const header = (
             <h4>
-                <span className='video-type'>
-                    <FormattedMessage
-                        {...videoType}
-                        values={{type: videoType}}
-                    />
-                </span>
-                <span className='video-title'>
-                    <ExternalLink
-                        href={this.props.link}
-                        location='youtube_video'
-                    >
-                        {videoTitle}
-                    </ExternalLink>
-                </span>
+                <FormattedMessage
+                    {...videoType}
+                    values={{
+                        title: (
+                            <span className='video-title'>
+                                <ExternalLink
+                                    href={this.props.link}
+                                    location='youtube_video'
+                                >
+                                    {videoTitle}
+                                </ExternalLink>
+                            </span>
+                        ),
+                        type: (v) => (<span className='video-type'>{v}</span>),
+                    }}
+                />
                 {isShorts && (
                     <WithTooltip
                         id={`${this.props.postId}_expand_shorts`}
@@ -169,11 +171,11 @@ export default class YoutubeVideo extends React.PureComponent<Props, State> {
 const messages = defineMessages({
     youtube: {
         id: 'youtube_video.type.youtube',
-        defaultMessage: 'YouTube - ',
+        defaultMessage: '<type>YouTube - </type>{title}',
     },
     shorts: {
         id: 'youtube_video.type.shorts',
-        defaultMessage: 'YouTube Shorts - ',
+        defaultMessage: '<type>YouTube Shorts - </type>{title}',
     },
 
     shrink: {

--- a/webapp/channels/src/sass/components/_videos.scss
+++ b/webapp/channels/src/sass/components/_videos.scss
@@ -76,13 +76,13 @@
     }
 
     .video-expand-shorts {
+        display: inline-block;
         padding: 0;
         margin: 0;
         margin-left: 6px;
-        display: inline-block;
         font-size: 15px;
-        opacity: 0.8;
         cursor: pointer;
+        opacity: 0.8;
 
         svg {
             margin-bottom: -2px;

--- a/webapp/channels/src/sass/components/_videos.scss
+++ b/webapp/channels/src/sass/components/_videos.scss
@@ -31,6 +31,36 @@
             margin: -75px 0 0 -100px;
             background-color: alpha-color($black, 0.5);
         }
+
+        &.video-shorts {
+            max-width: calc(360px * 560 / 995);
+
+            .block {
+                width: 150px;
+                height: 112px;
+                margin: -56px 0 0 -75px;
+            }
+
+            .play-button {
+                top: 21px;
+                right: 40px;
+                width: 70px;
+                height: 70px;
+                border-radius: 10px;
+
+                span {
+                    top: 7px;
+                    left: 13.75px;
+                    border-top: 24px solid transparent;
+                    border-bottom: 24px solid transparent;
+                    border-left: 40px solid alpha-color($white, 0.4);
+                }
+            }
+        }
+
+        &.video-shorts-expanded {
+            max-width: 405px;
+        }
     }
 
     .video-type {
@@ -43,6 +73,21 @@
     .video-title {
         margin-top: 3px;
         font-size: 15px;
+    }
+
+    .video-expand-shorts {
+        padding: 0;
+        margin: 0;
+        margin-left: 6px;
+        display: inline-block;
+        font-size: 15px;
+        opacity: 0.8;
+        cursor: pointer;
+
+        svg {
+            margin-bottom: -2px;
+            transform: rotate(45deg);
+        }
     }
 
     .play-button {

--- a/webapp/channels/src/utils/youtube.ts
+++ b/webapp/channels/src/utils/youtube.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-export const ytRegex = /(?:http|https):\/\/(?:www\.|m\.)?(?:(?:youtube\.com\/(?:(?:v\/)|(?:(?:watch|embed\/watch)(?:\/|.*v=))|(?:embed\/)|(?:user\/[^/]+\/u\/[0-9]\/)))|(?:youtu\.be\/))([^#&?]*)/;
+export const ytRegex = /(?:http|https):\/\/(?:www\.|m\.)?(?:(?:youtube\.com\/(?:(?:v\/)|(?:(?:watch|embed\/watch)(?:\/|.*v=))|(?:embed\/)|(?:shorts\/)|(?:user\/[^/]+\/u\/[0-9]\/)))|(?:youtu\.be\/))([^#&?]*)/;
 
 export function handleYoutubeTime(link: string) {
     const timeRegex = /[\\?&](t|time|start|time_continue)=([0-9]+h)?([0-9]+m)?([0-9]+s?)/;

--- a/webapp/channels/src/utils/youtube.ts
+++ b/webapp/channels/src/utils/youtube.ts
@@ -40,3 +40,12 @@ export function getVideoId(link: string) {
 
     return match[1];
 }
+
+export function getIsShortsVideoLink(link: string) {
+    const match = link.trim().match(ytRegex);
+    if (!match) {
+        return false;
+    }
+
+    return link.includes('/shorts/');
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

- Fix the problem that YouTube preview didn't shows Youtube Shorts
- Add Layout for YouTube Shorts
  - If you click expand icon, It will be show YouTube Shorts with the ratio of normal YouTube video.

#### Screenshots

##### Before

<img width="612" alt="image" src="https://github.com/user-attachments/assets/53fd15ae-e944-4cf5-9c1b-bd3ea430dad8">

##### After

| Shorts | Shorts (Expand Icon Hover) | Expanded Shorts (Collapse Icon Hover) |
| --- | --- | --- |
| <img width="231" alt="image" src="https://github.com/mattermost/mattermost/assets/26380261/7a7fd1e3-5af1-46f3-bde0-9144ed8b688e"> | <img width="364" alt="image" src="https://github.com/mattermost/mattermost/assets/26380261/1d1a487e-5926-4987-a781-fe17d52c8a83"> | <img width="421" alt="image" src="https://github.com/mattermost/mattermost/assets/26380261/a1ab2f64-0ad4-410d-9a2f-40e498ae115f"> |

<details>
<summary> <h5>Show Preview Video</h5> </summary>
<video src="https://github.com/mattermost/mattermost/assets/26380261/08eda914-cc9f-470a-b67e-9bfdc240796c">
</details>

#### Release Note
```release-note
Added video preview for YouTube Shorts
```
