### PR TITLE
Automated cherry pick of #28842

### DIFF
--- a/server/channels/store/sqlstore/shared_channel_store.go
+++ b/server/channels/store/sqlstore/shared_channel_store.go
@@ -108,7 +108,7 @@ func (s SqlSharedChannelStore) Get(channelId string) (*model.SharedChannel, erro
 		return nil, errors.Wrapf(err, "getsharedchannel_tosql")
 	}
 
-	if err := s.GetReplicaX().Get(&sc, squery, args...); err != nil {
+	if err := s.GetMasterX().Get(&sc, squery, args...); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("SharedChannel", channelId)
 		}


### PR DESCRIPTION
Cherry pick of #28842 on release-10.2.

/cc  @sbishel

```release-note
NONE
```