### PR TITLE
MM-53506 Fixed duplicated command response in thread/channel (#23969)

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.test.ts
@@ -722,6 +722,23 @@ describe('postsInChannel', () => {
             });
         });
 
+        it('should do nothing when a reply-post comes and CRT is ON, even if ephemeral', () => {
+            const state = deepFreeze({
+                channel1: [],
+            });
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {id: 'post1', channel_id: 'channel1', root_id: 'parent1', type: 'system_ephemeral'},
+                features: {crtEnabled: true},
+            }, {}, {});
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                channel1: [],
+            });
+        });
+
         it('should reset when called for (e.g. when CRT is TOGGLED)', () => {
             const state = deepFreeze({
                 channel1: [],

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
@@ -22,7 +22,6 @@ import type {
 import type {MMReduxAction} from 'mattermost-redux/action_types';
 import {ChannelTypes, PostTypes, UserTypes, ThreadTypes, CloudTypes} from 'mattermost-redux/action_types';
 import {Posts} from 'mattermost-redux/constants';
-import {PostTypes as PostConstant} from 'mattermost-redux/constants/posts';
 import {comparePosts, isPermalink, shouldUpdatePost} from 'mattermost-redux/utils/post_utils';
 
 export function removeUnneededMetadata(post: Post) {
@@ -472,7 +471,7 @@ export function postsInChannel(state: Record<string, PostOrderBlock[]> = {}, act
     case PostTypes.RECEIVED_NEW_POST: {
         const post = action.data as Post;
 
-        if (action.features?.crtEnabled && post.root_id && post.type !== PostConstant.EPHEMERAL) {
+        if (action.features?.crtEnabled && post.root_id) {
             return state;
         }
 


### PR DESCRIPTION
#### Summary
The issue is that the system answer to a command entered in a thread is also posted in the channel.
For me the problem was in the reducer that processes new posts, and especially the condition that allows not to display thread messages into channel.   
To fix it, I removed a particular clause that did an exception on ephemeral messages. I didn't find in commit log any reason why this particular clause has been added at first time (but maybe information was lost during monorepo migration). 

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/23969
Jira https://mattermost.atlassian.net/browse/MM-53506

#### Release Note

```release-note
Fixed an issue where the system answer to a command entered in a thread was also posted in the channel 
```