### PR TITLE
server/channels/app/export_test: fix a lint error due to err check

### DIFF
--- a/server/channels/app/export_test.go
+++ b/server/channels/app/export_test.go
@@ -373,7 +373,8 @@ func TestExportDMChannel(t *testing.T) {
 		assert.Equal(t, 2, len(channels))
 
 		// Permanentley delete other user
-		th1.App.PermanentDeleteUser(th1.Context, th1.BasicUser2)
+		appErr := th1.App.PermanentDeleteUser(th1.Context, th1.BasicUser2)
+		require.Nil(t, appErr)
 
 		var b bytes.Buffer
 		err := th1.App.BulkExport(th1.Context, &b, "somePath", nil, model.BulkExportOpts{})


### PR DESCRIPTION

#### Summary
My PR #28854 got in after https://github.com/mattermost/mattermost/pull/29004 hence linter rules started to apply. This PR addresses the necessary checks required by the linter.

#### Release Note

```release-note
NONE
```
