### PR TITLE
[MM-62609] Show Group Mentions permissions if custom groups is enabled

### DIFF
--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree.tsx
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree.tsx
@@ -240,7 +240,7 @@ export default class PermissionsTree extends React.PureComponent<Props, State> {
         if (scope === 'team_scope' && this.groups[0].id !== 'teams_team_scope') {
             this.groups[0].id = 'teams_team_scope';
         }
-        if (license?.IsLicensed === 'true' && license?.LDAPGroups === 'true' && !postsGroup.permissions.includes(Permissions.USE_GROUP_MENTIONS)) {
+        if (license?.IsLicensed === 'true' && (license?.LDAPGroups === 'true' || config.EnableCustomGroups === 'true') && !postsGroup.permissions.includes(Permissions.USE_GROUP_MENTIONS)) {
             postsGroup.permissions.push(Permissions.USE_GROUP_MENTIONS);
         }
         postsGroup.permissions.push({


### PR DESCRIPTION
#### Summary
The Custom Groups feature shares the same permission that the LDAP groups feature uses, but the permission toggle itself would not show up for non-Enterprise users. This PR makes sure the permission toggle shows for servers with Custom Groups enabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62609

```release-note
Fixed an issue where the group mentions permission was missing
```
