### PR TITLE
Open mattermost in browser when desktop landing page setting is disabled

### DIFF
--- a/webapp/channels/src/components/linking_landing_page/index.tsx
+++ b/webapp/channels/src/components/linking_landing_page/index.tsx
@@ -23,6 +23,7 @@ function mapStateToProps(state: GlobalState) {
         siteName: config.SiteName,
         brandImageUrl: Client4.getBrandImageUrl('0'),
         enableCustomBrand: config.EnableCustomBrand === 'true',
+        enableDesktopLandingPage: config.EnableDesktopLandingPage === 'true',
     };
 }
 

--- a/webapp/channels/src/components/linking_landing_page/linking_landing_page.tsx
+++ b/webapp/channels/src/components/linking_landing_page/linking_landing_page.tsx
@@ -24,6 +24,7 @@ type Props = {
     siteName?: string;
     brandImageUrl?: string;
     enableCustomBrand: boolean;
+    enableDesktopLandingPage: boolean;
 }
 
 type State = {
@@ -443,7 +444,7 @@ export default class LinkingLandingPage extends PureComponent<Props, State> {
     render() {
         const isMobile = UserAgent.isMobile();
 
-        if (this.checkLandingPreferenceBrowser() || this.isEmbedded()) {
+        if (!this.props.enableDesktopLandingPage || this.checkLandingPreferenceBrowser() || this.isEmbedded()) {
             this.openInBrowser();
             return null;
         }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Even with the desktop landing page setting disabled, email notification links in Mattermost still open to the landing page. It should redirect from /landing when the setting is disabled.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots

Desktop landing page setting:

![image](https://github.com/user-attachments/assets/b5bc8f31-9962-47ea-b50b-e6e3bae0a304)

Landing page:

![image](https://github.com/user-attachments/assets/cd852c2e-f8e1-41f2-8b45-9961fc8d1435)

#### Release Note

```release-note
NONE
```
