### PR TITLE
MM-61536 - enable schmsgs feature on license upgrade

### DIFF
--- a/webapp/channels/src/components/drafts/drafts.scss
+++ b/webapp/channels/src/components/drafts/drafts.scss
@@ -13,7 +13,6 @@
     }
 
     &__main {
-        position: absolute;
         display: flex;
         overflow: auto;
         width: 100%;

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/scheduled_posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/scheduled_posts.ts
@@ -1,11 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {ClientLicense, ClientConfig} from '@mattermost/types/config';
 import type {ScheduledPost, ScheduledPostsState} from '@mattermost/types/schedule_post';
 import type {GlobalState} from '@mattermost/types/store';
 
 import {createSelector} from 'mattermost-redux/selectors/create_selector';
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 
 const emptyList: string[] = [];
 
@@ -77,6 +78,11 @@ export function showChannelOrThreadScheduledPostIndicator(state: GlobalState, ch
     return data;
 }
 
-export function isScheduledPostsEnabled(state: GlobalState) {
-    return getConfig(state).ScheduledPosts === 'true';
-}
+export const isScheduledPostsEnabled: (a: GlobalState) => boolean = createSelector(
+    'isScheduledPostsEnabled',
+    getConfig,
+    getLicense,
+    (config: Partial<ClientConfig>, license: ClientLicense): boolean => {
+        return config.ScheduledPosts === 'true' && license.IsLicensed === 'true';
+    },
+);


### PR DESCRIPTION

#### Summary
This PR adds the required logic for the scheduled messages feature respond in a show/hide way when the product is licensed or not. With this PR, the feature will show immediately after the product has been licensed, and will hide in case the license expires or gets removed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61536

#### Screenshots

https://github.com/user-attachments/assets/dd457850-24e3-4fdb-91b9-5334fdc5e804



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
