### PR TITLE
Prepackage Calls v1.5.2 (`release-10.3`)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -144,7 +144,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.3.0
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.5.2
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.3.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.9.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.1.1


### PR DESCRIPTION
#### Summary

Manual cherry-pick of https://github.com/mattermost/mattermost/pull/30437 to `release-10.3`

#### Release Note

```release-note
Prepackage Calls v1.5.2
```
