### PR TITLE
Emit license details to logs when added or removed

### DIFF
--- a/server/channels/app/platform/license.go
+++ b/server/channels/app/platform/license.go
@@ -227,7 +227,16 @@ func (ps *PlatformService) SetLicense(license *model.License) bool {
 		ps.licenseValue.Store(license)
 
 		ps.clientLicenseValue.Store(utils.GetClientLicense(license))
+
+		if oldLicense == nil || oldLicense.Id != license.Id {
+			ps.logLicense("Set license", license)
+		}
+
 		return true
+	}
+
+	if oldLicense != nil {
+		ps.logLicense("Cleared license", oldLicense)
 	}
 
 	ps.licenseValue.Store((*model.License)(nil))
@@ -343,4 +352,21 @@ func (ps *PlatformService) RequestTrialLicense(trialRequest *model.TrialLicenseR
 
 func (ps *PlatformService) getRequestTrialURL() string {
 	return fmt.Sprintf("%s/api/v1/trials", *ps.Config().CloudSettings.CWSURL)
+}
+
+func (ps *PlatformService) logLicense(message string, license *model.License) {
+	ps.logger.Info(
+		message,
+		mlog.String("id", license.Id),
+		mlog.Time("issued_at", model.GetTimeForMillis(license.IssuedAt)),
+		mlog.Time("starts_at", model.GetTimeForMillis(license.StartsAt)),
+		mlog.Time("expires_at", model.GetTimeForMillis(license.ExpiresAt)),
+		mlog.String("customer_id", license.Customer.Id),
+		mlog.Int("features.users", *license.Features.Users),
+		mlog.Map("features", license.Features.ToMap()),
+		mlog.String("sku_name", license.SkuName),
+		mlog.String("sku_short_name", license.SkuShortName),
+		mlog.Bool("is_trial", license.IsTrial),
+		mlog.Bool("is_gov_sku", license.IsGovSku),
+	)
 }

--- a/server/channels/app/platform/license.go
+++ b/server/channels/app/platform/license.go
@@ -355,18 +355,27 @@ func (ps *PlatformService) getRequestTrialURL() string {
 }
 
 func (ps *PlatformService) logLicense(message string, license *model.License) {
-	ps.logger.Info(
-		message,
+	logger := ps.logger.With(
 		mlog.String("id", license.Id),
 		mlog.Time("issued_at", model.GetTimeForMillis(license.IssuedAt)),
 		mlog.Time("starts_at", model.GetTimeForMillis(license.StartsAt)),
 		mlog.Time("expires_at", model.GetTimeForMillis(license.ExpiresAt)),
-		mlog.String("customer_id", license.Customer.Id),
-		mlog.Int("features.users", *license.Features.Users),
-		mlog.Map("features", license.Features.ToMap()),
 		mlog.String("sku_name", license.SkuName),
 		mlog.String("sku_short_name", license.SkuShortName),
 		mlog.Bool("is_trial", license.IsTrial),
 		mlog.Bool("is_gov_sku", license.IsGovSku),
 	)
+
+	if license.Customer != nil {
+		logger = logger.With(mlog.String("customer_id", license.Customer.Id))
+	}
+
+	if license.Features != nil {
+		logger = logger.With(
+			mlog.Int("features.users", *license.Features.Users),
+			mlog.Map("features", license.Features.ToMap()),
+		)
+	}
+
+	logger.Info(message)
 }

--- a/server/channels/app/platform/license.go
+++ b/server/channels/app/platform/license.go
@@ -355,6 +355,10 @@ func (ps *PlatformService) getRequestTrialURL() string {
 }
 
 func (ps *PlatformService) logLicense(message string, license *model.License) {
+	if ps.logger == nil {
+		return
+	}
+
 	logger := ps.logger.With(
 		mlog.String("id", license.Id),
 		mlog.Time("issued_at", model.GetTimeForMillis(license.IssuedAt)),


### PR DESCRIPTION
#### Summary
To my surprise, we never log the details of a license when it's loaded or cleared. This makes it hard to debug certain scenarios from logs alone. Let's fix that!

![CleanShot 2024-09-27 at 11 35 18@2x](https://github.com/user-attachments/assets/bf69a26a-7214-44b5-ad5f-19c0599c1c8a)

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-60692

#### Release Note
```release-note
Emit license details to logs when added or removed.
```
