### PR TITLE
[MM-62515] Fix: Compliance exports fail when missing s3 file attachment

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -7819,10 +7819,6 @@
     "translation": "Failed to get file info for a post."
   },
   {
-    "id": "ent.message_export.global_relay.attach_file.app_error",
-    "translation": "Unable to add attachment to the Global Relay export."
-  },
-  {
     "id": "ent.message_export.global_relay.close_zip_file.app_error",
     "translation": "Unable to close the zip file."
   },


### PR DESCRIPTION
#### Summary
- Remove unneeded i18n string, for https://github.com/mattermost/enterprise/pull/1825

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-62515


#### Release Note

```release-note
NONE
```
