### PR TITLE
Prepackage Metrics Plugin v0.6.0

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -152,7 +152,7 @@ PLUGIN_PACKAGES += mattermost-plugin-msteams-v2.1.1
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.3.4
 PLUGIN_PACKAGES += mattermost-plugin-msteams-meetings-v2.2.0
-PLUGIN_PACKAGES += mattermost-plugin-metrics-v0.5.3
+PLUGIN_PACKAGES += mattermost-plugin-metrics-v0.6.0
 PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.2.1
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)


### PR DESCRIPTION
#### Summary

Prepackage [Metrics Plugin v0.6.0](https://github.com/mattermost/mattermost-plugin-metrics/releases/tag/v0.6.0) which includes the logic to scrape Calls metrics.

#### Ticket Link

```release-note
Prepackage Metrics Plugin v0.6.0
```

