### PR TITLE
fix missing newline in upgrader.go

### DIFF
--- a/server/platform/services/upgrader/upgrader.go
+++ b/server/platform/services/upgrader/upgrader.go
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 //go:build !linux
 // +build !linux
 


### PR DESCRIPTION
#### Summary
I have no idea why this only just started failing, but fixing the following error for all non-Linux users:

```
## Note that it is pinned to a specific commit, rather than a branch. This is to prevent
## having to backport the fix to multiple release branches for any new change.
go install github.com/mattermost/mattermost-govet/v2@8e4d46e3fad88497dbfe073788a87e75bbae717c
go vet -vettool=/Users/jesse/.local/share/mise/installs/go/1.23.7/bin/mattermost-govet -structuredLogging -inconsistentReceiverName -emptyStrCmp -tFatal -configtelemetry -errorAssertions -license -inconsistentReceiverName.ignore=session_serial_gen.go,team_member_serial_gen.go,user_serial_gen.go,utils_serial_gen.go ./...
# github.com/mattermost/mattermost/server/v8/platform/services/upgrader
platform/services/upgrader/upgrader.go:6:1: Must be an empty line between the build directive and the license
make: *** [vet] Error 1
```

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
