### PR TITLE
experiment: filter archived channels in store

### DIFF
--- a/server/channels/app/team.go
+++ b/server/channels/app/team.go
@@ -1659,6 +1659,9 @@ func (a *App) FindTeamByName(name string) bool {
 }
 
 func (a *App) GetTeamsUnreadForUser(excludeTeamId string, userID string, includeCollapsedThreads bool) ([]*model.TeamUnread, *model.AppError) {
+	// experimentalViewArchivedChannels := *a.Config().TeamSettings.ExperimentalViewArchivedChannels
+	experimentalViewArchivedChannels := false
+
 	data, err := a.Srv().Store().Team().GetChannelUnreadsForAllTeams(excludeTeamId, userID)
 	if err != nil {
 		return nil, model.NewAppError("GetTeamsUnreadForUser", "app.team.get_unread.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -1702,7 +1705,7 @@ func (a *App) GetTeamsUnreadForUser(excludeTeamId string, userID string, include
 	includeCollapsedThreads = includeCollapsedThreads && *a.Config().ServiceSettings.CollapsedThreads != model.CollapsedThreadsDisabled
 
 	if includeCollapsedThreads {
-		teamUnreads, err := a.Srv().Store().Thread().GetTeamsUnreadForUser(userID, teamIDs, a.IsPostPriorityEnabled())
+		teamUnreads, err := a.Srv().Store().Thread().GetTeamsUnreadForUser(userID, teamIDs, a.IsPostPriorityEnabled(), !experimentalViewArchivedChannels)
 		if err != nil {
 			return nil, model.NewAppError("GetTeamsUnreadForUser", "app.team.get_unread.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 		}

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -2598,6 +2598,9 @@ func (a *App) ConvertBotToUser(c request.CTX, bot *model.Bot, userPatch *model.U
 }
 
 func (a *App) GetThreadsForUser(userID, teamID string, options model.GetUserThreadsOpts) (*model.Threads, *model.AppError) {
+	// options.ExcludeArchivedChannels = !*a.Config().TeamSettings.ExperimentalViewArchivedChannels
+	options.ExcludeArchivedChannels = true
+
 	var result model.Threads
 	var eg errgroup.Group
 	postPriorityIsEnabled := a.IsPostPriorityEnabled()

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -13167,11 +13167,11 @@ func (s *RetryLayerThreadStore) GetMembershipsForUser(userID string, teamID stri
 
 }
 
-func (s *RetryLayerThreadStore) GetTeamsUnreadForUser(userID string, teamIDs []string, includeUrgentMentionCount bool) (map[string]*model.TeamUnread, error) {
+func (s *RetryLayerThreadStore) GetTeamsUnreadForUser(userID string, teamIDs []string, includeUrgentMentionCount bool, excludeArchivedChannels bool) (map[string]*model.TeamUnread, error) {
 
 	tries := 0
 	for {
-		result, err := s.ThreadStore.GetTeamsUnreadForUser(userID, teamIDs, includeUrgentMentionCount)
+		result, err := s.ThreadStore.GetTeamsUnreadForUser(userID, teamIDs, includeUrgentMentionCount, excludeArchivedChannels)
 		if err == nil {
 			return result, nil
 		}

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -340,7 +340,7 @@ type ThreadStore interface {
 	GetTotalUnreadUrgentMentions(userID, teamID string, opts model.GetUserThreadsOpts) (int64, error)
 	GetThreadsForUser(userID, teamID string, opts model.GetUserThreadsOpts) ([]*model.ThreadResponse, error)
 	GetThreadForUser(threadMembership *model.ThreadMembership, extended, postPriorityIsEnabled bool) (*model.ThreadResponse, error)
-	GetTeamsUnreadForUser(userID string, teamIDs []string, includeUrgentMentionCount bool) (map[string]*model.TeamUnread, error)
+	GetTeamsUnreadForUser(userID string, teamIDs []string, includeUrgentMentionCount bool, excludeArchivedChannels bool) (map[string]*model.TeamUnread, error)
 
 	MarkAllAsRead(userID string, threadIds []string) error
 	MarkAllAsReadByTeam(userID, teamID string) error

--- a/server/channels/store/storetest/mocks/ThreadStore.go
+++ b/server/channels/store/storetest/mocks/ThreadStore.go
@@ -169,9 +169,9 @@ func (_m *ThreadStore) GetMembershipsForUser(userID string, teamID string) ([]*m
 	return r0, r1
 }
 
-// GetTeamsUnreadForUser provides a mock function with given fields: userID, teamIDs, includeUrgentMentionCount
-func (_m *ThreadStore) GetTeamsUnreadForUser(userID string, teamIDs []string, includeUrgentMentionCount bool) (map[string]*model.TeamUnread, error) {
-	ret := _m.Called(userID, teamIDs, includeUrgentMentionCount)
+// GetTeamsUnreadForUser provides a mock function with given fields: userID, teamIDs, includeUrgentMentionCount, excludeArchivedChannels
+func (_m *ThreadStore) GetTeamsUnreadForUser(userID string, teamIDs []string, includeUrgentMentionCount bool, excludeArchivedChannels bool) (map[string]*model.TeamUnread, error) {
+	ret := _m.Called(userID, teamIDs, includeUrgentMentionCount, excludeArchivedChannels)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetTeamsUnreadForUser")
@@ -179,19 +179,19 @@ func (_m *ThreadStore) GetTeamsUnreadForUser(userID string, teamIDs []string, in
 
 	var r0 map[string]*model.TeamUnread
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, []string, bool) (map[string]*model.TeamUnread, error)); ok {
-		return rf(userID, teamIDs, includeUrgentMentionCount)
+	if rf, ok := ret.Get(0).(func(string, []string, bool, bool) (map[string]*model.TeamUnread, error)); ok {
+		return rf(userID, teamIDs, includeUrgentMentionCount, excludeArchivedChannels)
 	}
-	if rf, ok := ret.Get(0).(func(string, []string, bool) map[string]*model.TeamUnread); ok {
-		r0 = rf(userID, teamIDs, includeUrgentMentionCount)
+	if rf, ok := ret.Get(0).(func(string, []string, bool, bool) map[string]*model.TeamUnread); ok {
+		r0 = rf(userID, teamIDs, includeUrgentMentionCount, excludeArchivedChannels)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]*model.TeamUnread)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, []string, bool) error); ok {
-		r1 = rf(userID, teamIDs, includeUrgentMentionCount)
+	if rf, ok := ret.Get(1).(func(string, []string, bool, bool) error); ok {
+		r1 = rf(userID, teamIDs, includeUrgentMentionCount, excludeArchivedChannels)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/storetest/thread_store.go
+++ b/server/channels/store/storetest/thread_store.go
@@ -702,7 +702,7 @@ func testGetTeamsUnreadForUser(t *testing.T, rctx request.CTX, ss store.Store) {
 	threadStoreCreateReply(t, rctx, ss, channel1.Id, post.Id, post.UserId, model.GetMillis())
 	createThreadMembership(userID, post.Id)
 
-	teamsUnread, err := ss.Thread().GetTeamsUnreadForUser(userID, []string{team1.Id}, true)
+	teamsUnread, err := ss.Thread().GetTeamsUnreadForUser(userID, []string{team1.Id}, true, false)
 	require.NoError(t, err)
 	assert.Len(t, teamsUnread, 1)
 	assert.Equal(t, int64(1), teamsUnread[team1.Id].ThreadCount)
@@ -716,7 +716,7 @@ func testGetTeamsUnreadForUser(t *testing.T, rctx request.CTX, ss store.Store) {
 	threadStoreCreateReply(t, rctx, ss, channel1.Id, post.Id, post.UserId, model.GetMillis())
 	createThreadMembership(userID, post.Id)
 
-	teamsUnread, err = ss.Thread().GetTeamsUnreadForUser(userID, []string{team1.Id}, true)
+	teamsUnread, err = ss.Thread().GetTeamsUnreadForUser(userID, []string{team1.Id}, true, false)
 	require.NoError(t, err)
 	assert.Len(t, teamsUnread, 1)
 	assert.Equal(t, int64(2), teamsUnread[team1.Id].ThreadCount)
@@ -752,7 +752,7 @@ func testGetTeamsUnreadForUser(t *testing.T, rctx request.CTX, ss store.Store) {
 	threadStoreCreateReply(t, rctx, ss, channel2.Id, post2.Id, post2.UserId, model.GetMillis())
 	createThreadMembership(userID, post2.Id)
 
-	teamsUnread, err = ss.Thread().GetTeamsUnreadForUser(userID, []string{team1.Id, team2.Id}, true)
+	teamsUnread, err = ss.Thread().GetTeamsUnreadForUser(userID, []string{team1.Id, team2.Id}, true, false)
 	require.NoError(t, err)
 	assert.Len(t, teamsUnread, 2)
 	assert.Equal(t, int64(2), teamsUnread[team1.Id].ThreadCount)
@@ -765,7 +765,7 @@ func testGetTeamsUnreadForUser(t *testing.T, rctx request.CTX, ss store.Store) {
 	_, err = ss.Thread().MaintainMembership(userID, post2.Id, opts)
 	require.NoError(t, err)
 
-	teamsUnread, err = ss.Thread().GetTeamsUnreadForUser(userID, []string{team2.Id}, true)
+	teamsUnread, err = ss.Thread().GetTeamsUnreadForUser(userID, []string{team2.Id}, true, false)
 	require.NoError(t, err)
 	assert.Len(t, teamsUnread, 1)
 	assert.Equal(t, int64(1), teamsUnread[team2.Id].ThreadCount)
@@ -1337,7 +1337,7 @@ func testMarkAllAsReadByChannels(t *testing.T, rctx request.CTX, ss store.Store)
 	assertThreadReplyCount := func(t *testing.T, userID string, count int64) {
 		t.Helper()
 
-		teamsUnread, err := ss.Thread().GetTeamsUnreadForUser(userID, []string{team1.Id}, false)
+		teamsUnread, err := ss.Thread().GetTeamsUnreadForUser(userID, []string{team1.Id}, false, false)
 		require.NoError(t, err)
 		require.Len(t, teamsUnread, 1, "unexpected unread teams count")
 		assert.Equal(t, count, teamsUnread[team1.Id].ThreadCount, "unexpected thread count")
@@ -1453,7 +1453,7 @@ func testMarkAllAsReadByTeam(t *testing.T, rctx request.CTX, ss store.Store) {
 	assertThreadReplyCount := func(t *testing.T, userID, teamID string, count int64, message string) {
 		t.Helper()
 
-		teamsUnread, err := ss.Thread().GetTeamsUnreadForUser(userID, []string{teamID}, true)
+		teamsUnread, err := ss.Thread().GetTeamsUnreadForUser(userID, []string{teamID}, true, false)
 		require.NoError(t, err)
 		require.Lenf(t, teamsUnread, 1, "unexpected unread teams count: %s", message)
 		assert.Equalf(t, count, teamsUnread[teamID].ThreadCount, "unexpected thread count: %s", message)

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -10351,10 +10351,10 @@ func (s *TimerLayerThreadStore) GetMembershipsForUser(userID string, teamID stri
 	return result, err
 }
 
-func (s *TimerLayerThreadStore) GetTeamsUnreadForUser(userID string, teamIDs []string, includeUrgentMentionCount bool) (map[string]*model.TeamUnread, error) {
+func (s *TimerLayerThreadStore) GetTeamsUnreadForUser(userID string, teamIDs []string, includeUrgentMentionCount bool, excludeArchivedChannels bool) (map[string]*model.TeamUnread, error) {
 	start := time.Now()
 
-	result, err := s.ThreadStore.GetTeamsUnreadForUser(userID, teamIDs, includeUrgentMentionCount)
+	result, err := s.ThreadStore.GetTeamsUnreadForUser(userID, teamIDs, includeUrgentMentionCount, excludeArchivedChannels)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {

--- a/server/public/model/thread.go
+++ b/server/public/model/thread.go
@@ -90,6 +90,9 @@ type GetUserThreadsOpts struct {
 	IncludeIsUrgent bool
 
 	ExcludeDirect bool
+
+	// TODO: This isn't something the enduser should set.
+	ExcludeArchivedChannels bool
 }
 
 func (o *Thread) Etag() string {


### PR DESCRIPTION
#### Summary
This PR is not meant to be merged. It is an experiment to allow us to run CI-based load testing on the core idea of filtering out archived channels when doing thread store calls.

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
