### PR TITLE
Fix IDE warninings about comment

### DIFF
--- a/server/public/model/builtin.go
+++ b/server/public/model/builtin.go
@@ -7,7 +7,7 @@ package model
 func NewPointer[T any](t T) *T { return &t }
 
 // SafeDereference returns the zero value of T if t is nil.
-// Otherwise it return the derference of t.
+// Otherwise, it returns t dereferenced.
 func SafeDereference[T any](t *T) T {
 	if t == nil {
 		var t T


### PR DESCRIPTION
#### Summary

- Fix IDE comment warnings (typo, add a comma, change wording)

#### Ticket Link

N/A

#### Screenshots

Before:
![before](https://github.com/user-attachments/assets/8d39062b-db6e-42e8-ab83-a918eb52ec8b)

After:
![after](https://github.com/user-attachments/assets/1d5af86e-498c-43fe-b9e0-71359254a11f)


#### Release Note
```release-note
NONE
```
