### PR TITLE
Fix permission name in scheduled posts by team

### DIFF
--- a/api/v4/source/scheduled_post.yaml
+++ b/api/v4/source/scheduled_post.yaml
@@ -70,7 +70,7 @@
 
         ##### Permissions
 
-        Must have `access_team` permission for the team the scheduled posts are being fetched for.
+        Must have `view_team` permission for the team the scheduled posts are being fetched for.
 
         __Minimum server version__: 10.3
       operationId: GetUserScheduledPosts


### PR DESCRIPTION
#### Summary
Fixes the permission name. We use `view_team` in our API docs instead of access_team

#### Ticket Link
N/A

#### Release Note
```
NONE
```