### PR TITLE
[MM-63325, MM-63329] feat: dont register plugins or show the footer if MMEMBED cookie is set to `1`

### DIFF
--- a/webapp/channels/src/components/header_footer_route/footer.tsx
+++ b/webapp/channels/src/components/header_footer_route/footer.tsx
@@ -16,7 +16,7 @@ const Footer = () => {
     const {AboutLink, PrivacyPolicyLink, TermsOfServiceLink, HelpLink} = useSelector(getConfig);
 
     // Check if MMDEBUG cookie is set and if so, don't show the footer
-    if (document.cookie.includes('MMDEBUG=')) {
+    if (document.cookie.includes('MMEMBED=1')) {
         return null;
     }
 

--- a/webapp/channels/src/components/header_footer_route/footer.tsx
+++ b/webapp/channels/src/components/header_footer_route/footer.tsx
@@ -15,6 +15,11 @@ const Footer = () => {
 
     const {AboutLink, PrivacyPolicyLink, TermsOfServiceLink, HelpLink} = useSelector(getConfig);
 
+    // Check if MMDEBUG cookie is set and if so, don't show the footer
+    if (document.cookie.includes('MMDEBUG=')) {
+        return null;
+    }
+
     return (
         <div className='hfroute-footer'>
             <span

--- a/webapp/channels/src/components/header_footer_route/footer.tsx
+++ b/webapp/channels/src/components/header_footer_route/footer.tsx
@@ -15,7 +15,7 @@ const Footer = () => {
 
     const {AboutLink, PrivacyPolicyLink, TermsOfServiceLink, HelpLink} = useSelector(getConfig);
 
-    // Check if MMDEBUG cookie is set and if so, don't show the footer
+    // Check if MMEMBED cookie is set and if so, don't show the footer
     if (document.cookie.includes('MMEMBED=1')) {
         return null;
     }

--- a/webapp/channels/src/plugins/index.ts
+++ b/webapp/channels/src/plugins/index.ts
@@ -62,6 +62,11 @@ window.plugins = {};
 // During the beta, plugins manipulated the global window.plugins data structure directly. This
 // remains possible, but is officially deprecated and may be removed in a future release.
 function registerPlugin(id: string, plugin: Plugin): void {
+    // Don't register plugins if MMDEBUG cookie is set
+    if (document.cookie.includes('MMDEBUG=')) {
+        return;
+    }
+
     const oldPlugin = window.plugins[id];
     if (oldPlugin && oldPlugin.uninitialize) {
         oldPlugin.uninitialize();

--- a/webapp/channels/src/plugins/index.ts
+++ b/webapp/channels/src/plugins/index.ts
@@ -62,7 +62,7 @@ window.plugins = {};
 // During the beta, plugins manipulated the global window.plugins data structure directly. This
 // remains possible, but is officially deprecated and may be removed in a future release.
 function registerPlugin(id: string, plugin: Plugin): void {
-    // Don't register plugins if MMDEBUG cookie is set
+    // Don't register plugins if MMEMBED cookie is set
     if (document.cookie.includes('MMEMBED=1')) {
         return;
     }

--- a/webapp/channels/src/plugins/index.ts
+++ b/webapp/channels/src/plugins/index.ts
@@ -63,7 +63,7 @@ window.plugins = {};
 // remains possible, but is officially deprecated and may be removed in a future release.
 function registerPlugin(id: string, plugin: Plugin): void {
     // Don't register plugins if MMDEBUG cookie is set
-    if (document.cookie.includes('MMDEBUG=')) {
+    if (document.cookie.includes('MMEMBED=1')) {
         return;
     }
 


### PR DESCRIPTION
#### Summary

- Return early in `registerPlugin` if the `MMEMBED` cookie is `1`
- Don't render the `Footer` component if `MMEMBED` cookie is `1`

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-63325
https://mattermost.atlassian.net/browse/MM-63329

#### Screenshots
|  before  |  after  |
|----|----|
| ![Screenshot 2025-03-03 at 11 03 18](https://github.com/user-attachments/assets/405a8ce8-6540-4435-a15c-9d24a0b69466) | ![Screenshot 2025-03-03 at 11 03 08](https://github.com/user-attachments/assets/17504e2f-4bee-4518-83ce-de542ec3cbe4) |


#### Release Note

```release-note
feat: disable webapp plugin loading and footer if MMDEBUG cookie is set
```
