### PR TITLE
Fix flaky TestCreatePost and others

### DIFF
--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -3128,6 +3128,7 @@ func TestWebHubMembership(t *testing.T) {
 }
 
 func TestWebHubCloseConnOnDBFail(t *testing.T) {
+	t.Skip("MM-61780")
 	th := Setup(t).InitBasic()
 	defer func() {
 		th.TearDown()

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -165,7 +165,6 @@ func TestCreatePost(t *testing.T) {
 			select {
 			case event := <-WebSocketClient.EventChannel:
 				if event.EventType() == model.WebsocketEventEphemeralMessage {
-					require.Equal(t, model.WebsocketEventEphemeralMessage, event.EventType())
 					eventsToGo = eventsToGo - 1
 				}
 			case <-timeout:
@@ -3129,7 +3128,6 @@ func TestWebHubMembership(t *testing.T) {
 }
 
 func TestWebHubCloseConnOnDBFail(t *testing.T) {
-	t.Skip("https://mattermost.atlassian.net/browse/MM-61780")
 	th := Setup(t).InitBasic()
 	defer func() {
 		th.TearDown()

--- a/server/channels/app/platform/options.go
+++ b/server/channels/app/platform/options.go
@@ -51,6 +51,9 @@ func StoreOverrideWithCache(override store.Store) Option {
 			if err != nil {
 				return nil, err
 			}
+			// Clearing all the caches because the in-mem data
+			// is persisted in case of Redis.
+			lcl.Invalidate()
 			return lcl, nil
 		}
 

--- a/server/channels/app/platform/options.go
+++ b/server/channels/app/platform/options.go
@@ -44,6 +44,8 @@ func StoreOverride(override any) Option {
 	}
 }
 
+// StoreOverrideWithCache is a test option to construct the app with the store layer
+// wrapped on top of the store that is passed.
 func StoreOverrideWithCache(override store.Store) Option {
 	return func(ps *PlatformService) error {
 		ps.newStore = func() (store.Store, error) {


### PR DESCRIPTION
We don't clear the Redis cache for every test.
This can cause issues because the cache is shared
across test. We fix that with this PR.
```release-note
NONE
```
