### PR TITLE
Hyphenation

### DIFF
--- a/webapp/channels/src/components/about_build_modal/about_build_modal.test.tsx
+++ b/webapp/channels/src/components/about_build_modal/about_build_modal.test.tsx
@@ -119,7 +119,7 @@ describe('components/AboutBuildModal', () => {
         );
 
         expect(screen.getByText('Mattermost Cloud')).toBeInTheDocument();
-        expect(screen.getByText('High trust messaging for the enterprise')).toBeInTheDocument();
+        expect(screen.getByText('High-trust messaging for the enterprise')).toBeInTheDocument();
         expect(screen.getByTestId('aboutModalVersion')).toHaveTextContent('Mattermost Version: 3.6.0');
         expect(screen.getByText('0123456789abcdef', {exact: false})).toBeInTheDocument();
         expect(screen.getByRole('link', {name: 'server'})).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-server/blob/master/NOTICE.txt');

--- a/webapp/channels/src/components/about_build_modal/about_build_modal_cloud/about_build_modal_cloud.tsx
+++ b/webapp/channels/src/components/about_build_modal/about_build_modal_cloud/about_build_modal_cloud.tsx
@@ -43,7 +43,7 @@ export default function AboutBuildModalCloud(props: Props) {
     const subTitle = (
         <FormattedMessage
             id='about.enterpriseEditionSst'
-            defaultMessage='High trust messaging for the enterprise'
+            defaultMessage='High-trust messaging for the enterprise'
         />
     );
 

--- a/webapp/channels/src/i18n/en-AU.json
+++ b/webapp/channels/src/i18n/en-AU.json
@@ -14,7 +14,7 @@
   "about.date": "Build Date:",
   "about.dbversion": "Database Schema Version:",
   "about.enterpriseEditionLearn": "Learn more about Enterprise Edition at ",
-  "about.enterpriseEditionSst": "High trust messaging for the enterprise",
+  "about.enterpriseEditionSst": "High-trust messaging for the enterprise",
   "about.enterpriseEditionSt": "Modern communication from behind your firewall.",
   "about.enterpriseEditione1": "Enterprise Edition",
   "about.hash": "Build Hash:",

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -7,7 +7,7 @@
   "about.dbversion": "Database Schema Version:",
   "about.enterpriseEditione1": "Enterprise Edition",
   "about.enterpriseEditionLearn": "Learn more about Enterprise Edition at ",
-  "about.enterpriseEditionSst": "High trust messaging for the enterprise",
+  "about.enterpriseEditionSst": "High-trust messaging for the enterprise",
   "about.enterpriseEditionSt": "Modern communication from behind your firewall.",
   "about.hash": "Build Hash:",
   "about.hashee": "EE Build Hash:",


### PR DESCRIPTION
#### Summary
Grammar. "High-trust" is a compound adjective, and is already correctly hyphenated in [`server/channels/api4/cloud_test.go`][0].

#### Release Note
```release-note
NONE
```

[0]: https://github.com/mattermost/mattermost/blob/master/server/channels/api4/cloud_test.go#L435
