### PR TITLE
Bump plugins to latest

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -137,8 +137,8 @@ TEMPLATES_DIR=templates
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
 PLUGIN_PACKAGES += mattermost-plugin-calls-v1.5.1
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.3.0
-PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.9.1
-PLUGIN_PACKAGES += mattermost-plugin-jira-v4.2.0
+PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.10.0
+PLUGIN_PACKAGES += mattermost-plugin-jira-v4.2.1
 # We need to prepackage both versions of playbooks and install the correct one based on the server license. See MM-60025.
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v1.40.0
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.1.1
@@ -146,12 +146,12 @@ PLUGIN_PACKAGES += mattermost-plugin-nps-v1.3.3
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.3.4
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.8.0
 PLUGIN_PACKAGES += mattermost-plugin-ai-v1.1.1
-PLUGIN_PACKAGES += mattermost-plugin-boards-v9.1.1
+PLUGIN_PACKAGES += mattermost-plugin-boards-v9.1.2
 PLUGIN_PACKAGES += mattermost-plugin-msteams-v2.1.0
-PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
+PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.2.0
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.3.4
 PLUGIN_PACKAGES += mattermost-plugin-msteams-meetings-v2.2.0
-PLUGIN_PACKAGES += mattermost-plugin-metrics-v0.5.3
+PLUGIN_PACKAGES += mattermost-plugin-metrics-v0.6.0
 PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.2.1
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)


### PR DESCRIPTION
#### Summary

- Bump plugins to latest versions

#### Ticket Link

NA

#### Screenshots

NA

#### Release Note

```release-note
- Upgrade mattermost-plugin-gitlab from v1.9.1 to v.1.10.01
- Upgrade mattermost-plugin-jira from v4.2.0 to v4.2.1
- Upgrade mattermost-plugin-boards from v9.1.1 to 9.1.2
- Upgrade mattermost-plugin-user-survey from v1.1.1 to v1.2.0
- Upgrade mattermost-plugin-metrics from v0.5.3 to v0.6.0
```
