### PR TITLE
Change how Rudder is mocked in a test

### DIFF
--- a/webapp/channels/src/components/root/root.test.tsx
+++ b/webapp/channels/src/components/root/root.test.tsx
@@ -32,14 +32,12 @@ jest.mock('mattermost-redux/client/rudder', () => ({
     RudderTelemetryHandler: jest.fn(),
 }));
 
-jest.mock('mattermost-redux/client/rudder', () => {
-    const actual = jest.requireActual('mattermost-redux/client/rudder');
+jest.mock('rudder-sdk-js', () => {
     return {
-        ...actual,
-        rudderAnalytics: {
-            ...actual.rudderAnalytics,
-            ready: jest.fn((callback) => callback()),
-        },
+        identify: jest.fn(),
+        load: jest.fn(),
+        page: jest.fn(),
+        ready: jest.fn((callback) => callback()),
     };
 });
 


### PR DESCRIPTION
#### Summary
One of the tests in this file fails on my laptop because of a series of weird interactions with my local environment. I think what's happening is that, despite our tests using Nock to intercept HTTP requests, the library seems to still make a real request, but that's intercepted by Pi-hole (my ad blocker) which redirects it back to localhost, and then the request runs into an invalid certificate because of the HTTPS certificate I use on my local server.

Anyway, that can be fixed by just mocking all of Rudder's SDK instead of the one method that we care about in this test.

#### Release Note
```release-note
NONE
```
