### PR TITLE
MM-62926: Fix standard logger redirection issue

### DIFF
--- a/server/channels/app/platform/log.go
+++ b/server/channels/app/platform/log.go
@@ -54,7 +54,7 @@ func (ps *PlatformService) initLogging() error {
 	}
 
 	// redirect default Go logger to app logger.
-	ps.logger.RedirectStdLog(mlog.LvlStdLog)
+	ps.logger.RedirectStdLog(mlog.LvlWarn)
 
 	// use the app logger as the global logger (eventually remove all instances of global logging).
 	mlog.InitGlobalLogger(ps.logger)


### PR DESCRIPTION
We were redirecting any logging happening via the Go standard logger
to our own mlog instance. The issue is that all those logs were happening
at LvlStdLog level which is higher than LvlDebug.

LvlStdLog is at 10, and LvlDebug is at 5. So unless a customer
sets the log level specifically to "stdlog" or sets up advanced
logging to specifically log for that level, no standard logs will
ever get logged.

We fix this by logging it at warn level. The reason for warn
is that mostly external libraries use this facility to log
out-of-band errors that could not be returned using standard
error returns.

I saw another plugin error which was logged similarly. This
was never surfaced before due to this bug.

https://mattermost.atlassian.net/browse/MM-62926

```release-note
NONE
```
