### PR TITLE
Bugfix - Enforce URL length check in LinkMetadata before attempting to insert to database

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9526,7 +9526,7 @@
   },
   {
     "id": "model.link_metadata.is_valid.url_length.app_error",
-    "translation": "Link metadata URL is too long."
+    "translation": "Link metadata URL is {{ .Length }} characters long, longer then the maximum of {{ .MaxLength }} characters.."
   },
   {
     "id": "model.member.is_valid.channel.app_error",

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9525,6 +9525,10 @@
     "translation": "Link metadata URL must be set."
   },
   {
+    "id": "model.link_metadata.is_valid.url_length.app_error",
+    "translation": "Link metadata URL is too long."
+  },
+  {
     "id": "model.member.is_valid.channel.app_error",
     "translation": "Channel name is not valid"
   },

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9526,7 +9526,7 @@
   },
   {
     "id": "model.link_metadata.is_valid.url_length.app_error",
-    "translation": "Link metadata URL is {{ .Length }} characters long, longer then the maximum of {{ .MaxLength }} characters.."
+    "translation": "Length of link metadata URL is {{ .Length }} characters long, which exceeds the maximum limit of {{ .MaxLength }} characters."
   },
   {
     "id": "model.member.is_valid.channel.app_error",

--- a/server/public/model/link_metadata.go
+++ b/server/public/model/link_metadata.go
@@ -95,7 +95,7 @@ func (o *LinkMetadata) IsValid() *AppError {
 	}
 
 	if len(o.URL) > LinkMetadataMaxURLLength {
-		return NewAppError("LinkMetadata.IsValid", "model.linkmetadata.is_valid.url_length.app_error", map[string]any{"MaxLength": LinkMetadataMaxURLLength, "Length": len(o.URL)}, "", http.StatusBadRequest)
+		return NewAppError("LinkMetadata.IsValid", "model.link_metadata.is_valid.url_length.app_error", map[string]any{"MaxLength": LinkMetadataMaxURLLength, "Length": len(o.URL)}, "", http.StatusBadRequest)
 	}
 
 	if o.Timestamp == 0 || !isRoundedToNearestHour(o.Timestamp) {

--- a/server/public/model/link_metadata.go
+++ b/server/public/model/link_metadata.go
@@ -21,7 +21,7 @@ const (
 	LinkMetadataTypeNone      LinkMetadataType = "none"
 	LinkMetadataTypeOpengraph LinkMetadataType = "opengraph"
 	LinkMetadataMaxImages     int              = 5
-	LinkMetadataMaxURLLength  int              = 2048
+	LinkMetadataMaxURLLength  int              = 2048  // Maximum URL length in LinkMetadata table
 )
 
 type LinkMetadataType string

--- a/server/public/model/link_metadata.go
+++ b/server/public/model/link_metadata.go
@@ -95,7 +95,7 @@ func (o *LinkMetadata) IsValid() *AppError {
 	}
 
 	if len(o.URL) > LinkMetadataMaxURLLength {
-		return NewAppError("LinkMetadata.IsValid", "model.linkmetadata.is_valid.url_length.app_error", nil, "", http.StatusBadRequest)
+		return NewAppError("LinkMetadata.IsValid", "model.linkmetadata.is_valid.url_length.app_error", map[string]any{"MaxLength": LinkMetadataMaxURLLength, "Length": len(o.URL)}, "", http.StatusBadRequest)
 	}
 
 	if o.Timestamp == 0 || !isRoundedToNearestHour(o.Timestamp) {

--- a/server/public/model/link_metadata.go
+++ b/server/public/model/link_metadata.go
@@ -21,7 +21,7 @@ const (
 	LinkMetadataTypeNone      LinkMetadataType = "none"
 	LinkMetadataTypeOpengraph LinkMetadataType = "opengraph"
 	LinkMetadataMaxImages     int              = 5
-	LinkMetadataMaxURLLength  int              = 2048  // Maximum URL length in LinkMetadata table
+	LinkMetadataMaxURLLength  int              = 2048 // Maximum URL length in LinkMetadata table
 )
 
 type LinkMetadataType string

--- a/server/public/model/link_metadata.go
+++ b/server/public/model/link_metadata.go
@@ -89,7 +89,7 @@ func (o *LinkMetadata) PreSave() {
 }
 
 func (o *LinkMetadata) IsValid() *AppError {
-	if o.URL == "" {
+	if o.URL == "" || len(o.URL) > 2048 {
 		return NewAppError("LinkMetadata.IsValid", "model.link_metadata.is_valid.url.app_error", nil, "", http.StatusBadRequest)
 	}
 

--- a/server/public/model/link_metadata.go
+++ b/server/public/model/link_metadata.go
@@ -21,6 +21,7 @@ const (
 	LinkMetadataTypeNone      LinkMetadataType = "none"
 	LinkMetadataTypeOpengraph LinkMetadataType = "opengraph"
 	LinkMetadataMaxImages     int              = 5
+	LinkMetadataMaxURLLength  int              = 2048
 )
 
 type LinkMetadataType string
@@ -89,7 +90,7 @@ func (o *LinkMetadata) PreSave() {
 }
 
 func (o *LinkMetadata) IsValid() *AppError {
-	if o.URL == "" || len(o.URL) > 2048 {
+	if o.URL == "" || len(o.URL) > LinkMetadataMaxURLLength {
 		return NewAppError("LinkMetadata.IsValid", "model.link_metadata.is_valid.url.app_error", nil, "", http.StatusBadRequest)
 	}
 

--- a/server/public/model/link_metadata.go
+++ b/server/public/model/link_metadata.go
@@ -90,8 +90,12 @@ func (o *LinkMetadata) PreSave() {
 }
 
 func (o *LinkMetadata) IsValid() *AppError {
-	if o.URL == "" || len(o.URL) > LinkMetadataMaxURLLength {
+	if o.URL == "" {
 		return NewAppError("LinkMetadata.IsValid", "model.link_metadata.is_valid.url.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	if len(o.URL) > LinkMetadataMaxURLLength {
+		return NewAppError("LinkMetadata.IsValid", "model.linkmetadata.is_valid.url_length.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if o.Timestamp == 0 || !isRoundedToNearestHour(o.Timestamp) {

--- a/server/public/model/link_metadata_test.go
+++ b/server/public/model/link_metadata_test.go
@@ -146,6 +146,16 @@ func TestLinkMetadataIsValid(t *testing.T) {
 			},
 			Expected: false,
 		},
+		{
+			Name: "should be invalid because of URL length being too long",
+			Metadata: &LinkMetadata{
+				URL:       "http://example.com/?" + strings.Repeat("a", 2048),
+				Timestamp: 1546300800000,
+				Type:      LinkMetadataTypeImage,
+				Data:      &PostImage{},
+			},
+			Expected: false,
+		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			appErr := test.Metadata.IsValid()


### PR DESCRIPTION
#### Summary
URL lengths are not enforced in the LinkMetadata validation, which causes `INSERT` statements to fail repeatedly with long URLs.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/29588.

#### Release Note
```release-note
Fix insertion errors to LinkMetadata table.
```
