### PR TITLE
Upgrade language from alpha

### DIFF
--- a/webapp/channels/src/components/admin_console/__snapshots__/schema_admin_settings.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/__snapshots__/schema_admin_settings.test.tsx.snap
@@ -510,7 +510,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 16,
-                  "text": "Yкраїнська (Alpha)",
+                  "text": "Yкраїнська",
                   "value": "uk",
                 },
                 Object {

--- a/webapp/channels/src/components/admin_console/__snapshots__/schema_admin_settings.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/__snapshots__/schema_admin_settings.test.tsx.snap
@@ -381,7 +381,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 16,
-                  "text": "Yкраїнська (Alpha)",
+                  "text": "Yкраїнська",
                   "value": "uk",
                 },
                 Object {

--- a/webapp/channels/src/i18n/i18n.jsx
+++ b/webapp/channels/src/i18n/i18n.jsx
@@ -109,7 +109,7 @@ export const languages = {
     },
     uk: {
         value: 'uk',
-        name: 'Yкраїнська (Alpha)',
+        name: 'Yкраїнська',
         order: 16,
         url: langFiles.uk,
     },


### PR DESCRIPTION
Ukrainian language quality has been consistently climbing so it no longer needs an Alpha status.

```release-note
Upgraded Ukrainian language to official.
```