### PR TITLE
Display nickname or fullname in pc notifications based on settings

### DIFF
--- a/webapp/channels/src/actions/notification_actions.tsx
+++ b/webapp/channels/src/actions/notification_actions.tsx
@@ -16,7 +16,7 @@ import {
     isCollapsedThreadsEnabled,
 } from 'mattermost-redux/selectors/entities/preferences';
 import {getAllUserMentionKeys} from 'mattermost-redux/selectors/entities/search';
-import {getCurrentUserId, getCurrentUser, getStatusForUserId, getUser} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUserId, getCurrentUser, getStatusForUserId, getUser, getUsersByUsername} from 'mattermost-redux/selectors/entities/users';
 import {isChannelMuted} from 'mattermost-redux/utils/channel_utils';
 import {ensureString, isSystemMessage, isUserAddedInChannel} from 'mattermost-redux/utils/post_utils';
 import {displayUsername} from 'mattermost-redux/utils/user_utils';
@@ -31,7 +31,7 @@ import {stripMarkdown, formatWithRenderer} from 'utils/markdown';
 import MentionableRenderer from 'utils/markdown/mentionable_renderer';
 import {DesktopNotificationSounds, ding} from 'utils/notification_sounds';
 import {showNotification} from 'utils/notifications';
-import {cjkrPattern, escapeRegex} from 'utils/text_formatting';
+import {cjkrPattern, convertMentionNicknameOrFullName, escapeRegex} from 'utils/text_formatting';
 import {isDesktopApp, isMobileApp} from 'utils/user_agent';
 import * as Utils from 'utils/utils';
 
@@ -246,6 +246,10 @@ const getNotificationBody = (state: GlobalState, post: Post, msgProps: NewPostMe
     } else {
         body += `: ${strippedMarkdownNotifyText}`;
     }
+
+    const usersByUsername = getUsersByUsername(state);
+    const teammateNameDisplay = getTeammateNameDisplaySetting(state);
+    body= convertMentionNicknameOrFullName(body, usersByUsername, teammateNameDisplay)
 
     return body;
 };

--- a/webapp/channels/src/utils/notifications.ts
+++ b/webapp/channels/src/utils/notifications.ts
@@ -6,6 +6,10 @@ import iconWS from 'images/icon_WS.png';
 import * as UserAgent from 'utils/user_agent';
 
 import type {ThunkActionFunc} from 'types/store';
+import { convertMentionNicknameOrFullName } from './text_formatting';
+import { useSelector } from 'react-redux';
+import type {GlobalState} from 'types/store';
+import { getTeammateNameDisplaySetting } from 'mattermost-redux/selectors/entities/preferences';
 
 export type NotificationResult = {
     status: 'error' | 'not_sent' | 'success' | 'unsupported';
@@ -76,9 +80,13 @@ export function showNotification(
             }
         }
 
+        const usersByUsername = useSelector((state: GlobalState) => state.entities.users.profiles);
+        const teammateNameDisplay = useSelector((state: GlobalState) => getTeammateNameDisplaySetting(state));
+        const convertedMentionBody = convertMentionNicknameOrFullName(body, usersByUsername, teammateNameDisplay)
+
         const notification = new Notification(title, {
-            body,
-            tag: body,
+            body: convertedMentionBody,
+            tag: convertedMentionBody,
             icon,
             requireInteraction,
             silent,

--- a/webapp/channels/src/utils/notifications.ts
+++ b/webapp/channels/src/utils/notifications.ts
@@ -1,14 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {convertMentionNicknameOrFullName} from './text_formatting';
+import {getUsersByUsername} from 'mattermost-redux/selectors/entities/users';
+import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
+
 import icon50 from 'images/icon50x50.png';
 import iconWS from 'images/icon_WS.png';
 import * as UserAgent from 'utils/user_agent';
 
 import type {ThunkActionFunc} from 'types/store';
-import { convertMentionNicknameOrFullName } from './text_formatting';
-import { getUsersByUsername } from 'mattermost-redux/selectors/entities/users';
-import { getTeammateNameDisplaySetting } from 'mattermost-redux/selectors/entities/preferences';
 
 export type NotificationResult = {
     status: 'error' | 'not_sent' | 'success' | 'unsupported';

--- a/webapp/channels/src/utils/notifications.ts
+++ b/webapp/channels/src/utils/notifications.ts
@@ -1,10 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {convertMentionNicknameOrFullName} from './text_formatting';
-import {getUsersByUsername} from 'mattermost-redux/selectors/entities/users';
-import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
-
 import icon50 from 'images/icon50x50.png';
 import iconWS from 'images/icon_WS.png';
 import * as UserAgent from 'utils/user_agent';
@@ -48,7 +44,7 @@ export function showNotification(
         silent: false,
     },
 ): ThunkActionFunc<Promise<NotificationResult & {callback: () => void}>> {
-    return async (_, getState) => {
+    return async () => {
         let icon = icon50;
         if (UserAgent.isEdge()) {
             icon = iconWS;
@@ -80,14 +76,9 @@ export function showNotification(
             }
         }
 
-        const state = getState();
-        const usersByUsername = getUsersByUsername(state);
-        const teammateNameDisplay = getTeammateNameDisplaySetting(state);
-        const convertedMentionBody = convertMentionNicknameOrFullName(body, usersByUsername, teammateNameDisplay)
-
         const notification = new Notification(title, {
-            body: convertedMentionBody,
-            tag: convertedMentionBody,
+            body,
+            tag: body,
             icon,
             requireInteraction,
             silent,

--- a/webapp/channels/src/utils/notifications.ts
+++ b/webapp/channels/src/utils/notifications.ts
@@ -7,8 +7,7 @@ import * as UserAgent from 'utils/user_agent';
 
 import type {ThunkActionFunc} from 'types/store';
 import { convertMentionNicknameOrFullName } from './text_formatting';
-import { useSelector } from 'react-redux';
-import type {GlobalState} from 'types/store';
+import { getUsersByUsername } from 'mattermost-redux/selectors/entities/users';
 import { getTeammateNameDisplaySetting } from 'mattermost-redux/selectors/entities/preferences';
 
 export type NotificationResult = {
@@ -48,7 +47,7 @@ export function showNotification(
         silent: false,
     },
 ): ThunkActionFunc<Promise<NotificationResult & {callback: () => void}>> {
-    return async () => {
+    return async (_, getState) => {
         let icon = icon50;
         if (UserAgent.isEdge()) {
             icon = iconWS;
@@ -80,8 +79,9 @@ export function showNotification(
             }
         }
 
-        const usersByUsername = useSelector((state: GlobalState) => state.entities.users.profiles);
-        const teammateNameDisplay = useSelector((state: GlobalState) => getTeammateNameDisplaySetting(state));
+        const state = getState();
+        const usersByUsername = getUsersByUsername(state);
+        const teammateNameDisplay = getTeammateNameDisplaySetting(state);
         const convertedMentionBody = convertMentionNicknameOrFullName(body, usersByUsername, teammateNameDisplay)
 
         const notification = new Notification(title, {

--- a/webapp/channels/src/utils/text_formatting.test.ts
+++ b/webapp/channels/src/utils/text_formatting.test.ts
@@ -24,13 +24,11 @@ import {
     doFormatText,
     replaceTokens,
     isChannelNamesMap,
-    getUsernameMentions,
     convertMentionNicknameOrFullName
 } from 'utils/text_formatting';
 import type {ChannelNamesMap} from 'utils/text_formatting';
 import { Preferences } from 'mattermost-redux/constants';
 import {TestHelper} from 'utils/test_helper';
-import { displayUsername } from 'mattermost-redux/utils/user_utils';
 
 const emptyEmojiMap = new EmojiMap(new Map());
 
@@ -244,32 +242,6 @@ describe('highlightSearchTerms', () => {
         const output = highlightSearchTerms(text, tokens, searchPatterns);
         expect(output).toBe('$MM_SEARCHTERM1$');
         expect(tokens.get('$MM_SEARCHTERM1$')!.value).toBe('<span class="search-highlight">$MM_HASHTAG0$</span>');
-    });
-});
-
-describe("getUsernameMentions", () => {
-    it("should return mentions when there are valid usernames", () => {
-        const text = "Hello @alice and @bob!";
-        expect(getUsernameMentions(text)).toEqual(["@alice", "@bob"]);
-    });
-
-    it("should exclude special mentions", () => {
-        const text = "Hey @all, meet @alice!";
-        expect(getUsernameMentions(text)).toEqual(["@alice"]);
-    });
-
-    it("should return an empty array if there are no mentions", () => {
-        const text = "Hello world!";
-        expect(getUsernameMentions(text)).toEqual([]);
-    });
-
-    it("should handle mixed mentions correctly", () => {
-        const text = "@john @all @jane @here @bob";
-        expect(getUsernameMentions(text)).toEqual(["@john", "@jane", "@bob"]);
-    });
-
-    it("should return an empty array for an empty string", () => {
-        expect(getUsernameMentions("")).toEqual([]);
     });
 });
 

--- a/webapp/channels/src/utils/text_formatting.test.ts
+++ b/webapp/channels/src/utils/text_formatting.test.ts
@@ -302,6 +302,24 @@ describe('convertMentionNicknameOrFullName', () => {
         const result = convertMentionNicknameOrFullName(text, usersByUsername, teammateNameDisplay );
         expect(result).toBe(`@${user1.nickname} @${user2.nickname} Hi, how are you?`)
     })
+    test('should display duplicate mentions correctly', () => {
+        const teammateNameDisplay = Preferences.DISPLAY_PREFER_NICKNAME;
+        const text = `@${user1.username} @${user2.username} Hi, how are you?, @${user2.username}!`
+        const result = convertMentionNicknameOrFullName(text, usersByUsername, teammateNameDisplay );
+        expect(result).toBe(`@${user1.nickname} @${user2.nickname} Hi, how are you?, @${user2.nickname}!`)
+    })
+    test('should display correctly when name is partially matching', () => {
+        const teammateNameDisplay = Preferences.DISPLAY_PREFER_NICKNAME;
+        const userA = TestHelper.getUserMock(
+            {id: 'abc1', username: 'username1', first_name: 'Json', last_name: 'Doe', nickname: 'user1'},
+        )
+        const userB = TestHelper.getUserMock(
+            {id: 'abc2', username: 'username2', first_name: 'Jhon', last_name: 'Smith', nickname: 'user10'},
+        )
+        const text = `@${userA.nickname} @${userB.nickname}, tell @${userA.nickname} something`
+        const result = convertMentionNicknameOrFullName(text, {[userA.username]: userA, [userB.username]: userB}, teammateNameDisplay );
+        expect(result).toBe(`@${userA.nickname} @${userB.nickname}, tell @${userA.nickname} something`)
+    })
     test('should not display fullname if user is not found', () => {
         const teammateNameDisplay = Preferences.DISPLAY_PREFER_FULL_NAME;
         const text = `@hoge @${user2.username} Hi, how are you?`

--- a/webapp/channels/src/utils/text_formatting.test.ts
+++ b/webapp/channels/src/utils/text_formatting.test.ts
@@ -247,7 +247,7 @@ describe('highlightSearchTerms', () => {
     });
 });
 
-describe.only("getUsernameMentions", () => {
+describe("getUsernameMentions", () => {
     it("should return mentions when there are valid usernames", () => {
         const text = "Hello @alice and @bob!";
         expect(getUsernameMentions(text)).toEqual(["@alice", "@bob"]);
@@ -273,7 +273,7 @@ describe.only("getUsernameMentions", () => {
     });
 });
 
-describe.only('convertMentionNicknameOrFullName', () => {
+describe('convertMentionNicknameOrFullName', () => {
     const user1 = TestHelper.getUserMock(
         {id: 'abc1', username: 'username1', first_name: 'Json', last_name: 'Doe', nickname: 'JD'},
     )

--- a/webapp/channels/src/utils/text_formatting.test.ts
+++ b/webapp/channels/src/utils/text_formatting.test.ts
@@ -24,6 +24,7 @@ import {
     doFormatText,
     replaceTokens,
     isChannelNamesMap,
+    getUsernameMentions,
     convertMentionNicknameOrFullName
 } from 'utils/text_formatting';
 import type {ChannelNamesMap} from 'utils/text_formatting';
@@ -243,6 +244,32 @@ describe('highlightSearchTerms', () => {
         const output = highlightSearchTerms(text, tokens, searchPatterns);
         expect(output).toBe('$MM_SEARCHTERM1$');
         expect(tokens.get('$MM_SEARCHTERM1$')!.value).toBe('<span class="search-highlight">$MM_HASHTAG0$</span>');
+    });
+});
+
+describe.only("getUsernameMentions", () => {
+    it("should return mentions when there are valid usernames", () => {
+        const text = "Hello @alice and @bob!";
+        expect(getUsernameMentions(text)).toEqual(["@alice", "@bob"]);
+    });
+
+    it("should exclude special mentions", () => {
+        const text = "Hey @all, meet @alice!";
+        expect(getUsernameMentions(text)).toEqual(["@alice"]);
+    });
+
+    it("should return an empty array if there are no mentions", () => {
+        const text = "Hello world!";
+        expect(getUsernameMentions(text)).toEqual([]);
+    });
+
+    it("should handle mixed mentions correctly", () => {
+        const text = "@john @all @jane @here @bob";
+        expect(getUsernameMentions(text)).toEqual(["@john", "@jane", "@bob"]);
+    });
+
+    it("should return an empty array for an empty string", () => {
+        expect(getUsernameMentions("")).toEqual([]);
     });
 });
 

--- a/webapp/channels/src/utils/text_formatting.tsx
+++ b/webapp/channels/src/utils/text_formatting.tsx
@@ -16,6 +16,9 @@ import type EmojiMap from './emoji_map.js';
 import * as Emoticons from './emoticons';
 import * as Markdown from './markdown';
 
+import { displayUsername } from 'mattermost-redux/utils/user_utils';
+import { UserProfile } from '@mattermost/types/users';
+
 const punctuationRegex = /[^\p{L}\d]/u;
 const AT_MENTION_PATTERN = /(?:\B|\b_+)@([a-z0-9.\-_]+)/gi;
 const UNICODE_EMOJI_REGEX = emojiRegex();
@@ -562,6 +565,20 @@ export function getUsernameMentions(text: string): string[] {
     const excludedMentions = new Set(text.match(Constants.SPECIAL_MENTIONS_REGEX) || []);
     const mentions = text.match(AT_MENTION_PATTERN) || [];
     return mentions.filter((mention) => !excludedMentions.has(mention));
+}
+
+export function convertMentionNicknameOrFullName(text: string, usersByUsername: Record<string, UserProfile>, teammateNameDisplay: string): string {
+    return getUsernameMentions(text).reduce((msg, mention) => {
+        const username = mention.substring(1);
+        const mentionedUser = usersByUsername[username];
+
+        if (!mentionedUser) {
+            return msg;
+        }
+
+        const userDisplayName = displayUsername(mentionedUser, teammateNameDisplay);
+        return msg.replace(`@${username}`, `@${userDisplayName}`);
+    }, text);
 }
 
 export function autolinkChannelMentions(

--- a/webapp/channels/src/utils/text_formatting.tsx
+++ b/webapp/channels/src/utils/text_formatting.tsx
@@ -601,12 +601,6 @@ export function allAtMentions(text: string): string[] {
     return text.match(Constants.SPECIAL_MENTIONS_REGEX && AT_MENTION_PATTERN) || [];
 }
 
-export function getUsernameMentions(text: string): string[] {
-    const excludedMentions = new Set(text.match(Constants.SPECIAL_MENTIONS_REGEX) || []);
-    const mentions = text.match(AT_MENTION_PATTERN) || [];
-    return mentions.filter((mention) => !excludedMentions.has(mention));
-}
-
 export function convertMentionNicknameOrFullName(text: string, usersByUsername: Record<string, UserProfile>, teammateNameDisplay: string): string {
     let output = text;
     const tokens = new Tokens();

--- a/webapp/channels/src/utils/text_formatting.tsx
+++ b/webapp/channels/src/utils/text_formatting.tsx
@@ -519,7 +519,7 @@ export function autoPlanMentions(text: string, tokens: Tokens): string {
     return output;
 }
 
-export function autolinkAtMentions(text: string, tokens: Tokens): string {
+export function autolinkAtMentions(text: string, tokens: Tokens, tokenValueHandler = (username: string) => `<span data-mention="${username}">@${username}</span>`): string {
     function replaceAtMentionWithToken(fullMatch: string, username: string) {
         let originalText = fullMatch;
 
@@ -532,7 +532,7 @@ export function autolinkAtMentions(text: string, tokens: Tokens): string {
         const alias = `$MM_ATMENTION${index}$`;
 
         tokens.set(alias, {
-            value: `<span data-mention="${username}">@${username}</span>`,
+            value: tokenValueHandler(username),
             originalText,
         });
 
@@ -604,7 +604,11 @@ export function allAtMentions(text: string): string[] {
 export function convertMentionNicknameOrFullName(text: string, usersByUsername: Record<string, UserProfile>, teammateNameDisplay: string): string {
     let output = text;
     const tokens = new Tokens();
-    output = convertMentionsToTokens(output, tokens, usersByUsername, teammateNameDisplay);
+    const displayUserNameHandler = (username: string) => {
+        const mentionedUser = usersByUsername[username];
+        return mentionedUser ? `@${displayUsername(mentionedUser, teammateNameDisplay)}` : `@${username}`;
+    }
+    output = autolinkAtMentions(output, tokens, displayUserNameHandler);
     return replaceTokens(output, tokens) || text;
 }
 

--- a/webapp/channels/src/utils/text_formatting.tsx
+++ b/webapp/channels/src/utils/text_formatting.tsx
@@ -558,6 +558,12 @@ export function allAtMentions(text: string): string[] {
     return text.match(Constants.SPECIAL_MENTIONS_REGEX && AT_MENTION_PATTERN) || [];
 }
 
+export function getUsernameMentions(text: string): string[] {
+    const excludedMentions = new Set(text.match(Constants.SPECIAL_MENTIONS_REGEX) || []);
+    const mentions = text.match(AT_MENTION_PATTERN) || [];
+    return mentions.filter((mention) => !excludedMentions.has(mention));
+}
+
 export function autolinkChannelMentions(
     text: string,
     tokens: Tokens,

--- a/webapp/channels/src/utils/text_formatting.tsx
+++ b/webapp/channels/src/utils/text_formatting.tsx
@@ -18,6 +18,7 @@ import * as Markdown from './markdown';
 
 import { displayUsername } from 'mattermost-redux/utils/user_utils';
 import { UserProfile } from '@mattermost/types/users';
+import { getMentionDetails } from './post_utils';
 
 const punctuationRegex = /[^\p{L}\d]/u;
 const AT_MENTION_PATTERN = /(?:\B|\b_+)@([a-z0-9.\-_]+)/gi;
@@ -565,7 +566,7 @@ export function convertMentionNicknameOrFullName(text: string, usersByUsername: 
     let output = text;
     const tokens = new Tokens();
     const displayUserNameHandler = (username: string) => {
-        const mentionedUser = usersByUsername[username];
+        const mentionedUser = getMentionDetails(usersByUsername, username);
         return mentionedUser ? `@${displayUsername(mentionedUser, teammateNameDisplay)}` : `@${username}`;
     }
     output = autolinkAtMentions(output, tokens, displayUserNameHandler);

--- a/webapp/channels/src/utils/text_formatting.tsx
+++ b/webapp/channels/src/utils/text_formatting.tsx
@@ -608,17 +608,10 @@ export function getUsernameMentions(text: string): string[] {
 }
 
 export function convertMentionNicknameOrFullName(text: string, usersByUsername: Record<string, UserProfile>, teammateNameDisplay: string): string {
-    return getUsernameMentions(text).reduce((msg, mention) => {
-        const username = mention.substring(1);
-        const mentionedUser = usersByUsername[username];
-
-        if (!mentionedUser) {
-            return msg;
-        }
-
-        const userDisplayName = displayUsername(mentionedUser, teammateNameDisplay);
-        return msg.replace(`@${username}`, `@${userDisplayName}`);
-    }, text);
+    let output = text;
+    const tokens = new Tokens();
+    output = convertMentionsToTokens(output, tokens, usersByUsername, teammateNameDisplay);
+    return replaceTokens(output, tokens) || text;
 }
 
 export function autolinkChannelMentions(

--- a/webapp/channels/src/utils/text_formatting.tsx
+++ b/webapp/channels/src/utils/text_formatting.tsx
@@ -557,46 +557,6 @@ export function autolinkAtMentions(text: string, tokens: Tokens, tokenValueHandl
     return output;
 }
 
-export function convertMentionsToTokens(text: string, tokens: Tokens, usersByUsername: Record<string, UserProfile>, teammateNameDisplay: string): string {
-    function replaceAtMentionWithToken(fullMatch: string, username: string) {
-        let originalText = fullMatch;
-
-        // Deliberately remove all leading underscores since regex matches leading underscore by treating it as non word boundary
-        while (originalText[0] === '_') {
-            originalText = originalText.substring(1);
-        }
-
-        const index = tokens.size;
-        const alias = `$MM_ATMENTION${index}$`;
-
-        const mentionedUser = usersByUsername[username];
-
-        tokens.set(alias, {
-            value: mentionedUser ? `@${displayUsername(mentionedUser, teammateNameDisplay)}` : `@${username}`,
-            originalText,
-        });
-
-        return alias;
-    }
-
-    let output = text;
-
-    // handle @channel, @all, @here mentions first (supports trailing punctuation)
-    output = output.replace(
-        Constants.SPECIAL_MENTIONS_REGEX,
-        replaceAtMentionWithToken,
-    );
-
-    // handle all other mentions (supports trailing punctuation)
-    let match = output.match(AT_MENTION_PATTERN);
-    while (match && match.length > 0) {
-        output = output.replace(AT_MENTION_PATTERN, replaceAtMentionWithToken);
-        match = output.match(AT_MENTION_PATTERN);
-    }
-
-    return output;
-}
-
 export function allAtMentions(text: string): string[] {
     return text.match(Constants.SPECIAL_MENTIONS_REGEX && AT_MENTION_PATTERN) || [];
 }


### PR DESCRIPTION
#### Summary
A user can configure the Teammate Name Display in the System Console. Since usernames must be unique and cannot contain restricted characters, my organization configures using nicknames or full names.

However, when receiving PC notifications, only the username is displayed in mentions, even when the system is configured to use nicknames or full names. This is not user-friendly.

I implemented a change so that nicknames or full names are  displayed based on settings.

#### Ticket Link
https://github.com/mattermost/mattermost/issues/30433

#### Screenshots
Display nickname

before
<img width="384" alt="スクリーンショット 2025-03-11 19 22 39" src="https://github.com/user-attachments/assets/975e2848-3bcd-46eb-b47e-5f9c46e97f95" />

after
<img width="381" alt="スクリーンショット 2025-03-11 18 43 52" src="https://github.com/user-attachments/assets/658098dd-e4f1-4d10-a217-685f7cf6f27f" />

Display fullname
before
<img width="401" alt="スクリーンショット 2025-03-11 19 35 14" src="https://github.com/user-attachments/assets/ecaf8588-da9b-4f86-9a2f-a4ed8807a29c" />

after
<img width="370" alt="スクリーンショット 2025-03-11 18 44 36" src="https://github.com/user-attachments/assets/0e1adf6b-634a-488b-a163-f1e88e65bdb8" />


#### Release Note
```release-note
Display the nickname or full name based on settings when receiving PC notifications.
```
