### PR TITLE
Plugin groups sync ReAddRemovedMembers always true

### DIFF
--- a/server/channels/api4/group.go
+++ b/server/channels/api4/group.go
@@ -394,7 +394,7 @@ func linkGroupSyncable(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.AddEventObjectType("group_syncable")
 
 	c.App.Srv().Go(func() {
-		c.App.SyncRolesAndMembership(c.AppContext, syncableID, syncableType, false)
+		c.App.SyncRolesAndMembership(c.AppContext, syncableID, syncableType, c.Params.GroupId)
 	})
 
 	w.WriteHeader(http.StatusCreated)
@@ -579,7 +579,7 @@ func patchGroupSyncable(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.AddEventObjectType("group_syncable")
 
 	c.App.Srv().Go(func() {
-		c.App.SyncRolesAndMembership(c.AppContext, syncableID, syncableType, false)
+		c.App.SyncRolesAndMembership(c.AppContext, syncableID, syncableType, c.Params.GroupId)
 	})
 
 	b, err := json.Marshal(groupSyncable)
@@ -641,7 +641,7 @@ func unlinkGroupSyncable(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	c.App.Srv().Go(func() {
-		c.App.SyncRolesAndMembership(c.AppContext, syncableID, syncableType, false)
+		c.App.SyncRolesAndMembership(c.AppContext, syncableID, syncableType, c.Params.GroupId)
 	})
 
 	auditRec.Success()

--- a/server/channels/app/syncables.go
+++ b/server/channels/app/syncables.go
@@ -293,8 +293,6 @@ func (a *App) SyncRolesAndMembership(rctx request.CTX, syncableID string, syncab
 		includeRemovedMembers = false
 	}
 
-	rctx.Logger().Info("Syncing default memberships", mlog.Int("since", since))
-
 	params := model.CreateDefaultMembershipParams{Since: since, ReAddRemovedMembers: includeRemovedMembers}
 
 	switch syncableType {

--- a/server/channels/app/syncables.go
+++ b/server/channels/app/syncables.go
@@ -270,17 +270,30 @@ func (a *App) SyncSyncableRoles(rctx request.CTX, syncableID string, syncableTyp
 
 // SyncRolesAndMembership updates the SchemeAdmin status and membership of all of the members of the given
 // syncable.
-func (a *App) SyncRolesAndMembership(rctx request.CTX, syncableID string, syncableType model.GroupSyncableType, includeRemovedMembers bool) {
-	appErr := a.SyncSyncableRoles(rctx, syncableID, syncableType)
+func (a *App) SyncRolesAndMembership(rctx request.CTX, syncableID string, syncableType model.GroupSyncableType, groupID string) {
+	group, appErr := a.GetGroup(groupID, nil, nil)
+	if appErr != nil {
+		rctx.Logger().Warn("Error getting group", mlog.Err(appErr))
+		return
+	}
+
+	appErr = a.SyncSyncableRoles(rctx, syncableID, syncableType)
 	if appErr != nil {
 		rctx.Logger().Warn("Error syncing syncable roles", mlog.Err(appErr))
 	}
 
-	lastJob, _ := a.Srv().Store().Job().GetNewestJobByStatusAndType(model.JobStatusSuccess, model.JobTypeLdapSync)
 	var since int64
-	if lastJob != nil {
-		since = lastJob.StartAt
+	includeRemovedMembers := true
+	if group.Source == model.GroupSourceLdap {
+		lastJob, _ := a.Srv().Store().Job().GetNewestJobByStatusAndType(model.JobStatusSuccess, model.JobTypeLdapSync)
+		if lastJob != nil {
+			since = lastJob.StartAt
+		}
+
+		includeRemovedMembers = false
 	}
+
+	rctx.Logger().Info("Syncing default memberships", mlog.Int("since", since))
 
 	params := model.CreateDefaultMembershipParams{Since: since, ReAddRemovedMembers: includeRemovedMembers}
 


### PR DESCRIPTION
#### Summary
Our existing behaviour with LDAP is that users do not get re-added to channel and teams that they previously left when we update the group syncables for channels and teams in system console. It's a common complaint with LDAP that we do this but I don't want to change the default behaviour for LDAP groups. For plugin groups you will always be re-added.

#### Ticket Link
https://hub.mattermost.com/boards/team/qghzt68dq7bopgqamcnziq69ao/bfmucr8uaf7bptfu3d3mxwb4wxe/vu89hiii597gr3kwxi61rdogkih/c5bkijwkwj7dydkdp63g8f5ikhh


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
None
```
