### PR TITLE
[MM-63280] Forward ref properly through SwitchChannelSuggestion

### DIFF
--- a/webapp/channels/src/components/suggestion/switch_channel_provider.tsx
+++ b/webapp/channels/src/components/suggestion/switch_channel_provider.tsx
@@ -333,7 +333,7 @@ function mapStateToPropsForSwitchChannelSuggestion(state: GlobalState, ownProps:
     };
 }
 
-const ConnectedSwitchChannelSuggestion = connect(mapStateToPropsForSwitchChannelSuggestion, null, null, {forwardRef: true})(injectIntl(SwitchChannelSuggestion));
+const ConnectedSwitchChannelSuggestion = connect(mapStateToPropsForSwitchChannelSuggestion, null, null, {forwardRef: true})(injectIntl(SwitchChannelSuggestion, {forwardRef: true}));
 
 let prefix = '';
 


### PR DESCRIPTION
#### Summary
We made a change recently to add `injectIntl` to the `SwitchChannelSuggestion` component. This broke keyboard navigation as we were missing `forwardRef` which is needed to ensure scrolling works correctly with the keyboard.

This PR adds `forwardRef` to the `injectIntl` call.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63280

```release-note
Fix keyboard navigation with the Channel Switcher
```
