### PR TITLE
[MM-61637]: Add accessible name to the expand RHS button in RHS header

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/accessibility/accessibility_buttons_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/accessibility/accessibility_buttons_spec.js
@@ -35,11 +35,7 @@ describe('Verify Accessibility Support in different Buttons', () => {
             within(() => {
                 // * Verify accessibility support in Sidebar Expand and Shrink icon
                 cy.get('button.sidebar--right__expand').
-                    should('have.attr', 'aria-label', 'Expand').
-                    within(() => {
-                        cy.get('.icon-arrow-expand').should('have.attr', 'aria-label', 'Expand Sidebar Icon');
-                        cy.get('.icon-arrow-collapse').should('have.attr', 'aria-label', 'Collapse Sidebar Icon');
-                    });
+                    should('have.attr', 'aria-label', 'Expand Sidebar Icon');
 
                 // * Verify accessibility support in Close icon
                 cy.get('#rhsCloseButton').

--- a/e2e-tests/cypress/tests/support/ui/sidebar_right.js
+++ b/e2e-tests/cypress/tests/support/ui/sidebar_right.js
@@ -19,7 +19,7 @@ Cypress.Commands.add('uiCloseRHS', () => {
 });
 
 Cypress.Commands.add('uiExpandRHS', () => {
-    cy.findByLabelText('Expand').click();
+    cy.findByLabelText('Expand Sidebar Icon').click();
 });
 
 Cypress.Commands.add('isExpanded', {prevSubject: true}, (subject) => {

--- a/webapp/channels/src/components/post_edit_history/__snapshots__/post_edit_history.test.tsx.snap
+++ b/webapp/channels/src/components/post_edit_history/__snapshots__/post_edit_history.test.tsx.snap
@@ -35,9 +35,11 @@ exports[`components/post_edit_history should display error screen if errors are 
               type="button"
             >
               <i
+                aria-hidden="true"
                 class="icon icon-arrow-expand"
               />
               <i
+                aria-hidden="true"
                 class="icon icon-arrow-collapse"
               />
             </button>
@@ -196,9 +198,11 @@ exports[`components/post_edit_history should match snapshot 1`] = `
               type="button"
             >
               <i
+                aria-hidden="true"
                 class="icon icon-arrow-expand"
               />
               <i
+                aria-hidden="true"
                 class="icon icon-arrow-collapse"
               />
             </button>

--- a/webapp/channels/src/components/post_edit_history/__snapshots__/post_edit_history.test.tsx.snap
+++ b/webapp/channels/src/components/post_edit_history/__snapshots__/post_edit_history.test.tsx.snap
@@ -35,11 +35,9 @@ exports[`components/post_edit_history should display error screen if errors are 
               type="button"
             >
               <i
-                aria-hidden="true"
                 class="icon icon-arrow-expand"
               />
               <i
-                aria-hidden="true"
                 class="icon icon-arrow-collapse"
               />
             </button>
@@ -198,11 +196,9 @@ exports[`components/post_edit_history should match snapshot 1`] = `
               type="button"
             >
               <i
-                aria-hidden="true"
                 class="icon icon-arrow-expand"
               />
               <i
-                aria-hidden="true"
                 class="icon icon-arrow-collapse"
               />
             </button>

--- a/webapp/channels/src/components/rhs_card_header/rhs_card_header.tsx
+++ b/webapp/channels/src/components/rhs_card_header/rhs_card_header.tsx
@@ -130,6 +130,9 @@ class RhsCardHeader extends React.PureComponent<Props> {
             );
         }
 
+        const collapseIconLabel = this.props.intl.formatMessage({id: 'rhs_header.collapseSidebarTooltip.icon', defaultMessage: 'Collapse Sidebar Icon'});
+        const expandIconLabel = this.props.intl.formatMessage({id: 'rhs_header.expandSidebarTooltip.icon', defaultMessage: 'Expand Sidebar Icon'});
+
         return (
             <div className='sidebar--right__header'>
                 <span className='sidebar--right__title'>
@@ -146,16 +149,14 @@ class RhsCardHeader extends React.PureComponent<Props> {
                         <button
                             type='button'
                             className='sidebar--right__expand btn btn-icon btn-sm'
-                            aria-label='Expand'
+                            aria-label={this.props.isExpanded ? collapseIconLabel : expandIconLabel}
                             onClick={this.props.actions.toggleRhsExpanded}
                         >
                             <i
                                 className='icon icon-arrow-expand'
-                                aria-label={this.props.intl.formatMessage({id: 'rhs_header.expandSidebarTooltip.icon', defaultMessage: 'Expand Sidebar Icon'})}
                             />
                             <i
                                 className='icon icon-arrow-collapse'
-                                aria-label={this.props.intl.formatMessage({id: 'rhs_header.collapseSidebarTooltip.icon', defaultMessage: 'Collapse Sidebar Icon'})}
                             />
                         </button>
                     </WithTooltip>

--- a/webapp/channels/src/components/rhs_header_post/rhs_header_post.tsx
+++ b/webapp/channels/src/components/rhs_header_post/rhs_header_post.tsx
@@ -162,6 +162,9 @@ class RhsHeaderPost extends React.PureComponent<Props> {
             );
         }
 
+        const collapseIconLabel = formatMessage({id: 'rhs_header.collapseSidebarTooltip.icon', defaultMessage: 'Collapse Sidebar Icon'});
+        const expandIconLabel = formatMessage({id: 'rhs_header.expandSidebarTooltip.icon', defaultMessage: 'Expand Sidebar Icon'});
+
         return (
             <div className='sidebar--right__header'>
                 <span className='sidebar--right__title'>
@@ -194,16 +197,14 @@ class RhsHeaderPost extends React.PureComponent<Props> {
                         <button
                             type='button'
                             className='sidebar--right__expand btn btn-icon btn-sm'
-                            aria-label='Expand'
+                            aria-label={this.props.isExpanded ? collapseIconLabel : expandIconLabel}
                             onClick={this.props.toggleRhsExpanded}
                         >
                             <i
                                 className='icon icon-arrow-expand'
-                                aria-label={formatMessage({id: 'rhs_header.expandSidebarTooltip.icon', defaultMessage: 'Expand Sidebar Icon'})}
                             />
                             <i
                                 className='icon icon-arrow-collapse'
-                                aria-label={formatMessage({id: 'rhs_header.collapseSidebarTooltip.icon', defaultMessage: 'Collapse Sidebar Icon'})}
                             />
                         </button>
                     </WithTooltip>


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR adds accessible name to the expand RHS button in RHS header


#### Steps to reproduce  

- Locate the "Expand Sidebar Icon/ collapse Sidebar Icon" button.

- Inspect it with Chrome DevTools.

- In the Accessibility tab, expand the Computed Properties section.

- Review the value for "Name".


#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
FIxes: https://mattermost.atlassian.net/browse/MM-61637

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

[Screencast from 2024-12-31 12-35-36.webm](https://github.com/user-attachments/assets/a580a404-f561-4b67-b9a2-a8c9bd34cb7b)


#### Release Note
<!--
Add a release note for each of the following conditions:
* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
