### PR TITLE
Remove duplicate SAML login error message

### DIFF
--- a/server/channels/api4/limits.go
+++ b/server/channels/api4/limits.go
@@ -29,6 +29,6 @@ func getServerLimits(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewEncoder(w).Encode(serverLimits); err != nil {
-		c.Logger.Error("Error writing server limits response", mlog.Err(err))
+		c.Logger.Warn("Error writing server limits response", mlog.Err(err))
 	}
 }

--- a/server/channels/web/handlers.go
+++ b/server/channels/web/handlers.go
@@ -450,7 +450,7 @@ func (h Handler) handleContextError(c *Context, w http.ResponseWriter, r *http.R
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(c.Err.StatusCode)
 		if _, err := w.Write([]byte(c.Err.ToJSON())); err != nil {
-			c.Logger.Error("Failed to write error response", mlog.Err(err))
+			c.Logger.Warn("Failed to write error response", mlog.Err(err))
 		}
 	} else {
 		utils.RenderWebAppError(c.App.Config(), w, r, c.Err, c.App.AsymmetricSigningKey())

--- a/server/channels/web/oauth.go
+++ b/server/channels/web/oauth.go
@@ -80,7 +80,7 @@ func authorizeOAuthApp(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	_, err = w.Write([]byte(model.MapToJSON(map[string]string{"redirect": redirectURL})))
 	if err != nil {
-		c.Logger.Error("Error writing response", mlog.Err(err))
+		c.Logger.Warn("Error writing response", mlog.Err(err))
 	}
 }
 

--- a/server/channels/web/saml.go
+++ b/server/channels/web/saml.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
-	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/v8/channels/audit"
 	"github.com/mattermost/mattermost/server/v8/channels/utils"
 )
@@ -128,8 +127,6 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.Err = err
 			c.Err.StatusCode = http.StatusFound
 		}
-
-		c.Logger.Error("Failed to complete SAML login", mlog.Err(err))
 	}
 
 	if len(encodedXML) > maxSAMLResponseSize {


### PR DESCRIPTION
#### Summary
If a SAML login failed, there would be two almost identical error messages. This PR removes one of them.

**Before**
```
error [2025-01-07 09:23:34.934 +01:00] Failed to complete SAML login                 caller="web/saml.go:132" path=/login/sso/saml request_id=s68tq7w7upgopbepfzcyp8yn9e ip_addr="::1" user_id= method=POST error="SamlInterfaceImpl.DoLogin: SAML login was unsuccessful because one of the attributes is incorrect. Please contact your System Administrator., uid attribute is missing"
error [2025-01-07 09:23:34.934 +01:00] SAML login was unsuccessful because one of the attributes is incorrect. Please contact your System Administrator. caller="web/context.go:124" path=/login/sso/saml request_id=s68tq7w7upgopbepfzcyp8yn9e ip_addr="::1" user_id= method=POST err_where=SamlInterfaceImpl.DoLogin http_code=302 error="SamlInterfaceImpl.DoLogin: SAML login was unsuccessful because one of the attributes is incorrect. Please contact your System Administrator., uid attribute is missing"
```
**After** 
```
error [2025-01-07 09:31:34.233 +01:00] SAML login was unsuccessful because one of the attributes is incorrect. Please contact your System Administrator. caller="web/context.go:124" path=/login/sso/saml request_id=sqon6rt5e7nu9e8epo9fgojdac ip_addr="::1" user_id= method=POST err_where=SamlInterfaceImpl.DoLogin http_code=302 error="SamlInterfaceImpl.DoLogin: SAML login was unsuccessful because one of the attributes is incorrect. Please contact your System Administrator., uid attribute is missing"
```

#### Ticket Link
None


#### Release Note
```release-note
NONE
```
