### PR TITLE
Fixed the tabbing twice issue

### DIFF
--- a/webapp/channels/src/components/sidebar/sidebar_category_header.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_category_header.tsx
@@ -69,7 +69,10 @@ export const SidebarCategoryHeader = React.forwardRef((props: Props, ref?: React
                 />
                 <div
                     className='SidebarChannelGroupHeader_text'
-                    {...dragHandleProps}
+                    {...{
+                        ...dragHandleProps,
+                        tabIndex: -1,
+                    }}
                 >
                     {wrapEmojis(props.displayName)}
                 </div>

--- a/webapp/channels/src/utils/a11y_controller.ts
+++ b/webapp/channels/src/utils/a11y_controller.ts
@@ -810,6 +810,11 @@ export default class A11yController {
             break;
         case isKeyPressed(event, Constants.KeyCodes.ENTER):
             this.enterKeyIsPressed = true;
+            if (event.target.nodeName === 'BUTTON') {
+                event.preventDefault();
+                event.stopPropagation();
+                event.target.click();
+            }
             break;
         case isKeyPressed(event, Constants.KeyCodes.SPACE):
             if (event.target.nodeName === 'BUTTON') {


### PR DESCRIPTION
#### Summary

Fixed the tabbing twice and the Enter key press issue. The user can now switch to another category without clicking twice. Made the text inside the category not tabbable. Also, when the user presses enter on any category, the functionality is working as expected.

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/26488
Jira: https://mattermost.atlassian.net/browse/MM-55273

#### Screenshots

NA

#### Release Note

```release-note
Fixes the tabbing twice and the Enter key press issue. 
```

