### PR TITLE
MM-62371 Add additional error handling to PerformanceReporter

### DIFF
--- a/webapp/channels/src/utils/performance_telemetry/reporter.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.ts
@@ -196,7 +196,16 @@ export default class PerformanceReporter {
     }
 
     private handleMeasure(entry: PerformanceMeasure) {
-        if (!entry.detail?.report) {
+        let report;
+        try {
+            report = Boolean(entry.detail?.report);
+        } catch {
+            // Measures recorded by browser extensions may be in a separate context which causes accessing
+            // entry.detail to throw an error
+            report = false;
+        }
+
+        if (!report) {
             return;
         }
 
@@ -209,7 +218,16 @@ export default class PerformanceReporter {
     }
 
     private handleMark(entry: PerformanceMeasure) {
-        if (!entry.detail?.report) {
+        let report;
+        try {
+            report = Boolean(entry.detail?.report);
+        } catch {
+            // Measures recorded by browser extensions may be in a separate context which causes accessing
+            // entry.detail to throw an error
+            report = false;
+        }
+
+        if (!report) {
             return;
         }
 


### PR DESCRIPTION
#### Summary
As in the comments I added, this is to fix an error introduced by changes made by either Firefox or 1Password due to accessing a performance metric's details field when we're not allowed to. The error is more visible on servers like Community and Hub because of the error bar, but as far as I can tell, it doesn't cause any other issues.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62371
https://mattermost.atlassian.net/browse/MM-62393

#### Release Note
```release-note
Fixed errors logged by performance telemetry due to certain browser extensions
```
