### PR TITLE
MM-61270 - sysadmin sees private name from schmsg removed channels

### DIFF
--- a/webapp/channels/src/components/drafts/drafts.tsx
+++ b/webapp/channels/src/components/drafts/drafts.tsx
@@ -59,7 +59,7 @@ function Drafts({
     const isScheduledPostsTab = useRouteMatch('/:team/' + SCHEDULED_POST_URL_SUFFIX);
 
     const currentTeamId = useSelector(getCurrentTeamId);
-    const getScheduledPostsByTeam = makeGetScheduledPostsByTeam();
+    const getScheduledPostsByTeam = useMemo(() => makeGetScheduledPostsByTeam(), []);
     const scheduledPosts = useSelector((state: GlobalState) => getScheduledPostsByTeam(state, currentTeamId, true));
     const isScheduledPostEnabled = useSelector(isScheduledPostsEnabled);
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR solves an issue that happened during the scheduled messages list creation. During fetching channels data, it was also fetched for channels that the current user was no longer a member of.
 
Scenario: 
- User/Admin scheduled a message in a private channel.
- Then the user is removed from that channel.
- In the scheduled messages list, those scheduled messages were going to show but would try to fetch channel information
Outcome:
- For admins: it would cause a blink, cause after channel load (api4.getChannels) action would be dispatched and channel data was load to redux, causing draft component to re-render and causing a blink showing initially "No destination" and after the re-render shown the actual name of the channel.
- For regular users: it will try to fetch channel data but will fail with 403, nothing visible, just lots of failed unnecessary calls.

This PR makes sure that the only channels data that is fetched is actually the channels the user is member of. Also solves an issue where the calls were made multiple times.

TODO:
- review why these scheduled messages are not shown as error messages.
- check why when trying to modify data for those scheduled messages, like editing content, the save button fails silently, nothing happens.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61270

#### Screenshots
System Admin:
Before:

https://github.com/user-attachments/assets/cd3a6adb-2e7f-4c19-bfb8-42057e4115bd

After:

https://github.com/user-attachments/assets/d665d723-8f40-43e7-ad24-6e94066130dd




Regular User:
Before:

https://github.com/user-attachments/assets/d2c8748c-f83d-4f78-8794-b01a32e5cdd1


After:

https://github.com/user-attachments/assets/ed605518-b958-48f4-a84b-66be3568f65d


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
