### PR TITLE
MM-61699: Improve TestDeletePostEvent

### DIFF
--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -3165,10 +3165,8 @@ func TestDeletePostEvent(t *testing.T) {
 	_, err = th.SystemAdminClient.DeletePost(context.Background(), th.BasicPost.Id)
 	require.NoError(t, err)
 
-	var received bool
-
-	for {
-		var exit bool
+	var received, exit bool
+	for !received && !exit {
 		select {
 		case event := <-WebSocketClient.EventChannel:
 			if event.EventType() == model.WebsocketEventPostDeleted {
@@ -3179,9 +3177,6 @@ func TestDeletePostEvent(t *testing.T) {
 			}
 		case <-time.After(5 * time.Second):
 			exit = true
-		}
-		if exit {
-			break
 		}
 	}
 


### PR DESCRIPTION
This test failed because TestWebHubCloseConnOnDBFail failed
and therefore the ChannelMembers table failed to be
renamed back.

We can see that in the logs:

```
teams","request_id":"sdxjxsd1wibd9mb7kc3ixj6g1w","ip_addr":"127.0.0.1","user_id":"afw9qqjh7pnddqakraxnjf1oph","method":"POST","user_id":"afw9qqjh7pnddqakraxnjf1oph","team_id":"bocubwmn4jyrmc1p9uxrc4pwfc","error":"JoinDefaultChannels: Unable to save direct channel., channel_members_save: Error 1146 (42S02): Table 'dbrt3jzcosj3nb8g6mgwmqyss9rh.ChannelMembers' doesn't exist"}
{"timestamp":"2024-11-10 13:52:34.260 Z","level":"error","msg":"Error while invalidating channel member cache","caller":"platform/web_hub.go:524","user_id":"afw9qqjh7pnddqakraxnjf1oph","error":"failed to find ChannelMembers, TeamScheme and ChannelScheme data: Error 1146 (42S02): Table 'dbrt3jzcosj3nb8g6mgwmqyss9rh.ChannelMembers' doesn't exist"}
{"timestamp":"2024-11-10 13:52:34.260 Z","level":"error","msg":"Error while invalidating channel member cache","caller":"platform/web_hub.go:524","user_id":"afw9qqjh7pnddqakraxnjf1oph","error":"failed to find ChannelMembers, TeamScheme and ChannelScheme data: Error 1146 (42S02): Table 'dbrt3jzcosj3nb8g6mgwmqyss9rh.ChannelMembers' doesn't exist"}
```

There is nothing wrong with this test. And while
we are here, we slightly improve the for-select loop
to exit faster.

https://mattermost.atlassian.net/browse/MM-61699
```release-note
NONE
```
