### PR TITLE
Bump up test runners after Elasticsearch move

### DIFF
--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   test:
     name: ${{ inputs.name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-8-cores
     env:
       COMPOSE_PROJECT_NAME: ghactions
     steps:


### PR DESCRIPTION
When Elasticsearch/Opensearch was in enterprise repo,
we had to bump up the runners: https://github.com/mattermost/enterprise/commit/9b151defcc231c187960f29709f7b6f97a13c98c.

However, the ES code was moved inside server repo,
but the test runners were not changed. This led to frequent
test failures. So we are bumping up the test runners.

This will unfortunately lead to an increased cost, but
we have also cut down in other places viz. the build phase
uses the free runner now (https://github.com/mattermost/mattermost/pull/29297).
And the enterprise build also uses free runner (https://github.com/mattermost/enterprise/pull/1792).

```release-note
NONE
```
