### PR TITLE
server/Makefile: bump mattermost-plugin-metrics version

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -160,7 +160,7 @@ PLUGIN_PACKAGES += mattermost-plugin-msteams-v2.0.3
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.3.4
 PLUGIN_PACKAGES += mattermost-plugin-msteams-meetings-v2.2.0
-PLUGIN_PACKAGES += mattermost-plugin-metrics-v0.5.1
+PLUGIN_PACKAGES += mattermost-plugin-metrics-v0.5.3
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)
 


### PR DESCRIPTION


#### Summary
Bump `mattermost-plugin-metrics` to `v0.5.3` in prepackaged plugins to fix a versioning issue. Context: https://community.mattermost.com/core/pl/8dqradqz9id3jr7ocj3r39jwxa

#### Release Note

```release-note
NONE
```
