### PR TITLE
MM-61698: Fix TestWebHubCloseConnOnDBFail properly

### DIFF
--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -3147,7 +3147,7 @@ func TestWebHubCloseConnOnDBFail(t *testing.T) {
 
 	wsClient, err := th.CreateWebSocketClientWithClient(cli)
 	require.NoError(t, err)
-	defer wsClient.Close()
+	wsClient.Close()
 
 	require.NoError(t, th.TestLogger.Flush())
 }


### PR DESCRIPTION
Finally I figured out why the log message for
/api/v4/websocket does not appear. It is because
the log gets generated only when the request returns,
and for websockets, the request doesn't return
until the client closes. And because we were closing
the client in a defer clause, the flushing of the logger
would happen before closing the client, therefore
leading to a race condition of the log not appearing
from time to time.

https://mattermost.atlassian.net/browse/MM-61698
```release-note
NONE
```
