### PR TITLE
MM-62226 - set focus back to search button

### DIFF
--- a/webapp/channels/src/components/new_search/new_search.tsx
+++ b/webapp/channels/src/components/new_search/new_search.tsx
@@ -15,7 +15,8 @@ import {getSearchTerms, getSearchType} from 'selectors/rhs';
 import Popover from 'components/widgets/popover';
 
 import a11yController from 'utils/a11y_controller_instance';
-import Constants, { A11yCustomEventTypes, A11yFocusEventDetail } from 'utils/constants';
+import type {A11yFocusEventDetail} from 'utils/constants';
+import Constants, {A11yCustomEventTypes} from 'utils/constants';
 import * as Keyboard from 'utils/keyboard';
 import {isServerVersionGreaterThanOrEqualTo} from 'utils/server_version';
 import {isDesktopApp, getDesktopVersion, isMacApp} from 'utils/user_agent';

--- a/webapp/channels/src/components/new_search/new_search.tsx
+++ b/webapp/channels/src/components/new_search/new_search.tsx
@@ -14,7 +14,8 @@ import {getSearchTerms, getSearchType} from 'selectors/rhs';
 
 import Popover from 'components/widgets/popover';
 
-import Constants from 'utils/constants';
+import a11yController from 'utils/a11y_controller_instance';
+import Constants, { A11yCustomEventTypes, A11yFocusEventDetail } from 'utils/constants';
 import * as Keyboard from 'utils/keyboard';
 import {isServerVersionGreaterThanOrEqualTo} from 'utils/server_version';
 import {isDesktopApp, getDesktopVersion, isMacApp} from 'utils/user_agent';
@@ -102,6 +103,7 @@ const NewSearch = (): JSX.Element => {
     const [focused, setFocused] = useState<boolean>(false);
     const [currentChannel, setCurrentChannel] = useState('');
     const searchBoxRef = useRef<HTMLDivElement | null>(null);
+    const searchButtonRef = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
         const isDesktop = isDesktopApp() && isServerVersionGreaterThanOrEqualTo(getDesktopVersion(), '4.7.0');
@@ -160,10 +162,24 @@ const NewSearch = (): JSX.Element => {
     const closeSearchBox = useCallback(() => {
         setFocused(false);
         setCurrentChannel('');
+        if (searchButtonRef.current) {
+            document.dispatchEvent(
+                new CustomEvent<A11yFocusEventDetail>(A11yCustomEventTypes.FOCUS, {
+                    detail: {
+                        target: searchButtonRef.current,
+                        keyboardOnly: false,
+                    },
+                }),
+            );
+            a11yController.resetOriginElement();
+        }
     }, []);
 
     const openSearchBox = useCallback(() => {
         setFocused(true);
+        if (searchButtonRef.current) {
+            a11yController.storeOriginElement(searchButtonRef.current);
+        }
     }, []);
 
     const openSearchBoxOnKeyPress = useCallback(
@@ -220,6 +236,7 @@ const NewSearch = (): JSX.Element => {
             id='searchFormContainer'
             role='button'
             className='a11y__region'
+            ref={searchButtonRef}
         >
             <i className='icon icon-magnify'/>
             {(searchType === 'messages' || searchType === 'files') && (

--- a/webapp/channels/src/components/root/root.tsx
+++ b/webapp/channels/src/components/root/root.tsx
@@ -31,7 +31,7 @@ import SidebarMobileRightMenu from 'components/sidebar_mobile_right_menu';
 
 import webSocketClient from 'client/web_websocket_client';
 import {initializePlugins} from 'plugins';
-import A11yController from 'utils/a11y_controller';
+import 'utils/a11y_controller_instance';
 import {PageLoadContext, SCHEDULED_POST_URL_SUFFIX} from 'utils/constants';
 import DesktopApp from 'utils/desktop_api';
 import {EmojiIndicesByAlias} from 'utils/emoji';
@@ -92,8 +92,6 @@ interface State {
 export default class Root extends React.PureComponent<Props, State> {
     // The constructor adds a bunch of event listeners,
     // so we do need this.
-    private a11yController: A11yController;
-
     constructor(props: Props) {
         super(props);
 
@@ -107,8 +105,6 @@ export default class Root extends React.PureComponent<Props, State> {
         this.state = {
             shouldMountAppRoutes: false,
         };
-
-        this.a11yController = new A11yController();
     }
 
     setRudderConfig = () => {

--- a/webapp/channels/src/components/sidebar_right/sidebar_right.tsx
+++ b/webapp/channels/src/components/sidebar_right/sidebar_right.tsx
@@ -21,6 +21,7 @@ import RhsThread from 'components/rhs_thread';
 import Search from 'components/search/index';
 
 import RhsPlugin from 'plugins/rhs_plugin';
+import a11yController from 'utils/a11y_controller_instance';
 import type {A11yFocusEventDetail} from 'utils/constants';
 import Constants, {A11yCustomEventTypes} from 'utils/constants';
 import {cmdOrCtrlPressed, isKeyPressed} from 'utils/keyboard';
@@ -170,19 +171,23 @@ export default class SidebarRight extends React.PureComponent<Props, State> {
         } else if (!this.props.isOpen && wasOpen) {
             // RHS just was closed, restore focus to the previous element had it
             // this will have to change for upcoming work specially for search and probalby plugins
-            requestAnimationFrame(() => {
-                if (this.previousActiveElement) {
-                    document.dispatchEvent(
-                        new CustomEvent<A11yFocusEventDetail>(A11yCustomEventTypes.FOCUS, {
-                            detail: {
-                                target: this.previousActiveElement,
-                                keyboardOnly: false,
-                            },
-                        }),
-                    );
-                    this.previousActiveElement = null;
-                }
-            });
+            if (a11yController.originElement) {
+                a11yController.restoreOriginFocus();
+            } else {
+                requestAnimationFrame(() => {
+                    if (this.previousActiveElement) {
+                        document.dispatchEvent(
+                            new CustomEvent<A11yFocusEventDetail>(A11yCustomEventTypes.FOCUS, {
+                                detail: {
+                                    target: this.previousActiveElement,
+                                    keyboardOnly: false,
+                                },
+                            }),
+                        );
+                        this.previousActiveElement = null;
+                    }
+                });
+            }
         }
     }
 

--- a/webapp/channels/src/utils/a11y_controller_instance.ts
+++ b/webapp/channels/src/utils/a11y_controller_instance.ts
@@ -1,0 +1,7 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import A11yController from 'utils/a11y_controller';
+
+const a11yController = new A11yController();
+export default a11yController;


### PR DESCRIPTION
#### Summary
This PR adds the logic to keep in memory for the a11y controller the origin element that initially triggered the action that displayed a new element. This way, once that element is closed, we can return back the focus to the origin element.

**note:** the current approach for saved posts, recent mentions, files, members and channel info uses the document.activeElement to reference the origin that trigger the opening of the RHS in order to setting the focus back to that origin element.

Even when it works, in the case the feedback of this PR to be positive, the approach for those will also change to the approach added in this PR using the a11ycontroller originElement.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62226

#### Screenshots

https://github.com/user-attachments/assets/9aa63785-33d0-4338-a2a8-dc3a24b4907b



#### Release Note
```release-note
NONE
```
