### PR TITLE
MM-58521 Hide emoji categories while searching emoji picker

### DIFF
--- a/webapp/channels/src/components/emoji_picker/__snapshots__/emoji_picker.test.tsx.snap
+++ b/webapp/channels/src/components/emoji_picker/__snapshots__/emoji_picker.test.tsx.snap
@@ -36,6 +36,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
     </div>
     <div
       class="emoji-picker__categories"
+      data-testid="emojiPickerCategories"
       id="emojiPickerCategories"
     >
       <button

--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_categories.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_categories.tsx
@@ -70,6 +70,7 @@ function EmojiPickerCategories({
             id='emojiPickerCategories'
             className='emoji-picker__categories'
             onKeyDown={handleKeyDown}
+            data-testid='emojiPickerCategories'
         >
             {categoryNames.map((categoryName) => {
                 const category = categories[categoryName];

--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_current_results.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_current_results.tsx
@@ -13,7 +13,7 @@ import type {Emoji, EmojiCategory, CustomEmoji, SystemEmoji} from '@mattermost/t
 import type {ActionResult} from 'mattermost-redux/types/actions';
 
 import EmojiPickerCategoryOrEmojiRow from 'components/emoji_picker/components/emoji_picker_category_or_emoji_row';
-import {ITEM_HEIGHT, EMOJI_ROWS_OVERSCAN_COUNT, EMOJI_CONTAINER_HEIGHT, CUSTOM_EMOJIS_PER_PAGE, EMOJI_SCROLL_THROTTLE_DELAY} from 'components/emoji_picker/constants';
+import {ITEM_HEIGHT, EMOJI_ROWS_OVERSCAN_COUNT, EMOJI_CONTAINER_HEIGHT, CUSTOM_EMOJIS_PER_PAGE, EMOJI_SCROLL_THROTTLE_DELAY, CATEGORIES_CONTAINER_HEIGHT} from 'components/emoji_picker/constants';
 import type {CategoryOrEmojiRow, EmojiCursor} from 'components/emoji_picker/types';
 import {isCategoryHeaderRow} from 'components/emoji_picker/utils';
 
@@ -89,7 +89,7 @@ const EmojiPickerCurrentResults = forwardRef<InfiniteLoader, Props>(({categoryOr
     return (
         <div
             className='emoji-picker__items'
-            style={{height: EMOJI_CONTAINER_HEIGHT}}
+            style={{height: isFiltering ? EMOJI_CONTAINER_HEIGHT + CATEGORIES_CONTAINER_HEIGHT : EMOJI_CONTAINER_HEIGHT}}
         >
             <div
                 className='emoji-picker__container'

--- a/webapp/channels/src/components/emoji_picker/constants/index.ts
+++ b/webapp/channels/src/components/emoji_picker/constants/index.ts
@@ -125,9 +125,9 @@ export const CATEGORIES: Categories = Emoji.CategoryNames.
         };
     }, {} as Categories);
 
-export const EMOJI_PER_ROW = 9;
-export const ITEM_HEIGHT = 36;
-export const EMOJI_CONTAINER_HEIGHT = 290;
+export const EMOJI_PER_ROW = 9; // needs to match variable `$emoji-per-row` in _variables.scss
+export const ITEM_HEIGHT = 36; //as per .emoji-picker__item height in _emoticons.scss
+export const EMOJI_CONTAINER_HEIGHT = 290; // If this changes, the spaceRequiredAbove and spaceRequiredBelow props passed to the EmojiPickerOverlay must be updated
 export const CATEGORIES_CONTAINER_HEIGHT = 36; // height of categories container (28px) + margin (8px)
 
 export const CATEGORY_HEADER_ROW = 'categoryHeaderRow';

--- a/webapp/channels/src/components/emoji_picker/constants/index.ts
+++ b/webapp/channels/src/components/emoji_picker/constants/index.ts
@@ -125,9 +125,10 @@ export const CATEGORIES: Categories = Emoji.CategoryNames.
         };
     }, {} as Categories);
 
-export const EMOJI_PER_ROW = 9; // needs to match variable `$emoji-per-row` in _variables.scss
-export const ITEM_HEIGHT = 36; //as per .emoji-picker__item height in _emoticons.scss
-export const EMOJI_CONTAINER_HEIGHT = 290; // If this changes, the spaceRequiredAbove and spaceRequiredBelow props passed to the EmojiPickerOverlay must be updated
+export const EMOJI_PER_ROW = 9;
+export const ITEM_HEIGHT = 36;
+export const EMOJI_CONTAINER_HEIGHT = 290;
+export const CATEGORIES_CONTAINER_HEIGHT = 36; // height of categories container (28px) + margin (8px)
 
 export const CATEGORY_HEADER_ROW = 'categoryHeaderRow';
 export const EMOJIS_ROW = 'emojisRow';

--- a/webapp/channels/src/components/emoji_picker/emoji_picker.test.tsx
+++ b/webapp/channels/src/components/emoji_picker/emoji_picker.test.tsx
@@ -79,4 +79,30 @@ describe('components/emoji_picker/EmojiPicker', () => {
 
         expect(screen.queryByText('Preview for wave emoji')).not.toBeNull();
     });
+
+    test('Categories should be hidden when filter has text', () => {
+        const props = {
+            ...baseProps,
+            filter: 'smile',
+        };
+
+        renderWithContext(
+            <EmojiPicker {...props}/>,
+        );
+
+        expect(screen.queryByTestId('emojiPickerCategories')).toBeNull();
+    });
+
+    test('Categories should be visible when filter is empty', () => {
+        const props = {
+            ...baseProps,
+            filter: '',
+        };
+
+        renderWithContext(
+            <EmojiPicker {...props}/>,
+        );
+
+        expect(screen.queryByTestId('emojiPickerCategories')).not.toBeNull();
+    });
 });

--- a/webapp/channels/src/components/emoji_picker/emoji_picker.tsx
+++ b/webapp/channels/src/components/emoji_picker/emoji_picker.tsx
@@ -25,6 +25,8 @@ import {
     SEARCH_RESULTS,
     EMOJI_PER_ROW,
     CUSTOM_EMOJI_SEARCH_THROTTLE_TIME_MS,
+    EMOJI_CONTAINER_HEIGHT,
+    CATEGORIES_CONTAINER_HEIGHT,
 } from 'components/emoji_picker/constants';
 import {NavigationDirection} from 'components/emoji_picker/types';
 import type {CategoryOrEmojiRow, Categories, EmojiCursor, EmojiPosition, EmojiRow} from 'components/emoji_picker/types';
@@ -420,10 +422,15 @@ const EmojiPicker = ({
                 />
             )}
             {areSearchResultsEmpty ? (
-                <NoResultsIndicator
-                    variant={NoResultsVariant.Search}
-                    titleValues={{channelName: `${filter}`}}
-                />
+                <div
+                    className='emoji-picker__items'
+                    style={{height: EMOJI_CONTAINER_HEIGHT + CATEGORIES_CONTAINER_HEIGHT}}
+                >
+                    <NoResultsIndicator
+                        variant={NoResultsVariant.Search}
+                        titleValues={{channelName: `${filter}`}}
+                    />
+                </div>
             ) : (
                 <EmojiPickerCurrentResults
                     ref={infiniteLoaderRef}

--- a/webapp/channels/src/components/emoji_picker/emoji_picker.tsx
+++ b/webapp/channels/src/components/emoji_picker/emoji_picker.tsx
@@ -409,7 +409,7 @@ const EmojiPicker = ({
                     onSkinSelected={setUserSkinTone}
                 />
             </div>
-            {!filter.length && (
+            {filter.length === 0 && (
                 <EmojiPickerCategories
                     isFiltering={filter.length > 0}
                     active={activeCategory}

--- a/webapp/channels/src/components/emoji_picker/emoji_picker.tsx
+++ b/webapp/channels/src/components/emoji_picker/emoji_picker.tsx
@@ -409,14 +409,16 @@ const EmojiPicker = ({
                     onSkinSelected={setUserSkinTone}
                 />
             </div>
-            <EmojiPickerCategories
-                isFiltering={filter.length > 0}
-                active={activeCategory}
-                categories={categories}
-                onClick={handleCategoryClick}
-                onKeyDown={handleKeyboardEmojiNavigation}
-                focusOnSearchInput={focusOnSearchInput}
-            />
+            {!filter.length && (
+                <EmojiPickerCategories
+                    isFiltering={filter.length > 0}
+                    active={activeCategory}
+                    categories={categories}
+                    onClick={handleCategoryClick}
+                    onKeyDown={handleKeyboardEmojiNavigation}
+                    focusOnSearchInput={focusOnSearchInput}
+                />
+            )}
             {areSearchResultsEmpty ? (
                 <NoResultsIndicator
                     variant={NoResultsVariant.Search}

--- a/webapp/channels/src/sass/components/_emoticons.scss
+++ b/webapp/channels/src/sass/components/_emoticons.scss
@@ -485,6 +485,13 @@ $emoji-footer-height:  $emoji-footer-border-width + $emoji-half-height + $emoji-
     overflow-x: hidden;
     overflow-y: auto;
 
+    &:has(.no-results__wrapper) {
+        padding: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
     &.gif-picker__items {
         display: flex;
         height: 380px;

--- a/webapp/channels/src/sass/components/_emoticons.scss
+++ b/webapp/channels/src/sass/components/_emoticons.scss
@@ -486,10 +486,10 @@ $emoji-footer-height:  $emoji-footer-border-width + $emoji-half-height + $emoji-
     overflow-y: auto;
 
     &:has(.no-results__wrapper) {
-        padding: 0;
         display: flex;
         align-items: center;
         justify-content: center;
+        padding: 0;
     }
 
     &.gif-picker__items {


### PR DESCRIPTION
#### Summary
`AI-assisted`
Hide emoji categories when searching/filtering.

#### Ticket Link
[MM-58521](https://mattermost.atlassian.net/browse/MM-58521)

#### Screenshots
| Before | After |
| -- | -- |
| <img width="364" alt="image" src="https://github.com/user-attachments/assets/dd7d2527-d395-4b77-8ca3-036975343d1b" /> |  <img width="360" alt="image" src="https://github.com/user-attachments/assets/471d586d-d6ab-4fa2-9fc9-57d09be2f8ce" /> |

#### Release Note
```release-note
NONE
```

#### Test Information
1. Open emoji picker
2. Type in the search box
3. Verify categories are hidden while searching
4. Clear search text
5. Verify categories reappear

[MM-58521]: https://mattermost.atlassian.net/browse/MM-58521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ