### PR TITLE
MM-62105 use WARN log level when ws can't report hostname

### DIFF
--- a/server/channels/app/platform/web_conn.go
+++ b/server/channels/app/platform/web_conn.go
@@ -780,7 +780,10 @@ func (wc *WebConn) createHelloMessage() *model.WebSocketEvent {
 
 	hostname, err := os.Hostname()
 	if err != nil {
-		wc.Platform.logger.Error("Could not get hostname", mlog.Err(err))
+		wc.Platform.logger.Warn("Could not get hostname",
+			mlog.String("user_id", wc.UserId),
+			mlog.String("conn_id", wc.GetConnectionID()),
+			mlog.Err(err))
 		// return without the hostname in the message
 		return msg
 	}


### PR DESCRIPTION
#### Summary
When opening a websocket, we send a HELLO event that contains the server's hostname. Prior to this PR, if the server is unable to report the hostname we logged an error. Now, we log a warning. Additionally, we now include the user ID and connection ID in the log event.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62105

#### Release Note
```release-note
NONE
```