### PR TITLE
Support E2E stress tests in run_tests.js

### DIFF
--- a/e2e-tests/.ci/.e2erc
+++ b/e2e-tests/.ci/.e2erc
@@ -100,6 +100,7 @@ case "${TEST:-$TEST_DEFAULT}" in
   playwright )
     export TEST_FILTER_DEFAULT='tests/functional/system_console/system_users/actions.spec.ts --project=chrome' ;;
   * )
+    export TEST_FILTER_DEFAULT='' ;;
 esac
 # OS specific defaults overrides
 case $MME2E_OSTYPE in

--- a/e2e-tests/.ci/server.generate.sh
+++ b/e2e-tests/.ci/server.generate.sh
@@ -62,6 +62,7 @@ services:
       MM_SERVICEENVIRONMENT: "test"
       MM_FEATUREFLAGS_MOVETHREADSENABLED: "true"
       MM_LOGSETTINGS_ENABLEDIAGNOSTICS: "false"
+      MM_LOGSETTINGS_CONSOLELEVEL: "DEBUG"
     network_mode: host
     depends_on:
 $(for service in $ENABLED_DOCKER_SERVICES; do

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -61,3 +61,14 @@ Notes:
 
 ##### For code changes:
 * `make fmt-ci` to format and check yaml files and shell scripts.
+
+##### For test stressing an E2E testcase
+
+For Cypress:
+1. Enter the `cypress/` subdirectory
+2. Identify which test files you want to run, and how many times each. For instance: suppose you want to run `create_a_team_spec.js` and `demoted_user_spec.js` (which you can locate with the `find` command, under `cypress/tests/`), each run 3 times
+3. Run the chosen testcases the desired amount of times: `node run_tests.js --include-file=create_a_team_spec.js,demoted_user_spec.js --invert --stress-test-count=3`
+  * Your system needs to be setup for Cypress usage, to be able to run this command. Refer to the [E2E testing developer documentation](https://developers.mattermost.com/contribute/more-info/webapp/e2e-testing/) for this.
+4. The `cypress/results/testPasses.json` file will count, for each of the testfiles, how many times it was run, and how many times each of the testcases contained in it passed. It the attempts and passes numbers do not match, that specific testcase may be flaky.
+
+For Playwright: WIP

--- a/e2e-tests/cypress/run_tests.js
+++ b/e2e-tests/cypress/run_tests.js
@@ -32,6 +32,8 @@
  *      Exclude spec files with matching directory or filename pattern. Uses `find` command under the hood. It can be of multiple values separated by comma.
  *      E.g. "--exclude-file='channel'" will exclude files recursively under `channel` directory/s.
  *      E.g. "--exclude-file='*channel*'" will exclude files and files under directory/s recursively that matches the name with `*channel*`.
+ *   --stress-test-count=[number of repeated executions]
+ *      The amount of times to run each spec file for. If greater than 1, report how the percentage of successes over total runs for each spec.
 
  *
  * Environment:
@@ -83,8 +85,11 @@ async function runTests() {
     const browser = BROWSER || 'chrome';
     const headless = typeof HEADLESS === 'undefined' ? true : HEADLESS === 'true';
     const platform = os.platform();
+    const stressTestCount = argv.stressTestCount > 1 ? argv.stressTestCount : 1;
+    const testPasses = {};
 
-    const {sortedFiles} = getSortedTestFiles(platform, browser, headless);
+    const sortedFilesObject = getSortedTestFiles(platform, browser, headless);
+    const sortedFiles = sortedFilesObject.sortedFiles.flatMap((el) => Array(stressTestCount).fill(el));
     const numberOfTestFiles = sortedFiles.length;
 
     if (!numberOfTestFiles) {
@@ -102,6 +107,13 @@ async function runTests() {
         printMessage(sortedFiles, i, j + 1, count);
 
         const testFile = sortedFiles[i];
+        var testFileAttempt = 1;
+        if (testFile in testPasses === false) {
+            testPasses[testFile] = {attempt: 1};
+        } else {
+            testPasses[testFile].attempt += 1;
+            testFileAttempt = testPasses[testFile].attempt;
+        }
 
         const result = await cypress.run({
             browser,
@@ -111,6 +123,7 @@ async function runTests() {
                 screenshotsFolder: `${MOCHAWESOME_REPORT_DIR}/screenshots`,
                 videosFolder: `${MOCHAWESOME_REPORT_DIR}/videos`,
                 trashAssetsBeforeRuns: false,
+                retries: stressTestCount > 1 ? 0 : 2,
             },
             env: {
                 firstTest: j === 0,
@@ -135,10 +148,21 @@ async function runTests() {
                         headless,
                         branch: BRANCH,
                         buildId: BUILD_ID,
+                        testFileAttempt,
                     },
                 },
             },
         });
+
+        for (var testCase of result.runs[0].tests) {
+            var testCaseTitle = testCase.title.join(' - ');
+            if (testCaseTitle in testPasses[testFile] === false) {
+                testPasses[testFile][testCaseTitle] = 0;
+            }
+            if (testCase.state === 'passed') {
+                testPasses[testFile][testCaseTitle] += 1;
+            }
+        }
 
         // Write test environment details once only
         if (i === 0) {
@@ -155,6 +179,7 @@ async function runTests() {
             writeJsonToFile(environment, 'environment.json', RESULTS_DIR);
         }
     }
+    writeJsonToFile(testPasses, 'testPasses.json', RESULTS_DIR);
 }
 
 function printMessage(testFiles, overallIndex, currentItem, lastItem) {

--- a/e2e-tests/cypress/tests/integration/channels/messaging/channel_read_after_permalink_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/channel_read_after_permalink_spec.js
@@ -18,7 +18,7 @@ describe('Messaging', () => {
     let testUser;
     let otherUser;
 
-    before(() => {
+    beforeEach(() => {
         cy.apiInitSetup().then(({team, channel, user}) => {
             testTeam = team;
             testChannel = channel;

--- a/e2e-tests/cypress/tests/support/ui_commands.ts
+++ b/e2e-tests/cypress/tests/support/ui_commands.ts
@@ -325,12 +325,12 @@ function clickPostHeaderItem(postId: string, location: string, item: string) {
     }
 
     if (postId) {
-        cy.get(`#${idPrefix}_${postId}`).trigger('mouseover', {force: true});
-        cy.wait(TIMEOUTS.HALF_SEC).get(`#${location}_${item}_${postId}`).click({force: true});
+        cy.get(`#${idPrefix}_${postId}`).trigger('mouseover', {force: true}).
+            get(`#${location}_${item}_${postId}`).should('be.visible').trigger('mouseover', {force: true}).click({force: true});
     } else {
         cy.getLastPostId().then((lastPostId) => {
-            cy.get(`#${idPrefix}_${lastPostId}`).trigger('mouseover', {force: true});
-            cy.wait(TIMEOUTS.HALF_SEC).get(`#${location}_${item}_${lastPostId}`).click({force: true});
+            cy.get(`#${idPrefix}_${lastPostId}`).trigger('mouseover', {force: true}).
+                get(`#${location}_${item}_${lastPostId}`).should('be.visible').trigger('mouseover', {force: true}).click({force: true});
         });
     }
 }


### PR DESCRIPTION
#### Summary

This PR:
- Introduces and documents a stress-testing mechanism, to investigate possible E2E testcase flakyness
  * At the moment, this only concerns Cypress, and can only be run locally. Ideally we also have a readily-available GHA Workflow, to offload the testing to Github Action runners.
- Fixes two tests:
  * `focus_move_spec.js` ([example failure](https://automation-dashboard.vercel.app/cycle/12461414806_1-a649b64-pr-onprem-ent))
  * `channel_read_after_permalink_spec.js` ([example failure](https://automation-dashboard.vercel.app/cycle/12325401703_1-master-daily-cloud-ent))

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-8681

#### Release Note
```release-note
NONE
```
