### PR TITLE
MM-62365: Remove unused field from MetricSample

### DIFF
--- a/server/channels/app/metrics_test.go
+++ b/server/channels/app/metrics_test.go
@@ -64,16 +64,15 @@ func TestMobileMetrics(t *testing.T) {
 		var start float64 = 125
 		end := start + float64(len(ttcc))
 		// Precheck
-		for i, tc := range ttcc {
+		for _, tc := range ttcc {
 			actualMetric, err := tc.histogramVec.GetMetricWith(prometheus.Labels{"platform": platform})
 			require.NoError(t, err)
 			require.NoError(t, actualMetric.(prometheus.Histogram).Write(m))
 			require.Equal(t, uint64(0), m.Histogram.GetSampleCount())
 			require.Equal(t, 0.0, m.Histogram.GetSampleSum())
 			histograms = append(histograms, &model.MetricSample{
-				Metric:    tc.metricName,
-				Value:     tc.elapsed,
-				Timestamp: start + float64(i),
+				Metric: tc.metricName,
+				Value:  tc.elapsed,
 			})
 		}
 

--- a/server/public/model/metrics.go
+++ b/server/public/model/metrics.go
@@ -84,10 +84,9 @@ var (
 )
 
 type MetricSample struct {
-	Metric    MetricType        `json:"metric"`
-	Value     float64           `json:"value"`
-	Timestamp float64           `json:"timestamp,omitempty"`
-	Labels    map[string]string `json:"labels,omitempty"`
+	Metric MetricType        `json:"metric"`
+	Value  float64           `json:"value"`
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 func (s *MetricSample) GetLabelValue(name string, acceptedValues map[string]any, defaultValue string) string {


### PR DESCRIPTION
The Timestamp field was not used at all. Therefore
removing it.

https://mattermost.atlassian.net/browse/MM-62365

```release-note
NONE
```
