### PR TITLE
[MM-61697] Date time picker - use localized date format and don't reset time when changing dates

### DIFF
--- a/webapp/channels/src/components/custom_status/date_time_input.tsx
+++ b/webapp/channels/src/components/custom_status/date_time_input.tsx
@@ -31,8 +31,6 @@ import {getCurrentMomentForTimezone} from 'utils/timezone';
 
 const CUSTOM_STATUS_TIME_PICKER_INTERVALS_IN_MINUTES = 30;
 
-const DATE_FORMAT = 'yyyy-MM-dd';
-
 export function getRoundedTime(value: Moment, roundedTo = CUSTOM_STATUS_TIME_PICKER_INTERVALS_IN_MINUTES) {
     const start = moment(value);
     const diff = start.minute() % roundedTo;
@@ -118,12 +116,16 @@ const DateTimeInputContainer: React.FC<Props> = ({
 
     const handleDayChange = (day: Date, modifiers: DayModifiers) => {
         if (modifiers.today) {
-            const currentTime = getCurrentMomentForTimezone(timezone);
-            const roundedTime = getRoundedTime(currentTime, timePickerInterval);
+            const baseTime = getCurrentMomentForTimezone(timezone);
+            baseTime.hour(time.hours());
+            baseTime.minute(time.minutes());
+
+            const roundedTime = getRoundedTime(baseTime, timePickerInterval);
             handleChange(roundedTime);
         } else {
+            day.setHours(time.hour(), time.minute());
             const dayWithTimezone = timezone ? moment(day).tz(timezone, true) : moment(day);
-            handleChange(dayWithTimezone.startOf('day'));
+            handleChange(dayWithTimezone);
         }
         handlePopperOpenState(false);
     };
@@ -148,7 +150,7 @@ const DateTimeInputContainer: React.FC<Props> = ({
     }, []);
 
     const formatDate = (date: Moment): string => {
-        return relativeDate ? relativeFormatDate(date, formatMessage, DATE_FORMAT) : DateTime.fromJSDate(date.toDate()).toFormat(DATE_FORMAT);
+        return relativeDate ? relativeFormatDate(date, formatMessage) : DateTime.fromJSDate(date.toDate()).toLocaleString();
     };
 
     const inputIcon = (

--- a/webapp/channels/src/utils/datetime.ts
+++ b/webapp/channels/src/utils/datetime.ts
@@ -90,7 +90,7 @@ export function toUTCUnix(date: Date): number {
     return Math.round(new Date(date.toISOString()).getTime() / 1000);
 }
 
-export function relativeFormatDate(date: Moment, formatMessage: ReturnType<typeof useIntl>['formatMessage'], format = 'yyyy-MM-dd'): string {
+export function relativeFormatDate(date: Moment, formatMessage: ReturnType<typeof useIntl>['formatMessage'], format?: string): string {
     const now = moment();
     const inputDate = moment(date);
 
@@ -101,5 +101,10 @@ export function relativeFormatDate(date: Moment, formatMessage: ReturnType<typeo
     } else if (inputDate.isSame(now.clone().add(1, 'days'), 'day')) {
         return formatMessage({id: 'date_separator.tomorrow', defaultMessage: 'Tomorrow'});
     }
-    return DateTime.fromJSDate(date.toDate()).toFormat(format);
+
+    if (format) {
+        return DateTime.fromJSDate(date.toDate()).toFormat(format);
+    }
+
+    return DateTime.fromJSDate(date.toDate()).toLocaleString();
 }


### PR DESCRIPTION
#### Summary
Made following changes to date time picker common component (used in custom status, post reminder and scheduled messages)-
1. Show date in date picker in user's localized format
2. Don't reset time when changing date.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-61697
Fixes https://mattermost.atlassian.net/browse/MM-61720
Fixes https://mattermost.atlassian.net/browse/MM-61719

#### Release Note
```release-note
none
```
