### PR TITLE
MM-61992: Verify license.Features.Users is not nil

### DIFF
--- a/server/channels/app/platform/license.go
+++ b/server/channels/app/platform/license.go
@@ -130,13 +130,13 @@ func (ps *PlatformService) SaveLicense(licenseBytes []byte) (*model.License, *mo
 		return nil, model.NewAppError("addLicense", "api.license.add_license.invalid.app_error", nil, "", http.StatusBadRequest)
 	}
 
+	if license.Features.Users == nil {
+		return nil, model.NewAppError("addLicense", "api.license.add_license.invalid.app_error", nil, "", http.StatusBadRequest)
+	}
+
 	uniqueUserCount, err := ps.Store.User().Count(model.UserCountOptions{})
 	if err != nil {
 		return nil, model.NewAppError("addLicense", "api.license.add_license.invalid_count.app_error", nil, "", http.StatusBadRequest).Wrap(err)
-	}
-
-	if license.Features.Users == nil {
-		return nil, model.NewAppError("addLicense", "api.license.add_license.invalid.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if uniqueUserCount > int64(*license.Features.Users) {

--- a/server/channels/app/platform/license.go
+++ b/server/channels/app/platform/license.go
@@ -127,11 +127,11 @@ func (ps *PlatformService) SaveLicense(licenseBytes []byte) (*model.License, *mo
 	}
 
 	if license.Features == nil {
-		return nil, model.NewAppError("addLicense", "api.license.add_license.invalid.app_error", nil, "", http.StatusBadRequest)
+		return nil, model.NewAppError("addLicense", "api.license.add_license.invalid.app_error", nil, "", http.StatusBadRequest).Wrap(errors.New("license.Features is nil"))
 	}
 
 	if license.Features.Users == nil {
-		return nil, model.NewAppError("addLicense", "api.license.add_license.invalid.app_error", nil, "", http.StatusBadRequest)
+		return nil, model.NewAppError("addLicense", "api.license.add_license.invalid.app_error", nil, "", http.StatusBadRequest).Wrap(errors.New("license.Features.Users is nil"))
 	}
 
 	uniqueUserCount, err := ps.Store.User().Count(model.UserCountOptions{})

--- a/server/channels/app/platform/license.go
+++ b/server/channels/app/platform/license.go
@@ -126,9 +126,17 @@ func (ps *PlatformService) SaveLicense(licenseBytes []byte) (*model.License, *mo
 		return nil, model.NewAppError("addLicense", "api.unmarshal_error", nil, "", http.StatusInternalServerError).Wrap(jsonErr)
 	}
 
+	if license.Features == nil {
+		return nil, model.NewAppError("addLicense", "api.license.add_license.invalid.app_error", nil, "", http.StatusBadRequest)
+	}
+
 	uniqueUserCount, err := ps.Store.User().Count(model.UserCountOptions{})
 	if err != nil {
 		return nil, model.NewAppError("addLicense", "api.license.add_license.invalid_count.app_error", nil, "", http.StatusBadRequest).Wrap(err)
+	}
+
+	if license.Features.Users == nil {
+		return nil, model.NewAppError("addLicense", "api.license.add_license.invalid.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if uniqueUserCount > int64(*license.Features.Users) {


### PR DESCRIPTION
#### Summary
[A Sentry crash report](https://mattermost-mr.sentry.io/issues/6083616033/?project=5212327&referrer=webhooks_plugin) showed that dereferencing `license.Features.Users` in `SaveLicense` can end up in a `panic`, so we add some defense code around it.

Speaking of tests: is there a way I can generate a license on the fly for test purposes? I want to generate one with `license.Features` being nil and another with `license.Features.Users` being nil, but not sure if that's even possible without asking other team to do it for us.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61992

#### Screenshots
--

#### Release Note
```release-note
NONE
```
