### PR TITLE
Update mattermost-govet version to latest SHA for vet target

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -758,7 +758,7 @@ endif
 vet: ## Run mattermost go vet specific checks
 	## Note that it is pinned to a specific commit, rather than a branch. This is to prevent
 	## having to backport the fix to multiple release branches for any new change.
-	$(GO) install github.com/mattermost/mattermost-govet/v2@72e7752bcf59b57688fcb41173a6a1583c405adf
+	$(GO) install github.com/mattermost/mattermost-govet/v2@8e4d46e3fad88497dbfe073788a87e75bbae717c
 	$(GO) vet -vettool=$(GOBIN)/mattermost-govet -structuredLogging -inconsistentReceiverName -emptyStrCmp -tFatal -configtelemetry -errorAssertions -license -inconsistentReceiverName.ignore=session_serial_gen.go,team_member_serial_gen.go,user_serial_gen.go,utils_serial_gen.go ./...
  ifeq ($(BUILD_ENTERPRISE_READY),true)
   ifneq ($(MM_NO_ENTERPRISE_LINT),true)


### PR DESCRIPTION
#### Summary
Today, I learned that we use `mattermost-govet` in multiple make targets. :see_no_evil: 

Follow up to https://github.com/mattermost/mattermost/pull/30688

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
