### PR TITLE
MM-61893 Replace usage of hasOwnProperty with Object.hasOwn

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/plugins/upgrade_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/plugins/upgrade_spec.js
@@ -152,11 +152,11 @@ function waitForServerStatus(pluginId, version, state = {}) {
     const checkFn = () => {
         cy.log(`Waiting for ${pluginId}`);
         return cy.apiGetPluginStatus(pluginId, version).then((status) => {
-            if (state.hasOwnProperty('isActive')) {
+            if (Object.hasOwn(state, 'isActive')) {
                 return state.isActive === status.isActive;
             }
 
-            if (state.hasOwnProperty('isInstalled')) {
+            if (Object.hasOwn(state, 'isInstalled')) {
                 return state.isInstalled === status.isInstalled;
             }
 

--- a/e2e-tests/cypress/tests/support/api/system.js
+++ b/e2e-tests/cypress/tests/support/api/system.js
@@ -146,7 +146,7 @@ const expectConfigToBeUpdatable = (currentConfig, newConfig) => {
 
         if (setting) {
             Object.keys(newSubSetting).forEach((newSubKey) => {
-                const isAvailable = setting.hasOwnProperty(newSubKey);
+                const isAvailable = Object.hasOwn(setting, newSubKey);
                 const name = `${newMainKey}.${newSubKey}`;
                 expect(isAvailable, isAvailable ? `${name} setting can be updated.` : errorMessage(name)).to.equal(true);
             });

--- a/e2e-tests/cypress/tests/utils/benchmark.js
+++ b/e2e-tests/cypress/tests/utils/benchmark.js
@@ -15,7 +15,7 @@ function getTestName() {
     const testTitles = [];
 
     function extractTitles(obj) {
-        if (obj.hasOwnProperty('parent')) {
+        if (Object.hasOwn(obj, 'parent')) {
             testTitles.push(obj.title);
             const nextObj = obj.parent;
             extractTitles(nextObj);

--- a/e2e-tests/cypress/utils/file.js
+++ b/e2e-tests/cypress/utils/file.js
@@ -149,7 +149,7 @@ function removeFromFiles(files = {}, filesToRemove = []) {
 
     const removedFiles = intersection(Object.keys(testFilesObject), filesToRemove);
     removedFiles.forEach((file) => {
-        if (testFilesObject.hasOwnProperty(file)) {
+        if (Object.hasOwn(testFilesObject, file)) {
             delete testFilesObject[file];
         }
     });

--- a/webapp/channels/build/emoji/make_emojis.mjs
+++ b/webapp/channels/build/emoji/make_emojis.mjs
@@ -269,71 +269,71 @@ fullEmoji.forEach((emoji, index) => {
 });
 
 function trimPropertiesFromEmoji(emoji) {
-    if (emoji.hasOwnProperty('non_qualified')) {
+    if (Object.hasOwn(emoji, 'non_qualified')) {
         Reflect.deleteProperty(emoji, 'non_qualified');
     }
 
-    if (emoji.hasOwnProperty('docomo')) {
+    if (Object.hasOwn(emoji, 'docomo')) {
         Reflect.deleteProperty(emoji, 'docomo');
     }
 
-    if (emoji.hasOwnProperty('au')) {
+    if (Object.hasOwn(emoji, 'au')) {
         Reflect.deleteProperty(emoji, 'au');
     }
 
-    if (emoji.hasOwnProperty('softbank')) {
+    if (Object.hasOwn(emoji, 'softbank')) {
         Reflect.deleteProperty(emoji, 'softbank');
     }
 
-    if (emoji.hasOwnProperty('google')) {
+    if (Object.hasOwn(emoji, 'google')) {
         Reflect.deleteProperty(emoji, 'google');
     }
 
-    if (emoji.hasOwnProperty('sheet_x')) {
+    if (Object.hasOwn(emoji, 'sheet_x')) {
         Reflect.deleteProperty(emoji, 'sheet_x');
     }
 
-    if (emoji.hasOwnProperty('sheet_y')) {
+    if (Object.hasOwn(emoji, 'sheet_y')) {
         Reflect.deleteProperty(emoji, 'sheet_y');
     }
 
-    if (emoji.hasOwnProperty('added_in')) {
+    if (Object.hasOwn(emoji, 'added_in')) {
         Reflect.deleteProperty(emoji, 'added_in');
     }
 
-    if (emoji.hasOwnProperty('has_img_apple')) {
+    if (Object.hasOwn(emoji, 'has_img_apple')) {
         Reflect.deleteProperty(emoji, 'has_img_apple');
     }
 
-    if (emoji.hasOwnProperty('has_img_google')) {
+    if (Object.hasOwn(emoji, 'has_img_google')) {
         Reflect.deleteProperty(emoji, 'has_img_google');
     }
 
-    if (emoji.hasOwnProperty('has_img_twitter')) {
+    if (Object.hasOwn(emoji, 'has_img_twitter')) {
         Reflect.deleteProperty(emoji, 'has_img_twitter');
     }
 
-    if (emoji.hasOwnProperty('has_img_facebook')) {
+    if (Object.hasOwn(emoji, 'has_img_facebook')) {
         Reflect.deleteProperty(emoji, 'has_img_facebook');
     }
 
-    if (emoji.hasOwnProperty('source_index')) {
+    if (Object.hasOwn(emoji, 'source_index')) {
         Reflect.deleteProperty(emoji, 'source_index');
     }
 
-    if (emoji.hasOwnProperty('sort_order')) {
+    if (Object.hasOwn(emoji, 'sort_order')) {
         Reflect.deleteProperty(emoji, 'sort_order');
     }
 
-    if (emoji.hasOwnProperty('subcategory')) {
+    if (Object.hasOwn(emoji, 'subcategory')) {
         Reflect.deleteProperty(emoji, 'subcategory');
     }
 
-    if (emoji.hasOwnProperty('image')) {
+    if (Object.hasOwn(emoji, 'image')) {
         Reflect.deleteProperty(emoji, 'image');
     }
 
-    if (emoji.hasOwnProperty('fileName')) {
+    if (Object.hasOwn(emoji, 'fileName')) {
         Reflect.deleteProperty(emoji, 'fileName');
     }
 

--- a/webapp/channels/src/actions/status_actions.ts
+++ b/webapp/channels/src/actions/status_actions.ts
@@ -89,7 +89,7 @@ export function loadStatusesForProfilesMap(users: Record<string, UserProfile> | 
 
         const statusesToLoad = [];
         for (const userId in users) {
-            if ({}.hasOwnProperty.call(users, userId)) {
+            if (Object.hasOwn(users, userId)) {
                 statusesToLoad.push(userId);
             }
         }

--- a/webapp/channels/src/actions/websocket_actions.jsx
+++ b/webapp/channels/src/actions/websocket_actions.jsx
@@ -636,7 +636,7 @@ export function handleEvent(msg) {
             return;
         }
 
-        if (pluginEvents.hasOwnProperty(msg.event) && typeof pluginEvents[msg.event] === 'function') {
+        if (Object.hasOwn(pluginEvents, msg.event) && typeof pluginEvents[msg.event] === 'function') {
             pluginEvents[msg.event](msg);
         }
     });

--- a/webapp/channels/src/components/cloud_usage_modal/workspace_limits_panel.tsx
+++ b/webapp/channels/src/components/cloud_usage_modal/workspace_limits_panel.tsx
@@ -12,7 +12,7 @@ import {asGBString, inK} from 'utils/limits';
 import LimitLine from './limit_line';
 
 export function messageToElement(x: Message | React.ReactNode): React.ReactNode {
-    if (Object.hasOwn(x, 'defaultMessage')) {
+    if (x && typeof x === 'object' && Object.hasOwn(x, 'defaultMessage')) {
         return (
             <FormattedMessage
                 id={(x as Message).id}

--- a/webapp/channels/src/components/cloud_usage_modal/workspace_limits_panel.tsx
+++ b/webapp/channels/src/components/cloud_usage_modal/workspace_limits_panel.tsx
@@ -12,7 +12,7 @@ import {asGBString, inK} from 'utils/limits';
 import LimitLine from './limit_line';
 
 export function messageToElement(x: Message | React.ReactNode): React.ReactNode {
-    if (Object.prototype.hasOwnProperty.call(x, 'defaultMessage')) {
+    if (Object.hasOwn(x, 'defaultMessage')) {
         return (
             <FormattedMessage
                 id={(x as Message).id}

--- a/webapp/channels/src/components/data_prefetch/data_prefetch.tsx
+++ b/webapp/channels/src/components/data_prefetch/data_prefetch.tsx
@@ -89,13 +89,13 @@ export default class DataPrefetch extends React.PureComponent<Props> {
     private prefetchData = () => {
         const {prefetchRequestStatus, prefetchQueueObj} = this.props;
         for (const priority in prefetchQueueObj) {
-            if (!prefetchQueueObj.hasOwnProperty(priority)) {
+            if (!Object.hasOwn(prefetchQueueObj, priority)) {
                 continue;
             }
 
             const priorityQueue = prefetchQueueObj[priority];
             for (const channelId of priorityQueue) {
-                if (!prefetchRequestStatus.hasOwnProperty(channelId)) {
+                if (!Object.hasOwn(prefetchRequestStatus, channelId)) {
                     queue.add(async () => this.prefetchPosts(channelId));
                 }
             }

--- a/webapp/channels/src/components/invitation_modal/result_table.tsx
+++ b/webapp/channels/src/components/invitation_modal/result_table.tsx
@@ -114,7 +114,7 @@ export default function ResultTable(props: Props) {
                         let botBadge;
                         let reactKey = '';
 
-                        if (invitation.hasOwnProperty('user')) {
+                        if (Object.hasOwn(invitation, 'user')) {
                             className = 'name';
                             const user = (invitation as InviteUser).user;
                             reactKey = user.id;
@@ -133,7 +133,7 @@ export default function ResultTable(props: Props) {
                             if (isGuest(user.roles)) {
                                 guestBadge = <GuestTag/>;
                             }
-                        } else if (invitation.hasOwnProperty('email')) {
+                        } else if (Object.hasOwn(invitation, 'email')) {
                             const email = (invitation as InviteEmail).email;
                             reactKey = email;
                             className = 'email';

--- a/webapp/channels/src/components/message_with_additional_content.tsx
+++ b/webapp/channels/src/components/message_with_additional_content.tsx
@@ -22,7 +22,7 @@ type Props = {
 }
 
 export default function MessageWithAdditionalContent({post, isEmbedVisible, pluginPostTypes, isRHS, compactDisplay}: Props) {
-    const hasPlugin = post.type && pluginPostTypes?.hasOwnProperty(post.type);
+    const hasPlugin = post.type && pluginPostTypes && Object.hasOwn(pluginPostTypes, post.type);
     let msg;
     const messageWrapper = (
         <PostMessageView

--- a/webapp/channels/src/components/modal_controller/modal_controller.tsx
+++ b/webapp/channels/src/components/modal_controller/modal_controller.tsx
@@ -44,7 +44,7 @@ const ModalController = ({
     const modalOutput = [];
 
     for (const modalId in modalState) {
-        if (modalState.hasOwnProperty(modalId)) {
+        if (Object.hasOwn(modalState, modalId)) {
             const modal = modalState[modalId];
             if (modal.open) {
                 const modalComponent = React.createElement(modal.dialogType, Object.assign({}, modal.dialogProps, {

--- a/webapp/channels/src/components/post_view/post_message_view/post_message_view.tsx
+++ b/webapp/channels/src/components/post_view/post_message_view/post_message_view.tsx
@@ -117,7 +117,7 @@ export default class PostMessageView extends React.PureComponent<Props, State> {
 
         const postType = typeof post.props?.type === 'string' ? post.props.type : post.type;
 
-        if (pluginPostTypes && pluginPostTypes.hasOwnProperty(postType)) {
+        if (pluginPostTypes && Object.hasOwn(pluginPostTypes, postType)) {
             const PluginComponent = pluginPostTypes[postType].component;
             return (
                 <PluginComponent

--- a/webapp/channels/src/components/profile_popover/profile_popover.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover.tsx
@@ -100,7 +100,7 @@ const ProfilePopover = ({
 
     const handleCloseModals = useCallback(() => {
         for (const modal in modals?.modalState) {
-            if (!Object.prototype.hasOwnProperty.call(modals, modal)) {
+            if (!Object.hasOwn(modals, modal)) {
                 continue;
             }
             if (modals?.modalState[modal].open) {

--- a/webapp/channels/src/components/rhs_card/rhs_card.tsx
+++ b/webapp/channels/src/components/rhs_card/rhs_card.tsx
@@ -122,7 +122,7 @@ export default class RhsCard extends React.Component<Props, State> {
         const {selected, pluginPostCardTypes, teamUrl} = this.props;
         const postType = selected.type;
         let content: ReactNode = null;
-        if (pluginPostCardTypes?.hasOwnProperty(postType)) {
+        if (pluginPostCardTypes && Object.hasOwn(pluginPostCardTypes, postType)) {
             const PluginComponent = pluginPostCardTypes[postType].component;
             content = <PluginComponent post={selected}/>;
         }

--- a/webapp/channels/src/components/search_results/search_results.tsx
+++ b/webapp/channels/src/components/search_results/search_results.tsx
@@ -439,11 +439,11 @@ SearchResults.defaultProps = defaultProps;
 export const arePropsEqual = (props: Props, nextProps: Props): boolean => {
     // Shallow compare for all props except 'results' and 'fileResults'
     for (const key in nextProps) {
-        if (!Object.prototype.hasOwnProperty.call(nextProps, key) || key === 'results') {
+        if (!Object.hasOwn(nextProps, key) || key === 'results') {
             continue;
         }
 
-        if (!Object.prototype.hasOwnProperty.call(nextProps, key) || key === 'fileResults') {
+        if (!Object.hasOwn(nextProps, key) || key === 'fileResults') {
             continue;
         }
 

--- a/webapp/channels/src/components/system_notice/notices.tsx
+++ b/webapp/channels/src/components/system_notice/notices.tsx
@@ -127,7 +127,7 @@ const notices: Notice[] = [
             const USERS_THRESHOLD = 10000;
 
             // If we don't have the analytics yet, don't show
-            if (!analytics?.hasOwnProperty('TOTAL_USERS')) {
+            if (!analytics || Object.hasOwn(analytics, 'TOTAL_USERS')) {
                 return false;
             }
 

--- a/webapp/channels/src/components/user_settings/display/user_settings_theme/premade_theme_chooser/premade_theme_chooser.tsx
+++ b/webapp/channels/src/components/user_settings/display/user_settings_theme/premade_theme_chooser/premade_theme_chooser.tsx
@@ -22,7 +22,7 @@ const PremadeThemeChooser = ({theme, updateTheme, allowedThemes = []}: Props) =>
     const hasAllowedThemes = allowedThemes.length > 1 || (allowedThemes[0] && allowedThemes[0].trim().length > 0);
 
     for (const k in Preferences.THEMES) {
-        if (Preferences.THEMES.hasOwnProperty(k)) {
+        if (Object.hasOwn(Preferences.THEMES, k)) {
             if (hasAllowedThemes && allowedThemes.indexOf(k) < 0) {
                 continue;
             }

--- a/webapp/channels/src/components/user_settings/display/user_settings_theme/user_settings_theme.tsx
+++ b/webapp/channels/src/components/user_settings/display/user_settings_theme/user_settings_theme.tsx
@@ -118,7 +118,7 @@ export default class ThemeSetting extends React.PureComponent<Props, State> {
         let themeChanged = this.state.theme.length === theme.length;
         if (!themeChanged) {
             for (const field in theme) {
-                if (theme.hasOwnProperty(field)) {
+                if (Object.hasOwn(theme, field)) {
                     if (this.state.theme[field] !== theme[field]) {
                         themeChanged = true;
                         break;

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/teams.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/teams.test.ts
@@ -355,7 +355,7 @@ describe('Actions.Teams', () => {
         const member = members[TestHelper.basicTeam!.id];
 
         expect(member).toBeTruthy();
-        expect(Object.prototype.hasOwnProperty.call(member, 'mention_count')).toBeTruthy();
+        expect(Object.hasOwn(member, 'mention_count')).toBeTruthy();
     });
 
     it('getTeamMembersForUser', async () => {

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
@@ -405,7 +405,7 @@ export function getProfilesInGroupChannels(channelsIds: string[]): ActionFuncAsy
 
         const actions: AnyAction[] = [];
         for (const channelId in channelProfiles) {
-            if (channelProfiles.hasOwnProperty(channelId)) {
+            if (Object.hasOwn(channelProfiles, channelId)) {
                 const profiles = channelProfiles[channelId];
 
                 actions.push(

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/scheduled_posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/scheduled_posts.ts
@@ -15,7 +15,7 @@ function byId(state: ScheduledPostsState['byId'] = {}, action: AnyAction) {
         const newState = {...state};
 
         Object.keys(scheduledPostsByTeamId).forEach((teamId: string) => {
-            if (scheduledPostsByTeamId.hasOwnProperty(teamId)) {
+            if (Object.hasOwn(scheduledPostsByTeamId, teamId)) {
                 scheduledPostsByTeamId[teamId].forEach((scheduledPost: ScheduledPost) => {
                     newState[scheduledPost.id] = scheduledPost;
                 });
@@ -58,7 +58,7 @@ function byTeamId(state: ScheduledPostsState['byTeamId'] = {}, action: AnyAction
         const newState = {...state};
 
         Object.keys(scheduledPostsByTeamId).forEach((teamId: string) => {
-            if (scheduledPostsByTeamId.hasOwnProperty(teamId)) {
+            if (Object.hasOwn(scheduledPostsByTeamId, teamId)) {
                 newState[teamId] = scheduledPostsByTeamId[teamId].map((scheduledPost: ScheduledPost) => scheduledPost.id);
             }
         });
@@ -118,7 +118,7 @@ function errorsByTeamId(state: ScheduledPostsState['errorsByTeamId'] = {}, actio
         const newState = {...state};
 
         Object.keys(scheduledPostsByTeamId).forEach((teamId: string) => {
-            if (scheduledPostsByTeamId.hasOwnProperty(teamId)) {
+            if (Object.hasOwn(scheduledPostsByTeamId, teamId)) {
                 const teamScheduledPosts = scheduledPostsByTeamId[teamId] as ScheduledPost[];
                 newState[teamId] = teamScheduledPosts.filter((scheduledPost) => scheduledPost.error_code).map((scheduledPost) => scheduledPost.id);
             }
@@ -179,7 +179,7 @@ function byChannelOrThreadId(state: ScheduledPostsState['byChannelOrThreadId'] =
         const newState = {...state};
 
         Object.keys(scheduledPostsByTeamId).forEach((teamId: string) => {
-            if (scheduledPostsByTeamId.hasOwnProperty(teamId)) {
+            if (Object.hasOwn(scheduledPostsByTeamId, teamId)) {
                 scheduledPostsByTeamId[teamId].forEach((scheduledPost: ScheduledPost) => {
                     const id = scheduledPost.root_id || scheduledPost.channel_id;
 

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/teams.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/teams.ts
@@ -47,7 +47,7 @@ function teams(state: IDMappedObjects<Team> = {}, action: AnyAction) {
     case TeamTypes.RECEIVED_TEAM_DELETED: {
         const nextState = {...state};
         const teamId = action.data.id;
-        if (nextState.hasOwnProperty(teamId)) {
+        if (Object.hasOwn(nextState, teamId)) {
             Reflect.deleteProperty(nextState, teamId);
             return nextState;
         }
@@ -352,7 +352,7 @@ function membersInTeam(state: RelationOneToOne<Team, RelationOneToOne<UserProfil
     case TeamTypes.RECEIVED_TEAM_DELETED: {
         const nextState = {...state};
         const teamId = action.data.id;
-        if (nextState.hasOwnProperty(teamId)) {
+        if (Object.hasOwn(nextState, teamId)) {
             Reflect.deleteProperty(nextState, teamId);
             return nextState;
         }
@@ -381,7 +381,7 @@ function stats(state: any = {}, action: AnyAction) {
     case TeamTypes.RECEIVED_TEAM_DELETED: {
         const nextState = {...state};
         const teamId = action.data.id;
-        if (nextState.hasOwnProperty(teamId)) {
+        if (Object.hasOwn(nextState, teamId)) {
             Reflect.deleteProperty(nextState, teamId);
             return nextState;
         }

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/files.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/requests/files.ts
@@ -35,7 +35,7 @@ export function handleUploadFilesRequest(
         let error = action.error;
 
         if (error instanceof Error) {
-            error = error.hasOwnProperty('intl') ? {...error} : error.toString();
+            error = Object.hasOwn(error, 'intl') ? {...error} : error.toString();
         }
 
         return {

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channels.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channels.ts
@@ -545,7 +545,7 @@ export const getMyChannels: (state: GlobalState) => Channel[] = createSelector(
     getAllDirectChannels,
     getMyChannelMemberships,
     (channels: Channel[], directChannels: Channel[], myMembers: RelationOneToOne<Channel, ChannelMembership>): Channel[] => {
-        return [...channels, ...directChannels].filter((c) => myMembers.hasOwnProperty(c.id));
+        return [...channels, ...directChannels].filter((c) => Object.hasOwn(myMembers, c.id));
     },
 );
 
@@ -555,7 +555,7 @@ export const getOtherChannels: (state: GlobalState, archived?: boolean | null) =
     getMyChannelMemberships,
     (state: GlobalState, archived: boolean | undefined | null = true) => archived,
     (channels: Channel[], myMembers: RelationOneToOne<Channel, ChannelMembership>, archived?: boolean | null): Channel[] => {
-        return channels.filter((c) => !myMembers.hasOwnProperty(c.id) && c.type === General.OPEN_CHANNEL && (archived ? true : c.delete_at === 0));
+        return channels.filter((c) => !Object.hasOwn(myMembers, c.id) && c.type === General.OPEN_CHANNEL && (archived ? true : c.delete_at === 0));
     },
 );
 

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/groups.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/groups.ts
@@ -41,7 +41,7 @@ export const getAllGroupsByName: (state: GlobalState) => Record<string, Group> =
         const groupsByName: Record<string, Group> = {};
 
         for (const id in groups) {
-            if (groups.hasOwnProperty(id)) {
+            if (Object.hasOwn(groups, id)) {
                 const group = groups[id];
                 groupsByName[group.name] = group;
             }
@@ -140,7 +140,7 @@ export const getAssociatedGroupsByName: (state: GlobalState, teamID: string, cha
         const groupsByName: Record<string, Group> = {};
 
         for (const id in groups) {
-            if (groups.hasOwnProperty(id)) {
+            if (Object.hasOwn(groups, id)) {
                 const group = groups[id];
                 groupsByName[group.name] = group;
             }
@@ -271,7 +271,7 @@ export const getAllGroupsForReferenceByName: (state: GlobalState) => Record<stri
         const groupsByName: Record<string, Group> = {};
 
         for (const id in groups) {
-            if (groups.hasOwnProperty(id)) {
+            if (Object.hasOwn(groups, id)) {
                 const group = groups[id];
                 groupsByName[group.name] = group;
             }

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/roles.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/roles.ts
@@ -40,7 +40,7 @@ export const getMyGroupRoles: (state: GlobalState) => Record<string, Set<string>
         const roles: Record<string, Set<string>> = {};
         if (groupMemberships) {
             for (const key in groupMemberships) {
-                if (groupMemberships.hasOwnProperty(key) && groupMemberships[key].roles) {
+                if (Object.hasOwn(groupMemberships, key) && groupMemberships[key].roles) {
                     roles[key] = new Set<string>(groupMemberships[key].roles.split(' '));
                 }
             }
@@ -98,7 +98,7 @@ export const getMyTeamRoles: (state: GlobalState) => Record<string, Set<string>>
         const roles: Record<string, Set<string>> = {};
         if (teamsMemberships) {
             for (const key in teamsMemberships) {
-                if (teamsMemberships.hasOwnProperty(key) && teamsMemberships[key].roles) {
+                if (Object.hasOwn(teamsMemberships, key) && teamsMemberships[key].roles) {
                     roles[key] = new Set<string>(teamsMemberships[key].roles.split(' '));
                 }
             }

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/users.ts
@@ -104,7 +104,7 @@ export const getUsersByUsername: (a: GlobalState) => Record<string, UserProfile>
         const usersByUsername: Record<string, UserProfile> = {};
 
         for (const id in users) {
-            if (users.hasOwnProperty(id)) {
+            if (Object.hasOwn(users, id)) {
                 const user = users[id];
                 usersByUsername[user.username] = user;
             }

--- a/webapp/channels/src/packages/mattermost-redux/src/utils/deep_freeze.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/utils/deep_freeze.ts
@@ -36,7 +36,7 @@ export default function deepFreezeAndThrowOnMutation(object: any): any {
     }
 
     for (const key in object) {
-        if (object.hasOwnProperty(key)) {
+        if (Object.hasOwn(object, key)) {
             object.__defineGetter__(key, identity.bind(null, object[key])); // eslint-disable-line no-underscore-dangle
             object.__defineSetter__(key, throwOnImmutableMutation.bind(null, key)); // eslint-disable-line no-underscore-dangle
         }
@@ -46,7 +46,7 @@ export default function deepFreezeAndThrowOnMutation(object: any): any {
     Object.seal(object);
 
     for (const key in object) {
-        if (object.hasOwnProperty(key)) {
+        if (Object.hasOwn(object, key)) {
             deepFreezeAndThrowOnMutation(object[key]);
         }
     }

--- a/webapp/channels/src/packages/mattermost-redux/src/utils/integration_utils.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/utils/integration_utils.ts
@@ -72,7 +72,7 @@ export function checkDialogElementForError(elem: DialogElement, value: any): Dia
 
 export function checkIfErrorsMatchElements(errors: Record<string, string> = {}, elements: DialogElement[] = []) {
     for (const name in errors) {
-        if (!errors.hasOwnProperty(name)) {
+        if (!Object.hasOwn(errors, name)) {
             continue;
         }
         for (const elem of elements) {

--- a/webapp/channels/src/packages/mattermost-redux/src/utils/key_mirror.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/utils/key_mirror.ts
@@ -34,7 +34,7 @@ export default function keyMirror<T extends Record<string, unknown>>(obj: T): { 
 
     const ret: any = {};
     for (const key in obj) {
-        if (!obj.hasOwnProperty(key)) {
+        if (!Object.hasOwn(obj, key)) {
             continue;
         }
 

--- a/webapp/channels/src/packages/mattermost-redux/test/merge_objects.ts
+++ b/webapp/channels/src/packages/mattermost-redux/test/merge_objects.ts
@@ -38,7 +38,7 @@ export default function mergeObjects(a: Record<string, any>, b: Record<string, a
         }
 
         for (const key of Object.keys(b)) {
-            if (result.hasOwnProperty(key)) {
+            if (Object.hasOwn(result, key)) {
                 continue;
             }
 

--- a/webapp/channels/src/plugins/index.js
+++ b/webapp/channels/src/plugins/index.js
@@ -235,7 +235,7 @@ export async function loadPluginsIfNecessary() {
 
     // Remove old plugins
     Object.keys(oldManifests).forEach((id) => {
-        if (!newManifests.hasOwnProperty(id)) {
+        if (!Object.hasOwn(newManifests, id)) {
             const oldManifest = oldManifests[id];
             removePlugin(oldManifest);
         }

--- a/webapp/channels/src/plugins/pluggable/pluggable.tsx
+++ b/webapp/channels/src/plugins/pluggable/pluggable.tsx
@@ -64,7 +64,7 @@ export default function Pluggable(props: Props): JSX.Element | null {
         ...otherProps
     } = props;
 
-    if (!pluggableName || !Object.hasOwnProperty.call(components, pluggableName)) {
+    if (!pluggableName || !Object.hasOwn(components, pluggableName)) {
         return null;
     }
 

--- a/webapp/channels/src/reducers/views/marketplace.ts
+++ b/webapp/channels/src/reducers/views/marketplace.ts
@@ -65,7 +65,7 @@ function installing(state: {[id: string]: boolean} = {}, action: AnyAction): {[i
 
     case ActionTypes.INSTALLING_MARKETPLACE_ITEM_SUCCEEDED:
     case ActionTypes.INSTALLING_MARKETPLACE_ITEM_FAILED: {
-        if (!Object.prototype.hasOwnProperty.call(state, action.id)) {
+        if (!Object.hasOwn(state, action.id)) {
             return state;
         }
 
@@ -100,7 +100,7 @@ function errors(state: {[id: string]: string} = {}, action: AnyAction): {[id: st
 
     case ActionTypes.INSTALLING_MARKETPLACE_ITEM_SUCCEEDED:
     case ActionTypes.INSTALLING_MARKETPLACE_ITEM: {
-        if (!Object.prototype.hasOwnProperty.call(state, action.id)) {
+        if (!Object.hasOwn(state, action.id)) {
             return state;
         }
 

--- a/webapp/channels/src/utils/policy_roles_adapter.ts
+++ b/webapp/channels/src/utils/policy_roles_adapter.ts
@@ -139,7 +139,7 @@ function roleNamesInMapping() {
 
 function* mappingPartIterator(mappingPart: Record<string, MappingValueTypes[]>, roles: Record<string, Role>) {
     for (const value in mappingPart) {
-        if (mappingPart.hasOwnProperty(value)) {
+        if (Object.hasOwn(mappingPart, value)) {
             const roleRules = mappingPart[value];
 
             const hasUnmetCondition = roleRules.some((item: MappingValueTypes) => {

--- a/webapp/channels/src/utils/text_formatting.tsx
+++ b/webapp/channels/src/utils/text_formatting.tsx
@@ -565,7 +565,7 @@ export function autolinkChannelMentions(
     team?: Team,
 ) {
     function channelMentionExists(c: string) {
-        return channelNamesMap.hasOwnProperty(c);
+        return Object.hasOwn(channelNamesMap, c);
     }
     function addToken(channelName: string, teamName: string, mention: string, displayName: string) {
         const index = tokens.size;

--- a/webapp/platform/eslint-plugin/configs/.eslintrc.json
+++ b/webapp/platform/eslint-plugin/configs/.eslintrc.json
@@ -370,7 +370,7 @@
     "no-process-env": 2,
     "no-process-exit": 2,
     "no-proto": 2,
-    "no-prototype-builtins": 1,
+    "no-prototype-builtins": 2,
     "no-restricted-imports": [
       "error",
       {


### PR DESCRIPTION
#### Summary
We've had warnings enabled in ESLint about not using `obj.hasOwnProperty('key')` for a while now because it's vulnerable to prototype pollution. The original way to fix that was to call it with `Object.prototype.hasOwnProperty.call(obj, 'key')`, but recently (2015), `Object.hasOwn(obj, 'key')` was added to do this more easily.

I also took the opportunity to turn the old ESLint warning into an error.

#### Ticket Link
MM-61893

#### Release Note
```release-note
NONE
```
