### PR TITLE
Fixed a bug where files in scheduled post didn't show up until refresh

### DIFF
--- a/webapp/channels/src/actions/views/create_comment.tsx
+++ b/webapp/channels/src/actions/views/create_comment.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {Post} from '@mattermost/types/posts';
+import type {Post, PostMetadata} from '@mattermost/types/posts';
 import type {ScheduledPost, SchedulingInfo} from '@mattermost/types/schedule_post';
 
 import type {CreatePostReturnType, SubmitReactionReturnType} from 'mattermost-redux/actions/posts';
@@ -128,6 +128,15 @@ export function submitPost(
                 metadata: post.metadata,
                 priority: post.metadata.priority,
             };
+
+            if (draft.fileInfos?.length > 0) {
+                if (!scheduledPost.metadata) {
+                    scheduledPost.metadata = {} as PostMetadata;
+                }
+
+                scheduledPost.metadata.files = draft.fileInfos;
+            }
+
             return dispatch(createSchedulePostFromDraft(scheduledPost));
         }
 

--- a/webapp/channels/src/components/drafts/draft_actions/schedule_post_actions/scheduled_post_actions.tsx
+++ b/webapp/channels/src/components/drafts/draft_actions/schedule_post_actions/scheduled_post_actions.tsx
@@ -112,13 +112,17 @@ function ScheduledPostActions({scheduledPost, onReschedule, onDelete, channelDis
             {
                 !scheduledPost.error_code && (
                     <React.Fragment>
-                        <Action
-                            icon='icon-pencil-outline'
-                            id='edit'
-                            name='edit'
-                            tooltipText={editTooltipText}
-                            onClick={() => {}} // this will be implemented in an upcoming PR
-                        />
+                        <div className='hidden'>
+                            <Action
+                                icon='icon-pencil-outline'
+                                id='edit'
+                                name='edit'
+                                tooltipText={editTooltipText}
+                                onClick={() => {
+                                }} // this will be implemented in an upcoming PR
+
+                            />
+                        </div>
 
                         <Action
                             icon='icon-clock-send-outline'
@@ -128,13 +132,15 @@ function ScheduledPostActions({scheduledPost, onReschedule, onDelete, channelDis
                             onClick={handleReschedulePost}
                         />
 
-                        <Action
-                            icon='icon-send-outline'
-                            id='sendNow'
-                            name='sendNow'
-                            tooltipText={sendNowTooltipText}
-                            onClick={handleSend}
-                        />
+                        <div className='hidden'>
+                            <Action
+                                icon='icon-send-outline'
+                                id='sendNow'
+                                name='sendNow'
+                                tooltipText={sendNowTooltipText}
+                                onClick={handleSend}
+                            />
+                        </div>
                     </React.Fragment>
                 )
             }


### PR DESCRIPTION
#### Summary
Fixed a bug where file attachments in scheduled posts didn't show up until a refresh.
Also, I've hidden the "send now" and "edit" buttons on scheduled posts until they are implemented as a preparation for getting scheduled posts on community.

#### Release Note
```release-note
none
```
