### PR TITLE
MM-62944 Fix fileupload settings not being clickable

### DIFF
--- a/webapp/channels/src/components/admin_console/file_upload_setting.tsx
+++ b/webapp/channels/src/components/admin_console/file_upload_setting.tsx
@@ -40,6 +40,10 @@ export default class FileUploadSetting extends React.PureComponent<Props, State>
         };
     }
 
+    handleChooseClick = () => {
+        this.fileInputRef.current?.click();
+    };
+
     handleChange = () => {
         const files = this.fileInputRef.current?.files;
         if (files && files.length > 0) {
@@ -92,6 +96,7 @@ export default class FileUploadSetting extends React.PureComponent<Props, State>
                             type='button'
                             className='btn btn-tertiary'
                             disabled={this.props.disabled}
+                            onClick={this.handleChooseClick}
                         >
                             <FormattedMessage
                                 id='admin.file_upload.chooseFile'


### PR DESCRIPTION
#### Summary
Prior to https://github.com/mattermost/mattermost/pull/29510, settings involving uploading a file worked by making a button and then stretching a transparent file input over it, but that made them unusable for keyboard users. In that PR, I changed it so that the buttons for those would instead trigger the file input when clicked, but I missed doing it for this setting.

#### Ticket Link
MM-62944

#### Release Note
```release-note
NONE
```
