### PR TITLE
[GH-19914]-Adds ability to send direct message2

### DIFF
--- a/server/cmd/mmctl/client/client.go
+++ b/server/cmd/mmctl/client/client.go
@@ -162,4 +162,6 @@ type Client interface {
 	DeletePreferences(ctx context.Context, userId string, preferences model.Preferences) (*model.Response, error)
 	PermanentDeletePost(ctx context.Context, postID string) (*model.Response, error)
 	DeletePost(ctx context.Context, postId string) (*model.Response, error)
+	CreateDirectChannel(ctx context.Context, userId1, userId2 string) (*model.Channel, *model.Response, error)
+	GetMe(ctx context.Context, etag string) (*model.User, *model.Response, error)
 }

--- a/server/cmd/mmctl/commands/post.go
+++ b/server/cmd/mmctl/commands/post.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -28,7 +29,7 @@ var PostCreateCmd = &cobra.Command{
 	Use:     "create",
 	Short:   "Create a post",
 	Example: `  post create myteam:mychannel --message "some text for the post"`,
-	Args:    cobra.ExactArgs(1),
+	Args:    cobra.MinimumNArgs(1),
 	RunE:    withClient(postCreateCmdF),
 }
 
@@ -85,8 +86,12 @@ func init() {
 
 func postCreateCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	message, _ := cmd.Flags().GetString("message")
+	if args[1]!=""{
+		message = args[1]
+	}
+
 	if message == "" {
-		return errors.New("message cannot be empty")
+		return fmt.Errorf("message cannot be empty")
 	}
 
 	replyTo, _ := cmd.Flags().GetString("reply-to")
@@ -100,13 +105,36 @@ func postCreateCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	channel := getChannelFromChannelArg(c, args[0])
-	if channel == nil {
-		return errors.New("Unable to find channel '" + args[0] + "'")
+	channelID := ""
+	if strings.HasPrefix(args[0], "@"){
+
+	me,_, err := c.GetMe(context.TODO(), "")
+	if err!=nil{
+		return fmt.Errorf("could not get current user: %s", err.Error())
 	}
 
+	userArgString := strings.Split(args[0], "@")[1]
+	user := getUserFromUserArg(c,userArgString)
+	if user == nil {
+    return fmt.Errorf("unable to find user %q", userArgString)
+  }
+
+	directChannel,_,err := c.CreateDirectChannel(context.TODO(),me.Id,user.Id)
+	if err!=nil{
+    return fmt.Errorf("could not create direct channel: %s", err.Error())
+  }
+	channelID = directChannel.Id
+	}else{
+
+	channel := getChannelFromChannelArg(c, args[0])
+	if channel == nil {
+		return fmt.Errorf("unable to find channel %q",args[0])
+	}
+	channelID = channel.Id
+	}
+	
 	post := &model.Post{
-		ChannelId: channel.Id,
+		ChannelId: channelID,
 		Message:   message,
 		RootId:    replyTo,
 	}
@@ -122,6 +150,88 @@ func postCreateCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	}
 	return nil
 }
+
+
+// func postCreateCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+// 	message, _ := cmd.Flags().GetString("message")
+// 	if message == "" {
+// 		return errors.New("message cannot be empty")
+// 	}
+
+// 	replyTo, _ := cmd.Flags().GetString("reply-to")
+// 	if replyTo != "" {
+// 		replyToPost, _, err := c.GetPost(context.TODO(), replyTo, "")
+// 		if err != nil {
+// 			return err
+// 		}
+// 		if replyToPost.RootId != "" {
+// 			replyTo = replyToPost.RootId
+// 		}
+// 	}
+
+// 	channel := getChannelFromChannelArg(c, args[0])
+// 	if channel == nil {
+// 		return errors.New("Unable to find channel '" + args[0] + "'")
+// 	}
+
+// 	post := &model.Post{
+// 		ChannelId: channel.Id,
+// 		Message:   message,
+// 		RootId:    replyTo,
+// 	}
+
+// 	url := "/posts" + "?set_online=false"
+// 	data, err := post.ToJSON()
+// 	if err != nil {
+// 		return fmt.Errorf("could not decode post: %w", err)
+// 	}
+
+// 	if _, err := c.DoAPIPost(context.TODO(), url, data); err != nil {
+// 		return fmt.Errorf("could not create post: %s", err.Error())
+// 	}
+// 	return nil
+// }
+
+// func postCreateDMCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+// 	ctx := context.TODO()
+// 	message := args[1]
+// 	if message == "" {
+// 		return errors.New("message cannot be empty")
+// 	}
+
+// 	me,_, err := c.GetMe(ctx, "")
+// 	if err!=nil{
+// 		return fmt.Errorf("could not get current user: %s", err.Error())
+// 	}
+	
+// 	otherUser, err := getUserFromArg(c, args[0])
+// 	if err != nil {
+// 		return fmt.Errorf("could not find user: %s", err.Error())
+// 	}
+
+// 	directChannel,_, err := c.CreateDirectChannel(ctx, otherUser.Id, me.Id)
+// 	if err != nil {
+// 		return fmt.Errorf("could not create direct channel:  %w", err)
+// 	}
+
+// 	post := &model.Post{
+// 		Message:   message,
+// 		ChannelId: directChannel.Id,
+// 		UserId:    otherUser.Id,
+// 	}
+
+// 	data, err := post.ToJSON()
+// 	if err != nil {
+// 		return fmt.Errorf("could not decode post: %w", err)
+// 	}
+
+// 	if _, err := c.DoAPIPost(ctx, "/posts"+"?set_online=false", data); err != nil {
+// 		return fmt.Errorf("could not send message: %s", err.Error())
+// 	}
+
+// 	return nil
+// }
+
 
 func eventDataToPost(eventData map[string]any) (*model.Post, error) {
 	post := &model.Post{}


### PR DESCRIPTION
#### Summary
Extended the `mmctl post create` command to send direct messages. This PR also replaces the `--message` flag with a second argument representing the message string.
The two commands below illustrate how to send a post to a channel and how to send a DM resp.

```bash
mmctl post create myteam:mychannel "Message to channel"
```
```bash
mmctl post create @username "message to user"
```

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/19914
Jira https://mattermost.atlassian.net/browse/MM-40525

#### Release Note

```release-note
NONE
```

