### PR TITLE
[MM-61938] Strip IPv6 Zone from proxied URLs

### DIFF
--- a/server/public/go.mod
+++ b/server/public/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/tinylib/msgp v1.2.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	golang.org/x/crypto v0.25.0
+	golang.org/x/net v0.27.0
 	golang.org/x/oauth2 v0.21.0
 	golang.org/x/text v0.16.0
 	golang.org/x/tools v0.23.0
@@ -62,7 +63,6 @@ require (
 	github.com/wiggin77/srslog v1.0.1 // indirect
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 	golang.org/x/mod v0.19.0 // indirect
-	golang.org/x/net v0.27.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240722135656-d784300faade // indirect

--- a/server/public/shared/httpservice/client.go
+++ b/server/public/shared/httpservice/client.go
@@ -9,7 +9,11 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"net/netip"
+	"net/url"
 	"time"
+
+	"golang.org/x/net/http/httpproxy"
 )
 
 const (
@@ -155,6 +159,26 @@ func dialContextFilter(dial DialContextFunction, allowHost func(host string) boo
 	}
 }
 
+func getProxyFn() func(r *http.Request) (*url.URL, error) {
+	proxyFromEnvFn := httpproxy.FromEnvironment().ProxyFunc()
+	return func(r *http.Request) (*url.URL, error) {
+		// Mitigating against MM-61938
+		// TODO: Remove this code once the above issue is fixed upstream.
+		if r.URL != nil {
+			if addr, err := netip.ParseAddr(r.URL.Hostname()); err == nil && addr.Is6() && addr.Zone() != "" {
+				// Strip IPv6 zone and rebuild URL
+				if r.URL.Port() != "" {
+					r.URL.Host = addr.WithZone("").String() + ":" + r.URL.Port()
+				} else {
+					r.URL.Host = addr.WithZone("").String()
+				}
+			}
+		}
+
+		return proxyFromEnvFn(r.URL)
+	}
+}
+
 func NewTransport(enableInsecureConnections bool, allowHost func(host string) bool, allowIP func(ip net.IP) bool) *MattermostTransport {
 	dialContext := (&net.Dialer{
 		Timeout:   ConnectTimeout,
@@ -167,7 +191,7 @@ func NewTransport(enableInsecureConnections bool, allowHost func(host string) bo
 
 	return &MattermostTransport{
 		&http.Transport{
-			Proxy:                 http.ProxyFromEnvironment,
+			Proxy:                 getProxyFn(),
 			DialContext:           dialContext,
 			MaxIdleConns:          100,
 			IdleConnTimeout:       90 * time.Second,

--- a/server/public/shared/httpservice/client_test.go
+++ b/server/public/shared/httpservice/client_test.go
@@ -261,3 +261,82 @@ func TestSplitHostnames(t *testing.T) {
 	hostnames = strings.FieldsFunc(config, splitFields)
 	require.Equal(t, []string{"127.0.0.1", "localhost", "192.168.1.0"}, hostnames)
 }
+
+func TestGetProxyFn(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://proxy.example.org")
+	t.Setenv("HTTPS_PROXY", "https://proxy.example.org")
+	t.Setenv("NO_PROXY", ".example.com")
+
+	for _, tc := range []struct {
+		name   string
+		input  string
+		output string
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name:  "no proxy",
+			input: "http://test.example.com",
+		},
+		{
+			name:  "localhost",
+			input: "http://localhost",
+		},
+		{
+			name:   "hostname",
+			input:  "http://example.org",
+			output: "http://proxy.example.org",
+		},
+		{
+			name:   "hostname with port",
+			input:  "http://example.org:4545",
+			output: "http://proxy.example.org",
+		},
+		{
+			name:   "https",
+			input:  "https://example.org",
+			output: "https://proxy.example.org",
+		},
+		{
+			name:   "ipv4",
+			input:  "http://10.0.0.45",
+			output: "http://proxy.example.org",
+		},
+		{
+			name:   "ipv4 with port",
+			input:  "http://10.0.0.45:4545",
+			output: "http://proxy.example.org",
+		},
+		{
+			name:   "ipv6",
+			input:  "http://[fe80::8e87:5021:6f6c:605e]",
+			output: "http://proxy.example.org",
+		},
+		{
+			name:   "ipv6 with zone",
+			input:  "http://[fe80::8e87:5021:6f6c:605e%25.example.com]",
+			output: "http://proxy.example.org",
+		},
+		{
+			name:   "ipv6 with zone and port",
+			input:  "http://[fe80::8e87:5021:6f6c:605e%25.example.com]:4545",
+			output: "http://proxy.example.org",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			inURL, err := url.Parse(tc.input)
+			require.NoError(t, err)
+			outURL, err := getProxyFn()(&http.Request{
+				URL: inURL,
+			})
+			require.NoError(t, err)
+			if tc.output == "" { // not proxied case
+				require.Nil(t, outURL)
+			} else { // proxied case
+				require.NotNil(t, outURL)
+				require.Equal(t, tc.output, outURL.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Summary

We implement a proxy function wrapper for our HTTP client implementation that strips IPv6 zone IDs in case they are present since they are causing some issues (see ticket for details).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-61938

#### Release Note

```release-note
Fixed an issue when making proxied HTTP requests in which the URL had an IPv6 address containing a zone ID.
```

