### PR TITLE
fix(pluginapi/store): init master db if no replica

### DIFF
--- a/server/public/pluginapi/store.go
+++ b/server/public/pluginapi/store.go
@@ -55,6 +55,10 @@ func (s *StoreService) GetReplicaDB() (*sql.DB, error) {
 		return s.replicaDB, nil
 	}
 
+	if err := s.initializeMaster(); err != nil {
+		return nil, err
+	}
+
 	return s.masterDB, nil
 }
 

--- a/server/public/pluginapi/store_test.go
+++ b/server/public/pluginapi/store_test.go
@@ -66,6 +66,39 @@ func TestStore(t *testing.T) {
 		require.NoError(t, store.Close())
 	})
 
+	t.Run("master db fallback without get master first", func(t *testing.T) {
+		config := &model.Config{
+			SqlSettings: model.SqlSettings{
+				DriverName:                  model.NewPointer("ramsql"),
+				DataSource:                  model.NewPointer("TestStore-master-db"),
+				ConnMaxLifetimeMilliseconds: model.NewPointer(2),
+			},
+		}
+
+		driver := &plugintest.Driver{}
+		defer driver.AssertExpectations(t)
+		driver.On("Conn", true).Return("test", nil)
+		driver.On("ConnPing", "test").Return(nil)
+		driver.On("ConnClose", "test").Return(nil)
+
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+		store := pluginapi.NewClient(api, driver).Store
+
+		api.On("GetUnsanitizedConfig").Return(config)
+		// No replica is set up, should fallback to master
+		replicaDB, err := store.GetReplicaDB()
+		require.NoError(t, err)
+		require.NotNil(t, replicaDB)
+
+		masterDB, err := store.GetMasterDB()
+		require.NoError(t, err)
+		require.NotNil(t, masterDB)
+		require.Same(t, replicaDB, masterDB)
+
+		require.NoError(t, store.Close())
+	})
+
 	t.Run("replica db singleton", func(t *testing.T) {
 		config := &model.Config{
 			SqlSettings: model.SqlSettings{


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

GetReplicaDB return nil because masterDB is not initialized, the fix initialize the masterDB (this is skipped if masterDB is already initialized).

```go
dbDriver, err := p.pluginAPIClient.Store.GetReplicaDB()
```

--> dbDriver is nil

```go
p.pluginAPIClient.Store.GetMasterDB()
dbDriver, err := p.pluginAPIClient.Store.GetReplicaDB()
```

OK!

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
* Fix pluginapi.store.GetReplicaDB return nil if masterDB is not initialized
```
