### PR TITLE
[MM-60422] Add GetChannelsWithActivityDuring

### DIFF
--- a/server/channels/app/channel_test.go
+++ b/server/channels/app/channel_test.go
@@ -273,7 +273,7 @@ func TestJoinDefaultChannelsCreatesChannelMemberHistoryRecordTownSquare(t *testi
 	channel, err := th.App.Srv().Store().Channel().GetByName(th.BasicTeam.Id, "town-square", true)
 	require.NoError(t, err)
 	townSquareChannelID := channel.Id
-	users, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, townSquareChannelID)
+	users, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, []string{townSquareChannelID})
 	require.NoError(t, nErr)
 	initialNumTownSquareUsers := len(users)
 
@@ -282,7 +282,7 @@ func TestJoinDefaultChannelsCreatesChannelMemberHistoryRecordTownSquare(t *testi
 	th.App.JoinDefaultChannels(th.Context, th.BasicTeam.Id, user, false, "")
 
 	// there should be a ChannelMemberHistory record for the user
-	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, townSquareChannelID)
+	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, []string{townSquareChannelID})
 	require.NoError(t, nErr)
 	assert.Len(t, histories, initialNumTownSquareUsers+1)
 
@@ -304,7 +304,7 @@ func TestJoinDefaultChannelsCreatesChannelMemberHistoryRecordOffTopic(t *testing
 	channel, err := th.App.Srv().Store().Channel().GetByName(th.BasicTeam.Id, "off-topic", true)
 	require.NoError(t, err)
 	offTopicChannelId := channel.Id
-	users, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, offTopicChannelId)
+	users, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, []string{offTopicChannelId})
 	require.NoError(t, nErr)
 	initialNumTownSquareUsers := len(users)
 
@@ -313,7 +313,7 @@ func TestJoinDefaultChannelsCreatesChannelMemberHistoryRecordOffTopic(t *testing
 	th.App.JoinDefaultChannels(th.Context, th.BasicTeam.Id, user, false, "")
 
 	// there should be a ChannelMemberHistory record for the user
-	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, offTopicChannelId)
+	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, []string{offTopicChannelId})
 	require.NoError(t, nErr)
 	assert.Len(t, histories, initialNumTownSquareUsers+1)
 
@@ -385,7 +385,7 @@ func TestCreateChannelPublicCreatesChannelMemberHistoryRecord(t *testing.T) {
 	publicChannel := th.createChannel(th.Context, th.BasicTeam, model.ChannelTypeOpen)
 
 	// there should be a ChannelMemberHistory record for the user
-	histories, err := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, publicChannel.Id)
+	histories, err := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, []string{publicChannel.Id})
 	require.NoError(t, err)
 	assert.Len(t, histories, 1)
 	assert.Equal(t, th.BasicUser.Id, histories[0].UserId)
@@ -400,7 +400,7 @@ func TestCreateChannelPrivateCreatesChannelMemberHistoryRecord(t *testing.T) {
 	privateChannel := th.createChannel(th.Context, th.BasicTeam, model.ChannelTypePrivate)
 
 	// there should be a ChannelMemberHistory record for the user
-	histories, err := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, privateChannel.Id)
+	histories, err := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, []string{privateChannel.Id})
 	require.NoError(t, err)
 	assert.Len(t, histories, 1)
 	assert.Equal(t, th.BasicUser.Id, histories[0].UserId)
@@ -488,7 +488,7 @@ func TestCreateGroupChannelCreatesChannelMemberHistoryRecord(t *testing.T) {
 	channel, err := th.App.CreateGroupChannel(th.Context, groupUserIds, th.BasicUser.Id)
 
 	require.Nil(t, err, "Failed to create group channel.")
-	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, channel.Id)
+	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, []string{channel.Id})
 	require.NoError(t, nErr)
 	assert.Len(t, histories, 3)
 
@@ -513,7 +513,7 @@ func TestCreateDirectChannelCreatesChannelMemberHistoryRecord(t *testing.T) {
 	channel, err := th.App.GetOrCreateDirectChannel(th.Context, user1.Id, user2.Id)
 	require.Nil(t, err, "Failed to create direct channel.")
 
-	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, channel.Id)
+	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, []string{channel.Id})
 	require.NoError(t, nErr)
 	assert.Len(t, histories, 2)
 
@@ -541,7 +541,7 @@ func TestGetDirectChannelCreatesChannelMemberHistoryRecord(t *testing.T) {
 	require.Nil(t, err, "Failed to create direct channel.")
 
 	// there should be a ChannelMemberHistory record for both users
-	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, channel.Id)
+	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, []string{channel.Id})
 	require.NoError(t, nErr)
 	assert.Len(t, histories, 2)
 
@@ -576,7 +576,7 @@ func TestAddUserToChannelCreatesChannelMemberHistoryRecord(t *testing.T) {
 	require.Nil(t, err, "Failed to add user to channel.")
 
 	// there should be a ChannelMemberHistory record for the user
-	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, channel.Id)
+	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, []string{channel.Id})
 	require.NoError(t, nErr)
 	assert.Len(t, histories, 2)
 	channelMemberHistoryUserIds := make([]string, 0)
@@ -742,7 +742,7 @@ func TestAddChannelMemberNoUserRequestor(t *testing.T) {
 	require.Nil(t, err, "Failed to add user to channel.")
 
 	// there should be a ChannelMemberHistory record for the user
-	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, channel.Id)
+	histories, nErr := th.App.Srv().Store().ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, []string{channel.Id})
 	require.NoError(t, nErr)
 	assert.Len(t, histories, 2)
 	channelMemberHistoryUserIds := make([]string, 0)

--- a/server/channels/app/channel_test.go
+++ b/server/channels/app/channel_test.go
@@ -615,6 +615,8 @@ func TestUsersAndPostsCreateActivityInChannel(t *testing.T) {
 	_, err = th.App.AddUserToChannel(th.Context, user4, channel4, false)
 	require.Nil(t, err, "Failed to add user to channel.")
 
+	// make sure we don't catch earlier posts
+	time.Sleep(10 * time.Millisecond)
 	testStart := model.GetMillis()
 
 	// Test: previous activity (user3 and 4's adds) aren't showing up:
@@ -645,7 +647,7 @@ func TestUsersAndPostsCreateActivityInChannel(t *testing.T) {
 
 	testEnd := model.GetMillis()
 	// In case the tests are running very fast:
-	time.Sleep(time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	// Now, we do not find activity for new posts, leaves, or adds after the test is over
 	post2 := &model.Post{

--- a/server/channels/jobs/jobs_test.go
+++ b/server/channels/jobs/jobs_test.go
@@ -239,6 +239,38 @@ func TestSetJobSuccess(t *testing.T) {
 	})
 }
 
+func TestSetJobCustomStatus(t *testing.T) {
+	t.Run("error setting custom status", func(t *testing.T) {
+		jobServer, mockStore, _ := makeJobServer(t)
+
+		job := &model.Job{
+			Id:   "job_id",
+			Type: "job_type",
+		}
+		status := "some custom status"
+
+		mockStore.JobStore.On("UpdateStatus", "job_id", status).Return(job, &model.AppError{Message: "message"})
+
+		err := jobServer.SetJobCustomStatus(job, status)
+		expectErrorId(t, "app.job.update.app_error", err)
+	})
+
+	t.Run("custom status updated", func(t *testing.T) {
+		jobServer, mockStore, _ := makeJobServer(t)
+
+		job := &model.Job{
+			Id:   "job_id",
+			Type: "job_type",
+		}
+		status := "some custom status"
+
+		mockStore.JobStore.On("UpdateStatus", "job_id", status).Return(job, nil)
+
+		err := jobServer.SetJobCustomStatus(job, status)
+		require.Nil(t, err)
+	})
+}
+
 func TestSetJobError(t *testing.T) {
 	t.Run("nil provided job error", func(t *testing.T) {
 		t.Run("error setting status", func(t *testing.T) {

--- a/server/channels/jobs/jobs_test.go
+++ b/server/channels/jobs/jobs_test.go
@@ -239,38 +239,6 @@ func TestSetJobSuccess(t *testing.T) {
 	})
 }
 
-func TestSetJobCustomStatus(t *testing.T) {
-	t.Run("error setting custom status", func(t *testing.T) {
-		jobServer, mockStore, _ := makeJobServer(t)
-
-		job := &model.Job{
-			Id:   "job_id",
-			Type: "job_type",
-		}
-		status := "some custom status"
-
-		mockStore.JobStore.On("UpdateStatus", "job_id", status).Return(job, &model.AppError{Message: "message"})
-
-		err := jobServer.SetJobCustomStatus(job, status)
-		expectErrorId(t, "app.job.update.app_error", err)
-	})
-
-	t.Run("custom status updated", func(t *testing.T) {
-		jobServer, mockStore, _ := makeJobServer(t)
-
-		job := &model.Job{
-			Id:   "job_id",
-			Type: "job_type",
-		}
-		status := "some custom status"
-
-		mockStore.JobStore.On("UpdateStatus", "job_id", status).Return(job, nil)
-
-		err := jobServer.SetJobCustomStatus(job, status)
-		require.Nil(t, err)
-	})
-}
-
 func TestSetJobError(t *testing.T) {
 	t.Run("nil provided job error", func(t *testing.T) {
 		t.Run("error setting status", func(t *testing.T) {

--- a/server/channels/store/opentracinglayer/opentracinglayer.go
+++ b/server/channels/store/opentracinglayer/opentracinglayer.go
@@ -2851,7 +2851,7 @@ func (s *OpenTracingLayerChannelMemberHistoryStore) GetChannelsLeftSince(userID 
 	return result, err
 }
 
-func (s *OpenTracingLayerChannelMemberHistoryStore) GetUsersInChannelDuring(startTime int64, endTime int64, channelID string) ([]*model.ChannelMemberHistoryResult, error) {
+func (s *OpenTracingLayerChannelMemberHistoryStore) GetUsersInChannelDuring(startTime int64, endTime int64, channelID []string) ([]*model.ChannelMemberHistoryResult, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ChannelMemberHistoryStore.GetUsersInChannelDuring")
 	s.Root.Store.SetContext(newCtx)

--- a/server/channels/store/opentracinglayer/opentracinglayer.go
+++ b/server/channels/store/opentracinglayer/opentracinglayer.go
@@ -2851,6 +2851,24 @@ func (s *OpenTracingLayerChannelMemberHistoryStore) GetChannelsLeftSince(userID 
 	return result, err
 }
 
+func (s *OpenTracingLayerChannelMemberHistoryStore) GetChannelsWithActivityDuring(startTime int64, endTime int64) ([]string, error) {
+	origCtx := s.Root.Store.Context()
+	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ChannelMemberHistoryStore.GetChannelsWithActivityDuring")
+	s.Root.Store.SetContext(newCtx)
+	defer func() {
+		s.Root.Store.SetContext(origCtx)
+	}()
+
+	defer span.Finish()
+	result, err := s.ChannelMemberHistoryStore.GetChannelsWithActivityDuring(startTime, endTime)
+	if err != nil {
+		span.LogFields(spanlog.Error(err))
+		ext.Error.Set(span, true)
+	}
+
+	return result, err
+}
+
 func (s *OpenTracingLayerChannelMemberHistoryStore) GetUsersInChannelDuring(startTime int64, endTime int64, channelID []string) ([]*model.ChannelMemberHistoryResult, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ChannelMemberHistoryStore.GetUsersInChannelDuring")

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -3176,7 +3176,7 @@ func (s *RetryLayerChannelMemberHistoryStore) GetChannelsLeftSince(userID string
 
 }
 
-func (s *RetryLayerChannelMemberHistoryStore) GetUsersInChannelDuring(startTime int64, endTime int64, channelID string) ([]*model.ChannelMemberHistoryResult, error) {
+func (s *RetryLayerChannelMemberHistoryStore) GetUsersInChannelDuring(startTime int64, endTime int64, channelID []string) ([]*model.ChannelMemberHistoryResult, error) {
 
 	tries := 0
 	for {

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -3176,6 +3176,27 @@ func (s *RetryLayerChannelMemberHistoryStore) GetChannelsLeftSince(userID string
 
 }
 
+func (s *RetryLayerChannelMemberHistoryStore) GetChannelsWithActivityDuring(startTime int64, endTime int64) ([]string, error) {
+
+	tries := 0
+	for {
+		result, err := s.ChannelMemberHistoryStore.GetChannelsWithActivityDuring(startTime, endTime)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerChannelMemberHistoryStore) GetUsersInChannelDuring(startTime int64, endTime int64, channelID []string) ([]*model.ChannelMemberHistoryResult, error) {
 
 	tries := 0

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -315,7 +315,7 @@ type ChannelStore interface {
 type ChannelMemberHistoryStore interface {
 	LogJoinEvent(userID string, channelID string, joinTime int64) error
 	LogLeaveEvent(userID string, channelID string, leaveTime int64) error
-	GetUsersInChannelDuring(startTime int64, endTime int64, channelID string) ([]*model.ChannelMemberHistoryResult, error)
+	GetUsersInChannelDuring(startTime int64, endTime int64, channelID []string) ([]*model.ChannelMemberHistoryResult, error)
 	PermanentDeleteBatchForRetentionPolicies(now, globalPolicyEndTime, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)
 	DeleteOrphanedRows(limit int) (deleted int64, err error)
 	PermanentDeleteBatch(endTime int64, limit int64) (int64, error)

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -316,6 +316,7 @@ type ChannelMemberHistoryStore interface {
 	LogJoinEvent(userID string, channelID string, joinTime int64) error
 	LogLeaveEvent(userID string, channelID string, leaveTime int64) error
 	GetUsersInChannelDuring(startTime int64, endTime int64, channelID []string) ([]*model.ChannelMemberHistoryResult, error)
+	GetChannelsWithActivityDuring(startTime int64, endTime int64) ([]string, error)
 	PermanentDeleteBatchForRetentionPolicies(now, globalPolicyEndTime, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)
 	DeleteOrphanedRows(limit int) (deleted int64, err error)
 	PermanentDeleteBatch(endTime int64, limit int64) (int64, error)

--- a/server/channels/store/storetest/channel_member_history_store.go
+++ b/server/channels/store/storetest/channel_member_history_store.go
@@ -119,12 +119,12 @@ func testGetUsersInChannelAtChannelMemberHistory(t *testing.T, rctx request.CTX,
 	require.NoError(t, err)
 
 	// case 1: user joins and leaves the channel before the export period begins
-	channelMembers, err := ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime-500, joinTime-100, channel.Id)
+	channelMembers, err := ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime-500, joinTime-100, []string{channel.Id})
 	require.NoError(t, err)
 	assert.Empty(t, channelMembers)
 
 	// case 2: user joins the channel after the export period begins, but has not yet left the channel when the export period ends
-	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime-100, joinTime+500, channel.Id)
+	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime-100, joinTime+500, []string{channel.Id})
 	require.NoError(t, err)
 	assert.Len(t, channelMembers, 1)
 	assert.Equal(t, channel.Id, channelMembers[0].ChannelId)
@@ -135,7 +135,7 @@ func testGetUsersInChannelAtChannelMemberHistory(t *testing.T, rctx request.CTX,
 	assert.Nil(t, channelMembers[0].LeaveTime)
 
 	// case 3: user joins the channel before the export period begins, but has not yet left the channel when the export period ends
-	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime+100, joinTime+500, channel.Id)
+	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime+100, joinTime+500, []string{channel.Id})
 	require.NoError(t, err)
 	assert.Len(t, channelMembers, 1)
 	assert.Equal(t, channel.Id, channelMembers[0].ChannelId)
@@ -150,7 +150,7 @@ func testGetUsersInChannelAtChannelMemberHistory(t *testing.T, rctx request.CTX,
 	require.NoError(t, err)
 
 	// case 4: user joins the channel before the export period begins, but has not yet left the channel when the export period ends
-	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime+100, leaveTime-100, channel.Id)
+	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime+100, leaveTime-100, []string{channel.Id})
 	require.NoError(t, err)
 	assert.Len(t, channelMembers, 1)
 	assert.Equal(t, channel.Id, channelMembers[0].ChannelId)
@@ -161,7 +161,7 @@ func testGetUsersInChannelAtChannelMemberHistory(t *testing.T, rctx request.CTX,
 	assert.Equal(t, leaveTime, *channelMembers[0].LeaveTime)
 
 	// case 5: user joins the channel after the export period begins, and leaves the channel before the export period ends
-	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime-100, leaveTime+100, channel.Id)
+	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime-100, leaveTime+100, []string{channel.Id})
 	require.NoError(t, err)
 	assert.Len(t, channelMembers, 1)
 	assert.Equal(t, channel.Id, channelMembers[0].ChannelId)
@@ -172,7 +172,7 @@ func testGetUsersInChannelAtChannelMemberHistory(t *testing.T, rctx request.CTX,
 	assert.Equal(t, leaveTime, *channelMembers[0].LeaveTime)
 
 	// case 6: user has joined and left the channel long before the export period begins
-	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(leaveTime+100, leaveTime+200, channel.Id)
+	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(leaveTime+100, leaveTime+200, []string{channel.Id})
 	require.NoError(t, err)
 	assert.Empty(t, channelMembers)
 }
@@ -223,7 +223,7 @@ func testGetUsersInChannelAtChannelMembers(t *testing.T, rctx request.CTX, ss st
 	// the past, even though the time that they were actually in the channel doesn't necessarily overlap with the export period
 
 	// case 1: user joins and leaves the channel before the export period begins
-	channelMembers, err := ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime-500, joinTime-100, channel.Id)
+	channelMembers, err := ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime-500, joinTime-100, []string{channel.Id})
 	require.NoError(t, err)
 	assert.Len(t, channelMembers, 1)
 	assert.Equal(t, channel.Id, channelMembers[0].ChannelId)
@@ -234,7 +234,7 @@ func testGetUsersInChannelAtChannelMembers(t *testing.T, rctx request.CTX, ss st
 	assert.Equal(t, joinTime-100, *channelMembers[0].LeaveTime)
 
 	// case 2: user joins the channel after the export period begins, but has not yet left the channel when the export period ends
-	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime-100, joinTime+500, channel.Id)
+	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime-100, joinTime+500, []string{channel.Id})
 	require.NoError(t, err)
 	assert.Len(t, channelMembers, 1)
 	assert.Equal(t, channel.Id, channelMembers[0].ChannelId)
@@ -245,7 +245,7 @@ func testGetUsersInChannelAtChannelMembers(t *testing.T, rctx request.CTX, ss st
 	assert.Equal(t, joinTime+500, *channelMembers[0].LeaveTime)
 
 	// case 3: user joins the channel before the export period begins, but has not yet left the channel when the export period ends
-	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime+100, joinTime+500, channel.Id)
+	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime+100, joinTime+500, []string{channel.Id})
 	require.NoError(t, err)
 	assert.Len(t, channelMembers, 1)
 	assert.Equal(t, channel.Id, channelMembers[0].ChannelId)
@@ -256,7 +256,7 @@ func testGetUsersInChannelAtChannelMembers(t *testing.T, rctx request.CTX, ss st
 	assert.Equal(t, joinTime+500, *channelMembers[0].LeaveTime)
 
 	// case 4: user joins the channel before the export period begins, but has not yet left the channel when the export period ends
-	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime+100, leaveTime-100, channel.Id)
+	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime+100, leaveTime-100, []string{channel.Id})
 	require.NoError(t, err)
 	assert.Len(t, channelMembers, 1)
 	assert.Equal(t, channel.Id, channelMembers[0].ChannelId)
@@ -267,7 +267,7 @@ func testGetUsersInChannelAtChannelMembers(t *testing.T, rctx request.CTX, ss st
 	assert.Equal(t, leaveTime-100, *channelMembers[0].LeaveTime)
 
 	// case 5: user joins the channel after the export period begins, and leaves the channel before the export period ends
-	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime-100, leaveTime+100, channel.Id)
+	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime-100, leaveTime+100, []string{channel.Id})
 	require.NoError(t, err)
 	assert.Len(t, channelMembers, 1)
 	assert.Equal(t, channel.Id, channelMembers[0].ChannelId)
@@ -278,7 +278,7 @@ func testGetUsersInChannelAtChannelMembers(t *testing.T, rctx request.CTX, ss st
 	assert.Equal(t, leaveTime+100, *channelMembers[0].LeaveTime)
 
 	// case 6: user has joined and left the channel long before the export period begins
-	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(leaveTime+100, leaveTime+200, channel.Id)
+	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(leaveTime+100, leaveTime+200, []string{channel.Id})
 	require.NoError(t, err)
 	assert.Len(t, channelMembers, 1)
 	assert.Equal(t, channel.Id, channelMembers[0].ChannelId)
@@ -332,7 +332,7 @@ func testPermanentDeleteBatch(t *testing.T, rctx request.CTX, ss store.Store) {
 	require.NoError(t, err)
 
 	// in between the join time and the leave time, both users were members of the channel
-	channelMembers, err := ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime+10, leaveTime-10, channel.Id)
+	channelMembers, err := ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime+10, leaveTime-10, []string{channel.Id})
 	require.NoError(t, err)
 	assert.Len(t, channelMembers, 2)
 
@@ -343,7 +343,7 @@ func testPermanentDeleteBatch(t *testing.T, rctx request.CTX, ss store.Store) {
 	assert.NotEqual(t, int64(0), rowsDeleted)
 
 	// after the delete, there should be one less member in the channel
-	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime+10, leaveTime-10, channel.Id)
+	channelMembers, err = ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime+10, leaveTime-10, []string{channel.Id})
 	require.NoError(t, err)
 	assert.Len(t, channelMembers, 1)
 	assert.Equal(t, user2.Id, channelMembers[0].UserId)
@@ -387,7 +387,7 @@ func testPermanentDeleteBatchForRetentionPolicies(t *testing.T, rctx request.CTX
 	_, _, err = ss.ChannelMemberHistory().PermanentDeleteBatchForRetentionPolicies(
 		nowMillis, 0, limit, model.RetentionPolicyCursor{})
 	require.NoError(t, err)
-	result, err := ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime, leaveTime, channel.Id)
+	result, err := ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime, leaveTime, []string{channel.Id})
 	require.NoError(t, err)
 	require.Empty(t, result, "history should have been deleted by channel policy")
 	rows, err := ss.RetentionPolicy().GetIdsForDeletionByTableName("ChannelMemberHistory", 1000)

--- a/server/channels/store/storetest/channel_member_history_store.go
+++ b/server/channels/store/storetest/channel_member_history_store.go
@@ -84,8 +84,6 @@ func testLogLeaveEvent(t *testing.T, rctx request.CTX, ss store.Store) {
 }
 
 func testGetChannelsWithActivityDuring(t *testing.T, rctx request.CTX, ss store.Store) {
-	var channels []*model.Channel
-
 	// Need to wait to make sure channels and posts have nothing in them for this test.
 	time.Sleep(101 * time.Millisecond)
 
@@ -98,7 +96,6 @@ func testGetChannelsWithActivityDuring(t *testing.T, rctx request.CTX, ss store.
 	}
 	channel1, err := ss.Channel().Save(rctx, ch1, -1)
 	require.NoError(t, err)
-	channels = append(channels, channel1)
 
 	// channel2 will have no activity until case 6 (shouldn't show up until then)
 	ch2 := &model.Channel{
@@ -109,7 +106,6 @@ func testGetChannelsWithActivityDuring(t *testing.T, rctx request.CTX, ss store.
 	}
 	channel2, err := ss.Channel().Save(rctx, ch2, -1)
 	require.NoError(t, err)
-	channels = append(channels, channel2)
 
 	// and two test users
 	user1 := model.User{
@@ -196,7 +192,7 @@ func testGetChannelsWithActivityDuring(t *testing.T, rctx request.CTX, ss store.
 
 	newPost := post.Clone()
 	newPost.Message = "edited message"
-	post, err = ss.Post().Update(rctx, newPost, post)
+	_, err = ss.Post().Update(rctx, newPost, post)
 	require.NoError(t, err)
 
 	channelIds, err = ss.ChannelMemberHistory().GetChannelsWithActivityDuring(now-1, now+1000)
@@ -216,7 +212,7 @@ func testGetChannelsWithActivityDuring(t *testing.T, rctx request.CTX, ss store.
 		CreateAt:  now + 11,
 		UpdateAt:  now + 11,
 	}
-	post2, err = ss.Post().Save(rctx, post2)
+	_, err = ss.Post().Save(rctx, post2)
 	require.NoError(t, err)
 	err = ss.ChannelMemberHistory().LogLeaveEvent(user1.Id, channel1.Id, now+12)
 	require.NoError(t, err)

--- a/server/channels/store/storetest/mocks/ChannelMemberHistoryStore.go
+++ b/server/channels/store/storetest/mocks/ChannelMemberHistoryStore.go
@@ -73,7 +73,7 @@ func (_m *ChannelMemberHistoryStore) GetChannelsLeftSince(userID string, since i
 }
 
 // GetUsersInChannelDuring provides a mock function with given fields: startTime, endTime, channelID
-func (_m *ChannelMemberHistoryStore) GetUsersInChannelDuring(startTime int64, endTime int64, channelID string) ([]*model.ChannelMemberHistoryResult, error) {
+func (_m *ChannelMemberHistoryStore) GetUsersInChannelDuring(startTime int64, endTime int64, channelID []string) ([]*model.ChannelMemberHistoryResult, error) {
 	ret := _m.Called(startTime, endTime, channelID)
 
 	if len(ret) == 0 {
@@ -82,10 +82,10 @@ func (_m *ChannelMemberHistoryStore) GetUsersInChannelDuring(startTime int64, en
 
 	var r0 []*model.ChannelMemberHistoryResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(int64, int64, string) ([]*model.ChannelMemberHistoryResult, error)); ok {
+	if rf, ok := ret.Get(0).(func(int64, int64, []string) ([]*model.ChannelMemberHistoryResult, error)); ok {
 		return rf(startTime, endTime, channelID)
 	}
-	if rf, ok := ret.Get(0).(func(int64, int64, string) []*model.ChannelMemberHistoryResult); ok {
+	if rf, ok := ret.Get(0).(func(int64, int64, []string) []*model.ChannelMemberHistoryResult); ok {
 		r0 = rf(startTime, endTime, channelID)
 	} else {
 		if ret.Get(0) != nil {
@@ -93,7 +93,7 @@ func (_m *ChannelMemberHistoryStore) GetUsersInChannelDuring(startTime int64, en
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(int64, int64, string) error); ok {
+	if rf, ok := ret.Get(1).(func(int64, int64, []string) error); ok {
 		r1 = rf(startTime, endTime, channelID)
 	} else {
 		r1 = ret.Error(1)

--- a/server/channels/store/storetest/mocks/ChannelMemberHistoryStore.go
+++ b/server/channels/store/storetest/mocks/ChannelMemberHistoryStore.go
@@ -72,6 +72,36 @@ func (_m *ChannelMemberHistoryStore) GetChannelsLeftSince(userID string, since i
 	return r0, r1
 }
 
+// GetChannelsWithActivityDuring provides a mock function with given fields: startTime, endTime
+func (_m *ChannelMemberHistoryStore) GetChannelsWithActivityDuring(startTime int64, endTime int64) ([]string, error) {
+	ret := _m.Called(startTime, endTime)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetChannelsWithActivityDuring")
+	}
+
+	var r0 []string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(int64, int64) ([]string, error)); ok {
+		return rf(startTime, endTime)
+	}
+	if rf, ok := ret.Get(0).(func(int64, int64) []string); ok {
+		r0 = rf(startTime, endTime)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(int64, int64) error); ok {
+		r1 = rf(startTime, endTime)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetUsersInChannelDuring provides a mock function with given fields: startTime, endTime, channelID
 func (_m *ChannelMemberHistoryStore) GetUsersInChannelDuring(startTime int64, endTime int64, channelID []string) ([]*model.ChannelMemberHistoryResult, error) {
 	ret := _m.Called(startTime, endTime, channelID)

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -2622,7 +2622,7 @@ func (s *TimerLayerChannelMemberHistoryStore) GetChannelsLeftSince(userID string
 	return result, err
 }
 
-func (s *TimerLayerChannelMemberHistoryStore) GetUsersInChannelDuring(startTime int64, endTime int64, channelID string) ([]*model.ChannelMemberHistoryResult, error) {
+func (s *TimerLayerChannelMemberHistoryStore) GetUsersInChannelDuring(startTime int64, endTime int64, channelID []string) ([]*model.ChannelMemberHistoryResult, error) {
 	start := time.Now()
 
 	result, err := s.ChannelMemberHistoryStore.GetUsersInChannelDuring(startTime, endTime, channelID)

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -2622,6 +2622,22 @@ func (s *TimerLayerChannelMemberHistoryStore) GetChannelsLeftSince(userID string
 	return result, err
 }
 
+func (s *TimerLayerChannelMemberHistoryStore) GetChannelsWithActivityDuring(startTime int64, endTime int64) ([]string, error) {
+	start := time.Now()
+
+	result, err := s.ChannelMemberHistoryStore.GetChannelsWithActivityDuring(startTime, endTime)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("ChannelMemberHistoryStore.GetChannelsWithActivityDuring", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerChannelMemberHistoryStore) GetUsersInChannelDuring(startTime int64, endTime int64, channelID []string) ([]*model.ChannelMemberHistoryResult, error) {
 	start := time.Now()
 

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -7895,10 +7895,6 @@
     "translation": "unable to migrate."
   },
   {
-    "id": "ent.message_export.calculate_channel_exports.app_error",
-    "translation": "Failed to calculate channel export data."
-  },
-  {
     "id": "ent.message_export.actiance_export.calculate_channel_exports.activity_message",
     "translation": "Calculating channel activity: {{.NumCompleted}}/{{.NumChannels}} channels completed."
   },
@@ -7909,6 +7905,10 @@
   {
     "id": "ent.message_export.actiance_export.get_attachment_error",
     "translation": "Failed to get file info for a post."
+  },
+  {
+    "id": "ent.message_export.calculate_channel_exports.app_error",
+    "translation": "Failed to calculate channel export data."
   },
   {
     "id": "ent.message_export.csv_export.get_attachment_error",

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -7895,6 +7895,18 @@
     "translation": "unable to migrate."
   },
   {
+    "id": "ent.message_export.CalculateChannelExports.app_error",
+    "translation": "Failed to generate channel exports data."
+  },
+  {
+    "id": "ent.message_export.actiance_export.calculate_channel_exports.activity_message",
+    "translation": "Calculating channel activity: {{.NumCompleted}}/{{.NumChannels}} channels completed."
+  },
+  {
+    "id": "ent.message_export.actiance_export.calculate_channel_exports.channel_message",
+    "translation": "Exporting channel information for {{.NumChannels}} channels."
+  },
+  {
     "id": "ent.message_export.actiance_export.get_attachment_error",
     "translation": "Failed to get file info for a post."
   },

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -7895,8 +7895,8 @@
     "translation": "unable to migrate."
   },
   {
-    "id": "ent.message_export.CalculateChannelExports.app_error",
-    "translation": "Failed to generate channel exports data."
+    "id": "ent.message_export.calculate_channel_exports.app_error",
+    "translation": "Failed to calculate channel export data."
   },
   {
     "id": "ent.message_export.actiance_export.calculate_channel_exports.activity_message",

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -233,15 +233,18 @@ const (
 	PluginSettingsDefaultMarketplaceURL    = "https://api.integrations.mattermost.com"
 	PluginSettingsOldMarketplaceURL        = "https://marketplace.integrations.mattermost.com"
 
-	ComplianceExportDirectoryFormat    = "compliance-export-2006-01-02-15h04m"
-	ComplianceExportPath               = "export"
-	ComplianceExportTypeCsv            = "csv"
-	ComplianceExportTypeActiance       = "actiance"
-	ComplianceExportTypeGlobalrelay    = "globalrelay"
-	ComplianceExportTypeGlobalrelayZip = "globalrelay-zip"
-	GlobalrelayCustomerTypeA9          = "A9"
-	GlobalrelayCustomerTypeA10         = "A10"
-	GlobalrelayCustomerTypeCustom      = "CUSTOM"
+	ComplianceExportDirectoryFormat                = "compliance-export-2006-01-02-15h04m"
+	ComplianceExportPath                           = "export"
+	ComplianceExportTypeCsv                        = "csv"
+	ComplianceExportTypeActiance                   = "actiance"
+	ComplianceExportTypeGlobalrelay                = "globalrelay"
+	ComplianceExportTypeGlobalrelayZip             = "globalrelay-zip"
+	ComplianceExportChannelBatchSizeDefault        = 100
+	ComplianceExportChannelHistoryBatchSizeDefault = 10
+
+	GlobalrelayCustomerTypeA9     = "A9"
+	GlobalrelayCustomerTypeA10    = "A10"
+	GlobalrelayCustomerTypeCustom = "CUSTOM"
 
 	ClientSideCertCheckPrimaryAuth   = "primary"
 	ClientSideCertCheckSecondaryAuth = "secondary"
@@ -3361,12 +3364,14 @@ func (s *GlobalRelayMessageExportSettings) SetDefaults() {
 }
 
 type MessageExportSettings struct {
-	EnableExport          *bool   `access:"compliance_compliance_export"`
-	ExportFormat          *string `access:"compliance_compliance_export"`
-	DailyRunTime          *string `access:"compliance_compliance_export"`
-	ExportFromTimestamp   *int64  `access:"compliance_compliance_export"`
-	BatchSize             *int    `access:"compliance_compliance_export"`
-	DownloadExportResults *bool   `access:"compliance_compliance_export"`
+	EnableExport            *bool   `access:"compliance_compliance_export"`
+	ExportFormat            *string `access:"compliance_compliance_export"`
+	DailyRunTime            *string `access:"compliance_compliance_export"`
+	ExportFromTimestamp     *int64  `access:"compliance_compliance_export"`
+	BatchSize               *int    `access:"compliance_compliance_export"`
+	DownloadExportResults   *bool   `access:"compliance_compliance_export"`
+	ChannelBatchSize        *int    `access:"compliance_compliance_export"`
+	ChannelHistoryBatchSize *int    `access:"compliance_compliance_export"`
 
 	// formatter-specific settings - these are only expected to be non-nil if ExportFormat is set to the associated format
 	GlobalRelaySettings *GlobalRelayMessageExportSettings `access:"compliance_compliance_export"`
@@ -3395,6 +3400,14 @@ func (s *MessageExportSettings) SetDefaults() {
 
 	if s.BatchSize == nil {
 		s.BatchSize = NewPointer(10000)
+	}
+
+	if s.ChannelBatchSize == nil || *s.ChannelBatchSize == 0 {
+		s.ChannelBatchSize = NewPointer(ComplianceExportChannelBatchSizeDefault)
+	}
+
+	if s.ChannelHistoryBatchSize == nil || *s.ChannelHistoryBatchSize == 0 {
+		s.ChannelHistoryBatchSize = NewPointer(ComplianceExportChannelHistoryBatchSizeDefault)
 	}
 
 	if s.GlobalRelaySettings == nil {

--- a/webapp/channels/src/components/admin_console/message_export_settings.test.tsx
+++ b/webapp/channels/src/components/admin_console/message_export_settings.test.tsx
@@ -2,13 +2,12 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import type {Job} from '@mattermost/types/jobs';
 
 import MessageExportSettings from 'components/admin_console/message_export_settings';
 import type {MessageExportSettings as MessageExportSettingsClass} from 'components/admin_console/message_export_settings';
-
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import type {BaseProps} from './admin_settings';
 
@@ -183,12 +182,15 @@ describe('components/MessageExportSettings/getJobDetails', () => {
 
     const wrapper = shallowWithIntl(<MessageExportSettings {...baseProps}/>);
 
-    function runTest(testJob: Job, expectNull: boolean, expectedCount: number) {
+    function runTest(testJob: Job, expectNull: boolean, expectedCount: number, expectedMessage = '') {
         const jobDetails = (wrapper.instance() as MessageExportSettingsClass).getJobDetails(testJob);
         if (expectNull) {
             expect(jobDetails).toBe(null);
         } else {
             expect(jobDetails?.length).toBe(expectedCount);
+        }
+        if (expectedMessage) {
+            expect(jobDetails?.[0].props.children).toEqual(expectedMessage);
         }
     }
 
@@ -218,5 +220,14 @@ describe('components/MessageExportSettings/getJobDetails', () => {
             warning_count: 2,
         };
         runTest(job, false, 2);
+    });
+
+    test('test progress message', () => {
+        job.data = {
+            messages_exported: 0,
+            warning_count: 0,
+            progress_message: 'this is a custom progress message',
+        };
+        runTest(job, false, 1, 'this is a custom progress message');
     });
 });

--- a/webapp/channels/src/components/admin_console/message_export_settings.test.tsx
+++ b/webapp/channels/src/components/admin_console/message_export_settings.test.tsx
@@ -2,12 +2,13 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import type {Job} from '@mattermost/types/jobs';
 
 import MessageExportSettings from 'components/admin_console/message_export_settings';
 import type {MessageExportSettings as MessageExportSettingsClass} from 'components/admin_console/message_export_settings';
+
+import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import type {BaseProps} from './admin_settings';
 

--- a/webapp/channels/src/components/admin_console/message_export_settings.tsx
+++ b/webapp/channels/src/components/admin_console/message_export_settings.tsx
@@ -5,15 +5,14 @@ import React from 'react';
 import type {ReactNode} from 'react';
 import type {MessageDescriptor, WrappedComponentProps} from 'react-intl';
 import {FormattedMessage, defineMessage, defineMessages, injectIntl} from 'react-intl';
+import {DocLinks, JobTypes, exportFormats} from 'utils/constants';
+import {getSiteURL} from 'utils/url';
 
 import type {AdminConfig} from '@mattermost/types/config';
 import type {Job} from '@mattermost/types/jobs';
 
 import ExternalLink from 'components/external_link';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
-
-import {DocLinks, JobTypes, exportFormats} from 'utils/constants';
-import {getSiteURL} from 'utils/url';
 
 import type {BaseProps, BaseState} from './admin_settings';
 import AdminSettings from './admin_settings';
@@ -162,6 +161,11 @@ export class MessageExportSettings extends AdminSettings<BaseProps & WrappedComp
                         </div>,
                     );
                 }
+            }
+            if (job.data.progress_message) {
+                message.push(
+                    <div>{job.data.progress_message}</div>,
+                );
             }
             return message;
         }

--- a/webapp/channels/src/components/admin_console/message_export_settings.tsx
+++ b/webapp/channels/src/components/admin_console/message_export_settings.tsx
@@ -5,14 +5,15 @@ import React from 'react';
 import type {ReactNode} from 'react';
 import type {MessageDescriptor, WrappedComponentProps} from 'react-intl';
 import {FormattedMessage, defineMessage, defineMessages, injectIntl} from 'react-intl';
-import {DocLinks, JobTypes, exportFormats} from 'utils/constants';
-import {getSiteURL} from 'utils/url';
 
 import type {AdminConfig} from '@mattermost/types/config';
 import type {Job} from '@mattermost/types/jobs';
 
 import ExternalLink from 'components/external_link';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
+
+import {DocLinks, JobTypes, exportFormats} from 'utils/constants';
+import {getSiteURL} from 'utils/url';
 
 import type {BaseProps, BaseState} from './admin_settings';
 import AdminSettings from './admin_settings';


### PR DESCRIPTION
#### Summary
- [modify GetUsersInChannelDuring to accept a slice of channelIds](https://github.com/mattermost/mattermost/commit/e644d9c2064f778bd8bc8bc0be80533ce885f207)
- [add GetChannelsWithActivityDuring](https://github.com/mattermost/mattermost/commit/106458a1866d72e75d578fa975e5d7f6e95391e3)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-60422


#### Release Note
```release-note
GetUsersInChannelDuring now accepts a slice; added GetChannelsWithActivityDuring
```