### PR TITLE
Fix the empty search state container stretching issue

### DIFF
--- a/webapp/channels/src/sass/components/_search.scss
+++ b/webapp/channels/src/sass/components/_search.scss
@@ -239,7 +239,6 @@
     -webkit-overflow-scrolling: touch;
 
     &.no-results {
-        display: flex;
         padding-top: 0;
     }
 }


### PR DESCRIPTION
#### Summary
Removed `display: flex;` from the `.no-results` class. Removing `display: flex;` defaults it to `display: block;` ensures it takes its parent container's full width, aligning the layout as expected.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62719

#### Screenshots

https://github.com/user-attachments/assets/c842b802-645a-4d68-9897-4af510d52e0e



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
