### PR TITLE
MM-60123 - store most recently custom time

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/send_button/scheduled_post_custom_time_modal/scheduled_post_custom_time_modal.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/send_button/scheduled_post_custom_time_modal/scheduled_post_custom_time_modal.tsx
@@ -52,7 +52,7 @@ export default function ScheduledPostCustomTimeModal({channelId, onExited, onCon
                     user_id: currentUserId,
                     category: scheduledPosts.SCHEDULED_POSTS,
                     name: scheduledPosts.RECENTLY_USED_CUSTOM_TIME,
-                    value: JSON.stringify({used_at: now.valueOf(), custom_time: selectedTime}),
+                    value: JSON.stringify({update_at: moment().tz(userTimezone).valueOf(), timestamp: selectedTime}),
                 }]
             )
         );

--- a/webapp/channels/src/components/advanced_text_editor/send_button/scheduled_post_custom_time_modal/scheduled_post_custom_time_modal.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/send_button/scheduled_post_custom_time_modal/scheduled_post_custom_time_modal.tsx
@@ -5,14 +5,17 @@ import moment from 'moment';
 import type {Moment} from 'moment-timezone';
 import React, {useCallback, useMemo, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
-import {useSelector} from 'react-redux';
+import {useDispatch, useSelector} from 'react-redux';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import {generateCurrentTimezoneLabel, getCurrentTimezone} from 'mattermost-redux/selectors/entities/timezone';
+import {savePreferences} from 'mattermost-redux/actions/preferences';
 
 import {
     DMUserTimezone,
 } from 'components/advanced_text_editor/send_button/scheduled_post_custom_time_modal/dm_user_timezone';
 import DateTimePickerModal from 'components/date_time_picker_modal/date_time_picker_modal';
+import {Preferences, scheduledPosts} from 'utils/constants';
 
 type Props = {
     channelId: string;
@@ -25,19 +28,35 @@ export default function ScheduledPostCustomTimeModal({channelId, onExited, onCon
     const {formatMessage} = useIntl();
     const [errorMessage, setErrorMessage] = useState<string>();
     const userTimezone = useSelector(getCurrentTimezone);
+    const now = moment().tz(userTimezone);
+    const currentUserId = useSelector(getCurrentUserId);
+    const dispatch = useDispatch();
     const [selectedDateTime, setSelectedDateTime] = useState<Moment>(() => {
         if (initialTime) {
             return initialTime;
         }
 
-        const now = moment().tz(userTimezone);
         return now.add(1, 'days').set({hour: 9, minute: 0, second: 0, millisecond: 0});
     });
 
     const userTimezoneLabel = useMemo(() => generateCurrentTimezoneLabel(userTimezone), [userTimezone]);
 
     const handleOnConfirm = useCallback(async (dateTime: Moment) => {
-        const response = await onConfirm(dateTime.valueOf());
+        const selectedTime = dateTime.valueOf();
+        const response = await onConfirm(selectedTime);
+
+        dispatch(
+            savePreferences(
+                currentUserId, 
+                [{
+                    user_id: currentUserId,
+                    category: scheduledPosts.SCHEDULED_POSTS,
+                    name: scheduledPosts.RECENTLY_USED_CUSTOM_TIME,
+                    value: JSON.stringify({used_at: now.valueOf(), custom_time: selectedTime}),
+                }]
+            )
+        );
+
         if (response.error) {
             setErrorMessage(response.error);
         } else {

--- a/webapp/channels/src/components/advanced_text_editor/send_button/scheduled_post_custom_time_modal/scheduled_post_custom_time_modal.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/send_button/scheduled_post_custom_time_modal/scheduled_post_custom_time_modal.tsx
@@ -6,16 +6,17 @@ import type {Moment} from 'moment-timezone';
 import React, {useCallback, useMemo, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
-import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
-import {generateCurrentTimezoneLabel, getCurrentTimezone} from 'mattermost-redux/selectors/entities/timezone';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
+import {generateCurrentTimezoneLabel, getCurrentTimezone} from 'mattermost-redux/selectors/entities/timezone';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import {
     DMUserTimezone,
 } from 'components/advanced_text_editor/send_button/scheduled_post_custom_time_modal/dm_user_timezone';
 import DateTimePickerModal from 'components/date_time_picker_modal/date_time_picker_modal';
-import {Preferences, scheduledPosts} from 'utils/constants';
+
+import {scheduledPosts} from 'utils/constants';
 
 type Props = {
     channelId: string;
@@ -47,14 +48,14 @@ export default function ScheduledPostCustomTimeModal({channelId, onExited, onCon
 
         dispatch(
             savePreferences(
-                currentUserId, 
+                currentUserId,
                 [{
                     user_id: currentUserId,
                     category: scheduledPosts.SCHEDULED_POSTS,
                     name: scheduledPosts.RECENTLY_USED_CUSTOM_TIME,
                     value: JSON.stringify({update_at: moment().tz(userTimezone).valueOf(), timestamp: selectedTime}),
-                }]
-            )
+                }],
+            ),
         );
 
         if (response.error) {

--- a/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/core_menu_options.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/core_menu_options.test.tsx
@@ -43,6 +43,8 @@ const initialState = {
     },
 };
 
+const recentUsedCustomDateString = 'Recently used custom time';
+
 describe('CoreMenuOptions Component', () => {
     const teammateDisplayName = 'John Doe';
     const userCurrentTimezone = 'America/New_York';
@@ -112,7 +114,7 @@ describe('CoreMenuOptions Component', () => {
 
         renderComponent(state);
 
-        expect(screen.getByText(/Recently used custom time/)).toBeInTheDocument();
+        expect(screen.getByText(recentUsedCustomDateString)).toBeInTheDocument();
     });
 
     test('should not render recently used custom time when preference value is invalid JSON', () => {
@@ -122,7 +124,7 @@ describe('CoreMenuOptions Component', () => {
 
         renderComponent(state);
 
-        expect(screen.queryByText(/Recently used custom time/)).not.toBeInTheDocument();
+        expect(screen.queryByText(recentUsedCustomDateString)).not.toBeInTheDocument();
     });
 
     test('should call handleOnSelect with the correct timestamp when "Recently used custom time" is clicked', () => {
@@ -139,7 +141,7 @@ describe('CoreMenuOptions Component', () => {
 
         renderComponent(state, handleOnSelectMock);
 
-        const recentCustomOption = screen.getByText(/Recently used custom time/);
+        const recentCustomOption = screen.getByText(recentUsedCustomDateString);
         fireEvent.click(recentCustomOption);
 
         expect(handleOnSelectMock).toHaveBeenCalledWith(expect.anything(), recentTimestamp);
@@ -158,7 +160,7 @@ describe('CoreMenuOptions Component', () => {
 
         renderComponent(state);
 
-        expect(screen.queryByText(/Recently used custom time/)).not.toBeInTheDocument();
+        expect(screen.queryByText(recentUsedCustomDateString)).not.toBeInTheDocument();
     });
 
     it('should render tomorrow option on Sunday', () => {

--- a/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/core_menu_options.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/core_menu_options.test.tsx
@@ -163,6 +163,79 @@ describe('CoreMenuOptions Component', () => {
         expect(screen.queryByText(recentUsedCustomDateString)).not.toBeInTheDocument();
     });
 
+    test('should not render recently used custom time when timestamp is in the past', () => {
+        const now = DateTime.now().setZone(userCurrentTimezone);
+        const nowMillis = now.toMillis();
+
+        jest.useFakeTimers();
+        jest.setSystemTime(now.toJSDate());
+
+        const pastTimestamp = now.minus({days: 1}).toMillis();
+
+        const recentlyUsedCustomDateVal = {
+            update_at: nowMillis,
+            timestamp: pastTimestamp,
+        };
+
+        const state = createStateWithRecentlyUsedCustomDate(JSON.stringify(recentlyUsedCustomDateVal));
+
+        renderComponent(state);
+
+        expect(screen.queryByText(recentUsedCustomDateString)).not.toBeInTheDocument();
+    });
+
+    test('should not render recently used custom time when timestamp equals tomorrow9amTime', () => {
+        setMockDate(3);
+
+        const now = DateTime.now().setZone(userCurrentTimezone);
+        const nowMillis = now.toMillis();
+
+        const tomorrow9amTime = now.plus({days: 1}).
+            set({hour: 9, minute: 0, second: 0, millisecond: 0}).
+            toMillis();
+
+        const recentlyUsedCustomDateVal = {
+            update_at: nowMillis,
+            timestamp: tomorrow9amTime,
+        };
+
+        const state = createStateWithRecentlyUsedCustomDate(JSON.stringify(recentlyUsedCustomDateVal));
+
+        renderComponent(state);
+
+        expect(screen.queryByText(recentUsedCustomDateString)).not.toBeInTheDocument();
+    });
+
+    test('should not render recently used custom time when timestamp equals nextMonday', () => {
+        setMockDate(3);
+
+        const now = DateTime.now().setZone(userCurrentTimezone);
+        const nowMillis = now.toMillis();
+
+        function getNextWeekday(dateTime: DateTime, targetWeekday: number) {
+            const deltaDays = ((targetWeekday - dateTime.weekday) + 7) % 7 || 7;
+            return dateTime.plus({days: deltaDays});
+        }
+
+        const nextMonday = getNextWeekday(now, 1).set({
+            hour: 9,
+            minute: 0,
+            second: 0,
+            millisecond: 0,
+        }).toMillis();
+
+        const recentlyUsedCustomDateVal = {
+            update_at: nowMillis,
+            timestamp: nextMonday,
+        };
+
+        const state = createStateWithRecentlyUsedCustomDate(JSON.stringify(recentlyUsedCustomDateVal));
+
+        renderComponent(state);
+
+        expect(screen.queryByText(recentUsedCustomDateString)).not.toBeInTheDocument();
+    });
+
     it('should render tomorrow option on Sunday', () => {
         setMockDate(7); // Sunday
 

--- a/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/core_menu_options.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/core_menu_options.test.tsx
@@ -28,8 +28,6 @@ jest.mock('components/menu', () => ({
     Separator: jest.fn(() => <div className='menu-separator'/>),
 }));
 
-// jest.mock('components/timestamp', () => jest.fn(({value}) => <span>{value}</span>));
-
 const useTimePostBoxIndicator = require('components/advanced_text_editor/use_post_box_indicator').default;
 
 const initialState = {

--- a/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/core_menu_options.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/core_menu_options.tsx
@@ -53,6 +53,7 @@ function getScheduledTimeInTeammateTimezone(userCurrentTimestamp: number, teamma
 }
 
 function shouldShowRecentlyUsedCustomTime(
+    nowMillis: number,
     recentlyUsedCustomDateVal: RecentlyUsedCustomDate,
     userCurrentTimezone: string,
     tomorrow9amTime: number,
@@ -61,6 +62,7 @@ function shouldShowRecentlyUsedCustomTime(
     return recentlyUsedCustomDateVal &&
     typeof recentlyUsedCustomDateVal.update_at === 'number' &&
     typeof recentlyUsedCustomDateVal.timestamp === 'number' &&
+    recentlyUsedCustomDateVal.timestamp > nowMillis &&
     recentlyUsedCustomDateVal.timestamp !== tomorrow9amTime &&
     recentlyUsedCustomDateVal.timestamp !== nextMonday &&
     isTimestampWithinLast30Days(recentlyUsedCustomDateVal.update_at, userCurrentTimezone);
@@ -126,7 +128,7 @@ function CoreMenuOptions({handleOnSelect, channelId}: Props) {
     let recentCustomTime = null;
     const handleRecentlyUsedCustomTime = useCallback((e) => handleOnSelect(e, recentlyUsedCustomDateVal.timestamp!), [handleOnSelect, recentlyUsedCustomDateVal.timestamp]);
     if (
-        shouldShowRecentlyUsedCustomTime(recentlyUsedCustomDateVal, userCurrentTimezone, tomorrow9amTime, nextMonday)
+        shouldShowRecentlyUsedCustomTime(now.toMillis(), recentlyUsedCustomDateVal, userCurrentTimezone, tomorrow9amTime, nextMonday)
     ) {
         const USE_DATE_WEEKDAY_LONG = {weekday: 'long'} as const;
         const USE_TIME_HOUR_MINUTE_NUMERIC = {hour: 'numeric', minute: 'numeric'} as const;

--- a/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/core_menu_options.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/core_menu_options.tsx
@@ -53,6 +53,7 @@ function CoreMenuOptions({handleOnSelect, channelId}: Props) {
         );
     }, [currentUserId]);
     const recentlyUsedCustomDate = useSelector((state: GlobalState) => getPreference(state, scheduledPosts.SCHEDULED_POSTS, scheduledPosts.RECENTLY_USED_CUSTOM_TIME));
+
     interface RecentlyUsedCustomDate {
         update_at?: number;
         timestamp?: number;
@@ -80,15 +81,14 @@ function CoreMenuOptions({handleOnSelect, channelId}: Props) {
     }
 
     let recentCustomTime = null;
+    const handleRecentlyUsedCustomTime = useCallback((e) => handleOnSelect(e, recentlyUsedCustomDateVal.timestamp!), [handleOnSelect, recentlyUsedCustomDateVal.timestamp]);
     if (
         recentlyUsedCustomDateVal &&
         typeof recentlyUsedCustomDateVal.update_at === 'number' &&
         typeof recentlyUsedCustomDateVal.timestamp === 'number' &&
         isTimestampWithinLast30Days(recentlyUsedCustomDateVal.update_at, userCurrentTimezone)
     ) {
-        const handleRecentlyUsedCustomTime = useCallback((e) => handleOnSelect(e, recentlyUsedCustomDateVal.timestamp!), [handleOnSelect, recentlyUsedCustomDateVal.timestamp]);
-
-        const timestamp = useMemo(() => (
+        const timestamp = (
             <Timestamp
                 value={recentlyUsedCustomDateVal.timestamp}
                 timeZone={userCurrentTimezone}
@@ -96,25 +96,23 @@ function CoreMenuOptions({handleOnSelect, channelId}: Props) {
                 useDate={{weekday: 'long'}}
                 useTime={{hour: 'numeric', minute: 'numeric'}}
             />
-        ), [recentlyUsedCustomDateVal.timestamp, userCurrentTimezone]);
-
-        recentCustomTime = (
-            <>
-                <Menu.Separator/>
-                <Menu.Item
-                    key={'recently_used_custom_time'}
-                    onClick={handleRecentlyUsedCustomTime}
-                    labels={timestamp}
-                    className='core-menu-options'
-                    trailingElements={(
-                        <FormattedMessage
-                            id='create_post_button.option.schedule_message.options.recently_used_custom_time'
-                            defaultMessage='Recently used custom time'
-                        />
-                    )}
-                />
-            </>
         );
+
+        recentCustomTime = [
+            <Menu.Separator key='recent_custom_separator'/>,
+            <Menu.Item
+                key='recently_used_custom_time'
+                onClick={handleRecentlyUsedCustomTime}
+                labels={timestamp}
+                className='core-menu-options'
+                trailingElements={(
+                    <FormattedMessage
+                        id='create_post_button.option.schedule_message.options.recently_used_custom_time'
+                        defaultMessage='Recently used custom time'
+                    />
+                )}
+            />,
+        ];
     }
 
     const now = DateTime.now().setZone(userCurrentTimezone);
@@ -255,9 +253,9 @@ function CoreMenuOptions({handleOnSelect, channelId}: Props) {
     }
 
     return (
-        <div className='options'>
-            {recentCustomTime ? [...options, recentCustomTime] : options}
-        </div>
+        <>
+            {recentCustomTime ? [...options, ...recentCustomTime] : options}
+        </>
     );
 }
 

--- a/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/core_menu_options.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/core_menu_options.tsx
@@ -6,10 +6,13 @@ import React, {memo, useCallback, useEffect} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useSelector} from 'react-redux';
 
+import type {GlobalState} from '@mattermost/types/store';
+
 import {
     TrackPropertyUser, TrackPropertyUserAgent,
     TrackScheduledPostsFeature,
 } from 'mattermost-redux/constants/telemetry';
+import {get as getPreference} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import {trackFeatureEvent} from 'actions/telemetry_actions';
@@ -18,6 +21,8 @@ import useTimePostBoxIndicator from 'components/advanced_text_editor/use_post_bo
 import * as Menu from 'components/menu';
 import type {Props as MenuItemProps} from 'components/menu/menu_item';
 import Timestamp from 'components/timestamp';
+
+import {scheduledPosts} from 'utils/constants';
 
 type Props = {
     handleOnSelect: (e: React.FormEvent, scheduledAt: number) => void;
@@ -28,6 +33,7 @@ function CoreMenuOptions({handleOnSelect, channelId}: Props) {
     const {
         userCurrentTimezone,
         teammateTimezone,
+        currentUserTimesStamp,
         teammateDisplayName,
         isDM,
     } = useTimePostBoxIndicator(channelId);
@@ -47,6 +53,58 @@ function CoreMenuOptions({handleOnSelect, channelId}: Props) {
             },
         );
     }, [currentUserId]);
+    const recentlyUsedCustomDate = useSelector((state: GlobalState) => getPreference(state, scheduledPosts.SCHEDULED_POSTS, scheduledPosts.RECENTLY_USED_CUSTOM_TIME));
+    const recentlyUsedCustomDateVal = JSON.parse(recentlyUsedCustomDate);
+
+    function isWithinLast30Days(timestamp: number, timeZone = 'UTC') {
+        if (!timestamp || isNaN(timestamp)) {
+            return false;
+        }
+        const usedDate = DateTime.fromMillis(timestamp).setZone(timeZone);
+        const now = DateTime.now().setZone(timeZone);
+        const thirtyDaysAgo = now.minus({days: 30});
+
+        return usedDate >= thirtyDaysAgo && usedDate <= now;
+    }
+
+    let recentCustomTime = null;
+    if (isWithinLast30Days(recentlyUsedCustomDateVal.update_at, userCurrentTimezone)) {
+        const handleRecentlyUsedCustomTime = useCallback((e) => handleOnSelect(e, tomorrow9amTime), [handleOnSelect, recentlyUsedCustomDateVal.timestamp]);
+
+        const timestamp = (
+            <Timestamp
+                value={recentlyUsedCustomDateVal.timestamp}
+                timeZone={userCurrentTimezone}
+                useRelative={false}
+                useDate={{weekday: 'long'}}
+                useTime={{hour: 'numeric', minute: 'numeric'}}
+            />
+        );
+
+        recentCustomTime = (
+            <>
+                <Menu.Item
+                    key={'scheduling_time_tomorrow_9_am'}
+                    onClick={handleRecentlyUsedCustomTime}
+                    labels={
+                        <FormattedMessage
+                            id='create_post_button.option.schedule_message.options.recently_used_custom_time_value'
+                            defaultMessage='{customTime}'
+                            values={{weekday: 'Wednesday', customTime: timestamp}}
+                        />
+                    }
+                    className='core-menu-options'
+                    trailingElements={(
+                        <FormattedMessage
+                            id='create_post_button.option.schedule_message.options.recently_used_custom_time'
+                            defaultMessage='Recently used custom time'
+                        />
+                    )}
+                />
+                <Menu.Separator/>
+            </>
+        );
+    }
 
     const now = DateTime.now().setZone(userCurrentTimezone);
     const tomorrow9amTime = DateTime.now().
@@ -187,7 +245,7 @@ function CoreMenuOptions({handleOnSelect, channelId}: Props) {
 
     return (
         <div className='options'>
-            {options}
+            {recentCustomTime ? [...options, recentCustomTime] : recentCustomTime}
         </div>
     );
 }

--- a/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/recent_used_custom_date.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/recent_used_custom_date.test.tsx
@@ -1,0 +1,276 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {DateTime} from 'luxon';
+import React from 'react';
+
+import {getPreferenceKey} from 'mattermost-redux/utils/preference_utils';
+
+import {renderWithContext, fireEvent, screen} from 'tests/react_testing_utils';
+import {scheduledPosts} from 'utils/constants';
+
+import RecentUsedCustomDate from './recent_used_custom_date';
+
+jest.mock('components/advanced_text_editor/use_post_box_indicator', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+
+jest.mock('components/menu', () => ({
+    __esModule: true,
+    Item: jest.fn(({labels, trailingElements, children, ...props}) => (
+        <div {...props}>
+            {labels}
+            {children}
+            {trailingElements}
+        </div>
+    )),
+    Separator: jest.fn(() => <div className='menu-separator'/>),
+}));
+
+const initialState = {
+    entities: {
+        preferences: {
+            myPreferences: {},
+        },
+        users: {
+            currentUserId: 'currentUserId',
+        },
+    },
+};
+
+const recentUsedCustomDateString = 'Recently used custom time';
+
+describe('CoreMenuOptions Component', () => {
+    const userCurrentTimezone = 'America/New_York';
+
+    const handleOnSelect = jest.fn();
+
+    let now: DateTime;
+    let tomorrow9amTime: number;
+    let nextMonday: number;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        handleOnSelect.mockReset();
+        now = DateTime.fromISO('2024-11-01T10:00:00', {zone: userCurrentTimezone});
+        jest.useFakeTimers();
+        jest.setSystemTime(now.toJSDate());
+
+        // Hardcode `tomorrow9amTime` and `nextMonday`
+        tomorrow9amTime = DateTime.fromISO('2024-11-02T09:00:00', {zone: userCurrentTimezone}).toMillis();
+        nextMonday = DateTime.fromISO('2024-11-04T09:00:00', {zone: userCurrentTimezone}).toMillis();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    function createStateWithRecentlyUsedCustomDate(value: string) {
+        return {
+            ...initialState,
+            entities: {
+                ...initialState.entities,
+                preferences: {
+                    ...initialState.entities.preferences,
+                    myPreferences: {
+                        ...initialState.entities.preferences.myPreferences,
+                        [getPreferenceKey(scheduledPosts.SCHEDULED_POSTS, scheduledPosts.RECENTLY_USED_CUSTOM_TIME)]: {value},
+                    },
+                },
+            },
+        };
+    }
+
+    function renderComponent(state = initialState, handleOnSelectOverride = handleOnSelect) {
+        renderWithContext(
+            <RecentUsedCustomDate
+                handleOnSelect={handleOnSelectOverride}
+                userCurrentTimezone={userCurrentTimezone}
+                tomorrow9amTime={tomorrow9amTime}
+                nextMonday={nextMonday}
+            />,
+            state,
+        );
+    }
+
+    it('should render recently used custom time option when valid', () => {
+        const recentTimestamp = DateTime.now().plus({days: 7}).toMillis();
+
+        const recentlyUsedCustomDateVal = {
+            update_at: DateTime.now().toMillis(),
+            timestamp: recentTimestamp,
+        };
+
+        const state = createStateWithRecentlyUsedCustomDate(JSON.stringify(recentlyUsedCustomDateVal));
+
+        renderComponent(state);
+
+        expect(screen.getByText(recentUsedCustomDateString)).toBeInTheDocument();
+    });
+
+    it('should not render recently used custom time when preference value is invalid JSON', () => {
+        const invalidJson = '{ invalid JSON }';
+
+        const state = createStateWithRecentlyUsedCustomDate(invalidJson);
+
+        renderComponent(state);
+
+        expect(screen.queryByText(recentUsedCustomDateString)).not.toBeInTheDocument();
+    });
+
+    it('should call handleOnSelect with the correct timestamp when "Recently used custom time" is clicked', () => {
+        const recentTimestamp = DateTime.now().plus({days: 5}).toMillis();
+
+        const recentlyUsedCustomDateVal = {
+            update_at: DateTime.now().toMillis(),
+            timestamp: recentTimestamp,
+        };
+
+        const state = createStateWithRecentlyUsedCustomDate(JSON.stringify(recentlyUsedCustomDateVal));
+
+        const handleOnSelectMock = jest.fn();
+
+        renderComponent(state, handleOnSelectMock);
+
+        const recentCustomOption = screen.getByText(recentUsedCustomDateString);
+        fireEvent.click(recentCustomOption);
+
+        expect(handleOnSelectMock).toHaveBeenCalledWith(expect.anything(), recentTimestamp);
+    });
+
+    it('should not render recently used custom time when update_at is older than 30 days', () => {
+        const outdatedUpdateAt = DateTime.now().minus({days: 35}).toMillis();
+        const recentTimestamp = DateTime.now().plus({days: 5}).toMillis();
+
+        const recentlyUsedCustomDateVal = {
+            update_at: outdatedUpdateAt,
+            timestamp: recentTimestamp,
+        };
+
+        const state = createStateWithRecentlyUsedCustomDate(JSON.stringify(recentlyUsedCustomDateVal));
+
+        renderComponent(state);
+
+        expect(screen.queryByText(recentUsedCustomDateString)).not.toBeInTheDocument();
+    });
+
+    it('should not render recently used custom time when timestamp is in the past', () => {
+        const now = DateTime.now().setZone(userCurrentTimezone);
+        const nowMillis = now.toMillis();
+
+        jest.useFakeTimers();
+        jest.setSystemTime(now.toJSDate());
+
+        const pastTimestamp = now.minus({days: 1}).toMillis();
+
+        const recentlyUsedCustomDateVal = {
+            update_at: nowMillis,
+            timestamp: pastTimestamp,
+        };
+
+        const state = createStateWithRecentlyUsedCustomDate(JSON.stringify(recentlyUsedCustomDateVal));
+
+        renderComponent(state);
+
+        expect(screen.queryByText(recentUsedCustomDateString)).not.toBeInTheDocument();
+    });
+
+    it('should not render recently used custom time when timestamp equals tomorrow9amTime', () => {
+        const nowMillis = now.toMillis();
+
+        const recentlyUsedCustomDateVal = {
+            update_at: nowMillis,
+            timestamp: tomorrow9amTime, // Use the value from beforeEach
+        };
+
+        const state = createStateWithRecentlyUsedCustomDate(JSON.stringify(recentlyUsedCustomDateVal));
+
+        renderComponent(state);
+
+        expect(screen.queryByText(recentUsedCustomDateString)).not.toBeInTheDocument();
+    });
+
+    it('should not render recently used custom time when timestamp equals nextMonday', () => {
+        const nowMillis = now.toMillis();
+
+        const recentlyUsedCustomDateVal = {
+            update_at: nowMillis,
+            timestamp: nextMonday,
+        };
+
+        const state = createStateWithRecentlyUsedCustomDate(JSON.stringify(recentlyUsedCustomDateVal));
+
+        renderComponent(state);
+
+        expect(screen.queryByText(recentUsedCustomDateString)).not.toBeInTheDocument();
+    });
+
+    it('should render "Today at HH:MM AM/PM" when recently used custom date is TODAY', () => {
+        const now = DateTime.fromISO('2024-11-01T10:00:00', {zone: userCurrentTimezone});
+        jest.useFakeTimers();
+        jest.setSystemTime(now.toJSDate());
+
+        const recentTimestamp = now.plus({minutes: 5}).toMillis();
+
+        const recentlyUsedCustomDateVal = {
+            update_at: now.toMillis(),
+            timestamp: recentTimestamp,
+        };
+
+        const state = createStateWithRecentlyUsedCustomDate(JSON.stringify(recentlyUsedCustomDateVal));
+
+        renderComponent(state);
+
+        expect(screen.getByText(recentUsedCustomDateString)).toBeInTheDocument();
+        expect(screen.getByText(/Today at/)).toBeInTheDocument();
+    });
+
+    it('should render "Weekday at HH:MM AM/PM" if recent used custom date is in the SAME week', () => {
+        const now = DateTime.fromISO('2024-11-01T10:00:00', {zone: userCurrentTimezone});
+        jest.useFakeTimers();
+        jest.setSystemTime(now.toJSDate());
+
+        const recentTimestamp = now.plus({days: 2}).toMillis();
+
+        const recentlyUsedCustomDateVal = {
+            update_at: now.toMillis(),
+            timestamp: recentTimestamp,
+        };
+
+        const state = createStateWithRecentlyUsedCustomDate(JSON.stringify(recentlyUsedCustomDateVal));
+
+        renderComponent(state);
+
+        expect(screen.getByText(recentUsedCustomDateString)).toBeInTheDocument();
+
+        const scheduledDate = DateTime.fromMillis(recentTimestamp).setZone(userCurrentTimezone);
+        const weekdayName = scheduledDate.toFormat('EEEE');
+
+        expect(screen.getByText(new RegExp(`${weekdayName} at`))).toBeInTheDocument();
+    });
+
+    it('should render "Month Day at HH:MM AM/PM" if recent used custom date is NOT in the same week', () => {
+        const now = DateTime.fromISO('2024-11-01T10:00:00', {zone: userCurrentTimezone});
+        jest.useFakeTimers();
+        jest.setSystemTime(now.toJSDate());
+
+        const recentTimestamp = now.plus({days: 14}).toMillis();
+
+        const recentlyUsedCustomDateVal = {
+            update_at: now.toMillis(),
+            timestamp: recentTimestamp,
+        };
+
+        const state = createStateWithRecentlyUsedCustomDate(JSON.stringify(recentlyUsedCustomDateVal));
+
+        renderComponent(state);
+
+        expect(screen.getByText(recentUsedCustomDateString)).toBeInTheDocument();
+
+        const scheduledDate = DateTime.fromMillis(recentTimestamp).setZone(userCurrentTimezone);
+        const monthDay = scheduledDate.toFormat('MMMM d');
+
+        expect(screen.getByText(new RegExp(`${monthDay} at`))).toBeInTheDocument();
+    });
+});

--- a/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/recent_used_custom_date.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/recent_used_custom_date.tsx
@@ -1,0 +1,130 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {Zone} from 'luxon';
+import {DateTime} from 'luxon';
+import React, {memo, useCallback, useMemo} from 'react';
+import {FormattedMessage} from 'react-intl';
+import {useSelector} from 'react-redux';
+
+import type {GlobalState} from '@mattermost/types/store';
+
+import {get as getPreference} from 'mattermost-redux/selectors/entities/preferences';
+
+import * as Menu from 'components/menu';
+import Timestamp, {RelativeRanges} from 'components/timestamp';
+
+import {scheduledPosts} from 'utils/constants';
+
+type Props = {
+    handleOnSelect: (e: React.FormEvent, scheduledAt: number) => void;
+    userCurrentTimezone: string;
+    tomorrow9amTime: number;
+    nextMonday: number;
+}
+
+const DATE_RANGES = [
+    RelativeRanges.TODAY_TITLE_CASE,
+    RelativeRanges.TOMORROW_TITLE_CASE,
+];
+
+interface RecentlyUsedCustomDate {
+    update_at?: number;
+    timestamp?: number;
+}
+
+function isTimestampWithinLast30Days(timestamp: number, timeZone = 'UTC') {
+    if (!timestamp || isNaN(timestamp)) {
+        return false;
+    }
+    const usedDate = DateTime.fromMillis(timestamp).setZone(timeZone);
+    const now = DateTime.now().setZone(timeZone);
+    const thirtyDaysAgo = now.minus({days: 30});
+
+    return usedDate >= thirtyDaysAgo && usedDate <= now;
+}
+
+function shouldShowRecentlyUsedCustomTime(
+    nowMillis: number,
+    recentlyUsedCustomDateVal: RecentlyUsedCustomDate,
+    userCurrentTimezone: string,
+    tomorrow9amTime: number,
+    nextMonday: number,
+) {
+    return recentlyUsedCustomDateVal &&
+    typeof recentlyUsedCustomDateVal.update_at === 'number' &&
+    typeof recentlyUsedCustomDateVal.timestamp === 'number' &&
+    recentlyUsedCustomDateVal.timestamp > nowMillis && // is in the future
+    recentlyUsedCustomDateVal.timestamp !== tomorrow9amTime && // is not the existing option tomorrow 9a.m
+    recentlyUsedCustomDateVal.timestamp !== nextMonday && // is not the existing option tomorrow 9a.m
+    isTimestampWithinLast30Days(recentlyUsedCustomDateVal.update_at, userCurrentTimezone);
+}
+
+const USE_DATE_WEEKDAY_LONG = {weekday: 'long'} as const;
+const USE_TIME_HOUR_MINUTE_NUMERIC = {hour: 'numeric', minute: 'numeric'} as const;
+const USE_DATE_MONTH_DAY = {month: 'long', day: 'numeric'} as const;
+
+function getDateOption(now: DateTime, timestamp: number | undefined, userCurrentTimezone: string | Zone | undefined) {
+    if (!now || !timestamp || !userCurrentTimezone) {
+        return USE_DATE_WEEKDAY_LONG;
+    }
+    const scheduledDate = DateTime.fromMillis(timestamp).setZone(userCurrentTimezone);
+    const isInCurrentWeek = scheduledDate.weekNumber === now.weekNumber && scheduledDate.weekYear === now.weekYear;
+    return isInCurrentWeek ? USE_DATE_WEEKDAY_LONG : USE_DATE_MONTH_DAY;
+}
+
+function RecentUsedCustomDate({handleOnSelect, userCurrentTimezone, nextMonday, tomorrow9amTime}: Props) {
+    const now = DateTime.now().setZone(userCurrentTimezone);
+    const recentlyUsedCustomDate = useSelector((state: GlobalState) => getPreference(state, scheduledPosts.SCHEDULED_POSTS, scheduledPosts.RECENTLY_USED_CUSTOM_TIME));
+    const recentlyUsedCustomDateVal: RecentlyUsedCustomDate = useMemo(() => {
+        if (recentlyUsedCustomDate) {
+            try {
+                return JSON.parse(recentlyUsedCustomDate) as RecentlyUsedCustomDate;
+            } catch (e) {
+                return {};
+            }
+        }
+        return {};
+    }, [recentlyUsedCustomDate]);
+    const handleRecentlyUsedCustomTime = useCallback((e) => handleOnSelect(e, recentlyUsedCustomDateVal.timestamp!), [handleOnSelect, recentlyUsedCustomDateVal.timestamp]);
+
+    if (
+        !shouldShowRecentlyUsedCustomTime(now.toMillis(), recentlyUsedCustomDateVal, userCurrentTimezone, tomorrow9amTime, nextMonday)
+    ) {
+        return null;
+    }
+
+    const dateOption = getDateOption(now, recentlyUsedCustomDateVal.timestamp, userCurrentTimezone);
+
+    const timestamp = (
+        <Timestamp
+            ranges={DATE_RANGES}
+            value={recentlyUsedCustomDateVal.timestamp}
+            timeZone={userCurrentTimezone}
+            useDate={dateOption}
+            useTime={USE_TIME_HOUR_MINUTE_NUMERIC}
+        />
+    );
+
+    const trailingElement = (
+        <FormattedMessage
+            id='create_post_button.option.schedule_message.options.recently_used_custom_time'
+            defaultMessage='Recently used custom time'
+        />
+    );
+
+    return (
+        <>
+            <Menu.Separator key='recent_custom_separator'/>
+            <Menu.Item
+                key='recently_used_custom_time'
+                onClick={handleRecentlyUsedCustomTime}
+                labels={timestamp}
+                className='core-menu-options'
+                trailingElements={trailingElement}
+            />
+        </>
+    );
+}
+
+export default memo(RecentUsedCustomDate);

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -3455,6 +3455,7 @@
   "create_post_button.option.schedule_message.options.header": "Schedule message",
   "create_post_button.option.schedule_message.options.monday": "Monday at {9amTime}",
   "create_post_button.option.schedule_message.options.next_monday": "Next Monday at {9amTime}",
+  "create_post_button.option.schedule_message.options.recently_used_custom_time": "Recently used custom time",
   "create_post_button.option.schedule_message.options.teammate_user_hour": "{time} {user}’s time",
   "create_post_button.option.schedule_message.options.tomorrow": "Tomorrow at {9amTime}",
   "create_post_button.option.send_now": "Send Now",

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -2223,5 +2223,10 @@ export const PageLoadContext = {
 
 export const SCHEDULED_POST_URL_SUFFIX = 'scheduled_posts';
 
+export const scheduledPosts = {
+    RECENTLY_USED_CUSTOM_TIME: 'recently_used_custom_time',
+    SCHEDULED_POSTS: 'scheduled_posts',
+};
+
 export default Constants;
 


### PR DESCRIPTION
#### Summary
This PR adds the logic to store in the user preferences the most recently used custom time for scheduled messages so it can be shown in the available options for picking a time for a new schedule message.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60123

#### Screenshots

https://github.com/user-attachments/assets/12fe8372-3e60-4a0a-8a6c-c50ea900285a



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
