### PR TITLE
MM-63878: Fix INSERT IGNORE in saveChannelT

### DIFF
--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -742,19 +742,14 @@ func (s SqlChannelStore) saveChannelT(transaction *sqlxTxWrapper, channel *model
 		}
 	}
 
-	var insert sq.InsertBuilder
-	if s.DriverName() == model.DatabaseDriverMysql {
-		insert = s.getQueryBuilder().
+	insert := s.getQueryBuilder().
 			Insert("Channels").
-			Options("IGNORE").
 			Columns(channelSliceColumns()...).
 			Values(channelToSlice(channel)...)
+	if s.DriverName() == model.DatabaseDriverMysql {
+		insert = insert.SuffixExpr(sq.Expr("ON DUPLICATE KEY UPDATE Id=Id"))
 	} else {
-		insert = s.getQueryBuilder().
-			Insert("Channels").
-			Columns(channelSliceColumns()...).
-			Values(channelToSlice(channel)...).
-			SuffixExpr(sq.Expr("ON CONFLICT (TeamId, Name) DO NOTHING"))
+		insert = insert.SuffixExpr(sq.Expr("ON CONFLICT (TeamId, Name) DO NOTHING"))
 	}
 
 	query, params, err := insert.ToSql()

--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -743,9 +743,9 @@ func (s SqlChannelStore) saveChannelT(transaction *sqlxTxWrapper, channel *model
 	}
 
 	insert := s.getQueryBuilder().
-			Insert("Channels").
-			Columns(channelSliceColumns()...).
-			Values(channelToSlice(channel)...)
+		Insert("Channels").
+		Columns(channelSliceColumns()...).
+		Values(channelToSlice(channel)...)
 	if s.DriverName() == model.DatabaseDriverMysql {
 		insert = insert.SuffixExpr(sq.Expr("ON DUPLICATE KEY UPDATE Id=Id"))
 	} else {


### PR DESCRIPTION
INSERT IGNORE will ignore ALL errors in the INSERT statement.
This is not what was intended. The right way is to do a
redundant update on duplicate key.

It's not great, but that's how MySQL wants us to do it.

https://mattermost.atlassian.net/browse/MM-63878
```release-note
NONE
```
