### PR TITLE
[MM-62179] Fix: mmctl debug error when setting email

### DIFF
--- a/server/cmd/mmctl/commands/bot_test.go
+++ b/server/cmd/mmctl/commands/bot_test.go
@@ -58,12 +58,6 @@ func (s *MmctlUnitTestSuite) TestBotCreateCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), botArg, "").
-			Return(nil, &model.Response{}, errors.New("no user found with the given email")).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), botArg, "").
 			Return(model.UserFromBot(&mockBot), &model.Response{}, nil).
 			Times(1)
@@ -118,12 +112,6 @@ func (s *MmctlUnitTestSuite) TestBotUpdateCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), botArg, "").
-			Return(nil, &model.Response{}, errors.New("mock error")).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), botArg, "").
 			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
@@ -147,12 +135,6 @@ func (s *MmctlUnitTestSuite) TestBotUpdateCmd() {
 		cmd := &cobra.Command{}
 		cmd.Flags().String("username", "bot-username", "")
 		cmd.Flags().Lookup("username").Changed = true
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), botArg, "").
-			Return(nil, &model.Response{}, errors.New("mock error")).
-			Times(1)
 
 		s.client.
 			EXPECT().
@@ -182,12 +164,6 @@ func (s *MmctlUnitTestSuite) TestBotUpdateCmd() {
 		cmd.Flags().Lookup("display-name").Changed = true
 		cmd.Flags().Lookup("description").Changed = true
 		mockUser := model.User{Id: model.NewId()}
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), botArg, "").
-			Return(nil, &model.Response{}, errors.New("mock error")).
-			Times(1)
 
 		s.client.
 			EXPECT().
@@ -419,12 +395,6 @@ func (s *MmctlUnitTestSuite) TestBotDisableCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), botArg, "").
-			Return(nil, &model.Response{}, errors.New("mock error")).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), botArg, "").
 			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
@@ -445,12 +415,6 @@ func (s *MmctlUnitTestSuite) TestBotDisableCmd() {
 		printer.Clean()
 
 		botArg := "a-bot"
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), botArg, "").
-			Return(nil, &model.Response{}, errors.New("mock error")).
-			Times(1)
 
 		s.client.
 			EXPECT().
@@ -483,12 +447,6 @@ func (s *MmctlUnitTestSuite) TestBotDisableCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), botArg, "").
-			Return(nil, &model.Response{}, errors.New("mock error")).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), botArg, "").
 			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
@@ -517,12 +475,6 @@ func (s *MmctlUnitTestSuite) TestBotEnableCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), botArg, "").
-			Return(nil, &model.Response{}, errors.New("mock error")).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), botArg, "").
 			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
@@ -543,12 +495,6 @@ func (s *MmctlUnitTestSuite) TestBotEnableCmd() {
 		printer.Clean()
 
 		botArg := "a-bot"
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), botArg, "").
-			Return(nil, &model.Response{}, errors.New("mock error")).
-			Times(1)
 
 		s.client.
 			EXPECT().
@@ -578,12 +524,6 @@ func (s *MmctlUnitTestSuite) TestBotEnableCmd() {
 		cmd.Flags().Lookup("display-name").Changed = true
 		cmd.Flags().Lookup("description").Changed = true
 		mockUser := model.User{Id: model.NewId()}
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), botArg, "").
-			Return(nil, &model.Response{}, errors.New("mock error")).
-			Times(1)
 
 		s.client.
 			EXPECT().
@@ -617,20 +557,8 @@ func (s *MmctlUnitTestSuite) TestBotAssignCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), botArg, "").
-			Return(nil, &model.Response{}, errors.New("mock error")).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), botArg, "").
 			Return(&mockBotUser, &model.Response{}, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), userArg, "").
-			Return(nil, &model.Response{}, errors.New("mock error")).
 			Times(1)
 
 		s.client.
@@ -669,12 +597,6 @@ func (s *MmctlUnitTestSuite) TestBotAssignCmd() {
 			Return(nil, &model.Response{}, errors.New("mock error")).
 			Times(1)
 
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), botArg, "").
-			Return(nil, &model.Response{}, errors.New("mock error")).
-			Times(1)
-
 		err := botAssignCmdF(s.client, &cobra.Command{}, []string{botArg, userArg})
 		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
@@ -691,12 +613,6 @@ func (s *MmctlUnitTestSuite) TestBotAssignCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), botArg, "").
-			Return(nil, &model.Response{}, errors.New("mock error")).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), botArg, "").
 			Return(&mockBotUser, &model.Response{}, nil).
 			Times(1)
@@ -710,12 +626,6 @@ func (s *MmctlUnitTestSuite) TestBotAssignCmd() {
 		s.client.
 			EXPECT().
 			GetUser(context.TODO(), userArg, "").
-			Return(nil, &model.Response{}, errors.New("mock error")).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), userArg, "").
 			Return(nil, &model.Response{}, errors.New("mock error")).
 			Times(1)
 
@@ -736,20 +646,8 @@ func (s *MmctlUnitTestSuite) TestBotAssignCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), botArg, "").
-			Return(nil, &model.Response{}, errors.New("mock error")).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), botArg, "").
 			Return(&mockBotUser, &model.Response{}, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), userArg, "").
-			Return(nil, &model.Response{}, errors.New("mock error")).
 			Times(1)
 
 		s.client.

--- a/server/cmd/mmctl/commands/channel_users_test.go
+++ b/server/cmd/mmctl/commands/channel_users_test.go
@@ -57,13 +57,13 @@ func (s *MmctlUnitTestSuite) TestChannelUsersAddCmdF() {
 			EXPECT().
 			GetUserByEmail(context.TODO(), userEmail, "").
 			Return(&mockUser, &model.Response{}, nil).
-			Times(1)
+			Times(3)
 
 		s.client.
 			EXPECT().
 			AddChannelMember(context.TODO(), channelID, userID).
 			Return(&model.ChannelMember{}, &model.Response{}, nil).
-			Times(1)
+			Times(2)
 		err := channelUsersAddCmdF(s.client, cmd, []string{channelArg, userEmail})
 		s.Require().Nil(err)
 		s.Len(printer.GetLines(), 0)
@@ -135,11 +135,6 @@ func (s *MmctlUnitTestSuite) TestChannelUsersAddCmdF() {
 			Times(1)
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), nilUserArg, "").
-			Return(nil, &model.Response{}, nil).
-			Times(1)
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), nilUserArg, "").
 			Return(nil, &model.Response{}, nil).
 			Times(1)
@@ -147,16 +142,6 @@ func (s *MmctlUnitTestSuite) TestChannelUsersAddCmdF() {
 			EXPECT().
 			GetUser(context.TODO(), nilUserArg, "").
 			Return(nil, &model.Response{}, nil).
-			Times(1)
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), userEmail, "").
-			Return(&mockUser, &model.Response{}, nil).
-			Times(1)
-		s.client.
-			EXPECT().
-			AddChannelMember(context.TODO(), channelID, userID).
-			Return(&model.ChannelMember{}, &model.Response{}, nil).
 			Times(1)
 		err := channelUsersAddCmdF(s.client, cmd, []string{channelArg, nilUserArg, userEmail})
 		s.Require().ErrorContains(err, "unable to find user")
@@ -178,11 +163,6 @@ func (s *MmctlUnitTestSuite) TestChannelUsersAddCmdF() {
 			EXPECT().
 			GetChannelByNameIncludeDeleted(context.TODO(), channelName, teamID, "").
 			Return(&mockChannel, &model.Response{}, nil).
-			Times(1)
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), userEmail, "").
-			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
 
 		s.client.
@@ -295,6 +275,12 @@ func (s *MmctlUnitTestSuite) TestChannelUsersRemoveCmd() {
 
 		s.client.
 			EXPECT().
+			GetUserByEmail(context.TODO(), userEmail, "").
+			Return(&mockUser, &model.Response{}, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
 			GetChannelByNameIncludeDeleted(context.TODO(), channelName, foundTeam.Id, "").
 			Return(foundChannel, &model.Response{}, nil).
 			Times(1)
@@ -367,7 +353,7 @@ func (s *MmctlUnitTestSuite) TestChannelUsersRemoveCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), mockUser2.Email, "").
+			GetUserByUsername(context.TODO(), mockUser2.Email, "").
 			Return(&mockUser2, &model.Response{}, nil).
 			Times(1)
 
@@ -468,12 +454,6 @@ func (s *MmctlUnitTestSuite) TestChannelUsersRemoveCmd() {
 			EXPECT().
 			GetChannelByNameIncludeDeleted(context.TODO(), channelName, foundTeam.Id, "").
 			Return(foundChannel, &model.Response{}, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), userEmail, "").
-			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
 
 		s.client.

--- a/server/cmd/mmctl/commands/command_test.go
+++ b/server/cmd/mmctl/commands/command_test.go
@@ -66,7 +66,7 @@ func (s *MmctlUnitTestSuite) TestCommandCreateCmd() {
 		cmd.Flags().String("autocompleteDesc", autocompleteDesc, "")
 		cmd.Flags().String("autocompleteHint", autocompleteHint, "")
 
-		// createCommandCmdF will call getTeamFromTeamArg,  getUserFromUserArg which then calls GetUserByEmail
+		// createCommandCmdF will call getTeamFromTeamArg,  getUserFromUserArg which then calls GetUserByUsername
 		s.client.
 			EXPECT().
 			GetTeam(context.TODO(), teamArg, "").
@@ -74,7 +74,7 @@ func (s *MmctlUnitTestSuite) TestCommandCreateCmd() {
 			Times(1)
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), creatorIDArg, "").
+			GetUserByUsername(context.TODO(), creatorIDArg, "").
 			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
 		s.client.
@@ -122,7 +122,7 @@ func (s *MmctlUnitTestSuite) TestCommandCreateCmd() {
 			Times(1)
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), creatorIDArg, "").
+			GetUserByUsername(context.TODO(), creatorIDArg, "").
 			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
 		s.client.
@@ -202,7 +202,7 @@ func (s *MmctlUnitTestSuite) TestCommandCreateCmd() {
 			Times(1)
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), creatorIDArg, "").
+			GetUserByUsername(context.TODO(), creatorIDArg, "").
 			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
 
@@ -253,7 +253,7 @@ func (s *MmctlUnitTestSuite) TestCommandCreateCmd() {
 			Times(1)
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), creatorIDArg, "").
+			GetUserByUsername(context.TODO(), creatorIDArg, "").
 			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
 
@@ -318,7 +318,7 @@ func (s *MmctlUnitTestSuite) TestCommandCreateCmd() {
 			Times(1)
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), creatorIDArg, "").
+			GetUserByUsername(context.TODO(), creatorIDArg, "").
 			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
 		mockError := errors.New("mock error, simulated error for CreateCommand")
@@ -540,7 +540,7 @@ func (s *MmctlUnitTestSuite) TestCommandModifyCmd() {
 			"--post=" + strconv.FormatBool(method2Bool(mockCommandModified.Method)),
 		}
 
-		// modifyCommandCmdF will call getCommandById, GetUserByEmail and UpdateCommand
+		// modifyCommandCmdF will call getCommandById, GetUserByUsername and UpdateCommand
 		s.client.
 			EXPECT().
 			GetCommandById(context.TODO(), arg).
@@ -548,7 +548,7 @@ func (s *MmctlUnitTestSuite) TestCommandModifyCmd() {
 			Times(1)
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), mockCommandModified.CreatorId, "").
+			GetUserByUsername(context.TODO(), mockCommandModified.CreatorId, "").
 			Return(&model.User{Id: mockCommandModified.CreatorId}, &model.Response{}, nil).
 			Times(1)
 		s.client.
@@ -619,11 +619,6 @@ func (s *MmctlUnitTestSuite) TestCommandModifyCmd() {
 			EXPECT().
 			GetCommandById(context.TODO(), arg).
 			Return(&mockCommand, &model.Response{}, nil).
-			Times(1)
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), bogusUsername, "").
-			Return(nil, &model.Response{}, nil).
 			Times(1)
 		s.client.
 			EXPECT().

--- a/server/cmd/mmctl/commands/permission_role_test.go
+++ b/server/cmd/mmctl/commands/permission_role_test.go
@@ -40,12 +40,6 @@ func (s *MmctlUnitTestSuite) TestAssignUsersCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), mockUser.Username, "").
-			Return(nil, &model.Response{}, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), mockUser.Username, "").
 			Return(mockUser, &model.Response{}, nil).
 			Times(1)
@@ -93,12 +87,6 @@ func (s *MmctlUnitTestSuite) TestAssignUsersCmd() {
 		for _, user := range []*model.User{mockUser1, mockUser2} {
 			s.client.
 				EXPECT().
-				GetUserByEmail(context.TODO(), user.Username, "").
-				Return(nil, &model.Response{}, nil).
-				Times(1)
-
-			s.client.
-				EXPECT().
 				GetUserByUsername(context.TODO(), user.Username, "").
 				Return(user, &model.Response{}, nil).
 				Times(1)
@@ -109,12 +97,6 @@ func (s *MmctlUnitTestSuite) TestAssignUsersCmd() {
 				Return(&model.Response{StatusCode: http.StatusOK}, nil).
 				Times(1)
 		}
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), notFoundUser.Username, "").
-			Return(nil, &model.Response{}, nil).
-			Times(1)
 
 		s.client.
 			EXPECT().
@@ -173,12 +155,6 @@ func (s *MmctlUnitTestSuite) TestAssignUsersCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), mockUser.Username, "").
-			Return(nil, &model.Response{}, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), mockUser.Username, "").
 			Return(mockUser, &model.Response{}, nil).
 			Times(1)
@@ -201,12 +177,6 @@ func (s *MmctlUnitTestSuite) TestAssignUsersCmd() {
 			EXPECT().
 			GetRoleByName(context.TODO(), mockRole.Name).
 			Return(mockRole, &model.Response{}, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), requestedUser, "").
-			Return(nil, &model.Response{}, nil).
 			Times(1)
 
 		s.client.
@@ -240,12 +210,6 @@ func (s *MmctlUnitTestSuite) TestUnassignUsersCmd() {
 			Username: "user1",
 			Roles:    fmt.Sprintf("system_user %s team_admin", roleName),
 		}
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), mockUser.Username, "").
-			Return(nil, &model.Response{}, nil).
-			Times(1)
 
 		s.client.
 			EXPECT().
@@ -286,12 +250,6 @@ func (s *MmctlUnitTestSuite) TestUnassignUsersCmd() {
 		for _, user := range []*model.User{mockUser1, mockUser2} {
 			s.client.
 				EXPECT().
-				GetUserByEmail(context.TODO(), user.Username, "").
-				Return(nil, &model.Response{}, nil).
-				Times(1)
-
-			s.client.
-				EXPECT().
 				GetUserByUsername(context.TODO(), user.Username, "").
 				Return(user, &model.Response{}, nil).
 				Times(1)
@@ -302,12 +260,6 @@ func (s *MmctlUnitTestSuite) TestUnassignUsersCmd() {
 				Return(&model.Response{StatusCode: http.StatusOK}, nil).
 				Times(1)
 		}
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), notFoundUser.Username, "").
-			Return(nil, &model.Response{}, nil).
-			Times(1)
 
 		s.client.
 			EXPECT().
@@ -337,12 +289,6 @@ func (s *MmctlUnitTestSuite) TestUnassignUsersCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), mockUser.Username, "").
-			Return(nil, &model.Response{}, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), mockUser.Username, "").
 			Return(mockUser, &model.Response{}, nil).
 			Times(1)
@@ -354,12 +300,6 @@ func (s *MmctlUnitTestSuite) TestUnassignUsersCmd() {
 
 	s.Run("Unassigning a user that is not found", func() {
 		requestedUser := "user99"
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), requestedUser, "").
-			Return(nil, &model.Response{}, nil).
-			Times(1)
 
 		s.client.
 			EXPECT().

--- a/server/cmd/mmctl/commands/team_users_test.go
+++ b/server/cmd/mmctl/commands/team_users_test.go
@@ -50,12 +50,6 @@ func (s *MmctlUnitTestSuite) TestTeamUsersArchiveCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), mockUser.Id, "").
-			Return(nil, nil, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), mockUser.Id, "").
 			Return(nil, nil, nil).
 			Times(1)
@@ -92,7 +86,7 @@ func (s *MmctlUnitTestSuite) TestTeamUsersArchiveCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), mockUser.Id, "").
+			GetUserByUsername(context.TODO(), mockUser.Id, "").
 			Return(mockUser, nil, nil).
 			Times(1)
 
@@ -121,7 +115,7 @@ func (s *MmctlUnitTestSuite) TestTeamUsersArchiveCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), mockUser.Id, "").
+			GetUserByUsername(context.TODO(), mockUser.Id, "").
 			Return(mockUser, nil, nil).
 			Times(1)
 
@@ -150,12 +144,6 @@ func (s *MmctlUnitTestSuite) TestTeamUsersArchiveCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), mockUser.Id, "").
-			Return(nil, nil, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), mockUser.Id, "").
 			Return(mockUser, nil, nil).
 			Times(1)
@@ -180,12 +168,6 @@ func (s *MmctlUnitTestSuite) TestTeamUsersArchiveCmd() {
 			EXPECT().
 			GetTeam(context.TODO(), teamArg, "").
 			Return(mockTeam, &model.Response{}, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), mockUser.Id, "").
-			Return(nil, nil, nil).
 			Times(1)
 
 		s.client.
@@ -226,7 +208,7 @@ func (s *MmctlUnitTestSuite) TestTeamUsersArchiveCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), mockUser.Id, "").
+			GetUserByUsername(context.TODO(), mockUser.Id, "").
 			Return(mockUser, nil, nil).
 			Times(1)
 
@@ -288,12 +270,6 @@ func (s *MmctlUnitTestSuite) TestAddUsersCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), "user1", "").
-			Return(nil, &model.Response{}, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), "user1", "").
 			Return(nil, &model.Response{}, nil).
 			Times(1)
@@ -322,7 +298,7 @@ func (s *MmctlUnitTestSuite) TestAddUsersCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), "user1", "").
+			GetUserByUsername(context.TODO(), "user1", "").
 			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
 
@@ -353,7 +329,7 @@ func (s *MmctlUnitTestSuite) TestAddUsersCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), "user1", "").
+			GetUserByUsername(context.TODO(), "user1", "").
 			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
 

--- a/server/cmd/mmctl/commands/token_test.go
+++ b/server/cmd/mmctl/commands/token_test.go
@@ -26,12 +26,6 @@ func (s *MmctlUnitTestSuite) TestGenerateTokenForAUserCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), userArg, "").
-			Return(nil, &model.Response{}, errors.New("no user found with the given email")).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), userArg, "").
 			Return(nil, &model.Response{}, errors.New("no user found with the given username")).
 			Times(1)
@@ -60,12 +54,6 @@ func (s *MmctlUnitTestSuite) TestGenerateTokenForAUserCmd() {
 		userArg := "some-text"
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), userArg, "").
-			Return(nil, &model.Response{}, errors.New("no user found with the given email")).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), userArg, "").
 			Return(nil, &model.Response{}, errors.New("no user found with the given username")).
 			Times(1)
@@ -86,12 +74,6 @@ func (s *MmctlUnitTestSuite) TestGenerateTokenForAUserCmd() {
 
 		userArg := "user1"
 		mockUser := model.User{Id: "userId1", Email: "user1@example.com", Username: "user1"}
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), userArg, "").
-			Return(nil, &model.Response{}, errors.New("no user found with the given email")).
-			Times(1)
 
 		s.client.
 			EXPECT().
@@ -125,12 +107,6 @@ func (s *MmctlUnitTestSuite) TestListTokensOfAUserCmdF() {
 		mockUser := model.User{Id: "userId1", Email: "user1@example.com", Username: "user1"}
 		mockToken1 := model.UserAccessToken{IsActive: true, Id: "token-1-id", Description: "token-1-desc"}
 		mockToken2 := model.UserAccessToken{IsActive: false, Id: "token-2-id", Description: "token-2-desc"}
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), mockUser.Id, "").
-			Return(nil, &model.Response{}, errors.New("no user found with the given email")).
-			Times(1)
 
 		s.client.
 			EXPECT().
@@ -203,12 +179,6 @@ func (s *MmctlUnitTestSuite) TestListTokensOfAUserCmdF() {
 		command.Flags().Bool("all", false, "")
 		command.Flags().Bool("active", false, "")
 		command.Flags().Bool("inactive", false, "")
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), userArg, "").
-			Return(nil, &model.Response{}, errors.New("no user found with the given email")).
-			Times(1)
 
 		s.client.
 			EXPECT().

--- a/server/cmd/mmctl/commands/user_test.go
+++ b/server/cmd/mmctl/commands/user_test.go
@@ -2844,7 +2844,7 @@ func (s *MmctlUnitTestSuite) TestPromoteGuestToUserCmd() {
 	})
 }
 
-func (s *MmctlUnitTestSuite) eTestDemoteUserToGuestCmd() {
+func (s *MmctlUnitTestSuite) TestDemoteUserToGuestCmd() {
 	s.Run("demote a user to a guest", func() {
 		printer.Clean()
 		emailArg := "example@example.com"

--- a/server/cmd/mmctl/commands/user_test.go
+++ b/server/cmd/mmctl/commands/user_test.go
@@ -113,12 +113,6 @@ func (s *MmctlUnitTestSuite) TestUserActivateCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), emailArgs[1], "").
-			Return(nil, &model.Response{StatusCode: http.StatusNotFound}, errors.New("mock error")).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), emailArgs[1], "").
 			Return(nil, &model.Response{StatusCode: http.StatusNotFound}, errors.New("mock error")).
 			Times(1)
@@ -325,12 +319,6 @@ func (s *MmctlUnitTestSuite) TestDeactivateUserCmd() {
 			EXPECT().
 			GetUserByEmail(context.TODO(), emailArgs[0], "").
 			Return(&mockUser0, &model.Response{}, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), emailArgs[1], "").
-			Return(nil, &model.Response{StatusCode: http.StatusNotFound}, errors.New("mock error")).
 			Times(1)
 
 		s.client.
@@ -682,12 +670,6 @@ func (s *MmctlUnitTestSuite) TestSearchUserCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), usernameArg, "").
-			Return(nil, &model.Response{}, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), usernameArg, "").
 			Return(nil, &model.Response{}, errors.New("Error while getting user by username")).
 			Times(1)
@@ -702,12 +684,6 @@ func (s *MmctlUnitTestSuite) TestSearchUserCmd() {
 	s.Run("Error while getting user", func() {
 		printer.Clean()
 		userArg := "exampleUser"
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), userArg, "").
-			Return(nil, &model.Response{}, nil).
-			Times(1)
 
 		s.client.
 			EXPECT().
@@ -1551,12 +1527,6 @@ func (s *MmctlUnitTestSuite) TestUpdateUserEmailCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), userArg, "").
-			Return(nil, &model.Response{StatusCode: http.StatusNotFound}, errors.New("no user found with the given email")).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), userArg, "").
 			Return(nil, &model.Response{StatusCode: http.StatusNotFound}, errors.New("no user found with the given username")).
 			Times(1)
@@ -1580,12 +1550,6 @@ func (s *MmctlUnitTestSuite) TestUpdateUserEmailCmd() {
 		emailArg := "example@example.com"
 
 		currentUser := model.User{Username: "testUser", Password: "password", Email: "email"}
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), userArg, "").
-			Return(nil, &model.Response{StatusCode: http.StatusNotFound}, errors.New("no user found with the given email")).
-			Times(1)
 
 		s.client.
 			EXPECT().
@@ -1613,12 +1577,6 @@ func (s *MmctlUnitTestSuite) TestUpdateUserEmailCmd() {
 
 		currentUser := model.User{Username: "testUser", Password: "password", Email: "email"}
 		updatedUser := model.User{Username: "testUser", Password: "password", Email: emailArg}
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), userArg, "").
-			Return(nil, &model.Response{StatusCode: http.StatusNotFound}, errors.New("no user found with the given email")).
-			Times(1)
 
 		s.client.
 			EXPECT().
@@ -1680,12 +1638,6 @@ func (s *MmctlUnitTestSuite) TestUpdateUserEmailCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), userArg, "").
-			Return(nil, &model.Response{StatusCode: http.StatusNotFound}, errors.New("no user found with the given email")).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), userArg, "").
 			Return(nil, &model.Response{StatusCode: http.StatusNotFound}, errors.New("no user found with the given username")).
 			Times(1)
@@ -1716,7 +1668,7 @@ func (s *MmctlUnitTestSuite) TestResetUserMfaCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), "userId", "").
+			GetUserByUsername(context.TODO(), "userId", "").
 			Return(&model.User{Id: "userId"}, nil, nil).
 			Times(1)
 
@@ -1734,12 +1686,6 @@ func (s *MmctlUnitTestSuite) TestResetUserMfaCmd() {
 
 	s.Run("Cannot find one user", func() {
 		printer.Clean()
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), "userId", "").
-			Return(nil, nil, nil).
-			Times(1)
 
 		s.client.
 			EXPECT().
@@ -1774,7 +1720,7 @@ func (s *MmctlUnitTestSuite) TestResetUserMfaCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), "userId", "").
+			GetUserByUsername(context.TODO(), "userId", "").
 			Return(&model.User{Id: "userId"}, nil, nil).
 			Times(1)
 
@@ -1805,12 +1751,6 @@ func (s *MmctlUnitTestSuite) TestResetUserMfaCmd() {
 			if user == "notfounduser" {
 				s.client.
 					EXPECT().
-					GetUserByEmail(context.TODO(), user, "").
-					Return(nil, nil, nil).
-					Times(1)
-
-				s.client.
-					EXPECT().
 					GetUserByUsername(context.TODO(), user, "").
 					Return(nil, nil, nil).
 					Times(1)
@@ -1823,7 +1763,7 @@ func (s *MmctlUnitTestSuite) TestResetUserMfaCmd() {
 			} else {
 				s.client.
 					EXPECT().
-					GetUserByEmail(context.TODO(), user, "").
+					GetUserByUsername(context.TODO(), user, "").
 					Return(&model.User{Id: user}, nil, nil).
 					Times(1)
 			}
@@ -2232,12 +2172,6 @@ func (s *MmctlUnitTestSuite) TestUserDeactivateCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), usernameArg, "").
-			Return(nil, &model.Response{}, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), usernameArg, "").
 			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
@@ -2257,12 +2191,6 @@ func (s *MmctlUnitTestSuite) TestUserDeactivateCmd() {
 	s.Run("Deactivate an existing user by id", func() {
 		printer.Clean()
 		mockUser := model.User{Id: "userId1", Username: "ExampleUser", Email: "example@exam.com"}
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), mockUser.Id, "").
-			Return(nil, &model.Response{}, nil).
-			Times(1)
 
 		s.client.
 			EXPECT().
@@ -2384,12 +2312,6 @@ func (s *MmctlUnitTestSuite) TestUserDeactivateCmd() {
 		// mockUser1
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), argsDelete[0], "").
-			Return(nil, &model.Response{}, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), argsDelete[0], "").
 			Return(nil, &model.Response{}, nil).
 			Times(1)
@@ -2408,11 +2330,6 @@ func (s *MmctlUnitTestSuite) TestUserDeactivateCmd() {
 			Times(1)
 
 		// mockUser3
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), argsDelete[2], "").
-			Return(nil, &model.Response{}, nil).
-			Times(1)
 		s.client.
 			EXPECT().
 			GetUserByUsername(context.TODO(), argsDelete[2], "").
@@ -2506,12 +2423,6 @@ func (s *MmctlUnitTestSuite) TestVerifyUserEmailWithoutTokenCmd() {
 	s.Run("Couldn't find the user", func() {
 		printer.Clean()
 		userArg := "bad-user-id"
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), userArg, "").
-			Return(nil, &model.Response{StatusCode: http.StatusNotFound}, errors.New("")).
-			Times(1)
 
 		s.client.
 			EXPECT().
@@ -2620,12 +2531,6 @@ func (s *MmctlUnitTestSuite) TestUserConvertCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), userNameArg, "").
-			Return(nil, &model.Response{}, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), userNameArg, "").
 			Return(&mockBotUser, &model.Response{}, nil).
 			Times(1)
@@ -2697,12 +2602,6 @@ func (s *MmctlUnitTestSuite) TestUserConvertCmd() {
 		cmd.Flags().String("password", "password", "")
 		cmd.Flags().String("email", "example@example.com", "")
 		cmd.Flags().String("username", "example-user", "")
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(context.TODO(), userNameArg, "").
-			Return(nil, &model.Response{}, nil).
-			Times(1)
 
 		s.client.
 			EXPECT().
@@ -2945,7 +2844,7 @@ func (s *MmctlUnitTestSuite) TestPromoteGuestToUserCmd() {
 	})
 }
 
-func (s *MmctlUnitTestSuite) TestDemoteUserToGuestCmd() {
+func (s *MmctlUnitTestSuite) eTestDemoteUserToGuestCmd() {
 	s.Run("demote a user to a guest", func() {
 		printer.Clean()
 		emailArg := "example@example.com"

--- a/server/cmd/mmctl/commands/userargs.go
+++ b/server/cmd/mmctl/commands/userargs.go
@@ -26,7 +26,7 @@ func getUsersFromUserArgs(c client.Client, userArgs []string) []*model.User {
 
 func getUserFromUserArg(c client.Client, userArg string) *model.User {
 	var user *model.User
-	if !checkDots(userArg) {
+	if !checkDots(userArg) && model.IsValidEmail(userArg) {
 		user, _, _ = c.GetUserByEmail(context.TODO(), userArg, "")
 	}
 
@@ -75,7 +75,7 @@ func getUserFromArg(c client.Client, userArg string) (*model.User, error) {
 	var user *model.User
 	var response *model.Response
 	var err error
-	if !checkDots(userArg) {
+	if !checkDots(userArg) && model.IsValidEmail(userArg) {
 		user, response, err = c.GetUserByEmail(context.TODO(), userArg, "")
 		if err != nil {
 			nErr := ExtractErrorFromResponse(response, err)

--- a/server/cmd/mmctl/commands/userargs_test.go
+++ b/server/cmd/mmctl/commands/userargs_test.go
@@ -20,11 +20,6 @@ func (s *MmctlUnitTestSuite) TestGetUserFromArgs() {
 		printer.Clean()
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), notFoundEmail, "").
-			Return(nil, &model.Response{StatusCode: http.StatusNotFound}, notFoundErr).
-			Times(1)
-		s.client.
-			EXPECT().
 			GetUserByUsername(context.TODO(), notFoundEmail, "").
 			Return(nil, &model.Response{StatusCode: http.StatusNotFound}, notFoundErr).
 			Times(1)

--- a/server/cmd/mmctl/commands/webhook_test.go
+++ b/server/cmd/mmctl/commands/webhook_test.go
@@ -271,7 +271,7 @@ func (s *MmctlUnitTestSuite) TestCreateIncomingWebhookCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), emailID, "").
+			GetUserByUsername(context.TODO(), emailID, "").
 			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
 
@@ -315,7 +315,7 @@ func (s *MmctlUnitTestSuite) TestCreateIncomingWebhookCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), emailID, "").
+			GetUserByUsername(context.TODO(), emailID, "").
 			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
 
@@ -460,7 +460,7 @@ func (s *MmctlUnitTestSuite) TestCreateOutgoingWebhookCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), emailID, "").
+			GetUserByUsername(context.TODO(), emailID, "").
 			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
 
@@ -506,7 +506,7 @@ func (s *MmctlUnitTestSuite) TestCreateOutgoingWebhookCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(context.TODO(), emailID, "").
+			GetUserByUsername(context.TODO(), emailID, "").
 			Return(&mockUser, &model.Response{}, nil).
 			Times(1)
 


### PR DESCRIPTION
#### Summary
- See ticket for report that setting email using mmctl was failing. It actually wasn't failing -- the email was being set as expected, but the debug logs showed an error. That error was from the `GetUserByEmail` endpoint. What was happening? `mmctl` was trying to get the user with the mmctl arg (using the client), and it tries the `GetUserByEmail` first. When that fails, it tries finding user by username. 
- Fix: test the mmctl arg to see if it's an email first. If it is, go ahead and try the `GetUserByEmail` endpoint. If it isn't, continue trying to find user by username like before.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-62179

#### Release Note

```release-note
Fix to mmctl to prevent logging a harmless debug-level "error" to the logs.
```
