### PR TITLE
[CLD-8605] Remove write_restrictable from AdvancedLoggingJSON

### DIFF
--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -1497,7 +1497,7 @@ type ExperimentalAuditSettings struct {
 	FileMaxBackups      *int            `access:"experimental_features,write_restrictable,cloud_restrictable"`
 	FileCompress        *bool           `access:"experimental_features,write_restrictable,cloud_restrictable"`
 	FileMaxQueueSize    *int            `access:"experimental_features,write_restrictable,cloud_restrictable"`
-	AdvancedLoggingJSON json.RawMessage `access:"experimental_features,write_restrictable"`
+	AdvancedLoggingJSON json.RawMessage `access:"experimental_features"`
 }
 
 func (s *ExperimentalAuditSettings) SetDefaults() {


### PR DESCRIPTION

#### Summary
In Cloud environments where `ExperimentalSettings.RestrictSystemAdmin` are set, any setting that is attempted to be updated with an access type of `write_restrictable` will be silently thrown out, and set to `null`. Cloud-proper environments (ie, those created in the CWS installation group) will have this `RestrictSystemAdmin` setting set, so you're unable to edit the `ExperimentalAuditSettings.AdvancedLoggingJSON` config through the system console. 

This PR removes `write_restrictable` from the setting - it's still only set by system admins, but can now be set in Cloud as well. 
#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-8605

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
None
```
