### PR TITLE
[MM-59396] Update API docs to show common parameters, added per_page docs

### DIFF
--- a/api/v4/source/introduction.yaml
+++ b/api/v4/source/introduction.yaml
@@ -475,6 +475,13 @@ tags:
 
 
       To see how these actions work, please refer to either the [Golang WebSocket driver](https://github.com/mattermost/mattermost/blob/master/server/public/model/websocket_client.go) or our [JavaScript WebSocket driver](https://github.com/mattermost/mattermost/blob/master/webapp/platform/client/src/websocket.ts).
+  - name: common parameters
+    description: >
+      - `per_page`: For paged APIs, the number of items to return per page.
+
+        The maximum number of items returned per request is capped at 200. If `per_page` exceeds 200, the list will be silently truncated to 200 items.
+
+        If a paged API requires a `per_page` parameter and it is not provided, the default value is 60.
   - name: users
     description: >
       Endpoints for creating, getting and interacting with users.
@@ -564,6 +571,7 @@ x-tagGroups:
       - errors
       - rate limiting
       - WebSocket
+      - common parameters
   - name: Endpoints
     tags:
       - users


### PR DESCRIPTION
#### Summary
I've added a new section to the API docs to show our common parameters in more detail, and I added `per_page` at the request of a community member.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59396
Closes https://github.com/mattermost/mattermost/issues/27574

```release-note
NONE
```
