### PR TITLE
[MM-26973] Feature: Account setting for disabling GIF and emoji animation

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/emoji/custom_emoji_1_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/emoji/custom_emoji_1_spec.ts
@@ -187,8 +187,8 @@ function toggleAutoplayGifsAndEmojisSetting(toggleOff = true) {
     // # Open the Settings modal.
     cy.uiOpenSettingsModal('Display').within(() => {
         // # Open 'Autoplay GIFs and Emojis' and toggle it on/off.
-        cy.findByRole('heading', { name: 'Autoplay GIFs and Emojis' }).click();
-        cy.findByRole('radio', { name: toggleOff ? 'Off' : 'On' }).click();
+        cy.findByRole('heading', {name: 'Autoplay GIFs and Emojis'}).click();
+        cy.findByRole('radio', {name: toggleOff ? 'Off' : 'On'}).click();
 
         // # Save and close the modal
         cy.uiSave();
@@ -214,6 +214,9 @@ function verifyAnimatedEmojiStatus(isStaticEmoji = true) {
         cy.getLastPostId().as('postId').then((postId) => {
             // * Verify the static emoji is not rendered.
             cy.get(`#post_${postId}`).find(staticEmojiContainerSelector).should('not.exist');
+
+            // * Verify animated emoji is rendered and is visible.
+            cy.get(`#post_${postId}`).find('[data-testid*="postEmoji"]').should('exist').and('be.visible');
         });
     }
 }
@@ -223,7 +226,7 @@ function addAndPostCustomEmoji(animatedGifEmojiFile, testTeam, offTopicUrl, cust
     cy.uiOpenCustomEmoji();
 
     // # Click on add custom emoji
-    cy.findByRole('button', { name: 'Add Custom Emoji' }).should('be.visible').click();
+    cy.findByRole('button', {name: 'Add Custom Emoji'}).should('be.visible').click();
 
     // # Type emoji name
     cy.get('#name').should('be.visible').type(customEmojiWithColons);

--- a/e2e-tests/cypress/tests/integration/channels/messaging/message_with_gif_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/message_with_gif_spec.js
@@ -302,7 +302,7 @@ describe('Show GIF images properly', () => {
 function toggleAutoplayGifsAndEmojisSetting(toggleOff = true) {
     // # Open the Settings modal.
     cy.uiOpenSettingsModal('Display').within(() => {
-        // # Open 'Enable Join/Leave Messages' and turn it off
+        // # Open 'Autoplay GIFs and Emojis' and toggle it on/off.
         cy.findByRole('heading', {name: 'Autoplay GIFs and Emojis'}).click();
         cy.findByRole('radio', {name: toggleOff ? 'Off' : 'On'}).click();
 

--- a/e2e-tests/cypress/tests/integration/channels/messaging/message_with_gif_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/message_with_gif_spec.js
@@ -78,10 +78,7 @@ describe('Show GIF images properly', () => {
 
         cy.getLastPostId().as('postId').then((postId) => {
             // * Verify the static GIF is visible and has the right dimensions.
-            cy.get(`#post_${postId}`).find(selector.staticGifCanvas)
-                .should('be.visible')
-                .and('have.attr', 'width', '189')
-                .and('have.attr', 'height', '200');
+            cy.get(`#post_${postId}`).find(selector.staticGifCanvas).should('be.visible').and('have.attr', 'width', '189').and('have.attr', 'height', '200');
 
             // * Ensure the play button is visible.
             cy.get(`#post_${postId}`).find(selector.gifButton).should('be.visible');
@@ -95,10 +92,7 @@ describe('Show GIF images properly', () => {
 
         cy.getLastPostId().as('postId').then((postId) => {
             // * Validate static GIF is visible and has the right dimensions.
-            cy.get(`#post_${postId}`).find(selector.staticGifCanvas)
-                .should('be.visible')
-                .and('have.attr', 'width', '500')
-                .and('have.attr', 'height', '280');
+            cy.get(`#post_${postId}`).find(selector.staticGifCanvas).should('be.visible').and('have.attr', 'width', '500').and('have.attr', 'height', '280');
 
             // * Ensure the play button is visible.
             cy.get(`#post_${postId}`).find(selector.gifButton).should('be.visible');
@@ -211,7 +205,7 @@ describe('Show GIF images properly', () => {
         postGiphyGif();
 
         // * Click the pause button and verify the static GIF is shown.
-        clickGifButtonAndVerify(undefined,  false);
+        clickGifButtonAndVerify(undefined, false);
     });
 
     it('MM-{Zephyr Test Number here} Clicking a GIF\'s play button shows a playing GIF for GIFs posted as links', () => {
@@ -267,29 +261,18 @@ describe('Show GIF images properly', () => {
         cy.reload();
 
         cy.getLastPostId().as('postId').then((postId) => {
-            cy.get(`#post_${postId}`)
-                .as('lastPost')
-                .find('img.markdown-inline-img')
-                .then((image) => {
-                    // # Click the static GIF.
-                    cy.get('@lastPost')
-                        .find(selector.staticGifCanvas)
-                        .should('be.visible')
-                        .parent()
-                        .click('right');
+            cy.get(`#post_${postId}`).as('lastPost').find('img.markdown-inline-img').then((image) => {
+                // # Click the static GIF.
+                cy.get('@lastPost').find(selector.staticGifCanvas).should('be.visible').parent().click('right');
 
-                    // * Verify the dialog is opened and the image preview shows the correct GIF.
-                    cy.findByRole('dialog')
-                        .should('exist')
-                        .within(() => {
-                            cy.get('[data-testid="imagePreview"]')
-                                .should('be.visible')
-                                .and('have.attr', 'src', `${image[0].getAttribute('src')}`);
+                // * Verify the dialog is opened and the image preview shows the correct GIF.
+                cy.findByRole('dialog').should('exist').within(() => {
+                    cy.get('[data-testid="imagePreview"]').should('be.visible').and('have.attr', 'src', `${image[0].getAttribute('src')}`);
 
-                            // # Close the modal.
-                            cy.findByLabelText('Close').click();
-                        });
-                })
+                    // # Close the modal.
+                    cy.findByLabelText('Close').click();
+                });
+            });
         });
     });
 
@@ -330,7 +313,7 @@ function toggleAutoplayGifsAndEmojisSetting(toggleOff = true) {
 }
 
 function postGiphyGif() {
-     // # Open the emoji picker.
+    // # Open the emoji picker.
     cy.get('#emojiPickerButton').click();
 
     // # Click the GIF tab.
@@ -339,7 +322,7 @@ function postGiphyGif() {
     // # Click the first GIF from GIPHY.
     cy.get('.giphy-grid').within(() => {
         cy.get('a').eq(0).click();
-    })
+    });
 
     // # Post the GIF.
     cy.get('[data-testid="SendMessageButton"]').click();
@@ -361,14 +344,10 @@ function clickGifButtonAndVerify(imageSelector = 'img.markdown-inline-img', shou
     if (shouldPlayGif) {
         cy.getLastPostId().as('postId').then((postId) => {
             // # Click the play button.
-            cy.get(`#post_${postId}`)
-                .find(gifButtonSelector)
-                .should('have.text', gifText)
-                .click();
+            cy.get(`#post_${postId}`).find(gifButtonSelector).should('have.text', gifText).click();
 
             // * Verify static GIF is not visible.
-            cy.get(`#post_${postId}`).find(staticGifCanvasSelector)
-                .should('not.be.visible');
+            cy.get(`#post_${postId}`).find(staticGifCanvasSelector).should('not.be.visible');
 
             // * Verify the playing GIF is visible.
             cy.get(`#post_${postId}`).find(imageSelector).should('have.css', 'display', 'block');
@@ -379,14 +358,10 @@ function clickGifButtonAndVerify(imageSelector = 'img.markdown-inline-img', shou
     } else {
         cy.getLastPostId().as('postId').then((postId) => {
             // # Click the pause button.
-            cy.get(`#post_${postId}`)
-                .find(`.image-loaded-container>${gifButtonSelector}`)
-                .should('not.have.text', gifText)
-                .click({force: true});
+            cy.get(`#post_${postId}`).find(`.image-loaded-container>${gifButtonSelector}`).should('not.have.text', gifText).click({force: true});
 
             // * Verify static GIF is visible.
-            cy.get(`#post_${postId}`).find(staticGifCanvasSelector)
-                .should('be.visible');
+            cy.get(`#post_${postId}`).find(staticGifCanvasSelector).should('be.visible');
 
             // * Verify the playing GIF is hidden.
             cy.get(`#post_${postId}`).find(imageSelector).should('have.css', 'display', 'none');
@@ -404,8 +379,7 @@ function verifyGifStatus(imageSelector = '.attachment__image', isStaticGif = tru
     if (isStaticGif) {
         cy.getLastPostId().as('postId').then((postId) => {
             // * Verify the static GIF is visible.
-            cy.get(`#post_${postId}`).find(staticGifCanvasSelector)
-                .should('be.visible');
+            cy.get(`#post_${postId}`).find(staticGifCanvasSelector).should('be.visible');
 
             // * Ensure the play button is visible.
             cy.get(`#post_${postId}`).find(gifButtonSelector).should('be.visible');
@@ -416,8 +390,7 @@ function verifyGifStatus(imageSelector = '.attachment__image', isStaticGif = tru
     } else {
         cy.getLastPostId().as('postId').then((postId) => {
             // * Verify the static GIF is not visible.
-            cy.get(`#post_${postId}`).find(staticGifCanvasSelector)
-                .should('not.be.visible');
+            cy.get(`#post_${postId}`).find(staticGifCanvasSelector).should('not.be.visible');
 
             // * Ensure the pause button is initially hidden.
             cy.get(`#post_${postId}`).find(gifButtonSelector).should('not.be.visible');
@@ -436,29 +409,21 @@ function verifyThreadGifStatus(channelGifIsStatic, imageSelector) {
                 cy.wrap(lastPost).click();
 
                 // * Verify RHS is opened.
-                cy.get('#rhsContainer')
-                    .should('be.visible')
-                    .within(() => {
-                        // * Verify the user is viewing a thread.
-                        cy.get('.ThreadViewer').should('exist');
+                cy.get('#rhsContainer').should('be.visible').within(() => {
+                    // * Verify the user is viewing a thread.
+                    cy.get('.ThreadViewer').should('exist');
 
-                        // * Verify the thread's original post GIF is the same as the GIF in the channel and either
-                        // plays or is static accordingly.
-                        cy.findByLabelText('file thumbnail')
-                            .should('have.attr', 'src', channelGif[0].getAttribute('src'))
-                            .and(channelGifIsStatic ? 'not.be.visible' : 'be.visible')
-                            .then(() => {
-
-                                // * Verify the correct GIF is shown.
-                                cy.get('[data-testid="static-gif-canvas"]')
-                                    .should('exist')
-                                    .and(channelGifIsStatic ? 'be.visible' : 'not.be.visible');
-                            })
-
-                        // # Close the RHS.
-                        cy.get('#rhsCloseButton').click();
+                    // * Verify the thread's original post GIF is the same as the GIF in the channel and either
+                    // plays or is static accordingly.
+                    cy.findByLabelText('file thumbnail').should('have.attr', 'src', channelGif[0].getAttribute('src')).and(channelGifIsStatic ? 'not.be.visible' : 'be.visible').then(() => {
+                        // * Verify the correct GIF is shown.
+                        cy.get('[data-testid="static-gif-canvas"]').should('exist').and(channelGifIsStatic ? 'be.visible' : 'not.be.visible');
                     });
-            })
-        })
+
+                    // # Close the RHS.
+                    cy.get('#rhsCloseButton').click();
+                });
+            });
+        });
     });
 }

--- a/e2e-tests/cypress/tests/integration/channels/messaging/message_with_gif_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/message_with_gif_spec.js
@@ -13,11 +13,26 @@
 describe('Show GIF images properly', () => {
     let offtopiclink;
 
+    const selector = {
+        gifFile: 'img[aria-label*="file thumbnail"]',
+        sendButton: '[data-testid="SendMessageButton"]',
+        staticGifCanvas: '[data-testid="static-gif-canvas"]',
+        gifButton: '[data-testid="play-pause-gif-button"]',
+        attachmentImage: '.attachment__image',
+        markdownImage: '.markdown-inline-img',
+    };
+
+    const gifLink = {
+        tenor: 'https://media.tenor.com/yCFHzEvKa9MAAAAi/hello.gif',
+        giphy: 'https://media.giphy.com/media/XIqCQx02E1U9W/giphy.gif',
+    };
+
     before(() => {
-        // # Set the configuration on Link Previews
+        // # Set the configuration on Link Previews and GIF picker.
         cy.apiUpdateConfig({
             ServiceSettings: {
                 EnableLinkPreviews: true,
+                EnableGifPicker: true,
             },
         });
 
@@ -28,27 +43,422 @@ describe('Show GIF images properly', () => {
         });
     });
 
-    it('MM-T3318 Posting GIFs', () => {
+    beforeEach(() => {
         // # Got to a test channel on the side bar
         cy.get('#sidebarItem_off-topic').click({force: true});
 
         // * Validate if the channel has been opened
         cy.url().should('include', offtopiclink);
+    });
 
+    it('MM-T3318 Posting GIFs', () => {
         // # Post tenor GIF
-        cy.postMessage('https://media.tenor.com/yCFHzEvKa9MAAAAi/hello.gif');
+        cy.postMessage(gifLink.tenor);
 
         cy.getLastPostId().as('postId').then((postId) => {
             // * Validate image size
-            cy.get(`#post_${postId}`).find('.attachment__image').should('have.css', 'width', '189px');
+            cy.get(`#post_${postId}`).find(selector.attachmentImage).should('have.css', 'width', '189px');
         });
 
         // # Post giphy GIF
-        cy.postMessage('https://media.giphy.com/media/XIqCQx02E1U9W/giphy.gif');
+        cy.postMessage(gifLink.giphy);
 
         cy.getLastPostId().as('postId').then((postId) => {
             // * Validate image size
-            cy.get(`#post_${postId}`).find('.attachment__image').invoke('outerWidth').should('be.gte', 480);
+            cy.get(`#post_${postId}`).find(selector.attachmentImage).invoke('outerWidth').should('be.gte', 480);
         });
     });
+
+    it('MM-{Zephyr Test Number here} Toggling the GIF autoplay setting off shows a static GIF for GIFs posted as links', () => {
+        // # Toggle autoplay off.
+        toggleAutoplayGifsAndEmojisSetting(true);
+
+        // # Post tenor GIF
+        cy.postMessage(gifLink.tenor);
+
+        cy.getLastPostId().as('postId').then((postId) => {
+            // * Verify the static GIF is visible and has the right dimensions.
+            cy.get(`#post_${postId}`).find(selector.staticGifCanvas)
+                .should('be.visible')
+                .and('have.attr', 'width', '189')
+                .and('have.attr', 'height', '200');
+
+            // * Ensure the play button is visible.
+            cy.get(`#post_${postId}`).find(selector.gifButton).should('be.visible');
+
+            // * Ensure the canvas' image reference is hidden.
+            cy.get(`#post_${postId}`).find(selector.attachmentImage).should('have.css', 'display', 'none');
+        });
+
+        // # Post GIPHY GIF
+        cy.postMessage(gifLink.giphy);
+
+        cy.getLastPostId().as('postId').then((postId) => {
+            // * Validate static GIF is visible and has the right dimensions.
+            cy.get(`#post_${postId}`).find(selector.staticGifCanvas)
+                .should('be.visible')
+                .and('have.attr', 'width', '500')
+                .and('have.attr', 'height', '280');
+
+            // * Ensure the play button is visible.
+            cy.get(`#post_${postId}`).find(selector.gifButton).should('be.visible');
+
+            // * Ensure the canvas' image reference is hidden.
+            cy.get(`#post_${postId}`).find(selector.attachmentImage).should('have.css', 'display', 'none');
+        });
+    });
+
+    it('MM-{Zephyr Test Number here} Toggling the GIF autoplay setting off shows a static GIF for GIFs uploaded as images', () => {
+        // # Toggle autoplay off.
+        toggleAutoplayGifsAndEmojisSetting(true);
+
+        // # Upload a GIF on center view.
+        postGifAttachment();
+
+        // * Verify a static GIF is shown.
+        verifyGifStatus(selector.gifFile, true);
+    });
+
+    it('MM-{Zephyr Test Number here} Toggling the GIF autoplay setting off shows a static GIF for GIFs posted via GIPHY in the emoji picker', () => {
+        // # Toggle autoplay off.
+        toggleAutoplayGifsAndEmojisSetting(true);
+
+        // # Post a GIF from GIPHY using the emoji picker.
+        postGiphyGif();
+
+        // * Verify the play button is visible and the canvas image reference is hidden.
+        verifyGifStatus(selector.markdownImage, true);
+    });
+
+    it('MM-{Zephyr Test Number here} Toggling the GIF autoplay setting on shows a playing GIF for GIFs posted as links', () => {
+        // # Toggle autoplay off since it's on by default.
+        toggleAutoplayGifsAndEmojisSetting(true);
+
+        // # Post tenor GIF
+        cy.postMessage(gifLink.tenor);
+
+        // # Toggle autoplay on.
+        toggleAutoplayGifsAndEmojisSetting(false);
+
+        // * Verify the play button is visible and the canvas image reference is hidden.
+        verifyGifStatus(undefined, false);
+
+        // # Toggle autoplay off.
+        toggleAutoplayGifsAndEmojisSetting(true);
+
+        // # Post giphy GIF
+        cy.postMessage(gifLink.giphy);
+
+        // # Toggle autoplay on.
+        toggleAutoplayGifsAndEmojisSetting(false);
+
+        // * Verify the play button is visible and the canvas image reference is hidden.
+        verifyGifStatus(undefined, false);
+    });
+
+    it('MM-{Zephyr Test Number here} Toggling the GIF autoplay setting on shows a playing GIF for GIFs uploaded as images', () => {
+        // # Toggle autoplay off since it's on by default.
+        toggleAutoplayGifsAndEmojisSetting(true);
+
+        // # Upload a GIF on center view.
+        postGifAttachment();
+
+        // # Toggle autoplay on.
+        toggleAutoplayGifsAndEmojisSetting(false);
+
+        // * Verify a playing GIF is shown.
+        verifyGifStatus(selector.gifFile, false);
+    });
+
+    it('MM-{Zephyr Test Number here} Toggling the GIF autoplay setting on shows a playing GIF for GIFs posted via GIPHY in the emoji picker', () => {
+        // # Toggle autoplay off since it's on by default.
+        toggleAutoplayGifsAndEmojisSetting(true);
+
+        // # Post a GIF from GIPHY.
+        postGiphyGif();
+
+        // # Toggle autoplay on.
+        toggleAutoplayGifsAndEmojisSetting(false);
+
+        // * Verify the pause button is hidden initially and the GIF is playing.
+        verifyGifStatus(selector.markdownImage, false);
+    });
+
+    it('MM-{Zephyr Test Number here} Clicking a GIF\'s pause button shows a static GIF for GIFs posted as links', () => {
+        // # Post giphy GIF
+        cy.postMessage(gifLink.giphy);
+
+        // * Click the pause button and verify the static GIF is shown.
+        clickGifButtonAndVerify(selector.attachmentImage, false);
+
+        // # Post tenor GIF
+        cy.postMessage(gifLink.tenor);
+
+        // * Click the pause button and verify the static GIF is shown.
+        clickGifButtonAndVerify(selector.attachmentImage, false);
+    });
+
+    it('MM-{Zephyr Test Number here} Clicking a GIF\'s pause button shows a static GIF for GIFs uploaded as images', () => {
+        // # Upload a GIF on center view.
+        postGifAttachment();
+
+        // * Click the pause button and verify the static GIF is shown.
+        clickGifButtonAndVerify(selector.gifFile, false);
+    });
+
+    it('MM-{Zephyr Test Number here} Clicking a GIF\'s pause button shows a static GIF for GIFs posted via GIPHY in the emoji picker', () => {
+        // # Post a GIPHY gif.
+        postGiphyGif();
+
+        // * Click the pause button and verify the static GIF is shown.
+        clickGifButtonAndVerify(undefined,  false);
+    });
+
+    it('MM-{Zephyr Test Number here} Clicking a GIF\'s play button shows a playing GIF for GIFs posted as links', () => {
+        // # Turn autoplay off.
+        toggleAutoplayGifsAndEmojisSetting(true);
+
+        // # Post tenor GIF
+        cy.postMessage(gifLink.tenor);
+
+        // * Verify the GIF is playing after clicking the play button.
+        clickGifButtonAndVerify(selector.attachmentImage);
+
+        // # Post giphy GIF
+        cy.postMessage(gifLink.giphy);
+
+        // * Verify the GIF is playing after clicking the play button.
+        clickGifButtonAndVerify(selector.attachmentImage);
+    });
+
+    it('MM-{Zephyr Test Number here} Clicking a GIF\'s play button shows a playing GIF for GIFs uploaded as images', () => {
+        // # Turn autoplay off.
+        toggleAutoplayGifsAndEmojisSetting(true);
+
+        // # Upload a GIF on center view.
+        postGifAttachment();
+
+        // * Verify the GIF is playing after clicking the play button.
+        clickGifButtonAndVerify(selector.gifFile);
+    });
+
+    it('MM-{Zephyr Test Number here} Clicking a GIF\'s play button shows a playing GIF for GIFs posted via GIPHY in the emoji picker', () => {
+        // # Turn autoplay off.
+        toggleAutoplayGifsAndEmojisSetting(true);
+
+        // # Post a GIPHY gif.
+        postGiphyGif();
+
+        // * Verify the GIF is playing after clicking the play button.
+        clickGifButtonAndVerify();
+    });
+
+    // If all the tests above pass, we now have enough confidence to use a GIF posted in any way rather than
+    // testing all the ways GIFs can be uploaded.
+    it('MM-{Zephyr Test Number here} Clicking a static GIF opens it in an enlarged view', () => {
+        // # Turn autoplay off.
+        toggleAutoplayGifsAndEmojisSetting(true);
+
+        // # Post GIPHY gif.
+        postGiphyGif();
+
+        // Reload the page because the default image thumbnail is shown the first time you click a GIF after
+        // uploading it.
+        cy.reload();
+
+        cy.getLastPostId().as('postId').then((postId) => {
+            cy.get(`#post_${postId}`)
+                .as('lastPost')
+                .find('img.markdown-inline-img')
+                .then((image) => {
+                    // # Click the static GIF.
+                    cy.get('@lastPost')
+                        .find(selector.staticGifCanvas)
+                        .should('be.visible')
+                        .parent()
+                        .click('right');
+
+                    // * Verify the dialog is opened and the image preview shows the correct GIF.
+                    cy.findByRole('dialog')
+                        .should('exist')
+                        .within(() => {
+                            cy.get('[data-testid="imagePreview"]')
+                                .should('be.visible')
+                                .and('have.attr', 'src', `${image[0].getAttribute('src')}`);
+
+                            // # Close the modal.
+                            cy.findByLabelText('Close').click();
+                        });
+                })
+        });
+    });
+
+    it('MM-{Zephyr Test Number here} Starting a thread from a static GIF shows a static GIF as the thread\'s original post', () => {
+        // # Turn autoplay off.
+        toggleAutoplayGifsAndEmojisSetting(true);
+
+        // # Post GIPHY gif.
+        postGiphyGif();
+
+        // * Verify the thread's original post is a static GIF.
+        verifyThreadGifStatus(true, selector.markdownImage);
+    });
+
+    it('MM-{Zephyr Test Number here} Starting a thread from a playing GIF shows a playing GIF as the thread\'s original post', () => {
+        // # Turn autoplay on.
+        toggleAutoplayGifsAndEmojisSetting(false);
+
+        // # Post GIPHY gif.
+        postGiphyGif();
+
+        // * Verify the thread's original post is a playing GIF.
+        verifyThreadGifStatus(false, selector.markdownImage);
+    });
 });
+
+function toggleAutoplayGifsAndEmojisSetting(toggleOff = true) {
+    // # Open the Settings modal.
+    cy.uiOpenSettingsModal('Display').within(() => {
+        // # Open 'Enable Join/Leave Messages' and turn it off
+        cy.findByRole('heading', {name: 'Autoplay GIFs and Emojis'}).click();
+        cy.findByRole('radio', {name: toggleOff ? 'Off' : 'On'}).click();
+
+        // # Save and close the modal
+        cy.uiSave();
+        cy.uiClose();
+    });
+}
+
+function postGiphyGif() {
+     // # Open the emoji picker.
+    cy.get('#emojiPickerButton').click();
+
+    // # Click the GIF tab.
+    cy.get('#emoji-picker-tabs-tab-2').should('exist').click();
+
+    // # Click the first GIF from GIPHY.
+    cy.get('.giphy-grid').within(() => {
+        cy.get('a').eq(0).click();
+    })
+
+    // # Post the GIF.
+    cy.get('[data-testid="SendMessageButton"]').click();
+}
+
+function postGifAttachment() {
+    // # Upload a GIF on center view.
+    cy.get('#fileUploadInput').attachFile('animated-gif-image-file.gif');
+
+    // Post the GIF.
+    cy.get('[data-testid="SendMessageButton"]').click();
+}
+
+function clickGifButtonAndVerify(imageSelector = 'img.markdown-inline-img', shouldPlayGif = true) {
+    const gifButtonSelector = '[data-testid="play-pause-gif-button"]';
+    const staticGifCanvasSelector = '[data-testid="static-gif-canvas"]';
+    const gifText = 'GIF';
+
+    if (shouldPlayGif) {
+        cy.getLastPostId().as('postId').then((postId) => {
+            // # Click the play button.
+            cy.get(`#post_${postId}`)
+                .find(gifButtonSelector)
+                .should('have.text', gifText)
+                .click();
+
+            // * Verify static GIF is not visible.
+            cy.get(`#post_${postId}`).find(staticGifCanvasSelector)
+                .should('not.be.visible');
+
+            // * Verify the playing GIF is visible.
+            cy.get(`#post_${postId}`).find(imageSelector).should('have.css', 'display', 'block');
+
+            // * Verify the pause button is hidden initially.
+            cy.get(`#post_${postId}`).find(gifButtonSelector).should('not.be.visible');
+        });
+    } else {
+        cy.getLastPostId().as('postId').then((postId) => {
+            // # Click the pause button.
+            cy.get(`#post_${postId}`)
+                .find(`.image-loaded-container>${gifButtonSelector}`)
+                .should('not.have.text', gifText)
+                .click({force: true});
+
+            // * Verify static GIF is visible.
+            cy.get(`#post_${postId}`).find(staticGifCanvasSelector)
+                .should('be.visible');
+
+            // * Verify the playing GIF is hidden.
+            cy.get(`#post_${postId}`).find(imageSelector).should('have.css', 'display', 'none');
+
+            // * Verify the play button is visible.
+            cy.get(`#post_${postId}`).find(gifButtonSelector).should('be.visible');
+        });
+    }
+}
+
+function verifyGifStatus(imageSelector = '.attachment__image', isStaticGif = true) {
+    const gifButtonSelector = '[data-testid="play-pause-gif-button"]';
+    const staticGifCanvasSelector = '[data-testid="static-gif-canvas"]';
+
+    if (isStaticGif) {
+        cy.getLastPostId().as('postId').then((postId) => {
+            // * Verify the static GIF is visible.
+            cy.get(`#post_${postId}`).find(staticGifCanvasSelector)
+                .should('be.visible');
+
+            // * Ensure the play button is visible.
+            cy.get(`#post_${postId}`).find(gifButtonSelector).should('be.visible');
+
+            // * Ensure the canvas' image reference is hidden.
+            cy.get(`#post_${postId}`).find(imageSelector).should('have.css', 'display', 'none');
+        });
+    } else {
+        cy.getLastPostId().as('postId').then((postId) => {
+            // * Verify the static GIF is not visible.
+            cy.get(`#post_${postId}`).find(staticGifCanvasSelector)
+                .should('not.be.visible');
+
+            // * Ensure the pause button is initially hidden.
+            cy.get(`#post_${postId}`).find(gifButtonSelector).should('not.be.visible');
+
+            // * Ensure the playing GIF is visible.
+            cy.get(`#post_${postId}`).find(imageSelector).should('have.css', 'display', 'block');
+        });
+    }
+}
+
+function verifyThreadGifStatus(channelGifIsStatic, imageSelector) {
+    // # Click the post to open a thread.
+    cy.getLastPostId().as('postId').then((postId) => {
+        cy.get(`#post_${postId}`).as('postId').then((lastPost) => {
+            cy.get('@postId').find(imageSelector).then((channelGif) => {
+                cy.wrap(lastPost).click();
+
+                // * Verify RHS is opened.
+                cy.get('#rhsContainer')
+                    .should('be.visible')
+                    .within(() => {
+                        // * Verify the user is viewing a thread.
+                        cy.get('.ThreadViewer').should('exist');
+
+                        // * Verify the thread's original post GIF is the same as the GIF in the channel and either
+                        // plays or is static accordingly.
+                        cy.findByLabelText('file thumbnail')
+                            .should('have.attr', 'src', channelGif[0].getAttribute('src'))
+                            .and(channelGifIsStatic ? 'not.be.visible' : 'be.visible')
+                            .then(() => {
+
+                                // * Verify the correct GIF is shown.
+                                cy.get('[data-testid="static-gif-canvas"]')
+                                    .should('exist')
+                                    .and(channelGifIsStatic ? 'be.visible' : 'not.be.visible');
+                            })
+
+                        // # Close the RHS.
+                        cy.get('#rhsCloseButton').click();
+                    });
+            })
+        })
+    });
+}

--- a/webapp/channels/src/components/__snapshots__/size_aware_image.test.tsx.snap
+++ b/webapp/channels/src/components/__snapshots__/size_aware_image.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`components/SizeAwareImage should load download and copy link buttons wh
     style={
       Object {
         "display": "none",
+        "lineHeight": "initial",
       }
     }
   >
@@ -41,6 +42,11 @@ exports[`components/SizeAwareImage should load download and copy link buttons wh
         onKeyDown={[Function]}
         onLoad={[Function]}
         src="https://example.com/image.png"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
         tabIndex={0}
       />
       <span
@@ -121,6 +127,7 @@ exports[`components/SizeAwareImage should match snapshot when handleSmallImageCo
     style={
       Object {
         "display": "none",
+        "lineHeight": "initial",
       }
     }
   >
@@ -135,6 +142,11 @@ exports[`components/SizeAwareImage should match snapshot when handleSmallImageCo
         onKeyDown={[Function]}
         onLoad={[Function]}
         src="https://example.com/image.png"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
         tabIndex={0}
       />
       <span
@@ -228,6 +240,7 @@ exports[`components/SizeAwareImage should render a placeholder and has loader wh
     style={
       Object {
         "display": "none",
+        "lineHeight": "initial",
       }
     }
   >
@@ -242,6 +255,11 @@ exports[`components/SizeAwareImage should render a placeholder and has loader wh
         onKeyDown={[Function]}
         onLoad={[Function]}
         src="https://example.com/image.png"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
         tabIndex={0}
       />
       <span

--- a/webapp/channels/src/components/markdown_image/index.ts
+++ b/webapp/channels/src/components/markdown_image/index.ts
@@ -13,6 +13,8 @@ import type {GlobalState} from 'types/store';
 
 import MarkdownImage from './markdown_image';
 import type {Props} from './markdown_image';
+import {get} from 'mattermost-redux/selectors/entities/preferences';
+import {Preferences} from 'utils/constants';
 
 function mapStateToProps(state: GlobalState, ownProps: Props) {
     const post = getPost(state, ownProps.postId);
@@ -20,6 +22,7 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
 
     return {
         isUnsafeLinksPost,
+        autoplayGifsAndEmojis: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS_DEFAULT),
     };
 }
 

--- a/webapp/channels/src/components/markdown_image/index.ts
+++ b/webapp/channels/src/components/markdown_image/index.ts
@@ -6,15 +6,16 @@ import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {get} from 'mattermost-redux/selectors/entities/preferences';
 
 import {openModal} from 'actions/views/modals';
+
+import {Preferences} from 'utils/constants';
 
 import type {GlobalState} from 'types/store';
 
 import MarkdownImage from './markdown_image';
 import type {Props} from './markdown_image';
-import {get} from 'mattermost-redux/selectors/entities/preferences';
-import {Preferences} from 'utils/constants';
 
 function mapStateToProps(state: GlobalState, ownProps: Props) {
     const post = getPost(state, ownProps.postId);

--- a/webapp/channels/src/components/markdown_image/index.ts
+++ b/webapp/channels/src/components/markdown_image/index.ts
@@ -9,6 +9,7 @@ import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {get} from 'mattermost-redux/selectors/entities/preferences';
 
 import {openModal} from 'actions/views/modals';
+import {getIsMobileView} from 'selectors/views/browser';
 
 import {Preferences} from 'utils/constants';
 
@@ -24,6 +25,7 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
     return {
         isUnsafeLinksPost,
         autoplayGifsAndEmojis: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS_DEFAULT),
+        isMobileView: getIsMobileView(state),
     };
 }
 

--- a/webapp/channels/src/components/markdown_image/markdown_image.tsx
+++ b/webapp/channels/src/components/markdown_image/markdown_image.tsx
@@ -38,6 +38,7 @@ export type Props = {
     hideUtilities?: boolean;
     isUnsafeLinksPost: boolean;
     autoplayGifsAndEmojis: string;
+    isMobileView: boolean;
 };
 
 type State = {
@@ -212,6 +213,7 @@ export default class MarkdownImage extends PureComponent<Props, State> {
                             onImageLoadFail={this.handleLoadFail}
                             onImageLoaded={this.handleImageLoaded}
                             autoplayGifsAndEmojis={this.props.autoplayGifsAndEmojis}
+                            isMobileView={this.props.isMobileView}
                         />
                     );
 

--- a/webapp/channels/src/components/markdown_image/markdown_image.tsx
+++ b/webapp/channels/src/components/markdown_image/markdown_image.tsx
@@ -37,6 +37,7 @@ export type Props = {
     };
     hideUtilities?: boolean;
     isUnsafeLinksPost: boolean;
+    autoplayGifsAndEmojis: string;
 };
 
 type State = {
@@ -210,6 +211,7 @@ export default class MarkdownImage extends PureComponent<Props, State> {
                             hideUtilities={hideUtilities}
                             onImageLoadFail={this.handleLoadFail}
                             onImageLoaded={this.handleImageLoaded}
+                            autoplayGifsAndEmojis={this.props.autoplayGifsAndEmojis}
                         />
                     );
 

--- a/webapp/channels/src/components/post_emoji/index.tsx
+++ b/webapp/channels/src/components/post_emoji/index.tsx
@@ -3,9 +3,12 @@
 
 import {connect} from 'react-redux';
 
+import {get} from 'mattermost-redux/selectors/entities/preferences';
 import {getEmojiImageUrl} from 'mattermost-redux/utils/emoji_utils';
 
 import {getEmojiMap} from 'selectors/emojis';
+
+import {Preferences} from 'utils/constants';
 
 import type {GlobalState} from 'types/store';
 
@@ -21,6 +24,7 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
 
     return {
         imageUrl: emoji ? getEmojiImageUrl(emoji) : '',
+        autoplayGifsAndEmojis: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS_DEFAULT),
     };
 }
 

--- a/webapp/channels/src/components/post_emoji/post_emoji.test.tsx
+++ b/webapp/channels/src/components/post_emoji/post_emoji.test.tsx
@@ -12,6 +12,7 @@ describe('PostEmoji', () => {
         children: ':emoji:',
         imageUrl: '/api/v4/emoji/1234/image',
         name: 'emoji',
+        autoplayGifsAndEmojis: 'true',
     };
 
     test('should render image when imageUrl is provided', () => {
@@ -37,5 +38,32 @@ describe('PostEmoji', () => {
 
         expect(screen.queryByTestId('postEmoji.:' + baseProps.name + ':')).not.toBeInTheDocument();
         expect(screen.getByText(`:${props.name}:`)).toBeInTheDocument();
+    });
+
+    test('should render animated emoji when the autoplay GIFs and emojis setting is on', () => {
+        renderWithContext(<PostEmoji {...baseProps}/>);
+
+        expect(screen.queryByTestId('static-animated-post-emoji-container')).not.toBeInTheDocument();
+
+        expect(screen.queryByTestId('postEmoji.:' + baseProps.name + ':')).toBeInTheDocument();
+        expect(screen.queryByTestId('postEmoji.:' + baseProps.name + ':')).toHaveStyle(`backgroundImage: url(${baseProps.imageUrl})`);
+    });
+
+    test('should render static emoji when the autoplay GIFs and emojis setting is off', () => {
+        const props = {
+            ...baseProps,
+            autoplayGifsAndEmojis: 'false',
+        };
+
+        const canvasImageReference = 'canvas-image-reference';
+
+        renderWithContext(<PostEmoji {...props}/>);
+
+        expect(screen.queryByTestId('static-animated-post-emoji-container')).toBeInTheDocument();
+        expect(screen.queryByTestId('postEmoji.:' + baseProps.name + ':')).not.toBeInTheDocument();
+
+        expect(screen.queryByTestId(canvasImageReference)).toBeInTheDocument();
+        expect(screen.queryByTestId(canvasImageReference)).toHaveStyle('display: none');
+        expect(screen.queryByTestId(canvasImageReference)).toHaveAttribute('src', `${baseProps.imageUrl}`);
     });
 });

--- a/webapp/channels/src/components/post_emoji/post_emoji.tsx
+++ b/webapp/channels/src/components/post_emoji/post_emoji.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {useRef} from 'react';
 
 import WithTooltip from 'components/with_tooltip';
 
@@ -9,15 +9,33 @@ export interface Props {
     children: React.ReactNode;
     name: string;
     imageUrl: string;
+    autoplayGifsAndEmojis: string;
 }
 
-const PostEmoji = ({children, name, imageUrl}: Props) => {
+const PostEmoji = ({children, name, imageUrl, autoplayGifsAndEmojis}: Props) => {
     const emojiText = `:${name}:`;
     const backgroundImageUrl = `url(${imageUrl})`;
+
+    const staticAnimatedEmojiRef: React.RefObject<HTMLCanvasElement> = useRef(null);
+    const imageRef: React.RefObject<HTMLImageElement> = useRef(null);
 
     if (!imageUrl) {
         return <>{children}</>;
     }
+
+    const isAnimatedEmoji = !(/\/static\//).test(imageUrl);
+    const shouldShowStaticAnimatedEmoji = autoplayGifsAndEmojis === 'false' && isAnimatedEmoji;
+
+    const emoticonWidthAndHeight = 32;
+
+    const handleImageLoad = () => {
+        if (isAnimatedEmoji && staticAnimatedEmojiRef.current && imageRef.current) {
+            const context = staticAnimatedEmojiRef.current.getContext('2d');
+
+            // 32px is the height and width specified in the 'emoticon' CSS rule.
+            context?.drawImage(imageRef.current, 0, 0, emoticonWidthAndHeight, emoticonWidthAndHeight);
+        }
+    };
 
     return (
         <WithTooltip
@@ -25,13 +43,32 @@ const PostEmoji = ({children, name, imageUrl}: Props) => {
             emoji={name}
             isEmojiLarge={true}
         >
-            <span
-                className='emoticon'
-                data-testid={`postEmoji.${emojiText}`}
-                style={{backgroundImage: backgroundImageUrl}}
-            >
-                {children}
-            </span>
+            {
+                shouldShowStaticAnimatedEmoji ?
+                    <span>
+                        <img
+                            ref={imageRef}
+                            src={imageUrl}
+                            style={{display: 'none'}}
+                            onLoad={handleImageLoad}
+                        />
+                        <canvas
+                            ref={staticAnimatedEmojiRef}
+                            id='static-animated-emoji'
+
+                            // 32px is the height and width specified in the 'emoticon' CSS rule.
+                            width={emoticonWidthAndHeight}
+                            height={emoticonWidthAndHeight}
+                        />
+                    </span> :
+                    <span
+                        className='emoticon'
+                        data-testid={`postEmoji.${emojiText}`}
+                        style={{backgroundImage: backgroundImageUrl}}
+                    >
+                        {children}
+                    </span>
+            }
         </WithTooltip>
     );
 };

--- a/webapp/channels/src/components/post_emoji/post_emoji.tsx
+++ b/webapp/channels/src/components/post_emoji/post_emoji.tsx
@@ -45,10 +45,11 @@ const PostEmoji = ({children, name, imageUrl, autoplayGifsAndEmojis}: Props) => 
         >
             {
                 shouldShowStaticAnimatedEmoji ?
-                    <span>
+                    <span data-testid='static-animated-post-emoji-container'>
                         <img
                             ref={imageRef}
                             src={imageUrl}
+                            data-testid='canvas-image-reference'
                             style={{display: 'none'}}
                             onLoad={handleImageLoad}
                         />

--- a/webapp/channels/src/components/post_view/message_attachments/message_attachment/index.ts
+++ b/webapp/channels/src/components/post_view/message_attachments/message_attachment/index.ts
@@ -5,18 +5,18 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {GlobalState} from 'types/store';
-
 import {doPostActionWithCookie} from 'mattermost-redux/actions/posts';
+import {get} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 
 import {openModal} from 'actions/views/modals';
+import {getIsMobileView} from 'selectors/views/browser';
+
+import {Preferences} from 'utils/constants';
+
+import type {GlobalState} from 'types/store';
 
 import MessageAttachment from './message_attachment';
-
-import {get} from 'mattermost-redux/selectors/entities/preferences';
-import {getIsMobileView} from 'selectors/views/browser';
-import {Preferences} from 'utils/constants';
 
 function mapStateToProps(state: GlobalState) {
     return {

--- a/webapp/channels/src/components/post_view/message_attachments/message_attachment/index.ts
+++ b/webapp/channels/src/components/post_view/message_attachments/message_attachment/index.ts
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {GlobalState} from '@mattermost/types/store';
+import type {GlobalState} from 'types/store';
 
 import {doPostActionWithCookie} from 'mattermost-redux/actions/posts';
 import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
@@ -14,9 +14,15 @@ import {openModal} from 'actions/views/modals';
 
 import MessageAttachment from './message_attachment';
 
+import {get} from 'mattermost-redux/selectors/entities/preferences';
+import {getIsMobileView} from 'selectors/views/browser';
+import {Preferences} from 'utils/constants';
+
 function mapStateToProps(state: GlobalState) {
     return {
         currentRelativeTeamUrl: getCurrentRelativeTeamUrl(state),
+        autoplayGifsAndEmojis: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS_DEFAULT),
+        isMobileView: getIsMobileView(state),
     };
 }
 

--- a/webapp/channels/src/components/post_view/message_attachments/message_attachment/message_attachment.tsx
+++ b/webapp/channels/src/components/post_view/message_attachments/message_attachment/message_attachment.tsx
@@ -62,6 +62,10 @@ type Props = {
     };
 
     currentRelativeTeamUrl: string;
+
+    autoplayGifsAndEmojis: string;
+
+    isMobileView: boolean;
 }
 
 type State = {
@@ -475,6 +479,8 @@ export default class MessageAttachment extends React.PureComponent<Props, State>
                                 src={imageUrl}
                                 dimensions={imageMetadata}
                                 onClick={this.showModal}
+                                autoplayGifsAndEmojis={this.props.autoplayGifsAndEmojis}
+                                isMobileView={this.props.isMobileView}
                             />
                         )}
                     </ExternalImage>
@@ -529,6 +535,8 @@ export default class MessageAttachment extends React.PureComponent<Props, State>
                                 onImageLoaded={this.handleHeightReceivedForThumbUrl}
                                 src={thumbUrl}
                                 dimensions={thumbMetadata}
+                                autoplayGifsAndEmojis={this.props.autoplayGifsAndEmojis}
+                                isMobileView={this.props.isMobileView}
                             />
                         )}
                     </ExternalImage>

--- a/webapp/channels/src/components/post_view/post_image/index.ts
+++ b/webapp/channels/src/components/post_view/post_image/index.ts
@@ -4,16 +4,17 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
+
 import {get} from 'mattermost-redux/selectors/entities/preferences';
 
 import {openModal} from 'actions/views/modals';
-
-import PostImage from './post_image';
 import {getIsMobileView} from 'selectors/views/browser';
 
 import {Preferences} from 'utils/constants';
 
-import {GlobalState} from 'types/store';
+import type {GlobalState} from 'types/store';
+
+import PostImage from './post_image';
 
 function mapDispatchToProps(dispatch: Dispatch) {
     return {
@@ -27,7 +28,7 @@ function mapStateToProps(state: GlobalState) {
     return {
         autoplayGifsAndEmojis: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS_DEFAULT),
         isMobileView: getIsMobileView(state),
-    }
+    };
 }
 
 const connector = connect(mapStateToProps, mapDispatchToProps);

--- a/webapp/channels/src/components/post_view/post_image/index.ts
+++ b/webapp/channels/src/components/post_view/post_image/index.ts
@@ -4,10 +4,16 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
+import {get} from 'mattermost-redux/selectors/entities/preferences';
 
 import {openModal} from 'actions/views/modals';
 
 import PostImage from './post_image';
+import {getIsMobileView} from 'selectors/views/browser';
+
+import {Preferences} from 'utils/constants';
+
+import {GlobalState} from 'types/store';
 
 function mapDispatchToProps(dispatch: Dispatch) {
     return {
@@ -17,6 +23,13 @@ function mapDispatchToProps(dispatch: Dispatch) {
     };
 }
 
-const connector = connect(null, mapDispatchToProps);
+function mapStateToProps(state: GlobalState) {
+    return {
+        autoplayGifsAndEmojis: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS_DEFAULT),
+        isMobileView: getIsMobileView(state),
+    }
+}
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
 
 export default connector(PostImage);

--- a/webapp/channels/src/components/post_view/post_image/post_image.tsx
+++ b/webapp/channels/src/components/post_view/post_image/post_image.tsx
@@ -24,6 +24,8 @@ type PostImageProps = {
     actions: {
         openModal: <P>(modalData: ModalData<P>) => void;
     };
+    autoplayGifsAndEmojis: string;
+    isMobileView: boolean;
 }
 
 const PostImage = ({
@@ -31,6 +33,8 @@ const PostImage = ({
     link,
     post,
     actions,
+    autoplayGifsAndEmojis,
+    isMobileView,
 }: PostImageProps) => {
     const {openModal} = actions;
     const showModal = useCallback((
@@ -71,6 +75,8 @@ const PostImage = ({
                             dimensions={imageMetadata}
                             showLoader={true}
                             onClick={showModal}
+                            autoplayGifsAndEmojis={autoplayGifsAndEmojis}
+                            isMobileView={isMobileView}
                         />
                     </>
                 )}

--- a/webapp/channels/src/components/post_view/reaction/__snapshots__/reaction.test.tsx.snap
+++ b/webapp/channels/src/components/post_view/reaction/__snapshots__/reaction.test.tsx.snap
@@ -264,4 +264,151 @@ exports[`components/post_view/Reaction should match snapshot when a current user
 </Connect(ReactionTooltip)>
 `;
 
+exports[`components/post_view/Reaction should render animated emoji reaction when the autoplay GIFs and emojis setting is on 1`] = `
+<Connect(ReactionTooltip)
+  canAddReactions={true}
+  canRemoveReactions={true}
+  currentUserReacted={false}
+  emojiName="smile"
+  onShow={[Function]}
+  reactions={
+    Array [
+      Object {
+        "create_at": 0,
+        "emoji_name": ":smile:",
+        "post_id": "post_id",
+        "user_id": "user_id_2",
+      },
+      Object {
+        "create_at": 0,
+        "emoji_name": ":smile:",
+        "post_id": "post_id",
+        "user_id": "user_id_3",
+      },
+    ]
+  }
+>
+  <button
+    aria-label="react with smile"
+    className="Reaction Reaction--unreacted "
+    id="postReaction-post_id-smile"
+    onClick={[Function]}
+  >
+    <span
+      className="d-flex align-items-center"
+    >
+      <img
+        className="Reaction__emoji emoticon"
+        src="emoji_image_url"
+      />
+      <span
+        className="Reaction__count"
+      >
+        <span
+          className="Reaction__number"
+        >
+          <span
+            className="Reaction__number--display"
+          >
+            2
+          </span>
+          <span
+            className="Reaction__number--unreacted"
+            onAnimationEnd={[Function]}
+          >
+            2
+          </span>
+          <span
+            className="Reaction__number--reacted"
+          >
+            3
+          </span>
+        </span>
+      </span>
+    </span>
+  </button>
+</Connect(ReactionTooltip)>
+`;
+
+exports[`components/post_view/Reaction should render static emoji reaction when the autoplay GIFs and emojis setting is off 1`] = `
+<Connect(ReactionTooltip)
+  canAddReactions={true}
+  canRemoveReactions={true}
+  currentUserReacted={false}
+  emojiName="smile"
+  onShow={[Function]}
+  reactions={
+    Array [
+      Object {
+        "create_at": 0,
+        "emoji_name": ":smile:",
+        "post_id": "post_id",
+        "user_id": "user_id_2",
+      },
+      Object {
+        "create_at": 0,
+        "emoji_name": ":smile:",
+        "post_id": "post_id",
+        "user_id": "user_id_3",
+      },
+    ]
+  }
+>
+  <button
+    aria-label="react with smile"
+    className="Reaction Reaction--unreacted "
+    id="postReaction-post_id-smile"
+    onClick={[Function]}
+  >
+    <span
+      className="d-flex align-items-center"
+    >
+      <span
+        data-testid="static-emoji-reaction-container"
+      >
+        <img
+          className="Reaction__emoji emoticon"
+          onLoad={[Function]}
+          src="emoji_image_url"
+          style={
+            Object {
+              "display": "none",
+            }
+          }
+        />
+        <canvas
+          height={16}
+          id="static-emoji-reaction"
+          width={16}
+        />
+      </span>
+      <span
+        className="Reaction__count"
+      >
+        <span
+          className="Reaction__number"
+        >
+          <span
+            className="Reaction__number--display"
+          >
+            2
+          </span>
+          <span
+            className="Reaction__number--unreacted"
+            onAnimationEnd={[Function]}
+          >
+            2
+          </span>
+          <span
+            className="Reaction__number--reacted"
+          >
+            3
+          </span>
+        </span>
+      </span>
+    </span>
+  </button>
+</Connect(ReactionTooltip)>
+`;
+
 exports[`components/post_view/Reaction should return null/empty if no emojiImageUrl 1`] = `""`;

--- a/webapp/channels/src/components/post_view/reaction/index.ts
+++ b/webapp/channels/src/components/post_view/reaction/index.ts
@@ -14,12 +14,14 @@ import {removeReaction} from 'mattermost-redux/actions/posts';
 import {getMissingProfilesByIds} from 'mattermost-redux/actions/users';
 import {createSelector} from 'mattermost-redux/selectors/create_selector';
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
+import {get} from 'mattermost-redux/selectors/entities/preferences';
 import {canAddReactions, canRemoveReactions} from 'mattermost-redux/selectors/entities/reactions';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getEmojiImageUrl} from 'mattermost-redux/utils/emoji_utils';
 
 import {addReaction} from 'actions/post_actions';
 
+import {Preferences} from 'utils/constants';
 import * as Emoji from 'utils/emoji';
 
 import Reaction from './reaction';
@@ -64,6 +66,7 @@ function makeMapStateToProps() {
             canRemoveReactions: canRemoveReactions(state, channelId),
             emojiImageUrl,
             currentUserReacted: didCurrentUserReact(state, ownProps.reactions),
+            autoplayGifsAndEmojis: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS_DEFAULT),
         };
     };
 }

--- a/webapp/channels/src/components/post_view/reaction/reaction.test.tsx
+++ b/webapp/channels/src/components/post_view/reaction/reaction.test.tsx
@@ -43,6 +43,7 @@ describe('components/post_view/Reaction', () => {
         reactions,
         emojiImageUrl: 'emoji_image_url',
         actions,
+        autoplayGifsAndEmojis: 'true',
     };
 
     test('should match snapshot', () => {
@@ -100,5 +101,20 @@ describe('components/post_view/Reaction', () => {
 
         expect(actions.getMissingProfilesByIds).toHaveBeenCalledTimes(1);
         expect(actions.getMissingProfilesByIds).toHaveBeenCalledWith([reactions[0].user_id, reactions[1].user_id]);
+    });
+
+    test('should render animated emoji reaction when the autoplay GIFs and emojis setting is on', () => {
+        const wrapper = shallow<Reaction>(<Reaction {...baseProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should render static emoji reaction when the autoplay GIFs and emojis setting is off', () => {
+        const props = {
+            ...baseProps,
+            autoplayGifsAndEmojis: 'false',
+        };
+
+        const wrapper = shallow<Reaction>(<Reaction {...props}/>);
+        expect(wrapper).toMatchSnapshot();
     });
 });

--- a/webapp/channels/src/components/post_view/reaction/reaction.tsx
+++ b/webapp/channels/src/components/post_view/reaction/reaction.tsx
@@ -230,7 +230,7 @@ export default class Reaction extends React.PureComponent<Props, State> {
         // 16px is the height and width set in the 'Reaction__emoji' CSS rule.
         const reactionWidthAndHeight = 16;
         const staticEmojiIcon = (
-            <>
+            <span data-testid='static-emoji-reaction-container'>
                 <img
                     ref={this.reactionImageRef}
                     className='Reaction__emoji emoticon'
@@ -245,7 +245,7 @@ export default class Reaction extends React.PureComponent<Props, State> {
                     height={reactionWidthAndHeight}
                     width={reactionWidthAndHeight}
                 />
-            </>
+            </span>
         );
 
         return (

--- a/webapp/channels/src/components/single_image_view/index.ts
+++ b/webapp/channels/src/components/single_image_view/index.ts
@@ -8,18 +8,18 @@ import type {Dispatch} from 'redux';
 
 import {getFilePublicLink} from 'mattermost-redux/actions/files';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {get} from 'mattermost-redux/selectors/entities/preferences';
 
 import {toggleEmbedVisibility} from 'actions/post_actions';
 import {openModal} from 'actions/views/modals';
 import {getIsRhsOpen} from 'selectors/rhs';
+import {getIsMobileView} from 'selectors/views/browser';
 
 import SingleImageView from 'components/single_image_view/single_image_view';
 
-import type {GlobalState} from 'types/store';
-
-import {get} from 'mattermost-redux/selectors/entities/preferences';
-import {getIsMobileView} from 'selectors/views/browser';
 import {Preferences} from 'utils/constants';
+
+import type {GlobalState} from 'types/store';
 
 function mapStateToProps(state: GlobalState) {
     const isRhsOpen = getIsRhsOpen(state);

--- a/webapp/channels/src/components/single_image_view/index.ts
+++ b/webapp/channels/src/components/single_image_view/index.ts
@@ -17,6 +17,10 @@ import SingleImageView from 'components/single_image_view/single_image_view';
 
 import type {GlobalState} from 'types/store';
 
+import {get} from 'mattermost-redux/selectors/entities/preferences';
+import {getIsMobileView} from 'selectors/views/browser';
+import {Preferences} from 'utils/constants';
+
 function mapStateToProps(state: GlobalState) {
     const isRhsOpen = getIsRhsOpen(state);
     const config = getConfig(state);
@@ -24,6 +28,8 @@ function mapStateToProps(state: GlobalState) {
     return {
         isRhsOpen,
         enablePublicLink: config.EnablePublicLink === 'true',
+        autoplayGifsAndEmojis: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS_DEFAULT),
+        isMobileView: getIsMobileView(state),
     };
 }
 

--- a/webapp/channels/src/components/single_image_view/single_image_view.tsx
+++ b/webapp/channels/src/components/single_image_view/single_image_view.tsx
@@ -30,6 +30,8 @@ export interface Props extends PropsFromRedux {
     compactDisplay?: boolean;
     isEmbedVisible?: boolean;
     isInPermalink?: boolean;
+    autoplayGifsAndEmojis: string;
+    isMobileView: boolean;
 }
 
 type State = {
@@ -241,6 +243,8 @@ export default class SingleImageView extends React.PureComponent<Props, State> {
                                     handleSmallImageContainer={true}
                                     enablePublicLink={this.props.enablePublicLink}
                                     getFilePublicLink={this.getFilePublicLink}
+                                    autoplayGifsAndEmojis={this.props.autoplayGifsAndEmojis}
+                                    isMobileView={this.props.isMobileView}
                                 />
                             </div>
                         </div>

--- a/webapp/channels/src/components/size_aware_image.tsx
+++ b/webapp/channels/src/components/size_aware_image.tsx
@@ -348,6 +348,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
         const playPauseGifButton = (
             <button
                 type='button'
+                data-testid='play-pause-gif-button'
                 className={classNames('style--none',
                     'gif-button', this.state.shouldPlayGif ? 'gif-button--pause' : 'gif-button--play')
                 }
@@ -380,6 +381,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
                 <canvas
                     ref={this.canvasRef}
                     id='static-gif-canvas'
+                    data-testid='static-gif-canvas'
                     className={
                         this.props.className +
                         (this.props.handleSmallImageContainer &&

--- a/webapp/channels/src/components/size_aware_image.tsx
+++ b/webapp/channels/src/components/size_aware_image.tsx
@@ -201,12 +201,12 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
         if (this.isImageAGif && this.canvasRef.current) {
             const canvasElement = this.canvasRef.current;
 
-            if (image !== undefined) {
-                canvasElement.height = image.naturalHeight;
-                canvasElement.width = image.naturalWidth;
-            } else {
+            if (image === undefined) {
                 canvasElement.height = this.props.dimensions?.height ?? 0;
                 canvasElement.width = this.props.dimensions?.width ?? 0;
+            } else {
+                canvasElement.height = image.naturalHeight;
+                canvasElement.width = image.naturalWidth;
             }
 
             const context = canvasElement.getContext('2d');

--- a/webapp/channels/src/components/size_aware_image.tsx
+++ b/webapp/channels/src/components/size_aware_image.tsx
@@ -127,7 +127,7 @@ type State = {
 export class SizeAwareImage extends React.PureComponent<Props, State> {
     public heightTimeout = 0;
     public mounted = false;
-    private shouldShowStaticGif = this.props.dimensions?.format === 'gif' || (this.props.alt && (/GIF/i).test(this.props.alt));
+    private isImageAGif = this.props.dimensions?.format === 'gif' || (this.props.alt && (/GIF/i).test(this.props.alt)) || (this.props.fileInfo && this.props.fileInfo.extension === 'gif');
     public timeout: NodeJS.Timeout|null = null;
     private canvasRef: React.RefObject<HTMLCanvasElement> = React.createRef();
     private imageRef: React.RefObject<HTMLImageElement> = React.createRef();
@@ -188,7 +188,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
                 if (this.props.onImageLoaded && image.naturalHeight) {
                     this.props.onImageLoaded({height: image.naturalHeight, width: image.naturalWidth});
 
-                    // Draw a static im\age of the GIF on the canvas to simulate it being paused.
+                    // Draw a static image of the GIF on the canvas to simulate it being paused.
                     this.drawStaticGif(image);
                 } else {
                     this.drawStaticGif();
@@ -198,7 +198,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
     };
 
     drawStaticGif = (image?: HTMLImageElement) => {
-        if (this.shouldShowStaticGif && this.canvasRef.current) {
+        if (this.isImageAGif && this.canvasRef.current) {
             const canvasElement = this.canvasRef.current;
 
             if (image !== undefined) {
@@ -340,7 +340,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
                 // of not rendering it.
                 style={{
                     ...conditionalSVGStyleAttribute,
-                    display: !this.state.shouldPlayGif && this.shouldShowStaticGif ? 'none' : 'block',
+                    display: !this.state.shouldPlayGif && this.isImageAGif ? 'none' : 'block',
                 }}
             />
         );
@@ -532,7 +532,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
                 className={classNames('image-loaded-container', this.state.shouldPlayGif && 'align-gif-button')}
             >
                 {image}
-                {this.shouldShowStaticGif && staticGif}
+                {this.isImageAGif && staticGif}
 
                 {/*
                     Using separate buttons for different screen sizes because tapping on the GIF on mobile
@@ -612,7 +612,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
 
                         // Setting the lineHeight to 0 to prevent the sudden increase in height when playing
                         // a GIF.
-                        lineHeight: this.shouldShowStaticGif ? 0 : 'initial',
+                        lineHeight: this.isImageAGif ? 0 : 'initial',
                     }}
                 >
                     {this.renderImageWithContainerIfNeeded()}

--- a/webapp/channels/src/components/size_aware_image.tsx
+++ b/webapp/channels/src/components/size_aware_image.tsx
@@ -127,6 +127,7 @@ type State = {
 export class SizeAwareImage extends React.PureComponent<Props, State> {
     public heightTimeout = 0;
     public mounted = false;
+    private shouldShowStaticGif = this.props.dimensions?.format === 'gif' || (this.props.alt && (/GIF/i).test(this.props.alt));
     public timeout: NodeJS.Timeout|null = null;
     private canvasRef: React.RefObject<HTMLCanvasElement> = React.createRef();
     private imageRef: React.RefObject<HTMLImageElement> = React.createRef();
@@ -188,11 +189,11 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
                     this.props.onImageLoaded({height: image.naturalHeight, width: image.naturalWidth});
 
                     // Draw a static image of the GIF on the canvas to simulate it being paused.
-                    if (this.props.dimensions?.format === 'gif' && this.canvasRef.current) {
+                    if (this.shouldShowStaticGif && this.canvasRef.current) {
                         const canvasElement = this.canvasRef.current;
 
-                        canvasElement.height = this.props.dimensions.height ?? 0;
-                        canvasElement.width = this.props.dimensions.width ?? 0;
+                        canvasElement.height = image.naturalHeight;
+                        canvasElement.width = image.naturalWidth;
 
                         const context = canvasElement.getContext('2d');
 
@@ -328,7 +329,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
                 // of not rendering it.
                 style={{
                     ...conditionalSVGStyleAttribute,
-                    display: !this.state.shouldPlayGif && this.props.dimensions?.format === 'gif' ? 'none' : 'block',
+                    display: !this.state.shouldPlayGif && this.shouldShowStaticGif ? 'none' : 'block',
                 }}
             />
         );
@@ -520,7 +521,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
                 className={classNames('image-loaded-container', this.state.shouldPlayGif && 'align-gif-button')}
             >
                 {image}
-                {this.props.dimensions?.format === 'gif' && staticGif}
+                {this.shouldShowStaticGif && staticGif}
 
                 {/*
                     Using separate buttons for different screen sizes because tapping on the GIF on mobile
@@ -600,7 +601,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
 
                         // Setting the lineHeight to 0 to prevent the sudden increase in height when playing
                         // a GIF.
-                        lineHeight: this.props.dimensions?.format === 'gif' ? 0 : 'initial',
+                        lineHeight: this.shouldShowStaticGif ? 0 : 'initial',
                     }}
                 >
                     {this.renderImageWithContainerIfNeeded()}

--- a/webapp/channels/src/components/size_aware_image.tsx
+++ b/webapp/channels/src/components/size_aware_image.tsx
@@ -14,7 +14,7 @@ import {
     LinkVariantIcon,
     CheckIcon,
     PlayIcon,
-    PauseIcon
+    PauseIcon,
 } from '@mattermost/compass-icons/components';
 import type {FileInfo} from '@mattermost/types/files';
 import type {PostImage} from '@mattermost/types/posts';
@@ -217,7 +217,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
         } else {
             this.setState({...this.state, shouldPlayGif: true});
         }
-    }
+    };
 
     onEnterKeyDown = (e: KeyboardEvent<HTMLImageElement>) => {
         if (e.key === 'Enter') {
@@ -258,6 +258,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
         Reflect.deleteProperty(props, 'hideUtilities');
         Reflect.deleteProperty(props, 'getFilePublicLink');
         Reflect.deleteProperty(props, 'intl');
+        Reflect.deleteProperty(props, 'autoplayGifsAndEmojis');
 
         let ariaLabelImage = intl.formatMessage({id: 'file_attachment.thumbnail', defaultMessage: 'file thumbnail'});
         if (fileInfo) {
@@ -274,15 +275,9 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
             };
         }
 
-        // Remove 'autoplayGifsAndEmojis' because the 'img' tag doesn't recognize it.
-        // This is the error you get if you don't do so.
-        // Warning: React does not recognize the `autoplayGifsAndEmojis` prop on a DOM element
-        // https://legacy.reactjs.org/warnings/unknown-prop.html
-        const {autoplayGifsAndEmojis, ...otherProps} = props;
-
         const image = (
             <img
-                {...otherProps}
+                {...props}
                 ref={this.imageRef}
                 aria-label={ariaLabelImage}
                 tabIndex={0}
@@ -302,7 +297,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
                 // of not rendering it.
                 style={{
                     ...conditionalSVGStyleAttribute,
-                    display: !this.state.shouldPlayGif && this.props.dimensions?.format === 'gif' ? 'none' : 'block'
+                    display: !this.state.shouldPlayGif && this.props.dimensions?.format === 'gif' ? 'none' : 'block',
                 }}
             />
         );
@@ -311,28 +306,25 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
             <button
                 type='button'
                 className={classNames('style--none',
-                    'gif-button',this.state.shouldPlayGif ? 'gif-button--pause' : 'gif-button--play')
+                    'gif-button', this.state.shouldPlayGif ? 'gif-button--pause' : 'gif-button--play')
                 }
                 onClick={this.handleGifButtonClick}
             >
                 {
                     this.state.shouldPlayGif ?
 
-                    <span className='gif-button__icon-container'>
-                        <PauseIcon size={24} />
-                    </span>
-
-                    :
-
-                    <>
                         <span className='gif-button__icon-container'>
-                            <PlayIcon size={24} />
-                        </span>
+                            <PauseIcon size={24}/>
+                        </span> :
+                        <>
+                            <span className='gif-button__icon-container'>
+                                <PlayIcon size={24}/>
+                            </span>
 
-                        <span>
-                            GIF
-                        </span>
-                    </>
+                            <span>
+                                {'GIF'}
+                            </span>
+                        </>
                 }
             </button>
         );
@@ -349,8 +341,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
                         (this.props.handleSmallImageContainer &&
                         this.state.isSmallImage ? ' small-image--inside-container' : '')
                     }
-                >
-                </canvas>
+                />
                 {playPauseGifButton}
             </div>
         );

--- a/webapp/channels/src/components/size_aware_image.tsx
+++ b/webapp/channels/src/components/size_aware_image.tsx
@@ -99,6 +99,11 @@ export type Props = WrappedComponentProps & {
     * Prevents display of utility buttons when image in a location that makes them inappropriate
     */
     hideUtilities?: boolean;
+
+    /**
+     * Determines if GIFs and animated emojis autoplay by default.
+     */
+    autoplayGifsAndEmojis: string;
 }
 
 type State = {
@@ -132,7 +137,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
             linkCopyInProgress: false,
             error: false,
             imageWidth: 0,
-            shouldPlayGif: false,
+            shouldPlayGif: this.props.autoplayGifsAndEmojis === 'true',
         };
 
         this.heightTimeout = 0;
@@ -144,6 +149,14 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
 
     componentWillUnmount() {
         this.mounted = false;
+    }
+
+    componentDidUpdate(prevProps: Readonly<Props>) {
+        if (prevProps.autoplayGifsAndEmojis !== this.props.autoplayGifsAndEmojis) {
+            // The 'autoplay GIFs and emojis' setting has been toggled, so update state and re-render all GIFs
+            // as either static or playing depending on the new setting.
+            this.setState({...this.state, shouldPlayGif: this.props.autoplayGifsAndEmojis === 'true'});
+        }
     }
 
     dimensionsAvailable = (dimensions?: Partial<PostImage>) => {
@@ -261,9 +274,15 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
             };
         }
 
+        // Remove 'autoplayGifsAndEmojis' because the 'img' tag doesn't recognize it.
+        // This is the error you get if you don't do so.
+        // Warning: React does not recognize the `autoplayGifsAndEmojis` prop on a DOM element
+        // https://legacy.reactjs.org/warnings/unknown-prop.html
+        const {autoplayGifsAndEmojis, ...otherProps} = props;
+
         const image = (
             <img
-                {...props}
+                {...otherProps}
                 ref={this.imageRef}
                 aria-label={ariaLabelImage}
                 tabIndex={0}

--- a/webapp/channels/src/components/size_aware_image.tsx
+++ b/webapp/channels/src/components/size_aware_image.tsx
@@ -188,21 +188,32 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
                 if (this.props.onImageLoaded && image.naturalHeight) {
                     this.props.onImageLoaded({height: image.naturalHeight, width: image.naturalWidth});
 
-                    // Draw a static image of the GIF on the canvas to simulate it being paused.
-                    if (this.shouldShowStaticGif && this.canvasRef.current) {
-                        const canvasElement = this.canvasRef.current;
-
-                        canvasElement.height = image.naturalHeight;
-                        canvasElement.width = image.naturalWidth;
-
-                        const context = canvasElement.getContext('2d');
-
-                        if (this.imageRef.current) {
-                            context?.drawImage(this.imageRef.current, 0, 0);
-                        }
-                    }
+                    // Draw a static im\age of the GIF on the canvas to simulate it being paused.
+                    this.drawStaticGif(image);
+                } else {
+                    this.drawStaticGif();
                 }
             });
+        }
+    };
+
+    drawStaticGif = (image?: HTMLImageElement) => {
+        if (this.shouldShowStaticGif && this.canvasRef.current) {
+            const canvasElement = this.canvasRef.current;
+
+            if (image !== undefined) {
+                canvasElement.height = image.naturalHeight;
+                canvasElement.width = image.naturalWidth;
+            } else {
+                canvasElement.height = this.props.dimensions?.height ?? 0;
+                canvasElement.width = this.props.dimensions?.width ?? 0;
+            }
+
+            const context = canvasElement.getContext('2d');
+
+            if (this.imageRef.current) {
+                context?.drawImage(this.imageRef.current, 0, 0);
+            }
         }
     };
 

--- a/webapp/channels/src/components/user_settings/display/__snapshots__/user_settings_display.test.tsx.snap
+++ b/webapp/channels/src/components/user_settings/display/__snapshots__/user_settings_display.test.tsx.snap
@@ -154,6 +154,24 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
         active={false}
         areAllSectionsInactive={false}
         max={null}
+        section="autoplay_gifs_and_emojis"
+        title={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Autoplay GIFs and Emojis"
+            id="user.settings.display.autoplayGifsAndEmojis"
+          />
+        }
+        updateSection={[Function]}
+      />
+      <div
+        className="divider-dark"
+      />
+    </div>
+    <div>
+      <Memo(SettingItem)
+        active={false}
+        areAllSectionsInactive={false}
+        max={null}
         section="collapse"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -494,6 +512,24 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
           <Memo(MemoizedFormattedMessage)
             defaultMessage="Website Link Previews"
             id="user.settings.display.linkPreviewDisplay"
+          />
+        }
+        updateSection={[Function]}
+      />
+      <div
+        className="divider-dark"
+      />
+    </div>
+    <div>
+      <Memo(SettingItem)
+        active={false}
+        areAllSectionsInactive={false}
+        max={null}
+        section="autoplay_gifs_and_emojis"
+        title={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Autoplay GIFs and Emojis"
+            id="user.settings.display.autoplayGifsAndEmojis"
           />
         }
         updateSection={[Function]}
@@ -933,6 +969,24 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
         active={false}
         areAllSectionsInactive={false}
         max={null}
+        section="autoplay_gifs_and_emojis"
+        title={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Autoplay GIFs and Emojis"
+            id="user.settings.display.autoplayGifsAndEmojis"
+          />
+        }
+        updateSection={[Function]}
+      />
+      <div
+        className="divider-dark"
+      />
+    </div>
+    <div>
+      <Memo(SettingItem)
+        active={false}
+        areAllSectionsInactive={false}
+        max={null}
         section="collapse"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -1200,6 +1254,24 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
           <Memo(MemoizedFormattedMessage)
             defaultMessage="Website Link Previews"
             id="user.settings.display.linkPreviewDisplay"
+          />
+        }
+        updateSection={[Function]}
+      />
+      <div
+        className="divider-dark"
+      />
+    </div>
+    <div>
+      <Memo(SettingItem)
+        active={false}
+        areAllSectionsInactive={false}
+        max={null}
+        section="autoplay_gifs_and_emojis"
+        title={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Autoplay GIFs and Emojis"
+            id="user.settings.display.autoplayGifsAndEmojis"
           />
         }
         updateSection={[Function]}
@@ -1566,6 +1638,24 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
         active={false}
         areAllSectionsInactive={false}
         max={null}
+        section="autoplay_gifs_and_emojis"
+        title={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Autoplay GIFs and Emojis"
+            id="user.settings.display.autoplayGifsAndEmojis"
+          />
+        }
+        updateSection={[Function]}
+      />
+      <div
+        className="divider-dark"
+      />
+    </div>
+    <div>
+      <Memo(SettingItem)
+        active={false}
+        areAllSectionsInactive={false}
+        max={null}
         section="collapse"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -1815,6 +1905,24 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
           <Memo(MemoizedFormattedMessage)
             defaultMessage="Share last active time"
             id="user.settings.display.lastActiveDisplay"
+          />
+        }
+        updateSection={[Function]}
+      />
+      <div
+        className="divider-dark"
+      />
+    </div>
+    <div>
+      <Memo(SettingItem)
+        active={false}
+        areAllSectionsInactive={false}
+        max={null}
+        section="autoplay_gifs_and_emojis"
+        title={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Autoplay GIFs and Emojis"
+            id="user.settings.display.autoplayGifsAndEmojis"
           />
         }
         updateSection={[Function]}
@@ -2181,6 +2289,24 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
         active={false}
         areAllSectionsInactive={false}
         max={null}
+        section="autoplay_gifs_and_emojis"
+        title={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Autoplay GIFs and Emojis"
+            id="user.settings.display.autoplayGifsAndEmojis"
+          />
+        }
+        updateSection={[Function]}
+      />
+      <div
+        className="divider-dark"
+      />
+    </div>
+    <div>
+      <Memo(SettingItem)
+        active={false}
+        areAllSectionsInactive={false}
+        max={null}
         section="collapse"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -2448,6 +2574,24 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
           <Memo(MemoizedFormattedMessage)
             defaultMessage="Website Link Previews"
             id="user.settings.display.linkPreviewDisplay"
+          />
+        }
+        updateSection={[Function]}
+      />
+      <div
+        className="divider-dark"
+      />
+    </div>
+    <div>
+      <Memo(SettingItem)
+        active={false}
+        areAllSectionsInactive={false}
+        max={null}
+        section="autoplay_gifs_and_emojis"
+        title={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Autoplay GIFs and Emojis"
+            id="user.settings.display.autoplayGifsAndEmojis"
           />
         }
         updateSection={[Function]}
@@ -2832,6 +2976,24 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
         active={false}
         areAllSectionsInactive={true}
         max={null}
+        section="autoplay_gifs_and_emojis"
+        title={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Autoplay GIFs and Emojis"
+            id="user.settings.display.autoplayGifsAndEmojis"
+          />
+        }
+        updateSection={[Function]}
+      />
+      <div
+        className="divider-dark"
+      />
+    </div>
+    <div>
+      <Memo(SettingItem)
+        active={false}
+        areAllSectionsInactive={true}
+        max={null}
         section="collapse"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -3112,6 +3274,24 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
         active={false}
         areAllSectionsInactive={false}
         max={null}
+        section="autoplay_gifs_and_emojis"
+        title={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Autoplay GIFs and Emojis"
+            id="user.settings.display.autoplayGifsAndEmojis"
+          />
+        }
+        updateSection={[Function]}
+      />
+      <div
+        className="divider-dark"
+      />
+    </div>
+    <div>
+      <Memo(SettingItem)
+        active={false}
+        areAllSectionsInactive={false}
+        max={null}
         section="collapse"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -3379,6 +3559,24 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
           <Memo(MemoizedFormattedMessage)
             defaultMessage="Website Link Previews"
             id="user.settings.display.linkPreviewDisplay"
+          />
+        }
+        updateSection={[Function]}
+      />
+      <div
+        className="divider-dark"
+      />
+    </div>
+    <div>
+      <Memo(SettingItem)
+        active={false}
+        areAllSectionsInactive={false}
+        max={null}
+        section="autoplay_gifs_and_emojis"
+        title={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Autoplay GIFs and Emojis"
+            id="user.settings.display.autoplayGifsAndEmojis"
           />
         }
         updateSection={[Function]}
@@ -3684,6 +3882,24 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
         active={false}
         areAllSectionsInactive={false}
         max={null}
+        section="autoplay_gifs_and_emojis"
+        title={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Autoplay GIFs and Emojis"
+            id="user.settings.display.autoplayGifsAndEmojis"
+          />
+        }
+        updateSection={[Function]}
+      />
+      <div
+        className="divider-dark"
+      />
+    </div>
+    <div>
+      <Memo(SettingItem)
+        active={false}
+        areAllSectionsInactive={false}
+        max={null}
         section="collapse"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -3964,6 +4180,24 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
         active={false}
         areAllSectionsInactive={false}
         max={null}
+        section="autoplay_gifs_and_emojis"
+        title={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Autoplay GIFs and Emojis"
+            id="user.settings.display.autoplayGifsAndEmojis"
+          />
+        }
+        updateSection={[Function]}
+      />
+      <div
+        className="divider-dark"
+      />
+    </div>
+    <div>
+      <Memo(SettingItem)
+        active={false}
+        areAllSectionsInactive={false}
+        max={null}
         section="collapse"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -4207,6 +4441,24 @@ exports[`components/user_settings/display/UserSettingsDisplay should not show la
           <Memo(MemoizedFormattedMessage)
             defaultMessage="Website Link Previews"
             id="user.settings.display.linkPreviewDisplay"
+          />
+        }
+        updateSection={[Function]}
+      />
+      <div
+        className="divider-dark"
+      />
+    </div>
+    <div>
+      <Memo(SettingItem)
+        active={false}
+        areAllSectionsInactive={true}
+        max={null}
+        section="autoplay_gifs_and_emojis"
+        title={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Autoplay GIFs and Emojis"
+            id="user.settings.display.autoplayGifsAndEmojis"
           />
         }
         updateSection={[Function]}

--- a/webapp/channels/src/components/user_settings/display/index.ts
+++ b/webapp/channels/src/components/user_settings/display/index.ts
@@ -85,6 +85,7 @@ export function makeMapStateToProps() {
             collapsedReplyThreads: getCollapsedThreadsPreference(state),
             clickToReply: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CLICK_TO_REPLY, Preferences.CLICK_TO_REPLY_DEFAULT, userPreference),
             linkPreviewDisplay: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.LINK_PREVIEW_DISPLAY, Preferences.LINK_PREVIEW_DISPLAY_DEFAULT, userPreference),
+            autoplayGifsAndEmoji: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS, Preferences.AUTOPLAY_GIFS_AND_EMOJIS_DEFAULT, userPreference),
             oneClickReactionsOnPosts: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.ONE_CLICK_REACTIONS_ENABLED, Preferences.ONE_CLICK_REACTIONS_ENABLED_DEFAULT, userPreference),
             emojiPickerEnabled,
             lastActiveDisplay,

--- a/webapp/channels/src/components/user_settings/display/user_settings_display.test.tsx
+++ b/webapp/channels/src/components/user_settings/display/user_settings_display.test.tsx
@@ -306,10 +306,10 @@ describe('components/user_settings/display/UserSettingsDisplay', () => {
             </Provider>,
         ).find(UserSettingsDisplay);
 
-        (wrapper.instance() as UserSettingsDisplay).handlemessageDisplayRadio('clean');
+        (wrapper.instance() as UserSettingsDisplay).handleMessageDisplayRadio('clean');
         expect(wrapper.state('messageDisplay')).toBe('clean');
 
-        (wrapper.instance() as UserSettingsDisplay).handlemessageDisplayRadio('compact');
+        (wrapper.instance() as UserSettingsDisplay).handleMessageDisplayRadio('compact');
         expect(wrapper.state('messageDisplay')).toBe('compact');
     });
 

--- a/webapp/channels/src/components/user_settings/display/user_settings_display.tsx
+++ b/webapp/channels/src/components/user_settings/display/user_settings_display.tsx
@@ -60,7 +60,7 @@ type ChildOption = {
 
 type Option = {
     value: string;
-    radionButtonText: {
+    radioButtonText: {
         label: MessageDescriptor;
         more?: MessageDescriptor;
     };
@@ -340,7 +340,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
         this.setState({channelDisplayMode});
     }
 
-    handlemessageDisplayRadio(messageDisplay: string) {
+    handleMessageDisplayRadio(messageDisplay: string) {
         this.setState({messageDisplay});
     }
 
@@ -405,20 +405,20 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
 
         const firstMessage = (
             <FormattedMessage
-                id={firstOption.radionButtonText.label.id}
-                defaultMessage={firstOption.radionButtonText.label.defaultMessage}
+                id={firstOption.radioButtonText.label.id}
+                defaultMessage={firstOption.radioButtonText.label.defaultMessage}
             />
         );
 
         let moreColon;
         let firstMessageMore;
-        if (firstOption.radionButtonText.more?.id) {
+        if (firstOption.radioButtonText.more?.id) {
             moreColon = ': ';
             firstMessageMore = (
                 <span className='font-weight--normal'>
                     <FormattedMessage
-                        id={firstOption.radionButtonText.more.id}
-                        defaultMessage={firstOption.radionButtonText.more.defaultMessage}
+                        id={firstOption.radioButtonText.more.id}
+                        defaultMessage={firstOption.radioButtonText.more.defaultMessage}
                     />
                 </span>
             );
@@ -426,18 +426,18 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
 
         const secondMessage = (
             <FormattedMessage
-                id={secondOption.radionButtonText.label.id}
-                defaultMessage={secondOption.radionButtonText.label.defaultMessage}
+                id={secondOption.radioButtonText.label.id}
+                defaultMessage={secondOption.radioButtonText.label.defaultMessage}
             />
         );
 
         let secondMessageMore;
-        if (secondOption.radionButtonText.more?.id) {
+        if (secondOption.radioButtonText.more?.id) {
             secondMessageMore = (
                 <span className='font-weight--normal'>
                     <FormattedMessage
-                        id={secondOption.radionButtonText.more.id}
-                        defaultMessage={secondOption.radionButtonText.more.defaultMessage}
+                        id={secondOption.radioButtonText.more.id}
+                        defaultMessage={secondOption.radioButtonText.more.defaultMessage}
                     />
                 </span>
             );
@@ -447,8 +447,8 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
         if (thirdOption) {
             thirdMessage = (
                 <FormattedMessage
-                    id={thirdOption.radionButtonText.label.id}
-                    defaultMessage={thirdOption.radionButtonText.label.defaultMessage}
+                    id={thirdOption.radioButtonText.label.id}
+                    defaultMessage={thirdOption.radioButtonText.label.defaultMessage}
                 />
             );
         }
@@ -657,7 +657,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             }),
             firstOption: {
                 value: 'false',
-                radionButtonText: {
+                radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.display.collapseOn',
                         defaultMessage: 'Expanded',
@@ -666,7 +666,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             },
             secondOption: {
                 value: 'true',
-                radionButtonText: {
+                radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.display.collapseOff',
                         defaultMessage: 'Collapsed',
@@ -693,7 +693,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                 }),
                 firstOption: {
                     value: 'true',
-                    radionButtonText: {
+                    radioButtonText: {
                         label: defineMessage({
                             id: 'user.settings.display.linkPreviewOn',
                             defaultMessage: 'On',
@@ -702,7 +702,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                 },
                 secondOption: {
                     value: 'false',
-                    radionButtonText: {
+                    radioButtonText: {
                         label: defineMessage({
                             id: 'user.settings.display.linkPreviewOff',
                             defaultMessage: 'Off',
@@ -733,7 +733,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                 }),
                 firstOption: {
                     value: 'true',
-                    radionButtonText: {
+                    radioButtonText: {
                         label: defineMessage({
                             id: 'user.settings.display.lastActiveOn',
                             defaultMessage: 'On',
@@ -742,7 +742,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                 },
                 secondOption: {
                     value: 'false',
-                    radionButtonText: {
+                    radioButtonText: {
                         label: defineMessage({
                             id: 'user.settings.display.lastActiveOff',
                             defaultMessage: 'Off',
@@ -768,7 +768,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             }),
             firstOption: {
                 value: 'false',
-                radionButtonText: {
+                radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.display.normalClock',
                         defaultMessage: '12-hour clock (example: 4:00 PM)',
@@ -777,7 +777,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             },
             secondOption: {
                 value: 'true',
-                radionButtonText: {
+                radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.display.militaryClock',
                         defaultMessage: '24-hour clock (example: 16:00)',
@@ -801,7 +801,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             }),
             firstOption: {
                 value: Constants.TEAMMATE_NAME_DISPLAY.SHOW_USERNAME,
-                radionButtonText: {
+                radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.display.teammateNameDisplayUsername',
                         defaultMessage: 'Show username',
@@ -810,7 +810,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             },
             secondOption: {
                 value: Constants.TEAMMATE_NAME_DISPLAY.SHOW_NICKNAME_FULLNAME,
-                radionButtonText: {
+                radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.display.teammateNameDisplayNicknameFullname',
                         defaultMessage: 'Show nickname if one exists, otherwise show first and last name',
@@ -819,7 +819,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             },
             thirdOption: {
                 value: Constants.TEAMMATE_NAME_DISPLAY.SHOW_FULLNAME,
-                radionButtonText: {
+                radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.display.teammateNameDisplayFullname',
                         defaultMessage: 'Show first and last name',
@@ -844,7 +844,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             }),
             firstOption: {
                 value: 'true',
-                radionButtonText: {
+                radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.sidebar.on',
                         defaultMessage: 'On',
@@ -853,7 +853,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             },
             secondOption: {
                 value: 'false',
-                radionButtonText: {
+                radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.sidebar.off',
                         defaultMessage: 'Off',
@@ -915,7 +915,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             }),
             firstOption: {
                 value: Preferences.MESSAGE_DISPLAY_CLEAN,
-                radionButtonText: {
+                radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.display.messageDisplayClean',
                         defaultMessage: 'Standard',
@@ -928,7 +928,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             },
             secondOption: {
                 value: Preferences.MESSAGE_DISPLAY_COMPACT,
-                radionButtonText: {
+                radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.display.messageDisplayCompact',
                         defaultMessage: 'Compact',
@@ -971,7 +971,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                 }),
                 firstOption: {
                     value: Preferences.COLLAPSED_REPLY_THREADS_ON,
-                    radionButtonText: {
+                    radioButtonText: {
                         label: defineMessage({
                             id: 'user.settings.display.collapsedReplyThreadsOn',
                             defaultMessage: 'On',
@@ -980,7 +980,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                 },
                 secondOption: {
                     value: Preferences.COLLAPSED_REPLY_THREADS_OFF,
-                    radionButtonText: {
+                    radioButtonText: {
                         label: defineMessage({
                             id: 'user.settings.display.collapsedReplyThreadsOff',
                             defaultMessage: 'Off',
@@ -1005,7 +1005,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             }),
             firstOption: {
                 value: 'true',
-                radionButtonText: {
+                radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.sidebar.on',
                         defaultMessage: 'On',
@@ -1014,7 +1014,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             },
             secondOption: {
                 value: 'false',
-                radionButtonText: {
+                radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.sidebar.off',
                         defaultMessage: 'Off',
@@ -1038,7 +1038,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             }),
             firstOption: {
                 value: Preferences.CHANNEL_DISPLAY_MODE_FULL_SCREEN,
-                radionButtonText: {
+                radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.display.fullScreen',
                         defaultMessage: 'Full width',
@@ -1047,7 +1047,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             },
             secondOption: {
                 value: Preferences.CHANNEL_DISPLAY_MODE_CENTERED,
-                radionButtonText: {
+                radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.display.fixedWidthCentered',
                         defaultMessage: 'Fixed width, centered',
@@ -1124,7 +1124,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                 }),
                 firstOption: {
                     value: 'true',
-                    radionButtonText: {
+                    radioButtonText: {
                         label: defineMessage({
                             id: 'user.settings.sidebar.on',
                             defaultMessage: 'On',
@@ -1133,7 +1133,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                 },
                 secondOption: {
                     value: 'false',
-                    radionButtonText: {
+                    radioButtonText: {
                         label: defineMessage({
                             id: 'user.settings.sidebar.off',
                             defaultMessage: 'Off',

--- a/webapp/channels/src/components/user_settings/display/user_settings_display.tsx
+++ b/webapp/channels/src/components/user_settings/display/user_settings_display.tsx
@@ -236,76 +236,68 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
 
     handleSubmit = async () => {
         const userId = this.props.user.id;
-
-        const timePreference = {
+        const sharedProperties = {
             user_id: userId,
             category: Preferences.CATEGORY_DISPLAY_SETTINGS,
+        };
+
+        const timePreference = {
+            ...sharedProperties,
             name: Preferences.USE_MILITARY_TIME,
             value: this.state.militaryTime,
         };
         const availabilityStatusOnPostsPreference = {
-            user_id: userId,
-            category: Preferences.CATEGORY_DISPLAY_SETTINGS,
+            ...sharedProperties,
             name: Preferences.AVAILABILITY_STATUS_ON_POSTS,
             value: this.state.availabilityStatusOnPosts,
         };
         const teammateNameDisplayPreference = {
-            user_id: userId,
-            category: Preferences.CATEGORY_DISPLAY_SETTINGS,
+            ...sharedProperties,
             name: Preferences.NAME_NAME_FORMAT,
             value: this.state.teammateNameDisplay,
         };
         const channelDisplayModePreference = {
-            user_id: userId,
-            category: Preferences.CATEGORY_DISPLAY_SETTINGS,
+            ...sharedProperties,
             name: Preferences.CHANNEL_DISPLAY_MODE,
             value: this.state.channelDisplayMode,
         };
         const messageDisplayPreference = {
-            user_id: userId,
-            category: Preferences.CATEGORY_DISPLAY_SETTINGS,
+            ...sharedProperties,
             name: Preferences.MESSAGE_DISPLAY,
             value: this.state.messageDisplay,
         };
         const colorizeUsernamesPreference = {
-            user_id: userId,
-            category: Preferences.CATEGORY_DISPLAY_SETTINGS,
+            ...sharedProperties,
             name: Preferences.COLORIZE_USERNAMES,
             value: this.state.colorizeUsernames,
         };
         const collapseDisplayPreference = {
-            user_id: userId,
-            category: Preferences.CATEGORY_DISPLAY_SETTINGS,
+            ...sharedProperties,
             name: Preferences.COLLAPSE_DISPLAY,
             value: this.state.collapseDisplay,
         };
         const collapsedReplyThreadsPreference = {
-            user_id: userId,
-            category: Preferences.CATEGORY_DISPLAY_SETTINGS,
+            ...sharedProperties,
             name: Preferences.COLLAPSED_REPLY_THREADS,
             value: this.state.collapsedReplyThreads,
         };
         const linkPreviewDisplayPreference = {
-            user_id: userId,
-            category: Preferences.CATEGORY_DISPLAY_SETTINGS,
+            ...sharedProperties,
             name: Preferences.LINK_PREVIEW_DISPLAY,
             value: this.state.linkPreviewDisplay,
         };
         const oneClickReactionsOnPostsPreference = {
-            user_id: userId,
-            category: Preferences.CATEGORY_DISPLAY_SETTINGS,
+            ...sharedProperties,
             name: Preferences.ONE_CLICK_REACTIONS_ENABLED,
             value: this.state.oneClickReactionsOnPosts,
         };
         const clickToReplyPreference = {
-            user_id: userId,
-            category: Preferences.CATEGORY_DISPLAY_SETTINGS,
+            ...sharedProperties,
             name: Preferences.CLICK_TO_REPLY,
             value: this.state.clickToReply,
         };
         const autoplayGifsAndEmojisPreference = {
-            user_id: userId,
-            category: Preferences.CATEGORY_DISPLAY_SETTINGS,
+            ...sharedProperties,
             name: Preferences.AUTOPLAY_GIFS_AND_EMOJIS,
             value: this.state.autoplayGifsAndEmojis,
         }
@@ -540,9 +532,9 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                                 id={name + 'childOption'}
                                 type='checkbox'
                                 name={childOptionToShow.label.id}
-                                checked={childOptionToShow.value === 'true'}
+                                checked={childOptionToShow.value === Constants.BoolString.true}
                                 onChange={(e) => {
-                                    this.handleOnChange(e, {[childDisplay]: e.target.checked ? 'true' : 'false'});
+                                    this.handleOnChange(e, {[childDisplay]: e.target.checked ? Constants.BoolString.true : Constants.BoolString.false});
                                 }}
                             />
                             <FormattedMessage
@@ -606,11 +598,11 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                 </fieldset>,
             ];
 
-            if (display === 'teammateNameDisplay' && disabled) {
+            if (display === Constants.UserSettings.teammateNameDisplay && disabled) {
                 extraInfo = (
                     <span>
                         <FormattedMessage
-                            id='user.settings.display.teammateNameDisplay'
+                            id={`${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.teammateNameDisplay}`}
                             defaultMessage='This field is handled through your System Administrator. If you want to change it, you need to do so through your System Administrator.'
                         />
                     </span>
@@ -658,33 +650,33 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
     render() {
         const collapseSection = this.createSection({
             section: 'collapse',
-            display: 'collapseDisplay',
+            display: `${Constants.UserSettings.collapseDisplay}`,
             value: this.state.collapseDisplay,
-            defaultDisplay: 'false',
+            defaultDisplay: Constants.BoolString.false,
             title: defineMessage({
-                id: 'user.settings.display.collapseDisplay',
+                id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.collapseDisplay}`,
                 defaultMessage: 'Default Appearance of Image Previews',
             }),
             firstOption: {
-                value: 'false',
+                value: Constants.BoolString.false,
                 radioButtonText: {
                     label: defineMessage({
-                        id: 'user.settings.display.collapseOn',
+                        id: `${Constants.UserSettings.displayIdAnchorText}collapseOn`,
                         defaultMessage: 'Expanded',
                     }),
                 },
             },
             secondOption: {
-                value: 'true',
+                value: Constants.BoolString.true,
                 radioButtonText: {
                     label: defineMessage({
-                        id: 'user.settings.display.collapseOff',
+                        id: `${Constants.UserSettings.displayIdAnchorText}collapseOff`,
                         defaultMessage: 'Collapsed',
                     }),
                 },
             },
             description: defineMessage({
-                id: 'user.settings.display.collapseDesc',
+                id: `${Constants.UserSettings.displayIdAnchorText}collapseDesc`,
                 defaultMessage: 'Set whether previews of image links and image attachment thumbnails show as expanded or collapsed by default. This setting can also be controlled using the slash commands /expand and /collapse.',
             }),
         });
@@ -694,33 +686,33 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
         if (this.props.enableLinkPreviews) {
             linkPreviewSection = this.createSection({
                 section: 'linkpreview',
-                display: 'linkPreviewDisplay',
+                display: `${Constants.UserSettings.linkPreviewDisplay}`,
                 value: this.state.linkPreviewDisplay,
-                defaultDisplay: 'true',
+                defaultDisplay: Constants.BoolString.true,
                 title: defineMessage({
-                    id: 'user.settings.display.linkPreviewDisplay',
+                    id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.linkPreviewDisplay}`,
                     defaultMessage: 'Website Link Previews',
                 }),
                 firstOption: {
-                    value: 'true',
+                    value: Constants.BoolString.true,
                     radioButtonText: {
                         label: defineMessage({
-                            id: 'user.settings.display.linkPreviewOn',
+                            id: `${Constants.UserSettings.displayIdAnchorText}linkPreviewOn`,
                             defaultMessage: 'On',
                         }),
                     },
                 },
                 secondOption: {
-                    value: 'false',
+                    value: Constants.BoolString.false,
                     radioButtonText: {
                         label: defineMessage({
-                            id: 'user.settings.display.linkPreviewOff',
+                            id: `${Constants.UserSettings.displayIdAnchorText}linkPreviewOff`,
                             defaultMessage: 'Off',
                         }),
                     },
                 },
                 description: defineMessage({
-                    id: 'user.settings.display.linkPreviewDesc',
+                    id: `${Constants.UserSettings.displayIdAnchorText}linkPreviewDesc`,
                     defaultMessage: 'When available, the first web link in a message will show a preview of the website content below the message.',
                 }),
             });
@@ -731,33 +723,33 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
 
         const autoplayGifsAndEmojiSection = this.createSection({
             section: Preferences.AUTOPLAY_GIFS_AND_EMOJIS,
-            display: 'autoplayGifsAndEmojis',
+            display: `${Constants.UserSettings.autoplayGifsAndEmojis}`,
             value: this.state.autoplayGifsAndEmojis,
-            defaultDisplay: 'true',
+            defaultDisplay: Constants.BoolString.true,
             title: defineMessage({
-                id: 'user.settings.display.autoplayGifsAndEmojis',
+                id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.autoplayGifsAndEmojis}`,
                 defaultMessage: 'Autoplay GIFs and Emojis',
             }),
             firstOption: {
-                value: 'true',
+                value: Constants.BoolString.true,
                 radioButtonText: {
                     label: defineMessage({
-                        id: 'user.settings.display.autoplayGifsAndEmojisOn',
+                        id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.autoplayGifsAndEmojis}On`,
                         defaultMessage: 'On',
                     }),
                 },
             },
             secondOption: {
-                value: 'false',
+                value: Constants.BoolString.false,
                 radioButtonText: {
                     label: defineMessage({
-                        id: 'user.settings.display.autoplayGifsAndEmojisOff',
+                        id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.autoplayGifsAndEmojis}Off`,
                         defaultMessage: 'Off',
                     }),
                 },
             },
             description: defineMessage({
-                id: 'user.settings.display.autoplayGifsAndEmojisDesc',
+                id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.autoplayGifsAndEmojis}Desc`,
                 defaultMessage: 'When disabled, GIFs and animated emojis will appear as static images.',
             }),
         });
@@ -767,33 +759,33 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
         if (this.props.lastActiveTimeEnabled) {
             lastActiveSection = this.createSection({
                 section: 'lastactive',
-                display: 'lastActiveDisplay',
+                display: `${Constants.UserSettings.lastActiveDisplay}`,
                 value: this.state.lastActiveDisplay,
-                defaultDisplay: 'true',
+                defaultDisplay: Constants.BoolString.true,
                 title: defineMessage({
-                    id: 'user.settings.display.lastActiveDisplay',
+                    id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.lastActiveDisplay}`,
                     defaultMessage: 'Share last active time',
                 }),
                 firstOption: {
-                    value: 'true',
+                    value: Constants.BoolString.true,
                     radioButtonText: {
                         label: defineMessage({
-                            id: 'user.settings.display.lastActiveOn',
+                            id: `${Constants.UserSettings.displayIdAnchorText}lastActiveOn`,
                             defaultMessage: 'On',
                         }),
                     },
                 },
                 secondOption: {
-                    value: 'false',
+                    value: Constants.BoolString.false,
                     radioButtonText: {
                         label: defineMessage({
-                            id: 'user.settings.display.lastActiveOff',
+                            id: `${Constants.UserSettings.displayIdAnchorText}lastActiveOff`,
                             defaultMessage: 'Off',
                         }),
                     },
                 },
                 description: defineMessage({
-                    id: 'user.settings.display.lastActiveDesc',
+                    id: `${Constants.UserSettings.displayIdAnchorText}lastActiveDesc`,
                     defaultMessage: 'When enabled, other users will see when you were last active.',
                 }),
                 onSubmit: this.submitLastActive,
@@ -802,51 +794,51 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
 
         const clockSection = this.createSection({
             section: 'clock',
-            display: 'militaryTime',
+            display: `${Constants.UserSettings.militaryTime}`,
             value: this.state.militaryTime,
-            defaultDisplay: 'false',
+            defaultDisplay: Constants.BoolString.false,
             title: defineMessage({
-                id: 'user.settings.display.clockDisplay',
+                id: `${Constants.UserSettings.displayIdAnchorText}clockDisplay`,
                 defaultMessage: 'Clock Display',
             }),
             firstOption: {
-                value: 'false',
+                value: Constants.BoolString.false,
                 radioButtonText: {
                     label: defineMessage({
-                        id: 'user.settings.display.normalClock',
+                        id: `${Constants.UserSettings.displayIdAnchorText}normalClock`,
                         defaultMessage: '12-hour clock (example: 4:00 PM)',
                     }),
                 },
             },
             secondOption: {
-                value: 'true',
+                value: Constants.BoolString.true,
                 radioButtonText: {
                     label: defineMessage({
-                        id: 'user.settings.display.militaryClock',
+                        id: `${Constants.UserSettings.displayIdAnchorText}militaryClock`,
                         defaultMessage: '24-hour clock (example: 16:00)',
                     }),
                 },
             },
             description: defineMessage({
-                id: 'user.settings.display.preferTime',
+                id: `${Constants.UserSettings.displayIdAnchorText}preferTime`,
                 defaultMessage: 'Select how you prefer time displayed.',
             }),
         });
 
         const teammateNameDisplaySection = this.createSection({
             section: Preferences.NAME_NAME_FORMAT,
-            display: 'teammateNameDisplay',
+            display: Constants.UserSettings.teammateNameDisplay,
             value: this.props.lockTeammateNameDisplay ? this.props.configTeammateNameDisplay : this.state.teammateNameDisplay,
             defaultDisplay: this.props.configTeammateNameDisplay,
             title: defineMessage({
-                id: 'user.settings.display.teammateNameDisplayTitle',
+                id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.teammateNameDisplay}Title`,
                 defaultMessage: 'Teammate Name Display',
             }),
             firstOption: {
                 value: Constants.TEAMMATE_NAME_DISPLAY.SHOW_USERNAME,
                 radioButtonText: {
                     label: defineMessage({
-                        id: 'user.settings.display.teammateNameDisplayUsername',
+                        id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.teammateNameDisplay}Username`,
                         defaultMessage: 'Show username',
                     }),
                 },
@@ -855,7 +847,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                 value: Constants.TEAMMATE_NAME_DISPLAY.SHOW_NICKNAME_FULLNAME,
                 radioButtonText: {
                     label: defineMessage({
-                        id: 'user.settings.display.teammateNameDisplayNicknameFullname',
+                        id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.teammateNameDisplay}NicknameFullname`,
                         defaultMessage: 'Show nickname if one exists, otherwise show first and last name',
                     }),
                 },
@@ -864,13 +856,13 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                 value: Constants.TEAMMATE_NAME_DISPLAY.SHOW_FULLNAME,
                 radioButtonText: {
                     label: defineMessage({
-                        id: 'user.settings.display.teammateNameDisplayFullname',
+                        id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.teammateNameDisplay}Fullname`,
                         defaultMessage: 'Show first and last name',
                     }),
                 },
             },
             description: defineMessage({
-                id: 'user.settings.display.teammateNameDisplayDescription',
+                id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.teammateNameDisplay}Description`,
                 defaultMessage: 'Set how to display other user\'s names in posts and the Direct Messages list.',
             }),
             disabled: this.props.lockTeammateNameDisplay,
@@ -878,15 +870,15 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
 
         const availabilityStatusOnPostsSection = this.createSection({
             section: 'availabilityStatus',
-            display: 'availabilityStatusOnPosts',
+            display: `${Constants.UserSettings.availabilityStatusOnPosts}`,
             value: this.state.availabilityStatusOnPosts,
-            defaultDisplay: 'true',
+            defaultDisplay: Constants.BoolString.true,
             title: defineMessage({
-                id: 'user.settings.display.availabilityStatusOnPostsTitle',
+                id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.availabilityStatusOnPosts}Title`,
                 defaultMessage: 'Show user availability on posts',
             }),
             firstOption: {
-                value: 'true',
+                value: Constants.BoolString.true,
                 radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.sidebar.on',
@@ -895,7 +887,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                 },
             },
             secondOption: {
-                value: 'false',
+                value: Constants.BoolString.false,
                 radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.sidebar.off',
@@ -904,7 +896,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                 },
             },
             description: defineMessage({
-                id: 'user.settings.display.availabilityStatusOnPostsDescription',
+                id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.availabilityStatusOnPosts}Description`,
                 defaultMessage: 'When enabled, online availability is displayed on profile images in the message list.',
             }),
         });
@@ -933,7 +925,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                         areAllSectionsInactive={this.props.activeSection === ''}
                         title={
                             <FormattedMessage
-                                id='user.settings.display.timezone'
+                                id={`${Constants.UserSettings.displayIdAnchorText}timezone`}
                                 defaultMessage='Timezone'
                             />
                         }
@@ -949,22 +941,22 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
 
         const messageDisplaySection = this.createSection({
             section: Preferences.MESSAGE_DISPLAY,
-            display: 'messageDisplay',
+            display: `${Constants.UserSettings.messageDisplay}`,
             value: this.state.messageDisplay,
             defaultDisplay: Preferences.MESSAGE_DISPLAY_CLEAN,
             title: defineMessage({
-                id: 'user.settings.display.messageDisplayTitle',
+                id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.messageDisplay}Title`,
                 defaultMessage: 'Message Display',
             }),
             firstOption: {
                 value: Preferences.MESSAGE_DISPLAY_CLEAN,
                 radioButtonText: {
                     label: defineMessage({
-                        id: 'user.settings.display.messageDisplayClean',
+                        id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.messageDisplay}Clean`,
                         defaultMessage: 'Standard',
                     }),
                     more: defineMessage({
-                        id: 'user.settings.display.messageDisplayCleanDes',
+                        id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.messageDisplay}CleanDes`,
                         defaultMessage: 'Easy to scan and read.',
                     }),
                 },
@@ -973,29 +965,29 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                 value: Preferences.MESSAGE_DISPLAY_COMPACT,
                 radioButtonText: {
                     label: defineMessage({
-                        id: 'user.settings.display.messageDisplayCompact',
+                        id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.messageDisplay}Compact`,
                         defaultMessage: 'Compact',
                     }),
                     more: defineMessage({
-                        id: 'user.settings.display.messageDisplayCompactDes',
+                        id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.messageDisplay}CompactDes`,
                         defaultMessage: 'Fit as many messages on the screen as we can.',
                     }),
                 },
                 childOption: {
                     label: defineMessage({
-                        id: 'user.settings.display.colorize',
+                        id: `${Constants.UserSettings.displayIdAnchorText}colorize`,
                         defaultMessage: 'Colorize usernames',
                     }),
                     value: this.state.colorizeUsernames,
                     display: 'colorizeUsernames',
                     more: defineMessage({
-                        id: 'user.settings.display.colorizeDes',
+                        id: `${Constants.UserSettings.displayIdAnchorText}colorizeDes`,
                         defaultMessage: 'Use colors to distinguish users in compact mode',
                     }),
                 },
             },
             description: defineMessage({
-                id: 'user.settings.display.messageDisplayDescription',
+                id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.messageDisplay}Description`,
                 defaultMessage: 'Select how messages in a channel should be displayed.',
             }),
         });
@@ -1005,18 +997,18 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
         if (this.props.collapsedReplyThreadsAllowUserPreference) {
             collapsedReplyThreads = this.createSection({
                 section: Preferences.COLLAPSED_REPLY_THREADS,
-                display: 'collapsedReplyThreads',
+                display: `${Constants.UserSettings.collapsedReplyThreads}`,
                 value: this.state.collapsedReplyThreads,
                 defaultDisplay: Preferences.COLLAPSED_REPLY_THREADS_FALLBACK_DEFAULT,
                 title: defineMessage({
-                    id: 'user.settings.display.collapsedReplyThreadsTitle',
+                    id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.collapsedReplyThreads}Title`,
                     defaultMessage: 'Threaded Discussions',
                 }),
                 firstOption: {
                     value: Preferences.COLLAPSED_REPLY_THREADS_ON,
                     radioButtonText: {
                         label: defineMessage({
-                            id: 'user.settings.display.collapsedReplyThreadsOn',
+                            id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.collapsedReplyThreads}On`,
                             defaultMessage: 'On',
                         }),
                     },
@@ -1025,13 +1017,13 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                     value: Preferences.COLLAPSED_REPLY_THREADS_OFF,
                     radioButtonText: {
                         label: defineMessage({
-                            id: 'user.settings.display.collapsedReplyThreadsOff',
+                            id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.collapsedReplyThreads}Off`,
                             defaultMessage: 'Off',
                         }),
                     },
                 },
                 description: defineMessage({
-                    id: 'user.settings.display.collapsedReplyThreadsDescription',
+                    id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.collapsedReplyThreads}Description`,
                     defaultMessage: 'When enabled, reply messages are not shown in the channel and you\'ll be notified about threads you\'re following in the "Threads" view.',
                 }),
             });
@@ -1039,15 +1031,15 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
 
         const clickToReply = this.createSection({
             section: Preferences.CLICK_TO_REPLY,
-            display: 'clickToReply',
+            display: `${Constants.UserSettings.clickToReply}`,
             value: this.state.clickToReply,
-            defaultDisplay: 'true',
+            defaultDisplay: Constants.BoolString.true,
             title: defineMessage({
-                id: 'user.settings.display.clickToReply',
+                id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.clickToReply}`,
                 defaultMessage: 'Click to open threads',
             }),
             firstOption: {
-                value: 'true',
+                value: Constants.BoolString.true,
                 radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.sidebar.on',
@@ -1056,7 +1048,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                 },
             },
             secondOption: {
-                value: 'false',
+                value: Constants.BoolString.false,
                 radioButtonText: {
                     label: defineMessage({
                         id: 'user.settings.sidebar.off',
@@ -1065,25 +1057,25 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                 },
             },
             description: defineMessage({
-                id: 'user.settings.display.clickToReplyDescription',
+                id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.clickToReply}Description`,
                 defaultMessage: 'When enabled, click anywhere on a message to open the reply thread.',
             }),
         });
 
         const channelDisplayModeSection = this.createSection({
             section: Preferences.CHANNEL_DISPLAY_MODE,
-            display: 'channelDisplayMode',
+            display: `${Constants.UserSettings.channelDisplayMode}`,
             value: this.state.channelDisplayMode,
             defaultDisplay: Preferences.CHANNEL_DISPLAY_MODE_FULL_SCREEN,
             title: defineMessage({
-                id: 'user.settings.display.channelDisplayTitle',
+                id: `${Constants.UserSettings.displayIdAnchorText}channelDisplayTitle`,
                 defaultMessage: 'Channel Display',
             }),
             firstOption: {
                 value: Preferences.CHANNEL_DISPLAY_MODE_FULL_SCREEN,
                 radioButtonText: {
                     label: defineMessage({
-                        id: 'user.settings.display.fullScreen',
+                        id: `${Constants.UserSettings.displayIdAnchorText}fullScreen`,
                         defaultMessage: 'Full width',
                     }),
                 },
@@ -1092,13 +1084,13 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                 value: Preferences.CHANNEL_DISPLAY_MODE_CENTERED,
                 radioButtonText: {
                     label: defineMessage({
-                        id: 'user.settings.display.fixedWidthCentered',
+                        id: `${Constants.UserSettings.displayIdAnchorText}fixedWidthCentered`,
                         defaultMessage: 'Fixed width, centered',
                     }),
                 },
             },
             description: defineMessage({
-                id: 'user.settings.display.channeldisplaymode',
+                id: `${Constants.UserSettings.displayIdAnchorText}channeldisplaymode`,
                 defaultMessage: 'Select the width of the center channel.',
             }),
         });
@@ -1114,7 +1106,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                     areAllSectionsInactive={this.props.activeSection === ''}
                     title={
                         <FormattedMessage
-                            id='user.settings.display.language'
+                            id={`${Constants.UserSettings.displayIdAnchorText}language`}
                             defaultMessage='Language'
                         />
                     }
@@ -1158,15 +1150,15 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
         if (this.props.emojiPickerEnabled) {
             oneClickReactionsOnPostsSection = this.createSection({
                 section: Preferences.ONE_CLICK_REACTIONS_ENABLED,
-                display: 'oneClickReactionsOnPosts',
+                display: `${Constants.UserSettings.oneClickReactionsOnPosts}`,
                 value: this.state.oneClickReactionsOnPosts,
-                defaultDisplay: 'true',
+                defaultDisplay: Constants.BoolString.true,
                 title: defineMessage({
-                    id: 'user.settings.display.oneClickReactionsOnPostsTitle',
+                    id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.oneClickReactionsOnPosts}Title`,
                     defaultMessage: 'Quick reactions on messages',
                 }),
                 firstOption: {
-                    value: 'true',
+                    value: Constants.BoolString.true,
                     radioButtonText: {
                         label: defineMessage({
                             id: 'user.settings.sidebar.on',
@@ -1175,7 +1167,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                     },
                 },
                 secondOption: {
-                    value: 'false',
+                    value: Constants.BoolString.false,
                     radioButtonText: {
                         label: defineMessage({
                             id: 'user.settings.sidebar.off',
@@ -1184,7 +1176,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                     },
                 },
                 description: defineMessage({
-                    id: 'user.settings.display.oneClickReactionsOnPostsDescription',
+                    id: `${Constants.UserSettings.displayIdAnchorText}${Constants.UserSettings.oneClickReactionsOnPosts}Description`,
                     defaultMessage: 'When enabled, you can react in one-click with recently used reactions when hovering over a message.',
                 }),
             });
@@ -1197,7 +1189,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                     collapseModal={this.props.collapseModal}
                     text={
                         <FormattedMessage
-                            id='user.settings.display.title'
+                            id={`${Constants.UserSettings.displayIdAnchorText}title`}
                             defaultMessage='Display Settings'
                         />
                     }
@@ -1207,7 +1199,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                         id='displaySettingsTitle'
                         text={
                             <FormattedMessage
-                                id='user.settings.display.title'
+                                id={`${Constants.UserSettings.displayIdAnchorText}title`}
                                 defaultMessage='Display Settings'
                             />
                         }

--- a/webapp/channels/src/components/user_settings/display/user_settings_display.tsx
+++ b/webapp/channels/src/components/user_settings/display/user_settings_display.tsx
@@ -300,7 +300,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             ...sharedProperties,
             name: Preferences.AUTOPLAY_GIFS_AND_EMOJIS,
             value: this.state.autoplayGifsAndEmojis,
-        }
+        };
 
         this.setState({isSaving: true});
 

--- a/webapp/channels/src/components/user_settings/display/user_settings_display.tsx
+++ b/webapp/channels/src/components/user_settings/display/user_settings_display.tsx
@@ -48,6 +48,7 @@ function getDisplayStateFromProps(props: Props) {
         lastActiveDisplay: props.lastActiveDisplay.toString(),
         oneClickReactionsOnPosts: props.oneClickReactionsOnPosts,
         clickToReply: props.clickToReply,
+        autoplayGifsAndEmojis: props.autoplayGifsAndEmoji,
     };
 }
 
@@ -115,6 +116,7 @@ type Props = OwnProps & {
     collapsedReplyThreadsAllowUserPreference: boolean;
     clickToReply: string;
     linkPreviewDisplay: string;
+    autoplayGifsAndEmoji: string;
     oneClickReactionsOnPosts: string;
     emojiPickerEnabled: boolean;
     timezoneLabel: string;
@@ -140,6 +142,7 @@ type State = {
     collapseDisplay: string;
     collapsedReplyThreads: string;
     linkPreviewDisplay: string;
+    autoplayGifsAndEmojis: string;
     lastActiveDisplay: string;
     oneClickReactionsOnPosts: string;
     clickToReply: string;
@@ -300,6 +303,12 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             name: Preferences.CLICK_TO_REPLY,
             value: this.state.clickToReply,
         };
+        const autoplayGifsAndEmojisPreference = {
+            user_id: userId,
+            category: Preferences.CATEGORY_DISPLAY_SETTINGS,
+            name: Preferences.AUTOPLAY_GIFS_AND_EMOJIS,
+            value: this.state.autoplayGifsAndEmojis,
+        }
 
         this.setState({isSaving: true});
 
@@ -315,6 +324,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
             availabilityStatusOnPostsPreference,
             oneClickReactionsOnPostsPreference,
             colorizeUsernamesPreference,
+            autoplayGifsAndEmojisPreference,
         ];
 
         this.trackChangeIfNecessary(collapsedReplyThreadsPreference, this.props.collapsedReplyThreads);
@@ -718,6 +728,39 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
         } else {
             this.prevSections.message_display = this.prevSections.linkpreview;
         }
+
+        const autoplayGifsAndEmojiSection = this.createSection({
+            section: Preferences.AUTOPLAY_GIFS_AND_EMOJIS,
+            display: 'autoplayGifsAndEmojis',
+            value: this.state.autoplayGifsAndEmojis,
+            defaultDisplay: 'true',
+            title: defineMessage({
+                id: 'user.settings.display.autoplayGifsAndEmojis',
+                defaultMessage: 'Autoplay GIFs and Emojis',
+            }),
+            firstOption: {
+                value: 'true',
+                radioButtonText: {
+                    label: defineMessage({
+                        id: 'user.settings.display.autoplayGifsAndEmojisOn',
+                        defaultMessage: 'On',
+                    }),
+                },
+            },
+            secondOption: {
+                value: 'false',
+                radioButtonText: {
+                    label: defineMessage({
+                        id: 'user.settings.display.autoplayGifsAndEmojisOff',
+                        defaultMessage: 'Off',
+                    }),
+                },
+            },
+            description: defineMessage({
+                id: 'user.settings.display.autoplayGifsAndEmojisDesc',
+                defaultMessage: 'When disabled, GIFs and animated emojis will appear as static images.',
+            }),
+        });
 
         let lastActiveSection = null;
 
@@ -1178,6 +1221,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                     {lastActiveSection}
                     {timezoneSelection}
                     {linkPreviewSection}
+                    {autoplayGifsAndEmojiSection}
                     {collapseSection}
                     {messageDisplaySection}
                     {clickToReply}

--- a/webapp/channels/src/sass/base/_structure.scss
+++ b/webapp/channels/src/sass/base/_structure.scss
@@ -317,6 +317,6 @@ body.app__body #root {
     }
 }
 
-img {
+img, canvas {
     max-width: 100%;
 }

--- a/webapp/channels/src/sass/components/_files.scss
+++ b/webapp/channels/src/sass/components/_files.scss
@@ -229,7 +229,7 @@
                 max-height: 180px;
             }
 
-            img {
+            img, canvas {
                 position: relative;
                 z-index: 2;
                 overflow: hidden;
@@ -290,6 +290,12 @@
                 min-width: 40px;
                 min-height: 40px;
                 text-align: left;
+            }
+
+            .image-loaded-container.align-gif-button {
+                display: flex;
+                align-items: center;
+                justify-content: center;
             }
         }
 

--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -1713,19 +1713,18 @@
         }
 
         .gif-button {
+            position: absolute;
+            z-index: 2;
             display: flex;
-            align-items: center;
-            background-color: rgba(0, 0, 0, .72);
             height: 44px;
+            align-items: center;
             border-radius: 100px;
+            background-color: rgba(0, 0, 0, .72);
 
             font-family: 'Open Sans';
             font-size: 14px;
             font-weight: 600;
             line-height: 20px;
-
-            position: absolute;
-            z-index: 2;
 
             &__icon-container {
                 display: flex;
@@ -1735,22 +1734,22 @@
 
         .gif-button--play {
             @extend .gif-button;
-            padding: 12px;
             width: 78px;
+            padding: 12px;
             gap: 4px;
         }
 
         .gif-button--pause {
             @extend .gif-button;
             display: none;
-            padding: 10px;
             width: 44px;
+            padding: 10px;
         }
 
         .static-gif-container {
             display: flex;
-            justify-content: center;
             align-items: center;
+            justify-content: center;
         }
 
         .static-gif-container--none {

--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -1707,8 +1707,55 @@
         position: relative;
         display: inline-block;
 
-        &:hover .image-preview-utility-buttons-container {
+        &:hover .image-preview-utility-buttons-container,
+        &:hover .gif-button--pause {
             display: inline-block;
+        }
+
+        .gif-button {
+            display: flex;
+            align-items: center;
+            background-color: rgba(0, 0, 0, .72);
+            height: 44px;
+            border-radius: 100px;
+
+            font-family: 'Open Sans';
+            font-size: 14px;
+            font-weight: 600;
+            line-height: 20px;
+
+            position: absolute;
+            z-index: 2;
+
+            &__icon-container {
+                display: flex;
+                align-items: center;
+            }
+        }
+
+        .gif-button--play {
+            @extend .gif-button;
+            padding: 12px;
+            width: 78px;
+            gap: 4px;
+        }
+
+        .gif-button--pause {
+            @extend .gif-button;
+            display: none;
+            padding: 10px;
+            width: 44px;
+        }
+
+        .static-gif-container {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
+        .static-gif-container--none {
+            @extend .static-gif-container;
+            display: none;
         }
     }
 

--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -1390,6 +1390,12 @@
         padding-top: 5px;
         transition: max-height 500ms ease;
 
+        .image-loaded-container.align-gif-button {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
         &[hidden] {
             max-height: 0;
         }

--- a/webapp/channels/src/sass/layout/_markdown.scss
+++ b/webapp/channels/src/sass/layout/_markdown.scss
@@ -98,8 +98,8 @@ h6.markdown__heading {
         
         .image-loaded-container.align-gif-button {
             display: flex;
-            justify-content: center;
             align-items: center;
+            justify-content: center;
         }
 
         .markdown-inline-img {

--- a/webapp/channels/src/sass/layout/_markdown.scss
+++ b/webapp/channels/src/sass/layout/_markdown.scss
@@ -95,6 +95,12 @@ h6.markdown__heading {
         .image-loaded-container {
             display: inline-block;
         }
+        
+        .image-loaded-container.align-gif-button {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
 
         .markdown-inline-img {
             margin: 0;

--- a/webapp/channels/src/sass/responsive/_mobile.scss
+++ b/webapp/channels/src/sass/responsive/_mobile.scss
@@ -2000,7 +2000,7 @@
     .file-view--single {
         .file__image {
             .image-loaded {
-                img {
+                img, canvas {
                     max-width: 100%;
                 }
             }

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -1029,6 +1029,34 @@ export const UserSettingsNotificationSections = {
     AUTO_RESPONDER: 'autoResponder',
 };
 
+export const UserSettings = {
+    displayIdAnchorText: 'user.settings.display.',
+
+    // region The following constants ensure each section's display name
+    // name matches the one in state, otherwise, a user won't be able to change options
+    // because the radio button's 'handleOnChange()' relies on the 'display' string
+    // to match the state name to update the selected option. Code is in 'user_settings_display.tsx'.
+    collapseDisplay: 'collapseDisplay',
+    linkPreviewDisplay: 'linkPreviewDisplay',
+    autoplayGifsAndEmojis: 'autoplayGifsAndEmojis',
+    lastActiveDisplay: 'lastActiveDisplay',
+    militaryTime: 'militaryTime',
+    teammateNameDisplay: 'teammateNameDisplay',
+    availabilityStatusOnPosts: 'availabilityStatusOnPosts',
+    messageDisplay: 'messageDisplay',
+    collapsedReplyThreads: 'collapsedReplyThreads',
+    clickToReply: 'clickToReply',
+    channelDisplayMode: 'channelDisplayMode',
+    oneClickReactionsOnPosts: 'oneClickReactionsOnPosts',
+
+    // endregion
+}
+
+export const BoolString = {
+    true: 'true',
+    false: 'false',
+}
+
 export const AdvancedSections = {
     CONTROL_SEND: 'advancedCtrlSend',
     FORMATTING: 'formatting',
@@ -1481,6 +1509,8 @@ export const Constants = {
     FileTypes,
     Locations,
     PostListRowListIds,
+    UserSettings,
+    BoolString,
     MAX_POST_VISIBILITY: 1000000,
     REMOTE_USERS_HOUR_LIMIT_END_OF_THE_DAY: 22,
     REMOTE_USERS_HOUR_LIMIT_BEGINNING_OF_THE_DAY: 6,

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -93,6 +93,8 @@ export const Preferences = {
     COLLAPSED_REPLY_THREADS_FALLBACK_DEFAULT: 'off',
     LINK_PREVIEW_DISPLAY: 'link_previews',
     LINK_PREVIEW_DISPLAY_DEFAULT: 'true',
+    AUTOPLAY_GIFS_AND_EMOJIS: 'autoplay_gifs_and_emojis',
+    AUTOPLAY_GIFS_AND_EMOJIS_DEFAULT: 'true',
     COLLAPSE_DISPLAY: 'collapse_previews',
     COLLAPSE_DISPLAY_DEFAULT: 'false',
     AVAILABILITY_STATUS_ON_POSTS: 'availability_status_on_posts',

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -1050,12 +1050,12 @@ export const UserSettings = {
     oneClickReactionsOnPosts: 'oneClickReactionsOnPosts',
 
     // endregion
-}
+};
 
 export const BoolString = {
     true: 'true',
     false: 'false',
-}
+};
 
 export const AdvancedSections = {
     CONTROL_SEND: 'advancedCtrlSend',


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR adds a setting that lets users enable or disable GIFs and animated emojis from auto-playing.

##### QA Steps

1. Open the emoji picker, select a GIF from the GIF tab, and post it.
2. Verify the GIF is playing (autoplay is on by default), the pause button is hidden, and hovering over the GIF reveals it on desktop devices (clicking the GIF once reveals it on mobile devices and it's hidden again after 4 seconds).
3. Click Settings -> Display -> Autoplay GIFs and Animated Emojis -> Turn Off -> Save.
4. Verify a static GIF is shown with a play button.
5. Turn on autoplay and post a link to a GIF.
6. Repeat steps 3 and 4.
7. Turn on autoplay and upload a GIF attachment.
8. Repeat steps 3 and 4.
9. Turn on autoplay and post an animated emoji from the emoji picker.
10. Repeat step 3 and verify a static post emoji is shown.
11. Turn on autoplay and add an animated reaction to any post.
12. Repeat step 3 and verify a static reaction is shown.
13. Click the play button on any static GIF and verify a playing GIF is shown.
14. Click the pause button on any playing GIF and verify a static GIF is shown.
15. Start a thread from a static GIF and verify the original post is a static GIF. Vice versa for playing GIFs.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

Fixes https://github.com/mattermost/mattermost/issues/17740
Jira https://mattermost.atlassian.net/browse/MM-26973%7Csmart-link

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->


https://github.com/user-attachments/assets/592b6a79-7159-4729-9502-21d33cf8ce78


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Added 'Autoplay GIFs and Emojis' setting to toggle when GIFs and animated emojis should play.
```
