### PR TITLE
Updated minimum supported Edge and Chrome versions

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10144,11 +10144,11 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "Version 126+"
+    "translation": "Version 130+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "Version 126+"
+    "translation": "Version 130+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",


### PR DESCRIPTION
Desktop app v5.10 will include Electron 33.0.2 which supports Chrome 130+.

```release-note
Updated minimum Edge and Chrome versions to 130+.
```
