### PR TITLE
[MM-61463] Fix errcheck issues in post_helpers_test.go

### DIFF
--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -102,8 +102,6 @@ issues:
         channels/app/platform/session.go|\
         channels/app/platform/status.go|\
         channels/app/platform/web_hub_test.go|\
-        channels/app/plugin_test.go|\
-        channels/app/post_helpers_test.go|\
         channels/app/post_test.go|\
         channels/app/slack.go|\
         channels/app/slashcommands/auto_environment.go|\

--- a/server/channels/app/post_helpers_test.go
+++ b/server/channels/app/post_helpers_test.go
@@ -195,10 +195,11 @@ func TestGetTimeSortedPostAccessibleBounds(t *testing.T) {
 func TestFilterInaccessiblePosts(t *testing.T) {
 	th := Setup(t)
 	th.App.Srv().SetLicense(model.NewTestLicense("cloud"))
-	th.App.Srv().Store().System().Save(&model.System{
+	err := th.App.Srv().Store().System().Save(&model.System{
 		Name:  model.SystemLastAccessiblePostTime,
 		Value: "2",
 	})
+	require.NoError(t, err)
 
 	defer th.TearDown()
 
@@ -323,10 +324,11 @@ func TestFilterInaccessiblePosts(t *testing.T) {
 func TestGetFilteredAccessiblePosts(t *testing.T) {
 	th := Setup(t)
 	th.App.Srv().SetLicense(model.NewTestLicense("cloud"))
-	th.App.Srv().Store().System().Save(&model.System{
+	err := th.App.Srv().Store().System().Save(&model.System{
 		Name:  model.SystemLastAccessiblePostTime,
 		Value: "2",
 	})
+	require.NoError(t, err)
 
 	defer th.TearDown()
 
@@ -364,10 +366,11 @@ func TestGetFilteredAccessiblePosts(t *testing.T) {
 func TestIsInaccessiblePost(t *testing.T) {
 	th := Setup(t)
 	th.App.Srv().SetLicense(model.NewTestLicense("cloud"))
-	th.App.Srv().Store().System().Save(&model.System{
+	err := th.App.Srv().Store().System().Save(&model.System{
 		Name:  model.SystemLastAccessiblePostTime,
 		Value: "2",
 	})
+	require.NoError(t, err)
 
 	defer th.TearDown()
 


### PR DESCRIPTION
#### Summary
Fixed errcheck issues in post_helpers_test.go by properly handling errors from th.App.Srv().Store().System().Save() calls and removed post_helpers_test.go from errcheck ignore list in .golangci.yml.

This change improves code quality by ensuring all errors are properly checked rather than being ignored.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/29078
Jira https://mattermost.atlassian.net/browse/MM-61463

#### Screenshots
<!-- N/A - No UI changes -->

#### Release Note
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.ai/code)