### PR TITLE
[MM-63638] Don't set auto add to false when changing the schema of a syncable

### DIFF
--- a/webapp/channels/src/components/admin_console/group_settings/group_details/group_details.tsx
+++ b/webapp/channels/src/components/admin_console/group_settings/group_details/group_details.tsx
@@ -68,7 +68,7 @@ export type Props = {
             id: string,
             syncableID: string,
             syncableType: SyncableType,
-            patch: SyncablePatch
+            patch: Partial<SyncablePatch>
         ) => Promise<ActionResult>;
         patchGroup: (id: string, patch: GroupPatch) => Promise<ActionResult>;
         setNavigationBlocked: (blocked: boolean) => {
@@ -531,7 +531,7 @@ class GroupDetails extends React.PureComponent<Props, State> {
                             this.props.groupID,
                             syncableID,
                             syncableType,
-                            {scheme_admin: value, auto_add: false},
+                            {scheme_admin: value},
                         ),
                     );
                 }


### PR DESCRIPTION
#### Summary
Lorenzo found some strange behaviour where auto_add was being set to false when you change the syncable schema on the groups page. This was introduced by accident as part of a typescript refactor 3.5 years ago.... https://github.com/mattermost/mattermost-webapp/pull/9267.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63638

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```
NONE
```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
