### PR TITLE
MM-61126: Follow up to desktop landing page

### DIFF
--- a/e2e-tests/playwright/.eslintignore
+++ b/e2e-tests/playwright/.eslintignore
@@ -1,3 +1,4 @@
 node_modules
 playwright-report
 test-results
+results

--- a/e2e-tests/playwright/.prettierignore
+++ b/e2e-tests/playwright/.prettierignore
@@ -3,3 +3,5 @@ package.json
 package-lock.json
 playwright-report
 storage_state
+test-results
+results

--- a/e2e-tests/playwright/support/server/default_config.ts
+++ b/e2e-tests/playwright/support/server/default_config.ts
@@ -81,7 +81,7 @@ const onPremServerConfig = (): Partial<TestAdminConfig> => {
 };
 
 // Should be based only from the generated default config from ./server via "make config-reset"
-// Based on v10.0 server
+// Based on v10.2 server
 const defaultServerConfig: AdminConfig = {
     ServiceSettings: {
         SiteURL: '',
@@ -167,6 +167,7 @@ const defaultServerConfig: AdminConfig = {
         EnableAPITriggerAdminNotifications: false,
         EnableAPIUserDeletion: false,
         EnableAPIPostDeletion: false,
+        EnableDesktopLandingPage: true,
         ExperimentalEnableHardenedMode: false,
         ExperimentalStrictCSRFEnforcement: false,
         EnableEmailInvitations: false,
@@ -548,12 +549,14 @@ const defaultServerConfig: AdminConfig = {
         AppDownloadLink: 'https://mattermost.com/pl/download-apps',
         AndroidAppDownloadLink: 'https://mattermost.com/pl/android-app/',
         IosAppDownloadLink: 'https://mattermost.com/pl/ios-app/',
+        MobileExternalBrowser: false,
     },
     CacheSettings: {
         CacheType: 'lru',
         RedisAddress: '',
         RedisPassword: '',
         RedisDB: -1,
+        DisableClientCache: false,
     },
     ClusterSettings: {
         Enable: false,
@@ -731,7 +734,7 @@ const defaultServerConfig: AdminConfig = {
         ConsumePostHook: false,
         CloudAnnualRenewals: false,
         CloudDedicatedExportUI: false,
-        ChannelBookmarks: false,
+        ChannelBookmarks: true,
         WebSocketEventScope: true,
         NotificationMonitoring: true,
         ExperimentalAuditSettingsSystemConsoleUI: false,

--- a/webapp/platform/types/src/config.ts
+++ b/webapp/platform/types/src/config.ts
@@ -396,6 +396,7 @@ export type ServiceSettings = {
     RefreshPostStatsRunTime: string;
     MaximumPayloadSizeBytes: number;
     EnableAPIPostDeletion: boolean;
+    EnableDesktopLandingPage: boolean;
     MaximumURLLength: number;
 };
 
@@ -760,6 +761,7 @@ export type NativeAppSettings = {
     AppDownloadLink: string;
     AndroidAppDownloadLink: string;
     IosAppDownloadLink: string;
+    MobileExternalBrowser: boolean;
 };
 
 export type ClusterSettings = {
@@ -808,6 +810,7 @@ export type CacheSettings = {
     RedisAddress: string;
     RedisPassword: string;
     RedisDB: number;
+    DisableClientCache: boolean;
 };
 
 export type ElasticsearchSettings = {


### PR DESCRIPTION
#### Summary
- Use isolated `page` instance instead of explicitly using `chrome` so that we can ensure we're testing on the expected browser as defined in Playwright's test projects.
- Make use of page object model
- Updated server's default config and types

#### Ticket Link
Follow up to https://github.com/mattermost/mattermost/pull/28839
Jira https://mattermost.atlassian.net/browse/MM-61126

#### Screenshots
<img width="459" alt="Screenshot 2024-10-22 at 8 59 33 AM" src="https://github.com/user-attachments/assets/183b080b-4ccf-4029-ab62-3a7590bf8012">


#### Release Note
```release-note
NONE
```
