### PR TITLE
Stabilize replies_spec.ts

### DIFF
--- a/e2e-tests/cypress/tests/support/ui_commands.ts
+++ b/e2e-tests/cypress/tests/support/ui_commands.ts
@@ -172,7 +172,7 @@ Cypress.Commands.add('getLastPostId', getLastPostId);
 
 function uiWaitUntilMessagePostedIncludes(message: string): ChainableT<any> {
     const checkFn = () => {
-        return cy.getLastPost().then((el) => {
+        return cy.getLastPost().scrollIntoView().then((el) => {
             const postedMessageEl = el.find('.post-message__text')[0];
             return Boolean(postedMessageEl && postedMessageEl.textContent.includes(message));
         });


### PR DESCRIPTION
#### Summary

This PR stabilizes the  `replies_spec.ts` test by making sure the last post is scrolled into view, before proceeding with the rest of the test.

Hopefully this should also stabilize other tests that use this function.

#### Release Note

```release-note
NONE
```
