### PR TITLE
Improvement on Section Notice

### DIFF
--- a/webapp/channels/src/components/section_notice/index.test.tsx
+++ b/webapp/channels/src/components/section_notice/index.test.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import {renderWithContext} from 'tests/react_testing_utils';
 
-import SectionNotice from './section_notice';
+import SectionNotice from '.';
 
 type Props = ComponentProps<typeof SectionNotice>;
 

--- a/webapp/channels/src/components/section_notice/index.tsx
+++ b/webapp/channels/src/components/section_notice/index.tsx
@@ -7,25 +7,24 @@ import {useIntl} from 'react-intl';
 
 import Markdown from 'components/markdown';
 
+import SectionNoticeButton from './section_notice_button';
+
 import './section_notice.scss';
 
-type Button = {
-    onClick: () => void;
-    text: string;
-}
 type Props = {
     title: string | React.ReactElement;
     text?: string;
-    primaryButton?: Button;
-    secondaryButton?: Button;
-    linkButton?: Button;
-    type?: 'info' | 'success' | 'danger' | 'welcome' | 'warning';
+    primaryButton?: SectionNoticeButton;
+    secondaryButton?: SectionNoticeButton;
+    linkButton?: SectionNoticeButton;
+    type?: 'info' | 'success' | 'danger' | 'welcome' | 'warning' | 'hint';
     isDismissable?: boolean;
     onDismissClick?: () => void;
 };
 
 const iconByType = {
     info: 'icon-information-outline',
+    hint: 'icon-lightbulb-outline',
     success: 'icon-check',
     danger: 'icon-alert-outline',
     warning: 'icon-alert-outline',
@@ -45,7 +44,7 @@ const SectionNotice = ({
     const intl = useIntl();
     const icon = iconByType[type];
     const showDismiss = Boolean(isDismissable && onDismissClick);
-    const buttonClass = 'btn btn-sm sectionNoticeButton';
+    const hasButtons = Boolean(primaryButton || secondaryButton || linkButton);
     return (
         <div className={classNames('sectionNoticeContainer', type)}>
             <div className={'sectionNoticeContent'}>
@@ -53,32 +52,26 @@ const SectionNotice = ({
                 <div className='sectionNoticeBody'>
                     <h4 className={classNames('sectionNoticeTitle', {welcome: type === 'welcome', noText: !text})}>{title}</h4>
                     {text && <Markdown message={text}/>}
-                    {(primaryButton || secondaryButton || linkButton) && (
+                    {hasButtons && (
                         <div className='sectionNoticeActions'>
-                            {primaryButton && (
-                                <button
-                                    onClick={primaryButton.onClick}
-                                    className={classNames(buttonClass, 'btn-primary')}
-                                >
-                                    {primaryButton.text}
-                                </button>
-                            )}
-                            {secondaryButton && (
-                                <button
-                                    onClick={secondaryButton.onClick}
-                                    className={classNames(buttonClass, 'btn-secondary')}
-                                >
-                                    {secondaryButton.text}
-                                </button>
-                            )}
-                            {linkButton && (
-                                <button
-                                    onClick={linkButton.onClick}
-                                    className={classNames(buttonClass, 'btn-link')}
-                                >
-                                    {linkButton.text}
-                                </button>
-                            )}
+                            {primaryButton &&
+                                <SectionNoticeButton
+                                    button={primaryButton}
+                                    buttonClass='btn-primary'
+                                />
+                            }
+                            {secondaryButton &&
+                                <SectionNoticeButton
+                                    button={secondaryButton}
+                                    buttonClass='btn-tertiary'
+                                />
+                            }
+                            {linkButton &&
+                                <SectionNoticeButton
+                                    button={linkButton}
+                                    buttonClass='btn-link'
+                                />
+                            }
                         </div>
                     )}
                 </div>

--- a/webapp/channels/src/components/section_notice/index.tsx
+++ b/webapp/channels/src/components/section_notice/index.tsx
@@ -8,15 +8,16 @@ import {useIntl} from 'react-intl';
 import Markdown from 'components/markdown';
 
 import SectionNoticeButton from './section_notice_button';
+import type {SectionNoticeButtonProp} from './types';
 
 import './section_notice.scss';
 
 type Props = {
     title: string | React.ReactElement;
     text?: string;
-    primaryButton?: SectionNoticeButton;
-    secondaryButton?: SectionNoticeButton;
-    linkButton?: SectionNoticeButton;
+    primaryButton?: SectionNoticeButtonProp;
+    secondaryButton?: SectionNoticeButtonProp;
+    linkButton?: SectionNoticeButtonProp;
     type?: 'info' | 'success' | 'danger' | 'welcome' | 'warning' | 'hint';
     isDismissable?: boolean;
     onDismissClick?: () => void;

--- a/webapp/channels/src/components/section_notice/section_notice.scss
+++ b/webapp/channels/src/components/section_notice/section_notice.scss
@@ -8,7 +8,7 @@
         margin: 0;
     }
 
-    &.info {
+    &.info, &.hint {
         border-color: rgba(var(--sidebar-text-active-border-rgb), 0.16);
         background: rgba(var(--sidebar-text-active-border-rgb), 0.08);
 
@@ -76,7 +76,7 @@
 .sectionNoticeIcon {
     font-size: 20px;
 
-    &.info {
+    &.info, &.hint {
         color: var(--sidebar-text-active-border);
     }
 

--- a/webapp/channels/src/components/section_notice/section_notice_button.tsx
+++ b/webapp/channels/src/components/section_notice/section_notice_button.tsx
@@ -1,0 +1,31 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import classNames from 'classnames';
+import React from 'react';
+
+type ButtonProps = {
+    button: SectionNoticeButton;
+    buttonClass: 'btn-primary' | 'btn-tertiary' | 'btn-link';
+}
+
+const SectionNoticeButton = ({
+    button,
+    buttonClass,
+}: ButtonProps) => {
+    const leading = button.leadingIcon ? (<i className={classNames('icon', button.leadingIcon)}/>) : null;
+    const trailing = button.trailingIcon ? (<i className={classNames('icon', button.trailingIcon)}/>) : null;
+    return (
+        <button
+            onClick={button.onClick}
+            className={classNames('btn btn-sm sectionNoticeButton', buttonClass)}
+        >
+            {button.loading && (<i className='icon fa fa-pulse fa-spinner'/>)}
+            {leading}
+            {button.text}
+            {trailing}
+        </button>
+    );
+};
+
+export default SectionNoticeButton;

--- a/webapp/channels/src/components/section_notice/section_notice_button.tsx
+++ b/webapp/channels/src/components/section_notice/section_notice_button.tsx
@@ -4,15 +4,17 @@
 import classNames from 'classnames';
 import React from 'react';
 
-type ButtonProps = {
-    button: SectionNoticeButton;
+import type {SectionNoticeButtonProp} from './types';
+
+type Props = {
+    button: SectionNoticeButtonProp;
     buttonClass: 'btn-primary' | 'btn-tertiary' | 'btn-link';
 }
 
 const SectionNoticeButton = ({
     button,
     buttonClass,
-}: ButtonProps) => {
+}: Props) => {
     const leading = button.leadingIcon ? (<i className={classNames('icon', button.leadingIcon)}/>) : null;
     const trailing = button.trailingIcon ? (<i className={classNames('icon', button.trailingIcon)}/>) : null;
     return (

--- a/webapp/channels/src/components/section_notice/types.d.ts
+++ b/webapp/channels/src/components/section_notice/types.d.ts
@@ -1,0 +1,10 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+type SectionNoticeButton = {
+    onClick: () => void;
+    text: string;
+    trailingIcon?: string;
+    leadingIcon?: string;
+    loading?: boolean;
+}

--- a/webapp/channels/src/components/section_notice/types.ts
+++ b/webapp/channels/src/components/section_notice/types.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-type SectionNoticeButton = {
+export type SectionNoticeButtonProp = {
     onClick: () => void;
     text: string;
     trailingIcon?: string;


### PR DESCRIPTION
#### Summary
This PR is to clean the diff from https://github.com/mattermost/mattermost/pull/28334

This PR adds the "hint" section notice, the ability to add trailing, leading and loading icons to the buttons, and some minor refactoring.

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
