### PR TITLE
set update_at on bookmarks return when changing sort order

### DIFF
--- a/server/channels/store/sqlstore/channel_bookmark_store.go
+++ b/server/channels/store/sqlstore/channel_bookmark_store.go
@@ -270,6 +270,7 @@ func (s *SqlChannelBookmarkStore) UpdateSortOrder(bookmarkId, channelId string, 
 	ids := []string{}
 	for index, b := range bookmarks {
 		b.SortOrder = int64(index)
+		b.UpdateAt = now
 		caseStmt = caseStmt.When(sq.Eq{"Id": b.Id}, strconv.FormatInt(int64(index), 10))
 		ids = append(ids, b.Id)
 	}


### PR DESCRIPTION
#### Summary
When sorting channel bookmarks, even though the update_at field is modified in the database entry, the WebSocket event objects were not including the modified update_at property.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60644
https://mattermost.atlassian.net/browse/MM-60499

#### Release Note
```release-note
NONE
```
