### PR TITLE
MM-63923/MM-63925 Stop using API to update multiple channel categories at once

### DIFF
--- a/server/channels/api4/channel_category.go
+++ b/server/channels/api4/channel_category.go
@@ -307,13 +307,13 @@ func updateCategoryForTeamForUser(c *Context, w http.ResponseWriter, r *http.Req
 
 	categoryUpdateRequest.Id = c.Params.CategoryId
 
-	categories, appErr := c.App.UpdateSidebarCategories(c.AppContext, c.Params.UserId, c.Params.TeamId, []*model.SidebarCategoryWithChannels{&categoryUpdateRequest})
+	category, appErr := c.App.UpdateSidebarCategory(c.AppContext, &categoryUpdateRequest)
 	if appErr != nil {
 		c.Err = appErr
 		return
 	}
 
-	categoryJSON, err := json.Marshal(categories[0])
+	categoryJSON, err := json.Marshal(category)
 	if err != nil {
 		c.Err = model.NewAppError("updateCategoryForTeamForUser", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 		return

--- a/server/channels/api4/channel_category_test.go
+++ b/server/channels/api4/channel_category_test.go
@@ -628,6 +628,7 @@ func TestUpdateCategoryForTeamForUser(t *testing.T) {
 				Sorting:     model.SidebarCategorySortManual,
 			},
 		})
+		require.NoError(t, err)
 
 		teamBCategory, _, err := client.CreateSidebarCategoryForTeamForUser(context.Background(), user.Id, teamB.Id, &model.SidebarCategoryWithChannels{
 			SidebarCategory: model.SidebarCategory{

--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -3693,7 +3693,7 @@ func (a *App) setSidebarCategoriesForConvertedGroupMessage(c request.CTX, gmConv
 		// So what we do is fetch the category, so we get an auto-filled data,
 		// then call update category to persist the data and send the websocket events.
 		channelsCategory := categories.Categories[0]
-		_, appErr = a.UpdateSidebarCategories(c, user.Id, gmConversionRequest.TeamID, []*model.SidebarCategoryWithChannels{channelsCategory})
+		_, appErr = a.UpdateSidebarCategory(c, channelsCategory)
 		if appErr != nil {
 			c.Logger().Error("Failed to add converted GM to default sidebar category for user", mlog.String("user_id", user.Id), mlog.Err(err))
 		}

--- a/server/channels/app/channel_category.go
+++ b/server/channels/app/channel_category.go
@@ -148,7 +148,7 @@ func (a *App) UpdateSidebarCategories(c request.CTX, userID, teamID string, cate
 		return nil, model.NewAppError("UpdateSidebarCategory", "app.channel.sidebar_categories.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
-	updatedCategories, _, err := a.Srv().Store().Channel().UpdateSidebarCategories(userID, teamID, categories)
+	updatedCategories, err := a.Srv().Store().Channel().UpdateSidebarCategories(userID, teamID, categories)
 	if err != nil {
 		return nil, model.NewAppError("UpdateSidebarCategories", "app.channel.sidebar_categories.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}

--- a/server/channels/app/channel_category.go
+++ b/server/channels/app/channel_category.go
@@ -25,7 +25,7 @@ func (a *App) createInitialSidebarCategories(c request.CTX, userID string, opts 
 
 func (a *App) GetSidebarCategoriesForTeamForUser(c request.CTX, userID, teamID string) (*model.OrderedSidebarCategories, *model.AppError) {
 	var appErr *model.AppError
-	categories, err := a.Srv().Store().Channel().GetSidebarCategoriesForTeamForUser(userID, teamID)
+	categories, err := a.Srv().Store().Channel().GetSidebarCategoriesForTeamForUser(userID, teamID, false)
 	if err == nil && len(categories.Categories) == 0 {
 		// A user must always have categories, so migration must not have happened yet, and we should run it ourselves
 		categories, appErr = a.createInitialSidebarCategories(c, userID, &store.SidebarCategorySearchOpts{

--- a/server/channels/app/channel_category_test.go
+++ b/server/channels/app/channel_category_test.go
@@ -594,28 +594,27 @@ func TestDiffChannelsBetweenCategories(t *testing.T) {
 			t,
 			map[string]*categoryChannelDiff{
 				"channel1": {
-					fromCategoryId: "category1",
-					toCategoryId:   "category3",
+					fromCategory: originalCategories[0],
+					toCategory:   updatedCategories[2],
 				},
 				"channel2": {
-					fromCategoryId: "category1",
-					toCategoryId:   "category2",
+					fromCategory: originalCategories[0],
+					toCategory:   updatedCategories[1],
 				},
 				"channel3": {
-					fromCategoryId: "category1",
-					toCategoryId:   "category3",
+					fromCategory: originalCategories[0],
+					toCategory:   updatedCategories[2],
 				},
 				"channel4": {
-					fromCategoryId: "category2",
-					toCategoryId:   "category3",
+					fromCategory: originalCategories[1],
+					toCategory:   updatedCategories[2],
 				},
 			},
 			channelsDiff,
 		)
 	})
 
-	t.Run("should not return channels that are moved in our out of the categories implicitly", func(t *testing.T) {
-		// This case could change to actually return the channels in the future, but we don't need to handle it right now
+	t.Run("should not return channels that we aren't in updatedCategories", func(t *testing.T) {
 		originalCategories := []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: model.SidebarCategory{
@@ -655,8 +654,8 @@ func TestDiffChannelsBetweenCategories(t *testing.T) {
 			t,
 			map[string]*categoryChannelDiff{
 				"channel3": {
-					fromCategoryId: "category2",
-					toCategoryId:   "category1",
+					fromCategory: originalCategories[1],
+					toCategory:   updatedCategories[0],
 				},
 			},
 			channelsDiff,

--- a/server/channels/app/channel_test.go
+++ b/server/channels/app/channel_test.go
@@ -2893,8 +2893,18 @@ func TestConvertGroupMessageToChannel(t *testing.T) {
 			Categories: model.SidebarCategoriesWithChannels{
 				{
 					SidebarCategory: model.SidebarCategory{
-						Type: model.SidebarCategoryChannels,
+						Type:   model.SidebarCategoryChannels,
+						UserId: "user_id_1",
+						TeamId: "team_id_1",
 					},
+				},
+				{
+					SidebarCategory: model.SidebarCategory{
+						Type:   model.SidebarCategoryDirectMessages,
+						UserId: "user_id_1",
+						TeamId: "team_id_1",
+					},
+					Channels: []string{"channelidchannelidchanneli"},
 				},
 			},
 		}, nil)
@@ -2903,41 +2913,69 @@ func TestConvertGroupMessageToChannel(t *testing.T) {
 			Categories: model.SidebarCategoriesWithChannels{
 				{
 					SidebarCategory: model.SidebarCategory{
-						Type: model.SidebarCategoryChannels,
+						Type:   model.SidebarCategoryChannels,
+						UserId: "user_id_2",
+						TeamId: "team_id_1",
 					},
+				},
+				{
+					SidebarCategory: model.SidebarCategory{
+						Type:   model.SidebarCategoryDirectMessages,
+						UserId: "user_id_2",
+						TeamId: "team_id_1",
+					},
+					Channels: []string{"channelidchannelidchanneli"},
 				},
 			},
 		}, nil)
-	mockChannelStore.On("UpdateSidebarCategories", "user_id_1", "team_id_1", mock.Anything).Return(
-		[]*model.SidebarCategoryWithChannels{
-			{
-				SidebarCategory: model.SidebarCategory{
-					Type: model.SidebarCategoryChannels,
+	mockChannelStore.On("GetSidebarCategoriesForTeamForUser", "user_id_1", "team_id_1", false).Return(
+		&model.OrderedSidebarCategories{
+			Categories: []*model.SidebarCategoryWithChannels{
+				{
+					SidebarCategory: model.SidebarCategory{
+						Type:   model.SidebarCategoryChannels,
+						UserId: "user_id_1",
+						TeamId: "team_id_1",
+					},
 				},
-			},
-		},
-		[]*model.SidebarCategoryWithChannels{
-			{
-				SidebarCategory: model.SidebarCategory{
-					Type: model.SidebarCategoryChannels,
+				{
+					SidebarCategory: model.SidebarCategory{
+						Type:   model.SidebarCategoryDirectMessages,
+						UserId: "user_id_1",
+						TeamId: "team_id_1",
+					},
+					Channels: []string{"channelidchannelidchanneli"},
 				},
 			},
 		},
 		nil,
 	)
-	mockChannelStore.On("UpdateSidebarCategories", "user_id_2", "team_id_1", mock.Anything).Return(
-		[]*model.SidebarCategoryWithChannels{
-			{
-				SidebarCategory: model.SidebarCategory{
-					Type: model.SidebarCategoryChannels,
+	mockChannelStore.On("GetSidebarCategoriesForTeamForUser", "user_id_2", "team_id_1", false).Return(
+		&model.OrderedSidebarCategories{
+			Categories: []*model.SidebarCategoryWithChannels{
+				{
+					SidebarCategory: model.SidebarCategory{
+						Type:   model.SidebarCategoryChannels,
+						UserId: "user_id_2",
+						TeamId: "team_id_1",
+					},
+				},
+				{
+					SidebarCategory: model.SidebarCategory{
+						Type:   model.SidebarCategoryDirectMessages,
+						UserId: "user_id_2",
+						TeamId: "team_id_1",
+					},
+					Channels: []string{"channelidchannelidchanneli"},
 				},
 			},
 		},
-		[]*model.SidebarCategoryWithChannels{
-			{
-				SidebarCategory: model.SidebarCategory{
-					Type: model.SidebarCategoryChannels,
-				},
+		nil,
+	)
+	mockChannelStore.On("UpdateSidebarCategory", mock.Anything).Return(
+		&model.SidebarCategoryWithChannels{
+			SidebarCategory: model.SidebarCategory{
+				Type: model.SidebarCategoryChannels,
 			},
 		},
 		nil,

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -2260,11 +2260,11 @@ func (s *RetryLayerChannelStore) GetSidebarCategories(userID string, opts *store
 
 }
 
-func (s *RetryLayerChannelStore) GetSidebarCategoriesForTeamForUser(userID string, teamID string) (*model.OrderedSidebarCategories, error) {
+func (s *RetryLayerChannelStore) GetSidebarCategoriesForTeamForUser(userID string, teamID string, fromMaster bool) (*model.OrderedSidebarCategories, error) {
 
 	tries := 0
 	for {
-		result, err := s.ChannelStore.GetSidebarCategoriesForTeamForUser(userID, teamID)
+		result, err := s.ChannelStore.GetSidebarCategoriesForTeamForUser(userID, teamID, fromMaster)
 		if err == nil {
 			return result, nil
 		}

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -3163,6 +3163,27 @@ func (s *RetryLayerChannelStore) UpdateSidebarCategories(userID string, teamID s
 
 }
 
+func (s *RetryLayerChannelStore) UpdateSidebarCategory(category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, *model.SidebarCategoryWithChannels, error) {
+
+	tries := 0
+	for {
+		result, resultVar1, err := s.ChannelStore.UpdateSidebarCategory(category)
+		if err == nil {
+			return result, resultVar1, nil
+		}
+		if !isRepeatableError(err) {
+			return result, resultVar1, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, resultVar1, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerChannelStore) UpdateSidebarCategoryOrder(userID string, teamID string, categoryOrder []string) error {
 
 	tries := 0

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -3142,42 +3142,42 @@ func (s *RetryLayerChannelStore) UpdateMultipleMembers(members []*model.ChannelM
 
 }
 
-func (s *RetryLayerChannelStore) UpdateSidebarCategories(userID string, teamID string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, []*model.SidebarCategoryWithChannels, error) {
+func (s *RetryLayerChannelStore) UpdateSidebarCategories(userID string, teamID string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, error) {
 
 	tries := 0
 	for {
-		result, resultVar1, err := s.ChannelStore.UpdateSidebarCategories(userID, teamID, categories)
+		result, err := s.ChannelStore.UpdateSidebarCategories(userID, teamID, categories)
 		if err == nil {
-			return result, resultVar1, nil
+			return result, nil
 		}
 		if !isRepeatableError(err) {
-			return result, resultVar1, err
+			return result, err
 		}
 		tries++
 		if tries >= 3 {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
-			return result, resultVar1, err
+			return result, err
 		}
 		timepkg.Sleep(100 * timepkg.Millisecond)
 	}
 
 }
 
-func (s *RetryLayerChannelStore) UpdateSidebarCategory(category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, *model.SidebarCategoryWithChannels, error) {
+func (s *RetryLayerChannelStore) UpdateSidebarCategory(category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error) {
 
 	tries := 0
 	for {
-		result, resultVar1, err := s.ChannelStore.UpdateSidebarCategory(category)
+		result, err := s.ChannelStore.UpdateSidebarCategory(category)
 		if err == nil {
-			return result, resultVar1, nil
+			return result, nil
 		}
 		if !isRepeatableError(err) {
-			return result, resultVar1, err
+			return result, err
 		}
 		tries++
 		if tries >= 3 {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
-			return result, resultVar1, err
+			return result, err
 		}
 		timepkg.Sleep(100 * timepkg.Millisecond)
 	}

--- a/server/channels/store/sqlstore/channel_store_categories.go
+++ b/server/channels/store/sqlstore/channel_store_categories.go
@@ -731,14 +731,14 @@ func (s SqlChannelStore) UpdateSidebarCategories(userId, teamId string, categori
 
 	updatedCategories := []*model.SidebarCategoryWithChannels{}
 	for _, category := range categories {
-		srcCategory, err := s.getSidebarCategoryT(transaction, category.Id, false)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to find SidebarCategories")
+		srcCategory, nErr := s.getSidebarCategoryT(transaction, category.Id, false)
+		if nErr != nil {
+			return nil, errors.Wrap(nErr, "failed to find SidebarCategories")
 		}
 
-		destCategory, err := s.updateSidebarCategoryT(transaction, userId, teamId, category, srcCategory)
-		if err != nil {
-			return nil, err
+		destCategory, nErr := s.updateSidebarCategoryT(transaction, userId, teamId, category, srcCategory)
+		if nErr != nil {
+			return nil, nErr
 		}
 
 		updatedCategories = append(updatedCategories, destCategory)

--- a/server/channels/store/sqlstore/channel_store_categories.go
+++ b/server/channels/store/sqlstore/channel_store_categories.go
@@ -580,12 +580,20 @@ func (s SqlChannelStore) getSidebarCategoriesT(db dbSelecter, userId string, opt
 	return &oc, nil
 }
 
-func (s SqlChannelStore) GetSidebarCategoriesForTeamForUser(userId, teamId string) (*model.OrderedSidebarCategories, error) {
+func (s SqlChannelStore) GetSidebarCategoriesForTeamForUser(userId, teamId string, fromMaster bool) (*model.OrderedSidebarCategories, error) {
 	opts := &store.SidebarCategorySearchOpts{
 		TeamID:      teamId,
 		ExcludeTeam: false,
 	}
-	return s.getSidebarCategoriesT(s.GetReplica(), userId, opts)
+
+	var db dbSelecter
+	if fromMaster {
+		db = s.GetMaster()
+	} else {
+		db = s.GetReplica()
+	}
+
+	return s.getSidebarCategoriesT(db, userId, opts)
 }
 
 func (s SqlChannelStore) GetSidebarCategories(userID string, opts *store.SidebarCategorySearchOpts) (*model.OrderedSidebarCategories, error) {

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -287,7 +287,7 @@ type ChannelStore interface {
 	ResetAllChannelSchemes() error
 	ClearAllCustomRoleAssignments() error
 	CreateInitialSidebarCategories(c request.CTX, userID string, opts *SidebarCategorySearchOpts) (*model.OrderedSidebarCategories, error)
-	GetSidebarCategoriesForTeamForUser(userID, teamID string) (*model.OrderedSidebarCategories, error)
+	GetSidebarCategoriesForTeamForUser(userID, teamID string, fromMaster bool) (*model.OrderedSidebarCategories, error)
 	GetSidebarCategories(userID string, opts *SidebarCategorySearchOpts) (*model.OrderedSidebarCategories, error)
 	GetSidebarCategory(categoryID string) (*model.SidebarCategoryWithChannels, error)
 	GetSidebarCategoryOrder(userID, teamID string) ([]string, error)

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -293,8 +293,8 @@ type ChannelStore interface {
 	GetSidebarCategoryOrder(userID, teamID string) ([]string, error)
 	CreateSidebarCategory(userID, teamID string, newCategory *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error)
 	UpdateSidebarCategoryOrder(userID, teamID string, categoryOrder []string) error
-	UpdateSidebarCategory(category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, *model.SidebarCategoryWithChannels, error)
-	UpdateSidebarCategories(userID, teamID string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, []*model.SidebarCategoryWithChannels, error)
+	UpdateSidebarCategory(category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error)
+	UpdateSidebarCategories(userID, teamID string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, error)
 	UpdateSidebarChannelsByPreferences(preferences model.Preferences) error
 	DeleteSidebarChannelsByPreferences(preferences model.Preferences) error
 	DeleteSidebarCategory(categoryID string) error

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -293,6 +293,7 @@ type ChannelStore interface {
 	GetSidebarCategoryOrder(userID, teamID string) ([]string, error)
 	CreateSidebarCategory(userID, teamID string, newCategory *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error)
 	UpdateSidebarCategoryOrder(userID, teamID string, categoryOrder []string) error
+	UpdateSidebarCategory(category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, *model.SidebarCategoryWithChannels, error)
 	UpdateSidebarCategories(userID, teamID string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, []*model.SidebarCategoryWithChannels, error)
 	UpdateSidebarChannelsByPreferences(preferences model.Preferences) error
 	DeleteSidebarChannelsByPreferences(preferences model.Preferences) error

--- a/server/channels/store/storetest/channel_store_categories.go
+++ b/server/channels/store/storetest/channel_store_categories.go
@@ -1178,8 +1178,8 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 			TeamID:      team.Id,
 			ExcludeTeam: false,
 		}
-		res, nErr := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
-		require.NoError(t, nErr)
+		res, err := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
+		require.NoError(t, err)
 		require.NotEmpty(t, res)
 
 		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
@@ -1247,8 +1247,8 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 			TeamID:      team.Id,
 			ExcludeTeam: false,
 		}
-		res, nErr := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
-		require.NoError(t, nErr)
+		res, err := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
+		require.NoError(t, err)
 		require.NotEmpty(t, res)
 
 		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
@@ -1258,18 +1258,18 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.Equal(t, model.SidebarCategoryFavorites, favoritesCategory.Type)
 
 		// Join a channel
-		channel, nErr := ss.Channel().Save(rctx, &model.Channel{
+		channel, err := ss.Channel().Save(rctx, &model.Channel{
 			Name:   "channel",
 			Type:   model.ChannelTypeOpen,
 			TeamId: team.Id,
 		}, 10)
-		require.NoError(t, nErr)
-		_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{
+		require.NoError(t, err)
+		_, err = ss.Channel().SaveMember(rctx, &model.ChannelMember{
 			UserId:      userID,
 			ChannelId:   channel.Id,
 			NotifyProps: model.GetDefaultChannelNotifyProps(),
 		})
-		require.NoError(t, nErr)
+		require.NoError(t, err)
 
 		// Assign it to favorites
 		_, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
@@ -1278,8 +1278,8 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res2, nErr := ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, channel.Id)
-		assert.NoError(t, nErr)
+		res2, err := ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, channel.Id)
+		assert.NoError(t, err)
 		assert.NotNil(t, res2)
 		assert.Equal(t, "true", res2.Value)
 
@@ -1293,9 +1293,9 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res2, nErr = ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, channel.Id)
-		assert.Error(t, nErr)
-		assert.True(t, errors.Is(nErr, sql.ErrNoRows))
+		res2, err = ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, channel.Id)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, sql.ErrNoRows))
 		assert.Nil(t, res2)
 	})
 
@@ -1308,8 +1308,8 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 			TeamID:      team.Id,
 			ExcludeTeam: false,
 		}
-		res, nErr := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
-		require.NoError(t, nErr)
+		res, err := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
+		require.NoError(t, err)
 		require.NotEmpty(t, res)
 
 		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
@@ -1321,7 +1321,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		// Create a direct channel
 		otherUserID := model.NewId()
 
-		dmChannel, nErr := ss.Channel().SaveDirectChannel(rctx,
+		dmChannel, err := ss.Channel().SaveDirectChannel(rctx,
 			&model.Channel{
 				Name: model.GetDMNameFromIds(userID, otherUserID),
 				Type: model.ChannelTypeDirect,
@@ -1335,7 +1335,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 				NotifyProps: model.GetDefaultChannelNotifyProps(),
 			},
 		)
-		assert.NoError(t, nErr)
+		assert.NoError(t, err)
 
 		// Assign it to favorites
 		_, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
@@ -1344,8 +1344,8 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res2, nErr := ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, dmChannel.Id)
-		assert.NoError(t, nErr)
+		res2, err := ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, dmChannel.Id)
+		assert.NoError(t, err)
 		assert.NotNil(t, res2)
 		assert.Equal(t, "true", res2.Value)
 
@@ -1359,9 +1359,9 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res2, nErr = ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, dmChannel.Id)
-		assert.Error(t, nErr)
-		assert.True(t, errors.Is(nErr, sql.ErrNoRows))
+		res2, err = ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, dmChannel.Id)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, sql.ErrNoRows))
 		assert.Nil(t, res2)
 	})
 
@@ -1375,8 +1375,8 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 			TeamID:      team.Id,
 			ExcludeTeam: false,
 		}
-		res, nErr := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
-		require.NoError(t, nErr)
+		res, err := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
+		require.NoError(t, err)
 		require.NotEmpty(t, res)
 
 		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
@@ -1389,8 +1389,8 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 			TeamID:      team2.Id,
 			ExcludeTeam: false,
 		}
-		res, nErr = ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
-		require.NoError(t, nErr)
+		res, err = ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
+		require.NoError(t, err)
 		require.NotEmpty(t, res)
 
 		categories2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team2.Id, false)
@@ -1402,7 +1402,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		// Create a direct channel
 		otherUserID := model.NewId()
 
-		dmChannel, nErr := ss.Channel().SaveDirectChannel(rctx,
+		dmChannel, err := ss.Channel().SaveDirectChannel(rctx,
 			&model.Channel{
 				Name: model.GetDMNameFromIds(userID, otherUserID),
 				Type: model.ChannelTypeDirect,
@@ -1416,7 +1416,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 				NotifyProps: model.GetDefaultChannelNotifyProps(),
 			},
 		)
-		assert.NoError(t, nErr)
+		assert.NoError(t, err)
 
 		// Assign it to favorites on the first team. The favorites preference gets set for all teams.
 		_, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
@@ -1425,8 +1425,8 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res2, nErr := ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, dmChannel.Id)
-		assert.NoError(t, nErr)
+		res2, err := ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, dmChannel.Id)
+		assert.NoError(t, err)
 		assert.NotNil(t, res2)
 		assert.Equal(t, "true", res2.Value)
 
@@ -1438,8 +1438,8 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		assert.NoError(t, err)
 		assert.Equal(t, []string{dmChannel.Id}, updated.Channels)
 
-		res2, nErr = ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, dmChannel.Id)
-		assert.NoError(t, nErr)
+		res2, err = ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, dmChannel.Id)
+		assert.NoError(t, err)
 		assert.NotNil(t, res2)
 		assert.Equal(t, "true", res2.Value)
 
@@ -1450,8 +1450,8 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res2, nErr = ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, dmChannel.Id)
-		require.Error(t, nErr)
+		res2, err = ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, dmChannel.Id)
+		require.Error(t, err)
 		assert.Nil(t, res2)
 
 		// Remove it from favorites on the second team. The favorites preference was already deleted.
@@ -1461,8 +1461,8 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res2, nErr = ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, dmChannel.Id)
-		require.Error(t, nErr)
+		res2, err = ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, dmChannel.Id)
+		require.Error(t, err)
 		assert.Nil(t, res2)
 	})
 
@@ -1476,8 +1476,8 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 			TeamID:      team.Id,
 			ExcludeTeam: false,
 		}
-		res, nErr := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
-		require.NoError(t, nErr)
+		res, err := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
+		require.NoError(t, err)
 		require.NotEmpty(t, res)
 
 		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
@@ -1489,8 +1489,8 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.Equal(t, model.SidebarCategoryChannels, channelsCategory.Type)
 
 		// Create the other users' categories
-		res, nErr = ss.Channel().CreateInitialSidebarCategories(rctx, userID2, opts)
-		require.NoError(t, nErr)
+		res, err = ss.Channel().CreateInitialSidebarCategories(rctx, userID2, opts)
+		require.NoError(t, err)
 		require.NotEmpty(t, res)
 
 		categories2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID2, team.Id, false)
@@ -1502,24 +1502,24 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.Equal(t, model.SidebarCategoryChannels, channelsCategory2.Type)
 
 		// Have both users join a channel
-		channel, nErr := ss.Channel().Save(rctx, &model.Channel{
+		channel, err := ss.Channel().Save(rctx, &model.Channel{
 			Name:   "channel",
 			Type:   model.ChannelTypeOpen,
 			TeamId: team.Id,
 		}, 10)
-		require.NoError(t, nErr)
-		_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{
+		require.NoError(t, err)
+		_, err = ss.Channel().SaveMember(rctx, &model.ChannelMember{
 			UserId:      userID,
 			ChannelId:   channel.Id,
 			NotifyProps: model.GetDefaultChannelNotifyProps(),
 		})
-		require.NoError(t, nErr)
-		_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{
+		require.NoError(t, err)
+		_, err = ss.Channel().SaveMember(rctx, &model.ChannelMember{
 			UserId:      userID2,
 			ChannelId:   channel.Id,
 			NotifyProps: model.GetDefaultChannelNotifyProps(),
 		})
-		require.NoError(t, nErr)
+		require.NoError(t, err)
 
 		// Have user1 favorite it
 		_, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
@@ -1528,13 +1528,13 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res2, nErr := ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, channel.Id)
-		assert.NoError(t, nErr)
+		res2, err := ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, channel.Id)
+		assert.NoError(t, err)
 		assert.NotNil(t, res2)
 		assert.Equal(t, "true", res2.Value)
 
-		res2, nErr = ss.Preference().Get(userID2, model.PreferenceCategoryFavoriteChannel, channel.Id)
-		assert.True(t, errors.Is(nErr, sql.ErrNoRows))
+		res2, err = ss.Preference().Get(userID2, model.PreferenceCategoryFavoriteChannel, channel.Id)
+		assert.True(t, errors.Is(err, sql.ErrNoRows))
 		assert.Nil(t, res2)
 
 		// And user2 favorite it
@@ -1544,13 +1544,13 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res2, nErr = ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, channel.Id)
-		assert.NoError(t, nErr)
+		res2, err = ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, channel.Id)
+		assert.NoError(t, err)
 		assert.NotNil(t, res2)
 		assert.Equal(t, "true", res2.Value)
 
-		res2, nErr = ss.Preference().Get(userID2, model.PreferenceCategoryFavoriteChannel, channel.Id)
-		assert.NoError(t, nErr)
+		res2, err = ss.Preference().Get(userID2, model.PreferenceCategoryFavoriteChannel, channel.Id)
+		assert.NoError(t, err)
 		assert.NotNil(t, res2)
 		assert.Equal(t, "true", res2.Value)
 
@@ -1561,12 +1561,12 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res2, nErr = ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, channel.Id)
-		assert.True(t, errors.Is(nErr, sql.ErrNoRows))
+		res2, err = ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, channel.Id)
+		assert.True(t, errors.Is(err, sql.ErrNoRows))
 		assert.Nil(t, res2)
 
-		res2, nErr = ss.Preference().Get(userID2, model.PreferenceCategoryFavoriteChannel, channel.Id)
-		assert.NoError(t, nErr)
+		res2, err = ss.Preference().Get(userID2, model.PreferenceCategoryFavoriteChannel, channel.Id)
+		assert.NoError(t, err)
 		assert.NotNil(t, res2)
 		assert.Equal(t, "true", res2.Value)
 
@@ -1577,12 +1577,12 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res2, nErr = ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, channel.Id)
-		assert.True(t, errors.Is(nErr, sql.ErrNoRows))
+		res2, err = ss.Preference().Get(userID, model.PreferenceCategoryFavoriteChannel, channel.Id)
+		assert.True(t, errors.Is(err, sql.ErrNoRows))
 		assert.Nil(t, res2)
 
-		res2, nErr = ss.Preference().Get(userID2, model.PreferenceCategoryFavoriteChannel, channel.Id)
-		assert.True(t, errors.Is(nErr, sql.ErrNoRows))
+		res2, err = ss.Preference().Get(userID2, model.PreferenceCategoryFavoriteChannel, channel.Id)
+		assert.True(t, errors.Is(err, sql.ErrNoRows))
 		assert.Nil(t, res2)
 	})
 
@@ -1591,13 +1591,13 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		team := setupTeam(t, rctx, ss, userID)
 
 		// Create some channels
-		channel, nErr := ss.Channel().Save(rctx, &model.Channel{
+		channel, err := ss.Channel().Save(rctx, &model.Channel{
 			Name:   "channel",
 			Type:   model.ChannelTypeOpen,
 			TeamId: team.Id,
 		}, 10)
-		require.NoError(t, nErr)
-		_, err := ss.Channel().SaveMember(rctx, &model.ChannelMember{
+		require.NoError(t, err)
+		_, err = ss.Channel().SaveMember(rctx, &model.ChannelMember{
 			UserId:      userID,
 			ChannelId:   channel.Id,
 			NotifyProps: model.GetDefaultChannelNotifyProps(),
@@ -1605,7 +1605,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, err)
 
 		otherUserID := model.NewId()
-		dmChannel, nErr := ss.Channel().SaveDirectChannel(
+		dmChannel, err := ss.Channel().SaveDirectChannel(
 			rctx,
 			&model.Channel{
 				Name: model.GetDMNameFromIds(userID, otherUserID),
@@ -1620,19 +1620,19 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 				NotifyProps: model.GetDefaultChannelNotifyProps(),
 			},
 		)
-		require.NoError(t, nErr)
+		require.NoError(t, err)
 
 		opts := &store.SidebarCategorySearchOpts{
 			TeamID:      team.Id,
 			ExcludeTeam: false,
 		}
-		res, nErr := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
-		require.NoError(t, nErr)
+		res, err := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
+		require.NoError(t, err)
 		require.NotEmpty(t, res)
 
 		// And some categories
-		initialCategories, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
-		require.NoError(t, nErr)
+		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
+		require.NoError(t, err)
 
 		channelsCategory := initialCategories.Categories[1]
 		dmsCategory := initialCategories.Categories[2]
@@ -1641,21 +1641,21 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.Equal(t, []string{dmChannel.Id}, dmsCategory.Channels)
 
 		// Try to save the Channels categories with no channels in it
-		updatedChannelsCategory, nErr := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		updatedChannelsCategory, err := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: channelsCategory.SidebarCategory,
 			Channels:        []string{},
 		})
-		assert.NoError(t, nErr)
+		assert.NoError(t, err)
 
 		// The channels should still exist in the category because they would otherwise be orphaned
 		assert.Equal(t, []string{channel.Id}, updatedChannelsCategory.Channels)
 
 		// Try to save the DMs categories with no channels in it
-		updatedDMsCategory, nErr := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		updatedDMsCategory, err := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: dmsCategory.SidebarCategory,
 			Channels:        []string{},
 		})
-		assert.NoError(t, nErr)
+		assert.NoError(t, err)
 
 		// The channels should still exist in the category because they would otherwise be orphaned
 		assert.Equal(t, []string{dmChannel.Id}, updatedDMsCategory.Channels)
@@ -1666,7 +1666,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		team := setupTeam(t, rctx, ss, userID)
 
 		otherUserID := model.NewId()
-		dmChannel, nErr := ss.Channel().SaveDirectChannel(rctx,
+		dmChannel, err := ss.Channel().SaveDirectChannel(rctx,
 			&model.Channel{
 				Name: model.GetDMNameFromIds(userID, otherUserID),
 				Type: model.ChannelTypeDirect,
@@ -1680,14 +1680,14 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 				NotifyProps: model.GetDefaultChannelNotifyProps(),
 			},
 		)
-		require.NoError(t, nErr)
+		require.NoError(t, err)
 
 		opts := &store.SidebarCategorySearchOpts{
 			TeamID:      team.Id,
 			ExcludeTeam: false,
 		}
-		res, nErr := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
-		require.NoError(t, nErr)
+		res, err := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
+		require.NoError(t, err)
 		require.NotEmpty(t, res)
 
 		// The DM should start in the DMs category
@@ -1740,13 +1740,13 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		team := setupTeam(t, rctx, ss, userID)
 
 		// Join a channel
-		channel, nErr := ss.Channel().Save(rctx, &model.Channel{
+		channel, err := ss.Channel().Save(rctx, &model.Channel{
 			Name:   "channel",
 			Type:   model.ChannelTypeOpen,
 			TeamId: team.Id,
 		}, 10)
-		require.NoError(t, nErr)
-		_, err := ss.Channel().SaveMember(rctx, &model.ChannelMember{
+		require.NoError(t, err)
+		_, err = ss.Channel().SaveMember(rctx, &model.ChannelMember{
 			UserId:      userID,
 			ChannelId:   channel.Id,
 			NotifyProps: model.GetDefaultChannelNotifyProps(),
@@ -1758,33 +1758,33 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 			TeamID:      team.Id,
 			ExcludeTeam: false,
 		}
-		res, nErr := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
-		require.NoError(t, nErr)
+		res, err := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
+		require.NoError(t, err)
 		require.NotEmpty(t, res)
 
-		initialCategories, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
-		require.NoError(t, nErr)
+		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
+		require.NoError(t, err)
 
 		channelsCategory := initialCategories.Categories[1]
 		require.Equal(t, []string{channel.Id}, channelsCategory.Channels)
 
-		customCategory, nErr := ss.Channel().CreateSidebarCategory(userID, team.Id, &model.SidebarCategoryWithChannels{})
-		require.NoError(t, nErr)
+		customCategory, err := ss.Channel().CreateSidebarCategory(userID, team.Id, &model.SidebarCategoryWithChannels{})
+		require.NoError(t, err)
 
 		// Move the channel one way
-		updatedCustomCategory, nErr := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		updatedCustomCategory, err := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: customCategory.SidebarCategory,
 			Channels:        []string{channel.Id},
 		})
-		assert.NoError(t, nErr)
+		assert.NoError(t, err)
 		assert.Equal(t, []string{channel.Id}, updatedCustomCategory.Channels)
 
 		// And then the other
-		updatedChannelsCategory, nErr := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		updatedChannelsCategory, err := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: channelsCategory.SidebarCategory,
 			Channels:        []string{channel.Id},
 		})
-		assert.NoError(t, nErr)
+		assert.NoError(t, err)
 		assert.Equal(t, []string{channel.Id}, updatedChannelsCategory.Channels)
 	})
 }

--- a/server/channels/store/storetest/channel_store_categories.go
+++ b/server/channels/store/storetest/channel_store_categories.go
@@ -22,6 +22,7 @@ func TestChannelStoreCategories(t *testing.T, rctx request.CTX, ss store.Store, 
 	t.Run("CreateSidebarCategory", func(t *testing.T) { testCreateSidebarCategory(t, rctx, ss) })
 	t.Run("GetSidebarCategory", func(t *testing.T) { testGetSidebarCategory(t, rctx, ss, s) })
 	t.Run("GetSidebarCategories", func(t *testing.T) { testGetSidebarCategories(t, rctx, ss) })
+	t.Run("UpdateSidebarCategory", func(t *testing.T) { testUpdateSidebarCategory(t, rctx, ss) })
 	t.Run("UpdateSidebarCategories", func(t *testing.T) { testUpdateSidebarCategories(t, rctx, ss) })
 	t.Run("ClearSidebarOnTeamLeave", func(t *testing.T) { testClearSidebarOnTeamLeave(t, rctx, ss, s) })
 	t.Run("DeleteSidebarCategory", func(t *testing.T) { testDeleteSidebarCategory(t, rctx, ss, s) })
@@ -1199,7 +1200,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 			},
 			Channels: favoritesCategory.Channels,
 		})
-		assert.NoError(t, nil)
+		assert.NoError(t, err)
 		assert.Equal(t, "Favorites", updatedFavoritesCategory.DisplayName)
 
 		// Try to change the type of Channels
@@ -1210,7 +1211,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 			},
 			Channels: channelsCategory.Channels,
 		})
-		assert.NoError(t, nil)
+		assert.NoError(t, err)
 		assert.Equal(t, "Channels", updatedChannelsCategory.DisplayName)
 
 		// Try to change the Channels of DMs
@@ -1218,7 +1219,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 			SidebarCategory: dmsCategory.SidebarCategory,
 			Channels:        []string{"fakechannel"},
 		})
-		assert.NoError(t, nil)
+		assert.NoError(t, err)
 		assert.Equal(t, []string{}, updatedDMsCategory.Channels)
 
 		// Try to change the UserId/TeamId of a custom category
@@ -1232,7 +1233,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 			},
 			Channels: customCategory.Channels,
 		})
-		assert.NoError(t, nil)
+		assert.NoError(t, err)
 		assert.Equal(t, userID, updatedCustomCategory.UserId)
 		assert.Equal(t, team.Id, updatedCustomCategory.TeamId)
 	})

--- a/server/channels/store/storetest/channel_store_categories.go
+++ b/server/channels/store/storetest/channel_store_categories.go
@@ -1476,7 +1476,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		assert.Equal(t, "true", res2.Value)
 
 		// Assign it to favorites on the second team. The favorites preference is already set.
-		updated, _, err := ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
+		updated, _, err := ss.Channel().UpdateSidebarCategories(userID, team2.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: favoritesCategory2.SidebarCategory,
 				Channels:        []string{dmChannel.Id},
@@ -1504,7 +1504,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		assert.Nil(t, res2)
 
 		// Remove it from favorites on the second team. The favorites preference was already deleted.
-		_, _, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
+		_, _, err = ss.Channel().UpdateSidebarCategories(userID, team2.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: favoritesCategory2.SidebarCategory,
 				Channels:        []string{},

--- a/server/channels/store/storetest/channel_store_categories.go
+++ b/server/channels/store/storetest/channel_store_categories.go
@@ -71,7 +71,7 @@ func testCreateInitialSidebarCategories(t *testing.T, rctx request.CTX, ss store
 		assert.Equal(t, model.SidebarCategoryChannels, res.Categories[1].Type)
 		assert.Equal(t, model.SidebarCategoryDirectMessages, res.Categories[2].Type)
 
-		res2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		res2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		assert.NoError(t, err)
 		assert.Equal(t, res, res2)
 	})
@@ -97,7 +97,7 @@ func testCreateInitialSidebarCategories(t *testing.T, rctx request.CTX, ss store
 		assert.Equal(t, model.SidebarCategoryChannels, res.Categories[1].Type)
 		assert.Equal(t, model.SidebarCategoryDirectMessages, res.Categories[2].Type)
 
-		res2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID2, team.Id)
+		res2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID2, team.Id, false)
 		assert.NoError(t, err)
 		assert.Equal(t, res, res2)
 	})
@@ -127,7 +127,7 @@ func testCreateInitialSidebarCategories(t *testing.T, rctx request.CTX, ss store
 		assert.Equal(t, model.SidebarCategoryChannels, res.Categories[1].Type)
 		assert.Equal(t, model.SidebarCategoryDirectMessages, res.Categories[2].Type)
 
-		res2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team2.Id)
+		res2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team2.Id, false)
 		assert.NoError(t, err)
 		assert.Equal(t, res, res2)
 	})
@@ -145,7 +145,7 @@ func testCreateInitialSidebarCategories(t *testing.T, rctx request.CTX, ss store
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 		require.Equal(t, res, initialCategories)
 
@@ -154,7 +154,7 @@ func testCreateInitialSidebarCategories(t *testing.T, rctx request.CTX, ss store
 		assert.NoError(t, nErr)
 		assert.NotEmpty(t, res)
 
-		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		assert.NoError(t, err)
 		assert.Equal(t, initialCategories.Categories, res.Categories)
 	})
@@ -182,7 +182,7 @@ func testCreateInitialSidebarCategories(t *testing.T, rctx request.CTX, ss store
 
 		wg.Wait()
 
-		res, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		res, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		assert.NoError(t, err)
 		assert.Len(t, res.Categories, 3)
 	})
@@ -243,7 +243,7 @@ func testCreateInitialSidebarCategories(t *testing.T, rctx request.CTX, ss store
 		assert.Equal(t, []string{channel2.Id}, categories.Categories[1].Channels)
 
 		// Get and check the categories for channels
-		categories2, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories2, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, nErr)
 		require.Equal(t, categories, categories2)
 	})
@@ -310,7 +310,7 @@ func testCreateInitialSidebarCategories(t *testing.T, rctx request.CTX, ss store
 		assert.Equal(t, []string{channel2.Id, channel1.Id}, categories.Categories[0].Channels)
 
 		// Get and check the categories for channels
-		categories2, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories2, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, nErr)
 		require.Equal(t, categories, categories2)
 	})
@@ -380,7 +380,7 @@ func testCreateInitialSidebarCategories(t *testing.T, rctx request.CTX, ss store
 		assert.Equal(t, []string{dmChannel2.Id}, categories.Categories[2].Channels)
 
 		// Get and check the categories for channels
-		categories2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 		require.Equal(t, categories, categories2)
 	})
@@ -429,7 +429,7 @@ func testCreateInitialSidebarCategories(t *testing.T, rctx request.CTX, ss store
 		assert.Equal(t, []string{}, categories.Categories[1].Channels)
 
 		// Get and check the categories for channels
-		categories2, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories2, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, nErr)
 		require.Equal(t, categories, categories2)
 	})
@@ -474,7 +474,7 @@ func testCreateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, err)
 
 		// Confirm that it comes second
-		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 		require.Len(t, res.Categories, 4)
 		assert.Equal(t, model.SidebarCategoryFavorites, res.Categories[0].Type)
@@ -496,7 +496,7 @@ func testCreateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NotEmpty(t, res)
 
 		// Re-arrange the categories so that Favorites comes last
-		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 		require.Len(t, categories.Categories, 3)
 		require.Equal(t, model.SidebarCategoryFavorites, categories.Categories[0].Type)
@@ -517,7 +517,7 @@ func testCreateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, err)
 
 		// Confirm that it comes first
-		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 		require.Len(t, res.Categories, 4)
 		assert.Equal(t, model.SidebarCategoryCustom, res.Categories[0].Type)
@@ -578,7 +578,7 @@ func testCreateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 		require.Len(t, categories.Categories, 3)
 
@@ -652,7 +652,7 @@ func testCreateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, err)
 
 		// Confirm that sorting value is correct
-		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 		require.Len(t, res.Categories, 4)
 		// first category will be favorites and second will be newly created
@@ -714,7 +714,7 @@ func testGetSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store, s Sq
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 
 		channelsCategory := categories.Categories[1]
@@ -782,7 +782,7 @@ func testGetSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store, s Sq
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 		require.Equal(t, model.SidebarCategoryChannels, categories.Categories[1].Type)
 
@@ -825,7 +825,7 @@ func testGetSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store, s Sq
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory := categories.Categories[0]
@@ -892,7 +892,7 @@ func testGetSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store, s Sq
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 		require.Equal(t, model.SidebarCategoryDirectMessages, categories.Categories[2].Type)
 
@@ -937,7 +937,7 @@ func testGetSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store, s Sq
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 		require.Equal(t, model.SidebarCategoryDirectMessages, categories.Categories[2].Type)
 
@@ -979,7 +979,7 @@ func testGetSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store, s Sq
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 		require.Equal(t, model.SidebarCategoryDirectMessages, categories.Categories[2].Type)
 
@@ -1059,7 +1059,7 @@ func testGetSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store) {
 		gotCategory, err := ss.Channel().GetSidebarCategory(newCategory.Id)
 		require.NoError(t, err)
 
-		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 		require.Len(t, res.Categories, 4)
 
@@ -1146,7 +1146,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, err)
 		require.NotEmpty(t, res)
 
-		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory := initialCategories.Categories[0]
@@ -1181,7 +1181,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory := initialCategories.Categories[0]
@@ -1250,7 +1250,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory := categories.Categories[0]
@@ -1311,7 +1311,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory := categories.Categories[0]
@@ -1378,7 +1378,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory := categories.Categories[0]
@@ -1392,7 +1392,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team2.Id)
+		categories2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team2.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory2 := categories2.Categories[0]
@@ -1479,7 +1479,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory := categories.Categories[0]
@@ -1492,7 +1492,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID2, team.Id)
+		categories2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID2, team.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory2 := categories2.Categories[0]
@@ -1630,7 +1630,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NotEmpty(t, res)
 
 		// And some categories
-		initialCategories, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		initialCategories, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, nErr)
 
 		channelsCategory := initialCategories.Categories[1]
@@ -1690,7 +1690,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NotEmpty(t, res)
 
 		// The DM should start in the DMs category
-		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 
 		dmsCategory := initialCategories.Categories[2]
@@ -1761,7 +1761,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		initialCategories, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		initialCategories, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, nErr)
 
 		channelsCategory := initialCategories.Categories[1]
@@ -1814,7 +1814,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		initialCategories, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		initialCategories, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, nErr)
 
 		channelsCategory := initialCategories.Categories[1]
@@ -1865,7 +1865,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		require.NoError(t, err)
 		require.NotEmpty(t, res)
 
-		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory := initialCategories.Categories[0]
@@ -1903,7 +1903,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		require.NoError(t, err)
 		require.NotEmpty(t, res)
 
-		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory := initialCategories.Categories[0]
@@ -1934,7 +1934,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory := initialCategories.Categories[0]
@@ -2005,7 +2005,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory := categories.Categories[0]
@@ -2070,7 +2070,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory := categories.Categories[0]
@@ -2141,7 +2141,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory := categories.Categories[0]
@@ -2155,7 +2155,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team2.Id)
+		categories2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team2.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory2 := categories2.Categories[0]
@@ -2250,7 +2250,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		categories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory := categories.Categories[0]
@@ -2263,7 +2263,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		categories2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID2, team.Id)
+		categories2, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID2, team.Id, false)
 		require.NoError(t, err)
 
 		favoritesCategory2 := categories2.Categories[0]
@@ -2425,7 +2425,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		require.NotEmpty(t, res)
 
 		// And some categories
-		initialCategories, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		initialCategories, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, nErr)
 
 		channelsCategory := initialCategories.Categories[1]
@@ -2484,7 +2484,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		require.NotEmpty(t, res)
 
 		// The DM should start in the DMs category
-		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, err)
 
 		dmsCategory := initialCategories.Categories[2]
@@ -2575,7 +2575,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		initialCategories, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		initialCategories, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, nErr)
 
 		channelsCategory := initialCategories.Categories[1]
@@ -2643,7 +2643,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		require.NoError(t, nErr)
 		require.NotEmpty(t, res)
 
-		initialCategories, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+		initialCategories, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 		require.NoError(t, nErr)
 
 		channelsCategory := initialCategories.Categories[1]
@@ -2705,7 +2705,7 @@ func setupInitialSidebarCategories(t *testing.T, rctx request.CTX, ss store.Stor
 	require.NoError(t, nErr)
 	require.NotEmpty(t, res)
 
-	res, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+	res, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 	require.NoError(t, err)
 	require.Len(t, res.Categories, 3)
 
@@ -2832,7 +2832,7 @@ func testClearSidebarOnTeamLeave(t *testing.T, rctx request.CTX, ss store.Store,
 		require.NoError(t, err)
 		require.NotEmpty(t, res)
 
-		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team2.Id)
+		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team2.Id, false)
 		require.NoError(t, err)
 		require.Len(t, res.Categories, 3)
 
@@ -2889,7 +2889,7 @@ func testClearSidebarOnTeamLeave(t *testing.T, rctx request.CTX, ss store.Store,
 		assert.Equal(t, int64(2), count)
 
 		// Confirm that the categories on the second team are unchanged
-		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team2.Id)
+		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team2.Id, false)
 		require.NoError(t, err)
 		assert.Len(t, res.Categories, 4)
 
@@ -2908,7 +2908,7 @@ func testDeleteSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store, s
 		require.NotNil(t, newCategory)
 
 		// Ensure that the category was created properly
-		res, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, teamID)
+		res, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, teamID, false)
 		require.NoError(t, err)
 		require.Len(t, res.Categories, 4)
 
@@ -2916,7 +2916,7 @@ func testDeleteSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store, s
 		err = ss.Channel().DeleteSidebarCategory(newCategory.Id)
 		assert.NoError(t, err)
 
-		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, teamID)
+		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, teamID, false)
 		require.NoError(t, err)
 		require.Len(t, res.Categories, 3)
 	})
@@ -2960,7 +2960,7 @@ func testDeleteSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store, s
 		require.NotNil(t, newCategory)
 
 		// Ensure that the categories are set up correctly
-		res, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, teamID)
+		res, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, teamID, false)
 		require.NoError(t, err)
 		require.Len(t, res.Categories, 4)
 
@@ -2972,7 +2972,7 @@ func testDeleteSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store, s
 		assert.NoError(t, err)
 
 		// Confirm that the category was deleted...
-		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, teamID)
+		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userID, teamID, false)
 		assert.NoError(t, err)
 		assert.Len(t, res.Categories, 3)
 
@@ -2992,7 +2992,7 @@ func testDeleteSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store, s
 	t.Run("should not allow you to remove non-custom categories", func(t *testing.T) {
 		userID, teamID := setupInitialSidebarCategories(t, rctx, ss)
 		defer ss.User().PermanentDelete(rctx, userID)
-		res, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, teamID)
+		res, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, teamID, false)
 		require.NoError(t, err)
 		require.Len(t, res.Categories, 3)
 		require.Equal(t, model.SidebarCategoryFavorites, res.Categories[0].Type)
@@ -3094,7 +3094,7 @@ func testSidebarCategoryDeadlock(t *testing.T, rctx request.CTX, ss store.Store)
 	require.NoError(t, err)
 	require.NotEmpty(t, res)
 
-	initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id)
+	initialCategories, err := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
 	require.NoError(t, err)
 
 	channelsCategory := initialCategories.Categories[1]

--- a/server/channels/store/storetest/channel_store_categories.go
+++ b/server/channels/store/storetest/channel_store_categories.go
@@ -604,7 +604,7 @@ func testCreateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		// Assign them to categories
 		favoritesCategory.Channels = []string{channel1.Id}
 		channelsCategory.Channels = []string{channel2.Id}
-		_, _, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
 			favoritesCategory,
 			channelsCategory,
 		})
@@ -863,7 +863,7 @@ func testGetSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store, s Sq
 		require.NoError(t, nErr)
 
 		// And assign one to another category
-		_, _, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: favoritesCategory.SidebarCategory,
 				Channels:        []string{channel2.Id},
@@ -1154,7 +1154,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		dmsCategory := initialCategories.Categories[2]
 
 		// And then update one of them
-		updated, _, err := ss.Channel().UpdateSidebarCategory(channelsCategory)
+		updated, err := ss.Channel().UpdateSidebarCategory(channelsCategory)
 		require.NoError(t, err)
 		assert.Equal(t, channelsCategory, updated)
 		assert.Equal(t, "Channels", updated.DisplayName)
@@ -1192,7 +1192,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, err)
 
 		// Try to change the type of Favorites
-		updatedFavoritesCategory, _, err := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		updatedFavoritesCategory, err := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: model.SidebarCategory{
 				Id:          favoritesCategory.Id,
 				DisplayName: "something else",
@@ -1203,7 +1203,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		assert.Equal(t, "Favorites", updatedFavoritesCategory.DisplayName)
 
 		// Try to change the type of Channels
-		updatedChannelsCategory, _, err := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		updatedChannelsCategory, err := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: model.SidebarCategory{
 				Id:   channelsCategory.Id,
 				Type: model.SidebarCategoryDirectMessages,
@@ -1214,7 +1214,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		assert.Equal(t, "Channels", updatedChannelsCategory.DisplayName)
 
 		// Try to change the Channels of DMs
-		updatedDMsCategory, _, err := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		updatedDMsCategory, err := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: dmsCategory.SidebarCategory,
 			Channels:        []string{"fakechannel"},
 		})
@@ -1222,7 +1222,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		assert.Equal(t, []string{}, updatedDMsCategory.Channels)
 
 		// Try to change the UserId/TeamId of a custom category
-		updatedCustomCategory, _, err := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		updatedCustomCategory, err := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: model.SidebarCategory{
 				Id:          customCategory.Id,
 				UserId:      model.NewId(),
@@ -1271,7 +1271,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, nErr)
 
 		// Assign it to favorites
-		_, _, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: favoritesCategory.SidebarCategory,
 			Channels:        []string{channel.Id},
 		})
@@ -1286,7 +1286,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		channelsCategory := categories.Categories[1]
 		require.Equal(t, model.SidebarCategoryChannels, channelsCategory.Type)
 
-		_, _, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: channelsCategory.SidebarCategory,
 			Channels:        []string{channel.Id},
 		})
@@ -1337,7 +1337,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		assert.NoError(t, nErr)
 
 		// Assign it to favorites
-		_, _, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: favoritesCategory.SidebarCategory,
 			Channels:        []string{dmChannel.Id},
 		})
@@ -1352,7 +1352,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		dmsCategory := categories.Categories[2]
 		require.Equal(t, model.SidebarCategoryDirectMessages, dmsCategory.Type)
 
-		_, _, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: dmsCategory.SidebarCategory,
 			Channels:        []string{dmChannel.Id},
 		})
@@ -1418,7 +1418,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		assert.NoError(t, nErr)
 
 		// Assign it to favorites on the first team. The favorites preference gets set for all teams.
-		_, _, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: favoritesCategory.SidebarCategory,
 			Channels:        []string{dmChannel.Id},
 		})
@@ -1430,7 +1430,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		assert.Equal(t, "true", res2.Value)
 
 		// Assign it to favorites on the second team. The favorites preference is already set.
-		updated, _, err := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		updated, err := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: favoritesCategory2.SidebarCategory,
 			Channels:        []string{dmChannel.Id},
 		})
@@ -1443,7 +1443,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		assert.Equal(t, "true", res2.Value)
 
 		// Remove it from favorites on the first team. This clears the favorites preference for all teams.
-		_, _, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: favoritesCategory.SidebarCategory,
 			Channels:        []string{},
 		})
@@ -1454,7 +1454,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		assert.Nil(t, res2)
 
 		// Remove it from favorites on the second team. The favorites preference was already deleted.
-		_, _, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: favoritesCategory2.SidebarCategory,
 			Channels:        []string{},
 		})
@@ -1521,7 +1521,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, nErr)
 
 		// Have user1 favorite it
-		_, _, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: favoritesCategory.SidebarCategory,
 			Channels:        []string{channel.Id},
 		})
@@ -1537,7 +1537,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		assert.Nil(t, res2)
 
 		// And user2 favorite it
-		_, _, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: favoritesCategory2.SidebarCategory,
 			Channels:        []string{channel.Id},
 		})
@@ -1554,7 +1554,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		assert.Equal(t, "true", res2.Value)
 
 		// And then user1 unfavorite it
-		_, _, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: channelsCategory.SidebarCategory,
 			Channels:        []string{channel.Id},
 		})
@@ -1570,7 +1570,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		assert.Equal(t, "true", res2.Value)
 
 		// And finally user2 favorite it
-		_, _, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: channelsCategory2.SidebarCategory,
 			Channels:        []string{channel.Id},
 		})
@@ -1640,7 +1640,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.Equal(t, []string{dmChannel.Id}, dmsCategory.Channels)
 
 		// Try to save the Channels categories with no channels in it
-		updatedChannelsCategory, _, nErr := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		updatedChannelsCategory, nErr := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: channelsCategory.SidebarCategory,
 			Channels:        []string{},
 		})
@@ -1650,7 +1650,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		assert.Equal(t, []string{channel.Id}, updatedChannelsCategory.Channels)
 
 		// Try to save the DMs categories with no channels in it
-		updatedDMsCategory, _, nErr := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		updatedDMsCategory, nErr := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: dmsCategory.SidebarCategory,
 			Channels:        []string{},
 		})
@@ -1700,7 +1700,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		customCategory, err := ss.Channel().CreateSidebarCategory(userID, team.Id, &model.SidebarCategoryWithChannels{})
 		require.NoError(t, err)
 
-		responseCategory, _, err := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		responseCategory, err := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: customCategory.SidebarCategory,
 			Channels:        []string{dmChannel.Id},
 		})
@@ -1717,7 +1717,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		assert.Equal(t, []string{dmChannel.Id}, updatedCustomCategory.Channels)
 
 		// And move it back out of the custom category
-		responseCategory, _, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		responseCategory, err = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: customCategory.SidebarCategory,
 			Channels:        []string{},
 		})
@@ -1771,7 +1771,7 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, nErr)
 
 		// Move the channel one way
-		updatedCustomCategory, _, nErr := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		updatedCustomCategory, nErr := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: customCategory.SidebarCategory,
 			Channels:        []string{channel.Id},
 		})
@@ -1779,75 +1779,12 @@ func testUpdateSidebarCategory(t *testing.T, rctx request.CTX, ss store.Store) {
 		assert.Equal(t, []string{channel.Id}, updatedCustomCategory.Channels)
 
 		// And then the other
-		updatedChannelsCategory, _, nErr := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
+		updatedChannelsCategory, nErr := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
 			SidebarCategory: channelsCategory.SidebarCategory,
 			Channels:        []string{channel.Id},
 		})
 		assert.NoError(t, nErr)
 		assert.Equal(t, []string{channel.Id}, updatedChannelsCategory.Channels)
-	})
-
-	t.Run("should correctly return the original category that was modified", func(t *testing.T) {
-		userID := model.NewId()
-		team := setupTeam(t, rctx, ss, userID)
-
-		// Join a channel
-		channel, nErr := ss.Channel().Save(rctx, &model.Channel{
-			Name:   "channel",
-			Type:   model.ChannelTypeOpen,
-			TeamId: team.Id,
-		}, 10)
-		require.NoError(t, nErr)
-		_, err := ss.Channel().SaveMember(rctx, &model.ChannelMember{
-			UserId:      userID,
-			ChannelId:   channel.Id,
-			NotifyProps: model.GetDefaultChannelNotifyProps(),
-		})
-		require.NoError(t, err)
-
-		// And then create the initial categories so that Channels includes the channel
-		opts := &store.SidebarCategorySearchOpts{
-			TeamID:      team.Id,
-			ExcludeTeam: false,
-		}
-		res, nErr := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
-		require.NoError(t, nErr)
-		require.NotEmpty(t, res)
-
-		initialCategories, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
-		require.NoError(t, nErr)
-
-		channelsCategory := initialCategories.Categories[1]
-		require.Equal(t, []string{channel.Id}, channelsCategory.Channels)
-
-		customCategory, nErr := ss.Channel().CreateSidebarCategory(userID, team.Id, &model.SidebarCategoryWithChannels{
-			SidebarCategory: model.SidebarCategory{
-				DisplayName: "originalName",
-			},
-		})
-		require.NoError(t, nErr)
-
-		// Rename the custom category
-		updatedCustomCategory, originalCustomCategory, nErr := ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
-			SidebarCategory: model.SidebarCategory{
-				Id:          customCategory.Id,
-				DisplayName: "updatedName",
-			},
-		})
-		require.NoError(t, nErr)
-		assert.Equal(t, "originalName", originalCustomCategory.DisplayName)
-		assert.Equal(t, "updatedName", updatedCustomCategory.DisplayName)
-
-		// Move a channel
-		updatedCustomCategory, originalCustomCategory, nErr = ss.Channel().UpdateSidebarCategory(&model.SidebarCategoryWithChannels{
-			SidebarCategory: customCategory.SidebarCategory,
-			Channels:        []string{channel.Id},
-		})
-		require.NoError(t, nErr)
-		require.Equal(t, updatedCustomCategory.Id, originalCustomCategory.Id)
-
-		assert.Equal(t, []string{}, originalCustomCategory.Channels)
-		assert.Equal(t, []string{channel.Id}, updatedCustomCategory.Channels)
 	})
 }
 
@@ -1873,7 +1810,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		dmsCategory := initialCategories.Categories[2]
 
 		// And then update one of them
-		updated, _, err := ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
+		updated, err := ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
 			channelsCategory,
 		})
 		require.NoError(t, err)
@@ -1911,7 +1848,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		dmsCategory := initialCategories.Categories[2]
 
 		// And then update them
-		updatedCategories, _, err := ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
+		updatedCategories, err := ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
 			favoritesCategory,
 			channelsCategory,
 			dmsCategory,
@@ -1979,7 +1916,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 			},
 		}
 
-		updatedCategories, _, err := ss.Channel().UpdateSidebarCategories(userID, team.Id, categoriesToUpdate)
+		updatedCategories, err := ss.Channel().UpdateSidebarCategories(userID, team.Id, categoriesToUpdate)
 		assert.NoError(t, err)
 
 		assert.NotEqual(t, "Favorites", categoriesToUpdate[0].DisplayName)
@@ -2026,7 +1963,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		require.NoError(t, nErr)
 
 		// Assign it to favorites
-		_, _, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: favoritesCategory.SidebarCategory,
 				Channels:        []string{channel.Id},
@@ -2043,7 +1980,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		channelsCategory := categories.Categories[1]
 		require.Equal(t, model.SidebarCategoryChannels, channelsCategory.Type)
 
-		_, _, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: channelsCategory.SidebarCategory,
 				Channels:        []string{channel.Id},
@@ -2096,7 +2033,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		assert.NoError(t, nErr)
 
 		// Assign it to favorites
-		_, _, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: favoritesCategory.SidebarCategory,
 				Channels:        []string{dmChannel.Id},
@@ -2113,7 +2050,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		dmsCategory := categories.Categories[2]
 		require.Equal(t, model.SidebarCategoryDirectMessages, dmsCategory.Type)
 
-		_, _, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: dmsCategory.SidebarCategory,
 				Channels:        []string{dmChannel.Id},
@@ -2181,7 +2118,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		assert.NoError(t, nErr)
 
 		// Assign it to favorites on the first team. The favorites preference gets set for all teams.
-		_, _, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: favoritesCategory.SidebarCategory,
 				Channels:        []string{dmChannel.Id},
@@ -2195,7 +2132,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		assert.Equal(t, "true", res2.Value)
 
 		// Assign it to favorites on the second team. The favorites preference is already set.
-		updated, _, err := ss.Channel().UpdateSidebarCategories(userID, team2.Id, []*model.SidebarCategoryWithChannels{
+		updated, err := ss.Channel().UpdateSidebarCategories(userID, team2.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: favoritesCategory2.SidebarCategory,
 				Channels:        []string{dmChannel.Id},
@@ -2210,7 +2147,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		assert.Equal(t, "true", res2.Value)
 
 		// Remove it from favorites on the first team. This clears the favorites preference for all teams.
-		_, _, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: favoritesCategory.SidebarCategory,
 				Channels:        []string{},
@@ -2223,7 +2160,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		assert.Nil(t, res2)
 
 		// Remove it from favorites on the second team. The favorites preference was already deleted.
-		_, _, err = ss.Channel().UpdateSidebarCategories(userID, team2.Id, []*model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategories(userID, team2.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: favoritesCategory2.SidebarCategory,
 				Channels:        []string{},
@@ -2292,7 +2229,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		require.NoError(t, nErr)
 
 		// Have user1 favorite it
-		_, _, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: favoritesCategory.SidebarCategory,
 				Channels:        []string{channel.Id},
@@ -2314,7 +2251,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		assert.Nil(t, res2)
 
 		// And user2 favorite it
-		_, _, err = ss.Channel().UpdateSidebarCategories(userID2, team.Id, []*model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategories(userID2, team.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: favoritesCategory2.SidebarCategory,
 				Channels:        []string{channel.Id},
@@ -2337,7 +2274,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		assert.Equal(t, "true", res2.Value)
 
 		// And then user1 unfavorite it
-		_, _, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: channelsCategory.SidebarCategory,
 				Channels:        []string{channel.Id},
@@ -2359,7 +2296,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		assert.Equal(t, "true", res2.Value)
 
 		// And finally user2 favorite it
-		_, _, err = ss.Channel().UpdateSidebarCategories(userID2, team.Id, []*model.SidebarCategoryWithChannels{
+		_, err = ss.Channel().UpdateSidebarCategories(userID2, team.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: channelsCategory2.SidebarCategory,
 				Channels:        []string{channel.Id},
@@ -2446,7 +2383,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 			},
 		}
 
-		updatedCategories, _, nErr := ss.Channel().UpdateSidebarCategories(userID, team.Id, categoriesToUpdate)
+		updatedCategories, nErr := ss.Channel().UpdateSidebarCategories(userID, team.Id, categoriesToUpdate)
 		assert.NoError(t, nErr)
 
 		// The channels should still exist in the category because they would otherwise be orphaned
@@ -2505,7 +2442,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 			},
 		}
 
-		updatedCategories, _, err := ss.Channel().UpdateSidebarCategories(userID, team.Id, categoriesToUpdate)
+		updatedCategories, err := ss.Channel().UpdateSidebarCategories(userID, team.Id, categoriesToUpdate)
 		assert.NoError(t, err)
 		assert.Equal(t, dmsCategory.Id, updatedCategories[0].Id)
 		assert.Equal(t, []string{}, updatedCategories[0].Channels)
@@ -2532,7 +2469,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 			},
 		}
 
-		updatedCategories, _, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, categoriesToUpdate)
+		updatedCategories, err = ss.Channel().UpdateSidebarCategories(userID, team.Id, categoriesToUpdate)
 		assert.NoError(t, err)
 		assert.Equal(t, dmsCategory.Id, updatedCategories[0].Id)
 		assert.Equal(t, []string{dmChannel.Id}, updatedCategories[0].Channels)
@@ -2585,7 +2522,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		require.NoError(t, nErr)
 
 		// Move the channel one way
-		updatedCategories, _, nErr := ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
+		updatedCategories, nErr := ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: channelsCategory.SidebarCategory,
 				Channels:        []string{},
@@ -2601,7 +2538,7 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		assert.Equal(t, []string{channel.Id}, updatedCategories[1].Channels)
 
 		// And then the other
-		updatedCategories, _, nErr = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
+		updatedCategories, nErr = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: channelsCategory.SidebarCategory,
 				Channels:        []string{channel.Id},
@@ -2614,82 +2551,6 @@ func testUpdateSidebarCategories(t *testing.T, rctx request.CTX, ss store.Store)
 		assert.NoError(t, nErr)
 		assert.Equal(t, []string{channel.Id}, updatedCategories[0].Channels)
 		assert.Equal(t, []string{}, updatedCategories[1].Channels)
-	})
-
-	t.Run("should correctly return the original categories that were modified", func(t *testing.T) {
-		userID := model.NewId()
-		team := setupTeam(t, rctx, ss, userID)
-
-		// Join a channel
-		channel, nErr := ss.Channel().Save(rctx, &model.Channel{
-			Name:   "channel",
-			Type:   model.ChannelTypeOpen,
-			TeamId: team.Id,
-		}, 10)
-		require.NoError(t, nErr)
-		_, err := ss.Channel().SaveMember(rctx, &model.ChannelMember{
-			UserId:      userID,
-			ChannelId:   channel.Id,
-			NotifyProps: model.GetDefaultChannelNotifyProps(),
-		})
-		require.NoError(t, err)
-
-		// And then create the initial categories so that Channels includes the channel
-		opts := &store.SidebarCategorySearchOpts{
-			TeamID:      team.Id,
-			ExcludeTeam: false,
-		}
-		res, nErr := ss.Channel().CreateInitialSidebarCategories(rctx, userID, opts)
-		require.NoError(t, nErr)
-		require.NotEmpty(t, res)
-
-		initialCategories, nErr := ss.Channel().GetSidebarCategoriesForTeamForUser(userID, team.Id, false)
-		require.NoError(t, nErr)
-
-		channelsCategory := initialCategories.Categories[1]
-		require.Equal(t, []string{channel.Id}, channelsCategory.Channels)
-
-		customCategory, nErr := ss.Channel().CreateSidebarCategory(userID, team.Id, &model.SidebarCategoryWithChannels{
-			SidebarCategory: model.SidebarCategory{
-				DisplayName: "originalName",
-			},
-		})
-		require.NoError(t, nErr)
-
-		// Rename the custom category
-		updatedCategories, originalCategories, nErr := ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
-			{
-				SidebarCategory: model.SidebarCategory{
-					Id:          customCategory.Id,
-					DisplayName: "updatedName",
-				},
-			},
-		})
-		require.NoError(t, nErr)
-		require.Equal(t, len(updatedCategories), len(originalCategories))
-		assert.Equal(t, "originalName", originalCategories[0].DisplayName)
-		assert.Equal(t, "updatedName", updatedCategories[0].DisplayName)
-
-		// Move a channel
-		updatedCategories, originalCategories, nErr = ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
-			{
-				SidebarCategory: channelsCategory.SidebarCategory,
-				Channels:        []string{},
-			},
-			{
-				SidebarCategory: customCategory.SidebarCategory,
-				Channels:        []string{channel.Id},
-			},
-		})
-		require.NoError(t, nErr)
-		require.Equal(t, len(updatedCategories), len(originalCategories))
-		require.Equal(t, updatedCategories[0].Id, originalCategories[0].Id)
-		require.Equal(t, updatedCategories[1].Id, originalCategories[1].Id)
-
-		assert.Equal(t, []string{channel.Id}, originalCategories[0].Channels)
-		assert.Equal(t, []string{}, updatedCategories[0].Channels)
-		assert.Equal(t, []string{}, originalCategories[1].Channels)
-		assert.Equal(t, []string{channel.Id}, updatedCategories[1].Channels)
 	})
 }
 
@@ -3108,7 +2969,7 @@ func testSidebarCategoryDeadlock(t *testing.T, rctx request.CTX, ss store.Store)
 
 	go func() {
 		defer wg.Done()
-		_, _, err := ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
+		_, err := ss.Channel().UpdateSidebarCategories(userID, team.Id, []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: channelsCategory.SidebarCategory,
 				Channels:        []string{},

--- a/server/channels/store/storetest/mocks/ChannelStore.go
+++ b/server/channels/store/storetest/mocks/ChannelStore.go
@@ -1968,9 +1968,9 @@ func (_m *ChannelStore) GetSidebarCategories(userID string, opts *store.SidebarC
 	return r0, r1
 }
 
-// GetSidebarCategoriesForTeamForUser provides a mock function with given fields: userID, teamID
-func (_m *ChannelStore) GetSidebarCategoriesForTeamForUser(userID string, teamID string) (*model.OrderedSidebarCategories, error) {
-	ret := _m.Called(userID, teamID)
+// GetSidebarCategoriesForTeamForUser provides a mock function with given fields: userID, teamID, fromMaster
+func (_m *ChannelStore) GetSidebarCategoriesForTeamForUser(userID string, teamID string, fromMaster bool) (*model.OrderedSidebarCategories, error) {
+	ret := _m.Called(userID, teamID, fromMaster)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetSidebarCategoriesForTeamForUser")
@@ -1978,19 +1978,19 @@ func (_m *ChannelStore) GetSidebarCategoriesForTeamForUser(userID string, teamID
 
 	var r0 *model.OrderedSidebarCategories
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string) (*model.OrderedSidebarCategories, error)); ok {
-		return rf(userID, teamID)
+	if rf, ok := ret.Get(0).(func(string, string, bool) (*model.OrderedSidebarCategories, error)); ok {
+		return rf(userID, teamID, fromMaster)
 	}
-	if rf, ok := ret.Get(0).(func(string, string) *model.OrderedSidebarCategories); ok {
-		r0 = rf(userID, teamID)
+	if rf, ok := ret.Get(0).(func(string, string, bool) *model.OrderedSidebarCategories); ok {
+		r0 = rf(userID, teamID, fromMaster)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.OrderedSidebarCategories)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(userID, teamID)
+	if rf, ok := ret.Get(1).(func(string, string, bool) error); ok {
+		r1 = rf(userID, teamID, fromMaster)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/storetest/mocks/ChannelStore.go
+++ b/server/channels/store/storetest/mocks/ChannelStore.go
@@ -3061,7 +3061,7 @@ func (_m *ChannelStore) UpdateMultipleMembers(members []*model.ChannelMember) ([
 }
 
 // UpdateSidebarCategories provides a mock function with given fields: userID, teamID, categories
-func (_m *ChannelStore) UpdateSidebarCategories(userID string, teamID string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, []*model.SidebarCategoryWithChannels, error) {
+func (_m *ChannelStore) UpdateSidebarCategories(userID string, teamID string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, error) {
 	ret := _m.Called(userID, teamID, categories)
 
 	if len(ret) == 0 {
@@ -3069,9 +3069,8 @@ func (_m *ChannelStore) UpdateSidebarCategories(userID string, teamID string, ca
 	}
 
 	var r0 []*model.SidebarCategoryWithChannels
-	var r1 []*model.SidebarCategoryWithChannels
-	var r2 error
-	if rf, ok := ret.Get(0).(func(string, string, []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, []*model.SidebarCategoryWithChannels, error)); ok {
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, string, []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, error)); ok {
 		return rf(userID, teamID, categories)
 	}
 	if rf, ok := ret.Get(0).(func(string, string, []*model.SidebarCategoryWithChannels) []*model.SidebarCategoryWithChannels); ok {
@@ -3082,25 +3081,17 @@ func (_m *ChannelStore) UpdateSidebarCategories(userID string, teamID string, ca
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, string, []*model.SidebarCategoryWithChannels) []*model.SidebarCategoryWithChannels); ok {
+	if rf, ok := ret.Get(1).(func(string, string, []*model.SidebarCategoryWithChannels) error); ok {
 		r1 = rf(userID, teamID, categories)
 	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).([]*model.SidebarCategoryWithChannels)
-		}
+		r1 = ret.Error(1)
 	}
 
-	if rf, ok := ret.Get(2).(func(string, string, []*model.SidebarCategoryWithChannels) error); ok {
-		r2 = rf(userID, teamID, categories)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
+	return r0, r1
 }
 
 // UpdateSidebarCategory provides a mock function with given fields: category
-func (_m *ChannelStore) UpdateSidebarCategory(category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, *model.SidebarCategoryWithChannels, error) {
+func (_m *ChannelStore) UpdateSidebarCategory(category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error) {
 	ret := _m.Called(category)
 
 	if len(ret) == 0 {
@@ -3108,9 +3099,8 @@ func (_m *ChannelStore) UpdateSidebarCategory(category *model.SidebarCategoryWit
 	}
 
 	var r0 *model.SidebarCategoryWithChannels
-	var r1 *model.SidebarCategoryWithChannels
-	var r2 error
-	if rf, ok := ret.Get(0).(func(*model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, *model.SidebarCategoryWithChannels, error)); ok {
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error)); ok {
 		return rf(category)
 	}
 	if rf, ok := ret.Get(0).(func(*model.SidebarCategoryWithChannels) *model.SidebarCategoryWithChannels); ok {
@@ -3121,21 +3111,13 @@ func (_m *ChannelStore) UpdateSidebarCategory(category *model.SidebarCategoryWit
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*model.SidebarCategoryWithChannels) *model.SidebarCategoryWithChannels); ok {
+	if rf, ok := ret.Get(1).(func(*model.SidebarCategoryWithChannels) error); ok {
 		r1 = rf(category)
 	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*model.SidebarCategoryWithChannels)
-		}
+		r1 = ret.Error(1)
 	}
 
-	if rf, ok := ret.Get(2).(func(*model.SidebarCategoryWithChannels) error); ok {
-		r2 = rf(category)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
+	return r0, r1
 }
 
 // UpdateSidebarCategoryOrder provides a mock function with given fields: userID, teamID, categoryOrder

--- a/server/channels/store/storetest/mocks/ChannelStore.go
+++ b/server/channels/store/storetest/mocks/ChannelStore.go
@@ -3099,6 +3099,45 @@ func (_m *ChannelStore) UpdateSidebarCategories(userID string, teamID string, ca
 	return r0, r1, r2
 }
 
+// UpdateSidebarCategory provides a mock function with given fields: category
+func (_m *ChannelStore) UpdateSidebarCategory(category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, *model.SidebarCategoryWithChannels, error) {
+	ret := _m.Called(category)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateSidebarCategory")
+	}
+
+	var r0 *model.SidebarCategoryWithChannels
+	var r1 *model.SidebarCategoryWithChannels
+	var r2 error
+	if rf, ok := ret.Get(0).(func(*model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, *model.SidebarCategoryWithChannels, error)); ok {
+		return rf(category)
+	}
+	if rf, ok := ret.Get(0).(func(*model.SidebarCategoryWithChannels) *model.SidebarCategoryWithChannels); ok {
+		r0 = rf(category)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.SidebarCategoryWithChannels)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*model.SidebarCategoryWithChannels) *model.SidebarCategoryWithChannels); ok {
+		r1 = rf(category)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.SidebarCategoryWithChannels)
+		}
+	}
+
+	if rf, ok := ret.Get(2).(func(*model.SidebarCategoryWithChannels) error); ok {
+		r2 = rf(category)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
 // UpdateSidebarCategoryOrder provides a mock function with given fields: userID, teamID, categoryOrder
 func (_m *ChannelStore) UpdateSidebarCategoryOrder(userID string, teamID string, categoryOrder []string) error {
 	ret := _m.Called(userID, teamID, categoryOrder)

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -2624,6 +2624,22 @@ func (s *TimerLayerChannelStore) UpdateSidebarCategories(userID string, teamID s
 	return result, resultVar1, err
 }
 
+func (s *TimerLayerChannelStore) UpdateSidebarCategory(category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, *model.SidebarCategoryWithChannels, error) {
+	start := time.Now()
+
+	result, resultVar1, err := s.ChannelStore.UpdateSidebarCategory(category)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("ChannelStore.UpdateSidebarCategory", success, elapsed)
+	}
+	return result, resultVar1, err
+}
+
 func (s *TimerLayerChannelStore) UpdateSidebarCategoryOrder(userID string, teamID string, categoryOrder []string) error {
 	start := time.Now()
 

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -2608,10 +2608,10 @@ func (s *TimerLayerChannelStore) UpdateMultipleMembers(members []*model.ChannelM
 	return result, err
 }
 
-func (s *TimerLayerChannelStore) UpdateSidebarCategories(userID string, teamID string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, []*model.SidebarCategoryWithChannels, error) {
+func (s *TimerLayerChannelStore) UpdateSidebarCategories(userID string, teamID string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, error) {
 	start := time.Now()
 
-	result, resultVar1, err := s.ChannelStore.UpdateSidebarCategories(userID, teamID, categories)
+	result, err := s.ChannelStore.UpdateSidebarCategories(userID, teamID, categories)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -2621,13 +2621,13 @@ func (s *TimerLayerChannelStore) UpdateSidebarCategories(userID string, teamID s
 		}
 		s.Root.Metrics.ObserveStoreMethodDuration("ChannelStore.UpdateSidebarCategories", success, elapsed)
 	}
-	return result, resultVar1, err
+	return result, err
 }
 
-func (s *TimerLayerChannelStore) UpdateSidebarCategory(category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, *model.SidebarCategoryWithChannels, error) {
+func (s *TimerLayerChannelStore) UpdateSidebarCategory(category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error) {
 	start := time.Now()
 
-	result, resultVar1, err := s.ChannelStore.UpdateSidebarCategory(category)
+	result, err := s.ChannelStore.UpdateSidebarCategory(category)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -2637,7 +2637,7 @@ func (s *TimerLayerChannelStore) UpdateSidebarCategory(category *model.SidebarCa
 		}
 		s.Root.Metrics.ObserveStoreMethodDuration("ChannelStore.UpdateSidebarCategory", success, elapsed)
 	}
-	return result, resultVar1, err
+	return result, err
 }
 
 func (s *TimerLayerChannelStore) UpdateSidebarCategoryOrder(userID string, teamID string, categoryOrder []string) error {

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -1863,10 +1863,10 @@ func (s *TimerLayerChannelStore) GetSidebarCategories(userID string, opts *store
 	return result, err
 }
 
-func (s *TimerLayerChannelStore) GetSidebarCategoriesForTeamForUser(userID string, teamID string) (*model.OrderedSidebarCategories, error) {
+func (s *TimerLayerChannelStore) GetSidebarCategoriesForTeamForUser(userID string, teamID string, fromMaster bool) (*model.OrderedSidebarCategories, error) {
 	start := time.Now()
 
-	result, err := s.ChannelStore.GetSidebarCategoriesForTeamForUser(userID, teamID)
+	result, err := s.ChannelStore.GetSidebarCategoriesForTeamForUser(userID, teamID, fromMaster)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/channel_categories.test.js
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/channel_categories.test.js
@@ -550,8 +550,8 @@ describe('addChannelToCategory', () => {
         });
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [{...category1, channel_ids: ['channel5', 'channel1', 'channel2']}]);
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category1.id}`).
+            reply(200, {...category1, channel_ids: ['channel5', 'channel1', 'channel2']});
 
         await store.dispatch(Actions.addChannelToCategory('category1', 'channel5'));
 
@@ -583,11 +583,8 @@ describe('addChannelToCategory', () => {
         });
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [
-                {...category1, channel_ids: ['channel3', 'channel1', 'channel2']},
-                {...category2, channel_ids: ['channel4']},
-            ]);
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category1.id}`).
+            reply(200, {...category1, channel_ids: ['channel3', 'channel1', 'channel2']});
 
         await store.dispatch(Actions.addChannelToCategory('category1', 'channel3'));
 
@@ -627,8 +624,8 @@ describe('moveChannelToCategory', () => {
         });
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [{...category1, channel_ids: ['channel1', 'channel5', 'channel2']}]);
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category1.id}`).
+            reply(200, {...category1, channel_ids: ['channel1', 'channel5', 'channel2']});
 
         await store.dispatch(Actions.moveChannelToCategory('category1', 'channel5', 1));
 
@@ -639,8 +636,8 @@ describe('moveChannelToCategory', () => {
         expect(state.entities.channelCategories.byId.otherTeamCategory).toBe(otherTeamCategory);
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [{...category1, channel_ids: ['channel1', 'channel5', 'channel6', 'channel2']}]);
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category1.id}`).
+            reply(200, {...category1, channel_ids: ['channel1', 'channel5', 'channel6', 'channel2']});
 
         await store.dispatch(Actions.moveChannelToCategory('category1', 'channel6', 2));
 
@@ -672,11 +669,8 @@ describe('moveChannelToCategory', () => {
         });
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [
-                {...category1, channel_ids: ['channel2']},
-                {...category2, channel_ids: ['channel3', 'channel4', 'channel1']},
-            ]);
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category2.id}`).
+            reply(200, {...category2, channel_ids: ['channel3', 'channel4', 'channel1']});
 
         await store.dispatch(Actions.moveChannelToCategory('category2', 'channel1', 2));
 
@@ -704,8 +698,8 @@ describe('moveChannelToCategory', () => {
         });
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [{...category1, channel_ids: ['channel1', 'channel5', 'channel2', 'channel3', 'channel4']}]);
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category1.id}`).
+            reply(200, {...category1, channel_ids: ['channel1', 'aaa', 'channel5', 'channel2', 'channel3', 'channel4']});
 
         await store.dispatch(Actions.moveChannelToCategory('category1', 'channel5', 1));
 
@@ -714,8 +708,8 @@ describe('moveChannelToCategory', () => {
         expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel1', 'channel5', 'channel2', 'channel3', 'channel4']);
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [{...category1, channel_ids: ['channel5', 'channel2', 'channel3', 'channel1', 'channel4']}]);
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category1.id}`).
+            reply(200, {...category1, channel_ids: ['channel5', 'channel2', 'channel3', 'channel1', 'channel4']});
 
         await store.dispatch(Actions.moveChannelToCategory('category1', 'channel1', 3));
 
@@ -762,11 +756,8 @@ describe('moveChannelToCategory', () => {
         expect(isFavoriteChannel(state, 'channel1')).toBe(false);
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [
-                {...favoritesCategory, channel_ids: ['channel1']},
-                {...otherCategory, channel_ids: []},
-            ]);
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${favoritesCategory.id}`).
+            reply(200, {...favoritesCategory, channel_ids: ['channel1']});
 
         // Move the channel into favorites
         await store.dispatch(Actions.moveChannelToCategory('favoritesCategory', 'channel1', 0));
@@ -778,11 +769,8 @@ describe('moveChannelToCategory', () => {
         expect(isFavoriteChannel(state, 'channel1')).toBe(true);
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [
-                {...favoritesCategory, channel_ids: []},
-                {...otherCategory, channel_ids: ['channel1']},
-            ]);
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${otherCategory.id}`).
+            reply(200, {...otherCategory, channel_ids: ['channel1']});
 
         // And back out
         await store.dispatch(Actions.moveChannelToCategory('otherCategory', 'channel1', 0));
@@ -814,14 +802,13 @@ describe('moveChannelToCategory', () => {
             });
 
             nock(Client4.getBaseRoute()).
-                put(`/users/${currentUserId}/teams/${teamId}/channels/categories`, (body) => {
-                    return body.find((category) => category.id === 'category1').sorting !== CategorySorting.Manual &&
-                        body.find((category) => category.id === 'category2').sorting === CategorySorting.Manual;
+                put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category2.id}`, (body) => {
+                    return body.sorting === CategorySorting.Manual;
                 }).
-                reply(200, [
-                    {...category1, channel_ids: ['channel2']},
+                reply(
+                    200,
                     {...category2, channel_ids: ['channel1', 'channel3', 'channel4'], sorting: CategorySorting.Manual},
-                ]);
+                );
 
             await store.dispatch(Actions.moveChannelToCategory(category2.id, 'channel1', 0));
 
@@ -830,14 +817,13 @@ describe('moveChannelToCategory', () => {
             expect(state.entities.channelCategories.byId.category2.sorting).toBe(CategorySorting.Manual);
 
             nock(Client4.getBaseRoute()).
-                put(`/users/${currentUserId}/teams/${teamId}/channels/categories`, (body) => {
-                    return body.find((category) => category.id === 'category1').sorting === CategorySorting.Manual &&
-                        body.find((category) => category.id === 'category2').sorting === CategorySorting.Manual;
+                put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category1.id}`, (body) => {
+                    return body.sorting === CategorySorting.Manual;
                 }).
-                reply(200, [
+                reply(
+                    200,
                     {...category1, channel_ids: ['channel2', 'channel1'], sorting: CategorySorting.Manual},
-                    {...category2, channel_ids: ['channel3', 'channel4'], sorting: CategorySorting.Manual},
-                ]);
+                );
 
             await store.dispatch(Actions.moveChannelToCategory(category1.id, 'channel1', 2));
 
@@ -865,14 +851,10 @@ describe('moveChannelToCategory', () => {
             });
 
             nock(Client4.getBaseRoute()).
-                put(`/users/${currentUserId}/teams/${teamId}/channels/categories`, (body) => {
-                    return body.find((category) => category.id === 'category1').sorting !== CategorySorting.Manual &&
-                        body.find((category) => category.id === 'category2').sorting !== CategorySorting.Manual;
+                put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category2.id}`, (body) => {
+                    return body.sorting !== CategorySorting.Manual;
                 }).
-                reply(200, [
-                    {...category1, channel_ids: ['channel2']},
-                    {...category2, channel_ids: ['channel1', 'channel3', 'channel4']},
-                ]);
+                reply(200, {...category2, channel_ids: ['channel1', 'channel3', 'channel4']});
 
             await store.dispatch(Actions.moveChannelToCategory(category2.id, 'channel1', 0));
 
@@ -881,14 +863,13 @@ describe('moveChannelToCategory', () => {
             expect(state.entities.channelCategories.byId.category2.sorting).toBe(CategorySorting.Recency);
 
             nock(Client4.getBaseRoute()).
-                put(`/users/${currentUserId}/teams/${teamId}/channels/categories`, (body) => {
-                    return body.find((category) => category.id === 'category1').sorting !== CategorySorting.Manual &&
-                        body.find((category) => category.id === 'category2').sorting !== CategorySorting.Manual;
+                put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category1.id}`, (body) => {
+                    return body.sorting !== CategorySorting.Manual;
                 }).
-                reply(200, [
+                reply(
+                    200,
                     {...category1, channel_ids: ['channel2', 'channel1']},
-                    {...category2, channel_ids: ['channel3', 'channel4']},
-                ]);
+                );
 
             await store.dispatch(Actions.moveChannelToCategory(category1.id, 'channel1', 2));
 
@@ -917,12 +898,12 @@ describe('moveChannelToCategory', () => {
         });
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${favoritesCategory.id}`).
             delayBody(100).
-            reply(200, [
-                {...category1, channel_ids: ['channel2']},
+            reply(
+                200,
                 {...favoritesCategory, channel_ids: ['channel1'], sorting: CategorySorting.Manual},
-            ]);
+            );
 
         const moveRequest = store.dispatch(Actions.moveChannelToCategory(favoritesCategory.id, 'channel1', 0));
 
@@ -959,7 +940,7 @@ describe('moveChannelToCategory', () => {
         });
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${favoritesCategory.id}`).
             delayBody(100).
             reply(400);
 
@@ -1033,8 +1014,8 @@ describe('moveChannelsToCategory', () => {
         });
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [{...category1, channel_ids: ['channel1', 'channel5', 'channel6', 'channel2']}]);
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category1.id}`).
+            reply(200, {...category1, channel_ids: ['channel1', 'channel5', 'channel6', 'channel2']});
 
         await store.dispatch(Actions.moveChannelsToCategory('category1', ['channel5', 'channel6'], 1));
 
@@ -1045,8 +1026,8 @@ describe('moveChannelsToCategory', () => {
         expect(state.entities.channelCategories.byId.otherTeamCategory).toBe(otherTeamCategory);
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [{...category1, channel_ids: ['channel1', 'channel5', 'channel6', 'channel7', 'channel8', 'channel2']}]);
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category1.id}`).
+            reply(200, {...category1, channel_ids: ['channel1', 'channel5', 'channel6', 'channel7', 'channel8', 'channel2']});
 
         await store.dispatch(Actions.moveChannelsToCategory('category1', ['channel7', 'channel8'], 3));
 
@@ -1078,11 +1059,8 @@ describe('moveChannelsToCategory', () => {
         });
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [
-                {...category1, channel_ids: ['channel2']},
-                {...category2, channel_ids: ['channel4', 'channel5', 'channel6', 'channel1', 'channel3']},
-            ]);
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category2.id}`).
+            reply(200, {...category2, channel_ids: ['channel4', 'channel5', 'channel6', 'channel1', 'channel3']});
 
         await store.dispatch(Actions.moveChannelsToCategory('category2', ['channel1', 'channel3'], 3));
 
@@ -1110,8 +1088,8 @@ describe('moveChannelsToCategory', () => {
         });
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [{...category1, channel_ids: ['channel1', 'channel5', 'channel3', 'channel2', 'channel4']}]);
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category1.id}`).
+            reply(200, {...category1, channel_ids: ['channel1', 'channel5', 'channel3', 'channel2', 'channel4']});
 
         await store.dispatch(Actions.moveChannelsToCategory('category1', ['channel5', 'channel3'], 1));
 
@@ -1120,8 +1098,8 @@ describe('moveChannelsToCategory', () => {
         expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel1', 'channel5', 'channel3', 'channel2', 'channel4']);
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [{...category1, channel_ids: ['channel5', 'channel3', 'channel2', 'channel1', 'channel4']}]);
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category1.id}`).
+            reply(200, {...category1, channel_ids: ['channel5', 'channel3', 'channel2', 'channel1', 'channel4']});
 
         await store.dispatch(Actions.moveChannelsToCategory('category1', ['channel1', 'channel4'], 3));
 
@@ -1168,11 +1146,8 @@ describe('moveChannelsToCategory', () => {
         expect(isFavoriteChannel(state, 'channel1')).toBe(false);
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [
-                {...favoritesCategory, channel_ids: ['channel1', 'channel2']},
-                {...otherCategory, channel_ids: []},
-            ]);
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${favoritesCategory.id}`).
+            reply(200, {...favoritesCategory, channel_ids: ['channel1', 'channel2']});
 
         // Move the channel into favorites
         await store.dispatch(Actions.moveChannelsToCategory('favoritesCategory', ['channel1', 'channel2'], 0));
@@ -1185,11 +1160,8 @@ describe('moveChannelsToCategory', () => {
         expect(isFavoriteChannel(state, 'channel2')).toBe(true);
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [
-                {...favoritesCategory, channel_ids: []},
-                {...otherCategory, channel_ids: ['channel1']},
-            ]);
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${otherCategory.id}`).
+            reply(200, {...otherCategory, channel_ids: ['channel1']});
 
         // And back out
         await store.dispatch(Actions.moveChannelsToCategory('otherCategory', ['channel1', 'channel2'], 0));
@@ -1222,14 +1194,13 @@ describe('moveChannelsToCategory', () => {
             });
 
             nock(Client4.getBaseRoute()).
-                put(`/users/${currentUserId}/teams/${teamId}/channels/categories`, (body) => {
-                    return body.find((category) => category.id === 'category1').sorting !== CategorySorting.Manual &&
-                        body.find((category) => category.id === 'category2').sorting === CategorySorting.Manual;
+                put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category2.id}`, (body) => {
+                    return body.sorting === CategorySorting.Manual;
                 }).
-                reply(200, [
-                    {...category1, channel_ids: ['channel2']},
+                reply(
+                    200,
                     {...category2, channel_ids: ['channel1', 'channel3', 'channel4'], sorting: CategorySorting.Manual},
-                ]);
+                );
 
             await store.dispatch(Actions.moveChannelsToCategory(category2.id, ['channel1'], 0));
 
@@ -1238,14 +1209,13 @@ describe('moveChannelsToCategory', () => {
             expect(state.entities.channelCategories.byId.category2.sorting).toBe(CategorySorting.Manual);
 
             nock(Client4.getBaseRoute()).
-                put(`/users/${currentUserId}/teams/${teamId}/channels/categories`, (body) => {
-                    return body.find((category) => category.id === 'category1').sorting === CategorySorting.Manual &&
-                        body.find((category) => category.id === 'category2').sorting === CategorySorting.Manual;
+                put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category1.id}`, (body) => {
+                    return body.sorting === CategorySorting.Manual;
                 }).
-                reply(200, [
+                reply(
+                    200,
                     {...category1, channel_ids: ['channel2', 'channel1'], sorting: CategorySorting.Manual},
-                    {...category2, channel_ids: ['channel3', 'channel4'], sorting: CategorySorting.Manual},
-                ]);
+                );
 
             await store.dispatch(Actions.moveChannelsToCategory(category1.id, ['channel1'], 2));
 
@@ -1273,14 +1243,10 @@ describe('moveChannelsToCategory', () => {
             });
 
             nock(Client4.getBaseRoute()).
-                put(`/users/${currentUserId}/teams/${teamId}/channels/categories`, (body) => {
-                    return body.find((category) => category.id === 'category1').sorting !== CategorySorting.Manual &&
-                        body.find((category) => category.id === 'category2').sorting !== CategorySorting.Manual;
+                put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category2.id}`, (body) => {
+                    return body.sorting !== CategorySorting.Manual;
                 }).
-                reply(200, [
-                    {...category1, channel_ids: ['channel2']},
-                    {...category2, channel_ids: ['channel1', 'channel3', 'channel4']},
-                ]);
+                reply(200, {...category2, channel_ids: ['channel1', 'channel3', 'channel4']});
 
             await store.dispatch(Actions.moveChannelsToCategory(category2.id, ['channel1'], 0));
 
@@ -1289,14 +1255,10 @@ describe('moveChannelsToCategory', () => {
             expect(state.entities.channelCategories.byId.category2.sorting).toBe(CategorySorting.Recency);
 
             nock(Client4.getBaseRoute()).
-                put(`/users/${currentUserId}/teams/${teamId}/channels/categories`, (body) => {
-                    return body.find((category) => category.id === 'category1').sorting !== CategorySorting.Manual &&
-                        body.find((category) => category.id === 'category2').sorting !== CategorySorting.Manual;
+                put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category1.id}`, (body) => {
+                    return body.sorting !== CategorySorting.Manual;
                 }).
-                reply(200, [
-                    {...category1, channel_ids: ['channel2', 'channel1']},
-                    {...category2, channel_ids: ['channel3', 'channel4']},
-                ]);
+                reply(200, {...category1, channel_ids: ['channel2', 'channel1']});
 
             await store.dispatch(Actions.moveChannelsToCategory(category1.id, ['channel1'], 2));
 
@@ -1324,11 +1286,11 @@ describe('moveChannelsToCategory', () => {
         });
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [
-                {...category1, channel_ids: ['channel2']},
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category2.id}`).
+            reply(
+                200,
                 {...category2, channel_ids: ['channel1', 'channel3', 'channel4'], sorting: CategorySorting.Manual},
-            ]);
+            );
 
         await store.dispatch(Actions.moveChannelsToCategory(category2.id, ['channel1'], 0));
 
@@ -1337,11 +1299,8 @@ describe('moveChannelsToCategory', () => {
         expect(state.entities.channelCategories.byId.category2.sorting).toBe(CategorySorting.Manual);
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
-            reply(200, [
-                {...category1, channel_ids: ['channel2', 'channel1'], sorting: CategorySorting.Manual},
-                {...category2, channel_ids: ['channel3', 'channel4'], sorting: CategorySorting.Manual},
-            ]);
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category1.id}`).
+            reply(200, {...category1, channel_ids: ['channel2', 'channel1'], sorting: CategorySorting.Manual});
 
         await store.dispatch(Actions.moveChannelsToCategory(category1.id, ['channel1'], 2));
 
@@ -1369,12 +1328,9 @@ describe('moveChannelsToCategory', () => {
         });
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${favoritesCategory.id}`).
             delayBody(100).
-            reply(200, [
-                {...category1, channel_ids: ['channel2']},
-                {...favoritesCategory, channel_ids: ['channel1'], sorting: CategorySorting.Manual},
-            ]);
+            reply(200, {...favoritesCategory, channel_ids: ['channel1'], sorting: CategorySorting.Manual});
 
         const moveRequest = store.dispatch(Actions.moveChannelsToCategory(favoritesCategory.id, ['channel1'], 0));
 
@@ -1411,7 +1367,7 @@ describe('moveChannelsToCategory', () => {
         });
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${favoritesCategory.id}`).
             delayBody(100).
             reply(400);
 

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/channel_categories.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/channel_categories.ts
@@ -243,11 +243,12 @@ export function moveChannelToCategory(categoryId: string, channelId: string, new
         }
 
         // Add the channel to the new category
-        const categories = [{
+        const updatedTargetCategory = {
             ...targetCategory,
             sorting,
             channel_ids: insertWithoutDuplicates(targetCategory.channel_ids, channelId, newIndex),
-        }];
+        };
+        const categories = [updatedTargetCategory];
 
         // And remove it from the old category
         const sourceCategory = getCategoryInTeamWithChannel(getState(), targetCategory.team_id, channelId);
@@ -264,7 +265,7 @@ export function moveChannelToCategory(categoryId: string, channelId: string, new
         });
 
         try {
-            await Client4.updateChannelCategories(currentUserId, targetCategory.team_id, categories);
+            await Client4.updateChannelCategory(currentUserId, targetCategory.team_id, updatedTargetCategory);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));
@@ -301,12 +302,13 @@ export function moveChannelsToCategory(categoryId: string, channelIds: string[],
         }
 
         // Add the channels to the new category
+        const updatedTargetCategory = {
+            ...targetCategory,
+            sorting,
+            channel_ids: insertMultipleWithoutDuplicates(targetCategory.channel_ids, channelIds, newIndex),
+        };
         let categories = {
-            [targetCategory.id]: {
-                ...targetCategory,
-                sorting,
-                channel_ids: insertMultipleWithoutDuplicates(targetCategory.channel_ids, channelIds, newIndex),
-            },
+            [targetCategory.id]: updatedTargetCategory,
         };
 
         // Needed if we have to revert categories and for checking for favourites
@@ -343,7 +345,7 @@ export function moveChannelsToCategory(categoryId: string, channelIds: string[],
         });
 
         try {
-            await Client4.updateChannelCategories(currentUserId, targetCategory.team_id, categoriesArray);
+            await Client4.updateChannelCategory(currentUserId, targetCategory.team_id, updatedTargetCategory);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/channels.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/channels.test.ts
@@ -1782,11 +1782,8 @@ describe('Actions.Channels', () => {
         });
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${team.id}/channels/categories`).
-            reply(200, [
-                {...favoritesCategory, channel_ids: [channel.id]},
-                {...channelsCategory, channel_ids: []},
-            ]);
+            put(`/users/${currentUserId}/teams/${team.id}/channels/categories/${favoritesCategory.id}`).
+            reply(200, {...favoritesCategory, channel_ids: [channel.id]});
 
         await store.dispatch(Actions.favoriteChannel(channel.id));
 
@@ -1831,11 +1828,8 @@ describe('Actions.Channels', () => {
         });
 
         nock(Client4.getBaseRoute()).
-            put(`/users/${currentUserId}/teams/${team.id}/channels/categories`).
-            reply(200, [
-                {...favoritesCategory, channel_ids: []},
-                {...channelsCategory, channel_ids: [channel.id]},
-            ]);
+            put(`/users/${currentUserId}/teams/${team.id}/channels/categories/${channelsCategory.id}`).
+            reply(200, {...channelsCategory, channel_ids: [channel.id]});
 
         await store.dispatch(Actions.unfavoriteChannel(channel.id));
 


### PR DESCRIPTION
#### Summary
To reduce the chance of deadlocks in the channel category API, we're going to stop using the API to update multiple channel categories at once as two requests to that API for the same user at the same time can become deadlocked. This required:

1. Adding new store methods for updating a single category at a time
2. Having the client only pass a single category at a time when moving channels between categories
3. Fixing logic that previously relied on the client passing multiple categories when that happened

To give some more detail, the notable changes here are:

1. https://github.com/mattermost/mattermost/commit/c43bd7904af5d5689ffec6d758ee9eb5501077d3 - I've removed some nested transactions inside of the existing `SqlChannelStore.UpdateSidebarCategories` for MM-63925.
2. https://github.com/mattermost/mattermost/commit/6f011a2f60788b5fcdfbe875b60196ac434f0db5 - I re-added the ability to update the `Channels` inside one category and have the channels automatically removed from other categories. That was previously removed in https://github.com/mattermost/mattermost/pull/20215 as part of a fix for a related deadlock, and we never noticed because the web app worked that out itself and updated both the source and destination categories when a channel was moved. It's no longer to send both of those to the server, so we need that logic back. While this will potentially re-introduce that deadlock again, we're not going to be using that API any more and can remove it in the future.
3. https://github.com/mattermost/mattermost/commit/9683aff6348d176d6dd8ec23f94e98f9fd625587 - With that, I added separate `SqlChannelStore.UpdateSidebarCategory` that only updates a single category at a time. We didn't have that previously because I thought we could just always call the bulk version, but that's the deadlock-prone one.
4. https://github.com/mattermost/mattermost/commit/6766e59f63acf15a8a0e55145aa04f7fe0181f02 - This changes how the logic for muting and unmuting channels that move into or out of muted categories works. The previous way of doing it required knowing every category that was updated which, like the 2nd point above, only worked because the web app updated both the source and destination categories. The new way of doing it requires fetching all of the user's categories on that team again (sometimes twice), but I think the code is cleaner and optimized enough. As a bonus, it also let me remove the logic to populate the Channels/DMs category from `SqlChannelStore.UpdateSidebarCategories` which @agnivade had requested.
5. https://github.com/mattermost/mattermost/commit/a456209b3dd4e1f0a0ed37e6ba940ef93018f526 and https://github.com/mattermost/mattermost/commit/7e3615d2758106dc9c3f996e8a1556b4fa1a7e78 - Finally, it changes the web app to call the API to only update a single category when moving channels between categories

#### Ticket Link
MM-63923
MM-63925

#### Release Note
```release-note
Changed how moving channels between categories works to reduce risk of database deadlocks
```
