### PR TITLE
MM-62188 - Revoke user sessions when converted to bot

### DIFF
--- a/server/channels/app/bot.go
+++ b/server/channels/app/bot.go
@@ -614,5 +614,9 @@ func (a *App) ConvertUserToBot(rctx request.CTX, user *model.User) (*model.Bot, 
 			return nil, model.NewAppError("CreateBot", "app.bot.createbot.internal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 		}
 	}
+	if err := a.RevokeAllSessions(rctx, user.Id); err != nil {
+		return nil, err
+	}
+
 	return bot, nil
 }

--- a/server/channels/app/bot_test.go
+++ b/server/channels/app/bot_test.go
@@ -890,14 +890,14 @@ func TestConvertUserToBot(t *testing.T) {
 		})
 		require.Nil(t, err)
 		defer func() {
-			err := th.App.PermanentDeleteBot(th.Context, bot.UserId)
+			err = th.App.PermanentDeleteBot(th.Context, bot.UserId)
 			require.Nil(t, err)
 		}()
 		assert.Equal(t, "username", bot.Username)
 		assert.Equal(t, th.BasicUser.Id, bot.OwnerId)
 
 		// make sure session is no longer valid
-		testSession, err = th.App.GetSession(session.Token)
+		_, err = th.App.GetSession(session.Token)
 		require.NotNil(t, err)
 		require.Equal(t, "api.context.invalid_token.error", err.Id)
 	})

--- a/server/channels/app/bot_test.go
+++ b/server/channels/app/bot_test.go
@@ -872,9 +872,17 @@ func TestConvertUserToBot(t *testing.T) {
 		})
 	})
 
-	t.Run("valid user", func(t *testing.T) {
+	t.Run("valid user and session revoked", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
+
+		session, err := th.App.CreateSession(th.Context, &model.Session{UserId: th.BasicUser.Id, Props: model.StringMap{}})
+		require.Nil(t, err)
+
+		// make sure session is valid
+		testSession, err := th.App.GetSession(session.Token)
+		require.Nil(t, err)
+		require.False(t, testSession.IsExpired())
 
 		bot, err := th.App.ConvertUserToBot(th.Context, &model.User{
 			Username: "username",
@@ -887,6 +895,11 @@ func TestConvertUserToBot(t *testing.T) {
 		}()
 		assert.Equal(t, "username", bot.Username)
 		assert.Equal(t, th.BasicUser.Id, bot.OwnerId)
+
+		// make sure session is no longer valid
+		testSession, err = th.App.GetSession(session.Token)
+		require.NotNil(t, err)
+		require.Equal(t, "api.context.invalid_token.error", err.Id)
 	})
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Revokes user session after user is converted to a bot.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-62188

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
