### PR TITLE
Added precense check for scheduled posts before accessing error code

### DIFF
--- a/server/channels/api4/post.go
+++ b/server/channels/api4/post.go
@@ -915,7 +915,7 @@ func patchPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Updating the file_ids of a post is not a supported operation and will be ignored
-	post.FileIds = nil
+	//post.FileIds = nil
 
 	originalPost, err := c.App.GetSinglePost(c.AppContext, c.Params.PostId, false)
 	if err != nil {

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/scheduled_posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/scheduled_posts.ts
@@ -63,7 +63,7 @@ export function showChannelOrThreadScheduledPostIndicator(state: GlobalState, ch
     const allChannelScheduledPosts = state.entities.scheduledPosts.byChannelOrThreadId[channelOrThreadId] || emptyList;
     const eligibleScheduledPosts = allChannelScheduledPosts.filter((scheduledPostId: string) => {
         const scheduledPost = state.entities.scheduledPosts.byId[scheduledPostId];
-        return !scheduledPost.error_code;
+        return !scheduledPost?.error_code;
     });
 
     const data = {

--- a/webapp/platform/types/src/schedule_post.ts
+++ b/webapp/platform/types/src/schedule_post.ts
@@ -18,7 +18,7 @@ export type ScheduledPost = Omit<Draft, 'delete_at'> & SchedulingInfo & {
 
 export type ScheduledPostsState = {
     byId: {
-        [scheduledPostId: string]: ScheduledPost;
+        [scheduledPostId: string]: ScheduledPost | undefined;
     };
     byTeamId: {
         [teamId: string]: string[];


### PR DESCRIPTION
#### Summary
Added precense check for scheduled posts before accessing error code.

ideally scheduled posts there will not be null, but I suspect it can be in case of unstable websocket connection of lost messages.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-61854

#### Release Note
```release-note
none
```
