### PR TITLE
Fix LogAuditRecWithLevel doc comment and fix typo

### DIFF
--- a/server/channels/web/context.go
+++ b/server/channels/web/context.go
@@ -41,7 +41,7 @@ func (c *Context) LogAuditRec(rec *audit.Record) {
 	c.LogAuditRecWithLevel(rec, app.LevelAPI)
 }
 
-// LogAuditRec logs an audit record using specified Level.
+// LogAuditRecWithLevel logs an audit record using specified Level.
 // If the context is flagged with a permissions error then `level`
 // is ignored and the audit record is emitted with `LevelPerms`.
 func (c *Context) LogAuditRecWithLevel(rec *audit.Record, level mlog.Level) {
@@ -59,7 +59,7 @@ func (c *Context) LogAuditRecWithLevel(rec *audit.Record, level mlog.Level) {
 	c.App.Srv().Audit.LogRecord(level, *rec)
 }
 
-// MakeAuditRecord creates a audit record pre-populated with data from this context.
+// MakeAuditRecord creates an audit record pre-populated with data from this context.
 func (c *Context) MakeAuditRecord(event string, initialStatus string) *audit.Record {
 	rec := &audit.Record{
 		EventName: event,


### PR DESCRIPTION
#### Summary

- Fix Go doc comment so it has the correct method name
- Fix typo "a" -> "an"

#### Ticket Link

NA

#### Screenshots

Doc comment before/after:
![doc_comment_before](https://github.com/user-attachments/assets/d4eb4d8b-861f-4f2b-8635-f5fe9ac3b8ea)
![doc_comment_after](https://github.com/user-attachments/assets/af8ca180-bc5d-409d-8a90-5eae30f3ae0e)

Typo before/after:
![typo_before](https://github.com/user-attachments/assets/86c78eaa-78e4-48ef-a1e6-458f05904c0f)
![typo_after](https://github.com/user-attachments/assets/f59275d0-55f7-4bfb-9c90-87e0bc1e0556)


#### Release Note

```release-note
NONE
```

