### PR TITLE
[MM-60687] Log DoActionRequest requests to INFO

### DIFF
--- a/server/channels/app/app_iface.go
+++ b/server/channels/app/app_iface.go
@@ -135,6 +135,10 @@ type AppIface interface {
 	// DisablePlugin will set the config for an installed plugin to disabled, triggering deactivation if active.
 	// Notifies cluster peers through config change.
 	DisablePlugin(id string) *model.AppError
+	// DoActionRequest performs an HTTP POST request to an integration's action endpoint.
+	// Caller must consume and close returned http.Response as necessary.
+	// For internal requests, requests are routed directly to a plugin ServerHTTP hook
+	DoActionRequest(c request.CTX, rawURL string, body []byte) (*http.Response, *model.AppError)
 	// DoPermissionsMigrations execute all the permissions migrations need by the current version.
 	DoPermissionsMigrations() error
 	// EnablePlugin will set the config for an installed plugin to enabled, triggering asynchronous
@@ -290,10 +294,6 @@ type AppIface interface {
 	PatchBot(rctx request.CTX, botUserId string, botPatch *model.BotPatch) (*model.Bot, *model.AppError)
 	// PatchChannelModerationsForChannel Updates a channels scheme roles based on a given ChannelModerationPatch, if the permissions match the higher scoped role the scheme is deleted.
 	PatchChannelModerationsForChannel(c request.CTX, channel *model.Channel, channelModerationsPatch []*model.ChannelModerationPatch) ([]*model.ChannelModeration, *model.AppError)
-	// Perform an HTTP POST request to an integration's action endpoint.
-	// Caller must consume and close returned http.Response as necessary.
-	// For internal requests, requests are routed directly to a plugin ServerHTTP hook
-	DoActionRequest(c request.CTX, rawURL string, body []byte) (*http.Response, *model.AppError)
 	// PermanentDeleteBot permanently deletes a bot and its corresponding user.
 	PermanentDeleteBot(rctx request.CTX, botUserId string) *model.AppError
 	// PopulateWebConnConfig checks if the connection id already exists in the hub,

--- a/server/channels/app/integration_action.go
+++ b/server/channels/app/integration_action.go
@@ -234,6 +234,15 @@ func (a *App) DoPostActionWithCookie(c request.CTX, postID, actionId, userID, se
 		return "", model.NewAppError("DoPostActionWithCookie", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
+	// Log request, regardless of whether destination is internal or external
+	c.Logger().Info("DoPostActionWithCookie POST request, through DoActionRequest",
+		mlog.String("url", upstreamURL),
+		mlog.String("user_id", upstreamRequest.UserId),
+		mlog.String("post_id", upstreamRequest.PostId),
+		mlog.String("channel_id", upstreamRequest.ChannelId),
+		mlog.String("team_id", upstreamRequest.TeamId),
+	)
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*a.Config().ServiceSettings.OutgoingIntegrationRequestsTimeout)*time.Second)
 	defer cancel()
 	resp, appErr := a.DoActionRequest(c.WithContext(ctx), upstreamURL, requestJSON)
@@ -297,7 +306,7 @@ func (a *App) DoPostActionWithCookie(c request.CTX, postID, actionId, userID, se
 	return clientTriggerId, nil
 }
 
-// Perform an HTTP POST request to an integration's action endpoint.
+// DoActionRequest performs an HTTP POST request to an integration's action endpoint.
 // Caller must consume and close returned http.Response as necessary.
 // For internal requests, requests are routed directly to a plugin ServerHTTP hook
 func (a *App) DoActionRequest(c request.CTX, rawURL string, body []byte) (*http.Response, *model.AppError) {
@@ -488,6 +497,14 @@ func (a *App) SubmitInteractiveDialog(c request.CTX, request model.SubmitDialogR
 	if err != nil {
 		return nil, model.NewAppError("SubmitInteractiveDialog", "app.submit_interactive_dialog.json_error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
+
+	// Log request, regardless of whether destination is internal or external
+	c.Logger().Info("SubmitInteractiveDialog POST request, through DoActionRequest",
+		mlog.String("url", url),
+		mlog.String("user_id", request.UserId),
+		mlog.String("channel_id", request.ChannelId),
+		mlog.String("team_id", request.TeamId),
+	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*a.Config().ServiceSettings.OutgoingIntegrationRequestsTimeout)*time.Second)
 	defer cancel()


### PR DESCRIPTION
#### Summary
- We were lacking any sort of logging in the `POST` request made by `DoActionRequest`
- I chose to log in the two methods that call `DoActionRequest` so that we can log the `userId` and other available information.
- I chose `INFO` level, but open to any suggestions.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-60687

#### Release Note

```release-note
Added INFO level logging for DoActionRequest POST requests.
```
