### PR TITLE
MM-61733: Fix system console theme stability

### DIFF
--- a/webapp/channels/src/actions/websocket_actions.jsx
+++ b/webapp/channels/src/actions/websocket_actions.jsx
@@ -1503,6 +1503,10 @@ function handleSidebarCategoryCreated(msg) {
     return (doDispatch, doGetState) => {
         const state = doGetState();
 
+        if (!msg.broadcast.team_id) {
+            return;
+        }
+
         if (msg.broadcast.team_id !== getCurrentTeamId(state)) {
             // The new category will be loaded when we switch teams.
             return;
@@ -1518,6 +1522,10 @@ function handleSidebarCategoryUpdated(msg) {
     return (doDispatch, doGetState) => {
         const state = doGetState();
 
+        if (!msg.broadcast.team_id) {
+            return;
+        }
+
         if (msg.broadcast.team_id !== getCurrentTeamId(state)) {
             // The updated categories will be loaded when we switch teams.
             return;
@@ -1532,6 +1540,10 @@ function handleSidebarCategoryUpdated(msg) {
 function handleSidebarCategoryDeleted(msg) {
     return (doDispatch, doGetState) => {
         const state = doGetState();
+
+        if (!msg.broadcast.team_id) {
+            return;
+        }
 
         if (msg.broadcast.team_id !== getCurrentTeamId(state)) {
             // The category will be removed when we switch teams.

--- a/webapp/channels/src/components/root/root.test.tsx
+++ b/webapp/channels/src/components/root/root.test.tsx
@@ -15,6 +15,7 @@ import * as GlobalActions from 'actions/global_actions';
 import testConfigureStore from 'packages/mattermost-redux/test/test_store';
 import {renderWithContext, waitFor} from 'tests/react_testing_utils';
 import {StoragePrefixes} from 'utils/constants';
+import * as Utils from 'utils/utils';
 
 import {handleLoginLogoutSignal, redirectToOnboardingOrDefaultTeam} from './actions';
 import type {Props} from './root';
@@ -49,14 +50,9 @@ jest.mock('components/team_sidebar', () => () => <div/>);
 jest.mock('components/mobile_view_watcher', () => () => <div/>);
 jest.mock('./performance_reporter_controller', () => () => <div/>);
 
-jest.mock('utils/utils', () => {
-    const original = jest.requireActual('utils/utils');
-
-    return {
-        ...original,
-        applyTheme: jest.fn(),
-    };
-});
+jest.mock('utils/utils', () => ({
+    applyTheme: jest.fn(),
+}));
 
 jest.mock('actions/global_actions', () => ({
     redirectUserToDefaultTeam: jest.fn(),
@@ -74,7 +70,7 @@ describe('components/Root', () => {
     const store = testConfigureStore();
 
     const baseProps: Props = {
-        theme: {} as Theme,
+        theme: {sidebarBg: 'color'} as Theme,
         isConfigLoaded: true,
         telemetryEnabled: true,
         noAccounts: false,
@@ -370,6 +366,51 @@ describe('components/Root', () => {
             await waitFor(() => {
                 expect(props.history.push).not.toHaveBeenCalled();
             });
+        });
+    });
+
+    describe('applyTheme', () => {
+        test('should apply theme initially and on change', async () => {
+            const props = {
+                ...baseProps,
+            };
+
+            const {rerender} = renderWithContext(<Root {...props}/>);
+
+            await waitFor(() => {
+                expect(Utils.applyTheme).toHaveBeenCalledWith(props.theme);
+            });
+
+            const props2 = {
+                ...props,
+                theme: {sidebarBg: 'color2'} as Theme,
+            };
+
+            rerender(<Root {...props2}/>);
+
+            expect(Utils.applyTheme).toHaveBeenCalledWith(props2.theme);
+        });
+
+        test('should not apply theme in system console', async () => {
+            const props = {
+                ...baseProps,
+                ...{
+                    location: {
+                        pathname: '/admin_console',
+                    },
+                } as RouteComponentProps,
+            };
+
+            const {rerender} = renderWithContext(<Root {...props}/>);
+
+            const props2 = {
+                ...props,
+                theme: {sidebarBg: 'color2'} as Theme,
+            };
+
+            rerender(<Root {...props2}/>);
+
+            expect(Utils.applyTheme).not.toHaveBeenCalled();
         });
     });
 });

--- a/webapp/channels/src/components/root/root.tsx
+++ b/webapp/channels/src/components/root/root.tsx
@@ -192,7 +192,7 @@ export default class Root extends React.PureComponent<Props, State> {
 
         this.showLandingPageIfNecessary();
 
-        applyTheme(this.props.theme);
+        this.applyTheme();
     };
 
     private showLandingPageIfNecessary = () => {
@@ -258,7 +258,7 @@ export default class Root extends React.PureComponent<Props, State> {
 
     applyTheme() {
         // don't apply theme when in system console; system console hardcoded to THEMES.denim
-        // AdminConsole will re-apply theme on unmount
+        // AdminConsole will apply denim on mount re-apply user theme on unmount
         if (this.props.location.pathname.startsWith('/admin_console')) {
             return;
         }

--- a/webapp/channels/src/components/root/root.tsx
+++ b/webapp/channels/src/components/root/root.tsx
@@ -255,9 +255,19 @@ export default class Root extends React.PureComponent<Props, State> {
         BrowserStore.setLandingPageSeen(true);
     };
 
+    applyTheme() {
+        // don't apply theme when in system console; system console hardcoded to THEMES.denim
+        // AdminConsole will re-apply theme on unmount
+        if (this.props.location.pathname.startsWith('/admin_console')) {
+            return;
+        }
+
+        applyTheme(this.props.theme);
+    }
+
     componentDidUpdate(prevProps: Props, prevState: State) {
         if (!deepEqual(prevProps.theme, this.props.theme)) {
-            applyTheme(this.props.theme);
+            this.applyTheme();
         }
 
         if (this.props.location.pathname === '/') {

--- a/webapp/channels/src/components/root/root.tsx
+++ b/webapp/channels/src/components/root/root.tsx
@@ -13,6 +13,7 @@ import {setSystemEmojis} from 'mattermost-redux/actions/emojis';
 import {setUrl} from 'mattermost-redux/actions/general';
 import {Client4} from 'mattermost-redux/client';
 import {rudderAnalytics, RudderTelemetryHandler} from 'mattermost-redux/client/rudder';
+import {Preferences} from 'mattermost-redux/constants';
 
 import {measurePageLoadTelemetry, temporarilySetPageLoadContext, trackEvent, trackSelectorMetrics} from 'actions/telemetry_actions.jsx';
 import BrowserStore from 'stores/browser_store';
@@ -462,7 +463,7 @@ export default class Root extends React.PureComponent<Props, State> {
                     >
                         <Switch>
                             <LoggedInRoute
-                                theme={this.props.theme}
+                                theme={Preferences.THEMES.denim}
                                 path={'/admin_console'}
                                 component={AdminConsole}
                             />


### PR DESCRIPTION
#### Summary
- 22169fed7537104d962c0f9f00d69618d9efd466 fixes an issue in system console where a theme change from another tab would cause `<Root/>` to apply the new theme when it shouldn't be. System Console is statically themed in `denim`. It does this with `resetTheme()` on mount, and `applyTheme(currentTheme)` on dismount. 
- f982b7095d54cdf671b6aad5267c97deb6f9cd95 fixes the onboarding tasklist theming when in system console.
- 43e98aa3793ebdf364a887768a75323e8edb8ea1 fixes an erroneous/404 `fetchMyCategories` request in system console when user preferences are changed from another tab.
- d54c518ae3a10f6d3b715fbc4b398f887a52cd36 prevents applying the theme twice when loading system console directly

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-61733

#### Screenshots

1. Open system console, change theme from a light one to a dark one from another tab.

|  before  |  after  |
|----|----|
| ![7DF3E5C9-0284-417D-8B40-529049BAA393](https://github.com/user-attachments/assets/c40ee902-8770-4a86-97a6-af75b6159805) | ![image](https://github.com/user-attachments/assets/6fded31e-ce31-44e9-945c-0c2929dea91d) 


2. Double theme application

<details>
<summary>Details</summary>

https://github.com/user-attachments/assets/90a221fd-14a6-4a4e-ad38-c662e7b2108a

https://github.com/user-attachments/assets/f1255902-bef1-4b3b-8d32-2ba7d76632bf

https://github.com/user-attachments/assets/09964829-823d-4cd6-980e-e52bca628bdd

https://github.com/user-attachments/assets/bc136971-3aae-4608-8d4c-0527db4300fb

</details>








#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
