### PR TITLE
[MM-62897] Compliance export backwards compatibility

### DIFF
--- a/server/enterprise/message_export/worker.go
+++ b/server/enterprise/message_export/worker.go
@@ -327,6 +327,12 @@ func (w *MessageExportWorker) initJobData(logger mlog.LoggerIFace, job *model.Jo
 		if previousJob.Data == nil {
 			previousJob.Data = make(map[string]string)
 		}
+
+		// Backwards compatability for <10.5:
+		if batchStartTimestamp, prevExists := previousJob.Data["batch_start_timestamp"]; prevExists {
+			previousJob.Data[shared.JobDataBatchStartTime] = batchStartTimestamp
+		}
+
 		if _, prevExists := previousJob.Data[shared.JobDataBatchStartTime]; !prevExists {
 			exportFromTimestamp := strconv.FormatInt(*w.jobServer.Config().MessageExportSettings.ExportFromTimestamp, 10)
 			logger.Info("Worker: Previously successful job lacks job data, falling back to configured MessageExportSettings.ExportFromTimestamp", mlog.String("export_from_timestamp", exportFromTimestamp))

--- a/server/enterprise/message_export/worker.go
+++ b/server/enterprise/message_export/worker.go
@@ -328,7 +328,7 @@ func (w *MessageExportWorker) initJobData(logger mlog.LoggerIFace, job *model.Jo
 			previousJob.Data = make(map[string]string)
 		}
 
-		// Backwards compatability for <10.5:
+		// Backwards compatibility for <10.5:
 		if batchStartTimestamp, prevExists := previousJob.Data["batch_start_timestamp"]; prevExists {
 			previousJob.Data[shared.JobDataBatchStartTime] = batchStartTimestamp
 		}


### PR DESCRIPTION
#### Summary
- Early in development of Compliance overhaul, I was cleaning up the json fields we were using. I simplified from `Timestamp` -> `Time`, but I forgot to check for the case where a job from <10.5 would be used as the previous job for the first job in a 10.5 server.
- This PR fixes that case (and adds a test for it). 

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-62897

#### Release Note
```release-note
NONE
```
