### PR TITLE
server/channels/app/import_functions_test: fix build errors

### DIFF
--- a/server/channels/app/import_functions_test.go
+++ b/server/channels/app/import_functions_test.go
@@ -1667,48 +1667,76 @@ func TestImportImportUser(t *testing.T) {
 		assert.Equal(t, "", channelMember.ExplicitRoles)
 	})
 
-	// Test importing deleted guest with a valid team & valid channel name in apply mode.
-	username = model.NewUsername()
-	deleteAt = model.GetMillis()
-	deletedGuestData := &imports.UserImportData{
-		Username: &username,
-		DeleteAt: &deleteAt,
-		Email:    model.NewPointer(model.NewId() + "@example.com"),
-		Roles:    model.NewPointer("system_guest"),
-		Teams: &[]imports.UserTeamImportData{
-			{
-				Name:  &team.Name,
-				Roles: model.NewPointer("team_guest"),
-				Channels: &[]imports.UserChannelImportData{
-					{
-						Name:  &channel.Name,
-						Roles: model.NewPointer("channel_guest"),
+	t.Run("import deleted guest with a valid team & valid channel name in apply mode", func(t *testing.T) {
+		teamData := &imports.TeamImportData{
+			Name:            model.NewPointer(model.NewRandomTeamName()),
+			DisplayName:     model.NewPointer("Display Name"),
+			Type:            model.NewPointer("O"),
+			Description:     model.NewPointer("The team description."),
+			AllowOpenInvite: model.NewPointer(true),
+		}
+		appErr := th.App.importTeam(th.Context, teamData, false)
+		assert.Nil(t, appErr)
+
+		team, appErr2 := th.App.GetTeamByName(*teamData.Name)
+		require.Nil(t, appErr2, "Failed to get team from database.")
+
+		channelData := &imports.ChannelImportData{
+			Team:        teamData.Name,
+			Name:        model.NewPointer(NewTestId()),
+			DisplayName: model.NewPointer("Display Name"),
+			Type:        model.NewPointer(model.ChannelTypeOpen),
+			Header:      model.NewPointer("Channel Header"),
+			Purpose:     model.NewPointer("Channel Purpose"),
+		}
+		appErr2 = th.App.importChannel(th.Context, channelData, false)
+		assert.Nil(t, appErr2)
+		channel, appErr2 := th.App.GetChannelByName(th.Context, *channelData.Name, team.Id, false)
+		require.Nil(t, appErr2, "Failed to get channel from database")
+
+		username := model.NewUsername()
+		deleteAt := model.GetMillis()
+		deletedGuestData := &imports.UserImportData{
+			Username: &username,
+			DeleteAt: &deleteAt,
+			Email:    model.NewPointer(model.NewId() + "@example.com"),
+			Roles:    model.NewPointer("system_guest"),
+			Teams: &[]imports.UserTeamImportData{
+				{
+					Name:  &team.Name,
+					Roles: model.NewPointer("team_guest"),
+					Channels: &[]imports.UserChannelImportData{
+						{
+							Name:  &channel.Name,
+							Roles: model.NewPointer("channel_guest"),
+						},
 					},
 				},
 			},
-		},
-	}
-	appErr = th.App.importUser(th.Context, deletedGuestData, false)
-	assert.Nil(t, appErr)
+		}
 
-	user, appErr = th.App.GetUserByUsername(*deletedGuestData.Username)
-	require.Nil(t, appErr, "Failed to get user from database.")
+		appErr = th.App.importUser(th.Context, deletedGuestData, false)
+		assert.Nil(t, appErr)
 
-	teamMember, appErr = th.App.GetTeamMember(th.Context, team.Id, user.Id)
-	require.Nil(t, appErr, "Failed to get the team member")
+		user, appErr := th.App.GetUserByUsername(*deletedGuestData.Username)
+		require.Nil(t, appErr, "Failed to get user from database.")
 
-	assert.False(t, teamMember.SchemeAdmin)
-	assert.False(t, teamMember.SchemeUser)
-	assert.True(t, teamMember.SchemeGuest)
-	assert.Equal(t, "", teamMember.ExplicitRoles)
+		teamMember, appErr := th.App.GetTeamMember(th.Context, team.Id, user.Id)
+		require.Nil(t, appErr, "Failed to get the team member")
 
-	channelMember, appErr = th.App.GetChannelMember(th.Context, channel.Id, user.Id)
-	require.Nil(t, appErr, "Failed to get the channel member")
+		assert.False(t, teamMember.SchemeAdmin)
+		assert.False(t, teamMember.SchemeUser)
+		assert.True(t, teamMember.SchemeGuest)
+		assert.Equal(t, "", teamMember.ExplicitRoles)
 
-	assert.False(t, teamMember.SchemeAdmin)
-	assert.False(t, channelMember.SchemeUser)
-	assert.True(t, teamMember.SchemeGuest)
-	assert.Equal(t, "", channelMember.ExplicitRoles)
+		channelMember, appErr := th.App.GetChannelMember(th.Context, channel.Id, user.Id)
+		require.Nil(t, appErr, "Failed to get the channel member")
+
+		assert.False(t, teamMember.SchemeAdmin)
+		assert.False(t, channelMember.SchemeUser)
+		assert.True(t, teamMember.SchemeGuest)
+		assert.Equal(t, "", channelMember.ExplicitRoles)
+	})
 }
 
 func TestImportUserTeams(t *testing.T) {


### PR DESCRIPTION

#### Summary
Merge queue caught me this time. #29530 had some substantial refactor in `TestImportImportUser` hence some variables had to be declared again and also some entities should've been imported again. I basically had to merge #28658 after the other one. 


#### Release Note
```release-note
NONE
```
