### PR TITLE
[MM-62989][MM-63039][MM-63033][MM-63035] Various accessibility fixes for the Create Channel modal

### DIFF
--- a/webapp/channels/src/components/admin_console/billing/company_info_edit.scss
+++ b/webapp/channels/src/components/admin_console/billing/company_info_edit.scss
@@ -84,7 +84,7 @@
         }
 
         &.Input_fieldset___legend {
-            >legend {
+            >label {
                 margin-left: 11px;
             }
         }

--- a/webapp/channels/src/components/new_channel_modal/new_channel_modal.scss
+++ b/webapp/channels/src/components/new_channel_modal/new_channel_modal.scss
@@ -9,14 +9,16 @@
         .new-channel-modal-purpose-textarea {
             width: 100%;
             box-sizing: border-box;
-            padding: 12px 16px;
-            border: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
-            border-radius: 4px;
             background: var(--center-channel-bg);
             color: var(--center-channel-color);
             font-size: 14px;
             line-height: 20px;
             resize: none;
+
+            .Input_wrapper textarea.form-control {
+                border: none;
+                height: auto;
+            }
 
             &:hover {
                 border-color: rgba(var(--center-channel-color-rgb), 0.48);
@@ -42,26 +44,6 @@
             font-size: 12px;
             line-height: 16px;
             text-align: left;
-        }
-
-        .new-channel-modal-purpose-error {
-            display: flex;
-            margin-top: 5px;
-            color: var(--error-text);
-            font-size: 12px;
-            line-height: 16px;
-            text-align: left;
-
-            i {
-                height: 14px;
-                align-self: baseline;
-                margin-right: 7px;
-                font-size: 14px;
-
-                &::before {
-                    margin: 0;
-                }
-            }
         }
     }
 }

--- a/webapp/channels/src/components/new_channel_modal/new_channel_modal.scss
+++ b/webapp/channels/src/components/new_channel_modal/new_channel_modal.scss
@@ -16,8 +16,8 @@
             resize: none;
 
             .Input_wrapper textarea.form-control {
-                border: none;
                 height: auto;
+                border: none;
             }
 
             &:hover {

--- a/webapp/channels/src/components/new_channel_modal/new_channel_modal.test.tsx
+++ b/webapp/channels/src/components/new_channel_modal/new_channel_modal.test.tsx
@@ -145,9 +145,9 @@ describe('components/new_channel_modal', () => {
         expect(privateChannelHeading).toBeInTheDocument();
         expect(privateChannelHeading.nextSibling).toHaveTextContent('Only invited members');
 
-        const purposeTextArea = screen.getByPlaceholderText('Enter a purpose for this channel (optional)');
+        const purposeTextArea = screen.getByLabelText('Channel Purpose');
         expect(purposeTextArea).toBeInTheDocument();
-        expect(purposeTextArea).toHaveClass('new-channel-modal-purpose-textarea');
+        expect(purposeTextArea).toHaveClass('Input form-control medium');
 
         const purposeDesc = screen.getByText('This will be displayed when browsing for channels.');
         expect(purposeDesc).toBeInTheDocument();
@@ -263,7 +263,7 @@ describe('components/new_channel_modal', () => {
         );
 
         // Change purpose
-        const ChannelPurposeTextArea = screen.getByPlaceholderText('Enter a purpose for this channel (optional)');
+        const ChannelPurposeTextArea = screen.getByLabelText('Channel Purpose');
         expect(ChannelPurposeTextArea).toBeInTheDocument();
 
         userEvent.click(ChannelPurposeTextArea);

--- a/webapp/channels/src/components/new_channel_modal/new_channel_modal.tsx
+++ b/webapp/channels/src/components/new_channel_modal/new_channel_modal.tsx
@@ -23,6 +23,7 @@ import {switchToChannel} from 'actions/views/channel';
 import {closeModal} from 'actions/views/modals';
 
 import ChannelNameFormField from 'components/channel_name_form_field/channel_name_form_field';
+import Input from 'components/widgets/inputs/input/input';
 import PublicPrivateSelector from 'components/widgets/public-private-selector/public-private-selector';
 import WithTooltip from 'components/with_tooltip';
 
@@ -283,16 +284,18 @@ const NewChannelModal = () => {
                     onChange={handleOnTypeChange}
                 />
                 <div className='new-channel-modal-purpose-container'>
-                    <textarea
+                    <Input
                         id='new-channel-modal-purpose'
-                        className={classNames('new-channel-modal-purpose-textarea', {'with-error': purposeError})}
-                        placeholder={formatMessage({id: 'channel_modal.purpose.placeholder', defaultMessage: 'Enter a purpose for this channel (optional)'})}
-                        rows={4}
-                        maxLength={Constants.MAX_CHANNELPURPOSE_LENGTH}
-                        autoComplete='off'
+                        type='textarea'
                         value={purpose}
                         onChange={handleOnPurposeChange}
                         onKeyDown={handleOnPurposeKeyDown}
+                        label={formatMessage({id: 'channel_modal.purpose.label', defaultMessage: 'Channel Purpose'})}
+                        placeholder={formatMessage({id: 'channel_modal.purpose.placeholder', defaultMessage: 'Enter a purpose for this channel (optional)'})}
+                        maxLength={Constants.MAX_CHANNELPURPOSE_LENGTH}
+                        autoComplete='off'
+                        className={classNames('new-channel-modal-purpose-textarea', {'with-error': purposeError})}
+                        rows={4}
                     />
                     {purposeError ? (
                         <div className='new-channel-modal-purpose-error'>

--- a/webapp/channels/src/components/seats_calculator/seats_calculator.scss
+++ b/webapp/channels/src/components/seats_calculator/seats_calculator.scss
@@ -14,7 +14,7 @@
         padding-bottom: 12px;
         font-weight: 400;
 
-        fieldset {
+        .Input_fieldset {
             max-width: 110px;
         }
 

--- a/webapp/channels/src/components/start_trial_form_modal/__snapshots__/start_trial_form_modal.test.tsx.snap
+++ b/webapp/channels/src/components/start_trial_form_modal/__snapshots__/start_trial_form_modal.test.tsx.snap
@@ -66,10 +66,11 @@ Object {
               <div
                 class="Input_container"
               >
-                <fieldset
+                <div
                   class="Input_fieldset name_input"
+                  data-testid="input-fieldset"
                 >
-                  <legend
+                  <label
                     class="Input_legend"
                   />
                   <div
@@ -86,19 +87,20 @@ Object {
                       value=""
                     />
                   </div>
-                </fieldset>
+                </div>
               </div>
               <div
                 class="Input_container"
               >
-                <fieldset
+                <div
                   class="Input_fieldset email_input Input_fieldset___error Input_fieldset___legend"
+                  data-testid="input-fieldset"
                 >
-                  <legend
+                  <label
                     class="Input_legend Input_legend___focus"
                   >
                     Business Email
-                  </legend>
+                  </label>
                   <div
                     class="Input_wrapper"
                   >
@@ -114,7 +116,7 @@ Object {
                       value="test@mattermost.com"
                     />
                   </div>
-                </fieldset>
+                </div>
                 <div
                   class="Input___customMessage Input___error"
                   id="error_email"
@@ -131,10 +133,11 @@ Object {
               <div
                 class="Input_container"
               >
-                <fieldset
+                <div
                   class="Input_fieldset company_name_input"
+                  data-testid="input-fieldset"
                 >
-                  <legend
+                  <label
                     class="Input_legend"
                   />
                   <div
@@ -151,7 +154,7 @@ Object {
                       value=""
                     />
                   </div>
-                </fieldset>
+                </div>
               </div>
               <div
                 class="DropdownInput Input_container"

--- a/webapp/channels/src/components/team_settings/team_info_tab/team_info_tab.scss
+++ b/webapp/channels/src/components/team_settings/team_info_tab/team_info_tab.scss
@@ -6,7 +6,7 @@
     }
 
     .description-section-input {
-        fieldset {
+        .Input_fieldset {
             height: 100%;
         }
     }

--- a/webapp/channels/src/components/widgets/inputs/input/__snapshots__/input.test.tsx.snap
+++ b/webapp/channels/src/components/widgets/inputs/input/__snapshots__/input.test.tsx.snap
@@ -5,10 +5,11 @@ exports[`components/widgets/inputs/Input should match snapshot 1`] = `
   <div
     class="Input_container"
   >
-    <fieldset
+    <div
       class="Input_fieldset"
+      data-testid="input-fieldset"
     >
-      <legend
+      <label
         class="Input_legend"
       />
       <div
@@ -21,7 +22,7 @@ exports[`components/widgets/inputs/Input should match snapshot 1`] = `
           value=""
         />
       </div>
-    </fieldset>
+    </div>
   </div>
 </div>
 `;

--- a/webapp/channels/src/components/widgets/inputs/input/input.test.tsx
+++ b/webapp/channels/src/components/widgets/inputs/input/input.test.tsx
@@ -74,7 +74,7 @@ describe('components/widgets/inputs/Input', () => {
             expect(indicator).toBeInTheDocument();
 
             // Check for error styling
-            const fieldset = screen.getByRole('group');
+            const fieldset = screen.getByTestId('input-fieldset');
             expect(fieldset).toHaveClass('Input_fieldset___error');
         });
 
@@ -103,7 +103,7 @@ describe('components/widgets/inputs/Input', () => {
             expect(indicator).toBeInTheDocument();
 
             // Check for error styling
-            const fieldset = screen.getByRole('group');
+            const fieldset = screen.getByTestId('input-fieldset');
             expect(fieldset).toHaveClass('Input_fieldset___error');
 
             // Check for error message
@@ -153,7 +153,7 @@ describe('components/widgets/inputs/Input', () => {
             expect(indicator).toBeInTheDocument();
 
             // Check for error styling
-            const fieldset = screen.getByRole('group');
+            const fieldset = screen.getByTestId('input-fieldset');
             expect(fieldset).toHaveClass('Input_fieldset___error');
         });
 
@@ -204,7 +204,7 @@ describe('components/widgets/inputs/Input', () => {
             expect(errorMessage).toBeInTheDocument();
 
             // Check for error styling
-            const fieldset = screen.getByRole('group');
+            const fieldset = screen.getByTestId('input-fieldset');
             expect(fieldset).toHaveClass('Input_fieldset___error');
         });
 

--- a/webapp/channels/src/components/widgets/inputs/input/input.tsx
+++ b/webapp/channels/src/components/widgets/inputs/input/input.tsx
@@ -245,16 +245,17 @@ const Input = React.forwardRef((
 
     return (
         <div className={classNames('Input_container', containerClassName, {disabled})}>
-            <fieldset
+            <div
                 className={classNames('Input_fieldset', className, {
                     Input_fieldset___error: hasError || limitExceeded > 0 || isMinLengthError || customInputLabel?.type === 'error',
                     Input_fieldset___legend: showLegend,
                 })}
+                data-testid='input-fieldset'
             >
                 {useLegend && (
-                    <legend className={classNames('Input_legend', {Input_legend___focus: showLegend})}>
+                    <label className={classNames('Input_legend', {Input_legend___focus: showLegend})}>
                         {showLegend ? formatAsString(formatMessage, label || placeholder) : null}
-                    </legend>
+                    </label>
                 )}
                 <div className={classNames('Input_wrapper', wrapperClassName)}>
                     {inputPrefix}
@@ -274,7 +275,7 @@ const Input = React.forwardRef((
                     {clearButton}
                 </div>
                 {addon}
-            </fieldset>
+            </div>
             {/* Display custom or derived error messages */}
             {(customInputLabel || derivedErrorMessage) && (
                 <div

--- a/webapp/channels/src/components/widgets/inputs/input/input.tsx
+++ b/webapp/channels/src/components/widgets/inputs/input/input.tsx
@@ -42,6 +42,7 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
     clearable?: boolean;
     clearableTooltipText?: string;
     onClear?: () => void;
+    rows?: number;
 }
 
 const Input = React.forwardRef((
@@ -73,6 +74,7 @@ const Input = React.forwardRef((
         onBlur,
         onChange,
         onClear,
+        rows,
         ...otherProps
     }: InputProps,
     ref?: React.Ref<HTMLInputElement | HTMLTextAreaElement>,
@@ -210,7 +212,7 @@ const Input = React.forwardRef((
                     aria-label={ariaLabel}
                     aria-describedby={error ? errorId : undefined}
                     aria-invalid={error || hasError || limitExceeded > 0}
-                    rows={3}
+                    rows={rows || 3}
                     name={name}
                     disabled={disabled}
                     {...otherProps}

--- a/webapp/channels/src/components/widgets/inputs/url_input/url_input.tsx
+++ b/webapp/channels/src/components/widgets/inputs/url_input/url_input.tsx
@@ -116,6 +116,7 @@ function UrlInput({
                         hasError={hasError}
                         onChange={handleOnInputChange}
                         onBlur={handleOnInputBlur}
+                        aria-describedby='url-input-error'
                     />
                 )}
                 <button
@@ -131,7 +132,12 @@ function UrlInput({
             {error && (
                 <div className='url-input-error'>
                     <i className='icon icon-alert-outline'/>
-                    <span>{error}</span>
+                    <span
+                        id='url-input-error'
+                        role='alert'
+                    >
+                        {error}
+                    </span>
                 </div>
             )}
         </div>

--- a/webapp/channels/src/components/widgets/public-private-selector/public-private-selector.scss
+++ b/webapp/channels/src/components/widgets/public-private-selector/public-private-selector.scss
@@ -12,14 +12,16 @@
         border: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
         border-radius: 4px;
         background: var(--center-channel-bg);
-        box-shadow: var(--elevation-1);
+
+        &:not(.a11y--focused) {
+            box-shadow: var(--elevation-1);
+        }
 
         &:not(:first-child) {
             margin-left: 8px;
         }
 
-        &.a11y--focused,
-        &:hover {
+        &:not(.a11y--focused):hover {
             border: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
             box-shadow: var(--elevation-2);
         }
@@ -32,7 +34,7 @@
                 fill: var(--button-bg);
             }
 
-            &:hover {
+            &:not(.a11y--focused):hover {
                 border: 1px solid rgba(var(--sidebar-text-active-border-rgb), 0.4);
                 box-shadow: var(--elevation-2);
             }


### PR DESCRIPTION
#### Summary
A collection of fixes around the Create Channel Modal:
- MM-62989: We were relying on our placeholder text to describe the Input. The fix was to replace the basic `textarea` with an `Input` component that rolls in a lot more accessibility features.
- MM-63039: The `a11y--focused` border was not showing up due to CSS specificity. Fixed by removing the border that shows up by default when the `a11y--focused` class is applied.
- MM-63033: The error message for the URL input was not being read when we had an error on that input. Fixed by adding `role=alert` to make sure it's read, as well as `aria-describedby` to make sure it's read upon focus.
- MM-63035: The `fieldset` and `legend` tags were not being used properly in the `Input` component. The fix was to switch those to a `div` and `label` respectively.

```release-note
Various accessibility fixes for the Create Channel modal
```
