### PR TITLE
[MM-63586] Fix Jump to recents dismiss icon visibility

### DIFF
--- a/webapp/channels/src/components/scroll_to_bottom_toast/scroll_to_bottom_toast.scss
+++ b/webapp/channels/src/components/scroll_to_bottom_toast/scroll_to_bottom_toast.scss
@@ -50,13 +50,17 @@
 
         svg {
             padding-top: 1px; // To align vertically
-            fill: rgba(var(--button-bg-rgb), 0.64);
+            fill: rgba(var(--button-color-rgb), 0.64);
             vertical-align: middle;
         }
 
         .close-btn {
             cursor: pointer;
             line-height: normal;
+            
+            &:hover {
+                fill: var(--button-color);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fixed dismiss icon color in the Jump to recents toast by changing the fill from button-bg-rgb to button-color-rgb
- Added hover state for dismiss icon to increase visibility when hovered

A standard theme:
![CleanShot 2025-03-27 at 15 36 07](https://github.com/user-attachments/assets/2dbce849-f367-462a-a2f2-d5bbe918f6f8)

Custom theme:
![CleanShot 2025-03-27 at 15 37 16](https://github.com/user-attachments/assets/d74cc947-de98-4ab7-946e-ab339b622262)

## Ticket Link
- [MM-63586](https://mattermost.atlassian.net/browse/MM-63586)

## Screenshots
Before:
- Dismiss icon invisible due to using background color

![image](https://github.com/user-attachments/assets/50daa40d-a382-47a7-8a97-94f89390a181)

After:
- Dismiss icon visible with proper contrast

## Test Plan
- Add a "Setup Cloud Test Server" label to this PR to deploy a test server
- Once deployed, open a channel with unread messages
- Scroll up and observe the "Jump to recents" button appears
- Verify the X (dismiss) icon is visible in the button
- Hover over the X icon and verify it becomes more visible (full opacity)

### Release Note
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.ai/code)

[MM-63586]: https://mattermost.atlassian.net/browse/MM-63586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ