### PR TITLE
[MM-15755] Show auto-complete channel options when `/join` command suggestion is selected

### DIFF
--- a/webapp/channels/src/components/suggestion/command_provider/command_provider.tsx
+++ b/webapp/channels/src/components/suggestion/command_provider/command_provider.tsx
@@ -140,7 +140,11 @@ export default class CommandProvider extends Provider {
     }
 
     handleCompleteWord(term: string, pretext: string, callback: (s: string) => void) {
-        callback(term + ' ');
+        let newValue = term + ' ';
+        if (term === '/join') {
+            newValue = `${term} ~`;
+        }
+        callback(newValue);
     }
 
     handleMobile(pretext: string, resultCallback: ResultsCallback<AutocompleteSuggestion>) {

--- a/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.jsx
+++ b/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.jsx
@@ -396,7 +396,10 @@ export default class SuggestionBox extends React.PureComponent {
             return;
         }
 
-        const suffix = text.substring(caret);
+        let suffix = text.substring(caret);
+        if (term.endsWith('join')) {
+            suffix = '~';
+        }
 
         const newValue = prefix + term + ' ' + suffix;
         textbox.value = newValue;
@@ -414,7 +417,7 @@ export default class SuggestionBox extends React.PureComponent {
         // set the caret position after the next rendering
         window.requestAnimationFrame(() => {
             if (textbox.value === newValue) {
-                Utils.setCaretPosition(textbox, prefix.length + term.length + 1);
+                Utils.setCaretPosition(textbox, prefix.length + term.length + suffix.length + 1);
             }
         });
     };


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR is aimed resolve the issue raised in #15755 . The approach is to add the `~` character as an suffix when the `/join` command is selected via mouse or keyboard (Enter or Tab). By doing this, it would automatically display the auto-complete options for the `/join` command when selected.

##### QA steps:
1. Start typing a command prefixed by `/` so that the `/join` command is displayed in the auto-complete suggestions.
2. Select the `/join` command in the suggestion list by clicking it, or pressing the `Tab` / `Enter` key.
3. Selecting the `/join` command using anyone of the interactions mentioned in 2 should result in `/join ~` displayed in the message input, and the suggestion list for channel options should be displayed automatically.

#### Ticket Link
https://github.com/mattermost/mattermost/issues/15755

#### Screenshots
|  before  |  after  |
|----|----|
| [Screencast from 12-11-2024 13:26:28.webm](https://github.com/user-attachments/assets/f187a19f-8ce8-4729-ba37-c0978b37dbcb) | [Screencast from 12-11-2024 13:26:51.webm](https://github.com/user-attachments/assets/3756154a-58d4-4b6b-81c5-dd06ba2e6793) |

#### Release Note
- Improvement in the UI for auto displaying channel suggestion list when the `/join` command suggestion is selected.
