### PR TITLE
Fix mmctl build for FreeBSD

### DIFF
--- a/server/cmd/mmctl/commands/utils_unix.go
+++ b/server/cmd/mmctl/commands/utils_unix.go
@@ -1,8 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux || darwin || freebsd
+// +build linux darwin freebsd
 
 package commands
 


### PR DESCRIPTION
#### Summary
This fixes mmctl build for FreeBSD.

Previous build error was:
```
...
github.com/pelletier/go-toml/v2
github.com/spf13/viper/internal/encoding/toml
github.com/spf13/viper
github.com/mattermost/mattermost/server/v8/cmd/mmctl/commands
# github.com/mattermost/mattermost/server/v8/cmd/mmctl/commands
cmd/mmctl/commands/channel.go:617:13: undefined: getConfirmation
cmd/mmctl/commands/config.go:466:13: undefined: getConfirmation
cmd/mmctl/commands/init.go:241:12: undefined: checkValidSocket
cmd/mmctl/commands/integrity.go:81:13: undefined: getConfirmation
cmd/mmctl/commands/saml.go:58:13: undefined: getConfirmation
cmd/mmctl/commands/team.go:183:13: undefined: getConfirmation
cmd/mmctl/commands/team.go:304:13: undefined: getConfirmation
cmd/mmctl/commands/user.go:670:13: undefined: getConfirmation
cmd/mmctl/commands/user.go:729:13: undefined: getConfirmation
cmd/mmctl/commands/user.go:759:13: undefined: getConfirmation
cmd/mmctl/commands/user.go:759:13: too many errors
```

Tested on FreeBSD 14.1 with go 1.22.


#### Release Note

```release-note
NONE
```