### PR TITLE
MM-61643 - set role to none since react-boostrap set role='dialog' automagically

### DIFF
--- a/webapp/channels/src/components/user_settings/modal/user_settings_modal.tsx
+++ b/webapp/channels/src/components/user_settings/modal/user_settings_modal.tsx
@@ -343,8 +343,8 @@ class UserSettingsModal extends React.PureComponent<Props, State> {
                 onHide={this.handleHide}
                 onExited={this.handleHidden}
                 enforceFocus={this.state.enforceFocus}
-                role='dialog'
                 aria-label={modalTitle}
+                role='none'
             >
                 <Modal.Header
                     id='accountSettingsHeader'


### PR DESCRIPTION
#### Summary
This PR sets the role to none when creating the react-boostrap modal. Removing the prop also causes the outter div to have role='dialog' so the best shot is to set the role='none' and keep the role='dialog' in the inner div element which is set automatically. Screen readers should work fine with this approach. 

We should potentially do this with all the other modal creations, but let's see how the CI behaves with this change, not sure if there are parts of the tests relying on this role for grabbing elements.

Again, facing react-boostrap limitation in terms of usability improvements.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61643

#### Screenshots
Before:
<img width="1008" alt="Screenshot 2024-11-20 at 14 11 40" src="https://github.com/user-attachments/assets/d5bcc313-ff6e-4b44-9518-e7419d81e4d4">


After:
<img width="1467" alt="Screenshot 2024-11-20 at 14 07 44" src="https://github.com/user-attachments/assets/1d14c12c-0760-43d8-9829-837af7e60759">


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
