### PR TITLE
Fix license upload when already set by env variable

### DIFF
--- a/webapp/channels/src/components/admin_console/license_settings/enterprise_edition/enterprise_edition.scss
+++ b/webapp/channels/src/components/admin_console/license_settings/enterprise_edition/enterprise_edition.scss
@@ -171,22 +171,6 @@
                     }
                 }
             }
-
-            .add-new-licence-btn {
-                display: block;
-                padding: 12px 20px;
-                border: 1px solid var(--sys-button-bg);
-                border-radius: 4px;
-                margin-top: 15px;
-                background-color: var(--sys-center-channel-bg);
-                color: var(--sys-button-bg);
-
-                span {
-                    font-size: 14px;
-                    font-weight: 600;
-                    line-height: 14px;
-                }
-            }
         }
 
         #remove-button {

--- a/webapp/channels/src/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.tsx
+++ b/webapp/channels/src/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.tsx
@@ -35,6 +35,7 @@ export interface EnterpriseEditionProps {
     fileInputRef: RefObject<HTMLInputElement>;
     handleChange: () => void;
     statsActiveUsers: number;
+    isLicenseSetByEnvVar: boolean;
 }
 
 export const messages = defineMessages({
@@ -52,6 +53,7 @@ const EnterpriseEditionLeftPanel = ({
     fileInputRef,
     handleChange,
     statsActiveUsers,
+    isLicenseSetByEnvVar,
 }: EnterpriseEditionProps) => {
     const {formatMessage} = useIntl();
     const [unsanitizedLicense, setUnsanitizedLicense] = useState(license);
@@ -148,6 +150,7 @@ const EnterpriseEditionLeftPanel = ({
                         handleChange,
                         statsActiveUsers,
                         expirationDays,
+                        isLicenseSetByEnvVar,
                     )
                 }
             </div>
@@ -245,6 +248,7 @@ const renderLicenseContent = (
     handleChange: () => void,
     statsActiveUsers: number,
     expirationDays: number,
+    isLicenseSetByEnvVar: boolean,
 ) => {
     // Note: DO NOT LOCALISE THESE STRINGS. Legally we can not since the license is in English.
 
@@ -284,7 +288,7 @@ const renderLicenseContent = (
         <div className='licenseElements'>
             {licenseValues.map(renderLicenseValues(statsActiveUsers, parseInt(license.Users, 10), expirationDays))}
             <hr/>
-            {renderAddNewLicenseButton(fileInputRef, handleChange)}
+            {renderAddNewLicenseButton(fileInputRef, handleChange, isLicenseSetByEnvVar)}
             {renderRemoveButton(handleRemove, isDisabled, removing)}
         </div>
     );
@@ -293,12 +297,14 @@ const renderLicenseContent = (
 const renderAddNewLicenseButton = (
     fileInputRef: RefObject<HTMLInputElement>,
     handleChange: () => void,
+    isLicenseSetByEnvVar: boolean,
 ) => {
     return (
         <>
             <button
-                className='add-new-licence-btn'
+                className={'btn btn-secondary'}
                 onClick={() => fileInputRef.current?.click()}
+                disabled={isLicenseSetByEnvVar}
             >
                 <FormattedMessage
                     id='admin.license.keyAddNew'

--- a/webapp/channels/src/components/admin_console/license_settings/license_settings.tsx
+++ b/webapp/channels/src/components/admin_console/license_settings/license_settings.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {FormattedMessage, defineMessages} from 'react-intl';
 
 import type {StatusOK} from '@mattermost/types/client4';
-import type {ClientLicense} from '@mattermost/types/config';
+import type {ClientLicense, EnvironmentConfig} from '@mattermost/types/config';
 import type {ServerError} from '@mattermost/types/errors';
 import type {ServerLimits} from '@mattermost/types/limits';
 import type {GetFilteredUsersStatsOpts, UsersStats} from '@mattermost/types/users';
@@ -44,6 +44,7 @@ type Props = {
     totalUsers: number;
     isDisabled: boolean;
     prevTrialLicense: ClientLicense;
+    environmentConfig: Partial<EnvironmentConfig>;
     actions: {
         getLicenseConfig: () => void;
         uploadLicense: (file: File) => Promise<ActionResult>;
@@ -319,6 +320,7 @@ export default class LicenseSettings extends React.PureComponent<Props, State> {
                     fileInputRef={this.fileInputRef}
                     handleChange={this.handleChange}
                     statsActiveUsers={this.props.totalUsers || 0}
+                    isLicenseSetByEnvVar={Boolean(this.props.environmentConfig?.ServiceSettings?.LicenseFileLocation)}
                 />
             );
 


### PR DESCRIPTION
#### Summary
We didn't check whether the license was set as an Env variable, so the UI showed the button to upload the license, and allowed the users to interact with it.

Now the button is disabled, and shows a tooltip explaining that it is already set by environment variable.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62832

#### Release Note
```release-note
Disable "Add a license" button when the license is set by environment variable.
```
