### PR TITLE
Prepackage Calls v0.29.4 in `release-9.11`

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -144,7 +144,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v0.29.3
+PLUGIN_PACKAGES += mattermost-plugin-calls-v0.29.4
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.3.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.9.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.1.1


### PR DESCRIPTION
#### Summary

Backporting some fixes included in the latest v0.29 dot release.

#### Release Note

```release-note
Prepackage Calls v0.29.4
```

