### PR TITLE
MM-61380 Fix link in Compliance Monitoring page banner

### DIFF
--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import type {MessageDescriptor} from 'react-intl';
 import {FormattedMessage, defineMessage, defineMessages} from 'react-intl';
+import {Link} from 'react-router-dom';
 
 import {AccountMultipleOutlineIcon, ChartBarIcon, CogOutlineIcon, CreditCardOutlineIcon, FlaskOutlineIcon, FormatListBulletedIcon, InformationOutlineIcon, PowerPlugOutlineIcon, ServerVariantIcon, ShieldOutlineIcon, SitemapIcon} from '@mattermost/compass-icons/components';
 import type {CloudState, Product} from '@mattermost/types/cloud';
@@ -3198,7 +3199,6 @@ const AdminDefinition: AdminDefinitionType = {
                         {
                             type: 'banner',
                             label: defineMessage({id: 'admin.mfa.bannerDesc', defaultMessage: '<link>Multi-factor authentication</link> is available for accounts with AD/LDAP or email login. If other login methods are used, MFA should be configured with the authentication provider.'}),
-                            label_markdown: false,
                             label_values: {
                                 link: (msg: string) => (
                                     <ExternalLink
@@ -5795,9 +5795,14 @@ const AdminDefinition: AdminDefinitionType = {
                     settings: [
                         {
                             type: 'banner',
-                            label: defineMessage({id: 'admin.compliance.newComplianceExportBanner', defaultMessage: 'This feature is replaced by a new [Compliance Export]({siteURL}/admin_console/compliance/export) feature, and will be removed in a future release. We recommend migrating to the new system.'}),
-                            label_markdown: true,
-                            label_values: {siteURL: getSiteURL()},
+                            label: defineMessage({id: 'admin.compliance.newComplianceExportBanner', defaultMessage: 'This feature is replaced by a new <link>Compliance Export</link> feature, and will be removed in a future release. We recommend migrating to the new system.'}),
+                            label_values: {
+                                link: (msg: string) => (
+                                    <Link to='/admin_console/compliance/export'>
+                                        {msg}
+                                    </Link>
+                                ),
+                            },
                             banner_type: 'info',
                             isHidden: it.not(it.licensedForFeature('Compliance')),
                         },

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -578,7 +578,7 @@
   "admin.compliance.enableDailyTitle": "Enable Daily Report:",
   "admin.compliance.enableDesc": "When true, Mattermost allows compliance reporting from the <strong>Compliance and Auditing</strong> tab. See <link>documentation</link> to learn more.",
   "admin.compliance.enableTitle": "Enable Compliance Reporting:",
-  "admin.compliance.newComplianceExportBanner": "This feature is replaced by a new [Compliance Export]({siteURL}/admin_console/compliance/export) feature, and will be removed in a future release. We recommend migrating to the new system.",
+  "admin.compliance.newComplianceExportBanner": "This feature is replaced by a new <link>Compliance Export</link> feature, and will be removed in a future release. We recommend migrating to the new system.",
   "admin.complianceExport.createJob.help": "Initiates a Compliance Export job immediately.",
   "admin.complianceExport.createJob.title": "Run Compliance Export Job Now",
   "admin.complianceExport.exportFormat.actiance": "Actiance XML",


### PR DESCRIPTION
#### Summary
It looks like the changes in https://github.com/mattermost/mattermost/pull/25406 (specifically to the `renderBanner` method of `AdminSchemaSettings`) made it so that system console banner text couldn't be both translated and contain Markdown. Since we want to get rid of Markdown in translated text anyway, I just went ahead and got rid of that. 

I left the code in `AdminSchemaSettings` that handles `label_markdown` to avoid conflicts with Daniel's system console refactoring and because plugins may still use it, but now it's not referenced by the web app any more. Ideally, we'd probably remove it from the type definitions used for the `admin_definitions.tsx` to stop web app devs from using it.

#### Ticket Link
MM-61380

#### Release Note
```release-note
Fixed link in Compliance Monitoring page banner
```
