### PR TITLE
Disable morph logging during TestMain

### DIFF
--- a/server/channels/app/options.go
+++ b/server/channels/app/options.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/v8/channels/app/platform"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
+	"github.com/mattermost/mattermost/server/v8/channels/store/sqlstore"
 	"github.com/mattermost/mattermost/server/v8/config"
 	"github.com/mattermost/mattermost/server/v8/einterfaces"
 	"github.com/mattermost/mattermost/server/v8/platform/shared/filestore"
@@ -29,6 +30,13 @@ func StoreOverride(override any) Option {
 func StoreOverrideWithCache(override store.Store) Option {
 	return func(s *Server) error {
 		s.platformOptions = append(s.platformOptions, platform.StoreOverrideWithCache(override))
+		return nil
+	}
+}
+
+func StoreOption(option sqlstore.Option) Option {
+	return func(s *Server) error {
+		s.platformOptions = append(s.platformOptions, platform.StoreOption(option))
 		return nil
 	}
 }
@@ -110,8 +118,10 @@ func SkipPostInitialization() Option {
 	}
 }
 
-type AppOption func(a *App)
-type AppOptionCreator func() []AppOption
+type (
+	AppOption        func(a *App)
+	AppOptionCreator func() []AppOption
+)
 
 func ServerConnector(ch *Channels) AppOption {
 	return func(a *App) {

--- a/server/channels/app/platform/options.go
+++ b/server/channels/app/platform/options.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 	"github.com/mattermost/mattermost/server/v8/channels/store/localcachelayer"
+	"github.com/mattermost/mattermost/server/v8/channels/store/sqlstore"
 	"github.com/mattermost/mattermost/server/v8/config"
 	"github.com/mattermost/mattermost/server/v8/einterfaces"
 	"github.com/mattermost/mattermost/server/v8/platform/shared/filestore"
@@ -59,6 +60,16 @@ func StoreOverrideWithCache(override store.Store) Option {
 			return lcl, nil
 		}
 
+		return nil
+	}
+}
+
+// StoreOption allows passing options when constructing the store.
+//
+// This option has no effect if StoreOverride or StoreOverrideWithCache is also set.
+func StoreOption(option sqlstore.Option) Option {
+	return func(ps *PlatformService) error {
+		ps.storeOptions = append(ps.storeOptions, option)
 		return nil
 	}
 }

--- a/server/channels/app/platform/service.go
+++ b/server/channels/app/platform/service.go
@@ -38,9 +38,10 @@ import (
 // responsible for non-entity related functionalities that are required
 // by a product such as database access, configuration access, licensing etc.
 type PlatformService struct {
-	sqlStore *sqlstore.SqlStore
-	Store    store.Store
-	newStore func() (store.Store, error)
+	sqlStore     *sqlstore.SqlStore
+	Store        store.Store
+	newStore     func() (store.Store, error)
+	storeOptions []sqlstore.Option
 
 	WebSocketRouter *WebSocketRouter
 
@@ -232,7 +233,7 @@ func New(sc ServiceConfig, options ...Option) (*PlatformService, error) {
 			// Timer layer
 			// |
 			// Cache layer
-			ps.sqlStore, err = sqlstore.New(ps.Config().SqlSettings, ps.Log(), ps.metricsIFace)
+			ps.sqlStore, err = sqlstore.New(ps.Config().SqlSettings, ps.Log(), ps.metricsIFace, ps.storeOptions...)
 			if err != nil {
 				return nil, err
 			}

--- a/server/channels/app/plugin_api_tests/test_db_driver/main.go
+++ b/server/channels/app/plugin_api_tests/test_db_driver/main.go
@@ -33,7 +33,7 @@ func (p *MyPlugin) MessageWillBePosted(_ *plugin.Context, _ *model.Post) (*model
 	rctx := request.TestContext(p.t)
 	settings := p.API.GetUnsanitizedConfig().SqlSettings
 	settings.Trace = model.NewPointer(false)
-	store, err := sqlstore.New(settings, rctx.Logger(), nil)
+	store, err := sqlstore.New(settings, rctx.Logger(), nil, sqlstore.DisableMorphLogging())
 	if err != nil {
 		panic(err)
 	}

--- a/server/channels/store/localcachelayer/layer_test.go
+++ b/server/channels/store/localcachelayer/layer_test.go
@@ -108,7 +108,7 @@ func initStores(logger mlog.LoggerIFace) {
 		eg.Go(func() error {
 			var err error
 
-			st.SqlStore, err = sqlstore.New(*st.SqlSettings, logger, nil)
+			st.SqlStore, err = sqlstore.New(*st.SqlSettings, logger, nil, sqlstore.DisableMorphLogging())
 			if err != nil {
 				return err
 			}

--- a/server/channels/store/searchlayer/layer_test.go
+++ b/server/channels/store/searchlayer/layer_test.go
@@ -28,7 +28,7 @@ func TestUpdateConfigRace(t *testing.T) {
 		driverName = model.DatabaseDriverPostgres
 	}
 	settings := storetest.MakeSqlSettings(driverName, false)
-	store, err := sqlstore.New(*settings, logger, nil)
+	store, err := sqlstore.New(*settings, logger, nil, sqlstore.DisableMorphLogging())
 	require.NoError(t, err)
 
 	cfg := &model.Config{}

--- a/server/channels/store/sqlstore/migrate.go
+++ b/server/channels/store/sqlstore/migrate.go
@@ -6,6 +6,7 @@ package sqlstore
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"path"
 	"sort"
@@ -60,7 +61,7 @@ func NewMigrator(settings model.SqlSettings, logger mlog.LoggerIFace, dryRun boo
 		return nil, fmt.Errorf("error while checking DB collation: %w", err)
 	}
 
-	engine, err := ss.initMorph(dryRun)
+	engine, err := ss.initMorph(dryRun, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize morph: %w", err)
 	}
@@ -95,7 +96,7 @@ func (m *Migrator) GetFileName(plan *models.Plan) (string, error) {
 	return fmt.Sprintf("migration_plan_%d_%d", from, to), nil
 }
 
-func (ss *SqlStore) initMorph(dryRun bool) (*morph.Morph, error) {
+func (ss *SqlStore) initMorph(dryRun, disableLogging bool) (*morph.Morph, error) {
 	assets := db.Assets()
 
 	assetsList, err := assets.ReadDir(path.Join("migrations", ss.DriverName()))
@@ -149,8 +150,15 @@ func (ss *SqlStore) initMorph(dryRun bool) (*morph.Morph, error) {
 		return nil, err
 	}
 
+	var logWriter io.Writer
+	if disableLogging {
+		logWriter = io.Discard
+	} else {
+		logWriter = &morphWriter{}
+	}
+
 	opts := []morph.EngineOption{
-		morph.WithLogger(log.New(&morphWriter{}, "", log.Lshortfile)),
+		morph.WithLogger(log.New(logWriter, "", log.Lshortfile)),
 		morph.WithLock("mm-lock-key"),
 		morph.SetStatementTimeoutInSeconds(*ss.settings.MigrationsStatementTimeoutSeconds),
 		morph.SetDryRun(dryRun),
@@ -164,8 +172,8 @@ func (ss *SqlStore) initMorph(dryRun bool) (*morph.Morph, error) {
 	return engine, nil
 }
 
-func (ss *SqlStore) migrate(direction migrationDirection, dryRun bool) error {
-	engine, err := ss.initMorph(dryRun)
+func (ss *SqlStore) migrate(direction migrationDirection, dryRun, disableMorphLogging bool) error {
+	engine, err := ss.initMorph(dryRun, disableMorphLogging)
 	if err != nil {
 		return err
 	}

--- a/server/channels/store/storetest/settings.go
+++ b/server/channels/store/storetest/settings.go
@@ -188,7 +188,7 @@ func databaseSettings(driver, dataSource string) *model.SqlSettings {
 // execAsRoot executes the given sql as root against the testing database
 func execAsRoot(settings *model.SqlSettings, sqlCommand string) error {
 	var dsn string
-	var driver = *settings.DriverName
+	driver := *settings.DriverName
 
 	switch driver {
 	case model.DatabaseDriverMysql:
@@ -258,14 +258,13 @@ func MakeSqlSettings(driver string, withReplica bool) *model.SqlSettings {
 		panic("unsupported driver " + driver)
 	}
 
-	log("Created temporary " + driver + " database " + dbName)
 	settings.ReplicaMonitorIntervalSeconds = model.NewPointer(5)
 
 	return settings
 }
 
 func CleanupSqlSettings(settings *model.SqlSettings) {
-	var driver = *settings.DriverName
+	driver := *settings.DriverName
 	var dbName string
 
 	switch driver {
@@ -280,6 +279,4 @@ func CleanupSqlSettings(settings *model.SqlSettings) {
 	if err := execAsRoot(settings, "DROP DATABASE "+dbName); err != nil {
 		panic("failed to drop temporary database " + dbName + ": " + err.Error())
 	}
-
-	log("Dropped temporary database " + dbName)
 }

--- a/server/channels/store/storetest/settings.go
+++ b/server/channels/store/storetest/settings.go
@@ -69,7 +69,6 @@ func MySQLSettings(withReplica bool) *model.SqlSettings {
 	dsn := os.Getenv("TEST_DATABASE_MYSQL_DSN")
 	if dsn == "" {
 		dsn = getDefaultMysqlDSN()
-		mlog.Info("No TEST_DATABASE_MYSQL_DSN override, using default", mlog.String("default_dsn", dsn))
 	} else {
 		mlog.Info("Using TEST_DATABASE_MYSQL_DSN override", mlog.String("dsn", dsn))
 	}
@@ -96,7 +95,6 @@ func PostgreSQLSettings() *model.SqlSettings {
 	dsn := os.Getenv("TEST_DATABASE_POSTGRESQL_DSN")
 	if dsn == "" {
 		dsn = getDefaultPostgresqlDSN()
-		mlog.Info("No TEST_DATABASE_POSTGRESQL_DSN override, using default", mlog.String("default_dsn", dsn))
 	} else {
 		mlog.Info("Using TEST_DATABASE_POSTGRESQL_DSN override", mlog.String("dsn", dsn))
 	}

--- a/server/channels/testlib/helper.go
+++ b/server/channels/testlib/helper.go
@@ -143,7 +143,7 @@ func (h *MainHelper) setupStore(withReadReplica bool) {
 	h.ClusterInterface = &FakeClusterInterface{}
 
 	var err error
-	h.SQLStore, err = sqlstore.New(*h.Settings, h.Logger, nil)
+	h.SQLStore, err = sqlstore.New(*h.Settings, h.Logger, nil, sqlstore.DisableMorphLogging())
 	if err != nil {
 		panic(err)
 	}
@@ -160,7 +160,7 @@ func (h *MainHelper) ToggleReplicasOff() {
 	lic := h.SQLStore.GetLicense()
 
 	var err error
-	h.SQLStore, err = sqlstore.New(*h.Settings, h.Logger, nil)
+	h.SQLStore, err = sqlstore.New(*h.Settings, h.Logger, nil, sqlstore.DisableMorphLogging())
 	if err != nil {
 		panic(err)
 	}
@@ -175,7 +175,7 @@ func (h *MainHelper) ToggleReplicasOn() {
 	lic := h.SQLStore.GetLicense()
 
 	var err error
-	h.SQLStore, err = sqlstore.New(*h.Settings, h.Logger, nil)
+	h.SQLStore, err = sqlstore.New(*h.Settings, h.Logger, nil, sqlstore.DisableMorphLogging())
 	if err != nil {
 		panic(err)
 	}

--- a/server/platform/services/searchengine/bleveengine/bleve_test.go
+++ b/server/platform/services/searchengine/bleveengine/bleve_test.go
@@ -55,7 +55,7 @@ func (s *BleveEngineTestSuite) setupStore() {
 	s.SQLSettings = storetest.MakeSqlSettings(driverName, false)
 
 	var err error
-	s.SQLStore, err = sqlstore.New(*s.SQLSettings, s.Context.Logger(), nil)
+	s.SQLStore, err = sqlstore.New(*s.SQLSettings, s.Context.Logger(), nil, sqlstore.DisableMorphLogging())
 	if err != nil {
 		s.Require().FailNow("Cannot initialize store: %s", err.Error())
 	}

--- a/server/public/utils/sql/sql_utils.go
+++ b/server/public/utils/sql/sql_utils.go
@@ -64,13 +64,15 @@ func SetupConnection(logger mlog.LoggerIFace, connType string, dataSource string
 		mlog.String("dataSource", sanitized),
 	)
 
-	for i := 0; i < attempts; i++ {
-		logger.Info("Pinging SQL")
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if attempt > 1 {
+			logger.Info("Pinging SQL", mlog.Int("attempt", attempt))
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), DBPingTimeout)
 		defer cancel()
 		err = db.PingContext(ctx)
 		if err != nil {
-			if i == attempts-1 {
+			if attempt == attempts {
 				return nil, err
 			}
 			logger.Error("Failed to ping DB", mlog.Float("retrying in seconds", DBConnRetrySleep.Seconds()), mlog.Err(err))


### PR DESCRIPTION
#### Summary
- Add `DisableMorphLogging` option to reduce noise in test output
- Remove repetitive logging messages about database creation
- Only log "Pinging SQL" on retry attempts rather than every time
- Fix formatting in SqlStore to be consistent

#### Ticket Link
<!--
No specific ticket linked
-->

#### Screenshots
<!--
No UI changes
-->

#### Release Note
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.ai/code)