### PR TITLE
Update shared channel app layer to make active check optional

### DIFF
--- a/server/channels/app/shared_channel.go
+++ b/server/channels/app/shared_channel.go
@@ -16,11 +16,15 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 )
 
-func (a *App) getSharedChannelsService() (SharedChannelServiceIFace, error) {
+func (a *App) getSharedChannelsService(ensureIsActive bool) (SharedChannelServiceIFace, error) {
 	scService := a.Srv().GetSharedChannelSyncService()
-	if scService == nil || !scService.Active() {
+	if scService == nil {
 		return nil, model.NewAppError("getSharedChannelsService", "api.command_share.service_disabled",
 			nil, "", http.StatusBadRequest)
+	}
+	if ensureIsActive && !scService.Active() {
+		return nil, model.NewAppError("getSharedChannelsService", "api.command_share.service_inactive",
+			nil, "", http.StatusInternalServerError)
 	}
 	return scService, nil
 }
@@ -51,7 +55,7 @@ func (a *App) checkChannelIsShared(channelId string) error {
 }
 
 func (a *App) CheckCanInviteToSharedChannel(channelId string) error {
-	scService, err := a.getSharedChannelsService()
+	scService, err := a.getSharedChannelsService(false)
 	if err != nil {
 		return err
 	}
@@ -61,7 +65,7 @@ func (a *App) CheckCanInviteToSharedChannel(channelId string) error {
 // SharedChannels
 
 func (a *App) ShareChannel(c request.CTX, sc *model.SharedChannel) (*model.SharedChannel, error) {
-	scService, err := a.getSharedChannelsService()
+	scService, err := a.getSharedChannelsService(false)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +93,7 @@ func (a *App) GetSharedChannelsCount(opts model.SharedChannelFilterOpts) (int64,
 }
 
 func (a *App) UpdateSharedChannel(sc *model.SharedChannel) (*model.SharedChannel, error) {
-	scService, err := a.getSharedChannelsService()
+	scService, err := a.getSharedChannelsService(false)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +101,7 @@ func (a *App) UpdateSharedChannel(sc *model.SharedChannel) (*model.SharedChannel
 }
 
 func (a *App) UnshareChannel(channelID string) (bool, error) {
-	scService, err := a.getSharedChannelsService()
+	scService, err := a.getSharedChannelsService(false)
 	if err != nil {
 		return false, err
 	}
@@ -107,7 +111,7 @@ func (a *App) UnshareChannel(channelID string) (bool, error) {
 // SharedChannelRemotes
 
 func (a *App) InviteRemoteToChannel(channelID, remoteID, userID string, shareIfNotShared bool) error {
-	ssService, err := a.getSharedChannelsService()
+	ssService, err := a.getSharedChannelsService(false)
 	if err != nil {
 		return err
 	}
@@ -115,7 +119,7 @@ func (a *App) InviteRemoteToChannel(channelID, remoteID, userID string, shareIfN
 }
 
 func (a *App) UninviteRemoteFromChannel(channelID, remoteID string) error {
-	ssService, err := a.getSharedChannelsService()
+	ssService, err := a.getSharedChannelsService(false)
 	if err != nil {
 		return err
 	}

--- a/server/channels/app/status.go
+++ b/server/channels/app/status.go
@@ -71,7 +71,7 @@ func (a *App) UpdateDNDStatusOfUsers() {
 		return
 	}
 
-	scs, _ := a.getSharedChannelsService()
+	scs, _ := a.getSharedChannelsService(false)
 	for i := range statuses {
 		a.Srv().Platform().AddStatusCache(statuses[i])
 		a.Srv().Platform().BroadcastStatus(statuses[i])

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -1574,6 +1574,10 @@
     "translation": "Shared Channels Service is disabled."
   },
   {
+    "id": "api.command_share.service_inactive",
+    "translation": "Shared Channels Service is enabled but not active."
+  },
+  {
     "id": "api.command_share.share_channel.error",
     "translation": "Cannot share this channel: {{.Error}}"
   },


### PR DESCRIPTION
#### Summary
The `getSharedChannelsService` method was checking as well for the Shared Channels to be active, which only the lead node of a cluster is, so API operations that should run correctly like sharing/unsharing a channel or inviting/uninviting a remote were returning a 400 bad request.

This change updates the method to check for the Shared Channel service to be active only on request, and on doing so it changes the error and status code returned to indicate specifically that the service is running but inactive, and returns a 500 as the situation is not an error on the requester.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62183

#### Release Note
```release-note
NONE
```
