### PR TITLE
[MM-60833] Replace FormattedMarkdownMessage in 'webapp/channels/src/components/admin_console/group_settings/group_details/group_users.tsx' with FormattedMessage

### DIFF
--- a/webapp/channels/src/components/admin_console/group_settings/group_details/__snapshots__/group_users.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/group_settings/group_details/__snapshots__/group_users.test.tsx.snap
@@ -7,12 +7,12 @@ exports[`components/admin_console/group_settings/group_details/GroupUsers should
   <div
     className="group-users--header"
   >
-    <FormattedMarkdownMessage
-      defaultMessage="AD/LDAP Connector is configured to sync and manage this group and its users. [Click here to view]({siteURL}/admin_console/authentication/ldap)"
-      id="admin.group_settings.group_profile.group_users.ldapConnector"
+    <MemoizedFormattedMessage
+      defaultMessage="AD/LDAP Connector is configured to sync and manage this group and its users. <a>Click here to view</a>"
+      id="admin.group_settings.group_profile.group_users.ldapConnectorText"
       values={
         Object {
-          "siteURL": "http://localhost:8065",
+          "a": [Function],
         }
       }
     />
@@ -233,12 +233,12 @@ exports[`components/admin_console/group_settings/group_details/GroupUsers should
   <div
     className="group-users--header"
   >
-    <FormattedMarkdownMessage
-      defaultMessage="AD/LDAP Connector is configured to sync and manage this group and its users. [Click here to view]({siteURL}/admin_console/authentication/ldap)"
-      id="admin.group_settings.group_profile.group_users.ldapConnector"
+    <MemoizedFormattedMessage
+      defaultMessage="AD/LDAP Connector is configured to sync and manage this group and its users. <a>Click here to view</a>"
+      id="admin.group_settings.group_profile.group_users.ldapConnectorText"
       values={
         Object {
-          "siteURL": "http://localhost:8065",
+          "a": [Function],
         }
       }
     />
@@ -459,12 +459,12 @@ exports[`components/admin_console/group_settings/group_details/GroupUsers should
   <div
     className="group-users--header"
   >
-    <FormattedMarkdownMessage
-      defaultMessage="AD/LDAP Connector is configured to sync and manage this group and its users. [Click here to view]({siteURL}/admin_console/authentication/ldap)"
-      id="admin.group_settings.group_profile.group_users.ldapConnector"
+    <MemoizedFormattedMessage
+      defaultMessage="AD/LDAP Connector is configured to sync and manage this group and its users. <a>Click here to view</a>"
+      id="admin.group_settings.group_profile.group_users.ldapConnectorText"
       values={
         Object {
-          "siteURL": "http://localhost:8065",
+          "a": [Function],
         }
       }
     />
@@ -685,12 +685,12 @@ exports[`components/admin_console/group_settings/group_details/GroupUsers should
   <div
     className="group-users--header"
   >
-    <FormattedMarkdownMessage
-      defaultMessage="AD/LDAP Connector is configured to sync and manage this group and its users. [Click here to view]({siteURL}/admin_console/authentication/ldap)"
-      id="admin.group_settings.group_profile.group_users.ldapConnector"
+    <MemoizedFormattedMessage
+      defaultMessage="AD/LDAP Connector is configured to sync and manage this group and its users. <a>Click here to view</a>"
+      id="admin.group_settings.group_profile.group_users.ldapConnectorText"
       values={
         Object {
-          "siteURL": "http://localhost:8065",
+          "a": [Function],
         }
       }
     />
@@ -871,12 +871,12 @@ exports[`components/admin_console/group_settings/group_details/GroupUsers should
   <div
     className="group-users--header"
   >
-    <FormattedMarkdownMessage
-      defaultMessage="AD/LDAP Connector is configured to sync and manage this group and its users. [Click here to view]({siteURL}/admin_console/authentication/ldap)"
-      id="admin.group_settings.group_profile.group_users.ldapConnector"
+    <MemoizedFormattedMessage
+      defaultMessage="AD/LDAP Connector is configured to sync and manage this group and its users. <a>Click here to view</a>"
+      id="admin.group_settings.group_profile.group_users.ldapConnectorText"
       values={
         Object {
-          "siteURL": "http://localhost:8065",
+          "a": [Function],
         }
       }
     />
@@ -1097,12 +1097,12 @@ exports[`components/admin_console/group_settings/group_details/GroupUsers should
   <div
     className="group-users--header"
   >
-    <FormattedMarkdownMessage
-      defaultMessage="AD/LDAP Connector is configured to sync and manage this group and its users. [Click here to view]({siteURL}/admin_console/authentication/ldap)"
-      id="admin.group_settings.group_profile.group_users.ldapConnector"
+    <MemoizedFormattedMessage
+      defaultMessage="AD/LDAP Connector is configured to sync and manage this group and its users. <a>Click here to view</a>"
+      id="admin.group_settings.group_profile.group_users.ldapConnectorText"
       values={
         Object {
-          "siteURL": "http://localhost:8065",
+          "a": [Function],
         }
       }
     />
@@ -1139,12 +1139,12 @@ exports[`components/admin_console/group_settings/group_details/GroupUsers should
   <div
     className="group-users--header"
   >
-    <FormattedMarkdownMessage
-      defaultMessage="AD/LDAP Connector is configured to sync and manage this group and its users. [Click here to view]({siteURL}/admin_console/authentication/ldap)"
-      id="admin.group_settings.group_profile.group_users.ldapConnector"
+    <MemoizedFormattedMessage
+      defaultMessage="AD/LDAP Connector is configured to sync and manage this group and its users. <a>Click here to view</a>"
+      id="admin.group_settings.group_profile.group_users.ldapConnectorText"
       values={
         Object {
-          "siteURL": "http://localhost:8065",
+          "a": [Function],
         }
       }
     />
@@ -1365,12 +1365,12 @@ exports[`components/admin_console/group_settings/group_details/GroupUsers should
   <div
     className="group-users--header"
   >
-    <FormattedMarkdownMessage
-      defaultMessage="AD/LDAP Connector is configured to sync and manage this group and its users. [Click here to view]({siteURL}/admin_console/authentication/ldap)"
-      id="admin.group_settings.group_profile.group_users.ldapConnector"
+    <MemoizedFormattedMessage
+      defaultMessage="AD/LDAP Connector is configured to sync and manage this group and its users. <a>Click here to view</a>"
+      id="admin.group_settings.group_profile.group_users.ldapConnectorText"
       values={
         Object {
-          "siteURL": "http://localhost:8065",
+          "a": [Function],
         }
       }
     />

--- a/webapp/channels/src/components/admin_console/group_settings/group_details/group_users.tsx
+++ b/webapp/channels/src/components/admin_console/group_settings/group_details/group_users.tsx
@@ -164,7 +164,7 @@ export default class GroupUsers extends React.PureComponent<Props, State> {
                             'AD/LDAP Connector is configured to sync and manage this group and its users. <a>Click here to view</a>'
                         }
                         values={{
-                            a: (chunks) => (
+                            a: (chunks: string) => (
                                 <Link to='/admin_console/authentication/ldap'>
                                     {chunks}
                                 </Link>

--- a/webapp/channels/src/components/admin_console/group_settings/group_details/group_users.tsx
+++ b/webapp/channels/src/components/admin_console/group_settings/group_details/group_users.tsx
@@ -3,17 +3,15 @@
 
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
+import {Link} from 'react-router-dom';
 
 import type {UserProfile} from '@mattermost/types/users';
 
 import type {ActionResult} from 'mattermost-redux/types/actions';
 
 import GroupUsersRow from 'components/admin_console/group_settings/group_details/group_users_row';
-import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 import NextIcon from 'components/widgets/icons/fa_next_icon';
 import PreviousIcon from 'components/widgets/icons/fa_previous_icon';
-
-import {getSiteURL} from 'utils/url';
 
 const GROUP_MEMBERS_PAGE_SIZE = 20;
 
@@ -160,12 +158,18 @@ export default class GroupUsers extends React.PureComponent<Props, State> {
         return (
             <div className='group-users'>
                 <div className='group-users--header'>
-                    <FormattedMarkdownMessage
-                        id='admin.group_settings.group_profile.group_users.ldapConnector'
+                    <FormattedMessage
+                        id='admin.group_settings.group_profile.group_users.ldapConnectorText'
                         defaultMessage={
-                            'AD/LDAP Connector is configured to sync and manage this group and its users. [Click here to view]({siteURL}/admin_console/authentication/ldap)'
+                            'AD/LDAP Connector is configured to sync and manage this group and its users. <a>Click here to view</a>'
                         }
-                        values={{siteURL: getSiteURL()}}
+                        values={{
+                            a: (chunks) => (
+                                <Link to='/admin_console/authentication/ldap'>
+                                    {chunks}
+                                </Link>
+                            ),
+                        }}
                     />
                 </div>
                 <div className='group-users--body'>

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -1090,7 +1090,7 @@
   "admin.group_settings.group_profile.group_teams_and_channels.assignedRoles": "Assigned Roles",
   "admin.group_settings.group_profile.group_teams_and_channels.name": "Name",
   "admin.group_settings.group_profile.group_teams_and_channels.type": "Type",
-  "admin.group_settings.group_profile.group_users.ldapConnector": "AD/LDAP Connector is configured to sync and manage this group and its users. [Click here to view]({siteURL}/admin_console/authentication/ldap)",
+  "admin.group_settings.group_profile.group_users.ldapConnectorText": "AD/LDAP Connector is configured to sync and manage this group and its users. <a>Click here to view</a>",
   "admin.group_settings.group_row.configure": "Configure",
   "admin.group_settings.group_row.edit": "Edit",
   "admin.group_settings.group_row.link_failed": "Link failed",


### PR DESCRIPTION
#### Summary
This PR replaces all instances of FormattedMarkdownMessage with FormattedMessage from the react-intl library in group_users.tsx, ensuring rich text formatting is preserved. The message IDs have been updated, and npm run i18n-extract was executed to capture the new messages.

#### Ticket Link
Fixes #28601
Jira: [MM-60833](https://mattermost.atlassian.net/browse/MM-60833)

#### Release Note

```release-note
NONE
```

[MM-60833]: https://mattermost.atlassian.net/browse/MM-60833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ