### PR TITLE
[MM-63693] Don't log PING websocket events

### DIFF
--- a/server/channels/wsapi/websocket_handler.go
+++ b/server/channels/wsapi/websocket_handler.go
@@ -23,7 +23,10 @@ type webSocketHandler struct {
 }
 
 func (wh webSocketHandler) ServeWebSocket(conn *platform.WebConn, r *model.WebSocketRequest) {
-	mlog.Debug("Websocket request", mlog.String("action", r.Action))
+	// Don't log ping requests to reduce log noise
+	if r.Action != "ping" {
+		mlog.Debug("Websocket request", mlog.String("action", r.Action))
+	}
 
 	hub := wh.app.Srv().Platform().GetHubForUserId(conn.UserId)
 	if hub == nil {


### PR DESCRIPTION
#### Summary
In https://github.com/mattermost/mattermost/pull/30293, we started sending PINGs to the server websocket from the clients. The server logs each PING, which clutters the logs with a ton of useless messages.

This PR stops logging PING actions coming over the websocket.

#### Testing

Prior to this change, whenever a client connects, every 30 seconds you should see a debug log like the following on the server:

```
{"timestamp":"...","level":"debug","msg":"Websocket request","caller":"wsapi/websocket_handler.go:26","action":"ping"}
```

After this change, the log will be missing.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63693

#### Release Note
```release-note
Stop logging websocket PING events received by the server.
```