### PR TITLE
[MM-61684]: Updated the heading element tag

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/enterprise/system_console/user_management/user_management_admin_control_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/enterprise/system_console/user_management/user_management_admin_control_spec.js
@@ -107,7 +107,7 @@ describe('User Management', () => {
 
             cy.get('#cancelModalButton').should('be.visible').should('have.text', 'Cancel');
             cy.get('#confirmModalButton').should('be.visible').should('have.text', 'Manage User Settings').click();
-            cy.get('h1#accountSettingsModalLabel').should('be.visible').should('have.text', `Manage ${user.nickname}'s Settings`);
+            cy.get('h2#accountSettingsModalLabel').should('be.visible').should('have.text', `Manage ${user.nickname}'s Settings`);
             cy.get('.adminModeBadge').should('be.visible').should('have.text', 'Admin Mode');
         } else {
             cy.get('.manageUserSettingsBtn').should('not.exist');

--- a/webapp/channels/src/components/team_settings_modal/team_settings_modal.tsx
+++ b/webapp/channels/src/components/team_settings_modal/team_settings_modal.tsx
@@ -69,7 +69,10 @@ const TeamSettingsModal = ({onExited, canInviteUsers}: Props) => {
                 id='teamSettingsModalLabel'
                 closeButton={true}
             >
-                <Modal.Title componentClass='h1'>
+                <Modal.Title
+                    componentClass='h2'
+                    className='modal-header__title'
+                >
                     {formatMessage({id: 'team_settings_modal.title', defaultMessage: 'Team Settings'})}
                 </Modal.Title>
             </Modal.Header>

--- a/webapp/channels/src/components/user_settings/modal/user_settings_modal.tsx
+++ b/webapp/channels/src/components/user_settings/modal/user_settings_modal.tsx
@@ -351,8 +351,9 @@ class UserSettingsModal extends React.PureComponent<Props, State> {
                     closeButton={true}
                 >
                     <Modal.Title
-                        componentClass='h1'
+                        componentClass='h2'
                         id='accountSettingsModalLabel'
+                        className='modal-header__title'
                     >
                         {modalTitle}
                     </Modal.Title>

--- a/webapp/channels/src/sass/components/_settings-modal.scss
+++ b/webapp/channels/src/sass/components/_settings-modal.scss
@@ -1,13 +1,22 @@
 @use "utils/functions";
 
 .app__body {
-    .settings-modal {
+    .settings-modal {  
         h3 {
             font-size: 18px;
         }
 
         .modal-header {
             border-bottom: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
+
+            &__title {
+                color: var(--center-channel-color);
+                font-family: 'Metropolis', serif;
+                font-size: 22px;
+                font-weight: 600;
+                line-height: 28px;
+                word-break: break-word;
+            }
         }
 
         // Tabs


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

- Updated the user settings and team settings modal title component HTML tag from h1 to h2.

#### Steps to reproduce  
- Locate the Settings text heading.
- Inspect it with Chrome DevTools.
- In the Accessibility tab, expand the Computed Properties section.
- Review the value for "Level".

#### Expected behaviour 
- The heading does not match with the visual level on the page, Hence the modal heading should be h2.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Jira https://mattermost.atlassian.net/browse/MM-61684
#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

<table>
    <tr>
        <th>Before</th>
 <th>After</th>
    </tr>
    <tr>
        <td>
 <img src="https://github.com/user-attachments/assets/89cf74ff-35c1-4bd2-b96e-8bb04da6c216">
</td>
  <td>
 <img src="https://github.com/user-attachments/assets/98e5a924-2af7-4afd-9297-b358426efb37">
</td>
    </tr>
</table>

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.
!
Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
