### PR TITLE
Deleted file from post ID to file ID and file info part of store

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/use_submit.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_submit.tsx
@@ -8,6 +8,7 @@ import {useDispatch, useSelector} from 'react-redux';
 import type {ServerError} from '@mattermost/types/errors';
 import type {SchedulingInfo} from '@mattermost/types/schedule_post';
 
+import {FileTypes} from 'mattermost-redux/action_types';
 import {getChannelTimezones} from 'mattermost-redux/actions/channels';
 import {Permissions} from 'mattermost-redux/constants';
 import {getChannel, getAllChannelStats} from 'mattermost-redux/selectors/entities/channels';
@@ -174,6 +175,7 @@ const useSubmit = (
             let response;
             if (isInEditMode) {
                 response = await dispatch(editPost(submittingDraft));
+                handleFileChange(submittingDraft);
             } else {
                 response = await dispatch(onSubmit(submittingDraft, options, schedulingInfo));
             }
@@ -235,10 +237,18 @@ const useSubmit = (
         isInEditMode,
     ]);
 
+    const handleFileChange = useCallback((submittingDraft: PostDraft) => {
+        dispatch({
+            type: FileTypes.RECEIVED_FILES_FOR_POST,
+            data: submittingDraft.fileInfos,
+            postId,
+        });
+    }, [dispatch, postId]);
+
     const setUpdatedFileIds = useCallback((draft: PostDraft) => {
         // new object creation is needed here to support sending a draft with files.
         // In case of draft, the PostDraft object is fetched from the redux store, which is immutable.
-        // When user clicks 'Send Now' in drafts list, it will otherwise try to seta  field on an immutable object.
+        // When user clicks 'Send Now' in drafts list, it will otherwise try to set a field on an immutable object.
         // Hence, creating a new object here.
         return {
             ...draft,

--- a/webapp/channels/src/packages/mattermost-redux/src/action_types/files.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/action_types/files.ts
@@ -13,4 +13,6 @@ export default keyMirror({
     RECEIVED_FILES_FOR_POST: null,
     RECEIVED_UPLOAD_FILES: null,
     RECEIVED_FILE_PUBLIC_LINK: null,
+
+    REMOVED_FILE: null,
 });

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/files.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/files.ts
@@ -54,6 +54,18 @@ export function files(state: Record<string, FileInfo> = {}, action: MMReduxActio
         return state;
     }
 
+    case FileTypes.REMOVED_FILE: {
+        const nextState = {...state};
+        const {fileIds} = action.data;
+        if (fileIds) {
+            fileIds.forEach((id: string) => {
+                Reflect.deleteProperty(nextState, id);
+            });
+        }
+
+        return nextState;
+    }
+
     case ChannelBookmarkTypes.RECEIVED_BOOKMARKS: {
         const bookmarks: ChannelBookmark[] = action.data.bookmarks;
 

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/files.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/files.ts
@@ -21,7 +21,7 @@ function getAllFilesFromSearch(state: GlobalState) {
     return state.entities.files.filesFromSearch;
 }
 
-function getFilesIdsForPost(state: GlobalState, postId: string) {
+export function getFilesIdsForPost(state: GlobalState, postId: string) {
     if (postId) {
         return state.entities.files.fileIdsByPostId[postId] || [];
     }


### PR DESCRIPTION
#### Summary
When removing all/some files when editing, I'm making the following cleanup in store-
1. Set to to date file ID array in `store.entities.files.fileIdsByPostId[<post ID>]` , and
2. Removing the metadata of deleted files from `store.entities.files.files[<file ID]`

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-62464

#### Release Note
```release-note
none
```
