### PR TITLE
Fix race condition in app/channel_test.go

### DIFF
--- a/server/channels/app/channel_test.go
+++ b/server/channels/app/channel_test.go
@@ -2260,7 +2260,7 @@ func TestPatchChannelModerationsForChannel(t *testing.T) {
 			go func() {
 				_, appErr := th.App.PatchChannelModerationsForChannel(th.Context, channel.DeepCopy(), addCreatePosts)
 				require.Nil(t, appErr)
-				_, err = th.App.PatchChannelModerationsForChannel(th.Context, channel.DeepCopy(), removeCreatePosts)
+				_, appErr = th.App.PatchChannelModerationsForChannel(th.Context, channel.DeepCopy(), removeCreatePosts)
 				require.Nil(t, appErr)
 				wg.Done()
 			}()


### PR DESCRIPTION
We were writing to the `err` variable which was declared before. Fixed that to use the correct variable.


```release-note
NONE
```
