### PR TITLE
Improves validation and sanitization for CPA fields and values

### DIFF
--- a/server/public/model/custom_profile_attributes.go
+++ b/server/public/model/custom_profile_attributes.go
@@ -46,11 +46,13 @@ const (
 	CustomProfileAttributesVisibilityWhenSet = "when_set"
 	CustomProfileAttributesVisibilityAlways  = "always"
 	CustomProfileAttributesVisibilityDefault = CustomProfileAttributesVisibilityWhenSet
-)
 
-const (
+	// CPA options
 	CPAOptionNameMaxLength  = 128
 	CPAOptionColorMaxLength = 128
+
+	// CPA value constraints
+	CPAValueTypeTextMaxLength = 64
 )
 
 func IsKnownCPAValueType(valueType string) bool {
@@ -119,7 +121,7 @@ func (c CustomProfileAttributesSelectOption) IsValid() error {
 
 type CPAField struct {
 	PropertyField
-	Attrs CPAAttrs
+	Attrs CPAAttrs `json:"attrs"`
 }
 
 type CPAAttrs struct {
@@ -146,7 +148,28 @@ func (c *CPAField) ToPropertyField() *PropertyField {
 	return &pf
 }
 
+// SupportsOptions checks the CPAField type and determines if the type
+// supports the use of options
+func (c *CPAField) SupportsOptions() bool {
+	return c.Type == PropertyFieldTypeSelect || c.Type == PropertyFieldTypeMultiselect
+}
+
+// SupportsSyncing checks the CPAField type and determines if it
+// supports syncing with external sources of truth
+func (c *CPAField) SupportsSyncing() bool {
+	return c.Type == PropertyFieldTypeText
+}
+
 func (c *CPAField) SanitizeAndValidate() *AppError {
+	// first we clean unused attributes depending on the field type
+	if !c.SupportsOptions() {
+		c.Attrs.Options = nil
+	}
+	if !c.SupportsSyncing() {
+		c.Attrs.LDAP = ""
+		c.Attrs.SAML = ""
+	}
+
 	switch c.Type {
 	case PropertyFieldTypeText:
 		if valueType := strings.TrimSpace(c.Attrs.ValueType); valueType != "" {
@@ -230,6 +253,10 @@ func SanitizeAndValidatePropertyValue(cpaField *CPAField, rawValue json.RawMessa
 		value = strings.TrimSpace(value)
 
 		if fieldType == PropertyFieldTypeText {
+			if len(value) > CPAValueTypeTextMaxLength {
+				return nil, fmt.Errorf("value too long")
+			}
+
 			if cpaField.Attrs.ValueType == CustomProfileAttributesValueTypeEmail && !IsValidEmail(value) {
 				return nil, fmt.Errorf("invalid email")
 			}


### PR DESCRIPTION
#### Summary
This change automatically removes options and sync attributes when sanitizing fields that don't support them. As per values, it returns an error when the value for a text type field is longer than the 64 characters limit we're currently applying.

The PR fixes a bug on the create CPA field endpoint that was causing the attrs of the CPAField not to be decoded correctly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63654
https://mattermost.atlassian.net/browse/MM-63721

#### Release Note
```release-note
NONE
```
