### PR TITLE
MM-59947: Remove the remaining **model.User special casing

### DIFF
--- a/server/platform/services/cache/lru.go
+++ b/server/platform/services/cache/lru.go
@@ -206,22 +206,6 @@ func (l *LRU) get(key string, value any) error {
 		return err
 	}
 
-	// This is ugly and makes the cache package aware of the model package.
-	// But this is due to 2 things.
-	// 1. The msgp package works on methods on structs rather than functions.
-	// 2. Our cache interface passes pointers to empty pointers, and not pointers
-	// to values. This is mainly how all our model structs are passed around.
-	// It might be technically possible to use values _just_ for hot structs
-	// like these and then return a pointer while returning from the cache function,
-	// but it will make the codebase inconsistent, and has some edge-cases to take care of.
-	switch v := value.(type) {
-	case **model.User:
-		var u model.User
-		_, err := u.UnmarshalMsg(val)
-		*v = &u
-		return err
-	}
-
 	// Slow path for other structs.
 	return msgpack.Unmarshal(val, value)
 }

--- a/server/platform/services/cache/lru_test.go
+++ b/server/platform/services/cache/lru_test.go
@@ -286,16 +286,16 @@ func TestLRUMarshalUnMarshal(t *testing.T) {
 	err = l.SetWithDefaultExpiry("user", user)
 	require.NoError(t, err)
 
-	var u *model.User
+	var u model.User
 	err = l.Get("user", &u)
 	require.NoError(t, err)
 	// msgp returns an empty map instead of a nil map.
 	// This does not make an actual difference in terms of functionality.
 	u.Timezone = nil
-	require.Equal(t, user, u)
+	require.Equal(t, user, &u)
 
 	tt := make(model.UserMap)
-	tt["1"] = u
+	tt["1"] = &u
 	err = l.SetWithDefaultExpiry("mm", tt)
 	require.NoError(t, err)
 

--- a/server/platform/services/cache/redis.go
+++ b/server/platform/services/cache/redis.go
@@ -169,22 +169,6 @@ func (r *Redis) Get(key string, value any) error {
 		return err
 	}
 
-	// This is ugly and makes the cache package aware of the model package.
-	// But this is due to 2 things.
-	// 1. The msgp package works on methods on structs rather than functions.
-	// 2. Our cache interface passes pointers to empty pointers, and not pointers
-	// to values. This is mainly how all our model structs are passed around.
-	// It might be technically possible to use values _just_ for hot structs
-	// like these and then return a pointer while returning from the cache function,
-	// but it will make the codebase inconsistent, and has some edge-cases to take care of.
-	switch v := value.(type) {
-	case **model.User:
-		var u model.User
-		_, err := u.UnmarshalMsg(bytesVal)
-		*v = &u
-		return err
-	}
-
 	// Slow path for other structs.
 	return msgpack.Unmarshal(bytesVal, value)
 }
@@ -252,15 +236,6 @@ func (r *Redis) GetMulti(keys []string, values []any) []error {
 		// We use a fast path for hot structs.
 		if msgpVal, ok := values[i].(msgp.Unmarshaler); ok {
 			_, err := msgpVal.UnmarshalMsg(bytesVal)
-			errs[i] = err
-			continue
-		}
-
-		switch v := values[i].(type) {
-		case **model.User:
-			var u model.User
-			_, err := u.UnmarshalMsg(bytesVal)
-			*v = &u
 			errs[i] = err
 			continue
 		}


### PR DESCRIPTION
We remove the remaining special casing for **model.User
and add unit tests to lock in the behavior.

Additional load tests were done locally to confirm
there are no hidden code paths left out.

https://mattermost.atlassian.net/browse/MM-59947

```release-note
NONE
```
