### PR TITLE
[MM-60648] Don't start server until all routes are registered

### DIFF
--- a/server/channels/api4/api.go
+++ b/server/channels/api4/api.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/v8/channels/app"
+	"github.com/mattermost/mattermost/server/v8/channels/manualtesting"
 	"github.com/mattermost/mattermost/server/v8/channels/web"
 )
 
@@ -336,6 +337,11 @@ func Init(srv *app.Server) (*API, error) {
 	api.InitLimits()
 	api.InitOutgoingOAuthConnection()
 	api.InitClientPerformanceMetrics()
+
+	// If we allow testing then listen for manual testing URL hits
+	if *srv.Config().ServiceSettings.EnableTesting {
+		api.BaseRoutes.Root.Handle("/manualtest", api.APIHandler(manualtesting.ManualTest)).Methods(http.MethodGet)
+	}
 
 	srv.Router.Handle("/api/v4/{anything:.*}", http.HandlerFunc(api.Handle404))
 

--- a/server/channels/manualtesting/manual_testing.go
+++ b/server/channels/manualtesting/manual_testing.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
-	"github.com/mattermost/mattermost/server/v8/channels/api4"
 	"github.com/mattermost/mattermost/server/v8/channels/app"
 	"github.com/mattermost/mattermost/server/v8/channels/app/slashcommands"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
@@ -34,12 +33,7 @@ type TestEnvironment struct {
 	Request       *http.Request
 }
 
-// Init adds manualtest endpoint to the API.
-func Init(api4 *api4.API) {
-	api4.BaseRoutes.Root.Handle("/manualtest", api4.APIHandler(manualTest)).Methods(http.MethodGet)
-}
-
-func manualTest(c *web.Context, w http.ResponseWriter, r *http.Request) {
+func ManualTest(c *web.Context, w http.ResponseWriter, r *http.Request) {
 	// Let the world know
 	c.Logger.Info("Setting up for manual test...")
 

--- a/server/cmd/mattermost/commands/server.go
+++ b/server/cmd/mattermost/commands/server.go
@@ -18,7 +18,6 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/v8/channels/api4"
 	"github.com/mattermost/mattermost/server/v8/channels/app"
-	"github.com/mattermost/mattermost/server/v8/channels/manualtesting"
 	"github.com/mattermost/mattermost/server/v8/channels/utils"
 	"github.com/mattermost/mattermost/server/v8/channels/web"
 	"github.com/mattermost/mattermost/server/v8/channels/wsapi"
@@ -93,15 +92,12 @@ func runServer(configStore *config.Store, interruptChan chan os.Signal) error {
 		}
 	}()
 
-	api, err := api4.Init(server)
+	_, err = api4.Init(server)
 	if err != nil {
 		mlog.Error(err.Error())
 		return err
 	}
-	// If we allow testing then listen for manual testing URL hits
-	if *server.Config().ServiceSettings.EnableTesting {
-		manualtesting.Init(api)
-	}
+
 	wsapi.Init(server)
 	web.New(server)
 

--- a/server/cmd/mattermost/commands/server.go
+++ b/server/cmd/mattermost/commands/server.go
@@ -98,6 +98,10 @@ func runServer(configStore *config.Store, interruptChan chan os.Signal) error {
 		mlog.Error(err.Error())
 		return err
 	}
+	// If we allow testing then listen for manual testing URL hits
+	if *server.Config().ServiceSettings.EnableTesting {
+		manualtesting.Init(api)
+	}
 	wsapi.Init(server)
 	web.New(server)
 
@@ -105,11 +109,6 @@ func runServer(configStore *config.Store, interruptChan chan os.Signal) error {
 	if err != nil {
 		mlog.Error(err.Error())
 		return err
-	}
-
-	// If we allow testing then listen for manual testing URL hits
-	if *server.Config().ServiceSettings.EnableTesting {
-		manualtesting.Init(api)
 	}
 
 	notifyReady()


### PR DESCRIPTION
#### Summary
It likely won't affect production as `EnableTesting` should not be enabled for production servers.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60648

#### Release Note
```release-note
Fixed a race condition that would happen after the server start if EnableTesting is enabled 
```
