### PR TITLE
Automated cherry pick of #30467

### DIFF
--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -1846,6 +1846,13 @@ func addChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Security check: if the user is a guest, they must have access to the channel
+	// to view its members
+	if c.AppContext.Session().IsGuest() && !c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), c.Params.ChannelId, model.PermissionReadChannel) {
+		c.SetPermissionError(model.PermissionReadChannel)
+		return
+	}
+
 	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
 		c.Err = model.NewAppError("addUserToChannel", "api.channel.add_user_to_channel.type.app_error", nil, "", http.StatusBadRequest)
 		return

--- a/server/public/model/session.go
+++ b/server/public/model/session.go
@@ -254,6 +254,14 @@ func (s *Session) IsSSOLogin() bool {
 	return s.IsOAuthUser() || s.IsSaml()
 }
 
+func (s *Session) IsGuest() bool {
+	val, ok := s.Props[SessionPropIsGuest]
+	if !ok {
+		return false
+	}
+	return val == "true"
+}
+
 func (s *Session) GetUserRoles() []string {
 	return strings.Fields(s.Roles)
 }


### PR DESCRIPTION
Cherry pick of #30467 on release-10.8.

/cc  @catalintomai

```release-note
NONE
```