### PR TITLE
[MM-62568] Clicking on the channel header popover content throw js error

### DIFF
--- a/webapp/channels/src/components/channel_header/channel_header_text_popover.tsx
+++ b/webapp/channels/src/components/channel_header/channel_header_text_popover.tsx
@@ -19,7 +19,7 @@ import {
 } from '@floating-ui/react';
 import React, {useMemo, useRef, useState} from 'react';
 import type {MouseEvent} from 'react';
-import {useDispatch, useSelector} from 'react-redux';
+import {useSelector} from 'react-redux';
 
 import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 
@@ -56,8 +56,6 @@ interface Props {
     channelMentionsNameMap?: ChannelNamesMap;
 }
 export function ChannelHeaderTextPopover(props: Props) {
-    const dispatch = useDispatch();
-
     const currentRelativeTeamUrl = useSelector(getCurrentRelativeTeamUrl);
 
     const rootElementRef = useRef<HTMLDivElement>(null);
@@ -118,7 +116,7 @@ export function ChannelHeaderTextPopover(props: Props) {
     // This action processes clicks on formatted text elements like hashtags, user mentions,
     // channel mentions, etc. while also allowing other elements to function as is such as external links etc
     function handleClick(event: MouseEvent<HTMLDivElement>) {
-        dispatch(handleFormattedTextClick(event, currentRelativeTeamUrl));
+        handleFormattedTextClick(event, currentRelativeTeamUrl);
     }
 
     return (


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
`handleFormattedTextClick` isnt pure redux action but it an ~action~ function which uses the globally declared singleton store.

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-62568


#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
