### PR TITLE
Stabilize and demote tests

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/channel/browse_public_channels_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/channel/browse_public_channels_spec.ts
@@ -21,7 +21,7 @@ function ensureHideJoinedCheckboxEnabled(shouldBeChecked) {
     cy.get('#hideJoinedPreferenceCheckbox').then(($checkbox) => {
         cy.wrap($checkbox).findByText('Hide Joined').should('be.visible');
         cy.wrap($checkbox).find('button').invoke('attr', 'class').then(($classList) => {
-            if($classList.split(' ').includes('checked') ^ shouldBeChecked) {
+            if ($classList.split(' ').includes('checked') ^ shouldBeChecked) {
                 // We click on the button only when the XOR operands do not match
                 // e.g. checkbox is checked, but should not be checked; and vice-versa
                 cy.wrap($checkbox).click();

--- a/e2e-tests/cypress/tests/integration/channels/channel/browse_public_channels_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/channel/browse_public_channels_spec.ts
@@ -17,6 +17,23 @@ function verifyNoChannelToJoinMessage(isVisible) {
     cy.findByText('No public channels').should(isVisible ? 'be.visible' : 'not.exist');
 }
 
+function getHideJoinedCheckboxState() {
+}
+
+function ensureHideJoinedCheckboxEnabled(shouldBeChecked) {
+    cy.get('#hideJoinedPreferenceCheckbox').then(($checkbox) => {
+        cy.wrap($checkbox).findByText('Hide Joined').should('be.visible');
+        cy.wrap($checkbox).find('button').invoke('attr', 'class').then(($classList) => {
+            if($classList.split(' ').includes('checked') ^ shouldBeChecked) {
+                // We click on the button only when the XOR operands do not match
+                // e.g. checkbox is checked, but should not be checked; and vice-versa
+                cy.wrap($checkbox).click();
+                cy.wrap($checkbox).find('button').should(`${shouldBeChecked ? '' : 'not.'}have.class`, 'checked');
+            }
+        });
+    });
+}
+
 describe('browse public channels', () => {
     let testUser: UserProfile;
     let otherUser: UserProfile;
@@ -63,11 +80,7 @@ describe('browse public channels', () => {
             cy.findByText('Public channels').should('be.visible').click();
 
             // # Click hide joined checkbox if not already checked
-            cy.findByText('Hide Joined').should('be.visible').then(($checkbox) => {
-                if (!$checkbox.prop('checked')) {
-                    cy.wrap($checkbox).click();
-                }
-            });
+            ensureHideJoinedCheckboxEnabled(true);
 
             // * Assert that the moreChannelsList is visible and the number of channels is 31
             cy.get('#moreChannelsList').should('be.visible').children().should('have.length', 31);
@@ -107,6 +120,9 @@ describe('browse public channels', () => {
 
             // # Click archived channels
             cy.findByText('Public channels').should('be.visible').click();
+
+            // # Click hide joined checkbox if not already checked
+            ensureHideJoinedCheckboxEnabled(true);
 
             // * Assert that the "No more channels to join" message is visible
             verifyNoChannelToJoinMessage(true);

--- a/e2e-tests/cypress/tests/integration/channels/channel/browse_public_channels_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/channel/browse_public_channels_spec.ts
@@ -17,9 +17,6 @@ function verifyNoChannelToJoinMessage(isVisible) {
     cy.findByText('No public channels').should(isVisible ? 'be.visible' : 'not.exist');
 }
 
-function getHideJoinedCheckboxState() {
-}
-
 function ensureHideJoinedCheckboxEnabled(shouldBeChecked) {
     cy.get('#hideJoinedPreferenceCheckbox').then(($checkbox) => {
         cy.wrap($checkbox).findByText('Hide Joined').should('be.visible');

--- a/e2e-tests/cypress/tests/integration/channels/collapsed_reply_threads/last_viewed_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/collapsed_reply_threads/last_viewed_spec.ts
@@ -101,6 +101,7 @@ describe('Collapsed Reply Threads', () => {
     it('MM-T4843_2 should go to threads view when threads view is the penultimate view and leave the current channel', () => {
         // # Go to the ‘Threads’ view on Team A
         cy.uiGetSidebarThreadsButton().click();
+        cy.url().should('include', `${teamA.name}/threads`);
 
         // # Switch to Test Channel
         cy.uiClickSidebarItem(testChannel.name);

--- a/e2e-tests/cypress/tests/integration/channels/messaging/message_draft_with_attachment_then_switch_channel_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/message_draft_with_attachment_then_switch_channel_spec.js
@@ -23,6 +23,7 @@ describe('Message Draft with attachment and Switch Channels', () => {
                 testChannel2 = out.channel;
             });
             cy.visit(`/${team.name}/channels/town-square`);
+            cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
         });
     });
 

--- a/e2e-tests/cypress/tests/integration/channels/system_console/site_configuration/link_customization_cloud_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/system_console/site_configuration/link_customization_cloud_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @channels @system_console @enterprise @cloud_only
 
 import * as TIMEOUTS from '../../../../fixtures/timeouts';


### PR DESCRIPTION
#### Summary

This PR:
- Stabilizes some testcases: verifies that an expected page has fully been loaded, instead of relying purely on the timeout
- Demotes an unstable testcase

Fixes implemented after reviewing the videos from today's failures in the daily cloud tests: https://automation-dashboard.vercel.app/cycle/11964438064_1-master-daily-cloud-ent

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-8301

#### Release Note
```release-note
NONE
```
