### PR TITLE
Fix cases where args... was not spread

### DIFF
--- a/server/channels/store/sqlstore/sqlx_wrapper.go
+++ b/server/channels/store/sqlstore/sqlx_wrapper.go
@@ -227,7 +227,7 @@ func (w *sqlxDBWrapper) QueryX(query string, args ...any) (*sqlx.Rows, error) {
 		}(time.Now())
 	}
 
-	return w.checkErrWithRows(w.DB.QueryxContext(ctx, query, args))
+	return w.checkErrWithRows(w.DB.QueryxContext(ctx, query, args...))
 }
 
 func (w *sqlxDBWrapper) Select(dest any, query string, args ...any) error {
@@ -423,7 +423,7 @@ func (w *sqlxTxWrapper) QueryX(query string, args ...any) (*sqlx.Rows, error) {
 		}(time.Now())
 	}
 
-	return w.dbw.checkErrWithRows(w.Tx.QueryxContext(ctx, query, args))
+	return w.dbw.checkErrWithRows(w.Tx.QueryxContext(ctx, query, args...))
 }
 
 func (w *sqlxTxWrapper) Select(dest any, query string, args ...any) error {


### PR DESCRIPTION
#### Summary
In a recent [pull request](https://github.com/mattermost/mattermost/pull/29558#issuecomment-2557681771), a store was refactored to use a query builder and `args` set, but the args was not spread in the subsequent query. The tests caught the regression and the fix was simple (and done before merging):

```diff
- if err := s.GetReplica().Get(&token, query, args); err != nil {
+ if err := s.GetReplica().Get(&token, query, args...); err != nil {
```

But I wanted to check the code base for any other potential oversights. I found one in `QueryX` which this PR fixes, but fortunately it looks like we don't currently use this method anyway.

Note that the `args` vs `args...` is solved even more cleanly by using the `GetBuilder` versions of these APIs, but that's a separate campaign and we're trying not to make too many changes with the `SELECT *` migrations.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
