### PR TITLE
[MM-61674]: Added appropriate roles to the menu component of post priority

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/system_console/site_configuration/link_customization_e20_1_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/system_console/site_configuration/link_customization_e20_1_spec.js
@@ -140,7 +140,7 @@ describe('SupportSettings', () => {
         cy.uiOpenProductMenu().within(() => {
             // * Verify that 'Download Apps' has expected link
             cy.findByText('Download Apps').
-                parent().
+                parents('a').
                 should('have.attr', 'href', link);
         });
     });

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu_item/product_menu_item.tsx
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu_item/product_menu_item.tsx
@@ -61,6 +61,7 @@ const ProductMenuItem = ({icon, destination, text, active, onClick, tourTip, id}
             to={destination}
             onClick={onClick}
             id={id}
+            role='menuitem'
         >
             <ProductIcon
                 size={24}

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu_list/__snapshots__/product_menu_list.test.tsx.snap
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu_list/__snapshots__/product_menu_list.test.tsx.snap
@@ -501,6 +501,7 @@ exports[`components/global/product_switcher_menu should show integrations should
   <li
     className="MenuGroup menu-divider"
     onClick={[Function]}
+    role="presentation"
   />
   <div
     onClick={[Function]}

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu_list/__snapshots__/product_menu_list.test.tsx.snap
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu_list/__snapshots__/product_menu_list.test.tsx.snap
@@ -501,7 +501,7 @@ exports[`components/global/product_switcher_menu should show integrations should
   <li
     className="MenuGroup menu-divider"
     onClick={[Function]}
-    role="presentation"
+    role="separator"
   />
   <div
     onClick={[Function]}

--- a/webapp/channels/src/components/post_priority/post_priority_picker.tsx
+++ b/webapp/channels/src/components/post_priority/post_priority_picker.tsx
@@ -141,8 +141,11 @@ function PostPriorityPicker({
                     defaultMessage: 'Message priority',
                 })}
             </Header>
-            <div role='application'>
-                <Menu className='Menu'>
+            <div>
+                <Menu
+                    className='Menu'
+                    role='menu'
+                >
                     <MenuGroup>
                         <MenuItem
                             id='menu-item-priority-standard'

--- a/webapp/channels/src/components/post_priority/post_priority_picker.tsx
+++ b/webapp/channels/src/components/post_priority/post_priority_picker.tsx
@@ -141,85 +141,94 @@ function PostPriorityPicker({
                     defaultMessage: 'Message priority',
                 })}
             </Header>
-            <div>
-                <Menu
-                    className='Menu'
-                    role='menu'
-                >
+            <Menu
+                className='Menu'
+                role='menu'
+            >
+                <MenuGroup>
+                    <MenuItem
+                        id='menu-item-priority-standard'
+                        onClick={makeOnSelectPriority()}
+                        isSelected={!priority}
+                        icon={<StandardIcon size={18}/>}
+                        text={formatMessage({
+                            id: 'post_priority.priority.standard',
+                            defaultMessage: 'Standard',
+                        })}
+                    />
+                    <MenuItem
+                        id='menu-item-priority-important'
+                        onClick={makeOnSelectPriority(PostPriority.IMPORTANT)}
+                        isSelected={priority === PostPriority.IMPORTANT}
+                        icon={<ImportantIcon size={18}/>}
+                        text={formatMessage({
+                            id: 'post_priority.priority.important',
+                            defaultMessage: 'Important',
+                        })}
+                    />
+                    <MenuItem
+                        id='menu-item-priority-urgent'
+                        onClick={makeOnSelectPriority(PostPriority.URGENT)}
+                        isSelected={priority === PostPriority.URGENT}
+                        icon={<UrgentIcon size={18}/>}
+                        text={formatMessage({
+                            id: 'post_priority.priority.urgent',
+                            defaultMessage: 'Urgent',
+                        })}
+                    />
+                </MenuGroup>
+                {(postAcknowledgementsEnabled || persistentNotificationsEnabled) && (
                     <MenuGroup>
-                        <MenuItem
-                            id='menu-item-priority-standard'
-                            onClick={makeOnSelectPriority()}
-                            isSelected={!priority}
-                            icon={<StandardIcon size={18}/>}
-                            text={formatMessage({
-                                id: 'post_priority.priority.standard',
-                                defaultMessage: 'Standard',
-                            })}
-                        />
-                        <MenuItem
-                            id='menu-item-priority-important'
-                            onClick={makeOnSelectPriority(PostPriority.IMPORTANT)}
-                            isSelected={priority === PostPriority.IMPORTANT}
-                            icon={<ImportantIcon size={18}/>}
-                            text={formatMessage({
-                                id: 'post_priority.priority.important',
-                                defaultMessage: 'Important',
-                            })}
-                        />
-                        <MenuItem
-                            id='menu-item-priority-urgent'
-                            onClick={makeOnSelectPriority(PostPriority.URGENT)}
-                            isSelected={priority === PostPriority.URGENT}
-                            icon={<UrgentIcon size={18}/>}
-                            text={formatMessage({
-                                id: 'post_priority.priority.urgent',
-                                defaultMessage: 'Urgent',
-                            })}
-                        />
+                        <li
+                            role='none'
+                            style={{all: 'unset'}}
+                        >
+                            <ul
+                                role='group'
+                                aria-label='Message and Notification Settings'
+                                style={{all: 'unset'}}
+                            >
+                                {postAcknowledgementsEnabled && (
+                                    <ToggleItem
+                                        disabled={false}
+                                        onClick={handleAck}
+                                        toggled={requestedAck}
+                                        icon={<AcknowledgementIcon size={18}/>}
+                                        text={formatMessage({
+                                            id: 'post_priority.requested_ack.text',
+                                            defaultMessage: 'Request acknowledgement',
+                                        })}
+                                        description={formatMessage({
+                                            id: 'post_priority.requested_ack.description',
+                                            defaultMessage: 'An acknowledgement button will appear with your message',
+                                        })}
+                                    />
+                                )}
+                                {priority === PostPriority.URGENT && persistentNotificationsEnabled && (
+                                    <ToggleItem
+                                        disabled={priority !== PostPriority.URGENT}
+                                        onClick={handlePersistentNotifications}
+                                        toggled={persistentNotifications}
+                                        icon={<PersistentNotificationsIcon size={18}/>}
+                                        text={formatMessage({
+                                            id: 'post_priority.persistent_notifications.text',
+                                            defaultMessage: 'Send persistent notifications',
+                                        })}
+                                        description={formatMessage(
+                                            {
+                                                id: 'post_priority.persistent_notifications.description',
+                                                defaultMessage: 'Recipients will be notified every {interval, plural, one {1 minute} other {{interval} minutes}} until they acknowledge or reply',
+                                            }, {
+                                                interval,
+                                            },
+                                        )}
+                                    />
+                                )}
+                            </ul>
+                        </li>
                     </MenuGroup>
-                    {(postAcknowledgementsEnabled || persistentNotificationsEnabled) && (
-                        <MenuGroup>
-                            {postAcknowledgementsEnabled && (
-                                <ToggleItem
-                                    disabled={false}
-                                    onClick={handleAck}
-                                    toggled={requestedAck}
-                                    icon={<AcknowledgementIcon size={18}/>}
-                                    text={formatMessage({
-                                        id: 'post_priority.requested_ack.text',
-                                        defaultMessage: 'Request acknowledgement',
-                                    })}
-                                    description={formatMessage({
-                                        id: 'post_priority.requested_ack.description',
-                                        defaultMessage: 'An acknowledgement button will appear with your message',
-                                    })}
-                                />
-                            )}
-                            {priority === PostPriority.URGENT && persistentNotificationsEnabled && (
-                                <ToggleItem
-                                    disabled={priority !== PostPriority.URGENT}
-                                    onClick={handlePersistentNotifications}
-                                    toggled={persistentNotifications}
-                                    icon={<PersistentNotificationsIcon size={18}/>}
-                                    text={formatMessage({
-                                        id: 'post_priority.persistent_notifications.text',
-                                        defaultMessage: 'Send persistent notifications',
-                                    })}
-                                    description={formatMessage(
-                                        {
-                                            id: 'post_priority.persistent_notifications.description',
-                                            defaultMessage: 'Recipients will be notified every {interval, plural, one {1 minute} other {{interval} minutes}} until they acknowledge or reply',
-                                        }, {
-                                            interval,
-                                        },
-                                    )}
-                                />
-                            )}
-                        </MenuGroup>
-                    )}
-                </Menu>
-            </div>
+                )}
+            </Menu>
             {postAcknowledgementsEnabled && (
                 <Footer>
                     <button

--- a/webapp/channels/src/components/post_priority/post_priority_picker_item.tsx
+++ b/webapp/channels/src/components/post_priority/post_priority_picker_item.tsx
@@ -32,7 +32,7 @@ const ItemButton = styled.button`
     align-items: center !important;
 `;
 
-const Wrapper = styled.div`
+const Wrapper = styled.li`
     cursor: ${(props) => (props.disabled ? 'default' : 'pointer')};
 
     &:hover {
@@ -117,7 +117,7 @@ function ToggleItem({
         <Wrapper
             onClick={disabled ? undefined : onClick}
             disabled={disabled}
-            role='button'
+            role='menuitemcheckbox'
             aria-pressed={toggled}
         >
             <ToggleMain>

--- a/webapp/channels/src/components/widgets/menu/menu.test.tsx
+++ b/webapp/channels/src/components/widgets/menu/menu.test.tsx
@@ -23,11 +23,11 @@ describe('components/Menu', () => {
       <div
         aria-label="test-label"
         className="a11y__popup Menu"
-        role="menu"
       >
         <ul
           className="Menu__content dropdown-menu"
           onClick={[Function]}
+          role="menu"
           style={Object {}}
         >
           text
@@ -51,11 +51,11 @@ describe('components/Menu', () => {
         aria-label="test-label"
         className="a11y__popup Menu"
         id="test-id"
-        role="menu"
       >
         <ul
           className="Menu__content dropdown-menu"
           onClick={[Function]}
+          role="menu"
           style={Object {}}
         >
           text
@@ -79,11 +79,11 @@ describe('components/Menu', () => {
       <div
         aria-label="test-label"
         className="a11y__popup Menu"
-        role="menu"
       >
         <ul
           className="Menu__content dropdown-menu openLeft openUp"
           onClick={[Function]}
+          role="menu"
           style={Object {}}
         >
           text

--- a/webapp/channels/src/components/widgets/menu/menu.tsx
+++ b/webapp/channels/src/components/widgets/menu/menu.tsx
@@ -128,9 +128,9 @@ export default class Menu extends React.PureComponent<Props> {
                 aria-label={ariaLabel}
                 className='a11y__popup Menu'
                 id={id}
-                role='menu'
             >
                 <ul
+                    role='menu'
                     id={listId}
                     ref={this.node}
                     style={styles}

--- a/webapp/channels/src/components/widgets/menu/menu_group.test.tsx
+++ b/webapp/channels/src/components/widgets/menu/menu_group.test.tsx
@@ -15,6 +15,7 @@ describe('components/MenuItem', () => {
   <li
     className="MenuGroup menu-divider"
     onClick={[Function]}
+    role="presentation"
   />
   text
 </Fragment>

--- a/webapp/channels/src/components/widgets/menu/menu_group.test.tsx
+++ b/webapp/channels/src/components/widgets/menu/menu_group.test.tsx
@@ -15,7 +15,7 @@ describe('components/MenuItem', () => {
   <li
     className="MenuGroup menu-divider"
     onClick={[Function]}
-    role="presentation"
+    role="separator"
   />
   text
 </Fragment>

--- a/webapp/channels/src/components/widgets/menu/menu_group.tsx
+++ b/webapp/channels/src/components/widgets/menu/menu_group.tsx
@@ -23,6 +23,7 @@ const MenuGroup = (props: Props) => {
         <li
             className='MenuGroup menu-divider'
             onClick={handleDividerClick}
+            role='presentation'
         />
     );
 

--- a/webapp/channels/src/components/widgets/menu/menu_group.tsx
+++ b/webapp/channels/src/components/widgets/menu/menu_group.tsx
@@ -23,7 +23,7 @@ const MenuGroup = (props: Props) => {
         <li
             className='MenuGroup menu-divider'
             onClick={handleDividerClick}
-            role='presentation'
+            role='separator'
         />
     );
 

--- a/webapp/channels/src/plugins/test/__snapshots__/main_menu_action.test.tsx.snap
+++ b/webapp/channels/src/plugins/test/__snapshots__/main_menu_action.test.tsx.snap
@@ -4,11 +4,11 @@ exports[`plugins/MainMenuActions should match snapshot in mobile view with some 
 <div
   aria-label="main menu"
   className="a11y__popup Menu"
-  role="menu"
 >
   <ul
     className="Menu__content dropdown-menu"
     onClick={[Function]}
+    role="menu"
     style={Object {}}
   >
     <Memo(MenuGroup)>
@@ -438,11 +438,11 @@ exports[`plugins/MainMenuActions should match snapshot in web view 1`] = `
 <div
   aria-label="team menu"
   className="a11y__popup Menu"
-  role="menu"
 >
   <ul
     className="Menu__content dropdown-menu"
     onClick={[Function]}
+    role="menu"
     style={Object {}}
   >
     <Memo(MenuGroup)>


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
- The message priority menu does not follow the correct menu structure.
- Updated the Message priority menu structure as recommended by W3C please [refer](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/examples/menubar-editor/)

#### Steps to reproduce  
- Navigate to the Message priority button and select it.
- Now navigate to the Standard, Important and Urgent buttons list.
- Inspect the element.
- Notice that the list is implemented incorrectly.

#### Expected Behavior 
- Please [refer](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/examples/menubar-editor/)

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Jira https://mattermost.atlassian.net/browse/MM-61674

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->
<table>
    <tr>
        <th>Before</th>
 <th>After</th>
    </tr>
    <tr>
        <td>
 <img src="https://github.com/user-attachments/assets/c17b23f9-a7ee-4cba-838e-c21e96f06dcf">
</td>
  <td>
 <img src="https://github.com/user-attachments/assets/089d7d88-0b0c-46fb-97cf-32ccd0a20b06">
</td>
    </tr>
</table>

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
