### PR TITLE
Add readme to the remotecluster and sharedchannel service directories

### DIFF
--- a/server/platform/services/remotecluster/README.md
+++ b/server/platform/services/remotecluster/README.md
@@ -1,0 +1,36 @@
+## Remote Cluster Service
+
+Package `remotecluster` implements Mattermost's "Secured Connections" feature, which enables communication between different Mattermost clusters. Specifically, this package provides:
+
+ ### Service Management:
+
+- Manages inter-cluster communication via topic-based messages
+- Handles connection state (active/inactive) based on cluster leadership
+- Maintains concurrent send channels (MaxConcurrentSends = 10) for parallel message processing
+- Implements periodic health checks (pings) to monitor remote cluster connectivity
+
+ ### Message Handling:
+
+- Sends messages using a pool of goroutines to handle concurrent sends while preserving message order per remote
+- Uses hash-based routing to ensure messages for the same remote ID go to the same channel
+- Supports different types of sends: messages, files, and profile images
+- Implements topic-based message routing with listener callbacks
+
+ ### Connection Management:
+
+- Handles invitation confirmations between clusters
+- Maintains HTTP client connections with proper timeouts and transport settings
+- Supports connection state listeners for monitoring remote cluster availability
+- Implements ping mechanism to verify remote cluster health
+
+ ### Core Features:
+
+- Topic-based message routing
+- File transfer capabilities
+- Profile image synchronization
+- Invitation system for establishing connections
+- Health monitoring via pings
+- Concurrent message processing
+- Connection state management
+
+This package is designed to be thread-safe and handles leadership changes in clustered environments, only running active operations on the leader node.

--- a/server/platform/services/sharedchannel/README.md
+++ b/server/platform/services/sharedchannel/README.md
@@ -1,0 +1,34 @@
+## Shared Channel Service
+
+Package `sharedchannel` implements Mattermost's shared channels functionality, for sharing channel content across Mattermost instances/clusters. Here are the key responsibilities:
+
+### Channel Sharing:
+
+- Allows channels to be shared between different Mattermost instances/clusters
+- Handles inviting remote clusters to shared channels
+- Manages permissions and read-only status for shared channels
+
+### Content Synchronization:
+
+- Syncs posts, reactions, user profiles, and file attachments between instances
+- Handles permalink processing between instances
+- Manages user profile images sync
+- Maintains sync state and cursors to track what has been synchronized
+
+### Remote Communication:
+
+- Processes incoming sync messages from remote clusters
+- Sends updates to remote clusters when local changes occur
+- Handles connection state changes with remote clusters
+- Manages retry logic for failed sync attempts
+
+### Security:
+
+- Validates permissions for shared channel operations
+- Ensures users can only sync content they have access to
+- Verifies remote cluster authenticity
+- Sanitizes user data during sync
+
+The service acts as a bridge between Mattermost instances, allowing users from different instances to collaborate in shared channels while keeping content synchronized across all participating instances.
+
+This is implemented through a Service struct that handles all the shared channel operations and maintains the synchronization state. It works in conjunction with the RemoteCluster service to handle the actual communication between instances.


### PR DESCRIPTION
#### Summary
This PR adds a readme to the Remote Cluster and Shared Channels services packages.  This is simply to help anyone new to the project figure out what these packages do.

#### Ticket Link
NONE

#### Release Note
-->
```release-note
NONE
```
