### PR TITLE
MM-62613 - remove scheduled messages on ws reconnect

### DIFF
--- a/webapp/channels/src/actions/websocket_actions.jsx
+++ b/webapp/channels/src/actions/websocket_actions.jsx
@@ -240,7 +240,7 @@ export function reconnect() {
         }
 
         dispatch(fetchAllMyTeamsChannels());
-        dispatch(fetchTeamScheduledPosts(currentTeamId, true));
+        dispatch(fetchTeamScheduledPosts(currentTeamId, true, true));
         dispatch(fetchAllMyChannelMembers());
         dispatch(fetchMyCategories(currentTeamId));
         loadProfilesForSidebar();

--- a/webapp/channels/src/components/drafts/drafts_link/drafts_link.tsx
+++ b/webapp/channels/src/components/drafts/drafts_link/drafts_link.tsx
@@ -46,11 +46,12 @@ const pencilIcon = (
 function DraftsLink() {
     const dispatch = useDispatch();
 
+    const initialScheduledPostsLoaded = useRef(false);
+
     const syncedDraftsAllowedAndEnabled = useSelector(syncedDraftsAreAllowedAndEnabled);
     const draftCount = useSelector(getDraftsCount);
     const teamId = useSelector(getCurrentTeamId);
     const teamScheduledPostCount = useSelector((state: GlobalState) => getScheduledPostsByTeamCount(state, teamId, true));
-    const initialScheduledPostsLoaded = useRef(teamId);
     const isScheduledPostEnabled = useSelector(isScheduledPostsEnabled);
 
     const hasDrafts = draftCount > 0;
@@ -72,13 +73,13 @@ function DraftsLink() {
     }, [teamId, syncedDraftsAllowedAndEnabled, dispatch]);
 
     useEffect(() => {
-        const loadDMsAndGMs = initialScheduledPostsLoaded.current !== teamId;
+        const loadDMsAndGMs = !initialScheduledPostsLoaded.current;
 
         if (isScheduledPostEnabled) {
             dispatch(fetchTeamScheduledPosts(teamId, loadDMsAndGMs));
         }
 
-        initialScheduledPostsLoaded.current = teamId;
+        initialScheduledPostsLoaded.current = true;
     }, [dispatch, isScheduledPostEnabled, teamId]);
 
     const showScheduledPostCount = isScheduledPostEnabled && teamScheduledPostCount > 0;

--- a/webapp/channels/src/components/drafts/drafts_link/drafts_link.tsx
+++ b/webapp/channels/src/components/drafts/drafts_link/drafts_link.tsx
@@ -46,12 +46,11 @@ const pencilIcon = (
 function DraftsLink() {
     const dispatch = useDispatch();
 
-    const initialScheduledPostsLoaded = useRef(false);
-
     const syncedDraftsAllowedAndEnabled = useSelector(syncedDraftsAreAllowedAndEnabled);
     const draftCount = useSelector(getDraftsCount);
     const teamId = useSelector(getCurrentTeamId);
     const teamScheduledPostCount = useSelector((state: GlobalState) => getScheduledPostsByTeamCount(state, teamId, true));
+    const initialScheduledPostsLoaded = useRef(teamId);
     const isScheduledPostEnabled = useSelector(isScheduledPostsEnabled);
 
     const hasDrafts = draftCount > 0;
@@ -73,13 +72,13 @@ function DraftsLink() {
     }, [teamId, syncedDraftsAllowedAndEnabled, dispatch]);
 
     useEffect(() => {
-        const loadDMsAndGMs = !initialScheduledPostsLoaded.current;
+        const loadDMsAndGMs = initialScheduledPostsLoaded.current !== teamId;
 
         if (isScheduledPostEnabled) {
             dispatch(fetchTeamScheduledPosts(teamId, loadDMsAndGMs));
         }
 
-        initialScheduledPostsLoaded.current = true;
+        initialScheduledPostsLoaded.current = teamId;
     }, [dispatch, isScheduledPostEnabled, teamId]);
 
     const showScheduledPostCount = isScheduledPostEnabled && teamScheduledPostCount > 0;

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/scheduled_posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/scheduled_posts.ts
@@ -31,7 +31,7 @@ export function createSchedulePost(schedulePost: ScheduledPost, teamId: string, 
     };
 }
 
-export function fetchTeamScheduledPosts(teamId: string, includeDirectChannels: boolean) {
+export function fetchTeamScheduledPosts(teamId: string, includeDirectChannels: boolean, prune?: false) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         let scheduledPosts;
 
@@ -41,6 +41,7 @@ export function fetchTeamScheduledPosts(teamId: string, includeDirectChannels: b
                 type: ScheduledPostTypes.SCHEDULED_POSTS_RECEIVED,
                 data: {
                     scheduledPostsByTeamId: scheduledPosts.data,
+                    prune,
                 },
             });
         } catch (error) {

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/scheduled_posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/scheduled_posts.ts
@@ -176,28 +176,21 @@ function byChannelOrThreadId(state: ScheduledPostsState['byChannelOrThreadId'] =
     switch (action.type) {
     case ScheduledPostTypes.SCHEDULED_POSTS_RECEIVED: {
         const {scheduledPostsByTeamId} = action.data;
-        const newState = {...state};
-        const newIdsByChannel: {[channelOrThreadId: string]: Set<string>} = {};
 
-        Object.values(scheduledPostsByTeamId).forEach((scheduledPosts) => {
-            (scheduledPosts as ScheduledPost[]).forEach((scheduledPost: ScheduledPost) => {
+        const newState: ScheduledPostsState['byChannelOrThreadId'] = {};
+
+        Object.values(scheduledPostsByTeamId).forEach((scheduledPostsForOneTeam) => {
+            (scheduledPostsForOneTeam as ScheduledPost[]).forEach((scheduledPost: ScheduledPost) => {
                 const channelOrThreadId = scheduledPost.root_id || scheduledPost.channel_id;
-                if (!newIdsByChannel[channelOrThreadId]) {
-                    newIdsByChannel[channelOrThreadId] = new Set();
+                if (!newState[channelOrThreadId]) {
+                    newState[channelOrThreadId] = [];
                 }
-                newIdsByChannel[channelOrThreadId].add(scheduledPost.id);
+                newState[channelOrThreadId].push(scheduledPost.id);
             });
-        });
-
-        Object.keys(newIdsByChannel).forEach((channelOrThreadId) => {
-            const existingIDs = new Set(newState[channelOrThreadId] || []);
-            newIdsByChannel[channelOrThreadId].forEach((id) => existingIDs.add(id));
-            newState[channelOrThreadId] = Array.from(existingIDs);
         });
 
         return newState;
     }
-
     case ScheduledPostTypes.SINGLE_SCHEDULED_POST_RECEIVED: {
         const scheduledPost = action.data.scheduledPost;
         const newState = {...state};

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/scheduled_posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/scheduled_posts.ts
@@ -178,8 +178,8 @@ function byChannelOrThreadId(state: ScheduledPostsState['byChannelOrThreadId'] =
         const {scheduledPostsByTeamId} = action.data;
         const newState = {...state};
         const newIdsByChannel: {[channelOrThreadId: string]: Set<string>} = {};
-    
-        Object.entries(scheduledPostsByTeamId).forEach(([teamId, scheduledPosts]) => {
+
+        Object.values(scheduledPostsByTeamId).forEach((scheduledPosts) => {
             (scheduledPosts as ScheduledPost[]).forEach((scheduledPost: ScheduledPost) => {
                 const channelOrThreadId = scheduledPost.root_id || scheduledPost.channel_id;
                 if (!newIdsByChannel[channelOrThreadId]) {
@@ -194,10 +194,10 @@ function byChannelOrThreadId(state: ScheduledPostsState['byChannelOrThreadId'] =
             newIdsByChannel[channelOrThreadId].forEach((id) => existingIDs.add(id));
             newState[channelOrThreadId] = Array.from(existingIDs);
         });
-    
+
         return newState;
     }
-        
+
     case ScheduledPostTypes.SINGLE_SCHEDULED_POST_RECEIVED: {
         const scheduledPost = action.data.scheduledPost;
         const newState = {...state};


### PR DESCRIPTION
#### Summary
fix logic for channel or thread id scheduled messages count. With this change, the reducer will remove old ids that are no longer returned by the server preventing the count indicator to show invalid data count. Basically now the reducer will prevent duplicate IDs and properly merge new data. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62613


#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
