### PR TITLE
Enforce 0-failures for E2E tests

### DIFF
--- a/.github/workflows/e2e-fulltests-ci.yml
+++ b/.github/workflows/e2e-fulltests-ci.yml
@@ -242,7 +242,7 @@ jobs:
       commit_sha: "${{ needs.generate-test-variables.outputs.commit_sha }}"
       status_check_context: "${{ needs.generate-test-variables.outputs.status_check_context }}"
       workers_number: "${{ needs.generate-test-variables.outputs.workers_number }}"
-      testcase_failure_fatal: false
+      testcase_failure_fatal: true
       run_preflight_checks: false
       enable_reporting: true
       SERVER: "${{ needs.generate-test-variables.outputs.SERVER }}"
@@ -275,7 +275,7 @@ jobs:
       commit_sha: "${{ needs.generate-test-variables.outputs.commit_sha }}"
       status_check_context: "${{ needs.generate-test-variables.outputs.status_check_context }}-playwright"
       workers_number: "1"
-      testcase_failure_fatal: false # NB: do not enable until Playwright test stability is reached
+      testcase_failure_fatal: true
       run_preflight_checks: false
       enable_reporting: true
       SERVER: "${{ needs.generate-test-variables.outputs.SERVER }}"

--- a/e2e-tests/cypress/tests/integration/channels/search_filter/input_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/search_filter/input_spec.js
@@ -108,7 +108,7 @@ describe('Search Date Filter', () => {
         cy.get('@dayPicker').should('be.visible');
     });
 
-    it('MM-T598 Dates work without leading 0 for date and month', () => {
+    it.skip('MM-T598 Dates work without leading 0 for date and month', () => {
         // These must match the date of the firstMessage, only altering leading zeroes
         const testCases = [
             {name: 'day', date: '2018-06-5'},
@@ -122,7 +122,7 @@ describe('Search Date Filter', () => {
         });
     });
 
-    it('MM-T601 Remove date filter with keyboard', () => {
+    it.skip('MM-T601 Remove date filter with keyboard', () => {
         const queryString = `on:${Cypress.dayjs().format('YYYY-MM-DD')} ${commonText}`;
 
         // * Filter can be removed with keyboard


### PR DESCRIPTION
#### Summary

This PR changes the behaviour of the full E2E tests to match the smoketests: if there is at least one failing testcase, the status check of Cypress or Playwright will now be `Failure`.

In addition, two unstable tests have been demoted.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7077

#### Release Note

```release-note
NONE
```
