### PR TITLE
s/Get(Master|Replica)X/Get\1/g

### DIFF
--- a/server/channels/app/channel_category_test.go
+++ b/server/channels/app/channel_category_test.go
@@ -129,10 +129,10 @@ func TestGetSidebarCategories(t *testing.T) {
 
 		// Temporarily renaming a table to force a DB error.
 		sqlStore := mainHelper.GetSQLStore()
-		_, err := sqlStore.GetMasterX().Exec("ALTER TABLE SidebarCategories RENAME TO SidebarCategoriesTest")
+		_, err := sqlStore.GetMaster().Exec("ALTER TABLE SidebarCategories RENAME TO SidebarCategoriesTest")
 		require.NoError(t, err)
 		defer func() {
-			_, err := sqlStore.GetMasterX().Exec("ALTER TABLE SidebarCategoriesTest RENAME TO SidebarCategories")
+			_, err := sqlStore.GetMaster().Exec("ALTER TABLE SidebarCategoriesTest RENAME TO SidebarCategories")
 			require.NoError(t, err)
 		}()
 

--- a/server/channels/app/config_test.go
+++ b/server/channels/app/config_test.go
@@ -95,12 +95,12 @@ func TestEnsureInstallationDate(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
 			sqlStore := th.GetSqlStore()
-			sqlStore.GetMasterX().Exec("DELETE FROM Users")
+			sqlStore.GetMaster().Exec("DELETE FROM Users")
 
 			for _, createAt := range tc.UsersCreationDates {
 				user := th.CreateUser()
 				user.CreateAt = createAt
-				sqlStore.GetMasterX().Exec("UPDATE Users SET CreateAt = ? WHERE Id = ?", createAt, user.Id)
+				sqlStore.GetMaster().Exec("UPDATE Users SET CreateAt = ? WHERE Id = ?", createAt, user.Id)
 			}
 
 			if tc.PrevInstallationDate == nil {
@@ -125,7 +125,7 @@ func TestEnsureInstallationDate(t *testing.T) {
 				assert.True(t, *tc.ExpectedInstallationDate <= value && *tc.ExpectedInstallationDate+1000 >= value)
 			}
 
-			sqlStore.GetMasterX().Exec("DELETE FROM Users")
+			sqlStore.GetMaster().Exec("DELETE FROM Users")
 		})
 	}
 }

--- a/server/channels/app/helper_test.go
+++ b/server/channels/app/helper_test.go
@@ -651,34 +651,34 @@ func (th *TestHelper) ConfigureInbucketMail() {
 
 func (*TestHelper) ResetRoleMigration() {
 	sqlStore := mainHelper.GetSQLStore()
-	if _, err := sqlStore.GetMasterX().Exec("DELETE from Roles"); err != nil {
+	if _, err := sqlStore.GetMaster().Exec("DELETE from Roles"); err != nil {
 		panic(err)
 	}
 
 	mainHelper.GetClusterInterface().SendClearRoleCacheMessage()
 
-	if _, err := sqlStore.GetMasterX().Exec("DELETE from Systems where Name = ?", model.AdvancedPermissionsMigrationKey); err != nil {
+	if _, err := sqlStore.GetMaster().Exec("DELETE from Systems where Name = ?", model.AdvancedPermissionsMigrationKey); err != nil {
 		panic(err)
 	}
 }
 
 func (*TestHelper) ResetEmojisMigration() {
 	sqlStore := mainHelper.GetSQLStore()
-	if _, err := sqlStore.GetMasterX().Exec("UPDATE Roles SET Permissions=REPLACE(Permissions, ' create_emojis', '') WHERE builtin=True"); err != nil {
+	if _, err := sqlStore.GetMaster().Exec("UPDATE Roles SET Permissions=REPLACE(Permissions, ' create_emojis', '') WHERE builtin=True"); err != nil {
 		panic(err)
 	}
 
-	if _, err := sqlStore.GetMasterX().Exec("UPDATE Roles SET Permissions=REPLACE(Permissions, ' delete_emojis', '') WHERE builtin=True"); err != nil {
+	if _, err := sqlStore.GetMaster().Exec("UPDATE Roles SET Permissions=REPLACE(Permissions, ' delete_emojis', '') WHERE builtin=True"); err != nil {
 		panic(err)
 	}
 
-	if _, err := sqlStore.GetMasterX().Exec("UPDATE Roles SET Permissions=REPLACE(Permissions, ' delete_others_emojis', '') WHERE builtin=True"); err != nil {
+	if _, err := sqlStore.GetMaster().Exec("UPDATE Roles SET Permissions=REPLACE(Permissions, ' delete_others_emojis', '') WHERE builtin=True"); err != nil {
 		panic(err)
 	}
 
 	mainHelper.GetClusterInterface().SendClearRoleCacheMessage()
 
-	if _, err := sqlStore.GetMasterX().Exec("DELETE from Systems where Name = ?", EmojisPermissionsMigrationKey); err != nil {
+	if _, err := sqlStore.GetMaster().Exec("DELETE from Systems where Name = ?", EmojisPermissionsMigrationKey); err != nil {
 		panic(err)
 	}
 }

--- a/server/channels/app/platform/service_test.go
+++ b/server/channels/app/platform/service_test.go
@@ -40,7 +40,7 @@ func TestReadReplicaDisabledBasedOnLicense(t *testing.T) {
 			ConfigStore(configStore),
 		)
 		require.NoError(t, err)
-		require.Same(t, ps.sqlStore.GetMasterX(), ps.sqlStore.GetReplicaX())
+		require.Same(t, ps.sqlStore.GetMaster(), ps.sqlStore.GetReplica())
 		require.Len(t, ps.Config().SqlSettings.DataSourceReplicas, 1)
 	})
 
@@ -56,7 +56,7 @@ func TestReadReplicaDisabledBasedOnLicense(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		require.NotSame(t, ps.sqlStore.GetMasterX(), ps.sqlStore.GetReplicaX())
+		require.NotSame(t, ps.sqlStore.GetMaster(), ps.sqlStore.GetReplica())
 		require.Len(t, ps.Config().SqlSettings.DataSourceReplicas, 1)
 	})
 
@@ -68,7 +68,7 @@ func TestReadReplicaDisabledBasedOnLicense(t *testing.T) {
 			ConfigStore(configStore),
 		)
 		require.NoError(t, err)
-		require.Same(t, ps.sqlStore.GetMasterX(), ps.sqlStore.GetSearchReplicaX())
+		require.Same(t, ps.sqlStore.GetMaster(), ps.sqlStore.GetSearchReplicaX())
 		require.Len(t, ps.Config().SqlSettings.DataSourceSearchReplicas, 1)
 	})
 
@@ -84,7 +84,7 @@ func TestReadReplicaDisabledBasedOnLicense(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		require.NotSame(t, ps.sqlStore.GetMasterX(), ps.sqlStore.GetSearchReplicaX())
+		require.NotSame(t, ps.sqlStore.GetMaster(), ps.sqlStore.GetSearchReplicaX())
 		require.Len(t, ps.Config().SqlSettings.DataSourceSearchReplicas, 1)
 	})
 }

--- a/server/channels/app/plugin_api_tests/test_db_driver/main.go
+++ b/server/channels/app/plugin_api_tests/test_db_driver/main.go
@@ -37,7 +37,7 @@ func (p *MyPlugin) MessageWillBePosted(_ *plugin.Context, _ *model.Post) (*model
 	if err != nil {
 		panic(err)
 	}
-	store.GetMasterX().Close()
+	store.GetMaster().Close()
 
 	for _, isMaster := range []bool{true, false} {
 		handle := sql.OpenDB(driver.NewConnector(p.Driver, isMaster))
@@ -51,7 +51,7 @@ func (p *MyPlugin) MessageWillBePosted(_ *plugin.Context, _ *model.Post) (*model
 		storetest.TestChannelStore(p.t, rctx, store, wrapper)
 		storetest.TestBotStore(p.t, rctx, store, wrapper)
 
-		store.GetMasterX().Close()
+		store.GetMaster().Close()
 	}
 
 	// Use the API to instantiate the driver

--- a/server/channels/app/post_test.go
+++ b/server/channels/app/post_test.go
@@ -982,7 +982,7 @@ func TestCreatePost(t *testing.T) {
 		sqlStore := th.GetSqlStore()
 		sql := fmt.Sprintf("select count(*) from Posts where Id = '%[1]s' or OriginalId = '%[1]s';", previewPost.Id)
 		var val int64
-		err2 := sqlStore.GetMasterX().Get(&val, sql)
+		err2 := sqlStore.GetMaster().Get(&val, sql)
 		require.NoError(t, err2)
 
 		require.EqualValues(t, int64(1), val)

--- a/server/channels/app/user_test.go
+++ b/server/channels/app/user_test.go
@@ -1116,7 +1116,7 @@ func TestPermanentDeleteUser(t *testing.T) {
 	bots2 := []*model.Bot{}
 
 	sqlStore := mainHelper.GetSQLStore()
-	err1 := sqlStore.GetMasterX().Select(&bots1, "SELECT * FROM Bots")
+	err1 := sqlStore.GetMaster().Select(&bots1, "SELECT * FROM Bots")
 	assert.NoError(t, err1)
 	assert.Equal(t, 1, len(bots1))
 
@@ -1127,7 +1127,7 @@ func TestPermanentDeleteUser(t *testing.T) {
 	err = th.App.PermanentDeleteUser(th.Context, retUser1)
 	assert.Nil(t, err)
 
-	err1 = sqlStore.GetMasterX().Select(&bots2, "SELECT * FROM Bots")
+	err1 = sqlStore.GetMaster().Select(&bots2, "SELECT * FROM Bots")
 	assert.NoError(t, err1)
 	assert.Equal(t, 0, len(bots2))
 

--- a/server/channels/store/sqlstore/audit_store.go
+++ b/server/channels/store/sqlstore/audit_store.go
@@ -23,7 +23,7 @@ func (s SqlAuditStore) Save(audit *model.Audit) error {
 	audit.Id = model.NewId()
 	audit.CreateAt = model.GetMillis()
 
-	if _, err := s.GetMasterX().NamedExec(`INSERT INTO Audits
+	if _, err := s.GetMaster().NamedExec(`INSERT INTO Audits
 (Id, CreateAt, UserId, Action, ExtraInfo, IpAddress, SessionId)
 VALUES
 (:Id, :CreateAt, :UserId, :Action, :ExtraInfo, :IpAddress, :SessionId)`, audit); err != nil {
@@ -54,14 +54,14 @@ func (s SqlAuditStore) Get(userId string, offset int, limit int) (model.Audits, 
 	}
 
 	var audits model.Audits
-	if err := s.GetReplicaX().Select(&audits, queryString, args...); err != nil {
+	if err := s.GetReplica().Select(&audits, queryString, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to get Audit list for userId=%s", userId)
 	}
 	return audits, nil
 }
 
 func (s SqlAuditStore) PermanentDeleteByUser(userId string) error {
-	if _, err := s.GetMasterX().Exec("DELETE FROM Audits WHERE UserId = ?", userId); err != nil {
+	if _, err := s.GetMaster().Exec("DELETE FROM Audits WHERE UserId = ?", userId); err != nil {
 		return errors.Wrapf(err, "failed to delete Audit with userId=%s", userId)
 	}
 	return nil

--- a/server/channels/store/sqlstore/channel_bookmark_store.go
+++ b/server/channels/store/sqlstore/channel_bookmark_store.go
@@ -75,7 +75,7 @@ func (s *SqlChannelBookmarkStore) ErrorIfBookmarkFileInfoAlreadyAttached(fileId 
 		})
 
 	var attached int64
-	err := s.GetReplicaX().GetBuilder(&attached, alreadyAttachedQuery)
+	err := s.GetReplica().GetBuilder(&attached, alreadyAttachedQuery)
 	if err != nil {
 		return errors.Wrap(err, "unable_to_save_channel_bookmark")
 	}
@@ -105,7 +105,7 @@ func (s *SqlChannelBookmarkStore) Get(Id string, includeDeleted bool) (*model.Ch
 
 	bookmark := model.ChannelBookmarkAndFileInfo{}
 
-	if err := s.GetReplicaX().Get(&bookmark, queryString, args...); err != nil {
+	if err := s.GetReplica().Get(&bookmark, queryString, args...); err != nil {
 		return nil, store.NewErrNotFound("ChannelBookmark", Id)
 	}
 
@@ -118,7 +118,7 @@ func (s *SqlChannelBookmarkStore) Save(bookmark *model.ChannelBookmark, increase
 		return nil, err
 	}
 
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func (s *SqlChannelBookmarkStore) Update(bookmark *model.ChannelBookmark) error 
 		return errors.Wrap(err, "channel_bookmark_update_tosql")
 	}
 
-	res, err := s.GetMasterX().Exec(query, args...)
+	res, err := s.GetMaster().Exec(query, args...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update channel bookmark with id=%s", bookmark.Id)
 	}
@@ -232,7 +232,7 @@ func (s *SqlChannelBookmarkStore) Update(bookmark *model.ChannelBookmark) error 
 
 func (s *SqlChannelBookmarkStore) UpdateSortOrder(bookmarkId, channelId string, newIndex int64) ([]*model.ChannelBookmarkWithFileInfo, error) {
 	now := model.GetMillis()
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +292,7 @@ func (s *SqlChannelBookmarkStore) UpdateSortOrder(bookmarkId, channelId string, 
 
 func (s *SqlChannelBookmarkStore) Delete(bookmarkId string, deleteFile bool) error {
 	now := model.GetMillis()
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return err
 	}
@@ -368,7 +368,7 @@ func (s *SqlChannelBookmarkStore) GetBookmarksForChannelSince(channelId string, 
 	bookmarkRows := []model.ChannelBookmarkAndFileInfo{}
 	bookmarks := []*model.ChannelBookmarkWithFileInfo{}
 
-	if err := s.GetReplicaX().Select(&bookmarkRows, queryString, args...); err != nil {
+	if err := s.GetReplica().Select(&bookmarkRows, queryString, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find bookmarks")
 	}
 

--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -559,7 +559,7 @@ func (s SqlChannelStore) Save(rctx request.CTX, channel *model.Channel, maxChann
 	}
 
 	var newChannel *model.Channel
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
@@ -623,7 +623,7 @@ func (s SqlChannelStore) SaveDirectChannel(rctx request.CTX, directChannel *mode
 		return nil, store.NewErrInvalidInput("Channel", "Type", directChannel.Type)
 	}
 
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
@@ -702,7 +702,7 @@ func (s SqlChannelStore) saveChannelT(transaction *sqlxTxWrapper, channel *model
 
 	if rowAffected == 0 {
 		dupChannel := model.Channel{}
-		if serr := s.GetMasterX().Get(&dupChannel, "SELECT * FROM Channels WHERE TeamId = ? AND Name = ?", channel.TeamId, channel.Name); serr != nil {
+		if serr := s.GetMaster().Get(&dupChannel, "SELECT * FROM Channels WHERE TeamId = ? AND Name = ?", channel.TeamId, channel.Name); serr != nil {
 			return nil, errors.Wrapf(serr, "error while retrieving existing channel %s", channel.Name) // do not return this as a *store.ErrConflict as it would be treated as a recoverable error
 		}
 		return &dupChannel, store.NewErrConflict("Channel", err, "id="+channel.Id)
@@ -713,7 +713,7 @@ func (s SqlChannelStore) saveChannelT(transaction *sqlxTxWrapper, channel *model
 
 // Update writes the updated channel to the database.
 func (s SqlChannelStore) Update(rctx request.CTX, channel *model.Channel) (_ *model.Channel, err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
@@ -786,7 +786,7 @@ func (s SqlChannelStore) updateChannelT(transaction *sqlxTxWrapper, channel *mod
 
 func (s SqlChannelStore) GetChannelUnread(channelId, userId string) (*model.ChannelUnread, error) {
 	var unreadChannel model.ChannelUnread
-	err := s.GetReplicaX().Get(&unreadChannel,
+	err := s.GetReplica().Get(&unreadChannel,
 		`SELECT
 				Channels.TeamId TeamId, Channels.Id ChannelId, (Channels.TotalMsgCount - ChannelMembers.MsgCount) MsgCount, (Channels.TotalMsgCountRoot - ChannelMembers.MsgCountRoot) MsgCountRoot, ChannelMembers.MentionCount MentionCount, ChannelMembers.MentionCountRoot MentionCountRoot, COALESCE(ChannelMembers.UrgentMentionCount, 0) UrgentMentionCount, ChannelMembers.NotifyProps NotifyProps
 			FROM
@@ -819,7 +819,7 @@ func (s SqlChannelStore) GetPinnedPosts(channelId string) (*model.PostList, erro
 	pl := model.NewPostList()
 
 	posts := []*model.Post{}
-	if err := s.GetReplicaX().Select(&posts, "SELECT *, (SELECT count(Posts.Id) FROM Posts WHERE Posts.RootId = (CASE WHEN p.RootId = '' THEN p.Id ELSE p.RootId END) AND Posts.DeleteAt = 0) as ReplyCount  FROM Posts p WHERE IsPinned = true AND ChannelId = ? AND DeleteAt = 0 ORDER BY CreateAt ASC", channelId); err != nil {
+	if err := s.GetReplica().Select(&posts, "SELECT *, (SELECT count(Posts.Id) FROM Posts WHERE Posts.RootId = (CASE WHEN p.RootId = '' THEN p.Id ELSE p.RootId END) AND Posts.DeleteAt = 0) as ReplyCount  FROM Posts p WHERE IsPinned = true AND ChannelId = ? AND DeleteAt = 0 ORDER BY CreateAt ASC", channelId); err != nil {
 		return nil, errors.Wrap(err, "failed to find Posts")
 	}
 	for _, post := range posts {
@@ -832,7 +832,7 @@ func (s SqlChannelStore) GetPinnedPosts(channelId string) (*model.PostList, erro
 //nolint:unparam
 func (s SqlChannelStore) Get(id string, allowFromCache bool) (*model.Channel, error) {
 	ch := model.Channel{}
-	err := s.GetReplicaX().Get(&ch, `SELECT * FROM Channels WHERE Id=?`, id)
+	err := s.GetReplica().Get(&ch, `SELECT * FROM Channels WHERE Id=?`, id)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Channel", id)
@@ -855,7 +855,7 @@ func (s SqlChannelStore) GetMany(ids []string, allowFromCache bool) (model.Chann
 	}
 
 	channels := model.ChannelList{}
-	err = s.GetReplicaX().Select(&channels, sql, args...)
+	err = s.GetReplica().Select(&channels, sql, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get channels with ids %v", ids)
 	}
@@ -881,7 +881,7 @@ func (s SqlChannelStore) Restore(channelId string, time int64) error {
 func (s SqlChannelStore) SetDeleteAt(channelId string, deleteAt, updateAt int64) (err error) {
 	defer s.InvalidateChannel(channelId)
 
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "SetDeleteAt: begin_transaction")
 	}
@@ -925,7 +925,7 @@ func (s SqlChannelStore) setDeleteAtT(transaction *sqlxTxWrapper, channelId stri
 
 // PermanentDeleteByTeam removes all channels for the given team from the database.
 func (s SqlChannelStore) PermanentDeleteByTeam(teamId string) (err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "PermanentDeleteByTeam: begin_transaction")
 	}
@@ -962,7 +962,7 @@ func (s SqlChannelStore) permanentDeleteByTeamtT(transaction *sqlxTxWrapper, tea
 
 // PermanentDelete removes the given channel from the database.
 func (s SqlChannelStore) PermanentDelete(rctx request.CTX, channelId string) (err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "PermanentDelete: begin_transaction")
 	}
@@ -998,7 +998,7 @@ func (s SqlChannelStore) permanentDeleteT(transaction *sqlxTxWrapper, channelId 
 }
 
 func (s SqlChannelStore) PermanentDeleteMembersByChannel(rctx request.CTX, channelId string) error {
-	_, err := s.GetMasterX().Exec("DELETE FROM ChannelMembers WHERE ChannelId = ?", channelId)
+	_, err := s.GetMaster().Exec("DELETE FROM ChannelMembers WHERE ChannelId = ?", channelId)
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete Channel with channelId=%s", channelId)
 	}
@@ -1049,7 +1049,7 @@ func (s SqlChannelStore) GetChannels(teamId string, userId string, opts *model.C
 		return nil, errors.Wrapf(err, "getchannels_tosql")
 	}
 
-	err = s.GetReplicaX().Select(&channels, sql, args...)
+	err = s.GetReplica().Select(&channels, sql, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get channels with TeamId=%s and UserId=%s", teamId, userId)
 	}
@@ -1101,7 +1101,7 @@ func (s SqlChannelStore) GetChannelsByUser(userId string, includeDeleted bool, l
 	}
 
 	channels := model.ChannelList{}
-	err = s.GetReplicaX().Select(&channels, sql, args...)
+	err = s.GetReplica().Select(&channels, sql, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get channels with UserId=%s", userId)
 	}
@@ -1115,7 +1115,7 @@ func (s SqlChannelStore) GetChannelsByUser(userId string, includeDeleted bool, l
 
 func (s SqlChannelStore) GetAllChannelMemberIdsByChannelId(channelID string) ([]string, error) {
 	userIDs := []string{}
-	err := s.GetReplicaX().Select(&userIDs, `SELECT UserId
+	err := s.GetReplica().Select(&userIDs, `SELECT UserId
 		FROM ChannelMembers
 		WHERE ChannelId=?`, channelID)
 	if err != nil {
@@ -1139,7 +1139,7 @@ func (s SqlChannelStore) GetAllChannels(offset, limit int, opts store.ChannelSea
 	}
 
 	data := model.ChannelListWithTeamData{}
-	err = s.GetReplicaX().Select(&data, queryString, args...)
+	err = s.GetReplica().Select(&data, queryString, args...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get all channels")
 	}
@@ -1156,7 +1156,7 @@ func (s SqlChannelStore) GetAllChannelsCount(opts store.ChannelSearchOpts) (int6
 	}
 
 	var count int64
-	err = s.GetReplicaX().Get(&count, queryString, args...)
+	err = s.GetReplica().Get(&count, queryString, args...)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to count all channels")
 	}
@@ -1217,7 +1217,7 @@ func (s SqlChannelStore) getAllChannelsQuery(opts store.ChannelSearchOpts, forCo
 
 func (s SqlChannelStore) GetMoreChannels(teamId string, userId string, offset int, limit int) (model.ChannelList, error) {
 	channels := model.ChannelList{}
-	err := s.GetReplicaX().Select(&channels, `
+	err := s.GetReplica().Select(&channels, `
 		SELECT
 			Channels.*
 		FROM
@@ -1268,7 +1268,7 @@ func (s SqlChannelStore) GetPrivateChannelsForTeam(teamId string, offset int, li
 		return nil, errors.Wrap(err, "channels_tosql")
 	}
 
-	err = s.GetReplicaX().Select(&channels, query, args...)
+	err = s.GetReplica().Select(&channels, query, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find channel with teamId=%s", teamId)
 	}
@@ -1277,7 +1277,7 @@ func (s SqlChannelStore) GetPrivateChannelsForTeam(teamId string, offset int, li
 
 func (s SqlChannelStore) GetPublicChannelsForTeam(teamId string, offset int, limit int) (model.ChannelList, error) {
 	channels := model.ChannelList{}
-	err := s.GetReplicaX().Select(&channels, `
+	err := s.GetReplica().Select(&channels, `
 		SELECT
 			Channels.*
 		FROM
@@ -1331,7 +1331,7 @@ func (s SqlChannelStore) GetPublicChannelsByIdsForTeam(teamId string, channelIds
 	if err != nil {
 		return nil, errors.Wrap(err, "GetPublicChannelsByIdsForTeam to_sql")
 	}
-	err = s.GetReplicaX().Select(&data, queryString, args...)
+	err = s.GetReplica().Select(&data, queryString, args...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find Channels")
 	}
@@ -1350,7 +1350,7 @@ func (s SqlChannelStore) GetChannelCounts(teamId string, userId string) (*model.
 		TotalMsgCountRoot int64
 		UpdateAt          int64
 	}{}
-	err := s.GetReplicaX().Select(&data, `SELECT Id, TotalMsgCount, TotalMsgCountRoot, UpdateAt
+	err := s.GetReplica().Select(&data, `SELECT Id, TotalMsgCount, TotalMsgCountRoot, UpdateAt
 			FROM Channels
 			WHERE Id IN (SELECT ChannelId FROM ChannelMembers WHERE UserId = ?)
 				AND	(TeamId = ? OR TeamId = '')
@@ -1378,7 +1378,7 @@ func (s SqlChannelStore) GetChannelCounts(teamId string, userId string) (*model.
 
 func (s SqlChannelStore) GetTeamChannels(teamId string) (model.ChannelList, error) {
 	data := model.ChannelList{}
-	err := s.GetReplicaX().Select(&data, "SELECT * FROM Channels WHERE TeamId = ? And Type != ? ORDER BY DisplayName", teamId, model.ChannelTypeDirect)
+	err := s.GetReplica().Select(&data, "SELECT * FROM Channels WHERE TeamId = ? And Type != ? ORDER BY DisplayName", teamId, model.ChannelTypeDirect)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find Channels with teamId=%s", teamId)
 	}
@@ -1423,7 +1423,7 @@ func (s SqlChannelStore) getByNames(teamId string, names []string, allowFromCach
 			return nil, errors.Wrap(err, "GetByNames_tosql")
 		}
 
-		if err := s.GetReplicaX().Select(&channels, query, args...); err != nil && err != sql.ErrNoRows {
+		if err := s.GetReplica().Select(&channels, query, args...); err != nil && err != sql.ErrNoRows {
 			msg := fmt.Sprintf("failed to get channels with names=%v", names)
 			if teamId != "" {
 				msg += fmt.Sprintf(" teamId=%s", teamId)
@@ -1463,7 +1463,7 @@ func (s SqlChannelStore) getByName(teamId string, name string, includeDeleted bo
 	}
 
 	channel := model.Channel{}
-	if err := s.GetReplicaX().Get(&channel, queryStr, args...); err != nil {
+	if err := s.GetReplica().Get(&channel, queryStr, args...); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Channel", fmt.Sprintf("TeamId=%s&Name=%s", teamId, name))
 		}
@@ -1476,7 +1476,7 @@ func (s SqlChannelStore) getByName(teamId string, name string, includeDeleted bo
 func (s SqlChannelStore) GetDeletedByName(teamId string, name string) (*model.Channel, error) {
 	channel := model.Channel{}
 
-	if err := s.GetReplicaX().Get(&channel, `SELECT *
+	if err := s.GetReplica().Get(&channel, `SELECT *
 			FROM Channels
 			WHERE (TeamId = ? OR TeamId = '')
 			AND Name = ?
@@ -1520,7 +1520,7 @@ func (s SqlChannelStore) GetDeleted(teamId string, offset int, limit int, userId
 		return nil, errors.Wrapf(err, "GetDeleted_ToSql")
 	}
 
-	if err := s.GetReplicaX().Select(&channels, query, args...); err != nil {
+	if err := s.GetReplica().Select(&channels, query, args...); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Channel", fmt.Sprintf("TeamId=%s,UserId=%s", teamId, userId))
 		}
@@ -1639,7 +1639,7 @@ func (s SqlChannelStore) saveMultipleMembers(members []*model.ChannelMember) ([]
 		User  sql.NullString
 		Admin sql.NullString
 	}{}
-	err = s.GetMasterX().Select(&defaultChannelsRoles, channelRolesSql, channelRolesArgs...)
+	err = s.GetMaster().Select(&defaultChannelsRoles, channelRolesSql, channelRolesArgs...)
 	if err != nil {
 		return nil, errors.Wrap(err, "default_channel_roles_select")
 	}
@@ -1678,7 +1678,7 @@ func (s SqlChannelStore) saveMultipleMembers(members []*model.ChannelMember) ([]
 		User  sql.NullString
 		Admin sql.NullString
 	}{}
-	err = s.GetMasterX().Select(&defaultTeamsRoles, teamRolesSql, teamRolesArgs...)
+	err = s.GetMaster().Select(&defaultTeamsRoles, teamRolesSql, teamRolesArgs...)
 	if err != nil {
 		return nil, errors.Wrap(err, "default_team_roles_select")
 	}
@@ -1697,7 +1697,7 @@ func (s SqlChannelStore) saveMultipleMembers(members []*model.ChannelMember) ([]
 		return nil, errors.Wrap(err, "channel_members_tosql")
 	}
 
-	if _, err := s.GetMasterX().Exec(sql, args...); err != nil {
+	if _, err := s.GetMaster().Exec(sql, args...); err != nil {
 		if IsUniqueConstraintError(err, []string{"ChannelId", "channelmembers_pkey", "PRIMARY"}) {
 			return nil, store.NewErrConflict("ChannelMembers", err, "")
 		}
@@ -1748,7 +1748,7 @@ func (s SqlChannelStore) UpdateMultipleMembers(members []*model.ChannelMember) (
 
 	var transaction *sqlxTxWrapper
 
-	if transaction, err = s.GetMasterX().Beginx(); err != nil {
+	if transaction, err = s.GetMaster().Beginx(); err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
 	defer finalizeTransactionX(transaction, &err)
@@ -1807,7 +1807,7 @@ func (s SqlChannelStore) UpdateMember(rctx request.CTX, member *model.ChannelMem
 }
 
 func (s SqlChannelStore) UpdateMemberNotifyProps(channelID, userID string, props map[string]string) (_ *model.ChannelMember, err error) {
-	tx, err := s.GetMasterX().Beginx()
+	tx, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
@@ -1928,7 +1928,7 @@ func (s SqlChannelStore) PatchMultipleMembersNotifyProps(members []*model.Channe
 
 	builder = builder.Where(whereClause)
 
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
@@ -1978,7 +1978,7 @@ func (s SqlChannelStore) GetMembers(channelID string, offset, limit int) (model.
 	}
 
 	dbMembers := channelMemberWithSchemeRolesList{}
-	err = s.GetReplicaX().Select(&dbMembers, sql, args...)
+	err = s.GetReplica().Select(&dbMembers, sql, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get ChannelMembers with channelId=%s", channelID)
 	}
@@ -1988,7 +1988,7 @@ func (s SqlChannelStore) GetMembers(channelID string, offset, limit int) (model.
 
 func (s SqlChannelStore) GetChannelMembersTimezones(channelId string) ([]model.StringMap, error) {
 	dbMembersTimezone := []model.StringMap{}
-	err := s.GetReplicaX().Select(&dbMembersTimezone, `
+	err := s.GetReplica().Select(&dbMembersTimezone, `
 		SELECT
 			Users.Timezone
 		FROM
@@ -2039,7 +2039,7 @@ func (s SqlChannelStore) GetChannelsWithUnreadsAndWithMentions(ctx context.Conte
 		LastViewedAt  int64
 	}
 
-	err = s.GetReplicaX().Select(&channels, queryString, args...)
+	err = s.GetReplica().Select(&channels, queryString, args...)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "failed to find channels with unreads and with mentions data")
 	}
@@ -2164,7 +2164,7 @@ func (s SqlChannelStore) GetMemberForPost(postId string, userId string, includeA
 	if !includeArchivedChannels {
 		query += " AND Channels.DeleteAt = 0"
 	}
-	if err := s.GetReplicaX().Get(&dbMember, query, userId, postId); err != nil {
+	if err := s.GetReplica().Get(&dbMember, query, userId, postId); err != nil {
 		return nil, errors.Wrapf(err, "failed to get ChannelMember with postId=%s and userId=%s", postId, userId)
 	}
 	return dbMember.ToModel(), nil
@@ -2240,7 +2240,7 @@ func (s SqlChannelStore) GetChannelsMemberCount(channelIDs []string) (_ map[stri
 		return nil, errors.Wrap(err, "channels_member_count_tosql")
 	}
 
-	rows, err := s.GetReplicaX().DB.Query(queryString, args...)
+	rows, err := s.GetReplica().DB.Query(queryString, args...)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch member counts")
@@ -2279,7 +2279,7 @@ type allChannelMemberNotifyProps struct {
 
 func (s SqlChannelStore) GetAllChannelMembersNotifyPropsForChannel(channelId string, allowFromCache bool) (map[string]model.StringMap, error) {
 	data := []allChannelMemberNotifyProps{}
-	err := s.GetReplicaX().Select(&data, `
+	err := s.GetReplica().Select(&data, `
 		SELECT UserId, NotifyProps
 		FROM ChannelMembers
 		WHERE ChannelId = ?`, channelId)
@@ -2306,7 +2306,7 @@ func (s SqlChannelStore) GetMemberCountFromCache(channelId string) int64 {
 
 func (s SqlChannelStore) GetFileCount(channelId string) (int64, error) {
 	var count int64
-	err := s.GetReplicaX().Get(&count, `
+	err := s.GetReplica().Get(&count, `
 		SELECT
 		    COUNT(*)
 		FROM
@@ -2325,7 +2325,7 @@ func (s SqlChannelStore) GetFileCount(channelId string) (int64, error) {
 //nolint:unparam
 func (s SqlChannelStore) GetMemberCount(channelId string, allowFromCache bool) (int64, error) {
 	var count int64
-	err := s.GetReplicaX().Get(&count, `
+	err := s.GetReplica().Get(&count, `
 		SELECT
 			count(*)
 		FROM
@@ -2402,7 +2402,7 @@ func (s SqlChannelStore) InvalidatePinnedPostCount(channelId string) {
 //nolint:unparam
 func (s SqlChannelStore) GetPinnedPostCount(channelId string, allowFromCache bool) (int64, error) {
 	var count int64
-	err := s.GetReplicaX().Get(&count, `
+	err := s.GetReplica().Get(&count, `
 		SELECT count(*)
 			FROM Posts
 		WHERE
@@ -2428,7 +2428,7 @@ func (s SqlChannelStore) GetGuestCount(channelId string, allowFromCache bool) (i
 		indexHint = `USE INDEX(idx_channelmembers_channel_id_scheme_guest_user_id)`
 	}
 	var count int64
-	err := s.GetReplicaX().Get(&count, `
+	err := s.GetReplica().Get(&count, `
 		SELECT
 			count(*)
 		FROM
@@ -2454,7 +2454,7 @@ func (s SqlChannelStore) RemoveMembers(rctx request.CTX, channelId string, userI
 	if err != nil {
 		return errors.Wrap(err, "channel_tosql")
 	}
-	_, err = s.GetMasterX().Exec(query, args...)
+	_, err = s.GetMaster().Exec(query, args...)
 	if err != nil {
 		return errors.Wrap(err, "failed to delete ChannelMembers")
 	}
@@ -2469,7 +2469,7 @@ func (s SqlChannelStore) RemoveMembers(rctx request.CTX, channelId string, userI
 	if err != nil {
 		return errors.Wrap(err, "channel_tosql")
 	}
-	_, err = s.GetMasterX().Exec(query, args...)
+	_, err = s.GetMaster().Exec(query, args...)
 	if err != nil {
 		return errors.Wrap(err, "failed to delete SidebarChannels")
 	}
@@ -2498,7 +2498,7 @@ func (s SqlChannelStore) RemoveAllDeactivatedMembers(rctx request.CTX, channelId
 			ChannelMembers.ChannelId = ?
 	`
 
-	_, err := s.GetMasterX().Exec(query, channelId)
+	_, err := s.GetMaster().Exec(query, channelId)
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete ChannelMembers with channelId=%s", channelId)
 	}
@@ -2506,7 +2506,7 @@ func (s SqlChannelStore) RemoveAllDeactivatedMembers(rctx request.CTX, channelId
 }
 
 func (s SqlChannelStore) PermanentDeleteMembersByUser(rctx request.CTX, userId string) error {
-	if _, err := s.GetMasterX().Exec("DELETE FROM ChannelMembers WHERE UserId = ?", userId); err != nil {
+	if _, err := s.GetMaster().Exec("DELETE FROM ChannelMembers WHERE UserId = ?", userId); err != nil {
 		return errors.Wrapf(err, "failed to permanent delete ChannelMembers with userId=%s", userId)
 	}
 	return nil
@@ -2561,7 +2561,7 @@ func (s SqlChannelStore) UpdateLastViewedAt(channelIds []string, userId string) 
 		}
 	}
 
-	err = s.GetMasterX().Select(&lastPostAtTimes, sql, args...)
+	err = s.GetMaster().Select(&lastPostAtTimes, sql, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find ChannelMembers data with userId=%s and channelId in %v", userId, channelIds)
 	}
@@ -2614,7 +2614,7 @@ func (s SqlChannelStore) UpdateLastViewedAt(channelIds []string, userId string) 
 		return nil, errors.Wrap(err, "UpdateLastViewedAt_Update_Tosql")
 	}
 
-	if _, err := s.GetMasterX().Exec(sql, args...); err != nil {
+	if _, err := s.GetMaster().Exec(sql, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to update ChannelMembers with userId=%s and channelId in %v", userId, channelIds)
 	}
 
@@ -2638,7 +2638,7 @@ func (s SqlChannelStore) CountUrgentPostsAfter(channelId string, timestamp int64
 	}
 
 	var urgent int64
-	err := s.GetReplicaX().GetBuilder(&urgent, query)
+	err := s.GetReplica().GetBuilder(&urgent, query)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to count urgent Posts")
 	}
@@ -2680,7 +2680,7 @@ func (s SqlChannelStore) CountPostsAfter(channelId string, timestamp int64, excl
 	}
 
 	var unread int64
-	err = s.GetReplicaX().Get(&unread, sql, args...)
+	err = s.GetReplica().Get(&unread, sql, args...)
 	if err != nil {
 		return 0, 0, errors.Wrap(err, "failed to count Posts")
 	}
@@ -2690,7 +2690,7 @@ func (s SqlChannelStore) CountPostsAfter(channelId string, timestamp int64, excl
 	}
 
 	var unreadRoot int64
-	err = s.GetReplicaX().Get(&unreadRoot, sql2, args2...)
+	err = s.GetReplica().Get(&unreadRoot, sql2, args2...)
 	if err != nil {
 		return 0, 0, errors.Wrap(err, "failed to count root Posts")
 	}
@@ -2742,7 +2742,7 @@ func (s SqlChannelStore) UpdateLastViewedAtPost(unreadPost *model.Post, userID s
 		UserId = :userid
 		AND ChannelId = :channelid
 	`
-	_, err = s.GetMasterX().NamedExec(setUnreadQuery, params)
+	_, err = s.GetMaster().NamedExec(setUnreadQuery, params)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to update ChannelMembers")
 	}
@@ -2768,7 +2768,7 @@ func (s SqlChannelStore) UpdateLastViewedAtPost(unreadPost *model.Post, userID s
 		AND c.DeleteAt = 0
 	`
 	result := &model.ChannelUnreadAt{}
-	if err = s.GetMasterX().Get(result, chanUnreadQuery, userID, unreadPost.ChannelId); err != nil {
+	if err = s.GetMaster().Get(result, chanUnreadQuery, userID, unreadPost.ChannelId); err != nil {
 		return nil, errors.Wrapf(err, "failed to get ChannelMember with channelId=%s", unreadPost.ChannelId)
 	}
 
@@ -2804,7 +2804,7 @@ func (s SqlChannelStore) IncrementMentionCount(channelId string, userIDs []strin
 		return errors.Wrap(err, "IncrementMentionCount_Tosql")
 	}
 
-	_, err = s.GetMasterX().Exec(sql, args...)
+	_, err = s.GetMaster().Exec(sql, args...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to Update ChannelMembers with channelId=%s and userId=%v", channelId, userIDs)
 	}
@@ -2813,7 +2813,7 @@ func (s SqlChannelStore) IncrementMentionCount(channelId string, userIDs []strin
 
 func (s SqlChannelStore) GetAll(teamId string) ([]*model.Channel, error) {
 	data := []*model.Channel{}
-	err := s.GetReplicaX().Select(&data, "SELECT * FROM Channels WHERE TeamId = ? AND Type != ? ORDER BY Name", teamId, model.ChannelTypeDirect)
+	err := s.GetReplica().Select(&data, "SELECT * FROM Channels WHERE TeamId = ? AND Type != ? ORDER BY Name", teamId, model.ChannelTypeDirect)
 
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find Channels with teamId=%s", teamId)
@@ -2839,7 +2839,7 @@ func (s SqlChannelStore) GetChannelsByIds(channelIds []string, includeDeleted bo
 	}
 
 	channels := []*model.Channel{}
-	err = s.GetReplicaX().Select(&channels, sql, args...)
+	err = s.GetReplica().Select(&channels, sql, args...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find Channels")
 	}
@@ -2867,7 +2867,7 @@ func (s SqlChannelStore) GetChannelsWithTeamDataByIds(channelIDs []string, inclu
 	}
 
 	channels := []*model.ChannelWithTeamData{}
-	err = s.GetReplicaX().Select(&channels, sql, args...)
+	err = s.GetReplica().Select(&channels, sql, args...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find Channels")
 	}
@@ -2876,7 +2876,7 @@ func (s SqlChannelStore) GetChannelsWithTeamDataByIds(channelIDs []string, inclu
 
 func (s SqlChannelStore) GetForPost(postId string) (*model.Channel, error) {
 	channel := model.Channel{}
-	if err := s.GetReplicaX().Get(
+	if err := s.GetReplica().Get(
 		&channel,
 		`SELECT
 			Channels.*
@@ -2910,7 +2910,7 @@ func (s SqlChannelStore) AnalyticsTypeCount(teamId string, channelType model.Cha
 	}
 
 	var value int64
-	err = s.GetReplicaX().Get(&value, sql, args...)
+	err = s.GetReplica().Get(&value, sql, args...)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to count Channels")
 	}
@@ -2936,7 +2936,7 @@ func (s SqlChannelStore) AnalyticsDeletedTypeCount(teamId string, channelType mo
 	}
 
 	var v int64
-	err = s.GetReplicaX().Get(&v, sql, args...)
+	err = s.GetReplica().Get(&v, sql, args...)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to count Channels with teamId=%s and channelType=%s", teamId, channelType)
 	}
@@ -2959,7 +2959,7 @@ func (s SqlChannelStore) GetMembersForUser(teamID string, userID string) (model.
 	}
 
 	dbMembers := channelMemberWithSchemeRolesList{}
-	err = s.GetReplicaX().Select(&dbMembers, sql, args...)
+	err = s.GetReplica().Select(&dbMembers, sql, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find ChannelMembers data with teamId=%s and userId=%s", teamID, userID)
 	}
@@ -2970,7 +2970,7 @@ func (s SqlChannelStore) GetMembersForUser(teamID string, userID string) (model.
 func (s SqlChannelStore) GetMembersForUserWithPagination(userId string, page, perPage int) (model.ChannelMembersWithTeamData, error) {
 	dbMembers := channelMemberWithTeamWithSchemeRolesList{}
 	offset := page * perPage
-	err := s.GetReplicaX().Select(&dbMembers, channelMembersWithSchemeSelectQuery+"WHERE ChannelMembers.UserId = ? ORDER BY ChannelId ASC Limit ? Offset ?", userId, perPage, offset)
+	err := s.GetReplica().Select(&dbMembers, channelMembersWithSchemeSelectQuery+"WHERE ChannelMembers.UserId = ? ORDER BY ChannelId ASC Limit ? Offset ?", userId, perPage, offset)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find ChannelMembers data with and userId=%s", userId)
 	}
@@ -2980,7 +2980,7 @@ func (s SqlChannelStore) GetMembersForUserWithPagination(userId string, page, pe
 
 func (s SqlChannelStore) GetTeamMembersForChannel(channelID string) ([]string, error) {
 	teamMemberIDs := []string{}
-	if err := s.GetReplicaX().Select(&teamMemberIDs, `SELECT tm.UserId
+	if err := s.GetReplica().Select(&teamMemberIDs, `SELECT tm.UserId
 		FROM Channels c, Teams t, TeamMembers tm
 		WHERE
 			c.TeamId=t.Id
@@ -3043,7 +3043,7 @@ func (s SqlChannelStore) Autocomplete(rctx request.CTX, userID, term string, inc
 	}
 
 	channels := model.ChannelListWithTeamData{}
-	err = s.GetReplicaX().Select(&channels, sql, args...)
+	err = s.GetReplica().Select(&channels, sql, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not find channel with term=%s", trimInput(term))
 	}
@@ -3156,7 +3156,7 @@ func (s SqlChannelStore) AutocompleteInTeamForSearch(teamID string, userID strin
 	}
 
 	// query the database
-	err = s.GetReplicaX().Select(&channels, sql, args...)
+	err = s.GetReplica().Select(&channels, sql, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find Channels with term='%s'", trimInput(term))
 	}
@@ -3213,7 +3213,7 @@ func (s SqlChannelStore) autocompleteInTeamForSearchDirectMessages(userID string
 
 	// query the channel list from the database using SQLX
 	channels := model.ChannelList{}
-	if err := s.GetReplicaX().Select(&channels, sql, args...); err != nil {
+	if err := s.GetReplica().Select(&channels, sql, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find Channels with term='%s'", trimInput(term))
 	}
 
@@ -3446,7 +3446,7 @@ func (s SqlChannelStore) SearchAllChannels(term string, opts store.ChannelSearch
 		return nil, 0, errors.Wrap(err, "channel_tosql")
 	}
 	channels := model.ChannelListWithTeamData{}
-	if err2 := s.GetReplicaX().Select(&channels, queryString, args...); err2 != nil {
+	if err2 := s.GetReplica().Select(&channels, queryString, args...); err2 != nil {
 		return nil, 0, errors.Wrapf(err2, "failed to find Channels with term='%s'", trimInput(term))
 	}
 
@@ -3459,7 +3459,7 @@ func (s SqlChannelStore) SearchAllChannels(term string, opts store.ChannelSearch
 		if err != nil {
 			return nil, 0, errors.Wrap(err, "channel_tosql")
 		}
-		if err2 := s.GetReplicaX().Get(&totalCount, queryString, args...); err2 != nil {
+		if err2 := s.GetReplica().Get(&totalCount, queryString, args...); err2 != nil {
 			return nil, 0, errors.Wrapf(err2, "failed to find Channels with term='%s'", trimInput(term))
 		}
 	} else {
@@ -3634,7 +3634,7 @@ func (s SqlChannelStore) performSearch(searchQuery sq.SelectBuilder, term string
 	}
 
 	channels := model.ChannelList{}
-	err = s.GetReplicaX().Select(&channels, sql, args...)
+	err = s.GetReplica().Select(&channels, sql, args...)
 	if err != nil {
 		return channels, errors.Wrapf(err, "failed to find Channels with term='%s'", trimInput(term))
 	}
@@ -3727,7 +3727,7 @@ func (s SqlChannelStore) SearchGroupChannels(userId, term string) (model.Channel
 	}
 
 	groupChannels := model.ChannelList{}
-	if err := s.GetReplicaX().Select(&groupChannels, sql, params...); err != nil {
+	if err := s.GetReplica().Select(&groupChannels, sql, params...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find Channels with term='%s' and userId=%s", trimInput(term), userId)
 	}
 	return groupChannels, nil
@@ -3747,7 +3747,7 @@ func (s SqlChannelStore) GetMembersByIds(channelID string, userIDs []string) (mo
 	}
 
 	dbMembers := channelMemberWithSchemeRolesList{}
-	if err := s.GetReplicaX().Select(&dbMembers, sql, args...); err != nil {
+	if err := s.GetReplica().Select(&dbMembers, sql, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find ChannelMembers with channelId=%s and userId in %v", channelID, userIDs)
 	}
 
@@ -3768,7 +3768,7 @@ func (s SqlChannelStore) GetMembersByChannelIds(channelIDs []string, userID stri
 	}
 
 	dbMembers := channelMemberWithSchemeRolesList{}
-	if err := s.GetReplicaX().Select(&dbMembers, sql, args...); err != nil {
+	if err := s.GetReplica().Select(&dbMembers, sql, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find ChannelMembers with userId=%s and channelId in %v", userID, channelIDs)
 	}
 
@@ -3796,7 +3796,7 @@ func (s SqlChannelStore) GetMembersInfoByChannelIds(channelIDs []string) (map[st
 		ChannelId string
 	}{}
 
-	if err := s.GetReplicaX().Select(&res, sql, args...); err != nil {
+	if err := s.GetReplica().Select(&res, sql, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to find channels display name")
 	}
 
@@ -3814,7 +3814,7 @@ func (s SqlChannelStore) GetMembersInfoByChannelIds(channelIDs []string) (map[st
 
 func (s SqlChannelStore) GetChannelsByScheme(schemeId string, offset int, limit int) (model.ChannelList, error) {
 	channels := model.ChannelList{}
-	err := s.GetReplicaX().Select(&channels, "SELECT * FROM Channels WHERE SchemeId = ? ORDER BY DisplayName LIMIT ? OFFSET ?", schemeId, limit, offset)
+	err := s.GetReplica().Select(&channels, "SELECT * FROM Channels WHERE SchemeId = ? ORDER BY DisplayName LIMIT ? OFFSET ?", schemeId, limit, offset)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find Channels with schemeId=%s", schemeId)
 	}
@@ -3828,7 +3828,7 @@ func (s SqlChannelStore) GetChannelsByScheme(schemeId string, offset int, limit 
 func (s SqlChannelStore) MigrateChannelMembers(fromChannelId string, fromUserId string) (_ map[string]string, err error) {
 	var transaction *sqlxTxWrapper
 
-	if transaction, err = s.GetMasterX().Beginx(); err != nil {
+	if transaction, err = s.GetMaster().Beginx(); err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
 	defer finalizeTransactionX(transaction, &err)
@@ -3922,7 +3922,7 @@ func (s SqlChannelStore) MigrateChannelMembers(fromChannelId string, fromUserId 
 }
 
 func (s SqlChannelStore) ResetAllChannelSchemes() (err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
@@ -3956,7 +3956,7 @@ func (s SqlChannelStore) ClearAllCustomRoleAssignments() (err error) {
 	for {
 		var transaction *sqlxTxWrapper
 
-		if transaction, err = s.GetMasterX().Beginx(); err != nil {
+		if transaction, err = s.GetMaster().Beginx(); err != nil {
 			return errors.Wrap(err, "begin_transaction")
 		}
 
@@ -4030,7 +4030,7 @@ func (s SqlChannelStore) ClearAllCustomRoleAssignments() (err error) {
 
 func (s SqlChannelStore) GetAllChannelsForExportAfter(limit int, afterId string) ([]*model.ChannelForExport, error) {
 	channels := []*model.ChannelForExport{}
-	if err := s.GetReplicaX().Select(&channels, `
+	if err := s.GetReplica().Select(&channels, `
 		SELECT
 			Channels.*,
 			Teams.Name as TeamName,
@@ -4082,7 +4082,7 @@ func (s SqlChannelStore) GetChannelMembersForExport(userId string, teamId string
 	if !includeArchivedChannel {
 		q += " AND Channels.DeleteAt = 0"
 	}
-	err := s.GetReplicaX().Select(&members, q, userId, teamId)
+	err := s.GetReplica().Select(&members, q, userId, teamId)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find Channels for export")
 	}
@@ -4113,7 +4113,7 @@ func (s SqlChannelStore) GetAllDirectChannelsForExportAfter(limit int, afterId s
 		return nil, errors.Wrap(err, "channel_tosql")
 	}
 
-	if err2 := s.GetReplicaX().Select(&directChannelsForExport, queryString, args...); err2 != nil {
+	if err2 := s.GetReplica().Select(&directChannelsForExport, queryString, args...); err2 != nil {
 		return nil, errors.Wrap(err2, "failed to find direct Channels for export")
 	}
 
@@ -4133,7 +4133,7 @@ func (s SqlChannelStore) GetAllDirectChannelsForExportAfter(limit int, afterId s
 	}
 
 	channelMembers := []*model.ChannelMemberForExport{}
-	if err2 := s.GetReplicaX().Select(&channelMembers, queryString, args...); err2 != nil {
+	if err2 := s.GetReplica().Select(&channelMembers, queryString, args...); err2 != nil {
 		return nil, errors.Wrap(err2, "failed to find ChannelMembers")
 	}
 
@@ -4188,7 +4188,7 @@ func (s SqlChannelStore) UserBelongsToChannels(userId string, channelIds []strin
 		return false, errors.Wrap(err, "channel_tosql")
 	}
 	var c int64
-	err = s.GetReplicaX().Get(&c, queryString, args...)
+	err = s.GetReplica().Get(&c, queryString, args...)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to count ChannelMembers")
 	}
@@ -4201,7 +4201,7 @@ func (s SqlChannelStore) UserBelongsToChannels(userId string, channelIds []strin
 //
 // TODO: parameterize adminIDs
 func (s SqlChannelStore) UpdateMembersRole(channelID string, adminIDs []string) (_ []*model.ChannelMember, err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, err
 	}
@@ -4279,7 +4279,7 @@ func (s SqlChannelStore) GroupSyncedChannelCount() (int64, error) {
 	}
 
 	var count int64
-	err = s.GetReplicaX().Get(&count, sql, args...)
+	err = s.GetReplica().Get(&count, sql, args...)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to count Channels")
 	}
@@ -4298,7 +4298,7 @@ func (s SqlChannelStore) SetShared(channelId string, shared bool) error {
 		return errors.Wrap(err, "channel_set_shared_tosql")
 	}
 
-	result, err := s.GetMasterX().Exec(squery, args...)
+	result, err := s.GetMaster().Exec(squery, args...)
 	if err != nil {
 		return errors.Wrap(err, "failed to update `Shared` for Channels")
 	}
@@ -4327,7 +4327,7 @@ func (s SqlChannelStore) GetTeamForChannel(channelID string) (*model.Team, error
 	}
 
 	team := model.Team{}
-	err = s.GetReplicaX().Get(&team, query, args...)
+	err = s.GetReplica().Get(&team, query, args...)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Team", fmt.Sprintf("channel_id=%s", channelID))
@@ -4347,7 +4347,7 @@ func (s SqlChannelStore) IsReadOnlyChannel(channelID string) (bool, error) {
 	// there might be in effect a custom scheme for the user that doesn't allow to create posts, but that wouldn't
 	// be a readonly channel but a readonly user
 	var schemaId string
-	err = s.GetReplicaX().Get(&schemaId, squery, args...)
+	err = s.GetReplica().Get(&schemaId, squery, args...)
 	if err != nil {
 		return false, nil
 	}
@@ -4365,7 +4365,7 @@ func (s SqlChannelStore) IsChannelReadOnlyScheme(schemeID string) (bool, error) 
 		return false, err
 	}
 	var permissions string
-	err = s.GetReplicaX().Get(&permissions, squery, args...)
+	err = s.GetReplica().Get(&permissions, squery, args...)
 	if err != nil {
 		mlog.Err(err)
 		return false, err

--- a/server/channels/store/sqlstore/channel_store_categories.go
+++ b/server/channels/store/sqlstore/channel_store_categories.go
@@ -21,7 +21,7 @@ type dbSelecter interface {
 }
 
 func (s SqlChannelStore) CreateInitialSidebarCategories(c request.CTX, userId string, opts *store.SidebarCategorySearchOpts) (_ *model.OrderedSidebarCategories, err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "CreateInitialSidebarCategories: begin_transaction")
 	}
@@ -250,7 +250,7 @@ func (s SqlChannelStore) migrateFavoritesToSidebarT(transaction *sqlxTxWrapper, 
 // MigrateFavoritesToSidebarChannels populates the SidebarChannels table by analyzing existing user preferences for favorites
 // **IMPORTANT** This function should only be called from the migration task and shouldn't be used by itself
 func (s SqlChannelStore) MigrateFavoritesToSidebarChannels(lastUserId string, runningOrder int64) (_ map[string]any, err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +297,7 @@ type sidebarCategoryForJoin struct {
 }
 
 func (s SqlChannelStore) CreateSidebarCategory(userId, teamId string, newCategory *model.SidebarCategoryWithChannels) (_ *model.SidebarCategoryWithChannels, err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
@@ -419,7 +419,7 @@ func (s SqlChannelStore) CreateSidebarCategory(userId, teamId string, newCategor
 }
 
 func (s SqlChannelStore) completePopulatingCategoryChannels(category *model.SidebarCategoryWithChannels) (_ *model.SidebarCategoryWithChannels, err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
@@ -504,7 +504,7 @@ func (s SqlChannelStore) GetSidebarCategory(categoryId string) (*model.SidebarCa
 	}
 
 	categories := []*sidebarCategoryForJoin{}
-	if err = s.GetReplicaX().Select(&categories, sql, args...); err != nil {
+	if err = s.GetReplica().Select(&categories, sql, args...); err != nil {
 		return nil, store.NewErrNotFound("SidebarCategories", categoryId).Wrap(err)
 	}
 
@@ -600,11 +600,11 @@ func (s SqlChannelStore) GetSidebarCategoriesForTeamForUser(userId, teamId strin
 		TeamID:      teamId,
 		ExcludeTeam: false,
 	}
-	return s.getSidebarCategoriesT(s.GetReplicaX(), userId, opts)
+	return s.getSidebarCategoriesT(s.GetReplica(), userId, opts)
 }
 
 func (s SqlChannelStore) GetSidebarCategories(userID string, opts *store.SidebarCategorySearchOpts) (*model.OrderedSidebarCategories, error) {
-	return s.getSidebarCategoriesT(s.GetReplicaX(), userID, opts)
+	return s.getSidebarCategoriesT(s.GetReplica(), userID, opts)
 }
 
 func (s SqlChannelStore) GetSidebarCategoryOrder(userId, teamId string) ([]string, error) {
@@ -623,7 +623,7 @@ func (s SqlChannelStore) GetSidebarCategoryOrder(userId, teamId string) ([]strin
 		return nil, errors.Wrap(err, "sidebar_category_tosql")
 	}
 
-	if err := s.GetReplicaX().Select(&ids, sql, args...); err != nil {
+	if err := s.GetReplica().Select(&ids, sql, args...); err != nil {
 		return nil, store.NewErrNotFound("SidebarCategories", fmt.Sprintf("userId=%s,teamId=%s", userId, teamId)).Wrap(err)
 	}
 
@@ -650,7 +650,7 @@ func (s SqlChannelStore) updateSidebarCategoryOrderT(transaction *sqlxTxWrapper,
 }
 
 func (s SqlChannelStore) UpdateSidebarCategoryOrder(userId, teamId string, categoryOrder []string) (err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
@@ -693,7 +693,7 @@ func (s SqlChannelStore) UpdateSidebarCategoryOrder(userId, teamId string, categ
 
 //nolint:unparam
 func (s SqlChannelStore) UpdateSidebarCategories(userId, teamId string, categories []*model.SidebarCategoryWithChannels) (updated []*model.SidebarCategoryWithChannels, original []*model.SidebarCategoryWithChannels, err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "begin_transaction")
 	}
@@ -865,7 +865,7 @@ func (s SqlChannelStore) UpdateSidebarCategories(userId, teamId string, categori
 // UpdateSidebarChannelsByPreferences is called when the Preference table is being updated to keep SidebarCategories in sync
 // At the moment, it's only handling Favorites and NOT DMs/GMs (those will be handled client side)
 func (s SqlChannelStore) UpdateSidebarChannelsByPreferences(preferences model.Preferences) (err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "UpdateSidebarChannelsByPreferences: begin_transaction")
 	}
@@ -1013,7 +1013,7 @@ func (s SqlChannelStore) addChannelToFavoritesCategoryT(transaction *sqlxTxWrapp
 // DeleteSidebarChannelsByPreferences is called when the Preference table is being updated to keep SidebarCategories in sync
 // At the moment, it's only handling Favorites and NOT DMs/GMs (those will be handled client side)
 func (s SqlChannelStore) DeleteSidebarChannelsByPreferences(preferences model.Preferences) (err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "DeleteSidebarChannelsByPreferences: begin_transaction")
 	}
@@ -1041,7 +1041,7 @@ func (s SqlChannelStore) DeleteSidebarChannelsByPreferences(preferences model.Pr
 //nolint:unparam
 func (s SqlChannelStore) UpdateSidebarChannelCategoryOnMove(channel *model.Channel, newTeamId string) error {
 	// if channel is being moved, remove it from the categories, since it's possible that there's no matching category in the new team
-	if _, err := s.GetMasterX().Exec("DELETE FROM SidebarChannels WHERE ChannelId=?", channel.Id); err != nil {
+	if _, err := s.GetMaster().Exec("DELETE FROM SidebarChannels WHERE ChannelId=?", channel.Id); err != nil {
 		return errors.Wrapf(err, "failed to delete SidebarChannels with channelId=%s", channel.Id)
 	}
 	return nil
@@ -1068,10 +1068,10 @@ func (s SqlChannelStore) ClearSidebarOnTeamLeave(userId, teamId string) error {
 						AND SidebarCategories.TeamId = ?
 						AND SidebarChannels.UserId = ?)`
 	}
-	if _, err := s.GetMasterX().Exec(deleteQuery, teamId, userId); err != nil {
+	if _, err := s.GetMaster().Exec(deleteQuery, teamId, userId); err != nil {
 		return errors.Wrap(err, "failed to delete from SidebarChannels")
 	}
-	if _, err := s.GetMasterX().Exec("DELETE FROM SidebarCategories WHERE SidebarCategories.TeamId = ? AND SidebarCategories.UserId = ?", teamId, userId); err != nil {
+	if _, err := s.GetMaster().Exec("DELETE FROM SidebarCategories WHERE SidebarCategories.TeamId = ? AND SidebarCategories.UserId = ?", teamId, userId); err != nil {
 		return errors.Wrap(err, "failed to delete from SidebarCategories")
 	}
 	return nil
@@ -1080,7 +1080,7 @@ func (s SqlChannelStore) ClearSidebarOnTeamLeave(userId, teamId string) error {
 // DeleteSidebarCategory removes a custom category and moves any channels into it into the Channels and Direct Messages
 // categories respectively. Assumes that the provided user ID and team ID match the given category ID.
 func (s SqlChannelStore) DeleteSidebarCategory(categoryId string) (err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
@@ -1141,6 +1141,6 @@ func (s SqlChannelStore) DeleteAllSidebarChannelForChannel(channelID string) err
 		return errors.Wrap(err, "delete_all_sidebar_channel_for_channel_to_sql")
 	}
 
-	_, err = s.GetMasterX().Exec(query, args...)
+	_, err = s.GetMaster().Exec(query, args...)
 	return err
 }

--- a/server/channels/store/sqlstore/cluster_discovery_store.go
+++ b/server/channels/store/sqlstore/cluster_discovery_store.go
@@ -25,7 +25,7 @@ func (s sqlClusterDiscoveryStore) Save(ClusterDiscovery *model.ClusterDiscovery)
 		return err
 	}
 
-	if _, err := s.GetMasterX().NamedExec(`
+	if _, err := s.GetMaster().NamedExec(`
 		INSERT INTO 
 			ClusterDiscovery
 			(Id, Type, ClusterName, Hostname, GossipPort, Port, CreateAt, LastPingAt)
@@ -49,7 +49,7 @@ func (s sqlClusterDiscoveryStore) Delete(ClusterDiscovery *model.ClusterDiscover
 		return false, errors.Wrap(err, "cluster_discovery_tosql")
 	}
 
-	res, err := s.GetMasterX().Exec(queryString, args...)
+	res, err := s.GetMaster().Exec(queryString, args...)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to delete ClusterDiscovery")
 	}
@@ -76,7 +76,7 @@ func (s sqlClusterDiscoveryStore) Exists(ClusterDiscovery *model.ClusterDiscover
 	}
 
 	var count int
-	if err := s.GetMasterX().Get(&count, queryString, args...); err != nil {
+	if err := s.GetMaster().Get(&count, queryString, args...); err != nil {
 		return false, errors.Wrap(err, "failed to count ClusterDiscovery")
 	}
 
@@ -97,7 +97,7 @@ func (s sqlClusterDiscoveryStore) GetAll(ClusterDiscoveryType, clusterName strin
 	}
 
 	list := []*model.ClusterDiscovery{}
-	if err := s.GetMasterX().Select(&list, queryString, args...); err != nil {
+	if err := s.GetMaster().Select(&list, queryString, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to find ClusterDiscovery")
 	}
 	return list, nil
@@ -116,7 +116,7 @@ func (s sqlClusterDiscoveryStore) SetLastPingAt(ClusterDiscovery *model.ClusterD
 		return errors.Wrap(err, "cluster_discovery_tosql")
 	}
 
-	if _, err := s.GetMasterX().Exec(queryString, args...); err != nil {
+	if _, err := s.GetMaster().Exec(queryString, args...); err != nil {
 		return errors.Wrap(err, "failed to update ClusterDiscovery")
 	}
 	return nil
@@ -132,7 +132,7 @@ func (s sqlClusterDiscoveryStore) Cleanup() error {
 		return errors.Wrap(err, "cluster_discovery_tosql")
 	}
 
-	if _, err := s.GetMasterX().Exec(queryString, args...); err != nil {
+	if _, err := s.GetMaster().Exec(queryString, args...); err != nil {
 		return errors.Wrap(err, "failed to delete ClusterDiscoveries")
 	}
 	return nil

--- a/server/channels/store/sqlstore/command_store.go
+++ b/server/channels/store/sqlstore/command_store.go
@@ -42,7 +42,7 @@ func (s SqlCommandStore) Save(command *model.Command) (*model.Command, error) {
 	// Trigger is a keyword
 	trigger := s.toReserveCase("trigger")
 
-	if _, err := s.GetMasterX().NamedExec(`INSERT INTO Commands (Id, Token, CreateAt,
+	if _, err := s.GetMaster().NamedExec(`INSERT INTO Commands (Id, Token, CreateAt,
 		UpdateAt, DeleteAt, CreatorId, TeamId, `+trigger+`, Method, Username,
 		IconURL, AutoComplete, AutoCompleteDesc, AutoCompleteHint, DisplayName, Description,
 		URL, PluginId)
@@ -63,7 +63,7 @@ func (s SqlCommandStore) Get(id string) (*model.Command, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "commands_tosql")
 	}
-	if err = s.GetReplicaX().Get(&command, query, args...); err == sql.ErrNoRows {
+	if err = s.GetReplica().Get(&command, query, args...); err == sql.ErrNoRows {
 		return nil, store.NewErrNotFound("Command", id)
 	} else if err != nil {
 		return nil, errors.Wrapf(err, "selectone: command_id=%s", id)
@@ -80,7 +80,7 @@ func (s SqlCommandStore) GetByTeam(teamId string) ([]*model.Command, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "commands_tosql")
 	}
-	if err := s.GetReplicaX().Select(&commands, sql, args...); err != nil {
+	if err := s.GetReplica().Select(&commands, sql, args...); err != nil {
 		return nil, errors.Wrapf(err, "select: team_id=%s", teamId)
 	}
 
@@ -102,7 +102,7 @@ func (s SqlCommandStore) GetByTrigger(teamId string, trigger string) (*model.Com
 		return nil, errors.Wrapf(err, "commands_tosql")
 	}
 
-	if err := s.GetReplicaX().Get(&command, query, args...); err == sql.ErrNoRows {
+	if err := s.GetReplica().Get(&command, query, args...); err == sql.ErrNoRows {
 		errorId := "teamId=" + teamId + ", trigger=" + trigger
 		return nil, store.NewErrNotFound("Command", errorId)
 	} else if err != nil {
@@ -121,7 +121,7 @@ func (s SqlCommandStore) Delete(commandId string, time int64) error {
 		return errors.Wrapf(err, "commands_tosql")
 	}
 
-	_, err = s.GetMasterX().Exec(sql, args...)
+	_, err = s.GetMaster().Exec(sql, args...)
 	if err != nil {
 		errors.Wrapf(err, "delete: command_id=%s", commandId)
 	}
@@ -136,7 +136,7 @@ func (s SqlCommandStore) PermanentDeleteByTeam(teamId string) error {
 	if err != nil {
 		return errors.Wrapf(err, "commands_tosql")
 	}
-	_, err = s.GetMasterX().Exec(sql, args...)
+	_, err = s.GetMaster().Exec(sql, args...)
 	if err != nil {
 		return errors.Wrapf(err, "delete: team_id=%s", teamId)
 	}
@@ -150,7 +150,7 @@ func (s SqlCommandStore) PermanentDeleteByUser(userId string) error {
 	if err != nil {
 		return errors.Wrapf(err, "commands_tosql")
 	}
-	_, err = s.GetMasterX().Exec(sql, args...)
+	_, err = s.GetMaster().Exec(sql, args...)
 	if err != nil {
 		return errors.Wrapf(err, "delete: user_id=%s", userId)
 	}
@@ -192,7 +192,7 @@ func (s SqlCommandStore) Update(cmd *model.Command) (*model.Command, error) {
 		return nil, errors.Wrap(err, "commands_tosql")
 	}
 
-	res, err := s.GetMasterX().Exec(queryString, args...)
+	res, err := s.GetMaster().Exec(queryString, args...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to update commands")
 	}
@@ -222,7 +222,7 @@ func (s SqlCommandStore) AnalyticsCommandCount(teamId string) (int64, error) {
 	}
 
 	var c int64
-	err = s.GetReplicaX().Get(&c, sql, args...)
+	err = s.GetReplica().Get(&c, sql, args...)
 	if err != nil {
 		return 0, errors.Wrapf(err, "unable to count the commands: team_id=%s", teamId)
 	}

--- a/server/channels/store/sqlstore/command_webhook_store.go
+++ b/server/channels/store/sqlstore/command_webhook_store.go
@@ -32,7 +32,7 @@ func (s SqlCommandWebhookStore) Save(webhook *model.CommandWebhook) (*model.Comm
 		return nil, err
 	}
 
-	if _, err := s.GetMasterX().NamedExec(`INSERT INTO CommandWebhooks
+	if _, err := s.GetMaster().NamedExec(`INSERT INTO CommandWebhooks
 		(Id,CreateAt,CommandId,UserId,ChannelId,RootId,UseCount)
 		Values
 		(:Id, :CreateAt, :CommandId, :UserId, :ChannelId, :RootId, :UseCount)`, webhook); err != nil {
@@ -58,7 +58,7 @@ func (s SqlCommandWebhookStore) Get(id string) (*model.CommandWebhook, error) {
 		return nil, errors.Wrap(err, "get_tosql")
 	}
 
-	if err := s.GetReplicaX().Get(&webhook, queryString, args...); err != nil {
+	if err := s.GetReplica().Get(&webhook, queryString, args...); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("CommandWebhook", id)
 		}
@@ -80,7 +80,7 @@ func (s SqlCommandWebhookStore) TryUse(id string, limit int) error {
 		return errors.Wrap(err, "tryuse_tosql")
 	}
 
-	if sqlResult, err := s.GetMasterX().Exec(queryString, args...); err != nil {
+	if sqlResult, err := s.GetMaster().Exec(queryString, args...); err != nil {
 		return errors.Wrapf(err, "tryuse: id=%s limit=%d", id, limit)
 	} else if rows, err := sqlResult.RowsAffected(); rows == 0 {
 		return store.NewErrInvalidInput("CommandWebhook", "id", id).Wrap(err)
@@ -102,7 +102,7 @@ func (s SqlCommandWebhookStore) Cleanup() {
 		return
 	}
 
-	if _, err := s.GetMasterX().Exec(queryString, args...); err != nil {
+	if _, err := s.GetMaster().Exec(queryString, args...); err != nil {
 		mlog.Error("Unable to cleanup command webhook store.")
 	}
 }

--- a/server/channels/store/sqlstore/compliance_store.go
+++ b/server/channels/store/sqlstore/compliance_store.go
@@ -36,7 +36,7 @@ func (s SqlComplianceStore) Save(compliance *model.Compliance) (*model.Complianc
 	query := `INSERT INTO Compliances (Id, CreateAt, UserId, Status, Count, ` + desc + `, Type, StartAt, EndAt, Keywords, Emails)
 	VALUES
 	(:Id, :CreateAt, :UserId, :Status, :Count, :Desc, :Type, :StartAt, :EndAt, :Keywords, :Emails)`
-	if _, err := s.GetMasterX().NamedExec(query, compliance); err != nil {
+	if _, err := s.GetMaster().NamedExec(query, compliance); err != nil {
 		return nil, errors.Wrap(err, "failed to save Compliance")
 	}
 	return compliance, nil
@@ -68,7 +68,7 @@ func (s SqlComplianceStore) Update(compliance *model.Compliance) (*model.Complia
 		return nil, errors.Wrap(err, "compliances_tosql")
 	}
 
-	res, err := s.GetMasterX().Exec(queryString, args...)
+	res, err := s.GetMaster().Exec(queryString, args...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to update Compliance")
 	}
@@ -85,7 +85,7 @@ func (s SqlComplianceStore) Update(compliance *model.Compliance) (*model.Complia
 func (s SqlComplianceStore) GetAll(offset, limit int) (model.Compliances, error) {
 	query := "SELECT * FROM Compliances ORDER BY CreateAt DESC LIMIT ? OFFSET ?"
 	compliances := model.Compliances{}
-	if err := s.GetReplicaX().Select(&compliances, query, limit, offset); err != nil {
+	if err := s.GetReplica().Select(&compliances, query, limit, offset); err != nil {
 		return nil, errors.Wrap(err, "failed to find all Compliances")
 	}
 	return compliances, nil
@@ -93,7 +93,7 @@ func (s SqlComplianceStore) GetAll(offset, limit int) (model.Compliances, error)
 
 func (s SqlComplianceStore) Get(id string) (*model.Compliance, error) {
 	var compliance model.Compliance
-	if err := s.GetReplicaX().Get(&compliance, `SELECT * FROM Compliances WHERE Id = ?`, id); err != nil {
+	if err := s.GetReplica().Get(&compliance, `SELECT * FROM Compliances WHERE Id = ?`, id); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Compliances", id)
 		}
@@ -192,7 +192,7 @@ func (s SqlComplianceStore) ComplianceExport(job *model.Compliance, cursor model
 				` + keywordQuery + `
 		ORDER BY Posts.CreateAt, Posts.Id
 		LIMIT ?`
-		if err := s.GetReplicaX().Select(&channelPosts, channelsQuery, argsChannelsQuery...); err != nil {
+		if err := s.GetReplica().Select(&channelPosts, channelsQuery, argsChannelsQuery...); err != nil {
 			return nil, cursor, errors.Wrap(err, "unable to export compliance")
 		}
 		if len(channelPosts) < limit {
@@ -257,7 +257,7 @@ func (s SqlComplianceStore) ComplianceExport(job *model.Compliance, cursor model
 		ORDER BY Posts.CreateAt, Posts.Id
 		LIMIT ?`
 
-		if err := s.GetReplicaX().Select(&directMessagePosts, directMessagesQuery, argsDirectMessagesQuery...); err != nil {
+		if err := s.GetReplica().Select(&directMessagePosts, directMessagesQuery, argsDirectMessagesQuery...); err != nil {
 			return nil, cursor, errors.Wrap(err, "unable to export compliance")
 		}
 		if len(directMessagePosts) < limit {
@@ -330,7 +330,7 @@ func (s SqlComplianceStore) MessageExport(c request.CTX, cursor model.MessageExp
 	}
 
 	cposts := []*model.MessageExport{}
-	if err := s.GetReplicaX().SelectCtx(c.Context(), &cposts, query, args...); err != nil {
+	if err := s.GetReplica().SelectCtx(c.Context(), &cposts, query, args...); err != nil {
 		return nil, cursor, errors.Wrap(err, "unable to export messages")
 	}
 	if len(cposts) > 0 {

--- a/server/channels/store/sqlstore/context.go
+++ b/server/channels/store/sqlstore/context.go
@@ -48,7 +48,7 @@ func HasMaster(ctx context.Context) bool {
 // DBXFromContext is a helper utility that returns the sqlx DB handle from a given context.
 func (ss *SqlStore) DBXFromContext(ctx context.Context) *sqlxDBWrapper {
 	if HasMaster(ctx) {
-		return ss.GetMasterX()
+		return ss.GetMaster()
 	}
-	return ss.GetReplicaX()
+	return ss.GetReplica()
 }

--- a/server/channels/store/sqlstore/desktop_tokens_store.go
+++ b/server/channels/store/sqlstore/desktop_tokens_store.go
@@ -34,7 +34,7 @@ func (s *SqlDesktopTokensStore) GetUserId(token string, minCreateAt int64) (*str
 		})
 
 	dt := struct{ UserId string }{}
-	err := s.GetReplicaX().GetBuilder(&dt, query)
+	err := s.GetReplica().GetBuilder(&dt, query)
 
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -58,7 +58,7 @@ func (s *SqlDesktopTokensStore) Insert(token string, createAt int64, userId stri
 		return errors.Wrap(err, "insert_desktoptokens_tosql")
 	}
 
-	if _, err = s.GetMasterX().Exec(query, args...); err != nil {
+	if _, err = s.GetMaster().Exec(query, args...); err != nil {
 		return errors.Wrap(err, "failed to insert token row")
 	}
 
@@ -78,7 +78,7 @@ func (s *SqlDesktopTokensStore) Delete(token string) error {
 		return errors.Wrap(err, "delete_desktoptokens_tosql")
 	}
 
-	if _, err = s.GetMasterX().Exec(query, args...); err != nil {
+	if _, err = s.GetMaster().Exec(query, args...); err != nil {
 		return errors.Wrap(err, "failed to delete token row")
 	}
 	return nil
@@ -97,7 +97,7 @@ func (s *SqlDesktopTokensStore) DeleteByUserId(userId string) error {
 		return errors.Wrap(err, "delete_by_userid_desktoptokens_tosql")
 	}
 
-	if _, err = s.GetMasterX().Exec(query, args...); err != nil {
+	if _, err = s.GetMaster().Exec(query, args...); err != nil {
 		return errors.Wrap(err, "failed to delete token row")
 	}
 	return nil
@@ -116,7 +116,7 @@ func (s *SqlDesktopTokensStore) DeleteOlderThan(minCreateAt int64) error {
 		return errors.Wrap(err, "delete_old_desktoptokens_tosql")
 	}
 
-	if _, err = s.GetMasterX().Exec(query, args...); err != nil {
+	if _, err = s.GetMaster().Exec(query, args...); err != nil {
 		return errors.Wrap(err, "failed to delete token row")
 	}
 	return nil

--- a/server/channels/store/sqlstore/draft_store.go
+++ b/server/channels/store/sqlstore/draft_store.go
@@ -76,7 +76,7 @@ func (s *SqlDraftStore) Get(userId, channelId, rootId string, includeDeleted boo
 	}
 
 	dt := model.Draft{}
-	err := s.GetReplicaX().GetBuilder(&dt, query)
+	err := s.GetReplica().GetBuilder(&dt, query)
 
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -109,7 +109,7 @@ func (s *SqlDraftStore) Upsert(draft *model.Draft) (*model.Draft, error) {
 		return nil, errors.Wrap(err, "save_draft_tosql")
 	}
 
-	if _, err = s.GetMasterX().Exec(query, args...); err != nil {
+	if _, err = s.GetMaster().Exec(query, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to upsert Draft")
 	}
 
@@ -149,7 +149,7 @@ func (s *SqlDraftStore) GetDraftsForUser(userID, teamID string) ([]*model.Draft,
 			})
 	}
 
-	err := s.GetReplicaX().SelectBuilder(&drafts, query)
+	err := s.GetReplica().SelectBuilder(&drafts, query)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get user drafts")
@@ -172,7 +172,7 @@ func (s *SqlDraftStore) Delete(userID, channelID, rootID string) error {
 		return errors.Wrapf(err, "failed to convert to sql")
 	}
 
-	_, err = s.GetMasterX().Exec(sql, args...)
+	_, err = s.GetMaster().Exec(sql, args...)
 
 	if err != nil {
 		return errors.Wrap(err, "failed to delete Draft")
@@ -195,7 +195,7 @@ func (s *SqlDraftStore) DeleteDraftsAssociatedWithPost(channelID, rootID string)
 		return errors.Wrapf(err, "failed to convert to sql")
 	}
 
-	_, err = s.GetMasterX().Exec(sql, args...)
+	_, err = s.GetMaster().Exec(sql, args...)
 
 	if err != nil {
 		return errors.Wrap(err, "failed to delete Draft")
@@ -218,7 +218,7 @@ func (s *SqlDraftStore) determineMaxDraftSize() int {
 	if s.DriverName() == model.DatabaseDriverPostgres {
 		// The Draft.Message column in Postgres has historically been VARCHAR(4000), but
 		// may be manually enlarged to support longer drafts.
-		if err := s.GetReplicaX().Get(&maxDraftSizeBytes, `
+		if err := s.GetReplica().Get(&maxDraftSizeBytes, `
 			SELECT
 				COALESCE(character_maximum_length, 0)
 			FROM
@@ -232,7 +232,7 @@ func (s *SqlDraftStore) determineMaxDraftSize() int {
 	} else if s.DriverName() == model.DatabaseDriverMysql {
 		// The Draft.Message column in MySQL has historically been TEXT, with a maximum
 		// limit of 65535.
-		if err := s.GetReplicaX().Get(&maxDraftSizeBytes, `
+		if err := s.GetReplica().Get(&maxDraftSizeBytes, `
 			SELECT
 				COALESCE(CHARACTER_MAXIMUM_LENGTH, 0)
 			FROM
@@ -276,7 +276,7 @@ func (s *SqlDraftStore) GetLastCreateAtAndUserIdValuesForEmptyDraftsMigration(cr
 		OrderBy("CreateAt", "UserId ASC").
 		Limit(100)
 
-	err := s.GetReplicaX().SelectBuilder(&drafts, query)
+	err := s.GetReplica().SelectBuilder(&drafts, query)
 	if err != nil {
 		return 0, "", errors.Wrap(err, "failed to get the list of drafts")
 	}
@@ -337,7 +337,7 @@ func (s *SqlDraftStore) DeleteEmptyDraftsByCreateAtAndUserId(createAt int64, use
 			).Where(sq.Eq{"Message": ""})
 	}
 
-	if _, err := s.GetMasterX().ExecBuilder(builder); err != nil {
+	if _, err := s.GetMaster().ExecBuilder(builder); err != nil {
 		return errors.Wrapf(err, "failed to delete empty drafts")
 	}
 
@@ -393,7 +393,7 @@ func (s *SqlDraftStore) DeleteOrphanDraftsByCreateAtAndUserId(createAt int64, us
 			Suffix("AND (d.RootId IN (SELECT Id FROM Posts WHERE DeleteAt <> 0) OR NOT EXISTS (SELECT 1 FROM Posts WHERE Posts.Id = d.RootId))")
 	}
 
-	if _, err := s.GetMasterX().ExecBuilder(builder); err != nil {
+	if _, err := s.GetMaster().ExecBuilder(builder); err != nil {
 		return errors.Wrapf(err, "failed to delete orphan drafts")
 	}
 

--- a/server/channels/store/sqlstore/emoji_store.go
+++ b/server/channels/store/sqlstore/emoji_store.go
@@ -34,7 +34,7 @@ func (es SqlEmojiStore) Save(emoji *model.Emoji) (*model.Emoji, error) {
 		return nil, err
 	}
 
-	if _, err := es.GetMasterX().NamedExec(`INSERT INTO Emoji
+	if _, err := es.GetMaster().NamedExec(`INSERT INTO Emoji
 		(Id, CreateAt, UpdateAt, DeleteAt, CreatorId, Name)
 		VALUES
 		(:Id, :CreateAt, :UpdateAt, :DeleteAt, :CreatorId, :Name)`, emoji); err != nil {
@@ -82,14 +82,14 @@ func (es SqlEmojiStore) GetList(offset, limit int, sort string) ([]*model.Emoji,
 
 	query += " LIMIT ? OFFSET ?"
 
-	if err := es.GetReplicaX().Select(&emojis, query, limit, offset); err != nil {
+	if err := es.GetReplica().Select(&emojis, query, limit, offset); err != nil {
 		return nil, errors.Wrap(err, "could not get list of emojis")
 	}
 	return emojis, nil
 }
 
 func (es SqlEmojiStore) Delete(emoji *model.Emoji, time int64) error {
-	if sqlResult, err := es.GetMasterX().Exec(
+	if sqlResult, err := es.GetMaster().Exec(
 		`UPDATE
 			Emoji
 		SET
@@ -118,7 +118,7 @@ func (es SqlEmojiStore) Search(name string, prefixOnly bool, limit int) ([]*mode
 
 	term += name + "%"
 
-	if err := es.GetReplicaX().Select(&emojis,
+	if err := es.GetReplica().Select(&emojis,
 		`SELECT
 			*
 		FROM

--- a/server/channels/store/sqlstore/file_info_store.go
+++ b/server/channels/store/sqlstore/file_info_store.go
@@ -126,7 +126,7 @@ func (fs SqlFileInfoStore) Save(rctx request.CTX, info *model.FileInfo) (*model.
 			:Name, :Extension, :Size, :MimeType, :Width, :Height, :HasPreviewImage, :MiniPreview, :Content, :RemoteId)
 	`
 
-	if _, err := fs.GetMasterX().NamedExec(query, info); err != nil {
+	if _, err := fs.GetMaster().NamedExec(query, info); err != nil {
 		return nil, errors.Wrap(err, "failed to save FileInfo")
 	}
 	return info, nil
@@ -146,7 +146,7 @@ func (fs SqlFileInfoStore) GetByIds(ids []string) ([]*model.FileInfo, error) {
 	}
 
 	items := []fileInfoWithChannelID{}
-	if err := fs.GetReplicaX().Select(&items, queryString, args...); err != nil {
+	if err := fs.GetReplica().Select(&items, queryString, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to find FileInfos")
 	}
 	if len(items) == 0 {
@@ -194,7 +194,7 @@ func (fs SqlFileInfoStore) Upsert(rctx request.CTX, info *model.FileInfo) (*mode
 		return nil, errors.Wrap(err, "file_info_tosql")
 	}
 
-	sqlResult, err := fs.GetMasterX().Exec(queryString, args...)
+	sqlResult, err := fs.GetMaster().Exec(queryString, args...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to update FileInfo")
 	}
@@ -222,9 +222,9 @@ func (fs SqlFileInfoStore) get(id string, fromMaster bool) (*model.FileInfo, err
 		return nil, errors.Wrap(err, "file_info_tosql")
 	}
 
-	db := fs.GetReplicaX()
+	db := fs.GetReplica()
 	if fromMaster {
-		db = fs.GetMasterX()
+		db = fs.GetMaster()
 	}
 
 	if err := db.Get(info, queryString, args...); err != nil {
@@ -304,7 +304,7 @@ func (fs SqlFileInfoStore) GetWithOptions(page, perPage int, opt *model.GetFileI
 		return nil, errors.Wrap(err, "file_info_tosql")
 	}
 	infos := []*model.FileInfo{}
-	if err := fs.GetReplicaX().Select(&infos, queryString, args...); err != nil {
+	if err := fs.GetReplica().Select(&infos, queryString, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to find FileInfos")
 	}
 	return infos, nil
@@ -325,7 +325,7 @@ func (fs SqlFileInfoStore) GetByPath(path string) (*model.FileInfo, error) {
 		return nil, errors.Wrap(err, "file_info_tosql")
 	}
 
-	if err := fs.GetReplicaX().Get(info, queryString, args...); err != nil {
+	if err := fs.GetReplica().Get(info, queryString, args...); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("FileInfo", fmt.Sprintf("path=%s", path))
 		}
@@ -341,10 +341,10 @@ func (fs SqlFileInfoStore) InvalidateFileInfosForPostCache(postId string, delete
 func (fs SqlFileInfoStore) GetForPost(postId string, readFromMaster, includeDeleted, allowFromCache bool) ([]*model.FileInfo, error) {
 	infos := []*model.FileInfo{}
 
-	dbmap := fs.GetReplicaX()
+	dbmap := fs.GetReplica()
 
 	if readFromMaster {
-		dbmap = fs.GetMasterX()
+		dbmap = fs.GetMaster()
 	}
 
 	query := fs.getQueryBuilder().
@@ -383,7 +383,7 @@ func (fs SqlFileInfoStore) GetForUser(userId string) ([]*model.FileInfo, error) 
 		return nil, errors.Wrap(err, "file_info_tosql")
 	}
 
-	if err := fs.GetReplicaX().Select(&infos, queryString, args...); err != nil {
+	if err := fs.GetReplica().Select(&infos, queryString, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find FileInfos with creatorId=%s", userId)
 	}
 	return infos, nil
@@ -407,7 +407,7 @@ func (fs SqlFileInfoStore) AttachToPost(rctx request.CTX, fileId, postId, channe
 	if err != nil {
 		return errors.Wrap(err, "file_info_tosql")
 	}
-	sqlResult, err := fs.GetMasterX().Exec(queryString, args...)
+	sqlResult, err := fs.GetMaster().Exec(queryString, args...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update FileInfo with id=%s and postId=%s", fileId, postId)
 	}
@@ -434,7 +434,7 @@ func (fs SqlFileInfoStore) SetContent(rctx request.CTX, fileId, content string) 
 		return errors.Wrap(err, "file_info_tosql")
 	}
 
-	_, err = fs.GetMasterX().Exec(queryString, args...)
+	_, err = fs.GetMaster().Exec(queryString, args...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update FileInfo content with id=%s", fileId)
 	}
@@ -443,7 +443,7 @@ func (fs SqlFileInfoStore) SetContent(rctx request.CTX, fileId, content string) 
 }
 
 func (fs SqlFileInfoStore) DeleteForPost(rctx request.CTX, postId string) (string, error) {
-	if _, err := fs.GetMasterX().Exec(
+	if _, err := fs.GetMaster().Exec(
 		`UPDATE
 				FileInfo
 			SET
@@ -456,14 +456,14 @@ func (fs SqlFileInfoStore) DeleteForPost(rctx request.CTX, postId string) (strin
 }
 
 func (fs SqlFileInfoStore) PermanentDeleteForPost(rctx request.CTX, postID string) error {
-	if _, err := fs.GetMasterX().Exec(`DELETE FROM FileInfo WHERE PostId = ?`, postID); err != nil {
+	if _, err := fs.GetMaster().Exec(`DELETE FROM FileInfo WHERE PostId = ?`, postID); err != nil {
 		return errors.Wrapf(err, "failed to delete FileInfo with PostId=%s", postID)
 	}
 	return nil
 }
 
 func (fs SqlFileInfoStore) PermanentDelete(rctx request.CTX, fileId string) error {
-	if _, err := fs.GetMasterX().Exec(`DELETE FROM FileInfo WHERE Id = ?`, fileId); err != nil {
+	if _, err := fs.GetMaster().Exec(`DELETE FROM FileInfo WHERE Id = ?`, fileId); err != nil {
 		return errors.Wrapf(err, "failed to delete FileInfo with id=%s", fileId)
 	}
 	return nil
@@ -477,7 +477,7 @@ func (fs SqlFileInfoStore) PermanentDeleteBatch(rctx request.CTX, endTime int64,
 		query = "DELETE from FileInfo WHERE CreateAt < ? AND CreatorId != ? LIMIT ?"
 	}
 
-	sqlResult, err := fs.GetMasterX().Exec(query, endTime, model.BookmarkFileOwner, limit)
+	sqlResult, err := fs.GetMaster().Exec(query, endTime, model.BookmarkFileOwner, limit)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to delete FileInfos in batch")
 	}
@@ -493,7 +493,7 @@ func (fs SqlFileInfoStore) PermanentDeleteBatch(rctx request.CTX, endTime int64,
 func (fs SqlFileInfoStore) PermanentDeleteByUser(rctx request.CTX, userId string) (int64, error) {
 	query := "DELETE from FileInfo WHERE CreatorId = ?"
 
-	sqlResult, err := fs.GetMasterX().Exec(query, userId)
+	sqlResult, err := fs.GetMaster().Exec(query, userId)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to delete FileInfo with creatorId=%s", userId)
 	}
@@ -699,7 +699,7 @@ func (fs SqlFileInfoStore) CountAll() (int64, error) {
 	}
 
 	var count int64
-	err = fs.GetReplicaX().Get(&count, queryString, args...)
+	err = fs.GetReplica().Get(&count, queryString, args...)
 	if err != nil {
 		return int64(0), errors.Wrap(err, "failed to count Files")
 	}
@@ -744,7 +744,7 @@ func (fs SqlFileInfoStore) GetStorageUsage(allowFromCache, includeDeleted bool) 
 	}
 
 	var size int64
-	err := fs.GetReplicaX().GetBuilder(&size, query)
+	err := fs.GetReplica().GetBuilder(&size, query)
 	if err != nil {
 		return int64(0), errors.Wrap(err, "failed to get storage usage")
 	}
@@ -786,7 +786,7 @@ func (fs *SqlFileInfoStore) GetUptoNSizeFileTime(n int64) (int64, error) {
 	}
 
 	var createAt int64
-	if err := fs.GetReplicaX().Get(&createAt, query, queryArgs...); err != nil {
+	if err := fs.GetReplica().Get(&createAt, query, queryArgs...); err != nil {
 		if err == sql.ErrNoRows {
 			return 0, store.NewErrNotFound("File", "none")
 		}

--- a/server/channels/store/sqlstore/group_store.go
+++ b/server/channels/store/sqlstore/group_store.go
@@ -68,7 +68,7 @@ func (s *SqlGroupStore) Create(group *model.Group) (*model.Group, error) {
 	group.CreateAt = model.GetMillis()
 	group.UpdateAt = group.CreateAt
 
-	if _, err := s.GetMasterX().NamedExec(`INSERT INTO UserGroups
+	if _, err := s.GetMaster().NamedExec(`INSERT INTO UserGroups
 		(Id, Name, DisplayName, Description, Source, RemoteId, CreateAt, UpdateAt, DeleteAt, AllowReference)
 		VALUES
 		(:Id, :Name, :DisplayName, :Description, :Source, :RemoteId, :CreateAt, :UpdateAt, :DeleteAt, :AllowReference)`, group); err != nil {
@@ -114,7 +114,7 @@ func (s *SqlGroupStore) CreateWithUserIds(g *model.GroupWithUserIds) (_ *model.G
 		return nil, err
 	}
 
-	txn, err := s.GetMasterX().Beginx()
+	txn, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func (s *SqlGroupStore) checkUsersExist(userIDs []string) error {
 		return err
 	}
 	var rows []string
-	err = s.GetReplicaX().Select(&rows, usersSelectQuery, usersSelectArgs...)
+	err = s.GetReplica().Select(&rows, usersSelectQuery, usersSelectArgs...)
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func (s *SqlGroupStore) Get(groupId string) (*model.Group, error) {
 		From("UserGroups").
 		Where(sq.Eq{"Id": groupId})
 
-	if err := s.GetReplicaX().GetBuilder(&group, builder); err != nil {
+	if err := s.GetReplica().GetBuilder(&group, builder); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Group", groupId)
 		}
@@ -241,7 +241,7 @@ func (s *SqlGroupStore) GetByName(name string, opts model.GroupSearchOpts) (*mod
 	if err != nil {
 		return nil, errors.Wrap(err, "get_by_name_tosql")
 	}
-	if err := s.GetReplicaX().Get(&group, queryString, args...); err != nil {
+	if err := s.GetReplica().Get(&group, queryString, args...); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Group", fmt.Sprintf("name=%s", name))
 		}
@@ -258,7 +258,7 @@ func (s *SqlGroupStore) GetByIDs(groupIDs []string) ([]*model.Group, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "get_by_ids_tosql")
 	}
-	if err := s.GetReplicaX().Select(&groups, queryString, args...); err != nil {
+	if err := s.GetReplica().Select(&groups, queryString, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to find Groups by ids")
 	}
 	return groups, nil
@@ -274,7 +274,7 @@ func (s *SqlGroupStore) GetByRemoteID(remoteID string, groupSource model.GroupSo
 			"Source":   groupSource,
 		})
 
-	if err := s.GetReplicaX().GetBuilder(&group, builder); err != nil {
+	if err := s.GetReplica().GetBuilder(&group, builder); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Group", fmt.Sprintf("remoteId=%s", remoteID))
 		}
@@ -294,7 +294,7 @@ func (s *SqlGroupStore) GetAllBySource(groupSource model.GroupSource) ([]*model.
 			"Source":   groupSource,
 		})
 
-	if err := s.GetReplicaX().SelectBuilder(&groups, builder); err != nil {
+	if err := s.GetReplica().SelectBuilder(&groups, builder); err != nil {
 		return nil, errors.Wrapf(err, "failed to find Groups by groupSource=%v", groupSource)
 	}
 
@@ -313,7 +313,7 @@ func (s *SqlGroupStore) GetByUser(userId string) ([]*model.Group, error) {
 			"UserId":                userId,
 		})
 
-	if err := s.GetReplicaX().SelectBuilder(&groups, builder); err != nil {
+	if err := s.GetReplica().SelectBuilder(&groups, builder); err != nil {
 		return nil, errors.Wrapf(err, "failed to find Groups with userId=%s", userId)
 	}
 
@@ -327,7 +327,7 @@ func (s *SqlGroupStore) Update(group *model.Group) (*model.Group, error) {
 		From("UserGroups").
 		Where(sq.Eq{"Id": group.Id})
 
-	if err := s.GetReplicaX().GetBuilder(&retrievedGroup, builder); err != nil {
+	if err := s.GetReplica().GetBuilder(&retrievedGroup, builder); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Group", group.Id)
 		}
@@ -347,7 +347,7 @@ func (s *SqlGroupStore) Update(group *model.Group) (*model.Group, error) {
 		return nil, err
 	}
 
-	res, err := s.GetMasterX().NamedExec(`UPDATE UserGroups
+	res, err := s.GetMaster().NamedExec(`UPDATE UserGroups
 		SET Name=:Name, DisplayName=:DisplayName, Description=:Description, Source=:Source,
 		RemoteId=:RemoteId, CreateAt=:CreateAt, UpdateAt=:UpdateAt, DeleteAt=:DeleteAt, AllowReference=:AllowReference
 		WHERE Id=:Id`, group)
@@ -375,7 +375,7 @@ func (s *SqlGroupStore) Delete(groupID string) (*model.Group, error) {
 			"DeleteAt": 0,
 		})
 
-	if err := s.GetReplicaX().GetBuilder(&group, builder); err != nil {
+	if err := s.GetReplica().GetBuilder(&group, builder); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Group", groupID)
 		}
@@ -385,7 +385,7 @@ func (s *SqlGroupStore) Delete(groupID string) (*model.Group, error) {
 	time := model.GetMillis()
 	group.DeleteAt = time
 	group.UpdateAt = time
-	if _, err := s.GetMasterX().Exec(`UPDATE UserGroups
+	if _, err := s.GetMaster().Exec(`UPDATE UserGroups
 		SET DeleteAt=?, UpdateAt=?
 		WHERE Id=? AND DeleteAt=0`, group.DeleteAt, group.UpdateAt, groupID); err != nil {
 		return nil, errors.Wrapf(err, "failed to update Group with id=%s", groupID)
@@ -404,7 +404,7 @@ func (s *SqlGroupStore) Restore(groupID string) (*model.Group, error) {
 			sq.NotEq{"DeleteAt": 0},
 		})
 
-	if err := s.GetReplicaX().GetBuilder(&group, builder); err != nil {
+	if err := s.GetReplica().GetBuilder(&group, builder); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Group", groupID)
 		}
@@ -413,7 +413,7 @@ func (s *SqlGroupStore) Restore(groupID string) (*model.Group, error) {
 
 	group.UpdateAt = model.GetMillis()
 	group.DeleteAt = 0
-	if _, err := s.GetMasterX().Exec(`UPDATE UserGroups
+	if _, err := s.GetMaster().Exec(`UPDATE UserGroups
 		SET DeleteAt=0, UpdateAt=?
 		WHERE Id=? AND DeleteAt!=0`, group.UpdateAt, groupID); err != nil {
 		return nil, errors.Wrapf(err, "failed to update Group with id=%s", groupID)
@@ -430,7 +430,7 @@ func (s *SqlGroupStore) GetMember(groupID, userID string) (*model.GroupMember, e
 		Where(sq.Eq{"GroupId": groupID}).
 		Where(sq.Eq{"DeleteAt": 0})
 	var groupMember model.GroupMember
-	if err := s.GetReplicaX().GetBuilder(&groupMember, builder); err != nil {
+	if err := s.GetReplica().GetBuilder(&groupMember, builder); err != nil {
 		return nil, errors.Wrap(err, "GetMember")
 	}
 	return &groupMember, nil
@@ -449,7 +449,7 @@ func (s *SqlGroupStore) GetMemberUsers(groupID string) ([]*model.User, error) {
 			"GroupId":               groupID,
 		})
 
-	if err := s.GetReplicaX().SelectBuilder(&groupMembers, builder); err != nil {
+	if err := s.GetReplica().SelectBuilder(&groupMembers, builder); err != nil {
 		return nil, errors.Wrapf(err, "failed to find member Users for Group with id=%s", groupID)
 	}
 
@@ -511,7 +511,7 @@ func (s *SqlGroupStore) GetMemberUsersSortedPage(groupID string, page int, perPa
 		return nil, errors.Wrap(err, "")
 	}
 
-	if err := s.GetReplicaX().Select(&groupMembers, queryString, args...); err != nil {
+	if err := s.GetReplica().Select(&groupMembers, queryString, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find member Users for Group with id=%s", groupID)
 	}
 
@@ -526,7 +526,7 @@ func (s *SqlGroupStore) GetNonMemberUsersPage(groupID string, page int, perPage 
 		From("UserGroups").
 		Where(sq.Eq{"Id": groupID})
 
-	if err := s.GetReplicaX().GetBuilder(&model.Group{}, builder); err != nil {
+	if err := s.GetReplica().GetBuilder(&model.Group{}, builder); err != nil {
 		return nil, errors.Wrap(err, "GetNonMemberUsersPage")
 	}
 
@@ -542,7 +542,7 @@ func (s *SqlGroupStore) GetNonMemberUsersPage(groupID string, page int, perPage 
 
 	builder = applyViewRestrictionsFilter(builder, viewRestrictions, true)
 
-	if err := s.GetReplicaX().SelectBuilder(&groupMembers, builder); err != nil {
+	if err := s.GetReplica().SelectBuilder(&groupMembers, builder); err != nil {
 		return nil, errors.Wrapf(err, "failed to find member Users for Group with id=%s", groupID)
 	}
 
@@ -570,7 +570,7 @@ func (s *SqlGroupStore) GetMemberCountWithRestrictions(groupID string, viewRestr
 	}
 
 	var count int64
-	err = s.GetReplicaX().Get(&count, queryString, args...)
+	err = s.GetReplica().Get(&count, queryString, args...)
 	if err != nil {
 		return int64(0), errors.Wrapf(err, "failed to count member Users for Group with id=%s", groupID)
 	}
@@ -600,7 +600,7 @@ func (s *SqlGroupStore) GetMemberUsersInTeam(groupID string, teamID string) ([]*
 			AND Users.DeleteAt = 0
 		`
 
-	if err := s.GetReplicaX().Select(&groupMembers, query, groupID, teamID); err != nil {
+	if err := s.GetReplica().Select(&groupMembers, query, groupID, teamID); err != nil {
 		return nil, errors.Wrapf(err, "failed to member Users for groupId=%s and teamId=%s", groupID, teamID)
 	}
 
@@ -635,7 +635,7 @@ func (s *SqlGroupStore) GetMemberUsersNotInChannel(groupID string, channelID str
 			AND Users.DeleteAt = 0
 		`
 
-	if err := s.GetReplicaX().Select(&groupMembers, query, groupID, channelID, channelID); err != nil {
+	if err := s.GetReplica().Select(&groupMembers, query, groupID, channelID, channelID); err != nil {
 		return nil, errors.Wrapf(err, "failed to member Users for groupId=%s and channelId!=%s", groupID, channelID)
 	}
 
@@ -647,7 +647,7 @@ func (s *SqlGroupStore) UpsertMember(groupID string, userID string) (*model.Grou
 	if err != nil {
 		return nil, err
 	}
-	if _, err = s.GetMasterX().Exec(query, args...); err != nil {
+	if _, err = s.GetMaster().Exec(query, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to save GroupMember")
 	}
 	return members[0], nil
@@ -658,7 +658,7 @@ func (s *SqlGroupStore) DeleteMember(groupID string, userID string) (*model.Grou
 	if err != nil {
 		return nil, err
 	}
-	if _, err = s.GetMasterX().Exec(query, args...); err != nil {
+	if _, err = s.GetMaster().Exec(query, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to update GroupMember with groupId=%s and userId=%s", groupID, userID)
 	}
 
@@ -669,7 +669,7 @@ func (s *SqlGroupStore) PermanentDeleteMembersByUser(userId string) error {
 	builder := s.getQueryBuilder().
 		Delete("GroupMembers").
 		Where(sq.Eq{"UserId": userId})
-	if _, err := s.GetMasterX().ExecBuilder(builder); err != nil {
+	if _, err := s.GetMaster().ExecBuilder(builder); err != nil {
 		return errors.Wrapf(err, "failed to permanent delete GroupMember with userId=%s", userId)
 	}
 	return nil
@@ -693,7 +693,7 @@ func (s *SqlGroupStore) CreateGroupSyncable(groupSyncable *model.GroupSyncable) 
 			return nil, err
 		}
 
-		_, insertErr = s.GetMasterX().NamedExec(`INSERT INTO GroupTeams
+		_, insertErr = s.GetMaster().NamedExec(`INSERT INTO GroupTeams
 			(GroupId, AutoAdd, SchemeAdmin, CreateAt, DeleteAt, UpdateAt, TeamId)
 			VALUES
 			(:GroupId, :AutoAdd, :SchemeAdmin, :CreateAt, :DeleteAt, :UpdateAt, :TeamId)`, groupSyncableToGroupTeam(groupSyncable))
@@ -703,7 +703,7 @@ func (s *SqlGroupStore) CreateGroupSyncable(groupSyncable *model.GroupSyncable) 
 		if err != nil {
 			return nil, err
 		}
-		_, insertErr = s.GetMasterX().NamedExec(`INSERT INTO GroupChannels
+		_, insertErr = s.GetMaster().NamedExec(`INSERT INTO GroupChannels
 			(GroupId, AutoAdd, SchemeAdmin, CreateAt, DeleteAt, UpdateAt, ChannelId)
 			VALUES
 			(:GroupId, :AutoAdd, :SchemeAdmin, :CreateAt, :DeleteAt, :UpdateAt, :ChannelId)`, groupSyncableToGroupChannel(groupSyncable))
@@ -738,11 +738,11 @@ func (s *SqlGroupStore) getGroupSyncable(groupID string, syncableID string, sync
 	switch syncableType {
 	case model.GroupSyncableTypeTeam:
 		var team groupTeam
-		err = s.GetReplicaX().Get(&team, `SELECT * FROM GroupTeams WHERE GroupId=? AND TeamId=?`, groupID, syncableID)
+		err = s.GetReplica().Get(&team, `SELECT * FROM GroupTeams WHERE GroupId=? AND TeamId=?`, groupID, syncableID)
 		result = &team
 	case model.GroupSyncableTypeChannel:
 		var ch groupChannel
-		err = s.GetReplicaX().Get(&ch, `SELECT * FROM GroupChannels WHERE GroupId=? AND ChannelId=?`, groupID, syncableID)
+		err = s.GetReplica().Get(&ch, `SELECT * FROM GroupChannels WHERE GroupId=? AND ChannelId=?`, groupID, syncableID)
 		result = &ch
 	}
 
@@ -798,7 +798,7 @@ func (s *SqlGroupStore) GetAllGroupSyncablesByGroupId(groupID string, syncableTy
 				GroupId = ? AND GroupTeams.DeleteAt = 0`
 
 		results := []*groupTeamJoin{}
-		err := s.GetReplicaX().Select(&results, sqlQuery, groupID)
+		err := s.GetReplica().Select(&results, sqlQuery, groupID)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to find GroupTeams with groupId=%s", groupID)
 		}
@@ -834,7 +834,7 @@ func (s *SqlGroupStore) GetAllGroupSyncablesByGroupId(groupID string, syncableTy
 				GroupId = ? AND GroupChannels.DeleteAt = 0`
 
 		results := []*groupChannelJoin{}
-		err := s.GetReplicaX().Select(&results, sqlQuery, groupID)
+		err := s.GetReplica().Select(&results, sqlQuery, groupID)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to find GroupChannels with groupId=%s", groupID)
 		}
@@ -885,7 +885,7 @@ func (s *SqlGroupStore) UpdateGroupSyncable(groupSyncable *model.GroupSyncable) 
 
 	switch groupSyncable.Type {
 	case model.GroupSyncableTypeTeam:
-		_, err = s.GetMasterX().NamedExec(`UPDATE GroupTeams
+		_, err = s.GetMaster().NamedExec(`UPDATE GroupTeams
 			SET AutoAdd=:AutoAdd, SchemeAdmin=:SchemeAdmin, CreateAt=:CreateAt,
 				DeleteAt=:DeleteAt, UpdateAt=:UpdateAt
 			WHERE GroupId=:GroupId AND TeamId=:TeamId`, groupSyncableToGroupTeam(groupSyncable))
@@ -897,7 +897,7 @@ func (s *SqlGroupStore) UpdateGroupSyncable(groupSyncable *model.GroupSyncable) 
 			return nil, channelErr
 		}
 
-		_, err = s.GetMasterX().NamedExec(`UPDATE GroupChannels
+		_, err = s.GetMaster().NamedExec(`UPDATE GroupChannels
 			SET AutoAdd=:AutoAdd, SchemeAdmin=:SchemeAdmin, CreateAt=:CreateAt,
 				DeleteAt=:DeleteAt, UpdateAt=:UpdateAt
 			WHERE GroupId=:GroupId AND ChannelId=:ChannelId`, groupSyncableToGroupChannel(groupSyncable))
@@ -933,12 +933,12 @@ func (s *SqlGroupStore) DeleteGroupSyncable(groupID string, syncableID string, s
 
 	switch groupSyncable.Type {
 	case model.GroupSyncableTypeTeam:
-		_, err = s.GetMasterX().NamedExec(`UPDATE GroupTeams
+		_, err = s.GetMaster().NamedExec(`UPDATE GroupTeams
 			SET AutoAdd=:AutoAdd, SchemeAdmin=:SchemeAdmin, CreateAt=:CreateAt,
 				DeleteAt=:DeleteAt, UpdateAt=:UpdateAt
 			WHERE GroupId=:GroupId AND TeamId=:TeamId`, groupSyncableToGroupTeam(groupSyncable))
 	case model.GroupSyncableTypeChannel:
-		_, err = s.GetMasterX().NamedExec(`UPDATE GroupChannels
+		_, err = s.GetMaster().NamedExec(`UPDATE GroupChannels
 			SET AutoAdd=:AutoAdd, SchemeAdmin=:SchemeAdmin, CreateAt=:CreateAt,
 				DeleteAt=:DeleteAt, UpdateAt=:UpdateAt
 			WHERE GroupId=:GroupId AND ChannelId=:ChannelId`, groupSyncableToGroupChannel(groupSyncable))
@@ -982,7 +982,7 @@ func (s *SqlGroupStore) TeamMembersToAdd(since int64, teamID *string, includeRem
 
 	teamMembers := []*model.UserTeamIDPair{}
 
-	if err := s.GetMasterX().SelectBuilder(&teamMembers, builder); err != nil {
+	if err := s.GetMaster().SelectBuilder(&teamMembers, builder); err != nil {
 		return nil, errors.Wrap(err, "failed to find UserTeamIDPairs")
 	}
 
@@ -1021,7 +1021,7 @@ func (s *SqlGroupStore) ChannelMembersToAdd(since int64, channelID *string, incl
 
 	channelMembers := []*model.UserChannelIDPair{}
 
-	if err := s.GetMasterX().SelectBuilder(&channelMembers, builder); err != nil {
+	if err := s.GetMaster().SelectBuilder(&channelMembers, builder); err != nil {
 		return nil, errors.Wrap(err, "failed to find UserChannelIDPairs")
 	}
 
@@ -1086,7 +1086,7 @@ func (s *SqlGroupStore) TeamMembersToRemove(teamID *string) ([]*model.TeamMember
 
 	teamMembers := []*model.TeamMember{}
 
-	if err := s.GetReplicaX().SelectBuilder(&teamMembers, builder); err != nil {
+	if err := s.GetReplica().SelectBuilder(&teamMembers, builder); err != nil {
 		return nil, errors.Wrap(err, "failed to find TeamMembers")
 	}
 
@@ -1097,7 +1097,7 @@ func (s *SqlGroupStore) CountGroupsByChannel(channelId string, opts model.GroupS
 	builder := s.groupsBySyncableBaseQuery(model.GroupSyncableTypeChannel, selectCountGroups, channelId, opts)
 
 	var count int64
-	if err := s.GetReplicaX().GetBuilder(&count, builder); err != nil {
+	if err := s.GetReplica().GetBuilder(&count, builder); err != nil {
 		return int64(0), errors.Wrapf(err, "failed to count Groups by channel with channelId=%s", channelId)
 	}
 
@@ -1209,7 +1209,7 @@ func (s *SqlGroupStore) GetGroupsByChannel(channelId string, opts model.GroupSea
 	}
 
 	groups := groupsWithSchemeAdmin{}
-	if err := s.GetReplicaX().SelectBuilder(&groups, builder); err != nil {
+	if err := s.GetReplica().SelectBuilder(&groups, builder); err != nil {
 		return nil, errors.Wrapf(err, "failed to find Groups with channelId=%s", channelId)
 	}
 
@@ -1266,7 +1266,7 @@ func (s *SqlGroupStore) ChannelMembersToRemove(channelID *string) ([]*model.Chan
 
 	channelMembers := []*model.ChannelMember{}
 
-	if err := s.GetReplicaX().SelectBuilder(&channelMembers, builder); err != nil {
+	if err := s.GetReplica().SelectBuilder(&channelMembers, builder); err != nil {
 		return nil, errors.Wrap(err, "failed to find ChannelMembers")
 	}
 
@@ -1390,7 +1390,7 @@ func (s *SqlGroupStore) CountGroupsByTeam(teamId string, opts model.GroupSearchO
 	builder := s.groupsBySyncableBaseQuery(model.GroupSyncableTypeTeam, selectCountGroups, teamId, opts)
 
 	var count int64
-	if err := s.GetReplicaX().GetBuilder(&count, builder); err != nil {
+	if err := s.GetReplica().GetBuilder(&count, builder); err != nil {
 		return int64(0), errors.Wrapf(err, "failed to count Groups with teamId=%s", teamId)
 	}
 
@@ -1406,7 +1406,7 @@ func (s *SqlGroupStore) GetGroupsByTeam(teamId string, opts model.GroupSearchOpt
 	}
 
 	groups := groupsWithSchemeAdmin{}
-	if err := s.GetReplicaX().SelectBuilder(&groups, builder); err != nil {
+	if err := s.GetReplica().SelectBuilder(&groups, builder); err != nil {
 		return nil, errors.Wrapf(err, "failed to find Groups with teamId=%s", teamId)
 	}
 
@@ -1423,7 +1423,7 @@ func (s *SqlGroupStore) GetGroupsAssociatedToChannelsByTeam(teamId string, opts 
 
 	tgroups := groupsAssociatedToChannelWithSchemeAdmin{}
 
-	if err := s.GetReplicaX().SelectBuilder(&tgroups, builder); err != nil {
+	if err := s.GetReplica().SelectBuilder(&tgroups, builder); err != nil {
 		return nil, errors.Wrapf(err, "failed to find Groups with teamId=%s", teamId)
 	}
 
@@ -1627,7 +1627,7 @@ func (s *SqlGroupStore) GetGroups(page, perPage int, opts model.GroupSearchOpts,
 		return nil, errors.Wrap(err, "get_groups_tosql")
 	}
 
-	if err = s.GetReplicaX().Select(&groupsVar, queryString, args...); err != nil {
+	if err = s.GetReplica().Select(&groupsVar, queryString, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to find Groups")
 	}
 
@@ -1684,7 +1684,7 @@ func (s *SqlGroupStore) TeamMembersMinusGroupMembers(teamID string, groupIDs []s
 	builder = builder.OrderBy("Users.Username ASC").Limit(uint64(perPage)).Offset(uint64(page * perPage))
 
 	users := []*model.UserWithGroups{}
-	if err := s.GetReplicaX().SelectBuilder(&users, builder); err != nil {
+	if err := s.GetReplica().SelectBuilder(&users, builder); err != nil {
 		return nil, errors.Wrap(err, "failed to find UserWithGroups")
 	}
 
@@ -1700,7 +1700,7 @@ func (s *SqlGroupStore) CountTeamMembersMinusGroupMembers(teamID string, groupID
 	}
 
 	var count int64
-	if err := s.GetReplicaX().Get(&count, queryString, args...); err != nil {
+	if err := s.GetReplica().Get(&count, queryString, args...); err != nil {
 		return 0, errors.Wrap(err, "failed to count TeamMembers minus GroupMembers")
 	}
 
@@ -1756,7 +1756,7 @@ func (s *SqlGroupStore) ChannelMembersMinusGroupMembers(channelID string, groupI
 	builder = builder.OrderBy("Users.Username ASC").Limit(uint64(perPage)).Offset(uint64(page * perPage))
 
 	users := []*model.UserWithGroups{}
-	if err := s.GetReplicaX().SelectBuilder(&users, builder); err != nil {
+	if err := s.GetReplica().SelectBuilder(&users, builder); err != nil {
 		return nil, errors.Wrap(err, "failed to find UserWithGroups")
 	}
 
@@ -1772,7 +1772,7 @@ func (s *SqlGroupStore) CountChannelMembersMinusGroupMembers(channelID string, g
 	}
 
 	var count int64
-	if err := s.GetReplicaX().Get(&count, queryString, args...); err != nil {
+	if err := s.GetReplica().Get(&count, queryString, args...); err != nil {
 		return 0, errors.Wrap(err, "failed to count ChannelMembers")
 	}
 
@@ -1796,7 +1796,7 @@ func (s *SqlGroupStore) AdminRoleGroupsForSyncableMember(userID, syncableID stri
 			AND Group%[1]ss.DeleteAt = 0
 			AND Group%[1]ss.SchemeAdmin = TRUE`, syncableType)
 
-	err := s.GetReplicaX().Select(&groupIds, query, userID, syncableID)
+	err := s.GetReplica().Select(&groupIds, query, userID, syncableID)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find Group ids")
 	}
@@ -1810,7 +1810,7 @@ func (s *SqlGroupStore) PermittedSyncableAdmins(syncableID string, syncableType 
 		Join(fmt.Sprintf("GroupMembers ON GroupMembers.GroupId = Group%ss.GroupId AND Group%[1]ss.SchemeAdmin = TRUE AND GroupMembers.DeleteAt = 0", syncableType.String())).Where(fmt.Sprintf("Group%[1]ss.%[1]sId = ?", syncableType.String()), syncableID)
 
 	var userIDs []string
-	if err := s.GetMasterX().SelectBuilder(&userIDs, builder); err != nil {
+	if err := s.GetMaster().SelectBuilder(&userIDs, builder); err != nil {
 		return nil, errors.Wrapf(err, "failed to find User ids")
 	}
 
@@ -1849,7 +1849,7 @@ func (s *SqlGroupStore) DistinctGroupMemberCountForSource(source model.GroupSour
 		Where(sq.Eq{"UserGroups.Source": source, "GroupMembers.DeleteAt": 0})
 
 	var count int64
-	if err := s.GetReplicaX().GetBuilder(&count, builder); err != nil {
+	if err := s.GetReplica().GetBuilder(&count, builder); err != nil {
 		return 0, errors.Wrapf(err, "failed to select distinct groupmember count for source %q", source)
 	}
 
@@ -1877,7 +1877,7 @@ func (s *SqlGroupStore) countTableWithSelectAndWhere(selectStr, tableName string
 	}
 
 	var count int64
-	err = s.GetReplicaX().Get(&count, sql, args...)
+	err = s.GetReplica().Get(&count, sql, args...)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to count from table %s", tableName)
 	}
@@ -1891,7 +1891,7 @@ func (s *SqlGroupStore) UpsertMembers(groupID string, userIDs []string) ([]*mode
 		return nil, err
 	}
 
-	if _, err = s.GetMasterX().Exec(query, args...); err != nil {
+	if _, err = s.GetMaster().Exec(query, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to save GroupMember")
 	}
 
@@ -1901,7 +1901,7 @@ func (s *SqlGroupStore) UpsertMembers(groupID string, userIDs []string) ([]*mode
 func (s *SqlGroupStore) buildUpsertMembersQuery(groupID string, userIDs []string) (members []*model.GroupMember, query string, args []any, err error) {
 	var retrievedGroup model.Group
 	// Check Group exists
-	if err = s.GetReplicaX().Get(&retrievedGroup, "SELECT * FROM UserGroups WHERE Id = ?", groupID); err != nil {
+	if err = s.GetReplica().Get(&retrievedGroup, "SELECT * FROM UserGroups WHERE Id = ?", groupID); err != nil {
 		err = errors.Wrapf(err, "failed to get UserGroup with groupId=%s", groupID)
 		return
 	}
@@ -1944,7 +1944,7 @@ func (s *SqlGroupStore) DeleteMembers(groupID string, userIDs []string) ([]*mode
 		return nil, err
 	}
 
-	if _, err = s.GetMasterX().Exec(query, args...); err != nil {
+	if _, err = s.GetMaster().Exec(query, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to delete GroupMembers")
 	}
 	return members, err
@@ -1964,7 +1964,7 @@ func (s *SqlGroupStore) buildDeleteMembersQuery(groupID string, userIDs []string
 		return
 	}
 
-	err = s.GetReplicaX().Select(&members, membersSelectQuery, membersSelectArgs...)
+	err = s.GetReplica().Select(&members, membersSelectQuery, membersSelectArgs...)
 	if err != nil {
 		return
 	}

--- a/server/channels/store/sqlstore/integrity.go
+++ b/server/channels/store/sqlstore/integrity.go
@@ -57,7 +57,7 @@ func getOrphanedRecords(ss *SqlStore, cfg relationalCheckConfig) ([]model.Orphan
 		return nil, err
 	}
 
-	err = ss.GetMasterX().Select(&records, query, args...)
+	err = ss.GetMaster().Select(&records, query, args...)
 	return records, err
 }
 

--- a/server/channels/store/sqlstore/integrity_test.go
+++ b/server/channels/store/sqlstore/integrity_test.go
@@ -415,7 +415,7 @@ func TestCheckParentChildIntegrity(t *testing.T) {
 func TestCheckChannelsCommandWebhooksIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkChannelsCommandWebhooksIntegrity(store)
@@ -442,7 +442,7 @@ func TestCheckChannelsCommandWebhooksIntegrity(t *testing.T) {
 func TestCheckChannelsChannelMemberHistoryIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkChannelsChannelMemberHistoryIntegrity(store)
@@ -473,7 +473,7 @@ func TestCheckChannelsChannelMemberHistoryIntegrity(t *testing.T) {
 func TestCheckChannelsChannelMembersIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkChannelsChannelMembersIntegrity(store)
@@ -501,7 +501,7 @@ func TestCheckChannelsChannelMembersIntegrity(t *testing.T) {
 func TestCheckChannelsIncomingWebhooksIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkChannelsIncomingWebhooksIntegrity(store)
@@ -529,7 +529,7 @@ func TestCheckChannelsIncomingWebhooksIntegrity(t *testing.T) {
 func TestCheckChannelsOutgoingWebhooksIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkChannelsOutgoingWebhooksIntegrity(store)
@@ -559,7 +559,7 @@ func TestCheckChannelsOutgoingWebhooksIntegrity(t *testing.T) {
 func TestCheckChannelsPostsIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkChannelsPostsIntegrity(store)
@@ -586,7 +586,7 @@ func TestCheckChannelsPostsIntegrity(t *testing.T) {
 func TestCheckCommandsCommandWebhooksIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkCommandsCommandWebhooksIntegrity(store)
@@ -614,7 +614,7 @@ func TestCheckCommandsCommandWebhooksIntegrity(t *testing.T) {
 func TestCheckPostsFileInfoIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkPostsFileInfoIntegrity(store)
@@ -642,7 +642,7 @@ func TestCheckPostsFileInfoIntegrity(t *testing.T) {
 func TestCheckPostsPostsRootIdIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkPostsPostsRootIdIntegrity(store)
@@ -675,7 +675,7 @@ func TestCheckPostsPostsRootIdIntegrity(t *testing.T) {
 func TestCheckPostsReactionsIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkPostsReactionsIntegrity(store)
@@ -702,7 +702,7 @@ func TestCheckPostsReactionsIntegrity(t *testing.T) {
 func TestCheckSchemesChannelsIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkSchemesChannelsIntegrity(store)
@@ -733,7 +733,7 @@ func TestCheckSchemesChannelsIntegrity(t *testing.T) {
 func TestCheckSchemesTeamsIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkSchemesTeamsIntegrity(store)
@@ -764,7 +764,7 @@ func TestCheckSchemesTeamsIntegrity(t *testing.T) {
 func TestCheckSessionsAuditsIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkSessionsAuditsIntegrity(store)
@@ -795,7 +795,7 @@ func TestCheckSessionsAuditsIntegrity(t *testing.T) {
 func TestCheckTeamsChannelsIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkTeamsChannelsIntegrity(store)
@@ -871,7 +871,7 @@ func TestCheckTeamsChannelsIntegrity(t *testing.T) {
 func TestCheckTeamsCommandsIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkTeamsCommandsIntegrity(store)
@@ -899,7 +899,7 @@ func TestCheckTeamsCommandsIntegrity(t *testing.T) {
 func TestCheckTeamsIncomingWebhooksIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkTeamsIncomingWebhooksIntegrity(store)
@@ -927,7 +927,7 @@ func TestCheckTeamsIncomingWebhooksIntegrity(t *testing.T) {
 func TestCheckTeamsOutgoingWebhooksIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkTeamsOutgoingWebhooksIntegrity(store)
@@ -955,7 +955,7 @@ func TestCheckTeamsOutgoingWebhooksIntegrity(t *testing.T) {
 func TestCheckTeamsTeamMembersIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkTeamsTeamMembersIntegrity(store)
@@ -983,7 +983,7 @@ func TestCheckTeamsTeamMembersIntegrity(t *testing.T) {
 func TestCheckUsersAuditsIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersAuditsIntegrity(store)
@@ -1013,7 +1013,7 @@ func TestCheckUsersAuditsIntegrity(t *testing.T) {
 func TestCheckUsersCommandWebhooksIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersCommandWebhooksIntegrity(store)
@@ -1041,7 +1041,7 @@ func TestCheckUsersCommandWebhooksIntegrity(t *testing.T) {
 func TestCheckUsersChannelsIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersChannelsIntegrity(store)
@@ -1068,7 +1068,7 @@ func TestCheckUsersChannelsIntegrity(t *testing.T) {
 func TestCheckUsersChannelMemberHistoryIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersChannelMemberHistoryIntegrity(store)
@@ -1098,7 +1098,7 @@ func TestCheckUsersChannelMemberHistoryIntegrity(t *testing.T) {
 func TestCheckUsersChannelMembersIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersChannelMembersIntegrity(store)
@@ -1128,7 +1128,7 @@ func TestCheckUsersChannelMembersIntegrity(t *testing.T) {
 func TestCheckUsersCommandsIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersCommandsIntegrity(store)
@@ -1156,7 +1156,7 @@ func TestCheckUsersCommandsIntegrity(t *testing.T) {
 func TestCheckUsersCompliancesIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersCompliancesIntegrity(store)
@@ -1186,7 +1186,7 @@ func TestCheckUsersCompliancesIntegrity(t *testing.T) {
 func TestCheckUsersEmojiIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersEmojiIntegrity(store)
@@ -1216,7 +1216,7 @@ func TestCheckUsersEmojiIntegrity(t *testing.T) {
 func TestCheckUsersFileInfoIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersFileInfoIntegrity(store)
@@ -1246,7 +1246,7 @@ func TestCheckUsersFileInfoIntegrity(t *testing.T) {
 func TestCheckUsersIncomingWebhooksIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersIncomingWebhooksIntegrity(store)
@@ -1274,7 +1274,7 @@ func TestCheckUsersIncomingWebhooksIntegrity(t *testing.T) {
 func TestCheckUsersOAuthAccessDataIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersOAuthAccessDataIntegrity(store)
@@ -1304,7 +1304,7 @@ func TestCheckUsersOAuthAccessDataIntegrity(t *testing.T) {
 func TestCheckUsersOAuthAppsIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersOAuthAppsIntegrity(store)
@@ -1334,7 +1334,7 @@ func TestCheckUsersOAuthAppsIntegrity(t *testing.T) {
 func TestCheckUsersOAuthAuthDataIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersOAuthAuthDataIntegrity(store)
@@ -1364,7 +1364,7 @@ func TestCheckUsersOAuthAuthDataIntegrity(t *testing.T) {
 func TestCheckUsersOutgoingWebhooksIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersOutgoingWebhooksIntegrity(store)
@@ -1392,7 +1392,7 @@ func TestCheckUsersOutgoingWebhooksIntegrity(t *testing.T) {
 func TestCheckUsersPostsIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersPostsIntegrity(store)
@@ -1419,7 +1419,7 @@ func TestCheckUsersPostsIntegrity(t *testing.T) {
 func TestCheckUsersPreferencesIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersPreferencesIntegrity(store)
@@ -1465,7 +1465,7 @@ func TestCheckUsersPreferencesIntegrity(t *testing.T) {
 func TestCheckUsersReactionsIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersReactionsIntegrity(store)
@@ -1494,7 +1494,7 @@ func TestCheckUsersReactionsIntegrity(t *testing.T) {
 func TestCheckUsersSessionsIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersSessionsIntegrity(store)
@@ -1522,7 +1522,7 @@ func TestCheckUsersSessionsIntegrity(t *testing.T) {
 func TestCheckUsersStatusIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersStatusIntegrity(store)
@@ -1551,7 +1551,7 @@ func TestCheckUsersStatusIntegrity(t *testing.T) {
 func TestCheckUsersTeamMembersIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersTeamMembersIntegrity(store)
@@ -1581,7 +1581,7 @@ func TestCheckUsersTeamMembersIntegrity(t *testing.T) {
 func TestCheckUsersUserAccessTokensIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkUsersUserAccessTokensIntegrity(store)
@@ -1611,7 +1611,7 @@ func TestCheckUsersUserAccessTokensIntegrity(t *testing.T) {
 func TestCheckThreadsTeamsIntegrity(t *testing.T) {
 	StoreTest(t, func(t *testing.T, rctx request.CTX, ss store.Store) {
 		store := ss.(*SqlStore)
-		dbmap := store.GetMasterX()
+		dbmap := store.GetMaster()
 
 		t.Run("should generate a report with no records", func(t *testing.T) {
 			result := checkThreadsTeamsIntegrity(store)

--- a/server/channels/store/sqlstore/license_store.go
+++ b/server/channels/store/sqlstore/license_store.go
@@ -47,7 +47,7 @@ func (ls SqlLicenseStore) Save(license *model.LicenseRecord) error {
 		return errors.Wrap(err, "license_tosql")
 	}
 
-	if _, err := ls.GetMasterX().Exec(queryString, args...); err != nil {
+	if _, err := ls.GetMaster().Exec(queryString, args...); err != nil {
 		return errors.Wrapf(err, "failed to insert License with licenseId=%s", license.Id)
 	}
 
@@ -86,7 +86,7 @@ func (ls SqlLicenseStore) GetAll() ([]*model.LicenseRecord, error) {
 	}
 
 	licenses := []*model.LicenseRecord{}
-	if err := ls.GetReplicaX().Select(&licenses, queryString); err != nil {
+	if err := ls.GetReplica().Select(&licenses, queryString); err != nil {
 		return nil, errors.Wrap(err, "failed to fetch licenses")
 	}
 

--- a/server/channels/store/sqlstore/link_metadata_store.go
+++ b/server/channels/store/sqlstore/link_metadata_store.go
@@ -52,7 +52,7 @@ func (s SqlLinkMetadataStore) Save(metadata *model.LinkMetadata) (*model.LinkMet
 		return nil, errors.Wrap(err, "metadata_tosql")
 	}
 
-	_, err = s.GetMasterX().Exec(q, args...)
+	_, err = s.GetMaster().Exec(q, args...)
 	if err != nil && !IsUniqueConstraintError(err, []string{"PRIMARY", "linkmetadata_pkey"}) {
 		return nil, errors.Wrap(err, "could not save link metadata")
 	}
@@ -70,7 +70,7 @@ func (s SqlLinkMetadataStore) Get(url string, timestamp int64) (*model.LinkMetad
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create query with querybuilder")
 	}
-	err = s.GetReplicaX().Get(&metadata, query, args...)
+	err = s.GetReplica().Get(&metadata, query, args...)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("LinkMetadata", "url="+url)

--- a/server/channels/store/sqlstore/migrate.go
+++ b/server/channels/store/sqlstore/migrate.go
@@ -141,7 +141,7 @@ func (ss *SqlStore) initMorph(dryRun bool) (*morph.Morph, error) {
 		}
 		defer db.Close()
 	case model.DatabaseDriverPostgres:
-		driver, err = ps.WithInstance(ss.GetMasterX().DB.DB)
+		driver, err = ps.WithInstance(ss.GetMaster().DB.DB)
 	default:
 		err = fmt.Errorf("unsupported database type %s for migration", ss.DriverName())
 	}

--- a/server/channels/store/sqlstore/notify_admin_store.go
+++ b/server/channels/store/sqlstore/notify_admin_store.go
@@ -25,7 +25,7 @@ func newSqlNotifyAdminStore(sqlStore *SqlStore) store.NotifyAdminStore {
 
 func (s SqlNotifyAdminStore) insert(data *model.NotifyAdminData) (sql.Result, error) {
 	query := `INSERT INTO NotifyAdmin (UserId, CreateAt, RequiredPlan, RequiredFeature, Trial) VALUES (:UserId, :CreateAt, :RequiredPlan, :RequiredFeature, :Trial)`
-	return s.GetMasterX().NamedExec(query, data)
+	return s.GetMaster().NamedExec(query, data)
 }
 
 func (s SqlNotifyAdminStore) Save(data *model.NotifyAdminData) (*model.NotifyAdminData, error) {
@@ -54,7 +54,7 @@ func (s SqlNotifyAdminStore) GetDataByUserIdAndFeature(userId string, feature mo
 		return nil, errors.Wrap(err, "could not build sql query to get all notification data by user id and required feature")
 	}
 
-	if err := s.GetReplicaX().Select(&data, query, args...); err != nil {
+	if err := s.GetReplica().Select(&data, query, args...); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("NotifyAdmin", fmt.Sprintf("user id: %s and required feature: %s", userId, feature))
 		}
@@ -75,21 +75,21 @@ func (s SqlNotifyAdminStore) Get(trial bool) ([]*model.NotifyAdminData, error) {
 		return nil, errors.Wrap(err, "could not build sql query to get all notifcation data")
 	}
 
-	if err := s.GetReplicaX().Select(&data, query, args...); err != nil {
+	if err := s.GetReplica().Select(&data, query, args...); err != nil {
 		return nil, errors.Wrap(err, "notifcation data")
 	}
 	return data, nil
 }
 
 func (s SqlNotifyAdminStore) DeleteBefore(trial bool, now int64) error {
-	if _, err := s.GetMasterX().Exec("DELETE FROM NotifyAdmin WHERE Trial = ? AND CreateAt < ? AND SentAt IS NULL", trial, now); err != nil {
+	if _, err := s.GetMaster().Exec("DELETE FROM NotifyAdmin WHERE Trial = ? AND CreateAt < ? AND SentAt IS NULL", trial, now); err != nil {
 		return errors.Wrapf(err, "failed to remove all notification data with trial=%t", trial)
 	}
 	return nil
 }
 
 func (s SqlNotifyAdminStore) Update(userId string, requiredPlan string, requiredFeature model.MattermostFeature, now int64) error {
-	if _, err := s.GetMasterX().Exec("UPDATE NotifyAdmin SET SentAt = ? WHERE UserId = ? AND RequiredPlan = ? AND RequiredFeature = ?", now, userId, requiredPlan, requiredFeature); err != nil {
+	if _, err := s.GetMaster().Exec("UPDATE NotifyAdmin SET SentAt = ? WHERE UserId = ? AND RequiredPlan = ? AND RequiredFeature = ?", now, userId, requiredPlan, requiredFeature); err != nil {
 		return errors.Wrapf(err, "failed to update SentAt for userId=%s and requiredPlan=%s", userId, requiredPlan)
 	}
 	return nil

--- a/server/channels/store/sqlstore/post_acknowledgements_store.go
+++ b/server/channels/store/sqlstore/post_acknowledgements_store.go
@@ -32,7 +32,7 @@ func (s *SqlPostAcknowledgementStore) Get(postID, userID string) (*model.PostAck
 		})
 
 	var acknowledgement model.PostAcknowledgement
-	err := s.GetReplicaX().GetBuilder(&acknowledgement, query)
+	err := s.GetReplica().GetBuilder(&acknowledgement, query)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("PostAcknowledgement", postID)
@@ -59,7 +59,7 @@ func (s *SqlPostAcknowledgementStore) Save(postID, userID string, acknowledgedAt
 		return nil, err
 	}
 
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
@@ -95,7 +95,7 @@ func (s *SqlPostAcknowledgementStore) Save(postID, userID string, acknowledgedAt
 }
 
 func (s *SqlPostAcknowledgementStore) Delete(acknowledgement *model.PostAcknowledgement) error {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
@@ -138,7 +138,7 @@ func (s *SqlPostAcknowledgementStore) GetForPost(postID string) ([]*model.PostAc
 			sq.Eq{"PostId": postID},
 		})
 
-	err := s.GetReplicaX().SelectBuilder(&acknowledgements, query)
+	err := s.GetReplica().SelectBuilder(&acknowledgements, query)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get PostAcknowledgements for postID=%s", postID)
 	}
@@ -165,7 +165,7 @@ func (s *SqlPostAcknowledgementStore) GetForPosts(postIds []string) ([]*model.Po
 			})
 
 		var acknowledgementsBatch []*model.PostAcknowledgement
-		err := s.GetReplicaX().SelectBuilder(&acknowledgementsBatch, query)
+		err := s.GetReplica().SelectBuilder(&acknowledgementsBatch, query)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get PostAcknowledgements for post list")
 		}

--- a/server/channels/store/sqlstore/post_priority_store.go
+++ b/server/channels/store/sqlstore/post_priority_store.go
@@ -27,7 +27,7 @@ func (s *SqlPostPriorityStore) GetForPost(postId string) (*model.PostPriority, e
 		Where(sq.Eq{"PostId": postId})
 
 	var postPriority model.PostPriority
-	err := s.GetReplicaX().GetBuilder(&postPriority, query)
+	err := s.GetReplica().GetBuilder(&postPriority, query)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (s *SqlPostPriorityStore) GetForPosts(postIds []string) ([]*model.PostPrior
 			Where(sq.Eq{"PostId": postIds[i:j]})
 
 		var priorityBatch []*model.PostPriority
-		err := s.GetReplicaX().SelectBuilder(&priority, query)
+		err := s.GetReplica().SelectBuilder(&priority, query)
 
 		if err != nil {
 			return nil, err

--- a/server/channels/store/sqlstore/post_store.go
+++ b/server/channels/store/sqlstore/post_store.go
@@ -218,7 +218,7 @@ func (s *SqlPostStore) SaveMultiple(posts []*model.Post) ([]*model.Post, int, er
 		return nil, -1, errors.Wrap(err, "post_tosql")
 	}
 
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return posts, -1, errors.Wrap(err, "begin_transaction")
 	}
@@ -248,7 +248,7 @@ func (s *SqlPostStore) SaveMultiple(posts []*model.Post) ([]*model.Post, int, er
 	for channelId, count := range channelNewPosts {
 		countRoot := channelNewRootPosts[channelId]
 
-		if _, err = s.GetMasterX().NamedExec(`UPDATE Channels
+		if _, err = s.GetMaster().NamedExec(`UPDATE Channels
 			SET LastPostAt = GREATEST(:lastpostat, LastPostAt),
 				LastRootPostAt = GREATEST(:lastrootpostat, LastRootPostAt),
 				TotalMsgCount = TotalMsgCount + :count,
@@ -265,7 +265,7 @@ func (s *SqlPostStore) SaveMultiple(posts []*model.Post) ([]*model.Post, int, er
 	}
 
 	for rootId := range rootIds {
-		if _, err = s.GetMasterX().Exec("UPDATE Posts SET UpdateAt = ? WHERE Id = ?", maxDateRootIds[rootId], rootId); err != nil {
+		if _, err = s.GetMaster().Exec("UPDATE Posts SET UpdateAt = ? WHERE Id = ?", maxDateRootIds[rootId], rootId); err != nil {
 			mlog.Warn("Error updating Post UpdateAt.", mlog.Err(err))
 		}
 	}
@@ -319,7 +319,7 @@ func (s *SqlPostStore) populateReplyCount(posts []*model.Post) error {
 	if err != nil {
 		return errors.Wrap(err, "post_tosql")
 	}
-	err = s.GetMasterX().Select(&countList, queryString, args...)
+	err = s.GetMaster().Select(&countList, queryString, args...)
 	if err != nil {
 		return errors.Wrap(err, "failed to count Posts")
 	}
@@ -356,7 +356,7 @@ func (s *SqlPostStore) Update(rctx request.CTX, newPost *model.Post, oldPost *mo
 		return nil, err
 	}
 
-	if _, err := s.GetMasterX().NamedExec(`UPDATE Posts
+	if _, err := s.GetMaster().NamedExec(`UPDATE Posts
 		SET CreateAt=:CreateAt,
 			UpdateAt=:UpdateAt,
 			EditAt=:EditAt,
@@ -381,12 +381,12 @@ func (s *SqlPostStore) Update(rctx request.CTX, newPost *model.Post, oldPost *mo
 	}
 
 	time := model.GetMillis()
-	if _, err := s.GetMasterX().Exec("UPDATE Channels SET LastPostAt = ?  WHERE Id = ? AND LastPostAt < ?", time, newPost.ChannelId, time); err != nil {
+	if _, err := s.GetMaster().Exec("UPDATE Channels SET LastPostAt = ?  WHERE Id = ? AND LastPostAt < ?", time, newPost.ChannelId, time); err != nil {
 		return nil, errors.Wrap(err, "failed to update lastpostat of channels")
 	}
 
 	if newPost.RootId != "" {
-		if _, err := s.GetMasterX().Exec("UPDATE Posts SET UpdateAt = ? WHERE Id = ? AND UpdateAt < ?", time, newPost.RootId, time); err != nil {
+		if _, err := s.GetMaster().Exec("UPDATE Posts SET UpdateAt = ? WHERE Id = ? AND UpdateAt < ?", time, newPost.RootId, time); err != nil {
 			return nil, errors.Wrap(err, "failed to update updateAt of posts")
 		}
 	}
@@ -400,7 +400,7 @@ func (s *SqlPostStore) Update(rctx request.CTX, newPost *model.Post, oldPost *mo
 	if err != nil {
 		return nil, errors.Wrap(err, "post_tosql")
 	}
-	_, err = s.GetMasterX().Exec(query, args...)
+	_, err = s.GetMaster().Exec(query, args...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to insert the old post")
 	}
@@ -418,7 +418,7 @@ func (s *SqlPostStore) OverwriteMultiple(posts []*model.Post) (_ []*model.Post, 
 		}
 	}
 
-	tx, err := s.GetMasterX().Beginx()
+	tx, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, -1, errors.Wrap(err, "begin_transaction")
 	}
@@ -538,7 +538,7 @@ func (s *SqlPostStore) getFlaggedPosts(userId, channelId, teamId string, offset 
 
 	queryParams = append(queryParams, limit, offset)
 
-	if err := s.GetReplicaX().Select(&posts, query, queryParams...); err != nil {
+	if err := s.GetReplica().Select(&posts, query, queryParams...); err != nil {
 		return nil, errors.Wrap(err, "failed to find Posts")
 	}
 
@@ -594,7 +594,7 @@ func (s *SqlPostStore) getPostWithCollapsedThreads(id, userID string, opts model
 		return nil, errors.Wrap(err, "getPostWithCollapsedThreads_ToSql2")
 	}
 
-	err = s.GetReplicaX().Get(&post, postFetchQuery, args...)
+	err = s.GetReplica().Get(&post, postFetchQuery, args...)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Post", id)
@@ -662,7 +662,7 @@ func (s *SqlPostStore) getPostWithCollapsedThreads(id, userID string, opts model
 	if err != nil {
 		return nil, errors.Wrap(err, "getPostWithCollapsedThreads_Tosql2")
 	}
-	err = s.GetReplicaX().Select(&posts, sql, args...)
+	err = s.GetReplica().Select(&posts, sql, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find Posts for thread %s", id)
 	}
@@ -810,7 +810,7 @@ func (s *SqlPostStore) Get(ctx context.Context, id string, opts model.GetPostsOp
 		}
 
 		posts := []*model.Post{}
-		err = s.GetReplicaX().Select(&posts, sql, args...)
+		err = s.GetReplica().Select(&posts, sql, args...)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to find Posts")
 		}
@@ -893,7 +893,7 @@ func (s *SqlPostStore) GetEtag(channelId string, allowFromCache, collapsedThread
 	sql, args := q.MustSql()
 
 	var et etagPosts
-	err := s.GetReplicaX().Get(&et, sql, args...)
+	err := s.GetReplica().Get(&et, sql, args...)
 	var result string
 	if err != nil {
 		result = fmt.Sprintf("%v.%v", model.CurrentVersion, model.GetMillis())
@@ -907,7 +907,7 @@ func (s *SqlPostStore) GetEtag(channelId string, allowFromCache, collapsedThread
 // Soft deletes a post
 // and cleans up the thread if it's a comment
 func (s *SqlPostStore) Delete(rctx request.CTX, postID string, time int64, deleteByID string) (err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
@@ -976,7 +976,7 @@ func (s *SqlPostStore) PermanentDelete(rctx request.CTX, postID string) (err err
 }
 
 func (s *SqlPostStore) permanentDelete(postIds []string) (err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
@@ -1017,7 +1017,7 @@ type postIds struct {
 
 func (s *SqlPostStore) permanentDeleteAllCommentByUser(userId string) (err error) {
 	results := []postIds{}
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
@@ -1068,7 +1068,7 @@ func (s *SqlPostStore) PermanentDeleteByUser(rctx request.CTX, userId string) er
 	count := 0
 	for {
 		var ids []string
-		err := s.GetMasterX().Select(&ids, "SELECT Id FROM Posts WHERE UserId = ? LIMIT 1000", userId)
+		err := s.GetMaster().Select(&ids, "SELECT Id FROM Posts WHERE UserId = ? LIMIT 1000", userId)
 		if err != nil {
 			return errors.Wrapf(err, "failed to find Posts with userId=%s", userId)
 		}
@@ -1096,7 +1096,7 @@ func (s *SqlPostStore) PermanentDeleteByUser(rctx request.CTX, userId string) er
 // deletes all reactions
 // no thread comment cleanup needed, since we are deleting threads and thread memberships
 func (s *SqlPostStore) PermanentDeleteByChannel(rctx request.CTX, channelId string) (err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
@@ -1233,7 +1233,7 @@ func (s *SqlPostStore) getPostsCollapsedThreads(options model.GetPostsOptions, s
 		Offset(uint64(offset)).
 		OrderBy("Posts.CreateAt DESC").ToSql()
 
-	err := s.GetReplicaX().Select(&posts, postFetchQuery, args...)
+	err := s.GetReplica().Select(&posts, postFetchQuery, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find Posts with channelId=%s", options.ChannelId)
 	}
@@ -1321,7 +1321,7 @@ func (s *SqlPostStore) getPostsSinceCollapsedThreads(options model.GetPostsSince
 		return nil, errors.Wrapf(err, "getPostsSinceCollapsedThreads_ToSql")
 	}
 
-	err = s.GetReplicaX().Select(&posts, postFetchQuery, args...)
+	err = s.GetReplica().Select(&posts, postFetchQuery, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find Posts with channelId=%s", options.ChannelId)
 	}
@@ -1396,7 +1396,7 @@ func (s *SqlPostStore) GetPostsSince(options model.GetPostsSinceOptions, allowFr
 
 		params = []any{options.Time, options.ChannelId}
 	}
-	err := s.GetReplicaX().Select(&posts, query, params...)
+	err := s.GetReplica().Select(&posts, query, params...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find Posts with channelId=%s", options.ChannelId)
 	}
@@ -1429,7 +1429,7 @@ func (s *SqlPostStore) HasAutoResponsePostByUserSince(options model.GetPostsSinc
 				LIMIT 1)`
 
 	var exist bool
-	err := s.GetReplicaX().Get(&exist, query, options.Time, options.ChannelId, userId, model.PostTypeAutoResponder)
+	err := s.GetReplica().Get(&exist, query, options.Time, options.ChannelId, userId, model.PostTypeAutoResponder)
 	if err != nil {
 		return false, errors.Wrapf(err,
 			"failed to check if autoresponse posts in channelId=%s for userId=%s since %s", options.ChannelId, userId, model.GetTimeForMillis(options.Time))
@@ -1476,7 +1476,7 @@ func (s *SqlPostStore) GetPostsSinceForSync(options model.GetPostsSinceForSyncOp
 	}
 
 	posts := []*model.Post{}
-	err = s.GetReplicaX().Select(&posts, queryString, args...)
+	err = s.GetReplica().Select(&posts, queryString, args...)
 	if err != nil {
 		return nil, cursor, errors.Wrapf(err, "error getting Posts with channelId=%s", options.ChannelId)
 	}
@@ -1510,7 +1510,7 @@ func (s *SqlPostStore) GetPostsByThread(threadId string, since int64) ([]*model.
 		Where(sq.GtOrEq{"CreateAt": since})
 
 	result := []*model.Post{}
-	err := s.GetReplicaX().SelectBuilder(&result, query)
+	err := s.GetReplica().SelectBuilder(&result, query)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch thread posts")
 	}
@@ -1588,7 +1588,7 @@ func (s *SqlPostStore) getPostsAround(before bool, options model.GetPostsOptions
 	if err != nil {
 		return nil, errors.Wrap(err, "post_tosql")
 	}
-	err = s.GetReplicaX().Select(&posts, queryString, args...)
+	err = s.GetReplica().Select(&posts, queryString, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find Posts with channelId=%s", options.ChannelId)
 	}
@@ -1626,7 +1626,7 @@ func (s *SqlPostStore) getPostsAround(before bool, options model.GetPostsOptions
 		if nErr != nil {
 			return nil, errors.Wrap(nErr, "post_tosql")
 		}
-		nErr = s.GetReplicaX().Select(&parents, rootQueryString, rootArgs...)
+		nErr = s.GetReplica().Select(&parents, rootQueryString, rootArgs...)
 		if nErr != nil {
 			return nil, errors.Wrapf(nErr, "failed to find Posts with channelId=%s", options.ChannelId)
 		}
@@ -1695,7 +1695,7 @@ func (s *SqlPostStore) getPostIdAroundTime(channelId string, time int64, before 
 	}
 
 	var postId string
-	if err := s.GetMasterX().Get(&postId, queryString, args...); err != nil {
+	if err := s.GetMaster().Get(&postId, queryString, args...); err != nil {
 		if err != sql.ErrNoRows {
 			return "", errors.Wrapf(err, "failed to get Post id with channelId=%s", channelId)
 		}
@@ -1736,7 +1736,7 @@ func (s *SqlPostStore) GetPostAfterTime(channelId string, time int64, collapsedT
 	}
 
 	var post model.Post
-	if err := s.GetMasterX().Get(&post, queryString, args...); err != nil {
+	if err := s.GetMaster().Get(&post, queryString, args...); err != nil {
 		if err != sql.ErrNoRows {
 			return nil, errors.Wrapf(err, "failed to get Post with channelId=%s", channelId)
 		}
@@ -1760,7 +1760,7 @@ func (s *SqlPostStore) getRootPosts(channelId string, offset int, limit int, ski
 		}
 	}
 
-	err := s.GetReplicaX().Select(&posts, fetchQuery, channelId, limit, offset)
+	err := s.GetReplica().Select(&posts, fetchQuery, channelId, limit, offset)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find Posts")
 	}
@@ -1793,7 +1793,7 @@ func (s *SqlPostStore) getParentsPosts(channelId string, offset int, limit int, 
 			LIMIT ? OFFSET ?) q
 		WHERE q.RootId != ''`
 
-	err := s.GetReplicaX().Select(&roots, rootQuery, channelId, limit, offset)
+	err := s.GetReplica().Select(&roots, rootQuery, channelId, limit, offset)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find Posts")
 	}
@@ -1836,7 +1836,7 @@ func (s *SqlPostStore) getParentsPosts(channelId string, offset int, limit int, 
 	}
 
 	posts := []*model.Post{}
-	err = s.GetReplicaX().Select(&posts, sql, args...)
+	err = s.GetReplica().Select(&posts, sql, args...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find Posts")
 	}
@@ -1862,7 +1862,7 @@ func (s *SqlPostStore) getParentsPostsPostgreSQL(channelId string, offset int, l
 		deleteAtQueryCondition, deleteAtSubQueryCondition = "", ""
 	}
 
-	err := s.GetReplicaX().Select(&posts,
+	err := s.GetReplica().Select(&posts,
 		`SELECT q2.*`+replyCountQuery+`
         FROM
             Posts q2
@@ -1913,7 +1913,7 @@ func (s *SqlPostStore) GetNthRecentPostTime(n int64) (int64, error) {
 	}
 
 	var createAt int64
-	if err := s.GetMasterX().Get(&createAt, query, queryArgs...); err != nil {
+	if err := s.GetMaster().Get(&createAt, query, queryArgs...); err != nil {
 		if err == sql.ErrNoRows {
 			return 0, store.NewErrNotFound("Post", "none")
 		}
@@ -2281,7 +2281,7 @@ func (s *SqlPostStore) AnalyticsUserCountsWithPostsByDay(teamId string) (model.A
 	args = append(args, start, end)
 
 	rows := model.AnalyticsRows{}
-	err := s.GetReplicaX().Select(
+	err := s.GetReplica().Select(
 		&rows,
 		query,
 		args...)
@@ -2349,7 +2349,7 @@ func (s *SqlPostStore) AnalyticsPostCountsByDay(options *model.AnalyticsPostCoun
 	args = append(args, end, start)
 
 	rows := model.AnalyticsRows{}
-	err := s.GetReplicaX().Select(
+	err := s.GetReplica().Select(
 		&rows,
 		query,
 		args...)
@@ -2409,7 +2409,7 @@ func (s *SqlPostStore) AnalyticsPostCount(options *model.PostCountOptions) (int6
 	}
 
 	var v int64
-	err = s.GetReplicaX().Get(&v, queryString, args...)
+	err = s.GetReplica().Get(&v, queryString, args...)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to count Posts")
 	}
@@ -2421,7 +2421,7 @@ func (s *SqlPostStore) GetPostsCreatedAt(channelId string, time int64) ([]*model
 	query := `SELECT * FROM Posts WHERE CreateAt = ? AND ChannelId = ?`
 
 	posts := []*model.Post{}
-	err := s.GetReplicaX().Select(&posts, query, time, channelId)
+	err := s.GetReplica().Select(&posts, query, time, channelId)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find Posts with channelId=%s", channelId)
 	}
@@ -2440,7 +2440,7 @@ func (s *SqlPostStore) GetPostsByIds(postIds []string) ([]*model.Post, error) {
 	}
 	posts := []*model.Post{}
 
-	err = s.GetReplicaX().Select(&posts, query, args...)
+	err = s.GetReplica().Select(&posts, query, args...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find Posts")
 	}
@@ -2466,7 +2466,7 @@ func (s *SqlPostStore) GetEditHistoryForPost(postId string) ([]*model.Post, erro
 	}
 
 	posts := []*model.Post{}
-	err = s.GetReplicaX().Select(&posts, queryString, args...)
+	err = s.GetReplica().Select(&posts, queryString, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting posts edit history with postId=%s", postId)
 	}
@@ -2559,7 +2559,7 @@ func (s *SqlPostStore) PermanentDeleteBatch(endTime int64, limit int64) (int64, 
 		query = "DELETE from Posts WHERE CreateAt < ? LIMIT ?"
 	}
 
-	sqlResult, err := s.GetMasterX().Exec(query, endTime, limit)
+	sqlResult, err := s.GetMaster().Exec(query, endTime, limit)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to delete Posts")
 	}
@@ -2573,7 +2573,7 @@ func (s *SqlPostStore) PermanentDeleteBatch(endTime int64, limit int64) (int64, 
 
 func (s *SqlPostStore) GetOldest() (*model.Post, error) {
 	var post model.Post
-	err := s.GetReplicaX().Get(&post, "SELECT * FROM Posts ORDER BY CreateAt LIMIT 1")
+	err := s.GetReplica().Get(&post, "SELECT * FROM Posts ORDER BY CreateAt LIMIT 1")
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Post", "none")
@@ -2591,7 +2591,7 @@ func (s *SqlPostStore) determineMaxPostSize() int {
 	if s.DriverName() == model.DatabaseDriverPostgres {
 		// The Post.Message column in Postgres has historically been VARCHAR(4000), but
 		// may be manually enlarged to support longer posts.
-		if err := s.GetReplicaX().Get(&maxPostSizeBytes, `
+		if err := s.GetReplica().Get(&maxPostSizeBytes, `
 			SELECT
 				COALESCE(character_maximum_length, 0)
 			FROM
@@ -2605,7 +2605,7 @@ func (s *SqlPostStore) determineMaxPostSize() int {
 	} else if s.DriverName() == model.DatabaseDriverMysql {
 		// The Post.Message column in MySQL has historically been TEXT, with a maximum
 		// limit of 65535.
-		if err := s.GetReplicaX().Get(&maxPostSizeBytes, `
+		if err := s.GetReplica().Get(&maxPostSizeBytes, `
 			SELECT
 				COALESCE(CHARACTER_MAXIMUM_LENGTH, 0)
 			FROM
@@ -2649,7 +2649,7 @@ func (s *SqlPostStore) GetMaxPostSize() int {
 func (s *SqlPostStore) GetParentsForExportAfter(limit int, afterId string, includeArchivedChannel bool) ([]*model.PostForExport, error) {
 	for {
 		rootIds := []string{}
-		err := s.GetReplicaX().Select(&rootIds,
+		err := s.GetReplica().Select(&rootIds,
 			`SELECT
 				Id
 			FROM
@@ -2780,7 +2780,7 @@ func (s *SqlPostStore) GetDirectPostParentsForExportAfter(limit int, afterId str
 		return nil, errors.Wrap(err, "post_tosql")
 	}
 
-	if err2 := s.GetReplicaX().Select(&result, queryString, args...); err2 != nil {
+	if err2 := s.GetReplica().Select(&result, queryString, args...); err2 != nil {
 		return nil, errors.Wrap(err2, "failed to find Posts")
 	}
 	var channelIds []string
@@ -2801,7 +2801,7 @@ func (s *SqlPostStore) GetDirectPostParentsForExportAfter(limit int, afterId str
 	}
 
 	channelMembers := []*model.ChannelMemberForExport{}
-	if err = s.GetReplicaX().Select(&channelMembers, queryString, args...); err != nil {
+	if err = s.GetReplica().Select(&channelMembers, queryString, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to find ChannelMembers")
 	}
 
@@ -2889,7 +2889,7 @@ func (s *SqlPostStore) GetOldestEntityCreationTime() (int64, error) {
 	}
 
 	var oldest int64
-	err = s.GetReplicaX().Get(&oldest, queryString, args...)
+	err = s.GetReplica().Get(&oldest, queryString, args...)
 	if err != nil {
 		return -1, errors.Wrap(err, "unable to scan oldest entity creation time")
 	}
@@ -3206,7 +3206,7 @@ func (s *SqlPostStore) updateThreadsFromPosts(transaction *sqlxTxWrapper, posts 
 }
 
 func (s *SqlPostStore) SetPostReminder(reminder *model.PostReminder) error {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
@@ -3249,7 +3249,7 @@ func (s *SqlPostStore) SetPostReminder(reminder *model.PostReminder) error {
 func (s *SqlPostStore) GetPostReminders(now int64) (_ []*model.PostReminder, err error) {
 	reminders := []*model.PostReminder{}
 
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
@@ -3284,7 +3284,7 @@ func (s *SqlPostStore) GetPostReminders(now int64) (_ []*model.PostReminder, err
 
 func (s *SqlPostStore) GetPostReminderMetadata(postID string) (*store.PostReminderMetadata, error) {
 	meta := &store.PostReminderMetadata{}
-	err := s.GetReplicaX().Get(meta, `SELECT c.id as ChannelID,
+	err := s.GetReplica().Get(meta, `SELECT c.id as ChannelID,
 		COALESCE(t.name, '') as TeamName,
 		u.locale as UserLocale, u.username as Username
 	FROM Posts p

--- a/server/channels/store/sqlstore/preference_store.go
+++ b/server/channels/store/sqlstore/preference_store.go
@@ -30,14 +30,14 @@ func (s SqlPreferenceStore) deleteUnusedFeatures() {
 	if err != nil {
 		mlog.Warn("Could not build sql query to delete unused features", mlog.Err(err))
 	}
-	if _, err = s.GetMasterX().Exec(sql, args...); err != nil {
+	if _, err = s.GetMaster().Exec(sql, args...); err != nil {
 		mlog.Warn("Failed to delete unused features", mlog.Err(err))
 	}
 }
 
 func (s SqlPreferenceStore) Save(preferences model.Preferences) (err error) {
 	// wrap in a transaction so that if one fails, everything fails
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
@@ -132,7 +132,7 @@ func (s SqlPreferenceStore) Get(userId string, category string, name string) (*m
 	if err != nil {
 		return nil, errors.Wrap(err, "could not build sql query to get preference")
 	}
-	if err = s.GetReplicaX().Get(&preference, query, args...); err != nil {
+	if err = s.GetReplica().Get(&preference, query, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find Preference with userId=%s, category=%s, name=%s", userId, category, name)
 	}
 
@@ -150,7 +150,7 @@ func (s SqlPreferenceStore) GetCategoryAndName(category string, name string) (mo
 	if err != nil {
 		return nil, errors.Wrap(err, "could not build sql query to get preference")
 	}
-	if err = s.GetReplicaX().Select(&preferences, query, args...); err != nil {
+	if err = s.GetReplica().Select(&preferences, query, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find Preference with category=%s, name=%s", category, name)
 	}
 	return preferences, nil
@@ -167,7 +167,7 @@ func (s SqlPreferenceStore) GetCategory(userId string, category string) (model.P
 	if err != nil {
 		return nil, errors.Wrap(err, "could not build sql query to get preference")
 	}
-	if err = s.GetReplicaX().Select(&preferences, query, args...); err != nil {
+	if err = s.GetReplica().Select(&preferences, query, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find Preference with userId=%s, category=%s", userId, category)
 	}
 	return preferences, nil
@@ -183,7 +183,7 @@ func (s SqlPreferenceStore) GetAll(userId string) (model.Preferences, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not build sql query to get preference")
 	}
-	if err = s.GetReplicaX().Select(&preferences, query, args...); err != nil {
+	if err = s.GetReplica().Select(&preferences, query, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find Preference with userId=%s", userId)
 	}
 	return preferences, nil
@@ -196,7 +196,7 @@ func (s SqlPreferenceStore) PermanentDeleteByUser(userId string) error {
 	if err != nil {
 		return errors.Wrap(err, "could not build sql query to get delete preference by user")
 	}
-	if _, err := s.GetMasterX().Exec(sql, args...); err != nil {
+	if _, err := s.GetMaster().Exec(sql, args...); err != nil {
 		return errors.Wrapf(err, "failed to delete Preference with userId=%s", userId)
 	}
 	return nil
@@ -213,7 +213,7 @@ func (s SqlPreferenceStore) Delete(userId, category, name string) error {
 		return errors.Wrap(err, "could not build sql query to get delete preference")
 	}
 
-	if _, err = s.GetMasterX().Exec(sql, args...); err != nil {
+	if _, err = s.GetMaster().Exec(sql, args...); err != nil {
 		return errors.Wrapf(err, "failed to delete Preference with userId=%s, category=%s and name=%s", userId, category, name)
 	}
 
@@ -230,7 +230,7 @@ func (s SqlPreferenceStore) DeleteCategory(userId string, category string) error
 		return errors.Wrap(err, "could not build sql query to get delete preference by category")
 	}
 
-	if _, err = s.GetMasterX().Exec(sql, args...); err != nil {
+	if _, err = s.GetMaster().Exec(sql, args...); err != nil {
 		return errors.Wrapf(err, "failed to delete Preference with userId=%s and category=%s", userId, category)
 	}
 
@@ -247,7 +247,7 @@ func (s SqlPreferenceStore) DeleteCategoryAndName(category string, name string) 
 		return errors.Wrap(err, "could not build sql query to get delete preference by category and name")
 	}
 
-	if _, err = s.GetMasterX().Exec(sql, args...); err != nil {
+	if _, err = s.GetMaster().Exec(sql, args...); err != nil {
 		return errors.Wrapf(err, "failed to delete Preference with category=%s and name=%s", category, name)
 	}
 
@@ -268,7 +268,7 @@ func (s *SqlPreferenceStore) DeleteOrphanedRows(limit int) (deleted int64, err e
 		) AS A
 	)`
 
-	result, err := s.GetMasterX().Exec(query, model.PreferenceCategoryFlaggedPost, limit)
+	result, err := s.GetMaster().Exec(query, model.PreferenceCategoryFlaggedPost, limit)
 	if err != nil {
 		return
 	}
@@ -304,7 +304,7 @@ func (s SqlPreferenceStore) CleanupFlagsBatch(limit int64) (int64, error) {
 		return int64(0), errors.Wrap(err, "could not build sql query to delete preference")
 	}
 
-	sqlResult, err := s.GetMasterX().Exec(query, args...)
+	sqlResult, err := s.GetMaster().Exec(query, args...)
 	if err != nil {
 		return int64(0), errors.Wrap(err, "failed to delete Preference")
 	}
@@ -356,7 +356,7 @@ func (s SqlPreferenceStore) DeleteInvalidVisibleDmsGms() (int64, error) {
 		}
 	}
 
-	result, err := s.GetMasterX().Exec(queryString, args...)
+	result, err := s.GetMaster().Exec(queryString, args...)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to delete Preference")
 	}

--- a/server/channels/store/sqlstore/preference_store_test.go
+++ b/server/channels/store/sqlstore/preference_store_test.go
@@ -60,7 +60,7 @@ func TestDeleteUnusedFeatures(t *testing.T) {
 
 		//make sure features with value "false" have actually been deleted from the database
 		var val int64
-		if err := ss.Preference().(*SqlPreferenceStore).GetReplicaX().Get(&val, `SELECT COUNT(*)
+		if err := ss.Preference().(*SqlPreferenceStore).GetReplica().Get(&val, `SELECT COUNT(*)
                             FROM Preferences
                     WHERE Category = ?
                     AND Value = ?
@@ -71,7 +71,7 @@ func TestDeleteUnusedFeatures(t *testing.T) {
 		}
 		//
 		// make sure features with value "true" remain saved
-		if err := ss.Preference().(*SqlPreferenceStore).GetReplicaX().Get(&val, `SELECT COUNT(*)
+		if err := ss.Preference().(*SqlPreferenceStore).GetReplica().Get(&val, `SELECT COUNT(*)
                             FROM Preferences
                     WHERE Category = ?
                     AND Value = ?

--- a/server/channels/store/sqlstore/product_notices_store.go
+++ b/server/channels/store/sqlstore/product_notices_store.go
@@ -27,7 +27,7 @@ func (s SqlProductNoticesStore) Clear(notices []string) error {
 		return errors.Wrap(err, "product_notice_view_state_tosql")
 	}
 
-	if _, err := s.GetMasterX().Exec(sql, args...); err != nil {
+	if _, err := s.GetMaster().Exec(sql, args...); err != nil {
 		return errors.Wrap(err, "failed to delete records from ProductNoticeViewState")
 	}
 	return nil
@@ -43,14 +43,14 @@ func (s SqlProductNoticesStore) ClearOldNotices(currentNotices model.ProductNoti
 		return errors.Wrap(err, "product_notice_view_state_tosql")
 	}
 
-	if _, err := s.GetMasterX().Exec(sql, args...); err != nil {
+	if _, err := s.GetMaster().Exec(sql, args...); err != nil {
 		return errors.Wrapf(err, "failed to delete records from ProductNoticeViewState")
 	}
 	return nil
 }
 
 func (s SqlProductNoticesStore) View(userId string, notices []string) (err error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
@@ -119,7 +119,7 @@ func (s SqlProductNoticesStore) GetViews(userId string) ([]model.ProductNoticeVi
 	if err != nil {
 		return nil, errors.Wrap(err, "product_notice_view_state_tosql")
 	}
-	if err := s.GetReplicaX().Select(&noticeStates, sql, args...); err != nil {
+	if err := s.GetReplica().Select(&noticeStates, sql, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to get ProductNoticeViewState with userId=%s", userId)
 	}
 	return noticeStates, nil

--- a/server/channels/store/sqlstore/remote_cluster_store.go
+++ b/server/channels/store/sqlstore/remote_cluster_store.go
@@ -73,7 +73,7 @@ func (s sqlRemoteClusterStore) Save(remoteCluster *model.RemoteCluster) (*model.
 				(:RemoteId, :RemoteTeamId, :Name, :DisplayName, :SiteURL, :DefaultTeamId, :CreateAt,
 				:DeleteAt, :LastPingAt, :Token, :RemoteToken, :Topics, :CreatorId, :PluginID, :Options)`
 
-	if _, err := s.GetMasterX().NamedExec(query, remoteCluster); err != nil {
+	if _, err := s.GetMaster().NamedExec(query, remoteCluster); err != nil {
 		return nil, errors.Wrap(err, "failed to save RemoteCluster")
 	}
 	return remoteCluster, nil
@@ -102,14 +102,14 @@ func (s sqlRemoteClusterStore) Update(remoteCluster *model.RemoteCluster) (*mode
 			Options = :Options
 			WHERE RemoteId = :RemoteId AND Name = :Name`
 
-	if _, err := s.GetMasterX().NamedExec(query, remoteCluster); err != nil {
+	if _, err := s.GetMaster().NamedExec(query, remoteCluster); err != nil {
 		return nil, errors.Wrap(err, "failed to update RemoteCluster")
 	}
 	return remoteCluster, nil
 }
 
 func (s sqlRemoteClusterStore) Delete(remoteId string) (bool, error) {
-	transaction, err := s.GetMasterX().Beginx()
+	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return false, errors.Wrap(err, "DeleteRemoteCluster: begin_transaction")
 	}
@@ -175,7 +175,7 @@ func (s sqlRemoteClusterStore) Get(remoteId string, includeDeleted bool) (*model
 	}
 
 	var rc model.RemoteCluster
-	if err := s.GetReplicaX().Get(&rc, queryString, args...); err != nil {
+	if err := s.GetReplica().Get(&rc, queryString, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find RemoteCluster")
 	}
 	return &rc, nil
@@ -193,7 +193,7 @@ func (s sqlRemoteClusterStore) GetByPluginID(pluginID string) (*model.RemoteClus
 	}
 
 	var rc model.RemoteCluster
-	if err := s.GetReplicaX().Get(&rc, queryString, args...); err != nil {
+	if err := s.GetReplica().Get(&rc, queryString, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to find RemoteCluster by plugin_id")
 	}
 	return &rc, nil
@@ -269,7 +269,7 @@ func (s sqlRemoteClusterStore) GetAll(offset, limit int, filter model.RemoteClus
 	}
 
 	list := []*model.RemoteCluster{}
-	if err := s.GetReplicaX().Select(&list, queryString, args...); err != nil {
+	if err := s.GetReplica().Select(&list, queryString, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find RemoteClusters")
 	}
 	return list, nil
@@ -288,7 +288,7 @@ func (s sqlRemoteClusterStore) UpdateTopics(remoteClusterid string, topics strin
 			  SET Topics = :Topics
 			  WHERE	RemoteId = :RemoteId`
 
-	if _, err = s.GetMasterX().NamedExec(query, rc); err != nil {
+	if _, err = s.GetMaster().NamedExec(query, rc); err != nil {
 		return nil, err
 	}
 	return rc, nil
@@ -305,7 +305,7 @@ func (s sqlRemoteClusterStore) SetLastPingAt(remoteClusterId string) error {
 		return errors.Wrap(err, "remote_cluster_tosql")
 	}
 
-	if _, err := s.GetMasterX().Exec(queryString, args...); err != nil {
+	if _, err := s.GetMaster().Exec(queryString, args...); err != nil {
 		return errors.Wrap(err, "failed to update RemoteCluster")
 	}
 	return nil

--- a/server/channels/store/sqlstore/retention_policy_store.go
+++ b/server/channels/store/sqlstore/retention_policy_store.go
@@ -80,7 +80,7 @@ func (s *SqlRetentionPolicyStore) Save(policy *model.RetentionPolicyWithTeamAndC
 		return nil, err
 	}
 
-	txn, err := s.GetMasterX().Beginx()
+	txn, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (s *SqlRetentionPolicyStore) checkTeamsExist(teamIDs []string) error {
 			return err
 		}
 		rows := []*string{}
-		err = s.GetReplicaX().Select(&rows, teamsSelectQuery, teamsSelectArgs...)
+		err = s.GetReplica().Select(&rows, teamsSelectQuery, teamsSelectArgs...)
 		if err != nil {
 			return err
 		}
@@ -152,7 +152,7 @@ func (s *SqlRetentionPolicyStore) checkChannelsExist(channelIDs []string) error 
 			return err
 		}
 		rows := []*string{}
-		err = s.GetReplicaX().Select(&rows, channelsSelectQuery, channelsSelectArgs...)
+		err = s.GetReplica().Select(&rows, channelsSelectQuery, channelsSelectArgs...)
 		if err != nil {
 			return err
 		}
@@ -275,7 +275,7 @@ func (s *SqlRetentionPolicyStore) Patch(patch *model.RetentionPolicyWithTeamAndC
 		return nil, err
 	}
 
-	txn, err := s.GetMasterX().Beginx()
+	txn, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +389,7 @@ func (s *SqlRetentionPolicyStore) Get(id string) (*model.RetentionPolicyWithTeam
 	}
 
 	var policy model.RetentionPolicyWithTeamAndChannelCounts
-	if err := s.GetReplicaX().Get(&policy, queryString, args...); err != nil {
+	if err := s.GetReplica().Get(&policy, queryString, args...); err != nil {
 		return nil, err
 	}
 	return &policy, nil
@@ -401,13 +401,13 @@ func (s *SqlRetentionPolicyStore) GetAll(offset, limit int) ([]*model.RetentionP
 	if err != nil {
 		return policies, err
 	}
-	err = s.GetReplicaX().Select(&policies, queryString, args...)
+	err = s.GetReplica().Select(&policies, queryString, args...)
 	return policies, err
 }
 
 func (s *SqlRetentionPolicyStore) GetCount() (int64, error) {
 	var count int64
-	err := s.GetReplicaX().Get(&count, "SELECT COUNT(*) FROM RetentionPolicies")
+	err := s.GetReplica().Get(&count, "SELECT COUNT(*) FROM RetentionPolicies")
 	if err != nil {
 		return count, err
 	}
@@ -425,7 +425,7 @@ func (s *SqlRetentionPolicyStore) Delete(id string) error {
 		return errors.Wrap(err, "retention_policies_tosql")
 	}
 
-	sqlResult, err := s.GetMasterX().Exec(queryString, args...)
+	sqlResult, err := s.GetMaster().Exec(queryString, args...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to permanent delete retention policy with id=%s", id)
 	}
@@ -457,7 +457,7 @@ func (s *SqlRetentionPolicyStore) GetChannels(policyId string, offset, limit int
 	}
 
 	channels := model.ChannelListWithTeamData{}
-	if err := s.GetReplicaX().Select(&channels, queryString, args...); err != nil {
+	if err := s.GetReplica().Select(&channels, queryString, args...); err != nil {
 		return channels, errors.Wrap(err, "failed to find RetentionPoliciesChannels")
 	}
 
@@ -481,7 +481,7 @@ func (s *SqlRetentionPolicyStore) GetChannelsCount(policyId string) (int64, erro
 	}
 
 	var count int64
-	if err := s.GetReplicaX().Get(&count, queryString, args...); err != nil {
+	if err := s.GetReplica().Get(&count, queryString, args...); err != nil {
 		return 0, errors.Wrap(err, "failed to count RetentionPolicies")
 	}
 
@@ -508,7 +508,7 @@ func (s *SqlRetentionPolicyStore) AddChannels(policyId string, channelIds []stri
 		return errors.Wrap(err, "retention_policies_channels_tosql")
 	}
 
-	_, err = s.GetMasterX().Exec(queryString, args...)
+	_, err = s.GetMaster().Exec(queryString, args...)
 	if err != nil {
 		switch dbErr := err.(type) {
 		case *pq.Error:
@@ -541,7 +541,7 @@ func (s *SqlRetentionPolicyStore) RemoveChannels(policyId string, channelIds []s
 		return errors.Wrap(err, "retention_policies_channels_tosql")
 	}
 
-	if _, err := s.GetMasterX().Exec(queryString, args...); err != nil {
+	if _, err := s.GetMaster().Exec(queryString, args...); err != nil {
 		return errors.Wrapf(err, "failed to permanent delete retention policy channels with policyid=%s", policyId)
 	}
 
@@ -564,7 +564,7 @@ func (s *SqlRetentionPolicyStore) GetTeams(policyId string, offset, limit int) (
 	}
 
 	teams := []*model.Team{}
-	if err = s.GetReplicaX().Select(&teams, queryString, args...); err != nil {
+	if err = s.GetReplica().Select(&teams, queryString, args...); err != nil {
 		return teams, errors.Wrap(err, "failed to find Teams")
 	}
 
@@ -584,7 +584,7 @@ func (s *SqlRetentionPolicyStore) GetTeamsCount(policyId string) (int64, error) 
 	}
 
 	var count int64
-	if err := s.GetReplicaX().Get(&count, queryString, args...); err != nil {
+	if err := s.GetReplica().Get(&count, queryString, args...); err != nil {
 		return 0, errors.Wrap(err, "failed to count RetentionPolicies")
 	}
 
@@ -610,7 +610,7 @@ func (s *SqlRetentionPolicyStore) AddTeams(policyId string, teamIds []string) er
 		return errors.Wrap(err, "retention_policies_teams_tosql")
 	}
 
-	if _, err := s.GetMasterX().Exec(queryString, args...); err != nil {
+	if _, err := s.GetMaster().Exec(queryString, args...); err != nil {
 		return errors.Wrap(err, "failed to insert retention policies teams")
 	}
 
@@ -633,7 +633,7 @@ func (s *SqlRetentionPolicyStore) RemoveTeams(policyId string, teamIds []string)
 		return errors.Wrap(err, "retention_policies_teams_tosql")
 	}
 
-	if _, err := s.GetMasterX().Exec(queryString, args...); err != nil {
+	if _, err := s.GetMaster().Exec(queryString, args...); err != nil {
 		return errors.Wrapf(err, "unable to permanent delete retention policies teams with policyid=%s", policyId)
 	}
 
@@ -678,7 +678,7 @@ func (s *SqlRetentionPolicyStore) DeleteOrphanedRows(limit int) (deleted int64, 
 		return int64(0), errors.Wrap(err, "retention_policies_teams_tosql")
 	}
 
-	result, err := s.GetMasterX().Exec(rpcDeleteQuery, rpcArgs...)
+	result, err := s.GetMaster().Exec(rpcDeleteQuery, rpcArgs...)
 	if err != nil {
 		return
 	}
@@ -686,7 +686,7 @@ func (s *SqlRetentionPolicyStore) DeleteOrphanedRows(limit int) (deleted int64, 
 	if err != nil {
 		return
 	}
-	result, err = s.GetMasterX().Exec(rptDeleteQuery, rptArgs...)
+	result, err = s.GetMaster().Exec(rptDeleteQuery, rptArgs...)
 	if err != nil {
 		return
 	}
@@ -723,7 +723,7 @@ func (s *SqlRetentionPolicyStore) GetTeamPoliciesForUser(userID string, offset, 
 	}
 
 	policies := []*model.RetentionPolicyForTeam{}
-	if err := s.GetReplicaX().Select(&policies, queryString, args...); err != nil {
+	if err := s.GetReplica().Select(&policies, queryString, args...); err != nil {
 		return policies, errors.Wrap(err, "failed to find Users")
 	}
 
@@ -752,7 +752,7 @@ func (s *SqlRetentionPolicyStore) GetTeamPoliciesCountForUser(userID string) (in
 	}
 
 	var count int64
-	if err := s.GetReplicaX().Get(&count, queryString, args...); err != nil {
+	if err := s.GetReplica().Get(&count, queryString, args...); err != nil {
 		return 0, errors.Wrap(err, "failed to count TeamPoliciesCountForUser")
 	}
 
@@ -783,7 +783,7 @@ func (s *SqlRetentionPolicyStore) GetChannelPoliciesForUser(userID string, offse
 	}
 
 	policies := []*model.RetentionPolicyForChannel{}
-	if err := s.GetReplicaX().Select(&policies, queryString, args...); err != nil {
+	if err := s.GetReplica().Select(&policies, queryString, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to find Users")
 	}
 
@@ -811,7 +811,7 @@ func (s *SqlRetentionPolicyStore) GetChannelPoliciesCountForUser(userID string) 
 	}
 
 	var count int64
-	if err := s.GetReplicaX().Get(&count, queryString, args...); err != nil {
+	if err := s.GetReplica().Get(&count, queryString, args...); err != nil {
 		return 0, errors.Wrap(err, "failed to count ChannelPoliciesCountForUser")
 	}
 
@@ -862,7 +862,7 @@ func (s *SqlRetentionPolicyStore) GetIdsForDeletionByTableName(tableName string,
 		return nil, errors.Wrap(err, "get_ids_for_deletion_tosql")
 	}
 
-	rows, err := s.GetReplicaX().DB.Query(queryString, args...)
+	rows, err := s.GetReplica().DB.Query(queryString, args...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get ids for deletion")
 	}
@@ -1048,7 +1048,7 @@ func genericRetentionPoliciesDeletion(
 	}
 
 	if r.StoreDeletedIds {
-		txn, err := s.GetMasterX().Beginx()
+		txn, err := s.GetMaster().Beginx()
 		if err != nil {
 			return 0, err
 		}
@@ -1130,7 +1130,7 @@ func genericRetentionPoliciesDeletion(
 		} else {
 			query = getDeleteQueriesForMySQL(r, query)
 		}
-		result, err := s.GetMasterX().Exec(query, args...)
+		result, err := s.GetMaster().Exec(query, args...)
 		if err != nil {
 			return 0, errors.Wrap(err, "failed to delete "+r.Table)
 		}

--- a/server/channels/store/sqlstore/scheduled_post_store.go
+++ b/server/channels/store/sqlstore/scheduled_post_store.go
@@ -80,7 +80,7 @@ func (s *SqlScheduledPostStore) CreateScheduledPost(scheduledPost *model.Schedul
 		return nil, errors.Wrap(err, "SqlScheduledPostStore.CreateScheduledPost failed to generate SQL from query builder")
 	}
 
-	if _, err := s.GetMasterX().Exec(query, args...); err != nil {
+	if _, err := s.GetMaster().Exec(query, args...); err != nil {
 		mlog.Error("SqlScheduledPostStore.CreateScheduledPost failed to insert scheduled post", mlog.Err(err))
 		return nil, errors.Wrap(err, "SqlScheduledPostStore.CreateScheduledPost failed to insert scheduled post")
 	}
@@ -113,7 +113,7 @@ func (s *SqlScheduledPostStore) GetScheduledPostsForUser(userId, teamId string) 
 
 	var scheduledPosts []*model.ScheduledPost
 
-	if err := s.GetReplicaX().SelectBuilder(&scheduledPosts, query); err != nil {
+	if err := s.GetReplica().SelectBuilder(&scheduledPosts, query); err != nil {
 		mlog.Error("SqlScheduledPostStore.GetScheduledPostsForUser: failed to fetch scheduled posts for user", mlog.String("user_id", userId), mlog.String("team_id", teamId), mlog.Err(err))
 
 		return nil, errors.Wrapf(err, "SqlScheduledPostStore.GetScheduledPostsForUser: failed to fetch scheduled posts for user, userId: %s, teamID: %s", userId, teamId)
@@ -164,7 +164,7 @@ func (s *SqlScheduledPostStore) GetPendingScheduledPosts(beforeTime, afterTime i
 	}
 
 	var scheduledPosts []*model.ScheduledPost
-	if err := s.GetReplicaX().SelectBuilder(&scheduledPosts, query); err != nil {
+	if err := s.GetReplica().SelectBuilder(&scheduledPosts, query); err != nil {
 		mlog.Error(
 			"SqlScheduledPostStore.GetPendingScheduledPosts: failed to fetch pending scheduled posts for processing",
 			mlog.Int("before_time", beforeTime),
@@ -198,7 +198,7 @@ func (s *SqlScheduledPostStore) PermanentlyDeleteScheduledPosts(scheduledPostIDs
 		return errToReturn
 	}
 
-	if _, err := s.GetMasterX().Exec(sql, params...); err != nil {
+	if _, err := s.GetMaster().Exec(sql, params...); err != nil {
 		errToReturn := errors.Wrapf(err, "PermanentlyDeleteScheduledPosts: failed to delete batch of scheduled posts from database")
 		s.Logger().Error(errToReturn.Error())
 		return errToReturn
@@ -221,7 +221,7 @@ func (s *SqlScheduledPostStore) UpdatedScheduledPost(scheduledPost *model.Schedu
 		return errors.Wrap(err, "SqlScheduledPostStore.UpdatedScheduledPost failed to generate SQL from bulk updating scheduled posts")
 	}
 
-	_, err = s.GetMasterX().Exec(query, args...)
+	_, err = s.GetMaster().Exec(query, args...)
 	if err != nil {
 		mlog.Error("SqlScheduledPostStore.UpdatedScheduledPost failed to update scheduled post", mlog.String("scheduled_post_id", scheduledPost.Id), mlog.Err(err))
 		return errors.Wrap(err, "SqlScheduledPostStore.UpdatedScheduledPost failed to update scheduled post")
@@ -254,7 +254,7 @@ func (s *SqlScheduledPostStore) Get(scheduledPostId string) (*model.ScheduledPos
 
 	scheduledPost := &model.ScheduledPost{}
 
-	if err := s.GetReplicaX().GetBuilder(scheduledPost, query); err != nil {
+	if err := s.GetReplica().GetBuilder(scheduledPost, query); err != nil {
 		mlog.Error("SqlScheduledPostStore.Get: failed to get single scheduled post by ID from database", mlog.String("scheduled_post_id", scheduledPostId), mlog.Err(err))
 
 		return nil, errors.Wrapf(err, "SqlScheduledPostStore.Get: failed to get single scheduled post by ID from database, scheduledPostId: %s", scheduledPostId)
@@ -279,7 +279,7 @@ func (s *SqlScheduledPostStore) UpdateOldScheduledPosts(beforeTime int64) error 
 		return errors.Wrap(err, "SqlScheduledPostStore.UpdateOldScheduledPosts failed to generate SQL from updating old scheduled posts")
 	}
 
-	_, err = s.GetMasterX().Exec(query, args...)
+	_, err = s.GetMaster().Exec(query, args...)
 	if err != nil {
 		mlog.Error("SqlScheduledPostStore.UpdateOldScheduledPosts failed to update old scheduled posts", mlog.Err(err))
 		return errors.Wrap(err, "SqlScheduledPostStore.UpdateOldScheduledPosts failed to update old scheduled posts")
@@ -300,7 +300,7 @@ func (s *SqlScheduledPostStore) PermanentDeleteByUser(userId string) error {
 		return errToReturn
 	}
 
-	if _, err := s.GetMasterX().Exec(sql, params...); err != nil {
+	if _, err := s.GetMaster().Exec(sql, params...); err != nil {
 		errToReturn := errors.Wrapf(err, "PermanentDeleteByUser: failed to delete scheduled posts by user from database")
 		s.Logger().Error(errToReturn.Error())
 		return errToReturn

--- a/server/channels/store/sqlstore/sqlx_wrapper.go
+++ b/server/channels/store/sqlstore/sqlx_wrapper.go
@@ -30,8 +30,8 @@ func NewStoreTestWrapper(orig *SqlStore) *StoreTestWrapper {
 	return &StoreTestWrapper{orig}
 }
 
-func (w *StoreTestWrapper) GetMasterX() storetest.SqlXExecutor {
-	return w.orig.GetMasterX()
+func (w *StoreTestWrapper) GetMaster() storetest.SqlXExecutor {
+	return w.orig.GetMaster()
 }
 
 func (w *StoreTestWrapper) DriverName() string {

--- a/server/channels/store/sqlstore/sqlx_wrapper_test.go
+++ b/server/channels/store/sqlstore/sqlx_wrapper_test.go
@@ -42,7 +42,7 @@ func TestSqlX(t *testing.T) {
 
 			defer store.Close()
 
-			tx, err := store.GetMasterX().Beginx()
+			tx, err := store.GetMaster().Beginx()
 			require.NoError(t, err)
 
 			var query string

--- a/server/channels/store/sqlstore/store_test.go
+++ b/server/channels/store/sqlstore/store_test.go
@@ -207,7 +207,7 @@ func TestStoreLicenseRace(t *testing.T) {
 	}()
 
 	go func() {
-		store.GetReplicaX()
+		store.GetReplica()
 		wg.Done()
 	}()
 
@@ -305,7 +305,7 @@ func TestGetReplica(t *testing.T) {
 
 			replicas := make(map[*sqlxDBWrapper]bool)
 			for i := 0; i < 5; i++ {
-				replicas[store.GetReplicaX()] = true
+				replicas[store.GetReplica()] = true
 			}
 
 			searchReplicas := make(map[*sqlxDBWrapper]bool)
@@ -318,12 +318,12 @@ func TestGetReplica(t *testing.T) {
 				assert.Len(t, replicas, testCase.DataSourceReplicaNum)
 
 				for replica := range replicas {
-					assert.NotSame(t, store.GetMasterX(), replica)
+					assert.NotSame(t, store.GetMaster(), replica)
 				}
 			} else if assert.Len(t, replicas, 1) {
 				// Otherwise ensure the replicas contains only the master.
 				for replica := range replicas {
-					assert.Same(t, store.GetMasterX(), replica)
+					assert.Same(t, store.GetMaster(), replica)
 				}
 			}
 
@@ -332,7 +332,7 @@ func TestGetReplica(t *testing.T) {
 				assert.Len(t, searchReplicas, testCase.DataSourceSearchReplicaNum)
 
 				for searchReplica := range searchReplicas {
-					assert.NotSame(t, store.GetMasterX(), searchReplica)
+					assert.NotSame(t, store.GetMaster(), searchReplica)
 					for replica := range replicas {
 						assert.NotSame(t, searchReplica, replica)
 					}
@@ -345,7 +345,7 @@ func TestGetReplica(t *testing.T) {
 			} else if testCase.DataSourceReplicaNum == 0 && assert.Len(t, searchReplicas, 1) {
 				// Otherwise ensure the search replicas contains the master.
 				for searchReplica := range searchReplicas {
-					assert.Same(t, store.GetMasterX(), searchReplica)
+					assert.Same(t, store.GetMaster(), searchReplica)
 				}
 			}
 		})
@@ -376,7 +376,7 @@ func TestGetReplica(t *testing.T) {
 
 			replicas := make(map[*sqlxDBWrapper]bool)
 			for i := 0; i < 5; i++ {
-				replicas[store.GetReplicaX()] = true
+				replicas[store.GetReplica()] = true
 			}
 
 			searchReplicas := make(map[*sqlxDBWrapper]bool)
@@ -389,12 +389,12 @@ func TestGetReplica(t *testing.T) {
 				assert.Len(t, replicas, 1)
 
 				for replica := range replicas {
-					assert.Same(t, store.GetMasterX(), replica)
+					assert.Same(t, store.GetMaster(), replica)
 				}
 			} else if assert.Len(t, replicas, 1) {
 				// Otherwise ensure the replicas contains only the master.
 				for replica := range replicas {
-					assert.Same(t, store.GetMasterX(), replica)
+					assert.Same(t, store.GetMaster(), replica)
 				}
 			}
 
@@ -403,7 +403,7 @@ func TestGetReplica(t *testing.T) {
 				assert.Len(t, searchReplicas, 1)
 
 				for searchReplica := range searchReplicas {
-					assert.Same(t, store.GetMasterX(), searchReplica)
+					assert.Same(t, store.GetMaster(), searchReplica)
 				}
 			} else if testCase.DataSourceReplicaNum > 0 {
 				assert.Equal(t, len(replicas), len(searchReplicas))
@@ -413,7 +413,7 @@ func TestGetReplica(t *testing.T) {
 			} else if assert.Len(t, searchReplicas, 1) {
 				// Otherwise ensure the search replicas contains the master.
 				for searchReplica := range searchReplicas {
-					assert.Same(t, store.GetMasterX(), searchReplica)
+					assert.Same(t, store.GetMaster(), searchReplica)
 				}
 			}
 		})
@@ -831,7 +831,7 @@ func TestExecNoTimeout(t *testing.T) {
 		} else if sqlStore.DriverName() == model.DatabaseDriverPostgres {
 			query = `SELECT pg_sleep(2);`
 		}
-		_, err := sqlStore.GetMasterX().ExecNoTimeout(query)
+		_, err := sqlStore.GetMaster().ExecNoTimeout(query)
 		require.NoError(t, err)
 	})
 }
@@ -858,7 +858,7 @@ func TestMySQLReadTimeout(t *testing.T) {
 	require.NoError(t, store.initConnection())
 	defer store.Close()
 
-	_, err = store.GetMasterX().ExecNoTimeout(`SELECT SLEEP(3)`)
+	_, err = store.GetMaster().ExecNoTimeout(`SELECT SLEEP(3)`)
 	require.NoError(t, err)
 }
 

--- a/server/channels/store/sqlstore/system_store.go
+++ b/server/channels/store/sqlstore/system_store.go
@@ -24,7 +24,7 @@ func newSqlSystemStore(sqlStore *SqlStore) store.SystemStore {
 
 func (s SqlSystemStore) Save(system *model.System) error {
 	query := "INSERT INTO Systems (Name, Value) VALUES (:Name, :Value)"
-	if _, err := s.GetMasterX().NamedExec(query, system); err != nil {
+	if _, err := s.GetMaster().NamedExec(query, system); err != nil {
 		return errors.Wrapf(err, "failed to save system property with name=%s", system.Name)
 	}
 
@@ -48,7 +48,7 @@ func (s SqlSystemStore) SaveOrUpdate(system *model.System) error {
 		return errors.Wrap(err, "system_tosql")
 	}
 
-	if _, err := s.GetMasterX().Exec(queryString, args...); err != nil {
+	if _, err := s.GetMaster().Exec(queryString, args...); err != nil {
 		return errors.Wrap(err, "failed to upsert system property")
 	}
 
@@ -57,7 +57,7 @@ func (s SqlSystemStore) SaveOrUpdate(system *model.System) error {
 
 func (s SqlSystemStore) Update(system *model.System) error {
 	query := "UPDATE Systems SET Value=:Value WHERE Name=:Name"
-	if _, err := s.GetMasterX().NamedExec(query, system); err != nil {
+	if _, err := s.GetMaster().NamedExec(query, system); err != nil {
 		return errors.Wrapf(err, "failed to update system property with name=%s", system.Name)
 	}
 
@@ -68,7 +68,7 @@ func (s SqlSystemStore) Get() (model.StringMap, error) {
 	systems := []model.System{}
 	props := make(model.StringMap)
 
-	if err := s.GetReplicaX().Select(&systems, "SELECT * FROM Systems"); err != nil {
+	if err := s.GetReplica().Select(&systems, "SELECT * FROM Systems"); err != nil {
 		return nil, errors.Wrap(err, "failed to get System list")
 	}
 
@@ -81,7 +81,7 @@ func (s SqlSystemStore) Get() (model.StringMap, error) {
 
 func (s SqlSystemStore) GetByName(name string) (*model.System, error) {
 	var system model.System
-	if err := s.GetMasterX().Get(&system, "SELECT * FROM Systems WHERE Name = ?", name); err != nil {
+	if err := s.GetMaster().Get(&system, "SELECT * FROM Systems WHERE Name = ?", name); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("System", fmt.Sprintf("name=%s", system.Name))
 		}
@@ -93,7 +93,7 @@ func (s SqlSystemStore) GetByName(name string) (*model.System, error) {
 
 func (s SqlSystemStore) PermanentDeleteByName(name string) (*model.System, error) {
 	var system model.System
-	if _, err := s.GetMasterX().Exec("DELETE FROM Systems WHERE Name = ?", name); err != nil {
+	if _, err := s.GetMaster().Exec("DELETE FROM Systems WHERE Name = ?", name); err != nil {
 		return nil, errors.Wrapf(err, "failed to permanent delete system property with name=%s", system.Name)
 	}
 
@@ -103,7 +103,7 @@ func (s SqlSystemStore) PermanentDeleteByName(name string) (*model.System, error
 // InsertIfExists inserts a given system value if it does not already exist. If a value
 // already exists, it returns the old one, else returns the new one.
 func (s SqlSystemStore) InsertIfExists(system *model.System) (_ *model.System, err error) {
-	tx, err := s.GetMasterX().BeginXWithIsolation(&sql.TxOptions{
+	tx, err := s.GetMaster().BeginXWithIsolation(&sql.TxOptions{
 		Isolation: sql.LevelSerializable,
 	})
 	if err != nil {

--- a/server/channels/store/sqlstore/terms_of_service_store.go
+++ b/server/channels/store/sqlstore/terms_of_service_store.go
@@ -38,7 +38,7 @@ func (s SqlTermsOfServiceStore) Save(termsOfService *model.TermsOfService) (*mod
 				(:Id, :CreateAt, :UserId, :Text)
 				`
 
-	if _, err := s.GetMasterX().NamedExec(query, termsOfService); err != nil {
+	if _, err := s.GetMaster().NamedExec(query, termsOfService); err != nil {
 		return nil, errors.Wrapf(err, "could not save a new TermsOfService")
 	}
 
@@ -59,7 +59,7 @@ func (s SqlTermsOfServiceStore) GetLatest(allowFromCache bool) (*model.TermsOfSe
 		return nil, errors.Wrap(err, "could not build sql query to get latest TOS")
 	}
 
-	if err := s.GetReplicaX().Get(&termsOfService, queryString, args...); err != nil {
+	if err := s.GetReplica().Get(&termsOfService, queryString, args...); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("TermsOfService", "CreateAt=latest")
 		}
@@ -81,7 +81,7 @@ func (s SqlTermsOfServiceStore) Get(id string, allowFromCache bool) (*model.Term
 		return nil, errors.Wrap(err, "terms_of_service_to_sql")
 	}
 
-	err = s.GetReplicaX().Get(&termsOfService, queryString, id)
+	err = s.GetReplica().Get(&termsOfService, queryString, id)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("TermsOfService", "id")

--- a/server/channels/store/sqlstore/tokens_store.go
+++ b/server/channels/store/sqlstore/tokens_store.go
@@ -35,14 +35,14 @@ func (s SqlTokenStore) Save(token *model.Token) error {
 	if err != nil {
 		return errors.Wrap(err, "token_tosql")
 	}
-	if _, err := s.GetMasterX().Exec(query, args...); err != nil {
+	if _, err := s.GetMaster().Exec(query, args...); err != nil {
 		return errors.Wrap(err, "failed to save Token")
 	}
 	return nil
 }
 
 func (s SqlTokenStore) Delete(token string) error {
-	if _, err := s.GetMasterX().Exec("DELETE FROM Tokens WHERE Token = ?", token); err != nil {
+	if _, err := s.GetMaster().Exec("DELETE FROM Tokens WHERE Token = ?", token); err != nil {
 		return errors.Wrapf(err, "failed to delete Token with value %s", token)
 	}
 	return nil
@@ -51,7 +51,7 @@ func (s SqlTokenStore) Delete(token string) error {
 func (s SqlTokenStore) GetByToken(tokenString string) (*model.Token, error) {
 	var token model.Token
 
-	if err := s.GetReplicaX().Get(&token, "SELECT * FROM Tokens WHERE Token = ?", tokenString); err != nil {
+	if err := s.GetReplica().Get(&token, "SELECT * FROM Tokens WHERE Token = ?", tokenString); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Token", fmt.Sprintf("Token=%s", tokenString))
 		}
@@ -63,7 +63,7 @@ func (s SqlTokenStore) GetByToken(tokenString string) (*model.Token, error) {
 }
 
 func (s SqlTokenStore) Cleanup(expiryTime int64) {
-	if _, err := s.GetMasterX().Exec("DELETE FROM Tokens WHERE CreateAt < ?", expiryTime); err != nil {
+	if _, err := s.GetMaster().Exec("DELETE FROM Tokens WHERE CreateAt < ?", expiryTime); err != nil {
 		mlog.Error("Unable to cleanup token store.")
 	}
 }
@@ -79,14 +79,14 @@ func (s SqlTokenStore) GetAllTokensByType(tokenType string) ([]*model.Token, err
 		return nil, errors.Wrap(err, "could not build sql query to get all tokens by type")
 	}
 
-	if err := s.GetReplicaX().Select(&tokens, query, args...); err != nil {
+	if err := s.GetReplica().Select(&tokens, query, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to get all tokens of Type=%s", tokenType)
 	}
 	return tokens, nil
 }
 
 func (s SqlTokenStore) RemoveAllTokensByType(tokenType string) error {
-	if _, err := s.GetMasterX().Exec("DELETE FROM Tokens WHERE Type = ?", tokenType); err != nil {
+	if _, err := s.GetMaster().Exec("DELETE FROM Tokens WHERE Type = ?", tokenType); err != nil {
 		return errors.Wrapf(err, "failed to remove all Tokens with Type=%s", tokenType)
 	}
 	return nil

--- a/server/channels/store/sqlstore/upload_session_store.go
+++ b/server/channels/store/sqlstore/upload_session_store.go
@@ -40,7 +40,7 @@ func (us SqlUploadSessionStore) Save(session *model.UploadSession) (*model.Uploa
 	if err != nil {
 		return nil, errors.Wrap(err, "SqlUploadSessionStore.Save: failed to build query")
 	}
-	if _, err := us.GetMasterX().Exec(query, args...); err != nil {
+	if _, err := us.GetMaster().Exec(query, args...); err != nil {
 		return nil, errors.Wrap(err, "SqlUploadSessionStore.Save: failed to insert")
 	}
 	return session, nil
@@ -70,7 +70,7 @@ func (us SqlUploadSessionStore) Update(session *model.UploadSession) error {
 	if err != nil {
 		return errors.Wrap(err, "SqlUploadSessionStore.Update: failed to build query")
 	}
-	if _, err := us.GetMasterX().Exec(query, args...); err != nil {
+	if _, err := us.GetMaster().Exec(query, args...); err != nil {
 		if err == sql.ErrNoRows {
 			return store.NewErrNotFound("UploadSession", session.Id)
 		}
@@ -112,7 +112,7 @@ func (us SqlUploadSessionStore) GetForUser(userId string) ([]*model.UploadSessio
 		return nil, errors.Wrap(err, "SqlUploadSessionStore.GetForUser: failed to build query")
 	}
 	sessions := []*model.UploadSession{}
-	if err := us.GetReplicaX().Select(&sessions, query, args...); err != nil {
+	if err := us.GetReplica().Select(&sessions, query, args...); err != nil {
 		return nil, errors.Wrap(err, "SqlUploadSessionStore.GetForUser: failed to select")
 	}
 	return sessions, nil
@@ -131,7 +131,7 @@ func (us SqlUploadSessionStore) Delete(id string) error {
 		return errors.Wrap(err, "SqlUploadSessionStore.Delete: failed to build query")
 	}
 
-	if _, err := us.GetMasterX().Exec(query, args...); err != nil {
+	if _, err := us.GetMaster().Exec(query, args...); err != nil {
 		return errors.Wrap(err, "SqlUploadSessionStore.Delete: failed to delete")
 	}
 

--- a/server/channels/store/sqlstore/user_terms_of_service.go
+++ b/server/channels/store/sqlstore/user_terms_of_service.go
@@ -27,7 +27,7 @@ func (s SqlUserTermsOfServiceStore) GetByUser(userId string) (*model.UserTermsOf
 		FROM UserTermsOfService 
 		WHERE UserId = ?
 	`
-	if err := s.GetReplicaX().Get(&userTermsOfService, query, userId); err != nil {
+	if err := s.GetReplica().Get(&userTermsOfService, query, userId); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("UserTermsOfService", "userId="+userId)
 		}
@@ -49,7 +49,7 @@ func (s SqlUserTermsOfServiceStore) Save(userTermsOfService *model.UserTermsOfSe
 		SET UserId = :UserId, TermsOfServiceId = :TermsOfServiceId, CreateAt = :CreateAt
 		WHERE UserId = :UserId
 	`
-	result, err := s.GetMasterX().NamedExec(query, userTermsOfService)
+	result, err := s.GetMaster().NamedExec(query, userTermsOfService)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to update UserTermsOfService with userId=%s and termsOfServiceId=%s", userTermsOfService.UserId, userTermsOfService.TermsOfServiceId)
 	}
@@ -65,7 +65,7 @@ func (s SqlUserTermsOfServiceStore) Save(userTermsOfService *model.UserTermsOfSe
 			VALUES
 				(:UserId, :TermsOfServiceId, :CreateAt)
 		`
-		if _, err := s.GetMasterX().NamedExec(query, userTermsOfService); err != nil {
+		if _, err := s.GetMaster().NamedExec(query, userTermsOfService); err != nil {
 			return nil, errors.Wrapf(err, "failed to save UserTermsOfService with userId=%s and termsOfServiceId=%s", userTermsOfService.UserId, userTermsOfService.TermsOfServiceId)
 		}
 	}
@@ -79,7 +79,7 @@ func (s SqlUserTermsOfServiceStore) Delete(userId, termsOfServiceId string) erro
 		FROM UserTermsOfService 
 		WHERE UserId = ? AND TermsOfServiceId = ?
 	`
-	if _, err := s.GetMasterX().Exec(query, userId, termsOfServiceId); err != nil {
+	if _, err := s.GetMaster().Exec(query, userId, termsOfServiceId); err != nil {
 		return errors.Wrapf(err, "failed to delete UserTermsOfService with userId=%s and termsOfServiceId=%s", userId, termsOfServiceId)
 	}
 

--- a/server/channels/store/storetest/bot_store.go
+++ b/server/channels/store/storetest/bot_store.go
@@ -79,7 +79,7 @@ func testBotStoreGet(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore)
 	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, b2.UserId)) }()
 
 	// Artificially set b2.LastIconUpdate to NULL to verify handling of same.
-	_, sqlErr := s.GetMasterX().Exec("UPDATE Bots SET LastIconUpdate = NULL WHERE UserId = '" + b2.UserId + "'")
+	_, sqlErr := s.GetMaster().Exec("UPDATE Bots SET LastIconUpdate = NULL WHERE UserId = '" + b2.UserId + "'")
 	require.NoError(t, sqlErr)
 
 	t.Run("get non-existent bot", func(t *testing.T) {
@@ -167,7 +167,7 @@ func testBotStoreGetAll(t *testing.T, rctx request.CTX, ss store.Store, s SqlSto
 	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, b2.UserId)) }()
 
 	// Artificially set b2.LastIconUpdate to NULL to verify handling of same.
-	_, sqlErr := s.GetMasterX().Exec("UPDATE Bots SET LastIconUpdate = NULL WHERE UserId = '" + b2.UserId + "'")
+	_, sqlErr := s.GetMaster().Exec("UPDATE Bots SET LastIconUpdate = NULL WHERE UserId = '" + b2.UserId + "'")
 	require.NoError(t, sqlErr)
 
 	t.Run("get original bots", func(t *testing.T) {

--- a/server/channels/store/storetest/channel_store.go
+++ b/server/channels/store/storetest/channel_store.go
@@ -27,7 +27,7 @@ import (
 )
 
 type SqlStore interface {
-	GetMasterX() SqlXExecutor
+	GetMaster() SqlXExecutor
 	DriverName() string
 }
 
@@ -293,7 +293,7 @@ func testChannelStoreSaveDirectChannel(t *testing.T, rctx request.CTX, ss store.
 	require.ElementsMatch(t, []string{u1.Id}, userIDs)
 
 	// Manually truncate Channels table until testlib can handle cleanups
-	s.GetMasterX().Exec("TRUNCATE Channels")
+	s.GetMaster().Exec("TRUNCATE Channels")
 }
 
 func testChannelStoreCreateDirectChannel(t *testing.T, rctx request.CTX, ss store.Store) {
@@ -493,7 +493,7 @@ func testChannelStoreGet(t *testing.T, rctx request.CTX, ss store.Store, s SqlSt
 	require.True(t, errors.As(err, &nfErr))
 
 	// Manually truncate Channels table until testlib can handle cleanups
-	s.GetMasterX().Exec("TRUNCATE Channels")
+	s.GetMaster().Exec("TRUNCATE Channels")
 }
 
 func testChannelStoreGetMany(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
@@ -527,7 +527,7 @@ func testChannelStoreGetMany(t *testing.T, rctx request.CTX, ss store.Store, s S
 	require.True(t, errors.As(err, &nfErr))
 
 	// Manually truncate Channels table until testlib can handle cleanups
-	s.GetMasterX().Exec("TRUNCATE Channels")
+	s.GetMaster().Exec("TRUNCATE Channels")
 }
 
 func testChannelStoreGetChannelsByIds(t *testing.T, rctx request.CTX, ss store.Store) {
@@ -4006,7 +4006,7 @@ func testChannelStoreGetAllChannels(t *testing.T, rctx request.CTX, ss store.Sto
 	assert.Equal(t, *list[0].PolicyID, policy.ID)
 
 	// Manually truncate Channels table until testlib can handle cleanups
-	s.GetMasterX().Exec("TRUNCATE Channels")
+	s.GetMaster().Exec("TRUNCATE Channels")
 }
 
 func testChannelStoreGetMoreChannels(t *testing.T, rctx request.CTX, ss store.Store) {
@@ -5774,8 +5774,8 @@ func testChannelStoreSearchArchivedInTeam(t *testing.T, rctx request.CTX, ss sto
 
 	t.Run("error", func(t *testing.T) {
 		// trigger a SQL error
-		s.GetMasterX().Exec("ALTER TABLE Channels RENAME TO Channels_renamed")
-		defer s.GetMasterX().Exec("ALTER TABLE Channels_renamed RENAME TO Channels")
+		s.GetMaster().Exec("ALTER TABLE Channels RENAME TO Channels_renamed")
+		defer s.GetMaster().Exec("ALTER TABLE Channels_renamed RENAME TO Channels")
 
 		list, err := ss.Channel().SearchArchivedInTeam(teamID, "term", userID)
 		require.Error(t, err)
@@ -6219,7 +6219,7 @@ func testAutocomplete(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore
 	})
 
 	// Manually truncate Channels table until testlib can handle cleanups
-	s.GetMasterX().Exec("TRUNCATE Channels")
+	s.GetMaster().Exec("TRUNCATE Channels")
 }
 
 func testChannelStoreSearchForUserInTeam(t *testing.T, rctx request.CTX, ss store.Store) {
@@ -7484,7 +7484,7 @@ func testMaterializedPublicChannels(t *testing.T, rctx request.CTX, ss store.Sto
 		Type:        model.ChannelTypeOpen,
 	}
 
-	_, execerr := s.GetMasterX().NamedExec(`
+	_, execerr := s.GetMaster().NamedExec(`
 		INSERT INTO
 		    PublicChannels(Id, DeleteAt, TeamId, DisplayName, Name, Header, Purpose)
 		VALUES
@@ -7502,7 +7502,7 @@ func testMaterializedPublicChannels(t *testing.T, rctx request.CTX, ss store.Sto
 
 	o3.DisplayName = "Open Channel 3 - Modified"
 
-	_, execerr = s.GetMasterX().NamedExec(`
+	_, execerr = s.GetMaster().NamedExec(`
 		INSERT INTO
 		    Channels(Id, CreateAt, UpdateAt, DeleteAt, TeamId, Type, DisplayName, Name, Header, Purpose, LastPostAt, LastRootPostAt, TotalMsgCount, ExtraUpdateAt, CreatorId, TotalMsgCountRoot)
 		VALUES
@@ -7543,7 +7543,7 @@ func testMaterializedPublicChannels(t *testing.T, rctx request.CTX, ss store.Sto
 	_, nErr = ss.Channel().Save(rctx, &o4, -1)
 	require.NoError(t, nErr)
 
-	_, execerr = s.GetMasterX().Exec(`
+	_, execerr = s.GetMaster().Exec(`
 		DELETE FROM
 		    PublicChannels
 		WHERE
@@ -7738,7 +7738,7 @@ func testChannelStoreRemoveAllDeactivatedMembers(t *testing.T, rctx request.CTX,
 	require.ElementsMatch(t, []string{u3.Id}, userIDs)
 
 	// Manually truncate Channels table until testlib can handle cleanups
-	s.GetMasterX().Exec("TRUNCATE Channels")
+	s.GetMaster().Exec("TRUNCATE Channels")
 }
 
 func testChannelStoreExportAllDirectChannels(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
@@ -7795,7 +7795,7 @@ func testChannelStoreExportAllDirectChannels(t *testing.T, rctx request.CTX, ss 
 	assert.ElementsMatch(t, []string{o1.DisplayName, o2.DisplayName}, []string{d1[0].DisplayName, d1[1].DisplayName})
 
 	// Manually truncate Channels table until testlib can handle cleanups
-	s.GetMasterX().Exec("TRUNCATE Channels")
+	s.GetMaster().Exec("TRUNCATE Channels")
 }
 
 func testChannelStoreExportAllDirectChannelsExcludePrivateAndPublic(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
@@ -7857,7 +7857,7 @@ func testChannelStoreExportAllDirectChannelsExcludePrivateAndPublic(t *testing.T
 	assert.Equal(t, o1.DisplayName, d1[0].DisplayName)
 
 	// Manually truncate Channels table until testlib can handle cleanups
-	s.GetMasterX().Exec("TRUNCATE Channels")
+	s.GetMaster().Exec("TRUNCATE Channels")
 }
 
 func testChannelStoreExportAllDirectChannelsDeletedChannel(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
@@ -7912,7 +7912,7 @@ func testChannelStoreExportAllDirectChannelsDeletedChannel(t *testing.T, rctx re
 	assert.Len(t, d1[0].Members, 2)
 
 	// Manually truncate Channels table until testlib can handle cleanups
-	s.GetMasterX().Exec("TRUNCATE Channels")
+	s.GetMaster().Exec("TRUNCATE Channels")
 }
 
 func testChannelStoreGetChannelsBatchForIndexing(t *testing.T, rctx request.CTX, ss store.Store) {

--- a/server/channels/store/storetest/channel_store_categories.go
+++ b/server/channels/store/storetest/channel_store_categories.go
@@ -751,7 +751,7 @@ func testGetSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store, s Sq
 
 		// Confirm that they're not in the Channels category in the DB
 		var count int64
-		countErr := s.GetMasterX().Get(&count, `
+		countErr := s.GetMaster().Get(&count, `
 			SELECT
 				COUNT(*)
 			FROM
@@ -2021,11 +2021,11 @@ func testClearSidebarOnTeamLeave(t *testing.T, rctx request.CTX, ss store.Store,
 
 		// Confirm that we start with the right number of categories and SidebarChannels entries
 		var count int64
-		err = s.GetMasterX().Get(&count, "SELECT COUNT(*) FROM SidebarCategories WHERE UserId = ?", userID)
+		err = s.GetMaster().Get(&count, "SELECT COUNT(*) FROM SidebarCategories WHERE UserId = ?", userID)
 		require.NoError(t, err)
 		require.Equal(t, int64(4), count)
 
-		err = s.GetMasterX().Get(&count, "SELECT COUNT(*) FROM SidebarChannels WHERE UserId = ?", userID)
+		err = s.GetMaster().Get(&count, "SELECT COUNT(*) FROM SidebarChannels WHERE UserId = ?", userID)
 		require.NoError(t, err)
 		require.Equal(t, int64(2), count)
 
@@ -2034,11 +2034,11 @@ func testClearSidebarOnTeamLeave(t *testing.T, rctx request.CTX, ss store.Store,
 		assert.NoError(t, err)
 
 		// Confirm that all the categories and SidebarChannel entries have been deleted
-		err = s.GetMasterX().Get(&count, "SELECT COUNT(*) FROM SidebarCategories WHERE UserId = ?", userID)
+		err = s.GetMaster().Get(&count, "SELECT COUNT(*) FROM SidebarCategories WHERE UserId = ?", userID)
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), count)
 
-		err = s.GetMasterX().Get(&count, "SELECT COUNT(*) FROM SidebarChannels WHERE UserId = ?", userID)
+		err = s.GetMaster().Get(&count, "SELECT COUNT(*) FROM SidebarChannels WHERE UserId = ?", userID)
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), count)
 	})
@@ -2070,11 +2070,11 @@ func testClearSidebarOnTeamLeave(t *testing.T, rctx request.CTX, ss store.Store,
 
 		// Confirm that we start with the right number of categories and SidebarChannels entries
 		var count int64
-		err = s.GetMasterX().Get(&count, "SELECT COUNT(*) FROM SidebarCategories WHERE UserId = ?", userID)
+		err = s.GetMaster().Get(&count, "SELECT COUNT(*) FROM SidebarCategories WHERE UserId = ?", userID)
 		require.NoError(t, err)
 		require.Equal(t, int64(4), count)
 
-		err = s.GetMasterX().Get(&count, "SELECT COUNT(*) FROM SidebarChannels WHERE UserId = ?", userID)
+		err = s.GetMaster().Get(&count, "SELECT COUNT(*) FROM SidebarChannels WHERE UserId = ?", userID)
 		require.NoError(t, err)
 		require.Equal(t, int64(2), count)
 
@@ -2083,11 +2083,11 @@ func testClearSidebarOnTeamLeave(t *testing.T, rctx request.CTX, ss store.Store,
 		assert.NoError(t, err)
 
 		// Confirm that nothing has been deleted
-		err = s.GetMasterX().Get(&count, "SELECT COUNT(*) FROM SidebarCategories WHERE UserId = ?", userID)
+		err = s.GetMaster().Get(&count, "SELECT COUNT(*) FROM SidebarCategories WHERE UserId = ?", userID)
 		require.NoError(t, err)
 		assert.Equal(t, int64(4), count)
 
-		err = s.GetMasterX().Get(&count, "SELECT COUNT(*) FROM SidebarChannels WHERE UserId = ?", userID)
+		err = s.GetMaster().Get(&count, "SELECT COUNT(*) FROM SidebarChannels WHERE UserId = ?", userID)
 		require.NoError(t, err)
 		assert.Equal(t, int64(2), count)
 	})
@@ -2148,11 +2148,11 @@ func testClearSidebarOnTeamLeave(t *testing.T, rctx request.CTX, ss store.Store,
 
 		// Confirm that we start with the right number of categories and SidebarChannels entries
 		var count int64
-		err = s.GetMasterX().Get(&count, "SELECT COUNT(*) FROM SidebarCategories WHERE UserId = ?", userID)
+		err = s.GetMaster().Get(&count, "SELECT COUNT(*) FROM SidebarCategories WHERE UserId = ?", userID)
 		require.NoError(t, err)
 		require.Equal(t, int64(8), count)
 
-		err = s.GetMasterX().Get(&count, "SELECT COUNT(*) FROM SidebarChannels WHERE UserId = ?", userID)
+		err = s.GetMaster().Get(&count, "SELECT COUNT(*) FROM SidebarChannels WHERE UserId = ?", userID)
 		require.NoError(t, err)
 		require.Equal(t, int64(4), count)
 
@@ -2161,11 +2161,11 @@ func testClearSidebarOnTeamLeave(t *testing.T, rctx request.CTX, ss store.Store,
 		assert.NoError(t, err)
 
 		// Confirm that we have the correct number of categories and SidebarChannels entries left over
-		err = s.GetMasterX().Get(&count, "SELECT COUNT(*) FROM SidebarCategories WHERE UserId = ?", userID)
+		err = s.GetMaster().Get(&count, "SELECT COUNT(*) FROM SidebarCategories WHERE UserId = ?", userID)
 		require.NoError(t, err)
 		assert.Equal(t, int64(4), count)
 
-		err = s.GetMasterX().Get(&count, "SELECT COUNT(*) FROM SidebarChannels WHERE UserId = ?", userID)
+		err = s.GetMaster().Get(&count, "SELECT COUNT(*) FROM SidebarChannels WHERE UserId = ?", userID)
 		require.NoError(t, err)
 		assert.Equal(t, int64(2), count)
 
@@ -2259,7 +2259,7 @@ func testDeleteSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store, s
 
 		// ...and that the corresponding SidebarChannel entries were deleted
 		var count int64
-		countErr := s.GetMasterX().Get(&count, `
+		countErr := s.GetMaster().Get(&count, `
 			SELECT
 				COUNT(*)
 			FROM

--- a/server/channels/store/storetest/file_info_store.go
+++ b/server/channels/store/storetest/file_info_store.go
@@ -20,7 +20,7 @@ import (
 
 func TestFileInfoStore(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
 	t.Cleanup(func() {
-		s.GetMasterX().Exec("TRUNCATE FileInfo")
+		s.GetMaster().Exec("TRUNCATE FileInfo")
 	})
 	t.Run("FileInfoSaveGet", func(t *testing.T) { testFileInfoSaveGet(t, rctx, ss) })
 	t.Run("FileInfoSaveGetByPath", func(t *testing.T) { testFileInfoSaveGetByPath(t, rctx, ss) })

--- a/server/channels/store/storetest/post_store.go
+++ b/server/channels/store/storetest/post_store.go
@@ -3279,7 +3279,7 @@ func testPostStoreGetFlaggedPostsForTeam(t *testing.T, rctx request.CTX, ss stor
 	require.Len(t, r4.Order, 3, "should have 3 posts")
 
 	// Manually truncate Channels table until testlib can handle cleanups
-	s.GetMasterX().Exec("TRUNCATE Channels")
+	s.GetMaster().Exec("TRUNCATE Channels")
 }
 
 func testPostStoreGetFlaggedPosts(t *testing.T, rctx request.CTX, ss store.Store) {
@@ -4550,7 +4550,7 @@ func testPostStoreGetDirectPostParentsForExportAfter(t *testing.T, rctx request.
 	assert.Equal(t, p1.Message, r1[0].Message)
 
 	// Manually truncate Channels table until testlib can handle cleanups
-	s.GetMasterX().Exec("TRUNCATE Channels")
+	s.GetMaster().Exec("TRUNCATE Channels")
 }
 
 func testPostStoreGetDirectPostParentsForExportAfterDeleted(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
@@ -4613,7 +4613,7 @@ func testPostStoreGetDirectPostParentsForExportAfterDeleted(t *testing.T, rctx r
 	assert.Equal(t, 1, len(r1))
 
 	// Manually truncate Channels table until testlib can handle cleanups
-	s.GetMasterX().Exec("TRUNCATE Channels")
+	s.GetMaster().Exec("TRUNCATE Channels")
 }
 
 func testPostStoreGetDirectPostParentsForExportAfterBatched(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
@@ -4689,7 +4689,7 @@ func testPostStoreGetDirectPostParentsForExportAfterBatched(t *testing.T, rctx r
 	assert.ElementsMatch(t, postIds[:100], exportedPostIds)
 
 	// Manually truncate Channels table until testlib can handle cleanups
-	s.GetMasterX().Exec("TRUNCATE Channels")
+	s.GetMaster().Exec("TRUNCATE Channels")
 }
 
 func testHasAutoResponsePostByUserSince(t *testing.T, rctx request.CTX, ss store.Store) {
@@ -4827,7 +4827,7 @@ func testGetPostsSinceUpdateForSync(t *testing.T, rctx request.CTX, ss store.Sto
 
 	t.Run("UpdateAt collisions", func(t *testing.T) {
 		// this test requires all the UpdateAt timestamps to be the same.
-		result, err := s.GetMasterX().Exec("UPDATE Posts SET UpdateAt = ?", model.GetMillis())
+		result, err := s.GetMaster().Exec("UPDATE Posts SET UpdateAt = ?", model.GetMillis())
 		require.NoError(t, err)
 		rows, err := result.RowsAffected()
 		require.NoError(t, err)
@@ -4934,7 +4934,7 @@ func testGetPostsSinceCreateForSync(t *testing.T, rctx request.CTX, ss store.Sto
 
 	t.Run("CreateAt collisions", func(t *testing.T) {
 		// this test requires all the CreateAt timestamps to be the same.
-		result, err := s.GetMasterX().Exec("UPDATE Posts SET CreateAt = ?", model.GetMillis())
+		result, err := s.GetMaster().Exec("UPDATE Posts SET CreateAt = ?", model.GetMillis())
 		require.NoError(t, err)
 		rows, err := result.RowsAffected()
 		require.NoError(t, err)
@@ -4978,7 +4978,7 @@ func testSetPostReminder(t *testing.T, rctx request.CTX, ss store.Store, s SqlSt
 	require.NoError(t, ss.Post().SetPostReminder(reminder))
 
 	out := model.PostReminder{}
-	require.NoError(t, s.GetMasterX().Get(&out, `SELECT PostId, UserId, TargetTime FROM PostReminders WHERE PostId=? AND UserId=?`, reminder.PostId, reminder.UserId))
+	require.NoError(t, s.GetMaster().Get(&out, `SELECT PostId, UserId, TargetTime FROM PostReminders WHERE PostId=? AND UserId=?`, reminder.PostId, reminder.UserId))
 	assert.Equal(t, reminder, &out)
 
 	reminder.PostId = "notfound"
@@ -4994,7 +4994,7 @@ func testSetPostReminder(t *testing.T, rctx request.CTX, ss store.Store, s SqlSt
 	}
 
 	require.NoError(t, ss.Post().SetPostReminder(reminder))
-	require.NoError(t, s.GetMasterX().Get(&out, `SELECT PostId, UserId, TargetTime FROM PostReminders WHERE PostId=? AND UserId=?`, reminder.PostId, reminder.UserId))
+	require.NoError(t, s.GetMaster().Get(&out, `SELECT PostId, UserId, TargetTime FROM PostReminders WHERE PostId=? AND UserId=?`, reminder.PostId, reminder.UserId))
 	assert.Equal(t, reminder, &out)
 }
 

--- a/server/channels/store/storetest/preference_store.go
+++ b/server/channels/store/storetest/preference_store.go
@@ -458,7 +458,7 @@ func testDeleteInvalidVisibleDmsGms(t *testing.T, rctx request.CTX, ss store.Sto
 	}
 
 	// Can't insert with Save methods because the values are invalid
-	_, execerr := s.GetMasterX().NamedExec(`
+	_, execerr := s.GetMaster().NamedExec(`
 		INSERT INTO
 		    Preferences(UserId, Category, Name, Value)
 		VALUES

--- a/server/channels/store/storetest/reaction_store.go
+++ b/server/channels/store/storetest/reaction_store.go
@@ -441,7 +441,7 @@ func forceUpdateAt(reaction *model.Reaction, updateAt int64, s SqlStore) error {
 		"updateat":  updateAt,
 	}
 
-	sqlResult, err := s.GetMasterX().NamedExec(`
+	sqlResult, err := s.GetMaster().NamedExec(`
 		UPDATE
 			Reactions
 		SET
@@ -468,10 +468,10 @@ func forceUpdateAt(reaction *model.Reaction, updateAt int64, s SqlStore) error {
 }
 
 func forceNULL(reaction *model.Reaction, s SqlStore) error {
-	if _, err := s.GetMasterX().Exec(`UPDATE Reactions SET UpdateAt = NULL WHERE UpdateAt = 0`); err != nil {
+	if _, err := s.GetMaster().Exec(`UPDATE Reactions SET UpdateAt = NULL WHERE UpdateAt = 0`); err != nil {
 		return err
 	}
-	if _, err := s.GetMasterX().Exec(`UPDATE Reactions SET DeleteAt = NULL WHERE DeleteAt = 0`); err != nil {
+	if _, err := s.GetMaster().Exec(`UPDATE Reactions SET DeleteAt = NULL WHERE DeleteAt = 0`); err != nil {
 		return err
 	}
 	return nil

--- a/server/channels/store/storetest/retention_policy_store.go
+++ b/server/channels/store/storetest/retention_policy_store.go
@@ -151,7 +151,7 @@ func cleanupRetentionPolicyTest(s SqlStore) {
 	// Manually clear tables until testlib can handle cleanups
 	tables := []string{"RetentionPolicies", "RetentionPoliciesChannels", "RetentionPoliciesTeams"}
 	for _, table := range tables {
-		if _, err := s.GetMasterX().Exec("DELETE FROM " + table); err != nil {
+		if _, err := s.GetMaster().Exec("DELETE FROM " + table); err != nil {
 			panic(err)
 		}
 	}

--- a/server/channels/store/storetest/role_store.go
+++ b/server/channels/store/storetest/role_store.go
@@ -581,7 +581,7 @@ func testRoleStoreChannelHigherScopedPermissionsBlankTeamSchemeChannelGuest(t *t
 	require.NoError(t, err)
 
 	// blank-out the guest role to simulate an old team scheme, ensure it's blank
-	result, sqlErr := s.GetMasterX().Exec(fmt.Sprintf("UPDATE Schemes SET DefaultChannelGuestRole = '' WHERE Id = '%s'", teamScheme.Id))
+	result, sqlErr := s.GetMaster().Exec(fmt.Sprintf("UPDATE Schemes SET DefaultChannelGuestRole = '' WHERE Id = '%s'", teamScheme.Id))
 	require.NoError(t, sqlErr)
 	rows, serr := result.RowsAffected()
 	require.NoError(t, serr)

--- a/server/channels/store/storetest/thread_store.go
+++ b/server/channels/store/storetest/thread_store.go
@@ -654,7 +654,7 @@ func testThreadStorePermanentDeleteBatchThreadMembershipsForRetentionPolicies(t 
 	// Delete team policy and thread
 	err = ss.RetentionPolicy().Delete(teamPolicy.ID)
 	require.NoError(t, err)
-	_, err = s.GetMasterX().Exec("DELETE FROM Threads WHERE PostId='" + post.Id + "'")
+	_, err = s.GetMaster().Exec("DELETE FROM Threads WHERE PostId='" + post.Id + "'")
 	require.NoError(t, err)
 
 	deleted, err := ss.Thread().DeleteOrphanedRows(1000)

--- a/server/channels/store/storetest/user_store.go
+++ b/server/channels/store/storetest/user_store.go
@@ -28,7 +28,7 @@ const (
 )
 
 func cleanupStatusStore(t *testing.T, s SqlStore) {
-	_, execerr := s.GetMasterX().Exec(`DELETE FROM Status`)
+	_, execerr := s.GetMaster().Exec(`DELETE FROM Status`)
 	require.NoError(t, execerr)
 }
 

--- a/server/channels/testlib/helper.go
+++ b/server/channels/testlib/helper.go
@@ -222,7 +222,7 @@ func (h *MainHelper) PreloadMigrations() {
 			panic(fmt.Errorf("cannot read file: %v", err))
 		}
 	}
-	handle := h.SQLStore.GetMasterX()
+	handle := h.SQLStore.GetMaster()
 	_, err = handle.Exec(string(buf))
 	if err != nil {
 		panic(errors.Wrap(err, "Error preloading migrations. Check if you have &multiStatements=true in your DSN if you are using MySQL. Or perhaps the schema changed? If yes, then update the warmup files accordingly"))

--- a/server/config/database_test.go
+++ b/server/config/database_test.go
@@ -39,7 +39,7 @@ func setupConfigDatabase(t *testing.T, cfg *model.Config, files map[string][]byt
 
 	ds := &DatabaseStore{
 		driverName:     *mainHelper.GetSQLSettings().DriverName,
-		db:             mainHelper.GetSQLStore().GetMasterX().DB,
+		db:             mainHelper.GetSQLStore().GetMaster().DB,
 		dataSourceName: *mainHelper.Settings.DataSource,
 	}
 
@@ -80,7 +80,7 @@ func getActualDatabaseConfig(t *testing.T) (string, *model.Config) {
 			ID    string `db:"id"`
 			Value []byte `db:"value"`
 		}
-		err := mainHelper.GetSQLStore().GetMasterX().Get(&actual, "SELECT Id, Value FROM Configurations WHERE Active")
+		err := mainHelper.GetSQLStore().GetMaster().Get(&actual, "SELECT Id, Value FROM Configurations WHERE Active")
 		require.NoError(t, err)
 
 		var actualCfg *model.Config
@@ -92,7 +92,7 @@ func getActualDatabaseConfig(t *testing.T) (string, *model.Config) {
 		ID    string `db:"Id"`
 		Value []byte `db:"Value"`
 	}
-	err := mainHelper.GetSQLStore().GetMasterX().Get(&actual, "SELECT Id, Value FROM Configurations WHERE Active")
+	err := mainHelper.GetSQLStore().GetMaster().Get(&actual, "SELECT Id, Value FROM Configurations WHERE Active")
 	require.NoError(t, err)
 
 	var actualCfg *model.Config
@@ -548,7 +548,7 @@ func TestDatabaseStoreSet(t *testing.T) {
 		require.NoError(t, err)
 		defer ds.Close()
 
-		_, err = mainHelper.GetSQLStore().GetMasterX().Exec("DROP TABLE Configurations")
+		_, err = mainHelper.GetSQLStore().GetMaster().Exec("DROP TABLE Configurations")
 		require.NoError(t, err)
 
 		newCfg := minimalConfig
@@ -829,7 +829,7 @@ func TestDatabaseStoreLoad(t *testing.T) {
 
 		truncateTables(t)
 		id := model.NewId()
-		_, err = mainHelper.GetSQLStore().GetMasterX().NamedExec("INSERT INTO Configurations (Id, Value, CreateAt, Active) VALUES(:id, :value, :createat, TRUE)", map[string]any{
+		_, err = mainHelper.GetSQLStore().GetMaster().NamedExec("INSERT INTO Configurations (Id, Value, CreateAt, Active) VALUES(:id, :value, :createat, TRUE)", map[string]any{
 			"id":       id,
 			"value":    cfgData,
 			"createat": model.GetMillis(),

--- a/server/config/main_test.go
+++ b/server/config/main_test.go
@@ -36,7 +36,7 @@ func truncateTable(t *testing.T, table string) {
 
 	switch *sqlSetting.DriverName {
 	case model.DatabaseDriverMysql:
-		_, err := sqlStore.GetMasterX().Exec(fmt.Sprintf("TRUNCATE TABLE %s", table))
+		_, err := sqlStore.GetMaster().Exec(fmt.Sprintf("TRUNCATE TABLE %s", table))
 		if err != nil {
 			if driverErr, ok := err.(*mysql.MySQLError); ok {
 				// Ignore if the Configurations table does not exist.
@@ -48,7 +48,7 @@ func truncateTable(t *testing.T, table string) {
 		require.NoError(t, err)
 
 	case model.DatabaseDriverPostgres:
-		_, err := sqlStore.GetMasterX().Exec(fmt.Sprintf("TRUNCATE TABLE %s", table))
+		_, err := sqlStore.GetMaster().Exec(fmt.Sprintf("TRUNCATE TABLE %s", table))
 		if err != nil {
 			if driverErr, ok := err.(*pq.Error); ok {
 				// Ignore if the Configurations table does not exist.


### PR DESCRIPTION
#### Summary
Drop the legacy `X` suffix from `GetMasterX` and `GetReplicaX`. The presence of the suffix suggests there's a `non-X` version: but in fact we migrated these away a long time ago, so remove the cognitive overhead.

As an aside, this additionally helps avoid trip up LLMs that interpret this as "something to fix".

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
