### PR TITLE
MM-63301: Use break-word in profile popover fields

### DIFF
--- a/webapp/channels/src/components/profile_popover/profile_popover.scss
+++ b/webapp/channels/src/components/profile_popover/profile_popover.scss
@@ -201,7 +201,7 @@ $profilePopoverBorderWidth: 1px;
                 font-size: 16px;
             }
         }
-        
+
         .user-popover__custom_attributes {
             display: flex;
             flex-direction: column;
@@ -218,6 +218,7 @@ $profilePopoverBorderWidth: 1px;
 
             .user-popover__subtitle-text {
                 margin: 0;
+                overflow-wrap: break-word;
             }
         }
 


### PR DESCRIPTION
#### Summary
Normal text wrapping causes long words to overflow. Switching all `.user-popover__subtitle-text`s to use `overflow-wrap: break-word;` to fix.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63301

#### Screenshots

`70-characters-allowed-000000000000000000123456789012345678901234`
|  before  |  after  |
|----|----|
|  ![CleanShot 2025-02-27 at 08 53 41](https://github.com/user-attachments/assets/c7a5e415-986a-4909-9908-a654d8adb443) | ![CleanShot 2025-02-27 at 08 52 05](https://github.com/user-attachments/assets/6cd74741-44c1-4225-83c4-9751bde59434) |

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
