### PR TITLE
Remove obsolote docker version

### DIFF
--- a/server/build/docker-compose-generator/main.go
+++ b/server/build/docker-compose-generator/main.go
@@ -12,7 +12,6 @@ import (
 )
 
 type DockerCompose struct {
-	Version  string                `yaml:"version"`
 	Services map[string]*Container `yaml:"services"`
 }
 
@@ -51,7 +50,6 @@ func main() {
 	}
 
 	var dockerCompose DockerCompose
-	dockerCompose.Version = "2.4"
 	dockerCompose.Services = map[string]*Container{}
 	dockerCompose.Services["start_dependencies"] = &Container{
 		Image:     "mattermost/mattermost-wait-for-dep:latest",

--- a/server/build/docker-compose.common.yml
+++ b/server/build/docker-compose.common.yml
@@ -1,4 +1,3 @@
-version: '2.4'
 services:
   mysql:
     image: "mysql/mysql-server:8.0.32"

--- a/server/build/docker-compose.yml
+++ b/server/build/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.4'
 services:
   mysql:
     extends:

--- a/server/docker-compose.makefile.m1.yml
+++ b/server/docker-compose.makefile.m1.yml
@@ -1,4 +1,3 @@
-version: '2.4'
 services:
   elasticsearch:
     image: "mattermostdevelopment/mattermost-elasticsearch:8.9.0"

--- a/server/docker-compose.makefile.yml
+++ b/server/docker-compose.makefile.yml
@@ -1,4 +1,3 @@
-version: '2.4'
 services:
   mysql:
     restart: 'no'

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '2.4'
 services:
   mysql:
     container_name: mattermost-mysql


### PR DESCRIPTION
#### Summary

- Remove obsolete version in Docker files that produces a warning

#### Ticket Link

N/A

#### Screenshots

Before:
<img width="1372" alt="docker-version" src="https://github.com/user-attachments/assets/68aa79f0-d8cc-40ac-ac8d-83b47cd2d064" />

After:
<img width="1365" alt="docker-version-after" src="https://github.com/user-attachments/assets/a7d79bc2-af37-44d0-b8e8-3d394497ae83" />


#### Release Note

```release-note
NONE
```
