### PR TITLE
Update root post update at on reply delete

### DIFF
--- a/server/channels/store/sqlstore/post_store.go
+++ b/server/channels/store/sqlstore/post_store.go
@@ -942,6 +942,9 @@ func (s *SqlPostStore) Delete(rctx request.CTX, postID string, time int64, delet
 		err = s.deleteThread(transaction, postID, time)
 	} else {
 		err = s.updateThreadAfterReplyDeletion(transaction, id.RootId, id.UserId)
+		if _, err = s.GetMasterX().Exec("UPDATE Posts SET UpdateAt = ? WHERE Id = ?", time, id.RootId); err != nil {
+			mlog.Warn("Error updating Post UpdateAt.", mlog.Err(err))
+		}
 	}
 
 	if err != nil {

--- a/server/channels/store/sqlstore/post_store.go
+++ b/server/channels/store/sqlstore/post_store.go
@@ -942,7 +942,11 @@ func (s *SqlPostStore) Delete(rctx request.CTX, postID string, time int64, delet
 		err = s.deleteThread(transaction, postID, time)
 	} else {
 		err = s.updateThreadAfterReplyDeletion(transaction, id.RootId, id.UserId)
-		if _, err = s.GetMasterX().Exec("UPDATE Posts SET UpdateAt = ? WHERE Id = ?", time, id.RootId); err != nil {
+		updatePostQuery := s.getQueryBuilder().
+			Update("Posts").
+			Set("UpdateAt", time).
+			Where(sq.Eq{"Id": id.RootId})
+		if _, err = transaction.ExecBuilder(updatePostQuery); err != nil {
 			mlog.Warn("Error updating Post UpdateAt.", mlog.Err(err))
 		}
 	}


### PR DESCRIPTION
#### Summary
When we create or update a post in a thread, the root post also gets their update at updated to the same value. But when a post is deleted, it is not.

This created an issue when checking the etag, which was looking for the latest update at, and if two are the same, the one with the "highest id". If any post "in the middle" or a last post with "lower id" is removed, the update at would be the same (the same as the last posted post) and the id too,generating the same etag and forcing this issue.

By updating the `update_at` of the post whenever we delete a post fixes the issue.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-60791

#### Release Note
```release-note
Fix issue when deleted posts on threads may not appear as deleted on certain circumstances
```
