### PR TITLE
[MM-63504] When changing a team to group synced, it doesn't always clear members

### DIFF
--- a/server/channels/api4/team.go
+++ b/server/channels/api4/team.go
@@ -269,7 +269,7 @@ func patchTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If the channel was not previously group constrained but is now, delete members that aren't part of the channel's groups
+	// If the team is now group constrained but wasn't previously, delete members that aren't part of the team's groups
 	if patchedTeam.GroupConstrained != nil && *patchedTeam.GroupConstrained && (oldTeam.GroupConstrained == nil || !*oldTeam.GroupConstrained) {
 		c.App.Srv().Go(func() {
 			if err := c.App.DeleteGroupConstrainedTeamMemberships(c.AppContext, &c.Params.TeamId); err != nil {

--- a/server/channels/api4/team_test.go
+++ b/server/channels/api4/team_test.go
@@ -654,9 +654,11 @@ func TestPatchTeam(t *testing.T) {
 	})
 
 	t.Run("GroupConstrained flag set to true and non group members are removed", func(t *testing.T) {
+		var appErr *model.AppError
 		th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterprise))
 		defer func() {
-			th.App.Srv().RemoveLicense()
+			appErr := th.App.Srv().RemoveLicense()
+			require.Nil(t, appErr)
 		}()
 		th.LoginTeamAdmin()
 		team2 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: th.GenerateTestEmail(), Type: model.TeamOpen, AllowOpenInvite: false}
@@ -674,7 +676,7 @@ func TestPatchTeam(t *testing.T) {
 		th.LinkUserToTeam(groupUser, th.BasicTeam)
 
 		// Create a group member
-		_, appErr := th.App.UpsertGroupMember(group.Id, groupUser.Id)
+		_, appErr = th.App.UpsertGroupMember(group.Id, groupUser.Id)
 		require.Nil(t, appErr)
 
 		// Associate the group with the channel
@@ -705,7 +707,7 @@ func TestPatchTeam(t *testing.T) {
 				return
 			case <-ticker.C:
 				// Check if the user is still a member
-				tm, r, err := th.SystemAdminClient.GetTeamMember(context.Background(), team2.Id, th.BasicUser2.Id, "")
+				tm, r, err = th.SystemAdminClient.GetTeamMember(context.Background(), team2.Id, th.BasicUser2.Id, "")
 				if err == nil && r.StatusCode == http.StatusOK && tm.DeleteAt != 0 {
 					// User has been removed, we can continue the test
 					userRemoved = true

--- a/server/channels/api4/team_test.go
+++ b/server/channels/api4/team_test.go
@@ -696,6 +696,7 @@ func TestPatchTeam(t *testing.T) {
 		ticker := time.NewTicker(100 * time.Millisecond)
 		defer ticker.Stop()
 
+		var tm *model.TeamMember
 		userRemoved := false
 		for !userRemoved {
 			select {
@@ -704,15 +705,14 @@ func TestPatchTeam(t *testing.T) {
 				return
 			case <-ticker.C:
 				// Check if the user is still a member
-				teamMember, resp, err := th.SystemAdminClient.GetTeamMember(context.Background(), team2.Id, th.BasicUser2.Id, "")
-				if err == nil && resp.StatusCode == http.StatusOK && teamMember.DeleteAt != 0 {
+				tm, r, err := th.SystemAdminClient.GetTeamMember(context.Background(), team2.Id, th.BasicUser2.Id, "")
+				if err == nil && r.StatusCode == http.StatusOK && tm.DeleteAt != 0 {
 					// User has been removed, we can continue the test
 					userRemoved = true
 				}
 			}
 		}
 
-		var tm *model.TeamMember
 		tm, r, err = th.SystemAdminClient.GetTeamMember(context.Background(), team2.Id, th.BasicUser2.Id, "")
 		require.NoError(t, err)
 		CheckOKStatus(t, r)

--- a/server/channels/api4/team_test.go
+++ b/server/channels/api4/team_test.go
@@ -657,7 +657,7 @@ func TestPatchTeam(t *testing.T) {
 		var appErr *model.AppError
 		th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterprise))
 		defer func() {
-			appErr := th.App.Srv().RemoveLicense()
+			appErr = th.App.Srv().RemoveLicense()
 			require.Nil(t, appErr)
 		}()
 		th.LoginTeamAdmin()

--- a/server/channels/api4/team_test.go
+++ b/server/channels/api4/team_test.go
@@ -679,7 +679,7 @@ func TestPatchTeam(t *testing.T) {
 		_, appErr = th.App.UpsertGroupMember(group.Id, groupUser.Id)
 		require.Nil(t, appErr)
 
-		// Associate the group with the channel
+		// Associate the group with the team
 		autoAdd := true
 		schemeAdmin := true
 		_, r, err := th.SystemAdminClient.LinkGroupSyncable(context.Background(), group.Id, team2.Id, model.GroupSyncableTypeTeam, &model.GroupSyncablePatch{AutoAdd: &autoAdd, SchemeAdmin: &schemeAdmin})
@@ -720,6 +720,80 @@ func TestPatchTeam(t *testing.T) {
 		CheckOKStatus(t, r)
 		require.Equal(t, tm.UserId, th.BasicUser2.Id)
 		require.NotEqual(t, tm.DeleteAt, int64(0))
+	})
+
+	t.Run("GroupConstrained flag changed from true to false and non group members are not removed", func(t *testing.T) {
+		var appErr *model.AppError
+		th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterprise))
+		defer func() {
+			appErr = th.App.Srv().RemoveLicense()
+			require.Nil(t, appErr)
+		}()
+		th.LoginTeamAdmin()
+		team2 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: th.GenerateTestEmail(), Type: model.TeamOpen, AllowOpenInvite: false}
+		team2, _, _ = th.Client.CreateTeam(context.Background(), team2)
+
+		// Create a test group
+		group := th.CreateGroup()
+
+		// Create a group user
+		groupUser := th.CreateUser()
+		th.LinkUserToTeam(groupUser, th.BasicTeam)
+
+		// Create a group member
+		_, appErr = th.App.UpsertGroupMember(group.Id, groupUser.Id)
+		require.Nil(t, appErr)
+
+		// Associate the group with the team
+		autoAdd := true
+		schemeAdmin := true
+		_, r, err := th.SystemAdminClient.LinkGroupSyncable(context.Background(), group.Id, team2.Id, model.GroupSyncableTypeTeam, &model.GroupSyncablePatch{AutoAdd: &autoAdd, SchemeAdmin: &schemeAdmin})
+		require.NoError(t, err)
+		CheckCreatedStatus(t, r)
+
+		patch := &model.TeamPatch{}
+		patch.GroupConstrained = model.NewPointer(true)
+		_, r, err = th.SystemAdminClient.PatchTeam(context.Background(), team2.Id, patch)
+		require.NoError(t, err)
+		CheckOKStatus(t, r)
+
+		patch.GroupConstrained = model.NewPointer(false)
+		_, r, err = th.SystemAdminClient.PatchTeam(context.Background(), team2.Id, patch)
+		require.NoError(t, err)
+		CheckOKStatus(t, r)
+
+		// Unlink the group
+		r, err = th.SystemAdminClient.UnlinkGroupSyncable(context.Background(), group.Id, team2.Id, model.GroupSyncableTypeTeam)
+		require.NoError(t, err)
+		CheckOKStatus(t, r)
+
+		// Wait for a reasonable amount of time to ensure the user is not removed because the team is no longer group constrained
+		timeout := time.After(2 * time.Second)
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+
+		var tm *model.TeamMember
+		userStillPresent := true
+		for userStillPresent {
+			select {
+			case <-timeout:
+				// If we reach the timeout, the user is still present, which is what we want
+				// Verify the user is still a member of the team
+				tm, r, err = th.SystemAdminClient.GetTeamMember(context.Background(), team2.Id, groupUser.Id, "")
+				require.NoError(t, err)
+				CheckOKStatus(t, r)
+				require.Equal(t, tm.DeleteAt, int64(0))
+				return
+			case <-ticker.C:
+				// Check if the user is still a member
+				tm, r, err = th.SystemAdminClient.GetTeamMember(context.Background(), team2.Id, groupUser.Id, "")
+				if err == nil && r.StatusCode == http.StatusOK && tm.DeleteAt != 0 {
+					// User has been removed, which is not what we want
+					require.Fail(t, "User was incorrectly removed from the team")
+					userStillPresent = false
+				}
+			}
+		}
 	})
 }
 

--- a/server/channels/app/syncables.go
+++ b/server/channels/app/syncables.go
@@ -147,7 +147,7 @@ func (a *App) DeleteGroupConstrainedMemberships(rctx request.CTX) error {
 		return err
 	}
 
-	err = a.deleteGroupConstrainedTeamMemberships(rctx, nil)
+	err = a.DeleteGroupConstrainedTeamMemberships(rctx, nil)
 	if err != nil {
 		return err
 	}
@@ -155,10 +155,10 @@ func (a *App) DeleteGroupConstrainedMemberships(rctx request.CTX) error {
 	return nil
 }
 
-// deleteGroupConstrainedTeamMemberships deletes team memberships of users who aren't members of the allowed
+// DeleteGroupConstrainedTeamMemberships deletes team memberships of users who aren't members of the allowed
 // groups of the given group-constrained team. If a teamID is given then the procedure is scoped to the given team,
 // if teamID is nil then the procedure affects all teams.
-func (a *App) deleteGroupConstrainedTeamMemberships(rctx request.CTX, teamID *string) error {
+func (a *App) DeleteGroupConstrainedTeamMemberships(rctx request.CTX, teamID *string) error {
 	teamMembers, appErr := a.TeamMembersToRemove(teamID)
 	if appErr != nil {
 		return appErr
@@ -301,9 +301,6 @@ func (a *App) SyncRolesAndMembership(rctx request.CTX, syncableID string, syncab
 		if err := a.createDefaultTeamMemberships(rctx, params); err != nil {
 			rctx.Logger().Warn("Error creating default team memberships", mlog.Err(err))
 		}
-		if err := a.deleteGroupConstrainedTeamMemberships(rctx, &syncableID); err != nil {
-			rctx.Logger().Warn("Error deleting group constrained team memberships", mlog.Err(err))
-		}
 	case model.GroupSyncableTypeChannel:
 		params.ScopedChannelID = &syncableID
 		if err := a.createDefaultChannelMemberships(rctx, params); err != nil {
@@ -316,7 +313,7 @@ func (a *App) SyncRolesAndMembership(rctx request.CTX, syncableID string, syncab
 func (a *App) RemoveMembershipsFromUnlinkedSyncable(rctx request.CTX, syncableID string, syncableType model.GroupSyncableType) {
 	switch syncableType {
 	case model.GroupSyncableTypeTeam:
-		if err := a.deleteGroupConstrainedTeamMemberships(rctx, &syncableID); err != nil {
+		if err := a.DeleteGroupConstrainedTeamMemberships(rctx, &syncableID); err != nil {
 			rctx.Logger().Warn("Error deleting group constrained team memberships", mlog.Err(err))
 		}
 	case model.GroupSyncableTypeChannel:

--- a/webapp/channels/src/components/admin_console/team_channel_settings/team/details/team_details.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/team/details/team_details.tsx
@@ -180,12 +180,6 @@ export default class TeamDetails extends React.PureComponent<Props, State> {
             serverError = <NeedGroupsError/>;
             saveNeeded = true;
         } else {
-            const patchTeamPromise = actions.patchTeam({
-                ...team,
-                group_constrained: syncChecked,
-                allowed_domains: allowedDomainsChecked ? allowedDomains : '',
-                allow_open_invite: allAllowedChecked,
-            });
             const patchTeamSyncable = groups.
                 filter((g) => {
                     return origGroups.some((group) => group.id === g.id && group.scheme_admin !== g.scheme_admin);
@@ -201,11 +195,27 @@ export default class TeamDetails extends React.PureComponent<Props, State> {
                     return !origGroups.some((group) => group.id === g.id);
                 }).
                 map((g) => actions.linkGroupSyncable(g.id, teamID, SyncableType.Team, {auto_add: true, scheme_admin: g.scheme_admin}));
-            const result = await Promise.all([patchTeamPromise, ...patchTeamSyncable, ...unlink, ...link]);
-            const resultWithError = result.find((r) => r.error);
-            if (resultWithError) {
-                serverError = <FormError error={resultWithError.error?.message}/>;
-            } else {
+            
+            // First execute all group-related operations
+            const groupResult = await Promise.all([...patchTeamSyncable, ...unlink, ...link]);
+            const groupResultWithError = groupResult.find((r) => r.error);
+            
+            if (groupResultWithError) {
+                serverError = <FormError error={groupResultWithError.error?.message}/>;
+            }
+            // After group operations succeed, patch the team
+            const patchTeamResult = await actions.patchTeam({
+                ...team,
+                group_constrained: syncChecked,
+                allowed_domains: allowedDomainsChecked ? allowedDomains : '',
+                allow_open_invite: allAllowedChecked,
+            });
+            
+            if (patchTeamResult.error) {
+                serverError = <FormError error={patchTeamResult.error?.message}/>;
+            } 
+
+            if (!patchTeamResult.error && !groupResultWithError) {
                 if (unlink.length > 0) {
                     trackEvent('admin_team_config_page', 'groups_removed_from_team', {count: unlink.length, team_id: teamID});
                 }


### PR DESCRIPTION
#### Summary
This is the same problem as described in https://github.com/mattermost/mattermost/pull/30526 but this is for teams instead of channels.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63504

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Fixed a bug where there was inconsistent behaviour on removing non group members from group synced teams.
```
