### PR TITLE
MM-62060 Add title to onboarding video iframe and make thumbnail translatable

### DIFF
--- a/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist.tsx
+++ b/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useRef, useCallback, useEffect, useState} from 'react';
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 import styled, {css} from 'styled-components';
 
@@ -161,6 +161,8 @@ const Skeleton = styled.div`
 `;
 
 const OnBoardingTaskList = (): JSX.Element | null => {
+    const intl = useIntl();
+
     const hasPreferences = useSelector((state: GlobalState) => Object.keys(getMyPreferencesSelector(state)).length !== 0);
 
     useEffect(() => {
@@ -332,7 +334,7 @@ const OnBoardingTaskList = (): JSX.Element | null => {
                             <Skeleton>
                                 <img
                                     src={checklistImg}
-                                    alt={'On Boarding video'}
+                                    alt={intl.formatMessage({id: 'onboardingTask.checklist.video_thumbnail', defaultMessage: 'Mattermost overview video thumbnail'})}
                                     style={{display: 'block', margin: '1rem auto', borderRadius: '4px'}}
                                 />
                                 <PlayButton

--- a/webapp/channels/src/components/onboarding_tasks/onboarding_video_modal/onboarding_video_modal.tsx
+++ b/webapp/channels/src/components/onboarding_tasks/onboarding_video_modal/onboarding_video_modal.tsx
@@ -3,12 +3,14 @@
 
 import React, {useCallback, useState} from 'react';
 import {Modal} from 'react-bootstrap';
+import {useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 
 import {OnboardingTaskCategory, OnboardingTaskList} from '../constants';
+
 import './onboarding_video_modal.scss';
 
 type Props = {
@@ -16,6 +18,8 @@ type Props = {
 }
 
 const OnBoardingVideoModal = ({onExited}: Props) => {
+    const intl = useIntl();
+
     const [show, setShow] = useState(true);
     const dispatch = useDispatch();
     const currentUserId = useSelector(getCurrentUserId);
@@ -54,6 +58,7 @@ const OnBoardingVideoModal = ({onExited}: Props) => {
                     scrolling='no'
                     className='wistia_embed'
                     name='wistia_embed'
+                    title={intl.formatMessage({id: 'onboardingTask.checklist.video_title_full', defaultMessage: 'Mattermost overview video'})}
                     allowFullScreen={true}
                 />
             </Modal.Body>

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -4563,6 +4563,7 @@
   "onboardingTask.checklist.task_start_enterprise_trial": "Learn more about Enterprise-level high-security features.",
   "onboardingTask.checklist.task_visit_system_console": "Visit the System Console to configure your workspace.",
   "onboardingTask.checklist.video_title": "Watch overview",
+  "onboardingTask.checklist.video_title_full": "Mattermost overview video",
   "onboardingTask.completeYourProfileTour.Description": "Use this menu item to update your profile details and security settings.",
   "onboardingTask.completeYourProfileTour.title": "Edit your profile",
   "onboardingTask.visitSystemConsole.Description": "More detailed configuration settings for your workspace can be accessed here.",

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -4562,6 +4562,7 @@
   "onboardingTask.checklist.task_learn_more_about_messaging": "Take a tour of Channels.",
   "onboardingTask.checklist.task_start_enterprise_trial": "Learn more about Enterprise-level high-security features.",
   "onboardingTask.checklist.task_visit_system_console": "Visit the System Console to configure your workspace.",
+  "onboardingTask.checklist.video_thumbnail": "Mattermost overview video thumbnail",
   "onboardingTask.checklist.video_title": "Watch overview",
   "onboardingTask.checklist.video_title_full": "Mattermost overview video",
   "onboardingTask.completeYourProfileTour.Description": "Use this menu item to update your profile details and security settings.",

--- a/webapp/platform/eslint-plugin/configs/.eslintrc-react.json
+++ b/webapp/platform/eslint-plugin/configs/.eslintrc-react.json
@@ -26,7 +26,7 @@
     "jsx-a11y/click-events-have-key-events": "warn",
     "jsx-a11y/heading-has-content": "error",
     "jsx-a11y/html-has-lang": "error",
-    "jsx-a11y/iframe-has-title": "warn",
+    "jsx-a11y/iframe-has-title": "error",
     "jsx-a11y/img-redundant-alt": "warn",
     "jsx-a11y/interactive-supports-focus": "warn",
     "jsx-a11y/label-has-associated-control": "warn",


### PR DESCRIPTION
#### Summary
We only use iframes in a couple places (YouTube videos and this onboarding video), but as per the ESLint plugin, not giving an iframe a title can violate WCAG 2.4.1 and 4.1.2.

While I was in there, I noticed that part of the onboarding video text wasn't translatable, so I added that as well since that's sort of inaccessible as well.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62060

#### Release Note
```release-note
Added accessible title to onboarding video
Made onboarding thumbnail alt text translatable
```
