### PR TITLE
Checkout latest stable pgloader release

### DIFF
--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -40,6 +40,7 @@ jobs:
             apt install -y sbcl unzip libsqlite3-dev make curl gawk freetds-dev libzip-dev && \
             git clone https://github.com/dimitri/pgloader.git && \
             cd pgloader && \
+            git checkout $(git tag --list --sort=-v:refname "v*" | head -n1) && \
             make && \
             mv build/bin/pgloader /bin" >> dockerfile_tmp
           docker build -t $TEST_IMAGE - < dockerfile_tmp


### PR DESCRIPTION
#### Summary

Migration tests currently check out pgloader's master branch, to build the tool on the fly before the tests.

But this means that if pgloader's master branch has some kind of issue (like it's currently happening), we are instantly hit by it. The fact that it happens in a CI job that's required for PR mergeability further amplifies the impact on us, since we can't merge any PR as soon as pgloader's master branch is broken.

This PR checks out the latest tag in the `v*` format instead, as a best effort to increase the chances of tool stability. I'm also open to simply relying on the pgloader version that's contained in the `apt` repository, if possible.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-8353

#### Release Note
```release-note
NONE
```
