### PR TITLE
MM-62933 Revert position of post menu to match earlier versions

### DIFF
--- a/webapp/channels/src/sass/components/_post-menu.scss
+++ b/webapp/channels/src/sass/components/_post-menu.scss
@@ -11,6 +11,11 @@
     padding: 4px;
     border: 1px solid transparent;
     border-radius: 4px;
+
+    // Counteract the margins added to ul in _typography.scss
+    margin-top: 0;
+    margin-bottom: 0;
+
     list-style: none;
     white-space: normal;
 }

--- a/webapp/channels/src/sass/components/_search.scss
+++ b/webapp/channels/src/sass/components/_search.scss
@@ -335,12 +335,10 @@
     right: 0;
     font-size: 13px;
 
-    a {
-        vertical-align: top;
-    }
-
     .search-item__jump {
         position: relative;
+        display: block;
+        height: 100%;
         padding: 5px 4px 0;
         border-radius: 4px;
         color: rgba(var(--center-channel-color-rgb), 0.4);


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost/pull/29787 changed the structure of the post options to be lists for better accessibility, but the different HTML tags had some minor layout differences that weren't noticed.

This should fix those

#### Ticket Link
MM-62933

#### Screenshots
What changed|Master|10.3|Now
-|-|-|-
The menu is shifted downwards on master compared to 10.3|![1c community post](https://github.com/user-attachments/assets/6401893b-9d1c-45a6-98bf-bd199f534943)|![1a hub post](https://github.com/user-attachments/assets/1aa290d7-14f9-44c9-809d-f1e22b941e2f)|![1b pr post](https://github.com/user-attachments/assets/1282c046-d8a0-4e10-b783-727742ce08bf)
The box around the menu is shifted downwards while "Jump" is shifted upwards|![2c community search](https://github.com/user-attachments/assets/bebff8b3-6725-4f07-8dac-33a4569a0a15)|![2a hub search](https://github.com/user-attachments/assets/1c65d6f4-63c9-4115-b6ec-688d7ffdace4)|![2b pr search](https://github.com/user-attachments/assets/ec9bd635-c84d-4933-8547-6f14b5eec54f)
In the RHS, the menu is shifted downwards on master like in the centre channel|![3c community rhs](https://github.com/user-attachments/assets/0a1bc8d5-8295-4096-a3ec-b1765bf8e41c)|![3a hub rhs](https://github.com/user-attachments/assets/4346ed7c-7b63-412f-9ca2-9ee43fffb0d7)|![3b pr rhs](https://github.com/user-attachments/assets/01ec11bf-8be4-460b-8b8f-c95f3366adc9)

#### Release Note
```release-note
NONE
```
