### PR TITLE
Fix flaky test TestScheduledPostStore

### DIFF
--- a/server/channels/store/storetest/scheduled_post_store.go
+++ b/server/channels/store/storetest/scheduled_post_store.go
@@ -349,8 +349,6 @@ func testUpdatedScheduledPost(t *testing.T, rctx request.CTX, ss store.Store, s 
 		assert.NotEmpty(t, createdScheduledPost.Id)
 
 		// now we'll update the scheduled post
-		processedAt := model.GetMillis()
-		scheduledPost.ProcessedAt = processedAt
 		scheduledPost.ErrorCode = model.ScheduledPostErrorUnknownError
 
 		err = ss.ScheduledPost().UpdatedScheduledPost(scheduledPost)
@@ -358,7 +356,6 @@ func testUpdatedScheduledPost(t *testing.T, rctx request.CTX, ss store.Store, s 
 
 		updatedScheduledPost, err := ss.ScheduledPost().Get(scheduledPost.Id)
 		assert.NoError(t, err)
-		assert.Equal(t, processedAt, updatedScheduledPost.ProcessedAt)
 		assert.Equal(t, model.ScheduledPostErrorUnknownError, updatedScheduledPost.ErrorCode)
 	})
 }

--- a/server/channels/store/storetest/scheduled_post_store.go
+++ b/server/channels/store/storetest/scheduled_post_store.go
@@ -349,6 +349,7 @@ func testUpdatedScheduledPost(t *testing.T, rctx request.CTX, ss store.Store, s 
 		assert.NotEmpty(t, createdScheduledPost.Id)
 
 		// now we'll update the scheduled post
+		now := model.GetMillis()
 		scheduledPost.ErrorCode = model.ScheduledPostErrorUnknownError
 
 		err = ss.ScheduledPost().UpdatedScheduledPost(scheduledPost)
@@ -356,6 +357,7 @@ func testUpdatedScheduledPost(t *testing.T, rctx request.CTX, ss store.Store, s 
 
 		updatedScheduledPost, err := ss.ScheduledPost().Get(scheduledPost.Id)
 		assert.NoError(t, err)
+		assert.LessOrEqual(t, now, updatedScheduledPost.ProcessedAt)
 		assert.Equal(t, model.ScheduledPostErrorUnknownError, updatedScheduledPost.ErrorCode)
 	})
 }


### PR DESCRIPTION
There were couple of errors in the test:
1. UpdatedScheduledPost will automatically
set the ProcessedAt to now internally inside
toUpdateMap. So setting the value from outside
has no effect.
2. The bug was that if it took more than a
milisecond to capture the time, and then
do the internal call, then the Get call
will have a higher value and therefore fail.

Since UpdatedScheduledPost doesn't return
an updated post, so there is no need
to compare the timestamps at all.
```release-note
NONE
```
