### PR TITLE
Automated cherry pick of #28366

### DIFF
--- a/server/channels/api4/plugin_test.go
+++ b/server/channels/api4/plugin_test.go
@@ -1299,6 +1299,78 @@ func TestGetPrepackagedPluginInMarketplace(t *testing.T) {
 	})
 }
 
+func TestGetPrepackagedPlaybooksPluginIn(t *testing.T) {
+	th := Setup(t)
+	defer th.TearDown()
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusOK)
+		json, err := json.Marshal([]*model.MarketplacePlugin{})
+		require.NoError(t, err)
+		res.Write(json)
+	}))
+	defer testServer.Close()
+
+	prepackagePlugins := []*plugin.PrepackagedPlugin{
+		{
+			Manifest: &model.Manifest{
+				Version: "1.40.0",
+				Id:      "playbooks",
+			},
+		},
+		{
+			Manifest: &model.Manifest{
+				Version: "2.0.1",
+				Id:      "playbooks",
+			},
+		},
+	}
+	env := th.App.GetPluginsEnvironment()
+	env.SetPrepackagedPlugins(prepackagePlugins, nil)
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.PluginSettings.Enable = true
+		*cfg.PluginSettings.EnableMarketplace = true
+		*cfg.PluginSettings.MarketplaceURL = testServer.URL
+	})
+
+	t.Run("playbooks v1 is returned if not licensed", func(t *testing.T) {
+		plugins, _, err := th.SystemAdminClient.GetMarketplacePlugins(context.Background(), &model.MarketplacePluginFilter{})
+		require.NoError(t, err)
+
+		expectedPlugins := prepackagePlugins[0]
+
+		require.Equal(t, expectedPlugins.Manifest.Version, plugins[0].Manifest.Version)
+		require.Len(t, plugins, 1)
+	})
+
+	t.Run("playbooks v2 is returned if Enterprise licensed", func(t *testing.T) {
+		lic := th.App.Srv().License()
+		th.App.Srv().SetLicense(model.NewTestLicenseSKU("enterprise"))
+		defer th.App.Srv().SetLicense(lic)
+
+		plugins, _, err := th.SystemAdminClient.GetMarketplacePlugins(context.Background(), &model.MarketplacePluginFilter{})
+		require.NoError(t, err)
+
+		expectedPlugins := prepackagePlugins[1]
+		require.Equal(t, expectedPlugins.Manifest.Version, plugins[0].Manifest.Version)
+		require.Len(t, plugins, 1)
+	})
+
+	t.Run("playbooks v1 is returned if professional licensed", func(t *testing.T) {
+		lic := th.App.Srv().License()
+		th.App.Srv().SetLicense(model.NewTestLicenseSKU("professional"))
+		defer th.App.Srv().SetLicense(lic)
+
+		plugins, _, err := th.SystemAdminClient.GetMarketplacePlugins(context.Background(), &model.MarketplacePluginFilter{})
+		require.NoError(t, err)
+
+		expectedPlugins := prepackagePlugins[0]
+		require.Equal(t, expectedPlugins.Manifest.Version, plugins[0].Manifest.Version)
+		require.Len(t, plugins, 1)
+	})
+}
+
 func TestInstallMarketplacePlugin(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()

--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -651,6 +651,7 @@ func (a *App) mergePrepackagedPlugins(remoteMarketplacePlugins map[string]*model
 		return model.NewAppError("mergePrepackagedPlugins", "app.plugin.config.app_error", nil, "", http.StatusInternalServerError)
 	}
 
+	isEnterpriseLicense := a.License() != nil && a.License().IsE20OrEnterprise()
 	for _, prepackaged := range pluginsEnvironment.PrepackagedPlugins() {
 		if prepackaged.Manifest == nil {
 			continue
@@ -663,6 +664,22 @@ func (a *App) mergePrepackagedPlugins(remoteMarketplacePlugins map[string]*model
 				ReleaseNotesURL: prepackaged.Manifest.ReleaseNotesURL,
 				Manifest:        prepackaged.Manifest,
 			},
+		}
+
+		// If not enterprise, check version.
+		// Playbooks is not listed in the marketplace, this only handles prepackaged.
+		if !isEnterpriseLicense {
+			if prepackaged.Manifest.Id == model.PluginIdPlaybooks {
+				version, err := semver.Parse(prepackaged.Manifest.Version)
+				if err != nil {
+					mlog.Error("Unable to verify prepackaged playbooks version", mlog.Err(err))
+					continue
+				}
+				// Do not show playbooks >=v2 if we do not have an enterprise license
+				if version.GTE(SemVerV2) {
+					continue
+				}
+			}
 		}
 
 		// If not available in marketplace, add the prepackaged


### PR DESCRIPTION
Cherry pick of #28366 on release-10.0.

/cc  @sbishel

```release-note
NONE
```