### PR TITLE
only report flaky on master

### DIFF
--- a/.github/workflows/server-ci-report.yml
+++ b/.github/workflows/server-ci-report.yml
@@ -69,8 +69,8 @@ jobs:
           include_passed: true
           check_annotations: true
 
-      - name: Report retried tests via webhook (master || release-*)
-        if: ${{ steps.report.outputs.flaky_summary != '<table><tr><th>Test</th><th>Retries</th></tr></table>' && github.event.workflow_run.name == 'Server CI Master' }}
+      - name: Report retried tests via webhook (master)
+        if: ${{ steps.report.outputs.flaky_summary != '<table><tr><th>Test</th><th>Retries</th></tr></table>' && github.event.workflow_run.name == 'Server CI Master' && github.ref_name == 'master' }}
         uses: mattermost/action-mattermost-notify@b7d118e440bf2749cd18a4a8c88e7092e696257a # v2.0.0
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MM_COMMUNITY_DEVELOPERS_INCOMING_WEBHOOK_FROM_GH_ACTIONS }}


### PR DESCRIPTION
#### Summary
Reporting flaky tests on release branches isn't useful, as we aren't likely to go back and patch these. Let's only surface flaky reports from master. (PR semantics remain unchanged).

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
