### PR TITLE
[MM-62086][MM-62202] Don't include deleted DMs/GMs when returning archived channels

### DIFF
--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -1507,7 +1507,7 @@ func (s SqlChannelStore) GetDeleted(teamId string, offset int, limit int, userId
 
 	if !skipTeamMembershipCheck {
 		builder = builder.Where(sq.Or{
-			sq.NotEq{"Type": model.ChannelTypePrivate},
+			sq.Eq{"Type": model.ChannelTypeOpen},
 			sq.And{
 				sq.Eq{"Type": model.ChannelTypePrivate},
 				sq.Expr("Id IN (?)", sq.Select("ChannelId").From("ChannelMembers").Where(sq.Eq{"UserId": userId})),


### PR DESCRIPTION
#### Summary
When we go to view archived channels via the `/deleted` API, it was noticed that deleted DMs were coming through in the response. These aren't usually able to be created through the system, but it's possible that an admin may manually mark channels with a `DeleteAt` through the DB. This also caused an issue with the Browse Channels dialog where it would try to grab member counts for channels the user couldn't access.

This PR ensures that the API only returns channels that can be archived, to avoid the permissions issue and to avoid leaking any DMs/GMs by accident.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62202
https://mattermost.atlassian.net/browse/MM-62086

```release-note
Fixed an issue where DMs/GMs with a `DeleteAt` flag in the database might cause issues with a couple APIs
```
