### PR TITLE
GH-28752 fix errcheck lint issues in server/channels/testlib/helper.go

### DIFF
--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -205,7 +205,6 @@ issues:
         channels/store/storetest/team_store.go|\
         channels/store/storetest/thread_store.go|\
         channels/store/storetest/user_store.go|\
-        channels/testlib/helper.go|\
         channels/utils/license_test.go|\
         channels/web/oauth_test.go|\
         channels/web/saml.go|\

--- a/server/channels/testlib/helper.go
+++ b/server/channels/testlib/helper.go
@@ -73,10 +73,16 @@ func NewMainHelperWithOptions(options *HelperOptions) *MainHelper {
 		Logger: logger,
 	}
 
-	mlog.NewLogger()
+	_, err := mlog.NewLogger()
+	if err != nil {
+		log.Fatal(err)
+	}
 	flag.Parse()
 
-	utils.TranslationsPreInit()
+	err = utils.TranslationsPreInit()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	if options != nil {
 		if options.EnableStore && !testing.Short() {
@@ -92,7 +98,13 @@ func NewMainHelperWithOptions(options *HelperOptions) *MainHelper {
 }
 
 func (h *MainHelper) Main(m *testing.M) {
-	defer h.Logger.Shutdown()
+	defer func() {
+		err := h.Logger.Shutdown()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+
 	if h.testResourcePath != "" {
 		prevDir, err := os.Getwd()
 		if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Fixed `errcheck` lint errors in `server/channels/testlib/helpder.go`

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Fixes https://github.com/mattermost/mattermost/issues/28752

#### Release Noteitions or changes.
```release-note
NONE
```
