### PR TITLE
MM-63213 Remove background from more modal plus button

### DIFF
--- a/webapp/channels/src/sass/components/_modal.scss
+++ b/webapp/channels/src/sass/components/_modal.scss
@@ -940,6 +940,7 @@
         height: 32px;
         padding: 0;
         border: none;
+        background-color: initial;
         opacity: 0.75;
         text-align: center;
     }


### PR DESCRIPTION
#### Summary
As part of the accessibility improvements, we made this component use a button which automatically gave it a background on dark themes. This PR removes that

#### Ticket Link
MM-63213

#### Screenshots

|  before  |  after  |
|----|----|
|![Screenshot 2025-02-27 at 5 09 34 PM](https://github.com/user-attachments/assets/e70a5f89-4425-4e16-aef5-705ee05661f3)|![Screenshot 2025-02-27 at 5 09 16 PM](https://github.com/user-attachments/assets/32d654e0-d82e-4c3c-99e0-faec1030603f)

#### Release Note
This hasn't shipped in a release yet
```release-note
NONE
```
