### PR TITLE
Permanent deletion of Direct and Group channels

### DIFF
--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -1343,8 +1343,14 @@ func deleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	defer c.LogAuditRec(auditRec)
 
 	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
-		c.Err = model.NewAppError("deleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
-		return
+		if !c.Params.Permanent {
+			c.Err = model.NewAppError("deleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
+			return
+		}
+		if !c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), channel.Id, model.PermissionDeletePrivateChannel) {
+			c.SetPermissionError(model.PermissionDeletePrivateChannel)
+			return
+		}
 	}
 
 	if channel.Type == model.ChannelTypeOpen && !c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), channel.Id, model.PermissionDeletePublicChannel) {

--- a/server/channels/api4/channel_local.go
+++ b/server/channels/api4/channel_local.go
@@ -423,8 +423,10 @@ func localDeleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	audit.AddEventParameter(auditRec, "channel_id", c.Params.ChannelId)
 
 	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
-		c.Err = model.NewAppError("localDeleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
-		return
+		if !c.Params.Permanent {
+			c.Err = model.NewAppError("localDeleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
+			return
+		}
 	}
 
 	if c.Params.Permanent {

--- a/server/channels/api4/channel_local.go
+++ b/server/channels/api4/channel_local.go
@@ -427,6 +427,10 @@ func localDeleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.Err = model.NewAppError("localDeleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
 			return
 		}
+		if !c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), channel.Id, model.PermissionDeletePrivateChannel) {
+			c.SetPermissionError(model.PermissionDeletePrivateChannel)
+			return
+		}
 	}
 
 	if c.Params.Permanent {


### PR DESCRIPTION
#### Summary
Allows permanent deletion of Direct and Group channels. Soft deletion remains disallowed. Users require PermissionDeletePrivateChannel to delete.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/27489
Jira https://mattermost.atlassian.net/browse/MM-59260

#### Release Note
```release-note
Allows permanent deletion of Direct and Group channels. Soft deletion remains disallowed. Users require PermissionDeletePrivateChannel to delete.
```
