### PR TITLE
Fix automatic timezone not getting updated

### DIFF
--- a/webapp/channels/src/utils/timezone.ts
+++ b/webapp/channels/src/utils/timezone.ts
@@ -5,7 +5,7 @@ import type {Moment} from 'moment-timezone';
 import moment from 'moment-timezone';
 
 export function getBrowserTimezone() {
-    return moment.tz.guess();
+    return moment.tz.guess(true);
 }
 
 export function getBrowserUtcOffset() {


### PR DESCRIPTION
#### Summary
moment.tz.guess has a cache. If we change the timezones, it is not seen by moment because of the cache.

We can consider also updating the automatic timezone more often, since right now it only really updates when the visibility of the screen changes, or we check/uncheck the settings buttons. (There are a couple more places, but less relevant)

Testing notes:
- I tested this using the "sensors" dev tool from chromium, changing the location
- The timezone change does not get catched automatically. The logic we have so far is that the visibility of the screen has to change. Minimizing the screen and getting it back seems to work.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-63376

#### Release Note
```release-note
Fix times not showing the correct time when moving between timezones.
```
