### PR TITLE
[MM-61958][MM-53174][MM-60880] Always fetch team unreads for current team on reconnect

### DIFF
--- a/webapp/channels/src/actions/websocket_actions.jsx
+++ b/webapp/channels/src/actions/websocket_actions.jsx
@@ -257,7 +257,7 @@ export function reconnect() {
         }
 
         const crtEnabled = isCollapsedThreadsEnabled(state);
-        dispatch(TeamActions.getMyTeamUnreads(crtEnabled, true));
+        dispatch(TeamActions.getMyTeamUnreads(crtEnabled));
         if (crtEnabled) {
             const teams = getMyTeams(state);
             syncThreads(currentTeamId, currentUserId);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/teams.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/teams.ts
@@ -70,10 +70,7 @@ export function getMyTeams() {
     });
 }
 
-// The argument skipCurrentTeam is a (not ideal) workaround for CRT mention counts. Unread mentions are stored in the reducer per
-// team but we do not track unread mentions for DMs/GMs independently. This results in a bit of funky logic and edge case bugs
-// that need workarounds like this. In the future we should fix the root cause with better APIs and redux state.
-export function getMyTeamUnreads(collapsedThreads: boolean, skipCurrentTeam = false): ActionFuncAsync {
+export function getMyTeamUnreads(collapsedThreads: boolean): ActionFuncAsync {
     return async (dispatch, getState) => {
         let unreads;
         try {
@@ -82,16 +79,6 @@ export function getMyTeamUnreads(collapsedThreads: boolean, skipCurrentTeam = fa
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));
             return {error};
-        }
-
-        if (skipCurrentTeam) {
-            const currentTeamId = getCurrentTeamId(getState());
-            if (currentTeamId) {
-                const index = unreads.findIndex((member) => member.team_id === currentTeamId);
-                if (index >= 0) {
-                    unreads.splice(index, 1);
-                }
-            }
         }
 
         dispatch(


### PR DESCRIPTION
#### Summary
At one point, our unread mentions relied solely on the team-level unreads, which when we introduced CRT, caused a sync issue where we would pull down unreads for a specific team, and it would overwrite the ones that included the unreads/mentions for DMs and GMs.

A bit later on we changed the way we handled unreads/mention counts for other areas of the system, opting for a reducer that combined all of the unreads and used the much more robust channel-level unreads. However, we never went back and reverted the original fix that originally patched this issue. The lack of syncing we were caused the team unreads for the current team (still used by the sidebar to indicate the count ONLY for that team, not including DMs/GMs) caused a mismatch between the threads viewer/link and the team sidebar.

This PR effectively reverts the [original fix](https://github.com/mattermost/mattermost-webapp/pull/8702) which should allow syncing to work correctly going forward.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61958

```release-note
Fixed an issue where the team sidebar's mention count could be out of sync with the thread count
```
