### PR TITLE
MM-61698: Unskip TestWebHubCloseConnOnDBFail

### DIFF
--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -3128,14 +3128,13 @@ func TestWebHubMembership(t *testing.T) {
 }
 
 func TestWebHubCloseConnOnDBFail(t *testing.T) {
-	t.Skip("MM-61780")
 	th := Setup(t).InitBasic()
 	defer func() {
 		th.TearDown()
-		// Asserting that the error message is present in the log
-		testlib.AssertLog(t, th.LogBuffer, mlog.LvlError.Name, "Error while registering to hub")
 		_, err := th.Server.Store().GetInternalMasterDB().Exec(`ALTER TABLE dummy RENAME to ChannelMembers`)
 		require.NoError(t, err)
+		// Asserting that the error message is present in the log
+		testlib.AssertLog(t, th.LogBuffer, mlog.LvlError.Name, "Error while registering to hub")
 	}()
 
 	cli := th.CreateClient()


### PR DESCRIPTION
https://github.com/mattermost/mattermost/pull/29214 fixed the
race condition in web_hub initialization.

The failure in the test is strange because there's no log
for the websocket request. It's as if th.CreateWebSocketClientWithClient()
never got called at all.

I am re-arranging the lines so that even if it fails,
the table rename happens anyways. But overall, I don't see
any reason for the failure.

https://mattermost.atlassian.net/browse/MM-61698

```release-note
NONE
```
