### PR TITLE
use Promise.any vs try / catch

### DIFF
--- a/e2e-tests/playwright/lib/src/ui/components/channels/center_view.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/center_view.ts
@@ -144,7 +144,10 @@ export default class ChannelsCenterView {
         await this.postBoxIndicator.isVisible();
         await this.scheduledDraftChannelIcon.isVisible();
         const messageLocator = this.scheduledDraftChannelInfoMessage.first();
-        await expect(messageLocator).toContainText('Message scheduled for');
+        await Promise.any([
+            expect(messageLocator).toContainText('Message scheduled for'),
+            expect(messageLocator).toContainText('You have one scheduled message.'),
+        ]);
     }
 
     async clickOnLastEditedPost(postID: string | null) {


### PR DESCRIPTION
#### Summary
This avoids the "unused error" warning that's currently breaking the smoketests.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```