### PR TITLE
[MM-62776] Fix search not working anymore in responsive mode.

### DIFF
--- a/webapp/channels/src/components/search/search.tsx
+++ b/webapp/channels/src/components/search/search.tsx
@@ -155,6 +155,12 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
     }, [hideSearchBar, currentChannelName]);
 
     useEffect((): void => {
+        if (isMobileView && props.isSideBarRight) {
+            handleFocus();
+        }
+    }, [isMobileView, props.isSideBarRight]);
+
+    useEffect((): void => {
         if (!isMobileView) {
             setVisibleSearchHintOptions(determineVisibleSearchHintOptions(searchTerms, searchType));
         }

--- a/webapp/channels/src/components/search/search.tsx
+++ b/webapp/channels/src/components/search/search.tsx
@@ -6,10 +6,6 @@ import React, {useEffect, useState, useRef} from 'react';
 import type {ChangeEvent, MouseEvent, FormEvent} from 'react';
 import {useIntl} from 'react-intl';
 import {useSelector} from 'react-redux';
-import Constants, {searchHintOptions, RHSStates, searchFilesHintOptions} from 'utils/constants';
-import * as Keyboard from 'utils/keyboard';
-import {isServerVersionGreaterThanOrEqualTo} from 'utils/server_version';
-import {isDesktopApp, getDesktopVersion, isMacApp} from 'utils/user_agent';
 
 import {getCurrentChannelNameForSearchShortcut} from 'mattermost-redux/selectors/entities/channels';
 
@@ -27,6 +23,11 @@ import MentionsIcon from 'components/widgets/icons/mentions_icon';
 import SearchIcon from 'components/widgets/icons/search_icon';
 import Popover from 'components/widgets/popover';
 import {ShortcutKeys} from 'components/with_tooltip/tooltip_shortcut';
+
+import Constants, {searchHintOptions, RHSStates, searchFilesHintOptions} from 'utils/constants';
+import * as Keyboard from 'utils/keyboard';
+import {isServerVersionGreaterThanOrEqualTo} from 'utils/server_version';
+import {isDesktopApp, getDesktopVersion, isMacApp} from 'utils/user_agent';
 
 import type {SearchType} from 'types/store/rhs';
 


### PR DESCRIPTION
#### Summary
Search didn't work anymore in responsive mode. The code relied on the fact that nobody will ever call `preventDefault()` when the user press `Enter`, so eventually the form will trigger a `submit` event, but with our `document` being polluted by various event listeners, it was bound to happen 😅 

This fix deterministically call `handleSearch` when the user press `enter` from the search box if nothing else is supposed to happen. Please note that this is on the old search UI, and not (directly at least) related to the new one, and submitting the form is still handled the way it was before.

Additional change thanks to Lindy's test: in mobile mode, the input should take the focus.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62776

#### Release Note
```release-note
NONE
```
