### PR TITLE
MM-42819 mmctl: informative errors on permanent deletions

### DIFF
--- a/server/cmd/mmctl/commands/channel.go
+++ b/server/cmd/mmctl/commands/channel.go
@@ -6,6 +6,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/commands/constants"
 	"net/http"
 
 	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/client"
@@ -78,7 +79,8 @@ var DeleteChannelsCmd = &cobra.Command{
 	Use:   "delete [channels]",
 	Short: "Delete channels",
 	Long: `Permanently delete some channels.
-Permanently deletes one or multiple channels along with all related information including posts from the database.`,
+Permanently deletes one or multiple channels along with all related information including posts from the database.
+In order to use this command ServiceSettings.EnableAPIChannelDeletion must be set to true. See ` + constants.CONFIG_DOCUMENTATION_URL + ` for more information.`,
 	Example: "  channel delete myteam:mychannel",
 	Args:    cobra.MinimumNArgs(1),
 	RunE:    withClient(deleteChannelsCmdF),

--- a/server/cmd/mmctl/commands/constants/urls.go
+++ b/server/cmd/mmctl/commands/constants/urls.go
@@ -1,0 +1,5 @@
+package constants
+
+const (
+	CONFIG_DOCUMENTATION_URL = "https://docs.mattermost.com/configure/configuration-settings"
+)

--- a/server/cmd/mmctl/commands/team.go
+++ b/server/cmd/mmctl/commands/team.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/commands/constants"
 	"sort"
 
 	"github.com/hashicorp/go-multierror"
@@ -36,7 +37,8 @@ var DeleteTeamsCmd = &cobra.Command{
 	Use:   "delete [teams]",
 	Short: "Delete teams",
 	Long: `Permanently delete some teams.
-Permanently deletes a team along with all related information including posts from the database.`,
+Permanently deletes a team along with all related information including posts from the database.
+In order to use this command ServiceSettings.EnableAPITeamDeletion must be set to true. See ` + constants.CONFIG_DOCUMENTATION_URL + ` for more information.`,
 	Example: "  team delete myteam",
 	Args:    cobra.MinimumNArgs(1),
 	RunE:    withClient(deleteTeamsCmdF),

--- a/server/cmd/mmctl/commands/user.go
+++ b/server/cmd/mmctl/commands/user.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/commands/constants"
 	"net/http"
 	"net/url"
 	"os"
@@ -142,7 +143,8 @@ var DeleteUsersCmd = &cobra.Command{
 	Use:   "delete [users]",
 	Short: "Delete users",
 	Long: `Permanently delete some users.
-Permanently deletes one or multiple users along with all related information including posts from the database.`,
+Permanently deletes one or multiple users along with all related information including posts from the database.
+In order to use this command ServiceSettings.EnableAPIUserDeletion must be set to true. See ` + constants.CONFIG_DOCUMENTATION_URL + ` for more information.`,
 	Example: "  user delete user@example.com",
 	Args:    cobra.MinimumNArgs(1),
 	RunE:    withClient(deleteUsersCmdF),


### PR DESCRIPTION
#### Summary
A new constant for the configuration documentation URL has been introduced. This URL is now included in the long description of the delete commands for channels, teams, and users. The user is informed that certain service settings must be enabled to use these commands, and directed to the documentation for more information.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/19843

#### Release Note
```release-note
NONE
```
