### PR TITLE
[MM-61938] httpservice: improve validation of proxied URLs

### DIFF
--- a/server/public/go.mod
+++ b/server/public/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/tinylib/msgp v1.2.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	golang.org/x/crypto v0.25.0
+	golang.org/x/net v0.27.0
 	golang.org/x/oauth2 v0.21.0
 	golang.org/x/text v0.16.0
 	golang.org/x/tools v0.23.0
@@ -62,7 +63,6 @@ require (
 	github.com/wiggin77/srslog v1.0.1 // indirect
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 	golang.org/x/mod v0.19.0 // indirect
-	golang.org/x/net v0.27.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240722135656-d784300faade // indirect


### PR DESCRIPTION
#### Summary

Take two. We are simplifying a bit and simply rejecting proxied URLs that have an invalid IPv6 address in the host.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-61938

#### Release Notes

```release-note
NONE
```

