### PR TITLE
Fix dialog dropdown being cut-off

### DIFF
--- a/webapp/channels/src/components/interactive_dialog/interactive_dialog.tsx
+++ b/webapp/channels/src/components/interactive_dialog/interactive_dialog.tsx
@@ -205,6 +205,7 @@ export default class InteractiveDialog extends React.PureComponent<Props, State>
                 backdrop='static'
                 role='none'
                 aria-labelledby='interactiveDialogModalLabel'
+                style={{overflowY: 'hidden'}}
             >
                 <form
                     onSubmit={this.handleSubmit}

--- a/webapp/channels/src/components/suggestion/modal_suggestion_list.tsx
+++ b/webapp/channels/src/components/suggestion/modal_suggestion_list.tsx
@@ -80,7 +80,7 @@ export default class ModalSuggestionList extends React.PureComponent<Props, Stat
     onModalScroll = (e: Event) => {
         const eventTarget = e.target as HTMLElement;
         if (this.state.scroll !== eventTarget.scrollTop &&
-            this.latestHeight !== 0) {
+            this.props.open) {
             this.setState({scroll: eventTarget.scrollTop});
         }
     };
@@ -132,7 +132,7 @@ export default class ModalSuggestionList extends React.PureComponent<Props, Stat
             return 0;
         }
 
-        const listElement = this.suggestionList?.current?.getContent()?.[0];
+        const listElement = this.suggestionList?.current?.getContent();
         if (!listElement) {
             return 0;
         }
@@ -180,7 +180,7 @@ export default class ModalSuggestionList extends React.PureComponent<Props, Stat
             return;
         }
 
-        const modalBodyContainer = this.container.current.closest('.modal-body');
+        const modalBodyContainer = this.container.current.closest('.modal-content');
         const modalBounds = modalBodyContainer?.getBoundingClientRect();
 
         if (modalBounds) {
@@ -200,11 +200,13 @@ export default class ModalSuggestionList extends React.PureComponent<Props, Stat
         let position = {};
         if (this.state.position === 'top') {
             position = {bottom: this.state.modalBounds.bottom - this.state.inputBounds.top};
+        } else {
+            position = {top: this.state.inputBounds.bottom - this.state.modalBounds.top};
         }
 
         return (
             <div
-                style={{position: 'absolute', zIndex: 101, width: this.state.inputBounds.width, ...position}}
+                style={{position: 'fixed', zIndex: 101, width: this.state.inputBounds.width, ...position}}
                 ref={this.container}
             >
                 <SuggestionList


### PR DESCRIPTION
#### Summary
The dialog used to be fixed positioned. This caused some issues when (I guess) some rework on modals was done. Along it, other small things broke, like the positioning (top or bottom).

This PR handles all those issues.

The ticket originally asked for changes to use floatingUI but since the updates here were relatively simple and changing to floating UI seemed more involved, I ended up just fixing this.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63463

#### Release Note
```release-note
Fix dialog dropdowns being cut off
```
