### PR TITLE
[MM-59363] Shared channel event telemetry

### DIFF
--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -2698,6 +2698,17 @@ func (a *App) SetActiveChannel(c request.CTX, userID string, channelID string) *
 				},
 			)
 		}
+		isShared, shErr := a.Srv().Store().SharedChannel().HasChannel(channelID)
+		if shErr == nil && isShared {
+			a.Srv().telemetryService.SendTelemetryForFeature(
+				telemetry.TrackSharedChannelsFeature,
+				"shared_channel_viewed",
+				map[string]any{
+					telemetry.TrackPropertyUser:    userID,
+					telemetry.TrackPropertyChannel: channelID,
+				},
+			)
+		}
 	}
 
 	return nil

--- a/server/channels/app/notification.go
+++ b/server/channels/app/notification.go
@@ -879,6 +879,9 @@ func (a *App) SendNotifications(c request.CTX, post *model.Post, team *model.Tea
 				)
 			}
 		}
+		if user.IsRemote() && user.RemoteId != nil && *user.RemoteId != "" {
+			a.Srv().telemetryService.SendTelemetryForFeature(telemetry.TrackSharedChannelsFeature, "mentioned_remote_user", map[string]any{telemetry.TrackPropertyUser: user.Id, telemetry.TrackPropertyPostAuthor: sender.Id})
+		}
 	}
 	for groupId := range mentions.GroupMentions {
 		a.Srv().telemetryService.SendTelemetryForFeature(telemetry.TrackGroupsFeature, "post_mentioned_custom_group", map[string]any{telemetry.TrackPropertyUser: sender.Id, telemetry.TrackPropertyGroup: groupId, "group_size": groups[groupId].MemberCount})

--- a/server/channels/app/notification.go
+++ b/server/channels/app/notification.go
@@ -879,7 +879,7 @@ func (a *App) SendNotifications(c request.CTX, post *model.Post, team *model.Tea
 				)
 			}
 		}
-		if user.IsRemote() && user.RemoteId != nil && *user.RemoteId != "" {
+		if user.IsRemote() {
 			a.Srv().telemetryService.SendTelemetryForFeature(telemetry.TrackSharedChannelsFeature, "mentioned_remote_user", map[string]any{telemetry.TrackPropertyUser: user.Id, telemetry.TrackPropertyPostAuthor: sender.Id})
 		}
 	}

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -97,6 +97,21 @@ func (a *App) CreatePostAsUser(c request.CTX, post *model.Post, currentSessionId
 		}
 	}
 
+	if channel.IsShared() {
+		// if not marked as shared we don't try to reach the store, but needs double checking as it might not be truly shared
+		isShared, shErr := a.Srv().Store().SharedChannel().HasChannel(channel.Id)
+		if shErr == nil && isShared {
+			a.Srv().telemetryService.SendTelemetryForFeature(
+				telemetry.TrackSharedChannelsFeature,
+				"shared_channel_posted",
+				map[string]any{
+					telemetry.TrackPropertyUser:    post.UserId,
+					telemetry.TrackPropertyChannel: channel.Id,
+				},
+			)
+		}
+	}
+
 	return rp, nil
 }
 

--- a/server/platform/services/telemetry/telemetry.go
+++ b/server/platform/services/telemetry/telemetry.go
@@ -103,9 +103,10 @@ const (
 type TrackFeature string
 
 const (
-	TrackGuestFeature    TrackFeature = "guest_accounts"
-	TrackGroupsFeature   TrackFeature = "custom_groups"
-	TrackReadOnlyFeature TrackFeature = "read_only_channels"
+	TrackGuestFeature          TrackFeature = "guest_accounts"
+	TrackGroupsFeature         TrackFeature = "custom_groups"
+	TrackReadOnlyFeature       TrackFeature = "read_only_channels"
+	TrackSharedChannelsFeature TrackFeature = "shared_channels"
 )
 
 const (
@@ -147,9 +148,10 @@ type EventFeature struct {
 }
 
 var featureSKUS = map[TrackFeature][]TrackSKU{
-	TrackGuestFeature:    {TrackProfessionalSKU, TrackEnterpriseSKU},
-	TrackGroupsFeature:   {TrackProfessionalSKU, TrackEnterpriseSKU},
-	TrackReadOnlyFeature: {TrackProfessionalSKU, TrackEnterpriseSKU},
+	TrackGuestFeature:          {TrackProfessionalSKU, TrackEnterpriseSKU},
+	TrackGroupsFeature:         {TrackProfessionalSKU, TrackEnterpriseSKU},
+	TrackReadOnlyFeature:       {TrackProfessionalSKU, TrackEnterpriseSKU},
+	TrackSharedChannelsFeature: {TrackProfessionalSKU, TrackEnterpriseSKU},
 }
 
 func New(srv ServerIface, dbStore store.Store, searchEngine *searchengine.Broker, log *mlog.Logger, verbose bool) (*TelemetryService, error) {


### PR DESCRIPTION
#### Summary
Added events for:
- view shared channel
- mention a remote user
- post a message in a shared channel

Not added:
- DM a remote user as that has been removed from scope of Shared channels

#### Ticket Link
[MM-59363](https://mattermost.atlassian.net/browse/MM-59363)
#### Screenshots


#### Release Note
```release-note
NONE
```

[MM-59363]: https://mattermost.atlassian.net/browse/MM-59363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ