### PR TITLE
MM-60706: Implement a free-list InvalidateProfilesInChannelCacheByUser

### DIFF
--- a/server/channels/store/localcachelayer/layer.go
+++ b/server/channels/store/localcachelayer/layer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 	"github.com/mattermost/mattermost/server/v8/einterfaces"
 	"github.com/mattermost/mattermost/server/v8/platform/services/cache"
+	"github.com/mattermost/mattermost/server/v8/platform/shared/dequeue"
 )
 
 const (
@@ -353,6 +354,7 @@ func NewLocalCacheLayer(baseStore store.Store, metrics einterfaces.MetricsInterf
 		UserStore:                     baseStore.User(),
 		rootStore:                     &localCacheStore,
 		userProfileByIdsInvalidations: make(map[string]bool),
+		userMapFreeList:               dequeue.New[model.UserMap](),
 	}
 
 	// Teams

--- a/server/channels/store/localcachelayer/main_test.go
+++ b/server/channels/store/localcachelayer/main_test.go
@@ -30,7 +30,7 @@ func getMockCacheProvider() cache.Provider {
 	return &mockCacheProvider
 }
 
-func getMockStore(t *testing.T) *mocks.Store {
+func getMockStore(tb testing.TB) *mocks.Store {
 	mockStore := mocks.Store{}
 
 	fakeReaction := model.Reaction{PostId: "123"}
@@ -79,13 +79,13 @@ func getMockStore(t *testing.T) *mocks.Store {
 	mockEmojiStore.On("Get", mock.Anything, "123", true).Return(&fakeEmoji, nil)
 	mockEmojiStore.On("Get", mock.Anything, "123", false).Return(&fakeEmoji, nil)
 	mockEmojiStore.On("Get", mock.IsType(&request.Context{}), "master", true).Return(&ctxEmoji, nil)
-	mockEmojiStore.On("Get", sqlstore.RequestContextWithMaster(request.TestContext(t)), "master", true).Return(&ctxEmoji, nil)
+	mockEmojiStore.On("Get", sqlstore.RequestContextWithMaster(request.TestContext(tb)), "master", true).Return(&ctxEmoji, nil)
 	mockEmojiStore.On("GetByName", mock.Anything, "name123", true).Return(&fakeEmoji, nil)
 	mockEmojiStore.On("GetByName", mock.Anything, "name123", false).Return(&fakeEmoji, nil)
 	mockEmojiStore.On("GetMultipleByName", mock.IsType(&request.Context{}), []string{"name123"}).Return([]*model.Emoji{&fakeEmoji}, nil)
 	mockEmojiStore.On("GetMultipleByName", mock.IsType(&request.Context{}), []string{"name123", "name321"}).Return([]*model.Emoji{&fakeEmoji, &fakeEmoji2}, nil)
 	mockEmojiStore.On("GetByName", mock.IsType(&request.Context{}), "master", true).Return(&ctxEmoji, nil)
-	mockEmojiStore.On("GetByName", sqlstore.RequestContextWithMaster(request.TestContext(t)), "master", false).Return(&ctxEmoji, nil)
+	mockEmojiStore.On("GetByName", sqlstore.RequestContextWithMaster(request.TestContext(tb)), "master", false).Return(&ctxEmoji, nil)
 	mockEmojiStore.On("Delete", &fakeEmoji, int64(0)).Return(nil)
 	mockEmojiStore.On("Delete", &ctxEmoji, int64(0)).Return(nil)
 	mockStore.On("Emoji").Return(&mockEmojiStore)
@@ -162,9 +162,28 @@ func getMockStore(t *testing.T) *mocks.Store {
 	mockUserStore.On("GetProfileByIds", mock.Anything, []string{"123"}, &store.UserGetByIdsOpts{}, false).Return(fakeUser, nil)
 
 	fakeProfilesInChannelMap := map[string]*model.User{
-		"456": {Id: "456"},
+		"456": {
+			Id:          "456",
+			Props:       model.StringMap{},
+			NotifyProps: model.StringMap{},
+			Timezone:    model.StringMap{},
+		},
+		"user3": {
+			Id:          "user3",
+			Props:       model.StringMap{},
+			NotifyProps: model.StringMap{},
+			Timezone:    model.StringMap{},
+		},
+		"user4": {
+			Id:          "user4",
+			Props:       model.StringMap{},
+			NotifyProps: model.StringMap{},
+			Timezone:    model.StringMap{},
+		},
 	}
 	mockUserStore.On("GetAllProfilesInChannel", mock.Anything, "123", true).Return(fakeProfilesInChannelMap, nil)
+	mockUserStore.On("GetAllProfilesInChannel", mock.Anything, "ch2", true).Return(fakeProfilesInChannelMap, nil)
+	mockUserStore.On("GetAllProfilesInChannel", mock.Anything, "ch3", true).Return(fakeProfilesInChannelMap, nil)
 	mockUserStore.On("GetAllProfilesInChannel", mock.Anything, "123", false).Return(fakeProfilesInChannelMap, nil)
 	mockUserStore.On("GetAllProfiles", mock.AnythingOfType("*model.UserGetOptions")).Return(fakeUser, nil)
 

--- a/server/channels/store/localcachelayer/user_layer_test.go
+++ b/server/channels/store/localcachelayer/user_layer_test.go
@@ -162,7 +162,24 @@ func TestUserStoreProfilesInChannelCache(t *testing.T) {
 	fakeChannelId := "123"
 	fakeUserId := "456"
 	fakeMap := map[string]*model.User{
-		fakeUserId: {Id: "456"},
+		fakeUserId: {
+			Id:          fakeUserId,
+			Props:       model.StringMap{},
+			NotifyProps: model.StringMap{},
+			Timezone:    model.StringMap{},
+		},
+		"user3": {
+			Id:          "user3",
+			Props:       model.StringMap{},
+			NotifyProps: model.StringMap{},
+			Timezone:    model.StringMap{},
+		},
+		"user4": {
+			Id:          "user4",
+			Props:       model.StringMap{},
+			NotifyProps: model.StringMap{},
+			Timezone:    model.StringMap{},
+		},
 	}
 	logger := mlog.CreateConsoleTestLogger(t)
 
@@ -229,6 +246,26 @@ func TestUserStoreProfilesInChannelCache(t *testing.T) {
 		_, _ = cachedStore.User().GetAllProfilesInChannel(context.Background(), fakeChannelId, true)
 		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "GetAllProfilesInChannel", 2)
 	})
+}
+
+func BenchmarkInvalidateProfilesInChannelCacheByUser(b *testing.B) {
+	logger := mlog.CreateConsoleTestLogger(b)
+	fakeChannelId := "123"
+	mockStore := getMockStore(b)
+	cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, getMockCacheProvider(), logger)
+	require.NoError(b, err)
+
+	_, err = cachedStore.User().GetAllProfilesInChannel(context.Background(), fakeChannelId, true)
+	require.NoError(b, err)
+	_, err = cachedStore.User().GetAllProfilesInChannel(context.Background(), "ch2", true)
+	require.NoError(b, err)
+	_, err = cachedStore.User().GetAllProfilesInChannel(context.Background(), "ch3", true)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cachedStore.User().InvalidateProfilesInChannelCacheByUser("notfound")
+	}
 }
 
 func TestUserStoreGetCache(t *testing.T) {

--- a/server/platform/shared/dequeue/dequeue.go
+++ b/server/platform/shared/dequeue/dequeue.go
@@ -1,0 +1,241 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// The following is just a copy of the container/list package
+// from the stdlib changed to generic.
+
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package list implements a doubly linked list.
+//
+// To iterate over a list (where l is a *List):
+//
+//	for e := l.Front(); e != nil; e = e.Next() {
+//		// do something with e.Value
+//	}
+package dequeue
+
+// Element is an element of a linked list.
+type Element[T any] struct {
+	// Next and previous pointers in the doubly-linked list of elements.
+	// To simplify the implementation, internally a list l is implemented
+	// as a ring, such that &l.root is both the next element of the last
+	// list element (l.Back()) and the previous element of the first list
+	// element (l.Front()).
+	next, prev *Element[T]
+
+	// The list to which this element belongs.
+	list *List[T]
+
+	// The value stored with this element.
+	Value T
+}
+
+// Next returns the next list element or nil.
+func (e *Element[T]) Next() *Element[T] {
+	if p := e.next; e.list != nil && p != &e.list.root {
+		return p
+	}
+	return nil
+}
+
+// Prev returns the previous list element or nil.
+func (e *Element[T]) Prev() *Element[T] {
+	if p := e.prev; e.list != nil && p != &e.list.root {
+		return p
+	}
+	return nil
+}
+
+// List represents a doubly linked list.
+// The zero value for List is an empty list ready to use.
+type List[T any] struct {
+	root Element[T] // sentinel list element, only &root, root.prev, and root.next are used
+	len  int        // current list length excluding (this) sentinel element
+}
+
+// Init initializes or clears list l.
+func (l *List[T]) Init() *List[T] {
+	l.root.next = &l.root
+	l.root.prev = &l.root
+	l.len = 0
+	return l
+}
+
+// New returns an initialized list.
+func New[T any]() *List[T] { return new(List[T]).Init() }
+
+// Len returns the number of elements of list l.
+// The complexity is O(1).
+func (l *List[T]) Len() int { return l.len }
+
+// Front returns the first element of list l or nil if the list is empty.
+func (l *List[T]) Front() *Element[T] {
+	if l.len == 0 {
+		return nil
+	}
+	return l.root.next
+}
+
+// Back returns the last element of list l or nil if the list is empty.
+func (l *List[T]) Back() *Element[T] {
+	if l.len == 0 {
+		return nil
+	}
+	return l.root.prev
+}
+
+// lazyInit lazily initializes a zero List value.
+func (l *List[T]) lazyInit() {
+	if l.root.next == nil {
+		l.Init()
+	}
+}
+
+// insert inserts e after at, increments l.len, and returns e.
+func (l *List[T]) insert(e, at *Element[T]) *Element[T] {
+	e.prev = at
+	e.next = at.next
+	e.prev.next = e
+	e.next.prev = e
+	e.list = l
+	l.len++
+	return e
+}
+
+// insertValue is a convenience wrapper for insert(&Element{Value: v}, at).
+func (l *List[T]) insertValue(v T, at *Element[T]) *Element[T] {
+	return l.insert(&Element[T]{Value: v}, at)
+}
+
+// remove removes e from its list, decrements l.len
+func (l *List[T]) remove(e *Element[T]) {
+	e.prev.next = e.next
+	e.next.prev = e.prev
+	e.next = nil // avoid memory leaks
+	e.prev = nil // avoid memory leaks
+	e.list = nil
+	l.len--
+}
+
+// move moves e to next to at.
+func (l *List[T]) move(e, at *Element[T]) {
+	if e == at {
+		return
+	}
+	e.prev.next = e.next
+	e.next.prev = e.prev
+
+	e.prev = at
+	e.next = at.next
+	e.prev.next = e
+	e.next.prev = e
+}
+
+// Remove removes e from l if e is an element of list l.
+// It returns the element value e.Value.
+// The element must not be nil.
+func (l *List[T]) Remove(e *Element[T]) T {
+	if e.list == l {
+		// if e.list == l, l must have been initialized when e was inserted
+		// in l or l == nil (e is a zero Element) and l.remove will crash
+		l.remove(e)
+	}
+	return e.Value
+}
+
+// PushFront inserts a new element e with value v at the front of list l and returns e.
+func (l *List[T]) PushFront(v T) *Element[T] {
+	l.lazyInit()
+	return l.insertValue(v, &l.root)
+}
+
+// PushBack inserts a new element e with value v at the back of list l and returns e.
+func (l *List[T]) PushBack(v T) *Element[T] {
+	l.lazyInit()
+	return l.insertValue(v, l.root.prev)
+}
+
+// InsertBefore inserts a new element e with value v immediately before mark and returns e.
+// If mark is not an element of l, the list is not modified.
+// The mark must not be nil.
+func (l *List[T]) InsertBefore(v T, mark *Element[T]) *Element[T] {
+	if mark.list != l {
+		return nil
+	}
+	// see comment in List.Remove about initialization of l
+	return l.insertValue(v, mark.prev)
+}
+
+// InsertAfter inserts a new element e with value v immediately after mark and returns e.
+// If mark is not an element of l, the list is not modified.
+// The mark must not be nil.
+func (l *List[T]) InsertAfter(v T, mark *Element[T]) *Element[T] {
+	if mark.list != l {
+		return nil
+	}
+	// see comment in List.Remove about initialization of l
+	return l.insertValue(v, mark)
+}
+
+// MoveToFront moves element e to the front of list l.
+// If e is not an element of l, the list is not modified.
+// The element must not be nil.
+func (l *List[T]) MoveToFront(e *Element[T]) {
+	if e.list != l || l.root.next == e {
+		return
+	}
+	// see comment in List.Remove about initialization of l
+	l.move(e, &l.root)
+}
+
+// MoveToBack moves element e to the back of list l.
+// If e is not an element of l, the list is not modified.
+// The element must not be nil.
+func (l *List[T]) MoveToBack(e *Element[T]) {
+	if e.list != l || l.root.prev == e {
+		return
+	}
+	// see comment in List.Remove about initialization of l
+	l.move(e, l.root.prev)
+}
+
+// MoveBefore moves element e to its new position before mark.
+// If e or mark is not an element of l, or e == mark, the list is not modified.
+// The element and mark must not be nil.
+func (l *List[T]) MoveBefore(e, mark *Element[T]) {
+	if e.list != l || e == mark || mark.list != l {
+		return
+	}
+	l.move(e, mark.prev)
+}
+
+// MoveAfter moves element e to its new position after mark.
+// If e or mark is not an element of l, or e == mark, the list is not modified.
+// The element and mark must not be nil.
+func (l *List[T]) MoveAfter(e, mark *Element[T]) {
+	if e.list != l || e == mark || mark.list != l {
+		return
+	}
+	l.move(e, mark)
+}
+
+// PushBackList inserts a copy of another list at the back of list l.
+// The lists l and other may be the same. They must not be nil.
+func (l *List[T]) PushBackList(other *List[T]) {
+	l.lazyInit()
+	for i, e := other.Len(), other.Front(); i > 0; i, e = i-1, e.Next() {
+		l.insertValue(e.Value, l.root.prev)
+	}
+}
+
+// PushFrontList inserts a copy of another list at the front of list l.
+// The lists l and other may be the same. They must not be nil.
+func (l *List[T]) PushFrontList(other *List[T]) {
+	l.lazyInit()
+	for i, e := other.Len(), other.Back(); i > 0; i, e = i-1, e.Prev() {
+		l.insertValue(e.Value, &l.root)
+	}
+}

--- a/server/platform/shared/dequeue/dequeue_test.go
+++ b/server/platform/shared/dequeue/dequeue_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// The following is just a copy of the container/list package
+// from the stdlib changed to generic.
+
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dequeue
+
+import "testing"
+
+func checkListLen[T any](t *testing.T, l *List[T], len int) bool {
+	if n := l.Len(); n != len {
+		t.Errorf("l.Len() = %d, want %d", n, len)
+		return false
+	}
+	return true
+}
+
+func checkListPointers[T any](t *testing.T, l *List[T], es []*Element[T]) {
+	root := &l.root
+
+	if !checkListLen(t, l, len(es)) {
+		return
+	}
+
+	// zero length lists must be the zero value or properly initialized (sentinel circle)
+	if len(es) == 0 {
+		if l.root.next != nil && l.root.next != root || l.root.prev != nil && l.root.prev != root {
+			t.Errorf("l.root.next = %p, l.root.prev = %p; both should both be nil or %p", l.root.next, l.root.prev, root)
+		}
+		return
+	}
+	// len(es) > 0
+
+	// check internal and external prev/next connections
+	for i, e := range es {
+		prev := root
+		Prev := (*Element[T])(nil)
+		if i > 0 {
+			prev = es[i-1]
+			Prev = prev
+		}
+		if p := e.prev; p != prev {
+			t.Errorf("elt[%d](%p).prev = %p, want %p", i, e, p, prev)
+		}
+		if p := e.Prev(); p != Prev {
+			t.Errorf("elt[%d](%p).Prev() = %p, want %p", i, e, p, Prev)
+		}
+
+		next := root
+		Next := (*Element[T])(nil)
+		if i < len(es)-1 {
+			next = es[i+1]
+			Next = next
+		}
+		if n := e.next; n != next {
+			t.Errorf("elt[%d](%p).next = %p, want %p", i, e, n, next)
+		}
+		if n := e.Next(); n != Next {
+			t.Errorf("elt[%d](%p).Next() = %p, want %p", i, e, n, Next)
+		}
+	}
+}
+
+func TestList(t *testing.T) {
+	l := New[string]()
+	checkListPointers(t, l, []*Element[string]{})
+
+	// Single element list
+	e := l.PushFront("a")
+	checkListPointers(t, l, []*Element[string]{e})
+	l.MoveToFront(e)
+	checkListPointers(t, l, []*Element[string]{e})
+	l.MoveToBack(e)
+	checkListPointers(t, l, []*Element[string]{e})
+	l.Remove(e)
+	checkListPointers(t, l, []*Element[string]{})
+
+	// Bigger list
+	e2 := l.PushFront("apple")
+	e1 := l.PushFront("orange")
+	e3 := l.PushBack("pumpkin")
+	e4 := l.PushBack("banana")
+	checkListPointers(t, l, []*Element[string]{e1, e2, e3, e4})
+
+	l.Remove(e2)
+	checkListPointers(t, l, []*Element[string]{e1, e3, e4})
+
+	l.MoveToFront(e3) // move from middle
+	checkListPointers(t, l, []*Element[string]{e3, e1, e4})
+
+	l.MoveToFront(e1)
+	l.MoveToBack(e3) // move from middle
+	checkListPointers(t, l, []*Element[string]{e1, e4, e3})
+
+	l.MoveToFront(e3) // move from back
+	checkListPointers(t, l, []*Element[string]{e3, e1, e4})
+	l.MoveToFront(e3) // should be no-op
+	checkListPointers(t, l, []*Element[string]{e3, e1, e4})
+
+	l.MoveToBack(e3) // move from front
+	checkListPointers(t, l, []*Element[string]{e1, e4, e3})
+	l.MoveToBack(e3) // should be no-op
+	checkListPointers(t, l, []*Element[string]{e1, e4, e3})
+
+	e2 = l.InsertBefore("apple", e1) // insert before front
+	checkListPointers(t, l, []*Element[string]{e2, e1, e4, e3})
+	l.Remove(e2)
+	e2 = l.InsertBefore("apple", e4) // insert before middle
+	checkListPointers(t, l, []*Element[string]{e1, e2, e4, e3})
+	l.Remove(e2)
+	e2 = l.InsertBefore("apple", e3) // insert before back
+	checkListPointers(t, l, []*Element[string]{e1, e4, e2, e3})
+	l.Remove(e2)
+
+	e2 = l.InsertAfter("apple", e1) // insert after front
+	checkListPointers(t, l, []*Element[string]{e1, e2, e4, e3})
+	l.Remove(e2)
+	e2 = l.InsertAfter("apple", e4) // insert after middle
+	checkListPointers(t, l, []*Element[string]{e1, e4, e2, e3})
+	l.Remove(e2)
+	e2 = l.InsertAfter("apple", e3) // insert after back
+	checkListPointers(t, l, []*Element[string]{e1, e4, e3, e2})
+}


### PR DESCRIPTION
We implement a free-list of model.UserMap objects just for
InvalidateProfilesInChannelCacheByUser. From looking at heap profiles
at very high scales, it is clear that this method is called very often
and generate a lot of garbage primarily from generating a lot of
model.UserMap objects. Especially, the 3 map fields Props, NotifyProps
and Timezone.

This is due to the reason we have to scan the entire keyspace
of the cache to find out which users are part of the channels
and then delete them. But the allocated userMap objects
go out of scope as soon as the method is finished. This creates
extremely short-lived objects at a very high frequency.

We do not choose a sync.Pool because it is not suitable
for this purpose. Objects in sync.Pool are liable to be GC'd any time
and it allows for dynamically growing and shrinking of the pool.

For our purposes, we simply copy over the stdlib's container/list
implementation and generi-fy it and use a simple dequeue to store
the objects.

The current benchmark was artificially made to have just 3 channels,
but in production there would be hundreds and thousands of channels
which would lead to better results.

```
goos: linux
goarch: amd64
pkg: github.com/mattermost/mattermost/server/v8/channels/store/localcachelayer
cpu: Intel(R) Core(TM) i5-8265U CPU @ 1.60GHz
                                         │ master.txt  │              new.txt               │
                                         │   sec/op    │   sec/op     vs base               │
InvalidateProfilesInChannelCacheByUser-8   5.378µ ± 1%   5.694µ ± 1%  +5.88% (p=0.000 n=10)

                                         │  master.txt  │               new.txt                │
                                         │     B/op     │     B/op      vs base                │
InvalidateProfilesInChannelCacheByUser-8   5.984Ki ± 0%   5.328Ki ± 0%  -10.97% (p=0.000 n=10)

                                         │ master.txt │              new.txt              │
                                         │ allocs/op  │ allocs/op   vs base               │
InvalidateProfilesInChannelCacheByUser-8   68.00 ± 0%   65.00 ± 0%  -4.41% (p=0.000 n=10)
```

Another with 8 channels

```
goos: linux
goarch: amd64
pkg: github.com/mattermost/mattermost/server/v8/channels/store/localcachelayer
cpu: Intel(R) Core(TM) i5-8265U CPU @ 1.60GHz
                                         │ master_8.txt │              pr_8.txt              │
                                         │    sec/op    │   sec/op     vs base               │
InvalidateProfilesInChannelCacheByUser-8    12.28µ ± 4%   12.77µ ± 1%  +4.01% (p=0.011 n=10)

                                         │ master_8.txt │               pr_8.txt               │
                                         │     B/op     │     B/op      vs base                │
InvalidateProfilesInChannelCacheByUser-8   13.87Ki ± 0%   12.34Ki ± 0%  -11.04% (p=0.000 n=10)

                                         │ master_8.txt │             pr_8.txt              │
                                         │  allocs/op   │ allocs/op   vs base               │
InvalidateProfilesInChannelCacheByUser-8     152.0 ± 0%   145.0 ± 0%  -4.61% (p=0.000 n=10)
```

https://mattermost.atlassian.net/browse/MM-60706

```release-note
NONE
```
