### PR TITLE
[GH-28353] Fix errcheck issues in server/channels/api4/channel_bookmark_test.go 

### DIFF
--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -64,7 +64,6 @@ issues:
         channels/api4/brand.go|\
         channels/api4/brand_test.go|\
         channels/api4/channel.go|\
-        channels/api4/channel_bookmark_test.go|\
         channels/api4/channel_category.go|\
         channels/api4/channel_test.go|\
         channels/api4/cloud.go|\

--- a/server/channels/api4/channel_bookmark_test.go
+++ b/server/channels/api4/channel_bookmark_test.go
@@ -22,7 +22,8 @@ func TestCreateChannelBookmark(t *testing.T) {
 
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
-	th.App.SetPhase2PermissionsMigrationStatus(true)
+	err := th.App.SetPhase2PermissionsMigrationStatus(true)
+	require.NoError(t, err)
 
 	t.Run("should not work without a license", func(t *testing.T) {
 		channelBookmark := &model.ChannelBookmark{
@@ -268,7 +269,8 @@ func TestEditChannelBookmark(t *testing.T) {
 
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
-	th.App.SetPhase2PermissionsMigrationStatus(true)
+	err := th.App.SetPhase2PermissionsMigrationStatus(true)
+	require.NoError(t, err)
 
 	t.Run("should not work without a license", func(t *testing.T) {
 		_, _, err := th.Client.UpdateChannelBookmark(context.Background(), th.BasicChannel.Id, model.NewId(), &model.ChannelBookmarkPatch{})
@@ -646,7 +648,8 @@ func TestUpdateChannelBookmarkSortOrder(t *testing.T) {
 
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
-	th.App.SetPhase2PermissionsMigrationStatus(true)
+	err := th.App.SetPhase2PermissionsMigrationStatus(true)
+	require.NoError(t, err)
 
 	createBookmark := func(name, channelId string) *model.ChannelBookmarkWithFileInfo {
 		b := &model.ChannelBookmark{
@@ -780,7 +783,8 @@ func TestUpdateChannelBookmarkSortOrder(t *testing.T) {
 				originalBookmark, appErr := th.App.GetBookmark(tc.bookmarkId, false)
 				require.Nil(t, appErr)
 				defer func() {
-					th.App.UpdateChannelBookmarkSortOrder(originalBookmark.Id, originalBookmark.ChannelId, originalBookmark.SortOrder, "")
+					_, err := th.App.UpdateChannelBookmarkSortOrder(originalBookmark.Id, originalBookmark.ChannelId, originalBookmark.SortOrder, "")
+					require.NoError(t, err)
 				}()
 
 				bookmarks, resp, err := tc.userClient.UpdateChannelBookmarkSortOrder(context.Background(), tc.channelId, tc.bookmarkId, tc.sortOrder)
@@ -1015,7 +1019,8 @@ func TestDeleteChannelBookmark(t *testing.T) {
 
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
-	th.App.SetPhase2PermissionsMigrationStatus(true)
+	err := th.App.SetPhase2PermissionsMigrationStatus(true)
+	require.NoError(t, err)
 
 	th.Context.Session().UserId = th.BasicUser.Id // set the user for the session
 
@@ -1347,7 +1352,8 @@ func TestListChannelBookmarksForChannel(t *testing.T) {
 
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
-	th.App.SetPhase2PermissionsMigrationStatus(true)
+	err := th.App.SetPhase2PermissionsMigrationStatus(true)
+	require.NoError(t, err)
 
 	createBookmark := func(name, channelId string) *model.ChannelBookmarkWithFileInfo {
 		b := &model.ChannelBookmark{

--- a/server/channels/api4/channel_bookmark_test.go
+++ b/server/channels/api4/channel_bookmark_test.go
@@ -784,7 +784,7 @@ func TestUpdateChannelBookmarkSortOrder(t *testing.T) {
 				require.Nil(t, appErr)
 				defer func() {
 					_, err := th.App.UpdateChannelBookmarkSortOrder(originalBookmark.Id, originalBookmark.ChannelId, originalBookmark.SortOrder, "")
-					require.NoError(t, err)
+					require.Nil(t, err)
 				}()
 
 				bookmarks, resp, err := tc.userClient.UpdateChannelBookmarkSortOrder(context.Background(), tc.channelId, tc.bookmarkId, tc.sortOrder)


### PR DESCRIPTION
#### Summary
This PR solves issue https://github.com/mattermost/mattermost/issues/28353. This is done by capturing the error and handling it appropriately.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/28353

#### Release Note
```release-note
Fixed errcheck issues in server/channels/api4/channel_bookmark_test.go
Removed channel_bookmark_test.go from server/.golangci.yml
```
