### PR TITLE
fix guest user import when guest user doesn't have any memberships

### DIFF
--- a/server/channels/app/imports/import_validators.go
+++ b/server/channels/app/imports/import_validators.go
@@ -706,7 +706,7 @@ func isValidEmailBatchingInterval(emailInterval string) bool {
 		emailInterval == model.PreferenceEmailIntervalHour
 }
 
-// isValidGuestRoles checks if the user has both guest roles in the same team or channel.
+// isValidGuestRoles checks if the user has guest roles consistently across system, team, and channel levels.
 // at this point we assume that the user has a valid role scheme.
 func isValidGuestRoles(data UserImportData) bool {
 	if data.Roles == nil {
@@ -714,36 +714,67 @@ func isValidGuestRoles(data UserImportData) bool {
 	}
 	isSystemGuest := model.IsInRole(*data.Roles, model.SystemGuestRoleId)
 
+	// If user has no teams, they can still be a system guest without issue
+	if data.Teams == nil || len(*data.Teams) == 0 {
+		return true
+	}
+
 	var isTeamGuest, isChannelGuest bool
-	if data.Teams != nil {
-		// counters for guest roles for teams and channels
-		// we expect the total count of guest roles to be equal to the total count of teams and channels
-		var gtc, ctc int
-		for _, team := range *data.Teams {
-			if team.Roles != nil && model.IsInRole(*team.Roles, model.TeamGuestRoleId) {
-				gtc++
-			}
+	var hasTeams, hasChannels bool
 
-			if *team.Channels != nil {
-				for _, channel := range *team.Channels {
-					if channel.Roles != nil && model.IsInRole(*channel.Roles, model.ChannelGuestRoleId) {
-						ctc++
-					}
-				}
+	// counters for guest roles for teams and channels
+	var gtc, ctc int
+	var totalTeams, totalChannels int
 
-				if ctc == len(*team.Channels) {
-					isChannelGuest = true
-				}
-			}
+	totalTeams = len(*data.Teams)
+	hasTeams = totalTeams > 0
+
+	for _, team := range *data.Teams {
+		if team.Roles != nil && model.IsInRole(*team.Roles, model.TeamGuestRoleId) {
+			gtc++
 		}
-		if gtc == len(*data.Teams) {
-			isTeamGuest = true
+
+		// Check if the team has any channels
+		if team.Channels != nil && len(*team.Channels) > 0 {
+			hasChannels = true
+			teamChannels := len(*team.Channels)
+			totalChannels += teamChannels
+
+			for _, channel := range *team.Channels {
+				if channel.Roles != nil && model.IsInRole(*channel.Roles, model.ChannelGuestRoleId) {
+					ctc++
+				}
+			}
 		}
 	}
 
-	// basically we want to be sure if the user either fully guest in all 3 places or not at all
-	// (a | b | c) & !(a & b & c) -> 3-way XOR?
-	if (isSystemGuest || isTeamGuest || isChannelGuest) && !(isSystemGuest && isTeamGuest && isChannelGuest) {
+	// Set flags based on whether all available teams/channels have guest roles
+	if hasTeams && gtc == totalTeams {
+		isTeamGuest = true
+	}
+
+	if hasChannels && ctc == totalChannels {
+		isChannelGuest = true
+	}
+
+	// If the user is a system guest, they must have consistent guest roles in any teams/channels they belong to
+	if isSystemGuest {
+		// If they have teams, they must be a team guest in all teams
+		if hasTeams && !isTeamGuest {
+			return false
+		}
+
+		// If they have channels, they must be a channel guest in all channels
+		if hasChannels && !isChannelGuest {
+			return false
+		}
+
+		return true
+	}
+
+	// If not a system guest, ensure consistency in the other direction
+	// If they're a team or channel guest, they must be a system guest
+	if (isTeamGuest || isChannelGuest) && !isSystemGuest {
 		return false
 	}
 

--- a/server/channels/app/imports/import_validators_test.go
+++ b/server/channels/app/imports/import_validators_test.go
@@ -1546,11 +1546,19 @@ func TestIsValidGuestRoles(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "Invalid case: User is system guest but not guest in team and channel",
+			name: "Valid case: User is system guest with no teams",
 			input: UserImportData{
 				Roles: model.NewPointer(model.SystemGuestRoleId),
 			},
-			expected: false,
+			expected: true,
+		},
+		{
+			name: "Valid case: User is system guest with empty teams array",
+			input: UserImportData{
+				Roles: model.NewPointer(model.SystemGuestRoleId),
+				Teams: &[]UserTeamImportData{},
+			},
+			expected: true,
 		},
 		{
 			name: "Invalid case: User has mixed roles",
@@ -1566,6 +1574,31 @@ func TestIsValidGuestRoles(t *testing.T) {
 				},
 			},
 			expected: false,
+		},
+		{
+			name: "Valid case: User is system guest with team guest role but no channels",
+			input: UserImportData{
+				Roles: model.NewPointer(model.SystemGuestRoleId),
+				Teams: &[]UserTeamImportData{
+					{
+						Roles:    model.NewPointer(model.TeamGuestRoleId),
+						Channels: &[]UserChannelImportData{},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Valid case: User is system guest with team guest role and nil channels",
+			input: UserImportData{
+				Roles: model.NewPointer(model.SystemGuestRoleId),
+				Teams: &[]UserTeamImportData{
+					{
+						Roles: model.NewPointer(model.TeamGuestRoleId),
+					},
+				},
+			},
+			expected: true,
 		},
 		{
 			name:     "Valid case: User does not have any role defined in any place",


### PR DESCRIPTION
this pr fixes an issue where a guest user without channel or team memberships is not being imported and the importer will then throw an error and abort.