### PR TITLE
MM-61503 Updated golangci.yml configuration

### DIFF
--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -150,7 +150,6 @@ issues:
         channels/app/status.go|\
         channels/app/status_test.go|\
         channels/app/support_packet_test.go|\
-        channels/app/syncables.go|\
         channels/app/team.go|\
         channels/app/team_test.go|\
         channels/app/upload.go|\


### PR DESCRIPTION
#### Summary
Removed a line from the golangci.yml file that was excluding a specific go file from linting. This will now allow the linter to check this file for any potential issues.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/29107
Jira https://mattermost.atlassian.net/browse/MM-61503

#### Release Note
```release-note
NONE
```
