### PR TITLE
flaky test: Avoid team names that start with "A".

### DIFF
--- a/server/channels/app/import_functions_test.go
+++ b/server/channels/app/import_functions_test.go
@@ -522,7 +522,8 @@ func TestImportImportTeam(t *testing.T) {
 	require.NoError(t, err, "Failed to get team count.")
 
 	// we also assert that the team name can be upper case
-	teamName := "A" + model.NewId()
+	// Note there are no reserved team names starting with `Z`, making this flake-free.
+	teamName := "Z" + model.NewId()
 	sanitizedTeamName := strings.ToLower(teamName)
 
 	data := imports.TeamImportData{


### PR DESCRIPTION
#### Summary
This avoids a non-zero chance we append "pi" from the `model.NewId` and end up with an invalid prefix "Api".

#### Ticket Link
None

#### Release Note
```release-note
NONE
```