### PR TITLE
[MM-62845] Fix: Compliance export download link fails from S3 when using a dedicated file store

### DIFF
--- a/server/channels/api4/job.go
+++ b/server/channels/api4/job.go
@@ -126,7 +126,7 @@ func downloadJob(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	zipReader, err := c.App.ZipReader(cleanedExportDir, false)
+	zipReader, err := c.App.ExportZipReader(cleanedExportDir, false)
 	if err != nil {
 		c.Err = model.NewAppError("unableToDownloadJob", "api.job.unable_to_download_job", nil,
 			"error creating zip reader", http.StatusNotFound).Wrap(err)

--- a/server/channels/api4/job.go
+++ b/server/channels/api4/job.go
@@ -100,7 +100,7 @@ func downloadJob(c *Context, w http.ResponseWriter, r *http.Request) {
 		fileName = job.Id + ".zip"
 		filePath := filepath.Join(oldFilePath, fileName)
 		var fileReader filestore.ReadCloseSeeker
-		fileReader, err = c.App.FileReader(filePath)
+		fileReader, err = c.App.ExportFileReader(filePath)
 		if err != nil {
 			c.Err = model.NewAppError("unableToDownloadJob", "api.job.unable_to_download_job", nil,
 				"job.Data did not include export_dir, export_dir was malformed, or jobId.zip wasn't found",

--- a/server/channels/app/file.go
+++ b/server/channels/app/file.go
@@ -144,6 +144,10 @@ func (s *Server) exportFileReader(path string) (filestore.ReadCloseSeeker, *mode
 	return fileReader(s.ExportFileBackend(), path)
 }
 
+func (s *Server) exportZipReader(path string, deflate bool) (io.ReadCloser, *model.AppError) {
+	return zipReader(s.ExportFileBackend(), path, deflate)
+}
+
 // FileReader returns a ReadCloseSeeker for path from the FileBackend.
 //
 // The caller is responsible for closing the returned ReadCloseSeeker.
@@ -163,6 +167,14 @@ func (a *App) ZipReader(path string, deflate bool) (io.ReadCloser, *model.AppErr
 // The caller is responsible for closing the returned ReadCloseSeeker.
 func (a *App) ExportFileReader(path string) (filestore.ReadCloseSeeker, *model.AppError) {
 	return a.Srv().exportFileReader(path)
+}
+
+// ExportZipReader returns a ReadCloser for path from the ExportFileBackend.
+// If deflate is true, the zip will use compression.
+//
+// The caller is responsible for closing the returned ReadCloser.
+func (a *App) ExportZipReader(path string, deflate bool) (io.ReadCloser, *model.AppError) {
+	return a.Srv().exportZipReader(path, deflate)
 }
 
 func (a *App) FileExists(path string) (bool, *model.AppError) {


### PR DESCRIPTION
#### Summary
- Add the export file store version of the ZipReader and call that for job exports (since that's where exports are written, that's where we should read from).
- Thanks @DHaussermann for the great find.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-62845

#### Release Note
```release-note
NONE
```
