### PR TITLE
Add type annotation to generated language files map

### DIFF
--- a/webapp/channels/src/i18n/imports.ts
+++ b/webapp/channels/src/i18n/imports.ts
@@ -68,8 +68,12 @@ import vi from './vi.json';
 import zhCN from './zh-CN.json';
 import zhTW from './zh-TW.json';
 
+type TranslationsMap = {
+    [id: string]: string,
+};
+
 export const langIDs = ["am","ar","be","bg","bn","br","ca","cs","da","de","el","en-AU","es","et","eu","fa","fi","fil","fr","fy","gl","gu","he","hi","hr","hu","id","is","it","ja","ka","kk-Latn","kk","km","ko","la","lo","lt","lv","mk","ml","mn","nb-NO","ne","nl","pl","pr","pt-BR","pt","ro","ru","si","sl","sq","sr","sv","th","tr","uk","vi","zh-CN","zh-TW"];
 
 export const langLabels = {"am":"አማርኛ","ar":"العربية","be":"Беларуская","bg":"Български","bn":"বাংলা","br":"Brezhoneg","ca":"Català","cs":"Čeština","da":"Dansk","de":"Deutsch","el":"Ελληνικά","en-AU":"English (Australia)","es":"Español","et":"eesti keel","eu":"Euskara","fa":"فارسی","fi":"Suomi","fil":"Filipino","fr":"Français","fy":"Frysk","gl":"Galego","gu":"ગુજરાતી","he":"עברית‏","hi":"हिन्दी","hr":"Hrvatski","hu":"Magyar","id":"Bahasa Indonesia","is":"Íslenska","it":"Italiano","ja":"日本語","ka":"ქართული","kk-Latn":"Қазақша","kk":"Қазақша","km":"ភាសាខ្មែរ","ko":"한국어","la":"Latin","lo":"ພາສາລາວ","lt":"Lietuvių","lv":"Latviešu","mk":"Македонски","ml":"മലയാളം","mn":"Монгол","nb-NO":"Norsk (bokmål)","ne":"नेपाली","nl":"Nederlands","pl":"Polski","pr":"pr","pt-BR":"Português (Brasil)","pt":"Português","ro":"Română","ru":"Русский","si":"සිංහල","sl":"Slovenščina","sq":"Shqip","sr":"Српски","sv":"Svenska","th":"ภาษาไทย","tr":"Türkçe","uk":"Українська","vi":"Tiếng Việt","zh-CN":"中文（中国大陆）","zh-TW":"中文（台灣）"};
 
-export const langFiles = {am,ar,be,bg,bn,br,ca,cs,da,de,el,'en-AU':enAU,es,et,eu,fa,fi,fil,fr,fy,gl,gu,he,hi,hr,hu,id,is,it,ja,ka,'kk-Latn':kkLatn,kk,km,ko,la,lo,lt,lv,mk,ml,mn,'nb-NO':nbNO,ne,nl,pl,pr,'pt-BR':ptBR,pt,ro,ru,si,sl,sq,sr,sv,th,tr,uk,vi,'zh-CN':zhCN,'zh-TW':zhTW};
+export const langFiles: {[langID: string]: TranslationsMap} = {am,ar,be,bg,bn,br,ca,cs,da,de,el,'en-AU':enAU,es,et,eu,fa,fi,fil,fr,fy,gl,gu,he,hi,hr,hu,id,is,it,ja,ka,'kk-Latn':kkLatn,kk,km,ko,la,lo,lt,lv,mk,ml,mn,'nb-NO':nbNO,ne,nl,pl,pr,'pt-BR':ptBR,pt,ro,ru,si,sl,sq,sr,sv,th,tr,uk,vi,'zh-CN':zhCN,'zh-TW':zhTW};

--- a/webapp/scripts/gen_lang_imports.mjs
+++ b/webapp/scripts/gen_lang_imports.mjs
@@ -37,11 +37,16 @@ fs.readdirSync('./channels/src/i18n').forEach(file => {
   }
 });
 
+lines += `
+type TranslationsMap = {
+    [id: string]: string,
+};
+`;
 lines += `\nexport const langIDs = ${JSON.stringify(langIDs)};\n`
 lines += `\nexport const langLabels = ${JSON.stringify(langLabels)};\n`
 
 // To generate the file exports we need to do a bit more work to handle ids with dashes and also output a map of literals rather than strings.
-lines += '\nexport const langFiles = {' + Object.keys(langFiles).reduce((out, id, idx) => {
+lines += '\nexport const langFiles: {[langID: string]: TranslationsMap} = {' + Object.keys(langFiles).reduce((out, id, idx) => {
   if (id.includes('-')) {
     out += `'${id}':${langFiles[id]}`;
   } else {


### PR DESCRIPTION
#### Summary

After merging https://github.com/mattermost/mattermost/pull/29009 I noticed `tsc` started throwing with:

```
error TS7056: The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.
```

Adding the explicit annotation seems to fix it.

#### Release Note

```release-note
NONE
```
