### PR TITLE
MM-63138 Fix some console warnings

### DIFF
--- a/webapp/channels/src/components/new_search/search_box_input.tsx
+++ b/webapp/channels/src/components/new_search/search_box_input.tsx
@@ -75,7 +75,7 @@ type Props = {
     focus: (newPosition: number) => void;
 }
 
-const SearchInput = ({searchTerms, searchType, setSearchTerms, onKeyDown, focus}: Props, inputRef: React.Ref<HTMLInputElement>) => {
+const SearchInput = forwardRef<HTMLInputElement, Props>(({searchTerms, searchType, setSearchTerms, onKeyDown, focus}, inputRef) => {
     const intl = useIntl();
     let searchPlaceholder = intl.formatMessage({id: 'search_bar.search', defaultMessage: 'Search'});
 
@@ -131,6 +131,6 @@ const SearchInput = ({searchTerms, searchType, setSearchTerms, onKeyDown, focus}
             )}
         </SearchInputContainer>
     );
-};
+});
 
-export default forwardRef<HTMLInputElement, Props>(SearchInput);
+export default SearchInput;

--- a/webapp/channels/src/components/threading/channel_threads/thread_footer/__snapshots__/thread_footer.test.tsx.snap
+++ b/webapp/channels/src/components/threading/channel_threads/thread_footer/__snapshots__/thread_footer.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`components/threading/channel_threads/thread_footer should match snapsho
       isFollowing={true}
       onClick={[Function]}
     >
-      <Memo(Button)
+      <Button
         className="separated FollowButton"
         disabled={false}
         isActive={true}
@@ -32,7 +32,7 @@ exports[`components/threading/channel_threads/thread_footer should match snapsho
             Following
           </span>
         </button>
-      </Memo(Button)>
+      </Button>
     </Memo(FollowButton)>
   </div>
 </Memo(ThreadFooter)>
@@ -317,7 +317,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
         </WithTooltip>
       </div>
     </Memo(Avatars)>
-    <Memo(Button)
+    <Button
       className="ReplyButton separated"
       onClick={[Function]}
       prepend={
@@ -363,13 +363,13 @@ exports[`components/threading/channel_threads/thread_footer should report total 
           </FormattedMessage>
         </span>
       </button>
-    </Memo(Button)>
+    </Button>
     <Memo(FollowButton)
       className="separated"
       isFollowing={true}
       onClick={[Function]}
     >
-      <Memo(Button)
+      <Button
         className="separated FollowButton"
         disabled={false}
         isActive={true}
@@ -386,7 +386,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
             Following
           </span>
         </button>
-      </Memo(Button)>
+      </Button>
     </Memo(FollowButton)>
     <Connect(injectIntl(Timestamp))
       day="numeric"
@@ -828,7 +828,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
         </WithTooltip>
       </div>
     </Memo(Avatars)>
-    <Memo(Button)
+    <Button
       className="ReplyButton separated"
       onClick={[Function]}
       prepend={
@@ -874,13 +874,13 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
           </FormattedMessage>
         </span>
       </button>
-    </Memo(Button)>
+    </Button>
     <Memo(FollowButton)
       className="separated"
       isFollowing={true}
       onClick={[Function]}
     >
-      <Memo(Button)
+      <Button
         className="separated FollowButton"
         disabled={false}
         isActive={true}
@@ -897,7 +897,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
             Following
           </span>
         </button>
-      </Memo(Button)>
+      </Button>
     </Memo(FollowButton)>
     <Connect(injectIntl(Timestamp))
       day="numeric"

--- a/webapp/channels/src/components/threading/common/button/button.tsx
+++ b/webapp/channels/src/components/threading/common/button/button.tsx
@@ -18,18 +18,22 @@ type Props = {
 
 type Attrs = Exclude<ButtonHTMLAttributes<HTMLButtonElement>, Props>
 
-function Button({
-    prepend,
-    append,
-    children,
-    isActive,
-    hasDot,
-    marginTop,
-    allowTextOverflow = false,
-    ...attrs
-}: Props & Attrs) {
+const Button = React.forwardRef<HTMLButtonElement, Props & Attrs>((
+    {
+        prepend,
+        append,
+        children,
+        isActive,
+        hasDot,
+        marginTop,
+        allowTextOverflow = false,
+        ...attrs
+    },
+    ref,
+) => {
     return (
         <button
+            ref={ref}
             {...attrs}
             className={classNames('Button Button___transparent', {'is-active': isActive, allowTextOverflow}, attrs.className)}
         >
@@ -49,6 +53,7 @@ function Button({
             )}
         </button>
     );
-}
+});
+Button.displayName = 'Button';
 
 export default memo(Button);

--- a/webapp/channels/src/components/threading/common/follow_button/__snapshots__/follow_button.test.tsx.snap
+++ b/webapp/channels/src/components/threading/common/follow_button/__snapshots__/follow_button.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`components/threading/common/follow_button should say follow 1`] = `
   isFollowing={false}
   onClick={[MockFunction]}
 >
-  <Memo(Button)
+  <Button
     className="FollowButton"
     disabled={false}
     isActive={false}
@@ -22,7 +22,7 @@ exports[`components/threading/common/follow_button should say follow 1`] = `
         Follow
       </span>
     </button>
-  </Memo(Button)>
+  </Button>
 </Memo(FollowButton)>
 `;
 
@@ -30,7 +30,7 @@ exports[`components/threading/common/follow_button should say following 1`] = `
 <Memo(FollowButton)
   isFollowing={true}
 >
-  <Memo(Button)
+  <Button
     className="FollowButton"
     disabled={false}
     isActive={true}
@@ -45,6 +45,6 @@ exports[`components/threading/common/follow_button should say following 1`] = `
         Following
       </span>
     </button>
-  </Memo(Button)>
+  </Button>
 </Memo(FollowButton)>
 `;


### PR DESCRIPTION
#### Summary
This fixes some console warnings that are printed to the console when working on the web app. They only appeared in dev mode

For the first one, I don't think the error had any effect since I'm pretty confident that the only reason it caused an error was because of a Babel plugin that was adding `propTypes` to something that it thought was a component.

For the second one, this error was actually indicative of the tooltips for components which used the `Button` component in `components/threading/common/button` being broken because `WithTooltip` couldn't attach a ref to find where the tooltip should be placed. Those tooltips should now work again.

#### Ticket Link
MM-63138

#### Screenshots
The errors that should now be fixed are the following:
<img width="835" alt="Screenshot 2025-02-13 at 4 59 52 PM" src="https://github.com/user-attachments/assets/d330a181-c0c6-452d-9465-fed484bc1cf3" />
<img width="821" alt="Screenshot 2025-02-13 at 5 00 08 PM" src="https://github.com/user-attachments/assets/6b72eadf-e6a5-4a7f-a002-524bfd75eb92" />

#### Release Note
```release-note
NONE
```
