### PR TITLE
Removing test skip after a fix was applied as part of fixing MM-62079

### DIFF
--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -131,7 +131,6 @@ func TestCreatePost(t *testing.T) {
 	})
 
 	t.Run("Create posts without the USE_CHANNEL_MENTIONS Permission - returns ephemeral message with mentions and no ephemeral message without mentions", func(t *testing.T) {
-		t.Skip("MM-62764")
 		wsClient := th.CreateConnectedWebSocketClient(t)
 
 		defaultPerms := th.SaveDefaultRolePermissions()


### PR DESCRIPTION
#### Summary
This flaky test should be working fine after https://github.com/mattermost/mattermost/pull/29903

#### Release notes
```release-note
NONE
```