### PR TITLE
Add config settings for additional security features on mobile

### DIFF
--- a/server/config/client.go
+++ b/server/config/client.go
@@ -227,6 +227,12 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 			props["PostAcknowledgements"] = "true"
 			props["ScheduledPosts"] = strconv.FormatBool(*c.ServiceSettings.ScheduledPosts)
 		}
+
+		if license.SkuShortName == model.LicenseShortSkuEnterprise {
+			props["MobileEnableBiometrics"] = strconv.FormatBool(*c.NativeAppSettings.MobileEnableBiometrics)
+			props["MobilePreventScreenCapture"] = strconv.FormatBool(*c.NativeAppSettings.MobilePreventScreenCapture)
+			props["MobileJailbreakProtection"] = strconv.FormatBool(*c.NativeAppSettings.MobileJailbreakProtection)
+		}
 	}
 
 	return props
@@ -387,6 +393,12 @@ func GenerateLimitedClientConfig(c *model.Config, telemetryID string, license *m
 			props["EnableSignUpWithOpenId"] = strconv.FormatBool(*c.OpenIdSettings.Enable)
 			props["OpenIdButtonColor"] = *c.OpenIdSettings.ButtonColor
 			props["OpenIdButtonText"] = *c.OpenIdSettings.ButtonText
+		}
+
+		if license.SkuShortName == model.LicenseShortSkuEnterprise {
+			props["MobileEnableBiometrics"] = strconv.FormatBool(*c.NativeAppSettings.MobileEnableBiometrics)
+			props["MobilePreventScreenCapture"] = strconv.FormatBool(*c.NativeAppSettings.MobilePreventScreenCapture)
+			props["MobileJailbreakProtection"] = strconv.FormatBool(*c.NativeAppSettings.MobileJailbreakProtection)
 		}
 	}
 

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -2843,11 +2843,14 @@ func (s *SamlSettings) SetDefaults() {
 }
 
 type NativeAppSettings struct {
-	AppCustomURLSchemes    []string `access:"site_customization,write_restrictable,cloud_restrictable"` // telemetry: none
-	AppDownloadLink        *string  `access:"site_customization,write_restrictable,cloud_restrictable"`
-	AndroidAppDownloadLink *string  `access:"site_customization,write_restrictable,cloud_restrictable"`
-	IosAppDownloadLink     *string  `access:"site_customization,write_restrictable,cloud_restrictable"`
-	MobileExternalBrowser  *bool    `access:"site_customization,write_restrictable,cloud_restrictable"`
+	AppCustomURLSchemes        []string `access:"site_customization,write_restrictable,cloud_restrictable"` // telemetry: none
+	AppDownloadLink            *string  `access:"site_customization,write_restrictable,cloud_restrictable"`
+	AndroidAppDownloadLink     *string  `access:"site_customization,write_restrictable,cloud_restrictable"`
+	IosAppDownloadLink         *string  `access:"site_customization,write_restrictable,cloud_restrictable"`
+	MobileExternalBrowser      *bool    `access:"site_customization,write_restrictable,cloud_restrictable"`
+	MobileEnableBiometrics     *bool    `access:"site_customization,write_restrictable"`
+	MobilePreventScreenCapture *bool    `access:"site_customization,write_restrictable"`
+	MobileJailbreakProtection  *bool    `access:"site_customization,write_restrictable"`
 }
 
 func (s *NativeAppSettings) SetDefaults() {
@@ -2869,6 +2872,18 @@ func (s *NativeAppSettings) SetDefaults() {
 
 	if s.MobileExternalBrowser == nil {
 		s.MobileExternalBrowser = NewPointer(false)
+	}
+
+	if s.MobileEnableBiometrics == nil {
+		s.MobileEnableBiometrics = NewPointer(false)
+	}
+
+	if s.MobilePreventScreenCapture == nil {
+		s.MobilePreventScreenCapture = NewPointer(false)
+	}
+
+	if s.MobileJailbreakProtection == nil {
+		s.MobileJailbreakProtection = NewPointer(false)
 	}
 }
 


### PR DESCRIPTION
#### Summary
Currently on the mobile app is possible to prompt for biometric authentication as well as to prevent its use if the device is Jailbroken / Rooted and prevent screen captures, but these features are only available with the use of an EMM Provider.

The following config settings is to be able to set this features enabled or disabled on a per server basis and without the need of an EMM provider, although this settings are only available for the enterprise SKU and as soon as we release the Premium SKU it should be included there as well.

Mobile PR: https://github.com/mattermost/mattermost-mobile/pull/8645

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63361

#### Release Note
```release-note
Added configuration under the `NativeAppSettings` settings to enable mobile biometric authentication prompt, jailbreak / root detection and to prevent screen captures.

The settings are:
* MobileEnableBiometrics (default: false)
* MobilePreventScreenCapture (default: false)
* MobileJailbreakProtection (default: false)
```