### PR TITLE
Updated minimum supported Edge, Chrome and Firefox versions

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10522,15 +10522,15 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "Version 132+"
+    "translation": "Version 134+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "Version 132+"
+    "translation": "Version 134+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",
-    "translation": "Version 119+"
+    "translation": "Version 128+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.safari",


### PR DESCRIPTION
Desktop app v5.12 will include Electron 34.0.1 which supports Chrome 132+. Firefox oldest supported version is currently 128.

```release-note
Updated minimum Edge and Chrome versions to 132+, and updated minimum Firefox version to 128.
```