### PR TITLE
Improve Redis failure modes

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1
 	github.com/prometheus/client_model v0.6.1
-	github.com/redis/rueidis v1.0.45
+	github.com/redis/rueidis v1.0.50
 	github.com/reflog/dateconstraints v0.2.1
 	github.com/rs/cors v1.11.0
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible

--- a/server/go.sum
+++ b/server/go.sum
@@ -497,8 +497,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/redis/go-redis/v9 v9.6.0 h1:NLck+Rab3AOTHw21CGRpvQpgTrAU4sgdCswqGtlhGRA=
 github.com/redis/go-redis/v9 v9.6.0/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
-github.com/redis/rueidis v1.0.45 h1:j7hfcqfLLIqgTK3IkxBhXdeJcP34t3XLXvorDLqXfgM=
-github.com/redis/rueidis v1.0.45/go.mod h1:by+34b0cFXndxtYmPAHpoTHO5NkosDlBvhexoTURIxM=
+github.com/redis/rueidis v1.0.50 h1:UdsB/2EadJMGFIUuzxqFuWM2BSjXt8jYtml6eXkhJLE=
+github.com/redis/rueidis v1.0.50/go.mod h1:by+34b0cFXndxtYmPAHpoTHO5NkosDlBvhexoTURIxM=
 github.com/reflog/dateconstraints v0.2.1 h1:Hz1n2Q1vEm0Rj5gciDQcCN1iPBwfFjxUJy32NknGP/s=
 github.com/reflog/dateconstraints v0.2.1/go.mod h1:Ax8AxTBcJc3E/oVS2hd2j7RDM/5MDtuPwuR7lIHtPLo=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/server/platform/services/cache/provider.go
+++ b/server/platform/services/cache/provider.go
@@ -101,15 +101,7 @@ func NewRedisProvider(opts *RedisOptions) (Provider, error) {
 		// meant to be used at very high scales. The docs suggest 20us,
 		// but going as high as 250us doesn't make any material difference.
 		MaxFlushDelay: 250 * time.Microsecond,
-		RetryDelay: func(attempts int, _ rueidis.Completed, _ error) time.Duration {
-			// We only retry once.
-			if attempts > 1 {
-				return -1
-			}
-			// Sleep for a random duration within 1s
-			sleep := rand.Int63n(1000)
-			return time.Duration(sleep) * time.Millisecond
-		},
+		DisableRetry:  true,
 		// The default is 10s, which is a bit too high
 		ConnWriteTimeout: 5 * time.Second,
 	})

--- a/server/platform/services/cache/provider.go
+++ b/server/platform/services/cache/provider.go
@@ -6,7 +6,6 @@ package cache
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"

--- a/server/platform/services/cache/provider.go
+++ b/server/platform/services/cache/provider.go
@@ -100,6 +100,11 @@ func NewRedisProvider(opts *RedisOptions) (Provider, error) {
 		// meant to be used at very high scales. The docs suggest 20us,
 		// but going as high as 250us doesn't make any material difference.
 		MaxFlushDelay: 250 * time.Microsecond,
+		// The library doesn't have a maxRetry option.
+		// So it can get stuck in a loop.
+		DisableRetry: true,
+		// The default is 10s, which is a bit too high
+		ConnWriteTimeout: 5 * time.Second,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
While investigating code paths during
Redis downtime, I found out that the library
by default retries indefinitely for read commands.

This leads to it being stuck in a loop
while trying to read anything from Redis.
We fix that by disabling retry.

Secondly, we adjust the ConnWriteTimeout
value slightly from its default of 10s
which is a bit too high for normal working
conditions.

Ref: https://github.com/redis/rueidis/issues/680
```release-note
NONE
```
