### PR TITLE
Allow empty ExpiresAt when Duration set on CS

### DIFF
--- a/server/public/model/custom_status.go
+++ b/server/public/model/custom_status.go
@@ -50,7 +50,7 @@ func (cs *CustomStatus) AreDurationAndExpirationTimeValid() bool {
 		return true
 	}
 
-	if validCustomStatusDuration[cs.Duration] && !cs.ExpiresAt.Before(time.Now()) {
+	if validCustomStatusDuration[cs.Duration] && (cs.ExpiresAt.IsZero() || !cs.ExpiresAt.Before(time.Now())) {
 		return true
 	}
 


### PR DESCRIPTION
#### Summary
Currently, it is not possible to set a custom status which has no expiration date but a duration of e.g. `today`, this PR should fix this, although this commit only corrects the data validation check

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/29159

#### Release Note
```release-note
Fixes inability to set a custom status with duration but without expiration date via the API
```
