### PR TITLE
[MM-61648]: Fixed the aria-roles and plugins preferences tab list structure.

### DIFF
--- a/webapp/channels/src/components/settings_sidebar/settings_sidebar.tsx
+++ b/webapp/channels/src/components/settings_sidebar/settings_sidebar.tsx
@@ -110,17 +110,31 @@ export default class SettingsSidebar extends React.PureComponent<Props> {
             pluginTabList = (
                 <>
                     <hr/>
-                    <li
-                        key={'plugin preferences heading'}
-                        role='heading'
-                        className={'header'}
+                    <div
+                        aria-labelledby={'userSettingsModal.pluginPreferences.header'}
+                        role='region'
                     >
-                        <FormattedMessage
+                        <div
                             id={'userSettingsModal.pluginPreferences.header'}
-                            defaultMessage={'PLUGIN PREFERENCES'}
-                        />
-                    </li>
-                    {this.props.pluginTabs.map((tab, index) => this.renderTab(tab, index))}
+                            key={'plugin preferences heading'}
+                            role='heading'
+                            aria-level={3}
+                            className={'header'}
+                        >
+                            <FormattedMessage
+                                id={'userSettingsModal.pluginPreferences.header'}
+                                defaultMessage={'PLUGIN PREFERENCES'}
+                            />
+                        </div>
+                        <ul
+                            id='tabList.plugins'
+                            className='nav nav-pills nav-stacked'
+                            role='tablist'
+                            aria-orientation='vertical'
+                        >
+                            {this.props.pluginTabs.map((tab, index) => this.renderTab(tab, index))}
+                        </ul>
+                    </div>
                 </>
             );
         }
@@ -134,8 +148,8 @@ export default class SettingsSidebar extends React.PureComponent<Props> {
                     aria-orientation='vertical'
                 >
                     {tabList}
-                    {pluginTabList}
                 </ul>
+                {pluginTabList}
             </div>
         );
     }

--- a/webapp/channels/src/components/settings_sidebar/settings_sidebar.tsx
+++ b/webapp/channels/src/components/settings_sidebar/settings_sidebar.tsx
@@ -112,7 +112,7 @@ export default class SettingsSidebar extends React.PureComponent<Props> {
                     <hr/>
                     <div
                         aria-labelledby={'userSettingsModal.pluginPreferences.header'}
-                        role='region'
+                        role='group'
                     >
                         <div
                             id={'userSettingsModal.pluginPreferences.header'}

--- a/webapp/channels/src/sass/components/_settings-modal.scss
+++ b/webapp/channels/src/sass/components/_settings-modal.scss
@@ -15,11 +15,6 @@
             > li {
                 margin-bottom: 8px;
 
-                &.header {
-                    color: rgba(var(--center-channel-color-rgb), 0.75);
-                    font-weight: 600;
-                }
-
                 button {
                     height: 32px;
                     padding: 0 12px;
@@ -49,6 +44,12 @@
                     }
                 }
             }
+        }
+
+        .header {
+            margin-bottom: 8px;
+            color: rgba(var(--center-channel-color-rgb), 0.75);
+            font-weight: 600;
         }
 
         .settings-table {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
- Updated the Plugin preferences tab list structure in the user settings modal.
- Updated the aria-level and aria-role for the plugin's preferences heading.

#### Steps to reproduce  
- Navigate to the PLUGIN PREFERENCES heading text.
- Inspect the element.
- Notice that the aria-level attribute is not provided for the role="heading".

#### Expected Behavior 
- Plugin preferences must be in a separate region with its tab list.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Jira https://mattermost.atlassian.net/browse/MM-61648

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

<table>
    <tr>
        <th>Before</th>
 <th>After</th>
    </tr>
    <tr>
        <td>
 <img src="https://github.com/user-attachments/assets/7db3d72d-5e8d-40f2-bd9c-1bbfa2ddf4e4">
</td>
  <td>
 <img src="https://github.com/user-attachments/assets/e460238f-9cdb-4952-b842-c34d7bf4e1ae">
</td>
    </tr>
</table>

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
