### PR TITLE
Automated cherry pick of #29557

### DIFF
--- a/server/channels/api4/post.go
+++ b/server/channels/api4/post.go
@@ -262,7 +262,7 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	}
-	if !c.App.SessionHasPermissionToReadChannel(c.AppContext, *c.AppContext.Session(), channel) {
+	if !c.IsSystemAdmin() && !c.App.SessionHasPermissionToReadChannel(c.AppContext, *c.AppContext.Session(), channel) {
 		c.SetPermissionError(model.PermissionReadChannelContent)
 		return
 	}

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -1949,6 +1949,14 @@ func TestGetPostsForChannel(t *testing.T) {
 		require.NoError(t, err)
 		CheckOKStatus(t, resp)
 		require.Len(t, posts.Order, 10, "expected 10 posts")
+
+		// allow viewing of direct messages
+		dmChannel := th.CreateDmChannel(th.BasicUser2)
+		th.CreateMessagePostNoClient(dmChannel, "test1", model.GetMillis())
+
+		posts, resp, err = c.GetPostsForChannel(context.Background(), dmChannel.Id, 0, 100, "", false, false)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
 	})
 }
 


### PR DESCRIPTION
Cherry pick of #29557 on release-10.0.

/cc  @devinbinnie

```release-note
NONE
```