### PR TITLE
MM-62079: Using a cache prefix to isolate cache keys for each test

### DIFF
--- a/server/channels/api4/apitestlib.go
+++ b/server/channels/api4/apitestlib.go
@@ -113,6 +113,7 @@ func setupTestHelper(dbStore store.Store, searchEngine *searchengine.Broker, ent
 		*memoryConfig.CacheSettings.RedisAddress = redisHost + ":6379"
 		*memoryConfig.CacheSettings.DisableClientCache = true
 		*memoryConfig.CacheSettings.RedisDB = 0
+		*memoryConfig.CacheSettings.RedisCachePrefix = model.NewId()
 		options = append(options, app.ForceEnableRedis())
 	}
 	if updateConfig != nil {

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -131,7 +131,6 @@ func TestCreatePost(t *testing.T) {
 	})
 
 	t.Run("Create posts without the USE_CHANNEL_MENTIONS Permission - returns ephemeral message with mentions and no ephemeral message without mentions", func(t *testing.T) {
-		// t.Skip("MM-62764")
 		wsClient := th.CreateConnectedWebSocketClient(t)
 
 		defaultPerms := th.SaveDefaultRolePermissions()
@@ -148,7 +147,7 @@ func TestCreatePost(t *testing.T) {
 		require.NotNil(t, rPost)
 
 		// Message with no channel mentions should result in no ephemeral message
-		timeout := time.After(2 * time.Second)
+		timeout := time.After(5 * time.Second)
 		waiting := true
 		for waiting {
 			select {
@@ -188,7 +187,6 @@ func TestCreatePost(t *testing.T) {
 				}
 			case <-timeout:
 				require.Fail(t, fmt.Sprintf("Got %d ephemeral messages, expected: %d", gotEvents, expectedEvents))
-				break
 			}
 		}
 	})

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -131,7 +131,7 @@ func TestCreatePost(t *testing.T) {
 	})
 
 	t.Run("Create posts without the USE_CHANNEL_MENTIONS Permission - returns ephemeral message with mentions and no ephemeral message without mentions", func(t *testing.T) {
-		t.Skip("MM-62764")
+		// t.Skip("MM-62764")
 		wsClient := th.CreateConnectedWebSocketClient(t)
 
 		defaultPerms := th.SaveDefaultRolePermissions()
@@ -148,7 +148,7 @@ func TestCreatePost(t *testing.T) {
 		require.NotNil(t, rPost)
 
 		// Message with no channel mentions should result in no ephemeral message
-		timeout := time.After(5 * time.Second)
+		timeout := time.After(2 * time.Second)
 		waiting := true
 		for waiting {
 			select {

--- a/server/channels/app/platform/service.go
+++ b/server/channels/app/platform/service.go
@@ -168,10 +168,11 @@ func New(sc ServiceConfig, options ...Option) (*PlatformService, error) {
 	} else if *cacheConfig.CacheType == model.CacheTypeRedis {
 		ps.cacheProvider, err = cache.NewRedisProvider(
 			&cache.RedisOptions{
-				RedisAddr:     *cacheConfig.RedisAddress,
-				RedisPassword: *cacheConfig.RedisPassword,
-				RedisDB:       *cacheConfig.RedisDB,
-				DisableCache:  *cacheConfig.DisableClientCache,
+				RedisAddr:        *cacheConfig.RedisAddress,
+				RedisPassword:    *cacheConfig.RedisPassword,
+				RedisDB:          *cacheConfig.RedisDB,
+				RedisCachePrefix: *cacheConfig.RedisCachePrefix,
+				DisableCache:     *cacheConfig.DisableClientCache,
 			},
 		)
 	}

--- a/server/platform/services/cache/provider.go
+++ b/server/platform/services/cache/provider.go
@@ -74,15 +74,17 @@ func (c *cacheProvider) Type() string {
 }
 
 type redisProvider struct {
-	client  rueidis.Client
-	metrics einterfaces.MetricsInterface
+	client      rueidis.Client
+	cachePrefix string
+	metrics     einterfaces.MetricsInterface
 }
 
 type RedisOptions struct {
-	RedisAddr     string
-	RedisPassword string
-	RedisDB       int
-	DisableCache  bool
+	RedisAddr        string
+	RedisPassword    string
+	RedisDB          int
+	RedisCachePrefix string
+	DisableCache     bool
 }
 
 // NewProvider creates a new CacheProvider
@@ -107,11 +109,14 @@ func NewRedisProvider(opts *RedisOptions) (Provider, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &redisProvider{client: client}, nil
+	return &redisProvider{client: client, cachePrefix: opts.RedisCachePrefix}, nil
 }
 
 // NewCache creates a new cache with given opts
 func (r *redisProvider) NewCache(opts *CacheOptions) (Cache, error) {
+	if r.cachePrefix != "" {
+		opts.Name = r.cachePrefix + ":" + opts.Name
+	}
 	rr, err := NewRedis(opts, r.client)
 	rr.metrics = r.metrics
 	return rr, err

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -974,6 +974,7 @@ type CacheSettings struct {
 	RedisAddress       *string `access:",write_restrictable,cloud_restrictable"` // telemetry: none
 	RedisPassword      *string `access:",write_restrictable,cloud_restrictable"` // telemetry: none
 	RedisDB            *int    `access:",write_restrictable,cloud_restrictable"` // telemetry: none
+	RedisCachePrefix   *string `access:",write_restrictable,cloud_restrictable"` // telemetry: none
 	DisableClientCache *bool   `access:",write_restrictable,cloud_restrictable"` // telemetry: none
 }
 
@@ -992,6 +993,10 @@ func (s *CacheSettings) SetDefaults() {
 
 	if s.RedisDB == nil {
 		s.RedisDB = NewPointer(-1)
+	}
+
+	if s.RedisCachePrefix == nil {
+		s.RedisCachePrefix = NewPointer("")
 	}
 
 	if s.DisableClientCache == nil {


### PR DESCRIPTION
I was aware that the Redis cache was shared across tests. But we would clear the cache after every test and Redis was enabled only for the api4 package, so there was no chance of parallel tests causing issues.

Even then, it seems like this particular test was somehow a victim of the Redis cache somehow being stale.

It looks like adding a cache prefix has fixed it, but we'll never know until after a few days. In any case, this is essential to scale properly in Cloud. So the effort isn't wasted in any ways.

For now, we are not exposing this in the system console yet. That can be done as a later improvement.

https://mattermost.atlassian.net/browse/MM-62079

```release-note
NONE
```
