### PR TITLE
Bump prepackage Jira plugin version to 4.2.1

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -138,7 +138,7 @@ PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
 PLUGIN_PACKAGES += mattermost-plugin-calls-v1.5.1
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.3.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.9.1
-PLUGIN_PACKAGES += mattermost-plugin-jira-v4.2.0
+PLUGIN_PACKAGES += mattermost-plugin-jira-v4.2.1
 # We need to prepackage both versions of playbooks and install the correct one based on the server license. See MM-60025.
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v1.40.0
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.1.1


### PR DESCRIPTION
#### Summary
Prepackage Jira plugin v4.2.1.

#### Release Note
```release-note
Prepackage Jira plugin version [v4.2.1](https://github.com/mattermost/mattermost-plugin-jira/releases/tag/v4.2.1).
```
Prepackage Jira plugin version [v4.2.1](https://github.com/mattermost/mattermost-plugin-jira/releases/tag/v4.2.1).