### PR TITLE
[MM-63449] Update flaky unit test of "use_post_box_indicator.test.tsx"

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/use_post_box_indicator.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_post_box_indicator.test.tsx
@@ -9,6 +9,21 @@ import {renderHookWithContext} from 'tests/react_testing_utils';
 
 import type {GlobalState} from 'types/store';
 
+jest.mock('luxon', () => {
+    const actualLuxon = jest.requireActual('luxon');
+    return {
+        ...actualLuxon,
+        DateTime: {
+            ...actualLuxon.DateTime,
+            local: jest.fn(() => ({
+                setZone: jest.fn(() => actualLuxon.DateTime.fromObject({
+                    hour: 2,
+                })),
+            })),
+        },
+    };
+});
+
 function getBaseState(): DeepPartial<GlobalState> {
     return {
         entities: {

--- a/webapp/channels/src/components/advanced_text_editor/use_post_box_indicator.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_post_box_indicator.test.tsx
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {DateTime} from 'luxon';
+
 import type {DeepPartial} from '@mattermost/types/utilities';
 
 import useTimePostBoxIndicator from 'components/advanced_text_editor/use_post_box_indicator';
@@ -8,21 +10,6 @@ import useTimePostBoxIndicator from 'components/advanced_text_editor/use_post_bo
 import {renderHookWithContext} from 'tests/react_testing_utils';
 
 import type {GlobalState} from 'types/store';
-
-jest.mock('luxon', () => {
-    const actualLuxon = jest.requireActual('luxon');
-    return {
-        ...actualLuxon,
-        DateTime: {
-            ...actualLuxon.DateTime,
-            local: jest.fn(() => ({
-                setZone: jest.fn(() => actualLuxon.DateTime.fromObject({
-                    hour: 2,
-                })),
-            })),
-        },
-    };
-});
 
 function getBaseState(): DeepPartial<GlobalState> {
     return {
@@ -93,6 +80,12 @@ function getBaseState(): DeepPartial<GlobalState> {
 
 describe('useTimePostBoxIndicator', () => {
     it('should pass base case', () => {
+        const fakeLocal = DateTime.local(2025, 1, 1, 3, {
+            zone: 'Asia/Kolkata',
+        });
+
+        DateTime.local = jest.fn(() => fakeLocal);
+
         const {result: {current}} = renderHookWithContext(() => useTimePostBoxIndicator('dm_channel_id'), getBaseState());
 
         expect(current.isDM).toBe(true);
@@ -106,6 +99,11 @@ describe('useTimePostBoxIndicator', () => {
     });
 
     it('should work for DM with bots', () => {
+        const fakeLocal = DateTime.local(2025, 1, 1, 3, {
+            zone: 'Asia/Kolkata',
+        });
+
+        DateTime.local = jest.fn(() => fakeLocal);
         const {result: {current}} = renderHookWithContext(() => useTimePostBoxIndicator('bot_dm_channel_id'), getBaseState());
 
         expect(current.isDM).toBe(true);
@@ -119,6 +117,12 @@ describe('useTimePostBoxIndicator', () => {
     });
 
     it('should handle teammate not loaded', () => {
+        const fakeLocal = DateTime.local(2025, 1, 1, 1, {
+            zone: 'Asia/Kolkata',
+        });
+
+        DateTime.local = jest.fn(() => fakeLocal);
+
         const {result: {current}} = renderHookWithContext(() => useTimePostBoxIndicator('unknown_dm_channel_id'), getBaseState());
 
         expect(current.isDM).toBe(true);


### PR DESCRIPTION
#### Summary
The hook has function to get the user's current time, added a mock function to have time in its test.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63449

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
