### PR TITLE
MM-62030 Fix server update message not handling mutli-digit version numbers

### DIFF
--- a/webapp/channels/src/components/admin_console/workspace-optimization/dashboard_checks/updates.test.ts
+++ b/webapp/channels/src/components/admin_console/workspace-optimization/dashboard_checks/updates.test.ts
@@ -1,0 +1,113 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {fetchAndCompareVersion} from './updates';
+
+import {ItemStatus} from '../dashboard.type';
+
+jest.mock('mattermost-redux/client', () => ({
+    Client4: {
+        getBaseRoute: jest.fn(() => 'http://localhost/api/v4'),
+    },
+}));
+
+describe('fetchAndCompareVersion', () => {
+    beforeEach(() => {
+        global.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('should return major update available', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            json: jest.fn().mockResolvedValue({tag_name: 'v9.1.2', body: 'New major version available'}),
+        });
+
+        const formatMessage = jest.fn(({defaultMessage}) => defaultMessage);
+        const result = await fetchAndCompareVersion('5.6.0', formatMessage);
+
+        expect(result.type).toBe('Major');
+        expect(result.description).toBe('New major version available');
+        expect(result.status).toBe(ItemStatus.ERROR);
+    });
+
+    it('should return major update available - single to double digit', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            json: jest.fn().mockResolvedValue({tag_name: 'v10.0.0', body: 'New major version available'}),
+        });
+
+        const formatMessage = jest.fn(({defaultMessage}) => defaultMessage);
+        const result = await fetchAndCompareVersion('9.1.0', formatMessage);
+
+        expect(result.type).toBe('Major');
+        expect(result.description).toBe('New major version available');
+        expect(result.status).toBe(ItemStatus.ERROR);
+    });
+
+    it('should return minor update available', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            json: jest.fn().mockResolvedValue({tag_name: 'v9.2.0', body: 'New minor version available'}),
+        });
+
+        const formatMessage = jest.fn(({defaultMessage}) => defaultMessage);
+        const result = await fetchAndCompareVersion('9.1.0', formatMessage);
+
+        expect(result.type).toBe('Minor');
+        expect(result.description).toBe('New minor version available');
+        expect(result.status).toBe(ItemStatus.WARNING);
+    });
+
+    it('should return minor update available - single to double digit', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            json: jest.fn().mockResolvedValue({tag_name: 'v9.11.0', body: 'New minor version available'}),
+        });
+
+        const formatMessage = jest.fn(({defaultMessage}) => defaultMessage);
+        const result = await fetchAndCompareVersion('9.5.0', formatMessage);
+
+        expect(result.type).toBe('Minor');
+        expect(result.description).toBe('New minor version available');
+        expect(result.status).toBe(ItemStatus.WARNING);
+    });
+
+    it('should return patch update available', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            json: jest.fn().mockResolvedValue({tag_name: 'v9.1.1', body: 'New patch version available'}),
+        });
+
+        const formatMessage = jest.fn(({defaultMessage}) => defaultMessage);
+        const result = await fetchAndCompareVersion('9.1.0', formatMessage);
+
+        expect(result.type).toBe('Patch');
+        expect(result.description).toBe('New patch version available');
+        expect(result.status).toBe(ItemStatus.INFO);
+    });
+
+    it('should return patch update available - single to double digit', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            json: jest.fn().mockResolvedValue({tag_name: 'v9.1.11', body: 'New patch version available'}),
+        });
+
+        const formatMessage = jest.fn(({defaultMessage}) => defaultMessage);
+        const result = await fetchAndCompareVersion('9.1.4', formatMessage);
+
+        expect(result.type).toBe('Patch');
+        expect(result.description).toBe('New patch version available');
+        expect(result.status).toBe(ItemStatus.INFO);
+    });
+
+    it('should return no update available', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            json: jest.fn().mockResolvedValue({tag_name: 'v9.1.0', body: 'No new version available'}),
+        });
+
+        const formatMessage = jest.fn(({defaultMessage}) => defaultMessage);
+        const result = await fetchAndCompareVersion('9.1.0', formatMessage);
+
+        expect(result.type).toBe('');
+        expect(result.description).toBe('No new version available');
+        expect(result.status).toBe(ItemStatus.OK);
+    });
+});


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
The 'Server Updates' section of 'Workspace Optimizations' in the system console was not comparing version numbers correctly, particularly on double digit version numbers. For example '10.2.0' was returning as an older version than '9.1.0'.

I fixed it by ensuring we were doing proper numeric comparisons. Additionally we had no test coverage so I added those as well.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62030

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Fix incorrect reporting in 'Server Updates' section in  'System Console' -> 'Workspace Optimizations'
```
