### PR TITLE
MM-61205 - Updating RHS sidebar on smaller screens

### DIFF
--- a/webapp/channels/src/components/channel_info_rhs/header.test.tsx
+++ b/webapp/channels/src/components/channel_info_rhs/header.test.tsx
@@ -34,7 +34,7 @@ describe('channel_info_rhs/header', () => {
             />,
         );
 
-        fireEvent.click(screen.getByLabelText('Close Sidebar Icon'));
+        fireEvent.click(screen.getByLabelText('Close Sidebar Icon', {selector: 'button.sidebar--right__close'}));
 
         expect(onClose).toHaveBeenCalled();
     });

--- a/webapp/channels/src/components/channel_info_rhs/header.tsx
+++ b/webapp/channels/src/components/channel_info_rhs/header.tsx
@@ -41,6 +41,29 @@ const Header = ({channel, isArchived, isMobile, onClose}: Props) => {
                         />
                     </button>
                 )}
+
+                <WithTooltip
+                    id='closeSidebarTooltip'
+                    placement='top'
+                    title={
+                        <FormattedMessage
+                            id='rhs_header.closeSidebarTooltip'
+                            defaultMessage='Close'
+                        />
+                    }
+                >
+                    <button
+                        id='rhsCloseButton'
+                        type='button'
+                        className='sidebar--right__close-back btn btn-icon btn-sm'
+                        aria-label={formatMessage({id: 'rhs_header.closeTooltip.icon', defaultMessage: 'Close Sidebar Icon'})}
+                        onClick={onClose}
+                    >
+                        <i
+                            className='icon icon-arrow-back-ios'
+                        />
+                    </button>
+                </WithTooltip>
                 <HeaderTitle>
                     <FormattedMessage
                         id='channel_info_rhs.header.title'

--- a/webapp/channels/src/components/channel_members_rhs/header.tsx
+++ b/webapp/channels/src/components/channel_members_rhs/header.tsx
@@ -40,6 +40,29 @@ const Header = ({channel, canGoBack, onClose, goBack}: Props) => {
                     </button>
                 )}
 
+                <WithTooltip
+                    id='closeSidebarTooltip'
+                    placement='top'
+                    title={
+                        <FormattedMessage
+                            id='rhs_header.closeSidebarTooltip'
+                            defaultMessage='Close'
+                        />
+                    }
+                >
+                    <button
+                        id='rhsCloseButton'
+                        type='button'
+                        className='sidebar--right__close-back btn btn-icon btn-sm'
+                        aria-label={formatMessage({id: 'rhs_header.closeTooltip.icon', defaultMessage: 'Close Sidebar Icon'})}
+                        onClick={onClose}
+                    >
+                        <i
+                            className='icon icon-arrow-back-ios'
+                        />
+                    </button>
+                </WithTooltip>
+
                 <HeaderTitle>
                     <FormattedMessage
                         id='channel_members_rhs.header.title'

--- a/webapp/channels/src/components/post_edit_history/__snapshots__/post_edit_history.test.tsx.snap
+++ b/webapp/channels/src/components/post_edit_history/__snapshots__/post_edit_history.test.tsx.snap
@@ -19,6 +19,17 @@ exports[`components/post_edit_history should display error screen if errors are 
           <span
             class="sidebar--right__title"
           >
+            <button
+              aria-label="Close"
+              class="sidebar--right__close-back btn btn-icon btn-sm"
+              id="searchResultsCloseButton"
+              type="button"
+            >
+              <i
+                aria-label="Close Sidebar Icon"
+                class="icon icon-arrow-back-ios"
+              />
+            </button>
             Edit History
             <div
               class="sidebar--right__title__channel"
@@ -134,6 +145,17 @@ exports[`components/post_edit_history should match snapshot 1`] = `
           <span
             class="sidebar--right__title"
           >
+            <button
+              aria-label="Close"
+              class="sidebar--right__close-back btn btn-icon btn-sm"
+              id="searchResultsCloseButton"
+              type="button"
+            >
+              <i
+                aria-label="Close Sidebar Icon"
+                class="icon icon-arrow-back-ios"
+              />
+            </button>
             Edit History
             <div
               class="sidebar--right__title__channel"

--- a/webapp/channels/src/components/resizable_sidebar/resizable_rhs/index.tsx
+++ b/webapp/channels/src/components/resizable_sidebar/resizable_rhs/index.tsx
@@ -32,7 +32,6 @@ function ResizableRhs({
 
     const defaultWidth = RHS_MIN_MAX_WIDTH[rhsSize].default;
 
-    const shouldRhsOverlap = shouldRhsOverlapChannelView(rhsSize);
 
     const handleResize = (_: number, cssVarProp: string, cssVarValue: string) => {
         const rightWidthHolderRefElement = rightWidthHolderRef.current;
@@ -41,9 +40,7 @@ function ResizableRhs({
             return;
         }
 
-        if (!shouldRhsOverlap) {
-            rightWidthHolderRefElement.style.setProperty(cssVarProp, cssVarValue);
-        }
+        rightWidthHolderRefElement.style.setProperty(cssVarProp, cssVarValue);
     };
 
     const handleResizeEnd = (_: number, cssVarProp: string) => {

--- a/webapp/channels/src/components/rhs_header_post/rhs_header_post.tsx
+++ b/webapp/channels/src/components/rhs_header_post/rhs_header_post.tsx
@@ -168,6 +168,28 @@ class RhsHeaderPost extends React.PureComponent<Props> {
             <div className='sidebar--right__header'>
                 <span className='sidebar--right__title'>
                     {back}
+                    <WithTooltip
+                        id='closeSidebarTooltip'
+                        placement='top'
+                        title={
+                            <FormattedMessage
+                                id='rhs_header.closeSidebarTooltip'
+                                defaultMessage='Close'
+                            />
+                        }
+                    >
+                        <button
+                            id='rhsCloseButton'
+                            type='button'
+                            className='sidebar--right__close-back btn btn-icon btn-sm'
+                            aria-label={formatMessage({id: 'rhs_header.closeTooltip.icon', defaultMessage: 'Close Sidebar Icon'})}
+                            onClick={this.props.closeRightHandSide}
+                        >
+                            <i
+                                className='icon icon-arrow-back-ios'
+                            />
+                        </button>
+                    </WithTooltip>
                     <FormattedMessage
                         id='rhs_header.details'
                         defaultMessage='Thread'

--- a/webapp/channels/src/components/search_results_header/search_results_header.tsx
+++ b/webapp/channels/src/components/search_results_header/search_results_header.tsx
@@ -60,6 +60,29 @@ function SearchResultsHeader(props: Props) {
                         <i className='icon icon-arrow-back-ios'/>
                     </button>
                 )}
+                <WithTooltip
+                    placement='top'
+                    id='closeSidebarTooltip'
+                    title={
+                        <FormattedMessage
+                            id='rhs_header.closeSidebarTooltip'
+                            defaultMessage='Close'
+                        />
+                    }
+                >
+                    <button
+                        id='searchResultsCloseButton'
+                        type='button'
+                        className='sidebar--right__close-back btn btn-icon btn-sm'
+                        aria-label='Close'
+                        onClick={props.actions.closeRightHandSide}
+                    >
+                        <i
+                            className='icon icon-arrow-back-ios'
+                            aria-label={formatMessage({id: 'rhs_header.closeTooltip.icon', defaultMessage: 'Close Sidebar Icon'})}
+                        />
+                    </button>
+                </WithTooltip>
                 {props.children}
             </span>
             <div className='pull-right'>

--- a/webapp/channels/src/sass/base/_structure.scss
+++ b/webapp/channels/src/sass/base/_structure.scss
@@ -274,6 +274,25 @@ body.app__body #root {
         }
     }
 
+    @media screen and (max-width: 1080px) {
+        .sidebar--right--width-holder {
+            display: none;
+        }
+
+        #sidebar-right {
+            position: absolute;
+            width: 100%;
+            grid-area: center;
+            transition: width 0.25s ease-in-out;
+            border-radius: var(--radius-l);
+            max-width: none;
+
+            .sidebar--right__expand {
+                display: none;
+            }
+        }
+    }
+
     @media screen and (min-width: 768px) and (max-width: 1200px) {
         &.rhs-open-expanded {
             .sidebar--right--width-holder {
@@ -309,10 +328,8 @@ body.app__body #root {
 
 .rhs-open #channel_view.channel-view,
 .rhs-open-expanded #channel_view.channel.view {
-    @media screen and (min-width: 1200px) {
-        padding-right: 20px;
-        margin-right: -20px;
-    }
+    padding-right: 20px;
+    margin-right: -20px;
 }
 
 img {

--- a/webapp/channels/src/sass/layout/_sidebar-right.scss
+++ b/webapp/channels/src/sass/layout/_sidebar-right.scss
@@ -178,8 +178,22 @@
         color: inherit;
         white-space: nowrap;
 
+        .sidebar--right__close {
+            @media screen and (min-width: 768px) and (max-width: 1080px) {
+                display: none;
+            }
+        }
+
+        .sidebar--right__close-back {
+            margin-right: 8px;
+            display: none;
+
+            @media screen and (min-width: 768px) and (max-width: 1080px) {
+                display: flex;
+            }
+        }
+
         .btn-icon {
-            margin: 0 !important;
             font-size: 20px;
         }
 

--- a/webapp/channels/src/sass/layout/_sidebar-right.scss
+++ b/webapp/channels/src/sass/layout/_sidebar-right.scss
@@ -18,20 +18,9 @@
     &:not(.expanded):not(.resize-disabled) {
         min-width: 400px;
 
-        &.sidebar--right--width-holder {
-            @media screen and (min-width: 901px) and (max-width: 1200px) {
-                min-width: 304px;
-                max-width: 304px;
-            }
-        }
-
         @media screen and (min-width: 901px) {
             min-width: 304px;
             max-width: 400px;
-        }
-
-        @media screen and (min-width: 1201px) {
-            max-width: 464px;
         }
 
         @media screen and (min-width: 1681px) {
@@ -46,7 +35,7 @@
     .sidebar-right__table {
         display: table;
 
-        > div:not(.sidebar-collapse__container) {
+        >div:not(.sidebar-collapse__container) {
             display: table-cell;
             vertical-align: top;
 
@@ -300,6 +289,7 @@
 
 // global header style adjustments
 @media screen and (min-width: 769px) {
+
     // adjust RHS position and height
     #sidebar-right {
         // If this is changed, the interaction with the App Bar icons must be tested


### PR DESCRIPTION
#### Summary
MM-61205 - Updating RHS sidebar on smaller screens

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61205

#### Screenshots
![CleanShot 2024-10-30 at 15 11 23@2x](https://github.com/user-attachments/assets/aa1e9977-5bd7-4c14-941e-5aaf019d9a1e)


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
