### PR TITLE
Fix build: Remove call for removed attribute Page

### DIFF
--- a/server/channels/store/storetest/property_value_store.go
+++ b/server/channels/store/storetest/property_value_store.go
@@ -463,7 +463,6 @@ func testUpsertPropertyValue(t *testing.T, _ request.CTX, ss store.Store) {
 		// Verify the invalid value was not inserted
 		results, err := ss.PropertyValue().SearchPropertyValues(model.PropertyValueSearchOpts{
 			TargetID: invalidValue.TargetID,
-			Page:     0,
 			PerPage:  10,
 		})
 		require.NoError(t, err)


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost/pull/30163 and https://github.com/mattermost/mattermost/pull/30119 conflicted silently, this PR fixes the build on master.


#### Ticket Link
N/A


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
