### PR TITLE
Enabld the bidichk linter

### DIFF
--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -29,6 +29,7 @@ linters:
     - makezero
     - whitespace
     - errcheck
+    - bidichk
 
 issues:
   exclude-rules:


### PR DESCRIPTION
#### Summary

Enables the bidichk linter in golangci-lint

#### Ticket Link

https://mattermost.atlassian.net/browse/SEC-7737

#### Screenshots

Tested locally:
<img width="510" alt="bidichk" src="https://github.com/user-attachments/assets/76bb1fb6-0b66-43df-a7be-29dc6650c883" />

#### Release Note

```release-note
NONE
```

