### PR TITLE
Fix failing E2E smoketests

### DIFF
--- a/e2e-tests/playwright/lib/src/ui/components/channels/center_view.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/center_view.ts
@@ -133,7 +133,7 @@ export default class ChannelsCenterView {
         const messageLocator = this.scheduledDraftChannelInfoMessage.first();
         try {
             await expect(messageLocator).toContainText('Message scheduled for');
-        } catch (error) {
+        } catch {
             // First assertion failed, trying fallback
             await expect(messageLocator).toContainText('You have one scheduled message.');
         }


### PR DESCRIPTION
#### Summary
It seems like this the previous PR got caught before and after a dependency update which let a style error get through CI

#### Release Note
```release-note
NONE
```
