### PR TITLE
MM-61197, MM-60615: Move Connected Workspaces to Site Configuration

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/system_console/connected_workspaces_management_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/system_console/connected_workspaces_management_spec.ts
@@ -51,7 +51,7 @@ describe('Connected Workspaces', () => {
     it('empty state', () => {
         cy.visit('/admin_console');
 
-        cy.get("a[id='environment/secure_connections']").click();
+        cy.get("a[id='site_config/secure_connections']").click();
 
         cy.findByTestId('secureConnectionsSection').within(() => {
             cy.findByRole('heading', {name: 'Connected Workspaces'});
@@ -64,7 +64,7 @@ describe('Connected Workspaces', () => {
         const orgDisplayName = 'Testing Org Name ' + getRandomId();
 
         before(() => {
-            cy.visit('/admin_console/environment/secure_connections');
+            cy.visit('/admin_console/site_config/secure_connections');
         });
 
         it('accept - bad codes', () => {
@@ -123,7 +123,7 @@ describe('Connected Workspaces', () => {
         const orgDisplayName2 = 'new display name here ' + getRandomId();
 
         before(() => {
-            cy.visit('/admin_console/environment/secure_connections');
+            cy.visit('/admin_console/site_config/secure_connections');
         });
 
         it('create', () => {

--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -1885,44 +1885,6 @@ const AdminDefinition: AdminDefinitionType = {
                     ],
                 },
             },
-
-            secure_connection_detail: {
-                url: `environment/secure_connections/:connection_id(create|${ID_PATH_PATTERN})`,
-                isHidden: it.any(
-                    it.configIsTrue('ExperimentalSettings', 'RestrictSystemAdmin'),
-                    it.configIsFalse('ConnectedWorkspacesSettings', 'EnableSharedChannels'),
-                    it.configIsFalse('ConnectedWorkspacesSettings', 'EnableRemoteClusterService'),
-                    it.not(it.any(
-                        it.licensedForFeature('SharedChannels'),
-                        it.licensedForSku(LicenseSkus.Enterprise),
-                        it.licensedForSku(LicenseSkus.Professional),
-                    )),
-                ),
-                schema: {
-                    id: 'SecureConnectionDetail',
-                    component: SecureConnectionDetail,
-                },
-            },
-
-            secure_connections: {
-                url: 'environment/secure_connections',
-                title: defineMessage({id: 'admin.sidebar.secureConnections', defaultMessage: 'Connected Workspaces (Beta)'}),
-                searchableStrings: secureConnectionsSearchableStrings,
-                isHidden: it.any(
-                    it.configIsTrue('ExperimentalSettings', 'RestrictSystemAdmin'),
-                    it.configIsFalse('ConnectedWorkspacesSettings', 'EnableSharedChannels'),
-                    it.configIsFalse('ConnectedWorkspacesSettings', 'EnableRemoteClusterService'),
-                    it.not(it.any(
-                        it.licensedForFeature('SharedChannels'),
-                        it.licensedForSku(LicenseSkus.Enterprise),
-                        it.licensedForSku(LicenseSkus.Professional),
-                    )),
-                ),
-                schema: {
-                    id: 'SecureConnections',
-                    component: SecureConnections,
-                },
-            },
         },
     },
     site: {
@@ -3067,6 +3029,32 @@ const AdminDefinition: AdminDefinitionType = {
                 schema: {
                     id: 'IPFiltering',
                     component: IPFiltering,
+                },
+            },
+            secure_connection_detail: {
+                url: `site_config/secure_connections/:connection_id(create|${ID_PATH_PATTERN})`,
+                isHidden: it.not(it.all(
+                    it.configIsTrue('ConnectedWorkspacesSettings', 'EnableSharedChannels'),
+                    it.configIsTrue('ConnectedWorkspacesSettings', 'EnableRemoteClusterService'),
+                    it.licensedForFeature('SharedChannels'),
+                )),
+                schema: {
+                    id: 'SecureConnectionDetail',
+                    component: SecureConnectionDetail,
+                },
+            },
+            secure_connections: {
+                url: 'site_config/secure_connections',
+                title: defineMessage({id: 'admin.sidebar.secureConnections', defaultMessage: 'Connected Workspaces (Beta)'}),
+                searchableStrings: secureConnectionsSearchableStrings,
+                isHidden: it.not(it.all(
+                    it.configIsTrue('ConnectedWorkspacesSettings', 'EnableSharedChannels'),
+                    it.configIsTrue('ConnectedWorkspacesSettings', 'EnableRemoteClusterService'),
+                    it.licensedForFeature('SharedChannels'),
+                )),
+                schema: {
+                    id: 'SecureConnections',
+                    component: SecureConnections,
                 },
             },
         },

--- a/webapp/channels/src/components/admin_console/secure_connections/secure_connection_detail.tsx
+++ b/webapp/channels/src/components/admin_console/secure_connections/secure_connection_detail.tsx
@@ -108,7 +108,7 @@ export default function SecureConnectionDetail(props: Props) {
             <AdminHeader withBackButton={true}>
                 <div>
                     <BlockableLink
-                        to='/admin_console/environment/secure_connections'
+                        to='/admin_console/site_config/secure_connections'
                         className='fa fa-angle-left back'
                     />
                     <FormattedMessage
@@ -190,7 +190,7 @@ export default function SecureConnectionDetail(props: Props) {
 
             <SaveChangesPanel
                 saving={isCreating ? isPendingState(creating) : isPendingState(saving)}
-                cancelLink='/admin_console/environment/secure_connections'
+                cancelLink='/admin_console/site_config/secure_connections'
                 saveNeeded={hasChanges && isFormValid}
                 onClick={isCreating ? handleCreate : save}
                 serverError={(isErrorState(saving) || isErrorState(creating)) ? (

--- a/webapp/channels/src/components/admin_console/secure_connections/utils.ts
+++ b/webapp/channels/src/components/admin_console/secure_connections/utils.ts
@@ -235,11 +235,11 @@ export const useTeamOptions = () => {
 };
 
 export const getEditLocation = (rc: RemoteCluster): LocationDescriptor<RemoteCluster> => {
-    return {pathname: `/admin_console/environment/secure_connections/${rc.remote_id}`, state: rc};
+    return {pathname: `/admin_console/site_config/secure_connections/${rc.remote_id}`, state: rc};
 };
 
 export const getCreateLocation = (): LocationDescriptor<RemoteCluster> => {
-    return {pathname: '/admin_console/environment/secure_connections/create'};
+    return {pathname: '/admin_console/site_config/secure_connections/create'};
 };
 
 const SiteURLPendingPrefix = 'pending_';


### PR DESCRIPTION
#### Summary

Connected Workspaces in System Console:
- Remove from scope of Restrict System Admin
- Move to Site Configuration
- Consolidate license checks to `licensedForFeature('SharedChannels')`

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-61197
- https://mattermost.atlassian.net/browse/MM-60615

#### Screenshots

|  before  |  after  |
|----|----|
| ![Arc 2024-10-21 15 39 41](https://github.com/user-attachments/assets/30b0d5c5-4cea-4b84-be0f-af74286ff31b) | ![CleanShot 2024-10-21 at 16 16 19](https://github.com/user-attachments/assets/352fa053-93e7-4357-8a19-dbc563b4fb37) |

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
