### PR TITLE
Updates the property field and value update methods to use a single query for multiple entities

### DIFF
--- a/server/channels/store/sqlstore/property_field_store.go
+++ b/server/channels/store/sqlstore/property_field_store.go
@@ -128,44 +128,66 @@ func (s *SqlPropertyFieldStore) Update(fields []*model.PropertyField) (_ []*mode
 	defer finalizeTransactionX(transaction, &err)
 
 	updateTime := model.GetMillis()
-	for _, field := range fields {
-		field.UpdateAt = updateTime
+	isPostgres := s.DriverName() == model.DatabaseDriverPostgres
+	nameCase := sq.Case("id")
+	typeCase := sq.Case("id")
+	attrsCase := sq.Case("id")
+	targetIDCase := sq.Case("id")
+	targetTypeCase := sq.Case("id")
+	deleteAtCase := sq.Case("id")
+	ids := make([]string, len(fields))
 
+	for i, field := range fields {
+		field.UpdateAt = updateTime
 		if vErr := field.IsValid(); vErr != nil {
 			return nil, errors.Wrap(vErr, "property_field_update_isvalid")
 		}
 
-		queryString, args, err := s.getQueryBuilder().
-			Update("PropertyFields").
-			Set("Name", field.Name).
-			Set("Type", field.Type).
-			Set("Attrs", field.Attrs).
-			Set("TargetID", field.TargetID).
-			Set("TargetType", field.TargetType).
-			Set("UpdateAt", field.UpdateAt).
-			Set("DeleteAt", field.DeleteAt).
-			Where(sq.Eq{"id": field.ID}).
-			ToSql()
-		if err != nil {
-			return nil, errors.Wrap(err, "property_field_update_tosql")
-		}
+		ids[i] = field.ID
 
-		result, err := transaction.Exec(queryString, args...)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to update property field with id: %s", field.ID)
-		}
-
-		count, err := result.RowsAffected()
-		if err != nil {
-			return nil, errors.Wrap(err, "property_field_update_rowsaffected")
-		}
-		if count == 0 {
-			return nil, store.NewErrNotFound("PropertyField", field.ID)
+		if isPostgres {
+			nameCase = nameCase.When(sq.Expr("?", field.ID), sq.Expr("?::text", field.Name))
+			typeCase = typeCase.When(sq.Expr("?", field.ID), sq.Expr("?::property_field_type", field.Type))
+			attrsCase = attrsCase.When(sq.Expr("?", field.ID), sq.Expr("?::jsonb", field.Attrs))
+			targetIDCase = targetIDCase.When(sq.Expr("?", field.ID), sq.Expr("?::text", field.TargetID))
+			targetTypeCase = targetTypeCase.When(sq.Expr("?", field.ID), sq.Expr("?::text", field.TargetType))
+			deleteAtCase = deleteAtCase.When(sq.Expr("?", field.ID), sq.Expr("?::bigint", field.DeleteAt))
+		} else {
+			nameCase = nameCase.When(sq.Expr("?", field.ID), sq.Expr("?", field.Name))
+			typeCase = typeCase.When(sq.Expr("?", field.ID), sq.Expr("?", field.Type))
+			attrsCase = attrsCase.When(sq.Expr("?", field.ID), sq.Expr("?", field.Attrs))
+			targetIDCase = targetIDCase.When(sq.Expr("?", field.ID), sq.Expr("?", field.TargetID))
+			targetTypeCase = targetTypeCase.When(sq.Expr("?", field.ID), sq.Expr("?", field.TargetType))
+			deleteAtCase = deleteAtCase.When(sq.Expr("?", field.ID), sq.Expr("?", field.DeleteAt))
 		}
 	}
 
+	builder := s.getQueryBuilder().
+		Update("PropertyFields").
+		Set("Name", nameCase).
+		Set("Type", typeCase).
+		Set("Attrs", attrsCase).
+		Set("TargetID", targetIDCase).
+		Set("TargetType", targetTypeCase).
+		Set("UpdateAt", updateTime).
+		Set("DeleteAt", deleteAtCase).
+		Where(sq.Eq{"id": ids})
+
+	result, err := transaction.ExecBuilder(builder)
+	if err != nil {
+		return nil, errors.Wrap(err, "property_field_update_exec")
+	}
+
+	count, err := result.RowsAffected()
+	if err != nil {
+		return nil, errors.Wrap(err, "property_field_update_rowsaffected")
+	}
+	if count != int64(len(fields)) {
+		return nil, errors.Errorf("failed to update, some property fields were not found, got %d of %d", count, len(fields))
+	}
+
 	if err := transaction.Commit(); err != nil {
-		return nil, errors.Wrap(err, "property_field_update_commit")
+		return nil, errors.Wrap(err, "property_field_update_commit_transaction")
 	}
 
 	return fields, nil

--- a/server/channels/store/sqlstore/property_field_store.go
+++ b/server/channels/store/sqlstore/property_field_store.go
@@ -144,21 +144,21 @@ func (s *SqlPropertyFieldStore) Update(fields []*model.PropertyField) (_ []*mode
 		}
 
 		ids[i] = field.ID
-
+		whenID := sq.Expr("?", field.ID)
 		if isPostgres {
-			nameCase = nameCase.When(sq.Expr("?", field.ID), sq.Expr("?::text", field.Name))
-			typeCase = typeCase.When(sq.Expr("?", field.ID), sq.Expr("?::property_field_type", field.Type))
-			attrsCase = attrsCase.When(sq.Expr("?", field.ID), sq.Expr("?::jsonb", field.Attrs))
-			targetIDCase = targetIDCase.When(sq.Expr("?", field.ID), sq.Expr("?::text", field.TargetID))
-			targetTypeCase = targetTypeCase.When(sq.Expr("?", field.ID), sq.Expr("?::text", field.TargetType))
-			deleteAtCase = deleteAtCase.When(sq.Expr("?", field.ID), sq.Expr("?::bigint", field.DeleteAt))
+			nameCase = nameCase.When(whenID, sq.Expr("?::text", field.Name))
+			typeCase = typeCase.When(whenID, sq.Expr("?::property_field_type", field.Type))
+			attrsCase = attrsCase.When(whenID, sq.Expr("?::jsonb", field.Attrs))
+			targetIDCase = targetIDCase.When(whenID, sq.Expr("?::text", field.TargetID))
+			targetTypeCase = targetTypeCase.When(whenID, sq.Expr("?::text", field.TargetType))
+			deleteAtCase = deleteAtCase.When(whenID, sq.Expr("?::bigint", field.DeleteAt))
 		} else {
-			nameCase = nameCase.When(sq.Expr("?", field.ID), sq.Expr("?", field.Name))
-			typeCase = typeCase.When(sq.Expr("?", field.ID), sq.Expr("?", field.Type))
-			attrsCase = attrsCase.When(sq.Expr("?", field.ID), sq.Expr("?", field.Attrs))
-			targetIDCase = targetIDCase.When(sq.Expr("?", field.ID), sq.Expr("?", field.TargetID))
-			targetTypeCase = targetTypeCase.When(sq.Expr("?", field.ID), sq.Expr("?", field.TargetType))
-			deleteAtCase = deleteAtCase.When(sq.Expr("?", field.ID), sq.Expr("?", field.DeleteAt))
+			nameCase = nameCase.When(whenID, sq.Expr("?", field.Name))
+			typeCase = typeCase.When(whenID, sq.Expr("?", field.Type))
+			attrsCase = attrsCase.When(whenID, sq.Expr("?", field.Attrs))
+			targetIDCase = targetIDCase.When(whenID, sq.Expr("?", field.TargetID))
+			targetTypeCase = targetTypeCase.When(whenID, sq.Expr("?", field.TargetType))
+			deleteAtCase = deleteAtCase.When(whenID, sq.Expr("?", field.DeleteAt))
 		}
 	}
 


### PR DESCRIPTION
#### Summary
This PR refactors the Property Field and Value stores to use a single `UPDATE` query with `SET CASE` statements instead of multiple `UPDATE` queries within the same transaction for improved performance.

The query is still run in a transaction so it can be rolled back in case the amount of rows modified doesn't correspond with the amount of entities that were passed as parameters to be updated.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62556

#### Release Note
```release-note
NONE
```