### PR TITLE
[CLD-9052] Make trial form modal-body scrollable for small vertical screens

### DIFF
--- a/webapp/channels/src/components/start_trial_form_modal/start_trial_form_modal.scss
+++ b/webapp/channels/src/components/start_trial_form_modal/start_trial_form_modal.scss
@@ -77,7 +77,7 @@
 
     .modal-body {
         display: flex;
-        overflow: hidden;
+        overflow: scroll;
         width: 100%;
         flex-direction: column;
         padding-top: 32px;


### PR DESCRIPTION
#### Summary
Overflow was hidden so on small screens (<720 pixels vertically) the start trial button would go off the page never to be seen again. This makes the modal-body scrollable.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-9052

#### Screenshots
Before:
![image](https://github.com/user-attachments/assets/0eaa05c5-e331-4a78-8d36-d07c7d955884)

After:
![image](https://github.com/user-attachments/assets/b09fd2ef-e8b0-4c6e-9477-f0f1974055d3)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
None
```
