### PR TITLE
Remove docker hack around prometheus service

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -8,15 +8,6 @@ else
 	PLATFORM := $(shell uname)
 endif
 
-# Set an environment variable on Linux used to resolve `docker.host.internal` inconsistencies with
-# docker. This can be reworked once https://github.com/docker/for-linux/issues/264 is resolved
-# satisfactorily.
-ifeq ($(PLATFORM),Linux)
-	export IS_LINUX = -linux
-else
-	export IS_LINUX =
-endif
-
 # Detect Apple Silicon and set a flag.
 ifeq ($(shell uname)/$(shell uname -m),Darwin/arm64)
   ARM_BASED_MAC = true

--- a/server/build/docker-compose-generator/main.go
+++ b/server/build/docker-compose-generator/main.go
@@ -12,7 +12,6 @@ import (
 )
 
 type DockerCompose struct {
-	Version  string                `yaml:"version"`
 	Services map[string]*Container `yaml:"services"`
 }
 
@@ -51,7 +50,6 @@ func main() {
 	}
 
 	var dockerCompose DockerCompose
-	dockerCompose.Version = "2.4"
 	dockerCompose.Services = map[string]*Container{}
 	dockerCompose.Services["start_dependencies"] = &Container{
 		Image:     "mattermost/mattermost-wait-for-dep:latest",

--- a/server/build/docker-compose.common.yml
+++ b/server/build/docker-compose.common.yml
@@ -1,4 +1,3 @@
-version: '2.4'
 services:
   mysql:
     image: "mysql/mysql-server:8.0.32"

--- a/server/build/docker-compose.common.yml
+++ b/server/build/docker-compose.common.yml
@@ -145,10 +145,12 @@ services:
     image: "prom/prometheus:v2.46.0"
     user: root
     volumes:
-      - "./docker/prometheus${IS_LINUX}.yml:/etc/prometheus/prometheus.yml"
+      - "./docker/prometheus.yml:/etc/prometheus/prometheus.yml"
       - "/var/run/docker.sock:/var/run/docker.sock"
     networks:
       - mm-test
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   grafana:
     image: "grafana/grafana:10.4.2"
     volumes:

--- a/server/build/docker-compose.yml
+++ b/server/build/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.4'
 services:
   mysql:
     extends:

--- a/server/build/docker/prometheus-linux.yml
+++ b/server/build/docker/prometheus-linux.yml
@@ -1,8 +1,0 @@
-global:
-  scrape_interval: 5s
-  evaluation_interval: 60s
-
-scrape_configs:
-  - job_name: 'mattermost'
-    static_configs:
-      - targets: ['172.17.0.1:8067']

--- a/server/docker-compose.makefile.m1.yml
+++ b/server/docker-compose.makefile.m1.yml
@@ -1,4 +1,3 @@
-version: '2.4'
 services:
   elasticsearch:
     image: "mattermostdevelopment/mattermost-elasticsearch:8.9.0"

--- a/server/docker-compose.makefile.yml
+++ b/server/docker-compose.makefile.yml
@@ -1,4 +1,3 @@
-version: '2.4'
 services:
   mysql:
     restart: 'no'

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '2.4'
 services:
   mysql:
     container_name: mattermost-mysql


### PR DESCRIPTION
#### Summary
As the comment in the Makefile indicates, this can be reworked as the linked issue has been satisfactorily resolved
There could be issues if not using default docker bridge but it was already the case in the prometheus-linux.yml file which was using the default bridge IP

#### Release Note
```release-note
NONE
```