### PR TITLE
Enhance Scheduled Messaging with 15-minute time interval support

### DIFF
--- a/webapp/channels/src/components/custom_status/date_time_input.test.tsx
+++ b/webapp/channels/src/components/custom_status/date_time_input.test.tsx
@@ -36,15 +36,28 @@ describe('components/custom_status/date_time_input', () => {
     });
 
     it.each([
-        ['2024-03-02T02:00:00+0100', 48],
-        ['2024-03-31T02:00:00+0100', 46],
-        ['2024-10-07T02:00:00+0100', 48],
-        ['2024-10-27T02:00:00+0100', 48],
-        ['2025-01-01T03:00:00+0200', 48],
+        ['2024-03-02T02:00:00+0100', 96],
+        ['2024-03-31T02:00:00+0100', 92],
+        ['2024-10-07T02:00:00+0100', 96],
+        ['2024-10-27T02:00:00+0100', 96],
+        ['2025-01-01T03:00:00+0200', 96],
     ])('should not infinitely loop on DST', (time, expected) => {
         const timezone = 'Europe/Paris';
 
         const intervals = getTimeInIntervals(moment.tz(time, timezone).startOf('day'));
         expect(intervals).toHaveLength(expected);
+    });
+
+    it('should generate 15-minute intervals correctly', () => {
+        const timezone = 'Australia/Sydney';
+        const startTime = moment.tz('2024-04-01T00:00:00', timezone);
+
+        const intervals = getTimeInIntervals(startTime, 15);
+
+        expect(intervals.length).toBe(96);
+        expect(intervals[0].getMinutes()).toBe(0);
+        expect(intervals[1].getMinutes()).toBe(15);
+        expect(intervals[2].getMinutes()).toBe(30);
+        expect(intervals[3].getMinutes()).toBe(45);
     });
 });

--- a/webapp/channels/src/components/custom_status/date_time_input.tsx
+++ b/webapp/channels/src/components/custom_status/date_time_input.tsx
@@ -29,7 +29,7 @@ import {relativeFormatDate} from 'utils/datetime';
 import {isKeyPressed} from 'utils/keyboard';
 import {getCurrentMomentForTimezone, isBeforeTime} from 'utils/timezone';
 
-const CUSTOM_STATUS_TIME_PICKER_INTERVALS_IN_MINUTES = 30;
+const CUSTOM_STATUS_TIME_PICKER_INTERVALS_IN_MINUTES = 15;
 
 export function getRoundedTime(value: Moment, roundedTo = CUSTOM_STATUS_TIME_PICKER_INTERVALS_IN_MINUTES) {
     const start = moment(value);


### PR DESCRIPTION
Summary

Added a 15-minute interval for scheduling messages, allows users to set scheduled messages at fixed intervals 00:00, 00:15, 00:30 and 00:45

Ticket Link

https://github.com/mattermost/mattermost/issues/30523

Screenshots

<img width="705" alt="Screenshot 2025-04-05 at 11 36 40 PM" src="https://github.com/user-attachments/assets/869d09f3-2ec1-41f6-8914-70dc46eb2aef" />


