### PR TITLE
[MM-63352] Fix incorrect error handling in `api4.downloadJob`

### DIFF
--- a/server/channels/api4/job.go
+++ b/server/channels/api4/job.go
@@ -122,7 +122,7 @@ func downloadJob(c *Context, w http.ResponseWriter, r *http.Request) {
 	if !filepath.IsLocal(cleanedExportDir) {
 		c.Err = model.NewAppError("unableToDownloadJob", "api.job.unable_to_download_job", nil,
 			"job.Data did not include export_dir, export_dir was malformed, or jobId.zip wasn't found",
-			http.StatusNotFound).Wrap(err)
+			http.StatusNotFound)
 		return
 	}
 


### PR DESCRIPTION
#### Summary

PR fixes a panic due to incorrectly wrapping a `nil` error.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-63352

#### Release Note

```release-note
NONE
```
