### PR TITLE
MM-62077: Fix cluster broadcast for LRU caches

### DIFF
--- a/server/channels/app/platform/cluster_handlers.go
+++ b/server/channels/app/platform/cluster_handlers.go
@@ -134,7 +134,7 @@ func (ps *PlatformService) InvalidateAllCachesSkipSend() {
 func (ps *PlatformService) InvalidateAllCaches() *model.AppError {
 	ps.InvalidateAllCachesSkipSend()
 
-	if ps.clusterIFace != nil && *ps.Config().CacheSettings.CacheType == model.CacheTypeLRU {
+	if ps.clusterIFace != nil {
 		msg := &model.ClusterMessage{
 			Event:            model.ClusterEventInvalidateAllCaches,
 			SendType:         model.ClusterSendReliable,

--- a/server/channels/app/platform/status.go
+++ b/server/channels/app/platform/status.go
@@ -21,7 +21,7 @@ func (ps *PlatformService) AddStatusCacheSkipClusterSend(status *model.Status) {
 func (ps *PlatformService) AddStatusCache(status *model.Status) {
 	ps.AddStatusCacheSkipClusterSend(status)
 
-	if ps.Cluster() != nil && *ps.Config().CacheSettings.CacheType == model.CacheTypeLRU {
+	if ps.Cluster() != nil {
 		statusJSON, err := json.Marshal(status)
 		if err != nil {
 			ps.logger.Warn("Failed to encode status to JSON", mlog.Err(err))

--- a/server/channels/store/localcachelayer/layer.go
+++ b/server/channels/store/localcachelayer/layer.go
@@ -448,7 +448,7 @@ func (s *LocalCacheStore) doInvalidateCacheCluster(cache cache.Cache, key string
 	if err != nil {
 		s.logger.Warn("Error while removing cache entry", mlog.Err(err), mlog.String("cache_name", cache.Name()))
 	}
-	if s.cluster != nil && s.cacheType == model.CacheTypeLRU {
+	if s.cluster != nil && cache.GetInvalidateClusterEvent() != model.ClusterEventNone {
 		msg := &model.ClusterMessage{
 			Event:    cache.GetInvalidateClusterEvent(),
 			SendType: model.ClusterSendBestEffort,
@@ -466,7 +466,7 @@ func (s *LocalCacheStore) doMultiInvalidateCacheCluster(cache cache.Cache, keys 
 	if err != nil {
 		s.logger.Warn("Error while removing cache entry", mlog.Err(err), mlog.String("cache_name", cache.Name()))
 	}
-	if s.cluster != nil && s.cacheType == model.CacheTypeLRU {
+	if s.cluster != nil && cache.GetInvalidateClusterEvent() != model.ClusterEventNone {
 		for _, key := range keys {
 			msg := &model.ClusterMessage{
 				Event:    cache.GetInvalidateClusterEvent(),
@@ -538,7 +538,7 @@ func (s *LocalCacheStore) doClearCacheCluster(cache cache.Cache) {
 	if err != nil {
 		s.logger.Warn("Error while purging cache", mlog.Err(err), mlog.String("cache_name", cache.Name()))
 	}
-	if s.cluster != nil && s.cacheType == model.CacheTypeLRU {
+	if s.cluster != nil && cache.GetInvalidateClusterEvent() != model.ClusterEventNone {
 		msg := &model.ClusterMessage{
 			Event:    cache.GetInvalidateClusterEvent(),
 			SendType: model.ClusterSendBestEffort,

--- a/server/channels/store/localcachelayer/layer_test.go
+++ b/server/channels/store/localcachelayer/layer_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/testlib"
 	"github.com/mattermost/mattermost/server/v8/platform/services/cache"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -165,6 +166,12 @@ func TestClearCacheCluster(t *testing.T) {
 
 	lc.doClearCacheCluster(c)
 	assert.Len(t, cluster.GetMessages(), 1)
+	expectedMsg := &model.ClusterMessage{
+		Event:    model.ClusterEventInvalidateCacheForRoles,
+		SendType: model.ClusterSendBestEffort,
+		Data:     clearCacheMessageData,
+	}
+	require.Equal(t, expectedMsg, cluster.GetMessages()[0])
 
 	c = cache.NewLRU(&cache.CacheOptions{
 		Size:                   10,

--- a/server/channels/store/localcachelayer/layer_test.go
+++ b/server/channels/store/localcachelayer/layer_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 	"github.com/mattermost/mattermost/server/v8/channels/store/sqlstore"
 	"github.com/mattermost/mattermost/server/v8/channels/store/storetest"
+	"github.com/mattermost/mattermost/server/v8/channels/testlib"
 	"github.com/mattermost/mattermost/server/v8/platform/services/cache"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -147,4 +149,29 @@ func tearDownStores() {
 		}
 		wg.Wait()
 	})
+}
+
+func TestClearCacheCluster(t *testing.T) {
+	cluster := &testlib.FakeClusterInterface{}
+	lc := &LocalCacheStore{
+		cluster: cluster,
+	}
+
+	c := cache.NewLRU(&cache.CacheOptions{
+		Size:                   10,
+		Name:                   "test",
+		InvalidateClusterEvent: model.ClusterEventInvalidateCacheForRoles,
+	})
+
+	lc.doClearCacheCluster(c)
+	assert.Len(t, cluster.GetMessages(), 1)
+
+	c = cache.NewLRU(&cache.CacheOptions{
+		Size:                   10,
+		Name:                   "test",
+		InvalidateClusterEvent: model.ClusterEventNone,
+	})
+
+	lc.doClearCacheCluster(c)
+	assert.Len(t, cluster.GetMessages(), 1)
 }


### PR DESCRIPTION
We were incorrectly not broadcasting status cache updates
inspite of that being an LRU cache.

We were also not doing it for profilesInChannel cache.
Now we fix it by properly checking the invalidationEvent
which is something local to the cache itself rather
than the cache provider.

https://mattermost.atlassian.net/browse/MM-62077
```release-note
NONE
```
