### PR TITLE
MM-64155: Fix searchbox clear button to reset search type

### DIFF
--- a/e2e-tests/playwright/specs/functional/channels/search/search_box_clear_button.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/search/search_box_clear_button.spec.ts
@@ -16,27 +16,27 @@ test('MM-64155 search box clear button should not leave type badge after closing
 
     // # Open the search UI
     await channelsPage.globalHeader.openSearch();
-    
+
     // # Type something in the search box
     const searchText = 'abcdef';
     const {searchInput} = channelsPage.searchPopover;
     await searchInput.pressSequentially(searchText);
-    
+
     // * Verify text was entered
     await expect(searchInput).toHaveValue(searchText);
-    
+
     // # Click the clear button
     await channelsPage.searchPopover.clearIfPossible();
-    
+
     // * Verify the input is cleared
     await expect(searchInput).toHaveValue('');
-    
+
     // # Close the search box by clicking outside
     await channelsPage.page.click('body', {position: {x: 0, y: 0}});
-    
+
     // * Verify the search box is closed
     await expect(channelsPage.searchPopover.container).not.toBeVisible();
-    
+
     // * Verify there is no search type badge/chip in the search bar
     // The search type badge is rendered when searchType is either 'messages' or 'files'
     const searchTypeBadge = channelsPage.page.getByTestId('searchTypeBadge');

--- a/e2e-tests/playwright/specs/functional/channels/search/search_box_clear_button.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/search/search_box_clear_button.spec.ts
@@ -37,8 +37,8 @@ test('search box clear button should not leave type badge after closing the sear
     // * Verify the search box is closed
     await expect(channelsPage.searchPopover.container).not.toBeVisible();
     
-    // * Verify there is no "MESSAGES" badge/chip in the search bar
-    // The badge text is rendered based on the searchType in the component
-    const messagesBadge = channelsPage.page.getByText('MESSAGES', {exact: true});
-    await expect(messagesBadge).not.toBeVisible();
+    // * Verify there is no search type badge/chip in the search bar
+    // The search type badge is rendered when searchType is either 'messages' or 'files'
+    const searchTypeBadge = channelsPage.page.getByTestId('searchTypeBadge');
+    await expect(searchTypeBadge).not.toBeVisible();
 });

--- a/e2e-tests/playwright/specs/functional/channels/search/search_box_clear_button.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/search/search_box_clear_button.spec.ts
@@ -3,7 +3,7 @@
 
 import {expect, test} from '@mattermost/playwright-lib';
 
-test('search box clear button should not leave type badge after closing the search box', async ({pw}) => {
+test('MM-64155 search box clear button should not leave type badge after closing the search box', async ({pw}) => {
     // # Set up test with a user
     const {user} = await pw.initSetup();
 

--- a/e2e-tests/playwright/specs/functional/channels/search/search_box_clear_button.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/search/search_box_clear_button.spec.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+test('search box clear button should not leave type badge after closing the search box', async ({pw}) => {
+    // # Set up test with a user
+    const {user} = await pw.initSetup();
+
+    // # Log in as the test user
+    const {channelsPage} = await pw.testBrowser.login(user);
+
+    // # Visit a default channel page
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    // # Open the search UI
+    await channelsPage.globalHeader.openSearch();
+    
+    // # Type something in the search box
+    const searchText = 'abcdef';
+    const {searchInput} = channelsPage.searchPopover;
+    await searchInput.pressSequentially(searchText);
+    
+    // * Verify text was entered
+    await expect(searchInput).toHaveValue(searchText);
+    
+    // # Click the clear button
+    await channelsPage.searchPopover.clearIfPossible();
+    
+    // * Verify the input is cleared
+    await expect(searchInput).toHaveValue('');
+    
+    // # Close the search box by clicking outside
+    await channelsPage.page.click('body', {position: {x: 0, y: 0}});
+    
+    // * Verify the search box is closed
+    await expect(channelsPage.searchPopover.container).not.toBeVisible();
+    
+    // * Verify there is no "MESSAGES" badge/chip in the search bar
+    // The badge text is rendered based on the searchType in the component
+    const messagesBadge = channelsPage.page.getByText('MESSAGES', {exact: true});
+    await expect(messagesBadge).not.toBeVisible();
+});

--- a/webapp/channels/src/components/new_search/new_search.tsx
+++ b/webapp/channels/src/components/new_search/new_search.tsx
@@ -266,7 +266,7 @@ const NewSearch = (): JSX.Element => {
         >
             <i className='icon icon-magnify'/>
             {(searchType === 'messages' || searchType === 'files') && (
-                <SearchTypeBadge data-testid="searchTypeBadge">
+                <SearchTypeBadge data-testid='searchTypeBadge'>
                     {searchType === 'messages' && (
                         <FormattedMessage
                             id='search_bar.search_types.messages'

--- a/webapp/channels/src/components/new_search/new_search.tsx
+++ b/webapp/channels/src/components/new_search/new_search.tsx
@@ -266,7 +266,7 @@ const NewSearch = (): JSX.Element => {
         >
             <i className='icon icon-magnify'/>
             {(searchType === 'messages' || searchType === 'files') && (
-                <SearchTypeBadge>
+                <SearchTypeBadge data-testid="searchTypeBadge">
                     {searchType === 'messages' && (
                         <FormattedMessage
                             id='search_bar.search_types.messages'

--- a/webapp/channels/src/components/new_search/search_box_input.tsx
+++ b/webapp/channels/src/components/new_search/search_box_input.tsx
@@ -95,7 +95,7 @@ const SearchInput = forwardRef<HTMLInputElement, Props>(({searchTerms, searchTyp
     const clearSearch = useCallback(() => {
         setSearchTerms('');
         dispatch(updateSearchTerms(''));
-        dispatch(updateSearchType('messages'));
+        dispatch(updateSearchType(''));
         focus(0);
     }, [focus, setSearchTerms]);
 


### PR DESCRIPTION
#### Summary
Updates the clearSearch function to set searchType to empty string instead of 'messages' when clearing the search box. 
This fixes an issue where a "MESSAGES" badge would inappropriately appear in the search bar after clearing text and closing the search box.

Also adds an e2e test to verify this behavior.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-64155

#### Release Note
```release-note
Fixed an issue where a "MESSAGES" badge would appear in the search bar after clearing text and closing the search box.
```

Co-Authored-By: Claude <noreply@anthropic.com>