### PR TITLE
[MM-61619]: Added aria-live property for message sent status

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -2,36 +2,36 @@
 // See LICENSE.txt for license information.
 
 import classNames from 'classnames';
-import React, { lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
-import { useDispatch, useSelector } from 'react-redux';
+import React, {lazy, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
+import {useDispatch, useSelector} from 'react-redux';
 
-import type { ServerError } from '@mattermost/types/errors';
-import type { SchedulingInfo } from '@mattermost/types/schedule_post';
+import type {ServerError} from '@mattermost/types/errors';
+import type {SchedulingInfo} from '@mattermost/types/schedule_post';
 
-import { FileTypes } from 'mattermost-redux/action_types';
-import { savePreferences } from 'mattermost-redux/actions/preferences';
-import { Permissions } from 'mattermost-redux/constants';
-import { getChannel, makeGetChannel, getDirectChannel } from 'mattermost-redux/selectors/entities/channels';
-import { getFilesIdsForPost } from 'mattermost-redux/selectors/entities/files';
-import { getConfig, getFeatureFlagValue } from 'mattermost-redux/selectors/entities/general';
-import { get, getBool, getInt } from 'mattermost-redux/selectors/entities/preferences';
-import { haveIChannelPermission } from 'mattermost-redux/selectors/entities/roles';
-import { getCurrentUserId, isCurrentUserGuestUser, getStatusForUserId, makeGetDisplayName } from 'mattermost-redux/selectors/entities/users';
+import {FileTypes} from 'mattermost-redux/action_types';
+import {savePreferences} from 'mattermost-redux/actions/preferences';
+import {Permissions} from 'mattermost-redux/constants';
+import {getChannel, makeGetChannel, getDirectChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getFilesIdsForPost} from 'mattermost-redux/selectors/entities/files';
+import {getConfig, getFeatureFlagValue} from 'mattermost-redux/selectors/entities/general';
+import {get, getBool, getInt} from 'mattermost-redux/selectors/entities/preferences';
+import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
+import {getCurrentUserId, isCurrentUserGuestUser, getStatusForUserId, makeGetDisplayName} from 'mattermost-redux/selectors/entities/users';
 
 import * as GlobalActions from 'actions/global_actions';
-import type { CreatePostOptions } from 'actions/post_actions';
-import { actionOnGlobalItemsWithPrefix } from 'actions/storage';
-import type { SubmitPostReturnType } from 'actions/views/create_comment';
-import { removeDraft, updateDraft } from 'actions/views/drafts';
-import { openModal } from 'actions/views/modals';
-import { makeGetDraft } from 'selectors/drafts';
-import { getSelectedPostFocussedAt } from 'selectors/rhs';
-import { connectionErrorCount } from 'selectors/views/system';
+import type {CreatePostOptions} from 'actions/post_actions';
+import {actionOnGlobalItemsWithPrefix} from 'actions/storage';
+import type {SubmitPostReturnType} from 'actions/views/create_comment';
+import {removeDraft, updateDraft} from 'actions/views/drafts';
+import {openModal} from 'actions/views/modals';
+import {makeGetDraft} from 'selectors/drafts';
+import {getSelectedPostFocussedAt} from 'selectors/rhs';
+import {connectionErrorCount} from 'selectors/views/system';
 import LocalStorageStore from 'stores/local_storage_store';
 
 import PostBoxIndicator from 'components/advanced_text_editor/post_box_indicator/post_box_indicator';
-import { makeAsyncComponent } from 'components/async_load';
+import {makeAsyncComponent} from 'components/async_load';
 import AutoHeightSwitcher from 'components/common/auto_height_switcher';
 import useDidUpdate from 'components/common/hooks/useDidUpdate';
 import DeletePostModal from 'components/delete_post_modal';
@@ -43,10 +43,10 @@ import {
 import RhsSuggestionList from 'components/suggestion/rhs_suggestion_list';
 import SuggestionList from 'components/suggestion/suggestion_list';
 import Textbox from 'components/textbox';
-import type { TextboxElement } from 'components/textbox';
+import type {TextboxElement} from 'components/textbox';
 import type TextboxClass from 'components/textbox/textbox';
-import { OnboardingTourSteps, OnboardingTourStepsForGuestUsers, TutorialTourName } from 'components/tours/constant';
-import { SendMessageTour } from 'components/tours/onboarding_tour';
+import {OnboardingTourSteps, OnboardingTourStepsForGuestUsers, TutorialTourName} from 'components/tours/constant';
+import {SendMessageTour} from 'components/tours/onboarding_tour';
 
 import Constants, {
     Locations,
@@ -56,22 +56,22 @@ import Constants, {
     UserStatuses,
     ModalIdentifiers,
 } from 'utils/constants';
-import { canUploadFiles as canUploadFilesAccordingToConfig } from 'utils/file_utils';
-import type { ApplyMarkdownOptions } from 'utils/markdown/apply_markdown';
-import { applyMarkdown as applyMarkdownUtil } from 'utils/markdown/apply_markdown';
-import { isErrorInvalidSlashCommand } from 'utils/post_utils';
-import { allAtMentions } from 'utils/text_formatting';
+import {canUploadFiles as canUploadFilesAccordingToConfig} from 'utils/file_utils';
+import type {ApplyMarkdownOptions} from 'utils/markdown/apply_markdown';
+import {applyMarkdown as applyMarkdownUtil} from 'utils/markdown/apply_markdown';
+import {isErrorInvalidSlashCommand} from 'utils/post_utils';
+import {allAtMentions} from 'utils/text_formatting';
 import * as Utils from 'utils/utils';
 
-import type { GlobalState } from 'types/store';
-import type { PostDraft } from 'types/store/draft';
-import { isPostDraftEmpty } from 'types/store/draft';
+import type {GlobalState} from 'types/store';
+import type {PostDraft} from 'types/store/draft';
+import {isPostDraftEmpty} from 'types/store/draft';
 
 import DoNotDisturbWarning from './do_not_disturb_warning';
 import EditPostFooter from './edit_post_footer';
 import Footer from './footer';
 import FormattingBar from './formatting_bar';
-import { FormattingBarSpacer, Separator } from './formatting_bar/formatting_bar';
+import {FormattingBarSpacer, Separator} from './formatting_bar/formatting_bar';
 import MessageWithMentionsFooter from './message_with_mentions_footer';
 import SendButton from './send_button';
 import ShowFormat from './show_formatting';
@@ -124,7 +124,7 @@ const AdvancedTextEditor = ({
     afterSubmit,
     storageKey,
 }: Props) => {
-    const { formatMessage } = useIntl();
+    const {formatMessage} = useIntl();
 
     const dispatch = useDispatch();
 
@@ -224,7 +224,7 @@ const AdvancedTextEditor = ({
         GlobalActions.emitLocalUserTypingEvent(channelId, postId);
     }, [channelId, postId]);
 
-    const handleDraftChange = useCallback((draftToChange: PostDraft, options: { instant?: boolean; show?: boolean } = { instant: false, show: false }) => {
+    const handleDraftChange = useCallback((draftToChange: PostDraft, options: {instant?: boolean; show?: boolean} = {instant: false, show: false}) => {
         if (saveDraftFrame.current) {
             clearTimeout(saveDraftFrame.current);
         }
@@ -246,7 +246,7 @@ const AdvancedTextEditor = ({
             }
 
             if (options.show) {
-                dispatch(updateDraft(key, { ...draftToChange, show: true }, draftToChange.rootId, true));
+                dispatch(updateDraft(key, {...draftToChange, show: true}, draftToChange.rootId, true));
                 return;
             }
 
@@ -310,7 +310,7 @@ const AdvancedTextEditor = ({
         isInEditMode,
     );
 
-    const emojiPickerOffset = isInEditMode ? { right: 40 } : undefined;
+    const emojiPickerOffset = isInEditMode ? {right: 40} : undefined;
     const {
         emojiPicker,
         enableEmojiPicker,
@@ -340,7 +340,7 @@ const AdvancedTextEditor = ({
         isInEditMode,
     );
 
-    const onSubmit = useCallback((submittingDraft?: PostDraft, schedulingInfo?: SchedulingInfo, options?: CreatePostOptions) => {
+    const handleSubmitWithErrorHandling = useCallback((submittingDraft?: PostDraft, schedulingInfo?: SchedulingInfo, options?: CreatePostOptions) => {
         handleSubmit(submittingDraft, schedulingInfo, options);
         if (!errorClass) {
             const messageStatusElement = messageStatusRef.current;
@@ -407,8 +407,8 @@ const AdvancedTextEditor = ({
             handleFileChangesOnSave(draft);
         }
 
-        handleSubmit();
-    }, [dispatch, draft, handleFileChangesOnSave, handleSubmit, isInEditMode, isRHS]);
+        handleSubmitWithErrorHandling();
+    }, [dispatch, draft, handleFileChangesOnSave, handleSubmitWithErrorHandling, isInEditMode, isRHS]);
 
     const [handleKeyDown, postMsgKeyPress] = useKeyHandler(
         draft,
@@ -433,8 +433,8 @@ const AdvancedTextEditor = ({
 
     const handleSubmitWithEvent = useCallback((e: React.FormEvent) => {
         e.preventDefault();
-        onSubmit();
-    }, [onSubmit]);
+        handleSubmitWithErrorHandling();
+    }, [handleSubmitWithErrorHandling]);
 
     const handlePostError = useCallback((err: React.ReactNode) => {
         setPostError(err);
@@ -554,7 +554,7 @@ const AdvancedTextEditor = ({
         if (selectedPostFocussedAt) {
             focusTextbox();
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedPostFocussedAt]);
 
     // Remove show preview when we switch channels or posts
@@ -570,13 +570,13 @@ const AdvancedTextEditor = ({
                 return draft;
             }
 
-            return { ...draft, uploadsInProgress: [] };
+            return {...draft, uploadsInProgress: []};
         }));
     }, []);
 
     // Register listener to store the draft when the page unloads
     useEffect(() => {
-        const callback = () => handleDraftChange(draft, { instant: true, show: true });
+        const callback = () => handleDraftChange(draft, {instant: true, show: true});
         window.addEventListener('beforeunload', callback);
         return () => {
             window.removeEventListener('beforeunload', callback);
@@ -589,8 +589,8 @@ const AdvancedTextEditor = ({
     }, [draft]);
 
     const handleSubmitPostAndScheduledMessage = useCallback((schedulingInfo?: SchedulingInfo) => {
-        onSubmit(undefined, schedulingInfo);
-    }, [onSubmit]);
+        handleSubmitWithErrorHandling(undefined, schedulingInfo);
+    }, [handleSubmitWithErrorHandling]);
 
     // Set the draft from store when changing post or channels, and store the previous one
     useEffect(() => {
@@ -601,7 +601,7 @@ const AdvancedTextEditor = ({
 
         return () => {
             if (draftOnOpen !== draftRef.current) {
-                handleDraftChange(draftRef.current, { instant: true, show: true });
+                handleDraftChange(draftRef.current, {instant: true, show: true});
             }
         };
     }, [channelId, postId]);
@@ -631,7 +631,7 @@ const AdvancedTextEditor = ({
                 id: 'create_post.write',
                 defaultMessage: 'Write to {channelDisplayName}',
             },
-            { channelDisplayName },
+            {channelDisplayName},
         );
     } else if (readOnlyChannel) {
         createMessage = formatMessage(
@@ -648,7 +648,7 @@ const AdvancedTextEditor = ({
             },
         );
     } else {
-        createMessage = formatMessage({ id: 'create_comment.addComment', defaultMessage: 'Reply to this thread...' });
+        createMessage = formatMessage({id: 'create_comment.addComment', defaultMessage: 'Reply to this thread...'});
     }
 
     const messageValue = isDisabled ? '' : draft.message_source || draft.message;
@@ -656,15 +656,15 @@ const AdvancedTextEditor = ({
     let textboxId = 'textbox';
 
     switch (location) {
-        case Locations.CENTER:
-            textboxId = 'post_textbox';
-            break;
-        case Locations.RHS_COMMENT:
-            textboxId = 'reply_textbox';
-            break;
-        case Locations.MODAL:
-            textboxId = 'modal_textbox';
-            break;
+    case Locations.CENTER:
+        textboxId = 'post_textbox';
+        break;
+    case Locations.RHS_COMMENT:
+        textboxId = 'reply_textbox';
+        break;
+    case Locations.MODAL:
+        textboxId = 'modal_textbox';
+        break;
     }
 
     if (isInEditMode) {
@@ -752,9 +752,9 @@ const AdvancedTextEditor = ({
             onSubmit={handleSubmitWithEvent}
         >
             {canPost && (draft.fileInfos.length > 0 || draft.uploadsInProgress.length > 0) && (
-                <FileLimitStickyBanner />
+                <FileLimitStickyBanner/>
             )}
-            {showDndWarning && <DoNotDisturbWarning displayName={teammateDisplayName} />}
+            {showDndWarning && <DoNotDisturbWarning displayName={teammateDisplayName}/>}
             {!isInEditMode && (
                 <PostBoxIndicator
                     channelId={channelId}
@@ -848,7 +848,7 @@ const AdvancedTextEditor = ({
                                     active={showFormattingBar}
                                     disabled={showPreview}
                                 />
-                                <Separator />
+                                <Separator/>
                                 {fileUploadJSX}
                                 {emojiPicker}
                                 {sendButton}
@@ -865,7 +865,7 @@ const AdvancedTextEditor = ({
                 </div>
             </div>
             {isInEditMode && containsAtMentionsInMessage && (
-                <MessageWithMentionsFooter />
+                <MessageWithMentionsFooter/>
             )}
             <Footer
                 postError={postError}

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -198,6 +198,7 @@ const AdvancedTextEditor = ({
     const draftRef = useRef(draftFromStore);
     const storedDrafts = useRef<Record<string, PostDraft | undefined>>({});
     const lastBlurAt = useRef(0);
+    const messageStatusRef = useRef<HTMLDivElement | null>(null);
 
     const [draft, setDraft] = useState(draftFromStore);
     const [caretPosition, setCaretPosition] = useState(draft.message.length);
@@ -342,12 +343,12 @@ const AdvancedTextEditor = ({
     const onSubmit = useCallback((submittingDraft?: PostDraft, schedulingInfo?: SchedulingInfo, options?: CreatePostOptions) => {
         handleSubmit(submittingDraft, schedulingInfo, options);
         if (!errorClass) {
-            const messageStatusElement = document.getElementById('sentMessageStatus');
-            const messageStatusInnerText = messageStatusElement?.innerText;
+            const messageStatusElement = messageStatusRef.current;
+            const messageStatusInnerText = messageStatusElement?.textContent;
             if (messageStatusInnerText === 'Message Sent') {
-                messageStatusElement!.innerHTML = 'Message Sent &nbsp;';
+                messageStatusElement!.textContent = 'Message Sent &nbsp;';
             } else {
-                messageStatusElement!.innerText = 'Message Sent';
+                messageStatusElement!.textContent = 'Message Sent';
             }
         }
     }, [errorClass, handleSubmit]);
@@ -882,13 +883,10 @@ const AdvancedTextEditor = ({
                 />
             )}
             <div
-                id='sentMessageStatus'
+                ref={messageStatusRef}
                 aria-live='assertive'
-                style={{
-                    position: 'absolute',
-                    top: '-1000px',
-                }}
-            >{ }</div>
+                className='sr-only'
+            />
         </form>
     );
 };

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -2,35 +2,36 @@
 // See LICENSE.txt for license information.
 
 import classNames from 'classnames';
-import React, {lazy, useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {FormattedMessage, useIntl} from 'react-intl';
-import {useDispatch, useSelector} from 'react-redux';
+import React, { lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { useDispatch, useSelector } from 'react-redux';
 
-import type {ServerError} from '@mattermost/types/errors';
-import type {SchedulingInfo} from '@mattermost/types/schedule_post';
+import type { ServerError } from '@mattermost/types/errors';
+import type { SchedulingInfo } from '@mattermost/types/schedule_post';
 
-import {FileTypes} from 'mattermost-redux/action_types';
-import {savePreferences} from 'mattermost-redux/actions/preferences';
-import {Permissions} from 'mattermost-redux/constants';
-import {getChannel, makeGetChannel, getDirectChannel} from 'mattermost-redux/selectors/entities/channels';
-import {getFilesIdsForPost} from 'mattermost-redux/selectors/entities/files';
-import {getConfig, getFeatureFlagValue} from 'mattermost-redux/selectors/entities/general';
-import {get, getBool, getInt} from 'mattermost-redux/selectors/entities/preferences';
-import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
-import {getCurrentUserId, isCurrentUserGuestUser, getStatusForUserId, makeGetDisplayName} from 'mattermost-redux/selectors/entities/users';
+import { FileTypes } from 'mattermost-redux/action_types';
+import { savePreferences } from 'mattermost-redux/actions/preferences';
+import { Permissions } from 'mattermost-redux/constants';
+import { getChannel, makeGetChannel, getDirectChannel } from 'mattermost-redux/selectors/entities/channels';
+import { getFilesIdsForPost } from 'mattermost-redux/selectors/entities/files';
+import { getConfig, getFeatureFlagValue } from 'mattermost-redux/selectors/entities/general';
+import { get, getBool, getInt } from 'mattermost-redux/selectors/entities/preferences';
+import { haveIChannelPermission } from 'mattermost-redux/selectors/entities/roles';
+import { getCurrentUserId, isCurrentUserGuestUser, getStatusForUserId, makeGetDisplayName } from 'mattermost-redux/selectors/entities/users';
 
 import * as GlobalActions from 'actions/global_actions';
-import {actionOnGlobalItemsWithPrefix} from 'actions/storage';
-import type {SubmitPostReturnType} from 'actions/views/create_comment';
-import {removeDraft, updateDraft} from 'actions/views/drafts';
-import {openModal} from 'actions/views/modals';
-import {makeGetDraft} from 'selectors/drafts';
-import {getSelectedPostFocussedAt} from 'selectors/rhs';
-import {connectionErrorCount} from 'selectors/views/system';
+import type { CreatePostOptions } from 'actions/post_actions';
+import { actionOnGlobalItemsWithPrefix } from 'actions/storage';
+import type { SubmitPostReturnType } from 'actions/views/create_comment';
+import { removeDraft, updateDraft } from 'actions/views/drafts';
+import { openModal } from 'actions/views/modals';
+import { makeGetDraft } from 'selectors/drafts';
+import { getSelectedPostFocussedAt } from 'selectors/rhs';
+import { connectionErrorCount } from 'selectors/views/system';
 import LocalStorageStore from 'stores/local_storage_store';
 
 import PostBoxIndicator from 'components/advanced_text_editor/post_box_indicator/post_box_indicator';
-import {makeAsyncComponent} from 'components/async_load';
+import { makeAsyncComponent } from 'components/async_load';
 import AutoHeightSwitcher from 'components/common/auto_height_switcher';
 import useDidUpdate from 'components/common/hooks/useDidUpdate';
 import DeletePostModal from 'components/delete_post_modal';
@@ -42,10 +43,10 @@ import {
 import RhsSuggestionList from 'components/suggestion/rhs_suggestion_list';
 import SuggestionList from 'components/suggestion/suggestion_list';
 import Textbox from 'components/textbox';
-import type {TextboxElement} from 'components/textbox';
+import type { TextboxElement } from 'components/textbox';
 import type TextboxClass from 'components/textbox/textbox';
-import {OnboardingTourSteps, OnboardingTourStepsForGuestUsers, TutorialTourName} from 'components/tours/constant';
-import {SendMessageTour} from 'components/tours/onboarding_tour';
+import { OnboardingTourSteps, OnboardingTourStepsForGuestUsers, TutorialTourName } from 'components/tours/constant';
+import { SendMessageTour } from 'components/tours/onboarding_tour';
 
 import Constants, {
     Locations,
@@ -55,22 +56,22 @@ import Constants, {
     UserStatuses,
     ModalIdentifiers,
 } from 'utils/constants';
-import {canUploadFiles as canUploadFilesAccordingToConfig} from 'utils/file_utils';
-import type {ApplyMarkdownOptions} from 'utils/markdown/apply_markdown';
-import {applyMarkdown as applyMarkdownUtil} from 'utils/markdown/apply_markdown';
-import {isErrorInvalidSlashCommand} from 'utils/post_utils';
-import {allAtMentions} from 'utils/text_formatting';
+import { canUploadFiles as canUploadFilesAccordingToConfig } from 'utils/file_utils';
+import type { ApplyMarkdownOptions } from 'utils/markdown/apply_markdown';
+import { applyMarkdown as applyMarkdownUtil } from 'utils/markdown/apply_markdown';
+import { isErrorInvalidSlashCommand } from 'utils/post_utils';
+import { allAtMentions } from 'utils/text_formatting';
 import * as Utils from 'utils/utils';
 
-import type {GlobalState} from 'types/store';
-import type {PostDraft} from 'types/store/draft';
-import {isPostDraftEmpty} from 'types/store/draft';
+import type { GlobalState } from 'types/store';
+import type { PostDraft } from 'types/store/draft';
+import { isPostDraftEmpty } from 'types/store/draft';
 
 import DoNotDisturbWarning from './do_not_disturb_warning';
 import EditPostFooter from './edit_post_footer';
 import Footer from './footer';
 import FormattingBar from './formatting_bar';
-import {FormattingBarSpacer, Separator} from './formatting_bar/formatting_bar';
+import { FormattingBarSpacer, Separator } from './formatting_bar/formatting_bar';
 import MessageWithMentionsFooter from './message_with_mentions_footer';
 import SendButton from './send_button';
 import ShowFormat from './show_formatting';
@@ -123,7 +124,7 @@ const AdvancedTextEditor = ({
     afterSubmit,
     storageKey,
 }: Props) => {
-    const {formatMessage} = useIntl();
+    const { formatMessage } = useIntl();
 
     const dispatch = useDispatch();
 
@@ -222,7 +223,7 @@ const AdvancedTextEditor = ({
         GlobalActions.emitLocalUserTypingEvent(channelId, postId);
     }, [channelId, postId]);
 
-    const handleDraftChange = useCallback((draftToChange: PostDraft, options: {instant?: boolean; show?: boolean} = {instant: false, show: false}) => {
+    const handleDraftChange = useCallback((draftToChange: PostDraft, options: { instant?: boolean; show?: boolean } = { instant: false, show: false }) => {
         if (saveDraftFrame.current) {
             clearTimeout(saveDraftFrame.current);
         }
@@ -244,7 +245,7 @@ const AdvancedTextEditor = ({
             }
 
             if (options.show) {
-                dispatch(updateDraft(key, {...draftToChange, show: true}, draftToChange.rootId, true));
+                dispatch(updateDraft(key, { ...draftToChange, show: true }, draftToChange.rootId, true));
                 return;
             }
 
@@ -308,7 +309,7 @@ const AdvancedTextEditor = ({
         isInEditMode,
     );
 
-    const emojiPickerOffset = isInEditMode ? {right: 40} : undefined;
+    const emojiPickerOffset = isInEditMode ? { right: 40 } : undefined;
     const {
         emojiPicker,
         enableEmojiPicker,
@@ -337,6 +338,19 @@ const AdvancedTextEditor = ({
         undefined,
         isInEditMode,
     );
+
+    const onSubmit = useCallback((submittingDraft?: PostDraft, schedulingInfo?: SchedulingInfo, options?: CreatePostOptions) => {
+        handleSubmit(submittingDraft, schedulingInfo, options);
+        if (!errorClass) {
+            const messageStatusElement = document.getElementById('sentMessageStatus');
+            const messageStatusInnerText = messageStatusElement?.innerText;
+            if (messageStatusInnerText === 'Message Sent') {
+                messageStatusElement!.innerHTML = 'Message Sent &nbsp;';
+            } else {
+                messageStatusElement!.innerText = 'Message Sent';
+            }
+        }
+    }, [errorClass, handleSubmit]);
 
     const handleCancel = useCallback(() => {
         handleDraftChange({
@@ -418,8 +432,8 @@ const AdvancedTextEditor = ({
 
     const handleSubmitWithEvent = useCallback((e: React.FormEvent) => {
         e.preventDefault();
-        handleSubmit();
-    }, [handleSubmit]);
+        onSubmit();
+    }, [onSubmit]);
 
     const handlePostError = useCallback((err: React.ReactNode) => {
         setPostError(err);
@@ -539,7 +553,7 @@ const AdvancedTextEditor = ({
         if (selectedPostFocussedAt) {
             focusTextbox();
         }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedPostFocussedAt]);
 
     // Remove show preview when we switch channels or posts
@@ -555,13 +569,13 @@ const AdvancedTextEditor = ({
                 return draft;
             }
 
-            return {...draft, uploadsInProgress: []};
+            return { ...draft, uploadsInProgress: [] };
         }));
     }, []);
 
     // Register listener to store the draft when the page unloads
     useEffect(() => {
-        const callback = () => handleDraftChange(draft, {instant: true, show: true});
+        const callback = () => handleDraftChange(draft, { instant: true, show: true });
         window.addEventListener('beforeunload', callback);
         return () => {
             window.removeEventListener('beforeunload', callback);
@@ -573,7 +587,9 @@ const AdvancedTextEditor = ({
         draftRef.current = draft;
     }, [draft]);
 
-    const handleSubmitPostAndScheduledMessage = useCallback((schedulingInfo?: SchedulingInfo) => handleSubmit(undefined, schedulingInfo), [handleSubmit]);
+    const handleSubmitPostAndScheduledMessage = useCallback((schedulingInfo?: SchedulingInfo) => {
+        onSubmit(undefined, schedulingInfo);
+    }, [onSubmit]);
 
     // Set the draft from store when changing post or channels, and store the previous one
     useEffect(() => {
@@ -584,7 +600,7 @@ const AdvancedTextEditor = ({
 
         return () => {
             if (draftOnOpen !== draftRef.current) {
-                handleDraftChange(draftRef.current, {instant: true, show: true});
+                handleDraftChange(draftRef.current, { instant: true, show: true });
             }
         };
     }, [channelId, postId]);
@@ -614,7 +630,7 @@ const AdvancedTextEditor = ({
                 id: 'create_post.write',
                 defaultMessage: 'Write to {channelDisplayName}',
             },
-            {channelDisplayName},
+            { channelDisplayName },
         );
     } else if (readOnlyChannel) {
         createMessage = formatMessage(
@@ -631,7 +647,7 @@ const AdvancedTextEditor = ({
             },
         );
     } else {
-        createMessage = formatMessage({id: 'create_comment.addComment', defaultMessage: 'Reply to this thread...'});
+        createMessage = formatMessage({ id: 'create_comment.addComment', defaultMessage: 'Reply to this thread...' });
     }
 
     const messageValue = isDisabled ? '' : draft.message_source || draft.message;
@@ -639,15 +655,15 @@ const AdvancedTextEditor = ({
     let textboxId = 'textbox';
 
     switch (location) {
-    case Locations.CENTER:
-        textboxId = 'post_textbox';
-        break;
-    case Locations.RHS_COMMENT:
-        textboxId = 'reply_textbox';
-        break;
-    case Locations.MODAL:
-        textboxId = 'modal_textbox';
-        break;
+        case Locations.CENTER:
+            textboxId = 'post_textbox';
+            break;
+        case Locations.RHS_COMMENT:
+            textboxId = 'reply_textbox';
+            break;
+        case Locations.MODAL:
+            textboxId = 'modal_textbox';
+            break;
     }
 
     if (isInEditMode) {
@@ -735,9 +751,9 @@ const AdvancedTextEditor = ({
             onSubmit={handleSubmitWithEvent}
         >
             {canPost && (draft.fileInfos.length > 0 || draft.uploadsInProgress.length > 0) && (
-                <FileLimitStickyBanner/>
+                <FileLimitStickyBanner />
             )}
-            {showDndWarning && <DoNotDisturbWarning displayName={teammateDisplayName}/>}
+            {showDndWarning && <DoNotDisturbWarning displayName={teammateDisplayName} />}
             {!isInEditMode && (
                 <PostBoxIndicator
                     channelId={channelId}
@@ -831,7 +847,7 @@ const AdvancedTextEditor = ({
                                     active={showFormattingBar}
                                     disabled={showPreview}
                                 />
-                                <Separator/>
+                                <Separator />
                                 {fileUploadJSX}
                                 {emojiPicker}
                                 {sendButton}
@@ -848,7 +864,7 @@ const AdvancedTextEditor = ({
                 </div>
             </div>
             {isInEditMode && containsAtMentionsInMessage && (
-                <MessageWithMentionsFooter/>
+                <MessageWithMentionsFooter />
             )}
             <Footer
                 postError={postError}
@@ -865,6 +881,14 @@ const AdvancedTextEditor = ({
                     onCancel={handleCancel}
                 />
             )}
+            <div
+                id='sentMessageStatus'
+                aria-live='assertive'
+                style={{
+                    position: 'absolute',
+                    top: '-1000px',
+                }}
+            >{ }</div>
         </form>
     );
 };


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
- Added aria-live property to the message status element.
- Programmatically triggering the `Message Sent` prompt.

#### Steps to reproduce  
- Navigate to the write to town square edit field and type 'tester'.
- Now navigate to the Send a message button and select it.
- Notice that after selecting the Send a message button, the screen reader not announcing any status message.

#### Expected Behavior 
- When the message is successfully sent a screen should announce the status of sent message.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Jira https://mattermost.atlassian.net/browse/MM-61619

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

<table>
    <tr>
        <th>Before</th>
 <th>After</th>
    </tr>
    <tr>
        <td>
 <img src="https://github.com/user-attachments/assets/4122f9bc-c2cc-4a76-b3eb-b0044ef32d78">
</td>
  <td>
 <img src="https://github.com/user-attachments/assets/df3efa9b-1416-4175-afff-792dc6ffb4e9">
</td>
    </tr>
</table>

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
