### PR TITLE
migrate queries in scheme_store.go

### DIFF
--- a/server/channels/store/sqlstore/scheme_store.go
+++ b/server/channels/store/sqlstore/scheme_store.go
@@ -36,24 +36,23 @@ type SqlSchemeStore struct {
 }
 
 func newSqlSchemeStore(sqlStore *SqlStore) store.SchemeStore {
-    s := &SqlSchemeStore{
-        SqlStore: sqlStore,
-    }
+	s := &SqlSchemeStore{
+		SqlStore: sqlStore,
+	}
 
-    s.schemeSelectQuery = s.getQueryBuilder().
-        Select(
-            "Id", "Name", "DisplayName", "Description", "Scope",
-            "DefaultTeamAdminRole", "DefaultTeamUserRole", "DefaultTeamGuestRole",
-            "DefaultChannelAdminRole", "DefaultChannelUserRole", "DefaultChannelGuestRole",
-            "CreateAt", "UpdateAt", "DeleteAt",
-            "DefaultPlaybookAdminRole", "DefaultPlaybookMemberRole",
-            "DefaultRunAdminRole", "DefaultRunMemberRole",
-        ).
-        From("Schemes")
+	s.schemeSelectQuery = s.getQueryBuilder().
+		Select(
+			"Id", "Name", "DisplayName", "Description", "Scope",
+			"DefaultTeamAdminRole", "DefaultTeamUserRole", "DefaultTeamGuestRole",
+			"DefaultChannelAdminRole", "DefaultChannelUserRole", "DefaultChannelGuestRole",
+			"CreateAt", "UpdateAt", "DeleteAt",
+			"DefaultPlaybookAdminRole", "DefaultPlaybookMemberRole",
+			"DefaultRunAdminRole", "DefaultRunMemberRole",
+		).
+		From("Schemes")
 
-    return s
+	return s
 }
-
 
 func (s *SqlSchemeStore) Save(scheme *model.Scheme) (_ *model.Scheme, err error) {
 	if scheme.Id == "" {
@@ -85,7 +84,6 @@ func (s *SqlSchemeStore) Save(scheme *model.Scheme) (_ *model.Scheme, err error)
 		 DefaultChannelAdminRole=:DefaultChannelAdminRole, DefaultChannelUserRole=:DefaultChannelUserRole, DefaultChannelGuestRole=:DefaultChannelGuestRole,
 		 DefaultPlaybookMemberRole=:DefaultPlaybookMemberRole, DefaultPlaybookAdminRole=:DefaultPlaybookAdminRole, DefaultRunMemberRole=:DefaultRunMemberRole, DefaultRunAdminRole=:DefaultRunAdminRole
 		 WHERE Id=:Id`, scheme)
-
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to update Scheme")
 	}
@@ -328,8 +326,8 @@ func (s *SqlSchemeStore) Get(schemeId string) (*model.Scheme, error) {
 
 func (s *SqlSchemeStore) GetByName(schemeName string) (*model.Scheme, error) {
 	var scheme model.Scheme
-	query := s.schemeSelectQuery.Where(sq.Eq{"Name": schemeName}) 
-	if err := s.GetReplica().GetBuilder(&scheme,query); err != nil {
+	query := s.schemeSelectQuery.Where(sq.Eq{"Name": schemeName})
+	if err := s.GetReplica().GetBuilder(&scheme, query); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Scheme", fmt.Sprintf("schemeName=%s", schemeName))
 		}
@@ -341,7 +339,7 @@ func (s *SqlSchemeStore) GetByName(schemeName string) (*model.Scheme, error) {
 func (s *SqlSchemeStore) Delete(schemeId string) (*model.Scheme, error) {
 	scheme := model.Scheme{}
 	query := s.schemeSelectQuery.Where(sq.Eq{"Id": schemeId})
-	if err := s.GetMaster().GetBuilder(&scheme,query); err != nil {
+	if err := s.GetMaster().GetBuilder(&scheme, query); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Scheme", fmt.Sprintf("schemeId=%s", schemeId))
 		}
@@ -385,7 +383,6 @@ func (s *SqlSchemeStore) Delete(schemeId string) (*model.Scheme, error) {
 		Set("UpdateAt", time).
 		Set("DeleteAt", time).
 		ToSql()
-
 	if err != nil {
 		return nil, errors.Wrap(err, "status_tosql")
 	}
@@ -403,13 +400,11 @@ func (s *SqlSchemeStore) Delete(schemeId string) (*model.Scheme, error) {
 		 DefaultTeamAdminRole=:DefaultTeamAdminRole, DefaultTeamUserRole=:DefaultTeamUserRole, DefaultTeamGuestRole=:DefaultTeamGuestRole,
 		 DefaultChannelAdminRole=:DefaultChannelAdminRole, DefaultChannelUserRole=:DefaultChannelUserRole, DefaultChannelGuestRole=:DefaultChannelGuestRole
 		 WHERE Id=:Id`, &scheme)
-
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to update Scheme with schemeId=%s", schemeId)
 	}
 
 	rowsChanged, err := res.RowsAffected()
-
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get RowsAffected while updating scheme with schemeId=%s", schemeId)
 	}
@@ -457,7 +452,6 @@ func (s *SqlSchemeStore) PermanentDeleteAll() error {
 func (s *SqlSchemeStore) CountByScope(scope string) (int64, error) {
 	var count int64
 	err := s.GetReplica().Get(&count, `SELECT count(*) FROM Schemes WHERE Scope = ? AND DeleteAt = 0`, scope)
-
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to count Schemes by scope")
 	}


### PR DESCRIPTION
#### Summary
The changes migrate SELECT * queries in scheme_store.go to use the query builder pattern. This improves type safety and maintainability by explicitly defining columns and using structured queries instead of raw SQL strings.

#### Ticket Link
#29680

#### Release Note
```release-note
Changed: Migrated scheme store SELECT * queries to use structured query builder with explicit column definitions.
```

