### PR TITLE
fix: dm shared channel indicator

### DIFF
--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_direct_channel/sidebar_direct_channel.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_direct_channel/sidebar_direct_channel.tsx
@@ -102,10 +102,7 @@ class SidebarDirectChannel extends React.PureComponent<Props> {
             });
         }
 
-        let isSharedChannel = false;
-        if (teammate.remote_id) {
-            isSharedChannel = true;
-        }
+        const isSharedChannel = Boolean(teammate.remote_id);
 
         return (
             <SidebarChannelLink

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_direct_channel/sidebar_direct_channel.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_direct_channel/sidebar_direct_channel.tsx
@@ -102,8 +102,6 @@ class SidebarDirectChannel extends React.PureComponent<Props> {
             });
         }
 
-        const isSharedChannel = Boolean(teammate.remote_id);
-
         return (
             <SidebarChannelLink
                 teammateId={teammate.id}
@@ -112,7 +110,7 @@ class SidebarDirectChannel extends React.PureComponent<Props> {
                 label={displayName}
                 channelLeaveHandler={this.handleLeaveChannel}
                 icon={this.getIcon()}
-                isSharedChannel={isSharedChannel}
+                isSharedChannel={Boolean(teammate.remote_id)}
             />
         );
     }

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_direct_channel/sidebar_direct_channel.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_direct_channel/sidebar_direct_channel.tsx
@@ -102,6 +102,11 @@ class SidebarDirectChannel extends React.PureComponent<Props> {
             });
         }
 
+        let isSharedChannel = false;
+        if (teammate.remote_id) {
+            isSharedChannel = true;
+        }
+
         return (
             <SidebarChannelLink
                 teammateId={teammate.id}
@@ -110,7 +115,7 @@ class SidebarDirectChannel extends React.PureComponent<Props> {
                 label={displayName}
                 channelLeaveHandler={this.handleLeaveChannel}
                 icon={this.getIcon()}
-                isSharedChannel={teammate.remote_id !== undefined}
+                isSharedChannel={isSharedChannel}
             />
         );
     }


### PR DESCRIPTION
#### Summary

Modifies the condition for the shared channel indicator to show up, fixing an issue where all users in the DM list where being shown as shared.

#### Screenshots

Manually set `remoteId` to the channel exporter bot.

Before:
![Screenshot 2024-09-24 at 17 45 53](https://github.com/user-attachments/assets/5b0654b0-e3bc-4ddc-b823-e9f802a9ce85)

After:
![Screenshot 2024-09-24 at 17 45 33](https://github.com/user-attachments/assets/8f9c2f76-b4b1-4ed6-8bcc-23723c0fe94f)

#### Release Note
```release-note
NONE
```
