### PR TITLE
[MM-61079] Fix error checking in webhook.go

### DIFF
--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -168,7 +168,6 @@ issues:
         channels/web/oauth_test.go|\
         channels/web/saml.go|\
         channels/web/web_test.go|\
-        channels/web/webhook.go|\
         cmd/mattermost/commands/cmdtestlib.go|\
         cmd/mattermost/commands/db.go|\
         cmd/mattermost/commands/export.go|\

--- a/server/channels/web/webhook.go
+++ b/server/channels/web/webhook.go
@@ -27,7 +27,11 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 	id := params["id"]
 	errCtx := map[string]any{"hook_id": id}
 
-	r.ParseForm()
+	err := r.ParseForm()
+	if err != nil {
+		c.Err = model.NewAppError("incomingWebhook", "web.incoming_webhook.parse_form.app_error", errCtx, "", http.StatusBadRequest).Wrap(err)
+		return
+	}
 
 	var appErr *model.AppError
 	var mediaType string
@@ -69,7 +73,10 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else if mediaType == "multipart/form-data" {
-		r.ParseMultipartForm(0)
+		if err := r.ParseMultipartForm(0); err != nil {
+			c.Err = model.NewAppError("incomingWebhook", "web.incoming_webhook.parse_multipart.app_error", errCtx, "", http.StatusBadRequest).Wrap(err)
+			return
+		}
 
 		decoder := schema.NewDecoder()
 		err := decoder.Decode(incomingWebhookPayload, r.PostForm)
@@ -93,7 +100,10 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.Write([]byte("ok"))
+	if _, err := w.Write([]byte("ok")); err != nil {
+		c.Err = model.NewAppError("incomingWebhook", "web.incoming_webhook.write_response.app_error", errCtx, "", http.StatusInternalServerError).Wrap(err)
+		return
+	}
 }
 
 func commandWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -114,7 +124,10 @@ func commandWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/plain")
-	w.Write([]byte("ok"))
+	if _, err := w.Write([]byte("ok")); err != nil {
+		c.Err = model.NewAppError("commandWebhook", "web.command_webhook.write_response.app_error", errCtx, "", http.StatusInternalServerError).Wrap(err)
+		return
+	}
 }
 
 func decodePayload(payload io.Reader) (*model.IncomingWebhookRequest, *model.AppError) {

--- a/server/channels/web/webhook.go
+++ b/server/channels/web/webhook.go
@@ -101,7 +101,7 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/plain")
 	if _, err := w.Write([]byte("ok")); err != nil {
-		c.Err = model.NewAppError("incomingWebhook", "web.incoming_webhook.write_response.app_error", errCtx, "", http.StatusInternalServerError).Wrap(err)
+		c.Logger.Warn("Error while writing response", mlog.Err(err))
 		return
 	}
 }
@@ -125,7 +125,7 @@ func commandWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/plain")
 	if _, err := w.Write([]byte("ok")); err != nil {
-		c.Err = model.NewAppError("commandWebhook", "web.command_webhook.write_response.app_error", errCtx, "", http.StatusInternalServerError).Wrap(err)
+		c.Logger.Warn("Error while writing response", mlog.Err(err))
 		return
 	}
 }

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10525,6 +10525,14 @@
     "translation": "Unable to parse incoming data."
   },
   {
+    "id": "web.incoming_webhook.parse_form.app_error",
+    "translation": "Failed to parse form for webhook {{.hook_id}}."
+  },
+  {
+    "id": "web.incoming_webhook.parse_multipart.app_error",
+    "translation": "Failed to parse multipart form for webhook {{.hook_id}}."
+  },
+  {
     "id": "web.incoming_webhook.permissions.app_error",
     "translation": "User {{.user}} does not have appropriate permissions to channel {{.channel}}"
   },


### PR DESCRIPTION
#### Summary
- Fix errcheck linter issues in server/channels/web/webhook.go
- Add proper error checking for HTTP operations including form parsing and response writing
- Remove webhook.go exception from .golangci.yml

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/28751

#### Release Note
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.ai/code)