### PR TITLE
fix: mattermost-redux exports

### DIFF
--- a/webapp/platform/mattermost-redux/package.json
+++ b/webapp/platform/mattermost-redux/package.json
@@ -13,8 +13,7 @@
   ],
   "exports": {
     "./*": [
-      "./lib/*/index.js",
-      "./lib/*.js"
+      "./lib/*"
     ]
   },
   "typesVersions": {


### PR DESCRIPTION
#### Summary
I changed the export list to be a full wildcard under `/lib`.
With the previous version, importing specific selectors like `import {getConfig} from 'mattermost-redux/selectors/entities/general'`. did not work. This happens because exports just look for the first possible match, whether or not the file exists, and run with it. So adding additional paths with more specific directories would not work.
Alternatively fully specifying all exported files would work, but as I understand it, everything should be exported from the package.

#### Release Note
```release-note
Fixed mattermost-redux package exports
```
