### PR TITLE
Update User Limits for unlicensed servers

### DIFF
--- a/server/channels/app/limits.go
+++ b/server/channels/app/limits.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	maxUsersLimit     = 5_000
-	maxUsersHardLimit = 11_000
+	maxUsersLimit     = 2_500
+	maxUsersHardLimit = 5_000
 )
 
 func (a *App) GetServerLimits() (*model.ServerLimits, *model.AppError) {

--- a/server/channels/app/limits_test.go
+++ b/server/channels/app/limits_test.go
@@ -20,7 +20,7 @@ func TestGetServerLimits(t *testing.T) {
 
 		// InitBasic creates 3 users by default
 		require.Equal(t, int64(3), serverLimits.ActiveUserCount)
-		require.Equal(t, int64(5000), serverLimits.MaxUsersLimit)
+		require.Equal(t, int64(2500), serverLimits.MaxUsersLimit)
 	})
 
 	t.Run("user count should increase on creating new user and decrease on permanently deleting", func(t *testing.T) {

--- a/server/channels/app/user_test.go
+++ b/server/channels/app/user_test.go
@@ -2306,7 +2306,7 @@ func TestCreateUserOrGuest(t *testing.T) {
 		defer th.TearDown()
 
 		id := NewTestId()
-		userCreationMocks(t, th, id, 11000)
+		userCreationMocks(t, th, id, 5000)
 
 		user := &model.User{
 			Email:         "TestCreateUserOrGuest@example.com",

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/limits.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/limits.test.ts
@@ -76,7 +76,7 @@ describe('getServerLimits', () => {
     test('should return data if user is admin', async () => {
         const userLimits: ServerLimits = {
             activeUserCount: 600,
-            maxUsersLimit: 5_000,
+            maxUsersLimit: 2_500,
 
         };
 


### PR DESCRIPTION
#### Summary

Update User limits to 2.5K for soft limits (admin dismissible banner) and to 5K for hard limit (admin non-dismissible banner and no additional users can be added) for unlicensed servers. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-62769


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Update User limits to 2.5K for soft limits (admin dismissible banner) and to 5K for hard limit (admin non-dismissible banner and no additional users can be added) for unlicensed servers. 
```
