### PR TITLE
Update minimum supported Safari and Firefox versions

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10342,11 +10342,11 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",
-    "translation": "Version 115+"
+    "translation": "Version 119+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.safari",
-    "translation": "Version 17.0+"
+    "translation": "Version 17.4+"
   },
   {
     "id": "web.error.unsupported_browser.min_os_version.mac",


### PR DESCRIPTION
Harrison requested to bump the versions to use some new accessibility features of the browser.

```release-note
Updated minimum Safari version to 17.4+ and minimum Firefox version to 119+.
```
