### PR TITLE
[MM-60083] fix orphan DMs and GMs issue

### DIFF
--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -3599,7 +3599,75 @@ func (a *App) ConvertGroupMessageToChannel(c request.CTX, convertedByUserId stri
 	_ = a.postMessageForConvertGroupMessageToChannel(c, gmConversionRequest.ChannelID, convertedByUserId, users)
 
 	// the user conversion the GM becomes the channel admin.
-	_, appErr = a.UpdateChannelMemberSchemeRoles(c, gmConversionRequest.ChannelID, convertedByUserId, false, true, true)
+	if convertedByUserId != "" {
+		_, appErr = a.UpdateChannelMemberSchemeRoles(c, gmConversionRequest.ChannelID, convertedByUserId, false, true, true)
+		if appErr != nil {
+			return nil, appErr
+		}
+	} else {
+		// if there is no one converting the GM, then the everyone should become the channel admin.
+		// add an oprah meme here.
+		for _, user := range users {
+			_, appErr = a.UpdateChannelMemberSchemeRoles(c, gmConversionRequest.ChannelID, user.Id, false, true, true)
+			if appErr != nil {
+				return nil, appErr
+			}
+		}
+	}
+
+	return updatedChannel, nil
+}
+
+func (a *App) convertDirectMessageToChannel(c request.CTX, leavingUsername string, channelID string) (*model.Channel, *model.AppError) {
+	originalChannel, appErr := a.GetChannel(c, channelID)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	if originalChannel.Type != model.ChannelTypeDirect {
+		return nil, model.NewAppError("ConvertDirectMessageToChannel", "app.channel.direct_message_conversion.original_channel_not_dm", nil, "", http.StatusBadRequest)
+	}
+
+	if leavingUsername == "" {
+		leavingUsername = "Deleted User"
+	}
+
+	toUpdate := originalChannel.DeepCopy()
+	toUpdate.Type = model.ChannelTypePrivate
+	toUpdate.TeamId = originalChannel.TeamId
+	toUpdate.Name = originalChannel.Name
+	toUpdate.DisplayName = leavingUsername
+
+	updatedChannel, appErr := a.UpdateChannel(c, toUpdate)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	users, appErr := a.GetUsersInChannelPage(&model.UserGetOptions{
+		InChannelId: channelID,
+		Page:        0,
+		PerPage:     2,
+	}, false)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	a.Srv().Platform().InvalidateCacheForChannel(originalChannel)
+
+	_ = a.setSidebarCategoriesForConvertedGroupMessage(c, &model.GroupMessageConversionRequestBody{
+		TeamID: originalChannel.TeamId,
+	}, users)
+
+	var remainingUserId string
+	for _, user := range users {
+		if user.Username != leavingUsername {
+			remainingUserId = user.Id
+			break
+		}
+	}
+
+	// make other user channel admin
+	_, appErr = a.UpdateChannelMemberSchemeRoles(c, channelID, remainingUserId, false, true, true)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -3690,13 +3758,15 @@ func (a *App) validateForConvertGroupMessageToChannel(c request.CTX, convertedBy
 		)
 	}
 
-	channelMember, appErr := a.GetChannelMember(c, gmConversionRequest.ChannelID, convertedByUserId)
-	if appErr != nil {
-		return appErr
-	}
+	if convertedByUserId != "" {
+		channelMember, appErr := a.GetChannelMember(c, gmConversionRequest.ChannelID, convertedByUserId)
+		if appErr != nil {
+			return appErr
+		}
 
-	if channelMember == nil {
-		return model.NewAppError("ConvertGroupMessageToChannel", "app.channel.group_message_conversion.channel_member_missing", nil, "", http.StatusNotFound)
+		if channelMember == nil {
+			return model.NewAppError("ConvertGroupMessageToChannel", "app.channel.group_message_conversion.channel_member_missing", nil, "", http.StatusNotFound)
+		}
 	}
 
 	// apply dummy changes to check validity
@@ -3708,6 +3778,13 @@ func (a *App) validateForConvertGroupMessageToChannel(c request.CTX, convertedBy
 }
 
 func (a *App) postMessageForConvertGroupMessageToChannel(c request.CTX, channelID, convertedByUserId string, channelUsers []*model.User) *model.AppError {
+	if convertedByUserId == "" {
+		b, appErr := a.GetSystemBot(c)
+		if appErr != nil {
+			return appErr
+		}
+		convertedByUserId = b.UserId
+	}
 	convertedByUser, appErr := a.GetUser(convertedByUserId)
 	if appErr != nil {
 		return appErr

--- a/server/channels/app/migrations.go
+++ b/server/channels/app/migrations.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"reflect"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/mattermost/mattermost/server/public/model"
@@ -667,6 +669,68 @@ func (s *Server) doDeleteDmsPreferencesMigration(c request.CTX) error {
 	return nil
 }
 
+func (s *Server) doConvertIncompleteGMsMigration(c request.CTX) error {
+	if _, err := s.Store().System().GetByName(model.MigrationKeyConvertIncompleteGMs); err == nil {
+		return nil
+	}
+
+	afterId := strings.Repeat("0", 26)
+	for {
+		channels, err := s.Store().Channel().GetAllDirectChannelsForExportAfter(1000, afterId, true)
+		if err != nil {
+			return model.NewAppError("doConvertIncompleteGMsMigration", "app.channel.get_all_direct.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+		}
+
+		if len(channels) == 0 {
+			break
+		}
+		app := New(ServerConnector(s.ch))
+
+		for _, channel := range channels {
+			afterId = channel.Id
+			var newCh *model.Channel
+			var appErr *model.AppError
+
+			switch channel.Type {
+			case model.ChannelTypeGroup:
+				groupMembers := make([]string, len(channel.Members))
+				for i, m := range channel.Members {
+					groupMembers[i] = m.UserId
+				}
+				if channel.Name == model.GetGroupNameFromUserIds(groupMembers) {
+					// this is the case of a group channel reamined intact has no change required
+					continue
+				}
+				newCh, appErr = app.ConvertGroupMessageToChannel(c, "", &model.GroupMessageConversionRequestBody{
+					ChannelID:   channel.Id,
+					TeamID:      channel.TeamId,
+					Name:        channel.Name, // this should be a unique name hence should be okay to keep it
+					DisplayName: channel.DisplayName,
+				})
+			case model.ChannelTypeDirect:
+				if _, u2 := channel.GetBothUsersForDM(); u2 == "" || len(channel.Members) > 1 {
+					// we have two users in the channel, and member count is greater than 1, this is a valid direct channel
+					continue
+				}
+				newCh, appErr = app.convertDirectMessageToChannel(c, "", channel.Id)
+			default:
+				appErr = model.NewAppError("doConvertIncompleteGMsMigration", "app.channel.permanent_delete_user.unexpected_channel_type.app_error", nil, "", http.StatusInternalServerError)
+			}
+			if appErr != nil {
+				return appErr
+			}
+
+			// we finally soft delete the channel
+			appErr = app.DeleteChannel(c, newCh, "")
+			if appErr != nil {
+				return appErr
+			}
+		}
+	}
+
+	return nil
+}
+
 func (a *App) DoAppMigrations() {
 	a.Srv().doAppMigrations()
 }
@@ -710,6 +774,7 @@ func (s *Server) doAppMigrations() {
 		{"Delete Empty Drafts Migration", s.doDeleteEmptyDraftsMigration},
 		{"Delete Orphan Drafts Migration", s.doDeleteOrphanDraftsMigration},
 		{"Delete Invalid Dms Preferences Migration", s.doDeleteDmsPreferencesMigration},
+		{"Convert Incomplete GMs Migration", s.doConvertIncompleteGMsMigration},
 	}
 
 	c := request.EmptyContext(s.Log())

--- a/server/channels/store/opentracinglayer/opentracinglayer.go
+++ b/server/channels/store/opentracinglayer/opentracinglayer.go
@@ -1451,6 +1451,24 @@ func (s *OpenTracingLayerChannelStore) GetForPost(postID string) (*model.Channel
 	return result, err
 }
 
+func (s *OpenTracingLayerChannelStore) GetGroupAndDirectChannelsForUser(userId string, afterId string, limit int, includeArchivedChannels bool) ([]*model.Channel, error) {
+	origCtx := s.Root.Store.Context()
+	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ChannelStore.GetGroupAndDirectChannelsForUser")
+	s.Root.Store.SetContext(newCtx)
+	defer func() {
+		s.Root.Store.SetContext(origCtx)
+	}()
+
+	defer span.Finish()
+	result, err := s.ChannelStore.GetGroupAndDirectChannelsForUser(userId, afterId, limit, includeArchivedChannels)
+	if err != nil {
+		span.LogFields(spanlog.Error(err))
+		ext.Error.Set(span, true)
+	}
+
+	return result, err
+}
+
 func (s *OpenTracingLayerChannelStore) GetGuestCount(channelID string, allowFromCache bool) (int64, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ChannelStore.GetGuestCount")

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -1616,6 +1616,27 @@ func (s *RetryLayerChannelStore) GetForPost(postID string) (*model.Channel, erro
 
 }
 
+func (s *RetryLayerChannelStore) GetGroupAndDirectChannelsForUser(userId string, afterId string, limit int, includeArchivedChannels bool) ([]*model.Channel, error) {
+
+	tries := 0
+	for {
+		result, err := s.ChannelStore.GetGroupAndDirectChannelsForUser(userId, afterId, limit, includeArchivedChannels)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerChannelStore) GetGuestCount(channelID string, allowFromCache bool) (int64, error) {
 
 	tries := 0

--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -4322,3 +4322,34 @@ func (s SqlChannelStore) GetTeamForChannel(channelID string) (*model.Team, error
 	}
 	return &team, nil
 }
+
+func (s SqlChannelStore) GetGroupAndDirectChannelsForUser(userId, afterId string, limit int, includeArchivedChannels bool) ([]*model.Channel, error) {
+	query := s.getQueryBuilder().
+		Select("Channels.*").
+		From("Channels").
+		InnerJoin("ChannelMembers cm ON cm.ChannelId = " + userId).
+		Where(sq.And{
+			sq.Gt{"Channels.Id": afterId},
+			sq.Eq{"Channels.Type": []model.ChannelType{model.ChannelTypeDirect, model.ChannelTypeGroup}},
+		}).
+		OrderBy("Channels.Id").
+		Limit(uint64(limit))
+
+	if !includeArchivedChannels {
+		query = query.Where(
+			sq.Eq{"Channels.DeleteAt": int(0)},
+		)
+	}
+
+	queryString, args, err := query.ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "channel_tosql")
+	}
+
+	ch := []*model.Channel{}
+	if err2 := s.GetReplicaX().Select(&ch, queryString, args...); err2 != nil {
+		return nil, errors.Wrap(err2, "failed to find group Channels")
+	}
+
+	return ch, nil
+}

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -298,6 +298,7 @@ type ChannelStore interface {
 	RemoveAllDeactivatedMembers(ctx request.CTX, channelID string) error
 	GetChannelsBatchForIndexing(startTime int64, startChannelID string, limit int) ([]*model.Channel, error)
 	UserBelongsToChannels(userID string, channelIds []string) (bool, error)
+	GetGroupAndDirectChannelsForUser(userId, afterId string, limit int, includeArchivedChannels bool) ([]*model.Channel, error)
 
 	// UpdateMembersRole sets all of the given team members to admins and all of the other members of the team to
 	// non-admin members.

--- a/server/channels/store/storetest/mocks/ChannelStore.go
+++ b/server/channels/store/storetest/mocks/ChannelStore.go
@@ -1328,6 +1328,36 @@ func (_m *ChannelStore) GetForPost(postID string) (*model.Channel, error) {
 	return r0, r1
 }
 
+// GetGroupAndDirectChannelsForUser provides a mock function with given fields: userId, afterId, limit, includeArchivedChannels
+func (_m *ChannelStore) GetGroupAndDirectChannelsForUser(userId string, afterId string, limit int, includeArchivedChannels bool) ([]*model.Channel, error) {
+	ret := _m.Called(userId, afterId, limit, includeArchivedChannels)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGroupAndDirectChannelsForUser")
+	}
+
+	var r0 []*model.Channel
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, string, int, bool) ([]*model.Channel, error)); ok {
+		return rf(userId, afterId, limit, includeArchivedChannels)
+	}
+	if rf, ok := ret.Get(0).(func(string, string, int, bool) []*model.Channel); ok {
+		r0 = rf(userId, afterId, limit, includeArchivedChannels)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.Channel)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, string, int, bool) error); ok {
+		r1 = rf(userId, afterId, limit, includeArchivedChannels)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetGuestCount provides a mock function with given fields: channelID, allowFromCache
 func (_m *ChannelStore) GetGuestCount(channelID string, allowFromCache bool) (int64, error) {
 	ret := _m.Called(channelID, allowFromCache)

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -1349,6 +1349,22 @@ func (s *TimerLayerChannelStore) GetForPost(postID string) (*model.Channel, erro
 	return result, err
 }
 
+func (s *TimerLayerChannelStore) GetGroupAndDirectChannelsForUser(userId string, afterId string, limit int, includeArchivedChannels bool) ([]*model.Channel, error) {
+	start := time.Now()
+
+	result, err := s.ChannelStore.GetGroupAndDirectChannelsForUser(userId, afterId, limit, includeArchivedChannels)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("ChannelStore.GetGroupAndDirectChannelsForUser", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerChannelStore) GetGuestCount(channelID string, allowFromCache bool) (int64, error) {
 	start := time.Now()
 

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -4555,6 +4555,10 @@
     "translation": "Unable to delete the channel."
   },
   {
+    "id": "app.channel.direct_message_conversion.original_channel_not_dm",
+    "translation": "The channel is not a DM channel."
+  },
+  {
     "id": "app.channel.elasticsearch_channel_index.notify_admin.message",
     "translation": "Your Elasticsearch channel index schema is out of date. It is recommended to regenerate your channel index.\nClick the `Rebuild Channels Index` button in [Elasticsearch section in System Console]({{.ElasticsearchSection}}) to fix the issue.\nSee Mattermost changelog for more information."
   },
@@ -4745,6 +4749,10 @@
   {
     "id": "app.channel.permanent_delete_members_by_user.app_error",
     "translation": "Unable to remove the channel member."
+  },
+  {
+    "id": "app.channel.permanent_delete_user.unexpected_channel_type.app_error",
+    "translation": "Unable to find channel conversion strategy for the channel type."
   },
   {
     "id": "app.channel.pinned_posts.app_error",

--- a/server/public/model/migration.go
+++ b/server/public/model/migration.go
@@ -50,4 +50,5 @@ const (
 	MigrationKeyDeleteDmsPreferences                   = "delete_dms_preferences_migration"
 	MigrationKeyAddManageJobAncillaryPermissions       = "add_manage_jobs_ancillary_permissions"
 	MigrationKeyAddUploadFilePermission                = "add_upload_file_permission"
+	MigrationKeyConvertIncompleteGMs                   = "convert_incomplete_gms"
 )


### PR DESCRIPTION


#### Summary
To fix this edge case for once, we now convert DMs and GMs to private channels for the permanently deleted user. To fix previous orphan channels, we run an application migration and we do the same thing for the future cases.

I'm asking for a review to discuss logical point of view for the approach, I'll fix the issues before asking for a full review:
- CI issues
- Add unit tests
- Fix other tests
- Fix code repetition

#### Ticket Link
I'll update the ticket to reflect actual changes made here.

https://mattermost.atlassian.net/browse/MM-60083

#### Release Note

```release-note
A new application level migration added: GMs and DMs that has permanently deleted user will automatically converted to private and archived channel.

Whenever a user gets permanently deleted, the GMs and DMs that they were participating will automatically converted to private and archived channel.
```
