### PR TITLE
Fix edit positioning, including its tooltip

### DIFF
--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -969,7 +969,6 @@
     }
 
     .post-edited__indicator {
-        display: flex;
         align-items: center;
         color: rgba(var(--center-channel-color-rgb), 0.75);
         font-size: 11px;


### PR DESCRIPTION
#### Summary
An unneeded flex was making so when you cannot edit the message, the edit text was on a new line. Since it was flex, it cover the whole space, so the tooltip was also misplaced. Removing the flex fixes it.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-63887

#### Release Note
```release-note
Fix "edited" text and tooltip misplaced in some scenarios
```
