### PR TITLE
update menus for channel bookmarks

### DIFF
--- a/webapp/channels/src/components/channel_header_menu/channel_header_menu.tsx
+++ b/webapp/channels/src/components/channel_header_menu/channel_header_menu.tsx
@@ -23,6 +23,7 @@ import {
 
 import {getChannelHeaderMenuPluginComponents} from 'selectors/plugins';
 
+import {getIsChannelBookmarksEnabled} from 'components/channel_bookmarks/utils';
 import * as Menu from 'components/menu';
 
 import {Constants} from 'utils/constants';
@@ -53,6 +54,7 @@ export default function ChannelHeaderMenu({dmUser, gmMembers, isMobile, archived
     const isMuted = useSelector(isCurrentChannelMuted);
     const isLicensedForLDAPGroups = useSelector(getLicense).LDAPGroups === 'true';
     const pluginMenuItems = useSelector(getChannelHeaderMenuPluginComponents);
+    const isChannelBookmarksEnabled = useSelector(getIsChannelBookmarksEnabled);
 
     const isReadonly = false;
 
@@ -144,6 +146,7 @@ export default function ChannelHeaderMenu({dmUser, gmMembers, isMobile, archived
                     pluginItems={pluginItems}
                     isFavorite={isFavorite}
                     isMobile={isMobile || false}
+                    isChannelBookmarksEnabled={isChannelBookmarksEnabled}
                 />
             )}
             {isGroup && (
@@ -154,6 +157,7 @@ export default function ChannelHeaderMenu({dmUser, gmMembers, isMobile, archived
                     pluginItems={pluginItems}
                     isFavorite={isFavorite}
                     isMobile={isMobile || false}
+                    isChannelBookmarksEnabled={isChannelBookmarksEnabled}
                 />
             )}
             {(!isDirect && !isGroup) && (
@@ -167,6 +171,7 @@ export default function ChannelHeaderMenu({dmUser, gmMembers, isMobile, archived
                     isDefault={isDefault}
                     isReadonly={isReadonly}
                     isLicensedForLDAPGroups={isLicensedForLDAPGroups}
+                    isChannelBookmarksEnabled={isChannelBookmarksEnabled}
                 />
             )}
 

--- a/webapp/channels/src/components/channel_header_menu/channel_header_menu_items/channel_header_direct_menu.tsx
+++ b/webapp/channels/src/components/channel_header_menu/channel_header_menu_items/channel_header_direct_menu.tsx
@@ -8,9 +8,12 @@ import {CogOutlineIcon} from '@mattermost/compass-icons/components';
 import type {Channel} from '@mattermost/types/channels';
 import type {UserProfile} from '@mattermost/types/users';
 
+import {isGuest} from 'mattermost-redux/utils/user_utils';
+
 import ChannelMoveToSubMenu from 'components/channel_move_to_sub_menu';
 import * as Menu from 'components/menu';
 
+import MenuItemChannelBookmarks from '../menu_items/channel_bookmarks_submenu';
 import CloseMessage from '../menu_items/close_message';
 import EditConversationHeader from '../menu_items/edit_conversation_header';
 import MenuItemPluginItems from '../menu_items/plugins_submenu';
@@ -26,9 +29,10 @@ interface Props extends Menu.FirstMenuItemProps {
     isMobile: boolean;
     isFavorite: boolean;
     pluginItems: ReactNode[];
+    isChannelBookmarksEnabled: boolean;
 }
 
-const ChannelHeaderDirectMenu = ({channel, user, isMuted, isMobile, isFavorite, pluginItems, ...rest}: Props) => {
+const ChannelHeaderDirectMenu = ({channel, user, isMuted, isMobile, isFavorite, pluginItems, isChannelBookmarksEnabled, ...rest}: Props) => {
     return (
         <>
             <MenuItemToggleInfo
@@ -56,6 +60,11 @@ const ChannelHeaderDirectMenu = ({channel, user, isMuted, isMobile, isFavorite, 
                 channel={channel}
             />
             <Menu.Separator/>
+            {!isGuest(user.roles) && isChannelBookmarksEnabled && (
+                <MenuItemChannelBookmarks
+                    channel={channel}
+                />
+            )}
             <ChannelMoveToSubMenu
                 channel={channel}
             />

--- a/webapp/channels/src/components/channel_header_menu/channel_header_menu_items/channel_header_group_menu.tsx
+++ b/webapp/channels/src/components/channel_header_menu/channel_header_menu_items/channel_header_group_menu.tsx
@@ -19,6 +19,7 @@ import ChannelMoveToSubMenu from 'components/channel_move_to_sub_menu';
 import * as Menu from 'components/menu';
 import ChannelPermissionGate from 'components/permissions_gates/channel_permission_gate';
 
+import MenuItemChannelBookmarks from '../menu_items/channel_bookmarks_submenu';
 import CloseMessage from '../menu_items/close_message';
 import MenuItemConvertToPrivate from '../menu_items/convert_gm_to_private';
 import EditConversationHeader from '../menu_items/edit_conversation_header';
@@ -37,9 +38,10 @@ interface Props extends Menu.FirstMenuItemProps {
     isMobile: boolean;
     isFavorite: boolean;
     pluginItems: ReactNode[];
+    isChannelBookmarksEnabled: boolean;
 }
 
-const ChannelHeaderGroupMenu = ({channel, user, isMuted, isMobile, isFavorite, pluginItems, ...rest}: Props) => {
+const ChannelHeaderGroupMenu = ({channel, user, isMuted, isMobile, isFavorite, pluginItems, isChannelBookmarksEnabled, ...rest}: Props) => {
     const isGroupConstrained = channel?.group_constrained === true;
     const isArchived = channel.delete_at !== 0;
     const {formatMessage} = useIntl();
@@ -72,7 +74,7 @@ const ChannelHeaderGroupMenu = ({channel, user, isMuted, isMobile, isFavorite, p
                     channel={channel}
                 />
             )}
-            {(isArchived && isGroupConstrained && isGuest(user.roles)) && (
+            {(!isArchived && isGuest(user.roles)) && (
                 <EditConversationHeader
                     leadingElement={<CogOutlineIcon size='18px'/>}
                     channel={channel}
@@ -99,6 +101,11 @@ const ChannelHeaderGroupMenu = ({channel, user, isMuted, isMobile, isFavorite, p
                         channel={channel}
                     />
                 </Menu.SubMenu>
+            )}
+            {!isArchived && !isGuest(user.roles) && isChannelBookmarksEnabled && (
+                <MenuItemChannelBookmarks
+                    channel={channel}
+                />
             )}
             <Menu.Separator/>
             {(!isArchived && !isGroupConstrained) && (

--- a/webapp/channels/src/components/channel_header_menu/channel_header_menu_items/channel_header_public_private_menu.tsx
+++ b/webapp/channels/src/components/channel_header_menu/channel_header_menu_items/channel_header_public_private_menu.tsx
@@ -42,9 +42,10 @@ interface Props extends Menu.FirstMenuItemProps {
     isFavorite: boolean;
     isLicensedForLDAPGroups: boolean;
     pluginItems: ReactNode[];
+    isChannelBookmarksEnabled: boolean;
 }
 
-const ChannelHeaderPublicMenu = ({channel, user, isMuted, isReadonly, isDefault, isMobile, isFavorite, isLicensedForLDAPGroups, pluginItems, ...rest}: Props) => {
+const ChannelHeaderPublicMenu = ({channel, user, isMuted, isReadonly, isDefault, isMobile, isFavorite, isLicensedForLDAPGroups, pluginItems, isChannelBookmarksEnabled, ...rest}: Props) => {
     const isGroupConstrained = channel?.group_constrained === true;
     const isArchived = channel.delete_at !== 0;
     const isPrivate = channel?.type === Constants.PRIVATE_CHANNEL;
@@ -75,9 +76,11 @@ const ChannelHeaderPublicMenu = ({channel, user, isMuted, isReadonly, isDefault,
                         isDefault={isDefault}
                         channel={channel}
                     />
-                    <MenuItemChannelBookmarks
-                        channel={channel}
-                    />
+                    {isChannelBookmarksEnabled && (
+                        <MenuItemChannelBookmarks
+                            channel={channel}
+                        />
+                    )}
                 </>
             )}
             <Menu.Separator/>


### PR DESCRIPTION

#### Summary
New menu was not checking feature flag nor license for Channel Bookmarks.

In addition, the channel bookmarks menu was not added to the group and direct message menus...fixed that.


#### Ticket Link

Fixes [MM-63715-channel-bookmarks-menu-fix](https://mattermost.atlassian.net/browse/MM-63715)

#### Screenshots
![Screenshot 2025-04-17 at 10 20 09 AM](https://github.com/user-attachments/assets/c8fc5711-8100-4966-88f2-8b9742c0723d)
![Screenshot 2025-04-17 at 10 19 42 AM](https://github.com/user-attachments/assets/c2b2381f-5d23-4ae8-82b8-19ab81810a33)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
