### PR TITLE
[MM-57194] Don't return config values from plugins that are not installed

### DIFF
--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -3226,9 +3226,9 @@ func (s *PluginSettings) Sanitize(pluginManifests []*Manifest) {
 
 		for key := range settings {
 			if manifest == nil {
-				// Sanitize plugin settings for plugins that are not installed
-				settings[key] = FakeSetting
-				continue
+				// Don't return plugin settings for plugins that are not installed
+				delete(s.Plugins, id)
+				break
 			}
 
 			for _, definedSetting := range manifest.SettingsSchema.Settings {

--- a/server/public/model/config_test.go
+++ b/server/public/model/config_test.go
@@ -1488,9 +1488,6 @@ func TestPluginSettingsSanitize(t *testing.T) {
 					"secrettext":   FakeSetting,
 					"secretnumber": FakeSetting,
 				},
-				"another.plugin": {
-					"somesetting": FakeSetting,
-				},
 			},
 		},
 		"two plugins installed": {
@@ -1595,9 +1592,6 @@ func TestPluginSettingsSanitize(t *testing.T) {
 				"somesetting":  "some value",
 				"secrettext":   FakeSetting,
 				"secretnumber": FakeSetting,
-			},
-			"another.plugin": {
-				"somesetting": FakeSetting,
 			},
 		}
 		assert.Equal(t, expected, c.Plugins)

--- a/server/public/model/config_test.go
+++ b/server/public/model/config_test.go
@@ -1540,9 +1540,6 @@ func TestPluginSettingsSanitize(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			name := name // TODO: Remove once go1.22 is used
-			tc := tc     // TODO: Remove once go1.22 is used
-
 			if name != "one plugin installed" {
 				return
 			}
@@ -1556,46 +1553,6 @@ func TestPluginSettingsSanitize(t *testing.T) {
 			assert.Equal(t, tc.expected, c.Plugins, name)
 		})
 	}
-
-	t.Run("one plugin installed, two in the config", func(t *testing.T) {
-		c := PluginSettings{}
-		c.SetDefaults(*NewLogSettings())
-		c.Plugins = plugins
-
-		c.Sanitize([]*Manifest{
-			{
-				Id: "plugin.id",
-				SettingsSchema: &PluginSettingsSchema{
-					Settings: []*PluginSetting{
-						{
-							Key:    "somesetting",
-							Type:   "text",
-							Secret: false,
-						},
-						{
-							Key:    "secrettext",
-							Type:   "text",
-							Secret: true,
-						},
-						{
-							Key:    "secretnumber",
-							Type:   "number",
-							Secret: true,
-						},
-					},
-				},
-			},
-		})
-
-		expected := map[string]map[string]any{
-			"plugin.id": {
-				"somesetting":  "some value",
-				"secrettext":   FakeSetting,
-				"secretnumber": FakeSetting,
-			},
-		}
-		assert.Equal(t, expected, c.Plugins)
-	})
 }
 
 func TestConfigFilteredByTag(t *testing.T) {


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost/pull/27986 caused an issue with the Calls E2E tests as even for not installed plugin, the config API endpoint would return obfuscated values. See https://github.com/mattermost/mattermost/pull/27986#discussion_r1762107270 for more details.

With this PR, the config values of any non-installed plugin are not returned via the API at all.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57194

#### Release Note
```release-note
NONE
```
