### PR TITLE
Prepackage Calls v1.7.1 (v10.5)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -144,7 +144,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.5.2
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.7.1
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.3.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.9.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.2.1


### PR DESCRIPTION
#### Summary

Pre-emptively backporting [Calls v1.7.1](https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v1.7.1) to 10.5 ESR since it comes with some important fixes to long-standing race conditions.

#### Release Note

```release-note
Prepackage Calls v1.7.1
```
