### PR TITLE
[MM-61319] Delete the thread from state when the root post is deleted by another user

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/index.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/index.ts
@@ -26,6 +26,7 @@ export const threadsReducer = (state: ThreadsState['threads'] = {}, action: MMRe
             }, {}),
         };
     }
+    case PostTypes.POST_DELETED:
     case PostTypes.POST_REMOVED: {
         const post = action.data;
 

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/threads.test.js
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/threads.test.js
@@ -310,7 +310,7 @@ describe('threads', () => {
         expect(nextState.threadsInTeam.a).toBe(undefined);
     });
 
-    test('POST_REMOVED should remove the thread when root post', () => {
+    test.each([PostTypes.POST_REMOVED, PostTypes.POST_DELETED])('%s should remove the thread when root post', (action) => {
         const state = deepFreeze({
             threadsInTeam: {
                 a: ['t1', 't2', 't3'],
@@ -334,7 +334,7 @@ describe('threads', () => {
         });
 
         const nextState = threadsReducer(state, {
-            type: PostTypes.POST_REMOVED,
+            type: action,
             data: {id: 't2', root_id: ''},
         });
 
@@ -344,7 +344,7 @@ describe('threads', () => {
         expect(nextState.unreadThreadsInTeam.a).toEqual(['t1', 't3']);
     });
 
-    test('POST_REMOVED should remove the thread when root post from all teams', () => {
+    test.each([PostTypes.POST_REMOVED, PostTypes.POST_DELETED])('%s should remove the thread when root post from all teams', (action) => {
         const state = deepFreeze({
             threadsInTeam: {
                 a: ['t1', 't2', 't3'],
@@ -370,7 +370,7 @@ describe('threads', () => {
         });
 
         const nextState = threadsReducer(state, {
-            type: PostTypes.POST_REMOVED,
+            type: action,
             data: {id: 't2', root_id: ''},
         });
 
@@ -382,7 +382,7 @@ describe('threads', () => {
         expect(nextState.unreadThreadsInTeam.b).toEqual([]);
     });
 
-    test('POST_REMOVED should do nothing when not a root post', () => {
+    test.each([PostTypes.POST_REMOVED, PostTypes.POST_DELETED])('%s should do nothing when not a root post', (action) => {
         const state = deepFreeze({
             threadsInTeam: {
                 a: ['t1', 't2', 't3'],
@@ -406,7 +406,7 @@ describe('threads', () => {
         });
 
         const nextState = threadsReducer(state, {
-            type: PostTypes.POST_REMOVED,
+            type: action,
             data: {id: 't2', root_id: 't1'},
         });
 
@@ -416,7 +416,7 @@ describe('threads', () => {
         expect(nextState.unreadThreadsInTeam.a).toEqual(['t1', 't2', 't3']);
     });
 
-    test('POST_REMOVED should do nothing when post not exist', () => {
+    test.each([PostTypes.POST_REMOVED, PostTypes.POST_DELETED])('%s should do nothing when post not exist', (action) => {
         const state = deepFreeze({
             threadsInTeam: {
                 a: ['t1', 't2'],
@@ -437,7 +437,7 @@ describe('threads', () => {
         });
 
         const nextState = threadsReducer(state, {
-            type: PostTypes.POST_REMOVED,
+            type: action,
             data: {id: 't3', root_id: ''},
         });
 

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/threadsInTeam.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/threadsInTeam.ts
@@ -247,6 +247,7 @@ export const threadsInTeamReducer = (state: ThreadsState['threadsInTeam'] = {}, 
     switch (action.type) {
     case ThreadTypes.RECEIVED_THREAD:
         return handleReceivedThread(state, action, extra);
+    case PostTypes.POST_DELETED:
     case PostTypes.POST_REMOVED:
         return handlePostRemoved(state, action);
     case ThreadTypes.RECEIVED_THREADS:
@@ -292,6 +293,7 @@ export const unreadThreadsInTeamReducer = (state: ThreadsState['unreadThreadsInT
                 threads: action.data.threads.filter((thread: UserThreadWithPost) => thread.unread_replies > 0 || thread.unread_mentions > 0),
             },
         });
+    case PostTypes.POST_DELETED:
     case PostTypes.POST_REMOVED:
         return handlePostRemoved(state, action);
     case ThreadTypes.RECEIVED_UNREAD_THREADS:


### PR DESCRIPTION
#### Summary
When a thread is deleted by another user, the local Redux state is not updated to remove the thread from state, and as a result it gets stuck in the thread viewer if it was being followed/had replies.

This PR updates the reducer to remove the thread on the `POST_DELETED` action as well if a root post was deleted.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61319

```release-note
Fixed an issue where deleted threads would get stuck in the thread viewer
```
