### PR TITLE
[MM-28761] Fix errcheck linter issues in hosted_purchase_screening worker

### DIFF
--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -116,7 +116,6 @@ issues:
         channels/app/webhook_test.go|\
         channels/jobs/batch_worker_test.go|\
         channels/jobs/helper_test.go|\
-        channels/jobs/hosted_purchase_screening/worker.go|\
         channels/jobs/jobs.go|\
         channels/manualtesting/manual_testing.go|\
         channels/store/localcachelayer/channel_layer.go|\

--- a/server/channels/jobs/hosted_purchase_screening/worker.go
+++ b/server/channels/jobs/hosted_purchase_screening/worker.go
@@ -42,7 +42,9 @@ func MakeWorker(jobServer *jobs.JobServer, license *model.License, screenTimeSto
 		}
 
 		if now.After(time.UnixMilli(screenTime).Add(waitForScreeningDuration)) {
-			screenTimeStore.PermanentDeleteByName(model.SystemHostedPurchaseNeedsScreening)
+			if _, err := screenTimeStore.PermanentDeleteByName(model.SystemHostedPurchaseNeedsScreening); err != nil {
+				logger.Warn("Failed to delete screening time", mlog.Err(err))
+			}
 		}
 		return nil
 	}


### PR DESCRIPTION
#### Summary
This PR fixes the errcheck linter issues in the `channels/jobs/hosted_purchase_screening/worker.go` file by:

1. Removing the file from the errcheck exception list in `.golangci.yml`
2. Adding proper error handling for the `PermanentDeleteByName` method call

Now the error from `PermanentDeleteByName` is properly checked and logged if there's a failure, following Mattermost's error handling best practices.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/28761

#### Release Note
```release-note
NONE
```