### PR TITLE
MM-62158: group store no select star, part3

### DIFF
--- a/server/channels/store/sqlstore/group_store.go
+++ b/server/channels/store/sqlstore/group_store.go
@@ -1332,9 +1332,8 @@ func (s *SqlGroupStore) groupsBySyncableBaseQuery(st model.GroupSyncableType, t 
 }
 
 func (s *SqlGroupStore) getGroupsAssociatedToChannelsByTeam(teamID string, opts model.GroupSearchOpts) sq.SelectBuilder {
-	query := s.getQueryBuilder().
-		Select("gc.ChannelId, UserGroups.*, gc.SchemeAdmin AS SyncableSchemeAdmin").
-		From("UserGroups").
+	query := s.userGroupsSelectQuery.
+		Columns("gc.ChannelId", "gc.SchemeAdmin AS SyncableSchemeAdmin").
 		LeftJoin(`
 			(SELECT
 				GroupChannels.GroupId, GroupChannels.ChannelId, GroupChannels.DeleteAt, GroupChannels.SchemeAdmin
@@ -1350,9 +1349,8 @@ func (s *SqlGroupStore) getGroupsAssociatedToChannelsByTeam(teamID string, opts 
 		OrderBy("UserGroups.DisplayName")
 
 	if opts.IncludeMemberCount {
-		query = s.getQueryBuilder().
-			Select("gc.ChannelId, UserGroups.*, coalesce(Members.MemberCount, 0) AS MemberCount, gc.SchemeAdmin AS SyncableSchemeAdmin").
-			From("UserGroups").
+		query = s.userGroupsSelectQuery.
+			Columns("gc.ChannelId", "coalesce(Members.MemberCount, 0) AS MemberCount", "gc.SchemeAdmin AS SyncableSchemeAdmin").
 			LeftJoin(`
 				(SELECT
 					GroupChannels.ChannelId, GroupChannels.DeleteAt, GroupChannels.GroupId, GroupChannels.SchemeAdmin


### PR DESCRIPTION
#### Summary
Picking up after https://github.com/mattermost/mattermost/pull/30276 and https://github.com/mattermost/mattermost/pull/30926, this migrates a handful of GroupStore methods away from `SELECT *`.

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-62158

#### Release Note
```release-note
NONE
```