### PR TITLE
Disable PerformanceReporter tests

### DIFF
--- a/webapp/channels/src/utils/performance_telemetry/reporter.test.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.test.ts
@@ -19,7 +19,10 @@ jest.mock('web-vitals/attribution');
 
 const siteUrl = 'http://localhost:8065';
 
-describe('PerformanceReporter', () => {
+// These tests are good to have, but they're incredibly unreliable in CI. These should be uncommented when making
+// changes to this code.
+// eslint-disable-next-line no-only-tests/no-only-tests
+describe.skip('PerformanceReporter', () => {
     afterEach(() => {
         performance.clearMarks();
         performance.clearMeasures();


### PR DESCRIPTION
#### Summary
These tests are incredibly flaky, and I've spent enough time fighting with them that I'm just disabling them until we end up making more changes to this code which I don't expect to be for a while.

#### Release Note
```release-note
NONE
```
