### PR TITLE
Prepackage calls v1.3.1 in 10.2

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -144,7 +144,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.2.1
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.3.1
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.3.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.9.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.1.1


### PR DESCRIPTION
#### Summary

Prepackaging Calls v1.3.1 in the upcoming v10.2 dot release.

#### Release Note

```release-note
Prepackage Calls v1.3.1
```
