### PR TITLE
Prepackage Calls v0.29.7

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -144,7 +144,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v0.29.6
+PLUGIN_PACKAGES += mattermost-plugin-calls-v0.29.7
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.3.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.9.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.1.1


### PR DESCRIPTION
#### Summary

Prepackage [Calls v0.29.7](https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.29.7) dot release to ship with v9.11 latest dot release.

#### Ticket Link

```release-note
Prepackage Calls v0.29.7
```
