### PR TITLE
Allow mmctl to impersonate users

### DIFF
--- a/server/channels/api4/apitestlib.go
+++ b/server/channels/api4/apitestlib.go
@@ -540,7 +540,7 @@ func (th *TestHelper) waitForConnectivity() {
 }
 
 func (th *TestHelper) CreateClient() *model.Client4 {
-	return model.NewAPIv4Client(fmt.Sprintf("http://localhost:%v", th.App.Srv().ListenAddr.Port))
+	return model.NewAPIv4Client(fmt.Sprintf("http://localhost:%v", th.App.Srv().ListenAddr.Port), "")
 }
 
 // ToDo: maybe move this to NewAPIv4SocketClient and reuse it in mmctl

--- a/server/channels/api4/post_local.go
+++ b/server/channels/api4/post_local.go
@@ -11,6 +11,7 @@ import (
 )
 
 func (api *API) InitPostLocal() {
+	api.BaseRoutes.Posts.Handle("", api.APILocal(createPost)).Methods(http.MethodPost)
 	api.BaseRoutes.Post.Handle("", api.APILocal(getPost)).Methods(http.MethodGet)
 	api.BaseRoutes.PostsForChannel.Handle("", api.APILocal(getPostsForChannel)).Methods(http.MethodGet)
 	api.BaseRoutes.Post.Handle("", api.APILocal(localDeletePost)).Methods(http.MethodDelete)

--- a/server/channels/app/slashcommands/command_loadtest.go
+++ b/server/channels/app/slashcommands/command_loadtest.go
@@ -243,7 +243,7 @@ func (*LoadTestProvider) SetupCommand(a *app.App, rctx request.CTX, args *model.
 			numPosts, _ = strconv.Atoi(tokens[numArgs+2])
 		}
 	}
-	client := model.NewAPIv4Client(args.SiteURL)
+	client := model.NewAPIv4Client(args.SiteURL, "")
 
 	if doTeams {
 		if err := CreateBasicUser(rctx, a, client); err != nil {
@@ -344,7 +344,7 @@ func (*LoadTestProvider) UsersCommand(a *app.App, c request.CTX, args *model.Com
 		}
 	}
 
-	client := model.NewAPIv4Client(args.SiteURL)
+	client := model.NewAPIv4Client(args.SiteURL, "")
 	userCreator := NewAutoUserCreator(a, client, team)
 	userCreator.Fuzzy = doFuzz
 	userCreator.JoinTime = time
@@ -605,7 +605,7 @@ func (*LoadTestProvider) PostCommand(a *app.App, c request.CTX, args *model.Comm
 		return &model.CommandResponse{Text: "Failed to get a user", ResponseType: model.CommandResponseTypeEphemeral}, err
 	}
 
-	client := model.NewAPIv4Client(args.SiteURL)
+	client := model.NewAPIv4Client(args.SiteURL, "")
 	_, _, nErr := client.LoginById(context.Background(), user.Id, passwd)
 	if nErr != nil {
 		return &model.CommandResponse{Text: "Failed to login a user", ResponseType: model.CommandResponseTypeEphemeral}, nErr

--- a/server/channels/manualtesting/manual_testing.go
+++ b/server/channels/manualtesting/manual_testing.go
@@ -56,7 +56,7 @@ func ManualTest(c *web.Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create a client for tests to use
-	client := model.NewAPIv4Client("http://localhost" + *c.App.Config().ServiceSettings.ListenAddress)
+	client := model.NewAPIv4Client("http://localhost"+*c.App.Config().ServiceSettings.ListenAddress, "")
 
 	// Check for username parameter and create a user if present
 	username, ok1 := params["username"]

--- a/server/channels/web/handlers.go
+++ b/server/channels/web/handlers.go
@@ -340,7 +340,8 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// shape IP:PORT (it will be "@" in Linux, for example)
 		isLocalOrigin := !strings.Contains(r.RemoteAddr, ":")
 		if *c.App.Config().ServiceSettings.EnableLocalMode && isLocalOrigin {
-			c.AppContext = c.AppContext.WithSession(&model.Session{Local: true})
+			userID := r.Header.Get("X-Mattermost-Id")
+			c.AppContext = c.AppContext.WithSession(&model.Session{Local: true, UserId: userID})
 		} else if !isLocalOrigin {
 			c.Err = model.NewAppError("", "api.context.local_origin_required.app_error", nil, "LocalOriginRequired", http.StatusUnauthorized)
 		}

--- a/server/cmd/mmctl/commands/init.go
+++ b/server/cmd/mmctl/commands/init.go
@@ -84,7 +84,7 @@ func getClient(ctx context.Context, cmd *cobra.Command) (*model.Client4, string,
 	}
 
 	if useLocal {
-		c, err := InitUnixClient(viper.GetString("local-socket-path"))
+		c, err := InitUnixClient(viper.GetString("local-socket-path"), viper.GetString("local-user-id"))
 		if err != nil {
 			return nil, "", true, err
 		}
@@ -172,7 +172,7 @@ func VerifyCertificates(rawCerts [][]byte, verifiedChains [][]*x509.Certificate)
 }
 
 func NewAPIv4Client(instanceURL string, allowInsecureSHA1, allowInsecureTLS bool) *model.Client4 {
-	client := model.NewAPIv4Client(instanceURL)
+	client := model.NewAPIv4Client(instanceURL, "")
 	userAgent := fmt.Sprintf("mmctl/%s (%s)", Version, runtime.GOOS)
 	client.HTTPHeader = map[string]string{"User-Agent": userAgent}
 
@@ -251,12 +251,12 @@ func InitWebSocketClient() (*model.WebSocketClient, error) {
 	return client, nil
 }
 
-func InitUnixClient(socketPath string) (*model.Client4, error) {
+func InitUnixClient(socketPath string, userID string) (*model.Client4, error) {
 	if err := checkValidSocket(socketPath); err != nil {
 		return nil, err
 	}
 
-	return model.NewAPIv4SocketClient(socketPath), nil
+	return model.NewAPIv4SocketClient(socketPath, userID), nil
 }
 
 func checkInsecureTLSError(err error, allowInsecureTLS bool) error {

--- a/server/cmd/mmctl/commands/root.go
+++ b/server/cmd/mmctl/commands/root.go
@@ -45,6 +45,8 @@ func Run(args []string) error {
 	_ = viper.BindPFlag("insecure-tls-version", RootCmd.PersistentFlags().Lookup("insecure-tls-version"))
 	RootCmd.PersistentFlags().Bool("local", false, "allows communicating with the server through a unix socket")
 	_ = viper.BindPFlag("local", RootCmd.PersistentFlags().Lookup("local"))
+	RootCmd.PersistentFlags().String("local-user-id", "", "allows to set the user-id for local connections")
+	_ = viper.BindPFlag("local-user-id", RootCmd.PersistentFlags().Lookup("local-user-id"))
 	RootCmd.PersistentFlags().Bool("short-stat", false, "short stat will provide useful statistical data")
 	_ = RootCmd.PersistentFlags().MarkHidden("short-stat")
 	RootCmd.PersistentFlags().Bool("no-stat", false, "the statistical data won't be displayed")

--- a/server/public/model/client4.go
+++ b/server/public/model/client4.go
@@ -120,19 +120,19 @@ func closeBody(r *http.Response) {
 	}
 }
 
-func NewAPIv4Client(url string) *Client4 {
+func NewAPIv4Client(url string, userID string) *Client4 {
 	url = strings.TrimRight(url, "/")
-	return &Client4{url, url + APIURLSuffix, &http.Client{}, "", "", map[string]string{}, "", ""}
+	return &Client4{url, url + APIURLSuffix, &http.Client{}, "", "", map[string]string{"X-Mattermost-Id": userID}, "", ""}
 }
 
-func NewAPIv4SocketClient(socketPath string) *Client4 {
+func NewAPIv4SocketClient(socketPath string, userID string) *Client4 {
 	tr := &http.Transport{
 		Dial: func(network, addr string) (net.Conn, error) {
 			return net.Dial("unix", socketPath)
 		},
 	}
 
-	client := NewAPIv4Client("http://_")
+	client := NewAPIv4Client("http://_", userID)
 	client.HTTPClient = &http.Client{Transport: tr}
 
 	return client


### PR DESCRIPTION
#### Summary
This PR allows the mmctl command to impoersonate users. This opens the posibility of doing things like adding posts en behalf of a user, or creating channels as a user.

#### Release Note
```release-note
Add --local-user-id for local mode in mmctl
```