### PR TITLE
[MM-61201] Call reactAppInitialized() when app is done loading for Desktop App

### DIFF
--- a/webapp/channels/src/components/root/root.tsx
+++ b/webapp/channels/src/components/root/root.tsx
@@ -33,6 +33,7 @@ import webSocketClient from 'client/web_websocket_client';
 import {initializePlugins} from 'plugins';
 import A11yController from 'utils/a11y_controller';
 import {PageLoadContext} from 'utils/constants';
+import DesktopApp from 'utils/desktop_api';
 import {EmojiIndicesByAlias} from 'utils/emoji';
 import {TEAM_NAME_PATH_PATTERN} from 'utils/path';
 import {getSiteURL} from 'utils/url';
@@ -280,6 +281,7 @@ export default class Root extends React.PureComponent<Props, State> {
 
         if (prevState.shouldMountAppRoutes === false && this.state.shouldMountAppRoutes === true) {
             if (!doesRouteBelongToTeamControllerRoutes(this.props.location.pathname)) {
+                DesktopApp.reactAppInitialized();
                 InitialLoadingScreen.stop();
             }
         }

--- a/webapp/channels/src/components/team_controller/team_controller.tsx
+++ b/webapp/channels/src/components/team_controller/team_controller.tsx
@@ -19,6 +19,7 @@ import useTelemetryIdentitySync from 'components/common/hooks/useTelemetryIdenti
 import InitialLoadingScreen from 'components/initial_loading_screen';
 
 import Constants from 'utils/constants';
+import DesktopApp from 'utils/desktop_api';
 import {cmdOrCtrlPressed, isKeyPressed} from 'utils/keyboard';
 import {TEAM_NAME_PATH_PATTERN} from 'utils/path';
 import {isIosSafari} from 'utils/user_agent';
@@ -55,6 +56,7 @@ function TeamController(props: Props) {
 
     useEffect(() => {
         InitialLoadingScreen.stop();
+        DesktopApp.reactAppInitialized();
         async function fetchAllChannels() {
             await props.fetchAllMyTeamsChannels();
 

--- a/webapp/channels/src/utils/desktop_api.ts
+++ b/webapp/channels/src/utils/desktop_api.ts
@@ -217,8 +217,9 @@ export class DesktopAppAPI {
     updateUnreadsAndMentions = (isUnread: boolean, mentionCount: number) =>
         window.desktopAPI?.setUnreadsAndMentions && window.desktopAPI.setUnreadsAndMentions(isUnread, mentionCount);
     setSessionExpired = (expired: boolean) => window.desktopAPI?.setSessionExpired && window.desktopAPI.setSessionExpired(expired);
-    signalLogin = () => window.desktopAPI?.onLogin && window.desktopAPI?.onLogin();
-    signalLogout = () => window.desktopAPI?.onLogout && window.desktopAPI?.onLogout();
+    signalLogin = () => window.desktopAPI?.onLogin?.();
+    signalLogout = () => window.desktopAPI?.onLogout?.();
+    reactAppInitialized = () => window.desktopAPI?.reactAppInitialized?.();
 
     /*********************************************************************
      * Helper functions for legacy code


### PR DESCRIPTION
#### Summary
When I implemented the Desktop/Web App API, I neglected to get the Web App to call `reactAppInitialized()` when it was done loading to tell the Desktop App to hide the loading screen. This wasn't really noticed initially since the Desktop App will eventually just timeout and hide the loading screen anyways, but this issue made it feel like the app was taking longer to load.

This PR adds calls to `reactAppInitialized()` in the same places we hide the Web App specific loading screen, which makes the app feel a bit snappier.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61201

```release-note
Fixed an issue where the Web App would feel slower to load in the Desktop App
```
