### PR TITLE
MM-62489 Fix error bar showing with developer mode disabled

### DIFF
--- a/webapp/channels/src/components/do_verify_email/do_verify_email.tsx
+++ b/webapp/channels/src/components/do_verify_email/do_verify_email.tsx
@@ -6,7 +6,7 @@ import {useIntl} from 'react-intl';
 import {useSelector, useDispatch} from 'react-redux';
 import {useLocation, useHistory} from 'react-router-dom';
 
-import {clearErrors, logError} from 'mattermost-redux/actions/errors';
+import {clearErrors, logError, LogErrorBarMode} from 'mattermost-redux/actions/errors';
 import {verifyUserEmail, getMe} from 'mattermost-redux/actions/users';
 import {getIsOnboardingFlowEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
@@ -91,7 +91,7 @@ const DoVerifyEmail = () => {
         dispatch(logError({
             message: AnnouncementBarMessages.EMAIL_VERIFIED,
             type: AnnouncementBarTypes.SUCCESS,
-        } as any, true));
+        } as any, {errorBarMode: LogErrorBarMode.Always}));
 
         trackEvent('settings', 'verify_email');
 

--- a/webapp/channels/src/components/user_settings/general/user_settings_general.tsx
+++ b/webapp/channels/src/components/user_settings/general/user_settings_general.tsx
@@ -11,6 +11,8 @@ import type {UserPropertyField} from '@mattermost/types/properties';
 import type {UserProfile} from '@mattermost/types/users';
 import type {IDMappedObjects} from '@mattermost/types/utilities';
 
+import type {LogErrorOptions} from 'mattermost-redux/actions/errors';
+import {LogErrorBarMode} from 'mattermost-redux/actions/errors';
 import {Client4} from 'mattermost-redux/client';
 import type {ActionResult} from 'mattermost-redux/types/actions';
 import {isEmail} from 'mattermost-redux/utils/helpers';
@@ -111,7 +113,7 @@ export type Props = {
     maxFileSize: number;
     customProfileAttributeFields: IDMappedObjects<UserPropertyField>;
     actions: {
-        logError: ({message, type}: {message: any; type: string}, status: boolean) => void;
+        logError: ({message, type}: {message: any; type: string}, options?: LogErrorOptions) => void;
         clearErrors: () => void;
         updateMe: (user: UserProfile) => Promise<ActionResult>;
         sendVerificationEmail: (email: string) => Promise<ActionResult>;
@@ -324,7 +326,7 @@ export class UserSettingsGeneralTab extends PureComponent<Props, State> {
                         this.props.actions.logError({
                             message: AnnouncementBarMessages.EMAIL_VERIFICATION_REQUIRED,
                             type: AnnouncementBarTypes.SUCCESS,
-                        }, true);
+                        }, {errorBarMode: LogErrorBarMode.Always});
                     }
                 } else if (err) {
                     let serverError;

--- a/webapp/channels/src/entry.tsx
+++ b/webapp/channels/src/entry.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import {logError} from 'mattermost-redux/actions/errors';
+import {logError, LogErrorBarMode} from 'mattermost-redux/actions/errors';
 
 import store from 'stores/redux_store';
 
@@ -42,8 +42,7 @@ function preRenderSetup(onPreRenderSetupReady: () => void) {
                     stack: error?.stack,
                     url,
                 },
-                true,
-                true,
+                {errorBarMode: LogErrorBarMode.InDevMode},
             ),
         );
     };

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/errors.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/errors.test.ts
@@ -3,11 +3,11 @@
 
 import nock from 'nock';
 
-import {logError} from 'mattermost-redux/actions/errors';
+import {logError, LogErrorBarMode, shouldShowErrorBar} from 'mattermost-redux/actions/errors';
 import {Client4} from 'mattermost-redux/client';
 
 import TestHelper from '../../test/test_helper';
-import configureStore from '../../test/test_store';
+import configureStore, {makeInitialState} from '../../test/test_store';
 
 describe('Actions.Errors', () => {
     let store = configureStore();
@@ -59,4 +59,27 @@ describe('Actions.Errors', () => {
             throw new Error('should not add session expired errors to the reducer');
         }
     });
+});
+
+test('shouldShowErrorBar', () => {
+    function makeTestState(enableDevMode: boolean) {
+        return makeInitialState({
+            entities: {
+                general: {
+                    config: {
+                        EnableDeveloper: enableDevMode.toString(),
+                    },
+                },
+            },
+        });
+    }
+
+    expect(shouldShowErrorBar(makeTestState(false), {})).toBe(false);
+    expect(shouldShowErrorBar(makeTestState(true), {})).toBe(false);
+    expect(shouldShowErrorBar(makeTestState(false), {errorBarMode: LogErrorBarMode.Never})).toBe(false);
+    expect(shouldShowErrorBar(makeTestState(true), {errorBarMode: LogErrorBarMode.Never})).toBe(false);
+    expect(shouldShowErrorBar(makeTestState(false), {errorBarMode: LogErrorBarMode.Always})).toBe(true);
+    expect(shouldShowErrorBar(makeTestState(true), {errorBarMode: LogErrorBarMode.Always})).toBe(true);
+    expect(shouldShowErrorBar(makeTestState(false), {errorBarMode: LogErrorBarMode.InDevMode})).toBe(false);
+    expect(shouldShowErrorBar(makeTestState(true), {errorBarMode: LogErrorBarMode.InDevMode})).toBe(true);
 });

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/posts.ts
@@ -37,7 +37,7 @@ import {getCurrentUserId, getUsersByUsername} from 'mattermost-redux/selectors/e
 import type {ActionResult, DispatchFunc, GetStateFunc, ActionFunc, ActionFuncAsync, ThunkActionFunc} from 'mattermost-redux/types/actions';
 import {isCombinedUserActivityPost} from 'mattermost-redux/utils/post_list';
 
-import {logError} from './errors';
+import {logError, LogErrorBarMode} from './errors';
 
 // receivedPost should be dispatched after a single post from the server. This typically happens when an existing post
 // is updated.
@@ -1325,7 +1325,7 @@ export function restorePostVersion(postId: string, restoreVersionId: string, con
         } catch (error) {
             // Send to error bar if it's an edit post error about time limit.
             if (error.server_error_id === 'api.post.update_post.permissions_time_limit.app_error') {
-                dispatch(logError({type: 'announcement', message: error.message}, true));
+                dispatch(logError({type: 'announcement', message: error.message}, {errorBarMode: LogErrorBarMode.Always}));
             } else {
                 dispatch(logError(error));
             }

--- a/webapp/channels/src/packages/mattermost-redux/test/test_store.js
+++ b/webapp/channels/src/packages/mattermost-redux/test/test_store.js
@@ -3,6 +3,10 @@
 
 import configureStore from 'mattermost-redux/store';
 
+export function makeInitialState(preloadedState) {
+    return testConfigureStore(preloadedState).getState();
+}
+
 export default function testConfigureStore(preloadedState) {
     const store = configureStore({preloadedState, appReducers: {}, getAppReducers: () => {}});
 


### PR DESCRIPTION
#### Summary
The changes in `entry.tsx` in https://github.com/mattermost/mattermost-webapp/commit/0c431cd471c66c119608e8429aa55f863def64c5#diff-6bc7849f03060c613ebc8827104a4fabeedde73163f0b36515fdfc699b59aa4d accidentally made it so that `window.onerror` always dispatched `logError` with `displayable` set to true regardless of whether or not developer mode was enabled.

This fixes that and changes the parameters of `logError` to hopefully prevent similar things in the future.

#### Ticket Link
MM-62489

#### Release Note
```release-note
Fixed "An error has occurred" bar being shown with developer mode disabled
```
