### PR TITLE
[AI assisted] MM-62916: Read from master while getting job

### DIFF
--- a/server/channels/jobs/jobs.go
+++ b/server/channels/jobs/jobs.go
@@ -80,8 +80,8 @@ func (srv *JobServer) _createJob(c request.CTX, jobType string, jobData map[stri
 	return &job, nil
 }
 
-func (srv *JobServer) GetJob(c request.CTX, id string) (*model.Job, *model.AppError) {
-	job, err := srv.Store.Job().Get(c, id)
+func (srv *JobServer) GetJob(rctx request.CTX, id string) (*model.Job, *model.AppError) {
+	job, err := srv.Store.Job().Get(rctx, id)
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {

--- a/server/channels/jobs/simple_worker_test.go
+++ b/server/channels/jobs/simple_worker_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package jobs_test
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/v8/channels/jobs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimpleWorkerClaimOnce(t *testing.T) {
+	th := Setup(t)
+	defer th.TearDown()
+
+	// Create a job to test with
+	job, appErr := th.Server.Jobs.CreateJob(th.Context, model.JobTypeExportProcess, nil)
+	require.Nil(t, appErr)
+
+	// Track how many times the execute function is called
+	executeCount := 0
+	exec := func(_ mlog.LoggerIFace, _ *model.Job) error {
+		executeCount++
+		return nil
+	}
+
+	isEnabled := func(_ *model.Config) bool {
+		return true
+	}
+
+	sWorker := jobs.NewSimpleWorker("test", th.Server.Jobs, exec, isEnabled)
+
+	// First call should claim the job and execute it
+	sWorker.DoJob(job)
+
+	// Wait for the job to complete
+	th.WaitForJobStatus(t, job, model.JobStatusSuccess)
+
+	// Second call should fail to claim and return early
+	sWorker.DoJob(job)
+
+	// Verify the execute function was only called once
+	require.Equal(t, 1, executeCount, "Execute function should be called exactly once")
+
+	// Verify the job status is still success in the database
+	updatedJob, appErr := th.Server.Jobs.GetJob(th.Context, job.Id)
+	require.Nil(t, appErr)
+	th.WaitForJobStatus(t, updatedJob, model.JobStatusSuccess)
+}

--- a/server/channels/store/sqlstore/job_store.go
+++ b/server/channels/store/sqlstore/job_store.go
@@ -202,7 +202,7 @@ func (jss SqlJobStore) UpdateStatusOptimistically(id string, currentStatus strin
 	return true, nil
 }
 
-func (jss SqlJobStore) Get(c request.CTX, id string) (*model.Job, error) {
+func (jss SqlJobStore) Get(rctx request.CTX, id string) (*model.Job, error) {
 	query, args, err := jss.getQueryBuilder().
 		Select("*").
 		From("Jobs").
@@ -212,7 +212,7 @@ func (jss SqlJobStore) Get(c request.CTX, id string) (*model.Job, error) {
 	}
 
 	var status model.Job
-	if err = jss.GetReplica().Get(&status, query, args...); err != nil {
+	if err = jss.DBXFromContext(rctx.Context()).Get(&status, query, args...); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Job", id)
 		}


### PR DESCRIPTION
This was a classic read-after-write condition
where we would update the job status in the DB,
along with some other fields and then read
it back again from the replica.

This would cause a job struct with pending
status to be read from the DB and then passed
in the worker code. Then it would cause further
issues because while updating the job progress,
we would be setting the status from the job
struct while checking for "in-progress" status
in the DB.

So the DB value would be correct, but we were
incorrectly resetting the value to pending
because of the wrong value read from the replica.

Ideally, we should return the modified job value
after updating. But since we have to maintain
MySQL, so we need 2 code paths since MySQL
doesn't support "RETURNING *".

Therefore, using master for getting the job
seems simple enough.

Also, I re-did the tests with using a real store
to improve it.

https://mattermost.atlassian.net/browse/MM-62916

```release-note
NONE
```
