### PR TITLE
Fix: Moving closer to an input field when typing on iOS

### DIFF
--- a/webapp/channels/src/root.html
+++ b/webapp/channels/src/root.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
 
-    <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+    <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no'>
     <meta name='robots' content='noindex, nofollow'>
     <meta name='referrer' content='no-referrer'>
 


### PR DESCRIPTION
#### Summary

On iOS, when entering text into input fields (input/textarea) with a font size smaller than 16px, the system zooms in on the field for better readability. To prevent this zoom behavior without changing the font size in every component, a meta tag has been added to disable zooming.


#### Ticket Link
Contributions without ticket

#### Screenshots
<details>
    <summary>before</summary>
    

https://github.com/user-attachments/assets/d7ae595f-ab10-4c08-ac50-a011c26b00af


</details>

<details>
    <summary>after</summary>
    

https://github.com/user-attachments/assets/244471ad-5367-4be1-b1cc-6a2aa9ca27f6


</details>

#### Release Note


```release-note
NONE
```

