### PR TITLE
Automated cherry pick of #29656

### DIFF
--- a/server/channels/api4/file_test.go
+++ b/server/channels/api4/file_test.go
@@ -805,10 +805,91 @@ func TestGetFile(t *testing.T) {
 	_, resp, err = client.GetFile(context.Background(), fileId)
 	require.Error(t, err)
 	CheckUnauthorizedStatus(t, resp)
+}
 
-	_, _, err = th.SystemAdminClient.GetFile(context.Background(), fileId)
+func TestGetFileAsSystemAdmin(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	if *th.App.Config().FileSettings.DriverName == "" {
+		t.Skip("skipping because no file driver is enabled")
+	}
+
+	sent, err := testutils.ReadTestFile("test.png")
 	require.NoError(t, err)
-	CheckUnauthorizedStatus(t, resp)
+
+	t.Run("public channel without membership", func(t *testing.T) {
+		publicChannel := th.CreateChannelWithClient(th.Client, model.ChannelTypeOpen)
+		fileResp, _, err := th.Client.UploadFile(context.Background(), sent, publicChannel.Id, "test.png")
+		require.NoError(t, err)
+		_, _, err = th.SystemAdminClient.GetFile(context.Background(), fileResp.FileInfos[0].Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("public channel with membership", func(t *testing.T) {
+		publicChannel := th.CreatePublicChannel()
+		th.LinkUserToTeam(th.SystemAdminUser, th.BasicTeam)
+		th.AddUserToChannel(th.SystemAdminUser, publicChannel)
+		fileResp, _, err := th.Client.UploadFile(context.Background(), sent, publicChannel.Id, "test.png")
+		require.NoError(t, err)
+		_, _, err = th.SystemAdminClient.GetFile(context.Background(), fileResp.FileInfos[0].Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("private channel without membership", func(t *testing.T) {
+		privateChannel := th.CreatePrivateChannel()
+		privateFileResp, _, err := th.Client.UploadFile(context.Background(), sent, privateChannel.Id, "test.png")
+		require.NoError(t, err)
+		_, _, err = th.SystemAdminClient.GetFile(context.Background(), privateFileResp.FileInfos[0].Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("private channel with membership", func(t *testing.T) {
+		privateChannel := th.CreatePrivateChannel()
+		th.LinkUserToTeam(th.SystemAdminUser, th.BasicTeam)
+		th.AddUserToChannel(th.SystemAdminUser, privateChannel)
+		fileResp, _, err := th.Client.UploadFile(context.Background(), sent, privateChannel.Id, "test.png")
+		require.NoError(t, err)
+		_, _, err = th.SystemAdminClient.GetFile(context.Background(), fileResp.FileInfos[0].Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("direct message without membership", func(t *testing.T) {
+		dmChannel := th.CreateDmChannel(th.BasicUser2)
+		dmFileResp, _, err := th.Client.UploadFile(context.Background(), sent, dmChannel.Id, "test.png")
+		require.NoError(t, err)
+		_, _, err = th.SystemAdminClient.GetFile(context.Background(), dmFileResp.FileInfos[0].Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("direct message with membership", func(t *testing.T) {
+		dmChannel, _, err := th.SystemAdminClient.CreateDirectChannel(context.Background(), th.SystemAdminUser.Id, th.BasicUser.Id)
+		require.NoError(t, err)
+		fileResp, _, err := th.Client.UploadFile(context.Background(), sent, dmChannel.Id, "test.png")
+		require.NoError(t, err)
+		_, _, err = th.SystemAdminClient.GetFile(context.Background(), fileResp.FileInfos[0].Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("group message without membership", func(t *testing.T) {
+		user3 := th.CreateUser()
+		gmChannel, _, err := th.Client.CreateGroupChannel(context.Background(), []string{th.BasicUser.Id, th.BasicUser2.Id, user3.Id})
+		require.NoError(t, err)
+		gmFileResp, _, err := th.Client.UploadFile(context.Background(), sent, gmChannel.Id, "test.png")
+		require.NoError(t, err)
+		_, _, err = th.SystemAdminClient.GetFile(context.Background(), gmFileResp.FileInfos[0].Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("group message with membership", func(t *testing.T) {
+		user3 := th.CreateUser()
+		gmChannel, _, err := th.SystemAdminClient.CreateGroupChannel(context.Background(), []string{th.SystemAdminUser.Id, th.BasicUser.Id, user3.Id})
+		require.NoError(t, err)
+		fileResp, _, err := th.Client.UploadFile(context.Background(), sent, gmChannel.Id, "test.png")
+		require.NoError(t, err)
+		_, _, err = th.SystemAdminClient.GetFile(context.Background(), fileResp.FileInfos[0].Id)
+		require.NoError(t, err)
+	})
 }
 
 func TestGetFileHeaders(t *testing.T) {
@@ -874,7 +955,7 @@ func TestGetFileHeaders(t *testing.T) {
 	// t.Run("go", testHeaders(data, "test.go", "text/x-go; charset=utf-8", false, false))
 	t.Run("zip", testHeaders(data, "test.zip", "application/zip", false, false))
 	// Not every platform can recognize these
-	//t.Run("exe", testHeaders(data, "test.exe", "application/x-ms", false))
+	// t.Run("exe", testHeaders(data, "test.exe", "application/x-ms", false))
 	t.Run("no extension", testHeaders(data, "test", "application/octet-stream", false, false))
 	t.Run("no extension 2", testHeaders([]byte("<html></html>"), "test", "application/octet-stream", false, false))
 }
@@ -927,6 +1008,93 @@ func TestGetFileThumbnail(t *testing.T) {
 	_, _, err = th.SystemAdminClient.GetFileThumbnail(context.Background(), fileId)
 	require.NoError(t, err)
 	CheckForbiddenStatus(t, resp)
+}
+
+func TestGetFileThumbnailAsSystemAdmin(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	if *th.App.Config().FileSettings.DriverName == "" {
+		t.Skip("skipping because no file driver is enabled")
+	}
+
+	sent, err := testutils.ReadTestFile("test.png")
+	require.NoError(t, err)
+
+	t.Run("public channel without membership", func(t *testing.T) {
+		th.LinkUserToTeam(th.BasicUser, th.BasicTeam)
+		publicChannel := th.CreateChannelWithClient(th.Client, model.ChannelTypeOpen)
+		fileResp, _, err := th.Client.UploadFile(context.Background(), sent, publicChannel.Id, "test.png")
+		require.NoError(t, err)
+		_, _, err = th.SystemAdminClient.GetFileThumbnail(context.Background(), fileResp.FileInfos[0].Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("public channel with membership", func(t *testing.T) {
+		th.LinkUserToTeam(th.SystemAdminUser, th.BasicTeam)
+		publicChannel := th.CreateChannelWithClient(th.Client, model.ChannelTypeOpen)
+		th.AddUserToChannel(th.SystemAdminUser, publicChannel)
+		fileResp, _, err := th.Client.UploadFile(context.Background(), sent, publicChannel.Id, "test.png")
+		require.NoError(t, err)
+		_, _, err = th.SystemAdminClient.GetFileThumbnail(context.Background(), fileResp.FileInfos[0].Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("private channel without membership", func(t *testing.T) {
+		th.LinkUserToTeam(th.SystemAdminUser, th.BasicTeam)
+		privateChannel := th.CreatePrivateChannel()
+		privateFileResp, _, err := th.Client.UploadFile(context.Background(), sent, privateChannel.Id, "test.png")
+		require.NoError(t, err)
+		_, _, err = th.SystemAdminClient.GetFileThumbnail(context.Background(), privateFileResp.FileInfos[0].Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("private channel with membership", func(t *testing.T) {
+		th.LinkUserToTeam(th.SystemAdminUser, th.BasicTeam)
+		privateChannel := th.CreatePrivateChannel()
+		th.AddUserToChannel(th.SystemAdminUser, privateChannel)
+		privateFileResp, _, err := th.Client.UploadFile(context.Background(), sent, privateChannel.Id, "test.png")
+		require.NoError(t, err)
+		_, _, err = th.SystemAdminClient.GetFileThumbnail(context.Background(), privateFileResp.FileInfos[0].Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("direct message without membership", func(t *testing.T) {
+		dmChannel := th.CreateDmChannel(th.BasicUser2)
+		dmFileResp, _, err := th.Client.UploadFile(context.Background(), sent, dmChannel.Id, "test.png")
+		require.NoError(t, err)
+		_, _, err = th.SystemAdminClient.GetFileThumbnail(context.Background(), dmFileResp.FileInfos[0].Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("direct message with membership", func(t *testing.T) {
+		dmChannel, _, err := th.SystemAdminClient.CreateDirectChannel(context.Background(), th.SystemAdminUser.Id, th.BasicUser.Id)
+		require.NoError(t, err)
+		dmFileResp, _, err := th.Client.UploadFile(context.Background(), sent, dmChannel.Id, "test.png")
+		require.NoError(t, err)
+		_, _, err = th.SystemAdminClient.GetFileThumbnail(context.Background(), dmFileResp.FileInfos[0].Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("group message without membership", func(t *testing.T) {
+		user3 := th.CreateUser()
+		gmChannel, _, err := th.Client.CreateGroupChannel(context.Background(), []string{th.BasicUser.Id, th.BasicUser2.Id, user3.Id})
+		require.NoError(t, err)
+		gmFileResp, _, err := th.Client.UploadFile(context.Background(), sent, gmChannel.Id, "test.png")
+		require.NoError(t, err)
+		_, _, err = th.SystemAdminClient.GetFileThumbnail(context.Background(), gmFileResp.FileInfos[0].Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("group message with membership", func(t *testing.T) {
+		user3 := th.CreateUser()
+		gmChannel, _, err := th.SystemAdminClient.CreateGroupChannel(context.Background(), []string{th.SystemAdminUser.Id, th.BasicUser.Id, user3.Id})
+		require.NoError(t, err)
+		gmFileResp, _, err := th.Client.UploadFile(context.Background(), sent, gmChannel.Id, "test.png")
+		require.NoError(t, err)
+		_, _, err = th.SystemAdminClient.GetFileThumbnail(context.Background(), gmFileResp.FileInfos[0].Id)
+		require.NoError(t, err)
+	})
 }
 
 func TestGetFileLink(t *testing.T) {

--- a/server/channels/api4/post.go
+++ b/server/channels/api4/post.go
@@ -214,7 +214,7 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	}
-	if !c.IsSystemAdmin() && !c.App.SessionHasPermissionToReadChannel(c.AppContext, *c.AppContext.Session(), channel) {
+	if !c.App.SessionHasPermissionToReadChannel(c.AppContext, *c.AppContext.Session(), channel) {
 		c.SetPermissionError(model.PermissionReadChannelContent)
 		return
 	}

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -1994,13 +1994,39 @@ func TestGetPostsForChannel(t *testing.T) {
 		CheckOKStatus(t, resp)
 		require.Len(t, posts.Order, 10, "expected 10 posts")
 
-		// allow viewing of direct messages
+		// System admin can access public channel without being member
+		adminPublicChannel := th.CreatePublicChannel()
+		th.CreateMessagePostNoClient(adminPublicChannel, "admin channel post", model.GetMillis())
+		posts, resp, err = c.GetPostsForChannel(context.Background(), adminPublicChannel.Id, 0, 100, "", false, false)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.NotEmpty(t, posts.Order)
+
+		// System admin can access private channel without being member
+		privateChannel := th.CreatePrivateChannel()
+		th.CreateMessagePostNoClient(privateChannel, "private channel post", model.GetMillis())
+		posts, resp, err = c.GetPostsForChannel(context.Background(), privateChannel.Id, 0, 100, "", false, false)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.NotEmpty(t, posts.Order)
+
+		// System admin can access direct messages without being member
 		dmChannel := th.CreateDmChannel(th.BasicUser2)
 		th.CreateMessagePostNoClient(dmChannel, "test1", model.GetMillis())
-
 		posts, resp, err = c.GetPostsForChannel(context.Background(), dmChannel.Id, 0, 100, "", false, false)
 		require.NoError(t, err)
 		CheckOKStatus(t, resp)
+		require.NotEmpty(t, posts.Order)
+
+		// System admin can access group messages without being member
+		user3 := th.CreateUser()
+		gmChannel, _, err := th.Client.CreateGroupChannel(context.Background(), []string{th.BasicUser.Id, th.BasicUser2.Id, user3.Id})
+		require.NoError(t, err)
+		th.CreateMessagePostNoClient(gmChannel, "test2", model.GetMillis())
+		posts, resp, err = c.GetPostsForChannel(context.Background(), gmChannel.Id, 0, 100, "", false, false)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.NotEmpty(t, posts.Order)
 	})
 }
 
@@ -4549,7 +4575,7 @@ func TestPostGetInfo(t *testing.T) {
 			channel:   gmChannel,
 			post:      gmPost,
 			client:    sysadminClient,
-			hasAccess: false,
+			hasAccess: true,
 		},
 
 		// DM channel
@@ -4568,7 +4594,7 @@ func TestPostGetInfo(t *testing.T) {
 			channel:   dmChannel,
 			post:      dmPost,
 			client:    sysadminClient,
-			hasAccess: false,
+			hasAccess: true,
 		},
 
 		// Open channel - Open Team

--- a/server/channels/app/authorization.go
+++ b/server/channels/app/authorization.go
@@ -278,7 +278,7 @@ func (a *App) HasPermissionToChannel(c request.CTX, askingUserId string, channel
 	}
 
 	channel, appErr := a.GetChannel(c, channelID)
-	if appErr == nil {
+	if appErr == nil && channel.TeamId != "" {
 		return a.HasPermissionToTeam(c, askingUserId, channel.TeamId, permission)
 	}
 


### PR DESCRIPTION
Cherry pick of #29656 on release-10.4.

/cc  @lieut-data

```release-note
NONE
```