### PR TITLE
[MM-62113] Force reload of team unreads when following/unfollowing a thread

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/collapsed_reply_threads/unread_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/collapsed_reply_threads/unread_spec.ts
@@ -96,4 +96,67 @@ describe('Collapsed Reply Threads', () => {
             cy.uiCloseRHS();
         });
     });
+
+    it('MM-TXXXX should handle mention counts correctly when marking a thread as unread and unfollowing it', () => {
+        // # Post a root post as current user
+        cy.postMessageAs({
+            sender: otherUser,
+            message: `@${testUser.username} Root post for mention test`,
+            channelId: testChannel.id,
+        }).then(({id: rootId}) => {
+            // # Post a reply mentioning the user
+            cy.postMessageAs({
+                sender: otherUser,
+                message: `Hey @${testUser.username}, check this out!`,
+                channelId: testChannel.id,
+                rootId,
+            }).then(({id: replyId}) => {
+                // # Post another reply mentioning the user
+                cy.postMessageAs({
+                    sender: otherUser,
+                    message: `Hey @${testUser.username}, check this out too!`,
+                    channelId: testChannel.id,
+                    rootId,
+                });
+
+                // # Click root post to open RHS
+                cy.get(`#post_${rootId}`).click();
+
+                // # Wait for RHS to open
+                cy.wait(TIMEOUTS.ONE_SEC);
+
+                // # Mark the thread as unread
+                cy.uiClickPostDropdownMenu(replyId, 'Mark as Unread', 'RHS_COMMENT');
+
+                // # Wait for unread to be marked correctly
+                cy.wait(TIMEOUTS.ONE_SEC);
+
+                // # Close RHS
+                cy.uiCloseRHS();
+
+                // # Switch to a different team
+                cy.apiCreateTeam('team', 'Team').then(({team: otherTeam}) => {
+                    // # Click on the other team button to switch teams
+                    cy.get(`#${otherTeam.name}TeamButton`).click();
+
+                    // * Verify mention count on the original team
+                    cy.get(`#${testTeam.name}TeamButton`).find('.badge').should('be.visible');
+
+                    // # Click on the original team button to switch back
+                    cy.get(`#${testTeam.name}TeamButton`).click();
+
+                    // # Unfollow the thread
+                    cy.uiGetPostThreadFooter(rootId).findByText('Following').click();
+
+                    // # Switch to a different team and back
+                    cy.get(`#${otherTeam.name}TeamButton`).click();
+                    cy.get(`#${testTeam.name}TeamButton`).click();
+                    cy.get(`#${otherTeam.name}TeamButton`).click();
+
+                    // * Verify there is no mention count on the original team
+                    cy.get(`#${testTeam.name}TeamButton`).find('.badge').should('not.exist');
+                });
+            });
+        });
+    });
 });

--- a/e2e-tests/cypress/tests/integration/channels/collapsed_reply_threads/unread_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/collapsed_reply_threads/unread_spec.ts
@@ -97,7 +97,7 @@ describe('Collapsed Reply Threads', () => {
         });
     });
 
-    it('MM-TXXXX should handle mention counts correctly when marking a thread as unread and unfollowing it', () => {
+    it('MM-T5671 should handle mention counts correctly when marking a thread as unread and unfollowing it', () => {
         // # Post a root post as current user
         cy.postMessageAs({
             sender: otherUser,

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/threads.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/threads.ts
@@ -23,6 +23,7 @@ import type {DispatchFunc, GetStateFunc, ActionFunc, ActionFuncAsync} from 'matt
 import {logError} from './errors';
 import {forceLogoutIfNecessary} from './helpers';
 import {getPostThread} from './posts';
+import {getMyTeamUnreads} from './teams';
 
 type ExtendedPost = Post & { system_post_ids?: string[] };
 
@@ -391,6 +392,12 @@ export function setThreadFollow(userId: string, teamId: string, threadId: string
             dispatch(logError(error));
             return {error};
         }
+
+        // As a short term fix for https://mattermost.atlassian.net/browse/MM-62113, we will fetch
+        // the users team unreads after following or unfollowing a thread. This will ensure that the unreads are
+        // updated correctly in the case where the user is following or unfollowing a thread that has unread messages.
+        dispatch(getMyTeamUnreads(isCollapsedThreadsEnabled(getState())));
+
         return {};
     };
 }


### PR DESCRIPTION
#### Summary
Manually following/unfollowing threads causes some strange behaviour on the front-end, and one of the reasons for this is that we don't properly re-sync our unread information when the thread following status is changed. That status does actually affect the number of unreads that the team sidebar should show, so we should make sure to update that amount once we change that status, which we currently don't do.

To do this however, we'd need to manually figure out how many mentions were in that thread, as well as how many unreads and urgent mentions, which is a lot of information the reducer doesn't have and might not be a perfect calculation, as we don't replicate that calculation on the front-end anywhere else. So as a quick solution, and especially since team unreads may be deprecated in the near future, we will simply resync the team unreads on manual following/unfollowing of threads to ensure things don't get out of sync on the front-end.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62113

```release-note
Fixed an issue where the unread count in your team sidebar may be out of sync when following/unfollowing threads
```
