### PR TITLE
Add `typescript-eslint-language-service`

### DIFF
--- a/webapp/channels/tsconfig.json
+++ b/webapp/channels/tsconfig.json
@@ -26,7 +26,10 @@
     "paths": {
         "mattermost-redux/*": ["packages/mattermost-redux/src/*"],
         "@mui/styled-engine": ["./node_modules/@mui/styled-engine-sc"],
-    }
+    },
+    "plugins": [{
+        "name": "typescript-eslint-language-service"
+    }]
   },
   "include": [
     "./src/**/*",

--- a/webapp/channels/webpack.config.js
+++ b/webapp/channels/webpack.config.js
@@ -18,10 +18,14 @@ const packageJson = require('./package.json');
 
 const NPM_TARGET = process.env.npm_lifecycle_event;
 
+// list of known code editors that set an environment variable.
+const knownCodeEditors = ['VSCODE_CWD', 'INSIDE_EMACS'];
+const isInsideCodeEditor = knownCodeEditors.some((editor) => process.env[editor]);
+
 const targetIsRun = NPM_TARGET?.startsWith('run');
 const targetIsStats = NPM_TARGET === 'stats';
 const targetIsDevServer = NPM_TARGET?.startsWith('dev-server');
-const targetIsEslint = NPM_TARGET?.startsWith('check') || NPM_TARGET === 'fix' || process.env.VSCODE_CWD;
+const targetIsEslint = NPM_TARGET?.startsWith('check') || NPM_TARGET === 'fix' || isInsideCodeEditor;
 
 const DEV = targetIsRun || targetIsStats || targetIsDevServer;
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -44,6 +44,7 @@
         "sass-loader": "16.0.2",
         "strip-ansi": "7.1.0",
         "style-loader": "4.0.0",
+        "typescript-eslint-language-service": "5.0.5",
         "webpack": "5.95.0",
         "webpack-cli": "5.1.4",
         "webpack-dev-server": "5.1.0"
@@ -27026,6 +27027,17 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint-language-service": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/typescript-eslint-language-service/-/typescript-eslint-language-service-5.0.5.tgz",
+      "integrity": "sha512-b7gWXpwSTqMVKpPX3WttNZEyVAMKs/2jsHKF79H+qaD6mjzCyU5jboJe/lOZgLJD+QRsXCr0GjIVxvl5kI1NMw==",
+      "dev": true,
+      "peerDependencies": {
+        "@typescript-eslint/parser": ">= 5.0.0",
+        "eslint": ">= 8.0.0",
+        "typescript": ">= 4.0.0"
       }
     },
     "node_modules/ua-parser-js": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -50,6 +50,7 @@
     "sass-loader": "16.0.2",
     "strip-ansi": "7.1.0",
     "style-loader": "4.0.0",
+    "typescript-eslint-language-service": "5.0.5",
     "webpack": "5.95.0",
     "webpack-cli": "5.1.4",
     "webpack-dev-server": "5.1.0"


### PR DESCRIPTION
#### Summary
This PR adds `typescript-eslint-language-service`, which is something I hackily reinstall locally everyt ime we make a change the `package(-lock).json` or `tsconfig.json` 😅 

Behind the scene, this package makes your LSP (`typescript-language-server` for most people) report eslint errors, removing the need to obtain an eslint dedicated plugin for your IDE. 

see https://community.mattermost.com/core/pl/c7kp69zfjp8dfk7yf6so1k6kae

#### Ticket Link
N/A

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```
