### PR TITLE
Fix errcheck issues in server/channels/web/response_writer_wrapper_te…

### DIFF
--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -261,7 +261,6 @@ issues:
         channels/utils/license_test.go|\
         channels/web/oauth.go|\
         channels/web/oauth_test.go|\
-        channels/web/response_writer_wrapper_test.go|\
         channels/web/saml.go|\
         channels/web/static.go|\
         channels/web/web.go|\

--- a/server/channels/web/response_writer_wrapper_test.go
+++ b/server/channels/web/response_writer_wrapper_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 package web
 
 import (

--- a/server/channels/web/response_writer_wrapper_test.go
+++ b/server/channels/web/response_writer_wrapper_test.go
@@ -1,6 +1,5 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-
 package web
 
 import (
@@ -11,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type TestHandler struct {
@@ -48,7 +48,9 @@ func TestStatusCodeShouldBe200IfNotHeaderWritten(t *testing.T) {
 	resp := newWrappedWriter(httptest.NewRecorder())
 	req := httptest.NewRequest("GET", "/api/v4/test", nil)
 	handler := TestHandler{func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte{})
+		n, err := w.Write([]byte{})
+		require.NoError(t, err, "Failed to write response")
+		require.Equal(t, 0, n, "Expected to write 0 bytes")
 	}}
 	handler.ServeHTTP(resp, req)
 	assert.Equal(t, http.StatusOK, resp.StatusCode())
@@ -58,9 +60,11 @@ func TestForUnsupportedHijack(t *testing.T) {
 	resp := newWrappedWriter(httptest.NewRecorder())
 	req := httptest.NewRequest("GET", "/api/v4/test", nil)
 	handler := TestHandler{func(w http.ResponseWriter, r *http.Request) {
-		_, _, err := w.(*responseWriterWrapper).Hijack()
+		conn, rw, err := w.(*responseWriterWrapper).Hijack()
 		assert.Error(t, err)
 		assert.Equal(t, "Hijacker interface not supported by the wrapped ResponseWriter", err.Error())
+		assert.Nil(t, conn, "Expected nil connection")
+		assert.Nil(t, rw, "Expected nil buffer")
 	}}
 	handler.ServeHTTP(resp, req)
 }
@@ -69,8 +73,10 @@ func TestForSupportedHijack(t *testing.T) {
 	resp := newWrappedWriter(newResponseWithHijack(httptest.NewRecorder()))
 	req := httptest.NewRequest("GET", "/api/v4/test", nil)
 	handler := TestHandler{func(w http.ResponseWriter, r *http.Request) {
-		_, _, err := w.(*responseWriterWrapper).Hijack()
-		assert.NoError(t, err)
+		conn, rw, err := w.(*responseWriterWrapper).Hijack()
+		require.NoError(t, err, "Hijack should succeed with supporting ResponseWriter")
+		assert.Nil(t, conn, "Expected nil connection from test implementation")
+		assert.Nil(t, rw, "Expected nil buffer from test implementation")
 	}}
 	handler.ServeHTTP(resp, req)
 }
@@ -79,7 +85,9 @@ func TestForSupportedFlush(t *testing.T) {
 	resp := newWrappedWriter(httptest.NewRecorder())
 	req := httptest.NewRequest("GET", "/api/v4/test", nil)
 	handler := TestHandler{func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte{})
+		n, err := w.Write([]byte{})
+		require.NoError(t, err, "Failed to write response")
+		require.Equal(t, 0, n, "Expected to write 0 bytes")
 		w.(*responseWriterWrapper).Flush()
 	}}
 	handler.ServeHTTP(resp, req)


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/28747
JIRA: [MM-61075](https://mattermost.atlassian.net/browse/MM-61075)


#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```


[MM-61075]: https://mattermost.atlassian.net/browse/MM-61075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ