### PR TITLE
MM-57079: misaligned quote text

### DIFF
--- a/webapp/channels/src/components/__snapshots__/textbox.test.tsx.snap
+++ b/webapp/channels/src/components/__snapshots__/textbox.test.tsx.snap
@@ -21,134 +21,6 @@ exports[`components/TextBox should match snapshot with additional, optional prop
       message="some test text"
     />
   </div>
-  <Connect(SuggestionBox)
-    className="form-control custom-textarea textbox-edit-area custom-textarea--emoji-picker bad-connection"
-    contextId="channelId"
-    disabled={true}
-    id="someid"
-    inputComponent={
-      Object {
-        "$$typeof": Symbol(react.memo),
-        "compare": null,
-        "type": Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "propTypes": Object {
-            "className": [Function],
-            "defaultValue": [Function],
-            "disabled": [Function],
-            "id": [Function],
-            "onChange": [Function],
-            "onHeightChange": [Function],
-            "onInput": [Function],
-            "onWidthChange": [Function],
-            "placeholder": [Function],
-            "value": [Function],
-          },
-          "render": [Function],
-        },
-      }
-    }
-    listComponent={[Function]}
-    listPosition="top"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onComposition={[MockFunction]}
-    onHeightChange={[MockFunction]}
-    onKeyDown={[Function]}
-    onKeyPress={[MockFunction]}
-    onKeyUp={[Function]}
-    onMouseUp={[Function]}
-    openWhenEmpty={true}
-    placeholder="placeholder text"
-    providers={
-      Array [
-        AtMentionProvider {
-          "addLastViewAtToProfiles": [Function],
-          "autocompleteGroups": Array [
-            Object {
-              "allow_reference": true,
-              "create_at": 1,
-              "delete_at": 0,
-              "description": "",
-              "display_name": "group_display_name",
-              "has_syncables": false,
-              "id": "gid1",
-              "member_count": 0,
-              "name": "group_name",
-              "remote_id": "",
-              "scheme_admin": false,
-              "source": "",
-              "update_at": 1,
-            },
-            Object {
-              "allow_reference": true,
-              "create_at": 1,
-              "delete_at": 0,
-              "description": "",
-              "display_name": "group_display_name",
-              "has_syncables": false,
-              "id": "gid2",
-              "member_count": 0,
-              "name": "group_name",
-              "remote_id": "",
-              "scheme_admin": false,
-              "source": "",
-              "update_at": 1,
-            },
-          ],
-          "autocompleteUsersInChannel": [Function],
-          "channelId": "channelId",
-          "currentUserId": "currentUserId",
-          "data": null,
-          "disableDispatches": false,
-          "forceDispatch": false,
-          "getProfilesInChannel": [Function],
-          "lastCompletedWord": "",
-          "lastPrefixWithNoResults": "",
-          "latestComplete": true,
-          "latestPrefix": "",
-          "priorityProfiles": undefined,
-          "requestStarted": false,
-          "searchAssociatedGroupsForReference": [Function],
-          "triggerCharacter": "@",
-          "useChannelMentions": true,
-        },
-        ChannelMentionProvider {
-          "autocompleteChannels": [MockFunction],
-          "delayChannelAutocomplete": false,
-          "disableDispatches": false,
-          "forceDispatch": false,
-          "lastCompletedWord": "",
-          "lastPrefixTrimmed": "",
-          "lastPrefixWithNoResults": "",
-          "latestComplete": true,
-          "latestPrefix": "",
-          "requestStarted": false,
-          "triggerCharacter": "~",
-        },
-        EmoticonProvider {
-          "disableDispatches": false,
-          "forceDispatch": false,
-          "latestComplete": true,
-          "latestPrefix": "",
-          "requestStarted": false,
-          "triggerCharacter": ":",
-        },
-      ]
-    }
-    renderDividers={
-      Array [
-        "all",
-      ]
-    }
-    spellCheck="true"
-    style={
-      Object {
-        "visibility": "hidden",
-      }
-    }
-    value="some test text"
-  />
 </div>
 `;
 
@@ -156,23 +28,6 @@ exports[`components/TextBox should match snapshot with required props 1`] = `
 <div
   className="textarea-wrapper"
 >
-  <div
-    className="form-control custom-textarea textbox-preview-area"
-    onBlur={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[MockFunction]}
-    tabIndex={0}
-  >
-    <Connect(PostMarkdown)
-      channelId="channelId"
-      imageProps={
-        Object {
-          "hideUtilities": true,
-        }
-      }
-      message="some test text"
-    />
-  </div>
   <Connect(SuggestionBox)
     className="form-control custom-textarea textbox-edit-area"
     contextId="channelId"
@@ -289,11 +144,6 @@ exports[`components/TextBox should match snapshot with required props 1`] = `
       ]
     }
     spellCheck="true"
-    style={
-      Object {
-        "visibility": "visible",
-      }
-    }
     value="some test text"
   />
 </div>
@@ -303,23 +153,6 @@ exports[`components/TextBox should throw error when new property is too long 1`]
 <div
   className="textarea-wrapper"
 >
-  <div
-    className="form-control custom-textarea textbox-preview-area"
-    onBlur={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[MockFunction]}
-    tabIndex={0}
-  >
-    <Connect(PostMarkdown)
-      channelId="channelId"
-      imageProps={
-        Object {
-          "hideUtilities": true,
-        }
-      }
-      message="some test text that exceeds char limit"
-    />
-  </div>
   <Connect(SuggestionBox)
     className="form-control custom-textarea textbox-edit-area"
     contextId="channelId"
@@ -436,11 +269,6 @@ exports[`components/TextBox should throw error when new property is too long 1`]
       ]
     }
     spellCheck="true"
-    style={
-      Object {
-        "visibility": "visible",
-      }
-    }
     value="some test text that exceeds char limit"
   />
 </div>
@@ -450,23 +278,6 @@ exports[`components/TextBox should throw error when value is too long 1`] = `
 <div
   className="textarea-wrapper"
 >
-  <div
-    className="form-control custom-textarea textbox-preview-area"
-    onBlur={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[MockFunction]}
-    tabIndex={0}
-  >
-    <Connect(PostMarkdown)
-      channelId="channelId"
-      imageProps={
-        Object {
-          "hideUtilities": true,
-        }
-      }
-      message="some test text that exceeds char limit"
-    />
-  </div>
   <Connect(SuggestionBox)
     className="form-control custom-textarea textbox-edit-area"
     contextId="channelId"
@@ -583,11 +394,6 @@ exports[`components/TextBox should throw error when value is too long 1`] = `
       ]
     }
     spellCheck="true"
-    style={
-      Object {
-        "visibility": "visible",
-      }
-    }
     value="some test text that exceeds char limit"
   />
 </div>

--- a/webapp/channels/src/components/textbox/textbox.tsx
+++ b/webapp/channels/src/components/textbox/textbox.tsx
@@ -74,9 +74,6 @@ export type Props = {
     hasLabels?: boolean;
 };
 
-const VISIBLE = {visibility: 'visible'};
-const HIDDEN = {visibility: 'hidden'};
-
 export default class Textbox extends React.PureComponent<Props> {
     private readonly suggestionProviders: Provider[];
     private readonly wrapper: React.RefObject<HTMLDivElement>;
@@ -259,10 +256,6 @@ export default class Textbox extends React.PureComponent<Props> {
         this.getInputBox()?.blur();
     };
 
-    getStyle = () => {
-        return this.props.preview ? HIDDEN : VISIBLE;
-    };
-
     render() {
         let textboxClassName = 'form-control custom-textarea textbox-edit-area';
         if (this.props.emojiEnabled) {
@@ -275,25 +268,35 @@ export default class Textbox extends React.PureComponent<Props> {
             textboxClassName += ' textarea--has-labels';
         }
 
+        if (this.props.preview) {
+            return (
+                <div
+                    ref={this.wrapper}
+                    className={classNames('textarea-wrapper', 'textarea-wrapper-preview')}
+                >
+                    <div
+                        tabIndex={this.props.tabIndex || 0}
+                        ref={this.preview}
+                        className={classNames('form-control custom-textarea textbox-preview-area', {'textarea--has-labels': this.props.hasLabels})}
+                        onKeyPress={this.props.onKeyPress}
+                        onKeyDown={this.handleKeyDown}
+                        onBlur={this.handleBlur}
+                    >
+                        <PostMarkdown
+                            message={this.props.value}
+                            channelId={this.props.channelId}
+                            imageProps={{hideUtilities: true}}
+                        />
+                    </div>
+                </div>
+            );
+        }
+
         return (
             <div
                 ref={this.wrapper}
-                className={classNames('textarea-wrapper', {'textarea-wrapper-preview': this.props.preview})}
+                className={classNames('textarea-wrapper')}
             >
-                <div
-                    tabIndex={this.props.tabIndex || 0}
-                    ref={this.preview}
-                    className={classNames('form-control custom-textarea textbox-preview-area', {'textarea--has-labels': this.props.hasLabels})}
-                    onKeyPress={this.props.onKeyPress}
-                    onKeyDown={this.handleKeyDown}
-                    onBlur={this.handleBlur}
-                >
-                    <PostMarkdown
-                        message={this.props.value}
-                        channelId={this.props.channelId}
-                        imageProps={{hideUtilities: true}}
-                    />
-                </div>
                 <SuggestionBox
                     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                     // @ts-ignore
@@ -313,7 +316,6 @@ export default class Textbox extends React.PureComponent<Props> {
                     onHeightChange={this.props.onHeightChange}
                     onWidthChange={this.props.onWidthChange}
                     onPaste={this.props.onPaste}
-                    style={this.getStyle()}
                     inputComponent={this.props.inputComponent}
                     listComponent={this.props.suggestionList}
                     listPosition={this.props.suggestionListPosition}

--- a/webapp/channels/src/sass/components/_modal.scss
+++ b/webapp/channels/src/sass/components/_modal.scss
@@ -72,16 +72,6 @@
             }
         }
 
-        .textarea-wrapper-preview {
-            .custom-textarea.textbox-preview-area {
-                display: block;
-            }
-
-            .textbox-edit-area {
-                display: none;
-            }
-        }
-
         .edit-post-footer {
             position: relative;
             display: inline-block;

--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -40,6 +40,7 @@
         z-index: 2;
         top: 0;
         left: 0;
+        white-space: normal;
 
         &:focus {
             border-color: rgba(v(center-channel-color-rgb), 0.4);

--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -70,26 +70,6 @@
     }
 }
 
-.textarea-wrapper.textarea-wrapper-preview {
-    .textbox-preview-area {
-        display: block;
-    }
-
-    .textbox-edit-area {
-        display: none;
-    }
-}
-
-.textarea-wrapper:not(.textarea-wrapper-preview) {
-    .textbox-preview-area {
-        display: none;
-    }
-
-    .textbox-edit-area {
-        display: block;
-    }
-}
-
 .help__format-text {
     display: inline-block;
     font-size: 0.85em;


### PR DESCRIPTION
#### Summary
Previewing a quote when composing a post renders differently than when it's posted:

![CleanShot 2024-11-06 at 15 41 30@2x](https://github.com/user-attachments/assets/6e800069-865e-4953-9094-67c39a378e20)

This is the result of a `white-space: break-spaces` directive applied to `.custom-textarea` and that cascades to the `.textbox-preview-area`, diverging from the same CSS that would apply to the post rendered in the channel. Fix this by forcing `white-space: normal` for the `.textbox-preview-area`.

While in here, eliminate the complexity that was `.textarea-wrapper-preview` and flipping whether the edit or preview widgets were shown. Move this logic into the component instead for greater clarity when teasing apart the various rules dictating how these components are styled. (We keep setting the class to preserve compatibility with Playbooks use of this exported widget.)

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-57079

#### Screenshots

![CleanShot 2024-11-06 at 15 39 00@2x](https://github.com/user-attachments/assets/bd19617b-accc-4057-8748-a733485967ee)

#### Release Note
```release-note
Fix styling of quoted text when previewing composed post.
```
