### PR TITLE
[MM-62527] Fix: Compliance exports fail when missing s3 file attachment

### DIFF
--- a/server/enterprise/message_export/global_relay_export/global_relay_export.go
+++ b/server/enterprise/message_export/global_relay_export/global_relay_export.go
@@ -303,7 +303,9 @@ func generateEmail(rctx request.CTX, fileAttachmentBackend filestore.FileBackend
 
 			_, err = io.Copy(writer, reader)
 			if err != nil {
-				return model.NewAppError("GlobalRelayExport", "ent.message_export.global_relay.attach_file.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+				// Log the error as a warning instead of propagating the error to the mail writer.
+				rctx.Logger().Warn("Error copying file", mlog.String("Filename", path), mlog.Err(err))
+				warningCount += 1
 			}
 			return nil
 		}))

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -8081,10 +8081,6 @@
     "translation": "Failed to get file info for a post."
   },
   {
-    "id": "ent.message_export.global_relay.attach_file.app_error",
-    "translation": "Unable to add attachment to the Global Relay export."
-  },
-  {
     "id": "ent.message_export.global_relay.close_zip_file.app_error",
     "translation": "Unable to close the zip file."
   },


### PR DESCRIPTION
#### Summary
- This is cherry-picking https://github.com/mattermost/mattermost/pull/30017 from 10.3 to 10.4

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-62527

#### Release Note
```release-note
NONE
```
