### PR TITLE
[MM-60797] Fix errcheck issues in support_packet_test.go

### DIFF
--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -109,7 +109,6 @@ issues:
         channels/app/slashcommands/auto_environment.go|\
         channels/app/slashcommands/command_test.go|\
         channels/app/slashcommands/helper_test.go|\
-        channels/app/support_packet_test.go|\
         channels/app/team.go|\
         channels/app/team_test.go|\
         channels/app/upload.go|\

--- a/server/channels/app/support_packet_test.go
+++ b/server/channels/app/support_packet_test.go
@@ -25,7 +25,8 @@ func TestGenerateSupportPacket(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()
 
-	th.App.SetPhase2PermissionsMigrationStatus(true)
+	err := th.App.SetPhase2PermissionsMigrationStatus(true)
+	require.NoError(t, err)
 
 	dir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
@@ -295,7 +296,8 @@ func TestGetPluginsFile(t *testing.T) {
 	})
 
 	t.Run("two plugins are installed", func(t *testing.T) {
-		path, _ := fileutils.FindDir("tests")
+		path, found := fileutils.FindDir("tests")
+		require.True(t, found, "tests directory not found")
 
 		bundle1, err := os.ReadFile(filepath.Join(path, "testplugin.tar.gz"))
 		require.NoError(t, err)
@@ -577,7 +579,8 @@ func TestGetSupportPacketPermissionsInfo(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
-	th.App.SetPhase2PermissionsMigrationStatus(true)
+	err := th.App.SetPhase2PermissionsMigrationStatus(true)
+	require.NoError(t, err)
 
 	generatePermissionInfo := func(t *testing.T) *model.SupportPacketPermissionInfo {
 		t.Helper()


### PR DESCRIPTION
#### Summary
- Fix error handling in fileutils.FindDir() call by properly checking the returned boolean value
- Add proper error handling for SetPhase2PermissionsMigrationStatus calls
- Remove channels/app/support_packet_test.go from the errcheck exception list in .golangci.yml

🤖 Generated with [Claude Code](https://claude.ai/code)
#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/29102
https://mattermost.atlassian.net/browse/MM-60797


#### Release Note
```release-note
NONE
```
