### PR TITLE
MM-62188 - Revoke user sessions when converted to bot (#29573)

### DIFF
--- a/server/channels/app/bot.go
+++ b/server/channels/app/bot.go
@@ -610,5 +610,9 @@ func (a *App) ConvertUserToBot(rctx request.CTX, user *model.User) (*model.Bot, 
 			return nil, model.NewAppError("CreateBot", "app.bot.createbot.internal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 		}
 	}
+	if err := a.RevokeAllSessions(rctx, user.Id); err != nil {
+		return nil, err
+	}
+
 	return bot, nil
 }

--- a/server/channels/app/bot_test.go
+++ b/server/channels/app/bot_test.go
@@ -820,9 +820,17 @@ func TestConvertUserToBot(t *testing.T) {
 		})
 	})
 
-	t.Run("valid user", func(t *testing.T) {
+	t.Run("valid user and session revoked", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
+
+		session, err := th.App.CreateSession(th.Context, &model.Session{UserId: th.BasicUser.Id, Props: model.StringMap{}})
+		require.Nil(t, err)
+
+		// make sure session is valid
+		testSession, err := th.App.GetSession(session.Token)
+		require.Nil(t, err)
+		require.False(t, testSession.IsExpired())
 
 		bot, err := th.App.ConvertUserToBot(th.Context, &model.User{
 			Username: "username",
@@ -832,6 +840,11 @@ func TestConvertUserToBot(t *testing.T) {
 		defer th.App.PermanentDeleteBot(th.Context, bot.UserId)
 		assert.Equal(t, "username", bot.Username)
 		assert.Equal(t, th.BasicUser.Id, bot.OwnerId)
+
+		// make sure session is no longer valid
+		_, err = th.App.GetSession(session.Token)
+		require.NotNil(t, err)
+		require.Equal(t, "api.context.invalid_token.error", err.Id)
 	})
 }
 


### PR DESCRIPTION
* revoke user sessions when converted to bot

* lint fixes

(cherry picked from commit faa7e4f2ea0cca2fd2aba271912b9fc3be788842)

#### Summary
Revokes user session after user is converted to a bot.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-62188

#### Release Note
```release-note
NONE
```