### PR TITLE
MM-52512 fix ability to exclude archived channels in system console

### DIFF
--- a/webapp/channels/src/components/admin_console/team_channel_settings/channel/list/channel_list.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/channel/list/channel_list.tsx
@@ -106,11 +106,11 @@ export default class ChannelList extends React.PureComponent<ChannelListProps, C
         this.setState({page, loading: false});
     };
 
-    searchChannels = async (page = 0, term = '', filters = {}) => {
+    searchChannels = async (page = 0, term = '', filters: ChannelSearchOpts = {}) => {
         let channels = [];
         let total = 0;
         let searchErrored = true;
-        const response = await this.props.actions.searchAllChannels(term, {...filters, page, per_page: PAGE_SIZE, include_deleted: true, include_search_by_id: true});
+        const response = await this.props.actions.searchAllChannels(term, {...filters, page, per_page: PAGE_SIZE, include_deleted: filters.deleted ?? true, include_search_by_id: true});
         if (response?.data) {
             channels = page > 0 ? this.state.channels.concat(response.data.channels) : response.data.channels;
             total = response.data.total_count;


### PR DESCRIPTION
#### Summary
By default: no filters are applied, resulting in all channel being displayed. This PR ties `ChannelSearchOpts.include_deleted` to `ChannelSearchOpts.delted`, which alters the UX to make it possible again to exclude archived channels. 

I did not make all checkboxes checked by default as that would have negative effects on other filters. The filters UX here could use some refinement.

The meanings now equate to: 


"Public": Include public channels
"Private": Include private channels

"Archived": Exclude non-archived

"Group Sync" and "Manual Invites" are two sides of the "channels constrained to a group" coin.


#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-52512

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
