### PR TITLE
CLD-8147 Fix typo

### DIFF
--- a/.github/workflows/e2e-fulltests-ci.yml
+++ b/.github/workflows/e2e-fulltests-ci.yml
@@ -11,11 +11,11 @@ on:
         required: false
       PR_NUMBER:
         type: string
-        description: The PR number that the ref to test belongs to. Required, If testing a PR.
+        description: PR number (if applicable)
         required: false
       ROLLING_RELEASE_FROM_TAG:
         type: string
-        description: Mattermost release git tag to perform a RollingRelease from, before upgrading to the tested ref and perform the full E2E test. Optional.
+        description: Mattermost release git tag for RollingRelease tests. Optional.
         required: false
       MM_ENV:
         type: string
@@ -133,7 +133,7 @@ jobs:
               COMPUTED_REPORT_TYPE="${REPORT_TYPE}"
               ### Run sanity assertions after variable generations
               [ "$REF" = "${_COMMIT_SHA_COMPUTED}" ]             # 'inputs.ref' must be a full commit hash, and the commit must exist
-              [ "$REPORT_TYPE" != "PR" -o "$PR_NUMBER" -gt "0" ] # If report type is PR, then PR_NUMBER must be set to a number
+              [ "$REPORT_TYPE" != "PR" ] || [ "$PR_NUMBER" -gt "0" ] # If report type is PR, then PR_NUMBER must be set to a number
               ;;
             MASTER | MASTER_UNSTABLE | CLOUD | CLOUD_UNSTABLE)
               ### Populate support variables

--- a/.github/workflows/e2e-fulltests-ci.yml
+++ b/.github/workflows/e2e-fulltests-ci.yml
@@ -184,7 +184,7 @@ jobs:
             git show-ref --verify "refs/tags/${ROLLING_RELEASE_FROM_TAG}" # 'inputs.ROLLING_RELEASE_FROM_TAG' must be a tag, for release report types
           fi
           ENABLED_DOCKER_SERVICES="postgres inbucket minio openldap elasticsearch keycloak"
-          for SVC_OP in $(tr , ' '<<"$MM_SERVICE_OVERRIDES"); do
+          for SVC_OP in $(tr , ' '<<<"$MM_SERVICE_OVERRIDES"); do
             OP=$(cut -c1 <<<$SVC_OP)
             SVC=$(cut -c2- <<<$SVC_OP)
             case "$OP" in

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -26,5 +26,3 @@ To install dependencies for a workspace, simply run `npm install` from this fold
 
 - [Developer setup](https://developers.mattermost.com/contribute/developer-setup/), now included with the Mattermost server developer setup
 - [Web app developer documentation](https://developers.mattermost.com/contribute/more-info/webapp/)
-
-## Test change

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -26,3 +26,5 @@ To install dependencies for a workspace, simply run `npm install` from this fold
 
 - [Developer setup](https://developers.mattermost.com/contribute/developer-setup/), now included with the Mattermost server developer setup
 - [Web app developer documentation](https://developers.mattermost.com/contribute/more-info/webapp/)
+
+## Test change


### PR DESCRIPTION
#### Summary

Fix a typo in the workflow, for actually respecting the `MM_SERVICE_OVERRIDES` variable (herestring instead of heredoc, see [this error](https://github.com/mattermost/mattermost/actions/runs/11406709273/job/31741059739#step:3:117)).

Also improve:
- Fix error condition when running with `REPORT_TYPE=NONE`
- Less verbose parameter descriptions, since the `Run workflow` prompt became really big

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-8147

#### Release Note
```release-note
NONE
```
