### PR TITLE
MM-63560 Remove options on text fields

### DIFF
--- a/server/public/model/custom_profile_attributes.go
+++ b/server/public/model/custom_profile_attributes.go
@@ -158,6 +158,7 @@ func (c *CPAField) SanitizeAndValidate() *AppError {
 			}
 			c.Attrs.ValueType = valueType
 		}
+		c.Attrs.Options = PropertyOptions[*CustomProfileAttributesSelectOption]{}
 
 	case PropertyFieldTypeSelect, PropertyFieldTypeMultiselect:
 		options := c.Attrs.Options

--- a/server/public/model/custom_profile_attributes.go
+++ b/server/public/model/custom_profile_attributes.go
@@ -158,7 +158,9 @@ func (c *CPAField) SanitizeAndValidate() *AppError {
 			}
 			c.Attrs.ValueType = valueType
 		}
-		c.Attrs.Options = PropertyOptions[*CustomProfileAttributesSelectOption]{}
+		if len(c.Attrs.Options) > 0 {
+			c.Attrs.Options = PropertyOptions[*CustomProfileAttributesSelectOption]{}
+		}
 
 	case PropertyFieldTypeSelect, PropertyFieldTypeMultiselect:
 		options := c.Attrs.Options

--- a/server/public/model/custom_profile_attributes_test.go
+++ b/server/public/model/custom_profile_attributes_test.go
@@ -481,6 +481,31 @@ func TestCPAField_SanitizeAndValidate(t *testing.T) {
 			expectError: true,
 			errorId:     "app.custom_profile_attributes.sanitize_and_validate.app_error",
 		},
+		{
+			name: "clear options on non select field",
+			field: &CPAField{
+				PropertyField: PropertyField{
+					Type: PropertyFieldTypeText,
+				},
+				Attrs: CPAAttrs{
+					Options: []*CustomProfileAttributesSelectOption{
+						{
+							Name:  "Option 1",
+							Color: "opt1",
+						},
+						{
+							Name:  "Option 1",
+							Color: "opt2",
+						},
+					},
+				},
+			},
+			expectError: false,
+			expectedAttrs: CPAAttrs{
+				Visibility: CustomProfileAttributesVisibilityDefault,
+				Options:    PropertyOptions[*CustomProfileAttributesSelectOption]{},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#### Summary
Removes the `options` attribute when updating the field type to `text`

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-63560


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
