### PR TITLE
Prompt Team Admin before joining private channel

### DIFF
--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -1439,8 +1439,6 @@ func getChannelByNameForTeamName(c *Context, w http.ResponseWriter, r *http.Requ
 	}
 
 	channelOk := c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), channel.Id, model.PermissionReadChannel)
-
-	mlog.Debug("channel OK", mlog.Bool("ok", channelOk))
 	if channel.Type == model.ChannelTypeOpen {
 		teamOk := c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), channel.TeamId, model.PermissionReadPublicChannel)
 		if !teamOk && !channelOk {

--- a/server/channels/api4/channel_test.go
+++ b/server/channels/api4/channel_test.go
@@ -2498,6 +2498,12 @@ func TestGetChannelByNameForTeamName(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, th.BasicChannel.Name, channel.Name, "names did not match")
 
+	TeamAdminClient := th.CreateClient()
+	th.LoginTeamAdminWithClient(TeamAdminClient)
+	channel, _, err = TeamAdminClient.GetChannelByNameForTeamName(context.Background(), th.BasicChannel.Name, th.BasicTeam.Name, "")
+	require.NoError(t, err)
+	require.Equal(t, th.BasicChannel.Name, channel.Name, "names did not match")
+
 	_, _, err = client.GetChannelByNameForTeamName(context.Background(), th.BasicChannel.Name, th.BasicTeam.Name, "")
 	require.NoError(t, err)
 	require.Equal(t, th.BasicChannel.Name, channel.Name, "names did not match")

--- a/server/channels/api4/channel_test.go
+++ b/server/channels/api4/channel_test.go
@@ -2487,6 +2487,13 @@ func TestGetChannelByName(t *testing.T) {
 		_, _, err = client.GetChannelByName(context.Background(), th.BasicChannel.Name, th.BasicTeam.Id, "")
 		require.NoError(t, err)
 	})
+
+	th.SystemAdminClient.RemoveUserFromChannel(context.Background(), th.BasicPrivateChannel.Id, th.TeamAdminUser.Id)
+	TeamAdminClient := th.CreateClient()
+	th.LoginTeamAdminWithClient(TeamAdminClient)
+	channel, _, err = TeamAdminClient.GetChannelByName(context.Background(), th.BasicPrivateChannel.Name, th.BasicTeam.Id, "")
+	require.NoError(t, err)
+	require.Equal(t, th.BasicPrivateChannel.Name, channel.Name, "names did not match")
 }
 
 func TestGetChannelByNameForTeamName(t *testing.T) {
@@ -2498,13 +2505,14 @@ func TestGetChannelByNameForTeamName(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, th.BasicChannel.Name, channel.Name, "names did not match")
 
+	th.SystemAdminClient.RemoveUserFromChannel(context.Background(), th.BasicPrivateChannel.Id, th.TeamAdminUser.Id)
 	TeamAdminClient := th.CreateClient()
 	th.LoginTeamAdminWithClient(TeamAdminClient)
-	channel, _, err = TeamAdminClient.GetChannelByNameForTeamName(context.Background(), th.BasicChannel.Name, th.BasicTeam.Name, "")
+	channel, _, err = TeamAdminClient.GetChannelByNameForTeamName(context.Background(), th.BasicPrivateChannel.Name, th.BasicTeam.Name, "")
 	require.NoError(t, err)
-	require.Equal(t, th.BasicChannel.Name, channel.Name, "names did not match")
+	require.Equal(t, th.BasicPrivateChannel.Name, channel.Name, "names did not match")
 
-	_, _, err = client.GetChannelByNameForTeamName(context.Background(), th.BasicChannel.Name, th.BasicTeam.Name, "")
+	channel, _, err = client.GetChannelByNameForTeamName(context.Background(), th.BasicChannel.Name, th.BasicTeam.Name, "")
 	require.NoError(t, err)
 	require.Equal(t, th.BasicChannel.Name, channel.Name, "names did not match")
 

--- a/webapp/channels/src/components/channel_layout/channel_identifier_router/actions.ts
+++ b/webapp/channels/src/components/channel_layout/channel_identifier_router/actions.ts
@@ -10,7 +10,7 @@ import {joinChannel, getChannelByNameAndTeamName, getChannelMember, markGroupCha
 import {getUser, getUserByUsername, getUserByEmail} from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 import {getChannelByName, getOtherChannels, getChannel, getChannelsNameMapInTeam, getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
-import {getTeamByName} from 'mattermost-redux/selectors/entities/teams';
+import {getTeamByName, getMyTeamMember} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser, getCurrentUserId, getUserByUsername as selectUserByUsername, getUser as selectUser, getUserByEmail as selectUserByEmail} from 'mattermost-redux/selectors/entities/users';
 import * as UserUtils from 'mattermost-redux/utils/user_utils';
 
@@ -189,7 +189,14 @@ export function goToChannelByChannelName(match: Match, history: History): Action
             // Prompt system admin before joining the private channel
             const user = getCurrentUser(getState());
             const isSystemAdmin = UserUtils.isSystemAdmin(user?.roles);
+            let prompt = false;
             if (isSystemAdmin) {
+                prompt = true;
+            } else {
+                const teamMember = getMyTeamMember(state, teamObj.id);
+                prompt = Boolean(teamMember && teamMember.scheme_admin);
+            }
+            if (prompt) {
                 if (channel?.type === Constants.PRIVATE_CHANNEL) {
                     const joinPromptResult = await dispatch(joinPrivateChannelPrompt(teamObj, channel.display_name));
                     if ('data' in joinPromptResult && !joinPromptResult.data!.join) {
@@ -198,7 +205,7 @@ export function goToChannelByChannelName(match: Match, history: History): Action
                 }
             }
 
-            const joinChannelDispatchResult = await dispatch(joinChannel(getCurrentUserId(state), teamObj!.id, '', channelName));
+            const joinChannelDispatchResult = await dispatch(joinChannel(getCurrentUserId(state), teamObj!.id, channel?.id || '', channelName));
             if ('error' in joinChannelDispatchResult) {
                 if (!channel) {
                     const getChannelDispatchResult = await dispatch(getChannelByNameAndTeamName(team, channelName, true));

--- a/webapp/channels/src/components/channel_layout/channel_identifier_router/actions.ts
+++ b/webapp/channels/src/components/channel_layout/channel_identifier_router/actions.ts
@@ -186,18 +186,18 @@ export function goToChannelByChannelName(match: Match, history: History): Action
         }
 
         if (!channel || !member) {
-            // Prompt system admin before joining the private channel
-            const user = getCurrentUser(getState());
-            const isSystemAdmin = UserUtils.isSystemAdmin(user?.roles);
-            let prompt = false;
-            if (isSystemAdmin) {
-                prompt = true;
-            } else {
-                const teamMember = getMyTeamMember(state, teamObj.id);
-                prompt = Boolean(teamMember && teamMember.scheme_admin);
-            }
-            if (prompt) {
-                if (channel?.type === Constants.PRIVATE_CHANNEL) {
+            if (channel?.type === Constants.PRIVATE_CHANNEL) {
+                // Prompt system admins and team admins before joining the private channel
+                const user = getCurrentUser(getState());
+                const isSystemAdmin = UserUtils.isSystemAdmin(user?.roles);
+                let prompt = false;
+                if (isSystemAdmin) {
+                    prompt = true;
+                } else {
+                    const teamMember = getMyTeamMember(state, teamObj.id);
+                    prompt = Boolean(teamMember && teamMember.scheme_admin);
+                }
+                if (prompt) {
                     const joinPromptResult = await dispatch(joinPrivateChannelPrompt(teamObj, channel.display_name));
                     if ('data' in joinPromptResult && !joinPromptResult.data!.join) {
                         return {data: undefined};

--- a/webapp/channels/src/components/permalink_view/actions.ts
+++ b/webapp/channels/src/components/permalink_view/actions.ts
@@ -103,11 +103,11 @@ export function focusPost(postId: string, returnTo = '', currentUserId: string, 
             return;
         }
 
-        if (!postInfo.has_joined_channel && postInfo.channel_type === Constants.PRIVATE_CHANNEL) {
+        if (!postInfo.has_joined_channel) {
             // Prompt system admins and team admins before joining the private channel
             const user = getCurrentUser(state);
             let prompt = false;
-            if (isSystemAdmin(user.roles)) {
+            if (postInfo.channel_type === Constants.PRIVATE_CHANNEL && isSystemAdmin(user.roles)) {
                 prompt = true;
             } else {
                 const teamMember = getMyTeamMember(state, currentTeam.id);

--- a/webapp/channels/src/components/permalink_view/actions.ts
+++ b/webapp/channels/src/components/permalink_view/actions.ts
@@ -10,7 +10,7 @@ import {getMissingProfilesByIds} from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 import {getCurrentChannel, getChannel as getChannelFromRedux} from 'mattermost-redux/selectors/entities/channels';
 import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
-import {getCurrentTeam, getTeam} from 'mattermost-redux/selectors/entities/teams';
+import {getCurrentTeam, getTeam, getMyTeamMember} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getUserIdFromChannelName} from 'mattermost-redux/utils/channel_utils';
 import {isSystemAdmin} from 'mattermost-redux/utils/user_utils';
@@ -103,10 +103,17 @@ export function focusPost(postId: string, returnTo = '', currentUserId: string, 
             return;
         }
 
-        if (!postInfo.has_joined_channel) {
-            // Prompt system admin before joining the private channel
+        if (!postInfo.has_joined_channel && postInfo.channel_type === Constants.PRIVATE_CHANNEL) {
+            // Prompt system admins and team admins before joining the private channel
             const user = getCurrentUser(state);
-            if (postInfo.channel_type === Constants.PRIVATE_CHANNEL && isSystemAdmin(user.roles)) {
+            let prompt = false;
+            if (isSystemAdmin(user.roles)) {
+                prompt = true;
+            } else {
+                const teamMember = getMyTeamMember(state, currentTeam.id);
+                prompt = Boolean(teamMember && teamMember.scheme_admin);
+            }
+            if (prompt) {
                 privateChannelJoinPromptVisible = true;
                 const joinPromptResult = await dispatch(joinPrivateChannelPrompt(currentTeam, postInfo.channel_display_name));
                 privateChannelJoinPromptVisible = false;


### PR DESCRIPTION
#### Summary
There are two ways to join channel via link.
1 - via permalink to post in channel
2 - via channel link

These two methods use completely separate code paths. 

If a Team Admin attempts to join via a Permalink, they would automatically join the channel. This PR now prompts the TeamAdmin before allowing to join.

If a TeamAdmin attempts to join via a channel link, this path completely fails due to the TeamAdmin not being a member of the channel, the channel cannot be retrieved. Secondly, this path did not actually "join" the channel if not already a member so other areas would fail when attempting to view the channel.

This PR makes the changes necessary to allow a TeamAdmin to join via either method with a prompt. 

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-61847

#### Screenshots
<img width="610" alt="Screenshot 2025-01-22 at 1 09 49 PM" src="https://github.com/user-attachments/assets/026260af-4566-4f30-b03a-62b77fc81a32" />

<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
