### PR TITLE
Remove the CPA query parameter for the user profile endpoint

### DIFF
--- a/api/v4/source/users.yaml
+++ b/api/v4/source/users.yaml
@@ -756,12 +756,6 @@
           required: true
           schema:
             type: string
-        - name: cpa
-          in: query
-          description: Includes the Custom Profile Attributes information if set to true.
-          required: false
-          schema:
-            type: boolean
       responses:
         "200":
           description: User retrieval successful


### PR DESCRIPTION
#### Summary
The CPA information was never added to the user profile endpoint, but a reference to it was included by mistake on the docs. This change removes that reference.

#### Release Note
```release-note
NONE
```