### PR TITLE
[MM-61779] Skip flaky TestEditChannelBookmark/a_websockets_event_should_be_fired_as_part_of_editing_a_bookmark

### DIFF
--- a/server/channels/api4/channel_bookmark_test.go
+++ b/server/channels/api4/channel_bookmark_test.go
@@ -598,6 +598,7 @@ func TestEditChannelBookmark(t *testing.T) {
 	})
 
 	t.Run("a websockets event should be fired as part of editing a bookmark", func(t *testing.T) {
+		t.Skip("https://mattermost.atlassian.net/browse/MM-61779")
 		webSocketClient, err := th.CreateWebSocketClient()
 		require.NoError(t, err)
 		require.NotNil(t, webSocketClient, "webSocketClient should not be nil")


### PR DESCRIPTION
#### Summary
https://hub.mattermost.com/private-core/pl/tghzisj6ubnd9xneurki1tw1zh

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61779

#### Release Note
==
```release-note
NONE
```
