### PR TITLE
MM-62102 Scroll position resets when custom emojis requested #29512

### DIFF
--- a/webapp/channels/src/components/emoji_picker/emoji_picker.tsx
+++ b/webapp/channels/src/components/emoji_picker/emoji_picker.tsx
@@ -122,7 +122,10 @@ const EmojiPicker = ({
 
         const [updatedCategoryOrEmojisRows, updatedEmojiPositions] = createCategoryAndEmojiRows(allEmojis, categories, filter, userSkinTone);
 
-        selectFirstEmoji(updatedEmojiPositions);
+        if (activeCategory !== 'custom') {
+            selectFirstEmoji(updatedEmojiPositions);
+        }
+
         setCategoryOrEmojisRows(updatedCategoryOrEmojisRows);
         setEmojiPositionsArray(updatedEmojiPositions);
         throttledSearchCustomEmoji.current(filter, customEmojisEnabled);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
I have looked at PR #27467. The solution seems bad and not elegant. I have proposed a better and more elegant solution with minimal code. It saves the cursor state and uses already built-in functionality to navigate through icons and save their position.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62102
Fixes https://github.com/mattermost/mattermost/issues/29512

### Release Notes

```release-note
Improved Icon Navigation and Cursor State Management

Enhanced solution for icon navigation: The previous solution (PR #27467) lacked elegance and had unnecessary complexity. This release refines the approach, minimizing the amount of code and improving performance. 

Cursor state management: The cursor state is now saved and preserved, making it easier to navigate through icons seamlessly.

Built-in functionality usage: This change leverages already existing functionality for icon navigation, ensuring a cleaner and more efficient solution.

Addresses issues related to inefficient cursor handling and icon navigation in the user interface.
```
