### PR TITLE
Prepackage Calls v1.5.2

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -135,7 +135,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.5.1
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.5.2
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.3.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.9.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.2.1


### PR DESCRIPTION
#### Summary

Prepackage [Calls v1.5.2](https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v1.5.2) dot release to ship with latest dot releases for v10.3, v10.4, v10.5, v10.6 (pending cherry-picks)

#### Ticket Link

```release-note
Prepackage Calls v1.5.2
```

