### PR TITLE
stop reporting flaky tests

### DIFF
--- a/.github/workflows/server-ci-report.yml
+++ b/.github/workflows/server-ci-report.yml
@@ -69,17 +69,6 @@ jobs:
           include_passed: true
           check_annotations: true
 
-      - name: Report retried tests via webhook (master)
-        if: ${{ steps.report.outputs.flaky_summary != '<table><tr><th>Test</th><th>Retries</th></tr></table>' && github.event.workflow_run.name == 'Server CI Master' && github.event.workflow_run.head_branch == 'master' }}
-        uses: mattermost/action-mattermost-notify@b7d118e440bf2749cd18a4a8c88e7092e696257a # v2.0.0
-        with:
-          MATTERMOST_WEBHOOK_URL: ${{ secrets.MM_COMMUNITY_DEVELOPERS_INCOMING_WEBHOOK_FROM_GH_ACTIONS }}
-          TEXT: |-
-            #### ⚠️ One or more flaky tests detected ⚠️
-            * Failing job: [github.com/mattermost/mattermost:${{ matrix.test.name }}](${{ github.event.workflow_run.html_url }})
-            * Ideally, this would have been caught in a pull request, but now a volunteer is required. If you're willing to help, submit a separate pull request to skip the flaky tests (e.g. [23360](https://github.com/mattermost/mattermost/pull/23360)) and file JIRA ticket (e.g. [MM-52743](https://mattermost.atlassian.net/browse/MM-52743)) for later investigation.
-            * Finally, reply to this message with a link to the created JIRA ticket.
-  
       - name: Report retried tests (pull request)
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         if: ${{ steps.report.outputs.flaky_summary != '<table><tr><th>Test</th><th>Retries</th></tr></table>' && github.event.workflow_run.name == 'Server CI PR' }}


### PR DESCRIPTION
#### Summary
Let's stop reporting flaky tests on `master`. We'll continue to report on pull requests.

This addresses the steady stream of flaky tests notices in https://community.mattermost.com/core/channels/developers that lack shared ownership:

![CleanShot 2025-04-14 at 10 54 38@2x](https://github.com/user-attachments/assets/19cb496c-9095-45a8-b82c-c11daf3e8139)

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
