### PR TITLE
[MM-62092] Allow system admins to pull posts in from DMs they're not in

### DIFF
--- a/server/channels/api4/post.go
+++ b/server/channels/api4/post.go
@@ -214,7 +214,7 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	}
-	if !c.App.SessionHasPermissionToReadChannel(c.AppContext, *c.AppContext.Session(), channel) {
+	if !c.IsSystemAdmin() && !c.App.SessionHasPermissionToReadChannel(c.AppContext, *c.AppContext.Session(), channel) {
 		c.SetPermissionError(model.PermissionReadChannelContent)
 		return
 	}

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -1994,6 +1994,14 @@ func TestGetPostsForChannel(t *testing.T) {
 		require.NoError(t, err)
 		CheckOKStatus(t, resp)
 		require.Len(t, posts.Order, 10, "expected 10 posts")
+
+		// allow viewing of direct messages
+		dmChannel := th.CreateDmChannel(th.BasicUser2)
+		th.CreateMessagePostNoClient(dmChannel, "test1", model.GetMillis())
+
+		posts, resp, err = c.GetPostsForChannel(context.Background(), dmChannel.Id, 0, 100, "", false, false)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
 	})
 }
 


### PR DESCRIPTION
#### Summary
A change we made to permissions accidentally removed the ability for sysadmins to view posts for DMs they're not in. This PR fixes that permission for the particular call needed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62092

```release-note
Fixed an issue where system admins couldn't pull posts in from DMs they're not in
```
