### PR TITLE
Revert an accidental API change

### DIFF
--- a/server/channels/api4/post.go
+++ b/server/channels/api4/post.go
@@ -915,7 +915,7 @@ func patchPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Updating the file_ids of a post is not a supported operation and will be ignored
-	//post.FileIds = nil
+	post.FileIds = nil
 
 	originalPost, err := c.App.GetSinglePost(c.AppContext, c.Params.PostId, false)
 	if err != nil {


### PR DESCRIPTION
#### Summary
Revert an accidental API change. I pushed an accidental change along with some other changes. Reverting now.

#### Release Note
```release-note
None
```
