### PR TITLE
MM-63545: Fix post reminder off-by-one error

### DIFF
--- a/server/channels/store/sqlstore/post_store.go
+++ b/server/channels/store/sqlstore/post_store.go
@@ -3333,7 +3333,7 @@ func (s *SqlPostStore) GetPostReminders(now int64) (_ []*model.PostReminder, err
 
 	err = transaction.Select(&reminders, `SELECT PostId, UserId
 		FROM PostReminders
-		WHERE TargetTime < ?`, now)
+		WHERE TargetTime <= ?`, now)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, errors.Wrap(err, "failed to get post reminders")
 	}
@@ -3346,7 +3346,7 @@ func (s *SqlPostStore) GetPostReminders(now int64) (_ []*model.PostReminder, err
 	// Postgres supports RETURNING * in a DELETE statement, but MySQL doesn't.
 	// So we are stuck with 2 queries. Not taking separate paths for Postgres
 	// and MySQL for simplicity.
-	_, err = transaction.Exec(`DELETE from PostReminders WHERE TargetTime < ?`, now)
+	_, err = transaction.Exec(`DELETE from PostReminders WHERE TargetTime <= ?`, now)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to delete post reminders")
 	}

--- a/server/channels/store/storetest/post_store.go
+++ b/server/channels/store/storetest/post_store.go
@@ -5062,12 +5062,12 @@ func testGetPostReminders(t *testing.T, rctx request.CTX, ss store.Store, s SqlS
 		require.NoError(t, ss.Post().SetPostReminder(reminder))
 	}
 
-	reminders, err := ss.Post().GetPostReminders(102)
+	reminders, err := ss.Post().GetPostReminders(101)
 	require.NoError(t, err)
 	require.Len(t, reminders, 2)
 
 	// assert one reminder is left
-	reminders, err = ss.Post().GetPostReminders(103)
+	reminders, err = ss.Post().GetPostReminders(102)
 	require.NoError(t, err)
 	require.Len(t, reminders, 1)
 


### PR DESCRIPTION
We used < which meant we missed sending
reminders created for that timestamp, because
the job runs on that exact time.

Using <= to fix that.

https://mattermost.atlassian.net/browse/MM-63545
```release-note
NONE
```
