### PR TITLE
MM-44470 Fix SVG without width not displaying

### DIFF
--- a/webapp/channels/src/components/file_preview_modal/image_preview.tsx
+++ b/webapp/channels/src/components/file_preview_modal/image_preview.tsx
@@ -53,7 +53,7 @@ export default function ImagePreview({fileInfo, canDownloadFiles}: Props) {
                 data-testid='imagePreview'
                 alt={'preview url image'}
                 src={previewUrl}
-                {...conditionalSVGStyleAttribute}
+                style={conditionalSVGStyleAttribute}
             />
         </a>
     );

--- a/webapp/channels/src/components/file_preview_modal/image_preview.tsx
+++ b/webapp/channels/src/components/file_preview_modal/image_preview.tsx
@@ -33,6 +33,16 @@ export default function ImagePreview({fileInfo, canDownloadFiles}: Props) {
         return <img src={previewUrl}/>;
     }
 
+    let conditionalSVGStyleAttribute = {};
+    if (getFileType(fileInfo.extension) === FileTypes.SVG) {
+        conditionalSVGStyleAttribute = {
+            style: {
+                width: fileInfo.width,
+                height: 'auto',
+            },
+        };
+    }
+
     return (
         <a
             className='image_preview'
@@ -44,7 +54,7 @@ export default function ImagePreview({fileInfo, canDownloadFiles}: Props) {
                 data-testid='imagePreview'
                 alt={'preview url image'}
                 src={previewUrl}
-                style={getFileType(fileInfo.extension) === FileTypes.SVG ? {width: fileInfo.width, height: 'auto'} : {}}
+                {...conditionalSVGStyleAttribute}
             />
         </a>
     );

--- a/webapp/channels/src/components/file_preview_modal/image_preview.tsx
+++ b/webapp/channels/src/components/file_preview_modal/image_preview.tsx
@@ -7,9 +7,10 @@ import type {FileInfo} from '@mattermost/types/files';
 
 import {getFilePreviewUrl, getFileDownloadUrl} from 'mattermost-redux/utils/file_utils';
 
-import './image_preview.scss';
 import {FileTypes} from 'utils/constants';
 import {getFileType} from 'utils/utils';
+
+import './image_preview.scss';
 
 interface Props {
     fileInfo: FileInfo;
@@ -33,13 +34,11 @@ export default function ImagePreview({fileInfo, canDownloadFiles}: Props) {
         return <img src={previewUrl}/>;
     }
 
-    let conditionalSVGStyleAttribute = {};
+    let conditionalSVGStyleAttribute;
     if (getFileType(fileInfo.extension) === FileTypes.SVG) {
         conditionalSVGStyleAttribute = {
-            style: {
-                width: fileInfo.width,
-                height: 'auto',
-            },
+            width: fileInfo.width,
+            height: 'auto',
         };
     }
 

--- a/webapp/channels/src/components/file_preview_modal/image_preview.tsx
+++ b/webapp/channels/src/components/file_preview_modal/image_preview.tsx
@@ -8,6 +8,8 @@ import type {FileInfo} from '@mattermost/types/files';
 import {getFilePreviewUrl, getFileDownloadUrl} from 'mattermost-redux/utils/file_utils';
 
 import './image_preview.scss';
+import {FileTypes} from 'utils/constants';
+import {getFileType} from 'utils/utils';
 
 interface Props {
     fileInfo: FileInfo;
@@ -42,6 +44,7 @@ export default function ImagePreview({fileInfo, canDownloadFiles}: Props) {
                 data-testid='imagePreview'
                 alt={'preview url image'}
                 src={previewUrl}
+                style={getFileType(fileInfo.extension) === FileTypes.SVG ? {width: fileInfo.width, height: 'auto'} : {}}
             />
         </a>
     );

--- a/webapp/channels/src/components/size_aware_image.tsx
+++ b/webapp/channels/src/components/size_aware_image.tsx
@@ -218,13 +218,11 @@ export default class SizeAwareImage extends React.PureComponent<Props, State> {
 
         const fileType = getFileType(fileInfo?.extension ?? '');
 
-        let conditionalSVGStyleAttribute = {};
+        let conditionalSVGStyleAttribute;
         if (fileType === FileTypes.SVG) {
             conditionalSVGStyleAttribute = {
-                style: {
-                    width: dimensions?.width || MIN_IMAGE_SIZE,
-                    height: 'auto',
-                },
+                width: dimensions?.width || MIN_IMAGE_SIZE,
+                height: 'auto',
             };
         }
 
@@ -242,7 +240,7 @@ export default class SizeAwareImage extends React.PureComponent<Props, State> {
                 src={src}
                 onError={this.handleError}
                 onLoad={this.handleLoad}
-                {...conditionalSVGStyleAttribute}
+                style={conditionalSVGStyleAttribute}
             />
         );
 

--- a/webapp/channels/src/components/size_aware_image.tsx
+++ b/webapp/channels/src/components/size_aware_image.tsx
@@ -5,7 +5,7 @@
 
 import classNames from 'classnames';
 import React from 'react';
-import type {CSSProperties, KeyboardEvent, MouseEvent, SyntheticEvent} from 'react';
+import type {KeyboardEvent, MouseEvent, SyntheticEvent} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import {DownloadOutlineIcon, LinkVariantIcon, CheckIcon} from '@mattermost/compass-icons/components';
@@ -218,11 +218,13 @@ export default class SizeAwareImage extends React.PureComponent<Props, State> {
 
         const fileType = getFileType(fileInfo?.extension ?? '');
 
-        let conditionalSVGStyles: CSSProperties = {};
+        let conditionalSVGStyleAttribute = {};
         if (fileType === FileTypes.SVG) {
-            conditionalSVGStyles = {
-                width: dimensions?.width || MIN_IMAGE_SIZE,
-                height: 'auto',
+            conditionalSVGStyleAttribute = {
+                style: {
+                    width: dimensions?.width || MIN_IMAGE_SIZE,
+                    height: 'auto',
+                },
             };
         }
 
@@ -240,7 +242,7 @@ export default class SizeAwareImage extends React.PureComponent<Props, State> {
                 src={src}
                 onError={this.handleError}
                 onLoad={this.handleLoad}
-                style={conditionalSVGStyles}
+                {...conditionalSVGStyleAttribute}
             />
         );
 

--- a/webapp/channels/src/components/size_aware_image.tsx
+++ b/webapp/channels/src/components/size_aware_image.tsx
@@ -5,7 +5,7 @@
 
 import classNames from 'classnames';
 import React from 'react';
-import type {KeyboardEvent, MouseEvent, SyntheticEvent} from 'react';
+import type {CSSProperties, KeyboardEvent, MouseEvent, SyntheticEvent} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import {DownloadOutlineIcon, LinkVariantIcon, CheckIcon} from '@mattermost/compass-icons/components';
@@ -18,7 +18,8 @@ import {getFileMiniPreviewUrl} from 'mattermost-redux/utils/file_utils';
 import LoadingImagePreview from 'components/loading_image_preview';
 import WithTooltip from 'components/with_tooltip';
 
-import {localizeMessage, copyToClipboard} from 'utils/utils';
+import {FileTypes} from 'utils/constants';
+import {localizeMessage, copyToClipboard, getFileType} from 'utils/utils';
 
 const MIN_IMAGE_SIZE = 48;
 const MIN_IMAGE_SIZE_FOR_INTERNAL_BUTTONS = 100;
@@ -194,6 +195,7 @@ export default class SizeAwareImage extends React.PureComponent<Props, State> {
     renderImageWithContainerIfNeeded = () => {
         const {
             fileInfo,
+            dimensions,
             src,
             fileURL,
             enablePublicLink,
@@ -214,6 +216,16 @@ export default class SizeAwareImage extends React.PureComponent<Props, State> {
             ariaLabelImage += ` ${fileInfo.name}`.toLowerCase();
         }
 
+        const fileType = getFileType(fileInfo?.extension ?? '');
+
+        let conditionalSVGStyles: CSSProperties = {};
+        if (fileType === FileTypes.SVG) {
+            conditionalSVGStyles = {
+                width: dimensions?.width || MIN_IMAGE_SIZE,
+                height: 'auto',
+            };
+        }
+
         const image = (
             <img
                 {...props}
@@ -228,6 +240,7 @@ export default class SizeAwareImage extends React.PureComponent<Props, State> {
                 src={src}
                 onError={this.handleError}
                 onLoad={this.handleLoad}
+                style={conditionalSVGStyles}
             />
         );
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR fixes the issue where SVG files without width and height attributes failed to display in Chrome and Safari browsers. The fix applies conditional inline styling to SVG images in the ImagePreview and SizeAwareImage components, ensuring that images display with defined width and auto height.

- Adds conditional style attributes for SVG files, setting width from file dimensions when available and height to auto.
- Uses `getFileType` and `FileTypes.SVG` utilities to limit the style application to SVG files only.

**QA steps**

1. **Upload SVG File in Channel**:
   - Post an SVG file that does not have a set width and height in a channel.
   - Verify that the SVG displays correctly in the channel view.

2. **Open SVG File in File Preview Modal**:
   - Click on the posted SVG file to open it in the file preview modal.
   - Confirm that the SVG renders correctly.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:
-->
Fixes https://github.com/mattermost/mattermost/issues/20271
Jira https://mattermost.atlassian.net/browse/MM-44470

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

-->

|  before  |  after  |
|----|----|
| ![Screenshot from 2024-10-25 11-43-23](https://github.com/user-attachments/assets/7219d1da-f722-4136-8018-ab8071c78bd1) | ![Screenshot from 2024-10-25 11-42-39](https://github.com/user-attachments/assets/452bdc97-3e24-4a33-8710-c23e40c96dde) ![Screenshot from 2024-10-25 11-43-46](https://github.com/user-attachments/assets/1f59df15-a39c-45c5-a178-993b70cfc36b) |

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Fixed SVG image rendering issue by setting conditional width and height attributes in `ImagePreview` and `SizeAwareImage` components.

```
