### PR TITLE
Add a specific error when inviting a remote cluster to a remote channel

### DIFF
--- a/server/channels/api4/shared_channel.go
+++ b/server/channels/api4/shared_channel.go
@@ -173,7 +173,11 @@ func inviteRemoteClusterToChannel(c *Context, w http.ResponseWriter, r *http.Req
 	audit.AddEventParameter(auditRec, "user_id", c.AppContext.Session().UserId)
 
 	if err := c.App.InviteRemoteToChannel(c.Params.ChannelId, c.Params.RemoteId, c.AppContext.Session().UserId, true); err != nil {
-		c.Err = model.NewAppError("inviteRemoteClusterToChannel", "api.shared_channel.invite_remote_to_channel_error", nil, "", http.StatusInternalServerError).Wrap(err)
+		if appErr, ok := err.(*model.AppError); ok {
+			c.Err = appErr
+		} else {
+			c.Err = model.NewAppError("inviteRemoteClusterToChannel", "api.shared_channel.invite_remote_to_channel_error", nil, "", http.StatusInternalServerError).Wrap(err)
+		}
 		return
 	}
 

--- a/server/platform/services/sharedchannel/service_api.go
+++ b/server/platform/services/sharedchannel/service_api.go
@@ -150,7 +150,7 @@ func (scs *Service) InviteRemoteToChannel(channelID, remoteID, userID string, sh
 	// (also blocks cyclic invitations)
 	if err = scs.CheckCanInviteToSharedChannel(channelID); err != nil {
 		if errors.Is(err, model.ErrChannelHomedOnRemote) {
-			return model.NewAppError("InviteRemoteToChannel", "api.command_share.channel_invite_not_home.error", nil, "", http.StatusInternalServerError)
+			return model.NewAppError("InviteRemoteToChannel", "api.command_share.channel_invite_not_home.error", nil, "", http.StatusBadRequest)
 		}
 		scs.server.Log().Debug("InviteRemoteToChannel failed to check if can-invite",
 			mlog.String("name", rc.Name),


### PR DESCRIPTION
#### Summary
This PR changes the error returned by the shared channels service to be a `BadRequest` instead of an `InternalServerError` and updates the API to directly return the error returned by the service instead of a new one.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60601

#### Release Note
```release-note
NONE
```
