### PR TITLE
fix: Set explicit Content-Type header for client performance metrics endpoint

### DIFF
--- a/server/channels/api4/metrics.go
+++ b/server/channels/api4/metrics.go
@@ -15,6 +15,8 @@ func (api *API) InitClientPerformanceMetrics() {
 }
 
 func submitPerformanceReport(c *Context, w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
 	// we return early if server does not have any metrics infra available
 	if c.App.Metrics() == nil || !*c.App.Config().MetricsSettings.EnableClientMetrics {
 		return


### PR DESCRIPTION
#### Summary
Adding application/json to the content type of the client_perf api endpoint. This is 100% made with AI using aider tool.

#### Ticket Link
[MM-61530](https://mattermost.atlassian.net/browse/MM-61530)

#### Release Note
```release-note
NONE
```

[MM-61530]: https://mattermost.atlassian.net/browse/MM-61530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ