### PR TITLE
MM-63616 Remove react-hot-loader and hot-loader/react-dom

### DIFF
--- a/webapp/channels/.npm-upgrade.json
+++ b/webapp/channels/.npm-upgrade.json
@@ -80,10 +80,6 @@
       "versions": "",
       "reason": "MM-34914 - Breaking changes to how modules are loaded."
     },
-    "@hot-loader/react-dom": {
-      "versions": "",
-      "reason": "MM-45255 - React updates are handled separately from other dependencies."
-    },
     "@types/marked": {
       "versions": "",
       "reason": "Ignored since our forked version is wildly different from upstream."

--- a/webapp/channels/babel.config.js
+++ b/webapp/channels/babel.config.js
@@ -23,7 +23,6 @@ const config = {
         }],
     ],
     plugins: [
-        'react-hot-loader/babel',
         'babel-plugin-typescript-to-proptypes',
         [
             'babel-plugin-styled-components',

--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -68,7 +68,6 @@
     "react-custom-scrollbars": "4.2.1",
     "react-day-picker": "8.3.6",
     "react-dom": "17.0.2",
-    "react-hot-loader": "4.13.0",
     "react-intl": "*",
     "react-is": "17.0.2",
     "react-overlays": "0.9.3",
@@ -101,7 +100,6 @@
   },
   "devDependencies": {
     "@deanwhillier/jest-matchmedia-mock": "1.2.0",
-    "@hot-loader/react-dom": "17.0.2",
     "@mattermost/calls-common": "0.27.0",
     "@mattermost/eslint-plugin": "*",
     "@mattermost/mmjstool": "github:mattermost/mattermost-utilities#7b63833d208d482ba4a1c12230bb3e68dd9c5e5e",

--- a/webapp/channels/src/components/app.tsx
+++ b/webapp/channels/src/components/app.tsx
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import React, {lazy} from 'react';
-import {hot} from 'react-hot-loader/root';
 import {Provider} from 'react-redux';
 import {Router} from 'react-router-dom';
 
@@ -25,4 +24,4 @@ const App = () => {
     );
 };
 
-export default hot(React.memo(App));
+export default React.memo(App);

--- a/webapp/channels/webpack.config.js
+++ b/webapp/channels/webpack.config.js
@@ -274,7 +274,7 @@ function generateCSP() {
     let csp = 'script-src \'self\' cdn.rudderlabs.com/ js.stripe.com/v3';
 
     if (DEV) {
-        // react-hot-loader and development source maps require eval
+        // Development source maps require eval
         csp += ' \'unsafe-eval\'';
     }
 
@@ -428,13 +428,6 @@ if (targetIsDevServer) {
         optimization: {
             ...config.optimization,
             splitChunks: false,
-        },
-        resolve: {
-            ...config.resolve,
-            alias: {
-                ...config.resolve.alias,
-                'react-dom': '@hot-loader/react-dom',
-            },
         },
     };
 }

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -121,7 +121,6 @@
         "react-custom-scrollbars": "4.2.1",
         "react-day-picker": "8.3.6",
         "react-dom": "17.0.2",
-        "react-hot-loader": "4.13.0",
         "react-intl": "*",
         "react-is": "17.0.2",
         "react-overlays": "0.9.3",
@@ -154,7 +153,6 @@
       },
       "devDependencies": {
         "@deanwhillier/jest-matchmedia-mock": "1.2.0",
-        "@hot-loader/react-dom": "17.0.2",
         "@mattermost/calls-common": "0.27.0",
         "@mattermost/eslint-plugin": "*",
         "@mattermost/mmjstool": "github:mattermost/mattermost-utilities#7b63833d208d482ba4a1c12230bb3e68dd9c5e5e",
@@ -242,20 +240,6 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
-      }
-    },
-    "channels/node_modules/@hot-loader/react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-G2RZrFhsQClS+bdDh/Ojpk3SgocLPUGnvnJDTQYnmKSSwXtU+Yh+8QMs+Ia3zaAvBiOSpIIDSUxuN69cvKqrWg==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
-      },
-      "peerDependencies": {
-        "react": "17.0.2"
       }
     },
     "channels/node_modules/@mattermost/compass-components": {
@@ -424,34 +408,6 @@
       "peerDependencies": {
         "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
         "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "channels/node_modules/react-hot-loader": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.13.0.tgz",
-      "integrity": "sha512-JrLlvUPqh6wIkrK2hZDfOyq/Uh/WeVEr8nc7hkn2/3Ul0sx1Kr5y4kOGNacNRoj7RhwLNcQ3Udf1KJXrqc0ZtA==",
-      "dependencies": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "source-map": "^0.7.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "@types/react": "^15.0.0 || ^16.0.0 || ^17.0.0 ",
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 ",
-        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 "
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "channels/node_modules/react-redux": {
@@ -9246,6 +9202,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -11998,7 +11955,8 @@
     "node_modules/dom-walk": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+      "dev": true
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
@@ -12198,6 +12156,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -14512,6 +14471,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
       "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dev": true,
       "dependencies": {
         "min-document": "^2.19.0",
         "process": "^0.11.10"
@@ -20461,30 +20421,6 @@
         "node": ">=6.11.5"
       }
     },
-    "node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/loader-utils/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
     "node_modules/localforage": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
@@ -20916,6 +20852,7 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "dev": true,
       "dependencies": {
         "dom-walk": "^0.1.0"
       }
@@ -25136,14 +25073,6 @@
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
       "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
       "dev": true
-    },
-    "node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",


### PR DESCRIPTION
#### Summary
A few weeks back at the offsite, we did an experiment to use Aider to upgrade us to React 18. It couldn't do that, but I did get its help to remove some dependencies that would either block that upgrade or need to be updated with it.

In this case, we don't really maintain the path for working on the web app using Webpack's Dev Server, so hot loading hasn't really been something we support well. I'm removing it because of that.

#### Related Pull requests
#30743

#### Ticket Link
MM-63616

#### Release Note
```release-note
NONE
```
