### PR TITLE
[MM-63355] Add AuthData to mmctl user search output

### DIFF
--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -2946,6 +2946,27 @@ func TestGetUsers(t *testing.T) {
 		require.Equal(t, err.Error(), "Invalid or missing role in request body.")
 	})
 
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, c *model.Client4) {
+		user := &model.User{
+			Email:       th.GenerateTestEmail(),
+			Username:    GenerateTestUsername(),
+			AuthService: model.UserAuthServiceLdap,
+			AuthData:    model.NewPointer(model.NewId()),
+		}
+		u, resp, err := c.CreateUser(context.Background(), user)
+		require.NoError(t, err)
+		CheckCreatedStatus(t, resp)
+		require.NotNil(t, u)
+
+		u, resp, err = c.GetUser(context.Background(), u.Id, "")
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.NotNil(t, u)
+
+		assert.Equal(t, user.AuthService, u.AuthService)
+		assert.Equal(t, user.AuthData, u.AuthData)
+	}, "AuthData is returned for admins")
+
 	_, err := th.Client.Logout(context.Background())
 	require.NoError(t, err)
 	_, resp, err := th.Client.GetUsers(context.Background(), 0, 60, "")

--- a/server/channels/app/users/utils.go
+++ b/server/channels/app/users/utils.go
@@ -51,6 +51,7 @@ func (us *UserService) GetSanitizeOptions(asAdmin bool) map[string]bool {
 		options["email"] = true
 		options["fullname"] = true
 		options["authservice"] = true
+		options["authdata"] = true
 	}
 	return options
 }

--- a/server/cmd/mmctl/commands/user.go
+++ b/server/cmd/mmctl/commands/user.go
@@ -779,6 +779,7 @@ func deleteAllUsersCmdF(c client.Client, cmd *cobra.Command, args []string) erro
 type userOut struct {
 	*model.User
 	Deactivated bool
+	AuthData    string
 }
 
 func searchUserCmdF(c client.Client, cmd *cobra.Command, args []string) error {
@@ -799,6 +800,10 @@ func searchUserCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 			User:        user,
 			Deactivated: !(user.DeleteAt == 0),
 		}
+		if user.AuthData != nil {
+			uout.AuthData = *user.AuthData
+		}
+
 		tpl := `id: {{.Id}}
 deactivated: {{.Deactivated}}
 username: {{.Username}}
@@ -807,7 +812,8 @@ position: {{.Position}}
 first_name: {{.FirstName}}
 last_name: {{.LastName}}
 email: {{.Email}}
-auth_service: {{.AuthService}}`
+auth_service: {{.AuthService}}
+auth_data: {{.AuthData}}`
 		if i > 0 {
 			tpl = "------------------------------\n" + tpl
 		}

--- a/server/cmd/mmctl/commands/user_e2e_test.go
+++ b/server/cmd/mmctl/commands/user_e2e_test.go
@@ -128,6 +128,8 @@ func (s *MmctlE2ETestSuite) TestSearchUserCmd() {
 		user := printer.GetLines()[0].(userOut)
 		s.Equal(s.th.BasicUser.Username, user.Username)
 		s.False(user.Deactivated)
+		s.Empty(user.AuthData)
+		s.Empty(user.AuthService)
 		s.Len(printer.GetErrorLines(), 0)
 	})
 
@@ -149,6 +151,32 @@ func (s *MmctlE2ETestSuite) TestSearchUserCmd() {
 		user := printer.GetLines()[0].(userOut)
 		s.Equal(disabledUser.Username, user.Username)
 		s.True(user.Deactivated) // Verify user shows as deactivated
+		s.Empty(user.AuthData)
+		s.Empty(user.AuthService)
+		s.Len(printer.GetErrorLines(), 0)
+	})
+
+	s.RunForAllClients("Search for a user with authData", func(c client.Client) {
+		printer.Clean()
+
+		// Create a LDAP user
+		ldapUser, appErr := s.th.App.CreateUser(s.th.Context, &model.User{
+			Email:       s.th.GenerateTestEmail(),
+			Username:    model.NewUsername(),
+			Password:    model.NewId(),
+			AuthData:    model.NewPointer("1234"),
+			AuthService: model.UserAuthServiceLdap,
+		})
+		s.Require().Nil(appErr)
+
+		err := searchUserCmdF(c, &cobra.Command{}, []string{ldapUser.Email})
+		s.Require().Nil(err)
+		s.Len(printer.GetLines(), 1)
+		user := printer.GetLines()[0].(userOut)
+		s.Equal(ldapUser.Username, user.Username)
+		s.False(user.Deactivated)
+		s.Equal(*ldapUser.AuthData, user.AuthData)
+		s.Equal(ldapUser.AuthService, user.AuthService)
 		s.Len(printer.GetErrorLines(), 0)
 	})
 

--- a/server/cmd/mmctl/commands/user_test.go
+++ b/server/cmd/mmctl/commands/user_test.go
@@ -628,6 +628,24 @@ func (s *MmctlUnitTestSuite) TestSearchUserCmd() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
+	s.Run("Search for a user with authData", func() {
+		printer.Clean()
+		emailArg := "example@example.com"
+		mockUser := &model.User{Username: "ExampleUser", Email: emailArg, AuthData: model.NewPointer("1234"), AuthService: model.UserAuthServiceLdap}
+
+		s.client.
+			EXPECT().
+			GetUserByEmail(context.TODO(), emailArg, "").
+			Return(mockUser, &model.Response{}, nil).
+			Times(1)
+
+		err := searchUserCmdF(s.client, &cobra.Command{}, []string{emailArg})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(userOut{User: mockUser, Deactivated: false, AuthData: "1234"}, printer.GetLines()[0])
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
 	s.Run("Search for a nonexistent user", func() {
 		printer.Clean()
 		arg := "example@example.com"

--- a/server/public/model/user.go
+++ b/server/public/model/user.go
@@ -659,24 +659,28 @@ func (u *User) Etag(showFullName, showEmail bool) string {
 // Remove any private data from the user object
 func (u *User) Sanitize(options map[string]bool) {
 	u.Password = ""
-	u.AuthData = NewPointer("")
 	u.MfaSecret = ""
 	u.MfaUsedTimestamps = nil
 	u.LastLogin = 0
 
-	if len(options) != 0 && !options["email"] {
-		u.Email = ""
-		delete(u.Props, UserPropsKeyRemoteEmail)
-	}
-	if len(options) != 0 && !options["fullname"] {
-		u.FirstName = ""
-		u.LastName = ""
-	}
-	if len(options) != 0 && !options["passwordupdate"] {
-		u.LastPasswordUpdate = 0
-	}
-	if len(options) != 0 && !options["authservice"] {
-		u.AuthService = ""
+	if len(options) != 0 {
+		if !options["email"] {
+			u.Email = ""
+			delete(u.Props, UserPropsKeyRemoteEmail)
+		}
+		if !options["fullname"] {
+			u.FirstName = ""
+			u.LastName = ""
+		}
+		if !options["passwordupdate"] {
+			u.LastPasswordUpdate = 0
+		}
+		if !options["authservice"] {
+			u.AuthService = ""
+		}
+		if !options["authdata"] {
+			u.AuthData = NewPointer("")
+		}
 	}
 }
 
@@ -703,7 +707,6 @@ func (u *User) SanitizeInput(isAdmin bool) {
 
 func (u *User) ClearNonProfileFields(asAdmin bool) {
 	u.Password = ""
-	u.AuthData = NewPointer("")
 	u.MfaSecret = ""
 	u.MfaUsedTimestamps = nil
 	u.EmailVerified = false
@@ -712,6 +715,7 @@ func (u *User) ClearNonProfileFields(asAdmin bool) {
 	u.FailedAttempts = 0
 
 	if !asAdmin {
+		u.AuthData = NewPointer("")
 		u.NotifyProps = StringMap{}
 	}
 }


### PR DESCRIPTION
#### Summary


The PR targets https://github.com/mattermost/mattermost/pull/30379

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63355



#### Release Note
```release-note
Add AuthData to mmctl user search output
```
