### PR TITLE
[MM-61233] Revert breaking change in `registerSlashCommandWillBePostedHook`

### DIFF
--- a/webapp/channels/src/actions/views/create_comment.test.jsx
+++ b/webapp/channels/src/actions/views/create_comment.test.jsx
@@ -243,6 +243,16 @@ describe('rhs view actions', () => {
             expect(executeCommand).not.toHaveBeenCalled();
         });
 
+        test('it should not error in case of an empty response', async () => {
+            HookActions.runSlashCommandWillBePostedHooks.mockImplementation(() => () => ({data: {}}));
+
+            const res = await store.dispatch(submitCommand(channelId, rootId, draft));
+            expect(res).toStrictEqual({});
+
+            expect(HookActions.runSlashCommandWillBePostedHooks).toHaveBeenCalled();
+            expect(executeCommand).not.toHaveBeenCalled();
+        });
+
         test('it calls submitPost on error.sendMessage', async () => {
             jest.mock('actions/channel_actions', () => ({
                 executeCommand: jest.fn((message, _args, resolve, reject) => reject({sendMessage: 'test'})),

--- a/webapp/channels/src/actions/views/create_comment.tsx
+++ b/webapp/channels/src/actions/views/create_comment.tsx
@@ -110,7 +110,10 @@ export function submitCommand(channelId: string, rootId: string, draft: PostDraf
             return {error: hookResult.error};
         } else if (!hookResult.data!.message && !hookResult.data!.args) {
             // do nothing with an empty return from a hook
-            return {error: new Error('command not submitted due to plugin hook')};
+            // this is allowed by the registerSlashCommandWillBePostedHook API in case
+            // a plugin intercepts and handles the command on the client side
+            // but doesn't require it to be sent to the server. (e.g., /call start).
+            return {};
         }
 
         message = hookResult.data!.message;


### PR DESCRIPTION
#### Summary

Reverting a breaking change in the semantics of `registerSlashCommandWillBePostedHook` that is causing errors to be surfaced in case a plugin returns an empty object, which is a valid case.

https://github.com/mattermost/mattermost/blob/99a95508d2b1a768ee71ed2e848231bbd2b2200b/webapp/channels/src/plugins/registry.ts#L802-L803

Also adding some [extra checks](https://github.com/mattermost/mattermost-plugin-calls/pull/887) in Calls e2e that could have helped us catch this way sooner.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-61233

#### Release Note

```release-note
Reverted a breaking change in registerSlashCommandWillBePostedHook that caused errors to surface in case an expected empty object is returned.
```

