### PR TITLE
GH-27059: Rewrite error messages about msg length

### DIFF
--- a/server/i18n/be.json
+++ b/server/i18n/be.json
@@ -744,8 +744,8 @@
     "translation": "Няправільныя рэквізіты."
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Няправільнае паведамленне."
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "Уласцівасць паведамлення перавышае максімальна дапушчальную даўжыню."
   },
   {
     "id": "model.post.is_valid.id.app_error",

--- a/server/i18n/bg.json
+++ b/server/i18n/bg.json
@@ -1512,8 +1512,8 @@
     "translation": "Невалиден оригинален id."
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Невалидно съобщение."
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "Свойството на съобщението е по-дълго от максимално разрешената дължина."
   },
   {
     "id": "model.post.is_valid.id.app_error",

--- a/server/i18n/ca.json
+++ b/server/i18n/ca.json
@@ -200,8 +200,8 @@
     "translation": "Props no vàlid"
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Estat no vàlid"
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "La propietat del missatge supera la longitud màxima permesa."
   },
   {
     "id": "model.post.is_valid.id.app_error",

--- a/server/i18n/cs.json
+++ b/server/i18n/cs.json
@@ -356,8 +356,8 @@
     "translation": "Neplatné původní ID."
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Neplatná zpráva."
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "Vlastnost zprávy je delší než maximální povolená délka."
   },
   {
     "id": "model.post.is_valid.id.app_error",

--- a/server/i18n/de.json
+++ b/server/i18n/de.json
@@ -4311,8 +4311,8 @@
     "translation": "Ungültige Id."
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Ungültige Nachricht."
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "Die Nachrichten-Eigenschaft überschreitet die maximal zulässige Länge."
   },
   {
     "id": "model.post.is_valid.original_id.app_error",
@@ -8834,8 +8834,8 @@
     "translation": "Ungültige Eigenschaften."
   },
   {
-    "id": "model.draft.is_valid.msg.app_error",
-    "translation": "Ungültige Nachricht."
+    "id": "model.draft.is_valid.message_length.app_error",
+    "translation": "Die Eigenschaft der Entwurf-Nachricht ist länger als die maximal erlaubte Länge."
   },
   {
     "id": "model.draft.is_valid.file_ids.app_error",

--- a/server/i18n/en-AU.json
+++ b/server/i18n/en-AU.json
@@ -1792,8 +1792,8 @@
     "translation": "Invalid original ID."
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Invalid message."
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "Post Message property is longer than the maximum permitted length."
   },
   {
     "id": "model.post.is_valid.id.app_error",
@@ -8835,8 +8835,8 @@
     "translation": "Invalid props."
   },
   {
-    "id": "model.draft.is_valid.msg.app_error",
-    "translation": "Invalid message."
+    "id": "model.draft.is_valid.message_length.app_error",
+    "translation": "Draft Message property is longer than the maximum permitted length."
   },
   {
     "id": "model.draft.is_valid.file_ids.app_error",

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9214,8 +9214,8 @@
     "translation": "Invalid file ids."
   },
   {
-    "id": "model.draft.is_valid.msg.app_error",
-    "translation": "Invalid message."
+    "id": "model.draft.is_valid.message_length.app_error",
+    "translation": "Draft Message property is longer than the maximum permitted length."
   },
   {
     "id": "model.draft.is_valid.priority.app_error",
@@ -9666,8 +9666,8 @@
     "translation": "Invalid Id."
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Invalid message."
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "Post Message property is longer than the maximum permitted length."
   },
   {
     "id": "model.post.is_valid.original_id.app_error",

--- a/server/i18n/es.json
+++ b/server/i18n/es.json
@@ -4312,8 +4312,8 @@
     "translation": "Id inválido."
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Mensaje no es válido."
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "La propiedad del mensaje es más larga que la longitud máxima permitida."
   },
   {
     "id": "model.post.is_valid.original_id.app_error",

--- a/server/i18n/fa.json
+++ b/server/i18n/fa.json
@@ -244,8 +244,8 @@
     "translation": "شناسه اصلی نامعتبر است."
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "پیام نامعتبر است."
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "ویژگی پیام از حداکثر طول مجاز بیشتر است."
   },
   {
     "id": "model.post.is_valid.id.app_error",

--- a/server/i18n/fi.json
+++ b/server/i18n/fi.json
@@ -1528,8 +1528,8 @@
     "translation": "Virheellinen alkuperäinen ID"
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Virheellinen viesti"
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "Viestin ominaisuus on pidempi kuin sallittu enimmäispituus."
   },
   {
     "id": "model.post.is_valid.id.app_error",

--- a/server/i18n/fr.json
+++ b/server/i18n/fr.json
@@ -4316,8 +4316,8 @@
     "translation": "Id invalide"
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Message invalide"
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "La propriété du message est plus longue que la longueur maximale autorisée."
   },
   {
     "id": "model.post.is_valid.original_id.app_error",

--- a/server/i18n/hi.json
+++ b/server/i18n/hi.json
@@ -1608,8 +1608,8 @@
     "translation": "अमान्य प्रकार।"
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "अमान्य मैसेज।"
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "संदेश गुणधर्म अधिकतम अनुमत लंबाई से लंबा है।"
   },
   {
     "id": "model.post.is_valid.hashtags.app_error",

--- a/server/i18n/hu.json
+++ b/server/i18n/hu.json
@@ -1488,8 +1488,8 @@
     "translation": "Érvénytelen eredeti azonosító."
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Érvénytelen üzenet."
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "Az üzenet tulajdonsága hosszabb, mint a maximálisan megengedett hossz."
   },
   {
     "id": "model.post.is_valid.id.app_error",

--- a/server/i18n/id.json
+++ b/server/i18n/id.json
@@ -1440,8 +1440,8 @@
     "translation": "ID asli tidak valid"
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Pesan tidak valid"
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "Properti Pesan lebih panjang dari panjang maksimum yang diizinkan."
   },
   {
     "id": "model.post.is_valid.id.app_error",

--- a/server/i18n/it.json
+++ b/server/i18n/it.json
@@ -4312,8 +4312,8 @@
     "translation": "ID non valido."
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Messaggio invalido."
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "La proprietà del messaggio è più lunga della lunghezza massima consentita."
   },
   {
     "id": "model.post.is_valid.original_id.app_error",

--- a/server/i18n/ja.json
+++ b/server/i18n/ja.json
@@ -4306,8 +4306,8 @@
     "translation": "不正なIDです。"
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "不正なメッセージです。"
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "メッセージのプロパティは許可されている最大長を超えています。"
   },
   {
     "id": "model.post.is_valid.original_id.app_error",
@@ -8818,8 +8818,8 @@
     "translation": "不正なpropsです。"
   },
   {
-    "id": "model.draft.is_valid.msg.app_error",
-    "translation": "不正なmessageです。"
+    "id": "model.draft.is_valid.message_length.app_error",
+    "translation": "ドラフトメッセージのプロパティは、許可されている最大長を超えています。"
   },
   {
     "id": "model.draft.is_valid.file_ids.app_error",

--- a/server/i18n/ko.json
+++ b/server/i18n/ko.json
@@ -4304,8 +4304,8 @@
     "translation": "잘못된 ID"
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Invalid message"
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "메시지 속성의 길이가 허용된 최대 길이를 초과했습니다."
   },
   {
     "id": "model.post.is_valid.original_id.app_error",

--- a/server/i18n/nl.json
+++ b/server/i18n/nl.json
@@ -4311,8 +4311,8 @@
     "translation": "Ongeldig Id."
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Ongeldig bericht."
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "De berichteigenschap is langer dan de maximaal toegestane lengte."
   },
   {
     "id": "model.post.is_valid.original_id.app_error",
@@ -8850,8 +8850,8 @@
     "translation": "Ongeldige prioriteit"
   },
   {
-    "id": "model.draft.is_valid.msg.app_error",
-    "translation": "Ongeldig bericht."
+    "id": "model.draft.is_valid.message_length.app_error",
+    "translation": "De eigenschap van het conceptbericht is langer dan de maximaal toegestane lengte."
   },
   {
     "id": "model.draft.is_valid.file_ids.app_error",

--- a/server/i18n/pl.json
+++ b/server/i18n/pl.json
@@ -4316,8 +4316,8 @@
     "translation": "Nieprawidłowy identyfikator."
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Nieprawidłowa wiadomość."
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "Właściwość wiadomości jest dłuższa niż maksymalna dozwolona długość."
   },
   {
     "id": "model.post.is_valid.original_id.app_error",
@@ -8840,8 +8840,8 @@
     "translation": "Nieprawidłowa wartość."
   },
   {
-    "id": "model.draft.is_valid.msg.app_error",
-    "translation": "Nieprawidłowa wiadomość."
+    "id": "model.draft.is_valid.message_length.app_error",
+    "translation": "Właściwość wiadomości roboczej jest dłuższa niż maksymalna dozwolona długość."
   },
   {
     "id": "model.draft.is_valid.file_ids.app_error",

--- a/server/i18n/pt-BR.json
+++ b/server/i18n/pt-BR.json
@@ -4316,8 +4316,8 @@
     "translation": "ID inválida."
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Mensagem inválida."
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "A propriedade da mensagem é maior do que o comprimento máximo permitido."
   },
   {
     "id": "model.post.is_valid.original_id.app_error",

--- a/server/i18n/ro.json
+++ b/server/i18n/ro.json
@@ -4312,8 +4312,8 @@
     "translation": "ID Incorect."
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Mesaj inexistent."
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "Proprietatea mesajului depășește lungimea maximă permisă."
   },
   {
     "id": "model.post.is_valid.original_id.app_error",

--- a/server/i18n/ru.json
+++ b/server/i18n/ru.json
@@ -4316,8 +4316,8 @@
     "translation": "Недопустимый идентификатор."
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Неверное сообщение."
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "Свойство Сообщение превышает максимально допустимую длину."
   },
   {
     "id": "model.post.is_valid.original_id.app_error",
@@ -8840,8 +8840,8 @@
     "translation": "Некорректные свойства."
   },
   {
-    "id": "model.draft.is_valid.msg.app_error",
-    "translation": "Неверное сообщение."
+    "id": "model.draft.is_valid.message_length.app_error",
+    "translation": "Свойство Сообщение длиннее максимально допустимой длины."
   },
   {
     "id": "model.draft.is_valid.file_ids.app_error",

--- a/server/i18n/sl.json
+++ b/server/i18n/sl.json
@@ -400,8 +400,8 @@
     "translation": "Neveljaven original ID"
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Neveljavno sporočilo"
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "Lastnost sporočila je daljša od največje dovoljene dolžine."
   },
   {
     "id": "model.post.is_valid.id.app_error",

--- a/server/i18n/sv.json
+++ b/server/i18n/sv.json
@@ -1676,8 +1676,8 @@
     "translation": "Ogiltigt originalpost-id."
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Ogiltigt meddelande."
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "Egenskapen för meddelandet är längre än den maximalt tillåtna längden."
   },
   {
     "id": "model.post.is_valid.id.app_error",
@@ -8874,8 +8874,8 @@
     "translation": "Ogiltig prioritet"
   },
   {
-    "id": "model.draft.is_valid.msg.app_error",
-    "translation": "Ogiltigt meddelande."
+    "id": "model.draft.is_valid.message_length.app_error",
+    "translation": "Egenskapen för utkastmeddelandet är längre än den maximalt tillåtna längden."
   },
   {
     "id": "model.draft.is_valid.file_ids.app_error",

--- a/server/i18n/tr.json
+++ b/server/i18n/tr.json
@@ -4311,8 +4311,8 @@
     "translation": "Kimlik geçersiz."
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "İleti geçersiz."
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "Mesaj özelliği, izin verilen maksimum uzunluktan uzundur."
   },
   {
     "id": "model.post.is_valid.original_id.app_error",
@@ -8854,8 +8854,8 @@
     "translation": "Öncelik geçersiz"
   },
   {
-    "id": "model.draft.is_valid.msg.app_error",
-    "translation": "İleti geçersiz."
+    "id": "model.draft.is_valid.message_length.app_error",
+    "translation": "Taslak Mesaj özelliği, izin verilen maksimum uzunluktan daha uzundur."
   },
   {
     "id": "model.draft.is_valid.file_ids.app_error",

--- a/server/i18n/uk.json
+++ b/server/i18n/uk.json
@@ -4316,8 +4316,8 @@
     "translation": "Неприпустимий ідентифікатор"
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Недійсне повідомлення"
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "Властивість повідомлення перевищує максимально допустиму довжину."
   },
   {
     "id": "model.post.is_valid.original_id.app_error",

--- a/server/i18n/vi.json
+++ b/server/i18n/vi.json
@@ -4728,8 +4728,8 @@
     "translation": "ID nhóm không hợp lệ"
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "Tin nhắn không hợp lệ"
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "Thuộc tính tin nhắn dài hơn độ dài tối đa được phép."
   },
   {
     "id": "api.templates.mfa_activated_body.title",
@@ -9258,8 +9258,8 @@
     "translation": "Id tập tin không hợp lệ."
   },
   {
-    "id": "model.draft.is_valid.msg.app_error",
-    "translation": "Tin nhắn không hợp lệ."
+    "id": "model.draft.is_valid.message_length.app_error",
+    "translation": "Thuộc tính Tin nhắn bản nháp dài hơn độ dài tối đa cho phép."
   },
   {
     "id": "model.draft.is_valid.priority.app_error",

--- a/server/i18n/zh-CN.json
+++ b/server/i18n/zh-CN.json
@@ -4306,8 +4306,8 @@
     "translation": "无效的 Id。"
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "无效的消息。"
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "消息属性超出了最大允许长度。"
   },
   {
     "id": "model.post.is_valid.original_id.app_error",
@@ -8810,8 +8810,8 @@
     "translation": "不正确的优先级"
   },
   {
-    "id": "model.draft.is_valid.msg.app_error",
-    "translation": "不正确的消息。"
+    "id": "model.draft.is_valid.message_length.app_error",
+    "translation": "草稿消息属性超出了最大允许长度。"
   },
   {
     "id": "model.draft.is_valid.file_ids.app_error",

--- a/server/i18n/zh-TW.json
+++ b/server/i18n/zh-TW.json
@@ -4304,8 +4304,8 @@
     "translation": "ID 無效。"
   },
   {
-    "id": "model.post.is_valid.msg.app_error",
-    "translation": "訊息無效。"
+    "id": "model.post.is_valid.message_length.app_error",
+    "translation": "訊息屬性超過了最大允許長度。"
   },
   {
     "id": "model.post.is_valid.original_id.app_error",
@@ -7928,8 +7928,8 @@
     "translation": "檔案 ID 無效。"
   },
   {
-    "id": "model.draft.is_valid.msg.app_error",
-    "translation": "訊息無效。"
+    "id": "model.draft.is_valid.message_length.app_error",
+    "translation": "草稿訊息屬性超過了最大允許長度。"
   },
   {
     "id": "model.draft.is_valid.priority.app_error",

--- a/server/public/model/draft.go
+++ b/server/public/model/draft.go
@@ -28,7 +28,8 @@ type Draft struct {
 
 func (o *Draft) IsValid(maxDraftSize int) *AppError {
 	if utf8.RuneCountInString(o.Message) > maxDraftSize {
-		return NewAppError("Drafts.IsValid", "model.draft.is_valid.msg.app_error", nil, "channelid="+o.ChannelId, http.StatusBadRequest)
+		return NewAppError("Drafts.IsValid", "model.draft.is_valid.message_length.app_error",
+			map[string]any{"Length": utf8.RuneCountInString(o.Message), "MaxLength": maxDraftSize}, "channelid="+o.ChannelId, http.StatusBadRequest)
 	}
 
 	return o.BaseIsValid()

--- a/server/public/model/post.go
+++ b/server/public/model/post.go
@@ -437,7 +437,8 @@ func (o *Post) IsValid(maxPostSize int) *AppError {
 	}
 
 	if utf8.RuneCountInString(o.Message) > maxPostSize {
-		return NewAppError("Post.IsValid", "model.post.is_valid.msg.app_error", nil, "id="+o.Id, http.StatusBadRequest)
+		return NewAppError("Post.IsValid", "model.post.is_valid.message_length.app_error",
+			map[string]any{"Length": utf8.RuneCountInString(o.Message), "MaxLength": maxPostSize}, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if utf8.RuneCountInString(o.Hashtags) > PostHashtagsMaxRunes {

--- a/server/public/model/post_test.go
+++ b/server/public/model/post_test.go
@@ -59,6 +59,11 @@ func TestPostIsValid(t *testing.T) {
 	appErr = o.IsValid(maxPostSize)
 	require.NotNil(t, appErr)
 
+	// In case message property length is too long.
+	o.Message = strings.Repeat("0", maxPostSize+1)
+	appErr = o.IsValid(maxPostSize)
+	require.NotNil(t, appErr)
+
 	o.Message = strings.Repeat("0", maxPostSize)
 	appErr = o.IsValid(maxPostSize)
 	require.Nil(t, appErr)


### PR DESCRIPTION
#### Summary
Replaced `model.post.is_valid.msg.app_error` error by `model.post.is_valid.message_length.app_error` and `model.draft.is_valid.msg.app_error` by `model.draft.is_valid.message_length.app_error` to make in more clear what exactly invalid with provided message.
Also rewritten i18n texts related to these errors. Due to the fact that I am not a polyglot, these translations were made with the help of ChatGPT.

#### Ticket Link
Related issue: [GH-27059](https://github.com/mattermost/mattermost/issues/27059)

#### Release Note
```release-note
NONE
```
