### PR TITLE
[MM-61599]: Remove tabIndex from non-interactive elements

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/accessibility/accessibility_post_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/accessibility/accessibility_post_spec.js
@@ -157,8 +157,7 @@ describe('Verify Accessibility Support in Post', () => {
         postMessages(testChannel, otherUser, 1);
 
         // # Shift focus to the last post
-        cy.get('#FormattingControl_bold').focus().tab({shift: true}).tab({shift: true}).type('{uparrow}{downarrow}');
-        cy.focused().tab();
+        cy.get('#FormattingControl_bold').focus().tab({shift: true}).tab({shift: true}).tab({shift: true}).tab({shift: true});
 
         cy.getLastPostId().then((postId) => {
             cy.get(`#post_${postId}`).within(() => {
@@ -230,36 +229,32 @@ describe('Verify Accessibility Support in Post', () => {
         // * Verify reverse tab on RHS
         cy.getLastPostId().then((postId) => {
             cy.get(`#rhsPost_${postId}`).within(() => {
-                // * Verify focus is on the post text
-                cy.get(`#rhsPostMessageText_${postId}`).should('be.focused');
-                cy.focused().tab({shift: true});
-
-                // * Verify focus is on the more button
-                cy.get(`#RHS_COMMENT_button_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'more');
-                cy.focused().tab({shift: true});
-
-                // * Verify focus is on the actions button
-                cy.get(`#RHS_COMMENT_actions_button_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'actions');
-                cy.focused().tab({shift: true});
-
-                // * Verify focus is on the save icon
-                cy.get(`#RHS_COMMENT_flagIcon_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'save message');
-                cy.focused().tab({shift: true});
-
-                // * Verify focus is on the reactions button
-                cy.get(`#RHS_COMMENT_reaction_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'Add Reaction');
-                cy.focused().tab({shift: true});
-
-                // * Verify focus is on most recent action
-                cy.get('#recent_reaction_0').should('have.class', 'emoticon--post-menu').and('have.attr', 'aria-label');
-                cy.focused().tab({shift: true});
-
                 // * Verify focus is on the time
                 cy.get(`#RHS_COMMENT_time_${postId}`).should('be.focused');
                 cy.focused().tab({shift: true});
 
                 // * Verify focus is on the username
                 cy.get('button.user-popover').should('be.focused');
+                cy.focused().tab().tab();
+
+                // * Verify focus is on most recent action
+                cy.get('#recent_reaction_0').should('have.class', 'emoticon--post-menu').and('have.attr', 'aria-label');
+                cy.focused().tab();
+
+                // * Verify focus is on the reactions button
+                cy.get(`#RHS_COMMENT_reaction_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'Add Reaction');
+                cy.focused().tab();
+
+                // * Verify focus is on the save icon
+                cy.get(`#RHS_COMMENT_flagIcon_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'save message');
+                cy.focused().tab();
+
+                // * Verify focus is on the actions button
+                cy.get(`#RHS_COMMENT_actions_button_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'actions');
+                cy.focused().tab();
+
+                // * Verify focus is on the more button
+                cy.get(`#RHS_COMMENT_button_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'more');
                 cy.focused().tab({shift: true});
             });
         });

--- a/e2e-tests/cypress/tests/integration/channels/accessibility/accessibility_post_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/accessibility/accessibility_post_spec.js
@@ -198,9 +198,6 @@ describe('Verify Accessibility Support in Post', () => {
                 // * Verify focus is on the more button
                 cy.get(`#CENTER_button_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'more');
                 cy.focused().tab();
-
-                // * Verify focus is on the post text
-                cy.get(`#postMessageText_${postId}`).should('be.focused');
             });
         });
     });

--- a/e2e-tests/cypress/tests/integration/channels/enterprise/accessibility/accessibility_input_fields_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/enterprise/accessibility/accessibility_input_fields_spec.ts
@@ -231,7 +231,7 @@ describe('Verify Accessibility Support in different input fields', () => {
 
         cy.get('#rhsContainer').within(() => {
             // * Verify Accessibility Support in RHS input
-            cy.uiGetReplyTextBox().should('have.attr', 'placeholder', 'Reply to this thread...').and('have.attr', 'role', 'textbox').focus().type('test').tab({shift: true}).tab().tab();
+            cy.uiGetReplyTextBox().should('have.attr', 'placeholder', 'Reply to this thread...').and('have.attr', 'role', 'textbox').focus().type('test').tab();
 
             // * Verify if the focus is on the preview button
             cy.get('#PreviewInputTextButton').should('be.focused').and('have.attr', 'aria-label', 'preview').tab();

--- a/e2e-tests/cypress/tests/integration/channels/mark_as_unread/archive_channel_mark_as_unread_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/mark_as_unread/archive_channel_mark_as_unread_spec.js
@@ -75,12 +75,6 @@ describe('Channels', () => {
         // * Verify the "Mark as Unread" option is absent in post menu
         markAsUnreadShouldBeAbsent(post1.id);
 
-        // * Hover on the post with holding alt should show cursor
-        cy.get(`#post_${post1.id}`).trigger('mouseover').type('{alt}', {release: false}).should(notShowCursor);
-
-        // # Mouse click on the post holding alt
-        cy.get(`#post_${post1.id}`).type('{alt}', {release: false}).click();
-
         // * Verify the post is not marked as unread
         cy.get('.NotificationSeparator').should('not.exist');
     });

--- a/e2e-tests/cypress/tests/integration/channels/mark_as_unread/archive_channel_mark_as_unread_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/mark_as_unread/archive_channel_mark_as_unread_spec.js
@@ -10,7 +10,7 @@
 // Stage: @prod
 // Group: @channels @mark_as_unread
 
-import {notShowCursor, markAsUnreadShouldBeAbsent} from './helpers';
+import {markAsUnreadShouldBeAbsent} from './helpers';
 
 describe('Channels', () => {
     let testUser;

--- a/e2e-tests/cypress/tests/integration/channels/mark_as_unread/mark_as_unread_using_shortcuts_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/mark_as_unread/mark_as_unread_using_shortcuts_spec.js
@@ -61,8 +61,8 @@ describe('Mark as Unread', () => {
         // * Hover on the post with holding alt should show cursor
         cy.get(`#post_${post2.id}`).trigger('mouseover').type('{alt}', {release: false}).should(showCursor);
 
-        // # Mouse click on the post holding alt
-        cy.get(`#post_${post2.id}`).type('{alt}', {release: false}).click();
+        // # Mouse click on the post
+        cy.get(`#post_${post2.id}`).click();
 
         // * Verify the post is marked as unread
         verifyPostNextToNewMessageSeparator('post2');

--- a/e2e-tests/cypress/tests/integration/channels/messaging/message_reaction_gm_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/message_reaction_gm_spec.js
@@ -63,9 +63,6 @@ describe('Emoji reactions to posts/messages in GM channels', () => {
             // * Verify that the Add Reaction button isn't visible
             cy.findByLabelText('Add a reaction').should('not.be.visible');
 
-            // # Focus on the post since we can't hover with Cypress
-            // cy.get(`#post_${postId}`).focus().tab().tab();
-
             cy.get(`#post_${postId}`).within(() => {
                 // * Verify focus is on profile image
                 cy.get('.status-wrapper button').focus().tab();

--- a/e2e-tests/cypress/tests/integration/channels/messaging/message_reaction_gm_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/message_reaction_gm_spec.js
@@ -63,13 +63,7 @@ describe('Emoji reactions to posts/messages in GM channels', () => {
             // * Verify that the Add Reaction button isn't visible
             cy.findByLabelText('Add a reaction').should('not.be.visible');
 
-            cy.get(`#post_${postId}`).within(() => {
-                // * Verify focus is on profile image
-                cy.get('.status-wrapper button').focus().tab();
-
-                // * Verify that the Add Reaction button is now visible
-                cy.findByLabelText('Add a reaction').should('be.visible');
-            });
+            cy.get(`#post_${postId}`).trigger('mouseover');
 
             // # Click somewhere to clear the focus
             cy.get('#channelIntro').click();

--- a/e2e-tests/cypress/tests/integration/channels/messaging/message_reaction_gm_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/message_reaction_gm_spec.js
@@ -64,10 +64,15 @@ describe('Emoji reactions to posts/messages in GM channels', () => {
             cy.findByLabelText('Add a reaction').should('not.be.visible');
 
             // # Focus on the post since we can't hover with Cypress
-            cy.get(`#post_${postId}`).focus().tab().tab();
+            // cy.get(`#post_${postId}`).focus().tab().tab();
 
-            // * Verify that the Add Reaction button is now visible
-            cy.findByLabelText('Add a reaction').should('be.visible');
+            cy.get(`#post_${postId}`).within(() => {
+                // * Verify focus is on profile image
+                cy.get('.status-wrapper button').focus().tab();
+
+                // * Verify that the Add Reaction button is now visible
+                cy.findByLabelText('Add a reaction').should('be.visible');
+            });
 
             // # Click somewhere to clear the focus
             cy.get('#channelIntro').click();

--- a/webapp/channels/src/components/post/post_component.tsx
+++ b/webapp/channels/src/components/post/post_component.tsx
@@ -526,7 +526,6 @@ function PostComponent(props: Props) {
                 ref={postRef}
                 id={getTestId()}
                 data-testid={postAriaLabelDivTestId}
-                tabIndex={0}
                 post={post}
                 className={getClassName()}
                 onClick={handlePostClick}

--- a/webapp/channels/src/components/post_edit_history/__snapshots__/post_edit_history.test.tsx.snap
+++ b/webapp/channels/src/components/post_edit_history/__snapshots__/post_edit_history.test.tsx.snap
@@ -300,7 +300,6 @@ exports[`components/post_edit_history should match snapshot 1`] = `
                         class="post-message__text"
                         dir="auto"
                         id="rhsPostMessageText_post_id"
-                        tabindex="0"
                       >
                         <p>
                           post message

--- a/webapp/channels/src/components/post_edit_history/edited_post_item/__snapshots__/edited_post_item.test.tsx.snap
+++ b/webapp/channels/src/components/post_edit_history/edited_post_item/__snapshots__/edited_post_item.test.tsx.snap
@@ -131,7 +131,6 @@ exports[`components/post_edit_history/edited_post_item should match snapshot whe
                   class="post-message__text"
                   dir="auto"
                   id="rhsPostMessageText_post_id"
-                  tabindex="0"
                 >
                   <p>
                     post message

--- a/webapp/channels/src/components/post_view/post_message_view/__snapshots__/post_message_view.test.tsx.snap
+++ b/webapp/channels/src/components/post_view/post_message_view/__snapshots__/post_message_view.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`components/post_view/PostAttachment should match snapshot 1`] = `
     dir="auto"
     id="postMessageText_post_id"
     onClick={[Function]}
-    tabIndex={0}
   >
     <Connect(PostMarkdown)
       imageProps={
@@ -47,7 +46,6 @@ exports[`components/post_view/PostAttachment should match snapshot, on Show Less
     dir="auto"
     id="postMessageText_post_id"
     onClick={[Function]}
-    tabIndex={0}
   >
     <Connect(PostMarkdown)
       imageProps={
@@ -84,7 +82,6 @@ exports[`components/post_view/PostAttachment should match snapshot, on Show More
     dir="auto"
     id="postMessageText_post_id"
     onClick={[Function]}
-    tabIndex={0}
   >
     <Connect(PostMarkdown)
       imageProps={
@@ -139,7 +136,6 @@ exports[`components/post_view/PostAttachment should match snapshot, on edited po
     dir="auto"
     id="postMessageText_post_id"
     onClick={[Function]}
-    tabIndex={0}
   >
     <Connect(PostMarkdown)
       imageProps={
@@ -177,7 +173,6 @@ exports[`components/post_view/PostAttachment should match snapshot, on ephemeral
     dir="auto"
     id="postMessageText_post_id"
     onClick={[Function]}
-    tabIndex={0}
   >
     <Connect(PostMarkdown)
       imageProps={

--- a/webapp/channels/src/components/post_view/post_message_view/post_message_view.tsx
+++ b/webapp/channels/src/components/post_view/post_message_view/post_message_view.tsx
@@ -150,7 +150,6 @@ export default class PostMessageView extends React.PureComponent<Props, State> {
                 maxHeight={maxHeight}
             >
                 <div
-                    tabIndex={0}
                     id={id}
                     className='post-message__text'
                     dir='auto'

--- a/webapp/channels/src/plugins/test/__snapshots__/post_type.test.tsx.snap
+++ b/webapp/channels/src/plugins/test/__snapshots__/post_type.test.tsx.snap
@@ -113,7 +113,6 @@ exports[`plugins/PostMessageView should match snapshot with no extended post typ
     dir="auto"
     id="postMessageText_post_id"
     onClick={[Function]}
-    tabIndex={0}
   >
     <Connect(PostMarkdown)
       imageProps={


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
The PR ensures focus order of interactive elements on the page is logical and focus is not moved to non-interactive elements of the page. 

#### Steps to reproduce  
- Navigate to the page using tab key until reaches the entire section of the At 8:08 PM Monday, September 23, Someone wrote, user joined the team text.
- Notice that non-interactive elements receive focus.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Fixes: https://mattermost.atlassian.net/browse/MM-61599

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |
-->
[Screencast from 2024-12-16 18-04-35.webm](https://github.com/user-attachments/assets/583b5396-545c-4de5-8ea5-9445aca68127)


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
