### PR TITLE
[MM-61193] Create trackFeatureEvent telemetry handler for paid features in web

### DIFF
--- a/webapp/channels/src/actions/telemetry_actions.jsx
+++ b/webapp/channels/src/actions/telemetry_actions.jsx
@@ -39,7 +39,7 @@ export function trackEvent(category, event, props) {
 }
 
 export function trackPaidFeatureEvent(featureName, event, props) {
-  Client4.trackPaidFeatureEvent(featureName, event, props);
+    Client4.trackPaidFeatureEvent(featureName, event, props);
 }
 
 export function pageVisited(category, name) {

--- a/webapp/channels/src/actions/telemetry_actions.jsx
+++ b/webapp/channels/src/actions/telemetry_actions.jsx
@@ -38,6 +38,10 @@ export function trackEvent(category, event, props) {
     }
 }
 
+export function trackPaidFeatureEvent(featureName, event, props) {
+  Client4.trackPaidFeatureEvent(featureName, event, props);
+}
+
 export function pageVisited(category, name) {
     Client4.pageVisited(category, name);
 }

--- a/webapp/channels/src/actions/telemetry_actions.jsx
+++ b/webapp/channels/src/actions/telemetry_actions.jsx
@@ -38,8 +38,8 @@ export function trackEvent(category, event, props) {
     }
 }
 
-export function trackPaidFeatureEvent(featureName, event, props) {
-    Client4.trackPaidFeatureEvent(featureName, event, props);
+export function trackFeatureEvent(featureName, event, props) {
+    Client4.trackFeatureEvent(featureName, event, props);
 }
 
 export function pageVisited(category, name) {

--- a/webapp/channels/src/components/channel_invite_modal/group_option/group_option.tsx
+++ b/webapp/channels/src/components/channel_invite_modal/group_option/group_option.tsx
@@ -10,7 +10,10 @@ import type {Group} from '@mattermost/types/groups';
 import type {GlobalState} from '@mattermost/types/store';
 import type {UserProfile} from '@mattermost/types/users';
 
+import {TrackGroupsFeature} from 'mattermost-redux/client/rudder';
 import {getUser, makeDisplayNameGetter, makeGetProfilesByIdsAndUsernames} from 'mattermost-redux/selectors/entities/users';
+
+import {trackPaidFeatureEvent} from 'actions/telemetry_actions';
 
 import type {Value} from 'components/multiselect/multiselect';
 import WithTooltip from 'components/with_tooltip';
@@ -55,6 +58,7 @@ const GroupOption = (props: Props) => {
         for (const profile of profiles) {
             addUserProfile(profile);
         }
+        trackPaidFeatureEvent(TrackGroupsFeature, 'invite_group_to_channel', {});
     }, [addUserProfile, profiles]);
 
     const onKeyDown = useCallback((e: KeyboardEvent) => {

--- a/webapp/channels/src/components/channel_invite_modal/group_option/group_option.tsx
+++ b/webapp/channels/src/components/channel_invite_modal/group_option/group_option.tsx
@@ -10,7 +10,7 @@ import type {Group} from '@mattermost/types/groups';
 import type {GlobalState} from '@mattermost/types/store';
 import type {UserProfile} from '@mattermost/types/users';
 
-import {TrackGroupsFeature} from 'mattermost-redux/client/rudder';
+import {TrackGroupsFeature, TrackInviteGroupEvent} from 'mattermost-redux/client/rudder';
 import {getUser, makeDisplayNameGetter, makeGetProfilesByIdsAndUsernames} from 'mattermost-redux/selectors/entities/users';
 
 import {trackFeatureEvent} from 'actions/telemetry_actions';
@@ -58,7 +58,7 @@ const GroupOption = (props: Props) => {
         for (const profile of profiles) {
             addUserProfile(profile);
         }
-        trackFeatureEvent(TrackGroupsFeature, 'invite_group_to_channel', {});
+        trackFeatureEvent(TrackGroupsFeature, TrackInviteGroupEvent, {});
     }, [addUserProfile, profiles]);
 
     const onKeyDown = useCallback((e: KeyboardEvent) => {

--- a/webapp/channels/src/components/channel_invite_modal/group_option/group_option.tsx
+++ b/webapp/channels/src/components/channel_invite_modal/group_option/group_option.tsx
@@ -13,7 +13,7 @@ import type {UserProfile} from '@mattermost/types/users';
 import {TrackGroupsFeature} from 'mattermost-redux/client/rudder';
 import {getUser, makeDisplayNameGetter, makeGetProfilesByIdsAndUsernames} from 'mattermost-redux/selectors/entities/users';
 
-import {trackPaidFeatureEvent} from 'actions/telemetry_actions';
+import {trackFeatureEvent} from 'actions/telemetry_actions';
 
 import type {Value} from 'components/multiselect/multiselect';
 import WithTooltip from 'components/with_tooltip';
@@ -58,7 +58,7 @@ const GroupOption = (props: Props) => {
         for (const profile of profiles) {
             addUserProfile(profile);
         }
-        trackPaidFeatureEvent(TrackGroupsFeature, 'invite_group_to_channel', {});
+        trackFeatureEvent(TrackGroupsFeature, 'invite_group_to_channel', {});
     }, [addUserProfile, profiles]);
 
     const onKeyDown = useCallback((e: KeyboardEvent) => {

--- a/webapp/channels/src/components/channel_invite_modal/group_option/group_option.tsx
+++ b/webapp/channels/src/components/channel_invite_modal/group_option/group_option.tsx
@@ -10,7 +10,7 @@ import type {Group} from '@mattermost/types/groups';
 import type {GlobalState} from '@mattermost/types/store';
 import type {UserProfile} from '@mattermost/types/users';
 
-import {TrackGroupsFeature, TrackInviteGroupEvent} from 'mattermost-redux/client/rudder';
+import {TrackGroupsFeature, TrackInviteGroupEvent} from 'mattermost-redux/constants/telemetry';
 import {getUser, makeDisplayNameGetter, makeGetProfilesByIdsAndUsernames} from 'mattermost-redux/selectors/entities/users';
 
 import {trackFeatureEvent} from 'actions/telemetry_actions';

--- a/webapp/channels/src/packages/mattermost-redux/src/client/rudder.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/client/rudder.ts
@@ -16,7 +16,7 @@ const TrackProfessionalSKU = 'professional';
 const TrackEnterpriseSKU = 'enterprise';
 
 const featureSKUs: {[feature: string]: string[]} = {
-  [TrackGroupsFeature]: [TrackProfessionalSKU, TrackEnterpriseSKU],
+    [TrackGroupsFeature]: [TrackProfessionalSKU, TrackEnterpriseSKU],
 };
 
 export class RudderTelemetryHandler implements TelemetryHandler {
@@ -45,27 +45,26 @@ export class RudderTelemetryHandler implements TelemetryHandler {
     }
 
     trackPaidFeatureEvent(userId: string, userRoles: string, featureName: string, event: string, props?: any) {
-	console.log('XXX tracking paid feature ' + featureName + ':' + event);
         // TODO: add installation id to context.traits.installationId?
         const properties = Object.assign({
-            category: "paid_feature",
+            category: 'paid_feature',
             type: event,
             user_actual_id: userId,
-	    user_actual_role: getActualRoles(userRoles),
+            user_actual_role: getActualRoles(userRoles),
         }, props);
         const options = {
             context: {
-	        extra: {
-	            feature: {
-		        name: featureName,
-         skus: getSKUs(featureName),
-		    },
-		},
+                extra: {
+                    feature: {
+                        name: featureName,
+                        skus: getSKUs(featureName),
+                    },
+                },
             },
         };
 
         rudderAnalytics.track(event, properties, options);
-  }
+    }
 
     pageVisited(userId: string, userRoles: string, category: string, name: string) {
         rudderAnalytics.page(
@@ -95,10 +94,10 @@ function getActualRoles(userRoles: string) {
 }
 
 function getSKUs(featureName: string) {
-    let skus: string[] = featureSKUs[featureName] || [];
-    if (skus.length == 0) {
-	console.log('Paid feature ' + featureName + ' has no SKUs attached: ' + skus);
-	console.log(featureSKUs);
-  }
-  return skus;
+    const skus: string[] = featureSKUs[featureName] || [];
+    if (skus.length === 0) {
+        // eslint-disable-next-line
+        console.warn('Paid feature ' + featureName + ' has no SKUs attached');
+    }
+    return skus;
 }

--- a/webapp/channels/src/packages/mattermost-redux/src/client/rudder.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/client/rudder.ts
@@ -11,12 +11,12 @@ import {isSystemAdmin} from 'mattermost-redux/utils/user_utils';
 
 export {rudderAnalytics};
 
-const TrackGroupsFeature: string = 'custom_groups';
+export const TrackGroupsFeature: string = 'custom_groups';
 const TrackProfessionalSKU = 'professional';
 const TrackEnterpriseSKU = 'enterprise';
 
 const featureSKUs: {[feature: string]: string[]} = {
-  TrackGroupsFeature: [TrackProfessionalSKU, TrackEnterpriseSKU],
+  [TrackGroupsFeature]: [TrackProfessionalSKU, TrackEnterpriseSKU],
 };
 
 export class RudderTelemetryHandler implements TelemetryHandler {
@@ -45,6 +45,7 @@ export class RudderTelemetryHandler implements TelemetryHandler {
     }
 
     trackPaidFeatureEvent(userId: string, userRoles: string, featureName: string, event: string, props?: any) {
+	console.log('XXX tracking paid feature ' + featureName + ':' + event);
         // TODO: add installation id to context.traits.installationId?
         const properties = Object.assign({
             category: "paid_feature",
@@ -63,7 +64,7 @@ export class RudderTelemetryHandler implements TelemetryHandler {
             },
         };
 
-        rudderAnalytics.track('event', properties, options);
+        rudderAnalytics.track(event, properties, options);
   }
 
     pageVisited(userId: string, userRoles: string, category: string, name: string) {
@@ -96,7 +97,8 @@ function getActualRoles(userRoles: string) {
 function getSKUs(featureName: string) {
     let skus: string[] = featureSKUs[featureName] || [];
     if (skus.length == 0) {
-	console.log("Paid feature ${featureName} has no SKUs attached");
+	console.log('Paid feature ' + featureName + ' has no SKUs attached: ' + skus);
+	console.log(featureSKUs);
   }
   return skus;
 }

--- a/webapp/channels/src/packages/mattermost-redux/src/client/rudder.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/client/rudder.ts
@@ -22,7 +22,7 @@ const featureSKUs: {[feature: string]: string[]} = {
 const TrackSKUFeature: string = 'sku_feature';
 const featureCategory: {[feature: string]: string} = {
     [TrackGroupsFeature]: TrackSKUFeature,
-}
+};
 
 export class RudderTelemetryHandler implements TelemetryHandler {
     trackEvent(userId: string, userRoles: string, category: string, event: string, props?: any) {
@@ -110,8 +110,8 @@ function getSKUs(featureName: string) {
 function getFeatureCategory(featureName: string) {
     const category: string | undefined = featureCategory[featureName];
     if (category === undefined) {
-	// eslint-disable-next-line
-	console.warn(`feature ${featureName} doesn't have a category`);
+        // eslint-disable-next-line
+        console.warn(`feature ${featureName} doesn't have a category`);
     }
     return category ?? 'miscelanea';
 }

--- a/webapp/channels/src/packages/mattermost-redux/src/client/rudder.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/client/rudder.ts
@@ -7,21 +7,14 @@ import * as rudderAnalytics from 'rudder-sdk-js';
 
 import type {TelemetryHandler} from '@mattermost/client';
 
+import {TrackMiscCategory, TrackActionCategory, TrackEnterpriseSKU, TrackProfessionalSKU, TrackInviteGroupEvent} from 'mattermost-redux/constants/telemetry';
 import {isSystemAdmin} from 'mattermost-redux/utils/user_utils';
 
 export {rudderAnalytics};
 
-export const TrackGroupsFeature: string = 'custom_groups';
-const TrackProfessionalSKU = 'professional';
-const TrackEnterpriseSKU = 'enterprise';
-
-export const TrackInviteGroupEvent: string = 'invite_group_to_channel';
-
 const eventSKUs: {[event: string]: string[]} = {
     [TrackInviteGroupEvent]: [TrackProfessionalSKU, TrackEnterpriseSKU],
 };
-
-const TrackActionCategory: string = 'action';
 
 const eventCategory: {[event: string]: string} = {
     [TrackInviteGroupEvent]: TrackActionCategory,
@@ -114,5 +107,5 @@ function getEventCategory(eventName: string) {
         // eslint-disable-next-line
         console.warn(`Event ${eventName} doesn't have a category`);
     }
-    return category ?? 'miscelanea';
+    return category ?? TrackMiscCategory;
 }

--- a/webapp/channels/src/packages/mattermost-redux/src/client/rudder.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/client/rudder.ts
@@ -15,13 +15,16 @@ export const TrackGroupsFeature: string = 'custom_groups';
 const TrackProfessionalSKU = 'professional';
 const TrackEnterpriseSKU = 'enterprise';
 
-const featureSKUs: {[feature: string]: string[]} = {
-    [TrackGroupsFeature]: [TrackProfessionalSKU, TrackEnterpriseSKU],
+export const TrackInviteGroupEvent: string = 'invite_group_to_channel';
+
+const eventSKUs: {[event: string]: string[]} = {
+    [TrackInviteGroupEvent]: [TrackProfessionalSKU, TrackEnterpriseSKU],
 };
 
-const TrackSKUFeature: string = 'sku_feature';
-const featureCategory: {[feature: string]: string} = {
-    [TrackGroupsFeature]: TrackSKUFeature,
+const TrackActionCategory: string = 'action';
+
+const eventCategory: {[event: string]: string} = {
+    [TrackInviteGroupEvent]: TrackActionCategory,
 };
 
 export class RudderTelemetryHandler implements TelemetryHandler {
@@ -50,20 +53,17 @@ export class RudderTelemetryHandler implements TelemetryHandler {
     }
 
     trackFeatureEvent(userId: string, userRoles: string, featureName: string, event: string, props?: any) {
-        // TODO: add installation id to context.traits.installationId?
         const properties = Object.assign({
-            category: getFeatureCategory(featureName),
+            category: getEventCategory(event),
             type: event,
             user_actual_id: userId,
             user_actual_role: getActualRoles(userRoles),
         }, props);
         const options = {
             context: {
-                extra: {
-                    feature: {
-                        name: featureName,
-                        skus: getSKUs(featureName),
-                    },
+                feature: {
+                    name: featureName,
+                    skus: getSKUs(event),
                 },
             },
         };
@@ -98,20 +98,21 @@ function getActualRoles(userRoles: string) {
     return userRoles && isSystemAdmin(userRoles) ? 'system_admin, system_user' : 'system_user';
 }
 
-function getSKUs(featureName: string) {
-    const skus: string[] | undefined = featureSKUs[featureName];
+function getSKUs(eventName: string) {
+    const skus: string[] | undefined = eventSKUs[eventName];
     if (skus === undefined) {
+        // Next line is to be aware if you've forgotten to add a SKU, add an empty array for Team edition
         // eslint-disable-next-line
-        console.warn(`Feature ${featureName} has no SKUs attached`);
+        console.warn(`Event ${eventName} has no SKUs attached`);
     }
     return skus ?? [];
 }
 
-function getFeatureCategory(featureName: string) {
-    const category: string | undefined = featureCategory[featureName];
+function getEventCategory(eventName: string) {
+    const category: string | undefined = eventCategory[eventName];
     if (category === undefined) {
         // eslint-disable-next-line
-        console.warn(`feature ${featureName} doesn't have a category`);
+        console.warn(`Event ${eventName} doesn't have a category`);
     }
     return category ?? 'miscelanea';
 }

--- a/webapp/channels/src/packages/mattermost-redux/src/client/rudder.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/client/rudder.ts
@@ -19,6 +19,11 @@ const featureSKUs: {[feature: string]: string[]} = {
     [TrackGroupsFeature]: [TrackProfessionalSKU, TrackEnterpriseSKU],
 };
 
+const TrackSKUFeature: string = 'sku_feature';
+const featureCategory: {[feature: string]: string} = {
+    [TrackGroupsFeature]: TrackSKUFeature,
+}
+
 export class RudderTelemetryHandler implements TelemetryHandler {
     trackEvent(userId: string, userRoles: string, category: string, event: string, props?: any) {
         const properties = Object.assign({
@@ -44,10 +49,10 @@ export class RudderTelemetryHandler implements TelemetryHandler {
         rudderAnalytics.track('event', properties, options);
     }
 
-    trackPaidFeatureEvent(userId: string, userRoles: string, featureName: string, event: string, props?: any) {
+    trackFeatureEvent(userId: string, userRoles: string, featureName: string, event: string, props?: any) {
         // TODO: add installation id to context.traits.installationId?
         const properties = Object.assign({
-            category: 'paid_feature',
+            category: getFeatureCategory(featureName),
             type: event,
             user_actual_id: userId,
             user_actual_role: getActualRoles(userRoles),
@@ -94,10 +99,19 @@ function getActualRoles(userRoles: string) {
 }
 
 function getSKUs(featureName: string) {
-    const skus: string[] = featureSKUs[featureName] || [];
-    if (skus.length === 0) {
+    const skus: string[] | undefined = featureSKUs[featureName];
+    if (skus === undefined) {
         // eslint-disable-next-line
-        console.warn('Paid feature ' + featureName + ' has no SKUs attached');
+        console.warn(`Feature ${featureName} has no SKUs attached`);
     }
-    return skus;
+    return skus ?? [];
+}
+
+function getFeatureCategory(featureName: string) {
+    const category: string | undefined = featureCategory[featureName];
+    if (category === undefined) {
+	// eslint-disable-next-line
+	console.warn(`feature ${featureName} doesn't have a category`);
+    }
+    return category ?? 'miscelanea';
 }

--- a/webapp/channels/src/packages/mattermost-redux/src/constants/index.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/constants/index.ts
@@ -12,8 +12,9 @@ import RequestStatus from './request_status';
 import Roles from './roles';
 import Stats from './stats';
 import Teams from './teams';
+import Telemetry from './telemetry';
 import Threads from './threads';
 import Users from './users';
 import WebsocketEvents from './websocket';
 
-export {General, Preferences, Posts, Files, RequestStatus, WebsocketEvents, Teams, Stats, Permissions, Emoji, Plugins, Users, Roles, Threads};
+export {General, Preferences, Posts, Files, RequestStatus, WebsocketEvents, Teams, Stats, Permissions, Emoji, Plugins, Users, Roles, Threads, Telemetry};

--- a/webapp/channels/src/packages/mattermost-redux/src/constants/telemetry.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/constants/telemetry.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// SKUs
+export const TrackProfessionalSKU = 'professional';
+export const TrackEnterpriseSKU = 'enterprise';
+
+// Features
+export const TrackGroupsFeature: string = 'custom_groups';
+
+// Events
+export const TrackInviteGroupEvent: string = 'invite_group_to_channel';
+
+// Categories
+export const TrackActionCategory: string = 'action';
+export const TrackMiscCategory: string = 'miscellaneous';
+
+export default {TrackActionCategory, TrackMiscCategory, TrackInviteGroupEvent, TrackGroupsFeature, TrackEnterpriseSKU, TrackProfessionalSKU};

--- a/webapp/platform/client/src/client4.test.ts
+++ b/webapp/platform/client/src/client4.test.ts
@@ -82,7 +82,7 @@ describe('ClientError', () => {
 describe('trackEvent', () => {
     class TestTelemetryHandler implements TelemetryHandler {
         trackEvent = jest.fn();
-	trackPaidFeatureEvent = jest.fn();
+        trackPaidFeatureEvent = jest.fn();
         pageVisited = jest.fn();
     }
 

--- a/webapp/platform/client/src/client4.test.ts
+++ b/webapp/platform/client/src/client4.test.ts
@@ -82,6 +82,7 @@ describe('ClientError', () => {
 describe('trackEvent', () => {
     class TestTelemetryHandler implements TelemetryHandler {
         trackEvent = jest.fn();
+	trackPaidFeatureEvent = jest.fn();
         pageVisited = jest.fn();
     }
 

--- a/webapp/platform/client/src/client4.test.ts
+++ b/webapp/platform/client/src/client4.test.ts
@@ -82,7 +82,7 @@ describe('ClientError', () => {
 describe('trackEvent', () => {
     class TestTelemetryHandler implements TelemetryHandler {
         trackEvent = jest.fn();
-        trackPaidFeatureEvent = jest.fn();
+        trackFeatureEvent = jest.fn();
         pageVisited = jest.fn();
     }
 

--- a/webapp/platform/client/src/client4.ts
+++ b/webapp/platform/client/src/client4.ts
@@ -4330,7 +4330,7 @@ export default class Client4 {
         if (this.telemetryHandler) {
             this.telemetryHandler.trackPaidFeatureEvent(this.userId, this.userRoles, featureName, event, props);
         }
-  }
+    }
 
     pageVisited(category: string, name: string) {
         if (this.telemetryHandler) {

--- a/webapp/platform/client/src/client4.ts
+++ b/webapp/platform/client/src/client4.ts
@@ -4326,6 +4326,11 @@ export default class Client4 {
             this.telemetryHandler.trackEvent(this.userId, this.userRoles, category, event, props);
         }
     }
+    trackPaidFeatureEvent(featureName: string, event: string, props?: any) {
+        if (this.telemetryHandler) {
+            this.telemetryHandler.trackPaidFeatureEvent(this.userId, this.userRoles, featureName, event, props);
+        }
+  }
 
     pageVisited(category: string, name: string) {
         if (this.telemetryHandler) {

--- a/webapp/platform/client/src/client4.ts
+++ b/webapp/platform/client/src/client4.ts
@@ -4326,9 +4326,9 @@ export default class Client4 {
             this.telemetryHandler.trackEvent(this.userId, this.userRoles, category, event, props);
         }
     }
-    trackPaidFeatureEvent(featureName: string, event: string, props?: any) {
+    trackFeatureEvent(featureName: string, event: string, props?: any) {
         if (this.telemetryHandler) {
-            this.telemetryHandler.trackPaidFeatureEvent(this.userId, this.userRoles, featureName, event, props);
+            this.telemetryHandler.trackFeatureEvent(this.userId, this.userRoles, featureName, event, props);
         }
     }
 

--- a/webapp/platform/client/src/telemetry.ts
+++ b/webapp/platform/client/src/telemetry.ts
@@ -3,5 +3,6 @@
 
 export interface TelemetryHandler {
     trackEvent: (userId: string, userRoles: string, category: string, event: string, props?: any) => void;
+    trackPaidFeatureEvent: (userId: string, userRoles: string, featureName: string, event: string, props?: any) => void;
     pageVisited: (userId: string, userRoles: string, category: string, name: string) => void;
 }

--- a/webapp/platform/client/src/telemetry.ts
+++ b/webapp/platform/client/src/telemetry.ts
@@ -3,6 +3,6 @@
 
 export interface TelemetryHandler {
     trackEvent: (userId: string, userRoles: string, category: string, event: string, props?: any) => void;
-    trackPaidFeatureEvent: (userId: string, userRoles: string, featureName: string, event: string, props?: any) => void;
+    trackFeatureEvent: (userId: string, userRoles: string, featureName: string, event: string, props?: any) => void;
     pageVisited: (userId: string, userRoles: string, category: string, name: string) => void;
 }


### PR DESCRIPTION
#### Summary

Small PR to have a conversation on how to do frontend telemetry for paid features, @M-ZubairAhmed will also be needing this, so we decided to create a small PR so we work on the same code instead of duplicating efforts.

Also adds a small use case to send telemetry from adding a group to a channel using the "user add modal". (there are more cases when this happens, but with just one we can already check.

Some questions:
- category: is paid_features ok for this? 
- if we want to use this for non-paid features we might need to make a bit more generic and pass the category as well.
- installationID. As far as I can tell, we don't have that info in the front. Should we get it from the backend?
- in trackEvent we send a generic 'event', in trackPaidFeature we send the actual event. Let me know if that makes sense
- I removed some fields from trackEvent, that didn't make too much sense in my mind, but I might be wrong, let me know if I should add them back.

##### Images from Rudderstack
Some info redacted (probably more than needed)

![CleanShot 2024-10-17 at 16 39 44@2x](https://github.com/user-attachments/assets/1a847b89-e70c-47c8-9e3e-b90728c3cb93)
![CleanShot 2024-10-17 at 16 40 48@2x](https://github.com/user-attachments/assets/ac2bf0f9-478e-41e3-9c1c-57c9f17ff4e9)

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-59361


#### Release Note

```release-note
NONE
```