### PR TITLE
Fixed a bug where escape would delete all typed content

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/use_key_handler.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_key_handler.tsx
@@ -173,9 +173,9 @@ const useKeyHandler = (
         }
 
         if (Keyboard.isKeyPressed(e, KeyCodes.ESCAPE)) {
-            onCancel?.();
             textboxRef.current?.blur();
             if (isInEditMode) {
+                onCancel?.();
                 dispatch(unsetEditingPost());
             }
         }


### PR DESCRIPTION
#### Summary
Fixed a bug where pressing escape when typing a message in create post/comment cleared the input.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-63400

#### Release Note
```release-note
None
```
