### PR TITLE
Fix Playwright tests

### DIFF
--- a/e2e-tests/playwright/support/flag.ts
+++ b/e2e-tests/playwright/support/flag.ts
@@ -32,7 +32,7 @@ export async function shouldHaveFeatureFlag(name: string, value: string | boolea
 
 export async function shouldRunInLinux() {
     const platform = os.platform();
-    await expect(platform, 'Run in Linux or Playwright docker image only').toBe('linux');
+    expect(platform, 'Run in Linux or Playwright docker image only').toBe('linux');
 }
 
 export async function ensureLicense() {
@@ -41,7 +41,7 @@ export async function ensureLicense() {
 
     if (license?.IsLicensed !== 'true') {
         const config = await adminClient.getClientConfigOld();
-        await expect(
+        expect(
             config.ServiceEnvironment === 'dev',
             'The trial license request fails in the local development environment. Please manually upload the test license.',
         ).toBeFalsy();
@@ -51,7 +51,7 @@ export async function ensureLicense() {
         license = await adminClient.getClientLicenseOld();
     }
 
-    await expect(license?.IsLicensed === 'true', 'Ensure server has license').toBeTruthy();
+    expect(license?.IsLicensed === 'true', 'Ensure server has license').toBeTruthy();
 }
 
 export async function requestTrialLicense() {
@@ -74,4 +74,11 @@ export async function skipIfNoLicense() {
     const license = await adminClient.getClientLicenseOld();
 
     test.skip(license.IsLicensed === 'false', 'Skipping test - server not licensed');
+}
+
+export async function skipIfFeatureFlagNotSet(name: string, value: string | boolean) {
+    const {adminClient} = await getAdminClient();
+    const cfg = await adminClient.getConfig();
+
+    test.skip(cfg.FeatureFlags[name] !== value, `Skipping test - Feature Flag ${name} needs to be set to ${value}`);
 }

--- a/e2e-tests/playwright/support/test_fixture.ts
+++ b/e2e-tests/playwright/support/test_fixture.ts
@@ -3,7 +3,14 @@ import {AxeResults} from 'axe-core';
 import AxeBuilder from '@axe-core/playwright';
 
 import {TestBrowser} from './browser_context';
-import {shouldHaveCallsEnabled, shouldHaveFeatureFlag, shouldRunInLinux, ensureLicense, skipIfNoLicense} from './flag';
+import {
+    shouldHaveCallsEnabled,
+    shouldHaveFeatureFlag,
+    shouldRunInLinux,
+    ensureLicense,
+    skipIfNoLicense,
+    skipIfFeatureFlagNotSet,
+} from './flag';
 import {initSetup, getAdminClient} from './server';
 import {hideDynamicChannelsContent, waitForAnimationEnd, waitUntil} from './test_action';
 import pages from './ui/pages';
@@ -46,6 +53,7 @@ class PlaywrightExtended {
     readonly shouldRunInLinux;
     readonly ensureLicense;
     readonly skipIfNoLicense;
+    readonly skipIfFeatureFlagNotSet;
 
     // ./server
     readonly getAdminClient;
@@ -81,6 +89,7 @@ class PlaywrightExtended {
         this.shouldRunInLinux = shouldRunInLinux;
         this.ensureLicense = ensureLicense;
         this.skipIfNoLicense = skipIfNoLicense;
+        this.skipIfFeatureFlagNotSet = skipIfFeatureFlagNotSet;
 
         // ./server
         this.initSetup = initSetup;

--- a/e2e-tests/playwright/support/ui/components/channels/scheduled_draft_modal.ts
+++ b/e2e-tests/playwright/support/ui/components/channels/scheduled_draft_modal.ts
@@ -47,6 +47,7 @@ export default class ScheduledDraftModal {
         await this.dateInput.click();
 
         const pacificDate = this.getPacificDate();
+        const originDate = new Date(pacificDate.getTime());
 
         // If dayFromToday is provided, add days to the current date
         if (dayFromToday) {
@@ -57,7 +58,13 @@ export default class ScheduledDraftModal {
         const month = pacificDate.toLocaleString('default', {month: 'long'});
         const dayOfWeek = pacificDate.toLocaleDateString('en-US', {weekday: 'long'});
 
-        await this.dateLocator(day, month, dayOfWeek).click();
+        const dl = this.dateLocator(day, month, dayOfWeek);
+
+        // If the date is not visible and the month has changed, click the next month button
+        if (!(await dl.isVisible()) && pacificDate.getMonth() !== originDate.getMonth()) {
+            this.container.locator('button[aria-label="Go to next month"]').click();
+        }
+        await dl.click();
     }
 
     async confirm() {

--- a/e2e-tests/playwright/support/ui/components/channels/search_popover.ts
+++ b/e2e-tests/playwright/support/ui/components/channels/search_popover.ts
@@ -26,8 +26,13 @@ export default class SearchPopover {
         this.clearButton = container.locator('.input-clear-x');
     }
 
+    // clearIfPossible clears the search input if the clear button is visible. Returns true if the clear button was clicked.
     async clearIfPossible() {
-        (await this.clearButton.isVisible()) && (await this.clearButton.click());
+        if (await this.clearButton.isVisible()) {
+            await this.clearButton.click();
+            return true;
+        }
+        return false;
     }
 
     async toBeVisible() {

--- a/e2e-tests/playwright/support/ui/components/channels/search_popover.ts
+++ b/e2e-tests/playwright/support/ui/components/channels/search_popover.ts
@@ -12,6 +12,7 @@ export default class SearchPopover {
     readonly searchBoxClose;
     readonly selectedSuggestion;
     readonly searchHints;
+    readonly clearButton;
 
     constructor(container: Locator) {
         this.container = container;
@@ -22,6 +23,11 @@ export default class SearchPopover {
         this.searchBoxClose = container.getByTestId('searchBoxClose');
         this.selectedSuggestion = container.locator('.suggestion--selected').locator('.suggestion-list__main');
         this.searchHints = container.locator('#searchHints');
+        this.clearButton = container.locator('.input-clear-x');
+    }
+
+    async clearIfPossible() {
+        (await this.clearButton.isVisible()) && (await this.clearButton.click());
     }
 
     async toBeVisible() {

--- a/e2e-tests/playwright/support/ui/components/channels/sidebar_right.ts
+++ b/e2e-tests/playwright/support/ui/components/channels/sidebar_right.ts
@@ -29,7 +29,8 @@ export default class ChannelsSidebarRight {
         this.scheduledDraftChannelInfoMessageText = container.locator('span:has-text("Message scheduled for")');
         this.rhsPostBody = container.locator('.post-message__text');
         this.postCreate = new components.ChannelsPostCreate(container.getByTestId('comment-create'), true);
-        this.closeButton = container.locator('#rhsCloseButton');
+        this.closeButton = container.locator('.sidebar--right__close');
+
         this.editTextbox = container.locator('#edit_textbox');
         this.postEdit = new components.ChannelsPostEdit(container.locator('.post-edit__container'));
         this.currentVersionEditedPosttext = (postID: any) => container.locator(`#rhsPostMessageText_${postID} p`);

--- a/e2e-tests/playwright/tests/functional/channels/search/search_box_suggestions.spec.ts
+++ b/e2e-tests/playwright/tests/functional/channels/search/search_box_suggestions.spec.ts
@@ -22,7 +22,7 @@ test('Search box suggestion must be case insensitive', async ({pw}) => {
 
     // Should work as expected when using lowercase
     // # Type in lowercase "off" to search for the "Off-Topic" channel
-    const {searchInput} = await channelsPage.searchPopover;
+    const {searchInput} = channelsPage.searchPopover;
     await searchInput.pressSequentially(`In:${searchWord}`);
 
     // * The suggestion should be visible
@@ -37,9 +37,11 @@ test('Search box suggestion must be case insensitive', async ({pw}) => {
     await expect(channelsPage.globalHeader.searchBox.getByText(searchOutput, {exact: true})).toBeVisible();
 
     // Should work as expected when using uppercase
-    // # Close then open the search UI
-    await channelsPage.globalHeader.closeSearch();
+    // # Open the search bar
     await channelsPage.globalHeader.openSearch();
+
+    // # Clear its content
+    await channelsPage.searchPopover.clearIfPossible();
 
     // # Type in uppercase "OFF" to search for the "Off-Topic" channel
     await searchInput.pressSequentially(`In:${searchWord.toUpperCase()}`);

--- a/e2e-tests/playwright/tests/functional/channels/search/team_selector.spec.ts
+++ b/e2e-tests/playwright/tests/functional/channels/search/team_selector.spec.ts
@@ -5,17 +5,9 @@ import {createRandomTeam} from '@e2e-support/server';
 import {expect, test} from '@e2e-support/test_fixture';
 
 test('team selector must show all my teams', async ({pw}) => {
-    const {adminClient, adminConfig, user, team} = await pw.initSetup();
+    pw.skipIfFeatureFlagNotSet('ExperimentalCrossTeamSearch', true);
 
-    // # Enable Cross Team Search Feature Flag
-    const newConfig = {
-        ...adminConfig,
-        FeatureFlags: {
-            ...adminConfig.FeatureFlags,
-            ExperimentalCrossTeamSearch: true,
-        },
-    };
-    await adminClient.updateConfig(newConfig);
+    const {adminClient, user, team} = await pw.initSetup();
 
     // # create 2 more teams and add the user to them
     const teams = [team];


### PR DESCRIPTION
#### Summary
- One test (mine, oops) was depending on a FF that I was trying to set, turns out it didn't work (except locally because I had the FF set on my local instance)
- One test was trying to close the search box after the search was done, but the search box is already closed after a search.
- The last one want to select on a calendar today+2days, turns out when you do that on January 31st, February 2nd does not show on the calendar 😅 Fixed the test by clicking "next month" if the entry was not found in the first place.

#### Ticket Link
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
