### PR TITLE
[MM-61791] Skip flaky TestHandleFailedScheduledPosts

### DIFF
--- a/server/channels/app/scheduled_post_job_test.go
+++ b/server/channels/app/scheduled_post_job_test.go
@@ -266,6 +266,7 @@ func TestProcessScheduledPosts(t *testing.T) {
 }
 
 func TestHandleFailedScheduledPosts(t *testing.T) {
+	t.Skip("https://mattermost.atlassian.net/browse/MM-61791")
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 


### PR DESCRIPTION
#### Summary
`TestHandleFailedScheduledPosts`  was recently introduced and had been failing on `master` the last few days. Let's skip it until it gets fixed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61791

#### Release Note
```release-note
NONE
```
