### PR TITLE
MM-62891 Fixed incorrectly applied label in Team Settings modal

### DIFF
--- a/webapp/channels/src/components/team_settings/team_access_tab/allowed_domains_select.tsx
+++ b/webapp/channels/src/components/team_settings/team_access_tab/allowed_domains_select.tsx
@@ -58,7 +58,7 @@ const AllowedDomainsSelect = ({allowedDomains, setAllowedDomains, setHasChanges,
                     defaultMessage: 'When enabled, users can only join the team if their email matches a specific domain (e.g. "mattermost.org")',
                 })}
                 descriptionAboveContent={true}
-                inputFieldData={{name: 'name'}}
+                inputFieldData={{name: 'showAllowedDomains'}}
                 inputFieldValue={showAllowedDomains}
                 handleChange={handleEnableAllowedDomains}
             />

--- a/webapp/channels/src/components/team_settings/team_access_tab/open_invite.tsx
+++ b/webapp/channels/src/components/team_settings/team_access_tab/open_invite.tsx
@@ -57,10 +57,10 @@ const OpenInvite = ({isGroupConstrained, allowOpenInvite, setAllowOpenInvite}: P
             inputFieldTitle={
                 <FormattedMessage
                     id='general_tab.openInviteTitle'
-                    defaultMessage='Allow only users with a specific email domain to join this team'
+                    defaultMessage='Allow any user with an account on this server to join this team'
                 />
             }
-            inputFieldData={{name: 'name'}}
+            inputFieldData={{name: 'allowOpenInvite'}}
             inputFieldValue={allowOpenInvite}
             handleChange={setAllowOpenInvite}
             title={formatMessage({

--- a/webapp/channels/src/components/team_settings/team_access_tab/team_access_tab.test.tsx
+++ b/webapp/channels/src/components/team_settings/team_access_tab/team_access_tab.test.tsx
@@ -120,4 +120,31 @@ describe('components/TeamSettings', () => {
             id: defaultProps.team?.id,
         });
     });
+
+    test('MM-62891 should toggle the right checkboxes when their labels are clicked on', () => {
+        renderWithContext(<AccessTab {...defaultProps}/>);
+
+        expect(screen.getByRole('checkbox', {name: 'Allow only users with a specific email domain to join this team'})).not.toBeChecked();
+        expect(screen.getByRole('checkbox', {name: 'Allow any user with an account on this server to join this team'})).not.toBeChecked();
+
+        userEvent.click(screen.getByText('Allow only users with a specific email domain to join this team'));
+
+        expect(screen.getByRole('checkbox', {name: 'Allow only users with a specific email domain to join this team'})).toBeChecked();
+        expect(screen.getByRole('checkbox', {name: 'Allow any user with an account on this server to join this team'})).not.toBeChecked();
+
+        userEvent.click(screen.getByText('Allow only users with a specific email domain to join this team'));
+
+        expect(screen.getByRole('checkbox', {name: 'Allow only users with a specific email domain to join this team'})).not.toBeChecked();
+        expect(screen.getByRole('checkbox', {name: 'Allow any user with an account on this server to join this team'})).not.toBeChecked();
+
+        userEvent.click(screen.getByText('Allow any user with an account on this server to join this team'));
+
+        expect(screen.getByRole('checkbox', {name: 'Allow only users with a specific email domain to join this team'})).not.toBeChecked();
+        expect(screen.getByRole('checkbox', {name: 'Allow any user with an account on this server to join this team'})).toBeChecked();
+
+        userEvent.click(screen.getByText('Allow any user with an account on this server to join this team'));
+
+        expect(screen.getByRole('checkbox', {name: 'Allow only users with a specific email domain to join this team'})).not.toBeChecked();
+        expect(screen.getByRole('checkbox', {name: 'Allow any user with an account on this server to join this team'})).not.toBeChecked();
+    });
 });


### PR DESCRIPTION
#### Summary
The `name` passed into the checkbox component corresponds to the `id` attribute of the input and the `for` attribute of the label, so we previously had two inputs and labels with the same IDs

#### Ticket Link
MM-62891

#### Release Note
```release-note
NONE
```
