### PR TITLE
MM-60604 Hide pinned icon in channel header when no pinned posts

### DIFF
--- a/webapp/channels/src/components/channel_header/__snapshots__/channel_header.test.tsx.snap
+++ b/webapp/channels/src/components/channel_header/__snapshots__/channel_header.test.tsx.snap
@@ -72,18 +72,6 @@ exports[`components/ChannelHeader should match snapshot with last active display
             className="channel-header__icons"
           >
             <HeaderIconWrapper
-              buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left btn btn-icon btn-xs"
-              buttonId="channelHeaderPinButton"
-              iconComponent={
-                <i
-                  aria-hidden="true"
-                  className="icon icon-pin-outline channel-header__pin"
-                />
-              }
-              onClick={[Function]}
-              tooltip="Pinned messages"
-            />
-            <HeaderIconWrapper
               buttonClass="channel-header__icon channel-header__icon--left btn btn-icon btn-xs "
               buttonId="channelHeaderFilesButton"
               iconComponent={
@@ -363,18 +351,6 @@ exports[`components/ChannelHeader should match snapshot with no last active disp
             className="channel-header__icons"
           >
             <HeaderIconWrapper
-              buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left btn btn-icon btn-xs"
-              buttonId="channelHeaderPinButton"
-              iconComponent={
-                <i
-                  aria-hidden="true"
-                  className="icon icon-pin-outline channel-header__pin"
-                />
-              }
-              onClick={[Function]}
-              tooltip="Pinned messages"
-            />
-            <HeaderIconWrapper
               buttonClass="channel-header__icon channel-header__icon--left btn btn-icon btn-xs "
               buttonId="channelHeaderFilesButton"
               iconComponent={
@@ -605,18 +581,6 @@ exports[`components/ChannelHeader should render active channel files 1`] = `
               tooltip="Members"
             />
             <HeaderIconWrapper
-              buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left btn btn-icon btn-xs"
-              buttonId="channelHeaderPinButton"
-              iconComponent={
-                <i
-                  aria-hidden="true"
-                  className="icon icon-pin-outline channel-header__pin"
-                />
-              }
-              onClick={[Function]}
-              tooltip="Pinned messages"
-            />
-            <HeaderIconWrapper
               buttonClass="channel-header__icon channel-header__icon--left btn btn-icon btn-xs  channel-header__icon--active"
               buttonId="channelHeaderFilesButton"
               iconComponent={
@@ -840,18 +804,6 @@ exports[`components/ChannelHeader should render active flagged posts 1`] = `
               }
               onClick={[Function]}
               tooltip="Members"
-            />
-            <HeaderIconWrapper
-              buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left btn btn-icon btn-xs"
-              buttonId="channelHeaderPinButton"
-              iconComponent={
-                <i
-                  aria-hidden="true"
-                  className="icon icon-pin-outline channel-header__pin"
-                />
-              }
-              onClick={[Function]}
-              tooltip="Pinned messages"
             />
             <HeaderIconWrapper
               buttonClass="channel-header__icon channel-header__icon--left btn btn-icon btn-xs "
@@ -1079,18 +1031,6 @@ exports[`components/ChannelHeader should render active mentions posts 1`] = `
               tooltip="Members"
             />
             <HeaderIconWrapper
-              buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left btn btn-icon btn-xs"
-              buttonId="channelHeaderPinButton"
-              iconComponent={
-                <i
-                  aria-hidden="true"
-                  className="icon icon-pin-outline channel-header__pin"
-                />
-              }
-              onClick={[Function]}
-              tooltip="Pinned messages"
-            />
-            <HeaderIconWrapper
               buttonClass="channel-header__icon channel-header__icon--left btn btn-icon btn-xs "
               buttonId="channelHeaderFilesButton"
               iconComponent={
@@ -1316,18 +1256,6 @@ exports[`components/ChannelHeader should render active pinned posts 1`] = `
               tooltip="Members"
             />
             <HeaderIconWrapper
-              buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left btn btn-icon btn-xs channel-header__icon--active"
-              buttonId="channelHeaderPinButton"
-              iconComponent={
-                <i
-                  aria-hidden="true"
-                  className="icon icon-pin-outline channel-header__pin"
-                />
-              }
-              onClick={[Function]}
-              tooltip="Pinned messages"
-            />
-            <HeaderIconWrapper
               buttonClass="channel-header__icon channel-header__icon--left btn btn-icon btn-xs "
               buttonId="channelHeaderFilesButton"
               iconComponent={
@@ -1551,18 +1479,6 @@ exports[`components/ChannelHeader should render archived view 1`] = `
               }
               onClick={[Function]}
               tooltip="Members"
-            />
-            <HeaderIconWrapper
-              buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left btn btn-icon btn-xs"
-              buttonId="channelHeaderPinButton"
-              iconComponent={
-                <i
-                  aria-hidden="true"
-                  className="icon icon-pin-outline channel-header__pin"
-                />
-              }
-              onClick={[Function]}
-              tooltip="Pinned messages"
             />
             <HeaderIconWrapper
               buttonClass="channel-header__icon channel-header__icon--left btn btn-icon btn-xs "
@@ -1811,18 +1727,6 @@ exports[`components/ChannelHeader should render correct menu when muted 1`] = `
               tooltip="Members"
             />
             <HeaderIconWrapper
-              buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left btn btn-icon btn-xs"
-              buttonId="channelHeaderPinButton"
-              iconComponent={
-                <i
-                  aria-hidden="true"
-                  className="icon icon-pin-outline channel-header__pin"
-                />
-              }
-              onClick={[Function]}
-              tooltip="Pinned messages"
-            />
-            <HeaderIconWrapper
               buttonClass="channel-header__icon channel-header__icon--left btn btn-icon btn-xs "
               buttonId="channelHeaderFilesButton"
               iconComponent={
@@ -2046,18 +1950,6 @@ exports[`components/ChannelHeader should render not active channel files 1`] = `
               }
               onClick={[Function]}
               tooltip="Members"
-            />
-            <HeaderIconWrapper
-              buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left btn btn-icon btn-xs channel-header__icon--active"
-              buttonId="channelHeaderPinButton"
-              iconComponent={
-                <i
-                  aria-hidden="true"
-                  className="icon icon-pin-outline channel-header__pin"
-                />
-              }
-              onClick={[Function]}
-              tooltip="Pinned messages"
             />
             <HeaderIconWrapper
               buttonClass="channel-header__icon channel-header__icon--left btn btn-icon btn-xs "
@@ -2306,18 +2198,6 @@ exports[`components/ChannelHeader should render properly when custom status is e
           <div
             className="channel-header__icons"
           >
-            <HeaderIconWrapper
-              buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left btn btn-icon btn-xs"
-              buttonId="channelHeaderPinButton"
-              iconComponent={
-                <i
-                  aria-hidden="true"
-                  className="icon icon-pin-outline channel-header__pin"
-                />
-              }
-              onClick={[Function]}
-              tooltip="Pinned messages"
-            />
             <HeaderIconWrapper
               buttonClass="channel-header__icon channel-header__icon--left btn btn-icon btn-xs "
               buttonId="channelHeaderFilesButton"
@@ -2596,18 +2476,6 @@ exports[`components/ChannelHeader should render properly when custom status is s
             className="channel-header__icons"
           >
             <HeaderIconWrapper
-              buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left btn btn-icon btn-xs"
-              buttonId="channelHeaderPinButton"
-              iconComponent={
-                <i
-                  aria-hidden="true"
-                  className="icon icon-pin-outline channel-header__pin"
-                />
-              }
-              onClick={[Function]}
-              tooltip="Pinned messages"
-            />
-            <HeaderIconWrapper
               buttonClass="channel-header__icon channel-header__icon--left btn btn-icon btn-xs "
               buttonId="channelHeaderFilesButton"
               iconComponent={
@@ -2883,18 +2751,6 @@ exports[`components/ChannelHeader should render properly when empty 1`] = `
               tooltip="Members"
             />
             <HeaderIconWrapper
-              buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left btn btn-icon btn-xs"
-              buttonId="channelHeaderPinButton"
-              iconComponent={
-                <i
-                  aria-hidden="true"
-                  className="icon icon-pin-outline channel-header__pin"
-                />
-              }
-              onClick={[Function]}
-              tooltip="Pinned messages"
-            />
-            <HeaderIconWrapper
               buttonClass="channel-header__icon channel-header__icon--left btn btn-icon btn-xs "
               buttonId="channelHeaderFilesButton"
               iconComponent={
@@ -3120,18 +2976,6 @@ exports[`components/ChannelHeader should render properly when populated 1`] = `
               tooltip="Members"
             />
             <HeaderIconWrapper
-              buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left btn btn-icon btn-xs"
-              buttonId="channelHeaderPinButton"
-              iconComponent={
-                <i
-                  aria-hidden="true"
-                  className="icon icon-pin-outline channel-header__pin"
-                />
-              }
-              onClick={[Function]}
-              tooltip="Pinned messages"
-            />
-            <HeaderIconWrapper
               buttonClass="channel-header__icon channel-header__icon--left btn btn-icon btn-xs "
               buttonId="channelHeaderFilesButton"
               iconComponent={
@@ -3355,18 +3199,6 @@ exports[`components/ChannelHeader should render properly when populated with cha
               }
               onClick={[Function]}
               tooltip="Members"
-            />
-            <HeaderIconWrapper
-              buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left btn btn-icon btn-xs"
-              buttonId="channelHeaderPinButton"
-              iconComponent={
-                <i
-                  aria-hidden="true"
-                  className="icon icon-pin-outline channel-header__pin"
-                />
-              }
-              onClick={[Function]}
-              tooltip="Pinned messages"
             />
             <HeaderIconWrapper
               buttonClass="channel-header__icon channel-header__icon--left btn btn-icon btn-xs "
@@ -3618,18 +3450,6 @@ exports[`components/ChannelHeader should render shared view 1`] = `
               }
               onClick={[Function]}
               tooltip="Members"
-            />
-            <HeaderIconWrapper
-              buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left btn btn-icon btn-xs"
-              buttonId="channelHeaderPinButton"
-              iconComponent={
-                <i
-                  aria-hidden="true"
-                  className="icon icon-pin-outline channel-header__pin"
-                />
-              }
-              onClick={[Function]}
-              tooltip="Pinned messages"
             />
             <HeaderIconWrapper
               buttonClass="channel-header__icon channel-header__icon--left btn btn-icon btn-xs "

--- a/webapp/channels/src/components/channel_header/channel_header.tsx
+++ b/webapp/channels/src/components/channel_header/channel_header.tsx
@@ -374,6 +374,18 @@ class ChannelHeader extends React.PureComponent<Props, State> {
             />
         );
 
+        const pinnedButton = this.props.pinnedPostsCount ? (
+            <HeaderIconWrapper
+                iconComponent={pinnedIcon}
+                buttonClass={pinnedIconClass}
+                buttonId={'channelHeaderPinButton'}
+                onClick={this.showPinnedPosts}
+                tooltip={this.props.intl.formatMessage({id: 'channel_header.pinnedPosts', defaultMessage: 'Pinned messages'})}
+            />
+        ) : (
+            null
+        );
+
         let memberListButton = null;
         if (!isDirect) {
             const membersIconClass = classNames('member-rhs__trigger channel-header__icon channel-header__icon--wide channel-header__icon--left btn btn-icon btn-xs', {
@@ -599,13 +611,7 @@ class ChannelHeader extends React.PureComponent<Props, State> {
                                 >
                                     {muteTrigger}
                                     {memberListButton}
-                                    <HeaderIconWrapper
-                                        iconComponent={pinnedIcon}
-                                        buttonClass={pinnedIconClass}
-                                        buttonId={'channelHeaderPinButton'}
-                                        onClick={this.showPinnedPosts}
-                                        tooltip={this.props.intl.formatMessage({id: 'channel_header.pinnedPosts', defaultMessage: 'Pinned messages'})}
-                                    />
+                                    {pinnedButton}
                                     {this.props.isFileAttachmentsEnabled &&
                                         <HeaderIconWrapper
                                             iconComponent={channelFilesIcon}


### PR DESCRIPTION
#### Summary
This PR hides the pinned icon button in the channel header if there are no pinned posts in the channel. It's not particularly useful unless there are pinned posts in the channel, so we should hide it to reduce the extra visual noise it causes.

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/MM-60604*

#### Screenshots

| |  before  |  after  |
|----|----|----|
| No pinned posts | <img width="261" alt="image" src="https://github.com/user-attachments/assets/1de6c080-3e97-4d7c-ba75-d7911c7d79ed"> | <img width="264" alt="image" src="https://github.com/user-attachments/assets/6d66b38f-a3f0-4c62-a232-c1948595bd38"> |
| With pinned posts | <img width="271" alt="image" src="https://github.com/user-attachments/assets/d29ee568-e8b5-470f-aa7d-94fdb852e385"> | <img width="268" alt="image" src="https://github.com/user-attachments/assets/1c6d039f-96d4-473d-b03f-f5f504ecb73a"> |


#### Release Note
```release-note
Updated channel header to hide pinned posts when there aren't any in the channel.
```