### PR TITLE
server: Fix typo in Makefile

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -457,7 +457,7 @@ test-server: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)
 test-server: export GOTESTSUM_JUNITFILE := $(GOTESTSUM_JUNITFILE)
 test-server: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
 test-server: test-server-pre
-	$(GOBIN)/gotestsum --rerun-fails=3 --packages="$(TE_PACKAGES) $(EE_PACKAGES)" -- $(GOFLAGS)-timeout=90m
+	$(GOBIN)/gotestsum --rerun-fails=3 --packages="$(TE_PACKAGES) $(EE_PACKAGES)" -- $(GOFLAGS) -timeout=90m
 ifneq ($(IS_CI),true)
   ifneq ($(MM_NO_DOCKER),true)
     ifneq ($(TEMP_DOCKER_SERVICES),)

--- a/server/cmd/mmctl/commands/channel_test.go
+++ b/server/cmd/mmctl/commands/channel_test.go
@@ -884,8 +884,8 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 		publicChannel2 := &model.Channel{Name: "publicChannelName2"}
 		publicChannels := []*model.Channel{publicChannel1, publicChannel2}
 
-		privateChannel1 := &model.Channel{Name: "archivedChannelName1"}
-		privateChannel2 := &model.Channel{Name: "archivedChannelName2"}
+		privateChannel1 := &model.Channel{Name: "privateChannel1"}
+		privateChannel2 := &model.Channel{Name: "privateChannel2"}
 		privateChannels := []*model.Channel{privateChannel1, privateChannel2}
 		userChannels := []*model.Channel{}
 
@@ -964,8 +964,8 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 		archivedChannel1 := &model.Channel{Name: "archivedChannelName1"}
 		publicChannel1 := &model.Channel{Name: "publicChannelName1"}
 
-		privateChannel1 := &model.Channel{Name: "archivedChannelName1", Type: model.ChannelTypePrivate}
-		privateChannel2 := &model.Channel{Name: "archivedChannelName2", Type: model.ChannelTypePrivate}
+		privateChannel1 := &model.Channel{Name: "privateChannel1", Type: model.ChannelTypePrivate}
+		privateChannel2 := &model.Channel{Name: "privateChannel2", Type: model.ChannelTypePrivate}
 		userChannels := []*model.Channel{archivedChannel1, publicChannel1, privateChannel1, privateChannel2}
 
 		mockError := errors.New("user does not have permissions to list all private channels in team")


### PR DESCRIPTION
#### Summary
Fix potentially broken make test-server command if GOFLAGS is defined
Also fix channel names typos in channel_test

This PR is splited from https://github.com/mattermost/mattermost/pull/28676 to remove unrelated changes

#### Release Note
```release-note
NONE
```
