### PR TITLE
Add end to end tests to the "sendPasswordResetEmail" mmctl command

### DIFF
--- a/server/cmd/mmctl/commands/user_e2e_test.go
+++ b/server/cmd/mmctl/commands/user_e2e_test.go
@@ -1604,3 +1604,36 @@ func (s *MmctlE2ETestSuite) TestPreferenceDeleteCmd() {
 		s.Require().Error(err)
 	})
 }
+
+func (s *MmctlE2ETestSuite) TestSendPasswordResetEmailCmd() {
+	s.SetupTestHelper().InitBasic()
+	s.RunForAllClients("all users can send password reset email", func(c client.Client) {
+		printer.Clean()
+		emailArg1 := "demo1@example.com"
+		emailArg2 := "demo2@example.com"
+
+		err := sendPasswordResetEmailCmdF(c, &cobra.Command{}, []string{emailArg1, emailArg2})
+		s.Require().NoError(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.RunForAllClients("send valid and invalid email", func(c client.Client) {
+		printer.Clean()
+		emailArg1 := "demo@example.com"
+		emailArg2 := "invalid.Email@example.com"
+
+		var expected error
+		expected = multierror.Append(expected, fmt.Errorf("invalid email '%s'", emailArg2))
+
+		err := sendPasswordResetEmailCmdF(c, &cobra.Command{}, []string{emailArg1, emailArg2})
+		s.Require().EqualError(err, expected.Error())
+		s.Require().Len(printer.GetErrorLines(), 1)
+	})
+
+	s.RunForAllClients("no arguments passed", func(c client.Client) {
+		printer.Clean()
+		err := sendPasswordResetEmailCmdF(c, &cobra.Command{}, []string{})
+		s.Require().EqualError(err, "expected at least one argument. See help text for details")
+	})
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Add end to end tests to the "sendPasswordResetEmail" mmctl command

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/15488
Jira https://mattermost.atlassian.net/browse/MM-28673


#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
