### PR TITLE
MM-59260: allowed permanently deleting a direct and group message

### DIFF
--- a/server/channels/api4/channel_local.go
+++ b/server/channels/api4/channel_local.go
@@ -422,11 +422,6 @@ func localDeleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.AddEventPriorState(channel)
 	audit.AddEventParameter(auditRec, "channel_id", c.Params.ChannelId)
 
-	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
-		c.Err = model.NewAppError("localDeleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
-		return
-	}
-
 	if c.Params.Permanent {
 		err = c.App.PermanentDeleteChannel(c.AppContext, channel)
 	} else {

--- a/server/channels/api4/channel_test.go
+++ b/server/channels/api4/channel_test.go
@@ -695,13 +695,20 @@ func TestDeleteDirectChannel(t *testing.T) {
 	user := th.BasicUser
 	user2 := th.BasicUser2
 
+	enableAPIChannelDeletion := *th.App.Config().ServiceSettings.EnableAPIChannelDeletion
+	defer func() {
+		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableAPIChannelDeletion = &enableAPIChannelDeletion })
+	}()
+
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableAPIChannelDeletion = true })
+
 	rgc, resp, err := client.CreateDirectChannel(context.Background(), user.Id, user2.Id)
 	require.NoError(t, err)
 	CheckCreatedStatus(t, resp)
 	require.NotNil(t, rgc, "should have created a direct channel")
 
 	_, err = client.DeleteChannel(context.Background(), rgc.Id)
-	CheckErrorID(t, err, "api.channel.delete_channel.type.invalid")
+	require.NoError(t, err)
 }
 
 func TestCreateGroupChannel(t *testing.T) {
@@ -842,13 +849,20 @@ func TestDeleteGroupChannel(t *testing.T) {
 
 	userIds := []string{user.Id, user2.Id, user3.Id}
 
+	enableAPIChannelDeletion := *th.App.Config().ServiceSettings.EnableAPIChannelDeletion
+	defer func() {
+		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableAPIChannelDeletion = &enableAPIChannelDeletion })
+	}()
+
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableAPIChannelDeletion = true })
+
 	th.TestForAllClients(t, func(t *testing.T, client *model.Client4) {
 		rgc, resp, err := th.Client.CreateGroupChannel(context.Background(), userIds)
 		require.NoError(t, err)
 		CheckCreatedStatus(t, resp)
 		require.NotNil(t, rgc, "should have created a group channel")
 		_, err = client.DeleteChannel(context.Background(), rgc.Id)
-		CheckErrorID(t, err, "api.channel.delete_channel.type.invalid")
+		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
#### Summary
allowed permanently deleting a direct and group message

#### Ticket Link
[https://mattermost.atlassian.net/browse/MM-59260](https://mattermost.atlassian.net/browse/MM-59260)

 #### Release Note
 ```release-note
Modified the delete channel API to allow permanent deletion of direct and group messages. 
Users can no longer soft delete, instead it always permanently deletes.
  ```