### PR TITLE
Correctly detect branch to decide if notifying

### DIFF
--- a/.github/workflows/server-ci-report.yml
+++ b/.github/workflows/server-ci-report.yml
@@ -70,7 +70,7 @@ jobs:
           check_annotations: true
 
       - name: Report retried tests via webhook (master)
-        if: ${{ steps.report.outputs.flaky_summary != '<table><tr><th>Test</th><th>Retries</th></tr></table>' && github.event.workflow_run.name == 'Server CI Master' && github.ref_name == 'master' }}
+        if: ${{ steps.report.outputs.flaky_summary != '<table><tr><th>Test</th><th>Retries</th></tr></table>' && github.event.workflow_run.name == 'Server CI Master' && github.event.workflow_run.head_branch == 'master' }}
         uses: mattermost/action-mattermost-notify@b7d118e440bf2749cd18a4a8c88e7092e696257a # v2.0.0
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MM_COMMUNITY_DEVELOPERS_INCOMING_WEBHOOK_FROM_GH_ACTIONS }}


### PR DESCRIPTION
#### Summary
I had previously made a change to check `github.ref`, not realizing that this particular workflow always runs from `master` from a workflow completed on a different branch. Use `github.event.workflow_run.head_branch` instead.

#### Ticket Link
None

#### Screenshots
None

#### Release Note
```release-note
NONE
```
