### PR TITLE
[MM-62293]: Remove Elasticsearch from translation strings

### DIFF
--- a/server/enterprise/elasticsearch/elasticsearch/elasticsearch.go
+++ b/server/enterprise/elasticsearch/elasticsearch/elasticsearch.go
@@ -1323,7 +1323,7 @@ func (es *ElasticsearchInterfaceImpl) PurgeIndexes(rctx request.CTX) *model.AppE
 	_, err := es.client.Indices.Delete(indexesToDelete).Do(ctx)
 	if err != nil {
 		rctx.Logger().Error("Elastic Search PurgeIndexes Error", mlog.Err(err))
-		return model.NewAppError("Elasticsearch.PurgeIndexes", "ent.elasticsearch.purge_indexes.delete_failed", nil, "", http.StatusInternalServerError).Wrap(err)
+		return model.NewAppError("Elasticsearch.PurgeIndexes", "ent.elasticsearch.purge_index.delete_failed", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	return nil

--- a/server/enterprise/elasticsearch/opensearch/opensearch.go
+++ b/server/enterprise/elasticsearch/opensearch/opensearch.go
@@ -1435,7 +1435,7 @@ func (os *OpensearchInterfaceImpl) PurgeIndexes(rctx request.CTX) *model.AppErro
 	})
 	if err != nil {
 		rctx.Logger().Error("Opensearch PurgeIndexes Error", mlog.Err(err))
-		return model.NewAppError("Opensearch.PurgeIndexes", "ent.elasticsearch.purge_indexes.delete_failed", nil, "", http.StatusInternalServerError).Wrap(err)
+		return model.NewAppError("Opensearch.PurgeIndexes", "ent.elasticsearch.purge_index.delete_failed", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	return nil

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -7938,7 +7938,7 @@
   },
   {
     "id": "ent.elasticsearch.test_config.license.error",
-    "translation": "Your Mattermost license doesn't support indexed search for ElasticSearch or OpenSearch."
+    "translation": "Your Mattermost license doesn't support indexed search."
   },
   {
     "id": "ent.elasticsearch.test_config.reenter_password",
@@ -8874,11 +8874,11 @@
   },
   {
     "id": "model.config.is_valid.elastic_search.enable_autocomplete.app_error",
-    "translation": "Search EnableIndexing setting must be set to true when {{.SettingName}} is set to true"
+    "translation": "{{.EnableIndexing}} setting must be set to true when {{.Autocomplete}} is set to true"
   },
   {
     "id": "model.config.is_valid.elastic_search.enable_searching.app_error",
-    "translation": "Search EnableIndexing setting must be set to true when EnableSearching is set to true"
+    "translation": "{{.EnableIndexing}} setting must be set to true when {{.Searching}} is set to true"
   },
   {
     "id": "model.config.is_valid.elastic_search.ignored_indexes_dash_prefix.app_error",

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -4576,7 +4576,7 @@
   },
   {
     "id": "app.channel.elasticsearch_channel_index.notify_admin.message",
-    "translation": "Your Search channel index schema is out of date. It is recommended to regenerate your channel index.\nClick the `Rebuild Channels Index` button in [Elasticsearch section in System Console]({{.ElasticsearchSection}}) to fix the issue.\nSee Mattermost changelog for more information."
+    "translation": "Your search channel index schema is out of date. We recommend regenerating your channel index.\nClick the `Rebuild Channels Index` button in the [Elasticsearch page via the System Console]({{.ElasticsearchSection}}) to fix this issue.\nSee the Mattermost changelog for more information."
   },
   {
     "id": "app.channel.get.existing.app_error",
@@ -7862,11 +7862,7 @@
   },
   {
     "id": "ent.elasticsearch.purge_index.delete_failed",
-    "translation": "Failed to delete a Search index"
-  },
-  {
-    "id": "ent.elasticsearch.purge_indexes.delete_failed",
-    "translation": "Failed to delete Search index"
+    "translation": "Failed to delete a search index"
   },
   {
     "id": "ent.elasticsearch.purge_indexes.unknown_index",
@@ -7874,7 +7870,7 @@
   },
   {
     "id": "ent.elasticsearch.refresh_indexes.refresh_failed",
-    "translation": "Failed to refresh Search indexes"
+    "translation": "Failed to refresh search indexes"
   },
   {
     "id": "ent.elasticsearch.search_channels.disabled",
@@ -7942,7 +7938,7 @@
   },
   {
     "id": "ent.elasticsearch.test_config.license.error",
-    "translation": "Your license does not support Search."
+    "translation": "Your Mattermost license doesn't support indexed search for ElasticSearch or OpenSearch."
   },
   {
     "id": "ent.elasticsearch.test_config.reenter_password",
@@ -8878,7 +8874,7 @@
   },
   {
     "id": "model.config.is_valid.elastic_search.enable_autocomplete.app_error",
-    "translation": "Search EnableIndexing setting must be set to true when EnableAutocomplete is set to true"
+    "translation": "Search EnableIndexing setting must be set to true when {{.SettingName}} is set to true"
   },
   {
     "id": "model.config.is_valid.elastic_search.enable_searching.app_error",

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -4576,7 +4576,7 @@
   },
   {
     "id": "app.channel.elasticsearch_channel_index.notify_admin.message",
-    "translation": "Your Elasticsearch channel index schema is out of date. It is recommended to regenerate your channel index.\nClick the `Rebuild Channels Index` button in [Elasticsearch section in System Console]({{.ElasticsearchSection}}) to fix the issue.\nSee Mattermost changelog for more information."
+    "translation": "Your Search channel index schema is out of date. It is recommended to regenerate your channel index.\nClick the `Rebuild Channels Index` button in [Elasticsearch section in System Console]({{.ElasticsearchSection}}) to fix the issue.\nSee Mattermost changelog for more information."
   },
   {
     "id": "app.channel.get.existing.app_error",
@@ -7862,11 +7862,11 @@
   },
   {
     "id": "ent.elasticsearch.purge_index.delete_failed",
-    "translation": "Failed to delete an Elasticsearch index"
+    "translation": "Failed to delete a Search index"
   },
   {
     "id": "ent.elasticsearch.purge_indexes.delete_failed",
-    "translation": "Failed to delete Elasticsearch index"
+    "translation": "Failed to delete Search index"
   },
   {
     "id": "ent.elasticsearch.purge_indexes.unknown_index",
@@ -7874,7 +7874,7 @@
   },
   {
     "id": "ent.elasticsearch.refresh_indexes.refresh_failed",
-    "translation": "Failed to refresh Elasticsearch indexes"
+    "translation": "Failed to refresh Search indexes"
   },
   {
     "id": "ent.elasticsearch.search_channels.disabled",
@@ -7942,11 +7942,11 @@
   },
   {
     "id": "ent.elasticsearch.test_config.license.error",
-    "translation": "Your license does not support Elasticsearch."
+    "translation": "Your license does not support Search."
   },
   {
     "id": "ent.elasticsearch.test_config.reenter_password",
-    "translation": "The Elasticsearch Server URL or Username has changed. Please re-enter the Elasticsearch password to test connection."
+    "translation": "The Search Server URL or Username has changed. Please re-enter the password to test connection."
   },
   {
     "id": "ent.get_users_in_channel_during",
@@ -8878,11 +8878,11 @@
   },
   {
     "id": "model.config.is_valid.elastic_search.enable_autocomplete.app_error",
-    "translation": "Search EnableIndexing setting must be set to true when Elasticsearch EnableAutocomplete is set to true"
+    "translation": "Search EnableIndexing setting must be set to true when EnableAutocomplete is set to true"
   },
   {
     "id": "model.config.is_valid.elastic_search.enable_searching.app_error",
-    "translation": "Search EnableIndexing setting must be set to true when Elasticsearch EnableSearching is set to true"
+    "translation": "Search EnableIndexing setting must be set to true when EnableSearching is set to true"
   },
   {
     "id": "model.config.is_valid.elastic_search.ignored_indexes_dash_prefix.app_error",

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -4304,7 +4304,7 @@ func (s *ElasticsearchSettings) isValid() *AppError {
 	}
 
 	if *s.EnableAutocomplete && !*s.EnableIndexing {
-		return NewAppError("Config.IsValid", "model.config.is_valid.elastic_search.enable_autocomplete.app_error", nil, "", http.StatusBadRequest)
+		return NewAppError("Config.IsValid", "model.config.is_valid.elastic_search.enable_autocomplete.app_error", map[string]any{"SettingName": "ElasticsearchSettings.EnableIndexing"}, "", http.StatusBadRequest)
 	}
 
 	if *s.AggregatePostsAfterDays < 1 {

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -4300,11 +4300,17 @@ func (s *ElasticsearchSettings) isValid() *AppError {
 	}
 
 	if *s.EnableSearching && !*s.EnableIndexing {
-		return NewAppError("Config.IsValid", "model.config.is_valid.elastic_search.enable_searching.app_error", nil, "", http.StatusBadRequest)
+		return NewAppError("Config.IsValid", "model.config.is_valid.elastic_search.enable_searching.app_error", map[string]any{
+			"Searching":      "ElasticsearchSettings.EnableSearching",
+			"EnableIndexing": "ElasticsearchSettings.EnableIndexing",
+		}, "", http.StatusBadRequest)
 	}
 
 	if *s.EnableAutocomplete && !*s.EnableIndexing {
-		return NewAppError("Config.IsValid", "model.config.is_valid.elastic_search.enable_autocomplete.app_error", map[string]any{"SettingName": "ElasticsearchSettings.EnableIndexing"}, "", http.StatusBadRequest)
+		return NewAppError("Config.IsValid", "model.config.is_valid.elastic_search.enable_autocomplete.app_error", map[string]any{
+			"Autocomplete":   "ElasticsearchSettings.EnableAutocomplete",
+			"EnableIndexing": "ElasticsearchSettings.EnableIndexing",
+		}, "", http.StatusBadRequest)
 	}
 
 	if *s.AggregatePostsAfterDays < 1 {


### PR DESCRIPTION
We cannot simply use Elasticsearch any more because
we support Opensearch as well.

Therefore changing Elasticsearch to just say Search.

Note: There are still some cases where Elasticsearch
is used. That is intentional and necessary.

https://mattermost.atlassian.net/browse/MM-62293

```release-note
NONE
```
