### PR TITLE
Automated cherry pick of #29589

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9231,6 +9231,10 @@
     "translation": "Link metadata URL must be set."
   },
   {
+    "id": "model.link_metadata.is_valid.url_length.app_error",
+    "translation": "Length of link metadata URL is {{ .Length }} characters long, which exceeds the maximum limit of {{ .MaxLength }} characters."
+  },
+  {
     "id": "model.member.is_valid.channel.app_error",
     "translation": "Channel name is not valid"
   },

--- a/server/public/model/link_metadata.go
+++ b/server/public/model/link_metadata.go
@@ -21,6 +21,7 @@ const (
 	LinkMetadataTypeNone      LinkMetadataType = "none"
 	LinkMetadataTypeOpengraph LinkMetadataType = "opengraph"
 	LinkMetadataMaxImages     int              = 5
+	LinkMetadataMaxURLLength  int              = 2048 // Maximum URL length in LinkMetadata table
 )
 
 type LinkMetadataType string
@@ -91,6 +92,10 @@ func (o *LinkMetadata) PreSave() {
 func (o *LinkMetadata) IsValid() *AppError {
 	if o.URL == "" {
 		return NewAppError("LinkMetadata.IsValid", "model.link_metadata.is_valid.url.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	if len(o.URL) > LinkMetadataMaxURLLength {
+		return NewAppError("LinkMetadata.IsValid", "model.link_metadata.is_valid.url_length.app_error", map[string]any{"MaxLength": LinkMetadataMaxURLLength, "Length": len(o.URL)}, "", http.StatusBadRequest)
 	}
 
 	if o.Timestamp == 0 || !isRoundedToNearestHour(o.Timestamp) {

--- a/server/public/model/link_metadata_test.go
+++ b/server/public/model/link_metadata_test.go
@@ -146,6 +146,16 @@ func TestLinkMetadataIsValid(t *testing.T) {
 			},
 			Expected: false,
 		},
+		{
+			Name: "should be invalid because of URL length being too long",
+			Metadata: &LinkMetadata{
+				URL:       "http://example.com/?" + strings.Repeat("a", 2048),
+				Timestamp: 1546300800000,
+				Type:      LinkMetadataTypeImage,
+				Data:      &PostImage{},
+			},
+			Expected: false,
+		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			appErr := test.Metadata.IsValid()


### PR DESCRIPTION
Cherry pick of #29589 on release-9.11.

/cc  @NadavTasher

```release-note
NONE
```