### PR TITLE
Disable 8 core runners for mattermost build

### DIFF
--- a/.github/workflows/esrupgrade-common.yml
+++ b/.github/workflows/esrupgrade-common.yml
@@ -23,7 +23,7 @@ env:
   DIFF_NAME: esr.${{ inputs.initial-version }}-${{ inputs.final-version }}.diff
 jobs:
   esr-upgrade-server:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - name: Checkout mattermost project
@@ -94,7 +94,7 @@ jobs:
           name: upgraded-dump-server
           path: ${{ env.DUMP_SERVER_NAME }}.gz
   esr-upgrade-script:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - name: Checkout mattermost project

--- a/.github/workflows/server-ci-template.yml
+++ b/.github/workflows/server-ci-template.yml
@@ -300,7 +300,7 @@ jobs:
       logsartifact: mmctl-test-logs
   build-mattermost-server:
     name: Build mattermost server app
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: server


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
There is no need to use 8 core runners to support our build . 
Testing is using the default free runners 

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
