### PR TITLE
Use standard CSS rules to resize emoticons

### DIFF
--- a/webapp/channels/build/emoji/make_emojis.mjs
+++ b/webapp/channels/build/emoji/make_emojis.mjs
@@ -440,9 +440,14 @@ const cssRules = `.emojisprite-preview {
     background-repeat: no-repeat;
     cursor: pointer;
     -moz-transform: scale(0.5);
+    transform: scale(0.5);
     transform-origin: 0 0;
-    // Using zoom for now as it results in less blurry emojis on Chrome - MM-34178
-    zoom: 0.5;
+
+    @supports (zoom: 0.5) {
+        -moz-transform: none;
+        transform: none;
+        zoom: 0.5;
+    }
 }
 
 .emojisprite {
@@ -453,7 +458,7 @@ const cssRules = `.emojisprite-preview {
     border-radius: 18px;
     cursor: pointer;
     -moz-transform: scale(0.35);
-    zoom: 0.35;
+    transform: scale(0.35);
 }
 
 .emojisprite-loading {
@@ -465,7 +470,16 @@ const cssRules = `.emojisprite-preview {
     border-radius: 18px;
     cursor: pointer;
     -moz-transform: scale(0.35);
-    zoom: 0.35;
+    transform: scale(0.35);
+}
+
+@supports (zoom: 0.35) {
+    .emojisprite,
+    .emojisprite-loading {
+        -moz-transform: none;
+        transform: none;
+        zoom: 0.35;
+    }
 }
 
 ${cssCats.join('\n')}

--- a/webapp/channels/src/sass/components/_emojisprite.scss
+++ b/webapp/channels/src/sass/components/_emojisprite.scss
@@ -5,9 +5,14 @@
     background-repeat: no-repeat;
     cursor: pointer;
     -moz-transform: scale(0.5);
+    transform: scale(0.5);
     transform-origin: 0 0;
-    // Using zoom for now as it results in less blurry emojis on Chrome - MM-34178
-    zoom: 0.5;
+
+    @supports (zoom: 0.5) {
+        -moz-transform: none;
+        transform: none;
+        zoom: 0.5;
+    }
 }
 
 .emojisprite {
@@ -18,7 +23,7 @@
     background-repeat: no-repeat;
     cursor: pointer;
     -moz-transform: scale(0.35);
-    zoom: 0.35;
+    transform: scale(0.35);
 }
 
 .emojisprite-loading {
@@ -30,7 +35,16 @@
     background-repeat: no-repeat;
     cursor: pointer;
     -moz-transform: scale(0.35);
-    zoom: 0.35;
+    transform: scale(0.35);
+}
+
+@supports (zoom: 0.35) {
+    .emojisprite,
+    .emojisprite-loading {
+        -moz-transform: none;
+        transform: none;
+        zoom: 0.35;
+    }
 }
 
 .emoji-category-recent { background-image: url('images/emoji-sheets/apple-sheet.png'); }

--- a/webapp/channels/src/sass/components/_emoticons.scss
+++ b/webapp/channels/src/sass/components/_emoticons.scss
@@ -548,12 +548,23 @@ $emoji-footer-height:  $emoji-footer-border-width + $emoji-half-height + $emoji-
 
         img {
             -moz-transform: scale(0.45);
-            zoom: 0.45;
+            transform: scale(0.45);
+
+            @supports (zoom: 0.45) {
+                -moz-transform: none;
+                transform: none;
+                zoom: 0.45;
+            }
 
             &.emoji-category--custom {
                 -moz-transform: scale(1);
-                transform: scale(1.25);
-                zoom: 1;
+                transform: scale(1);
+
+                @supports (zoom: 1) {
+                    -moz-transform: none;
+                    transform: none;
+                    zoom: 1;
+                }
             }
         }
     }


### PR DESCRIPTION
#### Summary

Fixes a CSS issue in an upcoming Firefox version. Currently, a `-moz` prefixed `transform: scale` is applied together with non-standard `zoom` rule, causing them to be both applied at the same time, which makes emoticon sprites too small on Firefox 133.

Instead of the vendor-prefixed standard rule combined with a non-standard one, it is better to use the standard counterpart of `zoom`, which is `transform: scale`.

Original context of the issue can be found [here](https://github.com/mattermost/mattermost-webapp/pull/11936). However, as of the latest version of Chrome and Firefox, there does not seem to be a noticeable difference between `transform: scale` and `zoom` in terms of "blurriness", so non-standard `zoom` rule can probably be replaced with `transform: scale`.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/29114
Jira https://mattermost.atlassian.net/browse/MM-61527

#### Release Note

```release-note
NONE
```