### PR TITLE
[MM-62440] Fix flaky TestImportValidatePostImportData

### DIFF
--- a/server/channels/app/imports/import_validators_test.go
+++ b/server/channels/app/imports/import_validators_test.go
@@ -1039,18 +1039,20 @@ func TestImportValidatePostImportData(t *testing.T) {
 	})
 
 	t.Run("Test with valid all optional parameters", func(t *testing.T) {
-		t.Skip("MM-62440")
+		postCreateAt := model.GetMillis()
+		repliesCreateAt := postCreateAt + 1
+		reactionsCreateAt := postCreateAt + 2
 
 		reactions := []ReactionImportData{{
 			User:      model.NewPointer("username"),
 			EmojiName: model.NewPointer("emoji"),
-			CreateAt:  model.NewPointer(model.GetMillis()),
+			CreateAt:  model.NewPointer(reactionsCreateAt),
 		}}
 
 		replies := []ReplyImportData{{
 			User:     model.NewPointer("username"),
 			Message:  model.NewPointer("message"),
-			CreateAt: model.NewPointer(model.GetMillis()),
+			CreateAt: model.NewPointer(repliesCreateAt),
 		}}
 
 		data := PostImportData{
@@ -1058,7 +1060,7 @@ func TestImportValidatePostImportData(t *testing.T) {
 			Channel:   model.NewPointer("channelname"),
 			User:      model.NewPointer("username"),
 			Message:   model.NewPointer("message"),
-			CreateAt:  model.NewPointer(model.GetMillis()),
+			CreateAt:  model.NewPointer(postCreateAt),
 			Reactions: &reactions,
 			Replies:   &replies,
 		}


### PR DESCRIPTION
#### Summary

Our validation logic requires the creation timestamp of reactions to be consistent and be no earlier than their parent post.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-62440

#### Release Note

```release-note
NONE
```
