### PR TITLE
[#30491] Incoming webhook improvements

### DIFF
--- a/server/channels/app/webhook.go
+++ b/server/channels/app/webhook.go
@@ -723,9 +723,9 @@ func (a *App) RegenOutgoingWebhookToken(hook *model.OutgoingWebhook) (*model.Out
 	return webhook, nil
 }
 
-func (a *App) HandleIncomingWebhook(c request.CTX, hookID string, req *model.IncomingWebhookRequest) *model.AppError {
+func (a *App) HandleIncomingWebhook(c request.CTX, hookID string, req *model.IncomingWebhookRequest) (*model.Post, *model.AppError) {
 	if !*a.Config().ServiceSettings.EnableIncomingWebhooks {
-		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
+		return nil, model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	hchan := make(chan store.StoreResult[*model.IncomingWebhook], 1)
@@ -736,12 +736,12 @@ func (a *App) HandleIncomingWebhook(c request.CTX, hookID string, req *model.Inc
 	}()
 
 	if req == nil {
-		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.parse.app_error", nil, "", http.StatusBadRequest)
+		return nil, model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.parse.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	text := req.Text
 	if text == "" && req.Attachments == nil {
-		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.text.app_error", nil, "", http.StatusBadRequest)
+		return nil, model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.text.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	channelName := req.ChannelName
@@ -750,7 +750,7 @@ func (a *App) HandleIncomingWebhook(c request.CTX, hookID string, req *model.Inc
 	var hook *model.IncomingWebhook
 	result := <-hchan
 	if result.NErr != nil {
-		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.invalid.app_error", nil, "", http.StatusBadRequest).Wrap(result.NErr)
+		return nil, model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.invalid.app_error", nil, "", http.StatusBadRequest).Wrap(result.NErr)
 	}
 	hook = result.Data
 
@@ -782,11 +782,11 @@ func (a *App) HandleIncomingWebhook(c request.CTX, hookID string, req *model.Inc
 		if channelName[0] == '@' {
 			result, nErr := a.Srv().Store().User().GetByUsername(channelName[1:])
 			if nErr != nil {
-				return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.user.app_error", map[string]any{"user": channelName[1:]}, "", http.StatusBadRequest).Wrap(nErr)
+				return nil, model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.user.app_error", map[string]any{"user": channelName[1:]}, "", http.StatusBadRequest).Wrap(nErr)
 			}
 			ch, err := a.GetOrCreateDirectChannel(c, hook.UserId, result.Id)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			channel = ch
 		} else if channelName[0] == '#' {
@@ -812,9 +812,9 @@ func (a *App) HandleIncomingWebhook(c request.CTX, hookID string, req *model.Inc
 			var nfErr *store.ErrNotFound
 			switch {
 			case errors.As(err, &nfErr):
-				return model.NewAppError("HandleIncomingWebhook", "app.channel.get.existing.app_error", errCtx, "", http.StatusNotFound).Wrap(err)
+				return nil, model.NewAppError("HandleIncomingWebhook", "app.channel.get.existing.app_error", errCtx, "", http.StatusNotFound).Wrap(err)
 			default:
-				return model.NewAppError("HandleIncomingWebhook", "app.channel.get.find.app_error", errCtx, "", http.StatusInternalServerError).Wrap(err)
+				return nil, model.NewAppError("HandleIncomingWebhook", "app.channel.get.find.app_error", errCtx, "", http.StatusInternalServerError).Wrap(err)
 			}
 		}
 	}
@@ -825,25 +825,25 @@ func (a *App) HandleIncomingWebhook(c request.CTX, hookID string, req *model.Inc
 			var nfErr *store.ErrNotFound
 			switch {
 			case errors.As(result2.NErr, &nfErr):
-				return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.channel.app_error", nil, "", http.StatusNotFound).Wrap(result2.NErr)
+				return nil, model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.channel.app_error", nil, "", http.StatusNotFound).Wrap(result2.NErr)
 			default:
-				return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.channel.app_error", nil, "", http.StatusInternalServerError).Wrap(result2.NErr)
+				return nil, model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.channel.app_error", nil, "", http.StatusInternalServerError).Wrap(result2.NErr)
 			}
 		}
 		channel = result2.Data
 	}
 
 	if hook.ChannelLocked && hook.ChannelId != channel.Id {
-		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.channel_locked.app_error", map[string]any{"channel_id": channel.Id}, "", http.StatusForbidden)
+		return nil, model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.channel_locked.app_error", map[string]any{"channel_id": channel.Id}, "", http.StatusForbidden)
 	}
 
 	resultU := <-uchan
 	if resultU.NErr != nil {
-		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.user.app_error", map[string]any{"user": hook.UserId}, "", http.StatusForbidden).Wrap(resultU.NErr)
+		return nil, model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.user.app_error", map[string]any{"user": hook.UserId}, "", http.StatusForbidden).Wrap(resultU.NErr)
 	}
 
 	if channel.Type != model.ChannelTypeOpen && !a.HasPermissionToChannel(c, hook.UserId, channel.Id, model.PermissionReadChannelContent) {
-		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.permissions.app_error", map[string]any{"user": hook.UserId, "channel": channel.Id}, "", http.StatusForbidden)
+		return nil, model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.permissions.app_error", map[string]any{"user": hook.UserId, "channel": channel.Id}, "", http.StatusForbidden)
 	}
 
 	overrideUsername := hook.Username
@@ -856,8 +856,8 @@ func (a *App) HandleIncomingWebhook(c request.CTX, hookID string, req *model.Inc
 		overrideIconURL = req.IconURL
 	}
 
-	_, err := a.CreateWebhookPost(c, hook.UserId, channel, text, overrideUsername, overrideIconURL, req.IconEmoji, req.Props, webhookType, "", req.Priority)
-	return err
+	post, err := a.CreateWebhookPost(c, hook.UserId, channel, text, overrideUsername, overrideIconURL, req.IconEmoji, req.Props, webhookType, "", req.Priority)
+	return post, err
 }
 
 func (a *App) CreateCommandWebhook(commandID string, args *model.CommandArgs) (*model.CommandWebhook, *model.AppError) {

--- a/server/channels/app/webhook.go
+++ b/server/channels/app/webhook.go
@@ -856,7 +856,7 @@ func (a *App) HandleIncomingWebhook(c request.CTX, hookID string, req *model.Inc
 		overrideIconURL = req.IconURL
 	}
 
-	post, err := a.CreateWebhookPost(c, hook.UserId, channel, text, overrideUsername, overrideIconURL, req.IconEmoji, req.Props, webhookType, "", req.Priority)
+	post, err := a.CreateWebhookPost(c, hook.UserId, channel, text, overrideUsername, overrideIconURL, req.IconEmoji, req.Props, webhookType, req.RootId, req.Priority)
 	return post, err
 }
 

--- a/server/channels/web/web_test.go
+++ b/server/channels/web/web_test.go
@@ -39,6 +39,7 @@ type TestHelper struct {
 	BasicUser    *model.User
 	BasicChannel *model.Channel
 	BasicTeam    *model.Team
+	BasicPost    *model.Post
 
 	SystemAdminUser *model.User
 
@@ -170,6 +171,16 @@ func (th *TestHelper) InitBasic() *TestHelper {
 	th.BasicUser = user
 	th.BasicChannel = channel
 	th.BasicTeam = team
+
+	id := model.NewId()
+	post := &model.Post{
+		UserId:    th.BasicUser.Id,
+		ChannelId: th.BasicChannel.Id,
+		Message:   "message_" + id,
+		CreateAt:  model.GetMillis() - 10000,
+	}
+
+	th.BasicPost, _= th.App.CreatePost(th.Context, post, th.BasicChannel, model.CreatePostFlags{});
 
 	return th
 }

--- a/server/channels/web/webhook.go
+++ b/server/channels/web/webhook.go
@@ -92,13 +92,11 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	payload, err := json.Marshal(post)
-	if err != nil {
-		c.Err = model.NewAppError("incomingWebhook", "web.incoming_webhook.encode.app_error", errCtx, "", http.StatusInternalServerError).Wrap(appErr)
-		return
-	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(payload)
+
+	if err := post.EncodeJSON(w); err != nil {
+		c.Logger.Warn("Error while writing response", mlog.Err(err))
+	}
 }
 
 func commandWebhook(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/server/channels/web/webhook.go
+++ b/server/channels/web/webhook.go
@@ -86,14 +86,19 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	appErr = c.App.HandleIncomingWebhook(c.AppContext, id, incomingWebhookPayload)
+	post, appErr := c.App.HandleIncomingWebhook(c.AppContext, id, incomingWebhookPayload)
 	if appErr != nil {
 		c.Err = model.NewAppError("incomingWebhook", "web.incoming_webhook.general.app_error", errCtx, "", appErr.StatusCode).Wrap(appErr)
 		return
 	}
 
-	w.Header().Set("Content-Type", "text/plain")
-	w.Write([]byte("ok"))
+	payload, err := json.Marshal(post)
+	if err != nil {
+		c.Err = model.NewAppError("incomingWebhook", "web.incoming_webhook.encode.app_error", errCtx, "", http.StatusInternalServerError).Wrap(appErr)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(payload)
 }
 
 func commandWebhook(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/server/channels/web/webhook.go
+++ b/server/channels/web/webhook.go
@@ -86,17 +86,14 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	post, appErr := c.App.HandleIncomingWebhook(c.AppContext, id, incomingWebhookPayload)
+	appErr = c.App.HandleIncomingWebhook(c.AppContext, id, incomingWebhookPayload)
 	if appErr != nil {
 		c.Err = model.NewAppError("incomingWebhook", "web.incoming_webhook.general.app_error", errCtx, "", appErr.StatusCode).Wrap(appErr)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-
-	if err := post.EncodeJSON(w); err != nil {
-		c.Logger.Warn("Error while writing response", mlog.Err(err))
-	}
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write([]byte("ok"))
 }
 
 func commandWebhook(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/server/channels/web/webhook_test.go
+++ b/server/channels/web/webhook_test.go
@@ -61,6 +61,10 @@ func TestIncomingWebhook(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
+		resp, err = http.Post(url, "application/json", strings.NewReader("{\"text\":\"this is a test with root_id\", \"root_id\": \"" + th.BasicPost.Id + "\"}"))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
 		text := `this is a \"test\"
 	that contains a newline and a tab`
 		resp, err = http.Post(url, "application/json", strings.NewReader("{\"text\":\""+text+"\"}"))

--- a/server/public/model/incoming_webhook.go
+++ b/server/public/model/incoming_webhook.go
@@ -52,6 +52,7 @@ type IncomingWebhookRequest struct {
 	Username    string             `json:"username"`
 	IconURL     string             `json:"icon_url"`
 	ChannelName string             `json:"channel"`
+	RootId      string             `json:"root_id"`
 	Props       StringInterface    `json:"props"`
 	Attachments []*SlackAttachment `json:"attachments"`
 	Type        string             `json:"type"`


### PR DESCRIPTION
#### Summary
Improving the incoming webhooks:
- Allow webhooks to post messages in threads
- Webhook return a JSON representation of the created message object (Similarly to what the [CreatePost](https://api.mattermost.com/#tag/posts/operation/CreatePost) API endpoint does

~~Regarding the documentation: Webhooks are documented on the Developers docs, so a separate MR on the [doc repo](https://github.com/mattermost/mattermost-developer-documentation) will be needed. (Not sure why webhooks aren't documented with the API, as technically they are a part of it)~~

Documentation MR: https://github.com/mattermost/mattermost-developer-documentation/pull/1436

Misc considerations:
- My previous go experience is maybe 15 minutes ? What I did looks right to my eye, but please take this in consideration while reviewing :sweat_smile: 
- The webhook used to reply the string "OK" as text/plain. Now it return a JSON object. I'm not sure how this is considered a breaking change. It might mess up if someone was checking for this "OK" string for some reason instead of using status code.
- I haven't found existing tests on the `HandleIncomingWebhook` and the `incomingWebhook` functions that I modified. Am I looking in the wrong place ? If not, Do you want me to create some ? In that case i'd like to have some guidance on how to do this as I'm not familiar with go.

#### Ticket Link

Closes #30491

#### Release Note
```release-note
* Allow webhooks to post messages in threads
* Webhook return a JSON representation of the created message object (Similarly to what the [CreatePost](https://api.mattermost.com/#tag/posts/operation/CreatePost) API endpoint does
```
