### PR TITLE
[MM-62505] : Click to open thread doesn't work in an archived channel [Fixed]

### DIFF
--- a/webapp/channels/src/components/post/post_component.tsx
+++ b/webapp/channels/src/components/post/post_component.tsx
@@ -338,10 +338,10 @@ const PostComponent = (props: Props): JSX.Element => {
     const isEligibleForClick = useMemo(() => makeIsEligibleForClick('.post-image__column, .embed-responsive-item, .attachment, .hljs, code'), []);
 
     const handlePostClick = useCallback((e: MouseEvent<HTMLDivElement>) => {
-        if (!post || props.channelIsArchived) {
+        if (!post || (props.channelIsArchived && !props.clickToReply)) {
             return;
         }
-
+    
         if (
             !e.altKey &&
             props.clickToReply &&
@@ -349,7 +349,7 @@ const PostComponent = (props: Props): JSX.Element => {
             isEligibleForClick(e) &&
             props.location === Locations.CENTER &&
             !props.isPostBeingEdited
-        ) {
+        ) {   
             trackEvent('crt', 'clicked_to_reply');
             props.actions.selectPost(post);
         }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
This pull request addresses the issue where users were unable to use the "Click to open thread" functionality in an archived channel.

Solution: The click action on an archived post now checks whether the "Click to open thread" option is enabled. If the option is active, the functionality is allowed, even for posts in archived channels.
-->

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/29854
Jira https://mattermost.atlassian.net/browse/MM-62505
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
