### PR TITLE
[MM-60984] Force reload of all channels on reconnect to ensure we have updated message counts

### DIFF
--- a/webapp/channels/src/actions/websocket_actions.jsx
+++ b/webapp/channels/src/actions/websocket_actions.jsx
@@ -33,6 +33,7 @@ import {
     markMultipleChannelsAsRead,
     getChannelMemberCountsByGroup,
     fetchAllMyChannelMembers,
+    fetchAllMyTeamsChannels,
 } from 'mattermost-redux/actions/channels';
 import {getCloudSubscription} from 'mattermost-redux/actions/cloud';
 import {clearErrors, logError} from 'mattermost-redux/actions/errors';
@@ -238,6 +239,7 @@ export function reconnect() {
         }
 
         dispatch(loadChannelsForCurrentUser());
+        dispatch(fetchAllMyTeamsChannels());
         dispatch(fetchAllMyChannelMembers());
         dispatch(fetchMyCategories(currentTeamId));
 

--- a/webapp/channels/src/actions/websocket_actions.test.jsx
+++ b/webapp/channels/src/actions/websocket_actions.test.jsx
@@ -3,6 +3,7 @@
 
 import {UserTypes, CloudTypes} from 'mattermost-redux/action_types';
 import {fetchMyCategories} from 'mattermost-redux/actions/channel_categories';
+import {fetchAllMyTeamsChannels} from 'mattermost-redux/actions/channels';
 import {getGroup} from 'mattermost-redux/actions/groups';
 import {
     getPostThreads,
@@ -69,6 +70,7 @@ jest.mock('mattermost-redux/actions/users', () => ({
 jest.mock('mattermost-redux/actions/channels', () => ({
     getChannelStats: jest.fn(() => ({type: 'GET_CHANNEL_STATS'})),
     fetchAllMyChannelMembers: jest.fn(() => ({type: 'FETCH_ALL_MY_CHANNEL_MEMBERS'})),
+    fetchAllMyTeamsChannels: jest.fn(),
 }));
 
 jest.mock('actions/post_actions', () => ({
@@ -647,6 +649,11 @@ describe('reconnect', () => {
     test('should call fetchMyCategories when socket reconnects', () => {
         reconnect();
         expect(fetchMyCategories).toHaveBeenCalledWith('currentTeamId');
+    });
+
+    test('should call fetchAllMyTeamsChannels when socket reconnects', () => {
+        reconnect();
+        expect(fetchAllMyTeamsChannels).toHaveBeenCalled();
     });
 });
 


### PR DESCRIPTION
#### Summary
When a client reconnects the websocket, we only get updated data for channels that are in the current team. We do fetch all of the channel memberships, but for channels on other teams we do not sync them, meaning that unreads on other teams will not be shown in the sidebar until that team is manually clicked on. This can result in missed messages.

This PR forces the `reconnect` handler to grab channels for all teams making sure that we have the latest post counts, which allows the client to calculate unreads correctly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60984


```release-note
Fixed an issue where unread messages on other teams would not appear after the application reconnects to the server
```
