### PR TITLE
Prevent HEAD requests to a sub-path from infinite redirects (#28285)

### DIFF
--- a/server/channels/web/static.go
+++ b/server/channels/web/static.go
@@ -47,7 +47,7 @@ func (w *Web) InitStatic() {
 		w.MainRouter.PathPrefix("/static/").Handler(staticHandler)
 		w.MainRouter.Handle("/robots.txt", http.HandlerFunc(robotsHandler))
 		w.MainRouter.Handle("/unsupported_browser.js", http.HandlerFunc(unsupportedBrowserScriptHandler))
-		w.MainRouter.Handle("/{anything:.*}", w.NewStaticHandler(root)).Methods("GET")
+		w.MainRouter.Handle("/{anything:.*}", w.NewStaticHandler(root)).Methods(http.MethodGet, http.MethodHead)
 
 		// When a subpath is defined, it's necessary to handle redirects without a
 		// trailing slash. We don't want to use StrictSlash on the w.MainRouter and affect

--- a/server/channels/web/web_test.go
+++ b/server/channels/web/web_test.go
@@ -400,6 +400,14 @@ func TestStaticFilesCaching(t *testing.T) {
 	require.Equal(t, fakeRootHTML, res.Body.String())
 	require.Equal(t, []string{"no-cache, max-age=31556926, public"}, res.Result().Header[http.CanonicalHeaderKey("Cache-Control")])
 
+	// Checking for HEAD method as well.
+	req, _ = http.NewRequest(http.MethodHead, "/", nil)
+	res = httptest.NewRecorder()
+	th.Web.MainRouter.ServeHTTP(res, req)
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, fakeRootHTML, res.Body.String())
+	require.Equal(t, []string{"no-cache, max-age=31556926, public"}, res.Result().Header[http.CanonicalHeaderKey("Cache-Control")])
+
 	req, _ = http.NewRequest("GET", "/static/"+fakeMainBundleName, nil)
 	res = httptest.NewRecorder()
 	th.Web.MainRouter.ServeHTTP(res, req)


### PR DESCRIPTION
* adding test

```release-note
NONE
```

---------

Co-authored-by: Agniva De Sarker <agnivade@yahoo.co.in>
Co-authored-by: Mattermost Build <build@mattermost.com>
