### PR TITLE
[MM-62022] Fix (Styling): Inconsistent padding in the Enterprise Edition License modal

### DIFF
--- a/webapp/channels/src/components/admin_console/license_settings/modals/ee_license_modal.scss
+++ b/webapp/channels/src/components/admin_console/license_settings/modals/ee_license_modal.scss
@@ -20,7 +20,6 @@
 
     .enterprise-license-text {
         max-height: 200px;
-        // padding: 10px;
         background: white;
         overflow-y: auto;
         text-align: justify;

--- a/webapp/channels/src/components/admin_console/license_settings/modals/ee_license_modal.scss
+++ b/webapp/channels/src/components/admin_console/license_settings/modals/ee_license_modal.scss
@@ -20,7 +20,7 @@
 
     .enterprise-license-text {
         max-height: 200px;
-        padding: 10px;
+        // padding: 10px;
         background: white;
         overflow-y: auto;
         text-align: justify;

--- a/webapp/channels/src/components/admin_console/license_settings/modals/ee_license_modal.tsx
+++ b/webapp/channels/src/components/admin_console/license_settings/modals/ee_license_modal.tsx
@@ -50,21 +50,8 @@ const EELicenseModal: React.FC<Props> = (props: Props): JSX.Element | null => {
             id='EELicenseModal'
             onExited={handleOnClose}
             tabIndex={-1}
-            // Removing the props below will result in the 'Close' not being rendered.
-            handleConfirm={handleOnClose}
-            confirmButtonText={
-                <FormattedMessage
-                    id='EE_license_modal_close.defaultMsg'
-                    defaultMessage='Close'
-                />
-            }
         >
             <>
-                {/* <div
-                    className='title'
-                >
-                    {'Enterprise Edition License:'}
-                </div> */}
                 <div className='enterprise-license-text'>
                     <div>
                         <p>{'The Mattermost Enterprise Edition (EE) license (the “EE License”)'}</p>
@@ -73,14 +60,6 @@ const EELicenseModal: React.FC<Props> = (props: Props): JSX.Element | null => {
                         <p>{'EXCEPT AS OTHERWISE SET FORTH IN A BINDING WRITTEN AGREEMENT BETWEEN YOU AND MATTERMOST, THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.'}</p>
                     </div>
                 </div>
-                {/* <div className='content-footer'>
-                    <button
-                        onClick={handleOnClose}
-                        className='btn btn-primary'
-                    >
-                        {'Close'}
-                    </button>
-                </div> */}
             </>
         </GenericModal>
     );

--- a/webapp/channels/src/components/admin_console/license_settings/modals/ee_license_modal.tsx
+++ b/webapp/channels/src/components/admin_console/license_settings/modals/ee_license_modal.tsx
@@ -14,6 +14,7 @@ import {ModalIdentifiers} from 'utils/constants';
 import type {GlobalState} from 'types/store';
 
 import './ee_license_modal.scss';
+import { FormattedMessage } from 'react-intl';
 
 type Props = {
     onClose?: () => void;
@@ -37,18 +38,33 @@ const EELicenseModal: React.FC<Props> = (props: Props): JSX.Element | null => {
     // Note: DO NOT LOCALISE THESE STRINGS. Legally we can not since the license is in English.
     return (
         <GenericModal
+            modalHeaderText={
+                <FormattedMessage
+                    id='EE_license_modal.defaultMsg'
+                    defaultMessage='Enterprise Edition License'
+                />
+            }
             compassDesign={true}
             className={'EELicenseModal'}
             show={show}
             id='EELicenseModal'
             onExited={handleOnClose}
+            tabIndex={-1}
+            // Removing the props below will result in the 'Close' not being rendered.
+            handleConfirm={handleOnClose}
+            confirmButtonText={
+                <FormattedMessage
+                    id='EE_license_modal_close.defaultMsg'
+                    defaultMessage='Close'
+                />
+            }
         >
             <>
-                <div
+                {/* <div
                     className='title'
                 >
                     {'Enterprise Edition License:'}
-                </div>
+                </div> */}
                 <div className='enterprise-license-text'>
                     <div>
                         <p>{'The Mattermost Enterprise Edition (EE) license (the “EE License”)'}</p>
@@ -57,14 +73,14 @@ const EELicenseModal: React.FC<Props> = (props: Props): JSX.Element | null => {
                         <p>{'EXCEPT AS OTHERWISE SET FORTH IN A BINDING WRITTEN AGREEMENT BETWEEN YOU AND MATTERMOST, THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.'}</p>
                     </div>
                 </div>
-                <div className='content-footer'>
+                {/* <div className='content-footer'>
                     <button
                         onClick={handleOnClose}
                         className='btn btn-primary'
                     >
                         {'Close'}
                     </button>
-                </div>
+                </div> */}
             </>
         </GenericModal>
     );

--- a/webapp/platform/components/src/generic_modal/generic_modal.scss
+++ b/webapp/platform/components/src/generic_modal/generic_modal.scss
@@ -96,6 +96,13 @@
 
                     &.padding {
                         padding: 8px 32px 0;
+
+                        // This adds some 'padding-bottom' to the modal when no button is rendered at the bottom.
+                        // The modal header has 16px of 'padding-top' in addition to the header text's
+                        // 8px 'margin-top',thus, we get 24px;
+                        &.paddingBottom {
+                            padding-bottom: 24px;
+                        }
                     }
                 }
             }

--- a/webapp/platform/components/src/generic_modal/generic_modal.tsx
+++ b/webapp/platform/components/src/generic_modal/generic_modal.tsx
@@ -205,6 +205,9 @@ export class GenericModal extends React.PureComponent<Props, State> {
                     tabIndex={this.props.tabIndex || 0}
                     className='GenericModal__wrapper-enter-key-press-catcher'
                 >
+                {/* Consider only rendering a header when there's header text. EE License doesn't
+                have any header text but a header is still being rendered leaving a large, white, empty space
+                above the modal. Alternatively, the EE title could be moved to the header */}
                     <Modal.Header closeButton={true}>
                         <div className='GenericModal__header__text_container'>
                             {this.props.compassDesign && (

--- a/webapp/platform/components/src/generic_modal/generic_modal.tsx
+++ b/webapp/platform/components/src/generic_modal/generic_modal.tsx
@@ -205,9 +205,6 @@ export class GenericModal extends React.PureComponent<Props, State> {
                     tabIndex={this.props.tabIndex || 0}
                     className='GenericModal__wrapper-enter-key-press-catcher'
                 >
-                {/* Consider only rendering a header when there's header text. EE License doesn't
-                have any header text but a header is still being rendered leaving a large, white, empty space
-                above the modal. Alternatively, the EE title could be moved to the header */}
                     <Modal.Header closeButton={true}>
                         <div className='GenericModal__header__text_container'>
                             {this.props.compassDesign && (
@@ -241,7 +238,15 @@ export class GenericModal extends React.PureComponent<Props, State> {
                         ) : (
                             headerText
                         )}
-                        <div className={classNames('GenericModal__body', {padding: this.props.bodyPadding})}>
+                        <div className={classNames(
+                            'GenericModal__body',
+                            {
+                                padding: this.props.bodyPadding,
+                                // Add some bottom padding so content doesn't stick to the modal's bottom edge.
+                                // The 'padding' class above sets it to 0.
+                                paddingBottom: !confirmButton && !cancelButton && !this.props.footerContent,
+                            })}
+                        >
                             {this.props.children}
                         </div>
                     </Modal.Body>


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR corrects the inconsistent padding in the EE license modal and adds some bottom padding by default to the generic modal whenever it doesn't have bottom buttons or a footer for better spacing.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Fixes https://github.com/mattermost/mattermost/issues/29432#event-15504039509
Jira https://mattermost.atlassian.net/browse/MM-62022

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  Before  |  After  |
|----|
| |
-->

<details><summary>Before</summary>

![enterprise-edition-license-modal-no-padding](https://github.com/user-attachments/assets/c55e7b2e-8a81-41d7-98c2-53f18934f5b6)

</details> 

<details><summary>After</summary>

![mattermost-EE-license-modal-fixed-no-button](https://github.com/user-attachments/assets/307a2968-affb-4a0b-8292-bd79a85f1774)

</details> 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Fixed EE modal padding.
```
