### PR TITLE
fix elasticsearch on macbook m4

### DIFF
--- a/server/build/docker-compose.common.yml
+++ b/server/build/docker-compose.common.yml
@@ -100,7 +100,8 @@ services:
       transport.host: "127.0.0.1"
       xpack.security.enabled: "false"
       action.destructive_requires_name: "false"
-      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m -XX:UseSVE=0"
+      CLI_JAVA_OPTS: -XX:UseSVE=0
   opensearch:
     build:
       context: .


### PR DESCRIPTION
#### Summary
Apply suggested changes from https://github.com/elastic/elasticsearch/issues/118583#issuecomment-2546997587 to resolve issues starting Elasticsearch on a Macbook M4.

We should test this on non-Apple, non-M4 architectures before merging.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
