### PR TITLE
Fix accessibility issue with dropdown options 

### DIFF
--- a/webapp/channels/src/components/dropdown_input.tsx
+++ b/webapp/channels/src/components/dropdown_input.tsx
@@ -13,6 +13,7 @@ import type {CustomMessageInputType} from 'components/widgets/inputs/input/input
 import {ItemStatus} from 'utils/constants';
 
 import './dropdown_input.scss';
+import {getOptionLabel} from './widgets/modals/components/react_select_item';
 
 // TODO: This component needs work, should not be used outside of AddressInfo until this comment is removed.
 
@@ -104,7 +105,7 @@ const DropdownInput = <T extends ValueType>(props: Props<T>) => {
         }
     };
 
-    const {formatMessage} = useIntl();
+    const intl = useIntl();
     const [customInputLabel, setCustomInputLabel] = useState<CustomMessageInputType>(null);
     const ownValue = useRef<T>();
 
@@ -119,9 +120,9 @@ const DropdownInput = <T extends ValueType>(props: Props<T>) => {
             return;
         }
 
-        const validationErrorMsg = formatMessage({id: 'widget.input.required', defaultMessage: 'This field is required'});
+        const validationErrorMsg = intl.formatMessage({id: 'widget.input.required', defaultMessage: 'This field is required'});
         setCustomInputLabel({type: ItemStatus.ERROR, value: validationErrorMsg});
-    }, [required, formatMessage]);
+    }, [required, intl.formatMessage]);
 
     const onInputBlur = useCallback((event: React.FocusEvent<HTMLInputElement>) => {
         setFocused(false);
@@ -169,6 +170,7 @@ const DropdownInput = <T extends ValueType>(props: Props<T>) => {
                         value={value}
                         onChange={ownOnChange as any} // types are not working correctly for multiselect
                         styles={{...baseStyles, ...styles}}
+                        getOptionLabel={(option) => getOptionLabel(option, intl)}
                         {...otherProps}
                     />
                 </div>

--- a/webapp/channels/src/components/user_settings/display/manage_languages/manage_languages.tsx
+++ b/webapp/channels/src/components/user_settings/display/manage_languages/manage_languages.tsx
@@ -13,6 +13,7 @@ import type {ActionResult} from 'mattermost-redux/types/actions';
 
 import ExternalLink from 'components/external_link';
 import SettingItemMax from 'components/setting_item_max';
+import {getOptionLabel} from 'components/widgets/modals/components/react_select_item';
 
 import type {Language} from 'i18n/i18n';
 import Constants from 'utils/constants';
@@ -238,6 +239,7 @@ export class ManageLanguage extends React.PureComponent<Props, State> {
                         onMenuOpen={this.handleMenuOpen}
                         aria-labelledby='changeInterfaceLanguageLabel'
                         aria-live='assertive'
+                        getOptionLabel={(option) => getOptionLabel(option, intl)}
                     />
                     {serverError}
                 </div>

--- a/webapp/channels/src/components/user_settings/display/manage_timezones/manage_timezones.tsx
+++ b/webapp/channels/src/components/user_settings/display/manage_timezones/manage_timezones.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import type {IntlShape} from 'react-intl';
 import {FormattedMessage} from 'react-intl';
 import ReactSelect from 'react-select';
 import type {OnChangeValue, StylesConfig} from 'react-select';
@@ -13,6 +14,7 @@ import type {ActionResult} from 'mattermost-redux/types/actions';
 import {getTimezoneLabel} from 'mattermost-redux/utils/timezone_utils';
 
 import SettingItemMax from 'components/setting_item_max';
+import {getOptionLabel} from 'components/widgets/modals/components/react_select_item';
 
 import {getBrowserTimezone} from 'utils/timezone';
 
@@ -22,6 +24,7 @@ type Actions = {
 }
 
 type Props = {
+    intl: IntlShape;
     user: UserProfile;
     updateSection: (section: string) => void;
     useAutomaticTimezone: boolean;
@@ -244,7 +247,9 @@ export default class ManageTimezones extends React.PureComponent<Props, State> {
                     onChange={this.onChange}
                     value={this.state.selectedOption}
                     aria-labelledby='changeInterfaceTimezoneLabel'
+                    getOptionLabel={(option) => getOptionLabel(option, this.props.intl)}
                     isDisabled={useAutomaticTimezone}
+
                 />
                 {serverError}
             </div>

--- a/webapp/channels/src/components/user_settings/general/user_settings_general.tsx
+++ b/webapp/channels/src/components/user_settings/general/user_settings_general.tsx
@@ -23,6 +23,7 @@ import SettingItem from 'components/setting_item';
 import SettingItemMax from 'components/setting_item_max';
 import SettingPicture from 'components/setting_picture';
 import LoadingWrapper from 'components/widgets/loading/loading_wrapper';
+import {getOptionLabel} from 'components/widgets/modals/components/react_select_item';
 
 import {AnnouncementBarMessages, AnnouncementBarTypes, AcceptedProfileImageTypes, Constants, ValidationErrors} from 'utils/constants';
 import {validHttpUrl} from 'utils/url';
@@ -1478,6 +1479,7 @@ export class UserSettingsGeneralTab extends PureComponent<Props, State> {
                                 components={{IndicatorSeparator: null}}
                                 styles={selectStyles}
                                 value={getDisplayValue(this.state.customAttributeValues[attribute.id]) as SelectOption}
+                                getOptionLabel={(option) => getOptionLabel(option, this.props.intl)}
                                 onChange={(v, a) => this.updateSelectAttribute(v, a, attribute.id)}
                             />,
                         );

--- a/webapp/channels/src/components/user_settings/notifications/desktop_and_mobile_notification_setting/index.tsx
+++ b/webapp/channels/src/components/user_settings/notifications/desktop_and_mobile_notification_setting/index.tsx
@@ -3,7 +3,7 @@
 
 import React, {Fragment, useCallback, useEffect, useMemo, useRef, memo} from 'react';
 import type {ChangeEvent, ReactNode} from 'react';
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
 import ReactSelect from 'react-select';
 import type {OnChangeValue, Options} from 'react-select';
 
@@ -14,6 +14,7 @@ import SettingItemMin from 'components/setting_item_min';
 import type SettingItemMinComponent from 'components/setting_item_min';
 import NotificationPermissionSectionNotice from 'components/user_settings/notifications/desktop_and_mobile_notification_setting/notification_permission_section_notice';
 import NotificationPermissionTitleTag from 'components/user_settings/notifications/desktop_and_mobile_notification_setting/notification_permission_title_tag';
+import {getOptionLabel} from 'components/widgets/modals/components/react_select_item';
 
 import Constants, {NotificationLevels, UserSettingsNotificationSections} from 'utils/constants';
 
@@ -63,6 +64,7 @@ function DesktopAndMobileNotificationSettings({
 }: Props) {
     const editButtonRef = useRef<SettingItemMinComponent>(null);
     const previousActiveRef = useRef(active);
+    const intl = useIntl();
 
     // Focus back on the edit button, after this section was closed after it was opened
     useEffect(() => {
@@ -208,6 +210,8 @@ function DesktopAndMobileNotificationSettings({
                         components={{IndicatorSeparator: NoIndicatorSeparatorComponent}}
                         value={getValueOfSendMobileNotificationForSelect(pushActivity)}
                         onChange={handleChangeForSendMobileNotificationsSelect}
+                        getOptionLabel={(option) => getOptionLabel(option, intl)}
+
                     />
                 </React.Fragment>
             );
@@ -261,6 +265,7 @@ function DesktopAndMobileNotificationSettings({
                         components={{IndicatorSeparator: NoIndicatorSeparatorComponent}}
                         value={getValueOfSendMobileNotificationWhenSelect(pushStatus)}
                         onChange={handleChangeForTriggerMobileNotificationsSelect}
+                        getOptionLabel={(option) => getOptionLabel(option, intl)}
                     />
                 </React.Fragment>
             );

--- a/webapp/channels/src/components/user_settings/notifications/desktop_notification_sounds_setting/index.tsx
+++ b/webapp/channels/src/components/user_settings/notifications/desktop_notification_sounds_setting/index.tsx
@@ -12,6 +12,7 @@ import type {UserNotifyProps} from '@mattermost/types/users';
 import SettingItemMax from 'components/setting_item_max';
 import SettingItemMin from 'components/setting_item_min';
 import type SettingItemMinComponent from 'components/setting_item_min';
+import {getOptionLabel} from 'components/widgets/modals/components/react_select_item';
 
 import {UserSettingsNotificationSections} from 'utils/constants';
 import {
@@ -148,6 +149,8 @@ function DesktopNotificationSoundsSettings({
                         components={{IndicatorSeparator: NoIndicatorSeparatorComponent}}
                         value={getValueOfNotificationSoundsSelect(desktopNotificationSound)}
                         onChange={handleChangeForMessageNotificationSoundSelect}
+                        getOptionLabel={(option) => getOptionLabel(option, intl)}
+
                     />
                 </div>
             </Fragment>
@@ -187,6 +190,8 @@ function DesktopNotificationSoundsSettings({
                             })}
                             value={getValueOfIncomingCallSoundsSelect(callsNotificationSound)}
                             onChange={handleChangeForIncomingCallSoundSelect}
+                            getOptionLabel={(option) => getOptionLabel(option, intl)}
+
                         />
                     </div>
                 </Fragment>

--- a/webapp/channels/src/components/widgets/modals/components/checkbox_with_select_item.tsx
+++ b/webapp/channels/src/components/widgets/modals/components/checkbox_with_select_item.tsx
@@ -3,13 +3,14 @@
 
 import type {ReactNode} from 'react';
 import React from 'react';
+import {useIntl} from 'react-intl';
 import ReactSelect from 'react-select';
 import type {OnChangeValue} from 'react-select';
 
 import type {BaseSettingItemProps} from './base_setting_item';
 import BaseSettingItem from './base_setting_item';
 import type {FieldsetCheckbox} from './checkbox_setting_item';
-import type {FieldsetReactSelect, Option} from './react_select_item';
+import {getOptionLabel, type FieldsetReactSelect, type Option} from './react_select_item';
 
 type Props = BaseSettingItemProps & {
     containerClassName?: string;
@@ -40,6 +41,8 @@ export default function CheckboxWithSelectSettingItem({
     isSelectDisabled,
     selectPlaceholder,
 }: Props) {
+    const intl = useIntl();
+
     const content = (
         <>
             <fieldset
@@ -73,6 +76,7 @@ export default function CheckboxWithSelectSettingItem({
                     onChange={(value) => handleSelectChange(value)}
                     value={selectFieldValue}
                     components={{IndicatorSeparator: NoIndicatorSeparatorComponent}}
+                    getOptionLabel={(option) => getOptionLabel(option, intl)}
                 />
             </fieldset>
         </>

--- a/webapp/channels/src/components/widgets/modals/components/react_select_item.tsx
+++ b/webapp/channels/src/components/widgets/modals/components/react_select_item.tsx
@@ -3,6 +3,7 @@
 
 import type {ReactNode} from 'react';
 import React from 'react';
+import {useIntl} from 'react-intl';
 import type {OnChangeValue} from 'react-select';
 import ReactSelect from 'react-select';
 
@@ -30,6 +31,25 @@ type Props = BaseSettingItemProps & {
     handleChange: (selected: OnChangeValue<Option, boolean>) => void;
 }
 
+// Function to extract text from FormattedMessage components
+export const getOptionLabel = (option: Option, intl: ReturnType<typeof useIntl>) => {
+    if (typeof option.label === 'string') {
+        return option.label;
+    }
+
+    // For FormattedMessage components, extract the defaultMessage and id
+    if (React.isValidElement(option.label)) {
+        const formattedMessage = option.label as React.ReactElement<{id: string; defaultMessage: string}>;
+        const props = formattedMessage.props;
+
+        return intl.formatMessage({
+            id: props.id,
+            defaultMessage: props.defaultMessage,
+        });
+    }
+    return '';
+};
+
 function ReactSelectItemCreator({
     title,
     description,
@@ -37,6 +57,7 @@ function ReactSelectItemCreator({
     inputFieldValue,
     handleChange,
 }: Props): JSX.Element {
+    const intl = useIntl();
     const content = (
         <fieldset className='mm-modal-generic-section-item__fieldset-react-select'>
             <ReactSelect
@@ -52,6 +73,8 @@ function ReactSelectItemCreator({
                 onChange={handleChange}
                 value={inputFieldValue}
                 components={{IndicatorSeparator: NoIndicatorSeparatorComponent}}
+                getOptionLabel={(option) => getOptionLabel(option, intl)}
+
             />
         </fieldset>
     );


### PR DESCRIPTION
#### Summary

Added `getOptionLabel` to ReactSelect components to fix issue that the options label had an object from the `FormattedMessage` component and the accessibility readers were reading out `[object,object]` and now it's gets the string instead. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61651
https://mattermost.atlassian.net/browse/MM-61647


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```
None
```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
