### PR TITLE
MM-61731 - enhance failed sent system bot message

### DIFF
--- a/server/channels/app/scheduled_post_job.go
+++ b/server/channels/app/scheduled_post_job.go
@@ -441,7 +441,11 @@ func (a *App) notifyUser(rctx request.CTX, userId string, userFailedMessages []*
 			channelNames[channelId] = T("app.scheduled_post.unknown_channel")
 			continue
 		}
-		channelNames[channelId] = ch.DisplayName
+		if ch.Type != model.ChannelTypePrivate {
+			channelNames[channelId] = ch.DisplayName
+		} else {
+			channelNames[channelId] = T("app.scheduled_post.private_channel")
+		}
 	}
 
 	var messageBuilder strings.Builder

--- a/server/channels/app/scheduled_post_job.go
+++ b/server/channels/app/scheduled_post_job.go
@@ -484,10 +484,30 @@ func (a *App) notifyUser(rctx request.CTX, userId string, userFailedMessages []*
 }
 
 func getErrorReason(T i18n.TranslateFunc, errorCode string) string {
-	key := "app.scheduled_post.error_reason." + errorCode
-	reason := T(key)
-	if reason == key {
-		return errorCode
+	var reason string
+	switch errorCode {
+	case "unknown":
+		reason = T("app.scheduled_post.error_reason.unknown")
+	case "channel_archived":
+		reason = T("app.scheduled_post.error_reason.channel_archived")
+	case "channel_not_found":
+		reason = T("app.scheduled_post.error_reason.channel_not_found")
+	case "user_missing":
+		reason = T("app.scheduled_post.error_reason.user_missing")
+	case "user_deleted":
+		reason = T("app.scheduled_post.error_reason.user_deleted")
+	case "no_channel_permission":
+		reason = T("app.scheduled_post.error_reason.no_channel_permission")
+	case "no_channel_member":
+		reason = T("app.scheduled_post.error_reason.no_channel_member")
+	case "thread_deleted":
+		reason = T("app.scheduled_post.error_reason.thread_deleted")
+	case "unable_to_send":
+		reason = T("app.scheduled_post.error_reason.unable_to_send")
+	case "invalid_post":
+		reason = T("app.scheduled_post.error_reason.invalid_post")
+	default:
+		reason = errorCode
 	}
 	return reason
 }

--- a/server/channels/app/scheduled_post_job_test.go
+++ b/server/channels/app/scheduled_post_job_test.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -281,6 +282,9 @@ func TestHandleFailedScheduledPosts(t *testing.T) {
 		user1 := th.BasicUser
 		user2 := th.BasicUser2
 
+		channel1 := th.BasicChannel
+		channel2 := th.CreateChannel(th.Context, th.BasicTeam)
+
 		// Create failed scheduled posts: 1 for user1 and 2 for user2
 		failedScheduledPosts := []*model.ScheduledPost{
 			{
@@ -288,7 +292,7 @@ func TestHandleFailedScheduledPosts(t *testing.T) {
 				Draft: model.Draft{
 					CreateAt:  model.GetMillis(),
 					UserId:    user1.Id,
-					ChannelId: th.BasicChannel.Id,
+					ChannelId: channel1.Id,
 					Message:   "Failed scheduled post for user 1",
 				},
 				ErrorCode: model.ScheduledPostErrorUnknownError,
@@ -298,7 +302,7 @@ func TestHandleFailedScheduledPosts(t *testing.T) {
 				Draft: model.Draft{
 					CreateAt:  model.GetMillis(),
 					UserId:    user2.Id,
-					ChannelId: th.BasicChannel.Id,
+					ChannelId: channel1.Id,
 					Message:   "Failed scheduled post 1 for user 2",
 				},
 				ErrorCode: model.ScheduledPostErrorCodeNoChannelPermission,
@@ -308,7 +312,7 @@ func TestHandleFailedScheduledPosts(t *testing.T) {
 				Draft: model.Draft{
 					CreateAt:  model.GetMillis(),
 					UserId:    user2.Id,
-					ChannelId: th.BasicChannel.Id,
+					ChannelId: channel2.Id,
 					Message:   "Failed scheduled post 2 for user 2",
 				},
 				ErrorCode: model.ScheduledPostErrorNoChannelMember,
@@ -348,8 +352,8 @@ func TestHandleFailedScheduledPosts(t *testing.T) {
 		}
 
 		// Helper function to check notifications for a specific user
-		checkUserNotification := func(user *model.User, expectedCount int) {
-			// Wait time for notifications to be sent (adding 2 secs because it is run in a separate rountine)
+		checkUserNotification := func(user *model.User) {
+			// Wait time for notifications to be sent (adding 2 secs because it is run in a separate goroutine)
 			var timeout = 2 * time.Second
 			begin := time.Now()
 			channel, appErr := th.App.GetOrCreateDirectChannel(rctx, user.Id, systemBot.UserId)
@@ -357,7 +361,7 @@ func TestHandleFailedScheduledPosts(t *testing.T) {
 
 			var posts *model.PostList
 			// wait for the notification to be sent into the channel.
-			// idea is to get the channel and try to find posts, if not, wait 100ms and try again until timout or there is posts lengh
+			// idea is to get the channel and try to find posts, if not, wait 100ms and try again until timeout or there is posts length
 			for {
 				if time.Since(begin) > timeout {
 					break
@@ -371,24 +375,85 @@ func TestHandleFailedScheduledPosts(t *testing.T) {
 			}
 			assert.NotEmpty(t, posts.Posts, "Expected notification for user %s to have been sent", user.Id)
 
-			// Validate the actual content of the notification posted (to include count verification)
-			T := i18n.GetUserTranslations(user.Locale)
-			messageContent := T("app.scheduled_post.failed_messages", map[string]interface{}{
-				"Count": expectedCount,
-			})
+			// Collect failed messages for users
+			var userFailedMessages []*model.ScheduledPost
+			for _, sp := range failedScheduledPosts {
+				if sp.UserId == user.Id {
+					userFailedMessages = append(userFailedMessages, sp)
+				}
+			}
 
+			T := i18n.GetUserTranslations(user.Locale)
+
+			// Aggregate failed messages by channel and error code
+			type channelErrorKey struct {
+				ChannelId string
+				ErrorCode string
+			}
+
+			channelErrorCounts := make(map[channelErrorKey]int)
+			channelIdsSet := make(map[string]struct{})
+			for _, msg := range userFailedMessages {
+				key := channelErrorKey{ChannelId: msg.ChannelId, ErrorCode: msg.ErrorCode}
+				channelErrorCounts[key]++
+				channelIdsSet[msg.ChannelId] = struct{}{}
+			}
+
+			// Get the channel names
+			channelNames := make(map[string]string)
+			for channelId := range channelIdsSet {
+				ch, err := th.App.GetChannel(rctx, channelId)
+				assert.Nil(t, err)
+				channelNames[channelId] = ch.DisplayName
+			}
+
+			// Helper function to get error reason
+			getErrorReason := func(T i18n.TranslateFunc, errorCode string) string {
+				key := "app.scheduled_post.error_reason." + errorCode
+				reason := T(key)
+				if reason == key {
+					return errorCode
+				}
+				return reason
+			}
+
+			// Build the expected message content
+			var messageBuilder strings.Builder
+
+			messageHeader := T("app.scheduled_post.failed_messages", map[string]interface{}{
+				"Count": len(userFailedMessages),
+			})
+			messageBuilder.WriteString(messageHeader)
+			messageBuilder.WriteString("\n")
+
+			for key, count := range channelErrorCounts {
+				channelName := channelNames[key.ChannelId]
+				errorReason := getErrorReason(T, key.ErrorCode)
+
+				detailMessage := T("app.scheduled_post.failed_message_detail", map[string]interface{}{
+					"Count":       count,
+					"ChannelName": channelName,
+					"ErrorReason": errorReason,
+				})
+				messageBuilder.WriteString(detailMessage)
+				messageBuilder.WriteString("\n")
+			}
+
+			expectedMessageContent := messageBuilder.String()
+
+			// Validate the actual content of the notification posted
 			found := false
 			for _, post := range posts.Posts {
-				if post.UserId == systemBot.UserId && post.Message == messageContent {
+				if post.UserId == systemBot.UserId && post.Message == expectedMessageContent {
 					found = true
 					break
 				}
 			}
-			assert.True(t, found, "Notification post not found for user %s with expected count %d", user.Id, expectedCount)
+			assert.True(t, found, "Notification post not found for user %s with expected message", user.Id)
 		}
 
 		// Check notifications sent for failed messages for both users
-		checkUserNotification(user1, 1)
-		checkUserNotification(user2, 2)
+		checkUserNotification(user1)
+		checkUserNotification(user2)
 	})
 }

--- a/server/channels/app/scheduled_post_job_test.go
+++ b/server/channels/app/scheduled_post_job_test.go
@@ -346,15 +346,15 @@ func TestHandleFailedScheduledPosts(t *testing.T) {
 				if received.GetBroadcast().UserId == user2.Id {
 					assert.Equal(t, model.WebsocketScheduledPostUpdated, received.EventType())
 				}
-			case <-time.After(1 * time.Second):
+			case <-time.After(3 * time.Second):
 				t.Errorf("Timeout while waiting for a WebSocket event for scheduled post %d", i+1)
 			}
 		}
 
 		// Helper function to check notifications for a specific user
 		checkUserNotification := func(user *model.User) {
-			// Wait time for notifications to be sent (adding 2 secs because it is run in a separate goroutine)
-			var timeout = 2 * time.Second
+			// Wait time for notifications to be sent (adding 5 secs because it is run in a separate goroutine)
+			var timeout = 5 * time.Second
 			begin := time.Now()
 			channel, appErr := th.App.GetOrCreateDirectChannel(rctx, user.Id, systemBot.UserId)
 			assert.True(t, appErr == nil)
@@ -449,7 +449,7 @@ func TestHandleFailedScheduledPosts(t *testing.T) {
 					break
 				}
 			}
-			assert.True(t, found, "Notification post not found for user %s with expected message", user.Id)
+			assert.True(t, found, "\nNotification post not found for user %s with expected message. \n Expected: %s \n", user.Id, expectedMessageContent)
 		}
 
 		// Check notifications sent for failed messages for both users

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -6543,24 +6543,6 @@
     "translation": "Error occurred saving the scheduled post."
   },
   {
-    "id": "app.scheduled_post.failed_messages",
-    "translation": {
-      "one": "Failed to send {{.Count}} scheduled post.",
-      "other": "Failed to send {{.Count}} scheduled posts."
-    }
-  },
-  {
-    "id": "app.scheduled_post.failed_message_detail",
-    "translation": {
-      "one": "- {{.Count}} in channel {{.ChannelName}}. Reason: {{.ErrorReason}}",
-      "other": "- {{.Count}} in channel {{.ChannelName}}. Reason: {{.ErrorReason}}"
-    }
-  },
-  {
-    "id": "app.scheduled_post.error_reason.unknown",
-    "translation": "Unknown Error"
-  },
-  {
     "id": "app.scheduled_post.error_reason.channel_archived",
     "translation": "Channel is archived"
   },
@@ -6569,20 +6551,16 @@
     "translation": "Channel not found"
   },
   {
-    "id": "app.scheduled_post.error_reason.user_missing",
-    "translation": "User does not exist"
-  },
-  {
-    "id": "app.scheduled_post.error_reason.user_deleted",
-    "translation": "User account is deleted"
-  },
-  {
-    "id": "app.scheduled_post.error_reason.no_channel_permission",
-    "translation": "No permission to post in channel"
+    "id": "app.scheduled_post.error_reason.invalid_post",
+    "translation": "Invalid post content"
   },
   {
     "id": "app.scheduled_post.error_reason.no_channel_member",
     "translation": "Not a member of the channel"
+  },
+  {
+    "id": "app.scheduled_post.error_reason.no_channel_permission",
+    "translation": "No permission to post in channel"
   },
   {
     "id": "app.scheduled_post.error_reason.thread_deleted",
@@ -6593,16 +6571,38 @@
     "translation": "Unable to send the message"
   },
   {
-    "id": "app.scheduled_post.error_reason.invalid_post",
-    "translation": "Invalid post content"
+    "id": "app.scheduled_post.error_reason.unknown",
+    "translation": "Unknown Error"
+  },
+  {
+    "id": "app.scheduled_post.error_reason.user_deleted",
+    "translation": "User account is deleted"
+  },
+  {
+    "id": "app.scheduled_post.error_reason.user_missing",
+    "translation": "User does not exist"
+  },
+  {
+    "id": "app.scheduled_post.failed_message_detail",
+    "translation": {
+      "one": "- {{.Count}} in channel {{.ChannelName}}. Reason: {{.ErrorReason}}",
+      "other": "- {{.Count}} in channel {{.ChannelName}}. Reason: {{.ErrorReason}}"
+    }
+  },
+  {
+    "id": "app.scheduled_post.failed_messages",
+    "translation": {
+      "one": "Failed to send {{.Count}} scheduled post.",
+      "other": "Failed to send {{.Count}} scheduled posts."
+    }
+  },
+  {
+    "id": "app.scheduled_post.permanent_delete_by_user.app_error",
+    "translation": "Unable to delete scheduled posts for user."
   },
   {
     "id": "app.scheduled_post.unknown_channel",
     "translation": "Unknown Channel"
-  },  
-  {
-    "id": "app.scheduled_post.permanent_delete_by_user.app_error",
-    "translation": "Unable to delete scheduled posts for user."
   },
   {
     "id": "app.scheme.delete.app_error",

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -6550,6 +6550,57 @@
     }
   },
   {
+    "id": "app.scheduled_post.failed_message_detail",
+    "translation": {
+      "one": "- {{.Count}} in channel {{.ChannelName}}. Reason: {{.ErrorReason}}",
+      "other": "- {{.Count}} in channel {{.ChannelName}}. Reason: {{.ErrorReason}}"
+    }
+  },
+  {
+    "id": "app.scheduled_post.error_reason.unknown",
+    "translation": "Unknown Error"
+  },
+  {
+    "id": "app.scheduled_post.error_reason.channel_archived",
+    "translation": "Channel is archived"
+  },
+  {
+    "id": "app.scheduled_post.error_reason.channel_not_found",
+    "translation": "Channel not found"
+  },
+  {
+    "id": "app.scheduled_post.error_reason.user_missing",
+    "translation": "User does not exist"
+  },
+  {
+    "id": "app.scheduled_post.error_reason.user_deleted",
+    "translation": "User account is deleted"
+  },
+  {
+    "id": "app.scheduled_post.error_reason.no_channel_permission",
+    "translation": "No permission to post in channel"
+  },
+  {
+    "id": "app.scheduled_post.error_reason.no_channel_member",
+    "translation": "Not a member of the channel"
+  },
+  {
+    "id": "app.scheduled_post.error_reason.thread_deleted",
+    "translation": "Thread has been deleted"
+  },
+  {
+    "id": "app.scheduled_post.error_reason.unable_to_send",
+    "translation": "Unable to send the message"
+  },
+  {
+    "id": "app.scheduled_post.error_reason.invalid_post",
+    "translation": "Invalid post content"
+  },
+  {
+    "id": "app.scheduled_post.unknown_channel",
+    "translation": "Unknown Channel"
+  },  
+  {
     "id": "app.scheduled_post.permanent_delete_by_user.app_error",
     "translation": "Unable to delete scheduled posts for user."
   },

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -6601,6 +6601,10 @@
     "translation": "Unable to delete scheduled posts for user."
   },
   {
+    "id": "app.scheduled_post.private_channel",
+    "translation": "Private channel"
+  },
+  {
     "id": "app.scheduled_post.unknown_channel",
     "translation": "Unknown Channel"
   },

--- a/webapp/channels/src/components/custom_status/date_time_input.tsx
+++ b/webapp/channels/src/components/custom_status/date_time_input.tsx
@@ -29,7 +29,7 @@ import {relativeFormatDate} from 'utils/datetime';
 import {isKeyPressed} from 'utils/keyboard';
 import {getCurrentMomentForTimezone} from 'utils/timezone';
 
-const CUSTOM_STATUS_TIME_PICKER_INTERVALS_IN_MINUTES = 30;
+const CUSTOM_STATUS_TIME_PICKER_INTERVALS_IN_MINUTES = 5;
 
 export function getRoundedTime(value: Moment, roundedTo = CUSTOM_STATUS_TIME_PICKER_INTERVALS_IN_MINUTES) {
     const start = moment(value);

--- a/webapp/channels/src/components/custom_status/date_time_input.tsx
+++ b/webapp/channels/src/components/custom_status/date_time_input.tsx
@@ -29,7 +29,7 @@ import {relativeFormatDate} from 'utils/datetime';
 import {isKeyPressed} from 'utils/keyboard';
 import {getCurrentMomentForTimezone} from 'utils/timezone';
 
-const CUSTOM_STATUS_TIME_PICKER_INTERVALS_IN_MINUTES = 5;
+const CUSTOM_STATUS_TIME_PICKER_INTERVALS_IN_MINUTES = 30;
 
 export function getRoundedTime(value: Moment, roundedTo = CUSTOM_STATUS_TIME_PICKER_INTERVALS_IN_MINUTES) {
     const start = moment(value);


### PR DESCRIPTION
#### Summary
Enhance the message details for the system-bot message sent during the failed scheduled messages event.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61731

#### Screenshots
<img width="942" alt="Screenshot 2024-11-13 at 19 55 31" src="https://github.com/user-attachments/assets/12d4d57d-bd50-4395-a8ef-d92f013d48d7">
<img width="1025" alt="Screenshot 2024-11-13 at 21 09 48" src="https://github.com/user-attachments/assets/42fc4464-930a-40d4-ab2f-8cf74e90e68a">


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
