### PR TITLE
[MM-60514] Accessing bot_accounts page directly fails to load

### DIFF
--- a/webapp/channels/src/components/root/root.test.tsx
+++ b/webapp/channels/src/components/root/root.test.tsx
@@ -403,4 +403,17 @@ describe('doesRouteBelongToTeamControllerRoutes', () => {
         expect(doesRouteBelongToTeamControllerRoutes('/login')).toBe(false);
         expect(doesRouteBelongToTeamControllerRoutes('/error')).toBe(false);
     });
+
+    test('should return false for admin_console routes', () => {
+        expect(doesRouteBelongToTeamControllerRoutes('/admin_console/about')).toBe(false);
+        expect(doesRouteBelongToTeamControllerRoutes('/admin_console/reporting')).toBe(false);
+        expect(doesRouteBelongToTeamControllerRoutes('/admin_console/user_management')).toBe(false);
+        expect(doesRouteBelongToTeamControllerRoutes('/admin_console/environment')).toBe(false);
+        expect(doesRouteBelongToTeamControllerRoutes('/admin_console/site_config')).toBe(false);
+        expect(doesRouteBelongToTeamControllerRoutes('/admin_console/plugins/')).toBe(false);
+        expect(doesRouteBelongToTeamControllerRoutes('/admin_console/integrations/')).toBe(false);
+        expect(doesRouteBelongToTeamControllerRoutes('/admin_console/integrations/bot_accounts')).toBe(false);
+        expect(doesRouteBelongToTeamControllerRoutes('/admin_console/compliance')).toBe(false);
+        expect(doesRouteBelongToTeamControllerRoutes('/admin_console/experimental')).toBe(false);
+    });
 });

--- a/webapp/channels/src/components/root/root.tsx
+++ b/webapp/channels/src/components/root/root.tsx
@@ -571,6 +571,9 @@ export default class Root extends React.PureComponent<Props, State> {
 }
 
 export function doesRouteBelongToTeamControllerRoutes(pathname: RouteComponentProps['location']['pathname']): boolean {
-    const TEAM_CONTROLLER_PATH_PATTERN = /^\/([a-z0-9\-_]+)\/(channels|messages|threads|drafts|integrations|emoji)(\/.*)?$/;
+    // Note: we have specifically added admin_console to the negative lookahead as admin_console can have integrations as subpaths (admin_console/integrations/bot_accounts)
+    // and we don't want to treat those as team controller routes.
+    const TEAM_CONTROLLER_PATH_PATTERN = /^\/(?!admin_console)([a-z0-9\-_]+)\/(channels|messages|threads|drafts|integrations|emoji)(\/.*)?$/;
+
     return TEAM_CONTROLLER_PATH_PATTERN.test(pathname);
 }


### PR DESCRIPTION
#### Summary
Regex was failing to identify between `admin_console/integrations` and `team_name/integrations` page. Fixed to identify admin console as well 

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-60514


#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
