### PR TITLE
Emit service environment in client license

### DIFF
--- a/server/channels/api4/license.go
+++ b/server/channels/api4/license.go
@@ -45,6 +45,9 @@ func getClientLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 		clientLicense = c.App.Srv().GetSanitizedClientLicense()
 	}
 
+	// The ServiceEnvironment isn't strictly a property of the license, but explains the context in which the license applies.
+	clientLicense["ServiceEnvironment"] = model.GetServiceEnvironment()
+
 	if _, err := w.Write([]byte(model.MapToJSON(clientLicense))); err != nil {
 		c.Logger.Warn("Error while writing response", mlog.Err(err))
 	}

--- a/server/channels/api4/license_test.go
+++ b/server/channels/api4/license_test.go
@@ -51,6 +51,7 @@ func TestGetOldClientLicense(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotEmpty(t, license["IsLicensed"], "license not returned correctly")
+	require.Equal(t, model.GetServiceEnvironment(), license["ServiceEnvironment"])
 }
 
 func TestUploadLicenseFile(t *testing.T) {


### PR DESCRIPTION
#### Summary
Add the `ServiceEnvironment` setting to the license returned to clients.

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
