### PR TITLE
Automated cherry pick of #30384

### DIFF
--- a/server/channels/api4/config_test.go
+++ b/server/channels/api4/config_test.go
@@ -122,6 +122,7 @@ func TestGetConfigAnyFlagsAccess(t *testing.T) {
 	require.NoError(t, err)
 	t.Run("Can read value with permission", func(t *testing.T) {
 		assert.NotNil(t, cfg.FeatureFlags)
+		assert.NotNil(t, cfg.ExperimentalSettings.RestrictSystemAdmin)
 	})
 }
 

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -1114,7 +1114,7 @@ type ExperimentalSettings struct {
 	ClientSideCertEnable                                  *bool   `access:"experimental_features,cloud_restrictable"`
 	ClientSideCertCheck                                   *string `access:"experimental_features,cloud_restrictable"`
 	LinkMetadataTimeoutMilliseconds                       *int64  `access:"experimental_features,write_restrictable,cloud_restrictable"`
-	RestrictSystemAdmin                                   *bool   `access:"experimental_features,write_restrictable"`
+	RestrictSystemAdmin                                   *bool   `access:"*_read,write_restrictable"`
 	EnableSharedChannels                                  *bool   `access:"experimental_features"` // Deprecated: use `ConnectedWorkspacesSettings.EnableSharedChannels`
 	EnableRemoteClusterService                            *bool   `access:"experimental_features"` // Deprecated: use `ConnectedWorkspacesSettings.EnableRemoteClusterService`
 	DisableAppBar                                         *bool   `access:"experimental_features"`


### PR DESCRIPTION
Cherry pick of #30384 on release-10.5.

/cc  @sbishel

```release-note
NONE
```