### PR TITLE
MM-60570 - Server-side changes consolidating the export CLI with server/ent code

### DIFF
--- a/server/channels/store/sqlstore/post_store.go
+++ b/server/channels/store/sqlstore/post_store.go
@@ -2387,15 +2387,10 @@ func (s *SqlPostStore) AnalyticsPostCount(options *model.PostCountOptions) (int6
 		query = query.Where(sq.LtOrEq{"p.UpdateAt": options.UntilUpdateAt})
 	}
 
-	queryString, args, err := query.ToSql()
-	if err != nil {
-		return 0, errors.Wrap(err, "post_tosql")
-	}
-
 	var v int64
-	err = s.GetReplicaX().Get(&v, queryString, args...)
+	err := s.GetReplicaX().GetBuilder(&v, query)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to count Posts")
+		return 0, fmt.Errorf("post_tosql failed or failed to count Posts: %w", err)
 	}
 
 	return v, nil

--- a/server/channels/store/sqlstore/post_store.go
+++ b/server/channels/store/sqlstore/post_store.go
@@ -2383,6 +2383,10 @@ func (s *SqlPostStore) AnalyticsPostCount(options *model.PostCountOptions) (int6
 		})
 	}
 
+	if options.UntilUpdateAt > 0 {
+		query = query.Where(sq.LtOrEq{"p.UpdateAt": options.UntilUpdateAt})
+	}
+
 	queryString, args, err := query.ToSql()
 	if err != nil {
 		return 0, errors.Wrap(err, "post_tosql")

--- a/server/channels/store/storetest/compliance_store.go
+++ b/server/channels/store/storetest/compliance_store.go
@@ -58,6 +58,7 @@ func TestComplianceStore(t *testing.T, rctx request.CTX, ss store.Store) {
 	t.Run("MessageEditAfterExportMessage", func(t *testing.T) { testEditAfterExportMessage(t, rctx, ss) })
 	t.Run("MessageDeleteExportMessage", func(t *testing.T) { testDeleteExportMessage(t, rctx, ss) })
 	t.Run("MessageDeleteAfterExportMessage", func(t *testing.T) { testDeleteAfterExportMessage(t, rctx, ss) })
+	t.Run("MessageExport_UntilUpdateAt", func(t *testing.T) { testMessageExportUntilUpdateAt(t, rctx, ss) })
 }
 
 func testComplianceStore(t *testing.T, rctx request.CTX, ss store.Store) {
@@ -1173,4 +1174,105 @@ func testDeleteAfterExportMessage(t *testing.T, rctx request.CTX, ss store.Store
 	assert.Equal(t, user1.Id, *v.UserId)
 	assert.Equal(t, user1.Email, *v.UserEmail)
 	assert.Equal(t, user1.Username, *v.Username)
+}
+
+func testMessageExportUntilUpdateAt(t *testing.T, rctx request.CTX, ss store.Store) {
+	defer cleanupStoreState(t, rctx, ss)
+
+	// get the starting number of message export entries
+	startTime := model.GetMillis()
+	messages, _, err := ss.Compliance().MessageExport(rctx, model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, 10)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(messages))
+
+	// need a team
+	team := &model.Team{
+		DisplayName: "DisplayName",
+		Name:        NewTestId(),
+		Email:       MakeEmail(),
+		Type:        model.TeamOpen,
+	}
+	team, err = ss.Team().Save(team)
+	require.NoError(t, err)
+
+	// and two users that are a part of that team
+	user1 := &model.User{
+		Email:    MakeEmail(),
+		Username: model.NewUsername(),
+	}
+	user1, err = ss.User().Save(rctx, user1)
+	require.NoError(t, err)
+	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{
+		TeamId: team.Id,
+		UserId: user1.Id,
+	}, -1)
+	require.NoError(t, nErr)
+
+	user2 := &model.User{
+		Email:    MakeEmail(),
+		Username: model.NewUsername(),
+	}
+	user2, err = ss.User().Save(rctx, user2)
+	require.NoError(t, err)
+	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{
+		TeamId: team.Id,
+		UserId: user2.Id,
+	}, -1)
+	require.NoError(t, nErr)
+
+	// need a public channel
+	channel := &model.Channel{
+		TeamId:      team.Id,
+		Name:        model.NewId(),
+		DisplayName: "Public Channel",
+		Type:        model.ChannelTypeOpen,
+	}
+	channel, nErr = ss.Channel().Save(rctx, channel, -1)
+	require.NoError(t, nErr)
+
+	var posts []*model.Post
+	// user1 posts ten times in the public channel
+	for i := 0; i < 10; i++ {
+		post := &model.Post{
+			ChannelId: channel.Id,
+			UserId:    user1.Id,
+			CreateAt:  startTime + int64(i),
+			UpdateAt:  startTime + int64(i),
+			Message:   NewTestId(),
+		}
+		post, err = ss.Post().Save(rctx, post)
+		require.NoError(t, err)
+		posts = append(posts, post)
+	}
+
+	// fetch 5 starting from the third post, using LastPostUpdateAt and UntilUpdateAt.
+	// UntilUpdateAt is inclusive
+	messageExportMap := map[string]model.MessageExport{}
+	messages, _, err = ss.Compliance().MessageExport(rctx, model.MessageExportCursor{LastPostUpdateAt: posts[2].UpdateAt, UntilUpdateAt: posts[2].UpdateAt + 4}, 10000)
+	require.NoError(t, err)
+	assert.Equal(t, 5, len(messages))
+
+	for _, v := range messages {
+		messageExportMap[*v.PostId] = *v
+	}
+
+	for i := 2; i < 7; i++ {
+		assert.Equal(t, posts[i].Id, *messageExportMap[posts[i].Id].PostId)
+		assert.Equal(t, posts[i].CreateAt, *messageExportMap[posts[i].Id].PostCreateAt)
+		assert.Equal(t, posts[i].Message, *messageExportMap[posts[i].Id].PostMessage)
+		assert.Equal(t, channel.Id, *messageExportMap[posts[i].Id].ChannelId)
+		assert.Equal(t, channel.DisplayName, *messageExportMap[posts[i].Id].ChannelDisplayName)
+		assert.Equal(t, user1.Id, *messageExportMap[posts[i].Id].UserId)
+		assert.Equal(t, user1.Email, *messageExportMap[posts[i].Id].UserEmail)
+		assert.Equal(t, user1.Username, *messageExportMap[posts[i].Id].Username)
+	}
+
+	// Also test AnalyticsPostCount because they are used in tandem for MessageExports
+	count, err := ss.Post().AnalyticsPostCount(&model.PostCountOptions{
+		TeamId:             channel.TeamId,
+		ExcludeSystemPosts: true,
+		SinceUpdateAt:      posts[2].UpdateAt,
+		UntilUpdateAt:      posts[2].UpdateAt + 4,
+	})
+	require.Equal(t, 5, int(count))
 }

--- a/server/channels/store/storetest/compliance_store.go
+++ b/server/channels/store/storetest/compliance_store.go
@@ -1274,5 +1274,6 @@ func testMessageExportUntilUpdateAt(t *testing.T, rctx request.CTX, ss store.Sto
 		SinceUpdateAt:      posts[2].UpdateAt,
 		UntilUpdateAt:      posts[2].UpdateAt + 4,
 	})
+	require.NoError(t, err)
 	require.Equal(t, 5, int(count))
 }

--- a/server/einterfaces/message_export.go
+++ b/server/einterfaces/message_export.go
@@ -9,6 +9,6 @@ import (
 )
 
 type MessageExportInterface interface {
-	StartSynchronizeJob(c request.CTX, exportFromTimestamp int64) (*model.Job, *model.AppError)
-	RunExport(c request.CTX, format string, since int64, limit int) (int64, *model.AppError)
+	StartSynchronizeJob(rctx request.CTX, exportFromTimestamp int64) (*model.Job, *model.AppError)
+	RunExport(rctx request.CTX, format string, since int64, limit int) (int, *model.AppError)
 }

--- a/server/einterfaces/mocks/MessageExportInterface.go
+++ b/server/einterfaces/mocks/MessageExportInterface.go
@@ -15,27 +15,27 @@ type MessageExportInterface struct {
 	mock.Mock
 }
 
-// RunExport provides a mock function with given fields: c, format, since, limit
-func (_m *MessageExportInterface) RunExport(c request.CTX, format string, since int64, limit int) (int64, *model.AppError) {
-	ret := _m.Called(c, format, since, limit)
+// RunExport provides a mock function with given fields: rctx, format, since, limit
+func (_m *MessageExportInterface) RunExport(rctx request.CTX, format string, since int64, limit int) (int, *model.AppError) {
+	ret := _m.Called(rctx, format, since, limit)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RunExport")
 	}
 
-	var r0 int64
+	var r0 int
 	var r1 *model.AppError
-	if rf, ok := ret.Get(0).(func(request.CTX, string, int64, int) (int64, *model.AppError)); ok {
-		return rf(c, format, since, limit)
+	if rf, ok := ret.Get(0).(func(request.CTX, string, int64, int) (int, *model.AppError)); ok {
+		return rf(rctx, format, since, limit)
 	}
-	if rf, ok := ret.Get(0).(func(request.CTX, string, int64, int) int64); ok {
-		r0 = rf(c, format, since, limit)
+	if rf, ok := ret.Get(0).(func(request.CTX, string, int64, int) int); ok {
+		r0 = rf(rctx, format, since, limit)
 	} else {
-		r0 = ret.Get(0).(int64)
+		r0 = ret.Get(0).(int)
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, int64, int) *model.AppError); ok {
-		r1 = rf(c, format, since, limit)
+		r1 = rf(rctx, format, since, limit)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -45,9 +45,9 @@ func (_m *MessageExportInterface) RunExport(c request.CTX, format string, since 
 	return r0, r1
 }
 
-// StartSynchronizeJob provides a mock function with given fields: c, exportFromTimestamp
-func (_m *MessageExportInterface) StartSynchronizeJob(c request.CTX, exportFromTimestamp int64) (*model.Job, *model.AppError) {
-	ret := _m.Called(c, exportFromTimestamp)
+// StartSynchronizeJob provides a mock function with given fields: rctx, exportFromTimestamp
+func (_m *MessageExportInterface) StartSynchronizeJob(rctx request.CTX, exportFromTimestamp int64) (*model.Job, *model.AppError) {
+	ret := _m.Called(rctx, exportFromTimestamp)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StartSynchronizeJob")
@@ -56,10 +56,10 @@ func (_m *MessageExportInterface) StartSynchronizeJob(c request.CTX, exportFromT
 	var r0 *model.Job
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, int64) (*model.Job, *model.AppError)); ok {
-		return rf(c, exportFromTimestamp)
+		return rf(rctx, exportFromTimestamp)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, int64) *model.Job); ok {
-		r0 = rf(c, exportFromTimestamp)
+		r0 = rf(rctx, exportFromTimestamp)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Job)
@@ -67,7 +67,7 @@ func (_m *MessageExportInterface) StartSynchronizeJob(c request.CTX, exportFromT
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, int64) *model.AppError); ok {
-		r1 = rf(c, exportFromTimestamp)
+		r1 = rf(rctx, exportFromTimestamp)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -7359,42 +7359,6 @@
     "translation": "Unable to get SAML users."
   },
   {
-    "id": "ent.actiance.export.flush.xml.appError",
-    "translation": "Unable to flush the XML encoder."
-  },
-  {
-    "id": "ent.actiance.export.marshalToXml.appError",
-    "translation": "Unable to convert export to XML."
-  },
-  {
-    "id": "ent.actiance.export.writeExport.batch.create.temp.appError",
-    "translation": "Unable to create the batch temporary file."
-  },
-  {
-    "id": "ent.actiance.export.writeExport.temp.seek.appError",
-    "translation": "Unable to seek to the beginning of the the batch temporary file."
-  },
-  {
-    "id": "ent.actiance.export.writeExport.write.dest.appError",
-    "translation": "Unable to transfer the batch zip to the file backend."
-  },
-  {
-    "id": "ent.actiance.export.writeExport.zip.close.appError",
-    "translation": "Unable to close the zipFile created with the batch temporary file."
-  },
-  {
-    "id": "ent.actiance.export.writeExport.zip.creation.appError",
-    "translation": "Unable to create the xml file in the zipFile created with the batch temporary file."
-  },
-  {
-    "id": "ent.actiance.export.writeExport.zip.creation.warning.appError",
-    "translation": "Unable to create the warning file in the zipFile created with the batch temporary file."
-  },
-  {
-    "id": "ent.actiance.export.writeExport.zip.write.appError",
-    "translation": "Unable to write into the zipFile created with the batch temporary file."
-  },
-  {
     "id": "ent.api.post.send_notifications_and_forget.push_image_only",
     "translation": " attached a file."
   },
@@ -7413,78 +7377,6 @@
   {
     "id": "ent.cluster.timeout.error",
     "translation": "Timed out waiting for cluster response"
-  },
-  {
-    "id": "ent.compliance.bad_export_type.appError",
-    "translation": "Unknown output format {{.ExportType}}"
-  },
-  {
-    "id": "ent.compliance.csv.attachment.copy.appError",
-    "translation": "Unable to copy the attachment into the zip file."
-  },
-  {
-    "id": "ent.compliance.csv.attachment.export.appError",
-    "translation": "Unable to add attachment to the CSV export."
-  },
-  {
-    "id": "ent.compliance.csv.file.creation.appError",
-    "translation": "Unable to create temporary CSV export file."
-  },
-  {
-    "id": "ent.compliance.csv.header.export.appError",
-    "translation": "Unable to add header to the CSV export."
-  },
-  {
-    "id": "ent.compliance.csv.metadata.close.appError",
-    "translation": "Unable to close the zip file"
-  },
-  {
-    "id": "ent.compliance.csv.metadata.export.appError",
-    "translation": "Unable to add metadata file to the zip file."
-  },
-  {
-    "id": "ent.compliance.csv.metadata.json.marshalling.appError",
-    "translation": "Unable to convert metadata to json."
-  },
-  {
-    "id": "ent.compliance.csv.metadata.json.zipfile.appError",
-    "translation": "Unable to create the zip file"
-  },
-  {
-    "id": "ent.compliance.csv.post.export.appError",
-    "translation": "Unable to export a post."
-  },
-  {
-    "id": "ent.compliance.csv.seek.appError",
-    "translation": "Unable to seek to start of export file."
-  },
-  {
-    "id": "ent.compliance.csv.warning.appError",
-    "translation": "Unable to create the warning file."
-  },
-  {
-    "id": "ent.compliance.csv.write_file.appError",
-    "translation": "Unable to write the csv file."
-  },
-  {
-    "id": "ent.compliance.csv.zip.creation.appError",
-    "translation": "Unable to create the zip export file."
-  },
-  {
-    "id": "ent.compliance.global_relay.attachments_removed.appError",
-    "translation": "Uploaded file was removed from Global Relay export because it was too large to send."
-  },
-  {
-    "id": "ent.compliance.global_relay.open_temporary_file.appError",
-    "translation": "Unable to open the temporary export file."
-  },
-  {
-    "id": "ent.compliance.global_relay.rewind_temporary_file.appError",
-    "translation": "Unable to re-read the Global Relay temporary export file."
-  },
-  {
-    "id": "ent.compliance.global_relay.write_file.appError",
-    "translation": "Unable to write the global relay file."
   },
   {
     "id": "ent.compliance.licence_disable.app_error",
@@ -7759,10 +7651,6 @@
     "translation": "The Elasticsearch Server URL or Username has changed. Please re-enter the Elasticsearch password to test connection."
   },
   {
-    "id": "ent.get_users_in_channel_during",
-    "translation": "Failed to get users in channel during specified time period."
-  },
-  {
     "id": "ent.id_loaded.license_disable.app_error",
     "translation": "Your license does not support ID Loaded Push Notifications."
   },
@@ -7903,76 +7791,8 @@
     "translation": "Exporting channel information for {{.NumChannels}} channels."
   },
   {
-    "id": "ent.message_export.actiance_export.get_attachment_error",
-    "translation": "Failed to get file info for a post."
-  },
-  {
     "id": "ent.message_export.calculate_channel_exports.app_error",
     "translation": "Failed to calculate channel export data."
-  },
-  {
-    "id": "ent.message_export.csv_export.get_attachment_error",
-    "translation": "Failed to get file info for a post."
-  },
-  {
-    "id": "ent.message_export.global_relay.attach_file.app_error",
-    "translation": "Unable to add attachment to the Global Relay export."
-  },
-  {
-    "id": "ent.message_export.global_relay.close_zip_file.app_error",
-    "translation": "Unable to close the zip file."
-  },
-  {
-    "id": "ent.message_export.global_relay.create_file_in_zip.app_error",
-    "translation": "Unable to create the eml file."
-  },
-  {
-    "id": "ent.message_export.global_relay.generate_email.app_error",
-    "translation": "Unable to generate eml file data."
-  },
-  {
-    "id": "ent.message_export.global_relay_export.deliver.close.app_error",
-    "translation": "Unable to deliver the email to Global Relay."
-  },
-  {
-    "id": "ent.message_export.global_relay_export.deliver.from_address.app_error",
-    "translation": "Unable to set the email From address."
-  },
-  {
-    "id": "ent.message_export.global_relay_export.deliver.msg.app_error",
-    "translation": "Unable to set the email message."
-  },
-  {
-    "id": "ent.message_export.global_relay_export.deliver.msg_data.app_error",
-    "translation": "Unable to write the email message."
-  },
-  {
-    "id": "ent.message_export.global_relay_export.deliver.parse_mail.app_error",
-    "translation": "Unable to read the email information."
-  },
-  {
-    "id": "ent.message_export.global_relay_export.deliver.to_address.app_error",
-    "translation": "Unable to set the email To address."
-  },
-  {
-    "id": "ent.message_export.global_relay_export.deliver.unable_to_connect_smtp_server.app_error",
-    "translation": "Unable to connect to the smtp server"
-  },
-  {
-    "id": "ent.message_export.global_relay_export.deliver.unable_to_get_file_info.app_error",
-    "translation": "Unable to get the information of the export temporary file."
-  },
-  {
-    "id": "ent.message_export.global_relay_export.deliver.unable_to_open_email_file.app_error",
-    "translation": "Unable to get the an email from the temporary file."
-  },
-  {
-    "id": "ent.message_export.global_relay_export.deliver.unable_to_open_zip_file_data.app_error",
-    "translation": "Unable to open the export temporary file."
-  },
-  {
-    "id": "ent.message_export.global_relay_export.get_attachment_error",
-    "translation": "Failed to get file info for a post."
   },
   {
     "id": "ent.message_export.job_data_conversion.app_error",

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -7975,6 +7975,10 @@
     "translation": "Failed to get file info for a post."
   },
   {
+    "id": "ent.message_export.job_data_conversion.app_error",
+    "translation": "Failed to convert a value from the job's data field."
+  },
+  {
     "id": "ent.message_export.run_export.app_error",
     "translation": "Failed to select message export data."
   },

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -235,6 +235,7 @@ const (
 
 	ComplianceExportDirectoryFormat                = "compliance-export-2006-01-02-15h04m"
 	ComplianceExportPath                           = "export"
+	ComplianceExportPathCLI                        = "cli"
 	ComplianceExportTypeCsv                        = "csv"
 	ComplianceExportTypeActiance                   = "actiance"
 	ComplianceExportTypeGlobalrelay                = "globalrelay"

--- a/server/public/model/message_export.go
+++ b/server/public/model/message_export.go
@@ -32,9 +32,12 @@ type MessageExport struct {
 	PostFileIds    StringArray
 }
 
+// MessageExportCursor retrieves posts in the inclusive range:
+// [LastPostUpdateAt + LastPostId, UntilUpdateAt]
 type MessageExportCursor struct {
 	LastPostUpdateAt int64
 	LastPostId       string
+	UntilUpdateAt    int64
 }
 
 // PreviewID returns the value of the post's previewed_post prop, if present, or an empty string.

--- a/server/public/model/post.go
+++ b/server/public/model/post.go
@@ -389,8 +389,11 @@ type PostCountOptions struct {
 	UsersPostsOnly     bool
 	// AllowFromCache looks up cache only when ExcludeDeleted and UsersPostsOnly are true and rest are falsy.
 	AllowFromCache bool
-	SincePostID    string
-	SinceUpdateAt  int64
+
+	// retrieves posts in the inclusive range: [SinceUpdateAt + LastPostId, UntilUpdateAt]
+	SincePostID   string
+	SinceUpdateAt int64
+	UntilUpdateAt int64
 }
 
 func (o *Post) Etag() string {

--- a/server/public/shared/i18n/i18n.go
+++ b/server/public/shared/i18n/i18n.go
@@ -78,6 +78,28 @@ func TranslationsPreInit(translationsDir string) error {
 	return initTranslationsWithDir(translationsDir)
 }
 
+// TranslationsPreInitFromBuffer loads translations from a buffer -- useful if
+// we need to initialize i18n from an embedded i18n file (e.g., from a CLI tool)
+func TranslationsPreInitFromBuffer(filename string, buf []byte) error {
+	if T != nil {
+		return nil
+	}
+
+	// Set T even if we fail to load the translations. Lots of shutdown handling code will
+	// segfault trying to handle the error, and the untranslated IDs are strictly better.
+	T = tfuncWithFallback(defaultLocale)
+	TDefault = tfuncWithFallback(defaultLocale)
+
+	locale := strings.Split(filename, ".")[0]
+	if !isSupportedLocale(locale) {
+		return fmt.Errorf("locale not supported: %s", locale)
+	}
+
+	locales[locale] = filename
+
+	return i18n.ParseTranslationFileBytes(filename, buf)
+}
+
 // InitTranslations set the defaults configured in the server and initialize
 // the T function using the server default as fallback language
 func InitTranslations(serverLocale, clientLocale string) error {

--- a/server/public/shared/i18n/i18n.go
+++ b/server/public/shared/i18n/i18n.go
@@ -78,9 +78,9 @@ func TranslationsPreInit(translationsDir string) error {
 	return initTranslationsWithDir(translationsDir)
 }
 
-// TranslationsPreInitFromBuffer loads translations from a buffer -- useful if
+// TranslationsPreInitFromFileBytes loads translations from a buffer -- useful if
 // we need to initialize i18n from an embedded i18n file (e.g., from a CLI tool)
-func TranslationsPreInitFromBuffer(filename string, buf []byte) error {
+func TranslationsPreInitFromFileBytes(filename string, buf []byte) error {
 	if T != nil {
 		return nil
 	}


### PR DESCRIPTION
#### Summary
- Add `UntilUpdateAt` for `MessageExport` and `AnalyticsPostCount` -- this is needed for bounded exports (e.g., in the CLI and possibly in the future through the system console)
- Removed quite a few non-UI facing i18n strings -- slowly removing AppError from the internal code
- Add `TranslationsPreInitFromBuffer` to allow CLI to use i18n

Linked: https://github.com/mattermost/enterprise/pull/1769
- https://github.com/mattermost/mattermost-compliance-export/pull/16

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-60570

#### Release Note
```release-note
NONE
```
