### PR TITLE
fix(MM-60645): missing emoji on mobile

### DIFF
--- a/server/public/model/channel_bookmark.go
+++ b/server/public/model/channel_bookmark.go
@@ -5,6 +5,7 @@ package model
 
 import (
 	"net/http"
+	"strings"
 	"unicode/utf8"
 )
 
@@ -142,6 +143,7 @@ func (o *ChannelBookmark) PreSave() {
 	}
 
 	o.DisplayName = SanitizeUnicode(o.DisplayName)
+	o.Emoji = strings.Trim(o.Emoji, ":")
 	if o.CreateAt == 0 {
 		o.CreateAt = GetMillis()
 	}
@@ -151,6 +153,7 @@ func (o *ChannelBookmark) PreSave() {
 func (o *ChannelBookmark) PreUpdate() {
 	o.UpdateAt = GetMillis()
 	o.DisplayName = SanitizeUnicode(o.DisplayName)
+	o.Emoji = strings.Trim(o.Emoji, ":")
 }
 
 func (o *ChannelBookmark) ToBookmarkWithFileInfo(f *FileInfo) *ChannelBookmarkWithFileInfo {
@@ -167,7 +170,7 @@ func (o *ChannelBookmark) ToBookmarkWithFileInfo(f *FileInfo) *ChannelBookmarkWi
 			SortOrder:   o.SortOrder,
 			LinkUrl:     o.LinkUrl,
 			ImageUrl:    o.ImageUrl,
-			Emoji:       o.Emoji,
+			Emoji:       strings.Trim(o.Emoji, ":"),
 			Type:        o.Type,
 			OriginalId:  o.OriginalId,
 			ParentId:    o.ParentId,

--- a/server/public/model/channel_bookmark_test.go
+++ b/server/public/model/channel_bookmark_test.go
@@ -601,10 +601,10 @@ func TestChannelBookmarkPreUpdate(t *testing.T) {
 
 func TestToBookmarkWithFileInfo(t *testing.T) {
 	testCases := []struct {
-		name           string
-		bookmark       *ChannelBookmark
-		fileInfo       *FileInfo
-		expectedEmoji  string
+		name          string
+		bookmark      *ChannelBookmark
+		fileInfo      *FileInfo
+		expectedEmoji string
 	}{
 		{
 			name: "emoji with colons",

--- a/server/public/model/channel_bookmark_test.go
+++ b/server/public/model/channel_bookmark_test.go
@@ -599,6 +599,56 @@ func TestChannelBookmarkPreUpdate(t *testing.T) {
 	assert.Greater(t, bookmark.UpdateAt, originalBookmark.UpdateAt)
 }
 
+func TestToBookmarkWithFileInfo(t *testing.T) {
+	testCases := []struct {
+		name           string
+		bookmark       *ChannelBookmark
+		fileInfo       *FileInfo
+		expectedEmoji  string
+	}{
+		{
+			name: "emoji with colons",
+			bookmark: &ChannelBookmark{
+				Id:          NewId(),
+				DisplayName: "test bookmark",
+				Emoji:       ":smile:",
+				Type:        ChannelBookmarkLink,
+			},
+			fileInfo:      nil,
+			expectedEmoji: "smile",
+		},
+		{
+			name: "emoji without colons",
+			bookmark: &ChannelBookmark{
+				Id:          NewId(),
+				DisplayName: "test bookmark",
+				Emoji:       "smile",
+				Type:        ChannelBookmarkLink,
+			},
+			fileInfo:      nil,
+			expectedEmoji: "smile",
+		},
+		{
+			name: "empty emoji",
+			bookmark: &ChannelBookmark{
+				Id:          NewId(),
+				DisplayName: "test bookmark",
+				Emoji:       "",
+				Type:        ChannelBookmarkLink,
+			},
+			fileInfo:      nil,
+			expectedEmoji: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.bookmark.ToBookmarkWithFileInfo(tc.fileInfo)
+			assert.Equal(t, tc.expectedEmoji, result.Emoji)
+		})
+	}
+}
+
 func TestChannelBookmarkPatch(t *testing.T) {
 	p := &ChannelBookmarkPatch{
 		DisplayName: NewPointer(NewId()),


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

Emoji on mobile is missing because bookmarks are returning emoji name with `:`.  This fix ensure that the API will no longer return that, but at the same time, will also make sure that the emoji name is being stored without the `:`.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

[Ticket](https://mattermost.atlassian.net/browse/MM-60645)
[Mobile PR](https://github.com/mattermost/mattermost-mobile/pull/8518)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->
Combine web and mobile (after fix):
<img width="787" alt="mobile-web-with-builtin-and-custom-emojis" src="https://github.com/user-attachments/assets/61c3720d-ec04-4330-9961-10d7171a46b2" />


channelbookmarks table (after fix)
```
|id|ownerid|channelid|fileinfoid|createat|updateat|deleteat|displayname|sortorder|linkurl|imageurl|emoji|type|originalid|parentid|
|--|-------|---------|----------|--------|--------|--------|-----------|---------|-------|--------|-----|----|----------|--------|
|he8pdnxkkpbxzdr1gj195pyhfo|up8ng8gd6bnnbqsnz34mj3o3tr|cmkwrprzrirzmyy4ah8p84sw9c||1737752506535|1737752506535|0|www.twitter.com|0|http://www.twitter.com||smiley|link|||
|yxb3nqua53f85xygmyc75shbqh|up8ng8gd6bnnbqsnz34mj3o3tr|cmkwrprzrirzmyy4ah8p84sw9c||1737823523228|1737823523228|0|www.facebook.com|1|https://www.facebook.com||rahim|link|||
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
