### PR TITLE
Fix minio Web UI access

### DIFF
--- a/server/build/docker-compose.common.yml
+++ b/server/build/docker-compose.common.yml
@@ -61,7 +61,7 @@ services:
       retries: 3
   minio:
     image: "minio/minio:RELEASE.2024-06-22T05-26-45Z"
-    command: "server /data"
+    command: "server /data --console-address :9002"
     networks:
       - mm-test
     environment:

--- a/server/docker-compose.makefile.yml
+++ b/server/docker-compose.makefile.yml
@@ -29,6 +29,7 @@ services:
     container_name: mattermost-minio
     ports:
       - "9000:9000"
+      - "9002:9002"
     extends:
         file: build/docker-compose.common.yml
         service: minio


### PR DESCRIPTION
#### Summary

After we upgraded minio version, the WebUI (e.g., login page) is not exposed on port 9000 any longer but gets assigned a random port that is not forwarded correctly, so it's tricky to access, especially on non-Linux systems. Forcing the port to be stable (using 9002 since 9001 is already used by inbucket) and exposing it solves it.

#### Release Note

```release-note
NONE
```

