### PR TITLE
[MM-61946] Don't change the emoji picker search input text case

### DIFF
--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_search.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_search.tsx
@@ -31,7 +31,7 @@ const EmojiPickerSearch = forwardRef<HTMLInputElement, Props>(({value, cursorCat
         event.preventDefault();
 
         // remove trailing and leading colons
-        const value = event.target.value.toLowerCase().replace(/^:|:$/g, '');
+        const value = event.target.value.replace(/^:|:$/g, '');
         onChange(value);
 
         resetCursorPosition();

--- a/webapp/channels/src/components/emoji_picker/utils/index.test.ts
+++ b/webapp/channels/src/components/emoji_picker/utils/index.test.ts
@@ -233,6 +233,19 @@ describe('getFilteredEmojis', () => {
 
         expect(getFilteredEmojis(allEmojis as any, filter, recentEmojisString, userSkinTone)).toEqual(filteredResults);
     });
+
+    test('Should be case-insensitive', () => {
+        const allEmojis = {
+            smile: smileEmoji,
+            thumbsup: thumbsupEmoji,
+            thumbsdown: thumbsdownEmoji,
+        };
+        const filter = 'DoWn';
+        const recentEmojisString: string[] = [];
+        const userSkinTone = '';
+
+        expect(getFilteredEmojis(allEmojis as any, filter, recentEmojisString, userSkinTone)).toStrictEqual([thumbsdownEmoji]);
+    });
 });
 
 describe('calculateCategoryRowIndex', () => {

--- a/webapp/channels/src/components/emoji_picker/utils/index.ts
+++ b/webapp/channels/src/components/emoji_picker/utils/index.ts
@@ -63,7 +63,7 @@ export function getFilteredEmojis(allEmojis: Record<string, Emoji>, filter: stri
         const aliases = isSystemEmoji(emoji) ? emoji.short_names : [emoji.name];
 
         for (let i = 0; i < aliases.length; i++) {
-            if (aliases[i].toLowerCase().includes(filter)) {
+            if (aliases[i].toLowerCase().includes(filter.toLowerCase())) {
                 return true;
             }
         }


### PR DESCRIPTION
#### Summary

This removes the search input text lowercasing from the `EmojiPickerSearch` component, where it is used as the text displayed to the user.

Instead, filter lowercasing is done in the `getFilteredEmojis` function to make emoji search case-insensitive.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/29362
Jira https://mattermost.atlassian.net/browse/MM-61946

#### Screenshots
|  Before  |  After  |
|----|----|
| ![image](https://github.com/user-attachments/assets/ca6703e8-d935-46c3-b3ad-450cc7b7aef0) | ![image](https://github.com/user-attachments/assets/713a8c7c-6204-49c7-81de-8673b3e91390) |

(Before, the text in the input field didn't accept uppercase letters)

#### Release Note
```release-note
The search input field in the emoji picker now accepts uppercase letters.
```