### PR TITLE
Fix E2E test reporting message for webhook

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/enterprise/system_console/about/edition_and_license_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/enterprise/system_console/about/edition_and_license_spec.js
@@ -13,7 +13,7 @@
 import * as TIMEOUTS from '../../../../../fixtures/timeouts';
 import {getAdminAccount} from '../../../../../support/env';
 
-import {promoteToChannelOrTeamAdmin} from '../channel_moderation/helpers.js';
+import {promoteToChannelOrTeamAdmin} from '../channel_moderation/helpers.ts';
 
 describe('System console', () => {
     const sysadmin = getAdminAccount();

--- a/e2e-tests/cypress/tests/integration/channels/notifications/desktop_notifications_1_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/notifications/desktop_notifications_1_spec.js
@@ -115,7 +115,7 @@ describe('Desktop notifications', () => {
         });
     });
 
-    it('MM-T495 Desktop Notifications - Can set to DND and no notification fires on DM', () => {
+    it.skip('MM-T495 Desktop Notifications - Can set to DND and no notification fires on DM', () => {
         cy.apiCreateDirectChannel([otherUser.id, testUser.id]).then(({channel}) => {
             // # Ensure notifications are set up to fire a desktop notification if you receive a DM
             cy.apiPatchUser(testUser.id, {notify_props: {...testUser.notify_props, desktop: 'all'}});

--- a/e2e-tests/cypress/tests/integration/channels/team_settings/manage_members_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/team_settings/manage_members_spec.js
@@ -12,7 +12,7 @@
 
 import {
     promoteToChannelOrTeamAdmin,
-} from '../enterprise/system_console/channel_moderation/helpers.js';
+} from '../enterprise/system_console/channel_moderation/helpers.ts';
 
 describe('Manage Members', () => {
     let testTeam;

--- a/e2e-tests/cypress/utils/constants.js
+++ b/e2e-tests/cypress/utils/constants.js
@@ -3,8 +3,10 @@
 
 const RESULTS_DIR = 'results';
 const MOCHAWESOME_REPORT_DIR = 'results/mochawesome-report';
+const AD_CYCLE_FILE = 'results/ad_cycle.json';
 
 module.exports = {
     MOCHAWESOME_REPORT_DIR,
     RESULTS_DIR,
+    AD_CYCLE_FILE,
 };

--- a/e2e-tests/cypress/utils/report.js
+++ b/e2e-tests/cypress/utils/report.js
@@ -9,7 +9,7 @@ const dayjs = require('dayjs');
 const duration = require('dayjs/plugin/duration');
 dayjs.extend(duration);
 
-const {MOCHAWESOME_REPORT_DIR} = require('./constants');
+const {MOCHAWESOME_REPORT_DIR, AD_CYCLE_FILE} = require('./constants');
 
 const MAX_FAILED_TITLES = 5;
 
@@ -75,6 +75,16 @@ function generateShortSummary(report) {
 
     const failedFullTitles = tests.filter((t) => t.fail).map((t) => t.fullTitle);
     const statsFieldValue = generateStatsFieldValue(stats, failedFullTitles);
+
+    // If AD Cycle file is found, we have data from the Automation Dashboard available
+    // We are able to override the run stats with enriched information
+    const adCycle = readJsonFromFile(AD_CYCLE_FILE);
+    if (!(adCycle instanceof Error)) {
+        stats.passes = adCycle.pass;
+        stats.failures = adCycle.fail;
+        stats.tests = adCycle.pass + adCycle.fail;
+        stats.passPercent = 100 * (stats.passes / stats.tests);
+    }
 
     return {
         stats,


### PR DESCRIPTION
#### Summary

This PR increases again the stability and consistency of E2E tests:
- Make report message for the[Test Automation Reports channel](https://community.mattermost.com/core/channels/qa-test-automation-reports) consistent with the policy: `pass_rate = passes / (passes + failures)`, thus netting flaky/known/skipped/etc tests out
- Fix some testcase files with wrong references to their library file, using `.js` instead of `.ts`. The E2E test results have been affected by this for a while, e.g. see today's [onprem](https://automation-dashboard.vercel.app/cycle/11847590759_1-master-daily-onprem-ent) and [Cloud](https://automation-dashboard.vercel.app/cycle/11848265656_1-master-daily-cloud-ent) E2E test results.
- Demote another Flaky test case

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-8301

#### Release Note
```release-note
NONE
```
