### PR TITLE
Fixed RHS opy link icon styling

### DIFF
--- a/webapp/channels/src/components/channel_info_rhs/top_buttons.tsx
+++ b/webapp/channels/src/components/channel_info_rhs/top_buttons.tsx
@@ -69,6 +69,10 @@ const CopyButton = styled(Button)`
     &.success {
         background: var(--denim-status-online);
         color: var(--button-color);
+
+        & i {
+            color: var(--button-color);
+        }
     }
 `;
 


### PR DESCRIPTION
#### Summary

Fixed styling issue with the copy link icon in the success state. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-62824

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

|  before  |  after  |
|----|----|
| ![image-20250130-133721](https://github.com/user-attachments/assets/da010bd1-a23c-4995-a965-b5c8d99e4782)| <img width="582" alt="Screenshot 2025-03-09 at 7 16 49 PM" src="https://github.com/user-attachments/assets/dc12073a-bdfc-4b76-a0d6-43ba2fcb547f" /> |





#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
None
```
