### PR TITLE
MM-63577 Enable EnableLocalMode automatically during development

### DIFF
--- a/server/channels/app/platform/service.go
+++ b/server/channels/app/platform/service.go
@@ -361,9 +361,12 @@ func New(sc ServiceConfig, options ...Option) (*PlatformService, error) {
 
 	ps.Busy = NewBusy(ps.clusterIFace)
 
-	// Enable developer settings if this is a "dev" build
+	// Enable developer settings and mmctl local mode if this is a "dev" build
 	if model.BuildNumber == "dev" {
-		ps.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableDeveloper = true })
+		ps.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.EnableDeveloper = true
+			*cfg.ServiceSettings.EnableLocalMode = true
+		})
 	}
 
 	ps.AddLicenseListener(func(oldLicense, newLicense *model.License) {


### PR DESCRIPTION
#### Summary
This is to make it easier to use mmctl during development, particularly for new contributors to create their first admin account.

#### Ticket Link
MM-63577

#### Release Note
```release-note
NONE
```
