### PR TITLE
Fix errcheck issues in server/channels/utils/fileutils/fileutils_test.go

### DIFF
--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -256,7 +256,6 @@ issues:
         channels/store/storetest/thread_store.go|\
         channels/store/storetest/user_store.go|\
         channels/testlib/helper.go|\
-        channels/utils/fileutils/fileutils_test.go|\
         channels/utils/license_test.go|\
         channels/web/oauth.go|\
         channels/web/oauth_test.go|\

--- a/server/channels/utils/fileutils/fileutils_test.go
+++ b/server/channels/utils/fileutils/fileutils_test.go
@@ -1,6 +1,5 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-
 package fileutils
 
 import (
@@ -27,7 +26,10 @@ func TestFindFile(t *testing.T) {
 		//         tmpDir5/
 		tmpDir1, err := os.MkdirTemp("", "")
 		require.NoError(t, err)
-		defer os.RemoveAll(tmpDir1)
+		defer func() {
+			err := os.RemoveAll(tmpDir1)
+			require.NoError(t, err)
+		}()
 
 		tmpDir2, err := os.MkdirTemp(tmpDir1, "")
 		require.NoError(t, err)
@@ -46,16 +48,16 @@ func TestFindFile(t *testing.T) {
 
 		type testCase struct {
 			Description string
-			Cwd         *string
-			FileName    string
-			Expected    string
+			Cwd        *string
+			FileName   string
+			Expected   string
 		}
 
 		testCases := []testCase{}
-
 		for _, fileName := range []string{"file1.json", "file2.xml", "other.txt"} {
 			filePath := filepath.Join(tmpDir1, fileName)
-			require.NoError(t, os.WriteFile(filePath, []byte("{}"), 0600))
+			err = os.WriteFile(filePath, []byte("{}"), 0600)
+			require.NoError(t, err)
 
 			// Relative paths end up getting symlinks fully resolved, so use this below as necessary.
 			filePathResolved, err := filepath.EvalSymlinks(filePath)
@@ -112,10 +114,15 @@ func TestFindFile(t *testing.T) {
 				if testCase.Cwd != nil {
 					prevDir, err := os.Getwd()
 					require.NoError(t, err)
-					defer os.Chdir(prevDir)
-					os.Chdir(*testCase.Cwd)
+					
+					err = os.Chdir(*testCase.Cwd)
+					require.NoError(t, err)
+					
+					defer func() {
+						err := os.Chdir(prevDir)
+						require.NoError(t, err)
+					}()
 				}
-
 				assert.Equal(t, testCase.Expected, FindFile(testCase.FileName))
 			})
 		}

--- a/server/channels/utils/fileutils/fileutils_test.go
+++ b/server/channels/utils/fileutils/fileutils_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 package fileutils
 
 import (
@@ -48,9 +49,9 @@ func TestFindFile(t *testing.T) {
 
 		type testCase struct {
 			Description string
-			Cwd        *string
-			FileName   string
-			Expected   string
+			Cwd         *string
+			FileName    string
+			Expected    string
 		}
 
 		testCases := []testCase{}

--- a/server/channels/utils/fileutils/fileutils_test.go
+++ b/server/channels/utils/fileutils/fileutils_test.go
@@ -27,7 +27,7 @@ func TestFindFile(t *testing.T) {
 		tmpDir1, err := os.MkdirTemp("", "")
 		require.NoError(t, err)
 		defer func() {
-			err := os.RemoveAll(tmpDir1)
+			err = os.RemoveAll(tmpDir1)
 			require.NoError(t, err)
 		}()
 
@@ -119,7 +119,7 @@ func TestFindFile(t *testing.T) {
 					require.NoError(t, err)
 					
 					defer func() {
-						err := os.Chdir(prevDir)
+						err = os.Chdir(prevDir)
 						require.NoError(t, err)
 					}()
 				}

--- a/server/channels/utils/fileutils/fileutils_test.go
+++ b/server/channels/utils/fileutils/fileutils_test.go
@@ -115,10 +115,10 @@ func TestFindFile(t *testing.T) {
 				if testCase.Cwd != nil {
 					prevDir, err := os.Getwd()
 					require.NoError(t, err)
-					
+
 					err = os.Chdir(*testCase.Cwd)
 					require.NoError(t, err)
-					
+
 					defer func() {
 						err = os.Chdir(prevDir)
 						require.NoError(t, err)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/28753
JIRA: [MM-61081](https://mattermost.atlassian.net/browse/MM-61081)


#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```


[MM-61081]: https://mattermost.atlassian.net/browse/MM-61081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ