### PR TITLE
Add e2e tests for ConfigMigrateCmdF

### DIFF
--- a/server/cmd/mmctl/commands/config_e2e_test.go
+++ b/server/cmd/mmctl/commands/config_e2e_test.go
@@ -323,3 +323,44 @@ func (s *MmctlE2ETestSuite) TestConfigExportCmdF() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 }
+
+func (s *MmctlE2ETestSuite) TestConfigMigrateCmdF() {
+	s.SetupTestHelper().InitBasic()
+
+	s.Run("Should fail without the --local flag", func() {
+		printer.Clean()
+		args := []string{"from", "to"}
+
+		err := configMigrateCmdF(s.th.Client, &cobra.Command{}, args)
+		s.Require().Error(err)
+		s.Require().Equal("this command is only available in local mode. Please set the --local flag", err.Error())
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Should be able to migrate config", func() {
+		printer.Clean()
+		args := []string{"config.json", "toDb"}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("local", true, "")
+
+		err := configMigrateCmdF(s.th.LocalClient, cmd, args)
+		s.Require().NoError(err)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Should fail on error when migrating config", func() {
+		printer.Clean()
+		args := []string{"from", "to"}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("local", true, "")
+
+		err := configMigrateCmdF(s.th.LocalClient, cmd, args)
+		s.Require().Error(err)
+		s.Require().Equal("Failed to migrate config store.", err.Error())
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Add e2e tests for ConfigMigrateCmdF

#### Ticket Link
de both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/15997
Jira https://mattermost.atlassian.net/browse/MM-29801


#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
