### PR TITLE
MM-62079: Fix permissions being reset properly

### DIFF
--- a/server/channels/api4/bot_test.go
+++ b/server/channels/api4/bot_test.go
@@ -55,7 +55,8 @@ func TestCreateBot(t *testing.T) {
 	t.Run("create bot with permissions", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		_, appErr := th.App.UpdateUserRoles(th.Context, th.BasicUser.Id, model.TeamUserRoleId, false)
@@ -148,7 +149,8 @@ func TestCreateBot(t *testing.T) {
 	t.Run("create bot with null value", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		_, appErr := th.App.UpdateUserRoles(th.Context, th.BasicUser.Id, model.TeamUserRoleId, false)
@@ -169,7 +171,8 @@ func TestPatchBot(t *testing.T) {
 	t.Run("patch non-existent bot", func(t *testing.T) {
 		th := Setup(t)
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
 			_, resp, err := client.PatchBot(context.Background(), model.NewId(), &model.BotPatch{})
@@ -181,7 +184,8 @@ func TestPatchBot(t *testing.T) {
 	t.Run("system admin and local client can patch any bot", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		_, appErr := th.App.UpdateUserRoles(th.Context, th.BasicUser.Id, model.TeamUserRoleId, false)
@@ -248,7 +252,8 @@ func TestPatchBot(t *testing.T) {
 	t.Run("patch someone else's bot without permission", func(t *testing.T) {
 		th := Setup(t)
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.App.UpdateConfig(func(cfg *model.Config) {
 			*cfg.ServiceSettings.EnableBotAccountCreation = true
@@ -273,7 +278,8 @@ func TestPatchBot(t *testing.T) {
 	t.Run("patch someone else's bot without permission, but with read others permission", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionReadOthersBots.Id, model.TeamUserRoleId)
 		_, appErr := th.App.UpdateUserRoles(th.Context, th.BasicUser.Id, model.TeamUserRoleId, false)
@@ -301,7 +307,8 @@ func TestPatchBot(t *testing.T) {
 	t.Run("patch someone else's bot with permission", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionManageOthersBots.Id, model.TeamUserRoleId)
 		_, appErr := th.App.UpdateUserRoles(th.Context, th.BasicUser.Id, model.TeamUserRoleId, false)
@@ -357,7 +364,8 @@ func TestPatchBot(t *testing.T) {
 	t.Run("patch my bot without permission", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		_, appErr := th.App.UpdateUserRoles(th.Context, th.BasicUser.Id, model.TeamUserRoleId, false)
@@ -391,7 +399,8 @@ func TestPatchBot(t *testing.T) {
 	t.Run("patch my bot without permission, but with read permission", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
@@ -426,7 +435,8 @@ func TestPatchBot(t *testing.T) {
 	t.Run("patch my bot with permission", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionManageBots.Id, model.TeamUserRoleId)
@@ -466,7 +476,8 @@ func TestPatchBot(t *testing.T) {
 	t.Run("partial patch my bot with permission", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionManageBots.Id, model.TeamUserRoleId)
@@ -506,7 +517,8 @@ func TestPatchBot(t *testing.T) {
 	t.Run("update bot, internally managed fields ignored", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionManageBots.Id, model.TeamUserRoleId)
@@ -547,7 +559,8 @@ func TestPatchBot(t *testing.T) {
 	t.Run("patch with null bot", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionManageBots.Id, model.TeamUserRoleId)
@@ -644,7 +657,8 @@ func TestGetBot(t *testing.T) {
 	th.RemovePermissionFromRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 
 	t.Run("get unknown bot", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadOthersBots.Id, model.TeamUserRoleId)
@@ -657,7 +671,8 @@ func TestGetBot(t *testing.T) {
 	})
 
 	t.Run("get bot1", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadOthersBots.Id, model.TeamUserRoleId)
@@ -674,7 +689,8 @@ func TestGetBot(t *testing.T) {
 	})
 
 	t.Run("get bot2", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadOthersBots.Id, model.TeamUserRoleId)
@@ -691,7 +707,8 @@ func TestGetBot(t *testing.T) {
 	})
 
 	t.Run("get bot1 without PermissionReadOthersBots permission", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
@@ -705,7 +722,8 @@ func TestGetBot(t *testing.T) {
 	})
 
 	t.Run("get myBot without ReadBots OR ReadOthersBots permissions", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionManageBots.Id, model.TeamUserRoleId)
@@ -718,7 +736,8 @@ func TestGetBot(t *testing.T) {
 	})
 
 	t.Run("get deleted bot", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadOthersBots.Id, model.TeamUserRoleId)
@@ -731,7 +750,8 @@ func TestGetBot(t *testing.T) {
 	})
 
 	t.Run("get deleted bot, include deleted", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadOthersBots.Id, model.TeamUserRoleId)
@@ -847,7 +867,8 @@ func TestGetBots(t *testing.T) {
 	CheckOKStatus(t, resp)
 
 	t.Run("get bots, page=0, perPage=10", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadOthersBots.Id, model.TeamUserRoleId)
@@ -868,7 +889,8 @@ func TestGetBots(t *testing.T) {
 	})
 
 	t.Run("get bots, page=0, perPage=1", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadOthersBots.Id, model.TeamUserRoleId)
@@ -889,7 +911,8 @@ func TestGetBots(t *testing.T) {
 	})
 
 	t.Run("get bots, page=1, perPage=2", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadOthersBots.Id, model.TeamUserRoleId)
@@ -910,7 +933,8 @@ func TestGetBots(t *testing.T) {
 	})
 
 	t.Run("get bots, page=2, perPage=2", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadOthersBots.Id, model.TeamUserRoleId)
@@ -931,7 +955,8 @@ func TestGetBots(t *testing.T) {
 	})
 
 	t.Run("get bots, page=0, perPage=10, include deleted", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadOthersBots.Id, model.TeamUserRoleId)
@@ -952,7 +977,8 @@ func TestGetBots(t *testing.T) {
 	})
 
 	t.Run("get bots, page=0, perPage=1, include deleted", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadOthersBots.Id, model.TeamUserRoleId)
@@ -973,7 +999,8 @@ func TestGetBots(t *testing.T) {
 	})
 
 	t.Run("get bots, page=1, perPage=2, include deleted", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadOthersBots.Id, model.TeamUserRoleId)
@@ -994,7 +1021,8 @@ func TestGetBots(t *testing.T) {
 	})
 
 	t.Run("get bots, page=2, perPage=2, include deleted", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadOthersBots.Id, model.TeamUserRoleId)
@@ -1015,7 +1043,8 @@ func TestGetBots(t *testing.T) {
 	})
 
 	t.Run("get bots, page=0, perPage=10, only orphaned", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadOthersBots.Id, model.TeamUserRoleId)
@@ -1036,7 +1065,8 @@ func TestGetBots(t *testing.T) {
 	})
 
 	t.Run("get bots without permission", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionManageBots.Id, model.TeamUserRoleId)
@@ -1064,7 +1094,8 @@ func TestDisableBot(t *testing.T) {
 	t.Run("disable bot without permission", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		_, appErr := th.App.UpdateUserRoles(th.Context, th.BasicUser.Id, model.TeamUserRoleId, false)
@@ -1093,7 +1124,8 @@ func TestDisableBot(t *testing.T) {
 	t.Run("disable bot without permission, but with read permission", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
@@ -1123,7 +1155,8 @@ func TestDisableBot(t *testing.T) {
 	t.Run("disable bot with permission", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionManageBots.Id, model.TeamUserRoleId)
@@ -1181,7 +1214,8 @@ func TestEnableBot(t *testing.T) {
 	t.Run("enable bot without permission", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		_, appErr := th.App.UpdateUserRoles(th.Context, th.BasicUser.Id, model.TeamUserRoleId, false)
@@ -1214,7 +1248,8 @@ func TestEnableBot(t *testing.T) {
 	t.Run("enable bot without permission, but with read permission", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.TeamUserRoleId)
@@ -1248,7 +1283,8 @@ func TestEnableBot(t *testing.T) {
 	t.Run("enable bot with permission", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionManageBots.Id, model.TeamUserRoleId)
@@ -1309,7 +1345,8 @@ func TestAssignBot(t *testing.T) {
 	})
 
 	t.Run("system admin and local mode assign bot", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.SystemUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.SystemUserRoleId)
@@ -1361,7 +1398,8 @@ func TestAssignBot(t *testing.T) {
 	})
 
 	t.Run("random user assign bot", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.SystemUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.SystemUserRoleId)
@@ -1396,7 +1434,8 @@ func TestAssignBot(t *testing.T) {
 	})
 
 	t.Run("delegated user assign bot", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.SystemUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.SystemUserRoleId)
@@ -1435,7 +1474,8 @@ func TestAssignBot(t *testing.T) {
 	})
 
 	t.Run("bot assigned to bot fails", func(t *testing.T) {
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.SystemUserRoleId)
 		th.AddPermissionToRole(model.PermissionReadBots.Id, model.SystemUserRoleId)

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -38,7 +38,12 @@ func TestCreatePost(t *testing.T) {
 	defer th.TearDown()
 	client := th.Client
 
-	post := &model.Post{ChannelId: th.BasicChannel.Id, Message: "#hashtag a" + model.NewId() + "a", Props: model.StringInterface{model.PropsAddChannelMember: "no good"}, DeleteAt: 101}
+	post := &model.Post{
+		ChannelId: th.BasicChannel.Id,
+		Message:   "#hashtag a" + model.NewId() + "a",
+		Props:     model.StringInterface{model.PropsAddChannelMember: "no good"},
+		DeleteAt:  101,
+	}
 
 	rpost, resp, err2 := client.CreatePost(context.Background(), post)
 	require.NoError(t, err2)
@@ -119,12 +124,12 @@ func TestCreatePost(t *testing.T) {
 	})
 
 	t.Run("Create posts without the USE_CHANNEL_MENTIONS Permission - returns ephemeral message with mentions and no ephemeral message without mentions", func(t *testing.T) {
-		t.Skip("MM-62079")
 		WebSocketClient, err := th.CreateWebSocketClient()
 		WebSocketClient.Listen()
 		require.NoError(t, err)
 
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		th.RemovePermissionFromRole(model.PermissionUseChannelMentions.Id, model.ChannelUserRoleId)
 
@@ -161,16 +166,17 @@ func TestCreatePost(t *testing.T) {
 		require.NoError(t, err)
 
 		timeout = time.After(5 * time.Second)
-		eventsToGo := 3 // 3 Posts created with @ mentions should result in 3 websocket events
-		for eventsToGo > 0 {
+		expectedEvents := 3 // 3 Posts created with @ mentions should result in 3 websocket events
+		gotEvents := 0
+		for gotEvents < expectedEvents {
 			select {
 			case event := <-WebSocketClient.EventChannel:
 				if event.EventType() == model.WebsocketEventEphemeralMessage {
-					eventsToGo = eventsToGo - 1
+					gotEvents++
 				}
 			case <-timeout:
-				require.Fail(t, "Should have received ephemeral message event and not timedout")
-				eventsToGo = 0
+				require.Fail(t, fmt.Sprintf("Got %d ephemeral messages, expected: %d", gotEvents, expectedEvents))
+				break
 			}
 		}
 	})
@@ -1666,7 +1672,8 @@ func TestPatchPost(t *testing.T) {
 		CheckForbiddenStatus(t, resp)
 
 		// Add permission to edit others'
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 		th.RemovePermissionFromRole(model.PermissionEditPost.Id, model.ChannelUserRoleId)
 		th.AddPermissionToRole(model.PermissionEditOthersPosts.Id, model.ChannelUserRoleId)
 
@@ -4394,7 +4401,8 @@ func TestPostGetInfo(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
-	defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+	defaultPerms := th.SaveDefaultRolePermissions()
+	defer th.RestoreDefaultRolePermissions(defaultPerms)
 	th.RemovePermissionFromRole(model.PermissionManagePrivateChannelMembers.Id, model.SystemUserRoleId)
 	th.RemovePermissionFromRole(model.PermissionManagePrivateChannelMembers.Id, model.ChannelUserRoleId)
 	th.RemovePermissionFromRole(model.PermissionManagePrivateChannelMembers.Id, model.TeamUserRoleId)

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -1145,7 +1145,8 @@ func TestGetBotUser(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
-	defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+	defaultPerms := th.SaveDefaultRolePermissions()
+	defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 	th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 	_, appErr := th.App.UpdateUserRoles(th.Context, th.BasicUser.Id, model.SystemUserRoleId+" "+model.TeamUserRoleId, false)
@@ -5100,7 +5101,8 @@ func TestCreateUserAccessToken(t *testing.T) {
 
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionCreateUserAccessToken.Id, model.TeamUserRoleId)
 		_, appErr := th.App.UpdateUserRoles(th.Context, th.BasicUser.Id, model.TeamUserRoleId, false)
@@ -5145,7 +5147,8 @@ func TestCreateUserAccessToken(t *testing.T) {
 
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionManageBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionCreateUserAccessToken.Id, model.TeamUserRoleId)
@@ -5255,7 +5258,8 @@ func TestGetUserAccessToken(t *testing.T) {
 
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionManageBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionCreateUserAccessToken.Id, model.TeamUserRoleId)
@@ -5307,7 +5311,8 @@ func TestGetUserAccessToken(t *testing.T) {
 
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionManageBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionCreateUserAccessToken.Id, model.TeamUserRoleId)
@@ -5543,7 +5548,8 @@ func TestRevokeUserAccessToken(t *testing.T) {
 
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionManageBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionCreateUserAccessToken.Id, model.TeamUserRoleId)
@@ -5591,7 +5597,8 @@ func TestRevokeUserAccessToken(t *testing.T) {
 
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionManageBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionCreateUserAccessToken.Id, model.TeamUserRoleId)
@@ -5671,7 +5678,8 @@ func TestDisableUserAccessToken(t *testing.T) {
 
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionManageBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionCreateUserAccessToken.Id, model.TeamUserRoleId)
@@ -5719,7 +5727,8 @@ func TestDisableUserAccessToken(t *testing.T) {
 
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionManageBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionCreateUserAccessToken.Id, model.TeamUserRoleId)
@@ -5807,7 +5816,8 @@ func TestEnableUserAccessToken(t *testing.T) {
 
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionManageBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionCreateUserAccessToken.Id, model.TeamUserRoleId)
@@ -5858,7 +5868,8 @@ func TestEnableUserAccessToken(t *testing.T) {
 
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 		th.AddPermissionToRole(model.PermissionCreateBot.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionManageBots.Id, model.TeamUserRoleId)
 		th.AddPermissionToRole(model.PermissionCreateUserAccessToken.Id, model.TeamUserRoleId)

--- a/server/channels/api4/user_viewmembers_test.go
+++ b/server/channels/api4/user_viewmembers_test.go
@@ -120,7 +120,8 @@ func TestAPIRestrictedViewMembers(t *testing.T) {
 				"api.context.permissions.app_error",
 			},
 		}
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		for _, tc := range testCases {
 			t.Run(tc.Name, func(t *testing.T) {
@@ -201,7 +202,8 @@ func TestAPIRestrictedViewMembers(t *testing.T) {
 				"api.context.permissions.app_error",
 			},
 		}
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		for _, tc := range testCases {
 			t.Run(tc.Name, func(t *testing.T) {
@@ -282,7 +284,8 @@ func TestAPIRestrictedViewMembers(t *testing.T) {
 				"api.context.permissions.app_error",
 			},
 		}
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		for _, tc := range testCases {
 			t.Run(tc.Name, func(t *testing.T) {
@@ -363,7 +366,8 @@ func TestAPIRestrictedViewMembers(t *testing.T) {
 				"api.context.permissions.app_error",
 			},
 		}
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		for _, tc := range testCases {
 			t.Run(tc.Name, func(t *testing.T) {
@@ -444,7 +448,8 @@ func TestAPIRestrictedViewMembers(t *testing.T) {
 				"api.context.permissions.app_error",
 			},
 		}
-		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
+		defaultPerms := th.SaveDefaultRolePermissions()
+		defer th.RestoreDefaultRolePermissions(defaultPerms)
 
 		for _, tc := range testCases {
 			t.Run(tc.Name, func(t *testing.T) {


### PR DESCRIPTION
The default role permissions weren't being saved
to a separate variable which would have not restored
them properly. This was a problem in various other
tests, potentially causing side-effects in other
flaky tests as well.

We fix that, as well as clean up the for loop
a bit and mention how many messages were recieved
in the failure message so that it becomes clear
whether no messages were recieved, or atleast some
were received.

https://mattermost.atlassian.net/browse/MM-62079
```release-note
NONE
```
