### PR TITLE
Fix typo in the word repository in api/package.json

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mattermost-api-reference",
   "version": "1.0.0",
-  "description": "This respository holds the API reference available at [https://api.mattermost.com](https://api.mattermost.com).",
+  "description": "This repository holds the API reference available at [https://api.mattermost.com](https://api.mattermost.com).",
   "main": "index.js",
   "dependencies": {
     "@redocly/cli": "^1.13.0",


### PR DESCRIPTION
#### Summary

Fix typo in the word repository in api/package.json

#### Ticket Link

N/A

#### Release Note

```release-note
NONE
```

