### PR TITLE
[MM-61461] Fix errcheck error in plugin_test.go

### DIFF
--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -102,7 +102,6 @@ issues:
         channels/app/platform/session.go|\
         channels/app/platform/status.go|\
         channels/app/platform/web_hub_test.go|\
-        channels/app/plugin_test.go|\
         channels/app/post_helpers_test.go|\
         channels/app/post_test.go|\
         channels/app/slack.go|\

--- a/server/channels/app/plugin_test.go
+++ b/server/channels/app/plugin_test.go
@@ -1355,7 +1355,8 @@ func TestProcessPrepackagedPlugins(t *testing.T) {
 		require.Len(t, transitionalPlugins, 1)
 		expectPrepackagedPlugin(t, "testplugin", "0.0.1", transitionalPlugins[0])
 
-		th.App.ch.RemovePlugin("testplugin")
+		appErr := th.App.ch.RemovePlugin("testplugin")
+		require.Nil(t, appErr)
 
 		pluginStatus, err := env.Statuses()
 		require.NoError(t, err)


### PR DESCRIPTION
#### Summary
Fixed errcheck error in plugin_test.go by properly handling error from th.App.ch.RemovePlugin and removed plugin_test.go from the errcheck ignore list in .golangci.yml.

This change improves code quality by ensuring all errors are properly checked rather than being ignored.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/29076

#### Screenshots
<!-- N/A - No UI changes -->

#### Release Note
```release-note
NONE
```
#### Test Plan
- Run errcheck linter to verify the error is now properly handled
- Run existing tests to ensure functionality remains correct

🤖 Generated with [Claude Code](https://claude.ai/code)