### PR TITLE
[MM-59405] Dismiss notifications automatically after some time

### DIFF
--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -2071,6 +2071,7 @@ export const Constants = {
     MENTION_RECENT_CHANNELS: 'mention.recent.channels',
     MENTION_SPECIAL: 'mention.special',
     MENTION_GROUPS: 'search.group',
+    DEFAULT_NOTIFICATION_DURATION: 5000,
     STATUS_INTERVAL: 60000,
     AUTOCOMPLETE_TIMEOUT: 100,
     AUTOCOMPLETE_SPLIT_CHARACTERS: ['.', '-', '_'],


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

MM-59404 introduced a UX regression in commit
0227ac0fc19173b520aa74febcf53715c29d4393, causing all notifications persisting until manually dismissed (or automatically by the OS, if it supports it, but Windows nor Ubuntu don't, at least not out-of-box), even after the respective channel/thread is viewed.

As MM-59405 suggests, notifications should be tracked until the respective channel/thread is viewed and then automatically dismissed.

Until that is implemented, this pull request effectively reverts 0227ac0fc19173b520aa74febcf53715c29d4393 and documents in the code the current plans for notifications.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
https://mattermost.atlassian.net/browse/MM-59405

Ticket is not claimed because this is not a final fix, just reverts UX regression.

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
* Fix notifications piling up endlessly until manually dismissed
```
