### PR TITLE
Automated cherry pick of #29228

### DIFF
--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -2805,6 +2805,11 @@ func TestGetPost(t *testing.T) {
 
 		_, err = client.RemoveUserFromChannel(context.Background(), th.BasicChannel.Id, th.BasicUser.Id)
 		require.NoError(t, err)
+		t.Cleanup(func() {
+			// Add the user back to the channel
+			_, _, err = client.AddChannelMember(context.Background(), th.BasicChannel.Id, th.BasicUser.Id)
+			require.NoError(t, err)
+		})
 
 		// Channel is public, should be able to read post
 		_, _, err = c.GetPost(context.Background(), th.BasicPost.Id, "")

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -6147,6 +6147,7 @@ func TestPromoteGuestToUser(t *testing.T) {
 	}, "promote a guest to user")
 
 	t.Run("websocket update user event", func(t *testing.T) {
+		t.Skip("https://mattermost.atlassian.net/browse/MM-61736")
 		webSocketClient, err := th.CreateWebSocketClient()
 		assert.NoError(t, err)
 		defer webSocketClient.Close()


### PR DESCRIPTION
Cherry pick of #29228 on release-10.3.

/cc  @hanzei

```release-note
NONE
```