### PR TITLE
MM-62901: Apply constLabels on all metrics

### DIFF
--- a/server/enterprise/metrics/metrics.go
+++ b/server/enterprise/metrics/metrics.go
@@ -1190,10 +1190,11 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.ClientTimeToFirstByte = NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsWeb,
-			Name:      "time_to_first_byte",
-			Help:      "Duration from when a browser starts to request a page from a server until when it starts to receive data in response (seconds)",
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsWeb,
+			Name:        "time_to_first_byte",
+			Help:        "Duration from when a browser starts to request a page from a server until when it starts to receive data in response (seconds)",
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent"},
 		m.Platform.Log(),
@@ -1202,10 +1203,11 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.ClientTimeToLastByte = NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsWeb,
-			Name:      "time_to_last_byte",
-			Help:      "Duration from when a browser starts to request a page from a server until when it receives the last byte of the resource or immediately before the transport connection is closed, whichever comes first. (seconds)",
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsWeb,
+			Name:        "time_to_last_byte",
+			Help:        "Duration from when a browser starts to request a page from a server until when it receives the last byte of the resource or immediately before the transport connection is closed, whichever comes first. (seconds)",
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent"},
 		m.Platform.Log(),
@@ -1214,11 +1216,12 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.ClientTimeToDOMInteractive = NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsWeb,
-			Name:      "dom_interactive",
-			Help:      "Duration from when a browser starts to request a page from a server until when it sets the document's readyState to interactive. (seconds)",
-			Buckets:   []float64{.1, .25, .5, 1, 2.5, 5, 7.5, 10, 12.5, 15},
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsWeb,
+			Name:        "dom_interactive",
+			Help:        "Duration from when a browser starts to request a page from a server until when it sets the document's readyState to interactive. (seconds)",
+			Buckets:     []float64{.1, .25, .5, 1, 2.5, 5, 7.5, 10, 12.5, 15},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent"},
 		m.Platform.Log(),
@@ -1227,11 +1230,12 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.ClientSplashScreenEnd = NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsWeb,
-			Name:      "splash_screen",
-			Help:      "Duration from when a browser starts to request a page from a server until when the splash screen ends. (seconds)",
-			Buckets:   []float64{.1, .25, .5, 1, 2.5, 5, 7.5, 10, 12.5, 15},
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsWeb,
+			Name:        "splash_screen",
+			Help:        "Duration from when a browser starts to request a page from a server until when the splash screen ends. (seconds)",
+			Buckets:     []float64{.1, .25, .5, 1, 2.5, 5, 7.5, 10, 12.5, 15},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent", "page_type"},
 		m.Platform.Log(),
@@ -1246,7 +1250,8 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 			Help:      "Duration of how long it takes for any content to be displayed on screen to a user (seconds)",
 
 			// Extend the range of buckets for this while we get a better idea of the expected range of this metric is
-			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 15, 20},
+			Buckets:     []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 15, 20},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent"},
 	)
@@ -1260,7 +1265,8 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 			Help:      "Duration of how long it takes for large content to be displayed on screen to a user (seconds)",
 
 			// Extend the range of buckets for this while we get a better idea of the expected range of this metric is
-			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 15, 20},
+			Buckets:     []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 15, 20},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent", "region"},
 	)
@@ -1268,10 +1274,11 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.ClientInteractionToNextPaint = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsWeb,
-			Name:      "interaction_to_next_paint",
-			Help:      "Measure of how long it takes for a user to see the effects of clicking with a mouse, tapping with a touchscreen, or pressing a key on the keyboard (seconds)",
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsWeb,
+			Name:        "interaction_to_next_paint",
+			Help:        "Measure of how long it takes for a user to see the effects of clicking with a mouse, tapping with a touchscreen, or pressing a key on the keyboard (seconds)",
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent", "interaction"},
 	)
@@ -1279,10 +1286,11 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.ClientCumulativeLayoutShift = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsWeb,
-			Name:      "cumulative_layout_shift",
-			Help:      "Measure of how much a page's content shifts unexpectedly",
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsWeb,
+			Name:        "cumulative_layout_shift",
+			Help:        "Measure of how much a page's content shifts unexpectedly",
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent"},
 	)
@@ -1290,10 +1298,11 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.ClientLongTasks = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsWeb,
-			Name:      "long_tasks",
-			Help:      "Counter of the number of times that the browser's main UI thread is blocked for more than 50ms by a single task",
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsWeb,
+			Name:        "long_tasks",
+			Help:        "Counter of the number of times that the browser's main UI thread is blocked for more than 50ms by a single task",
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent"},
 	)
@@ -1301,11 +1310,12 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.ClientPageLoadDuration = NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsWeb,
-			Name:      "page_load",
-			Help:      "The amount of time from when the browser starts loading the web app until when the web app's load event has finished (seconds)",
-			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 40},
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsWeb,
+			Name:        "page_load",
+			Help:        "The amount of time from when the browser starts loading the web app until when the web app's load event has finished (seconds)",
+			Buckets:     []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 40},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent"},
 		m.Platform.Log(),
@@ -1314,10 +1324,11 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.ClientChannelSwitchDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsWeb,
-			Name:      "channel_switch",
-			Help:      "Duration of the time taken from when a user clicks on a channel in the LHS to when posts in that channel become visible (seconds)",
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsWeb,
+			Name:        "channel_switch",
+			Help:        "Duration of the time taken from when a user clicks on a channel in the LHS to when posts in that channel become visible (seconds)",
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent", "fresh"},
 	)
@@ -1325,10 +1336,11 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.ClientTeamSwitchDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsWeb,
-			Name:      "team_switch",
-			Help:      "Duration of the time taken from when a user clicks on a team in the LHS to when posts in that team become visible (seconds)",
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsWeb,
+			Name:        "team_switch",
+			Help:        "Duration of the time taken from when a user clicks on a team in the LHS to when posts in that team become visible (seconds)",
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent", "fresh"},
 	)
@@ -1336,10 +1348,11 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.ClientRHSLoadDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsWeb,
-			Name:      "rhs_load",
-			Help:      "Duration of the time taken from when a user clicks to open a thread in the RHS until when posts in that thread become visible (seconds)",
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsWeb,
+			Name:        "rhs_load",
+			Help:        "Duration of the time taken from when a user clicks to open a thread in the RHS until when posts in that thread become visible (seconds)",
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent"},
 	)
@@ -1347,10 +1360,11 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.ClientGlobalThreadsLoadDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsWeb,
-			Name:      "global_threads_load",
-			Help:      "Duration of the time taken from when a user clicks to open Threads in the LHS until when the global threads view becomes visible (milliseconds)",
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsWeb,
+			Name:        "global_threads_load",
+			Help:        "Duration of the time taken from when a user clicks to open Threads in the LHS until when the global threads view becomes visible (milliseconds)",
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent"},
 	)
@@ -1358,110 +1372,120 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.MobileClientLoadDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsMobileApp,
-			Name:      "mobile_load",
-			Help:      "Duration of the time taken from when a user opens the app and the app finally loads all relevant information (seconds)",
-			Buckets:   []float64{1, 1.5, 2, 3, 4, 4.5, 5, 5.5, 6, 7.5, 10, 20, 25, 30},
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsMobileApp,
+			Name:        "mobile_load",
+			Help:        "Duration of the time taken from when a user opens the app and the app finally loads all relevant information (seconds)",
+			Buckets:     []float64{1, 1.5, 2, 3, 4, 4.5, 5, 5.5, 6, 7.5, 10, 20, 25, 30},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform"},
 	)
 
 	m.MobileClientNetworkRequestsAverageSpeed = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsMobileApp,
-			Name:      "mobile_network_requests_average_speed",
-			Help:      "Average speed of network requests in megabytes per second (MBps)",
-			Buckets:   []float64{1000, 10000, 50000, 100000, 500000, 1000000, 5000000},
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsMobileApp,
+			Name:        "mobile_network_requests_average_speed",
+			Help:        "Average speed of network requests in megabytes per second (MBps)",
+			Buckets:     []float64{1000, 10000, 50000, 100000, 500000, 1000000, 5000000},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent", "network_request_group"},
 	)
 
 	m.MobileClientNetworkRequestsEffectiveLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsMobileApp,
-			Name:      "mobile_network_requests_effective_latency",
-			Help:      "Effective latency of network requests in seconds",
-			Buckets:   []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsMobileApp,
+			Name:        "mobile_network_requests_effective_latency",
+			Help:        "Effective latency of network requests in seconds",
+			Buckets:     []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent", "network_request_group"},
 	)
 
 	m.MobileClientNetworkRequestsElapsedTime = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsMobileApp,
-			Name:      "mobile_network_requests_elapsed_time",
-			Help:      "Total elapsed time of network requests in seconds",
-			Buckets:   []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsMobileApp,
+			Name:        "mobile_network_requests_elapsed_time",
+			Help:        "Total elapsed time of network requests in seconds",
+			Buckets:     []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent", "network_request_group"},
 	)
 
 	m.MobileClientNetworkRequestsLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsMobileApp,
-			Name:      "mobile_network_requests_latency",
-			Help:      "Latency of network requests in seconds",
-			Buckets:   []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsMobileApp,
+			Name:        "mobile_network_requests_latency",
+			Help:        "Latency of network requests in seconds",
+			Buckets:     []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent", "network_request_group"},
 	)
 
 	m.MobileClientNetworkRequestsTotalCompressedSize = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsMobileApp,
-			Name:      "mobile_network_requests_total_compressed_size",
-			Help:      "Total compressed size of network requests in bytes",
-			Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 20, 50},
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsMobileApp,
+			Name:        "mobile_network_requests_total_compressed_size",
+			Help:        "Total compressed size of network requests in bytes",
+			Buckets:     []float64{0.1, 0.5, 1, 2, 5, 10, 20, 50},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent", "network_request_group"},
 	)
 
 	m.MobileClientNetworkRequestsTotalParallelRequests = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsMobileApp,
-			Name:      "mobile_network_requests_total_parallel_requests",
-			Help:      "Total number of parallel network requests made",
-			Buckets:   []float64{1, 2, 5, 10, 20, 50, 100},
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsMobileApp,
+			Name:        "mobile_network_requests_total_parallel_requests",
+			Help:        "Total number of parallel network requests made",
+			Buckets:     []float64{1, 2, 5, 10, 20, 50, 100},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent", "network_request_group"},
 	)
 
 	m.MobileClientNetworkRequestsTotalRequests = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsMobileApp,
-			Name:      "mobile_network_requests_total_requests",
-			Help:      "Total number of network requests made",
-			Buckets:   []float64{1, 2, 5, 10, 20, 50, 100},
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsMobileApp,
+			Name:        "mobile_network_requests_total_requests",
+			Help:        "Total number of network requests made",
+			Buckets:     []float64{1, 2, 5, 10, 20, 50, 100},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent", "network_request_group"},
 	)
 
 	m.MobileClientNetworkRequestsTotalSequentialRequests = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsMobileApp,
-			Name:      "mobile_network_requests_total_sequential_requests",
-			Help:      "Total number of sequential network requests made",
-			Buckets:   []float64{1, 2, 5, 10, 20, 50, 100},
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsMobileApp,
+			Name:        "mobile_network_requests_total_sequential_requests",
+			Help:        "Total number of sequential network requests made",
+			Buckets:     []float64{1, 2, 5, 10, 20, 50, 100},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent", "network_request_group"},
 	)
 
 	m.MobileClientNetworkRequestsTotalSize = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsMobileApp,
-			Name:      "mobile_network_requests_total_size",
-			Help:      "Total uncompressed size of network requests in bytes",
-			Buckets:   []float64{1000, 10000, 50000, 100000, 500000, 1000000, 5000000},
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsMobileApp,
+			Name:        "mobile_network_requests_total_size",
+			Help:        "Total uncompressed size of network requests in bytes",
+			Buckets:     []float64{1000, 10000, 50000, 100000, 500000, 1000000, 5000000},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "agent", "network_request_group"},
 	)
@@ -1479,11 +1503,12 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.MobileClientChannelSwitchDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsMobileApp,
-			Name:      "mobile_channel_switch",
-			Help:      "Duration of the time taken from when a user clicks on a channel name, and the full channel sreen is loaded (seconds)",
-			Buckets:   []float64{0.150, 0.200, 0.300, 0.400, 0.450, 0.500, 0.550, 0.600, 0.750, 1, 2, 3},
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsMobileApp,
+			Name:        "mobile_channel_switch",
+			Help:        "Duration of the time taken from when a user clicks on a channel name, and the full channel sreen is loaded (seconds)",
+			Buckets:     []float64{0.150, 0.200, 0.300, 0.400, 0.450, 0.500, 0.550, 0.600, 0.750, 1, 2, 3},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform"},
 	)
@@ -1491,11 +1516,12 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.MobileClientTeamSwitchDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsMobileApp,
-			Name:      "mobile_team_switch",
-			Help:      "Duration of the time taken from when a user clicks on a team, and the full categories screen is loaded (seconds)",
-			Buckets:   []float64{0.150, 0.200, 0.250, 0.300, 0.350, 0.400, 0.500, 0.750, 1, 2, 3},
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsMobileApp,
+			Name:        "mobile_team_switch",
+			Help:        "Duration of the time taken from when a user clicks on a team, and the full categories screen is loaded (seconds)",
+			Buckets:     []float64{0.150, 0.200, 0.250, 0.300, 0.350, 0.400, 0.500, 0.750, 1, 2, 3},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform"},
 	)
@@ -1503,10 +1529,11 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.MobileClientSessionMetadataGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsMobileApp,
-			Name:      "mobile_session_metadata",
-			Help:      "The number of mobile sessions in each version, platform and whether they have the notifications disabled",
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsMobileApp,
+			Name:        "mobile_session_metadata",
+			Help:        "The number of mobile sessions in each version, platform and whether they have the notifications disabled",
+			ConstLabels: additionalLabels,
 		},
 		[]string{"version", "platform", "notifications_disabled"},
 	)
@@ -1514,11 +1541,12 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.DesktopClientCPUUsage = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsDesktopApp,
-			Name:      "cpu_usage",
-			Help:      "Average CPU usage of a specific process over an interval",
-			Buckets:   []float64{0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 80, 100},
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsDesktopApp,
+			Name:        "cpu_usage",
+			Help:        "Average CPU usage of a specific process over an interval",
+			Buckets:     []float64{0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 80, 100},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "version", "processName"},
 	)
@@ -1526,11 +1554,12 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 
 	m.DesktopClientMemoryUsage = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: MetricsSubsystemClientsDesktopApp,
-			Name:      "memory_usage",
-			Help:      "Memory usage in MB of a specific process",
-			Buckets:   []float64{0, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 3000, 5000},
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemClientsDesktopApp,
+			Name:        "memory_usage",
+			Help:        "Memory usage in MB of a specific process",
+			Buckets:     []float64{0, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 3000, 5000},
+			ConstLabels: additionalLabels,
 		},
 		[]string{"platform", "version", "processName"},
 	)


### PR DESCRIPTION
When the client side metrics were added constLabels
got missed out. Without this, we cannot do the high
level grouping by rings.

https://mattermost.atlassian.net/browse/MM-62901

```release-note
NONE
```
