### PR TITLE
[MM-61766] Fix errcheck issues in server/channels/app/platform/link_cache.go

### DIFF
--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -101,7 +101,6 @@ issues:
         channels/app/platform/cluster_handlers.go|\
         channels/app/platform/helper_test.go|\
         channels/app/platform/license.go|\
-        channels/app/platform/link_cache.go|\
         channels/app/platform/log.go|\
         channels/app/platform/metrics.go|\
         channels/app/platform/searchengine.go|\

--- a/server/channels/app/platform/link_cache.go
+++ b/server/channels/app/platform/link_cache.go
@@ -17,8 +17,7 @@ var linkCache = cache.NewLRU(&cache.CacheOptions{
 })
 
 func PurgeLinkCache() error {
-	err := linkCache.Purge()
-	return err
+	return linkCache.Purge()
 }
 
 func LinkCache() cache.Cache {

--- a/server/channels/app/platform/link_cache.go
+++ b/server/channels/app/platform/link_cache.go
@@ -16,8 +16,9 @@ var linkCache = cache.NewLRU(&cache.CacheOptions{
 	Size: LinkCacheSize,
 })
 
-func PurgeLinkCache() {
-	linkCache.Purge()
+func PurgeLinkCache() error {
+	err := linkCache.Purge()
+	return err
 }
 
 func LinkCache() cache.Cache {

--- a/server/channels/app/post_metadata.go
+++ b/server/channels/app/post_metadata.go
@@ -47,7 +47,7 @@ func (s *Server) initPostMetadata() {
 			(before.ImageProxySettings.RemoteImageProxyURL != after.ImageProxySettings.RemoteImageProxyURL) ||
 			(before.ImageProxySettings.RemoteImageProxyOptions != after.ImageProxySettings.RemoteImageProxyOptions) {
 			if err := platform.PurgeLinkCache(); err != nil {
-				mlog.Warn("Failed to remove cached links when the proxy settings have changed", mlog.Err(err))
+				mlog.Warn("Failed to remove cached links when the proxy settings changed", mlog.Err(err))
 			}
 		}
 	})

--- a/server/channels/app/post_metadata.go
+++ b/server/channels/app/post_metadata.go
@@ -46,7 +46,9 @@ func (s *Server) initPostMetadata() {
 			(before.ImageProxySettings.ImageProxyType != after.ImageProxySettings.ImageProxyType) ||
 			(before.ImageProxySettings.RemoteImageProxyURL != after.ImageProxySettings.RemoteImageProxyURL) ||
 			(before.ImageProxySettings.RemoteImageProxyOptions != after.ImageProxySettings.RemoteImageProxyOptions) {
-			platform.PurgeLinkCache()
+			if err := platform.PurgeLinkCache(); err != nil {
+				mlog.Warn("Failed to remove cached links when the proxy settings have changed", mlog.Err(err))
+			}
 		}
 	})
 }

--- a/server/channels/app/post_metadata_test.go
+++ b/server/channels/app/post_metadata_test.go
@@ -2043,7 +2043,8 @@ func TestGetLinkMetadata(t *testing.T) {
 			*cfg.ServiceSettings.AllowedUntrustedInternalConnections = "127.0.0.1"
 		})
 
-		platform.PurgeLinkCache()
+		err := platform.PurgeLinkCache()
+		require.NoError(t, err)
 
 		return th
 	}
@@ -2195,7 +2196,8 @@ func TestGetLinkMetadata(t *testing.T) {
 		th.App.saveLinkMetadataToDatabase(requestURL, timestamp, &opengraph.OpenGraph{Title: title}, nil)
 
 		t.Run("should use database if saved entry exists", func(t *testing.T) {
-			platform.PurgeLinkCache()
+			err := platform.PurgeLinkCache()
+			require.NoError(t, err)
 
 			_, _, _, ok := getLinkMetadataFromCache(requestURL, timestamp)
 			require.False(t, ok, "data should not exist in in-memory cache")
@@ -2212,7 +2214,8 @@ func TestGetLinkMetadata(t *testing.T) {
 		})
 
 		t.Run("should use database if saved entry exists near time", func(t *testing.T) {
-			platform.PurgeLinkCache()
+			err := platform.PurgeLinkCache()
+			require.NoError(t, err)
 
 			_, _, _, ok := getLinkMetadataFromCache(requestURL, timestamp)
 			require.False(t, ok, "data should not exist in in-memory cache")
@@ -2229,7 +2232,8 @@ func TestGetLinkMetadata(t *testing.T) {
 		})
 
 		t.Run("should not use database if URL is different", func(t *testing.T) {
-			platform.PurgeLinkCache()
+			err := platform.PurgeLinkCache()
+			require.NoError(t, err)
 
 			differentURL := requestURL + "/other"
 
@@ -2247,7 +2251,8 @@ func TestGetLinkMetadata(t *testing.T) {
 		})
 
 		t.Run("should not use database if timestamp is different", func(t *testing.T) {
-			platform.PurgeLinkCache()
+			err := platform.PurgeLinkCache()
+			require.NoError(t, err)
 
 			differentTimestamp := timestamp + 60*60*1000
 
@@ -2455,7 +2460,8 @@ func TestGetLinkMetadata(t *testing.T) {
 		_, _, _, ok = getLinkMetadataFromCache(requestURL, timestamp)
 		require.True(t, ok, "data should now exist in in-memory cache")
 
-		platform.PurgeLinkCache()
+		err = platform.PurgeLinkCache()
+		require.NoError(t, err)
 		_, _, _, ok = getLinkMetadataFromCache(requestURL, timestamp)
 		require.False(t, ok, "data should no longer exist in in-memory cache")
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Fixes errcheck issues in `server/channels/app/platform/link_cache.go`
Fixes subsequent errcheck issues in `server/channels/app/post_metadata.go`
Fixes subsequent errcheck issues in `server/channels/app/post_metadata_test.go`

#### Ticket Link

Fixes  [#29335](https://github.com/mattermost/mattermost/issues/29335)
Jira  [https://mattermost.atlassian.net/browse/MM-61766](https://mattermost.atlassian.net/browse/MM-61766)

<!--
#### Screenshots
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
