### PR TITLE
[MM-60886] Fix TypeAssertionError in `api4.addChannelMember`

### DIFF
--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -1780,9 +1780,9 @@ func addChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		for _, userId := range interfaceIds {
-			uid, ok := userId.(string)
+			uid, isString := userId.(string)
 
-			if !ok || !model.IsValidId(uid) {
+			if !isString || !model.IsValidId(uid) {
 				c.SetInvalidParam("user_id in user_ids")
 				return
 			}

--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -1780,7 +1780,14 @@ func addChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		for _, userId := range interfaceIds {
-			userIds = append(userIds, userId.(string))
+			uid, ok := userId.(string)
+
+			if !ok || !model.IsValidId(uid) {
+				c.SetInvalidParam("user_id in user_ids")
+				return
+			}
+
+			userIds = append(userIds, uid)
 		}
 	} else {
 		userId, ok2 := props["user_id"].(string)


### PR DESCRIPTION
#### Summary

We assumed the elements were strings in case a list of `user_ids` is passed in. Now, we are checking for the right type and also running validation. 

Of note, we are failing the request in case a single element is not valid. I think this is better than ignoring them and proceeding with whatever is left, but we are not very consistent on this front, so I am happy to reconsider if you have concerns.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-60886

#### Release note

```release-note
NONE
```
