### PR TITLE
MM-61755 - Simplifying and Support reporting to the db from the CLI

### DIFF
--- a/server/enterprise/message_export/message_export_test.go
+++ b/server/enterprise/message_export/message_export_test.go
@@ -273,13 +273,13 @@ func setup(t *testing.T) *api4.TestHelper {
 
 // jobDataInvariantsShouldBeEqual tests that the parts of the job.Data that shouldn't change, don't change.
 func jobDataInvariantsShouldBeEqual(t *testing.T, expected map[string]string, received map[string]string) {
-	require.Equal(t, expected[JobDataExportType], received[JobDataExportType])
-	require.Equal(t, expected[jobDataBatchSize], received[jobDataBatchSize])
-	require.Equal(t, expected[jobDataChannelBatchSize], received[jobDataChannelBatchSize])
-	require.Equal(t, expected[jobDataChannelHistoryBatchSize], received[jobDataChannelHistoryBatchSize])
-	require.Equal(t, expected[JobDataExportDir], received[JobDataExportDir])
-	require.Equal(t, expected[JobDataEndTimestamp], received[JobDataEndTimestamp])
-	require.Equal(t, expected[JobDataStartTimestamp], received[JobDataStartTimestamp])
+	require.Equal(t, expected[shared.JobDataExportType], received[shared.JobDataExportType])
+	require.Equal(t, expected[shared.JobDataBatchSize], received[shared.JobDataBatchSize])
+	require.Equal(t, expected[shared.JobDataChannelBatchSize], received[shared.JobDataChannelBatchSize])
+	require.Equal(t, expected[shared.JobDataChannelHistoryBatchSize], received[shared.JobDataChannelHistoryBatchSize])
+	require.Equal(t, expected[shared.JobDataExportDir], received[shared.JobDataExportDir])
+	require.Equal(t, expected[shared.JobDataJobEndTime], received[shared.JobDataJobEndTime])
+	require.Equal(t, expected[shared.JobDataJobStartTime], received[shared.JobDataJobStartTime])
 }
 
 func TestRunExportJobE2EByType(t *testing.T) {
@@ -366,11 +366,11 @@ func testRunExportJobE2E(t *testing.T, exportBackend filestore.FileBackend, expo
 
 		job := runJobForTest(t, th, nil)
 
-		warnings, err := strconv.Atoi(job.Data[JobDataWarningCount])
+		warnings, err := strconv.Atoi(job.Data[shared.JobDataWarningCount])
 		require.NoError(t, err)
 		require.Equal(t, 0, warnings)
 
-		numExported, err := strconv.ParseInt(job.Data[JobDataMessagesExported], 0, 64)
+		numExported, err := strconv.ParseInt(job.Data[shared.JobDataMessagesExported], 0, 64)
 		require.NoError(t, err)
 		require.Equal(t, int64(3), numExported)
 	})
@@ -440,17 +440,17 @@ func testRunExportJobE2E(t *testing.T, exportBackend filestore.FileBackend, expo
 
 		job := runJobForTest(t, th, nil)
 
-		warnings, err := strconv.Atoi(job.Data[JobDataWarningCount])
+		warnings, err := strconv.Atoi(job.Data[shared.JobDataWarningCount])
 		require.NoError(t, err)
 		require.Equal(t, 0, warnings)
 
-		numExported, err := strconv.ParseInt(job.Data[JobDataMessagesExported], 0, 64)
+		numExported, err := strconv.ParseInt(job.Data[shared.JobDataMessagesExported], 0, 64)
 		require.NoError(t, err)
 		require.Equal(t, int64(11), numExported)
 
-		jobEnd, err := strconv.ParseInt(job.Data[JobDataEndTimestamp], 0, 64)
+		jobEnd, err := strconv.ParseInt(job.Data[shared.JobDataJobEndTime], 0, 64)
 		require.NoError(t, err)
-		jobExportDir := job.Data[JobDataExportDir]
+		jobExportDir := job.Data[shared.JobDataExportDir]
 		batch001 := shared.GetBatchPath(jobExportDir, jobStart, now+3, 1)
 		batch002 := shared.GetBatchPath(jobExportDir, now+3, now+8, 2)
 		batch003 := shared.GetBatchPath(jobExportDir, now+8, jobEnd, 3)
@@ -512,22 +512,22 @@ func testRunExportJobE2E(t *testing.T, exportBackend filestore.FileBackend, expo
 
 		// start at the 2nd post and get till the 7th post (inclusive) = 6 posts
 		job := runJobForTest(t, th, map[string]string{
-			JobDataBatchStartTimestamp: strconv.Itoa(int(now) + 1),
-			JobDataEndTimestamp:        strconv.Itoa(int(now) + 6),
+			shared.JobDataBatchStartTime: strconv.Itoa(int(now) + 1),
+			shared.JobDataJobEndTime:     strconv.Itoa(int(now) + 6),
 		})
-		numExported, err := strconv.ParseInt(job.Data[JobDataMessagesExported], 0, 64)
+		numExported, err := strconv.ParseInt(job.Data[shared.JobDataMessagesExported], 0, 64)
 		require.NoError(t, err)
-		numExpected, err := strconv.ParseInt(job.Data[JobDataTotalPostsExpected], 0, 64)
+		numExpected, err := strconv.ParseInt(job.Data[shared.JobDataTotalPostsExpected], 0, 64)
 		require.NoError(t, err)
-		// test that we only exported 6 (because the JobDataEndTimestamp was translated to the cursor's UntilUpdateAt)
+		// test that we only exported 6 (because the JobDataJobEndTime was translated to the cursor's UntilUpdateAt)
 		require.Equal(t, 6, int(numExported))
 		// test that we were reporting that correctly in the UI
 		require.Equal(t, 6, int(numExpected))
 
-		jobEnd, err := strconv.ParseInt(job.Data[JobDataEndTimestamp], 0, 64)
+		jobEnd, err := strconv.ParseInt(job.Data[shared.JobDataJobEndTime], 0, 64)
 		require.NoError(t, err)
 		require.Equal(t, now+6, jobEnd)
-		jobExportDir := job.Data[JobDataExportDir]
+		jobExportDir := job.Data[shared.JobDataExportDir]
 		batch001 := shared.GetBatchPath(jobExportDir, now+1, now+3, 1)
 		// lastPostUpdateAt will be post#4 (now+3), even though we exported it above, because LastPostId will exclude it
 		batch002 := shared.GetBatchPath(jobExportDir, now+3, now+6, 2)
@@ -791,7 +791,7 @@ func testRunExportJobE2E(t *testing.T, exportBackend filestore.FileBackend, expo
 					LastActivityAt: 0,
 					Status:         model.JobStatusSuccess,
 					Progress:       100,
-					Data:           map[string]string{JobDataBatchStartTimestamp: strconv.Itoa(int(start))},
+					Data:           map[string]string{shared.JobDataBatchStartTime: strconv.Itoa(int(start))},
 				})
 				require.NoError(t, err)
 
@@ -800,7 +800,7 @@ func testRunExportJobE2E(t *testing.T, exportBackend filestore.FileBackend, expo
 				require.NotNilf(t, previousJob, "prevJob")
 
 				var prevUpdatedAt int64
-				if timestamp, prevExists := previousJob.Data[JobDataBatchStartTimestamp]; prevExists {
+				if timestamp, prevExists := previousJob.Data[shared.JobDataBatchStartTime]; prevExists {
 					prevUpdatedAt, err = strconv.ParseInt(timestamp, 10, 64)
 					require.NoError(t, err)
 				}
@@ -849,16 +849,16 @@ func testRunExportJobE2E(t *testing.T, exportBackend filestore.FileBackend, expo
 					job = runJobForTest(t, th, nil)
 				}
 
-				warnings, err := strconv.Atoi(job.Data[JobDataWarningCount])
+				warnings, err := strconv.Atoi(job.Data[shared.JobDataWarningCount])
 				require.NoError(t, err)
 				require.Equal(t, 0, warnings)
 
-				numExported, err := strconv.Atoi(job.Data[JobDataMessagesExported])
+				numExported, err := strconv.Atoi(job.Data[shared.JobDataMessagesExported])
 				require.NoError(t, err)
 				require.Equal(t, 9, numExported)
 
-				jobExportDir := job.Data[JobDataExportDir]
-				jobEndTime, err := strconv.ParseInt(job.Data[JobDataEndTimestamp], 10, 64)
+				jobExportDir := job.Data[shared.JobDataExportDir]
+				jobEndTime, err := strconv.ParseInt(job.Data[shared.JobDataJobEndTime], 10, 64)
 				require.NoError(t, err)
 
 				// Expected data:
@@ -1063,7 +1063,7 @@ func testRunExportJobE2E(t *testing.T, exportBackend filestore.FileBackend, expo
 			LastActivityAt: 0,
 			Status:         model.JobStatusSuccess,
 			Progress:       100,
-			Data:           map[string]string{JobDataBatchStartTimestamp: strconv.Itoa(int(start))},
+			Data:           map[string]string{shared.JobDataBatchStartTime: strconv.Itoa(int(start))},
 		})
 		require.NoError(t, err)
 
@@ -1072,7 +1072,7 @@ func testRunExportJobE2E(t *testing.T, exportBackend filestore.FileBackend, expo
 		require.NotNilf(t, previousJob, "prevJob")
 
 		var prevUpdatedAt int64
-		if timestamp, prevExists := previousJob.Data[JobDataBatchStartTimestamp]; prevExists {
+		if timestamp, prevExists := previousJob.Data[shared.JobDataBatchStartTime]; prevExists {
 			prevUpdatedAt, err = strconv.ParseInt(timestamp, 10, 64)
 			require.NoError(t, err)
 		}
@@ -1089,16 +1089,16 @@ func testRunExportJobE2E(t *testing.T, exportBackend filestore.FileBackend, expo
 		// Now run the exports
 		job := runJobForTest(t, th, nil)
 
-		warnings, err := strconv.Atoi(job.Data[JobDataWarningCount])
+		warnings, err := strconv.Atoi(job.Data[shared.JobDataWarningCount])
 		require.NoError(t, err)
 		require.Equal(t, 0, warnings)
 
-		numExported, err := strconv.ParseInt(job.Data[JobDataMessagesExported], 0, 64)
+		numExported, err := strconv.ParseInt(job.Data[shared.JobDataMessagesExported], 0, 64)
 		require.NoError(t, err)
 		require.Equal(t, 2, int(numExported))
 
-		jobExportDir := job.Data[JobDataExportDir]
-		jobEndTime, err := strconv.ParseInt(job.Data[JobDataEndTimestamp], 10, 64)
+		jobExportDir := job.Data[shared.JobDataExportDir]
+		jobEndTime, err := strconv.ParseInt(job.Data[shared.JobDataJobEndTime], 10, 64)
 		require.NoError(t, err)
 
 		// Expected data:
@@ -1329,12 +1329,12 @@ func testRunExportJobE2E(t *testing.T, exportBackend filestore.FileBackend, expo
 		// Now run the exports
 		job := runJobForTest(t, th, nil)
 
-		numExported, err := strconv.Atoi(job.Data[JobDataMessagesExported])
+		numExported, err := strconv.Atoi(job.Data[shared.JobDataMessagesExported])
 		require.NoError(t, err)
 		require.Equal(t, 8, numExported)
 
-		jobExportDir := job.Data[JobDataExportDir]
-		jobEndTime, err := strconv.ParseInt(job.Data[JobDataEndTimestamp], 10, 64)
+		jobExportDir := job.Data[shared.JobDataExportDir]
+		jobEndTime, err := strconv.ParseInt(job.Data[shared.JobDataJobEndTime], 10, 64)
 		require.NoError(t, err)
 
 		// using posts[7] because it's updateAt is what posts[6] is changed to (after the edit)
@@ -1651,12 +1651,12 @@ func testRunExportJobE2E(t *testing.T, exportBackend filestore.FileBackend, expo
 		_, err = th.App.Srv().Store().Job().Delete(job.Id)
 		require.NoError(t, err)
 
-		numExported, err := strconv.Atoi(job.Data[JobDataMessagesExported])
+		numExported, err := strconv.Atoi(job.Data[shared.JobDataMessagesExported])
 		require.NoError(t, err)
 		require.Equal(t, 5, numExported)
 
-		jobExportDir := job.Data[JobDataExportDir]
-		jobEndTime, err := strconv.ParseInt(job.Data[JobDataEndTimestamp], 10, 64)
+		jobExportDir := job.Data[shared.JobDataExportDir]
+		jobEndTime, err := strconv.ParseInt(job.Data[shared.JobDataJobEndTime], 10, 64)
 		require.NoError(t, err)
 
 		batch001 := shared.GetBatchPath(jobExportDir, start, jobEndTime, 1)
@@ -1795,12 +1795,12 @@ func testRunExportJobE2E(t *testing.T, exportBackend filestore.FileBackend, expo
 		// Now run the exports
 		job := runJobForTest(t, th, nil)
 
-		numExported, err := strconv.Atoi(job.Data[JobDataMessagesExported])
+		numExported, err := strconv.Atoi(job.Data[shared.JobDataMessagesExported])
 		require.NoError(t, err)
 		require.Equal(t, 1, numExported)
 
-		jobExportDir := job.Data[JobDataExportDir]
-		jobEndTime, err := strconv.ParseInt(job.Data[JobDataEndTimestamp], 10, 64)
+		jobExportDir := job.Data[shared.JobDataExportDir]
+		jobEndTime, err := strconv.ParseInt(job.Data[shared.JobDataJobEndTime], 10, 64)
 		require.NoError(t, err)
 
 		batch001 := shared.GetBatchPath(jobExportDir, start, jobEndTime, 1)
@@ -1903,12 +1903,12 @@ func testRunExportJobE2E(t *testing.T, exportBackend filestore.FileBackend, expo
 		// Now run the exports
 		job = runJobForTest(t, th, nil)
 
-		numExported, err = strconv.Atoi(job.Data[JobDataMessagesExported])
+		numExported, err = strconv.Atoi(job.Data[shared.JobDataMessagesExported])
 		require.NoError(t, err)
 		require.Equal(t, 2, numExported)
 
-		jobExportDir = job.Data[JobDataExportDir]
-		jobEndTime, err = strconv.ParseInt(job.Data[JobDataEndTimestamp], 10, 64)
+		jobExportDir = job.Data[shared.JobDataExportDir]
+		jobEndTime, err = strconv.ParseInt(job.Data[shared.JobDataJobEndTime], 10, 64)
 		require.NoError(t, err)
 
 		// use the message1 updateAt, because the message0's updateAt is now after
@@ -2029,12 +2029,12 @@ func testRunExportJobE2E(t *testing.T, exportBackend filestore.FileBackend, expo
 		// Now run the exports
 		job = runJobForTest(t, th, nil)
 
-		numExported, err = strconv.Atoi(job.Data[JobDataMessagesExported])
+		numExported, err = strconv.Atoi(job.Data[shared.JobDataMessagesExported])
 		require.NoError(t, err)
 		require.Equal(t, 2, numExported)
 
-		jobExportDir = job.Data[JobDataExportDir]
-		jobEndTime, err = strconv.ParseInt(job.Data[JobDataEndTimestamp], 10, 64)
+		jobExportDir = job.Data[shared.JobDataExportDir]
+		jobEndTime, err = strconv.ParseInt(job.Data[shared.JobDataJobEndTime], 10, 64)
 		require.NoError(t, err)
 
 		batch001 = shared.GetBatchPath(jobExportDir, start, jobEndTime, 1)
@@ -2132,12 +2132,12 @@ func testRunExportJobE2E(t *testing.T, exportBackend filestore.FileBackend, expo
 		// Now run the exports
 		job = runJobForTest(t, th, nil)
 
-		numExported, err = strconv.Atoi(job.Data[JobDataMessagesExported])
+		numExported, err = strconv.Atoi(job.Data[shared.JobDataMessagesExported])
 		require.NoError(t, err)
 		require.Equal(t, 3, numExported)
 
-		jobExportDir = job.Data[JobDataExportDir]
-		jobEndTime, err = strconv.ParseInt(job.Data[JobDataEndTimestamp], 10, 64)
+		jobExportDir = job.Data[shared.JobDataExportDir]
+		jobEndTime, err = strconv.ParseInt(job.Data[shared.JobDataJobEndTime], 10, 64)
 		require.NoError(t, err)
 
 		batch001 = shared.GetBatchPath(jobExportDir, start, jobEndTime, 1)
@@ -2268,17 +2268,17 @@ func testRunExportJobE2E(t *testing.T, exportBackend filestore.FileBackend, expo
 
 		job := runJobForTest(t, th, nil)
 
-		warnings, err := strconv.Atoi(job.Data[JobDataWarningCount])
+		warnings, err := strconv.Atoi(job.Data[shared.JobDataWarningCount])
 		require.NoError(t, err)
 		require.Equal(t, 0, warnings)
 
-		numExported, err := strconv.ParseInt(job.Data[JobDataMessagesExported], 0, 64)
+		numExported, err := strconv.ParseInt(job.Data[shared.JobDataMessagesExported], 0, 64)
 		require.NoError(t, err)
 		require.Equal(t, int64(11), numExported)
-		jobEnd, err := strconv.ParseInt(job.Data[JobDataEndTimestamp], 0, 64)
+		jobEnd, err := strconv.ParseInt(job.Data[shared.JobDataJobEndTime], 0, 64)
 		require.NoError(t, err)
 
-		jobExportDir := job.Data[JobDataExportDir]
+		jobExportDir := job.Data[shared.JobDataExportDir]
 		batch001 := shared.GetBatchPath(jobExportDir, jobStart, now+3, 1)
 		batch002 := shared.GetBatchPath(jobExportDir, now+3, now+8, 2)
 		batch003 := shared.GetBatchPath(jobExportDir, now+8, jobEnd, 3)

--- a/server/enterprise/message_export/shared/shared.go
+++ b/server/enterprise/message_export/shared/shared.go
@@ -116,6 +116,108 @@ func JobDataToStringMap(jd JobData) map[string]string {
 	return ret
 }
 
+func StringMapToJobDataWithZeroValues(sm map[string]string) (JobData, error) {
+	var jd JobData
+	var err error
+
+	jd.ExportType = sm[JobDataExportType]
+	jd.ExportDir = sm[JobDataExportDir]
+
+	batchStartTime, ok := sm[JobDataBatchStartTime]
+	if !ok {
+		batchStartTime = "0"
+	}
+	if jd.BatchStartTime, err = strconv.ParseInt(batchStartTime, 10, 64); err != nil {
+		return jd, fmt.Errorf("StringMapToJobDataWithZeroValues, error converting JobDataBatchStartTime, err: %w", err)
+	}
+
+	jd.BatchStartId = sm[JobDataBatchStartId]
+
+	jobStartTime, ok := sm[JobDataJobStartTime]
+	if !ok {
+		jobStartTime = "0"
+	}
+	if jd.JobStartTime, err = strconv.ParseInt(jobStartTime, 10, 64); err != nil {
+		return jd, fmt.Errorf("StringMapToJobDataWithZeroValues, error converting JobDataJobStartTime, err: %w", err)
+	}
+
+	jobEndTime, ok := sm[JobDataJobEndTime]
+	if !ok {
+		jobEndTime = "0"
+	}
+	if jd.JobEndTime, err = strconv.ParseInt(jobEndTime, 10, 64); err != nil {
+		return jd, fmt.Errorf("StringMapToJobDataWithZeroValues, error converting JobDataJobEndTime, err: %w", err)
+	}
+
+	jd.JobStartId = sm[JobDataJobStartId]
+
+	jobBatchSize, ok := sm[JobDataBatchSize]
+	if !ok {
+		jobBatchSize = "0"
+	}
+	if jd.BatchSize, err = strconv.Atoi(jobBatchSize); err != nil {
+		return jd, fmt.Errorf("StringMapToJobDataWithZeroValues, error converting JobDataBatchSize, err: %w", err)
+	}
+
+	channelBatchSize, ok := sm[JobDataChannelBatchSize]
+	if !ok {
+		channelBatchSize = "0"
+	}
+	if jd.ChannelBatchSize, err = strconv.Atoi(channelBatchSize); err != nil {
+		return jd, fmt.Errorf("StringMapToJobDataWithZeroValues, error converting JobDataChannelBatchSize, err: %w", err)
+	}
+
+	channelHistoryBatchSize, ok := sm[JobDataChannelHistoryBatchSize]
+	if !ok {
+		channelHistoryBatchSize = "0"
+	}
+	if jd.ChannelHistoryBatchSize, err = strconv.Atoi(channelHistoryBatchSize); err != nil {
+		return jd, fmt.Errorf("StringMapToJobDataWithZeroValues, error converting JobDataChannelHistoryBatchSize, err: %w", err)
+	}
+
+	batchNumber, ok := sm[JobDataBatchNumber]
+	if !ok {
+		batchNumber = "0"
+	}
+	if jd.BatchNumber, err = strconv.Atoi(batchNumber); err != nil {
+		return jd, fmt.Errorf("StringMapToJobDataWithZeroValues, error converting JobDataBatchNumber, err: %w", err)
+	}
+
+	totalPostsExpected, ok := sm[JobDataTotalPostsExpected]
+	if !ok {
+		totalPostsExpected = "0"
+	}
+	if jd.TotalPostsExpected, err = strconv.Atoi(totalPostsExpected); err != nil {
+		return jd, fmt.Errorf("StringMapToJobDataWithZeroValues, error converting JobDataTotalPostsExpected, err: %w", err)
+	}
+
+	messagesExported, ok := sm[JobDataMessagesExported]
+	if !ok {
+		messagesExported = "0"
+	}
+	if jd.MessagesExported, err = strconv.Atoi(messagesExported); err != nil {
+		return jd, fmt.Errorf("StringMapToJobDataWithZeroValues, error converting JobDataMessagesExported, err: %w", err)
+	}
+
+	warningCount, ok := sm[JobDataWarningCount]
+	if !ok {
+		warningCount = "0"
+	}
+	if jd.WarningCount, err = strconv.Atoi(warningCount); err != nil {
+		return jd, fmt.Errorf("StringMapToJobDataWithZeroValues, error converting JobDataWarningCount, err: %w", err)
+	}
+
+	isDownloadable, ok := sm[JobDataIsDownloadable]
+	if !ok {
+		isDownloadable = "0"
+	}
+	if jd.IsDownloadable, err = strconv.ParseBool(isDownloadable); err != nil {
+		return jd, fmt.Errorf("StringMapToJobDataWithZeroValues, error converting JobDataIsDownloadable, err: %w", err)
+	}
+
+	return jd, nil
+}
+
 func StringDataToJobData(strMap map[string]string) (JobData, error) {
 	mapBytes, err := json.Marshal(strMap)
 	if err != nil {

--- a/server/enterprise/message_export/shared/shared.go
+++ b/server/enterprise/message_export/shared/shared.go
@@ -4,7 +4,6 @@
 package shared
 
 import (
-	"encoding/json"
 	"fmt"
 	"path"
 	"strconv"
@@ -216,18 +215,6 @@ func StringMapToJobDataWithZeroValues(sm map[string]string) (JobData, error) {
 	}
 
 	return jd, nil
-}
-
-func StringDataToJobData(strMap map[string]string) (JobData, error) {
-	mapBytes, err := json.Marshal(strMap)
-	if err != nil {
-		return JobData{}, err
-	}
-	var ret JobData
-	if err := json.Unmarshal(mapBytes, &ret); err != nil {
-		return JobData{}, err
-	}
-	return ret, nil
 }
 
 type BackendParams struct {

--- a/server/enterprise/message_export/shared/shared_test.go
+++ b/server/enterprise/message_export/shared/shared_test.go
@@ -272,23 +272,25 @@ func Test_GetBatchPath(t *testing.T) {
 
 func TestJobDataToStringMap_and_StringMapToJobData(t *testing.T) {
 	jd := JobData{
-		ExportType:              "cli_message_export",
-		ExportDir:               "/here/there/34234-123",
-		BatchStartTime:          45,
-		BatchStartId:            "34arsitenaorsten",
-		ExportPeriodStartTime:   123456, // not exported
-		JobStartTime:            99,
-		JobEndTime:              1234,
-		JobStartId:              "99abcdef34",
-		BatchSize:               2000,
-		ChannelBatchSize:        30000,
-		ChannelHistoryBatchSize: 30,
-		BatchNumber:             4,
-		TotalPostsExpected:      999999,
-		MessagesExported:        343499,
-		WarningCount:            39,
-		BatchEndTime:            999999999,               // not exported
-		BatchPath:               "/another/path/123-123", // not exported
+		JobDataExported: JobDataExported{
+			ExportType:              "cli_message_export",
+			ExportDir:               "/here/there/34234-123",
+			BatchStartTime:          45,
+			BatchStartId:            "34arsitenaorsten",
+			JobStartTime:            99,
+			JobEndTime:              1234,
+			JobStartId:              "99abcdef34",
+			BatchSize:               2000,
+			ChannelBatchSize:        30000,
+			ChannelHistoryBatchSize: 30,
+			BatchNumber:             4,
+			TotalPostsExpected:      999999,
+			MessagesExported:        343499,
+			WarningCount:            39,
+		},
+		ExportPeriodStartTime: 123456,                  // not exported
+		BatchEndTime:          999999999,               // not exported
+		BatchPath:             "/another/path/123-123", // not exported
 	}
 
 	strMap := JobDataToStringMap(jd)

--- a/server/enterprise/message_export/shared/shared_test.go
+++ b/server/enterprise/message_export/shared/shared_test.go
@@ -269,3 +269,64 @@ func Test_GetBatchPath(t *testing.T) {
 		})
 	}
 }
+
+func TestJobDataToStringMapAndBack(t *testing.T) {
+	jd := JobData{
+		ExportType:              "cli_message_export",
+		ExportDir:               "/here/there/34234-123",
+		BatchStartTime:          45,
+		BatchStartId:            "34arsitenaorsten",
+		ExportPeriodStartTime:   123456, // not exported
+		JobStartTime:            99,
+		JobEndTime:              1234,
+		JobStartId:              "99abcdef34",
+		BatchSize:               2000,
+		ChannelBatchSize:        30000,
+		ChannelHistoryBatchSize: 30,
+		BatchNumber:             4,
+		TotalPostsExpected:      999999,
+		MessagesExported:        343499,
+		WarningCount:            39,
+		BatchEndTime:            999999999,
+		BatchPath:               "/another/path/123-123",
+		MessageExportMs:         nil,
+		ProcessingPostsMs:       nil,
+		ProcessingXmlMs:         nil,
+		TransferringFilesMs:     nil,
+		TransferringZipMs:       nil,
+		TotalBatchMs:            nil,
+		Finished:                false,
+		IsDownloadable:          false,
+	}
+
+	strMap := JobDataToStringMap(jd)
+
+	expected := make(map[string]string)
+	expected[JobDataExportType] = "cli_message_export"
+	expected[JobDataExportDir] = "/here/there/34234-123"
+	expected[JobDataBatchStartTime] = "45"
+	expected[JobDataBatchStartId] = "34arsitenaorsten"
+	expected[JobDataJobStartTime] = "99"
+	expected[JobDataJobEndTime] = "1234"
+	expected[JobDataJobStartId] = "99abcdef34"
+	expected[JobDataBatchSize] = "2000"
+	expected[JobDataChannelBatchSize] = "30000"
+	expected[JobDataChannelHistoryBatchSize] = "30"
+	expected[JobDataBatchNumber] = "4"
+	expected[JobDataTotalPostsExpected] = "999999"
+	expected[JobDataMessagesExported] = "343499"
+	expected[JobDataWarningCount] = "39"
+	expected[JobDataIsDownloadable] = "false"
+
+	for k, v := range expected {
+		val, ok := strMap[k]
+		assert.True(t, ok)
+		assert.Equal(t, v, val)
+	}
+
+	// not exported:
+	for _, k := range []string{"export_period_start_time", "batch_end_time", "batch_path"} {
+		_, ok := strMap[k]
+		assert.False(t, ok)
+	}
+}

--- a/server/enterprise/message_export/worker.go
+++ b/server/enterprise/message_export/worker.go
@@ -22,33 +22,7 @@ import (
 	"github.com/mattermost/mattermost/server/v8/platform/shared/templates"
 )
 
-const (
-	// JobDataBatchStartTimestamp is the posts.updateat value from the previous batch. Posts are selected using
-	// keyset pagination sorted by (posts.updateat, posts.id).
-	JobDataBatchStartTimestamp = "batch_start_timestamp"
-
-	// JobDataStartTimestamp is the start of the job (doesn't change across batches)
-	JobDataStartTimestamp = "job_start_timestamp"
-
-	// JobDataBatchStartId is the posts.id value from the previous batch.
-	JobDataBatchStartId = "batch_start_id"
-
-	// JobDataEndTimestamp is the point up to which this job is exporting. It is the time the job was started,
-	// i.e., we export everything from the end of previous batch to the moment this batch started.
-	JobDataEndTimestamp            = "batch_end_timestamp"
-	JobDataStartId                 = "start_id"
-	JobDataExportType              = "export_type"
-	jobDataBatchSize               = "batch_size"
-	jobDataChannelBatchSize        = "channel_batch_size"
-	jobDataChannelHistoryBatchSize = "channel_history_batch_size"
-	JobDataMessagesExported        = "messages_exported"
-	JobDataWarningCount            = "warning_count"
-	JobDataIsDownloadable          = "is_downloadable"
-	JobDataExportDir               = "export_dir"
-	JobDataBatchNumber             = "job_batch_number"
-	JobDataTotalPostsExpected      = "total_posts_expected"
-	TimeBetweenBatchesMs           = 100
-)
+const TimeBetweenBatchesMs = 100
 
 // testEndOfBatchCb is only used for testing
 var testEndOfBatchCb func(worker *MessageExportWorker)
@@ -222,7 +196,7 @@ func (w *MessageExportWorker) DoJob(job *model.Job) {
 		w.setJobError(logger, job, model.NewAppError("DoJob", "ent.message_export.calculate_channel_exports.app_error", nil, "", http.StatusInternalServerError).Wrap(err))
 		return
 	}
-	job.Data[JobDataTotalPostsExpected] = strconv.Itoa(data.TotalPostsExpected)
+	job.Data[shared.JobDataTotalPostsExpected] = strconv.Itoa(data.TotalPostsExpected)
 
 	for {
 		select {
@@ -254,12 +228,12 @@ func (w *MessageExportWorker) DoJob(job *model.Job) {
 			setJobDataEndOfBatch(job, data)
 
 			if data.Finished {
-				w.finishExport(rctx, logger, job, data.TotalWarningCount)
+				w.finishExport(rctx, logger, job, data.WarningCount)
 				return
 			}
 
 			// also saves job.Data
-			if err := w.setJobProgress(logger, job, getJobProgress(data.TotalPostsExported, data.TotalPostsExpected)); err != nil {
+			if err := w.setJobProgress(logger, job, getJobProgress(data.MessagesExported, data.TotalPostsExpected)); err != nil {
 				// TODO: MM-59093 handle job errors (robust, recoverable)
 				return
 			}
@@ -273,11 +247,11 @@ func (w *MessageExportWorker) DoJob(job *model.Job) {
 }
 
 func (w *MessageExportWorker) finishExport(rctx request.CTX, logger *mlog.Logger, job *model.Job, totalWarningCount int) {
-	job.Data[JobDataWarningCount] = strconv.Itoa(totalWarningCount)
+	job.Data[shared.JobDataWarningCount] = strconv.Itoa(totalWarningCount)
 	// we've exported everything up to the current time
 	logger.Debug("FormatExport complete")
 
-	job.Data[JobDataIsDownloadable] = "false"
+	job.Data[shared.JobDataIsDownloadable] = "false"
 
 	if totalWarningCount > 0 {
 		w.setJobWarning(logger, job)
@@ -291,33 +265,33 @@ func (w *MessageExportWorker) initJobData(logger mlog.LoggerIFace, job *model.Jo
 	if job.Data == nil {
 		job.Data = make(map[string]string)
 	}
-	if _, exists := job.Data[JobDataMessagesExported]; !exists {
+	if _, exists := job.Data[shared.JobDataMessagesExported]; !exists {
 		logger.Info("Worker: JobDataMessagesExported does not exist, starting at 0")
-		job.Data[JobDataMessagesExported] = "0"
+		job.Data[shared.JobDataMessagesExported] = "0"
 	}
-	if _, exists := job.Data[JobDataExportType]; !exists {
+	if _, exists := job.Data[shared.JobDataExportType]; !exists {
 		exportFormat := *w.jobServer.Config().MessageExportSettings.ExportFormat
 		logger.Info("Worker: Defaulting to configured export format", mlog.String("export_format", exportFormat))
-		job.Data[JobDataExportType] = exportFormat
+		job.Data[shared.JobDataExportType] = exportFormat
 	}
-	if _, exists := job.Data[jobDataBatchSize]; !exists {
+	if _, exists := job.Data[shared.JobDataBatchSize]; !exists {
 		batchSize := strconv.Itoa(*w.jobServer.Config().MessageExportSettings.BatchSize)
 		logger.Info("Worker: Defaulting to configured batch size", mlog.String("batch_size", batchSize))
-		job.Data[jobDataBatchSize] = batchSize
+		job.Data[shared.JobDataBatchSize] = batchSize
 	}
-	if _, exists := job.Data[jobDataChannelBatchSize]; !exists {
+	if _, exists := job.Data[shared.JobDataChannelBatchSize]; !exists {
 		channelBatchSize := strconv.Itoa(*w.jobServer.Config().MessageExportSettings.ChannelBatchSize)
 		logger.Info("Worker: Defaulting to configured channel batch size", mlog.String("channel_batch_size", channelBatchSize))
-		job.Data[jobDataChannelBatchSize] = channelBatchSize
+		job.Data[shared.JobDataChannelBatchSize] = channelBatchSize
 	}
-	if _, exists := job.Data[jobDataChannelHistoryBatchSize]; !exists {
+	if _, exists := job.Data[shared.JobDataChannelHistoryBatchSize]; !exists {
 		channelHistoryBatchSize := strconv.Itoa(*w.jobServer.Config().MessageExportSettings.ChannelHistoryBatchSize)
 		logger.Info("Worker: Defaulting to configured channel history batch size", mlog.String("channel_history_batch_size", channelHistoryBatchSize))
-		job.Data[jobDataChannelHistoryBatchSize] = channelHistoryBatchSize
+		job.Data[shared.JobDataChannelHistoryBatchSize] = channelHistoryBatchSize
 	}
-	if _, exists := job.Data[JobDataBatchNumber]; !exists {
+	if _, exists := job.Data[shared.JobDataBatchNumber]; !exists {
 		logger.Info("Worker: JobDataBatchNumber does not exist, starting at 0")
-		job.Data[JobDataBatchNumber] = "0"
+		job.Data[shared.JobDataBatchNumber] = "0"
 	}
 
 	// If this is a new job (JobEndTime doesn't exist), set it to now, because this is when the job has first started.
@@ -327,20 +301,20 @@ func (w *MessageExportWorker) initJobData(logger mlog.LoggerIFace, job *model.Jo
 	// starting from the last successful batchStartTimestamp up until now. This is intentional (for now) because failed
 	// jobs do not get rescheduled properly yet, and when they are run again it means that new day's worth of messages
 	// need to be exported.
-	if _, exists := job.Data[JobDataEndTimestamp]; !exists {
-		job.Data[JobDataEndTimestamp] = strconv.FormatInt(model.GetMillisForTime(now), 10)
+	if _, exists := job.Data[shared.JobDataJobEndTime]; !exists {
+		job.Data[shared.JobDataJobEndTime] = strconv.FormatInt(model.GetMillisForTime(now), 10)
 	}
 
-	if _, exists := job.Data[JobDataBatchStartTimestamp]; !exists {
+	if _, exists := job.Data[shared.JobDataBatchStartTime]; !exists {
 		previousJob, err := w.jobServer.Store.Job().GetNewestJobByStatusesAndType([]string{model.JobStatusWarning, model.JobStatusSuccess}, model.JobTypeMessageExport)
 		if err != nil {
 			exportFromTimestamp := strconv.FormatInt(*w.jobServer.Config().MessageExportSettings.ExportFromTimestamp, 10)
 			logger.Info("Worker: No previously successful job found, falling back to configured MessageExportSettings.ExportFromTimestamp", mlog.String("export_from_timestamp", exportFromTimestamp))
-			job.Data[JobDataBatchStartTimestamp] = exportFromTimestamp
-			job.Data[JobDataStartTimestamp] = exportFromTimestamp
-			job.Data[JobDataBatchStartId] = ""
-			job.Data[JobDataStartId] = job.Data[JobDataBatchStartId]
-			job.Data[JobDataExportDir] = getJobExportDir(logger, job.Data, exportFromTimestamp, job.Data[JobDataEndTimestamp])
+			job.Data[shared.JobDataBatchStartTime] = exportFromTimestamp
+			job.Data[shared.JobDataJobStartTime] = exportFromTimestamp
+			job.Data[shared.JobDataBatchStartId] = ""
+			job.Data[shared.JobDataJobStartId] = job.Data[shared.JobDataBatchStartId]
+			job.Data[shared.JobDataExportDir] = getJobExportDir(logger, job.Data, exportFromTimestamp, job.Data[shared.JobDataJobEndTime])
 			return
 		}
 
@@ -351,44 +325,44 @@ func (w *MessageExportWorker) initJobData(logger mlog.LoggerIFace, job *model.Jo
 		if previousJob.Data == nil {
 			previousJob.Data = make(map[string]string)
 		}
-		if _, prevExists := previousJob.Data[JobDataBatchStartTimestamp]; !prevExists {
+		if _, prevExists := previousJob.Data[shared.JobDataBatchStartTime]; !prevExists {
 			exportFromTimestamp := strconv.FormatInt(*w.jobServer.Config().MessageExportSettings.ExportFromTimestamp, 10)
 			logger.Info("Worker: Previously successful job lacks job data, falling back to configured MessageExportSettings.ExportFromTimestamp", mlog.String("export_from_timestamp", exportFromTimestamp))
-			job.Data[JobDataBatchStartTimestamp] = exportFromTimestamp
-			job.Data[JobDataStartTimestamp] = exportFromTimestamp
+			job.Data[shared.JobDataBatchStartTime] = exportFromTimestamp
+			job.Data[shared.JobDataJobStartTime] = exportFromTimestamp
 		} else {
-			job.Data[JobDataBatchStartTimestamp] = previousJob.Data[JobDataBatchStartTimestamp]
+			job.Data[shared.JobDataBatchStartTime] = previousJob.Data[shared.JobDataBatchStartTime]
 		}
-		if _, prevExists := previousJob.Data[JobDataBatchStartId]; !prevExists {
+		if _, prevExists := previousJob.Data[shared.JobDataBatchStartId]; !prevExists {
 			logger.Info("Worker: Previously successful job lacks post ID, falling back to empty string")
-			job.Data[JobDataBatchStartId] = ""
+			job.Data[shared.JobDataBatchStartId] = ""
 		} else {
-			job.Data[JobDataBatchStartId] = previousJob.Data[JobDataBatchStartId]
+			job.Data[shared.JobDataBatchStartId] = previousJob.Data[shared.JobDataBatchStartId]
 		}
-		job.Data[JobDataStartId] = job.Data[JobDataBatchStartId]
+		job.Data[shared.JobDataJobStartId] = job.Data[shared.JobDataBatchStartId]
 	} else {
-		logger.Info("Worker: JobDataBatchStartTimestamp start time was already set",
-			mlog.String("batch_start_timestamp", job.Data[JobDataBatchStartTimestamp]))
+		logger.Info("Worker: JobDataBatchStartTime start time was already set",
+			mlog.String(shared.JobDataBatchStartTime, job.Data[shared.JobDataBatchStartTime]))
 	}
 
-	if _, exists := job.Data[JobDataStartTimestamp]; !exists {
-		// Just in case, if we don't have this (JobDataBatchStartTimestamp was already set, but this wasn't) set it:
-		job.Data[JobDataStartTimestamp] = job.Data[JobDataBatchStartTimestamp]
-		logger.Info("Worker: JobDataStartTimestamp start time was not set, using batch startTimestamp",
-			mlog.String("job_start_timestamp", job.Data[JobDataStartTimestamp]))
+	if _, exists := job.Data[shared.JobDataJobStartTime]; !exists {
+		// Just in case, if we don't have this (JobDataBatchStartTime was already set, but this wasn't) set it:
+		job.Data[shared.JobDataJobStartTime] = job.Data[shared.JobDataBatchStartTime]
+		logger.Info("Worker: JobDataJobStartTime start time was not set, using batch startTimestamp",
+			mlog.String(shared.JobDataJobStartTime, job.Data[shared.JobDataJobStartTime]))
 	}
 
-	job.Data[JobDataExportDir] = getJobExportDir(logger, job.Data, job.Data[JobDataStartTimestamp], job.Data[JobDataEndTimestamp])
+	job.Data[shared.JobDataExportDir] = getJobExportDir(logger, job.Data, job.Data[shared.JobDataJobStartTime], job.Data[shared.JobDataJobEndTime])
 }
 
 func extractJobData(logger *mlog.Logger, strmap map[string]string) (data shared.JobData, err error) {
-	data.ExportType = strmap[JobDataExportType]
+	data.ExportType = strmap[shared.JobDataExportType]
 
-	data.BatchStartTime, err = strconv.ParseInt(strmap[JobDataBatchStartTimestamp], 10, 64)
+	data.BatchStartTime, err = strconv.ParseInt(strmap[shared.JobDataBatchStartTime], 10, 64)
 	if err != nil {
-		return data, fmt.Errorf("JobDataBatchStartTimestamp conversion error: %w", err)
+		return data, fmt.Errorf("JobDataBatchStartTime conversion error: %w", err)
 	}
-	data.BatchStartId = strmap[JobDataBatchStartId]
+	data.BatchStartId = strmap[shared.JobDataBatchStartId]
 
 	// ExportPeriodStartTime is initialized to BatchStartTime because this is where we will start exporting. But unlike
 	// BatchStartTime, it won't change as we process the batches.
@@ -400,42 +374,42 @@ func extractJobData(logger *mlog.Logger, strmap map[string]string) (data shared.
 
 	// JobStartTime is the start of this job. It is different from ExportPeriodStartTime because JobStartTime won't change
 	// if the job processes some batches, is stopped, and picked up again.
-	data.JobStartTime, err = strconv.ParseInt(strmap[JobDataStartTimestamp], 10, 64)
+	data.JobStartTime, err = strconv.ParseInt(strmap[shared.JobDataJobStartTime], 10, 64)
 	if err != nil {
-		return data, fmt.Errorf("JobDataStartTimestamp conversion error: %w", err)
+		return data, fmt.Errorf("JobDataJobStartTime conversion error: %w", err)
 	}
 
-	data.JobEndTime, err = strconv.ParseInt(strmap[JobDataEndTimestamp], 10, 64)
+	data.JobEndTime, err = strconv.ParseInt(strmap[shared.JobDataJobEndTime], 10, 64)
 	if err != nil {
-		return data, fmt.Errorf("JobDataEndTimestamp conversion error: %w", err)
+		return data, fmt.Errorf("JobDataJobEndTime conversion error: %w", err)
 	}
 
-	data.JobStartId = strmap[JobDataStartId]
+	data.JobStartId = strmap[shared.JobDataJobStartId]
 
-	data.BatchSize, err = strconv.Atoi(strmap[jobDataBatchSize])
+	data.BatchSize, err = strconv.Atoi(strmap[shared.JobDataBatchSize])
 	if err != nil {
-		return data, fmt.Errorf("jobDataBatchSize conversion error: %w", err)
+		return data, fmt.Errorf("JobDataBatchSize conversion error: %w", err)
 	}
-	data.ChannelBatchSize, err = strconv.Atoi(strmap[jobDataChannelBatchSize])
+	data.ChannelBatchSize, err = strconv.Atoi(strmap[shared.JobDataChannelBatchSize])
 	if err != nil {
-		return data, fmt.Errorf("jobDataChannelBatchSize conversion error: %w", err)
+		return data, fmt.Errorf("JobDataChannelBatchSize conversion error: %w", err)
 	}
-	data.ChannelHistoryBatchSize, err = strconv.Atoi(strmap[jobDataChannelHistoryBatchSize])
+	data.ChannelHistoryBatchSize, err = strconv.Atoi(strmap[shared.JobDataChannelHistoryBatchSize])
 	if err != nil {
-		return data, fmt.Errorf("jobDataChannelHistoryBatchSize conversion error: %w", err)
+		return data, fmt.Errorf("JobDataChannelHistoryBatchSize conversion error: %w", err)
 	}
 
-	data.BatchNumber, err = strconv.Atoi(strmap[JobDataBatchNumber])
+	data.BatchNumber, err = strconv.Atoi(strmap[shared.JobDataBatchNumber])
 	if err != nil {
 		return data, fmt.Errorf("JobDataBatchNumber conversion error: %w", err)
 	}
 
-	data.TotalPostsExported, err = strconv.Atoi(strmap[JobDataMessagesExported])
+	data.MessagesExported, err = strconv.Atoi(strmap[shared.JobDataMessagesExported])
 	if err != nil {
 		return data, fmt.Errorf("JobDataMessagesExported conversion error: %w", err)
 	}
 
-	data.ExportDir = strmap[JobDataExportDir]
+	data.ExportDir = strmap[shared.JobDataExportDir]
 
 	logger.Info("Worker: initial job variables set",
 		mlog.String("export_type", data.ExportType),
@@ -449,23 +423,22 @@ func extractJobData(logger *mlog.Logger, strmap map[string]string) (data shared.
 		mlog.Int("channel_batch_size", data.ChannelBatchSize),
 		mlog.Int("channel_history_batch_size", data.ChannelHistoryBatchSize),
 		mlog.Int("batch_number", data.BatchNumber),
-		mlog.Int("total_posts_exported", data.TotalPostsExported))
+		mlog.Int("total_posts_exported", data.MessagesExported))
 
 	return
 }
 
 func setJobDataEndOfBatch(job *model.Job, data shared.JobData) {
-	// batchEndTime will be the JobEndTime if this is the lastBatch (see GetDataForBatch)
-	job.Data[JobDataBatchStartTimestamp] = strconv.FormatInt(data.BatchStartTime, 10)
-	job.Data[JobDataBatchStartId] = data.Cursor.LastPostId
-	job.Data[JobDataMessagesExported] = strconv.Itoa(data.TotalPostsExported)
-	job.Data[JobDataBatchNumber] = strconv.Itoa(data.BatchNumber)
+	job.Data[shared.JobDataBatchStartTime] = strconv.FormatInt(data.BatchStartTime, 10)
+	job.Data[shared.JobDataBatchStartId] = data.Cursor.LastPostId
+	job.Data[shared.JobDataMessagesExported] = strconv.Itoa(data.MessagesExported)
+	job.Data[shared.JobDataBatchNumber] = strconv.Itoa(data.BatchNumber)
 }
 
 // getJobExportDir will use the existing JobDataExportDir if available. If it's not available, this is the first run
 // for the job, so we use the startTime and endTime passed in.
 func getJobExportDir(logger mlog.LoggerIFace, data model.StringMap, startTime string, endTime string) string {
-	exportDir, exists := data[JobDataExportDir]
+	exportDir, exists := data[shared.JobDataExportDir]
 	if !exists {
 		// If we don't have a jobDataExportDir, this is the first run for the job, so we use the batch startTime
 		exportDir = path.Join(model.ComplianceExportPath, fmt.Sprintf("%s-%s-%s", time.Now().Format(model.ComplianceExportDirectoryFormat), startTime, endTime))

--- a/server/enterprise/message_export/worker_test.go
+++ b/server/enterprise/message_export/worker_test.go
@@ -69,11 +69,11 @@ func TestInitJobDataNoJobData(t *testing.T) {
 	now := time.Now()
 	worker.initJobData(logger, job, now)
 
-	assert.Equal(t, model.ComplianceExportTypeActiance, job.Data[JobDataExportType])
-	assert.Equal(t, strconv.Itoa(*worker.jobServer.Config().MessageExportSettings.BatchSize), job.Data[jobDataBatchSize])
-	assert.Equal(t, strconv.FormatInt(*worker.jobServer.Config().MessageExportSettings.ExportFromTimestamp, 10), job.Data[JobDataBatchStartTimestamp])
+	assert.Equal(t, model.ComplianceExportTypeActiance, job.Data[shared.JobDataExportType])
+	assert.Equal(t, strconv.Itoa(*worker.jobServer.Config().MessageExportSettings.BatchSize), job.Data[shared.JobDataBatchSize])
+	assert.Equal(t, strconv.FormatInt(*worker.jobServer.Config().MessageExportSettings.ExportFromTimestamp, 10), job.Data[shared.JobDataBatchStartTime])
 	expectedDir := path.Join(model.ComplianceExportPath, fmt.Sprintf("%s-%d-%d", now.Format(model.ComplianceExportDirectoryFormat), 0, now.UnixMilli()))
-	assert.Equal(t, expectedDir, job.Data[JobDataExportDir])
+	assert.Equal(t, expectedDir, job.Data[shared.JobDataExportDir])
 }
 
 func TestInitJobDataPreviousJobNoJobData(t *testing.T) {
@@ -124,11 +124,11 @@ func TestInitJobDataPreviousJobNoJobData(t *testing.T) {
 	now := time.Now()
 	worker.initJobData(logger, job, now)
 
-	assert.Equal(t, model.ComplianceExportTypeActiance, job.Data[JobDataExportType])
-	assert.Equal(t, strconv.Itoa(*worker.jobServer.Config().MessageExportSettings.BatchSize), job.Data[jobDataBatchSize])
-	assert.Equal(t, strconv.FormatInt(*worker.jobServer.Config().MessageExportSettings.ExportFromTimestamp, 10), job.Data[JobDataBatchStartTimestamp])
+	assert.Equal(t, model.ComplianceExportTypeActiance, job.Data[shared.JobDataExportType])
+	assert.Equal(t, strconv.Itoa(*worker.jobServer.Config().MessageExportSettings.BatchSize), job.Data[shared.JobDataBatchSize])
+	assert.Equal(t, strconv.FormatInt(*worker.jobServer.Config().MessageExportSettings.ExportFromTimestamp, 10), job.Data[shared.JobDataBatchStartTime])
 	expectedDir := path.Join(model.ComplianceExportPath, fmt.Sprintf("%s-%d-%d", now.Format(model.ComplianceExportDirectoryFormat), 0, now.UnixMilli()))
-	assert.Equal(t, expectedDir, job.Data[JobDataExportDir])
+	assert.Equal(t, expectedDir, job.Data[shared.JobDataExportDir])
 }
 
 func TestInitJobDataPreviousJobWithJobData(t *testing.T) {
@@ -143,7 +143,7 @@ func TestInitJobDataPreviousJobWithJobData(t *testing.T) {
 		Type:           model.JobTypeMessageExport,
 		StartAt:        model.GetMillis() - 1000,
 		LastActivityAt: model.GetMillis() - 1000,
-		Data:           map[string]string{JobDataBatchStartTimestamp: "123"},
+		Data:           map[string]string{shared.JobDataBatchStartTime: "123"},
 	}
 
 	job := &model.Job{
@@ -151,7 +151,7 @@ func TestInitJobDataPreviousJobWithJobData(t *testing.T) {
 		CreateAt: model.GetMillis(),
 		Status:   model.JobStatusPending,
 		Type:     model.JobTypeMessageExport,
-		Data:     map[string]string{JobDataExportDir: "this-is-the-export-dir"},
+		Data:     map[string]string{shared.JobDataExportDir: "this-is-the-export-dir"},
 	}
 
 	// mock job store returns a previously successful job that has the config that we're looking for, so we use it
@@ -181,11 +181,11 @@ func TestInitJobDataPreviousJobWithJobData(t *testing.T) {
 	now := time.Now()
 	worker.initJobData(logger, job, now)
 
-	assert.Equal(t, model.ComplianceExportTypeActiance, job.Data[JobDataExportType])
-	assert.Equal(t, strconv.Itoa(*worker.jobServer.Config().MessageExportSettings.BatchSize), job.Data[jobDataBatchSize])
-	assert.Equal(t, previousJob.Data[JobDataBatchStartTimestamp], job.Data[JobDataBatchStartTimestamp])
+	assert.Equal(t, model.ComplianceExportTypeActiance, job.Data[shared.JobDataExportType])
+	assert.Equal(t, strconv.Itoa(*worker.jobServer.Config().MessageExportSettings.BatchSize), job.Data[shared.JobDataBatchSize])
+	assert.Equal(t, previousJob.Data[shared.JobDataBatchStartTime], job.Data[shared.JobDataBatchStartTime])
 	expectedDir := "this-is-the-export-dir"
-	assert.Equal(t, expectedDir, job.Data[JobDataExportDir])
+	assert.Equal(t, expectedDir, job.Data[shared.JobDataExportDir])
 }
 
 func TestDoJobNoPostsToExport(t *testing.T) {

--- a/server/public/model/job.go
+++ b/server/public/model/job.go
@@ -10,6 +10,7 @@ import (
 const (
 	JobTypeDataRetention                 = "data_retention"
 	JobTypeMessageExport                 = "message_export"
+	JobTypeCLIMessageExport              = "cli_message_export"
 	JobTypeElasticsearchPostIndexing     = "elasticsearch_post_indexing"
 	JobTypeElasticsearchPostAggregation  = "elasticsearch_post_aggregation"
 	JobTypeBlevePostIndexing             = "bleve_post_indexing"


### PR DESCRIPTION
#### Summary
- This refactoring/simplification felt very good. It's been bugging me for a long time.
- It allows the CLI to do a quick conversion from `job.Data` -> stringMap and post the status of the job to the db, which was a big request from our customer in yesterday's call.
- CLI side PR: https://github.com/mattermost/mattermost-compliance-export/pull/29

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-61755

#### Release Note
Will be added to the feature branch release note.

```release-note
NONE
```
