### PR TITLE
Automated cherry pick of #29029

### DIFF
--- a/server/config/utils.go
+++ b/server/config/utils.go
@@ -88,6 +88,14 @@ func desanitize(actual, target *model.Config) {
 	if *target.ServiceSettings.SplitKey == model.FakeSetting {
 		*target.ServiceSettings.SplitKey = *actual.ServiceSettings.SplitKey
 	}
+
+	for id, settings := range target.PluginSettings.Plugins {
+		for k, v := range settings {
+			if v == model.FakeSetting {
+				settings[k] = actual.PluginSettings.Plugins[id][k]
+			}
+		}
+	}
 }
 
 // fixConfig patches invalid or missing data in the configuration.

--- a/server/config/utils_test.go
+++ b/server/config/utils_test.go
@@ -35,6 +35,12 @@ func TestDesanitize(t *testing.T) {
 	actual.SqlSettings.DataSourceReplicas = append(actual.SqlSettings.DataSourceReplicas, "replica1")
 	actual.SqlSettings.DataSourceSearchReplicas = append(actual.SqlSettings.DataSourceSearchReplicas, "search_replica0")
 	actual.SqlSettings.DataSourceSearchReplicas = append(actual.SqlSettings.DataSourceSearchReplicas, "search_replica1")
+	actual.PluginSettings.Plugins = map[string]map[string]any{
+		"plugin1": {
+			"secret":    "value1",
+			"no_secret": "value2",
+		},
+	}
 
 	target := &model.Config{}
 	target.SetDefaults()
@@ -55,6 +61,12 @@ func TestDesanitize(t *testing.T) {
 	target.ElasticsearchSettings.Password = model.NewPointer(model.FakeSetting)
 	target.SqlSettings.DataSourceReplicas = []string{model.FakeSetting, model.FakeSetting}
 	target.SqlSettings.DataSourceSearchReplicas = []string{model.FakeSetting, model.FakeSetting}
+	target.PluginSettings.Plugins = map[string]map[string]any{
+		"plugin1": {
+			"secret":    model.FakeSetting,
+			"no_secret": "value2",
+		},
+	}
 
 	actualClone := actual.Clone()
 	desanitize(actual, target)
@@ -77,6 +89,7 @@ func TestDesanitize(t *testing.T) {
 	assert.Equal(t, actual.SqlSettings.DataSourceReplicas, target.SqlSettings.DataSourceReplicas)
 	assert.Equal(t, actual.SqlSettings.DataSourceSearchReplicas, target.SqlSettings.DataSourceSearchReplicas)
 	assert.Equal(t, actual.ServiceSettings.SplitKey, target.ServiceSettings.SplitKey)
+	assert.Equal(t, actual.PluginSettings.Plugins, target.PluginSettings.Plugins)
 }
 
 func TestFixInvalidLocales(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #29029 on release-10.1.

/cc  @hanzei

```release-note
NONE
```