### PR TITLE
[MM-46472] Items are overflowing in the channel menu

### DIFF
--- a/webapp/channels/src/components/channel_header_dropdown/channel_header_dropdown.tsx
+++ b/webapp/channels/src/components/channel_header_dropdown/channel_header_dropdown.tsx
@@ -13,6 +13,7 @@ const ChannelHeaderDropdown = ({ariaLabel}: {
         <Menu
             id='channelHeaderDropdownMenu'
             ariaLabel={ariaLabel}
+            className='channel-header-dropdown-menu'
         >
             <ChannelHeaderDropdownItems isMobile={false}/>
         </Menu>

--- a/webapp/channels/src/components/widgets/menu/menu.scss
+++ b/webapp/channels/src/components/widgets/menu/menu.scss
@@ -26,6 +26,11 @@
         }
     }
 
+    .channel-header-dropdown-menu {
+        overflow: hidden;
+        overflow-y: auto;
+    }
+
     &.Menu-enter {
         .dropdown-menu {
             opacity: 0;
@@ -72,7 +77,8 @@
             @media screen and (min-width: 768px) {
                 max-height: 0;
                 overflow-y: hidden;
-                transition: max-height 1000ms ease-in 0ms, opacity 250ms linear 750ms;
+                transition: max-height 1000ms ease-in 0ms,
+                    opacity 250ms linear 750ms;
             }
 
             @media screen and (max-width: 768px) {


### PR DESCRIPTION
#### Summary

:bug: Fix Items are overflowing in the channel menu

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-29913

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

<img width="596" alt="image" src="https://github.com/user-attachments/assets/df316ce7-0e52-4a22-958c-221418614549" />

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
