### PR TITLE
MM-45724: [P3] Webapp/ATE: Accessibility on ATE unexpectedly able to tab on hidden formatting controls/buttons 

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_bar.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_bar.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useFloating, offset, useClick, useDismiss, useInteractions, useFocus} from '@floating-ui/react';
+import {useFloating, offset, useClick, useDismiss, useInteractions} from '@floating-ui/react';
 import classNames from 'classnames';
 import React, {memo, useCallback, useEffect, useRef, useState} from 'react';
 import {useIntl} from 'react-intl';
@@ -279,7 +279,7 @@ const FormattingBar = (props: FormattingBarProps): JSX.Element => {
                                 onClick={makeFormattingHandler(mode)}
                                 disabled={disableControls}
                                 {...!showHiddenControls && {
-                                    tabIndex: -1
+                                    tabIndex: -1,
                                 }}
                             />
                         );

--- a/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_bar.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_bar.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useFloating, offset, useClick, useDismiss, useInteractions} from '@floating-ui/react';
+import {useFloating, offset, useClick, useDismiss, useInteractions, useFocus} from '@floating-ui/react';
 import classNames from 'classnames';
 import React, {memo, useCallback, useEffect, useRef, useState} from 'react';
 import {useIntl} from 'react-intl';
@@ -278,6 +278,9 @@ const FormattingBar = (props: FormattingBarProps): JSX.Element => {
                                 className='control'
                                 onClick={makeFormattingHandler(mode)}
                                 disabled={disableControls}
+                                {...!showHiddenControls && {
+                                    tabIndex: -1
+                                }}
                             />
                         );
                     })}

--- a/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_icon.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_icon.tsx
@@ -76,6 +76,7 @@ interface FormattingIconProps {
     onClick?: () => void;
     className?: string;
     disabled?: boolean;
+    tabIndex?: number;
 }
 
 const MAP_MARKDOWN_MODE_TO_ICON: Record<FormattingIconProps['mode'], React.FC<IconProps>> = {


### PR DESCRIPTION
#### Summary
- Fixed the tab behaviour for controls in the Advance Text editor.

#### Steps to reproduce:

- Click on post text box or comment text box.
- Press tabs to move focus to Advanced Text Editor controls/buttons until it moves to hidden formatting controls (see screen recording)

#### Observed:
Hidden element is getting focused and tooltip is showing up.

#### Expected:

The focus should not be on hidden elements until you click Enter on the button to show and then the focus should continue there as you tab. 


#### Jira Link
https://mattermost.atlassian.net/browse/MM-45724

#### Video

Before:

[398065932-0286a34d-37a0-4e58-b306-b0091699ab5a.webm](https://github.com/user-attachments/assets/549b6ecb-4af5-4f2a-b314-096b5971df3b) 

After:

[398065728-f662383f-9bd9-4af1-911d-a5ac1536518a.webm](https://github.com/user-attachments/assets/f458b436-a7a7-4528-99fa-9ca70957765c)


#### Release Note

```release-note
NONE
```




