### PR TITLE
Add missing parenthesis in mmctl webhook list

### DIFF
--- a/server/cmd/mmctl/commands/webhook.go
+++ b/server/cmd/mmctl/commands/webhook.go
@@ -128,7 +128,7 @@ func listWebhookCmdF(c client.Client, command *cobra.Command, args []string) err
 		if result := <-incomingResult; result.Err == nil {
 			hooks := result.Data.([]*model.IncomingWebhook)
 			for _, hook := range hooks {
-				printer.PrintT("Incoming:\t{{.DisplayName}} ({{.Id}}", hook)
+				printer.PrintT("Incoming:\t{{.DisplayName}} ({{.Id}})", hook)
 			}
 		} else {
 			printer.PrintError("Unable to list incoming webhooks for '" + team.Id + "': " + result.Err.Error())

--- a/server/cmd/mmctl/commands/webhook.go
+++ b/server/cmd/mmctl/commands/webhook.go
@@ -15,8 +15,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type StoreResult struct {
-	Data interface{}
+type StoreResult[T any] struct {
+	Data T
 	Err  error
 }
 
@@ -108,26 +108,25 @@ func listWebhookCmdF(c client.Client, command *cobra.Command, args []string) err
 			continue
 		}
 
-		incomingResult := make(chan StoreResult, 1)
+		incomingResult := make(chan StoreResult[[]*model.IncomingWebhook], 1)
 		go func() {
 			incomingHooks, err := getPages(func(page, numPerPage int, etag string) ([]*model.IncomingWebhook, *model.Response, error) {
 				return c.GetIncomingWebhooksForTeam(context.TODO(), team.Id, page, numPerPage, etag)
 			}, DefaultPageSize)
-			incomingResult <- StoreResult{Data: incomingHooks, Err: err}
+			incomingResult <- StoreResult[[]*model.IncomingWebhook]{Data: incomingHooks, Err: err}
 			close(incomingResult)
 		}()
-		outgoingResult := make(chan StoreResult, 1)
+		outgoingResult := make(chan StoreResult[[]*model.OutgoingWebhook], 1)
 		go func() {
 			outgoingHooks, err := getPages(func(page, numPerPage int, etag string) ([]*model.OutgoingWebhook, *model.Response, error) {
 				return c.GetOutgoingWebhooksForTeam(context.TODO(), team.Id, page, numPerPage, etag)
 			}, DefaultPageSize)
-			outgoingResult <- StoreResult{Data: outgoingHooks, Err: err}
+			outgoingResult <- StoreResult[[]*model.OutgoingWebhook]{Data: outgoingHooks, Err: err}
 			close(outgoingResult)
 		}()
 
 		if result := <-incomingResult; result.Err == nil {
-			hooks := result.Data.([]*model.IncomingWebhook)
-			for _, hook := range hooks {
+			for _, hook := range result.Data {
 				printer.PrintT("Incoming:\t{{.DisplayName}} ({{.Id}})", hook)
 			}
 		} else {
@@ -135,8 +134,7 @@ func listWebhookCmdF(c client.Client, command *cobra.Command, args []string) err
 		}
 
 		if result := <-outgoingResult; result.Err == nil {
-			hooks := result.Data.([]*model.OutgoingWebhook)
-			for _, hook := range hooks {
+			for _, hook := range result.Data {
 				printer.PrintT("Outgoing:\t {{.DisplayName}} ({{.Id}})", hook)
 			}
 		} else {


### PR DESCRIPTION
#### Summary
- e5f9325b58bc718b691ecb2d0225ec1eed3737dd: Add missing parenthesis in mmctl webhook list
- e30e11115b7504499d3aa02eb353fd2d17bbf411: Use generics in StoreResult, similar to the main server

#### Ticket Link
None


#### Release Note
```release-note
NONE
```
