### PR TITLE
Update DeepPartial to not make the contents of arrays partial as well

### DIFF
--- a/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
+++ b/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
@@ -113,7 +113,7 @@ describe('custom plugin sections and settings', () => {
                                         settings: [
                                             {
                                                 key: 'customsection1numbersetting',
-                                                label: 'Custom Section Number Setting',
+                                                display_name: 'Custom Section Number Setting',
                                                 type: 'number' as const,
                                                 help_text: 'Custom Section Number Setting Help Text',
                                             },
@@ -126,7 +126,7 @@ describe('custom plugin sections and settings', () => {
                                         settings: [
                                             {
                                                 key: 'customsection2numbersetting',
-                                                label: 'Custom Section Number Setting',
+                                                display_name: 'Custom Section Number Setting',
                                                 type: 'number' as const,
                                                 help_text: 'Custom Section Number Setting Help Text',
                                             },
@@ -184,8 +184,8 @@ describe('custom plugin sections and settings', () => {
                                         settings: [
                                             {
                                                 key: 'customsection1numbersetting',
-                                                label: 'Custom Section Number Setting',
-                                                type: 'number' as const,
+                                                display_name: 'Custom Section Number Setting',
+                                                type: 'number',
                                                 help_text: 'Custom Section Number Setting Help Text',
                                             },
                                         ],
@@ -198,14 +198,14 @@ describe('custom plugin sections and settings', () => {
                                         settings: [
                                             {
                                                 key: 'customsection2numbersetting',
-                                                label: 'Custom Section Bool Setting',
-                                                type: 'bool' as const,
+                                                display_name: 'Custom Section Bool Setting',
+                                                type: 'bool',
                                                 help_text: 'Custom Section Bool Setting Help Text',
                                             },
                                             {
                                                 key: 'customsection2customsetting',
-                                                label: 'Custom Section Custom Setting',
-                                                type: 'custom' as const,
+                                                display_name: 'Custom Section Custom Setting',
+                                                type: 'custom',
                                                 help_text: 'Custom Section Custom Setting Help Text',
                                             },
                                         ],
@@ -279,8 +279,8 @@ describe('custom plugin sections and settings', () => {
                                         settings: [
                                             {
                                                 key: 'customsection1numbersetting',
-                                                label: 'Custom Section Number Setting',
-                                                type: 'number' as const,
+                                                display_name: 'Custom Section Number Setting',
+                                                type: 'number',
                                                 help_text: 'Custom Section Number Setting Help Text',
                                             },
                                         ],
@@ -292,8 +292,8 @@ describe('custom plugin sections and settings', () => {
                                         settings: [
                                             {
                                                 key: 'customsection2numbersetting',
-                                                label: 'Custom Section Number Setting',
-                                                type: 'number' as const,
+                                                display_name: 'Custom Section Number Setting',
+                                                type: 'number',
                                                 help_text: 'Custom Section Number Setting Help Text',
                                             },
                                         ],

--- a/webapp/channels/src/components/app_bar/__snapshots__/app_bar.test.tsx.snap
+++ b/webapp/channels/src/components/app_bar/__snapshots__/app_bar.test.tsx.snap
@@ -20,9 +20,6 @@ exports[`components/app_bar/app_bar should match snapshot on mount 1`] = `
           fallback_component
         </div>
       </div>
-      <hr
-        class="app-bar__divider"
-      />
       <div
         aria-label="Create Subscription"
         class="app-bar__icon"
@@ -59,9 +56,6 @@ exports[`components/app_bar/app_bar should match snapshot on mount when App Bar 
           fallback_component
         </div>
       </div>
-      <hr
-        class="app-bar__divider"
-      />
       <div
         aria-label="Create Subscription"
         class="app-bar__icon"

--- a/webapp/channels/src/components/app_bar/app_bar.test.tsx
+++ b/webapp/channels/src/components/app_bar/app_bar.test.tsx
@@ -59,7 +59,7 @@ describe('components/app_bar/app_bar', () => {
         },
         plugins: {
             components: {
-                AppBar: channelHeaderComponents,
+                ChannelHeaderButton: channelHeaderComponents,
                 RightHandSidebarComponent: rhsComponents,
                 Product: [],
             },

--- a/webapp/channels/src/components/new_search/search_box_hints.test.tsx
+++ b/webapp/channels/src/components/new_search/search_box_hints.test.tsx
@@ -75,7 +75,7 @@ describe('components/new_search/SearchBoxHints', () => {
         renderWithContext(
             <SearchBoxHints {...props}/>,
             {
-                plugins: {components: {SearchHints: [{component: TestPluginProviderComponent as React.ComponentType, pluginId: 'test-id'}]}},
+                plugins: {components: {SearchHints: [{id: 'test-id', component: TestPluginProviderComponent, pluginId: 'test-id'}]}},
                 entities: {general: {license: {IsLicensed: 'false'}}},
             },
         );
@@ -88,7 +88,7 @@ describe('components/new_search/SearchBoxHints', () => {
         renderWithContext(
             <SearchBoxHints {...props}/>,
             {
-                plugins: {components: {SearchHints: [{component: TestPluginProviderComponent as React.ComponentType, pluginId: 'test-id'}]}},
+                plugins: {components: {SearchHints: [{id: 'test-id', component: TestPluginProviderComponent, pluginId: 'test-id'}]}},
                 entities: {general: {license: {IsLicensed: 'true'}}},
             },
         );
@@ -101,7 +101,7 @@ describe('components/new_search/SearchBoxHints', () => {
         renderWithContext(
             <SearchBoxHints {...props}/>,
             {
-                plugins: {components: {SearchHints: [{component: TestPluginProviderComponent as React.ComponentType, pluginId: 'test-id'}]}},
+                plugins: {components: {SearchHints: [{id: 'test-id', component: TestPluginProviderComponent, pluginId: 'test-id'}]}},
                 entities: {general: {license: {IsLicensed: 'true'}}},
             },
         );

--- a/webapp/channels/src/components/new_search/search_box_suggestions.test.tsx
+++ b/webapp/channels/src/components/new_search/search_box_suggestions.test.tsx
@@ -90,7 +90,7 @@ describe('components/new_search/SearchBoxSuggestions', () => {
         renderWithContext(
             <SearchBoxSuggestions {...props}/>,
             {
-                plugins: {components: {SearchSuggestions: [{component: TestPluginProviderComponent as React.ComponentType, pluginId: 'test-id'}]}},
+                plugins: {components: {SearchSuggestions: [{id: 'test-id', component: TestPluginProviderComponent, pluginId: 'test-id'}]}},
                 entities: {general: {license: {IsLicensed: 'false'}}},
             },
         );
@@ -103,7 +103,7 @@ describe('components/new_search/SearchBoxSuggestions', () => {
         renderWithContext(
             <SearchBoxSuggestions {...props}/>,
             {
-                plugins: {components: {SearchSuggestions: [{component: TestPluginProviderComponent as React.ComponentType, pluginId: 'test-id'}]}},
+                plugins: {components: {SearchSuggestions: [{id: 'test-id', component: TestPluginProviderComponent, pluginId: 'test-id'}]}},
                 entities: {general: {license: {IsLicensed: 'true'}}},
             },
         );
@@ -116,7 +116,7 @@ describe('components/new_search/SearchBoxSuggestions', () => {
         renderWithContext(
             <SearchBoxSuggestions {...props}/>,
             {
-                plugins: {components: {SearchSuggestions: [{component: TestPluginProviderComponent as React.ComponentType, pluginId: 'test-id'}]}},
+                plugins: {components: {SearchSuggestions: [{id: 'test-id', component: TestPluginProviderComponent, pluginId: 'test-id'}]}},
                 entities: {general: {license: {IsLicensed: 'true'}}},
             },
         );
@@ -129,7 +129,7 @@ describe('components/new_search/SearchBoxSuggestions', () => {
         renderWithContext(
             <SearchBoxSuggestions {...props}/>,
             {
-                plugins: {components: {SearchSuggestions: [{component: TestPluginProviderComponent as React.ComponentType, pluginId: 'test-id'}]}},
+                plugins: {components: {SearchSuggestions: [{id: 'test-id', component: TestPluginProviderComponent, pluginId: 'test-id'}]}},
                 entities: {general: {license: {IsLicensed: 'true'}}},
             },
         );

--- a/webapp/channels/src/components/new_search/search_box_type_selector.test.tsx
+++ b/webapp/channels/src/components/new_search/search_box_type_selector.test.tsx
@@ -32,7 +32,7 @@ describe('components/new_search/SearchBoxTypeSelector', () => {
         renderWithContext(
             <SearchBoxTypeSelector {...baseProps}/>,
             {
-                plugins: {components: {SearchButtons: [{component: (() => <pre>{'test'}</pre>) as React.ComponentType, pluginId: 'test-id'}]}},
+                plugins: {components: {SearchButtons: [{id: 'test-id', action: jest.fn(), component: (() => <pre>{'test'}</pre>), pluginId: 'test-id'}]}},
                 entities: {general: {license: {IsLicensed: 'false'}}},
             },
         );
@@ -43,7 +43,7 @@ describe('components/new_search/SearchBoxTypeSelector', () => {
         renderWithContext(
             <SearchBoxTypeSelector {...baseProps}/>,
             {
-                plugins: {components: {SearchButtons: [{component: (() => <pre>{'test'}</pre>) as React.ComponentType, pluginId: 'test-id'}]}},
+                plugins: {components: {SearchButtons: [{id: 'test-id', action: jest.fn(), component: (() => <pre>{'test'}</pre>), pluginId: 'test-id'}]}},
                 entities: {general: {license: {IsLicensed: 'true'}}},
             },
         );
@@ -54,7 +54,7 @@ describe('components/new_search/SearchBoxTypeSelector', () => {
         renderWithContext(
             <SearchBoxTypeSelector {...baseProps}/>,
             {
-                plugins: {components: {SearchButtons: [{component: (() => <pre>{'test'}</pre>) as React.ComponentType, pluginId: 'test-id'}]}},
+                plugins: {components: {SearchButtons: [{id: 'test-id', action: jest.fn(), component: (() => <pre>{'test'}</pre>), pluginId: 'test-id'}]}},
                 entities: {general: {license: {IsLicensed: 'true'}}},
             },
         );

--- a/webapp/channels/src/components/plugin_link_tooltip/index.test.tsx
+++ b/webapp/channels/src/components/plugin_link_tooltip/index.test.tsx
@@ -24,7 +24,7 @@ describe('PluginLinkTooltip', () => {
                     {
                         id: 'test',
                         pluginId: 'example.test',
-                        component: TestLinkTooltip as any,
+                        component: TestLinkTooltip,
                     },
                 ],
             },

--- a/webapp/channels/src/components/profile_popover/profile_popover.test.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover.test.tsx
@@ -137,7 +137,13 @@ function getBasePropsAndState(): [Props, DeepPartial<GlobalState>] {
         },
         plugins: {
             components: {
-                CallButton: [{}],
+                CallButton: [{
+                    id: 'call',
+                    pluginId: 'test',
+                    action: jest.fn(),
+                    button: () => 'button',
+                    dropdownButton: () => 'dropdownButton',
+                }],
             },
             plugins: {
                 'com.mattermost.calls': {
@@ -218,7 +224,7 @@ describe('components/ProfilePopover', () => {
             return (<span>{`${status} ${user.id}`}</span>);
         };
 
-        initialState.plugins!.components!.PopoverUserAttributes = [{component: mockPluginComponent as any}];
+        initialState.plugins!.components!.PopoverUserAttributes = [{id: 'test', pluginId: 'test', component: mockPluginComponent as any}];
 
         renderWithPluginReducers(<ProfilePopover {...props}/>, initialState);
         expect(props.hide).toHaveBeenCalled();
@@ -240,7 +246,7 @@ describe('components/ProfilePopover', () => {
             return (<span>{`${status} ${user.id}`}</span>);
         };
 
-        initialState.plugins!.components!.PopoverUserActions = [{component: mockPluginComponent as any}];
+        initialState.plugins!.components!.PopoverUserActions = [{id: 'test', pluginId: 'test', component: mockPluginComponent as any}];
 
         renderWithPluginReducers(<ProfilePopover {...props}/>, initialState);
         expect(props.hide).toHaveBeenCalled();

--- a/webapp/channels/src/components/user_settings/modal/user_settings_modal.test.tsx
+++ b/webapp/channels/src/components/user_settings/modal/user_settings_modal.test.tsx
@@ -122,6 +122,9 @@ describe('tabs are properly rendered', () => {
                                 settings: [
                                     {
                                         name: 'plugin A setting',
+                                        type: 'radio',
+                                        options: [],
+                                        default: 'on',
                                     },
                                 ],
                             },
@@ -136,6 +139,9 @@ describe('tabs are properly rendered', () => {
                                 settings: [
                                     {
                                         name: 'plugin B setting',
+                                        type: 'radio',
+                                        options: [],
+                                        default: 'on',
                                     },
                                 ],
                             },

--- a/webapp/channels/src/components/widgets/inputs/dropdown_input_hybrid.tsx
+++ b/webapp/channels/src/components/widgets/inputs/dropdown_input_hybrid.tsx
@@ -228,7 +228,7 @@ const DropdownInputHybrid = <T extends OptionType = OptionType>(props: Props<T>)
                         width: showInput ? `${width}px` : '100%',
                     }}
                 >
-                    <ReactSelect<T>
+                    <ReactSelect<T, false>
                         id={`DropdownInput_${name}`}
                         placeholder={focused ? '' : placeholder}
                         components={{

--- a/webapp/channels/src/plugins/pluggable/pluggable.test.tsx
+++ b/webapp/channels/src/plugins/pluggable/pluggable.test.tsx
@@ -30,6 +30,7 @@ describe('plugins/Pluggable', () => {
                         component: ProfilePopoverPlugin,
                         id: 'some id',
                         pluginId: 'some plugin id',
+                        title: 'some title',
                     }],
                 },
             },

--- a/webapp/platform/types/src/plugins.ts
+++ b/webapp/platform/types/src/plugins.ts
@@ -64,8 +64,8 @@ export type PluginSetting = {
     type: string;
     help_text: string | MessageDescriptor;
     regenerate_help_text?: string;
-    placeholder: string;
-    default: any;
+    placeholder?: string;
+    default?: any;
     options?: PluginSettingOption[];
     hosting?: 'on-prem' | 'cloud';
 };

--- a/webapp/platform/types/src/utilities.ts
+++ b/webapp/platform/types/src/utilities.ts
@@ -25,18 +25,19 @@ export type DeepPartial<T> = {
     // For each field of T, make it optional and...
     [K in keyof T]?: (
 
-        // If that field is a Set or a Map, don't go further
-        T[K] extends Set<any> ? T[K] :
-            T[K] extends Map<any, any> ? T[K] :
+        // If that field is a Set/Map/Array, don't go further
+        T[K] extends Set<unknown> ? T[K] :
+            T[K] extends Map<unknown, unknown> ? T[K] :
+                T[K] extends unknown[] ? T[K] :
 
-            // If that field is an object, make it a deep partial object
-                T[K] extends object ? DeepPartial<T[K]> :
+                    // If that field is an object, make it a deep partial object
+                    T[K] extends object ? DeepPartial<T[K]> :
 
-                // Else if that field is an optional object, make that a deep partial object
-                    T[K] extends object | undefined ? DeepPartial<T[K]> :
+                        // Else if that field is an optional object, make that a deep partial object
+                        T[K] extends object | undefined ? DeepPartial<T[K]> :
 
-                    // Else leave it as an optional primitive
-                        T[K]
+                            // Else leave it as an optional primitive
+                            T[K]
     );
 }
 


### PR DESCRIPTION
#### Summary
This is a followup to MM-30663 that I split off. Making items in an array partial seems to mess up the types of plugin components for some reason

#### Release Note
```release-note
NONE
```
