### PR TITLE
[MM-63504] When changing a channel to group synced, it doesn't always clear members

### DIFF
--- a/server/channels/api4/group.go
+++ b/server/channels/api4/group.go
@@ -641,7 +641,7 @@ func unlinkGroupSyncable(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	c.App.Srv().Go(func() {
-		c.App.SyncRolesAndMembership(c.AppContext, syncableID, syncableType, c.Params.GroupId)
+		c.App.RemoveMembershipsFromUnlinkedSyncable(c.AppContext, syncableID, syncableType)
 	})
 
 	auditRec.Success()

--- a/server/channels/app/syncables.go
+++ b/server/channels/app/syncables.go
@@ -142,7 +142,7 @@ func (a *App) CreateDefaultMemberships(rctx request.CTX, params model.CreateDefa
 // DeleteGroupConstrainedMemberships deletes team and channel memberships of users who aren't members of the allowed
 // groups of all group-constrained teams and channels.
 func (a *App) DeleteGroupConstrainedMemberships(rctx request.CTX) error {
-	err := a.deleteGroupConstrainedChannelMemberships(rctx, nil)
+	err := a.DeleteGroupConstrainedChannelMemberships(rctx, nil)
 	if err != nil {
 		return err
 	}
@@ -183,10 +183,10 @@ func (a *App) deleteGroupConstrainedTeamMemberships(rctx request.CTX, teamID *st
 	return multiErr.ErrorOrNil()
 }
 
-// deleteGroupConstrainedChannelMemberships deletes channel memberships of users who aren't members of the allowed
+// DeleteGroupConstrainedChannelMemberships deletes channel memberships of users who aren't members of the allowed
 // groups of the given group-constrained channel. If a channelID is given then the procedure is scoped to the given team,
 // if channelID is nil then the procedure affects all teams.
-func (a *App) deleteGroupConstrainedChannelMemberships(rctx request.CTX, channelID *string) error {
+func (a *App) DeleteGroupConstrainedChannelMemberships(rctx request.CTX, channelID *string) error {
 	channelMembers, appErr := a.ChannelMembersToRemove(channelID)
 	if appErr != nil {
 		return appErr
@@ -309,8 +309,19 @@ func (a *App) SyncRolesAndMembership(rctx request.CTX, syncableID string, syncab
 		if err := a.createDefaultChannelMemberships(rctx, params); err != nil {
 			rctx.Logger().Warn("Error creating default channel memberships", mlog.Err(err))
 		}
-		if err := a.deleteGroupConstrainedChannelMemberships(rctx, &syncableID); err != nil {
+	}
+}
+
+// This method should be called when a syncable is unlinked from a group
+func (a *App) RemoveMembershipsFromUnlinkedSyncable(rctx request.CTX, syncableID string, syncableType model.GroupSyncableType) {
+	switch syncableType {
+	case model.GroupSyncableTypeTeam:
+		if err := a.deleteGroupConstrainedTeamMemberships(rctx, &syncableID); err != nil {
 			rctx.Logger().Warn("Error deleting group constrained team memberships", mlog.Err(err))
+		}
+	case model.GroupSyncableTypeChannel:
+		if err := a.DeleteGroupConstrainedChannelMemberships(rctx, &syncableID); err != nil {
+			rctx.Logger().Warn("Error deleting group constrained channel memberships", mlog.Err(err))
 		}
 	}
 }


### PR DESCRIPTION
#### Summary
When you link a group to a channel and set sync group members to true, it means that only members of that group can be part of the channel. Anyone who is not part of the channel should be automatically removed as per the screenshot below.

![Screenshot 2025-03-20 at 10 39 40 AM](https://github.com/user-attachments/assets/7dbd4287-4b5e-48c9-a800-f068829e9ef0)

You can also set sync group members to false and link a group to the channel. This means non group members can be part of the channel.

The api requests that occur when you link groups to channel and set the channel to sync group members are:

- POST `/{group_id:[A-Za-z0-9]+}/{syncable_type:teams|channels}/{syncable_id:[A-Za-z0-9]+}/link` for every group that was linked to the channel at that time.
- PUT `/channels/<channel-id>/patch` which sets group_constrained to true.

Those requests occur concurrently.

The problem is that the `link` endpoint has a side effect where it calls https://github.com/mattermost/mattermost/blob/master/server/channels/app/syncables.go#L273 in a go routine. That function adds group members for **all** groups linked to the channel and removes anyone not part of **any** of the linked groups. This is obviously inefficient because if we link multiple groups at once each group will run this function. There is definitely a chance of a weird race condition because of the concurrent calls to `link`.

The reason I created this ticket is that if you change a channel to group synced but do not `link` any new groups to the channel, non-group members will not get cleaned up. Granted, if you run an LDAP sync job it will clean up the non group members from the channel but the UI states they are removed immediately. Also, this doesn't work for my new keycloak groups plugin because there is no sync.

I had a few options of how to clean this up but each has their own caveats, also it's clear this needs a much bigger lift than I can do in a bug ticket. 

I decided to change the order of save requests so that the patch request for the channel happens after the links/unlinks. We now also call `DeleteGroupConstrainedChannelMemberships` in the patch channel request so that removing non group members is handled outside the `link` endpoint, I don't think it made sense for it to be in there in the first place. `Unlink` now calls `RemoveMembershipsFromUnlinkedSyncable` in order to remove the group members from a group synced channel after they're unlinked.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63504

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Fixed a bug where there was inconsistent behaviour on removing non group members from group synced channels.
```
