### PR TITLE
[MM-61598]: Fix ARIA roles, states, and properties are valid in user profile image and @user buttons

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/accessibility/accessibility_keyboard_usability_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/accessibility/accessibility_keyboard_usability_spec.js
@@ -156,8 +156,6 @@ describe('Verify Accessibility keyboard usability across different regions in th
                 cy.get(region).should('have.attr', 'role', 'application');
             });
             cy.get('.search__form').should('have.attr', 'role', 'search');
-            cy.get(`#post_${postId}`).children('.post__content').eq(0).should('have.attr', 'role', 'application');
-            cy.get(`#rhsPost_${postId}`).children('.post__content').eq(0).should('have.attr', 'role', 'application');
         });
     });
 });

--- a/e2e-tests/cypress/tests/integration/channels/accessibility/accessibility_post_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/accessibility/accessibility_post_spec.js
@@ -163,7 +163,7 @@ describe('Verify Accessibility Support in Post', () => {
         cy.getLastPostId().then((postId) => {
             cy.get(`#post_${postId}`).within(() => {
                 // * Verify focus is on profile image
-                cy.get('.status-wrapper button').first().should('be.focused');
+                cy.get('button.status-wrapper').first().should('be.focused');
                 cy.focused().tab();
 
                 // * Verify focus is on the username

--- a/webapp/channels/src/components/admin_console/admin_user_card/__snapshots__/admin_user_card.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/admin_user_card/__snapshots__/admin_user_card.test.tsx.snap
@@ -8,26 +8,23 @@ exports[`components/admin_console/admin_user_card/admin_user_card should match d
     <div
       class="AdminUserCard__header"
     >
-      <span
+      <button
         aria-expanded="false"
         aria-haspopup="dialog"
-        class="status-wrapper admin-user-card"
+        class="status-wrapper style--none admin-user-card"
+        style="border-radius: 50%; width: 128px; height: 128px;"
       >
-        <button
-          class="RoundButton-dvlhqG gnYSKj style--none"
+        <span
+          class="profile-icon "
         >
-          <span
-            class="profile-icon "
-          >
-            <img
-              alt="user profile image"
-              class="Avatar Avatar-xxl"
-              loading="lazy"
-              src="/api/v4/users/1234/image"
-            />
-          </span>
-        </button>
-      </span>
+          <img
+            alt="user profile image"
+            class="Avatar Avatar-xxl"
+            loading="lazy"
+            src="/api/v4/users/1234/image"
+          />
+        </span>
+      </button>
       <div
         class="AdminUserCard__user-info"
       >
@@ -69,26 +66,23 @@ exports[`components/admin_console/admin_user_card/admin_user_card should match s
     <div
       class="AdminUserCard__header"
     >
-      <span
+      <button
         aria-expanded="false"
         aria-haspopup="dialog"
-        class="status-wrapper admin-user-card"
+        class="status-wrapper style--none admin-user-card"
+        style="border-radius: 50%; width: 128px; height: 128px;"
       >
-        <button
-          class="RoundButton-dvlhqG gnYSKj style--none"
+        <span
+          class="profile-icon "
         >
-          <span
-            class="profile-icon "
-          >
-            <img
-              alt="user profile image"
-              class="Avatar Avatar-xxl"
-              loading="lazy"
-              src="/api/v4/users/1234/image"
-            />
-          </span>
-        </button>
-      </span>
+          <img
+            alt="user profile image"
+            class="Avatar Avatar-xxl"
+            loading="lazy"
+            src="/api/v4/users/1234/image"
+          />
+        </span>
+      </button>
       <div
         class="AdminUserCard__user-info"
       >
@@ -125,26 +119,23 @@ exports[`components/admin_console/admin_user_card/admin_user_card should match s
     <div
       class="AdminUserCard__header"
     >
-      <span
+      <button
         aria-expanded="false"
         aria-haspopup="dialog"
-        class="status-wrapper admin-user-card"
+        class="status-wrapper style--none admin-user-card"
+        style="border-radius: 50%; width: 128px; height: 128px;"
       >
-        <button
-          class="RoundButton-dvlhqG gnYSKj style--none"
+        <span
+          class="profile-icon "
         >
-          <span
-            class="profile-icon "
-          >
-            <img
-              alt="user profile image"
-              class="Avatar Avatar-xxl"
-              loading="lazy"
-              src="/api/v4/users/1234/image"
-            />
-          </span>
-        </button>
-      </span>
+          <img
+            alt="user profile image"
+            class="Avatar Avatar-xxl"
+            loading="lazy"
+            src="/api/v4/users/1234/image"
+          />
+        </span>
+      </button>
       <div
         class="AdminUserCard__user-info"
       >
@@ -179,26 +170,23 @@ exports[`components/admin_console/admin_user_card/admin_user_card should match s
     <div
       class="AdminUserCard__header"
     >
-      <span
+      <button
         aria-expanded="false"
         aria-haspopup="dialog"
-        class="status-wrapper admin-user-card"
+        class="status-wrapper style--none admin-user-card"
+        style="border-radius: 50%; width: 128px; height: 128px;"
       >
-        <button
-          class="RoundButton-dvlhqG gnYSKj style--none"
+        <span
+          class="profile-icon "
         >
-          <span
-            class="profile-icon "
-          >
-            <img
-              alt="user profile image"
-              class="Avatar Avatar-xxl"
-              loading="lazy"
-              src="/api/v4/users/1234/image"
-            />
-          </span>
-        </button>
-      </span>
+          <img
+            alt="user profile image"
+            class="Avatar Avatar-xxl"
+            loading="lazy"
+            src="/api/v4/users/1234/image"
+          />
+        </span>
+      </button>
       <div
         class="AdminUserCard__user-info"
       >

--- a/webapp/channels/src/components/admin_console/system_user_detail/__snapshots__/system_user_detail.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/system_user_detail/__snapshots__/system_user_detail.test.tsx.snap
@@ -28,26 +28,23 @@ exports[`SystemUserDetail should match default snapshot 1`] = `
           <div
             class="AdminUserCard__header"
           >
-            <span
+            <button
               aria-expanded="false"
               aria-haspopup="dialog"
-              class="status-wrapper admin-user-card"
+              class="status-wrapper style--none admin-user-card"
+              style="border-radius: 50%; width: 128px; height: 128px;"
             >
-              <button
-                class="RoundButton-dvlhqG gnYSKj style--none"
+              <span
+                class="profile-icon "
               >
-                <span
-                  class="profile-icon "
-                >
-                  <img
-                    alt="user profile image"
-                    class="Avatar Avatar-xxl"
-                    loading="lazy"
-                    src="/api/v4/users/user_id/image"
-                  />
-                </span>
-              </button>
-            </span>
+                <img
+                  alt="user profile image"
+                  class="Avatar Avatar-xxl"
+                  loading="lazy"
+                  src="/api/v4/users/user_id/image"
+                />
+              </span>
+            </button>
             <div
               class="AdminUserCard__user-info"
             >
@@ -240,26 +237,23 @@ exports[`SystemUserDetail should match snapshot if MFA is enabled 1`] = `
           <div
             class="AdminUserCard__header"
           >
-            <span
+            <button
               aria-expanded="false"
               aria-haspopup="dialog"
-              class="status-wrapper admin-user-card"
+              class="status-wrapper style--none admin-user-card"
+              style="border-radius: 50%; width: 128px; height: 128px;"
             >
-              <button
-                class="RoundButton-dvlhqG gnYSKj style--none"
+              <span
+                class="profile-icon "
               >
-                <span
-                  class="profile-icon "
-                >
-                  <img
-                    alt="user profile image"
-                    class="Avatar Avatar-xxl"
-                    loading="lazy"
-                    src="/api/v4/users/user_id/image"
-                  />
-                </span>
-              </button>
-            </span>
+                <img
+                  alt="user profile image"
+                  class="Avatar Avatar-xxl"
+                  loading="lazy"
+                  src="/api/v4/users/user_id/image"
+                />
+              </span>
+            </button>
             <div
               class="AdminUserCard__user-info"
             >
@@ -452,26 +446,23 @@ exports[`SystemUserDetail should not show manage user settings button when user 
           <div
             class="AdminUserCard__header"
           >
-            <span
+            <button
               aria-expanded="false"
               aria-haspopup="dialog"
-              class="status-wrapper admin-user-card"
+              class="status-wrapper style--none admin-user-card"
+              style="border-radius: 50%; width: 128px; height: 128px;"
             >
-              <button
-                class="RoundButton-dvlhqG gnYSKj style--none"
+              <span
+                class="profile-icon "
               >
-                <span
-                  class="profile-icon "
-                >
-                  <img
-                    alt="user profile image"
-                    class="Avatar Avatar-xxl"
-                    loading="lazy"
-                    src="/api/v4/users/user_id/image"
-                  />
-                </span>
-              </button>
-            </span>
+                <img
+                  alt="user profile image"
+                  class="Avatar Avatar-xxl"
+                  loading="lazy"
+                  src="/api/v4/users/user_id/image"
+                />
+              </span>
+            </button>
             <div
               class="AdminUserCard__user-info"
             >
@@ -664,26 +655,23 @@ exports[`SystemUserDetail should show manage user settings button as activated 1
           <div
             class="AdminUserCard__header"
           >
-            <span
+            <button
               aria-expanded="false"
               aria-haspopup="dialog"
-              class="status-wrapper admin-user-card"
+              class="status-wrapper style--none admin-user-card"
+              style="border-radius: 50%; width: 128px; height: 128px;"
             >
-              <button
-                class="RoundButton-dvlhqG gnYSKj style--none"
+              <span
+                class="profile-icon "
               >
-                <span
-                  class="profile-icon "
-                >
-                  <img
-                    alt="user profile image"
-                    class="Avatar Avatar-xxl"
-                    loading="lazy"
-                    src="/api/v4/users/user_id/image"
-                  />
-                </span>
-              </button>
-            </span>
+                <img
+                  alt="user profile image"
+                  class="Avatar Avatar-xxl"
+                  loading="lazy"
+                  src="/api/v4/users/user_id/image"
+                />
+              </span>
+            </button>
             <div
               class="AdminUserCard__user-info"
             >
@@ -881,26 +869,23 @@ exports[`SystemUserDetail should show manage user settings button as disabled wh
           <div
             class="AdminUserCard__header"
           >
-            <span
+            <button
               aria-expanded="false"
               aria-haspopup="dialog"
-              class="status-wrapper admin-user-card"
+              class="status-wrapper style--none admin-user-card"
+              style="border-radius: 50%; width: 128px; height: 128px;"
             >
-              <button
-                class="RoundButton-dvlhqG gnYSKj style--none"
+              <span
+                class="profile-icon "
               >
-                <span
-                  class="profile-icon "
-                >
-                  <img
-                    alt="user profile image"
-                    class="Avatar Avatar-xxl"
-                    loading="lazy"
-                    src="/api/v4/users/user_id/image"
-                  />
-                </span>
-              </button>
-            </span>
+                <img
+                  alt="user profile image"
+                  class="Avatar Avatar-xxl"
+                  loading="lazy"
+                  src="/api/v4/users/user_id/image"
+                />
+              </span>
+            </button>
             <div
               class="AdminUserCard__user-info"
             >
@@ -1093,26 +1078,23 @@ exports[`SystemUserDetail should show the activate user button as disabled when 
           <div
             class="AdminUserCard__header"
           >
-            <span
+            <button
               aria-expanded="false"
               aria-haspopup="dialog"
-              class="status-wrapper admin-user-card"
+              class="status-wrapper style--none admin-user-card"
+              style="border-radius: 50%; width: 128px; height: 128px;"
             >
-              <button
-                class="RoundButton-dvlhqG gnYSKj style--none"
+              <span
+                class="profile-icon "
               >
-                <span
-                  class="profile-icon "
-                >
-                  <img
-                    alt="user profile image"
-                    class="Avatar Avatar-xxl"
-                    loading="lazy"
-                    src="/api/v4/users/user_id/image"
-                  />
-                </span>
-              </button>
-            </span>
+                <img
+                  alt="user profile image"
+                  class="Avatar Avatar-xxl"
+                  loading="lazy"
+                  src="/api/v4/users/user_id/image"
+                />
+              </span>
+            </button>
             <div
               class="AdminUserCard__user-info"
             >

--- a/webapp/channels/src/components/at_mention/__snapshots__/at_mention.test.tsx.snap
+++ b/webapp/channels/src/components/at_mention/__snapshots__/at_mention.test.tsx.snap
@@ -96,7 +96,8 @@ exports[`components/AtMention should match snapshot when mentioning current user
   <ProfilePopoverController
     returnFocus={[Function]}
     src="/api/v4/users/abc1/image"
-    triggerComponentClass="mention--highlight"
+    triggerComponentAs="button"
+    triggerComponentClass="style--none mention--highlight"
     userId="abc1"
   >
     <a
@@ -115,7 +116,8 @@ exports[`components/AtMention should match snapshot when mentioning user 1`] = `
   <ProfilePopoverController
     returnFocus={[Function]}
     src="/api/v4/users/abc2/image"
-    triggerComponentClass=""
+    triggerComponentAs="button"
+    triggerComponentClass="style--none"
     userId="abc2"
   >
     <a
@@ -134,7 +136,8 @@ exports[`components/AtMention should match snapshot when mentioning user contain
   <ProfilePopoverController
     returnFocus={[Function]}
     src="/api/v4/users/abc3/image"
-    triggerComponentClass=""
+    triggerComponentAs="button"
+    triggerComponentClass="style--none"
     userId="abc3"
   >
     <a
@@ -154,7 +157,8 @@ exports[`components/AtMention should match snapshot when mentioning user contain
   <ProfilePopoverController
     returnFocus={[Function]}
     src="/api/v4/users/abc3/image"
-    triggerComponentClass=""
+    triggerComponentAs="button"
+    triggerComponentClass="style--none"
     userId="abc3"
   >
     <a
@@ -173,7 +177,8 @@ exports[`components/AtMention should match snapshot when mentioning user followe
   <ProfilePopoverController
     returnFocus={[Function]}
     src="/api/v4/users/abc2/image"
-    triggerComponentClass=""
+    triggerComponentAs="button"
+    triggerComponentClass="style--none"
     userId="abc2"
   >
     <a
@@ -193,7 +198,8 @@ exports[`components/AtMention should match snapshot when mentioning user with di
   <ProfilePopoverController
     returnFocus={[Function]}
     src="/api/v4/users/abc2/image"
-    triggerComponentClass=""
+    triggerComponentAs="button"
+    triggerComponentClass="style--none"
     userId="abc2"
   >
     <a
@@ -212,7 +218,8 @@ exports[`components/AtMention should match snapshot when mentioning user with mi
   <ProfilePopoverController
     returnFocus={[Function]}
     src="/api/v4/users/abc2/image"
-    triggerComponentClass=""
+    triggerComponentAs="button"
+    triggerComponentClass="style--none"
     userId="abc2"
   >
     <a

--- a/webapp/channels/src/components/at_mention/__snapshots__/at_mention.test.tsx.snap
+++ b/webapp/channels/src/components/at_mention/__snapshots__/at_mention.test.tsx.snap
@@ -100,13 +100,11 @@ exports[`components/AtMention should match snapshot when mentioning current user
     triggerComponentClass="style--none mention--highlight"
     userId="abc1"
   >
-    <a
+    <span
       className="mention-link"
-      role="button"
-      tabIndex={0}
     >
       @First Last
-    </a>
+    </span>
   </ProfilePopoverController>
 </Fragment>
 `;
@@ -120,13 +118,11 @@ exports[`components/AtMention should match snapshot when mentioning user 1`] = `
     triggerComponentClass="style--none"
     userId="abc2"
   >
-    <a
+    <span
       className="mention-link"
-      role="button"
-      tabIndex={0}
     >
       @Nick
-    </a>
+    </span>
   </ProfilePopoverController>
 </Fragment>
 `;
@@ -140,13 +136,11 @@ exports[`components/AtMention should match snapshot when mentioning user contain
     triggerComponentClass="style--none"
     userId="abc3"
   >
-    <a
+    <span
       className="mention-link"
-      role="button"
-      tabIndex={0}
     >
       @Dot Matrix
-    </a>
+    </span>
   </ProfilePopoverController>
   .
 </Fragment>
@@ -161,13 +155,11 @@ exports[`components/AtMention should match snapshot when mentioning user contain
     triggerComponentClass="style--none"
     userId="abc3"
   >
-    <a
+    <span
       className="mention-link"
-      role="button"
-      tabIndex={0}
     >
       @Dot Matrix
-    </a>
+    </span>
   </ProfilePopoverController>
 </Fragment>
 `;
@@ -181,13 +173,11 @@ exports[`components/AtMention should match snapshot when mentioning user followe
     triggerComponentClass="style--none"
     userId="abc2"
   >
-    <a
+    <span
       className="mention-link"
-      role="button"
-      tabIndex={0}
     >
       @Nick
-    </a>
+    </span>
   </ProfilePopoverController>
   ...
 </Fragment>
@@ -202,13 +192,11 @@ exports[`components/AtMention should match snapshot when mentioning user with di
     triggerComponentClass="style--none"
     userId="abc2"
   >
-    <a
+    <span
       className="mention-link"
-      role="button"
-      tabIndex={0}
     >
       @user1
-    </a>
+    </span>
   </ProfilePopoverController>
 </Fragment>
 `;
@@ -222,13 +210,11 @@ exports[`components/AtMention should match snapshot when mentioning user with mi
     triggerComponentClass="style--none"
     userId="abc2"
   >
-    <a
+    <span
       className="mention-link"
-      role="button"
-      tabIndex={0}
     >
       @Nick
-    </a>
+    </span>
   </ProfilePopoverController>
 </Fragment>
 `;

--- a/webapp/channels/src/components/at_mention/at_mention.tsx
+++ b/webapp/channels/src/components/at_mention/at_mention.tsx
@@ -67,14 +67,12 @@ const AtMention = (props: Props) => {
                     returnFocus={returnFocus}
                     triggerComponentAs='button'
                 >
-                    <a
+                    <span
                         ref={ref}
                         className='mention-link'
-                        role='button'
-                        tabIndex={0}
                     >
                         {'@' + userDisplayName}
-                    </a>
+                    </span>
                 </ProfilePopover>
                 {userMentionNameSuffix}
             </>

--- a/webapp/channels/src/components/at_mention/at_mention.tsx
+++ b/webapp/channels/src/components/at_mention/at_mention.tsx
@@ -60,11 +60,12 @@ const AtMention = (props: Props) => {
         return (
             <>
                 <ProfilePopover
-                    triggerComponentClass={classNames({'mention--highlight': highlightMention})}
+                    triggerComponentClass={classNames('style--none', {'mention--highlight': highlightMention})}
                     userId={user.id}
                     src={Client4.getProfilePictureUrl(user.id, user.last_picture_update)}
                     channelId={props.channelId}
                     returnFocus={returnFocus}
+                    triggerComponentAs='button'
                 >
                     <a
                         ref={ref}

--- a/webapp/channels/src/components/drafts/panel/__snapshots__/panel_body.test.tsx.snap
+++ b/webapp/channels/src/components/drafts/panel/__snapshots__/panel_body.test.tsx.snap
@@ -40,47 +40,52 @@ exports[`components/drafts/panel/panel_body should have called handleFormattedTe
           <ProfilePopoverController
             channelId="channel_id"
             src="/api/v4/users/user_id/image?_=0"
-            triggerComponentClass="status-wrapper"
+            triggerComponentAs="button"
+            triggerComponentClass="status-wrapper style--none"
+            triggerComponentStyle={
+              Object {
+                "borderRadius": "50%",
+                "height": "32px",
+                "width": "32px",
+              }
+            }
             userId="user_id"
             username="username"
           >
-            <span
+            <button
               aria-expanded="false"
               aria-haspopup="dialog"
-              className="status-wrapper"
+              className="status-wrapper style--none"
               onClick={[Function]}
               onKeyDown={[Function]}
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onPointerDown={[Function]}
+              style={
+                Object {
+                  "borderRadius": "50%",
+                  "height": "32px",
+                  "width": "32px",
+                }
+              }
             >
-              <RoundButton
-                className="style--none"
-                size="md"
+              <span
+                className="profile-icon "
               >
-                <button
-                  className="RoundButton-dvlhqG gfRzmz style--none"
+                <Avatar
                   size="md"
+                  url="/api/v4/users/user_id/image?_=0"
+                  username="username"
                 >
-                  <span
-                    className="profile-icon "
-                  >
-                    <Avatar
-                      size="md"
-                      url="/api/v4/users/user_id/image?_=0"
-                      username="username"
-                    >
-                      <img
-                        alt="username profile image"
-                        className="Avatar Avatar-md"
-                        loading="lazy"
-                        onError={[Function]}
-                        src="/api/v4/users/user_id/image?_=0"
-                      />
-                    </Avatar>
-                  </span>
-                </button>
-              </RoundButton>
+                  <img
+                    alt="username profile image"
+                    className="Avatar Avatar-md"
+                    loading="lazy"
+                    onError={[Function]}
+                    src="/api/v4/users/user_id/image?_=0"
+                  />
+                </Avatar>
+              </span>
               <Memo(StatusIcon)
                 status="status"
               >
@@ -113,7 +118,7 @@ exports[`components/drafts/panel/panel_body should have called handleFormattedTe
                   </span>
                 </StatusOfflineIcon>
               </Memo(StatusIcon)>
-            </span>
+            </button>
           </ProfilePopoverController>
         </ProfilePicture>
       </div>
@@ -267,47 +272,52 @@ exports[`components/drafts/panel/panel_body should match snapshot 1`] = `
           <ProfilePopoverController
             channelId="channel_id"
             src="/api/v4/users/user_id/image?_=0"
-            triggerComponentClass="status-wrapper"
+            triggerComponentAs="button"
+            triggerComponentClass="status-wrapper style--none"
+            triggerComponentStyle={
+              Object {
+                "borderRadius": "50%",
+                "height": "32px",
+                "width": "32px",
+              }
+            }
             userId="user_id"
             username="username"
           >
-            <span
+            <button
               aria-expanded="false"
               aria-haspopup="dialog"
-              className="status-wrapper"
+              className="status-wrapper style--none"
               onClick={[Function]}
               onKeyDown={[Function]}
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onPointerDown={[Function]}
+              style={
+                Object {
+                  "borderRadius": "50%",
+                  "height": "32px",
+                  "width": "32px",
+                }
+              }
             >
-              <RoundButton
-                className="style--none"
-                size="md"
+              <span
+                className="profile-icon "
               >
-                <button
-                  className="RoundButton-dvlhqG gfRzmz style--none"
+                <Avatar
                   size="md"
+                  url="/api/v4/users/user_id/image?_=0"
+                  username="username"
                 >
-                  <span
-                    className="profile-icon "
-                  >
-                    <Avatar
-                      size="md"
-                      url="/api/v4/users/user_id/image?_=0"
-                      username="username"
-                    >
-                      <img
-                        alt="username profile image"
-                        className="Avatar Avatar-md"
-                        loading="lazy"
-                        onError={[Function]}
-                        src="/api/v4/users/user_id/image?_=0"
-                      />
-                    </Avatar>
-                  </span>
-                </button>
-              </RoundButton>
+                  <img
+                    alt="username profile image"
+                    className="Avatar Avatar-md"
+                    loading="lazy"
+                    onError={[Function]}
+                    src="/api/v4/users/user_id/image?_=0"
+                  />
+                </Avatar>
+              </span>
               <Memo(StatusIcon)
                 status="status"
               >
@@ -340,7 +350,7 @@ exports[`components/drafts/panel/panel_body should match snapshot 1`] = `
                   </span>
                 </StatusOfflineIcon>
               </Memo(StatusIcon)>
-            </span>
+            </button>
           </ProfilePopoverController>
         </ProfilePicture>
       </div>
@@ -500,47 +510,52 @@ exports[`components/drafts/panel/panel_body should match snapshot for priority 1
           <ProfilePopoverController
             channelId="channel_id"
             src="/api/v4/users/user_id/image?_=0"
-            triggerComponentClass="status-wrapper"
+            triggerComponentAs="button"
+            triggerComponentClass="status-wrapper style--none"
+            triggerComponentStyle={
+              Object {
+                "borderRadius": "50%",
+                "height": "32px",
+                "width": "32px",
+              }
+            }
             userId="user_id"
             username="username"
           >
-            <span
+            <button
               aria-expanded="false"
               aria-haspopup="dialog"
-              className="status-wrapper"
+              className="status-wrapper style--none"
               onClick={[Function]}
               onKeyDown={[Function]}
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onPointerDown={[Function]}
+              style={
+                Object {
+                  "borderRadius": "50%",
+                  "height": "32px",
+                  "width": "32px",
+                }
+              }
             >
-              <RoundButton
-                className="style--none"
-                size="md"
+              <span
+                className="profile-icon "
               >
-                <button
-                  className="RoundButton-dvlhqG gfRzmz style--none"
+                <Avatar
                   size="md"
+                  url="/api/v4/users/user_id/image?_=0"
+                  username="username"
                 >
-                  <span
-                    className="profile-icon "
-                  >
-                    <Avatar
-                      size="md"
-                      url="/api/v4/users/user_id/image?_=0"
-                      username="username"
-                    >
-                      <img
-                        alt="username profile image"
-                        className="Avatar Avatar-md"
-                        loading="lazy"
-                        onError={[Function]}
-                        src="/api/v4/users/user_id/image?_=0"
-                      />
-                    </Avatar>
-                  </span>
-                </button>
-              </RoundButton>
+                  <img
+                    alt="username profile image"
+                    className="Avatar Avatar-md"
+                    loading="lazy"
+                    onError={[Function]}
+                    src="/api/v4/users/user_id/image?_=0"
+                  />
+                </Avatar>
+              </span>
               <Memo(StatusIcon)
                 status="status"
               >
@@ -573,7 +588,7 @@ exports[`components/drafts/panel/panel_body should match snapshot for priority 1
                   </span>
                 </StatusOfflineIcon>
               </Memo(StatusIcon)>
-            </span>
+            </button>
           </ProfilePopoverController>
         </ProfilePicture>
       </div>
@@ -790,47 +805,52 @@ exports[`components/drafts/panel/panel_body should match snapshot for requested_
           <ProfilePopoverController
             channelId="channel_id"
             src="/api/v4/users/user_id/image?_=0"
-            triggerComponentClass="status-wrapper"
+            triggerComponentAs="button"
+            triggerComponentClass="status-wrapper style--none"
+            triggerComponentStyle={
+              Object {
+                "borderRadius": "50%",
+                "height": "32px",
+                "width": "32px",
+              }
+            }
             userId="user_id"
             username="username"
           >
-            <span
+            <button
               aria-expanded="false"
               aria-haspopup="dialog"
-              className="status-wrapper"
+              className="status-wrapper style--none"
               onClick={[Function]}
               onKeyDown={[Function]}
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onPointerDown={[Function]}
+              style={
+                Object {
+                  "borderRadius": "50%",
+                  "height": "32px",
+                  "width": "32px",
+                }
+              }
             >
-              <RoundButton
-                className="style--none"
-                size="md"
+              <span
+                className="profile-icon "
               >
-                <button
-                  className="RoundButton-dvlhqG gfRzmz style--none"
+                <Avatar
                   size="md"
+                  url="/api/v4/users/user_id/image?_=0"
+                  username="username"
                 >
-                  <span
-                    className="profile-icon "
-                  >
-                    <Avatar
-                      size="md"
-                      url="/api/v4/users/user_id/image?_=0"
-                      username="username"
-                    >
-                      <img
-                        alt="username profile image"
-                        className="Avatar Avatar-md"
-                        loading="lazy"
-                        onError={[Function]}
-                        src="/api/v4/users/user_id/image?_=0"
-                      />
-                    </Avatar>
-                  </span>
-                </button>
-              </RoundButton>
+                  <img
+                    alt="username profile image"
+                    className="Avatar Avatar-md"
+                    loading="lazy"
+                    onError={[Function]}
+                    src="/api/v4/users/user_id/image?_=0"
+                  />
+                </Avatar>
+              </span>
               <Memo(StatusIcon)
                 status="status"
               >
@@ -863,7 +883,7 @@ exports[`components/drafts/panel/panel_body should match snapshot for requested_
                   </span>
                 </StatusOfflineIcon>
               </Memo(StatusIcon)>
-            </span>
+            </button>
           </ProfilePopoverController>
         </ProfilePicture>
       </div>

--- a/webapp/channels/src/components/post/post_component.tsx
+++ b/webapp/channels/src/components/post/post_component.tsx
@@ -567,7 +567,6 @@ function PostComponent(props: Props) {
                     channelId={post.channel_id}
                 />
                 <div
-                    role='application'
                     className={`post__content ${props.center ? 'center' : ''}`}
                     data-testid='postContent'
                 >

--- a/webapp/channels/src/components/profile_picture/__snapshots__/profile_picture.test.tsx.snap
+++ b/webapp/channels/src/components/profile_picture/__snapshots__/profile_picture.test.tsx.snap
@@ -39,21 +39,24 @@ exports[`components/ProfilePicture should match snapshot, no user specified, ove
 exports[`components/ProfilePicture should match snapshot, profile and src, default props 1`] = `
 <ProfilePopoverController
   src="http://example.com/image.png"
-  triggerComponentClass="status-wrapper"
+  triggerComponentAs="button"
+  triggerComponentClass="status-wrapper style--none"
+  triggerComponentStyle={
+    Object {
+      "borderRadius": "50%",
+      "height": "32px",
+      "width": "32px",
+    }
+  }
   userId="uid"
 >
-  <RoundButton
-    className="style--none"
-    size="md"
+  <span
+    className="profile-icon "
   >
-    <span
-      className="profile-icon "
-    >
-      <Memo(Avatar)
-        url="http://example.com/emoji.png"
-      />
-    </span>
-  </RoundButton>
+    <Memo(Avatar)
+      url="http://example.com/emoji.png"
+    />
+  </span>
   <Memo(StatusIcon)
     status="away"
   />

--- a/webapp/channels/src/components/profile_picture/index.tsx
+++ b/webapp/channels/src/components/profile_picture/index.tsx
@@ -3,7 +3,6 @@
 
 import classNames from 'classnames';
 import React from 'react';
-import styled from 'styled-components';
 
 import ProfilePopover from 'components/profile_popover';
 import StatusIcon from 'components/status_icon';
@@ -42,7 +41,7 @@ function ProfilePicture(props: Props) {
     if (props.userId) {
         return (
             <ProfilePopover
-                triggerComponentClass={classNames('status-wrapper', props.wrapperClass)}
+                triggerComponentClass={classNames('status-wrapper style--none', props.wrapperClass)}
                 userId={props.userId}
                 src={profileSrc}
                 username={props.username}
@@ -51,20 +50,21 @@ function ProfilePicture(props: Props) {
                 overwriteIcon={props.overwriteIcon}
                 overwriteName={props.overwriteName}
                 fromWebhook={props.fromWebhook}
+                triggerComponentAs='button'
+                triggerComponentStyle={{
+                    borderRadius: '50%',
+                    width: `${getAvatarWidth(props?.size ?? 'md')}px`,
+                    height: `${getAvatarWidth(props?.size ?? 'md')}px`,
+                }}
             >
                 <>
-                    <RoundButton
-                        className='style--none'
-                        size={props?.size ?? 'md'}
-                    >
-                        <span className={profileIconClass}>
-                            <Avatar
-                                username={props.username}
-                                size={props.size}
-                                url={props.src}
-                            />
-                        </span>
-                    </RoundButton>
+                    <span className={profileIconClass}>
+                        <Avatar
+                            username={props.username}
+                            size={props.size}
+                            url={props.src}
+                        />
+                    </span>
                     <StatusIcon status={props.status}/>
                 </>
             </ProfilePopover>
@@ -92,11 +92,5 @@ function ProfilePicture(props: Props) {
         </span>
     );
 }
-
-const RoundButton = styled.button<{size: TAvatarSizeToken}>`
-    border-radius: 50%;
-    width: ${(p) => getAvatarWidth(p.size)}px;
-    height: ${(p) => getAvatarWidth(p.size)}px;
-`;
 
 export default ProfilePicture;

--- a/webapp/channels/src/sass/components/_mentions.scss
+++ b/webapp/channels/src/sass/components/_mentions.scss
@@ -21,6 +21,15 @@ del .group-mention-link:focus {
     color: variables.$white;
 }
 
+.mention-link {
+    color:rgb(56, 111, 229)
+}
+
+.mention-link:hover,
+.mention-link:focus {
+    text-decoration: underline;
+}
+
 .badge {
     display: inline-block;
     min-width: 10px;

--- a/webapp/channels/src/sass/components/_mentions.scss
+++ b/webapp/channels/src/sass/components/_mentions.scss
@@ -25,7 +25,7 @@ del .group-mention-link:focus {
     color: var(--link-color);
 
     &:hover,
-    :focus {
+    &:focus {
         text-decoration: underline;
     }
 }

--- a/webapp/channels/src/sass/components/_mentions.scss
+++ b/webapp/channels/src/sass/components/_mentions.scss
@@ -22,12 +22,12 @@ del .group-mention-link:focus {
 }
 
 .mention-link {
-    color:rgb(56, 111, 229)
-}
+    color: var(--link-color);
 
-.mention-link:hover,
-.mention-link:focus {
-    text-decoration: underline;
+    &:hover,
+    :focus {
+        text-decoration: underline;
+    }
 }
 
 .badge {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR ensure ARIA roles, states, and properties are valid in user profile image and @user buttons.

#### Steps to reproduce  
- Navigate to the user profile image button (Avatar) or the @user mention link.
- Inspect the element.
- Notice that the aria-expanded and aria-haspopup attributes implemented for the <span>tag is invalid.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Fixes: https://mattermost.atlassian.net/browse/MM-61598

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->
![Screenshot from 2024-12-16 14-35-49](https://github.com/user-attachments/assets/87415900-c8a5-476b-accf-d80678730da5)
![Screenshot from 2024-12-16 14-36-01](https://github.com/user-attachments/assets/01da7318-0a02-450a-bb03-bb2fb5e928a0)

[Screencast from 2025-01-02 16-51-43.webm](https://github.com/user-attachments/assets/90e57d3e-9f08-401f-9e9e-bb0b2ce14897)

[Screencast from 2025-01-02 16-53-40.webm](https://github.com/user-attachments/assets/283b60bd-d8e8-405d-9bba-697d6af411a3)


#### Release Note
<!--
Add a release note for each of the following conditions:
* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
