### PR TITLE
MM-61127: Fix text overflow in channels input for SC

### DIFF
--- a/webapp/channels/src/components/admin_console/secure_connections/modals/shared_channels_add_modal.tsx
+++ b/webapp/channels/src/components/admin_console/secure_connections/modals/shared_channels_add_modal.tsx
@@ -234,6 +234,10 @@ const ChannelError = (props: {id: string; err: ServerError}) => {
 };
 
 const ChannelLabelWrapper = styled.span`
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+
     svg {
         vertical-align: middle;
         margin-left: 6px;
@@ -281,7 +285,12 @@ const ChannelIcon = ({channel, size = 16, ...otherProps}: {channel: Channel} & I
 
 const SecondaryTextRight = styled.span`
     color: rgba(var(--center-channel-color-rgb), 0.64);
-    margin-left: 5px;
+    padding-left: 5px;
+
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+
     &:last-child {
         margin-left: auto;
     }


### PR DESCRIPTION
#### Summary
Fix text overflow

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-61127
#### Screenshots

|  before  |  after  |
|----|----|
| ![CleanShot 2024-10-24 at 10 37 03](https://github.com/user-attachments/assets/813f5b9f-c413-45a6-be2a-6afd5fb146f6) | ![CleanShot 2024-10-24 at 14 59 00](https://github.com/user-attachments/assets/c5473666-e7c0-4a26-83d1-a4f30f06efab) |

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
