### PR TITLE
Normalize nickname to fit 64 character boundry

### DIFF
--- a/server/public/model/user.go
+++ b/server/public/model/user.go
@@ -441,6 +441,10 @@ func NormalizeUsername(username string) string {
 	return strings.ToLower(username)
 }
 
+func NormalizeNickname(nickname string) string {
+	return nickname[max(0, len(nickname)-UserNicknameMaxRunes):]
+}
+
 func NormalizeEmail(email string) string {
 	return strings.ToLower(email)
 }
@@ -467,6 +471,7 @@ func (u *User) PreSave() *AppError {
 	u.Nickname = SanitizeUnicode(u.Nickname)
 
 	u.Username = NormalizeUsername(u.Username)
+	u.Nickname = NormalizeNickname(u.Nickname)
 	u.Email = NormalizeEmail(u.Email)
 
 	if u.CreateAt == 0 {

--- a/server/public/model/user_test.go
+++ b/server/public/model/user_test.go
@@ -488,6 +488,11 @@ func TestNormalizeUsername(t *testing.T) {
 	assert.Equal(t, NormalizeUsername("spin"), "spin", "didn't normalize username properly")
 }
 
+func TestNormalizeNickname(t *testing.T) {
+	assert.Equal(t, NormalizeNickname("Department Name - Full Name"), "Department Name - Full Name", "didn't normalize nickname properly")
+	assert.Equal(t, NormalizeNickname("Office Location - Department Name - Sub-department Name - Team Name - Job Title - Full Name"), "t Name - Sub-department Name - Team Name - Job Title - Full Name", "didn't normalize nickname properly")
+}
+
 func TestNormalizeEmail(t *testing.T) {
 	assert.Equal(t, NormalizeEmail("TEST@EXAMPLE.COM"), "test@example.com", "didn't normalize email properly")
 	assert.Equal(t, NormalizeEmail("TEST2@example.com"), "test2@example.com", "didn't normalize email properly")


### PR DESCRIPTION
#### Summary
User nicknames are only allowed to have 64 characters.
In some cases, LDAP users might have longer nicknames, which would then prohibit them from logging in to Mattermost.
This PR attempts to fix this issue in the most unobtrusive way - we'll just use the last 64 characters of the nickname instead of generating an error.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/30541

#### Release Note
```release-note
Fixed LDAP sync issue related to user nickname lengths
```
