### PR TITLE
MM-61589 Keep Help and Preview links visible on small screen sizes

### DIFF
--- a/webapp/channels/src/sass/responsive/_mobile.scss
+++ b/webapp/channels/src/sass/responsive/_mobile.scss
@@ -617,10 +617,6 @@
             top: 0;
             margin: 8px 0;
         }
-
-        .help__text {
-            display: none;
-        }
     }
 
     .suggestion-list__content {


### PR DESCRIPTION
#### Summary
This modal is likely going to be removed with the new Channel Settings modal, but I'm trying out Cursor for some stuff.

This mobile-specific CSS seems like it was supposed to apply to the post textbox to hide those links back before the Advanced Text Editor was added. It doesn't seem like it needs to apply to the other place the old Textbox is used (ie. this modal)

#### Ticket Link
MM-61589

#### Screenshots
<img width="865" alt="Screenshot 2025-03-31 at 5 24 34 PM" src="https://github.com/user-attachments/assets/883fd5df-3e7d-4e5a-93f4-d1cd2e9e17fb" />
<img width="603" alt="Screenshot 2025-03-31 at 5 24 41 PM" src="https://github.com/user-attachments/assets/b44ac6f0-743d-402c-ace7-fa00050478c1" />

#### Release Note
```release-note
NONE
```
