### PR TITLE
Remove unnecessary `dispatch` call

### DIFF
--- a/webapp/channels/src/actions/websocket_actions.jsx
+++ b/webapp/channels/src/actions/websocket_actions.jsx
@@ -241,7 +241,7 @@ export function reconnect() {
         dispatch(fetchAllMyTeamsChannels());
         dispatch(fetchAllMyChannelMembers());
         dispatch(fetchMyCategories(currentTeamId));
-        dispatch(loadProfilesForSidebar());
+        loadProfilesForSidebar();
 
         if (mostRecentPost) {
             dispatch(syncPostsInChannel(currentChannelId, mostRecentPost.create_at));


### PR DESCRIPTION
#### Summary
A change I made was causing a JS error, turns out I didn't need to call `dispatch` on `loadProfilesForSidebar`, so I've removed that call to avoid the JS error.

```release-note
NONE
```
