### PR TITLE
[MM-63663 ]add pagination to Access Control Policy store GetAll

### DIFF
--- a/server/channels/store/sqlstore/access_control_policy_store.go
+++ b/server/channels/store/sqlstore/access_control_policy_store.go
@@ -389,6 +389,10 @@ func (s *SqlAccessControlPolicyStore) getT(_ request.CTX, tx *sqlxTxWrapper, id 
 }
 
 func (s *SqlAccessControlPolicyStore) GetAll(_ request.CTX, opts store.GetPolicyOptions) ([]*model.AccessControlPolicy, error) {
+	if opts.PerPage <= 0 {
+		opts.PerPage = 1000
+	}
+
 	p := []storeAccessControlPolicy{}
 	query := s.selectQueryBuilder
 
@@ -403,6 +407,9 @@ func (s *SqlAccessControlPolicyStore) GetAll(_ request.CTX, opts store.GetPolicy
 	if opts.Type != "" {
 		query = query.Where(sq.Eq{"Type": opts.Type})
 	}
+
+	// append limit, offset
+	query = query.Limit(uint64(opts.PerPage)).Offset(uint64(opts.Page * opts.PerPage))
 
 	err := s.GetReplica().SelectBuilder(&p, query)
 	if err != nil {

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -1215,4 +1215,7 @@ type GetPolicyOptions struct {
 	ParentID string
 	// Type will filter policy records where they are associated with the Type.
 	Type string
+
+	Page    int
+	PerPage int
 }

--- a/server/channels/store/storetest/access_control_policy_store.go
+++ b/server/channels/store/storetest/access_control_policy_store.go
@@ -326,4 +326,19 @@ func testAccessControlPolicyStoreGetAll(t *testing.T, rctx request.CTX, ss store
 		require.NotNil(t, policies)
 		require.Len(t, policies, 0)
 	})
+
+	t.Run("Paged query", func(t *testing.T) {
+		var page int
+		for {
+			policies, err := ss.AccessControlPolicy().GetAll(rctx, store.GetPolicyOptions{Page: page, PerPage: 1})
+			if len(policies) == 0 {
+				break
+			}
+			require.NoError(t, err)
+			require.NotNil(t, policies)
+			require.Len(t, policies, 1)
+			page++
+		}
+		require.Equal(t, 2, page)
+	})
 }


### PR DESCRIPTION

#### Summary
[AI generated] This pull request introduces pagination to the `GetAll` method in the `SqlAccessControlPolicyStore` to improve performance and manageability when retrieving access control policies. The changes include adding pagination parameters to the `GetPolicyOptions` struct, updating the `GetAll` method to use these parameters, and adding a test case to ensure the pagination works correctly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63663

#### Release Note

```release-note
NONE
```
