### PR TITLE
Only consider error-free scheduled posts for indicator in channel and RHS

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/scheduled_posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/scheduled_posts.ts
@@ -56,7 +56,7 @@ export function hasScheduledPostError(state: GlobalState, teamId: string) {
 }
 
 export function showChannelOrThreadScheduledPostIndicator(state: GlobalState, channelOrThreadId: string): ChannelScheduledPostIndicatorData {
-    const allChannelScheduledPosts = state.entities.scheduledPosts.byChannelOrThreadId[channelOrThreadId];
+    const allChannelScheduledPosts = state.entities.scheduledPosts.byChannelOrThreadId[channelOrThreadId] || emptyList;
     const eligibleScheduledPosts = allChannelScheduledPosts.filter((scheduledPostId: string) => {
         const scheduledPost = state.entities.scheduledPosts.byId[scheduledPostId];
         return !scheduledPost.error_code;

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/scheduled_posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/scheduled_posts.ts
@@ -56,13 +56,18 @@ export function hasScheduledPostError(state: GlobalState, teamId: string) {
 }
 
 export function showChannelOrThreadScheduledPostIndicator(state: GlobalState, channelOrThreadId: string): ChannelScheduledPostIndicatorData {
-    const channelScheduledPosts = state.entities.scheduledPosts.byChannelOrThreadId[channelOrThreadId] || emptyList;
+    const allChannelScheduledPosts = state.entities.scheduledPosts.byChannelOrThreadId[channelOrThreadId];
+    const eligibleScheduledPosts = allChannelScheduledPosts.filter((scheduledPostId: string) => {
+        const scheduledPost = state.entities.scheduledPosts.byId[scheduledPostId];
+        return !scheduledPost.error_code;
+    });
+
     const data = {
-        count: channelScheduledPosts.length,
+        count: eligibleScheduledPosts.length,
     } as ChannelScheduledPostIndicatorData;
 
     if (data.count === 1) {
-        const scheduledPostId = channelScheduledPosts[0];
+        const scheduledPostId = eligibleScheduledPosts[0];
         data.scheduledPost = state.entities.scheduledPosts.byId[scheduledPostId];
     }
 


### PR DESCRIPTION
#### Summary
Previously I was checking if there is any scheduled post for the channel and showing the post box indicator accordingly. Now I show it only if there is an error-free scheduled post. I also considered showing only for future scheduled posts but since the backend process scheduled posts up tp 24 hours old, it is possible for a scheduled posts few hours in the past to still be processed.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-60944

#### Release Note
```release-note
None
```
