### PR TITLE
Renamed premium SKU to Enterprise Advanced

### DIFF
--- a/e2e-tests/playwright/specs/functional/channels/channel_banner/channel_banner.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/channel_banner/channel_banner.spec.ts
@@ -7,7 +7,7 @@ import {getRandomId} from 'utils/utils';
 test('Should show channel banner when configured', async ({pw}) => {
     const {adminUser, adminClient} = await pw.initSetup();
     const license = await adminClient.getClientLicenseOld();
-    test.skip(license.SkuShortName !== 'premium', 'Skipping test - server does not have Premium license');
+    test.skip(license.SkuShortName !== 'advanced', 'Skipping test - server does not have Enterprise Advanced license');
 
     const {channelsPage} = await pw.testBrowser.login(adminUser);
     await channelsPage.goto();
@@ -52,7 +52,7 @@ test('Should show channel banner when configured', async ({pw}) => {
 test('Should render markdown', async ({pw}) => {
     const {adminUser, adminClient} = await pw.initSetup();
     const license = await adminClient.getClientLicenseOld();
-    test.skip(license.SkuShortName !== 'premium', 'Skipping test - server does not have Premium license');
+    test.skip(license.SkuShortName !== 'advanced', 'Skipping test - server does not have Enterprise Advanced license');
 
     const {channelsPage} = await pw.testBrowser.login(adminUser);
     await channelsPage.goto();

--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -2460,7 +2460,7 @@ func convertGroupMessageToChannel(c *Context, w http.ResponseWriter, r *http.Req
 }
 
 func canEditChannelBanner(license *model.License, originalChannel *model.Channel) *model.AppError {
-	if !model.MinimumPremiumLicense(license) {
+	if !model.MinimumEnterpriseAdvancedLicense(license) {
 		return model.NewAppError("", "license_error.feature_unavailable.specific", map[string]any{"Feature": "Channel Banner"}, "feature is not available for the current license", http.StatusForbidden)
 	}
 

--- a/server/channels/api4/channel_test.go
+++ b/server/channels/api4/channel_test.go
@@ -810,7 +810,7 @@ func TestPatchChannel(t *testing.T) {
 	t.Run("Should be able to configure channel banner on a channel", func(t *testing.T) {
 		client.Logout(context.Background())
 		th.LoginBasic()
-		th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuPremium))
+		th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
 		defer func() {
 			th.App.Srv().RemoveLicense()
 		}()
@@ -845,7 +845,7 @@ func TestPatchChannel(t *testing.T) {
 	t.Run("Cannot enable channel banner without configuring it", func(t *testing.T) {
 		client.Logout(context.Background())
 		th.LoginBasic()
-		th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuPremium))
+		th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
 		defer func() {
 			th.App.Srv().RemoveLicense()
 		}()
@@ -905,7 +905,7 @@ func TestPatchChannel(t *testing.T) {
 	t.Run("Cannot configure channel banner on a DM channel", func(t *testing.T) {
 		client.Logout(context.Background())
 		th.LoginBasic()
-		th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuPremium))
+		th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
 		defer func() {
 			th.App.Srv().RemoveLicense()
 		}()
@@ -932,7 +932,7 @@ func TestPatchChannel(t *testing.T) {
 	t.Run("Cannot configure channel banner on a GM channel", func(t *testing.T) {
 		client.Logout(context.Background())
 		th.LoginBasic()
-		th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuPremium))
+		th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
 		defer func() {
 			th.App.Srv().RemoveLicense()
 		}()
@@ -5765,7 +5765,7 @@ func TestCanEditChannelBanner(t *testing.T) {
 	})
 
 	t.Run("when channel type is direct message", func(t *testing.T) {
-		license := model.NewTestLicenseSKU(model.LicenseShortSkuPremium)
+		license := model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced)
 		channel := &model.Channel{
 			Type: model.ChannelTypeDirect,
 		}
@@ -5778,7 +5778,7 @@ func TestCanEditChannelBanner(t *testing.T) {
 	})
 
 	t.Run("when channel type is group message", func(t *testing.T) {
-		license := model.NewTestLicenseSKU(model.LicenseShortSkuPremium)
+		license := model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced)
 		channel := &model.Channel{
 			Type: model.ChannelTypeGroup,
 		}
@@ -5790,7 +5790,7 @@ func TestCanEditChannelBanner(t *testing.T) {
 	})
 
 	t.Run("when channel type is open and license is valid", func(t *testing.T) {
-		license := model.NewTestLicenseSKU(model.LicenseShortSkuPremium)
+		license := model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced)
 		channel := &model.Channel{
 			Type: model.ChannelTypeOpen,
 		}
@@ -5800,7 +5800,7 @@ func TestCanEditChannelBanner(t *testing.T) {
 	})
 
 	t.Run("when channel type is private and license is valid", func(t *testing.T) {
-		license := model.NewTestLicenseSKU(model.LicenseShortSkuPremium)
+		license := model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced)
 		channel := &model.Channel{
 			Type: model.ChannelTypePrivate,
 		}

--- a/server/platform/services/telemetry/telemetry.go
+++ b/server/platform/services/telemetry/telemetry.go
@@ -97,9 +97,9 @@ const (
 type TrackSKU string
 
 const (
-	TrackProfessionalSKU TrackSKU = "professional"
-	TrackEnterpriseSKU   TrackSKU = "enterprise"
-	TrackPremiumSKU      TrackSKU = "premium"
+	TrackProfessionalSKU       TrackSKU = "professional"
+	TrackEnterpriseSKU         TrackSKU = "enterprise"
+	TrackEnterpriseAdvancedSKU TrackSKU = "advanced"
 )
 
 type TrackFeature string

--- a/server/public/model/license.go
+++ b/server/public/model/license.go
@@ -19,21 +19,21 @@ const (
 	LicenseGracePeriod  = DayInMilliseconds * 10 //10 days
 	LicenseRenewalLink  = "https://mattermost.com/renew/"
 
-	LicenseShortSkuE10          = "E10"
-	LicenseShortSkuE20          = "E20"
-	LicenseShortSkuProfessional = "professional"
-	LicenseShortSkuEnterprise   = "enterprise"
-	LicenseShortSkuPremium      = "premium"
+	LicenseShortSkuE10                = "E10"
+	LicenseShortSkuE20                = "E20"
+	LicenseShortSkuProfessional       = "professional"
+	LicenseShortSkuEnterprise         = "enterprise"
+	LicenseShortSkuEnterpriseAdvanced = "advanced"
 
-	ProfessionalTier = 10
-	EnterpriseTier   = 20
-	PremiumTier      = 30
+	ProfessionalTier       = 10
+	EnterpriseTier         = 20
+	EnterpriseAdvancedTier = 30
 )
 
 var LicenseToLicenseTier = map[string]int{
-	LicenseShortSkuProfessional: ProfessionalTier,
-	LicenseShortSkuEnterprise:   EnterpriseTier,
-	LicenseShortSkuPremium:      PremiumTier,
+	LicenseShortSkuProfessional:       ProfessionalTier,
+	LicenseShortSkuEnterprise:         EnterpriseTier,
+	LicenseShortSkuEnterpriseAdvanced: EnterpriseAdvancedTier,
 }
 
 const (
@@ -474,7 +474,7 @@ func MinimumEnterpriseLicense(license *License) bool {
 	return license != nil && LicenseToLicenseTier[license.SkuShortName] >= EnterpriseTier
 }
 
-// MinimumPremiumLicense returns true if the provided license is at least a premium license.
-func MinimumPremiumLicense(license *License) bool {
-	return license != nil && LicenseToLicenseTier[license.SkuShortName] >= PremiumTier
+// MinimumEnterpriseAdvancedLicense returns true if the provided license is at least an Enterprise Advanced license.
+func MinimumEnterpriseAdvancedLicense(license *License) bool {
+	return license != nil && LicenseToLicenseTier[license.SkuShortName] >= EnterpriseAdvancedTier
 }

--- a/server/public/model/license_test.go
+++ b/server/public/model/license_test.go
@@ -512,9 +512,9 @@ func TestMinimumProfessionalLicense(t *testing.T) {
 			true,
 		},
 		{
-			"premium license",
+			"enterprise advanced license",
 			&License{
-				SkuShortName: LicenseShortSkuPremium,
+				SkuShortName: LicenseShortSkuEnterpriseAdvanced,
 			},
 			true,
 		},
@@ -574,9 +574,9 @@ func TestMinimumEnterpriseLicense(t *testing.T) {
 			true,
 		},
 		{
-			"premium license",
+			"enterprise advanced license",
 			&License{
-				SkuShortName: LicenseShortSkuPremium,
+				SkuShortName: LicenseShortSkuEnterpriseAdvanced,
 			},
 			true,
 		},
@@ -610,7 +610,7 @@ func TestMinimumEnterpriseLicense(t *testing.T) {
 	}
 }
 
-func TestMinimumPremiumLicense(t *testing.T) {
+func TestMinimumEnterpriseAdvancedLicense(t *testing.T) {
 	testCases := []struct {
 		description   string
 		license       *License
@@ -636,9 +636,9 @@ func TestMinimumPremiumLicense(t *testing.T) {
 			false,
 		},
 		{
-			"premium license",
+			"enterprise advanced license",
 			&License{
-				SkuShortName: LicenseShortSkuPremium,
+				SkuShortName: LicenseShortSkuEnterpriseAdvanced,
 			},
 			true,
 		},
@@ -667,7 +667,7 @@ func TestMinimumPremiumLicense(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			assert.Equal(t, testCase.expectedValue, MinimumPremiumLicense(testCase.license))
+			assert.Equal(t, testCase.expectedValue, MinimumEnterpriseAdvancedLicense(testCase.license))
 		})
 	}
 }

--- a/server/public/pluginapi/license.go
+++ b/server/public/pluginapi/license.go
@@ -23,7 +23,7 @@ func isValidSkuShortName(license *model.License) bool {
 	}
 
 	switch license.SkuShortName {
-	case model.LicenseShortSkuE10, model.LicenseShortSkuE20, model.LicenseShortSkuProfessional, model.LicenseShortSkuEnterprise, model.LicenseShortSkuPremium:
+	case model.LicenseShortSkuE10, model.LicenseShortSkuE20, model.LicenseShortSkuProfessional, model.LicenseShortSkuEnterprise, model.LicenseShortSkuEnterpriseAdvanced:
 		return true
 	default:
 		return false
@@ -74,10 +74,10 @@ func IsE20LicensedOrDevelopment(config *model.Config, license *model.License) bo
 	return IsConfiguredForDevelopment(config)
 }
 
-// IsPremiumLicensedOrDevelopment returns true when the server is licensed with a Mattermost
-// Premium License, or has `EnableDeveloper` and `EnableTesting` configuration settings
-func IsPremiumLicensedOrDevelopment(config *model.Config, license *model.License) bool {
-	if license != nil && license.SkuShortName == model.LicenseShortSkuPremium {
+// IsEnterpriseAdvancedLicensedOrDevelopment returns true when the server is licensed with a Mattermost
+// Enterprise Advanced License, or has `EnableDeveloper` and `EnableTesting` configuration settings
+func IsEnterpriseAdvancedLicensedOrDevelopment(config *model.Config, license *model.License) bool {
+	if license != nil && license.SkuShortName == model.LicenseShortSkuEnterpriseAdvanced {
 		return true
 	}
 

--- a/server/public/pluginapi/license_test.go
+++ b/server/public/pluginapi/license_test.go
@@ -285,82 +285,82 @@ func TestIsValidSKUShortName(t *testing.T) {
 	})
 }
 
-func TestIsPremiumOrDevelopment(t *testing.T) {
+func TestIsEnterpriseAdvancedOrDevelopment(t *testing.T) {
 	t.Run("nil license features", func(t *testing.T) {
-		assert.False(t, IsPremiumLicensedOrDevelopment(nil, &model.License{}))
+		assert.False(t, IsEnterpriseAdvancedLicensedOrDevelopment(nil, &model.License{}))
 	})
 
 	t.Run("nil future features", func(t *testing.T) {
-		assert.False(t, IsPremiumLicensedOrDevelopment(nil, &model.License{Features: &model.Features{}}))
+		assert.False(t, IsEnterpriseAdvancedLicensedOrDevelopment(nil, &model.License{Features: &model.Features{}}))
 	})
 
 	t.Run("disabled future features", func(t *testing.T) {
-		assert.False(t, IsPremiumLicensedOrDevelopment(nil, &model.License{Features: &model.Features{
+		assert.False(t, IsEnterpriseAdvancedLicensedOrDevelopment(nil, &model.License{Features: &model.Features{
 			FutureFeatures: bToP(false),
 		}}))
 	})
 
 	t.Run("should have no affect of future features", func(t *testing.T) {
-		assert.False(t, IsPremiumLicensedOrDevelopment(nil, &model.License{Features: &model.Features{
+		assert.False(t, IsEnterpriseAdvancedLicensedOrDevelopment(nil, &model.License{Features: &model.Features{
 			FutureFeatures: bToP(true),
 		}}))
 	})
 
 	t.Run("no license, no config", func(t *testing.T) {
-		assert.False(t, IsPremiumLicensedOrDevelopment(nil, nil))
+		assert.False(t, IsEnterpriseAdvancedLicensedOrDevelopment(nil, nil))
 	})
 
 	t.Run("no license, nil config", func(t *testing.T) {
-		assert.False(t, IsPremiumLicensedOrDevelopment(
+		assert.False(t, IsEnterpriseAdvancedLicensedOrDevelopment(
 			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: nil, EnableTesting: nil}},
 			nil,
 		))
 	})
 
 	t.Run("no license, only developer mode", func(t *testing.T) {
-		assert.False(t, IsPremiumLicensedOrDevelopment(
+		assert.False(t, IsEnterpriseAdvancedLicensedOrDevelopment(
 			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: bToP(true), EnableTesting: bToP(false)}},
 			nil,
 		))
 	})
 
 	t.Run("no license, only testing mode", func(t *testing.T) {
-		assert.False(t, IsPremiumLicensedOrDevelopment(
+		assert.False(t, IsEnterpriseAdvancedLicensedOrDevelopment(
 			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: bToP(false), EnableTesting: bToP(true)}},
 			nil,
 		))
 	})
 
 	t.Run("no license, developer and testing mode", func(t *testing.T) {
-		assert.True(t, IsPremiumLicensedOrDevelopment(
+		assert.True(t, IsEnterpriseAdvancedLicensedOrDevelopment(
 			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: bToP(true), EnableTesting: bToP(true)}},
 			nil,
 		))
 	})
 
 	t.Run("license with E10 SKU name, disabled future features", func(t *testing.T) {
-		assert.False(t, IsPremiumLicensedOrDevelopment(nil, &model.License{
+		assert.False(t, IsEnterpriseAdvancedLicensedOrDevelopment(nil, &model.License{
 			SkuShortName: "E10",
 			Features:     &model.Features{FutureFeatures: bToP(false)},
 		}))
 	})
 
 	t.Run("license with E10 SKU name, enabled future features", func(t *testing.T) {
-		assert.False(t, IsPremiumLicensedOrDevelopment(nil, &model.License{
+		assert.False(t, IsEnterpriseAdvancedLicensedOrDevelopment(nil, &model.License{
 			SkuShortName: "E10",
 			Features:     &model.Features{FutureFeatures: bToP(true)},
 		}))
 	})
 
 	t.Run("license with E20 SKU name, disabled future features", func(t *testing.T) {
-		assert.False(t, IsPremiumLicensedOrDevelopment(nil, &model.License{
+		assert.False(t, IsEnterpriseAdvancedLicensedOrDevelopment(nil, &model.License{
 			SkuShortName: "E20",
 			Features:     &model.Features{FutureFeatures: bToP(false)},
 		}))
 	})
 
 	t.Run("license with E20 SKU name, enabled future features", func(t *testing.T) {
-		assert.False(t, IsPremiumLicensedOrDevelopment(nil, &model.License{
+		assert.False(t, IsEnterpriseAdvancedLicensedOrDevelopment(nil, &model.License{
 			SkuShortName: "E20",
 			Features:     &model.Features{FutureFeatures: bToP(true)},
 		}))

--- a/webapp/channels/src/components/channel_banner/channel_banner.test.tsx
+++ b/webapp/channels/src/components/channel_banner/channel_banner.test.tsx
@@ -86,7 +86,7 @@ describe('components/channel_banner', () => {
             general: {
                 license: {
                     IsLicensed: 'true',
-                    SkuShortName: LicenseSkus.Premium,
+                    SkuShortName: LicenseSkus.EnterpriseAdvanced,
                 },
             },
             channels: {

--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_modal.test.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_modal.test.tsx
@@ -277,12 +277,12 @@ describe('ChannelSettingsModal', () => {
         expect(screen.queryByTestId('configuration-tab-button')).not.toBeInTheDocument();
     });
 
-    it('should show configuration tab when premium license', async () => {
+    it('should show configuration tab when enterprise advanced license', async () => {
         const baseState: DeepPartial<GlobalState> = {
             entities: {
                 general: {
                     license: {
-                        SkuShortName: 'premium',
+                        SkuShortName: 'advanced',
                     },
                 },
             },

--- a/webapp/channels/src/packages/mattermost-redux/src/constants/general.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/constants/general.ts
@@ -77,5 +77,5 @@ export default {
     CUSTOM_GROUP_USER_ROLE: 'custom_group_user',
     MAX_GET_ROLES_BY_NAMES: 100,
     SKUEnterprise: 'enterprise',
-    SKUPremium: 'premium',
+    SKUEnterpriseAdvanced: 'advanced',
 };

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channel_banner.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channel_banner.test.ts
@@ -17,7 +17,7 @@ describe('Selectors.ChannelBanner', () => {
         entities: {
             general: {
                 license: {
-                    SkuShortName: General.SKUPremium,
+                    SkuShortName: General.SKUEnterpriseAdvanced,
                 },
             },
             channels: {
@@ -37,7 +37,7 @@ describe('Selectors.ChannelBanner', () => {
         },
     };
 
-    test('should return false when license is not premium', () => {
+    test('should return false when license is not enterprise advanced', () => {
         const state: DeepPartial<GlobalState> = {
             ...baseState,
             entities: {

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channel_banner.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channel_banner.ts
@@ -10,7 +10,7 @@ import {getLicense} from 'mattermost-redux/selectors/entities/general';
 
 export const selectChannelBannerEnabled = (state: GlobalState): boolean => {
     const license = getLicense(state);
-    return license?.SkuShortName === General.SKUPremium;
+    return license?.SkuShortName === General.SKUEnterpriseAdvanced;
 };
 
 export const selectShowChannelBanner = (state: GlobalState, channelId: string): boolean => {

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -542,7 +542,7 @@ export enum LicenseSkus {
     Starter = 'starter',
     Professional = 'professional',
     Enterprise = 'enterprise',
-    Premium = 'premium',
+    EnterpriseAdvanced = 'advanced',
 }
 
 export function getLicenseTier(licenseSku: string): number {
@@ -551,7 +551,7 @@ export function getLicenseTier(licenseSku: string): number {
         return 10;
     case LicenseSkus.Enterprise:
         return 20;
-    case LicenseSkus.Premium:
+    case LicenseSkus.EnterpriseAdvanced:
         return 30;
     default:
         return 0;

--- a/webapp/channels/src/utils/license_utils.ts
+++ b/webapp/channels/src/utils/license_utils.ts
@@ -88,7 +88,7 @@ export const isEnterpriseLicense = (license?: ClientLicense) => {
     switch (license?.SkuShortName) {
     case LicenseSkus.Enterprise:
     case LicenseSkus.E20:
-    case LicenseSkus.Premium:
+    case LicenseSkus.EnterpriseAdvanced:
         return true;
     }
 

--- a/webapp/channels/src/utils/subscription.ts
+++ b/webapp/channels/src/utils/subscription.ts
@@ -22,7 +22,7 @@ export const getSkuDisplayName = (skuShortName: string, isGovSku: boolean): stri
         skuName = 'Enterprise';
         break;
     default:
-        skuName = 'Premium';
+        skuName = 'Enterprise Advanced';
         break;
     }
 


### PR DESCRIPTION
#### Summary
Renamed Premium SKU to `Enterprise Advanced`.

Mobile PR - https://github.com/mattermost/mattermost-mobile/pull/8819

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-63928

#### Release Note
```release-note
None
```
