### PR TITLE
MM-62344 Disable mouse-events-have-key-events ESLint rule

### DIFF
--- a/webapp/platform/eslint-plugin/configs/.eslintrc-react.json
+++ b/webapp/platform/eslint-plugin/configs/.eslintrc-react.json
@@ -31,7 +31,7 @@
     "jsx-a11y/interactive-supports-focus": "warn",
     "jsx-a11y/label-has-associated-control": "error",
     "jsx-a11y/media-has-caption": "warn",
-    "jsx-a11y/mouse-events-have-key-events": "warn",
+    "jsx-a11y/mouse-events-have-key-events": "off",
     "jsx-a11y/no-access-key": "error",
     "jsx-a11y/no-aria-hidden-on-focusable": "error",
     "jsx-a11y/no-autofocus": "warn",


### PR DESCRIPTION
#### Summary
This rule warns us if an element has an onMouseOver/onMouseLeave attributes without corresponding onFocus/onBlur ones. It's helpful for showing where we may be missing some accessible interactions, and I've filed MM-62343 and MM-62345 to follow up on two of these.

In other cases, the component either has alternate accessibility support (the emoji picker), it's something that may not make sense to be accessible (the expanded view of the channel header), or something we're already planning to review accessiblity for (the search component), so I'm going to disable it to avoid introducing noise for the time being.

#### Ticket Link
MM-62344

#### Release Note
```release-note
NONE
```
