### PR TITLE
Adding error context in license validation

### DIFF
--- a/server/channels/api4/license.go
+++ b/server/channels/api4/license.go
@@ -117,7 +117,7 @@ func addLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 
 		canStartTrialLicense, err := lm.CanStartTrial()
 		if err != nil {
-			c.Err = model.NewAppError("addLicense", "api.license.add_license.open.app_error", nil, "", http.StatusInternalServerError)
+			c.Err = model.NewAppError("addLicense", "api.license.add_license.open.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 			return
 		}
 


### PR DESCRIPTION
While investigating https://mattermost.atlassian.net/browse/MM-61529,
I noticed that we weren't adding the internal error which made
it impossible to understand what was really happening.

```release-note
NONE
```
