### PR TITLE
[MM-62086] Don't include deleted DMs/GMs when returning archived channels (#29572)

### DIFF
--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -1475,7 +1475,7 @@ func (s SqlChannelStore) GetDeleted(teamId string, offset int, limit int, userId
 		SELECT * FROM Channels
 		WHERE (TeamId = ? OR TeamId = '')
 		AND DeleteAt != 0
-		AND Type != ?
+		AND Type = ?
 		UNION
 			SELECT * FROM Channels
 			WHERE (TeamId = ? OR TeamId = '')
@@ -1485,7 +1485,7 @@ func (s SqlChannelStore) GetDeleted(teamId string, offset int, limit int, userId
 		ORDER BY DisplayName LIMIT ? OFFSET ?
 	`
 
-	if err := s.GetReplicaX().Select(&channels, query, teamId, model.ChannelTypePrivate, teamId, model.ChannelTypePrivate, userId, limit, offset); err != nil {
+	if err := s.GetReplicaX().Select(&channels, query, teamId, model.ChannelTypeOpen, teamId, model.ChannelTypePrivate, userId, limit, offset); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Channel", fmt.Sprintf("TeamId=%s,UserId=%s", teamId, userId))
 		}


### PR DESCRIPTION
#### Summary
Cherry-pick of #29572 to `release-9.11`
Modified as the code to do this changed since v10.

```release-note
NONE
```
