### PR TITLE
Fix accessibility for reminder submenu focus

### DIFF
--- a/webapp/channels/src/components/dot_menu/post_reminder_submenu.tsx
+++ b/webapp/channels/src/components/dot_menu/post_reminder_submenu.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {memo} from 'react';
+import React, {memo, useEffect} from 'react';
 import {FormattedMessage, FormattedDate, FormattedTime, useIntl} from 'react-intl';
 import {useDispatch} from 'react-redux';
 
@@ -37,6 +37,20 @@ const PostReminders = {
 function PostReminderSubmenu(props: Props) {
     const {formatMessage} = useIntl();
     const dispatch = useDispatch();
+    
+    useEffect(() => {
+        const observer = new MutationObserver(() => {
+            const firstMenuItem = document.getElementById(`remind_post_options_${PostReminders.THIRTY_MINUTES}`);
+            firstMenuItem?.focus();
+        });
+    
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true, // Not needed now but included to handle potential future DOM changes
+        });
+    
+        return () => observer.disconnect();
+    }, [props.post.id]);
 
     function handlePostReminderMenuClick(id: string) {
         if (id === PostReminders.CUSTOM) {

--- a/webapp/channels/src/components/menu/menu_item.tsx
+++ b/webapp/channels/src/components/menu/menu_item.tsx
@@ -215,6 +215,11 @@ export const MenuItemStyled = styled(MuiMenuItem, {
                     'background-color': isRegular ? 'rgba(var(--button-bg-rgb), 0.08)' : 'background-color: rgba(var(--error-text-color-rgb), 0.16)',
                 },
 
+                // Hide focus on parent MenuItem when a keyboard opens its submenu
+                '&[aria-expanded="true"].Mui-focusVisible': {
+                    boxShadow: 'none',
+                },
+
                 '&:hover': {
                     backgroundColor: isRegular ? 'rgba(var(--center-channel-color-rgb), 0.08)' : 'var(--error-text)',
                     color: isDestructive && 'var(--button-color)',


### PR DESCRIPTION
#### Summary
Makes the first item in the reminder submenu receive focus upon opening the submenu

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/27070
Jira https://mattermost.atlassian.net/browse/MM-55278

#### Demo
![ScreenRecording2024-11-16at15 28 33-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/f14e0c58-8213-4fae-ba42-ede4946a8735)

#### Release Note
```release-note
NONE
```
