### PR TITLE
[MM-61612]: Added dialog role to the emoji picker

### DIFF
--- a/webapp/channels/src/components/emoji_picker/emoji_picker_tabs.tsx
+++ b/webapp/channels/src/components/emoji_picker/emoji_picker_tabs.tsx
@@ -170,6 +170,9 @@ export default class EmojiPickerTabs extends PureComponent<Props, State> {
                 className={classNames('a11y__popup', 'emoji-picker', 'emoji-picker--single', {
                     bottom: this.props.placement === 'bottom',
                 })}
+                role='dialog'
+                aria-label='Emoji picker'
+                aria-modal='true'
             >
                 <EmojiPickerHeader handleEmojiPickerClose={this.handleEmojiPickerClose}/>
                 <EmojiPicker

--- a/webapp/channels/src/components/emoji_picker/emoji_picker_tabs.tsx
+++ b/webapp/channels/src/components/emoji_picker/emoji_picker_tabs.tsx
@@ -5,7 +5,8 @@ import classNames from 'classnames';
 import type {CSSProperties, RefObject} from 'react';
 import React, {PureComponent, createRef} from 'react';
 import {Tab, Tabs} from 'react-bootstrap';
-import {FormattedMessage} from 'react-intl';
+import type {WrappedComponentProps} from 'react-intl';
+import {injectIntl, FormattedMessage} from 'react-intl';
 
 import type {Emoji} from '@mattermost/types/emojis';
 
@@ -17,7 +18,7 @@ import GifIcon from 'components/widgets/icons/giphy_icon';
 
 const GifPicker = makeAsyncComponent('GifPicker', React.lazy(() => import('components/gif_picker/gif_picker')));
 
-export interface Props {
+export interface Props extends WrappedComponentProps {
     style?: CSSProperties;
     rightOffset?: number;
     topOffset?: number;
@@ -33,9 +34,10 @@ export interface Props {
 type State = {
     emojiTabVisible: boolean;
     filter: string;
+    activeKey: number;
 }
 
-export default class EmojiPickerTabs extends PureComponent<Props, State> {
+class EmojiPickerTabs extends PureComponent<Props, State> {
     private rootPickerNodeRef: RefObject<HTMLDivElement>;
 
     static defaultProps = {
@@ -50,6 +52,7 @@ export default class EmojiPickerTabs extends PureComponent<Props, State> {
         this.state = {
             emojiTabVisible: true,
             filter: '',
+            activeKey: 1,
         };
 
         this.rootPickerNodeRef = createRef();
@@ -68,7 +71,9 @@ export default class EmojiPickerTabs extends PureComponent<Props, State> {
     };
 
     render() {
+        const {intl} = this.props;
         let pickerStyle;
+
         if (this.props.style && !(this.props.style.left === 0 && this.props.style.top === 0)) {
             if (this.props.placement === 'top' || this.props.placement === 'bottom') {
                 // Only take the top/bottom position passed by React Bootstrap since we want to be right-aligned
@@ -102,7 +107,9 @@ export default class EmojiPickerTabs extends PureComponent<Props, State> {
                         bottom: this.props.placement === 'bottom',
                     })}
                     role='dialog'
-                    aria-label='Emoji picker'
+                    aria-label={this.state.activeKey === 1 ? intl.formatMessage({id: 'emoji_gif_picker.dialog.emojis', defaultMessage: 'Emoji Picker'}) : intl.formatMessage({id: 'emoji_gif_picker.dialog.gifs', defaultMessage: 'GIF Picker'})
+                    }
+
                     aria-modal='true'
                 >
                     <Tabs
@@ -111,6 +118,8 @@ export default class EmojiPickerTabs extends PureComponent<Props, State> {
                         justified={true}
                         mountOnEnter={true}
                         unmountOnExit={true}
+                        activeKey={this.state.activeKey}
+                        onSelect={(activeKey) => this.setState({activeKey})}
                     >
                         <EmojiPickerHeader handleEmojiPickerClose={this.handleEmojiPickerClose}/>
                         <Tab
@@ -174,7 +183,8 @@ export default class EmojiPickerTabs extends PureComponent<Props, State> {
                     bottom: this.props.placement === 'bottom',
                 })}
                 role='dialog'
-                aria-label='Emoji picker'
+                aria-label={
+                    intl.formatMessage({id: 'emoji_gif_picker.dialog.emojis', defaultMessage: 'Emoji Picker'})}
                 aria-modal='true'
             >
                 <EmojiPickerHeader handleEmojiPickerClose={this.handleEmojiPickerClose}/>
@@ -189,3 +199,5 @@ export default class EmojiPickerTabs extends PureComponent<Props, State> {
         );
     }
 }
+
+export default injectIntl(EmojiPickerTabs);

--- a/webapp/channels/src/components/emoji_picker/emoji_picker_tabs.tsx
+++ b/webapp/channels/src/components/emoji_picker/emoji_picker_tabs.tsx
@@ -101,6 +101,9 @@ export default class EmojiPickerTabs extends PureComponent<Props, State> {
                     className={classNames('a11y__popup', 'emoji-picker', {
                         bottom: this.props.placement === 'bottom',
                     })}
+                    role='dialog'
+                    aria-label='Emoji picker'
+                    aria-modal='true'
                 >
                     <Tabs
                         id='emoji-picker-tabs'

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -3694,6 +3694,8 @@
   "email_verify.return": "Return to log in",
   "email_verify.sending": "Sending email…",
   "email_verify.sent": "Verification email sent",
+  "emoji_gif_picker.dialog.emojis": "Emoji Picker",
+  "emoji_gif_picker.dialog.gifs": "GIF Picker",
   "emoji_gif_picker.tabs.emojis": "Emojis",
   "emoji_gif_picker.tabs.gifs": "GIFs",
   "emoji_list.actions": "Actions",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
- Added dialog role to the emoji picker.
- Added ARIA properties such as aria-label and aria-modal to the emoji picker.

#### Steps to reproduce  
- Locate the Emoji Picker dialog.
- Inspect it with Chrome DevTools.
- In the Accessibility tab, expand the Computed Properties section.
- Review the values for "Name" and "Role".

#### Expected Behavior 
- Dialog containers must have role="dialog". If the dialog has a visible title, set aria-labelledby on the dialog container to the ID of the visible title. For dialogs without a visible title, set a descriptive aria-label on the dialog element.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Jira https://mattermost.atlassian.net/browse/MM-61612

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

<table>
    <tr>
        <th>Before</th>
 <th>After</th>
    </tr>
    <tr>
        <td>
 <img src="https://github.com/user-attachments/assets/193811e8-4d6c-4e46-9142-e7a4877228ff">
</td>
  <td>
 <img src="https://github.com/user-attachments/assets/a4f150aa-2970-46b8-b2bd-f47088ecae51">
</td>
    </tr>
</table>

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
