### PR TITLE
Display the nickname or full name based on settings when drafting posts

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -220,6 +220,7 @@ const AdvancedTextEditor = ({
     const messageStatusRef = useRef<HTMLDivElement | null>(null);
 
     const [draft, setDraft] = useState(draftFromStore);
+    const [saveDraftForPreview, setSaveDraftForPreview] = useState("");
     const [caretPosition, setCaretPosition] = useState(draft.message.length);
     const [serverError, setServerError] = useState<(ServerError & { submittedMessage?: string }) | null>(null);
     const [postError, setPostError] = useState<React.ReactNode>(null);
@@ -236,8 +237,15 @@ const AdvancedTextEditor = ({
     const isDisabled = Boolean(readOnlyChannel || (!enableSharedChannelsDMs && isDMOrGMRemote));
 
     const handleShowPreview = useCallback(() => {
+        if (showPreview) {
+            setDraft({...draft, message: saveDraftForPreview});
+            setSaveDraftForPreview("");
+        } else {
+            setSaveDraftForPreview(draft.message)
+            setDraft({...draft, message: eliminateMentionNicknameOrFullName(draft.message)});
+        }
         setShowPreview((prev) => !prev);
-    }, []);
+    }, [showPreview, draft]);
 
     const emitTypingEvent = useCallback(() => {
         GlobalActions.emitLocalUserTypingEvent(channelId, postId);

--- a/webapp/channels/src/components/advanced_text_editor/use_submit.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_submit.tsx
@@ -372,7 +372,6 @@ const useSubmit = (
                 return;
             }
         }
-        
         await doSubmit(submittingDraft, schedulingInfo, options);
     }, [
         doSubmit,

--- a/webapp/channels/src/components/advanced_text_editor/use_submit.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_submit.tsx
@@ -15,7 +15,7 @@ import {getChannel, getAllChannelStats} from 'mattermost-redux/selectors/entitie
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
-import {getCurrentUserId, getStatusForUserId, getUsersByUsername} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUserId, getStatusForUserId} from 'mattermost-redux/selectors/entities/users';
 
 import {unsetEditingPost, type CreatePostOptions} from 'actions/post_actions';
 import {scrollPostListToBottom} from 'actions/views/channel';
@@ -38,9 +38,6 @@ import type {PostDraft} from 'types/store/draft';
 import {isPostDraftEmpty} from 'types/store/draft';
 
 import useGroups from './use_groups';
-import { getUsernameMentions } from 'utils/text_formatting';
-import { displayUsername } from 'mattermost-redux/utils/user_utils';
-import { getTeammateNameDisplaySetting } from 'mattermost-redux/selectors/entities/preferences';
 
 function getStatusFromSlashCommand(message: string) {
     const tokens = message.split(' ');
@@ -119,9 +116,6 @@ const useSubmit = (
         }
         return haveIChannelPermission(state, channel.team_id, channel.id, Permissions.USE_CHANNEL_MENTIONS);
     });
-
-    const usersByUsername = useSelector((state: GlobalState) => getUsersByUsername(state));
-    const teammateNameDisplay = useSelector((state: GlobalState) => getTeammateNameDisplaySetting(state));
 
     const showPostDeletedModal = useCallback(() => {
         dispatch(openModal({
@@ -378,18 +372,6 @@ const useSubmit = (
                 return;
             }
         }
-
-        submittingDraft.message = getUsernameMentions(submittingDraft.message).reduce((msg, mention) => {
-            const username = mention.substring(1);
-            const mentionedUser = usersByUsername[username];
-        
-            if (!mentionedUser) {
-                return msg;
-            }
-        
-            const userDisplayName = displayUsername(mentionedUser, teammateNameDisplay);
-            return msg.replace(`@${username}(${userDisplayName})`, `@${username}`);
-        }, submittingDraft.message);
         
         await doSubmit(submittingDraft, schedulingInfo, options);
     }, [

--- a/webapp/channels/src/components/suggestion/at_mention_provider/at_mention_provider.tsx
+++ b/webapp/channels/src/components/suggestion/at_mention_provider/at_mention_provider.tsx
@@ -22,6 +22,7 @@ import AtMentionSuggestion from './at_mention_suggestion';
 
 import Provider from '../provider';
 import { getTeammateNameDisplaySetting } from 'mattermost-redux/selectors/entities/preferences';
+import { getFullName } from 'utils/utils';
 
 const profilesInChannelOptions = {active: true};
 const regexForAtMention = /(?:^|\W)@([\p{L}\d\-_. ]*)$/iu;
@@ -370,16 +371,17 @@ export default class AtMentionProvider extends Provider {
                 const teammateNameDisplay = getTeammateNameDisplaySetting(state)
 
                 if (teammateNameDisplay == 'nickname_full_name') {
-                    if (item.nickname) {
-                        return `@${item.username}(${item.nickname})`;
-                    } else if (item.fullname) {
-                        return `@${item.username}(${item.fullname})`;
+                    const fullname = getFullName(item);
+                    const displayName = item.nickname || fullname;
+                    if (displayName) {
+                        return `@${item.username}(${displayName})`;
                     }
                 }
 
                 if (teammateNameDisplay == 'full_name') {
-                    if (item.fullname) {
-                        return `@${item.username}(${item.fullname})`;
+                    const fullname = getFullName(item);
+                    if (fullname) {
+                        return `@${item.username}(${fullname})`;
                     }
                 }
             }

--- a/webapp/channels/src/components/suggestion/at_mention_provider/at_mention_provider.tsx
+++ b/webapp/channels/src/components/suggestion/at_mention_provider/at_mention_provider.tsx
@@ -371,15 +371,15 @@ export default class AtMentionProvider extends Provider {
 
                 if (teammateNameDisplay == 'nickname_full_name') {
                     if (item.nickname) {
-                        return '@' + item.nickname;
-                    } else if (item.first_name && item.last_name) {
-                        return '@' + item.first_name + ' ' + item.last_name;
+                        return `@${item.username}(${item.nickname})`;
+                    } else if (item.fullname) {
+                        return `@${item.username}(${item.fullname})`;
                     }
                 }
 
                 if (teammateNameDisplay == 'full_name') {
-                    if (item.first_name && item.last_name) {
-                        return '@' + item.first_name + ' ' + item.last_name;
+                    if (item.fullname) {
+                        return `@${item.username}(${item.fullname})`;
                     }
                 }
             }

--- a/webapp/channels/src/components/suggestion/at_mention_provider/at_mention_provider.tsx
+++ b/webapp/channels/src/components/suggestion/at_mention_provider/at_mention_provider.tsx
@@ -21,6 +21,7 @@ import type {GlobalState} from 'types/store';
 import AtMentionSuggestion from './at_mention_suggestion';
 
 import Provider from '../provider';
+import { getTeammateNameDisplaySetting } from 'mattermost-redux/selectors/entities/preferences';
 
 const profilesInChannelOptions = {active: true};
 const regexForAtMention = /(?:^|\W)@([\p{L}\d\-_. ]*)$/iu;
@@ -362,12 +363,33 @@ export default class AtMentionProvider extends Provider {
         } else if (this.lastPrefixWithNoResults === this.latestPrefix) {
             this.lastPrefixWithNoResults = '';
         }
+
         const mentions = items.map((item) => {
+            if (item.type === Constants.MENTION_MEMBERS) {
+                const state = store.getState();
+                const teammateNameDisplay = getTeammateNameDisplaySetting(state)
+
+                if (teammateNameDisplay == 'nickname_full_name') {
+                    if (item.nickname) {
+                        return '@' + item.nickname;
+                    } else if (item.first_name && item.last_name) {
+                        return '@' + item.first_name + ' ' + item.last_name;
+                    }
+                }
+
+                if (teammateNameDisplay == 'full_name') {
+                    if (item.first_name && item.last_name) {
+                        return '@' + item.first_name + ' ' + item.last_name;
+                    }
+                }
+            }
+
             if (item.username) {
                 return '@' + item.username;
             } else if (item.name) {
                 return '@' + item.name;
             }
+
             return '';
         });
 

--- a/webapp/channels/src/components/suggestion/at_mention_provider/at_mention_provider.tsx
+++ b/webapp/channels/src/components/suggestion/at_mention_provider/at_mention_provider.tsx
@@ -10,7 +10,7 @@ import type {Filters} from 'mattermost-redux/selectors/entities/users';
 import {makeGetProfilesInChannel} from 'mattermost-redux/selectors/entities/users';
 import {makeAddLastViewAtToProfiles} from 'mattermost-redux/selectors/entities/utils';
 import type {ActionResult} from 'mattermost-redux/types/actions';
-import {getSuggestionsSplitBy, getSuggestionsSplitByMultiple} from 'mattermost-redux/utils/user_utils';
+import {displayUsername, getSuggestionsSplitBy, getSuggestionsSplitByMultiple} from 'mattermost-redux/utils/user_utils';
 
 import store from 'stores/redux_store';
 
@@ -369,20 +369,9 @@ export default class AtMentionProvider extends Provider {
             if (item.type === Constants.MENTION_MEMBERS) {
                 const state = store.getState();
                 const teammateNameDisplay = getTeammateNameDisplaySetting(state)
-
-                if (teammateNameDisplay == 'nickname_full_name') {
-                    const fullname = getFullName(item);
-                    const displayName = item.nickname || fullname;
-                    if (displayName) {
-                        return `@${item.username}(${displayName})`;
-                    }
-                }
-
-                if (teammateNameDisplay == 'full_name') {
-                    const fullname = getFullName(item);
-                    if (fullname) {
-                        return `@${item.username}(${fullname})`;
-                    }
+                const displayName = displayUsername(item, teammateNameDisplay);
+                if (item.username !== displayName) {
+                    return `@${item.username}(${displayName})`;
                 }
             }
 

--- a/webapp/channels/src/components/suggestion/at_mention_provider/at_mention_provider.tsx
+++ b/webapp/channels/src/components/suggestion/at_mention_provider/at_mention_provider.tsx
@@ -22,7 +22,6 @@ import AtMentionSuggestion from './at_mention_suggestion';
 
 import Provider from '../provider';
 import { getTeammateNameDisplaySetting } from 'mattermost-redux/selectors/entities/preferences';
-import { getFullName } from 'utils/utils';
 
 const profilesInChannelOptions = {active: true};
 const regexForAtMention = /(?:^|\W)@([\p{L}\d\-_. ]*)$/iu;

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/users.ts
@@ -224,6 +224,16 @@ export const getCurrentUserMentionKeys: (state: GlobalState) => UserMentionKey[]
             keys.push({key: usernameKey});
         }
 
+        const usernicknameKey = '@' + user.nickname;
+        if (keys.findIndex((key) => key.key === usernicknameKey) === -1) {
+            keys.push({key: usernicknameKey});
+        }
+
+        const userfullnameKey = '@' + user.first_name + ' ' + user.last_name;
+        if (keys.findIndex((key) => key.key === userfullnameKey) === -1) {
+            keys.push({key: userfullnameKey});
+        }
+
         return keys;
     },
 );

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/users.ts
@@ -224,16 +224,6 @@ export const getCurrentUserMentionKeys: (state: GlobalState) => UserMentionKey[]
             keys.push({key: usernameKey});
         }
 
-        const usernicknameKey = '@' + user.nickname;
-        if (keys.findIndex((key) => key.key === usernicknameKey) === -1) {
-            keys.push({key: usernicknameKey});
-        }
-
-        const userfullnameKey = '@' + user.first_name + ' ' + user.last_name;
-        if (keys.findIndex((key) => key.key === userfullnameKey) === -1) {
-            keys.push({key: userfullnameKey});
-        }
-
         return keys;
     },
 );

--- a/webapp/channels/src/utils/text_formatting.tsx
+++ b/webapp/channels/src/utils/text_formatting.tsx
@@ -558,6 +558,12 @@ export function allAtMentions(text: string): string[] {
     return text.match(Constants.SPECIAL_MENTIONS_REGEX && AT_MENTION_PATTERN) || [];
 }
 
+export function getUsernameMentions(text: string): string[] {
+    const excludedMentions = new Set(text.match(Constants.SPECIAL_MENTIONS_REGEX) || []);
+    const mentions = text.match(AT_MENTION_PATTERN) || [];
+    return mentions.filter((mention) => !excludedMentions.has(mention));
+}
+
 export function autolinkChannelMentions(
     text: string,
     tokens: Tokens,

--- a/webapp/channels/src/utils/text_formatting.tsx
+++ b/webapp/channels/src/utils/text_formatting.tsx
@@ -15,6 +15,8 @@ import Constants from './constants';
 import type EmojiMap from './emoji_map.js';
 import * as Emoticons from './emoticons';
 import * as Markdown from './markdown';
+import { displayUsername } from 'mattermost-redux/utils/user_utils';
+import { UserProfile } from '@mattermost/types/users';
 
 const punctuationRegex = /[^\p{L}\d]/u;
 const AT_MENTION_PATTERN = /(?:\B|\b_+)@([a-z0-9.\-_]+)/gi;
@@ -562,6 +564,20 @@ export function getUsernameMentions(text: string): string[] {
     const excludedMentions = new Set(text.match(Constants.SPECIAL_MENTIONS_REGEX) || []);
     const mentions = text.match(AT_MENTION_PATTERN) || [];
     return mentions.filter((mention) => !excludedMentions.has(mention));
+}
+
+export function eliminateMentionNicknameOrFullName(text: string, usersByUsername: Record<string, UserProfile>, teammateNameDisplay: string): string {
+    return getUsernameMentions(text).reduce((msg, mention) => {
+        const username = mention.substring(1);
+        const mentionedUser = usersByUsername[username];
+    
+        if (!mentionedUser) {
+            return msg;
+        }
+    
+        const userDisplayName = displayUsername(mentionedUser, teammateNameDisplay);
+        return msg.replace(`@${username}(${userDisplayName})`, `@${username}`);
+    }, text);
 }
 
 export function autolinkChannelMentions(


### PR DESCRIPTION
#### Summary
A user can configure the Teammate Name Display in the System Console. Since usernames must be unique and cannot contain restricted characters, my organization configures using nicknames or full names.

However, when drafting posts, only the username is displayed in mentions, even when the system is configured to use nicknames or full names. This is not user-friendly.

By aligning the display with the mention list format, improves the clarity of username display. 

The username is still stored in the database. While the nickname or full name is displayed in the draft, it is removed before submission and sent to the server. Therefore, the impact of this implementation is minimized.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/30038

#### Screenshots
**Before**
Only displaying username is very difficult to understand.

https://github.com/user-attachments/assets/8be81dd6-b1b7-417a-a71c-0561367ec6b2

**After**

https://github.com/user-attachments/assets/4d4f1a08-439f-49d1-aad4-9c1e2a6a6e3c

Here is a preview behavior.

https://github.com/user-attachments/assets/8a21c3fa-002e-44b6-9bad-d872506ea3e6

#### Release Note
```release-note
Display the nickname or full name based on settings when drafting posts.
```
