### PR TITLE
Automated cherry pick of #30628

### DIFF
--- a/server/channels/app/authorization.go
+++ b/server/channels/app/authorization.go
@@ -85,13 +85,15 @@ func (a *App) SessionHasPermissionToChannel(c request.CTX, session model.Session
 	channel, appErr := a.GetChannel(c, channelID)
 	if appErr != nil && appErr.StatusCode == http.StatusNotFound {
 		return false
+	} else if appErr != nil {
+		c.Logger().Warn("Failed to get channel", mlog.String("channel_id", channelID), mlog.Err(appErr))
 	}
 
 	if session.IsUnrestricted() || a.RolesGrantPermission(session.GetUserRoles(), model.PermissionManageSystem.Id) {
 		return true
 	}
 
-	if a.isChannelArchivedAndHidden(channel) {
+	if appErr == nil && a.isChannelArchivedAndHidden(channel) {
 		return false
 	}
 

--- a/server/channels/app/authorization_test.go
+++ b/server/channels/app/authorization_test.go
@@ -187,6 +187,15 @@ func TestSessionHasPermissionToChannel(t *testing.T) {
 		// If there's an error returned from the GetChannel call the code should continue to cascade and since there
 		// are no session level permissions in this test case, the permission should be denied.
 		assert.False(t, th.App.SessionHasPermissionToChannel(th.Context, session, th.BasicUser.Id, model.PermissionAddReaction))
+
+		// MM-63624, check with TeamSettings.ExperimentalViewArchivedChannels off
+		th.App.Srv().SetStore(mainHelper.GetStore())
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.TeamSettings.ExperimentalViewArchivedChannels = false
+		})
+
+		th.App.Srv().SetStore(&mockStore)
+		assert.False(t, th.App.SessionHasPermissionToChannel(th.Context, session, th.BasicUser.Id, model.PermissionAddReaction))
 	})
 }
 
@@ -326,6 +335,14 @@ func TestSessionHasPermissionToChannels(t *testing.T) {
 		session := model.Session{
 			UserId: th.BasicUser.Id,
 		}
+		assert.False(t, th.App.SessionHasPermissionToChannels(th.Context, session, allChannels, model.PermissionReadChannel))
+
+		// MM-63624, check with TeamSettings.ExperimentalViewArchivedChannels off
+		th.App.Srv().SetStore(mainHelper.GetStore())
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.TeamSettings.ExperimentalViewArchivedChannels = false
+		})
+		th.App.Srv().SetStore(&mockStore)
 		assert.False(t, th.App.SessionHasPermissionToChannels(th.Context, session, allChannels, model.PermissionReadChannel))
 	})
 }


### PR DESCRIPTION
Cherry pick of #30628 on release-10.5.

/cc  @streamer45

```release-note
NONE
```