### PR TITLE
Fixed a bug where webhook's overridden username didn't show up in a reply when CRT is disabled

### DIFF
--- a/webapp/channels/src/components/post/post_component.tsx
+++ b/webapp/channels/src/components/post/post_component.tsx
@@ -407,6 +407,7 @@ function PostComponent(props: Props) {
             <CommentedOn
                 onCommentClick={handleCommentClick}
                 rootId={post.root_id}
+                enablePostUsernameOverride={props.enablePostUsernameOverride}
             />
         );
     }

--- a/webapp/channels/src/components/post_view/commented_on/commented_on.test.tsx
+++ b/webapp/channels/src/components/post_view/commented_on/commented_on.test.tsx
@@ -282,6 +282,91 @@ describe('components/post_view/CommentedOn', () => {
 
         expect(onCommentClick).toHaveBeenCalledTimes(1);
     });
+
+    test("should render the root post's overwritten username", () => {
+        const webhookPost = TestHelper.getPostMock({
+            id: 'webhook_post_id',
+            user_id: user1.id,
+            message: 'text message',
+            props: {
+                from_webhook: 'true',
+                override_username: 'overridden_username',
+            },
+        });
+
+        const post1 = TestHelper.getPostMock({
+            id: 'post1',
+            user_id: user1.id,
+            message: 'text message',
+            root_id: webhookPost.id,
+        });
+
+        renderWithContext(
+            <CommentedOn
+                rootId={webhookPost.id}
+                enablePostUsernameOverride={true}
+            />,
+            {
+                entities: {
+                    posts: {
+                        posts: {
+                            post1,
+                            webhook_post_id: webhookPost,
+                        },
+                    },
+                    users: {
+                        profiles: {
+                            user1,
+                        },
+                    },
+                },
+            },
+        );
+
+        expect(screen.getByText(textInChildren("Commented on overridden_username's message: text message"))).toBeInTheDocument();
+    });
+
+    test("should not render the root post's overwritten username if post is not from webhook", () => {
+        const webhookPost = TestHelper.getPostMock({
+            id: 'webhook_post_id',
+            user_id: user1.id,
+            message: 'text message',
+            props: {
+                override_username: 'overridden_username',
+            },
+        });
+
+        const post1 = TestHelper.getPostMock({
+            id: 'post1',
+            user_id: user1.id,
+            message: 'text message',
+            root_id: webhookPost.id,
+        });
+
+        renderWithContext(
+            <CommentedOn
+                rootId={webhookPost.id}
+                enablePostUsernameOverride={true}
+            />,
+            {
+                entities: {
+                    posts: {
+                        posts: {
+                            post1,
+                            webhook_post_id: webhookPost,
+                        },
+                    },
+                    users: {
+                        profiles: {
+                            user1,
+                        },
+                    },
+                },
+            },
+        );
+
+        expect(screen.getByText(textInChildren("Commented on some-user's message: text message"))).toBeInTheDocument();
+    });
 });
 
 function textInChildren(matchedText: string) {


### PR DESCRIPTION
#### Summary
Fixed a bug where webhook's overridden username didn't show up in a reply when CRT is disabled

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-63564

#### Screenshots
![Screenshot 2025-05-12 at 3 16 34 PM](https://github.com/user-attachments/assets/a4d0925f-8165-4e9e-9ddc-ed120c771a9c)


#### Release Note
```release-note
Fixed a bug where webhook's overridden username didn't show up in a reply when CRT is disabled
```
