### PR TITLE
Add placeholder MMAction and MMReduxAction types

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/action_types/index.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/action_types/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
+
 import AdminTypes from './admin';
 import AppsTypes from './apps';
 import BotTypes from './bots';
@@ -60,3 +62,8 @@ export {
     ChannelBookmarkTypes,
     ScheduledPostTypes,
 };
+
+/**
+ * An MMReduxAction is any non-Thunk Redux action accepted by mattermost-redux.
+ */
+export type MMReduxAction = AnyAction;

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/helpers.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/helpers.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {AnyAction} from 'redux';
+
 import type {ServerError} from '@mattermost/types/errors';
 import type {GlobalState} from '@mattermost/types/store';
 
@@ -12,7 +14,7 @@ import {logError} from './errors';
 
 type ActionType = string;
 const HTTP_UNAUTHORIZED = 401;
-export function forceLogoutIfNecessary(err: ServerError, dispatch: DispatchFunc, getState: GetStateFunc) {
+export function forceLogoutIfNecessary(err: ServerError, dispatch: DispatchFunc<AnyAction>, getState: GetStateFunc) {
     const {currentUserId} = getState().entities.users;
 
     if ('status_code' in err && err.status_code === HTTP_UNAUTHORIZED && err.url && err.url.indexOf('/login') === -1 && currentUserId) {
@@ -21,7 +23,7 @@ export function forceLogoutIfNecessary(err: ServerError, dispatch: DispatchFunc,
     }
 }
 
-function dispatcher(type: ActionType, data: any, dispatch: DispatchFunc) {
+function dispatcher(type: ActionType, data: any, dispatch: DispatchFunc<AnyAction>) {
     if (type.indexOf('SUCCESS') === -1) { // we don't want to pass the data for the request types
         dispatch(requestSuccess(type, data));
     } else {
@@ -76,7 +78,7 @@ export function bindClientFunc<Func extends(...args: any[]) => Promise<any>>({
     onSuccess?: ActionType | ActionType[];
     onFailure?: ActionType;
     params?: Parameters<Func>;
-}): ActionFuncAsync<Awaited<ReturnType<Func>>, GlobalState> {
+}): ActionFuncAsync<Awaited<ReturnType<Func>>, GlobalState, AnyAction> {
     return async (dispatch, getState) => {
         if (onRequest) {
             dispatch(requestData(onRequest));

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/admin.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/admin.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {ClusterInfo, AnalyticsRow, AnalyticsState, AdminState} from '@mattermost/types/admin';
@@ -15,11 +14,12 @@ import type {SamlCertificateStatus, SamlMetadataResponse} from '@mattermost/type
 import type {UserAccessToken, UserProfile} from '@mattermost/types/users';
 import type {RelationOneToOne, IDMappedObjects} from '@mattermost/types/utilities';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {AdminTypes, UserTypes} from 'mattermost-redux/action_types';
 import {Stats} from 'mattermost-redux/constants';
 import PluginState from 'mattermost-redux/constants/plugins';
 
-function logs(state: string[] = [], action: AnyAction) {
+function logs(state: string[] = [], action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_LOGS: {
         return action.data;
@@ -32,7 +32,7 @@ function logs(state: string[] = [], action: AnyAction) {
     }
 }
 
-function plainLogs(state: string[] = [], action: AnyAction) {
+function plainLogs(state: string[] = [], action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_PLAIN_LOGS: {
         return action.data;
@@ -45,7 +45,7 @@ function plainLogs(state: string[] = [], action: AnyAction) {
     }
 }
 
-function audits(state: Record<string, Audit> = {}, action: AnyAction) {
+function audits(state: Record<string, Audit> = {}, action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_AUDITS: {
         const nextState = {...state};
@@ -62,7 +62,7 @@ function audits(state: Record<string, Audit> = {}, action: AnyAction) {
     }
 }
 
-function config(state: Partial<AdminConfig> = {}, action: AnyAction) {
+function config(state: Partial<AdminConfig> = {}, action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_CONFIG: {
         return action.data;
@@ -89,7 +89,7 @@ function config(state: Partial<AdminConfig> = {}, action: AnyAction) {
     }
 }
 
-function prevTrialLicense(state: Partial<AdminConfig> = {}, action: AnyAction) {
+function prevTrialLicense(state: Partial<AdminConfig> = {}, action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.PREV_TRIAL_LICENSE_SUCCESS: {
         return action.data;
@@ -99,7 +99,7 @@ function prevTrialLicense(state: Partial<AdminConfig> = {}, action: AnyAction) {
     }
 }
 
-function environmentConfig(state: Partial<EnvironmentConfig> = {}, action: AnyAction) {
+function environmentConfig(state: Partial<EnvironmentConfig> = {}, action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_ENVIRONMENT_CONFIG: {
         return action.data;
@@ -112,7 +112,7 @@ function environmentConfig(state: Partial<EnvironmentConfig> = {}, action: AnyAc
     }
 }
 
-function complianceReports(state: Record<string, Compliance> = {}, action: AnyAction) {
+function complianceReports(state: Record<string, Compliance> = {}, action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_COMPLIANCE_REPORT: {
         const nextState = {...state};
@@ -134,7 +134,7 @@ function complianceReports(state: Record<string, Compliance> = {}, action: AnyAc
     }
 }
 
-function clusterInfo(state: ClusterInfo[] = [], action: AnyAction) {
+function clusterInfo(state: ClusterInfo[] = [], action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_CLUSTER_STATUS: {
         return action.data;
@@ -147,7 +147,7 @@ function clusterInfo(state: ClusterInfo[] = [], action: AnyAction) {
     }
 }
 
-function samlCertStatus(state: Partial<SamlCertificateStatus> = {}, action: AnyAction) {
+function samlCertStatus(state: Partial<SamlCertificateStatus> = {}, action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_SAML_CERT_STATUS: {
         return action.data;
@@ -249,7 +249,7 @@ export function convertAnalyticsRowsToStats(data: AnalyticsRow[], name: string):
     return stats;
 }
 
-function analytics(state: AdminState['analytics'] = {}, action: AnyAction) {
+function analytics(state: AdminState['analytics'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_SYSTEM_ANALYTICS: {
         const stats = convertAnalyticsRowsToStats(action.data, action.name);
@@ -263,7 +263,7 @@ function analytics(state: AdminState['analytics'] = {}, action: AnyAction) {
     }
 }
 
-function teamAnalytics(state: AdminState['teamAnalytics'] = {}, action: AnyAction) {
+function teamAnalytics(state: AdminState['teamAnalytics'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_TEAM_ANALYTICS: {
         const nextState = {...state};
@@ -280,7 +280,7 @@ function teamAnalytics(state: AdminState['teamAnalytics'] = {}, action: AnyActio
     }
 }
 
-function userAccessTokens(state: Record<string, UserAccessToken> = {}, action: AnyAction) {
+function userAccessTokens(state: Record<string, UserAccessToken> = {}, action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_USER_ACCESS_TOKEN: {
         return {...state, [action.data.id]: action.data};
@@ -314,7 +314,7 @@ function userAccessTokens(state: Record<string, UserAccessToken> = {}, action: A
     }
 }
 
-function userAccessTokensByUser(state: RelationOneToOne<UserProfile, Record<string, UserAccessToken>> = {}, action: AnyAction) {
+function userAccessTokensByUser(state: RelationOneToOne<UserProfile, Record<string, UserAccessToken>> = {}, action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_USER_ACCESS_TOKEN: { // UserAccessToken
         const nextUserState: UserAccessToken | Record<string, UserAccessToken> = {...(state[action.data.user_id] || {})};
@@ -380,7 +380,7 @@ function userAccessTokensByUser(state: RelationOneToOne<UserProfile, Record<stri
     }
 }
 
-function plugins(state: Record<string, PluginRedux> = {}, action: AnyAction) {
+function plugins(state: Record<string, PluginRedux> = {}, action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_PLUGINS: {
         const nextState = {...state};
@@ -426,7 +426,7 @@ function plugins(state: Record<string, PluginRedux> = {}, action: AnyAction) {
     }
 }
 
-function pluginStatuses(state: Record<string, PluginStatusRedux> = {}, action: AnyAction) {
+function pluginStatuses(state: Record<string, PluginStatusRedux> = {}, action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_PLUGIN_STATUSES: {
         const nextState: any = {};
@@ -527,7 +527,7 @@ function pluginStatuses(state: Record<string, PluginStatusRedux> = {}, action: A
     }
 }
 
-function ldapGroupsCount(state = 0, action: AnyAction) {
+function ldapGroupsCount(state = 0, action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_LDAP_GROUPS:
         return action.data.count;
@@ -538,7 +538,7 @@ function ldapGroupsCount(state = 0, action: AnyAction) {
     }
 }
 
-function ldapGroups(state: Record<string, MixedUnlinkedGroupRedux> = {}, action: AnyAction) {
+function ldapGroups(state: Record<string, MixedUnlinkedGroupRedux> = {}, action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_LDAP_GROUPS: {
         const nextState: any = {};
@@ -594,7 +594,7 @@ function ldapGroups(state: Record<string, MixedUnlinkedGroupRedux> = {}, action:
     }
 }
 
-function samlMetadataResponse(state: Partial<SamlMetadataResponse> = {}, action: AnyAction) {
+function samlMetadataResponse(state: Partial<SamlMetadataResponse> = {}, action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_SAML_METADATA_RESPONSE: {
         return action.data;
@@ -604,7 +604,7 @@ function samlMetadataResponse(state: Partial<SamlMetadataResponse> = {}, action:
     }
 }
 
-function dataRetentionCustomPolicies(state: IDMappedObjects<DataRetentionCustomPolicy> = {}, action: AnyAction): IDMappedObjects<DataRetentionCustomPolicy> {
+function dataRetentionCustomPolicies(state: IDMappedObjects<DataRetentionCustomPolicy> = {}, action: MMReduxAction): IDMappedObjects<DataRetentionCustomPolicy> {
     switch (action.type) {
     case AdminTypes.CREATE_DATA_RETENTION_CUSTOM_POLICY_SUCCESS:
     case AdminTypes.RECEIVED_DATA_RETENTION_CUSTOM_POLICY:
@@ -638,7 +638,7 @@ function dataRetentionCustomPolicies(state: IDMappedObjects<DataRetentionCustomP
         return state;
     }
 }
-function dataRetentionCustomPoliciesCount(state = 0, action: AnyAction) {
+function dataRetentionCustomPoliciesCount(state = 0, action: MMReduxAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_DATA_RETENTION_CUSTOM_POLICIES:
         return action.data.total_count;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/apps.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/apps.ts
@@ -1,15 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {AppBinding, AppCommandFormMap} from '@mattermost/types/apps';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {AppsTypes} from 'mattermost-redux/action_types';
 import {validateBindings} from 'mattermost-redux/utils/apps';
 
-export function mainBindings(state: AppBinding[] = [], action: AnyAction): AppBinding[] {
+export function mainBindings(state: AppBinding[] = [], action: MMReduxAction): AppBinding[] {
     switch (action.type) {
     case AppsTypes.FAILED_TO_FETCH_APP_BINDINGS: {
         if (!state.length) {
@@ -34,7 +34,7 @@ export function mainBindings(state: AppBinding[] = [], action: AnyAction): AppBi
     }
 }
 
-function mainForms(state: AppCommandFormMap = {}, action: AnyAction): AppCommandFormMap {
+function mainForms(state: AppCommandFormMap = {}, action: MMReduxAction): AppCommandFormMap {
     switch (action.type) {
     case AppsTypes.RECEIVED_APP_BINDINGS:
         return {};
@@ -56,7 +56,7 @@ const main = combineReducers({
     forms: mainForms,
 });
 
-function rhsBindings(state: AppBinding[] = [], action: AnyAction): AppBinding[] {
+function rhsBindings(state: AppBinding[] = [], action: MMReduxAction): AppBinding[] {
     switch (action.type) {
     case AppsTypes.RECEIVED_APP_RHS_BINDINGS: {
         const bindings = action.data;
@@ -67,7 +67,7 @@ function rhsBindings(state: AppBinding[] = [], action: AnyAction): AppBinding[] 
     }
 }
 
-function rhsForms(state: AppCommandFormMap = {}, action: AnyAction): AppCommandFormMap {
+function rhsForms(state: AppCommandFormMap = {}, action: MMReduxAction): AppCommandFormMap {
     switch (action.type) {
     case AppsTypes.RECEIVED_APP_RHS_BINDINGS:
         return {};
@@ -89,7 +89,7 @@ const rhs = combineReducers({
     forms: rhsForms,
 });
 
-export function pluginEnabled(state = true, action: AnyAction): boolean {
+export function pluginEnabled(state = true, action: MMReduxAction): boolean {
     switch (action.type) {
     case AppsTypes.APPS_PLUGIN_ENABLED: {
         return true;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/bots.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/bots.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {Bot} from '@mattermost/types/bots';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {BotTypes, UserTypes} from 'mattermost-redux/action_types';
 
-function accounts(state: Record<string, Bot> = {}, action: AnyAction) {
+function accounts(state: Record<string, Bot> = {}, action: MMReduxAction) {
     switch (action.type) {
     case BotTypes.RECEIVED_BOT_ACCOUNTS: {
         const newBots = action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channel_bookmarks.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channel_bookmarks.ts
@@ -1,12 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {combineReducers, type AnyAction} from 'redux';
+import {combineReducers} from 'redux';
 
 import type {ChannelBookmark, ChannelBookmarksState} from '@mattermost/types/channel_bookmarks';
 import type {Channel} from '@mattermost/types/channels';
 import type {IDMappedObjects} from '@mattermost/types/utilities';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {ChannelBookmarkTypes, UserTypes, ChannelTypes} from 'mattermost-redux/action_types';
 
 const toNewObj = <T extends {id: string}>(current: IDMappedObjects<T>, arr: T[]) => {
@@ -15,7 +16,7 @@ const toNewObj = <T extends {id: string}>(current: IDMappedObjects<T>, arr: T[])
     }, {...current});
 };
 
-export function byChannelId(state: ChannelBookmarksState['byChannelId'] = {}, action: AnyAction) {
+export function byChannelId(state: ChannelBookmarksState['byChannelId'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case ChannelBookmarkTypes.RECEIVED_BOOKMARKS: {
         const channelId: Channel['id'] = action.data.channelId;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channel_categories.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channel_categories.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {ChannelCategory} from '@mattermost/types/channel_categories';
@@ -9,10 +8,11 @@ import type {Channel} from '@mattermost/types/channels';
 import type {Team} from '@mattermost/types/teams';
 import type {IDMappedObjects, RelationOneToOne} from '@mattermost/types/utilities';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {ChannelCategoryTypes, TeamTypes, UserTypes, ChannelTypes} from 'mattermost-redux/action_types';
 import {removeItem} from 'mattermost-redux/utils/array_utils';
 
-export function byId(state: IDMappedObjects<ChannelCategory> = {}, action: AnyAction) {
+export function byId(state: IDMappedObjects<ChannelCategory> = {}, action: MMReduxAction) {
     switch (action.type) {
     case ChannelCategoryTypes.RECEIVED_CATEGORIES: {
         const categories: ChannelCategory[] = action.data;
@@ -132,7 +132,7 @@ export function byId(state: IDMappedObjects<ChannelCategory> = {}, action: AnyAc
     }
 }
 
-export function orderByTeam(state: RelationOneToOne<Team, Array<ChannelCategory['id']>> = {}, action: AnyAction) {
+export function orderByTeam(state: RelationOneToOne<Team, Array<ChannelCategory['id']>> = {}, action: MMReduxAction) {
     switch (action.type) {
     case ChannelCategoryTypes.RECEIVED_CATEGORY_ORDER: {
         const teamId: string = action.data.teamId;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channels.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channels.ts
@@ -22,6 +22,7 @@ import type {
     IDMappedObjects,
 } from '@mattermost/types/utilities';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {AdminTypes, ChannelTypes, UserTypes, SchemeTypes, GroupTypes, PostTypes} from 'mattermost-redux/action_types';
 import {General} from 'mattermost-redux/constants';
 import {MarkUnread} from 'mattermost-redux/constants/channels';
@@ -60,7 +61,7 @@ function removeChannelFromSet(state: RelationOneToManyUnique<Team, Channel>, act
     };
 }
 
-function currentChannelId(state = '', action: AnyAction) {
+function currentChannelId(state = '', action: MMReduxAction) {
     switch (action.type) {
     case ChannelTypes.SELECT_CHANNEL:
         return action.data;
@@ -71,7 +72,7 @@ function currentChannelId(state = '', action: AnyAction) {
     }
 }
 
-function channels(state: IDMappedObjects<Channel> = {}, action: AnyAction) {
+function channels(state: IDMappedObjects<Channel> = {}, action: MMReduxAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL: {
         const channel: Channel = toClientChannel(action.data);
@@ -221,7 +222,7 @@ function toClientChannel(serverChannel: ServerChannel): Channel {
     return channel;
 }
 
-function channelsInTeam(state: ChannelsState['channelsInTeam'] = {}, action: AnyAction) {
+function channelsInTeam(state: ChannelsState['channelsInTeam'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL: {
         const nextSet = new Set(state[action.data.team_id]);
@@ -247,7 +248,7 @@ function channelsInTeam(state: ChannelsState['channelsInTeam'] = {}, action: Any
     }
 }
 
-export function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = {}, action: AnyAction) {
+export function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = {}, action: MMReduxAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER: {
         const channelMember: ChannelMembership = action.data;
@@ -507,7 +508,7 @@ function receiveChannelMember(state: RelationOneToOne<Channel, ChannelMembership
     };
 }
 
-function membersInChannel(state: RelationOneToOne<Channel, Record<string, ChannelMembership>> = {}, action: AnyAction) {
+function membersInChannel(state: RelationOneToOne<Channel, Record<string, ChannelMembership>> = {}, action: MMReduxAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER:
     case ChannelTypes.RECEIVED_CHANNEL_MEMBER: {
@@ -580,7 +581,7 @@ function membersInChannel(state: RelationOneToOne<Channel, Record<string, Channe
     }
 }
 
-function stats(state: RelationOneToOne<Channel, ChannelStats> = {}, action: AnyAction) {
+function stats(state: RelationOneToOne<Channel, ChannelStats> = {}, action: MMReduxAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL_STATS: {
         const stat: ChannelStats = action.data;
@@ -687,7 +688,7 @@ function stats(state: RelationOneToOne<Channel, ChannelStats> = {}, action: AnyA
     }
 }
 
-function channelsMemberCount(state: Record<string, number> = {}, action: AnyAction) {
+function channelsMemberCount(state: Record<string, number> = {}, action: MMReduxAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNELS_MEMBER_COUNT: {
         const memberCount = action.data;
@@ -703,7 +704,7 @@ function channelsMemberCount(state: Record<string, number> = {}, action: AnyActi
     }
 }
 
-function groupsAssociatedToChannel(state: any = {}, action: AnyAction) {
+function groupsAssociatedToChannel(state: any = {}, action: MMReduxAction) {
     switch (action.type) {
     case GroupTypes.RECEIVED_ALL_GROUPS_ASSOCIATED_TO_CHANNELS_IN_TEAM: {
         const {groupsByChannelId} = action.data;
@@ -797,7 +798,7 @@ function updateChannelMemberSchemeRoles(state: any, action: AnyAction) {
     return state;
 }
 
-function totalCount(state = 0, action: AnyAction) {
+function totalCount(state = 0, action: MMReduxAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_TOTAL_CHANNEL_COUNT: {
         return action.data;
@@ -807,7 +808,7 @@ function totalCount(state = 0, action: AnyAction) {
     }
 }
 
-export function manuallyUnread(state: RelationOneToOne<Channel, boolean> = {}, action: AnyAction) {
+export function manuallyUnread(state: RelationOneToOne<Channel, boolean> = {}, action: MMReduxAction) {
     switch (action.type) {
     case ChannelTypes.REMOVE_MANUALLY_UNREAD: {
         if (state[action.data.channelId]) {
@@ -831,7 +832,7 @@ export function manuallyUnread(state: RelationOneToOne<Channel, boolean> = {}, a
     }
 }
 
-export function channelModerations(state: any = {}, action: AnyAction) {
+export function channelModerations(state: any = {}, action: MMReduxAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL_MODERATIONS: {
         const {channelId, moderations} = action.data;
@@ -845,7 +846,7 @@ export function channelModerations(state: any = {}, action: AnyAction) {
     }
 }
 
-export function channelMemberCountsByGroup(state: any = {}, action: AnyAction) {
+export function channelMemberCountsByGroup(state: any = {}, action: MMReduxAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL_MEMBER_COUNTS_BY_GROUP: {
         const {channelId, memberCounts} = action.data;
@@ -879,7 +880,7 @@ export function channelMemberCountsByGroup(state: any = {}, action: AnyAction) {
     }
 }
 
-function roles(state: RelationOneToOne<Channel, Set<string>> = {}, action: AnyAction) {
+function roles(state: RelationOneToOne<Channel, Set<string>> = {}, action: MMReduxAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER: {
         const channelMember = action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channels/message_counts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/channels/message_counts.ts
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
-
 import type {
     Channel,
     ChannelMessageCount,
@@ -10,6 +8,7 @@ import type {
 } from '@mattermost/types/channels';
 import type {RelationOneToOne} from '@mattermost/types/utilities';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {
     AdminTypes,
     ChannelTypes,
@@ -18,7 +17,7 @@ import {
 } from 'mattermost-redux/action_types';
 import {General} from 'mattermost-redux/constants';
 
-export default function messageCounts(state: RelationOneToOne<Channel, ChannelMessageCount> = {}, action: AnyAction): RelationOneToOne<Channel, ChannelMessageCount> {
+export default function messageCounts(state: RelationOneToOne<Channel, ChannelMessageCount> = {}, action: MMReduxAction): RelationOneToOne<Channel, ChannelMessageCount> {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL: {
         const channel: ServerChannel = action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/cloud.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/cloud.test.ts
@@ -16,7 +16,7 @@ const minimalLimits = {
 
 describe('limits reducer', () => {
     test('returns empty limits by default', () => {
-        expect(limits(undefined, {type: 'some action', data: minimalLimits})).toEqual({
+        expect(limits(undefined, {type: undefined})).toEqual({
             limits: {},
             limitsLoaded: false,
         });
@@ -26,13 +26,7 @@ describe('limits reducer', () => {
         const unchangedLimits = limits(
             minimalLimits,
             {
-                type: 'some action',
-                data: {
-                    ...minimalLimits,
-                    integrations: {
-                        enabled: 10,
-                    },
-                },
+                type: undefined,
             },
         );
         expect(unchangedLimits).toEqual(minimalLimits);

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/cloud.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/cloud.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {Product, Subscription, CloudCustomer, Invoice, Limits} from '@mattermost/types/cloud';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {CloudTypes} from 'mattermost-redux/action_types';
 
-export function subscription(state: Subscription | null = null, action: AnyAction) {
+export function subscription(state: Subscription | null = null, action: MMReduxAction) {
     switch (action.type) {
     case CloudTypes.RECEIVED_CLOUD_SUBSCRIPTION: {
         return action.data;
@@ -18,7 +18,7 @@ export function subscription(state: Subscription | null = null, action: AnyActio
     }
 }
 
-function customer(state: CloudCustomer | null = null, action: AnyAction) {
+function customer(state: CloudCustomer | null = null, action: MMReduxAction) {
     switch (action.type) {
     case CloudTypes.RECEIVED_CLOUD_CUSTOMER: {
         return action.data;
@@ -28,7 +28,7 @@ function customer(state: CloudCustomer | null = null, action: AnyAction) {
     }
 }
 
-function products(state: Record<string, Product> | null = null, action: AnyAction) {
+function products(state: Record<string, Product> | null = null, action: MMReduxAction) {
     switch (action.type) {
     case CloudTypes.RECEIVED_CLOUD_PRODUCTS: {
         const productList: Product[] = action.data;
@@ -46,7 +46,7 @@ function products(state: Record<string, Product> | null = null, action: AnyActio
     }
 }
 
-function invoices(state: Record<string, Invoice> | null = null, action: AnyAction) {
+function invoices(state: Record<string, Invoice> | null = null, action: MMReduxAction) {
     switch (action.type) {
     case CloudTypes.RECEIVED_CLOUD_INVOICES: {
         const invoiceList: Invoice[] = action.data;
@@ -74,7 +74,7 @@ const emptyLimits = {
     limitsLoaded: false,
 };
 
-export function limits(state: LimitsReducer = emptyLimits, action: AnyAction) {
+export function limits(state: LimitsReducer = emptyLimits, action: MMReduxAction) {
     switch (action.type) {
     case CloudTypes.RECEIVED_CLOUD_LIMITS: {
         return {
@@ -99,7 +99,7 @@ export interface ErrorsReducer {
     trueUpReview?: true;
 }
 const emptyErrors = {};
-export function errors(state: ErrorsReducer = emptyErrors, action: AnyAction) {
+export function errors(state: ErrorsReducer = emptyErrors, action: MMReduxAction) {
     switch (action.type) {
     case CloudTypes.CLOUD_SUBSCRIPTION_FAILED: {
         return {...state, subscription: true};

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/emojis.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/emojis.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {CustomEmoji} from '@mattermost/types/emojis';
 import type {Post} from '@mattermost/types/posts';
 import type {IDMappedObjects} from '@mattermost/types/utilities';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {EmojiTypes, PostTypes, UserTypes} from 'mattermost-redux/action_types';
 
-export function customEmoji(state: IDMappedObjects<CustomEmoji> = {}, action: AnyAction): IDMappedObjects<CustomEmoji> {
+export function customEmoji(state: IDMappedObjects<CustomEmoji> = {}, action: MMReduxAction): IDMappedObjects<CustomEmoji> {
     switch (action.type) {
     case EmojiTypes.RECEIVED_CUSTOM_EMOJI: {
         const emoji: CustomEmoji = action.data;
@@ -75,7 +75,7 @@ function storeEmojisForPost(state: IDMappedObjects<CustomEmoji>, post: Post): ID
     return post.metadata.emojis.reduce(storeEmoji, state);
 }
 
-function nonExistentEmoji(state: Set<string> = new Set(), action: AnyAction): Set<string> {
+function nonExistentEmoji(state: Set<string> = new Set(), action: MMReduxAction): Set<string> {
     switch (action.type) {
     case EmojiTypes.CUSTOM_EMOJI_DOES_NOT_EXIST: {
         if (!state.has(action.data)) {

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/files.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/files.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {PostTypes} from 'mattermost-redux/action_types';
+import {FileTypes, PostTypes} from 'mattermost-redux/action_types';
 import {
     files as filesReducer,
     filesFromSearch as filesFromSearchReducer,
@@ -11,7 +11,7 @@ import deepFreeze from 'mattermost-redux/utils/deep_freeze';
 
 describe('reducers/entities/files', () => {
     describe('files', () => {
-        const testForSinglePost = (actionType: string) => () => {
+        const testForSinglePost = (actionType: typeof PostTypes['RECEIVED_NEW_POST'] | typeof PostTypes['RECEIVED_POST']) => () => {
             it('no post metadata attribute', () => {
                 const state = deepFreeze({});
                 const action = {
@@ -268,7 +268,7 @@ describe('reducers/entities/files', () => {
     describe('filesFromSearch', () => {
         const state = deepFreeze({});
         const action = {
-            type: 'RECEIVED_FILES_FOR_SEARCH',
+            type: FileTypes.RECEIVED_FILES_FOR_SEARCH,
             data: {
                 file1: {id: 'file1', post_id: 'post'},
                 file2: {id: 'file2', post_id: 'post'},
@@ -282,7 +282,7 @@ describe('reducers/entities/files', () => {
     });
 
     describe('fileIdsByPostId', () => {
-        const testForSinglePost = (actionType: string) => () => {
+        const testForSinglePost = (actionType: typeof PostTypes['RECEIVED_NEW_POST'] | typeof PostTypes['RECEIVED_POST']) => () => {
             describe('no post metadata', () => {
                 const action = {
                     type: actionType,

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/files.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/files.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {ChannelBookmark} from '@mattermost/types/channel_bookmarks';
 import type {FileInfo, FileSearchResultItem} from '@mattermost/types/files';
 import type {Post} from '@mattermost/types/posts';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {FileTypes, PostTypes, UserTypes, ChannelBookmarkTypes} from 'mattermost-redux/action_types';
 
-export function files(state: Record<string, FileInfo> = {}, action: AnyAction) {
+export function files(state: Record<string, FileInfo> = {}, action: MMReduxAction) {
     switch (action.type) {
     case FileTypes.RECEIVED_UPLOAD_FILES:
     case FileTypes.RECEIVED_FILES_FOR_POST: {
@@ -98,7 +98,7 @@ export function files(state: Record<string, FileInfo> = {}, action: AnyAction) {
     }
 }
 
-export function filesFromSearch(state: Record<string, FileSearchResultItem> = {}, action: AnyAction) {
+export function filesFromSearch(state: Record<string, FileSearchResultItem> = {}, action: MMReduxAction) {
     switch (action.type) {
     case FileTypes.RECEIVED_FILES_FOR_SEARCH: {
         return {...state,
@@ -150,7 +150,7 @@ function storeFilesForPost(state: Record<string, FileInfo>, post: Post) {
     }, state);
 }
 
-export function fileIdsByPostId(state: Record<string, string[]> = {}, action: AnyAction) {
+export function fileIdsByPostId(state: Record<string, string[]> = {}, action: MMReduxAction) {
     switch (action.type) {
     case FileTypes.RECEIVED_FILES_FOR_POST: {
         const {data, postId} = action;
@@ -204,7 +204,7 @@ function storeFilesIdsForPost(state: Record<string, string[]>, post: Post) {
     };
 }
 
-function filePublicLink(state: {link: string} = {link: ''}, action: AnyAction) {
+function filePublicLink(state: {link: string} = {link: ''}, action: MMReduxAction) {
     switch (action.type) {
     case FileTypes.RECEIVED_FILE_PUBLIC_LINK: {
         return action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/general.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/general.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {ClientLicense, ClientConfig} from '@mattermost/types/config';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {GeneralTypes, UserTypes} from 'mattermost-redux/action_types';
 
-function config(state: Partial<ClientConfig> = {}, action: AnyAction) {
+function config(state: Partial<ClientConfig> = {}, action: MMReduxAction) {
     switch (action.type) {
     case GeneralTypes.CLIENT_CONFIG_RECEIVED:
         return Object.assign({}, state, action.data);
@@ -23,7 +23,7 @@ function config(state: Partial<ClientConfig> = {}, action: AnyAction) {
     }
 }
 
-function license(state: ClientLicense = {}, action: AnyAction) {
+function license(state: ClientLicense = {}, action: MMReduxAction) {
     switch (action.type) {
     case GeneralTypes.CLIENT_LICENSE_RECEIVED:
         return action.data;
@@ -37,7 +37,7 @@ function license(state: ClientLicense = {}, action: AnyAction) {
     }
 }
 
-function serverVersion(state = '', action: AnyAction) {
+function serverVersion(state = '', action: MMReduxAction) {
     switch (action.type) {
     case GeneralTypes.RECEIVED_SERVER_VERSION:
         return action.data;
@@ -48,7 +48,7 @@ function serverVersion(state = '', action: AnyAction) {
     }
 }
 
-function firstAdminVisitMarketplaceStatus(state = false, action: AnyAction) {
+function firstAdminVisitMarketplaceStatus(state = false, action: MMReduxAction) {
     switch (action.type) {
     case GeneralTypes.FIRST_ADMIN_VISIT_MARKETPLACE_STATUS_RECEIVED:
         return action.data;
@@ -58,7 +58,7 @@ function firstAdminVisitMarketplaceStatus(state = false, action: AnyAction) {
     }
 }
 
-function firstAdminCompleteSetup(state = false, action: AnyAction) {
+function firstAdminCompleteSetup(state = false, action: MMReduxAction) {
     switch (action.type) {
     case GeneralTypes.FIRST_ADMIN_COMPLETE_SETUP_RECEIVED:
         return action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/groups.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/groups.test.ts
@@ -9,7 +9,7 @@ describe('reducers/entities/groups', () => {
         it('initial state', () => {
             const state = undefined;
             const action = {
-                type: '',
+                type: undefined,
             };
             const expectedState = {
                 syncables: {},

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/groups.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/groups.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {GroupChannel, GroupSyncablesState, GroupTeam, Group} from '@mattermost/types/groups';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {GroupTypes} from 'mattermost-redux/action_types';
 
-function syncables(state: Record<string, GroupSyncablesState> = {}, action: AnyAction) {
+function syncables(state: Record<string, GroupSyncablesState> = {}, action: MMReduxAction) {
     switch (action.type) {
     case GroupTypes.RECEIVED_GROUP_TEAMS: {
         return {
@@ -141,7 +141,7 @@ function syncables(state: Record<string, GroupSyncablesState> = {}, action: AnyA
     }
 }
 
-function myGroups(state: string[] = [], action: AnyAction) {
+function myGroups(state: string[] = [], action: MMReduxAction) {
     switch (action.type) {
     case GroupTypes.ADD_MY_GROUP: {
         const groupId = action.id;
@@ -185,7 +185,7 @@ function myGroups(state: string[] = [], action: AnyAction) {
     }
 }
 
-function stats(state: any = {}, action: AnyAction) {
+function stats(state: any = {}, action: MMReduxAction) {
     switch (action.type) {
     case GroupTypes.RECEIVED_GROUP_STATS: {
         const stat = action.data;
@@ -199,7 +199,7 @@ function stats(state: any = {}, action: AnyAction) {
     }
 }
 
-function groups(state: Record<string, Group> = {}, action: AnyAction) {
+function groups(state: Record<string, Group> = {}, action: MMReduxAction) {
     switch (action.type) {
     case GroupTypes.CREATE_GROUP_SUCCESS:
     case GroupTypes.PATCHED_GROUP:

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/hosted_customer.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/hosted_customer.ts
@@ -1,11 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {Product} from '@mattermost/types/cloud';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {HostedCustomerTypes} from 'mattermost-redux/action_types';
 
 export interface SelfHostedProducts {
@@ -18,7 +18,7 @@ const initialProducts = {
     productsLoaded: false,
 };
 
-function products(state: SelfHostedProducts = initialProducts, action: AnyAction) {
+function products(state: SelfHostedProducts = initialProducts, action: MMReduxAction) {
     switch (action.type) {
     case HostedCustomerTypes.RECEIVED_SELF_HOSTED_PRODUCTS: {
         const productList: Product[] = action.data;
@@ -46,7 +46,7 @@ export interface ErrorsReducer {
 }
 
 const emptyErrors = {};
-export function errors(state: ErrorsReducer = emptyErrors, action: AnyAction) {
+export function errors(state: ErrorsReducer = emptyErrors, action: MMReduxAction) {
     switch (action.type) {
     case HostedCustomerTypes.SELF_HOSTED_PRODUCTS_FAILED: {
         return {...state, products: true};

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/integrations.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/integrations.ts
@@ -1,15 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {Command, IncomingWebhook, OutgoingWebhook, OAuthApp, OutgoingOAuthConnection} from '@mattermost/types/integrations';
 import type {IDMappedObjects} from '@mattermost/types/utilities';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {IntegrationTypes, UserTypes, ChannelTypes} from 'mattermost-redux/action_types';
 
-function incomingHooks(state: IDMappedObjects<IncomingWebhook> = {}, action: AnyAction) {
+function incomingHooks(state: IDMappedObjects<IncomingWebhook> = {}, action: MMReduxAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_INCOMING_HOOK: {
         const nextState = {...state};
@@ -52,7 +52,7 @@ function incomingHooks(state: IDMappedObjects<IncomingWebhook> = {}, action: Any
     }
 }
 
-function incomingHooksTotalCount(state: number = 0, action: AnyAction) {
+function incomingHooksTotalCount(state: number = 0, action: MMReduxAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_INCOMING_HOOKS_TOTAL_COUNT: {
         return action.data;
@@ -65,7 +65,7 @@ function incomingHooksTotalCount(state: number = 0, action: AnyAction) {
     }
 }
 
-function outgoingHooks(state: IDMappedObjects<OutgoingWebhook> = {}, action: AnyAction) {
+function outgoingHooks(state: IDMappedObjects<OutgoingWebhook> = {}, action: MMReduxAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_OUTGOING_HOOK: {
         const nextState = {...state};
@@ -108,7 +108,7 @@ function outgoingHooks(state: IDMappedObjects<OutgoingWebhook> = {}, action: Any
     }
 }
 
-function commands(state: IDMappedObjects<Command> = {}, action: AnyAction) {
+function commands(state: IDMappedObjects<Command> = {}, action: MMReduxAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_COMMANDS:
     case IntegrationTypes.RECEIVED_CUSTOM_TEAM_COMMANDS: {
@@ -154,7 +154,7 @@ function commands(state: IDMappedObjects<Command> = {}, action: AnyAction) {
     }
 }
 
-function systemCommands(state: IDMappedObjects<Command> = {}, action: AnyAction) {
+function systemCommands(state: IDMappedObjects<Command> = {}, action: MMReduxAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_COMMANDS: {
         const nextCommands: Record<string, Command> = {};
@@ -182,7 +182,7 @@ function systemCommands(state: IDMappedObjects<Command> = {}, action: AnyAction)
     }
 }
 
-function oauthApps(state: IDMappedObjects<OAuthApp> = {}, action: AnyAction) {
+function oauthApps(state: IDMappedObjects<OAuthApp> = {}, action: MMReduxAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_OAUTH_APPS: {
         const nextState = {...state};
@@ -209,7 +209,7 @@ function oauthApps(state: IDMappedObjects<OAuthApp> = {}, action: AnyAction) {
     }
 }
 
-function appsOAuthAppIDs(state: string[] = [], action: AnyAction) {
+function appsOAuthAppIDs(state: string[] = [], action: MMReduxAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_APPS_OAUTH_APP_IDS: {
         if (state.length === 0 && action.data.length === 0) {
@@ -237,7 +237,7 @@ function appsOAuthAppIDs(state: string[] = [], action: AnyAction) {
     }
 }
 
-function outgoingOAuthConnections(state: IDMappedObjects<OutgoingOAuthConnection> = {}, action: AnyAction) {
+function outgoingOAuthConnections(state: IDMappedObjects<OutgoingOAuthConnection> = {}, action: MMReduxAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_OUTGOING_OAUTH_CONNECTIONS: {
         const nextState = {...state};
@@ -264,7 +264,7 @@ function outgoingOAuthConnections(state: IDMappedObjects<OutgoingOAuthConnection
     }
 }
 
-function appsBotIDs(state: string[] = [], action: AnyAction) {
+function appsBotIDs(state: string[] = [], action: MMReduxAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_APPS_BOT_IDS: {
         if (!action.data) {
@@ -296,7 +296,7 @@ function appsBotIDs(state: string[] = [], action: AnyAction) {
     }
 }
 
-function dialogTriggerId(state = '', action: AnyAction) {
+function dialogTriggerId(state = '', action: MMReduxAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_DIALOG_TRIGGER_ID:
         return action.data;
@@ -305,7 +305,7 @@ function dialogTriggerId(state = '', action: AnyAction) {
     }
 }
 
-function dialog(state = '', action: AnyAction) {
+function dialog(state = '', action: MMReduxAction) {
     switch (action.type) {
     case IntegrationTypes.RECEIVED_DIALOG:
         return action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/jobs.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/jobs.ts
@@ -1,15 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {JobType, Job, JobsByType} from '@mattermost/types/jobs';
 import type {IDMappedObjects} from '@mattermost/types/utilities';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {JobTypes} from 'mattermost-redux/action_types';
 
-function jobs(state: IDMappedObjects<Job> = {}, action: AnyAction): IDMappedObjects<Job> {
+function jobs(state: IDMappedObjects<Job> = {}, action: MMReduxAction): IDMappedObjects<Job> {
     switch (action.type) {
     case JobTypes.RECEIVED_JOB: {
         const nextState = {...state};
@@ -28,7 +28,7 @@ function jobs(state: IDMappedObjects<Job> = {}, action: AnyAction): IDMappedObje
     }
 }
 
-function jobsByTypeList(state: JobsByType = {}, action: AnyAction): JobsByType {
+function jobsByTypeList(state: JobsByType = {}, action: MMReduxAction): JobsByType {
     switch (action.type) {
     case JobTypes.RECEIVED_JOBS_BY_TYPE: {
         const nextState = {...state};

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/limits.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/limits.ts
@@ -1,12 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {LimitsTypes} from 'mattermost-redux/action_types';
 
-function serverLimits(state = {}, action: AnyAction) {
+function serverLimits(state = {}, action: MMReduxAction) {
     switch (action.type) {
     case LimitsTypes.RECIEVED_APP_LIMITS: {
         const serverLimits = action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
-
 import type {
     OpenGraphMetadata,
     Post,
@@ -21,6 +19,7 @@ import type {
     RelationOneToMany,
 } from '@mattermost/types/utilities';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {ChannelTypes, PostTypes, UserTypes, ThreadTypes, CloudTypes} from 'mattermost-redux/action_types';
 import {Posts} from 'mattermost-redux/constants';
 import {PostTypes as PostConstant} from 'mattermost-redux/constants/posts';
@@ -99,7 +98,7 @@ export function removeUnneededMetadata(post: Post) {
     };
 }
 
-export function nextPostsReplies(state: {[x in Post['id']]: number} = {}, action: AnyAction) {
+export function nextPostsReplies(state: {[x in Post['id']]: number} = {}, action: MMReduxAction) {
     switch (action.type) {
     case PostTypes.RECEIVED_POST:
     case PostTypes.RECEIVED_NEW_POST: {
@@ -158,7 +157,7 @@ export function nextPostsReplies(state: {[x in Post['id']]: number} = {}, action
     }
 }
 
-export function handlePosts(state: IDMappedObjects<Post> = {}, action: AnyAction) {
+export function handlePosts(state: IDMappedObjects<Post> = {}, action: MMReduxAction) {
     switch (action.type) {
     case PostTypes.RECEIVED_POST:
     case PostTypes.RECEIVED_NEW_POST: {
@@ -399,7 +398,7 @@ function handlePostReceived(nextState: any, post: Post, nestedPermalinkLevel?: n
     return currentState;
 }
 
-export function handlePendingPosts(state: string[] = [], action: AnyAction) {
+export function handlePendingPosts(state: string[] = [], action: MMReduxAction) {
     switch (action.type) {
     case PostTypes.RECEIVED_NEW_POST: {
         const post = action.data;
@@ -465,7 +464,7 @@ export function handlePendingPosts(state: string[] = [], action: AnyAction) {
     }
 }
 
-export function postsInChannel(state: Record<string, PostOrderBlock[]> = {}, action: AnyAction, prevPosts: IDMappedObjects<Post>, nextPosts: Record<string, Post>) {
+export function postsInChannel(state: Record<string, PostOrderBlock[]> = {}, action: MMReduxAction, prevPosts: IDMappedObjects<Post>, nextPosts: Record<string, Post>) {
     switch (action.type) {
     case PostTypes.RESET_POSTS_IN_CHANNEL: {
         return {};
@@ -955,7 +954,7 @@ export function mergePostOrder(left: string[], right: string[], posts: Record<st
     return result;
 }
 
-export function postsInThread(state: RelationOneToMany<Post, Post> = {}, action: AnyAction, prevPosts: Record<string, Post>) {
+export function postsInThread(state: RelationOneToMany<Post, Post> = {}, action: MMReduxAction, prevPosts: Record<string, Post>) {
     switch (action.type) {
     case PostTypes.RECEIVED_NEW_POST:
     case PostTypes.RECEIVED_POST: {
@@ -1154,7 +1153,7 @@ export function postsInThread(state: RelationOneToMany<Post, Post> = {}, action:
     }
 }
 
-export function postEditHistory(state: Post[] = [], action: AnyAction) {
+export function postEditHistory(state: Post[] = [], action: MMReduxAction) {
     switch (action.type) {
     case PostTypes.RECEIVED_POST_HISTORY:
         return action.data;
@@ -1165,7 +1164,7 @@ export function postEditHistory(state: Post[] = [], action: AnyAction) {
     }
 }
 
-function currentFocusedPostId(state = '', action: AnyAction) {
+function currentFocusedPostId(state = '', action: MMReduxAction) {
     switch (action.type) {
     case PostTypes.RECEIVED_FOCUSED_POST:
         return action.data;
@@ -1176,7 +1175,7 @@ function currentFocusedPostId(state = '', action: AnyAction) {
     }
 }
 
-export function reactions(state: RelationOneToOne<Post, Record<string, Reaction>> = {}, action: AnyAction) {
+export function reactions(state: RelationOneToOne<Post, Record<string, Reaction>> = {}, action: MMReduxAction) {
     switch (action.type) {
     case PostTypes.RECEIVED_REACTION: {
         const reaction = action.data as Reaction;
@@ -1237,7 +1236,7 @@ export function reactions(state: RelationOneToOne<Post, Record<string, Reaction>
     }
 }
 
-export function acknowledgements(state: RelationOneToOne<Post, Record<UserProfile['id'], number>> = {}, action: AnyAction) {
+export function acknowledgements(state: RelationOneToOne<Post, Record<UserProfile['id'], number>> = {}, action: MMReduxAction) {
     switch (action.type) {
     case PostTypes.CREATE_ACK_POST_SUCCESS: {
         const ack = action.data as PostAcknowledgement;
@@ -1349,7 +1348,7 @@ function storeAcknowledgementsForPost(state: any, post: Post) {
     };
 }
 
-export function openGraph(state: RelationOneToOne<Post, Record<string, OpenGraphMetadata>> = {}, action: AnyAction) {
+export function openGraph(state: RelationOneToOne<Post, Record<string, OpenGraphMetadata>> = {}, action: MMReduxAction) {
     switch (action.type) {
     case PostTypes.RECEIVED_NEW_POST:
     case PostTypes.RECEIVED_POST: {
@@ -1413,7 +1412,7 @@ function messagesHistory(state: Partial<MessageHistory> = {
         post: -1,
         comment: -1,
     },
-}, action: AnyAction) {
+}, action: MMReduxAction) {
     switch (action.type) {
     case PostTypes.ADD_MESSAGE_INTO_HISTORY: {
         const nextIndex: Record<string, number> = {};
@@ -1495,7 +1494,7 @@ export const zeroStateLimitedViews = {
 
 export function limitedViews(
     state: PostsState['limitedViews'] = zeroStateLimitedViews,
-    action: AnyAction,
+    action: MMReduxAction,
 ): PostsState['limitedViews'] {
     switch (action.type) {
     case PostTypes.RECEIVED_POSTS:
@@ -1561,7 +1560,7 @@ export function limitedViews(
     }
 }
 
-export default function reducer(state: Partial<PostsState> = {}, action: AnyAction) {
+export default function reducer(state: Partial<PostsState> = {}, action: MMReduxAction) {
     const nextPosts = handlePosts(state.posts, action);
     const nextPostsInChannel = postsInChannel(state.postsInChannel, action, state.posts!, nextPosts);
 

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/preferences.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/preferences.ts
@@ -1,11 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {PreferencesType, PreferenceType} from '@mattermost/types/preferences';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {PreferenceTypes, UserTypes} from 'mattermost-redux/action_types';
 
 function getKey(preference: PreferenceType) {
@@ -42,7 +42,7 @@ function setAllUserPreferences(preferences: PreferenceType[]): {[key: string]: P
     return nextState;
 }
 
-function myPreferences(state: Record<string, PreferenceType> = {}, action: AnyAction) {
+function myPreferences(state: Record<string, PreferenceType> = {}, action: MMReduxAction) {
     switch (action.type) {
     case PreferenceTypes.RECEIVED_ALL_PREFERENCES:
         return setAllPreferences(action.data);
@@ -80,7 +80,7 @@ function myPreferences(state: Record<string, PreferenceType> = {}, action: AnyAc
     }
 }
 
-function userPreferences(state: Record<string, PreferencesType> = {}, action: AnyAction) {
+function userPreferences(state: Record<string, PreferencesType> = {}, action: MMReduxAction) {
     switch (action.type) {
     case PreferenceTypes.RECEIVED_USER_ALL_PREFERENCES:
         return setAllUserPreferences(action.data);

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/roles.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/roles.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {Role} from '@mattermost/types/roles';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {RoleTypes, UserTypes} from 'mattermost-redux/action_types';
 
-function pending(state: Set<string> = new Set(), action: AnyAction) {
+function pending(state: Set<string> = new Set(), action: MMReduxAction) {
     switch (action.type) {
     case RoleTypes.SET_PENDING_ROLES:
         return action.data;
@@ -19,7 +19,7 @@ function pending(state: Set<string> = new Set(), action: AnyAction) {
     }
 }
 
-function roles(state: Record<string, Role> = {}, action: AnyAction) {
+function roles(state: Record<string, Role> = {}, action: MMReduxAction) {
     switch (action.type) {
     case RoleTypes.RECEIVED_ROLES: {
         if (action.data) {

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/scheduled_posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/scheduled_posts.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {ScheduledPost, ScheduledPostsState} from '@mattermost/types/schedule_post';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {ScheduledPostTypes, UserTypes} from 'mattermost-redux/action_types';
 
-function byId(state: ScheduledPostsState['byId'] = {}, action: AnyAction) {
+function byId(state: ScheduledPostsState['byId'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case ScheduledPostTypes.SCHEDULED_POSTS_RECEIVED: {
         const {scheduledPostsByTeamId} = action.data;
@@ -51,7 +51,7 @@ function byId(state: ScheduledPostsState['byId'] = {}, action: AnyAction) {
     }
 }
 
-function byTeamId(state: ScheduledPostsState['byTeamId'] = {}, action: AnyAction) {
+function byTeamId(state: ScheduledPostsState['byTeamId'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case ScheduledPostTypes.SCHEDULED_POSTS_RECEIVED: {
         const {scheduledPostsByTeamId} = action.data;
@@ -111,7 +111,7 @@ function byTeamId(state: ScheduledPostsState['byTeamId'] = {}, action: AnyAction
     }
 }
 
-function errorsByTeamId(state: ScheduledPostsState['errorsByTeamId'] = {}, action: AnyAction) {
+function errorsByTeamId(state: ScheduledPostsState['errorsByTeamId'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case ScheduledPostTypes.SCHEDULED_POSTS_RECEIVED: {
         const {scheduledPostsByTeamId} = action.data;
@@ -172,7 +172,7 @@ function errorsByTeamId(state: ScheduledPostsState['errorsByTeamId'] = {}, actio
     }
 }
 
-function byChannelOrThreadId(state: ScheduledPostsState['byChannelOrThreadId'] = {}, action: AnyAction) {
+function byChannelOrThreadId(state: ScheduledPostsState['byChannelOrThreadId'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case ScheduledPostTypes.SCHEDULED_POSTS_RECEIVED: {
         const {scheduledPostsByTeamId} = action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/schemes.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/schemes.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {Scheme} from '@mattermost/types/schemes';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {SchemeTypes, UserTypes} from 'mattermost-redux/action_types';
 
 function schemes(state: {
     [x: string]: Scheme;
-} = {}, action: AnyAction): {
+} = {}, action: MMReduxAction): {
         [x: string]: Scheme;
     } {
     switch (action.type) {

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/search.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/search.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {Post} from '@mattermost/types/posts';
 import type {PreferenceType} from '@mattermost/types/preferences';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {PostTypes, PreferenceTypes, SearchTypes, UserTypes} from 'mattermost-redux/action_types';
 import {Preferences} from 'mattermost-redux/constants';
 
-function results(state: string[] = [], action: AnyAction) {
+function results(state: string[] = [], action: MMReduxAction) {
     switch (action.type) {
     case SearchTypes.RECEIVED_SEARCH_POSTS: {
         if (action.isGettingMore) {
@@ -37,7 +37,7 @@ function results(state: string[] = [], action: AnyAction) {
     }
 }
 
-function fileResults(state: string[] = [], action: AnyAction) {
+function fileResults(state: string[] = [], action: MMReduxAction) {
     switch (action.type) {
     case SearchTypes.RECEIVED_SEARCH_FILES: {
         if (action.isGettingMore) {
@@ -54,7 +54,7 @@ function fileResults(state: string[] = [], action: AnyAction) {
     }
 }
 
-function matches(state: Record<string, string[]> = {}, action: AnyAction) {
+function matches(state: Record<string, string[]> = {}, action: MMReduxAction) {
     switch (action.type) {
     case SearchTypes.RECEIVED_SEARCH_POSTS:
         if (action.isGettingMore) {
@@ -79,7 +79,7 @@ function matches(state: Record<string, string[]> = {}, action: AnyAction) {
     }
 }
 
-function flagged(state: string[] = [], action: AnyAction) {
+function flagged(state: string[] = [], action: MMReduxAction) {
     switch (action.type) {
     case SearchTypes.RECEIVED_SEARCH_FLAGGED_POSTS: {
         return action.data.order;
@@ -160,7 +160,7 @@ function removePinnedPost(state: Record<string, string[]>, post: Post) {
     return state;
 }
 
-function pinned(state: Record<string, string[]> = {}, action: AnyAction) {
+function pinned(state: Record<string, string[]> = {}, action: MMReduxAction) {
     switch (action.type) {
     case SearchTypes.RECEIVED_SEARCH_PINNED_POSTS: {
         const {channelId, pinned: posts} = action.data;
@@ -203,12 +203,11 @@ function pinned(state: Record<string, string[]> = {}, action: AnyAction) {
     }
 }
 
-function current(state: any = {}, action: AnyAction) {
-    const {data, type} = action;
-    switch (type) {
+function current(state: any = {}, action: MMReduxAction) {
+    switch (action.type) {
     case SearchTypes.RECEIVED_SEARCH_TERM: {
         const nextState = {...state};
-        const {teamId, params, isEnd, isFilesEnd} = data;
+        const {teamId, params, isEnd, isFilesEnd} = action.data;
         return {
             ...nextState,
             [teamId]: {
@@ -226,7 +225,7 @@ function current(state: any = {}, action: AnyAction) {
     }
 }
 
-function isSearchingTerm(state = false, action: AnyAction) {
+function isSearchingTerm(state = false, action: MMReduxAction) {
     switch (action.type) {
     case SearchTypes.SEARCH_POSTS_REQUEST:
         return !action.isGettingMore;
@@ -237,7 +236,7 @@ function isSearchingTerm(state = false, action: AnyAction) {
     }
 }
 
-function isSearchGettingMore(state = false, action: AnyAction) {
+function isSearchGettingMore(state = false, action: MMReduxAction) {
     switch (action.type) {
     case SearchTypes.SEARCH_POSTS_REQUEST:
         return action.isGettingMore;
@@ -248,7 +247,7 @@ function isSearchGettingMore(state = false, action: AnyAction) {
     }
 }
 
-function isLimitedResults(state = -1, action: AnyAction): number {
+function isLimitedResults(state = -1, action: MMReduxAction): number {
     switch (action.type) {
     case SearchTypes.SEARCH_POSTS_REQUEST: {
         if (!action.isGettingMore) {

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/teams.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/teams.ts
@@ -8,10 +8,11 @@ import type {Team, TeamMembership, TeamUnread} from '@mattermost/types/teams';
 import type {UserProfile} from '@mattermost/types/users';
 import type {RelationOneToOne, IDMappedObjects} from '@mattermost/types/utilities';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {AdminTypes, ChannelTypes, TeamTypes, UserTypes, SchemeTypes, GroupTypes} from 'mattermost-redux/action_types';
 import {teamListToMap} from 'mattermost-redux/utils/team_utils';
 
-function currentTeamId(state = '', action: AnyAction) {
+function currentTeamId(state = '', action: MMReduxAction) {
     switch (action.type) {
     case TeamTypes.SELECT_TEAM:
         return action.data;
@@ -23,7 +24,7 @@ function currentTeamId(state = '', action: AnyAction) {
     }
 }
 
-function teams(state: IDMappedObjects<Team> = {}, action: AnyAction) {
+function teams(state: IDMappedObjects<Team> = {}, action: MMReduxAction) {
     switch (action.type) {
     case TeamTypes.RECEIVED_TEAMS_LIST:
     case SchemeTypes.RECEIVED_SCHEME_TEAMS:
@@ -94,7 +95,7 @@ function teams(state: IDMappedObjects<Team> = {}, action: AnyAction) {
     }
 }
 
-function myMembers(state: RelationOneToOne<Team, TeamMembership> = {}, action: AnyAction) {
+function myMembers(state: RelationOneToOne<Team, TeamMembership> = {}, action: MMReduxAction) {
     function updateState(receivedTeams: IDMappedObjects<Team> = {}, currentState: RelationOneToOne<Team, TeamMembership> = {}) {
         return Object.keys(receivedTeams).forEach((teamId) => {
             if (receivedTeams[teamId].delete_at > 0 && currentState[teamId]) {
@@ -289,7 +290,7 @@ function myMembers(state: RelationOneToOne<Team, TeamMembership> = {}, action: A
     }
 }
 
-function membersInTeam(state: RelationOneToOne<Team, RelationOneToOne<UserProfile, TeamMembership>> = {}, action: AnyAction) {
+function membersInTeam(state: RelationOneToOne<Team, RelationOneToOne<UserProfile, TeamMembership>> = {}, action: MMReduxAction) {
     switch (action.type) {
     case TeamTypes.RECEIVED_MEMBER_IN_TEAM: {
         const data = action.data;
@@ -369,7 +370,7 @@ function membersInTeam(state: RelationOneToOne<Team, RelationOneToOne<UserProfil
     }
 }
 
-function stats(state: any = {}, action: AnyAction) {
+function stats(state: any = {}, action: MMReduxAction) {
     switch (action.type) {
     case TeamTypes.RECEIVED_TEAM_STATS: {
         const stat = action.data;
@@ -395,7 +396,7 @@ function stats(state: any = {}, action: AnyAction) {
     }
 }
 
-function groupsAssociatedToTeam(state: RelationOneToOne<Team, {ids: string[]; totalCount: number}> = {}, action: AnyAction) {
+function groupsAssociatedToTeam(state: RelationOneToOne<Team, {ids: string[]; totalCount: number}> = {}, action: MMReduxAction) {
     switch (action.type) {
     case GroupTypes.RECEIVED_GROUP_ASSOCIATED_TO_TEAM: {
         const {teamID, groups} = action.data;
@@ -483,7 +484,7 @@ function updateMyTeamMemberSchemeRoles(state: RelationOneToOne<Team, TeamMembers
     return state;
 }
 
-function totalCount(state = 0, action: AnyAction) {
+function totalCount(state = 0, action: MMReduxAction) {
     switch (action.type) {
     case TeamTypes.RECEIVED_TOTAL_TEAM_COUNT: {
         return action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/counts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/counts.ts
@@ -7,6 +7,7 @@ import type {Channel} from '@mattermost/types/channels';
 import type {Team, TeamUnread} from '@mattermost/types/teams';
 import type {ThreadsState, UserThread} from '@mattermost/types/threads';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {ChannelTypes, TeamTypes, ThreadTypes, UserTypes} from 'mattermost-redux/action_types';
 import {General} from 'mattermost-redux/constants';
 
@@ -153,7 +154,7 @@ function handleDecrementThreadCounts(state: ThreadsState['counts'], action: AnyA
     };
 }
 
-export function countsIncludingDirectReducer(state: ThreadsState['counts'] = {}, action: AnyAction, extra: ExtraData) {
+export function countsIncludingDirectReducer(state: ThreadsState['counts'] = {}, action: MMReduxAction, extra: ExtraData) {
     switch (action.type) {
     case ThreadTypes.ALL_TEAM_THREADS_READ:
         return handleAllTeamThreadsRead(state, action);
@@ -220,7 +221,7 @@ export function countsIncludingDirectReducer(state: ThreadsState['counts'] = {},
     return state;
 }
 
-export function countsReducer(state: ThreadsState['counts'] = {}, action: AnyAction, extra: ExtraData) {
+export function countsReducer(state: ThreadsState['counts'] = {}, action: MMReduxAction, extra: ExtraData) {
     switch (action.type) {
     case ThreadTypes.ALL_TEAM_THREADS_READ:
         return handleAllTeamThreadsRead(state, action);

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/index.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/index.ts
@@ -1,20 +1,19 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
-
 import type {Post} from '@mattermost/types/posts';
 import type {ThreadsState, UserThread} from '@mattermost/types/threads';
 import type {UserProfile} from '@mattermost/types/users';
 import type {IDMappedObjects} from '@mattermost/types/utilities';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {ChannelTypes, PostTypes, ThreadTypes, UserTypes} from 'mattermost-redux/action_types';
 
 import {countsReducer, countsIncludingDirectReducer} from './counts';
 import {threadsInTeamReducer, unreadThreadsInTeamReducer} from './threadsInTeam';
 import type {ExtraData} from './types';
 
-export const threadsReducer = (state: ThreadsState['threads'] = {}, action: AnyAction, extra: ExtraData) => {
+export const threadsReducer = (state: ThreadsState['threads'] = {}, action: MMReduxAction, extra: ExtraData) => {
     switch (action.type) {
     case ThreadTypes.RECEIVED_UNREAD_THREADS:
     case ThreadTypes.RECEIVED_THREADS: {
@@ -165,7 +164,7 @@ const initialState = {
 
 // custom combineReducers function
 // enables passing data between reducers
-function reducer(state: ThreadsState = initialState, action: AnyAction): ThreadsState {
+function reducer(state: ThreadsState = initialState, action: MMReduxAction): ThreadsState {
     const extra: ExtraData = {
         threads: state.threads,
     };

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/threadsInTeam.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/threadsInTeam.ts
@@ -7,6 +7,7 @@ import type {Team} from '@mattermost/types/teams';
 import type {ThreadsState, UserThread, UserThreadWithPost} from '@mattermost/types/threads';
 import type {IDMappedObjects, RelationOneToMany} from '@mattermost/types/utilities';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {ChannelTypes, PostTypes, TeamTypes, ThreadTypes, UserTypes} from 'mattermost-redux/action_types';
 
 import type {ExtraData} from './types';
@@ -242,7 +243,7 @@ function handleSingleTeamThreadRead(state: ThreadsState['unreadThreadsInTeam'], 
     };
 }
 
-export const threadsInTeamReducer = (state: ThreadsState['threadsInTeam'] = {}, action: AnyAction, extra: ExtraData) => {
+export const threadsInTeamReducer = (state: ThreadsState['threadsInTeam'] = {}, action: MMReduxAction, extra: ExtraData) => {
     switch (action.type) {
     case ThreadTypes.RECEIVED_THREAD:
         return handleReceivedThread(state, action, extra);
@@ -262,7 +263,7 @@ export const threadsInTeamReducer = (state: ThreadsState['threadsInTeam'] = {}, 
     return state;
 };
 
-export const unreadThreadsInTeamReducer = (state: ThreadsState['unreadThreadsInTeam'] = {}, action: AnyAction, extra: ExtraData) => {
+export const unreadThreadsInTeamReducer = (state: ThreadsState['unreadThreadsInTeam'] = {}, action: MMReduxAction, extra: ExtraData) => {
     switch (action.type) {
     case ThreadTypes.READ_CHANGED_THREAD: {
         const {teamId} = action.data;

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/usage.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/usage.ts
@@ -1,10 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
-
 import type {CloudUsage} from '@mattermost/types/cloud';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {CloudTypes} from 'mattermost-redux/action_types';
 
 const emptyUsage = {
@@ -28,7 +27,7 @@ const emptyUsage = {
 };
 
 // represents the usage associated with this workspace
-export default function usage(state: CloudUsage = emptyUsage, action: AnyAction) {
+export default function usage(state: CloudUsage = emptyUsage, action: MMReduxAction) {
     switch (action.type) {
     case CloudTypes.RECEIVED_MESSAGES_USAGE: {
         return {

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/users.ts
@@ -9,6 +9,7 @@ import type {Team} from '@mattermost/types/teams';
 import type {UserProfile, UsersState} from '@mattermost/types/users';
 import type {IDMappedObjects, RelationOneToManyUnique, RelationOneToOne} from '@mattermost/types/utilities';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {UserTypes, ChannelTypes} from 'mattermost-redux/action_types';
 
 function profilesToSet(state: RelationOneToManyUnique<Team, UserProfile>, action: AnyAction) {
@@ -88,7 +89,7 @@ function removeProfileFromSet(state: RelationOneToManyUnique<Team, UserProfile>,
     };
 }
 
-function currentUserId(state: UsersState['currentUserId'] = '', action: AnyAction) {
+function currentUserId(state: UsersState['currentUserId'] = '', action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_ME: {
         const data = action.data;
@@ -108,7 +109,7 @@ function currentUserId(state: UsersState['currentUserId'] = '', action: AnyActio
     return state;
 }
 
-function mySessions(state: UsersState['mySessions'] = [], action: AnyAction) {
+function mySessions(state: UsersState['mySessions'] = [], action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_SESSIONS:
         return [...action.data];
@@ -146,7 +147,7 @@ function mySessions(state: UsersState['mySessions'] = [], action: AnyAction) {
     }
 }
 
-function myAudits(state: UsersState['myAudits'] = [], action: AnyAction) {
+function myAudits(state: UsersState['myAudits'] = [], action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_AUDITS:
         return [...action.data];
@@ -218,7 +219,7 @@ function receiveUserProfile(state: IDMappedObjects<UserProfile>, received: UserP
     };
 }
 
-function profiles(state: UsersState['profiles'] = {}, action: AnyAction) {
+function profiles(state: UsersState['profiles'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_ME:
     case UserTypes.RECEIVED_PROFILE: {
@@ -264,7 +265,7 @@ function profiles(state: UsersState['profiles'] = {}, action: AnyAction) {
     }
 }
 
-function profilesInTeam(state: UsersState['profilesInTeam'] = {}, action: AnyAction) {
+function profilesInTeam(state: UsersState['profilesInTeam'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_PROFILE_IN_TEAM:
         return addProfileToSet(state, action.data.id, action.data.user_id);
@@ -292,7 +293,7 @@ function profilesInTeam(state: UsersState['profilesInTeam'] = {}, action: AnyAct
     }
 }
 
-function profilesNotInTeam(state: UsersState['profilesNotInTeam'] = {}, action: AnyAction) {
+function profilesNotInTeam(state: UsersState['profilesNotInTeam'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_PROFILE_NOT_IN_TEAM:
         return addProfileToSet(state, action.data.id, action.data.user_id);
@@ -320,7 +321,7 @@ function profilesNotInTeam(state: UsersState['profilesNotInTeam'] = {}, action: 
     }
 }
 
-function profilesWithoutTeam(state: UsersState['profilesWithoutTeam'] = new Set<string>(), action: AnyAction) {
+function profilesWithoutTeam(state: UsersState['profilesWithoutTeam'] = new Set<string>(), action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_PROFILE_WITHOUT_TEAM: {
         const nextSet = new Set(state);
@@ -351,7 +352,7 @@ function profilesWithoutTeam(state: UsersState['profilesWithoutTeam'] = new Set<
     }
 }
 
-function profilesInChannel(state: UsersState['profilesInChannel'] = {}, action: AnyAction) {
+function profilesInChannel(state: UsersState['profilesInChannel'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_PROFILE_IN_CHANNEL:
         return addProfileToSet(state, action.data.id, action.data.user_id);
@@ -383,7 +384,7 @@ function profilesInChannel(state: UsersState['profilesInChannel'] = {}, action: 
     }
 }
 
-function profilesNotInChannel(state: UsersState['profilesNotInChannel'] = {}, action: AnyAction) {
+function profilesNotInChannel(state: UsersState['profilesNotInChannel'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_PROFILE_NOT_IN_CHANNEL:
         return addProfileToSet(state, action.data.id, action.data.user_id);
@@ -422,7 +423,7 @@ function profilesNotInChannel(state: UsersState['profilesNotInChannel'] = {}, ac
     }
 }
 
-function profilesInGroup(state: UsersState['profilesInGroup'] = {}, action: AnyAction) {
+function profilesInGroup(state: UsersState['profilesInGroup'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_PROFILES_LIST_IN_GROUP: {
         return profileListToSet(state, action);
@@ -468,7 +469,7 @@ function profilesInGroup(state: UsersState['profilesInGroup'] = {}, action: AnyA
     }
 }
 
-function profilesNotInGroup(state: UsersState['profilesNotInGroup'] = {}, action: AnyAction) {
+function profilesNotInGroup(state: UsersState['profilesNotInGroup'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_PROFILES_FOR_GROUP: {
         const id = action.id;
@@ -499,7 +500,7 @@ function profilesNotInGroup(state: UsersState['profilesNotInGroup'] = {}, action
     }
 }
 
-function dndEndTimes(state: UsersState['dndEndTimes'] = {}, action: AnyAction) {
+function dndEndTimes(state: UsersState['dndEndTimes'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_DND_END_TIMES: {
         return {...state, ...action.data};
@@ -520,7 +521,7 @@ function dndEndTimes(state: UsersState['dndEndTimes'] = {}, action: AnyAction) {
     }
 }
 
-function statuses(state: RelationOneToOne<UserProfile, string> = {}, action: AnyAction) {
+function statuses(state: RelationOneToOne<UserProfile, string> = {}, action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_STATUSES: {
         return {...state, ...action.data};
@@ -542,7 +543,7 @@ function statuses(state: RelationOneToOne<UserProfile, string> = {}, action: Any
     }
 }
 
-function isManualStatus(state: RelationOneToOne<UserProfile, boolean> = {}, action: AnyAction) {
+function isManualStatus(state: RelationOneToOne<UserProfile, boolean> = {}, action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_STATUSES_IS_MANUAL: {
         return {...state, ...action.data};
@@ -564,7 +565,7 @@ function isManualStatus(state: RelationOneToOne<UserProfile, boolean> = {}, acti
     }
 }
 
-function myUserAccessTokens(state: UsersState['myUserAccessTokens'] = {}, action: AnyAction) {
+function myUserAccessTokens(state: UsersState['myUserAccessTokens'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_MY_USER_ACCESS_TOKEN: {
         const nextState = {...state};
@@ -615,7 +616,7 @@ function myUserAccessTokens(state: UsersState['myUserAccessTokens'] = {}, action
     }
 }
 
-function stats(state: UsersState['stats'] = {}, action: AnyAction) {
+function stats(state: UsersState['stats'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_USER_STATS: {
         const stat = action.data;
@@ -629,7 +630,7 @@ function stats(state: UsersState['stats'] = {}, action: AnyAction) {
     }
 }
 
-function filteredStats(state: UsersState['filteredStats'] = {}, action: AnyAction) {
+function filteredStats(state: UsersState['filteredStats'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_FILTERED_USER_STATS: {
         const stat = action.data;
@@ -643,7 +644,7 @@ function filteredStats(state: UsersState['filteredStats'] = {}, action: AnyActio
     }
 }
 
-function lastActivity(state: UsersState['lastActivity'] = {}, action: AnyAction) {
+function lastActivity(state: UsersState['lastActivity'] = {}, action: MMReduxAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_LAST_ACTIVITIES: {
         return {...state, ...action.data};

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/errors/index.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/errors/index.ts
@@ -1,11 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
-
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {ErrorTypes} from 'mattermost-redux/action_types';
 
-export default ((state: Array<{error: any;displayable?: boolean;date: string}> = [], action: AnyAction) => {
+export default ((state: Array<{error: any;displayable?: boolean;date: string}> = [], action: MMReduxAction) => {
     switch (action.type) {
     case ErrorTypes.DISMISS_ERROR: {
         const nextState = [...state];

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/websocket.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/websocket.ts
@@ -1,8 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
-
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {GeneralTypes, UserTypes} from 'mattermost-redux/action_types';
 
 function getInitialState() {
@@ -15,7 +14,7 @@ function getInitialState() {
     };
 }
 
-export default function reducer(state = getInitialState(), action: AnyAction) {
+export default function reducer(state = getInitialState(), action: MMReduxAction) {
     if (!state.connected && action.type === GeneralTypes.WEBSOCKET_SUCCESS) {
         return {
             ...state,
@@ -29,10 +28,6 @@ export default function reducer(state = getInitialState(), action: AnyAction) {
             lastDisconnectAt: action.timestamp,
             serverHostname: '',
         };
-    }
-
-    if (action.type === UserTypes.LOGOUT_SUCCESS) {
-        return getInitialState();
     }
 
     if (action.type === UserTypes.LOGOUT_SUCCESS) {

--- a/webapp/channels/src/packages/mattermost-redux/src/types/actions.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/types/actions.ts
@@ -1,10 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {Action, AnyAction, Dispatch} from 'redux';
+import type {Action, Dispatch} from 'redux';
 import type {ThunkAction} from 'redux-thunk';
 
 import type {GlobalState} from '@mattermost/types/store';
+
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 
 /**
  * This file extends Redux's Dispatch type and bindActionCreators function to support Thunk actions by default.
@@ -13,7 +15,7 @@ import type {GlobalState} from '@mattermost/types/store';
  */
 import 'redux-thunk/extend-redux';
 
-export type DispatchFunc = Dispatch;
+export type DispatchFunc<TAction extends Action = MMReduxAction> = Dispatch<TAction>;
 export type GetStateFunc<State = GlobalState> = () => State;
 
 /**
@@ -28,13 +30,21 @@ export type ActionResult<Data = any, Error = any> = {
  * ActionFunc should be the return type of most non-async Thunk action creators. If that action requires web app state,
  * the second type parameter should be used to pass the version of GlobalState from 'types/store'.
  */
-export type ActionFunc<Data = unknown, State extends GlobalState = GlobalState> = ThunkAction<ActionResult<Data>, State, unknown, Action>;
+export type ActionFunc<
+    Data = unknown,
+    State extends GlobalState = GlobalState,
+    TAction extends Action = MMReduxAction
+> = ThunkAction<ActionResult<Data>, State, unknown, TAction>;
 
 /**
  * ActionFuncAsync should be the return type of most async Thunk action creators. If that action requires web app state,
  * the second type parameter should be used to pass the version of GlobalState from 'types/store'.
  */
-export type ActionFuncAsync<Data = unknown, State extends GlobalState = GlobalState> = ThunkAction<Promise<ActionResult<Data>>, State, unknown, Action>;
+export type ActionFuncAsync<
+    Data = unknown,
+    State extends GlobalState = GlobalState,
+    TAction extends Action = MMReduxAction
+> = ThunkAction<Promise<ActionResult<Data>>, State, unknown, TAction>;
 
 /**
  * ThunkActionFunc is a type that extends ActionFunc with defaults that match our other ActionFunc variants to save
@@ -42,4 +52,8 @@ export type ActionFuncAsync<Data = unknown, State extends GlobalState = GlobalSt
  *
  * ActionFunc or ActionFuncAsync should generally be preferred, but this type is available for legacy code.
  */
-export type ThunkActionFunc<ReturnType, State extends GlobalState = GlobalState> = ThunkAction<ReturnType, State, unknown, AnyAction>;
+export type ThunkActionFunc<
+    ReturnType,
+    State extends GlobalState = GlobalState,
+    TAction extends Action = MMReduxAction
+> = ThunkAction<ReturnType, State, unknown, TAction>;

--- a/webapp/channels/src/reducers/plugins/index.ts
+++ b/webapp/channels/src/reducers/plugins/index.ts
@@ -13,6 +13,7 @@ import {UserTypes} from 'mattermost-redux/action_types';
 import {ActionTypes} from 'utils/constants';
 import {extractPluginConfiguration} from 'utils/plugins/plugin_setting_extraction';
 
+import type {MMAction} from 'types/store';
 import type {
     PluginsState,
     PluginComponent,
@@ -144,7 +145,7 @@ function removePluginComponent(state: PluginsState['components'], action: AnyAct
     return newState;
 }
 
-function plugins(state: IDMappedObjects<ClientPluginManifest> = {}, action: AnyAction) {
+function plugins(state: IDMappedObjects<ClientPluginManifest> = {}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_WEBAPP_PLUGINS: {
         if (action.data) {
@@ -205,7 +206,7 @@ const initialComponents: PluginsState['components'] = {
     SlashCommandWillBePosted: [],
 };
 
-function components(state: PluginsState['components'] = initialComponents, action: AnyAction) {
+function components(state: PluginsState['components'] = initialComponents, action: MMAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_PLUGIN_COMPONENT: {
         if (action.name && action.data) {
@@ -242,7 +243,7 @@ function components(state: PluginsState['components'] = initialComponents, actio
     }
 }
 
-function postTypes(state: PluginsState['postTypes'] = {}, action: AnyAction) {
+function postTypes(state: PluginsState['postTypes'] = {}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_PLUGIN_POST_COMPONENT: {
         if (action.data) {
@@ -271,7 +272,7 @@ function postTypes(state: PluginsState['postTypes'] = {}, action: AnyAction) {
     }
 }
 
-function postCardTypes(state: PluginsState['postTypes'] = {}, action: AnyAction) {
+function postCardTypes(state: PluginsState['postTypes'] = {}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_PLUGIN_POST_CARD_COMPONENT: {
         if (action.data) {
@@ -300,7 +301,7 @@ function postCardTypes(state: PluginsState['postTypes'] = {}, action: AnyAction)
     }
 }
 
-function adminConsoleReducers(state: {[pluginId: string]: any} = {}, action: AnyAction) {
+function adminConsoleReducers(state: {[pluginId: string]: any} = {}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_ADMIN_CONSOLE_REDUCER: {
         if (action.data) {
@@ -333,7 +334,7 @@ function adminConsoleReducers(state: {[pluginId: string]: any} = {}, action: Any
     }
 }
 
-function adminConsoleCustomComponents(state: {[pluginId: string]: Record<string, AdminConsolePluginComponent>} = {}, action: AnyAction) {
+function adminConsoleCustomComponents(state: {[pluginId: string]: Record<string, AdminConsolePluginComponent>} = {}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_ADMIN_CONSOLE_CUSTOM_COMPONENT: {
         if (!action.data) {
@@ -371,7 +372,7 @@ function adminConsoleCustomComponents(state: {[pluginId: string]: Record<string,
     }
 }
 
-function adminConsoleCustomSections(state: {[pluginId: string]: Record<string, AdminConsolePluginCustomSection>} = {}, action: AnyAction) {
+function adminConsoleCustomSections(state: {[pluginId: string]: Record<string, AdminConsolePluginCustomSection>} = {}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_ADMIN_CONSOLE_CUSTOM_SECTION: {
         if (!action.data) {
@@ -409,7 +410,7 @@ function adminConsoleCustomSections(state: {[pluginId: string]: Record<string, A
     }
 }
 
-function siteStatsHandlers(state: PluginsState['siteStatsHandlers'] = {}, action: AnyAction) {
+function siteStatsHandlers(state: PluginsState['siteStatsHandlers'] = {}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_PLUGIN_STATS_HANDLER:
         if (action.data) {
@@ -434,7 +435,7 @@ function siteStatsHandlers(state: PluginsState['siteStatsHandlers'] = {}, action
     }
 }
 
-function userSettings(state: PluginsState['userSettings'] = {}, action: AnyAction) {
+function userSettings(state: PluginsState['userSettings'] = {}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_PLUGIN_USER_SETTINGS:
         if (action.data) {

--- a/webapp/channels/src/reducers/storage.ts
+++ b/webapp/channels/src/reducers/storage.ts
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import localForage from 'localforage';
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 import {createMigrate, persistReducer, REHYDRATE} from 'redux-persist';
 import type {MigrationManifest, PersistedState} from 'redux-persist';
@@ -13,12 +12,14 @@ import {General} from 'mattermost-redux/constants';
 import {StoragePrefixes, StorageTypes} from 'utils/constants';
 import {getDraftInfoFromKey} from 'utils/storage_utils';
 
+import type {MMAction} from 'types/store';
+
 type StorageEntry = {
     timestamp: Date;
     data: any;
 }
 
-function storage(state: Record<string, any> = {}, action: AnyAction) {
+function storage(state: Record<string, any> = {}, action: MMAction) {
     switch (action.type) {
     case REHYDRATE: {
         if (!action.payload || action.key !== 'storage') {
@@ -134,7 +135,7 @@ function migrateDrafts(state: any) {
     return drafts;
 }
 
-function initialized(state = false, action: AnyAction) {
+function initialized(state = false, action: MMAction) {
     switch (action.type) {
     case General.STORE_REHYDRATION_COMPLETE:
         return state || action.complete;

--- a/webapp/channels/src/reducers/views/add_channel_cta_dropdown.ts
+++ b/webapp/channels/src/reducers/views/add_channel_cta_dropdown.ts
@@ -1,12 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {ActionTypes} from 'utils/constants';
 
-export function isOpen(state = false, action: AnyAction) {
+import type {MMAction} from 'types/store';
+
+export function isOpen(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.ADD_CHANNEL_CTA_DROPDOWN_TOGGLE:
         return action.open;

--- a/webapp/channels/src/reducers/views/add_channel_dropdown.ts
+++ b/webapp/channels/src/reducers/views/add_channel_dropdown.ts
@@ -1,12 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {ActionTypes} from 'utils/constants';
 
-export function isOpen(state = false, action: AnyAction) {
+import type {MMAction} from 'types/store';
+
+export function isOpen(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.ADD_CHANNEL_DROPDOWN_TOGGLE:
         return action.open;

--- a/webapp/channels/src/reducers/views/admin.test.ts
+++ b/webapp/channels/src/reducers/views/admin.test.ts
@@ -8,7 +8,7 @@ import {needsLoggedInLimitReachedCheck} from './admin';
 describe('views/admin reducers', () => {
     describe('needsLoggedInLimitReachedCheck', () => {
         it('defaults to false', () => {
-            const actual = needsLoggedInLimitReachedCheck(undefined, {type: 'asdf'});
+            const actual = needsLoggedInLimitReachedCheck(undefined, {type: undefined});
             expect(actual).toBe(false);
         });
 

--- a/webapp/channels/src/reducers/views/admin.ts
+++ b/webapp/channels/src/reducers/views/admin.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {CursorPaginationDirection} from '@mattermost/types/reports';
@@ -10,6 +9,7 @@ import {UserTypes} from 'mattermost-redux/action_types';
 
 import {ActionTypes} from 'utils/constants';
 
+import type {MMAction} from 'types/store';
 import type {AdminConsoleUserManagementTableProperties} from 'types/store/views';
 
 const navigationBlockInitialState = {
@@ -18,7 +18,7 @@ const navigationBlockInitialState = {
     showNavigationPrompt: false,
 };
 
-function navigationBlock(state = navigationBlockInitialState, action: AnyAction) {
+function navigationBlock(state = navigationBlockInitialState, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SET_NAVIGATION_BLOCKED:
         return {...state, blocked: action.blocked};
@@ -49,7 +49,7 @@ function navigationBlock(state = navigationBlockInitialState, action: AnyAction)
     }
 }
 
-export function needsLoggedInLimitReachedCheck(state = false, action: AnyAction) {
+export function needsLoggedInLimitReachedCheck(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.NEEDS_LOGGED_IN_LIMIT_REACHED_CHECK:
         return action.data;
@@ -74,7 +74,7 @@ export const adminConsoleUserManagementTablePropertiesInitialState: AdminConsole
     filterRole: '',
 };
 
-export function adminConsoleUserManagementTableProperties(state = adminConsoleUserManagementTablePropertiesInitialState, action: AnyAction) {
+export function adminConsoleUserManagementTableProperties(state = adminConsoleUserManagementTablePropertiesInitialState, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SET_ADMIN_CONSOLE_USER_MANAGEMENT_TABLE_PROPERTIES: {
         return {...state, ...action.data};

--- a/webapp/channels/src/reducers/views/announcement_bar.ts
+++ b/webapp/channels/src/reducers/views/announcement_bar.ts
@@ -1,14 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {UserTypes} from 'mattermost-redux/action_types';
 
 import {ActionTypes} from 'utils/constants';
 
-function announcementBarState(state = {announcementBarCount: 0}, action: AnyAction) {
+import type {MMAction} from 'types/store';
+
+function announcementBarState(state = {announcementBarCount: 0}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.TRACK_ANNOUNCEMENT_BAR:
         return {

--- a/webapp/channels/src/reducers/views/browser.ts
+++ b/webapp/channels/src/reducers/views/browser.ts
@@ -1,12 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {ActionTypes, WindowSizes} from 'utils/constants';
 
-function focused(state = true, action: AnyAction) {
+import type {MMAction} from 'types/store';
+
+function focused(state = true, action: MMAction) {
     switch (action.type) {
     case ActionTypes.BROWSER_CHANGE_FOCUS:
         return action.focus;
@@ -15,7 +16,7 @@ function focused(state = true, action: AnyAction) {
     }
 }
 
-function windowSize(state = WindowSizes.DESKTOP_VIEW, action: AnyAction) {
+function windowSize(state = WindowSizes.DESKTOP_VIEW, action: MMAction) {
     switch (action.type) {
     case ActionTypes.BROWSER_WINDOW_RESIZED:
         return action.data;

--- a/webapp/channels/src/reducers/views/channel.ts
+++ b/webapp/channels/src/reducers/views/channel.ts
@@ -1,14 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {ChannelTypes, PostTypes, UserTypes, GeneralTypes} from 'mattermost-redux/action_types';
 
 import {ActionTypes, Constants} from 'utils/constants';
 
-function postVisibility(state: {[channelId: string]: number} = {}, action: AnyAction) {
+import type {MMAction} from 'types/store';
+
+function postVisibility(state: {[channelId: string]: number} = {}, action: MMAction) {
     switch (action.type) {
     case ChannelTypes.SELECT_CHANNEL: {
         const nextState = {...state};
@@ -41,7 +42,7 @@ function postVisibility(state: {[channelId: string]: number} = {}, action: AnyAc
     }
 }
 
-function lastChannelViewTime(state: {[channelId: string]: number} = {}, action: AnyAction) {
+function lastChannelViewTime(state: {[channelId: string]: number} = {}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SELECT_CHANNEL_WITH_MEMBER: {
         if (action.member) {
@@ -69,7 +70,7 @@ function lastChannelViewTime(state: {[channelId: string]: number} = {}, action: 
     }
 }
 
-function loadingPosts(state: {[channelId: string]: boolean} = {}, action: AnyAction) {
+function loadingPosts(state: {[channelId: string]: boolean} = {}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.LOADING_POSTS: {
         const nextState = {...state};
@@ -84,7 +85,7 @@ function loadingPosts(state: {[channelId: string]: boolean} = {}, action: AnyAct
     }
 }
 
-function focusedPostId(state = '', action: AnyAction) {
+function focusedPostId(state = '', action: MMAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_FOCUSED_POST:
         return action.data;
@@ -98,7 +99,7 @@ function focusedPostId(state = '', action: AnyAction) {
     }
 }
 
-function mobileView(state = false, action: AnyAction) {
+function mobileView(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_MOBILE_VIEW:
         return action.data;
@@ -109,7 +110,7 @@ function mobileView(state = false, action: AnyAction) {
 }
 
 // lastUnreadChannel tracks if the current channel was unread and if it had mentions when the user switched to it.
-function lastUnreadChannel(state: ({channelId: string; hadMentions: boolean}) | null = null, action: AnyAction) {
+function lastUnreadChannel(state: ({channelId: string; hadMentions: boolean}) | null = null, action: MMAction) {
     switch (action.type) {
     case ChannelTypes.LEAVE_CHANNEL:
         if (action.data.id === state?.channelId) {
@@ -140,7 +141,7 @@ function lastUnreadChannel(state: ({channelId: string; hadMentions: boolean}) | 
     }
 }
 
-function lastGetPosts(state: {[channelId: string]: number} = {}, action: AnyAction) {
+function lastGetPosts(state: {[channelId: string]: number} = {}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_POSTS_FOR_CHANNEL_AT_TIME:
         return {
@@ -154,7 +155,7 @@ function lastGetPosts(state: {[channelId: string]: number} = {}, action: AnyActi
     }
 }
 
-function toastStatus(state = false, action: AnyAction) {
+function toastStatus(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SELECT_CHANNEL_WITH_MEMBER:
         return false;
@@ -167,7 +168,7 @@ function toastStatus(state = false, action: AnyAction) {
     }
 }
 
-function channelPrefetchStatus(state: {[channelId: string]: string} = {}, action: AnyAction) {
+function channelPrefetchStatus(state: {[channelId: string]: string} = {}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.PREFETCH_POSTS_FOR_CHANNEL:
         return {

--- a/webapp/channels/src/reducers/views/channel_selector_modal.ts
+++ b/webapp/channels/src/reducers/views/channel_selector_modal.ts
@@ -1,14 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {Channel} from '@mattermost/types/channels';
 
 import {ChannelTypes, UserTypes} from 'mattermost-redux/action_types';
 
-function channels(state: string[] = [], action: AnyAction) {
+import type {MMAction} from 'types/store';
+
+function channels(state: string[] = [], action: MMAction) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_ALL_CHANNELS:
         return action.data.map((v: Channel) => v.id);

--- a/webapp/channels/src/reducers/views/channel_sidebar.ts
+++ b/webapp/channels/src/reducers/views/channel_sidebar.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {ChannelCategory} from '@mattermost/types/channel_categories';
@@ -11,9 +10,9 @@ import {removeItem} from 'mattermost-redux/utils/array_utils';
 
 import {ActionTypes} from 'utils/constants';
 
-import type {DraggingState} from 'types/store';
+import type {DraggingState, MMAction} from 'types/store';
 
-export function unreadFilterEnabled(state = false, action: AnyAction) {
+export function unreadFilterEnabled(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SET_UNREAD_FILTER_ENABLED:
         return action.enabled;
@@ -25,7 +24,7 @@ export function unreadFilterEnabled(state = false, action: AnyAction) {
     }
 }
 
-export function draggingState(state: DraggingState = {}, action: AnyAction): DraggingState {
+export function draggingState(state: DraggingState = {}, action: MMAction): DraggingState {
     switch (action.type) {
     case ActionTypes.SIDEBAR_DRAGGING_SET_STATE:
         return {
@@ -42,7 +41,7 @@ export function draggingState(state: DraggingState = {}, action: AnyAction): Dra
     }
 }
 
-export function newCategoryIds(state: string[] = [], action: AnyAction): string[] {
+export function newCategoryIds(state: string[] = [], action: MMAction): string[] {
     switch (action.type) {
     case ActionTypes.ADD_NEW_CATEGORY_ID:
         return [...state, action.data];
@@ -74,7 +73,7 @@ export function newCategoryIds(state: string[] = [], action: AnyAction): string[
     }
 }
 
-export function multiSelectedChannelIds(state: string[] = [], action: AnyAction): string[] {
+export function multiSelectedChannelIds(state: string[] = [], action: MMAction): string[] {
     switch (action.type) {
     case ActionTypes.MULTISELECT_CHANNEL:
         // Channel was not previously selected
@@ -116,7 +115,7 @@ export function multiSelectedChannelIds(state: string[] = [], action: AnyAction)
     }
 }
 
-export function lastSelectedChannel(state = '', action: AnyAction): string {
+export function lastSelectedChannel(state = '', action: MMAction): string {
     switch (action.type) {
     case ActionTypes.MULTISELECT_CHANNEL:
     case ActionTypes.MULTISELECT_CHANNEL_ADD:

--- a/webapp/channels/src/reducers/views/drafts.ts
+++ b/webapp/channels/src/reducers/views/drafts.ts
@@ -1,12 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {ActionTypes} from 'utils/constants';
 
-function remotes(state: Record<string, boolean> = {}, action: AnyAction) {
+import type {MMAction} from 'types/store';
+
+function remotes(state: Record<string, boolean> = {}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SET_DRAFT_SOURCE:
         return {

--- a/webapp/channels/src/reducers/views/emoji.ts
+++ b/webapp/channels/src/reducers/views/emoji.ts
@@ -1,14 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {UserTypes} from 'mattermost-redux/action_types';
 
 import {ActionTypes, Locations} from 'utils/constants';
 
-function emojiPickerCustomPage(state = 0, action: AnyAction) {
+import type {MMAction} from 'types/store';
+
+function emojiPickerCustomPage(state = 0, action: MMAction) {
     switch (action.type) {
     case ActionTypes.INCREMENT_EMOJI_PICKER_PAGE:
         return state + 1;
@@ -19,7 +20,7 @@ function emojiPickerCustomPage(state = 0, action: AnyAction) {
     }
 }
 
-function shortcutReactToLastPostEmittedFrom(state = '', action: AnyAction) {
+function shortcutReactToLastPostEmittedFrom(state = '', action: MMAction) {
     switch (action.type) {
     case ActionTypes.EMITTED_SHORTCUT_REACT_TO_LAST_POST:
         if (action.payload === Locations.CENTER) {

--- a/webapp/channels/src/reducers/views/i18n.ts
+++ b/webapp/channels/src/reducers/views/i18n.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {ActionTypes} from 'utils/constants';
 
+import type {MMAction} from 'types/store';
 import type {Translations} from 'types/store/i18n';
 
-function translations(state: Translations = {}, action: AnyAction) {
+function translations(state: Translations = {}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.RECEIVED_TRANSLATIONS:
         return {

--- a/webapp/channels/src/reducers/views/lhs.ts
+++ b/webapp/channels/src/reducers/views/lhs.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {TeamTypes, UserTypes} from 'mattermost-redux/action_types';
@@ -10,7 +9,9 @@ import {SidebarSize} from 'components/resizable_sidebar/constants';
 
 import {ActionTypes} from 'utils/constants';
 
-function isOpen(state = false, action: AnyAction) {
+import type {MMAction} from 'types/store';
+
+function isOpen(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.TOGGLE_LHS:
         return !state;
@@ -32,7 +33,7 @@ function isOpen(state = false, action: AnyAction) {
     }
 }
 
-function size(state = SidebarSize.MEDIUM, action: AnyAction) {
+function size(state = SidebarSize.MEDIUM, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SET_LHS_SIZE:
         return action.size;
@@ -41,7 +42,7 @@ function size(state = SidebarSize.MEDIUM, action: AnyAction) {
     }
 }
 
-function currentStaticPageId(state = '', action: AnyAction) {
+function currentStaticPageId(state = '', action: MMAction) {
     switch (action.type) {
     case ActionTypes.SELECT_STATIC_PAGE:
         return action.data;

--- a/webapp/channels/src/reducers/views/marketplace.ts
+++ b/webapp/channels/src/reducers/views/marketplace.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import type {MarketplaceApp, MarketplacePlugin} from '@mattermost/types/marketplace';
@@ -10,8 +9,10 @@ import {UserTypes} from 'mattermost-redux/action_types';
 
 import {ActionTypes, ModalIdentifiers} from 'utils/constants';
 
+import type {MMAction} from 'types/store';
+
 // plugins tracks the set of marketplace plugins returned by the server
-function plugins(state: MarketplacePlugin[] = [], action: AnyAction): MarketplacePlugin[] {
+function plugins(state: MarketplacePlugin[] = [], action: MMAction): MarketplacePlugin[] {
     switch (action.type) {
     case ActionTypes.RECEIVED_MARKETPLACE_PLUGINS:
         return action.plugins ? action.plugins : [];
@@ -31,7 +32,7 @@ function plugins(state: MarketplacePlugin[] = [], action: AnyAction): Marketplac
 }
 
 // apps tracks the set of marketplace apps returned by the apps plugin
-function apps(state: MarketplaceApp[] = [], action: AnyAction): MarketplaceApp[] {
+function apps(state: MarketplaceApp[] = [], action: MMAction): MarketplaceApp[] {
     switch (action.type) {
     case ActionTypes.RECEIVED_MARKETPLACE_APPS:
         return action.apps ? action.apps : [];
@@ -51,7 +52,7 @@ function apps(state: MarketplaceApp[] = [], action: AnyAction): MarketplaceApp[]
 }
 
 // installing tracks the items pending installation
-function installing(state: {[id: string]: boolean} = {}, action: AnyAction): {[id: string]: boolean} {
+function installing(state: {[id: string]: boolean} = {}, action: MMAction): {[id: string]: boolean} {
     switch (action.type) {
     case ActionTypes.INSTALLING_MARKETPLACE_ITEM:
         if (state[action.id]) {
@@ -90,7 +91,7 @@ function installing(state: {[id: string]: boolean} = {}, action: AnyAction): {[i
 }
 
 // errors tracks the error messages for items that failed installation
-function errors(state: {[id: string]: string} = {}, action: AnyAction): {[id: string]: string} {
+function errors(state: {[id: string]: string} = {}, action: MMAction): {[id: string]: string} {
     switch (action.type) {
     case ActionTypes.INSTALLING_MARKETPLACE_ITEM_FAILED:
         return {
@@ -125,7 +126,7 @@ function errors(state: {[id: string]: string} = {}, action: AnyAction): {[id: st
 }
 
 // filter tracks the current marketplace search query filter
-function filter(state = '', action: AnyAction): string {
+function filter(state = '', action: MMAction): string {
     switch (action.type) {
     case ActionTypes.FILTER_MARKETPLACE_LISTING:
         return action.filter;

--- a/webapp/channels/src/reducers/views/modals.ts
+++ b/webapp/channels/src/reducers/views/modals.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {GeneralTypes, UserTypes} from 'mattermost-redux/action_types';
 
 import {ActionTypes} from 'utils/constants';
 
+import type {MMAction} from 'types/store';
 import type {ViewsState} from 'types/store/views';
 
-export function modalState(state: ViewsState['modals']['modalState'] = {}, action: AnyAction) {
+export function modalState(state: ViewsState['modals']['modalState'] = {}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.MODAL_OPEN:
         return {
@@ -34,7 +34,7 @@ export function modalState(state: ViewsState['modals']['modalState'] = {}, actio
     }
 }
 
-export function showLaunchingWorkspace(state = false, action: AnyAction) {
+export function showLaunchingWorkspace(state = false, action: MMAction) {
     switch (action.type) {
     case GeneralTypes.SHOW_LAUNCHING_WORKSPACE:
         return action.open;

--- a/webapp/channels/src/reducers/views/notice.ts
+++ b/webapp/channels/src/reducers/views/notice.ts
@@ -1,14 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {UserTypes} from 'mattermost-redux/action_types';
 
 import {ActionTypes} from 'utils/constants';
 
-function hasBeenDismissed(state: Record<string, boolean> = {}, action: AnyAction) {
+import type {MMAction} from 'types/store';
+
+function hasBeenDismissed(state: Record<string, boolean> = {}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.DISMISS_NOTICE:
         return {...state, [action.data]: true};

--- a/webapp/channels/src/reducers/views/onboarding_tasks.ts
+++ b/webapp/channels/src/reducers/views/onboarding_tasks.ts
@@ -1,12 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {ActionTypes} from 'utils/constants';
 
-export function isShowOnboardingTaskCompletion(state = false, action: AnyAction) {
+import type {MMAction} from 'types/store';
+
+export function isShowOnboardingTaskCompletion(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SHOW_ONBOARDING_TASK_COMPLETION:
         return action.open;
@@ -15,7 +16,7 @@ export function isShowOnboardingTaskCompletion(state = false, action: AnyAction)
     }
 }
 
-export function isShowOnboardingCompleteProfileTour(state = false, action: AnyAction) {
+export function isShowOnboardingCompleteProfileTour(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SHOW_ONBOARDING_COMPLETE_PROFILE_TOUR:
         return action.open;
@@ -24,7 +25,7 @@ export function isShowOnboardingCompleteProfileTour(state = false, action: AnyAc
     }
 }
 
-export function isShowOnboardingVisitConsoleTour(state = false, action: AnyAction) {
+export function isShowOnboardingVisitConsoleTour(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SHOW_ONBOARDING_VISIT_CONSOLE_TOUR:
         return action.open;

--- a/webapp/channels/src/reducers/views/posts.ts
+++ b/webapp/channels/src/reducers/views/posts.ts
@@ -1,19 +1,20 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {UserTypes} from 'mattermost-redux/action_types';
 
 import {ActionTypes} from 'utils/constants';
 
+import type {MMAction} from 'types/store';
+
 const defaultState = {
     post: {},
     show: false,
 };
 
-function editingPost(state = defaultState, action: AnyAction) {
+function editingPost(state = defaultState, action: MMAction) {
     switch (action.type) {
     case ActionTypes.TOGGLE_EDITING_POST:
         return {
@@ -28,7 +29,7 @@ function editingPost(state = defaultState, action: AnyAction) {
     }
 }
 
-function menuActions(state: {[postId: string]: {[actionId: string]: {text: string; value: string}}} = {}, action: AnyAction) {
+function menuActions(state: {[postId: string]: {[actionId: string]: {text: string; value: string}}} = {}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SELECT_ATTACHMENT_MENU_ACTION: {
         const nextState = {...state};

--- a/webapp/channels/src/reducers/views/product_menu.ts
+++ b/webapp/channels/src/reducers/views/product_menu.ts
@@ -1,12 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {ActionTypes} from 'utils/constants';
 
-export function switcherOpen(state = false, action: AnyAction) {
+import type {MMAction} from 'types/store';
+
+export function switcherOpen(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SET_PRODUCT_SWITCHER_OPEN:
         return action.open;

--- a/webapp/channels/src/reducers/views/rhs.ts
+++ b/webapp/channels/src/reducers/views/rhs.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {
@@ -15,9 +14,10 @@ import {SidebarSize} from 'components/resizable_sidebar/constants';
 
 import {ActionTypes, RHSStates, Threads} from 'utils/constants';
 
+import type {MMAction} from 'types/store';
 import type {RhsState} from 'types/store/rhs';
 
-function selectedPostId(state = '', action: AnyAction) {
+function selectedPostId(state = '', action: MMAction) {
     switch (action.type) {
     case ActionTypes.SELECT_POST:
         return action.postId;
@@ -41,7 +41,7 @@ function selectedPostId(state = '', action: AnyAction) {
 
 // selectedPostFocussedAt keeps track of the last time a post was selected, whether or not it
 // is currently selected.
-function selectedPostFocussedAt(state = 0, action: AnyAction) {
+function selectedPostFocussedAt(state = 0, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SELECT_POST:
         return action.timestamp || 0;
@@ -54,7 +54,7 @@ function selectedPostFocussedAt(state = 0, action: AnyAction) {
     }
 }
 
-function highlightedPostId(state = '', action: AnyAction) {
+function highlightedPostId(state = '', action: MMAction) {
     switch (action.type) {
     case ActionTypes.HIGHLIGHT_REPLY:
         return action.postId;
@@ -70,7 +70,7 @@ function highlightedPostId(state = '', action: AnyAction) {
 }
 
 // filesSearchExtFilter keeps track of the extension filters used for file search.
-function filesSearchExtFilter(state: string[] = [], action: AnyAction) {
+function filesSearchExtFilter(state: string[] = [], action: MMAction) {
     switch (action.type) {
     case ActionTypes.SET_FILES_FILTER_BY_EXT:
         return action.data;
@@ -82,7 +82,7 @@ function filesSearchExtFilter(state: string[] = [], action: AnyAction) {
     }
 }
 
-function selectedPostCardId(state = '', action: AnyAction) {
+function selectedPostCardId(state = '', action: MMAction) {
     switch (action.type) {
     case ActionTypes.SELECT_POST_CARD:
         return action.postId;
@@ -103,7 +103,7 @@ function selectedPostCardId(state = '', action: AnyAction) {
     }
 }
 
-function selectedChannelId(state = '', action: AnyAction) {
+function selectedChannelId(state = '', action: MMAction) {
     switch (action.type) {
     case ActionTypes.SELECT_POST:
         return action.channelId;
@@ -128,7 +128,7 @@ function selectedChannelId(state = '', action: AnyAction) {
     }
 }
 
-function previousRhsStates(state: any = [], action: AnyAction) {
+function previousRhsStates(state: any = [], action: MMAction) {
     switch (action.type) {
     case ActionTypes.SELECT_POST:
         if (action.previousRhsState) {
@@ -166,7 +166,7 @@ function previousRhsStates(state: any = [], action: AnyAction) {
     }
 }
 
-function rhsState(state: RhsState = null, action: AnyAction) {
+function rhsState(state: RhsState = null, action: MMAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_RHS_STATE:
         return action.state;
@@ -184,7 +184,7 @@ function rhsState(state: RhsState = null, action: AnyAction) {
     }
 }
 
-function size(state: SidebarSize = SidebarSize.MEDIUM, action: AnyAction) {
+function size(state: SidebarSize = SidebarSize.MEDIUM, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SET_RHS_SIZE:
         return action.size;
@@ -193,7 +193,7 @@ function size(state: SidebarSize = SidebarSize.MEDIUM, action: AnyAction) {
     }
 }
 
-function searchTerms(state = '', action: AnyAction) {
+function searchTerms(state = '', action: MMAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_RHS_SEARCH_TERMS:
         return action.terms;
@@ -209,7 +209,7 @@ function searchTerms(state = '', action: AnyAction) {
     }
 }
 
-function searchTeam(state = null, action: AnyAction) {
+function searchTeam(state = null, action: MMAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_RHS_SEARCH_TEAM:
         return action.teamId;
@@ -225,7 +225,7 @@ function searchTeam(state = null, action: AnyAction) {
     }
 }
 
-function searchType(state = '', action: AnyAction) {
+function searchType(state = '', action: MMAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_RHS_SEARCH_TYPE:
         return action.searchType;
@@ -241,7 +241,7 @@ function searchType(state = '', action: AnyAction) {
     }
 }
 
-function pluggableId(state = '', action: AnyAction) {
+function pluggableId(state = '', action: MMAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_RHS_STATE:
         if (action.state === RHSStates.PLUGIN) {
@@ -259,7 +259,7 @@ function pluggableId(state = '', action: AnyAction) {
     }
 }
 
-function searchResultsTerms(state = '', action: AnyAction) {
+function searchResultsTerms(state = '', action: MMAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_RHS_SEARCH_RESULTS_TERMS:
         return action.terms;
@@ -271,7 +271,7 @@ function searchResultsTerms(state = '', action: AnyAction) {
     }
 }
 
-function searchResultsType(state = '', action: AnyAction) {
+function searchResultsType(state = '', action: MMAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_RHS_SEARCH_RESULTS_TYPE:
         return action.searchType;
@@ -283,7 +283,7 @@ function searchResultsType(state = '', action: AnyAction) {
     }
 }
 
-function isSearchingFlaggedPost(state = false, action: AnyAction) {
+function isSearchingFlaggedPost(state = false, action: MMAction) {
     switch (action.type) {
     case SearchTypes.SEARCH_FLAGGED_POSTS_REQUEST:
         return true;
@@ -298,7 +298,7 @@ function isSearchingFlaggedPost(state = false, action: AnyAction) {
     }
 }
 
-function isSearchingPinnedPost(state = false, action: AnyAction) {
+function isSearchingPinnedPost(state = false, action: MMAction) {
     switch (action.type) {
     case SearchTypes.SEARCH_PINNED_POSTS_REQUEST:
         return true;
@@ -313,7 +313,7 @@ function isSearchingPinnedPost(state = false, action: AnyAction) {
     }
 }
 
-function isSidebarOpen(state = false, action: AnyAction) {
+function isSidebarOpen(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_RHS_STATE:
         return Boolean(action.state);
@@ -337,7 +337,7 @@ function isSidebarOpen(state = false, action: AnyAction) {
     }
 }
 
-function isSidebarExpanded(state = false, action: AnyAction) {
+function isSidebarExpanded(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SET_RHS_EXPANDED:
         return action.expanded;
@@ -369,7 +369,7 @@ function isSidebarExpanded(state = false, action: AnyAction) {
     }
 }
 
-function isMenuOpen(state = false, action: AnyAction) {
+function isMenuOpen(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.TOGGLE_RHS_MENU:
         return !state;
@@ -391,7 +391,7 @@ function isMenuOpen(state = false, action: AnyAction) {
     }
 }
 
-function editChannelMembers(state = false, action: AnyAction) {
+function editChannelMembers(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SET_EDIT_CHANNEL_MEMBERS:
         return action.active;
@@ -408,7 +408,7 @@ function editChannelMembers(state = false, action: AnyAction) {
     }
 }
 
-function shouldFocusRHS(state = false, action: AnyAction) {
+function shouldFocusRHS(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SELECT_POST:
         return Boolean(action.postId);

--- a/webapp/channels/src/reducers/views/rhs_suppressed.ts
+++ b/webapp/channels/src/reducers/views/rhs_suppressed.ts
@@ -1,15 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
-
 import {UserTypes} from 'mattermost-redux/action_types';
 
 import {ActionTypes} from 'utils/constants';
 
+import type {MMAction} from 'types/store';
 import type {ViewsState} from 'types/store/views';
 
-export default function rhsSuppressed(state: ViewsState['rhsSuppressed'] = false, action: AnyAction): boolean {
+export default function rhsSuppressed(state: ViewsState['rhsSuppressed'] = false, action: MMAction): boolean {
     switch (action.type) {
     case ActionTypes.SUPPRESS_RHS:
         return true;

--- a/webapp/channels/src/reducers/views/search.ts
+++ b/webapp/channels/src/reducers/views/search.ts
@@ -1,16 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {UserTypes} from 'mattermost-redux/action_types';
 
 import {SearchTypes} from 'utils/constants';
 
+import type {MMAction} from 'types/store';
 import type {ViewsState} from 'types/store/views';
 
-function modalSearch(state = '', action: AnyAction) {
+function modalSearch(state = '', action: MMAction) {
     switch (action.type) {
     case SearchTypes.SET_MODAL_SEARCH: {
         return action.data.trim();
@@ -23,7 +23,7 @@ function modalSearch(state = '', action: AnyAction) {
     }
 }
 
-function popoverSearch(state = '', action: AnyAction) {
+function popoverSearch(state = '', action: MMAction) {
     switch (action.type) {
     case SearchTypes.SET_POPOVER_SEARCH: {
         return action.data.trim();
@@ -34,7 +34,7 @@ function popoverSearch(state = '', action: AnyAction) {
     }
 }
 
-function channelMembersRhsSearch(state = '', action: AnyAction) {
+function channelMembersRhsSearch(state = '', action: MMAction) {
     switch (action.type) {
     case SearchTypes.SET_CHANNEL_MEMBERS_RHS_SEARCH: {
         return action.data;
@@ -47,7 +47,7 @@ function channelMembersRhsSearch(state = '', action: AnyAction) {
     }
 }
 
-function modalFilters(state: ViewsState['search']['modalFilters'] = {}, action: AnyAction) {
+function modalFilters(state: ViewsState['search']['modalFilters'] = {}, action: MMAction) {
     switch (action.type) {
     case SearchTypes.SET_MODAL_FILTERS: {
         const filters = action.data;
@@ -63,7 +63,7 @@ function modalFilters(state: ViewsState['search']['modalFilters'] = {}, action: 
     }
 }
 
-function userGridSearch(state: Partial<ViewsState['search']['userGridSearch']> = {}, action: AnyAction) {
+function userGridSearch(state: Partial<ViewsState['search']['userGridSearch']> = {}, action: MMAction) {
     switch (action.type) {
     case SearchTypes.SET_USER_GRID_SEARCH: {
         const term = action.data.trim();
@@ -87,7 +87,7 @@ function userGridSearch(state: Partial<ViewsState['search']['userGridSearch']> =
     }
 }
 
-function teamListSearch(state = '', action: AnyAction) {
+function teamListSearch(state = '', action: MMAction) {
     switch (action.type) {
     case SearchTypes.SET_TEAM_LIST_SEARCH: {
         return action.data.trim();
@@ -100,7 +100,7 @@ function teamListSearch(state = '', action: AnyAction) {
     }
 }
 
-function channelListSearch(state: Partial<ViewsState['search']['channelListSearch']> = {}, action: AnyAction) {
+function channelListSearch(state: Partial<ViewsState['search']['channelListSearch']> = {}, action: MMAction) {
     switch (action.type) {
     case SearchTypes.SET_CHANNEL_LIST_SEARCH: {
         const term = action.data.trim();

--- a/webapp/channels/src/reducers/views/settings.ts
+++ b/webapp/channels/src/reducers/views/settings.ts
@@ -1,15 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
-
 import {UserTypes} from 'mattermost-redux/action_types';
 
 import {ActionTypes} from 'utils/constants';
 
+import type {MMAction} from 'types/store';
 import type {ViewsState} from 'types/store/views';
 
-export default function settings(state: ViewsState['settings'] = {activeSection: '', previousActiveSection: ''}, action: AnyAction) {
+export default function settings(state: ViewsState['settings'] = {activeSection: '', previousActiveSection: ''}, action: MMAction) {
     switch (action.type) {
     case ActionTypes.UPDATE_ACTIVE_SECTION:
         return {

--- a/webapp/channels/src/reducers/views/status_dropdown.ts
+++ b/webapp/channels/src/reducers/views/status_dropdown.ts
@@ -1,14 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {UserTypes} from 'mattermost-redux/action_types';
 
 import {ActionTypes} from 'utils/constants';
 
-export function isOpen(state = false, action: AnyAction) {
+import type {MMAction} from 'types/store';
+
+export function isOpen(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.STATUS_DROPDOWN_TOGGLE:
         return action.open;

--- a/webapp/channels/src/reducers/views/system.ts
+++ b/webapp/channels/src/reducers/views/system.ts
@@ -1,14 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {UserTypes} from 'mattermost-redux/action_types';
 
 import {ActionTypes} from 'utils/constants';
 
-function websocketConnectionErrorCount(state = 0, action: AnyAction) {
+import type {MMAction} from 'types/store';
+
+function websocketConnectionErrorCount(state = 0, action: MMAction) {
     switch (action.type) {
     case ActionTypes.INCREMENT_WS_ERROR_COUNT: {
         return state + 1;

--- a/webapp/channels/src/reducers/views/textbox.ts
+++ b/webapp/channels/src/reducers/views/textbox.ts
@@ -1,14 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {UserTypes} from 'mattermost-redux/action_types';
 
 import {ActionTypes} from 'utils/constants';
 
-function shouldShowPreviewOnCreateComment(state = false, action: AnyAction) {
+import type {MMAction} from 'types/store';
+
+function shouldShowPreviewOnCreateComment(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SET_SHOW_PREVIEW_ON_CREATE_COMMENT:
         return action.showPreview;
@@ -20,7 +21,7 @@ function shouldShowPreviewOnCreateComment(state = false, action: AnyAction) {
     }
 }
 
-function shouldShowPreviewOnCreatePost(state = false, action: AnyAction) {
+function shouldShowPreviewOnCreatePost(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SET_SHOW_PREVIEW_ON_CREATE_POST:
         return action.showPreview;
@@ -32,7 +33,7 @@ function shouldShowPreviewOnCreatePost(state = false, action: AnyAction) {
     }
 }
 
-function shouldShowPreviewOnEditChannelHeaderModal(state = false, action: AnyAction) {
+function shouldShowPreviewOnEditChannelHeaderModal(state = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SET_SHOW_PREVIEW_ON_EDIT_CHANNEL_HEADER_MODAL:
         return action.showPreview;

--- a/webapp/channels/src/reducers/views/threads.ts
+++ b/webapp/channels/src/reducers/views/threads.ts
@@ -2,16 +2,16 @@
 // See LICENSE.txt for license information.
 
 import findKey from 'lodash/findKey';
-import type {AnyAction} from 'redux';
 import {combineReducers} from 'redux';
 
 import {PostTypes, UserTypes} from 'mattermost-redux/action_types';
 
 import {Threads, ActionTypes} from 'utils/constants';
 
+import type {MMAction} from 'types/store';
 import type {ViewsState} from 'types/store/views';
 
-export const selectedThreadIdInTeam = (state: ViewsState['threads']['selectedThreadIdInTeam'] = {}, action: AnyAction) => {
+export const selectedThreadIdInTeam = (state: ViewsState['threads']['selectedThreadIdInTeam'] = {}, action: MMAction) => {
     switch (action.type) {
     case PostTypes.POST_REMOVED: {
         const key = findKey(state, (id) => id === action.data.id);
@@ -36,7 +36,7 @@ export const selectedThreadIdInTeam = (state: ViewsState['threads']['selectedThr
     }
 };
 
-export const lastViewedAt = (state: ViewsState['threads']['lastViewedAt'] = {}, action: AnyAction) => {
+export const lastViewedAt = (state: ViewsState['threads']['lastViewedAt'] = {}, action: MMAction) => {
     switch (action.type) {
     case Threads.CHANGED_LAST_VIEWED_AT:
         return {
@@ -51,7 +51,7 @@ export const lastViewedAt = (state: ViewsState['threads']['lastViewedAt'] = {}, 
     }
 };
 
-export function manuallyUnread(state: ViewsState['threads']['manuallyUnread'] = {}, action: AnyAction) {
+export function manuallyUnread(state: ViewsState['threads']['manuallyUnread'] = {}, action: MMAction) {
     switch (action.type) {
     case Threads.CHANGED_LAST_VIEWED_AT:
         return {
@@ -71,7 +71,7 @@ export function manuallyUnread(state: ViewsState['threads']['manuallyUnread'] = 
     }
 }
 
-export function toastStatus(state: ViewsState['threads']['toastStatus'] = false, action: AnyAction) {
+export function toastStatus(state: ViewsState['threads']['toastStatus'] = false, action: MMAction) {
     switch (action.type) {
     case ActionTypes.SELECT_POST:
         return false;

--- a/webapp/channels/src/types/store/index.ts
+++ b/webapp/channels/src/types/store/index.ts
@@ -3,6 +3,7 @@
 
 import type {GlobalState as BaseGlobalState} from '@mattermost/types/store';
 
+import type {MMReduxAction} from 'mattermost-redux/action_types';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import type * as MMReduxTypes from 'mattermost-redux/types/actions';
 
@@ -25,9 +26,14 @@ export type GlobalState = BaseGlobalState & {
 };
 
 /**
+ * An MMAction is any non-Thunk Redux action accepted by the web app and mattermost-redux.
+ */
+export type MMAction = MMReduxAction;
+
+/**
  * A version of {@link MMReduxTypes.DispatchFunc} which supports dispatching web app actions.
  */
-export type DispatchFunc = MMReduxTypes.DispatchFunc;
+export type DispatchFunc = MMReduxTypes.DispatchFunc<MMAction>;
 
 /**
  * A version of {@link MMReduxTypes.GetStateFunc} which supports web app state.
@@ -40,7 +46,7 @@ export type GetStateFunc<State extends GlobalState = GlobalState> = MMReduxTypes
 export type ActionFunc<
     Data = unknown,
     State extends GlobalState = GlobalState,
-> = MMReduxTypes.ActionFunc<Data, State>;
+> = MMReduxTypes.ActionFunc<Data, State, MMAction>;
 
 /**
  * A version of {@link MMReduxTypes.ActionFuncAsync} which supports web app state and allows dispatching its actions.
@@ -48,7 +54,7 @@ export type ActionFunc<
 export type ActionFuncAsync<
     Data = unknown,
     State extends GlobalState = GlobalState,
-> = MMReduxTypes.ActionFuncAsync<Data, State>;
+> = MMReduxTypes.ActionFuncAsync<Data, State, MMAction>;
 
 /**
  * A version of {@link MMReduxTypes.ThunkActionFunc} which supports web app state and allows dispatching its actions.
@@ -56,4 +62,4 @@ export type ActionFuncAsync<
 export type ThunkActionFunc<
     ReturnType,
     State extends GlobalState = GlobalState
-> = MMReduxTypes.ThunkActionFunc<ReturnType, State>;
+> = MMReduxTypes.ThunkActionFunc<ReturnType, State, MMAction>;


### PR DESCRIPTION
#### Summary
Continuing on from #29483, this includes more type changes to add new `MMAction` and `MMReduxAction` types to the general web app and mattermost-redux. Similar to the last PR, this one is almost exclusively type changes. There's a few changes to test code which aren't 100% needed now, but they'll be needed when we start to define those action types next.

The reason those types are still just placeholders is because I wanted to get all the name changes out of the way before the actual changes that matter to make it so that we can more strongly type Redux actions.

#### Release Note
```release-note
NONE
```
