### PR TITLE
Fixed bug where post with only attachments didn't auto-focus on editing

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.test.tsx
@@ -445,4 +445,23 @@ describe('components/avanced_text_editor/advanced_text_editor', () => {
         rerender(<AdvancedTextEditor {...props}/>);
         expect(container.querySelector('#editPostFileDropOverlay')).toBeVisible();
     });
+
+    it('should have focus for empty message', () => {
+        renderWithContext(
+            <AdvancedTextEditor
+                {...baseProps}
+            />,
+            mergeObjects(initialState, {
+                entities: {
+                    roles: {
+                        roles: {
+                            user_roles: {permissions: [Permissions.CREATE_POST]},
+                        },
+                    },
+                },
+            }),
+        );
+        const textbox = screen.getByTestId('post_textbox');
+        expect(textbox).toHaveFocus();
+    });
 });

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -547,10 +547,10 @@ const AdvancedTextEditor = ({
     // Update the caret position in the input box when changed by a side effect
     useEffect(() => {
         const textbox: HTMLInputElement | HTMLTextAreaElement | undefined = textboxRef.current?.getInputBox();
-        if (textbox && textbox.selectionStart !== caretPosition) {
+        if (textbox && (textbox.selectionStart !== caretPosition || draft.message.length === 0)) {
             Utils.setCaretPosition(textbox, caretPosition);
         }
-    }, [caretPosition]);
+    }, [caretPosition, draft.message.length]);
 
     // Handle width change when there is no message.
     useEffect(() => {

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -547,10 +547,10 @@ const AdvancedTextEditor = ({
     // Update the caret position in the input box when changed by a side effect
     useEffect(() => {
         const textbox: HTMLInputElement | HTMLTextAreaElement | undefined = textboxRef.current?.getInputBox();
-        if (textbox && (textbox.selectionStart !== caretPosition || draft.message.length === 0)) {
+        if (textbox && textbox.selectionStart !== caretPosition) {
             Utils.setCaretPosition(textbox, caretPosition);
         }
-    }, [caretPosition, draft.message.length]);
+    }, [caretPosition]);
 
     // Handle width change when there is no message.
     useEffect(() => {
@@ -570,6 +570,13 @@ const AdvancedTextEditor = ({
             focusTextbox();
         }
     }, [showPreview]);
+
+    useEffect(() => {
+        focusTextbox();
+
+        // Focus on the editor at fisrt render
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     // Focus textbox when selectedPostFocussedAt changes
     useEffect(() => {


### PR DESCRIPTION
#### Summary
Fixed bug where post with only attachments didn't auto-focus on editing.

This was occurring because the focused post data has way too many flows and empty post is not handled well. I didn't want to mingle with the already complex flow, hence, this fix.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-63241


#### Release Note
```release-note
None
```
