### PR TITLE
fix default field type if missing value_type in attrs

### DIFF
--- a/webapp/channels/src/components/admin_console/system_properties/user_properties_type_menu.test.tsx
+++ b/webapp/channels/src/components/admin_console/system_properties/user_properties_type_menu.test.tsx
@@ -48,6 +48,21 @@ describe('UserPropertyTypeMenu', () => {
         expect(screen.getByText('Text')).toBeInTheDocument();
     });
 
+    it('renders legacy text field with no value_type in attrs', () => {
+        const legacyField = {
+            ...baseField,
+            type: 'text' as const,
+            attrs: {
+                sort_order: 0,
+            },
+        };
+
+        renderComponent(legacyField as UserPropertyField);
+
+        // The menu button should show the current type
+        expect(screen.getByText('Text')).toBeInTheDocument();
+    });
+
     it('disables menu button when field is marked for deletion', () => {
         const deletedField = {
             ...baseField,

--- a/webapp/channels/src/components/admin_console/system_properties/user_properties_type_menu.tsx
+++ b/webapp/channels/src/components/admin_console/system_properties/user_properties_type_menu.tsx
@@ -119,12 +119,15 @@ export default SelectType;
 
 const getTypeDescriptor = (field: UserPropertyField): TypeDescriptor => {
     for (const descriptor of Object.values(TYPE_DESCRIPTOR)) {
-        if (descriptor.fieldType === field.type && descriptor.valueType === field.attrs?.value_type) {
+        if (
+            descriptor.fieldType === field.type &&
+            descriptor.valueType === (field.attrs?.value_type ?? '')
+        ) {
             return descriptor;
         }
     }
 
-    throw new Error('Invalid type');
+    return TYPE_DESCRIPTOR.text;
 };
 
 type TypeID = 'text' | 'email' | 'phone' | 'url' | 'select' | 'multiselect';


### PR DESCRIPTION
#### Summary
System Console -> User Properties -> Field type menu now defaults to `text` when dealing with legacy fields that are missing `value_type` and `visibility` attrs. This change prevents a runtime error/blank screen crash.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-63934

#### Screenshots
![image](https://github.com/user-attachments/assets/fea9de6f-58cd-4712-9a95-2a1e1f088c91)
![CleanShot 2025-05-01 at 14 45 46](https://github.com/user-attachments/assets/831de111-4e5f-4d97-9e5d-e39b120edbee)


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
