### PR TITLE
[MM-60619] Annotate cluster logs messages

### DIFF
--- a/server/channels/api4/system.go
+++ b/server/channels/api4/system.go
@@ -378,9 +378,9 @@ func queryLogs(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logs, logerr := c.App.QueryLogs(c.AppContext, c.Params.Page, c.Params.LogsPerPage, logFilter)
-	if logerr != nil {
-		c.Err = logerr
+	logs, appErr := c.App.QueryLogs(c.AppContext, c.Params.Page, c.Params.LogsPerPage, logFilter)
+	if appErr != nil {
+		c.Err = appErr
 		return
 	}
 
@@ -388,11 +388,11 @@ func queryLogs(c *Context, w http.ResponseWriter, r *http.Request) {
 	var result interface{}
 	for node, logLines := range logs {
 		for _, log := range logLines {
-			err2 := json.Unmarshal([]byte(log), &result)
-			if err2 == nil {
-				logsJSON[node] = append(logsJSON[node], result)
+			err = json.Unmarshal([]byte(log), &result)
+			if err != nil {
+				c.Logger.Warn("Error parsing log line in Server Logs", mlog.String("from_node", node), mlog.Err(err))
 			} else {
-				c.Logger.Warn("Error parsing log line in Server Logs")
+				logsJSON[node] = append(logsJSON[node], result)
 			}
 		}
 	}

--- a/server/channels/app/analytics.go
+++ b/server/channels/app/analytics.go
@@ -157,7 +157,7 @@ func (a *App) getAnalytics(rctx request.CTX, name string, teamID string, forSupp
 
 		// If in HA mode then aggregate all the stats
 		if a.Cluster() != nil && *a.Config().ClusterSettings.Enable {
-			stats, err2 := a.Cluster().GetClusterStats()
+			stats, err2 := a.Cluster().GetClusterStats(rctx)
 			if err2 != nil {
 				return nil, err2
 			}

--- a/server/channels/app/busy_test.go
+++ b/server/channels/app/busy_test.go
@@ -135,16 +135,18 @@ func (c *ClusterMock) StartInterNodeCommunication() {}
 func (c *ClusterMock) StopInterNodeCommunication()  {}
 func (c *ClusterMock) RegisterClusterMessageHandler(event model.ClusterEvent, crm einterfaces.ClusterMessageHandler) {
 }
-func (c *ClusterMock) GetClusterId() string                                      { return "cluster_mock" }
-func (c *ClusterMock) IsLeader() bool                                            { return false }
-func (c *ClusterMock) GetMyClusterInfo() *model.ClusterInfo                      { return nil }
-func (c *ClusterMock) GetClusterInfos() []*model.ClusterInfo                     { return nil }
-func (c *ClusterMock) NotifyMsg(buf []byte)                                      {}
-func (c *ClusterMock) GetClusterStats() ([]*model.ClusterStats, *model.AppError) { return nil, nil }
-func (c *ClusterMock) GetLogs(page, perPage int) ([]string, *model.AppError) {
+func (c *ClusterMock) GetClusterId() string                  { return "cluster_mock" }
+func (c *ClusterMock) IsLeader() bool                        { return false }
+func (c *ClusterMock) GetMyClusterInfo() *model.ClusterInfo  { return nil }
+func (c *ClusterMock) GetClusterInfos() []*model.ClusterInfo { return nil }
+func (c *ClusterMock) NotifyMsg(buf []byte)                  {}
+func (c *ClusterMock) GetClusterStats(rctx request.CTX) ([]*model.ClusterStats, *model.AppError) {
 	return nil, nil
 }
-func (c *ClusterMock) QueryLogs(page, perPage int) (map[string][]string, *model.AppError) {
+func (c *ClusterMock) GetLogs(rctx request.CTX, page, perPage int) ([]string, *model.AppError) {
+	return nil, nil
+}
+func (c *ClusterMock) QueryLogs(rctx request.CTX, page, perPage int) (map[string][]string, *model.AppError) {
 	return nil, nil
 }
 func (c *ClusterMock) GenerateSupportPacket(rctx request.CTX, options *model.SupportPacketOptions) (map[string][]model.FileData, error) {

--- a/server/channels/app/platform/busy_test.go
+++ b/server/channels/app/platform/busy_test.go
@@ -135,14 +135,18 @@ func (c *ClusterMock) StartInterNodeCommunication() {}
 func (c *ClusterMock) StopInterNodeCommunication()  {}
 func (c *ClusterMock) RegisterClusterMessageHandler(event model.ClusterEvent, crm einterfaces.ClusterMessageHandler) {
 }
-func (c *ClusterMock) GetClusterId() string                                      { return "cluster_mock" }
-func (c *ClusterMock) IsLeader() bool                                            { return false }
-func (c *ClusterMock) GetMyClusterInfo() *model.ClusterInfo                      { return nil }
-func (c *ClusterMock) GetClusterInfos() []*model.ClusterInfo                     { return nil }
-func (c *ClusterMock) NotifyMsg(buf []byte)                                      {}
-func (c *ClusterMock) GetClusterStats() ([]*model.ClusterStats, *model.AppError) { return nil, nil }
-func (c *ClusterMock) GetLogs(page, perPage int) ([]string, *model.AppError)     { return nil, nil }
-func (c *ClusterMock) QueryLogs(page, perPage int) (map[string][]string, *model.AppError) {
+func (c *ClusterMock) GetClusterId() string                  { return "cluster_mock" }
+func (c *ClusterMock) IsLeader() bool                        { return false }
+func (c *ClusterMock) GetMyClusterInfo() *model.ClusterInfo  { return nil }
+func (c *ClusterMock) GetClusterInfos() []*model.ClusterInfo { return nil }
+func (c *ClusterMock) NotifyMsg(buf []byte)                  {}
+func (c *ClusterMock) GetClusterStats(rctx request.CTX) ([]*model.ClusterStats, *model.AppError) {
+	return nil, nil
+}
+func (c *ClusterMock) GetLogs(rctx request.CTX, page, perPage int) ([]string, *model.AppError) {
+	return nil, nil
+}
+func (c *ClusterMock) QueryLogs(rctx request.CTX, page, perPage int) (map[string][]string, *model.AppError) {
 	return nil, nil
 }
 func (c *ClusterMock) GenerateSupportPacket(rctx request.CTX, options *model.SupportPacketOptions) (map[string][]model.FileData, error) {

--- a/server/channels/app/platform/log.go
+++ b/server/channels/app/platform/log.go
@@ -121,7 +121,7 @@ func (ps *PlatformService) RemoveUnlicensedLogTargets(license *model.License) {
 	})
 }
 
-func (ps *PlatformService) GetLogsSkipSend(page, perPage int, logFilter *model.LogFilter) ([]string, *model.AppError) {
+func (ps *PlatformService) GetLogsSkipSend(rctx request.CTX, page, perPage int, logFilter *model.LogFilter) ([]string, *model.AppError) {
 	var lines []string
 
 	if *ps.Config().LogSettings.EnableFile {
@@ -175,10 +175,10 @@ func (ps *PlatformService) GetLogsSkipSend(page, perPage int, logFilter *model.L
 					var entry *model.LogEntry
 					err = json.Unmarshal(line, &entry)
 					if err != nil {
-						mlog.Debug("Failed to parse line, skipping")
+						rctx.Logger().Debug("Failed to parse line, skipping")
 					} else {
 						filtered = isLogFilteredByLevel(logFilter, entry) || filtered
-						filtered = isLogFilteredByDate(logFilter, entry) || filtered
+						filtered = isLogFilteredByDate(rctx, logFilter, entry) || filtered
 					}
 
 					if filtered {
@@ -257,7 +257,7 @@ func isLogFilteredByLevel(logFilter *model.LogFilter, entry *model.LogEntry) boo
 	return true
 }
 
-func isLogFilteredByDate(logFilter *model.LogFilter, entry *model.LogEntry) bool {
+func isLogFilteredByDate(rctx request.CTX, logFilter *model.LogFilter, entry *model.LogEntry) bool {
 	if logFilter.DateFrom == "" && logFilter.DateTo == "" {
 		return false
 	}
@@ -273,7 +273,7 @@ func isLogFilteredByDate(logFilter *model.LogFilter, entry *model.LogEntry) bool
 
 	timestamp, err := time.Parse("2006-01-02 15:04:05.999 -07:00", entry.Timestamp)
 	if err != nil {
-		mlog.Debug("Cannot parse timestamp, skipping")
+		rctx.Logger().Debug("Cannot parse timestamp, skipping")
 		return false
 	}
 

--- a/server/channels/testlib/cluster.go
+++ b/server/channels/testlib/cluster.go
@@ -52,15 +52,15 @@ func (c *FakeClusterInterface) SendClusterMessageToNode(nodeID string, message *
 
 func (c *FakeClusterInterface) NotifyMsg(buf []byte) {}
 
-func (c *FakeClusterInterface) GetClusterStats() ([]*model.ClusterStats, *model.AppError) {
+func (c *FakeClusterInterface) GetClusterStats(rctx request.CTX) ([]*model.ClusterStats, *model.AppError) {
 	return nil, nil
 }
 
-func (c *FakeClusterInterface) GetLogs(page, perPage int) ([]string, *model.AppError) {
+func (c *FakeClusterInterface) GetLogs(rctx request.CTX, page, perPage int) ([]string, *model.AppError) {
 	return []string{}, nil
 }
 
-func (c *FakeClusterInterface) QueryLogs(page, perPage int) (map[string][]string, *model.AppError) {
+func (c *FakeClusterInterface) QueryLogs(rctx request.CTX, page, perPage int) (map[string][]string, *model.AppError) {
 	return make(map[string][]string), nil
 }
 

--- a/server/einterfaces/cluster.go
+++ b/server/einterfaces/cluster.go
@@ -25,9 +25,9 @@ type ClusterInterface interface {
 	SendClusterMessage(msg *model.ClusterMessage)
 	SendClusterMessageToNode(nodeID string, msg *model.ClusterMessage) error
 	NotifyMsg(buf []byte)
-	GetClusterStats() ([]*model.ClusterStats, *model.AppError)
-	GetLogs(page, perPage int) ([]string, *model.AppError)
-	QueryLogs(page, perPage int) (map[string][]string, *model.AppError)
+	GetClusterStats(rctx request.CTX) ([]*model.ClusterStats, *model.AppError)
+	GetLogs(ctx request.CTX, page, perPage int) ([]string, *model.AppError)
+	QueryLogs(rctx request.CTX, page, perPage int) (map[string][]string, *model.AppError)
 	GenerateSupportPacket(rctx request.CTX, options *model.SupportPacketOptions) (map[string][]model.FileData, error)
 	GetPluginStatuses() (model.PluginStatuses, *model.AppError)
 	ConfigChanged(previousConfig *model.Config, newConfig *model.Config, sendToOtherServer bool) *model.AppError

--- a/server/einterfaces/mocks/ClusterInterface.go
+++ b/server/einterfaces/mocks/ClusterInterface.go
@@ -106,9 +106,9 @@ func (_m *ClusterInterface) GetClusterInfos() []*model.ClusterInfo {
 	return r0
 }
 
-// GetClusterStats provides a mock function with given fields:
-func (_m *ClusterInterface) GetClusterStats() ([]*model.ClusterStats, *model.AppError) {
-	ret := _m.Called()
+// GetClusterStats provides a mock function with given fields: rctx
+func (_m *ClusterInterface) GetClusterStats(rctx request.CTX) ([]*model.ClusterStats, *model.AppError) {
+	ret := _m.Called(rctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetClusterStats")
@@ -116,19 +116,19 @@ func (_m *ClusterInterface) GetClusterStats() ([]*model.ClusterStats, *model.App
 
 	var r0 []*model.ClusterStats
 	var r1 *model.AppError
-	if rf, ok := ret.Get(0).(func() ([]*model.ClusterStats, *model.AppError)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(request.CTX) ([]*model.ClusterStats, *model.AppError)); ok {
+		return rf(rctx)
 	}
-	if rf, ok := ret.Get(0).(func() []*model.ClusterStats); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(request.CTX) []*model.ClusterStats); ok {
+		r0 = rf(rctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.ClusterStats)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() *model.AppError); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(request.CTX) *model.AppError); ok {
+		r1 = rf(rctx)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -138,9 +138,9 @@ func (_m *ClusterInterface) GetClusterStats() ([]*model.ClusterStats, *model.App
 	return r0, r1
 }
 
-// GetLogs provides a mock function with given fields: page, perPage
-func (_m *ClusterInterface) GetLogs(page int, perPage int) ([]string, *model.AppError) {
-	ret := _m.Called(page, perPage)
+// GetLogs provides a mock function with given fields: ctx, page, perPage
+func (_m *ClusterInterface) GetLogs(ctx request.CTX, page int, perPage int) ([]string, *model.AppError) {
+	ret := _m.Called(ctx, page, perPage)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetLogs")
@@ -148,19 +148,19 @@ func (_m *ClusterInterface) GetLogs(page int, perPage int) ([]string, *model.App
 
 	var r0 []string
 	var r1 *model.AppError
-	if rf, ok := ret.Get(0).(func(int, int) ([]string, *model.AppError)); ok {
-		return rf(page, perPage)
+	if rf, ok := ret.Get(0).(func(request.CTX, int, int) ([]string, *model.AppError)); ok {
+		return rf(ctx, page, perPage)
 	}
-	if rf, ok := ret.Get(0).(func(int, int) []string); ok {
-		r0 = rf(page, perPage)
+	if rf, ok := ret.Get(0).(func(request.CTX, int, int) []string); ok {
+		r0 = rf(ctx, page, perPage)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(int, int) *model.AppError); ok {
-		r1 = rf(page, perPage)
+	if rf, ok := ret.Get(1).(func(request.CTX, int, int) *model.AppError); ok {
+		r1 = rf(ctx, page, perPage)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -263,9 +263,9 @@ func (_m *ClusterInterface) NotifyMsg(buf []byte) {
 	_m.Called(buf)
 }
 
-// QueryLogs provides a mock function with given fields: page, perPage
-func (_m *ClusterInterface) QueryLogs(page int, perPage int) (map[string][]string, *model.AppError) {
-	ret := _m.Called(page, perPage)
+// QueryLogs provides a mock function with given fields: rctx, page, perPage
+func (_m *ClusterInterface) QueryLogs(rctx request.CTX, page int, perPage int) (map[string][]string, *model.AppError) {
+	ret := _m.Called(rctx, page, perPage)
 
 	if len(ret) == 0 {
 		panic("no return value specified for QueryLogs")
@@ -273,19 +273,19 @@ func (_m *ClusterInterface) QueryLogs(page int, perPage int) (map[string][]strin
 
 	var r0 map[string][]string
 	var r1 *model.AppError
-	if rf, ok := ret.Get(0).(func(int, int) (map[string][]string, *model.AppError)); ok {
-		return rf(page, perPage)
+	if rf, ok := ret.Get(0).(func(request.CTX, int, int) (map[string][]string, *model.AppError)); ok {
+		return rf(rctx, page, perPage)
 	}
-	if rf, ok := ret.Get(0).(func(int, int) map[string][]string); ok {
-		r0 = rf(page, perPage)
+	if rf, ok := ret.Get(0).(func(request.CTX, int, int) map[string][]string); ok {
+		r0 = rf(rctx, page, perPage)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string][]string)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(int, int) *model.AppError); ok {
-		r1 = rf(page, perPage)
+	if rf, ok := ret.Get(1).(func(request.CTX, int, int) *model.AppError); ok {
+		r1 = rf(rctx, page, perPage)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)


### PR DESCRIPTION
#### Summary
This PR improves the log messages related to cluster communication by
- Passing `request.CTX` all the way down to the `GossipClient`
- Use an annoyed longer inside the cluster event handlers
- Replace calls to the global logger with ones to the request specific one

Related discussion: https://hub.mattermost.com/private-core/pl/nyytm167rpfzbqawfejjm9cuwr and ticket: https://mattermost.zendesk.com/agent/tickets/43714

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60619

#### Release Note
```release-note
Improve log messages for cluster communication
```
