### PR TITLE
Skip flaky test TestCreatePost/Create_posts_without_the_USE_CHANNEL_MENTIONS_Permission

### DIFF
--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -119,6 +119,7 @@ func TestCreatePost(t *testing.T) {
 	})
 
 	t.Run("Create posts without the USE_CHANNEL_MENTIONS Permission - returns ephemeral message with mentions and no ephemeral message without mentions", func(t *testing.T) {
+		t.Skip("MM-62079")
 		WebSocketClient, err := th.CreateWebSocketClient()
 		WebSocketClient.Listen()
 		require.NoError(t, err)


### PR DESCRIPTION
#### Summary
- Failing test: `TestCreatePost/Create_posts_without_the_USE_CHANNEL_MENTIONS_Permission_-_returns_ephemeral_message_with_mentions_and_no_ephemeral_message_without_mentions`
- Failing job: https://github.com/mattermost/mattermost/actions/runs/12177120268/job/33964435856 
- Output:
```
2024-12-05T09:56:51.7489258Z     post_test.go:171: 
2024-12-05T09:56:51.7490091Z         	Error Trace:	/mattermost/server/channels/api4/post_test.go:171
2024-12-05T09:56:51.7491131Z         	Error:      	Should have received ephemeral message event and not timedout
2024-12-05T09:56:51.7493041Z         	Test:       	TestCreatePost/Create_posts_without_the_USE_CHANNEL_MENTIONS_Permission_-_returns_ephemeral_message_with_mentions_and_no_ephemeral_message_without_mentions
2024-12-05T09:56:51.7494925Z --- FAIL: TestCreatePost/Create_posts_without_the_USE_CHANNEL_MENTIONS_Permission_-_returns_ephemeral_message_with_mentions_and_no_ephemeral_message_without_mentions (10.16s)
2024-12-05T09:56:51.7496925Z FAIL channels/api4.TestCreatePost/Create_posts_without_the_USE_CHANNEL_MENTIONS_Permission_-_returns_ephemeral_message_with_mentions_and_no_ephemeral_message_without_mentions (10.16s)
```
Tracked in https://mattermost.atlassian.net/browse/MM-62079

#### Ticket Link
--

#### Screenshots
--

#### Release Note
```release-note
NONE
```
