### PR TITLE
MM-60913 - Removing css override from webhook buttons

### DIFF
--- a/webapp/channels/src/sass/layout/_webhooks.scss
+++ b/webapp/channels/src/sass/layout/_webhooks.scss
@@ -371,26 +371,7 @@
             }
 
             button {
-                border: none;
                 margin-top: 8px;
-                background-color: rgba(var(--center-channel-color-rgb), 0.08);
-                color: var(--center-channel-color);
-                font-size: 13px;
-                outline: 0;
-
-                &:hover {
-                    background-color: rgba(var(--center-channel-color-rgb), 0.12);
-                    text-decoration: none;
-                }
-
-                &[disabled] {
-                    cursor: auto;
-                    opacity: 0.5;
-                }
-
-                a {
-                    color: inherit;
-                }
             }
 
             .alert {


### PR DESCRIPTION
#### Summary
MM-60913 - Removing css override from webhook buttons

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60913

#### Screenshots
No major changes can be seen right now, but if someone adds a `btn-primary` to the buttons now, it would look like this.
![CleanShot 2024-10-14 at 19 38 35@2x](https://github.com/user-attachments/assets/fe986c8b-7cd4-432c-b538-eca2b2a50ec8)


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
