### PR TITLE
Only build and package linux

### DIFF
--- a/server/build/release.mk
+++ b/server/build/release.mk
@@ -86,9 +86,11 @@ else
 	env GOOS=windows GOARCH=amd64 $(GO) build -o $(GOBIN)/windows_amd64 $(GOFLAGS) -trimpath -tags '$(BUILD_TAGS) production' -ldflags '$(LDFLAGS)' ./cmd/...
 endif
 
-build: setup-go-work build-client build-linux build-windows build-osx
+# Only build linux by default. Other platforms can be built by specifying the platform.
+build: setup-go-work build-client build-linux
 
-build-cmd: setup-go-work build-client build-cmd-linux build-cmd-windows build-cmd-osx
+# Only build linux by default. Other platforms can be built by specifying the platform.
+build-cmd: setup-go-work build-client build-cmd-linux
 
 build-client:
 	@echo Building mattermost web app
@@ -218,6 +220,7 @@ package-windows: package-prep
 	@# Cleanup
 	rm -rf $(DIST_ROOT)/windows
 
-package: package-linux package-osx
+# Only package linux by default. Other platforms can be packaged by specifying the platform.
+package: package-linux
 	rm -rf tmpprepackaged
 	rm -rf $(DIST_PATH)


### PR DESCRIPTION
#### Summary
As part of https://github.com/mattermost/mattermost/pull/29932, we stopped packaging Windows for releases. Let's go one step further and stop building it too (saves build time!). And while we're in here, stop doing this for OSX as well.

Both these targets remain buildable on demand, but we don't support these platforms for production deployments.

I was prompted to address this while I'm watching the enterprise build take 4+ minutes per target, 8 of which were wasted on artifacts we never use.

#### Ticket Link
None

#### Release Note
```release-note
Stop building and packaging Windows and MacOS releases
```
