### PR TITLE
[MM-63717] LDAP Wizard skeleton

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -8233,6 +8233,10 @@
     "translation": "ldap interface was nil."
   },
   {
+    "id": "ent.ldap.connection.test",
+    "translation": ""
+  },
+  {
     "id": "ent.ldap.cpa_field_mapping.list_error",
     "translation": "Failed to retrieve CPA fields"
   },

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -8233,10 +8233,6 @@
     "translation": "ldap interface was nil."
   },
   {
-    "id": "ent.ldap.connection.test",
-    "translation": ""
-  },
-  {
     "id": "ent.ldap.cpa_field_mapping.list_error",
     "translation": "Failed to retrieve CPA fields"
   },

--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -6287,7 +6287,7 @@ export const ldapWizardAdminDefinition: AdminDefinitionSubSectionSchema = {
     name: defineMessage({id: 'admin.authentication.ldap.wizard', defaultMessage: 'AD/LDAP Wizard'}),
     sections: [{
         key: 'admin.authentication.ldap.connection',
-        title: 'Connection!',
+        title: 'Connection',
         subtitle: 'Connection and security level to your AD/LDAP server.',
         settings: [
             {

--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -16,13 +16,25 @@ import type {Job} from '@mattermost/types/jobs';
 import {RESOURCE_KEYS} from 'mattermost-redux/constants/permissions_sysconsole';
 
 import {
-    ldapTest, invalidateAllCaches, reloadConfig, testS3Connection,
-    removeIdpSamlCertificate, uploadIdpSamlCertificate,
-    removePrivateSamlCertificate, uploadPrivateSamlCertificate,
-    removePublicSamlCertificate, uploadPublicSamlCertificate,
-    removePrivateLdapCertificate, uploadPrivateLdapCertificate,
-    removePublicLdapCertificate, uploadPublicLdapCertificate,
-    invalidateAllEmailInvites, testSmtp, testSiteURL, getSamlMetadataFromIdp, setSamlIdpCertificateFromMetadata,
+    getSamlMetadataFromIdp,
+    invalidateAllCaches,
+    invalidateAllEmailInvites,
+    ldapTest,
+    reloadConfig,
+    removeIdpSamlCertificate,
+    removePrivateLdapCertificate,
+    removePrivateSamlCertificate,
+    removePublicLdapCertificate,
+    removePublicSamlCertificate,
+    setSamlIdpCertificateFromMetadata,
+    testS3Connection,
+    testSiteURL,
+    testSmtp,
+    uploadIdpSamlCertificate,
+    uploadPrivateLdapCertificate,
+    uploadPrivateSamlCertificate,
+    uploadPublicLdapCertificate,
+    uploadPublicSamlCertificate,
 } from 'actions/admin_actions';
 import {trackEvent} from 'actions/telemetry_actions.jsx';
 
@@ -67,24 +79,25 @@ import GlobalDataRetentionForm from './data_retention_settings/global_policy_for
 import DatabaseSettings, {searchableStrings as databaseSearchableStrings} from './database_settings';
 import ElasticSearchSettings, {searchableStrings as elasticSearchSearchableStrings} from './elasticsearch_settings';
 import {
-    LDAPFeatureDiscovery,
-    SAMLFeatureDiscovery,
-    OpenIDFeatureDiscovery,
-    OpenIDCustomFeatureDiscovery,
     AnnouncementBannerFeatureDiscovery,
     ComplianceExportFeatureDiscovery,
     CustomTermsOfServiceFeatureDiscovery,
     DataRetentionFeatureDiscovery,
-    GuestAccessFeatureDiscovery,
-    SystemRolesFeatureDiscovery,
     GroupsFeatureDiscovery,
+    GuestAccessFeatureDiscovery,
+    LDAPFeatureDiscovery,
     MobileSecurityFeatureDiscovery,
+    OpenIDCustomFeatureDiscovery,
+    OpenIDFeatureDiscovery,
+    SAMLFeatureDiscovery,
+    SystemRolesFeatureDiscovery,
 } from './feature_discovery/features';
 import AttributeBasedAccessControlFeatureDiscovery from './feature_discovery/features/attribute_based_access_control';
 import FeatureFlags, {messages as featureFlagsMessages} from './feature_flags';
 import GroupDetails from './group_settings/group_details';
 import GroupSettings from './group_settings/group_settings';
 import IPFiltering from './ip_filtering';
+import LDAPWizard from './ldap_wizard';
 import LicenseSettings from './license_settings';
 import {searchableStrings as licenseSettingsSearchableStrings} from './license_settings/license_settings';
 import MessageExportSettings, {searchableStrings as messageExportSearchableStrings} from './message_export_settings';
@@ -111,7 +124,7 @@ import ChannelSettings from './team_channel_settings/channel';
 import ChannelDetails from './team_channel_settings/channel/details';
 import TeamSettings from './team_channel_settings/team';
 import TeamDetails from './team_channel_settings/team/details';
-import type {Check, AdminDefinition as AdminDefinitionType, ConsoleAccess} from './types';
+import type {AdminDefinitionSubSectionSchema, AdminDefinition as AdminDefinitionType, Check, ConsoleAccess} from './types';
 import ValidationResult from './validation';
 import WorkspaceOptimizationDashboard from './workspace-optimization/dashboard';
 
@@ -298,7 +311,7 @@ const getRestrictedIndicator = (displayBlocked = false, minimumPlanRequiredForFe
             })}
         />
     ),
-    shouldDisplay: (license: ClientLicense, subscriptionProduct: Product|undefined) => displayBlocked || (isCloudLicense(license) && subscriptionProduct?.sku === CloudProducts.STARTER),
+    shouldDisplay: (license: ClientLicense, subscriptionProduct: Product | undefined) => displayBlocked || (isCloudLicense(license) && subscriptionProduct?.sku === CloudProducts.STARTER),
 });
 
 const adminDefinitionMessages = defineMessages({
@@ -3714,715 +3727,9 @@ const AdminDefinition: AdminDefinitionType = {
                     it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
                 ),
                 schema: {
-                    id: 'LdapSettings',
-                    name: defineMessage({id: 'admin.authentication.ldap', defaultMessage: 'AD/LDAP'}),
-                    sections: [
-                        {
-                            key: 'admin.authentication.ldap.connection',
-                            title: 'Connection',
-                            subtitle: 'Connection and security level to your AD/LDAP server.',
-                            settings: [
-                                {
-                                    type: 'bool',
-                                    key: 'LdapSettings.Enable',
-                                    label: defineMessage({id: 'admin.ldap.enableTitle', defaultMessage: 'Enable sign-in with AD/LDAP:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.enableDesc', defaultMessage: 'When true, Mattermost allows login using AD/LDAP'}),
-                                    isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                },
-                                {
-                                    type: 'bool',
-                                    key: 'LdapSettings.EnableSync',
-                                    label: defineMessage({id: 'admin.ldap.enableSyncTitle', defaultMessage: 'Enable Synchronization with AD/LDAP:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.enableSyncDesc', defaultMessage: 'When true, Mattermost periodically synchronizes users from AD/LDAP. When false, user attributes are updated from AD/LDAP during user login only.'}),
-                                    isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                },
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.LoginFieldName',
-                                    label: defineMessage({id: 'admin.ldap.loginNameTitle', defaultMessage: 'Login Field Name:'}),
-                                    placeholder: defineMessage({id: 'admin.ldap.loginNameEx', defaultMessage: 'E.g.: "AD/LDAP Username"'}),
-                                    help_text: defineMessage({id: 'admin.ldap.loginNameDesc', defaultMessage: 'The placeholder text that appears in the login field on the login page. Defaults to "AD/LDAP Username".'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'number',
-                                    key: 'LdapSettings.MaximumLoginAttempts',
-                                    label: defineMessage({id: 'admin.ldap.maximumLoginAttemptsTitle', defaultMessage: 'Maximum Login Attempts:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.maximumLoginAttemptsDesc', defaultMessage: 'The maximum number of login attempts before the Mattermost account is locked. You can unlock the account in system console on the users page. Setting this value lower than your LDAP maximum login attempts ensures that the users won\'t be locked out of your LDAP server because of failed login attempts in Mattermost.'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.LdapServer',
-                                    label: defineMessage({id: 'admin.ldap.serverTitle', defaultMessage: 'AD/LDAP Server:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.serverDesc', defaultMessage: 'The domain or IP address of AD/LDAP server.'}),
-                                    placeholder: defineMessage({id: 'admin.ldap.serverEx', defaultMessage: 'E.g.: "10.0.0.23"'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'number',
-                                    key: 'LdapSettings.LdapPort',
-                                    label: defineMessage({id: 'admin.ldap.portTitle', defaultMessage: 'AD/LDAP Port:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.portDesc', defaultMessage: 'The port Mattermost will use to connect to the AD/LDAP server. Default is 389.'}),
-                                    placeholder: defineMessage({id: 'admin.ldap.portEx', defaultMessage: 'E.g.: "389"'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'dropdown',
-                                    key: 'LdapSettings.ConnectionSecurity',
-                                    label: defineMessage({id: 'admin.connectionSecurityTitle', defaultMessage: 'Connection Security:'}),
-                                    help_text: DefinitionConstants.CONNECTION_SECURITY_HELP_TEXT_LDAP,
-                                    options: [
-                                        {
-                                            value: '',
-                                            display_name: defineMessage({id: 'admin.connectionSecurityNone', defaultMessage: 'None'}),
-                                        },
-                                        {
-                                            value: 'TLS',
-                                            display_name: defineMessage({id: 'admin.connectionSecurityTls', defaultMessage: 'TLS (Recommended)'}),
-                                        },
-                                        {
-                                            value: 'STARTTLS',
-                                            display_name: defineMessage({id: 'admin.connectionSecurityStart', defaultMessage: 'STARTTLS'}),
-                                        },
-                                    ],
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'bool',
-                                    key: 'LdapSettings.SkipCertificateVerification',
-                                    label: defineMessage({id: 'admin.ldap.skipCertificateVerification', defaultMessage: 'Skip Certificate Verification:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.skipCertificateVerificationDesc', defaultMessage: 'Skips the certificate verification step for TLS or STARTTLS connections. Skipping certificate verification is not recommended for production environments where TLS is required.'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.stateIsFalse('LdapSettings.ConnectionSecurity'),
-                                    ),
-                                },
-                                {
-                                    type: 'fileupload',
-                                    key: 'LdapSettings.PrivateKeyFile',
-                                    label: defineMessage({id: 'admin.ldap.privateKeyFileTitle', defaultMessage: 'Private Key:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.privateKeyFileFileDesc', defaultMessage: 'The private key file for TLS Certificate. If using TLS client certificates as primary authentication mechanism. This will be provided by your LDAP Authentication Provider.'}),
-                                    remove_help_text: defineMessage({id: 'admin.ldap.privateKeyFileFileRemoveDesc', defaultMessage: 'Remove the private key file for TLS Certificate.'}),
-                                    remove_button_text: defineMessage({id: 'admin.ldap.remove.privKey', defaultMessage: 'Remove TLS Certificate Private Key'}),
-                                    removing_text: defineMessage({id: 'admin.ldap.removing.privKey', defaultMessage: 'Removing Private Key...'}),
-                                    uploading_text: defineMessage({id: 'admin.ldap.uploading.privateKey', defaultMessage: 'Uploading Private Key...'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                    fileType: '.key',
-                                    upload_action: uploadPrivateLdapCertificate,
-                                    remove_action: removePrivateLdapCertificate,
-                                },
-                                {
-                                    type: 'fileupload',
-                                    key: 'LdapSettings.PublicCertificateFile',
-                                    label: defineMessage({id: 'admin.ldap.publicCertificateFileTitle', defaultMessage: 'Public Certificate:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.publicCertificateFileDesc', defaultMessage: 'The public certificate file for TLS Certificate. If using TLS client certificates as primary authentication mechanism. This will be provided by your LDAP Authentication Provider.'}),
-                                    remove_help_text: defineMessage({id: 'admin.ldap.publicCertificateFileRemoveDesc', defaultMessage: 'Remove the public certificate file for TLS Certificate.'}),
-                                    remove_button_text: defineMessage({id: 'admin.ldap.remove.sp_certificate', defaultMessage: 'Remove Service Provider Certificate'}),
-                                    removing_text: defineMessage({id: 'admin.ldap.removing.certificate', defaultMessage: 'Removing Certificate...'}),
-                                    uploading_text: defineMessage({id: 'admin.ldap.uploading.certificate', defaultMessage: 'Uploading Certificate...'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                    fileType: '.crt,.cer',
-                                    upload_action: uploadPublicLdapCertificate,
-                                    remove_action: removePublicLdapCertificate,
-                                },
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.BindUsername',
-                                    label: defineMessage({id: 'admin.ldap.bindUserTitle', defaultMessage: 'Bind Username:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.bindUserDesc', defaultMessage: 'The username used to perform the AD/LDAP search. This should typically be an account created specifically for use with Mattermost. It should have access limited to read the portion of the AD/LDAP tree specified in the Base DN field.'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.BindPassword',
-                                    label: defineMessage({id: 'admin.ldap.bindPwdTitle', defaultMessage: 'Bind Password:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.bindPwdDesc', defaultMessage: 'Password of the user given in "Bind Username".'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                            ],
-                        },
-                        {
-                            key: 'admin.authentication.ldap.dn_and_filters',
-                            title: 'Base DN & Filters',
-                            settings: [
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.BaseDN',
-                                    label: defineMessage({id: 'admin.ldap.baseTitle', defaultMessage: 'Base DN:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.baseDesc', defaultMessage: 'The Base DN is the Distinguished Name of the location where Mattermost should start its search for user and group objects in the AD/LDAP tree.'}),
-                                    placeholder: defineMessage({id: 'admin.ldap.baseEx', defaultMessage: 'E.g.: "ou=Unit Name,dc=corp,dc=example,dc=com"'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.UserFilter',
-                                    label: defineMessage({id: 'admin.ldap.userFilterTitle', defaultMessage: 'User Filter:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.userFilterDisc', defaultMessage: '(Optional) Enter an AD/LDAP filter to use when searching for user objects. Only the users selected by the query will be able to access Mattermost. For Active Directory, the query to filter out disabled users is (&(objectCategory=Person)(!(UserAccountControl:1.2.840.113556.1.4.803:=2))).'}),
-                                    placeholder: defineMessage({id: 'admin.ldap.userFilterEx', defaultMessage: 'Ex. "(objectClass=user)"'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.GroupFilter',
-                                    label: defineMessage({id: 'admin.ldap.groupFilterTitle', defaultMessage: 'Group Filter:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.groupFilterFilterDesc', defaultMessage: '(Optional) Enter an AD/LDAP filter to use when searching for group objects. Only the groups selected by the query will be available to Mattermost. From [User Management > Groups]({siteURL}/admin_console/user_management/groups), select which AD/LDAP groups should be linked and configured.'}),
-                                    help_text_markdown: true,
-                                    help_text_values: {siteURL: getSiteURL()},
-                                    placeholder: defineMessage({id: 'admin.ldap.groupFilterEx', defaultMessage: 'E.g.: "(objectClass=group)"'}),
-                                    isHidden: it.not(it.licensedForFeature('LDAPGroups')),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.stateIsFalse('LdapSettings.EnableSync'),
-                                    ),
-                                },
-                                {
-                                    type: 'bool',
-                                    key: 'LdapSettings.EnableAdminFilter',
-                                    label: defineMessage({id: 'admin.ldap.enableAdminFilterTitle', defaultMessage: 'Enable Admin Filter:'}),
-                                    isDisabled: it.any(
-                                        it.not(it.isSystemAdmin),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.AdminFilter',
-                                    label: defineMessage({id: 'admin.ldap.adminFilterTitle', defaultMessage: 'Admin Filter:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.adminFilterFilterDesc', defaultMessage: '(Optional) Enter an AD/LDAP filter to use for designating System Admins. The users selected by the query will have access to your Mattermost server as System Admins. By default, System Admins have complete access to the Mattermost System Console. Existing members that are identified by this attribute will be promoted from member to System Admin upon next login. The next login is based upon Session lengths set in **System Console > Session Lengths**. It is highly recommend to manually demote users to members in **System Console > User Management** to ensure access is restricted immediately. Note: If this filter is removed/changed, System Admins that were promoted via this filter will be demoted to members and will not retain access to the System Console. When this filter is not in use, System Admins can be manually promoted/demoted in **System Console > User Management**.'}),
-                                    help_text_markdown: true,
-                                    placeholder: defineMessage({id: 'admin.ldap.adminFilterEx', defaultMessage: 'E.g.: "(objectClass=user)"'}),
-                                    isDisabled: it.any(
-                                        it.not(it.isSystemAdmin),
-                                        it.stateIsFalse('LdapSettings.EnableAdminFilter'),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.GuestFilter',
-                                    label: defineMessage({id: 'admin.ldap.guestFilterTitle', defaultMessage: 'Guest Filter:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.guestFilterFilterDesc', defaultMessage: '(Optional) Requires Guest Access to be enabled before being applied. Enter an AD/LDAP filter to use when searching for guest objects. Only the users selected by the query will be able to access Mattermost as Guests. Guests are prevented from accessing teams or channels upon logging in until they are assigned a team and at least one channel. Note: If this filter is removed/changed, active guests will not be promoted to a member and will retain their Guest role. Guests can be promoted in **System Console > User Management**. Existing members that are identified by this attribute as a guest will be demoted from a member to a guest when they are asked to login next. The next login is based upon Session lengths set in **System Console > Session Lengths**. It is highly recommend to manually demote users to guests in **System Console > User Management ** to ensure access is restricted immediately.'}),
-                                    help_text_markdown: true,
-                                    placeholder: defineMessage({id: 'admin.ldap.guestFilterEx', defaultMessage: 'E.g.: "(objectClass=user)"'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.configIsFalse('GuestAccountsSettings', 'Enable'),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                            ],
-                        },
-                        {
-                            key: 'admin.authentication.ldap.account_synchronization',
-                            title: 'Account Synchronization',
-                            settings: [
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.IdAttribute',
-                                    label: defineMessage({id: 'admin.ldap.idAttrTitle', defaultMessage: 'ID Attribute: '}),
-                                    placeholder: defineMessage({id: 'admin.ldap.idAttrEx', defaultMessage: 'E.g.: "objectGUID" or "uid"'}),
-                                    help_text: defineMessage({id: 'admin.ldap.idAttrDesc', defaultMessage: "The attribute in the AD/LDAP server used as a unique identifier in Mattermost. It should be an AD/LDAP attribute with a value that does not change such as `uid` for LDAP or `objectGUID` for Active Directory. If a user's ID Attribute changes, it will create a new Mattermost account unassociated with their old one. If you need to change this field after users have already logged in, use the <link>mattermost ldap idmigrate</link> CLI tool."}),
-                                    help_text_markdown: false,
-                                    help_text_values: {
-                                        link: (msg: string) => (
-                                            <ExternalLink
-                                                location='admin_console'
-                                                href='https://docs.mattermost.com/manage/command-line-tools.html#mattermost-ldap-idmigrate'
-                                            >
-                                                {msg}
-                                            </ExternalLink>
-                                        ),
-                                    },
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateEquals('LdapSettings.Enable', false),
-                                            it.stateEquals('LdapSettings.EnableSync', false),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.LoginIdAttribute',
-                                    label: defineMessage({id: 'admin.ldap.loginAttrTitle', defaultMessage: 'Login ID Attribute: '}),
-                                    placeholder: defineMessage({id: 'admin.ldap.loginIdAttrEx', defaultMessage: 'E.g.: "sAMAccountName"'}),
-                                    help_text: defineMessage({id: 'admin.ldap.loginAttrDesc', defaultMessage: 'The attribute in the AD/LDAP server used to log in to Mattermost. Normally this attribute is the same as the "Username Attribute" field above. If your team typically uses domain/username to log in to other services with AD/LDAP, you may enter domain/username in this field to maintain consistency between sites.'}),
-                                    help_text_markdown: false,
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.UsernameAttribute',
-                                    label: defineMessage({id: 'admin.ldap.usernameAttrTitle', defaultMessage: 'Username Attribute:'}),
-                                    placeholder: defineMessage({id: 'admin.ldap.usernameAttrEx', defaultMessage: 'E.g.: "sAMAccountName"'}),
-                                    help_text: defineMessage({id: 'admin.ldap.usernameAttrDesc', defaultMessage: 'The attribute in the AD/LDAP server used to populate the username field in Mattermost. This may be the same as the Login ID Attribute.'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.EmailAttribute',
-                                    label: defineMessage({id: 'admin.ldap.emailAttrTitle', defaultMessage: 'Email Attribute:'}),
-                                    placeholder: defineMessage({id: 'admin.ldap.emailAttrEx', defaultMessage: 'E.g.: "mail" or "userPrincipalName"'}),
-                                    help_text: defineMessage({id: 'admin.ldap.emailAttrDesc', defaultMessage: 'The attribute in the AD/LDAP server used to populate the email address field in Mattermost.'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.FirstNameAttribute',
-                                    label: defineMessage({id: 'admin.ldap.firstnameAttrTitle', defaultMessage: 'First Name Attribute:'}),
-                                    placeholder: defineMessage({id: 'admin.ldap.firstnameAttrEx', defaultMessage: 'E.g.: "givenName"'}),
-                                    help_text: defineMessage({id: 'admin.ldap.firstnameAttrDesc', defaultMessage: '(Optional) The attribute in the AD/LDAP server used to populate the first name of users in Mattermost. When set, users cannot edit their first name, since it is synchronized with the LDAP server. When left blank, users can set their first name in <strong>Account Menu > Account Settings > Profile</strong>.'}),
-                                    help_text_values: {
-                                        strong: (msg: string) => <strong>{msg}</strong>,
-                                    },
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.LastNameAttribute',
-                                    label: defineMessage({id: 'admin.ldap.lastnameAttrTitle', defaultMessage: 'Last Name Attribute:'}),
-                                    placeholder: defineMessage({id: 'admin.ldap.lastnameAttrEx', defaultMessage: 'E.g.: "sn"'}),
-                                    help_text: defineMessage({id: 'admin.ldap.lastnameAttrDesc', defaultMessage: '(Optional) The attribute in the AD/LDAP server used to populate the last name of users in Mattermost. When set, users cannot edit their last name, since it is synchronized with the LDAP server. When left blank, users can set their last name in <strong>Account Menu > Account Settings > Profile</strong>.'}),
-                                    help_text_values: {
-                                        strong: (msg: string) => <strong>{msg}</strong>,
-                                    },
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.NicknameAttribute',
-                                    label: defineMessage({id: 'admin.ldap.nicknameAttrTitle', defaultMessage: 'Nickname Attribute:'}),
-                                    placeholder: defineMessage({id: 'admin.ldap.nicknameAttrEx', defaultMessage: 'E.g.: "nickname"'}),
-                                    help_text: defineMessage({id: 'admin.ldap.nicknameAttrDesc', defaultMessage: '(Optional) The attribute in the AD/LDAP server used to populate the nickname of users in Mattermost. When set, users cannot edit their nickname, since it is synchronized with the LDAP server. When left blank, users can set their nickname in <strong>Account Menu > Account Settings > Profile</strong>.'}),
-                                    help_text_values: {
-                                        strong: (msg: string) => <strong>{msg}</strong>,
-                                    },
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.PositionAttribute',
-                                    label: defineMessage({id: 'admin.ldap.positionAttrTitle', defaultMessage: 'Position Attribute:'}),
-                                    placeholder: defineMessage({id: 'admin.ldap.positionAttrEx', defaultMessage: 'E.g.: "title"'}),
-                                    help_text: defineMessage({id: 'admin.ldap.positionAttrDesc', defaultMessage: '(Optional) The attribute in the AD/LDAP server used to populate the position field in Mattermost. When set, users cannot edit their position, since it is synchronized with the LDAP server. When left blank, users can set their position in <strong>Account Menu > Account Settings > Profile</strong>.'}),
-                                    help_text_values: {
-                                        strong: (msg: string) => <strong>{msg}</strong>,
-                                    },
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.PictureAttribute',
-                                    label: defineMessage({id: 'admin.ldap.pictureAttrTitle', defaultMessage: 'Profile Picture Attribute:'}),
-                                    placeholder: defineMessage({id: 'admin.ldap.pictureAttrEx', defaultMessage: 'E.g.: "thumbnailPhoto" or "jpegPhoto"'}),
-                                    help_text: defineMessage({id: 'admin.ldap.pictureAttrDesc', defaultMessage: '(Optional) The attribute in the AD/LDAP server used to populate the profile picture in Mattermost.'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'custom',
-                                    key: 'LdapSettings.CustomProfileAttributes',
-                                    component: CustomProfileAttributes,
-                                    isHidden: it.not(it.all(
-                                        it.minLicenseTier(LicenseSkus.Enterprise),
-                                        it.configIsTrue('FeatureFlags', 'CustomProfileAttributes'),
-                                    )),
-                                },
-                            ],
-                        },
-                        {
-                            key: 'admin.authentication.ldap.group_synchronization',
-                            title: 'Group Synchronization',
-                            settings: [
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.GroupDisplayNameAttribute',
-                                    label: defineMessage({id: 'admin.ldap.groupDisplayNameAttributeTitle', defaultMessage: 'Group Display Name Attribute:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.groupDisplayNameAttributeDesc', defaultMessage: 'The attribute in the AD/LDAP server used to populate the group display names.'}),
-                                    placeholder: defineMessage({id: 'admin.ldap.groupDisplayNameAttributeEx', defaultMessage: 'E.g.: "cn"'}),
-                                    isHidden: it.not(it.licensedForFeature('LDAPGroups')),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.stateIsFalse('LdapSettings.EnableSync'),
-                                    ),
-                                },
-                                {
-                                    type: 'text',
-                                    key: 'LdapSettings.GroupIdAttribute',
-                                    label: defineMessage({id: 'admin.ldap.groupIdAttributeTitle', defaultMessage: 'Group ID Attribute:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.groupIdAttributeDesc', defaultMessage: 'The attribute in the AD/LDAP server used as a unique identifier for Groups. This should be a AD/LDAP attribute with a value that does not change such as `entryUUID` for LDAP or `objectGUID` for Active Directory.'}),
-                                    help_text_markdown: true,
-                                    placeholder: defineMessage({id: 'admin.ldap.groupIdAttributeEx', defaultMessage: 'E.g.: "objectGUID" or "entryUUID"'}),
-                                    isHidden: it.not(it.licensedForFeature('LDAPGroups')),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.stateIsFalse('LdapSettings.EnableSync'),
-                                    ),
-                                },
-                            ],
-                        },
-                        {
-                            key: 'admin.authentication.ldap.synchronization_performance',
-                            title: 'Synchronization Performance',
-                            settings: [
-                                {
-                                    type: 'number',
-                                    key: 'LdapSettings.SyncIntervalMinutes',
-                                    label: defineMessage({id: 'admin.ldap.syncIntervalTitle', defaultMessage: 'Synchronization Interval (minutes):'}),
-                                    help_text: defineMessage({id: 'admin.ldap.syncIntervalHelpText', defaultMessage: 'AD/LDAP Synchronization updates Mattermost user information to reflect updates on the AD/LDAP server. For example, when a user\'s name changes on the AD/LDAP server, the change updates in Mattermost when synchronization is performed. Accounts removed from or disabled in the AD/LDAP server have their Mattermost accounts set to "Inactive" and have their account sessions revoked. Mattermost performs synchronization on the interval entered. For example, if 60 is entered, Mattermost synchronizes every 60 minutes.'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'bool',
-                                    key: 'LdapSettings.ReAddRemovedMembers',
-                                    label: defineMessage({id: 'admin.ldap.reAddRemovedMembersTitle', defaultMessage: 'Re-add removed members on sync:'}),
-                                    help_text: defineMessage({id: 'admin.ldap.reAddRemovedMembersDesc', defaultMessage: 'When enabled, members who were previously removed from group-synced teams or channels will be re-added during LDAP synchronization if they are still a member of the LDAP group.'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'number',
-                                    key: 'LdapSettings.MaxPageSize',
-                                    label: defineMessage({id: 'admin.ldap.maxPageSizeTitle', defaultMessage: 'Maximum Page Size:'}),
-                                    placeholder: defineMessage({id: 'admin.ldap.maxPageSizeEx', defaultMessage: 'E.g.: "2000"'}),
-                                    help_text: defineMessage({id: 'admin.ldap.maxPageSizeHelpText', defaultMessage: 'The maximum number of users the Mattermost server will request from the AD/LDAP server at one time. 0 is unlimited.'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'number',
-                                    key: 'LdapSettings.QueryTimeout',
-                                    label: defineMessage({id: 'admin.ldap.queryTitle', defaultMessage: 'Query Timeout (seconds):'}),
-                                    placeholder: defineMessage({id: 'admin.ldap.queryEx', defaultMessage: 'E.g.: "60"'}),
-                                    help_text: defineMessage({id: 'admin.ldap.queryDesc', defaultMessage: 'The timeout value for queries to the AD/LDAP server. Increase if you are getting timeout errors caused by a slow AD/LDAP server.'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                                {
-                                    type: 'button',
-                                    action: ldapTest,
-                                    key: 'LdapSettings.LdapTest',
-                                    label: defineMessage({id: 'admin.ldap.ldap_test_button', defaultMessage: 'AD/LDAP Test'}),
-                                    help_text: defineMessage({id: 'admin.ldap.testHelpText', defaultMessage: 'Tests if the Mattermost server can connect to the AD/LDAP server specified. Please review "System Console > Logs" and <link>documentation</link> to troubleshoot errors.'}),
-                                    help_text_values: {
-                                        link: (msg: string) => (
-                                            <ExternalLink
-                                                location='admin_console'
-                                                href={DocLinks.CONFIGURE_AD_LDAP_QUERY_TIMEOUT}
-                                            >
-                                                {msg}
-                                            </ExternalLink>
-                                        ),
-                                    },
-                                    help_text_markdown: false,
-                                    error_message: defineMessage({id: 'admin.ldap.testFailure', defaultMessage: 'AD/LDAP Test Failure: {error}'}),
-                                    success_message: defineMessage({id: 'admin.ldap.testSuccess', defaultMessage: 'AD/LDAP Test Successful'}),
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.all(
-                                            it.stateIsFalse('LdapSettings.Enable'),
-                                            it.stateIsFalse('LdapSettings.EnableSync'),
-                                        ),
-                                    ),
-                                },
-                            ],
-                        },
-                        {
-                            key: 'admin.authentication.ldap.synchronization_history',
-                            title: 'Synchronization History',
-                            subtitle: 'See the table below for the status of each synchronization',
-                            settings: [
-                                {
-                                    type: 'jobstable',
-                                    job_type: Constants.JobTypes.LDAP_SYNC,
-                                    label: defineMessage({id: 'admin.ldap.sync_button', defaultMessage: 'AD/LDAP Synchronize Now'}),
-                                    help_text: defineMessage({id: 'admin.ldap.syncNowHelpText', defaultMessage: 'Initiates an AD/LDAP synchronization immediately. See the table below for status of each synchronization. Please review "System Console > Logs" and <link>documentation</link> to troubleshoot errors.'}),
-                                    help_text_markdown: false,
-                                    help_text_values: {
-                                        link: (msg: string) => (
-                                            <ExternalLink
-                                                location='admin_console'
-                                                href={DocLinks.SETUP_LDAP}
-                                            >
-                                                {msg}
-                                            </ExternalLink>
-                                        ),
-                                    },
-                                    isDisabled: it.any(
-                                        it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
-                                        it.stateIsFalse('LdapSettings.EnableSync'),
-                                    ),
-                                    render_job: (job: Job) => {
-                                        if (job.status === 'pending') {
-                                            return <span>{'--'}</span>;
-                                        }
-
-                                        let ldapUsers = 0;
-                                        let deleteCount = 0;
-                                        let updateCount = 0;
-                                        let linkedLdapGroupsCount; // Deprecated.
-                                        let totalLdapGroupsCount = 0;
-                                        let groupDeleteCount = 0;
-                                        let groupMemberDeleteCount = 0;
-                                        let groupMemberAddCount = 0;
-
-                                        if (job && job.data) {
-                                            if (job.data.ldap_users_count && job.data.ldap_users_count.length > 0) {
-                                                ldapUsers = job.data.ldap_users_count;
-                                            }
-
-                                            if (job.data.delete_count && job.data.delete_count.length > 0) {
-                                                deleteCount = job.data.delete_count;
-                                            }
-
-                                            if (job.data.update_count && job.data.update_count.length > 0) {
-                                                updateCount = job.data.update_count;
-                                            }
-
-                                            // Deprecated groups count representing the number of linked LDAP groups.
-                                            if (job.data.ldap_groups_count) {
-                                                linkedLdapGroupsCount = job.data.ldap_groups_count;
-                                            }
-
-                                            // Groups count representing the total number of LDAP groups available based on
-                                            // the configured based DN and groups filter.
-                                            if (job.data.total_ldap_groups_count) {
-                                                totalLdapGroupsCount = job.data.total_ldap_groups_count;
-                                            }
-
-                                            if (job.data.group_delete_count) {
-                                                groupDeleteCount = job.data.group_delete_count;
-                                            }
-
-                                            if (job.data.group_member_delete_count) {
-                                                groupMemberDeleteCount = job.data.group_member_delete_count;
-                                            }
-
-                                            if (job.data.group_member_add_count) {
-                                                groupMemberAddCount = job.data.group_member_add_count;
-                                            }
-                                        }
-
-                                        return (
-                                            <span>
-                                                <FormattedMessage
-                                                    id={linkedLdapGroupsCount ? 'admin.ldap.jobExtraInfo' : 'admin.ldap.jobExtraInfoTotal'}
-                                                    defaultMessage={linkedLdapGroupsCount ? 'Scanned {ldapUsers, number} LDAP users and {ldapGroups, number} linked groups.' : 'Scanned {ldapUsers, number} LDAP users and {ldapGroups, number} groups.'}
-                                                    values={{
-                                                        ldapUsers,
-                                                        ldapGroups: linkedLdapGroupsCount || totalLdapGroupsCount, // Show the old count for jobs records containing the old JSON key.
-                                                    }}
-                                                />
-                                                <ul>
-                                                    {updateCount > 0 &&
-                                                    <li>
-                                                        <FormattedMessage
-                                                            id='admin.ldap.jobExtraInfo.updatedUsers'
-                                                            defaultMessage='Updated {updateCount, number} users.'
-                                                            values={{
-                                                                updateCount,
-                                                            }}
-                                                        />
-                                                    </li>
-                                                    }
-                                                    {deleteCount > 0 &&
-                                                    <li>
-                                                        <FormattedMessage
-                                                            id='admin.ldap.jobExtraInfo.deactivatedUsers'
-                                                            defaultMessage='Deactivated {deleteCount, number} users.'
-                                                            values={{
-                                                                deleteCount,
-                                                            }}
-                                                        />
-                                                    </li>
-                                                    }
-                                                    {groupDeleteCount > 0 &&
-                                                    <li>
-                                                        <FormattedMessage
-                                                            id='admin.ldap.jobExtraInfo.deletedGroups'
-                                                            defaultMessage='Deleted {groupDeleteCount, number} groups.'
-                                                            values={{
-                                                                groupDeleteCount,
-                                                            }}
-                                                        />
-                                                    </li>
-                                                    }
-                                                    {groupMemberDeleteCount > 0 &&
-                                                    <li>
-                                                        <FormattedMessage
-                                                            id='admin.ldap.jobExtraInfo.deletedGroupMembers'
-                                                            defaultMessage='Deleted {groupMemberDeleteCount, number} group members.'
-                                                            values={{
-                                                                groupMemberDeleteCount,
-                                                            }}
-                                                        />
-                                                    </li>
-                                                    }
-                                                    {groupMemberAddCount > 0 &&
-                                                    <li>
-                                                        <FormattedMessage
-                                                            id='admin.ldap.jobExtraInfo.addedGroupMembers'
-                                                            defaultMessage='Added {groupMemberAddCount, number} group members.'
-                                                            values={{
-                                                                groupMemberAddCount,
-                                                            }}
-                                                        />
-                                                    </li>
-                                                    }
-                                                </ul>
-                                            </span>
-                                        );
-                                    },
-                                },
-                            ],
-                        },
-                    ],
+                    id: 'LdapWizard',
+                    component: LDAPWizard,
                 },
-                restrictedIndicator: getRestrictedIndicator(),
             },
             ldap_feature_discovery: {
                 url: 'authentication/ldap',
@@ -6973,6 +6280,701 @@ const AdminDefinition: AdminDefinitionType = {
             },
         },
     },
+};
+
+export const ldapWizardAdminDefinition: AdminDefinitionSubSectionSchema = {
+    id: 'LdapSettings',
+    name: defineMessage({id: 'admin.authentication.ldap.wizard', defaultMessage: 'AD/LDAP Wizard!'}),
+    sections: [{
+        key: 'admin.authentication.ldap.connection',
+        title: 'Connection!',
+        subtitle: 'Connection and security level to your AD/LDAP server.',
+        settings: [
+            {
+                type: 'bool',
+                key: 'LdapSettings.Enable',
+                label: defineMessage({id: 'admin.ldap.enableTitle', defaultMessage: 'Enable sign-in with AD/LDAP:'}),
+                help_text: defineMessage({id: 'admin.ldap.enableDesc', defaultMessage: 'When true, Mattermost allows login using AD/LDAP'}),
+                isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+            },
+            {
+                type: 'bool',
+                key: 'LdapSettings.EnableSync',
+                label: defineMessage({id: 'admin.ldap.enableSyncTitle', defaultMessage: 'Enable Synchronization with AD/LDAP:'}),
+                help_text: defineMessage({id: 'admin.ldap.enableSyncDesc', defaultMessage: 'When true, Mattermost periodically synchronizes users from AD/LDAP. When false, user attributes are updated from AD/LDAP during user login only.'}),
+                isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+            },
+            {
+                type: 'text',
+                key: 'LdapSettings.LoginFieldName',
+                label: defineMessage({id: 'admin.ldap.loginNameTitle', defaultMessage: 'Login Field Name:'}),
+                placeholder: defineMessage({id: 'admin.ldap.loginNameEx', defaultMessage: 'E.g.: "AD/LDAP Username"'}),
+                help_text: defineMessage({id: 'admin.ldap.loginNameDesc', defaultMessage: 'The placeholder text that appears in the login field on the login page. Defaults to "AD/LDAP Username".'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'number',
+                key: 'LdapSettings.MaximumLoginAttempts',
+                label: defineMessage({id: 'admin.ldap.maximumLoginAttemptsTitle', defaultMessage: 'Maximum Login Attempts:'}),
+                help_text: defineMessage({id: 'admin.ldap.maximumLoginAttemptsDesc', defaultMessage: 'The maximum number of login attempts before the Mattermost account is locked. You can unlock the account in system console on the users page. Setting this value lower than your LDAP maximum login attempts ensures that the users won\'t be locked out of your LDAP server because of failed login attempts in Mattermost.'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'text',
+                key: 'LdapSettings.LdapServer',
+                label: defineMessage({id: 'admin.ldap.serverTitle', defaultMessage: 'AD/LDAP Server:'}),
+                help_text: defineMessage({id: 'admin.ldap.serverDesc', defaultMessage: 'The domain or IP address of AD/LDAP server.'}),
+                placeholder: defineMessage({id: 'admin.ldap.serverEx', defaultMessage: 'E.g.: "10.0.0.23"'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'number',
+                key: 'LdapSettings.LdapPort',
+                label: defineMessage({id: 'admin.ldap.portTitle', defaultMessage: 'AD/LDAP Port:'}),
+                help_text: defineMessage({id: 'admin.ldap.portDesc', defaultMessage: 'The port Mattermost will use to connect to the AD/LDAP server. Default is 389.'}),
+                placeholder: defineMessage({id: 'admin.ldap.portEx', defaultMessage: 'E.g.: "389"'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'dropdown',
+                key: 'LdapSettings.ConnectionSecurity',
+                label: defineMessage({id: 'admin.connectionSecurityTitle', defaultMessage: 'Connection Security:'}),
+                help_text: DefinitionConstants.CONNECTION_SECURITY_HELP_TEXT_LDAP,
+                options: [
+                    {
+                        value: '',
+                        display_name: defineMessage({id: 'admin.connectionSecurityNone', defaultMessage: 'None'}),
+                    },
+                    {
+                        value: 'TLS',
+                        display_name: defineMessage({id: 'admin.connectionSecurityTls', defaultMessage: 'TLS (Recommended)'}),
+                    },
+                    {
+                        value: 'STARTTLS',
+                        display_name: defineMessage({id: 'admin.connectionSecurityStart', defaultMessage: 'STARTTLS'}),
+                    },
+                ],
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'bool',
+                key: 'LdapSettings.SkipCertificateVerification',
+                label: defineMessage({id: 'admin.ldap.skipCertificateVerification', defaultMessage: 'Skip Certificate Verification:'}),
+                help_text: defineMessage({id: 'admin.ldap.skipCertificateVerificationDesc', defaultMessage: 'Skips the certificate verification step for TLS or STARTTLS connections. Skipping certificate verification is not recommended for production environments where TLS is required.'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.stateIsFalse('LdapSettings.ConnectionSecurity'),
+                ),
+            },
+            {
+                type: 'fileupload',
+                key: 'LdapSettings.PrivateKeyFile',
+                label: defineMessage({id: 'admin.ldap.privateKeyFileTitle', defaultMessage: 'Private Key:'}),
+                help_text: defineMessage({id: 'admin.ldap.privateKeyFileFileDesc', defaultMessage: 'The private key file for TLS Certificate. If using TLS client certificates as primary authentication mechanism. This will be provided by your LDAP Authentication Provider.'}),
+                remove_help_text: defineMessage({id: 'admin.ldap.privateKeyFileFileRemoveDesc', defaultMessage: 'Remove the private key file for TLS Certificate.'}),
+                remove_button_text: defineMessage({id: 'admin.ldap.remove.privKey', defaultMessage: 'Remove TLS Certificate Private Key'}),
+                removing_text: defineMessage({id: 'admin.ldap.removing.privKey', defaultMessage: 'Removing Private Key...'}),
+                uploading_text: defineMessage({id: 'admin.ldap.uploading.privateKey', defaultMessage: 'Uploading Private Key...'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+                fileType: '.key',
+                upload_action: uploadPrivateLdapCertificate,
+                remove_action: removePrivateLdapCertificate,
+            },
+            {
+                type: 'fileupload',
+                key: 'LdapSettings.PublicCertificateFile',
+                label: defineMessage({id: 'admin.ldap.publicCertificateFileTitle', defaultMessage: 'Public Certificate:'}),
+                help_text: defineMessage({id: 'admin.ldap.publicCertificateFileDesc', defaultMessage: 'The public certificate file for TLS Certificate. If using TLS client certificates as primary authentication mechanism. This will be provided by your LDAP Authentication Provider.'}),
+                remove_help_text: defineMessage({id: 'admin.ldap.publicCertificateFileRemoveDesc', defaultMessage: 'Remove the public certificate file for TLS Certificate.'}),
+                remove_button_text: defineMessage({id: 'admin.ldap.remove.sp_certificate', defaultMessage: 'Remove Service Provider Certificate'}),
+                removing_text: defineMessage({id: 'admin.ldap.removing.certificate', defaultMessage: 'Removing Certificate...'}),
+                uploading_text: defineMessage({id: 'admin.ldap.uploading.certificate', defaultMessage: 'Uploading Certificate...'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+                fileType: '.crt,.cer',
+                upload_action: uploadPublicLdapCertificate,
+                remove_action: removePublicLdapCertificate,
+            },
+            {
+                type: 'text',
+                key: 'LdapSettings.BindUsername',
+                label: defineMessage({id: 'admin.ldap.bindUserTitle', defaultMessage: 'Bind Username:'}),
+                help_text: defineMessage({id: 'admin.ldap.bindUserDesc', defaultMessage: 'The username used to perform the AD/LDAP search. This should typically be an account created specifically for use with Mattermost. It should have access limited to read the portion of the AD/LDAP tree specified in the Base DN field.'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'text',
+                key: 'LdapSettings.BindPassword',
+                label: defineMessage({id: 'admin.ldap.bindPwdTitle', defaultMessage: 'Bind Password:'}),
+                help_text: defineMessage({id: 'admin.ldap.bindPwdDesc', defaultMessage: 'Password of the user given in "Bind Username".'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+        ],
+    },
+    {
+        key: 'admin.authentication.ldap.dn_and_filters',
+        title: 'Base DN & Filters',
+        settings: [
+            {
+                type: 'text',
+                key: 'LdapSettings.BaseDN',
+                label: defineMessage({id: 'admin.ldap.baseTitle', defaultMessage: 'Base DN:'}),
+                help_text: defineMessage({id: 'admin.ldap.baseDesc', defaultMessage: 'The Base DN is the Distinguished Name of the location where Mattermost should start its search for user and group objects in the AD/LDAP tree.'}),
+                placeholder: defineMessage({id: 'admin.ldap.baseEx', defaultMessage: 'E.g.: "ou=Unit Name,dc=corp,dc=example,dc=com"'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'text',
+                key: 'LdapSettings.UserFilter',
+                label: defineMessage({id: 'admin.ldap.userFilterTitle', defaultMessage: 'User Filter:'}),
+                help_text: defineMessage({id: 'admin.ldap.userFilterDisc', defaultMessage: '(Optional) Enter an AD/LDAP filter to use when searching for user objects. Only the users selected by the query will be able to access Mattermost. For Active Directory, the query to filter out disabled users is (&(objectCategory=Person)(!(UserAccountControl:1.2.840.113556.1.4.803:=2))).'}),
+                placeholder: defineMessage({id: 'admin.ldap.userFilterEx', defaultMessage: 'Ex. "(objectClass=user)"'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'text',
+                key: 'LdapSettings.GroupFilter',
+                label: defineMessage({id: 'admin.ldap.groupFilterTitle', defaultMessage: 'Group Filter:'}),
+                help_text: defineMessage({id: 'admin.ldap.groupFilterFilterDesc', defaultMessage: '(Optional) Enter an AD/LDAP filter to use when searching for group objects. Only the groups selected by the query will be available to Mattermost. From [User Management > Groups]({siteURL}/admin_console/user_management/groups), select which AD/LDAP groups should be linked and configured.'}),
+                help_text_markdown: true,
+                help_text_values: {siteURL: getSiteURL()},
+                placeholder: defineMessage({id: 'admin.ldap.groupFilterEx', defaultMessage: 'E.g.: "(objectClass=group)"'}),
+                isHidden: it.not(it.licensedForFeature('LDAPGroups')),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.stateIsFalse('LdapSettings.EnableSync'),
+                ),
+            },
+            {
+                type: 'bool',
+                key: 'LdapSettings.EnableAdminFilter',
+                label: defineMessage({id: 'admin.ldap.enableAdminFilterTitle', defaultMessage: 'Enable Admin Filter:'}),
+                isDisabled: it.any(
+                    it.not(it.isSystemAdmin),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'text',
+                key: 'LdapSettings.AdminFilter',
+                label: defineMessage({id: 'admin.ldap.adminFilterTitle', defaultMessage: 'Admin Filter:'}),
+                help_text: defineMessage({id: 'admin.ldap.adminFilterFilterDesc', defaultMessage: '(Optional) Enter an AD/LDAP filter to use for designating System Admins. The users selected by the query will have access to your Mattermost server as System Admins. By default, System Admins have complete access to the Mattermost System Console. Existing members that are identified by this attribute will be promoted from member to System Admin upon next login. The next login is based upon Session lengths set in **System Console > Session Lengths**. It is highly recommend to manually demote users to members in **System Console > User Management** to ensure access is restricted immediately. Note: If this filter is removed/changed, System Admins that were promoted via this filter will be demoted to members and will not retain access to the System Console. When this filter is not in use, System Admins can be manually promoted/demoted in **System Console > User Management**.'}),
+                help_text_markdown: true,
+                placeholder: defineMessage({id: 'admin.ldap.adminFilterEx', defaultMessage: 'E.g.: "(objectClass=user)"'}),
+                isDisabled: it.any(
+                    it.not(it.isSystemAdmin),
+                    it.stateIsFalse('LdapSettings.EnableAdminFilter'),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'text',
+                key: 'LdapSettings.GuestFilter',
+                label: defineMessage({id: 'admin.ldap.guestFilterTitle', defaultMessage: 'Guest Filter:'}),
+                help_text: defineMessage({id: 'admin.ldap.guestFilterFilterDesc', defaultMessage: '(Optional) Requires Guest Access to be enabled before being applied. Enter an AD/LDAP filter to use when searching for guest objects. Only the users selected by the query will be able to access Mattermost as Guests. Guests are prevented from accessing teams or channels upon logging in until they are assigned a team and at least one channel. Note: If this filter is removed/changed, active guests will not be promoted to a member and will retain their Guest role. Guests can be promoted in **System Console > User Management**. Existing members that are identified by this attribute as a guest will be demoted from a member to a guest when they are asked to login next. The next login is based upon Session lengths set in **System Console > Session Lengths**. It is highly recommend to manually demote users to guests in **System Console > User Management ** to ensure access is restricted immediately.'}),
+                help_text_markdown: true,
+                placeholder: defineMessage({id: 'admin.ldap.guestFilterEx', defaultMessage: 'E.g.: "(objectClass=user)"'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.configIsFalse('GuestAccountsSettings', 'Enable'),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+        ],
+    },
+    {
+        key: 'admin.authentication.ldap.account_synchronization',
+        title: 'Account Synchronization',
+        settings: [
+            {
+                type: 'text',
+                key: 'LdapSettings.IdAttribute',
+                label: defineMessage({id: 'admin.ldap.idAttrTitle', defaultMessage: 'ID Attribute: '}),
+                placeholder: defineMessage({id: 'admin.ldap.idAttrEx', defaultMessage: 'E.g.: "objectGUID" or "uid"'}),
+                help_text: defineMessage({id: 'admin.ldap.idAttrDesc', defaultMessage: "The attribute in the AD/LDAP server used as a unique identifier in Mattermost. It should be an AD/LDAP attribute with a value that does not change such as `uid` for LDAP or `objectGUID` for Active Directory. If a user's ID Attribute changes, it will create a new Mattermost account unassociated with their old one. If you need to change this field after users have already logged in, use the <link>mattermost ldap idmigrate</link> CLI tool."}),
+                help_text_markdown: false,
+                help_text_values: {
+                    link: (msg: string) => (
+                        <ExternalLink
+                            location='admin_console'
+                            href='https://docs.mattermost.com/manage/command-line-tools.html#mattermost-ldap-idmigrate'
+                        >
+                            {msg}
+                        </ExternalLink>
+                    ),
+                },
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateEquals('LdapSettings.Enable', false),
+                        it.stateEquals('LdapSettings.EnableSync', false),
+                    ),
+                ),
+            },
+            {
+                type: 'text',
+                key: 'LdapSettings.LoginIdAttribute',
+                label: defineMessage({id: 'admin.ldap.loginAttrTitle', defaultMessage: 'Login ID Attribute: '}),
+                placeholder: defineMessage({id: 'admin.ldap.loginIdAttrEx', defaultMessage: 'E.g.: "sAMAccountName"'}),
+                help_text: defineMessage({id: 'admin.ldap.loginAttrDesc', defaultMessage: 'The attribute in the AD/LDAP server used to log in to Mattermost. Normally this attribute is the same as the "Username Attribute" field above. If your team typically uses domain/username to log in to other services with AD/LDAP, you may enter domain/username in this field to maintain consistency between sites.'}),
+                help_text_markdown: false,
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'text',
+                key: 'LdapSettings.UsernameAttribute',
+                label: defineMessage({id: 'admin.ldap.usernameAttrTitle', defaultMessage: 'Username Attribute:'}),
+                placeholder: defineMessage({id: 'admin.ldap.usernameAttrEx', defaultMessage: 'E.g.: "sAMAccountName"'}),
+                help_text: defineMessage({id: 'admin.ldap.usernameAttrDesc', defaultMessage: 'The attribute in the AD/LDAP server used to populate the username field in Mattermost. This may be the same as the Login ID Attribute.'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'text',
+                key: 'LdapSettings.EmailAttribute',
+                label: defineMessage({id: 'admin.ldap.emailAttrTitle', defaultMessage: 'Email Attribute:'}),
+                placeholder: defineMessage({id: 'admin.ldap.emailAttrEx', defaultMessage: 'E.g.: "mail" or "userPrincipalName"'}),
+                help_text: defineMessage({id: 'admin.ldap.emailAttrDesc', defaultMessage: 'The attribute in the AD/LDAP server used to populate the email address field in Mattermost.'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'text',
+                key: 'LdapSettings.FirstNameAttribute',
+                label: defineMessage({id: 'admin.ldap.firstnameAttrTitle', defaultMessage: 'First Name Attribute:'}),
+                placeholder: defineMessage({id: 'admin.ldap.firstnameAttrEx', defaultMessage: 'E.g.: "givenName"'}),
+                help_text: defineMessage({id: 'admin.ldap.firstnameAttrDesc', defaultMessage: '(Optional) The attribute in the AD/LDAP server used to populate the first name of users in Mattermost. When set, users cannot edit their first name, since it is synchronized with the LDAP server. When left blank, users can set their first name in <strong>Account Menu > Account Settings > Profile</strong>.'}),
+                help_text_values: {
+                    strong: (msg: string) => <strong>{msg}</strong>,
+                },
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'text',
+                key: 'LdapSettings.LastNameAttribute',
+                label: defineMessage({id: 'admin.ldap.lastnameAttrTitle', defaultMessage: 'Last Name Attribute:'}),
+                placeholder: defineMessage({id: 'admin.ldap.lastnameAttrEx', defaultMessage: 'E.g.: "sn"'}),
+                help_text: defineMessage({id: 'admin.ldap.lastnameAttrDesc', defaultMessage: '(Optional) The attribute in the AD/LDAP server used to populate the last name of users in Mattermost. When set, users cannot edit their last name, since it is synchronized with the LDAP server. When left blank, users can set their last name in <strong>Account Menu > Account Settings > Profile</strong>.'}),
+                help_text_values: {
+                    strong: (msg: string) => <strong>{msg}</strong>,
+                },
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'text',
+                key: 'LdapSettings.NicknameAttribute',
+                label: defineMessage({id: 'admin.ldap.nicknameAttrTitle', defaultMessage: 'Nickname Attribute:'}),
+                placeholder: defineMessage({id: 'admin.ldap.nicknameAttrEx', defaultMessage: 'E.g.: "nickname"'}),
+                help_text: defineMessage({id: 'admin.ldap.nicknameAttrDesc', defaultMessage: '(Optional) The attribute in the AD/LDAP server used to populate the nickname of users in Mattermost. When set, users cannot edit their nickname, since it is synchronized with the LDAP server. When left blank, users can set their nickname in <strong>Account Menu > Account Settings > Profile</strong>.'}),
+                help_text_values: {
+                    strong: (msg: string) => <strong>{msg}</strong>,
+                },
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'text',
+                key: 'LdapSettings.PositionAttribute',
+                label: defineMessage({id: 'admin.ldap.positionAttrTitle', defaultMessage: 'Position Attribute:'}),
+                placeholder: defineMessage({id: 'admin.ldap.positionAttrEx', defaultMessage: 'E.g.: "title"'}),
+                help_text: defineMessage({id: 'admin.ldap.positionAttrDesc', defaultMessage: '(Optional) The attribute in the AD/LDAP server used to populate the position field in Mattermost. When set, users cannot edit their position, since it is synchronized with the LDAP server. When left blank, users can set their position in <strong>Account Menu > Account Settings > Profile</strong>.'}),
+                help_text_values: {
+                    strong: (msg: string) => <strong>{msg}</strong>,
+                },
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'text',
+                key: 'LdapSettings.PictureAttribute',
+                label: defineMessage({id: 'admin.ldap.pictureAttrTitle', defaultMessage: 'Profile Picture Attribute:'}),
+                placeholder: defineMessage({id: 'admin.ldap.pictureAttrEx', defaultMessage: 'E.g.: "thumbnailPhoto" or "jpegPhoto"'}),
+                help_text: defineMessage({id: 'admin.ldap.pictureAttrDesc', defaultMessage: '(Optional) The attribute in the AD/LDAP server used to populate the profile picture in Mattermost.'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'custom',
+                key: 'LdapSettings.CustomProfileAttributes',
+                component: CustomProfileAttributes,
+                isHidden: it.not(it.all(
+                    it.minLicenseTier(LicenseSkus.Enterprise),
+                    it.configIsTrue('FeatureFlags', 'CustomProfileAttributes'),
+                )),
+            },
+        ],
+    },
+    {
+        key: 'admin.authentication.ldap.group_synchronization',
+        title: 'Group Synchronization',
+        settings: [
+            {
+                type: 'text',
+                key: 'LdapSettings.GroupDisplayNameAttribute',
+                label: defineMessage({id: 'admin.ldap.groupDisplayNameAttributeTitle', defaultMessage: 'Group Display Name Attribute:'}),
+                help_text: defineMessage({id: 'admin.ldap.groupDisplayNameAttributeDesc', defaultMessage: 'The attribute in the AD/LDAP server used to populate the group display names.'}),
+                placeholder: defineMessage({id: 'admin.ldap.groupDisplayNameAttributeEx', defaultMessage: 'E.g.: "cn"'}),
+                isHidden: it.not(it.licensedForFeature('LDAPGroups')),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.stateIsFalse('LdapSettings.EnableSync'),
+                ),
+            },
+            {
+                type: 'text',
+                key: 'LdapSettings.GroupIdAttribute',
+                label: defineMessage({id: 'admin.ldap.groupIdAttributeTitle', defaultMessage: 'Group ID Attribute:'}),
+                help_text: defineMessage({id: 'admin.ldap.groupIdAttributeDesc', defaultMessage: 'The attribute in the AD/LDAP server used as a unique identifier for Groups. This should be a AD/LDAP attribute with a value that does not change such as `entryUUID` for LDAP or `objectGUID` for Active Directory.'}),
+                help_text_markdown: true,
+                placeholder: defineMessage({id: 'admin.ldap.groupIdAttributeEx', defaultMessage: 'E.g.: "objectGUID" or "entryUUID"'}),
+                isHidden: it.not(it.licensedForFeature('LDAPGroups')),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.stateIsFalse('LdapSettings.EnableSync'),
+                ),
+            },
+        ],
+    },
+    {
+        key: 'admin.authentication.ldap.synchronization_performance',
+        title: 'Synchronization Performance',
+        settings: [
+            {
+                type: 'number',
+                key: 'LdapSettings.SyncIntervalMinutes',
+                label: defineMessage({id: 'admin.ldap.syncIntervalTitle', defaultMessage: 'Synchronization Interval (minutes):'}),
+                help_text: defineMessage({id: 'admin.ldap.syncIntervalHelpText', defaultMessage: 'AD/LDAP Synchronization updates Mattermost user information to reflect updates on the AD/LDAP server. For example, when a user\'s name changes on the AD/LDAP server, the change updates in Mattermost when synchronization is performed. Accounts removed from or disabled in the AD/LDAP server have their Mattermost accounts set to "Inactive" and have their account sessions revoked. Mattermost performs synchronization on the interval entered. For example, if 60 is entered, Mattermost synchronizes every 60 minutes.'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'number',
+                key: 'LdapSettings.MaxPageSize',
+                label: defineMessage({id: 'admin.ldap.maxPageSizeTitle', defaultMessage: 'Maximum Page Size:'}),
+                placeholder: defineMessage({id: 'admin.ldap.maxPageSizeEx', defaultMessage: 'E.g.: "2000"'}),
+                help_text: defineMessage({id: 'admin.ldap.maxPageSizeHelpText', defaultMessage: 'The maximum number of users the Mattermost server will request from the AD/LDAP server at one time. 0 is unlimited.'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'number',
+                key: 'LdapSettings.QueryTimeout',
+                label: defineMessage({id: 'admin.ldap.queryTitle', defaultMessage: 'Query Timeout (seconds):'}),
+                placeholder: defineMessage({id: 'admin.ldap.queryEx', defaultMessage: 'E.g.: "60"'}),
+                help_text: defineMessage({id: 'admin.ldap.queryDesc', defaultMessage: 'The timeout value for queries to the AD/LDAP server. Increase if you are getting timeout errors caused by a slow AD/LDAP server.'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+            {
+                type: 'button',
+                action: ldapTest,
+                key: 'LdapSettings.LdapTest',
+                label: defineMessage({id: 'admin.ldap.ldap_test_button', defaultMessage: 'AD/LDAP Test'}),
+                help_text: defineMessage({id: 'admin.ldap.testHelpText', defaultMessage: 'Tests if the Mattermost server can connect to the AD/LDAP server specified. Please review "System Console > Logs" and <link>documentation</link> to troubleshoot errors.'}),
+                help_text_values: {
+                    link: (msg: string) => (
+                        <ExternalLink
+                            location='admin_console'
+                            href={DocLinks.CONFIGURE_AD_LDAP_QUERY_TIMEOUT}
+                        >
+                            {msg}
+                        </ExternalLink>
+                    ),
+                },
+                help_text_markdown: false,
+                error_message: defineMessage({id: 'admin.ldap.testFailure', defaultMessage: 'AD/LDAP Test Failure: {error}'}),
+                success_message: defineMessage({id: 'admin.ldap.testSuccess', defaultMessage: 'AD/LDAP Test Successful'}),
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.all(
+                        it.stateIsFalse('LdapSettings.Enable'),
+                        it.stateIsFalse('LdapSettings.EnableSync'),
+                    ),
+                ),
+            },
+        ],
+    },
+    {
+        key: 'admin.authentication.ldap.synchronization_history',
+        title: 'Synchronization History',
+        subtitle: 'See the table below for the status of each synchronization',
+        settings: [
+            {
+                type: 'jobstable',
+                job_type: Constants.JobTypes.LDAP_SYNC,
+                label: defineMessage({id: 'admin.ldap.sync_button', defaultMessage: 'AD/LDAP Synchronize Now'}),
+                help_text: defineMessage({id: 'admin.ldap.syncNowHelpText', defaultMessage: 'Initiates an AD/LDAP synchronization immediately. See the table below for status of each synchronization. Please review "System Console > Logs" and <link>documentation</link> to troubleshoot errors.'}),
+                help_text_markdown: false,
+                help_text_values: {
+                    link: (msg: string) => (
+                        <ExternalLink
+                            location='admin_console'
+                            href={DocLinks.SETUP_LDAP}
+                        >
+                            {msg}
+                        </ExternalLink>
+                    ),
+                },
+                isDisabled: it.any(
+                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
+                    it.stateIsFalse('LdapSettings.EnableSync'),
+                ),
+                render_job: (job: Job) => {
+                    if (job.status === 'pending') {
+                        return <span>{'--'}</span>;
+                    }
+
+                    let ldapUsers = 0;
+                    let deleteCount = 0;
+                    let updateCount = 0;
+                    let linkedLdapGroupsCount; // Deprecated.
+                    let totalLdapGroupsCount = 0;
+                    let groupDeleteCount = 0;
+                    let groupMemberDeleteCount = 0;
+                    let groupMemberAddCount = 0;
+
+                    if (job && job.data) {
+                        if (job.data.ldap_users_count && job.data.ldap_users_count.length > 0) {
+                            ldapUsers = job.data.ldap_users_count;
+                        }
+
+                        if (job.data.delete_count && job.data.delete_count.length > 0) {
+                            deleteCount = job.data.delete_count;
+                        }
+
+                        if (job.data.update_count && job.data.update_count.length > 0) {
+                            updateCount = job.data.update_count;
+                        }
+
+                        // Deprecated groups count representing the number of linked LDAP groups.
+                        if (job.data.ldap_groups_count) {
+                            linkedLdapGroupsCount = job.data.ldap_groups_count;
+                        }
+
+                        // Groups count representing the total number of LDAP groups available based on
+                        // the configured based DN and groups filter.
+                        if (job.data.total_ldap_groups_count) {
+                            totalLdapGroupsCount = job.data.total_ldap_groups_count;
+                        }
+
+                        if (job.data.group_delete_count) {
+                            groupDeleteCount = job.data.group_delete_count;
+                        }
+
+                        if (job.data.group_member_delete_count) {
+                            groupMemberDeleteCount = job.data.group_member_delete_count;
+                        }
+
+                        if (job.data.group_member_add_count) {
+                            groupMemberAddCount = job.data.group_member_add_count;
+                        }
+                    }
+
+                    return (
+                        <span>
+                            <FormattedMessage
+                                id={linkedLdapGroupsCount ? 'admin.ldap.jobExtraInfo' : 'admin.ldap.jobExtraInfoTotal'}
+                                defaultMessage={linkedLdapGroupsCount ? 'Scanned {ldapUsers, number} LDAP users and {ldapGroups, number} linked groups.' : 'Scanned {ldapUsers, number} LDAP users and {ldapGroups, number} groups.'}
+                                values={{
+                                    ldapUsers,
+                                    ldapGroups: linkedLdapGroupsCount || totalLdapGroupsCount, // Show the old count for jobs records containing the old JSON key.
+                                }}
+                            />
+                            <ul>
+                                {updateCount > 0 &&
+                                    <li>
+                                        <FormattedMessage
+                                            id='admin.ldap.jobExtraInfo.updatedUsers'
+                                            defaultMessage='Updated {updateCount, number} users.'
+                                            values={{
+                                                updateCount,
+                                            }}
+                                        />
+                                    </li>
+                                }
+                                {deleteCount > 0 &&
+                                    <li>
+                                        <FormattedMessage
+                                            id='admin.ldap.jobExtraInfo.deactivatedUsers'
+                                            defaultMessage='Deactivated {deleteCount, number} users.'
+                                            values={{
+                                                deleteCount,
+                                            }}
+                                        />
+                                    </li>
+                                }
+                                {groupDeleteCount > 0 &&
+                                    <li>
+                                        <FormattedMessage
+                                            id='admin.ldap.jobExtraInfo.deletedGroups'
+                                            defaultMessage='Deleted {groupDeleteCount, number} groups.'
+                                            values={{
+                                                groupDeleteCount,
+                                            }}
+                                        />
+                                    </li>
+                                }
+                                {groupMemberDeleteCount > 0 &&
+                                    <li>
+                                        <FormattedMessage
+                                            id='admin.ldap.jobExtraInfo.deletedGroupMembers'
+                                            defaultMessage='Deleted {groupMemberDeleteCount, number} group members.'
+                                            values={{
+                                                groupMemberDeleteCount,
+                                            }}
+                                        />
+                                    </li>
+                                }
+                                {groupMemberAddCount > 0 &&
+                                    <li>
+                                        <FormattedMessage
+                                            id='admin.ldap.jobExtraInfo.addedGroupMembers'
+                                            defaultMessage='Added {groupMemberAddCount, number} group members.'
+                                            values={{
+                                                groupMemberAddCount,
+                                            }}
+                                        />
+                                    </li>
+                                }
+                            </ul>
+                        </span>
+                    );
+                },
+            },
+        ],
+    }],
 };
 
 export default AdminDefinition;

--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -6284,7 +6284,7 @@ const AdminDefinition: AdminDefinitionType = {
 
 export const ldapWizardAdminDefinition: AdminDefinitionSubSectionSchema = {
     id: 'LdapSettings',
-    name: defineMessage({id: 'admin.authentication.ldap.wizard', defaultMessage: 'AD/LDAP Wizard!'}),
+    name: defineMessage({id: 'admin.authentication.ldap.wizard', defaultMessage: 'AD/LDAP Wizard'}),
     sections: [{
         key: 'admin.authentication.ldap.connection',
         title: 'Connection!',

--- a/webapp/channels/src/components/admin_console/custom_profile_attributes/custom_profile_attributes.tsx
+++ b/webapp/channels/src/components/admin_console/custom_profile_attributes/custom_profile_attributes.tsx
@@ -112,7 +112,7 @@ const CustomProfileAttributes: React.FC<Props> = (props: Props): JSX.Element | n
 
         props.registerSaveAction(handleSave);
         return () => props.unRegisterSaveAction(handleSave);
-    }, [props.registerSaveAction, props.unRegisterSaveAction, attributes, originalAttributes, attributeKey, props]);
+    }, [props.registerSaveAction, props.unRegisterSaveAction, attributes, originalAttributes, attributeKey]);
 
     if (attributes.length === 0) {
         return null;

--- a/webapp/channels/src/components/admin_console/ldap_wizard/index.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/index.tsx
@@ -1,0 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import LDAPWizard from './ldap_wizard';
+
+export default LDAPWizard;

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_boolean_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_boolean_setting.tsx
@@ -1,0 +1,41 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import BooleanSetting from 'components/admin_console/boolean_setting';
+
+import type {GeneralSettingProps} from './ldap_wizard';
+
+import {renderLabel, renderSettingHelpText} from '../schema_admin_settings';
+
+type BoolSettingProps = {
+    value: boolean;
+    onChange(id: string, value: any): void;
+    disabled: boolean;
+    setByEnv: boolean;
+} & GeneralSettingProps
+
+const LDAPBooleanSetting = (props: BoolSettingProps) => {
+    if (!props.schema || !props.setting.key || props.setting.type !== 'bool') {
+        return (<></>);
+    }
+
+    const label = renderLabel(props.setting, props.schema, props.intl);
+    const helpText = renderSettingHelpText(props.setting, props.schema, Boolean(props.disabled));
+
+    return (
+        <BooleanSetting
+            key={props.schema.id + '_bool_' + props.setting.key}
+            id={props.setting.key}
+            label={label}
+            helpText={helpText}
+            value={props.value}
+            disabled={props.disabled}
+            setByEnv={props.setByEnv}
+            onChange={props.onChange}
+        />
+    );
+};
+
+export default LDAPBooleanSetting;

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_boolean_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_boolean_setting.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {useIntl} from 'react-intl';
 
 import BooleanSetting from 'components/admin_console/boolean_setting';
 
@@ -17,11 +18,13 @@ type BoolSettingProps = {
 } & GeneralSettingProps
 
 const LDAPBooleanSetting = (props: BoolSettingProps) => {
+    const intl = useIntl();
+
     if (!props.schema || !props.setting.key || props.setting.type !== 'bool') {
         return (<></>);
     }
 
-    const label = renderLabel(props.setting, props.schema, props.intl);
+    const label = renderLabel(props.setting, props.schema, intl);
     const helpText = renderSettingHelpText(props.setting, props.schema, Boolean(props.disabled));
 
     return (

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_boolean_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_boolean_setting.tsx
@@ -21,7 +21,7 @@ const LDAPBooleanSetting = (props: BoolSettingProps) => {
     const intl = useIntl();
 
     if (!props.schema || !props.setting.key || props.setting.type !== 'bool') {
-        return (<></>);
+        return null;
     }
 
     const label = renderLabel(props.setting, props.schema, intl);

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_button_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_button_setting.tsx
@@ -1,0 +1,62 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import type {GeneralSettingProps} from './ldap_wizard';
+
+import RequestButton from '../request_button/request_button';
+import {descriptorOrStringToString, renderLabel, renderSettingHelpText} from '../schema_admin_settings';
+import type {AdminDefinitionSettingButton} from '../types';
+
+type Props = {
+    setting: AdminDefinitionSettingButton;
+    saveNeeded: boolean;
+    onChange(id: string, value: any): void;
+    disabled: boolean;
+} & GeneralSettingProps
+
+const LDAPButtonSetting = (props: Props) => {
+    if (!props.schema || props.setting.type !== 'button') {
+        return (<></>);
+    }
+
+    const handleRequestAction = (success: () => void, error: (error: { message: string }) => void) => {
+        if (!props.setting.skipSaveNeeded && props.saveNeeded !== false) {
+            error({
+                message: props.intl.formatMessage({id: 'admin_settings.save_unsaved_changes', defaultMessage: 'Please save unsaved changes first'}),
+            });
+            return;
+        }
+        const successCallback = () => {
+            // NOTE: we don't have any settings with 'setFromMetadataField' in the LDAP wizard
+            if (success && typeof success === 'function') {
+                success();
+            }
+        };
+
+        // NOTE: we don't use the sourceUrlKey in the LDAP wizard
+        props.setting.action(successCallback, error, '');
+    };
+
+    const helpText = renderSettingHelpText(props.setting, props.schema, Boolean(props.disabled));
+    const label = renderLabel(props.setting, props.schema, props.intl);
+
+    return (
+        <RequestButton
+            id={props.setting.key}
+            key={props.schema.id + '_text_' + props.setting.key}
+            requestAction={handleRequestAction}
+            helpText={helpText}
+            loadingText={descriptorOrStringToString(props.setting.loading, props.intl)}
+            buttonText={<span>{label}</span>}
+            showSuccessMessage={Boolean(props.setting.success_message)}
+            includeDetailedError={true}
+            disabled={props.disabled}
+            errorMessage={props.setting.error_message}
+            successMessage={props.setting.success_message}
+        />
+    );
+};
+
+export default LDAPButtonSetting;

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_button_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_button_setting.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {useIntl} from 'react-intl';
 
 import type {GeneralSettingProps} from './ldap_wizard';
 
@@ -17,6 +18,8 @@ type Props = {
 } & GeneralSettingProps
 
 const LDAPButtonSetting = (props: Props) => {
+    const intl = useIntl();
+
     if (!props.schema || props.setting.type !== 'button') {
         return (<></>);
     }
@@ -24,7 +27,7 @@ const LDAPButtonSetting = (props: Props) => {
     const handleRequestAction = (success: () => void, error: (error: { message: string }) => void) => {
         if (!props.setting.skipSaveNeeded && props.saveNeeded !== false) {
             error({
-                message: props.intl.formatMessage({id: 'admin_settings.save_unsaved_changes', defaultMessage: 'Please save unsaved changes first'}),
+                message: intl.formatMessage({id: 'admin_settings.save_unsaved_changes', defaultMessage: 'Please save unsaved changes first'}),
             });
             return;
         }
@@ -40,7 +43,7 @@ const LDAPButtonSetting = (props: Props) => {
     };
 
     const helpText = renderSettingHelpText(props.setting, props.schema, Boolean(props.disabled));
-    const label = renderLabel(props.setting, props.schema, props.intl);
+    const label = renderLabel(props.setting, props.schema, intl);
 
     return (
         <RequestButton
@@ -48,7 +51,7 @@ const LDAPButtonSetting = (props: Props) => {
             key={props.schema.id + '_text_' + props.setting.key}
             requestAction={handleRequestAction}
             helpText={helpText}
-            loadingText={descriptorOrStringToString(props.setting.loading, props.intl)}
+            loadingText={descriptorOrStringToString(props.setting.loading, intl)}
             buttonText={<span>{label}</span>}
             showSuccessMessage={Boolean(props.setting.success_message)}
             includeDetailedError={true}

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_button_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_button_setting.tsx
@@ -21,7 +21,7 @@ const LDAPButtonSetting = (props: Props) => {
     const intl = useIntl();
 
     if (!props.schema || props.setting.type !== 'button') {
-        return (<></>);
+        return null;
     }
 
     const handleRequestAction = (success: () => void, error: (error: { message: string }) => void) => {
@@ -33,9 +33,7 @@ const LDAPButtonSetting = (props: Props) => {
         }
         const successCallback = () => {
             // NOTE: we don't have any settings with 'setFromMetadataField' in the LDAP wizard
-            if (success && typeof success === 'function') {
-                success();
-            }
+            success?.();
         };
 
         // NOTE: we don't use the sourceUrlKey in the LDAP wizard

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_custom_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_custom_setting.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import type {AdminConfig, ClientLicense} from '@mattermost/types/config';
+
+import type {GeneralSettingProps} from './ldap_wizard';
+
+import {renderLabel, renderSettingHelpText} from '../schema_admin_settings';
+import Setting from '../setting';
+
+type Props = {
+    config: Partial<AdminConfig>;
+    license: ClientLicense;
+    value: any;
+    registerSaveAction: (saveAction: () => Promise<{error?: {message?: string}}>) => void;
+    unRegisterSaveAction: (saveAction: () => Promise<{error?: {message?: string}}>) => void;
+    setSaveNeeded: () => void;
+    cancelSubmit: () => void;
+    showConfirmId: string;
+    onChange: (id: string, value: any, confirm: boolean, doSubmit: boolean, warning: boolean) => void;
+    disabled: boolean;
+    setByEnv: boolean;
+} & GeneralSettingProps
+
+const LDAPCustomSetting = (props: Props) => {
+    if (!props.schema || props.setting.type !== 'custom') {
+        return (<></>);
+    }
+
+    const label = renderLabel(props.setting, props.schema, props.intl);
+    const helpText = renderSettingHelpText(props.setting, props.schema, Boolean(props.disabled));
+
+    const CustomComponent = props.setting.component;
+
+    const componentInstance = (
+        <CustomComponent
+            key={props.schema.id + '_custom_' + props.setting.key}
+            id={props.setting.key}
+            label={label}
+            helpText={helpText}
+            value={props.value}
+            disabled={props.disabled}
+            config={props.config}
+            license={props.license}
+            setByEnv={props.setByEnv}
+            onChange={props.onChange}
+            registerSaveAction={props.registerSaveAction}
+            setSaveNeeded={props.setSaveNeeded}
+            unRegisterSaveAction={props.unRegisterSaveAction}
+            cancelSubmit={props.cancelSubmit}
+            showConfirm={props.showConfirmId === props.setting.key}
+        />);
+
+    // Show the plugin custom setting title
+    // consistently as other settings with the Setting component
+    if (props.setting.showTitle) {
+        return (
+            <Setting
+                label={props.setting.label}
+                inputId={props.setting.key}
+                helpText={props.setting.help_text}
+            >
+                {componentInstance}
+            </Setting>
+        );
+    }
+
+    return componentInstance;
+};
+
+export default LDAPCustomSetting;

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_custom_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_custom_setting.tsx
@@ -13,7 +13,7 @@ import Setting from '../setting';
 type Props = {
     config: Partial<AdminConfig>;
     license: ClientLicense;
-    value: any;
+    value?: any;
     registerSaveAction: (saveAction: () => Promise<{error?: {message?: string}}>) => void;
     unRegisterSaveAction: (saveAction: () => Promise<{error?: {message?: string}}>) => void;
     setSaveNeeded: () => void;

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_custom_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_custom_setting.tsx
@@ -29,7 +29,7 @@ const LDAPCustomSetting = (props: Props) => {
     const intl = useIntl();
 
     if (!props.schema || props.setting.type !== 'custom') {
-        return (<></>);
+        return null;
     }
 
     const label = renderLabel(props.setting, props.schema, intl);

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_custom_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_custom_setting.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {useIntl} from 'react-intl';
 
 import type {AdminConfig, ClientLicense} from '@mattermost/types/config';
 
@@ -25,11 +26,13 @@ type Props = {
 } & GeneralSettingProps
 
 const LDAPCustomSetting = (props: Props) => {
+    const intl = useIntl();
+
     if (!props.schema || props.setting.type !== 'custom') {
         return (<></>);
     }
 
-    const label = renderLabel(props.setting, props.schema, props.intl);
+    const label = renderLabel(props.setting, props.schema, intl);
     const helpText = renderSettingHelpText(props.setting, props.schema, Boolean(props.disabled));
 
     const CustomComponent = props.setting.component;

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_dropdown_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_dropdown_setting.tsx
@@ -1,0 +1,82 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import type {ClientLicense} from '@mattermost/types/config';
+
+import DropdownSetting from 'components/admin_console/dropdown_setting';
+
+import type {GeneralSettingProps} from './ldap_wizard';
+
+import {descriptorOrStringToString, renderDropdownOptionHelpText, renderLabel, renderSettingHelpText} from '../schema_admin_settings';
+import type {AdminDefinitionSettingDropdownOption} from '../types';
+
+type Props = {
+    state: any;
+    license: ClientLicense;
+    enterpriseReady: boolean;
+    onChange(id: string, value: any): void;
+    disabled: boolean;
+    setByEnv: boolean;
+} & GeneralSettingProps
+
+const LDAPDropdownSetting = (props: Props) => {
+    if (!props.schema || !props.setting.key || props.setting.type !== 'dropdown') {
+        return (<></>);
+    }
+
+    const options: AdminDefinitionSettingDropdownOption[] = [];
+    props.setting.options.forEach((option) => {
+        if (!option.isHidden || (typeof option.isHidden === 'function' &&
+            !option.isHidden(props.config, props.state, props.license, props.enterpriseReady))) {
+            options.push(option);
+        }
+    });
+
+    const values = options.map((o) => ({value: o.value, text: descriptorOrStringToString(o.display_name, props.intl)!}));
+    const selectedValue = props.state[props.setting.key] ?? values[0].value;
+
+    let selectedOptionForHelpText = null;
+    for (const option of options) {
+        if (option.help_text && option.value === selectedValue) {
+            selectedOptionForHelpText = option;
+            break;
+        }
+    }
+
+    // used to hide help in case of cloud-starter and open-id selection to show upgrade notice.
+    let hideHelp = false;
+    if (props.setting.isHelpHidden) {
+        if (typeof (props.setting.isHelpHidden) === 'function') {
+            hideHelp = props.setting.isHelpHidden(props.config, props.state, props.license, props.enterpriseReady);
+        } else {
+            hideHelp = props.setting.isHelpHidden;
+        }
+    }
+
+    const label = renderLabel(props.setting, props.schema, props.intl);
+
+    let helpText: string | JSX.Element = '';
+    if (!hideHelp) {
+        helpText = selectedOptionForHelpText ? renderDropdownOptionHelpText(selectedOptionForHelpText) : renderSettingHelpText(props.setting, props.schema, Boolean(props.disabled));
+    }
+    return (
+        <DropdownSetting
+            key={props.schema.id + '_dropdown_' + props.setting.key}
+            id={props.setting.key}
+            values={values}
+            label={label}
+            helpText={helpText}
+            value={selectedValue}
+            disabled={props.disabled}
+            setByEnv={props.setByEnv}
+            onChange={props.onChange}
+        />
+    );
+};
+
+export default LDAPDropdownSetting;

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_dropdown_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_dropdown_setting.tsx
@@ -1,9 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
-// See LICENSE.txt for license information.
-
 import React from 'react';
 
 import type {ClientLicense} from '@mattermost/types/config';

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_dropdown_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_dropdown_setting.tsx
@@ -27,7 +27,7 @@ const LDAPDropdownSetting = (props: Props) => {
     const intl = useIntl();
 
     if (!props.schema || !props.setting.key || props.setting.type !== 'dropdown') {
-        return (<></>);
+        return null;
     }
 
     const options: AdminDefinitionSettingDropdownOption[] = [];

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_dropdown_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_dropdown_setting.tsx
@@ -2,8 +2,9 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {useIntl} from 'react-intl';
 
-import type {ClientLicense} from '@mattermost/types/config';
+import type {AdminConfig, ClientLicense} from '@mattermost/types/config';
 
 import DropdownSetting from 'components/admin_console/dropdown_setting';
 
@@ -13,7 +14,8 @@ import {descriptorOrStringToString, renderDropdownOptionHelpText, renderLabel, r
 import type {AdminDefinitionSettingDropdownOption} from '../types';
 
 type Props = {
-    state: any;
+    config: Partial<AdminConfig>;
+    state: Record<string, unknown>;
     license: ClientLicense;
     enterpriseReady: boolean;
     onChange(id: string, value: any): void;
@@ -22,6 +24,8 @@ type Props = {
 } & GeneralSettingProps
 
 const LDAPDropdownSetting = (props: Props) => {
+    const intl = useIntl();
+
     if (!props.schema || !props.setting.key || props.setting.type !== 'dropdown') {
         return (<></>);
     }
@@ -34,8 +38,8 @@ const LDAPDropdownSetting = (props: Props) => {
         }
     });
 
-    const values = options.map((o) => ({value: o.value, text: descriptorOrStringToString(o.display_name, props.intl)!}));
-    const selectedValue = props.state[props.setting.key] ?? values[0].value;
+    const values = options.map((o) => ({value: o.value, text: descriptorOrStringToString(o.display_name, intl)!}));
+    const selectedValue = (props.state[props.setting.key] as string) ?? values[0].value;
 
     let selectedOptionForHelpText = null;
     for (const option of options) {
@@ -55,7 +59,7 @@ const LDAPDropdownSetting = (props: Props) => {
         }
     }
 
-    const label = renderLabel(props.setting, props.schema, props.intl);
+    const label = renderLabel(props.setting, props.schema, intl);
 
     let helpText: string | JSX.Element = '';
     if (!hideHelp) {

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_file_upload_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_file_upload_setting.tsx
@@ -13,7 +13,7 @@ import type {AdminDefinitionSettingFileUpload} from '../types';
 
 type Props = {
     setting: AdminDefinitionSettingFileUpload;
-    value: string;
+    value?: string;
     error?: string;
     onChange(id: string, value: any): void;
     fileUploadSetstate: (key: string, filename: string | null, error_message: string | null) => void;

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_file_upload_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_file_upload_setting.tsx
@@ -1,0 +1,94 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import FileUploadSetting from 'components/admin_console/file_upload_setting';
+import RemoveFileSetting from 'components/admin_console/remove_file_setting';
+
+import type {GeneralSettingProps} from './ldap_wizard';
+
+import {descriptorOrStringToString, renderLabel, renderSettingHelpText} from '../schema_admin_settings';
+import type {AdminDefinitionSettingFileUpload} from '../types';
+
+type Props = {
+    setting: AdminDefinitionSettingFileUpload;
+    value: string;
+    error?: string;
+    onChange(id: string, value: any): void;
+    fileUploadSetstate: (key: string, filename: string | null, error_message: string | null) => void;
+    disabled: boolean;
+    setByEnv: boolean;
+} & GeneralSettingProps
+
+const LDAPFileUploadSetting = (props: Props) => {
+    if (!props.schema || props.setting.type !== 'fileupload' || !props.setting.key) {
+        return (<></>);
+    }
+
+    if (props.value) {
+        const removeFile = (id: string, callback: () => void) => {
+            const successCallback = () => {
+                props.onChange(id, '');
+                props.fileUploadSetstate(props.setting.key!, null, null);
+            };
+            const errorCallback = (error: any) => {
+                callback();
+                props.fileUploadSetstate(props.setting.key!, null, error.message);
+            };
+            props.setting.remove_action(successCallback, errorCallback);
+        };
+
+        const label = renderLabel(props.setting, props.schema, props.intl);
+        const helpText = renderSettingHelpText(props.setting, props.schema, Boolean(props.disabled));
+
+        return (
+            <RemoveFileSetting
+                id={props.schema.id}
+                key={props.schema.id + '_fileupload_' + props.setting.key}
+                label={label}
+                helpText={helpText}
+                removeButtonText={descriptorOrStringToString(props.setting.remove_button_text, props.intl)}
+                removingText={descriptorOrStringToString(props.setting.removing_text, props.intl)}
+                fileName={props.value}
+                onSubmit={removeFile}
+                disabled={props.disabled}
+                setByEnv={props.setByEnv}
+            />
+        );
+    }
+    const uploadFile = (id: string, file: File, callback: (error?: string) => void) => {
+        const successCallback = (filename: string) => {
+            props.onChange(id, filename);
+            props.fileUploadSetstate(props.setting.key!, filename, null);
+            if (callback && typeof callback === 'function') {
+                callback();
+            }
+        };
+        const errorCallback = (error: any) => {
+            if (callback && typeof callback === 'function') {
+                callback(error.message);
+            }
+        };
+        props.setting.upload_action(file, successCallback, errorCallback);
+    };
+
+    const label = renderLabel(props.setting, props.schema, props.intl);
+    const helpText = renderSettingHelpText(props.setting, props.schema, Boolean(props.disabled));
+
+    return (
+        <FileUploadSetting
+            id={props.setting.key}
+            key={props.schema.id + '_fileupload_' + props.setting.key}
+            label={label}
+            helpText={helpText}
+            uploadingText={descriptorOrStringToString(props.setting.uploading_text, props.intl)}
+            disabled={props.disabled}
+            fileType={props.setting.fileType}
+            onSubmit={uploadFile}
+            error={props.error}
+        />
+    );
+};
+
+export default LDAPFileUploadSetting;

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_file_upload_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_file_upload_setting.tsx
@@ -26,7 +26,7 @@ const LDAPFileUploadSetting = (props: Props) => {
     const intl = useIntl();
 
     if (!props.schema || props.setting.type !== 'fileupload' || !props.setting.key) {
-        return (<></>);
+        return null;
     }
 
     if (props.value) {
@@ -64,14 +64,10 @@ const LDAPFileUploadSetting = (props: Props) => {
         const successCallback = (filename: string) => {
             props.onChange(id, filename);
             props.fileUploadSetstate(props.setting.key!, filename, null);
-            if (callback && typeof callback === 'function') {
-                callback();
-            }
+            callback?.();
         };
         const errorCallback = (error: any) => {
-            if (callback && typeof callback === 'function') {
-                callback(error.message);
-            }
+            callback?.(error.message);
         };
         props.setting.upload_action(file, successCallback, errorCallback);
     };

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_file_upload_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_file_upload_setting.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {useIntl} from 'react-intl';
 
 import FileUploadSetting from 'components/admin_console/file_upload_setting';
 import RemoveFileSetting from 'components/admin_console/remove_file_setting';
@@ -22,6 +23,8 @@ type Props = {
 } & GeneralSettingProps
 
 const LDAPFileUploadSetting = (props: Props) => {
+    const intl = useIntl();
+
     if (!props.schema || props.setting.type !== 'fileupload' || !props.setting.key) {
         return (<></>);
     }
@@ -39,7 +42,7 @@ const LDAPFileUploadSetting = (props: Props) => {
             props.setting.remove_action(successCallback, errorCallback);
         };
 
-        const label = renderLabel(props.setting, props.schema, props.intl);
+        const label = renderLabel(props.setting, props.schema, intl);
         const helpText = renderSettingHelpText(props.setting, props.schema, Boolean(props.disabled));
 
         return (
@@ -48,8 +51,8 @@ const LDAPFileUploadSetting = (props: Props) => {
                 key={props.schema.id + '_fileupload_' + props.setting.key}
                 label={label}
                 helpText={helpText}
-                removeButtonText={descriptorOrStringToString(props.setting.remove_button_text, props.intl)}
-                removingText={descriptorOrStringToString(props.setting.removing_text, props.intl)}
+                removeButtonText={descriptorOrStringToString(props.setting.remove_button_text, intl)}
+                removingText={descriptorOrStringToString(props.setting.removing_text, intl)}
                 fileName={props.value}
                 onSubmit={removeFile}
                 disabled={props.disabled}
@@ -73,7 +76,7 @@ const LDAPFileUploadSetting = (props: Props) => {
         props.setting.upload_action(file, successCallback, errorCallback);
     };
 
-    const label = renderLabel(props.setting, props.schema, props.intl);
+    const label = renderLabel(props.setting, props.schema, intl);
     const helpText = renderSettingHelpText(props.setting, props.schema, Boolean(props.disabled));
 
     return (
@@ -82,7 +85,7 @@ const LDAPFileUploadSetting = (props: Props) => {
             key={props.schema.id + '_fileupload_' + props.setting.key}
             label={label}
             helpText={helpText}
-            uploadingText={descriptorOrStringToString(props.setting.uploading_text, props.intl)}
+            uploadingText={descriptorOrStringToString(props.setting.uploading_text, intl)}
             disabled={props.disabled}
             fileType={props.setting.fileType}
             onSubmit={uploadFile}

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_jobs_table_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_jobs_table_setting.tsx
@@ -1,0 +1,35 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import JobsTable from 'components/admin_console/jobs';
+
+import type {GeneralSettingProps} from './ldap_wizard';
+
+import {descriptorOrStringToString, renderSettingHelpText} from '../schema_admin_settings';
+
+type Props = {
+    disabled: boolean;
+} & GeneralSettingProps
+
+const LDAPJobsTableSetting = (props: Props) => {
+    if (!props.schema || props.setting.type !== 'jobstable') {
+        return (<></>);
+    }
+
+    const helpText = renderSettingHelpText(props.setting, props.schema, Boolean(props.disabled));
+
+    return (
+        <JobsTable
+            key={props.schema.id + '_jobstable_' + props.setting.key}
+            jobType={props.setting.job_type}
+            getExtraInfoText={props.setting.render_job}
+            disabled={props.disabled}
+            createJobButtonText={descriptorOrStringToString(props.setting.label, props.intl)}
+            createJobHelpText={helpText}
+        />
+    );
+};
+
+export default LDAPJobsTableSetting;

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_jobs_table_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_jobs_table_setting.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {useIntl} from 'react-intl';
 
 import JobsTable from 'components/admin_console/jobs';
 
@@ -14,6 +15,8 @@ type Props = {
 } & GeneralSettingProps
 
 const LDAPJobsTableSetting = (props: Props) => {
+    const intl = useIntl();
+
     if (!props.schema || props.setting.type !== 'jobstable') {
         return (<></>);
     }
@@ -26,7 +29,7 @@ const LDAPJobsTableSetting = (props: Props) => {
             jobType={props.setting.job_type}
             getExtraInfoText={props.setting.render_job}
             disabled={props.disabled}
-            createJobButtonText={descriptorOrStringToString(props.setting.label, props.intl)}
+            createJobButtonText={descriptorOrStringToString(props.setting.label, intl)}
             createJobHelpText={helpText}
         />
     );

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_jobs_table_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_jobs_table_setting.tsx
@@ -18,7 +18,7 @@ const LDAPJobsTableSetting = (props: Props) => {
     const intl = useIntl();
 
     if (!props.schema || props.setting.type !== 'jobstable') {
-        return (<></>);
+        return null;
     }
 
     const helpText = renderSettingHelpText(props.setting, props.schema, Boolean(props.disabled));

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_text_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_text_setting.tsx
@@ -64,7 +64,7 @@ const LDAPTextSetting = (props: TextSettingProps) => {
             type={inputType}
             label={label}
             helpText={helpText}
-            placeholder={props.placeholder}
+            placeholder={props.setting.placeholder}
             value={value}
             disabled={props.disabled}
             setByEnv={props.setByEnv}

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_text_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_text_setting.tsx
@@ -1,0 +1,78 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import type {MessageDescriptor} from 'react-intl';
+
+import TextSetting from 'components/admin_console/text_setting';
+import FormError, {TYPE_BACKSTAGE} from 'components/form_error';
+
+import Constants from 'utils/constants';
+
+import type {GeneralSettingProps} from './ldap_wizard';
+
+import {renderLabel, renderSettingHelpText} from '../schema_admin_settings';
+
+type TextSettingProps = {
+    state: any;
+    placeholder?: string | MessageDescriptor;
+    onChange(id: string, value: any): void;
+    disabled: boolean;
+    setByEnv: boolean;
+} & GeneralSettingProps
+
+const LDAPTextSetting = (props: TextSettingProps) => {
+    if (!props.schema || !props.setting.key || (props.setting.type !== 'text' && props.setting.type !== 'longtext' && props.setting.type !== 'number')) {
+        return (<></>);
+    }
+
+    let inputType: 'text' | 'number' | 'textarea' = 'text';
+    if (props.setting.type === Constants.SettingsTypes.TYPE_NUMBER) {
+        inputType = 'number';
+    } else if (props.setting.type === Constants.SettingsTypes.TYPE_LONG_TEXT) {
+        inputType = 'textarea';
+    }
+
+    let value = '';
+    if (props.setting.dynamic_value) {
+        value = props.setting.dynamic_value(value, props.config, props.state);
+    } else if (props.setting.multiple) {
+        value = props.state[props.setting.key] ? props.state[props.setting.key].join(',') : '';
+    } else {
+        value = props.state[props.setting.key] ?? (props.setting.default || '');
+    }
+
+    let footer = null;
+    if (props.setting.validate) {
+        const err = props.setting.validate(value).error(props.intl);
+        footer = err ? (
+            <FormError
+                type={TYPE_BACKSTAGE}
+                error={err}
+            />
+        ) : footer;
+    }
+
+    const label = renderLabel(props.setting, props.schema, props.intl);
+    const helpText = renderSettingHelpText(props.setting, props.schema, Boolean(props.disabled));
+
+    return (
+        <TextSetting
+            key={props.schema.id + '_text_' + props.setting.key}
+            id={props.setting.key}
+            multiple={props.setting.multiple}
+            type={inputType}
+            label={label}
+            helpText={helpText}
+            placeholder={props.placeholder}
+            value={value}
+            disabled={props.disabled}
+            setByEnv={props.setByEnv}
+            onChange={props.onChange}
+            maxLength={props.setting.max_length}
+            footer={footer}
+        />
+    );
+};
+
+export default LDAPTextSetting;

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_text_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_text_setting.tsx
@@ -29,7 +29,7 @@ const LDAPTextSetting = (props: TextSettingProps) => {
     const intl = useIntl();
 
     if (!props.schema || !props.setting.key || (props.setting.type !== 'text' && props.setting.type !== 'longtext' && props.setting.type !== 'number')) {
-        return (<></>);
+        return null;
     }
 
     let inputType: 'text' | 'number' | 'textarea' = 'text';

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_text_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_text_setting.tsx
@@ -3,6 +3,9 @@
 
 import React from 'react';
 import type {MessageDescriptor} from 'react-intl';
+import {useIntl} from 'react-intl';
+
+import type {AdminConfig} from '@mattermost/types/config';
 
 import TextSetting from 'components/admin_console/text_setting';
 import FormError, {TYPE_BACKSTAGE} from 'components/form_error';
@@ -14,7 +17,8 @@ import type {GeneralSettingProps} from './ldap_wizard';
 import {renderLabel, renderSettingHelpText} from '../schema_admin_settings';
 
 type TextSettingProps = {
-    state: any;
+    config: Partial<AdminConfig>;
+    state: Record<string, unknown>;
     placeholder?: string | MessageDescriptor;
     onChange(id: string, value: any): void;
     disabled: boolean;
@@ -22,6 +26,8 @@ type TextSettingProps = {
 } & GeneralSettingProps
 
 const LDAPTextSetting = (props: TextSettingProps) => {
+    const intl = useIntl();
+
     if (!props.schema || !props.setting.key || (props.setting.type !== 'text' && props.setting.type !== 'longtext' && props.setting.type !== 'number')) {
         return (<></>);
     }
@@ -37,14 +43,14 @@ const LDAPTextSetting = (props: TextSettingProps) => {
     if (props.setting.dynamic_value) {
         value = props.setting.dynamic_value(value, props.config, props.state);
     } else if (props.setting.multiple) {
-        value = props.state[props.setting.key] ? props.state[props.setting.key].join(',') : '';
+        value = props.state[props.setting.key] ? (props.state[props.setting.key] as string[]).join(',') : '';
     } else {
-        value = props.state[props.setting.key] ?? (props.setting.default || '');
+        value = (props.state[props.setting.key] as string) ?? (props.setting.default as string || '');
     }
 
     let footer = null;
     if (props.setting.validate) {
-        const err = props.setting.validate(value).error(props.intl);
+        const err = props.setting.validate(value).error(intl);
         footer = err ? (
             <FormError
                 type={TYPE_BACKSTAGE}
@@ -53,7 +59,7 @@ const LDAPTextSetting = (props: TextSettingProps) => {
         ) : footer;
     }
 
-    const label = renderLabel(props.setting, props.schema, props.intl);
+    const label = renderLabel(props.setting, props.schema, intl);
     const helpText = renderSettingHelpText(props.setting, props.schema, Boolean(props.disabled));
 
     return (

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_wizard.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_wizard.tsx
@@ -81,7 +81,7 @@ const LDAPWizard = (props: Props) => {
     React.useEffect(() => {
         if (props.config && schema) {
             const initialStateFromConfig = SchemaAdminSettings.getStateFromConfig(props.config, schema, props.roles);
-            setState(prevState => ({
+            setState((prevState) => ({
                 ...prevState,
                 ...initialStateFromConfig,
                 prevSchemaId: schema.id,

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_wizard.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_wizard.tsx
@@ -84,6 +84,7 @@ const LDAPWizard = (props: Props) => {
         return (
             <LDAPTextSetting
                 {...props}
+                key={schema.id + '_text_' + setting.key}
                 state={state}
                 onChange={handleChange}
                 schema={schema}
@@ -98,6 +99,7 @@ const LDAPWizard = (props: Props) => {
         return (
             <LDAPBooleanSetting
                 {...props}
+                key={schema.id + '_bool_' + setting.key}
                 value={state[setting.key!] || false}
                 onChange={handleChange}
                 schema={schema}
@@ -112,6 +114,7 @@ const LDAPWizard = (props: Props) => {
         return (
             <LDAPDropdownSetting
                 {...props}
+                key={schema.id + '_dropdown_' + setting.key}
                 state={state}
                 onChange={handleChange}
                 schema={schema}
@@ -126,6 +129,7 @@ const LDAPWizard = (props: Props) => {
         return (
             <LDAPButtonSetting
                 {...props}
+                key={schema.id + '_button_' + setting.key}
                 onChange={handleChange}
                 saveNeeded={false}
                 schema={schema}
@@ -139,6 +143,7 @@ const LDAPWizard = (props: Props) => {
         return (
             <LDAPJobsTableSetting
                 {...props}
+                key={schema.id + '_jobstable_' + setting.key}
                 schema={schema}
                 disabled={isDisabled(setting)}
                 setting={setting}
@@ -158,6 +163,7 @@ const LDAPWizard = (props: Props) => {
         return (
             <LDAPFileUploadSetting
                 {...props}
+                key={schema.id + '_fileupload_' + setting.key}
                 value={state[setting.key!]}
                 onChange={handleChange}
                 fileUploadSetstate={fileUploadSetstate}
@@ -173,6 +179,7 @@ const LDAPWizard = (props: Props) => {
         return (
             <LDAPCustomSetting
                 {...props}
+                key={schema.id + '_custom_' + setting.key}
                 schema={schema}
                 setting={setting}
                 value={state[setting.key!]}

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_wizard.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_wizard.tsx
@@ -1,0 +1,581 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useCallback, useState} from 'react';
+import type {IntlShape, MessageDescriptor, WrappedComponentProps} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
+
+import type {CloudState} from '@mattermost/types/cloud';
+import type {AdminConfig, ClientLicense, EnvironmentConfig} from '@mattermost/types/config';
+import type {Role} from '@mattermost/types/roles';
+import type {DeepPartial} from '@mattermost/types/utilities';
+
+import type {ActionResult} from 'mattermost-redux/types/actions';
+
+import SettingsGroup from 'components/admin_console/settings_group';
+import FormError from 'components/form_error';
+import SaveButton from 'components/save_button';
+import AdminHeader from 'components/widgets/admin_console/admin_header';
+import WithTooltip from 'components/with_tooltip';
+
+import Constants from 'utils/constants';
+
+import LDAPBooleanSetting from './ldap_boolean_setting';
+import LDAPButtonSetting from './ldap_button_setting';
+import LDAPCustomSetting from './ldap_custom_setting';
+import LDAPDropdownSetting from './ldap_dropdown_setting';
+import LDAPFileUploadSetting from './ldap_file_upload_setting';
+import LDAPJobsTableSetting from './ldap_jobs_table_setting';
+import LDAPTextSetting from './ldap_text_setting';
+
+import {ldapWizardAdminDefinition} from '../admin_definition';
+import {getConfigFromState, isSetByEnv, SchemaAdminSettings} from '../schema_admin_settings';
+import SchemaText from '../schema_text';
+import type {AdminDefinitionSetting, AdminDefinitionSettingButton, AdminDefinitionSettingFileUpload, AdminDefinitionSubSectionSchema, ConsoleAccess} from '../types';
+
+export type GeneralSettingProps = {
+    setting: AdminDefinitionSetting;
+    schema: AdminDefinitionSubSectionSchema | null;
+    config: Partial<AdminConfig>;
+    intl: IntlShape;
+}
+
+type Props = {
+    config: Partial<AdminConfig>;
+    environmentConfig: Partial<EnvironmentConfig>;
+    setNavigationBlocked: (blocked: boolean) => void;
+    roles: Record<string, Role>;
+    license: ClientLicense;
+    editRole: (role: Role) => void;
+    patchConfig: (config: DeepPartial<AdminConfig>) => Promise<ActionResult>;
+    isDisabled: boolean;
+    consoleAccess: ConsoleAccess;
+    cloud: CloudState;
+    isCurrentUserSystemAdmin: boolean;
+    enterpriseReady: boolean;
+} & WrappedComponentProps
+
+type State = {
+    [x: string]: any;
+    saveNeeded: false | 'both' | 'permissions' | 'config';
+    saving: boolean;
+    serverError: null;
+    confirmNeededId: string;
+    showConfirmId: string;
+    clientWarning: string | boolean;
+    prevSchemaId?: string;
+}
+
+const LDAPWizard = (props: Props) => {
+    const schema = ldapWizardAdminDefinition;
+
+    const [state, setState] = useState<State>({
+        saveNeeded: false,
+        saving: false,
+        serverError: null,
+        confirmNeededId: '',
+        showConfirmId: '',
+        clientWarning: '',
+    });
+
+    const [saveActions, setSaveActions] = useState<Array<() => Promise<{error?: {message?: string}}>>>([]);
+
+    const buildTextSetting = (setting: AdminDefinitionSetting) => {
+        return (
+            <LDAPTextSetting
+                {...props}
+                state={state}
+                onChange={handleChange}
+                schema={schema}
+                disabled={isDisabled(setting)}
+                setByEnv={isSetByEnv(setting.key!, props.environmentConfig)}
+                setting={setting}
+            />
+        );
+    };
+
+    const buildBoolSetting = (setting: AdminDefinitionSetting) => {
+        return (
+            <LDAPBooleanSetting
+                {...props}
+                value={state[setting.key!] || false}
+                onChange={handleChange}
+                schema={schema}
+                disabled={isDisabled(setting)}
+                setByEnv={isSetByEnv(setting.key!, props.environmentConfig)}
+                setting={setting}
+            />
+        );
+    };
+
+    const buildDropdownSetting = (setting: AdminDefinitionSetting) => {
+        return (
+            <LDAPDropdownSetting
+                {...props}
+                state={state}
+                onChange={handleChange}
+                schema={schema}
+                disabled={isDisabled(setting)}
+                setByEnv={isSetByEnv(setting.key!, props.environmentConfig)}
+                setting={setting}
+            />
+        );
+    };
+
+    const buildButtonSetting = (setting: AdminDefinitionSetting) => {
+        return (
+            <LDAPButtonSetting
+                {...props}
+                onChange={handleChange}
+                saveNeeded={false}
+                schema={schema}
+                disabled={isDisabled(setting)}
+                setting={setting as AdminDefinitionSettingButton}
+            />
+        );
+    };
+
+    const buildJobsTableSetting = (setting: AdminDefinitionSetting) => {
+        return (
+            <LDAPJobsTableSetting
+                {...props}
+                schema={schema}
+                disabled={isDisabled(setting)}
+                setting={setting}
+            />
+        );
+    };
+
+    const fileUploadSetstate = (key: string, filename: string | null, errorMessage: string | null) => {
+        setState((prev) => ({
+            ...prev,
+            [key]: filename,
+            [key + 'Error']: errorMessage,
+        }));
+    };
+
+    const buildFileUploadSetting = (setting: AdminDefinitionSetting) => {
+        return (
+            <LDAPFileUploadSetting
+                {...props}
+                value={state[setting.key!]}
+                onChange={handleChange}
+                fileUploadSetstate={fileUploadSetstate}
+                schema={schema}
+                disabled={isDisabled(setting)}
+                setByEnv={isSetByEnv(setting.key!, props.environmentConfig)}
+                setting={setting as AdminDefinitionSettingFileUpload}
+            />
+        );
+    };
+
+    const buildCustomSetting = (setting: AdminDefinitionSetting) => {
+        return (
+            <LDAPCustomSetting
+                {...props}
+                schema={schema}
+                setting={setting}
+                value={state[setting.key!]}
+                disabled={isDisabled(setting)}
+                setByEnv={isSetByEnv(setting.key!, props.environmentConfig)}
+                onChange={handleChange}
+                registerSaveAction={registerSaveAction}
+                setSaveNeeded={setSaveNeeded}
+                unRegisterSaveAction={unRegisterSaveAction}
+                cancelSubmit={cancelSubmit}
+                showConfirmId={state.showConfirmId}
+            />
+        );
+    };
+
+    // To satisfy type checking
+    const nullFunction = () => {
+        return null;
+    };
+
+    const buildSettingFunctions = {
+        [Constants.SettingsTypes.TYPE_TEXT]: buildTextSetting,
+        [Constants.SettingsTypes.TYPE_LONG_TEXT]: buildTextSetting,
+        [Constants.SettingsTypes.TYPE_NUMBER]: buildTextSetting,
+        [Constants.SettingsTypes.TYPE_BOOL]: buildBoolSetting,
+        [Constants.SettingsTypes.TYPE_DROPDOWN]: buildDropdownSetting,
+        [Constants.SettingsTypes.TYPE_BUTTON]: buildButtonSetting,
+        [Constants.SettingsTypes.TYPE_JOBSTABLE]: buildJobsTableSetting,
+        [Constants.SettingsTypes.TYPE_FILE_UPLOAD]: buildFileUploadSetting,
+        [Constants.SettingsTypes.TYPE_CUSTOM]: buildCustomSetting,
+        [Constants.SettingsTypes.TYPE_COLOR]: nullFunction,
+        [Constants.SettingsTypes.TYPE_PERMISSION]: nullFunction,
+        [Constants.SettingsTypes.TYPE_RADIO]: nullFunction,
+        [Constants.SettingsTypes.TYPE_BANNER]: nullFunction,
+        [Constants.SettingsTypes.TYPE_GENERATED]: nullFunction,
+        [Constants.SettingsTypes.TYPE_USERNAME]: nullFunction,
+        [Constants.SettingsTypes.TYPE_LANGUAGE]: nullFunction,
+        [Constants.SettingsTypes.TYPE_ROLES]: nullFunction,
+    };
+
+    const isDisabled = (setting: AdminDefinitionSetting) => {
+        if (typeof setting.isDisabled === 'function') {
+            return setting.isDisabled(props.config, state, props.license, props.enterpriseReady, props.consoleAccess, props.cloud, props.isCurrentUserSystemAdmin);
+        }
+        return Boolean(setting.isDisabled);
+    };
+
+    const isHidden = (setting: AdminDefinitionSetting) => {
+        if (typeof setting.isHidden === 'function') {
+            return setting.isHidden(props.config, state, props.license);
+        }
+        return Boolean(setting.isHidden);
+    };
+
+    const renderTitle = () => {
+        if (!schema) {
+            return '';
+        }
+
+        let name: string | MessageDescriptor = schema.id;
+        if (('name' in schema)) {
+            name = schema.name;
+        }
+
+        if (typeof name === 'string') {
+            return (
+                <AdminHeader>
+                    {name}
+                </AdminHeader>
+            );
+        }
+
+        return (
+            <AdminHeader>
+                <FormattedMessage
+                    {...name}
+                />
+            </AdminHeader>
+        );
+    };
+
+    const doSubmit = async (
+        getStateFromConfig: (
+            config: Partial<AdminConfig>,
+            schema: AdminDefinitionSubSectionSchema,
+            roles?: Record<string, Role>,
+        ) => Partial<State>,
+    ) => {
+        if (!schema) {
+            return;
+        }
+
+        // clone config so that we aren't modifying data in the stores
+        let config = JSON.parse(JSON.stringify(props.config));
+        config = getConfigFromState(config, state, schema, isDisabled);
+
+        const {error} = await props.patchConfig(config);
+        if (error) {
+            setState((prev) => ({
+                ...prev,
+                serverError: error.message,
+                serverErrorId: error.id,
+            }));
+        } else {
+            setState((prevState) => ({
+                ...prevState,
+                ...getStateFromConfig(config, schema),
+            }));
+        }
+
+        const results = [];
+        for (const saveAction of saveActions) {
+            results.push(saveAction());
+        }
+
+        const hasSaveActionError = await Promise.all(results).then((values) => values.some(((value) => value.error && value.error.message)));
+
+        const hasError = state.serverError || hasSaveActionError;
+        if (hasError) {
+            setState((prev) => ({
+                ...prev,
+                saving: false,
+            }));
+        } else {
+            setState((prev) => ({
+                ...prev,
+                saving: false,
+                saveNeeded: false,
+                confirmNeededId: '',
+                showConfirmId: '',
+                clientWarning: '',
+            }));
+        }
+    };
+
+    const handleChange = (id: string, value: any, confirm = false, shouldSubmit = false, warning = false) => {
+        let saveNeeded: State['saveNeeded'] = state.saveNeeded === 'permissions' ? 'both' : 'config';
+
+        // Exception: Since OpenId-Custom is treated as feature discovery for Cloud Starter licenses, save button is disabled.
+        const isCloudStarter = props.license.Cloud === 'true' && props.license.SkuShortName === 'starter';
+        if (id === 'openidType' && value === 'openid' && isCloudStarter) {
+            saveNeeded = false;
+        }
+
+        const clientWarning = warning === false ? state.clientWarning : warning;
+
+        let confirmNeededId = confirm ? id : state.confirmNeededId;
+        if (id === state.confirmNeededId && !confirm) {
+            confirmNeededId = '';
+        }
+
+        setState((prev) => ({
+            ...prev,
+            saveNeeded,
+            confirmNeededId,
+            clientWarning,
+            [id]: value,
+        }));
+
+        if (shouldSubmit) {
+            doSubmit(SchemaAdminSettings.getStateFromConfig);
+        }
+
+        props.setNavigationBlocked(true);
+    };
+
+    const handleSubmit = async (
+        e: React.MouseEvent<HTMLButtonElement, MouseEvent> | React.FormEvent<HTMLFormElement>,
+    ) => {
+        e.preventDefault();
+
+        if (state.confirmNeededId) {
+            setState((prev) => ({
+                ...prev,
+                showConfirmId: prev.confirmNeededId,
+            }));
+            return;
+        }
+
+        setState((prev) => ({
+            ...prev,
+            saving: true,
+            serverError: null,
+        }));
+
+        if (state.saveNeeded === 'both' || state.saveNeeded === 'config') {
+            doSubmit(SchemaAdminSettings.getStateFromConfig);
+        } else {
+            setState((prev) => ({
+                ...prev,
+                saving: false,
+                saveNeeded: false,
+                serverError: null,
+            }));
+            props.setNavigationBlocked(false);
+        }
+    };
+
+    const unRegisterSaveAction = useCallback((saveAction: () => Promise<{error?: {message?: string}}>) => {
+        setSaveActions((prev) => prev.filter((action) => action !== saveAction));
+    }, []);
+
+    const registerSaveAction = useCallback((saveAction: () => Promise<{error?: {message?: string}}>) => {
+        setSaveActions((prev) => [...prev, saveAction]);
+    }, []);
+
+    const setSaveNeeded = () => {
+        setState((prev) => ({
+            ...prev,
+            saveNeeded: 'config',
+        }));
+        props.setNavigationBlocked(true);
+    };
+
+    const cancelSubmit = () => {
+        setState((prev) => ({
+            ...prev,
+            showConfirmId: '',
+        }));
+    };
+
+    const canSave = () => {
+        if (!schema || !('settings' in schema) || !schema.settings) {
+            return true;
+        }
+
+        for (const setting of schema.settings) {
+            // Some settings are actually not settings (banner)
+            // and don't have a key, skip those ones
+            if (!('key' in setting) || !setting.key) {
+                continue;
+            }
+
+            // don't validate elements set by env.
+            if (isSetByEnv(setting.key, props.environmentConfig)) {
+                continue;
+            }
+
+            if ('validate' in setting && setting.validate) {
+                if ('isHidden' in setting) {
+                    let hidden = false;
+                    if (typeof setting.isHidden === 'function') {
+                        hidden = setting.isHidden?.(props.config, state, props.license, props.enterpriseReady, props.consoleAccess, props.cloud, props.isCurrentUserSystemAdmin);
+                    } else {
+                        hidden = Boolean(setting.isHidden);
+                    }
+
+                    // MM-50952
+                    // If the setting is hidden, then it is not being set in state so there is
+                    // nothing to validate, and validation would fail anyways and prevent saving
+                    // In practice, this only happens in custom cloud setup environments like RFQA
+                    // where it sets things in the config file directly instead of in the environment
+                    // (like cloud Mattermost does)
+                    if (hidden) {
+                        continue;
+                    }
+                }
+                const result = setting.validate(state[setting.key]);
+                if (!result.isValid()) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    };
+
+    const hybridSchemaAndComponent = () => {
+        if (schema && 'component' in schema && schema.component) {
+            const CustomComponent = schema.component;
+            return (
+                <CustomComponent
+                    {...props}
+                    disabled={props.isDisabled}
+                />
+            );
+        }
+        return null;
+    };
+
+    const renderSettings = () => {
+        // For type checking
+        if (!('sections' in schema && schema.sections)) {
+            return null;
+        }
+
+        const sections: React.ReactNode[] = [];
+
+        schema.sections.forEach((section) => {
+            const settingsList: React.ReactNode[] = [];
+            if (section.settings) {
+                section.settings.forEach((setting) => {
+                    if (buildSettingFunctions[setting.type] && !isHidden(setting)) {
+                        settingsList.push(buildSettingFunctions[setting.type](setting));
+                    }
+                });
+            }
+
+            if (section.component) {
+                const CustomComponent = section.component;
+                sections.push((
+                    <CustomComponent
+                        settingsList={settingsList}
+                        key={section.key}
+                    />
+                ));
+                return;
+            }
+
+            let header;
+            if (section.header) {
+                header = (
+                    <div className='banner'>
+                        <SchemaText
+                            text={section.header}
+                            isMarkdown={true}
+                        />
+                    </div>
+                );
+            }
+
+            let footer;
+            if (section.footer) {
+                footer = (
+                    <div className='banner'>
+                        <SchemaText
+                            text={section.footer}
+                            isMarkdown={true}
+                        />
+                    </div>
+                );
+            }
+
+            sections.push(
+                <div
+                    className={'config-section'}
+                    key={section.key}
+                >
+                    <SettingsGroup
+                        show={true}
+                        title={section.title}
+                        subtitle={section.subtitle}
+                    >
+                        <div className={'section-body'}>
+                            {header}
+                            {settingsList}
+                            {footer}
+                        </div>
+                    </SettingsGroup>
+                </div>,
+            );
+        });
+
+        return (
+            <div>
+                {sections}
+            </div>
+        );
+    };
+
+    return (
+        <div
+            className={'wrapper--fixed'}
+            data-testid={`sysconsole_section_${schema?.id}`}
+        >
+            {renderTitle()}
+            <div className='admin-console__wrapper'>
+                <div className='admin-console__content'>
+                    <form
+                        className='form-horizontal'
+                        role='form'
+                        onSubmit={handleSubmit}
+                    >
+                        {renderSettings()}
+                    </form>
+                    {hybridSchemaAndComponent()}
+                </div>
+            </div>
+            <div className='admin-console-save'>
+                <SaveButton
+                    saving={state.saving}
+                    disabled={!state.saveNeeded || (canSave && !canSave())}
+                    onClick={handleSubmit}
+                    savingMessage={props.intl.formatMessage({id: 'admin.saving', defaultMessage: 'Saving Config...'})}
+                />
+                <WithTooltip
+                    title={state?.serverError ?? ''}
+                >
+                    <div
+                        className='error-message'
+                        data-testid='errorMessage'
+                    >
+                        <FormError
+                            iconClassName='fa-exclamation-triangle'
+                            textClassName='has-warning'
+                            error={state.clientWarning}
+                        />
+                        <FormError error={state.serverError}/>
+                    </div>
+                </WithTooltip>
+            </div>
+        </div>
+    );
+};
+
+export default LDAPWizard;

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_wizard.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_wizard.tsx
@@ -59,7 +59,7 @@ type State = {
     [x: string]: any;
     saveNeeded: false | 'both' | 'permissions' | 'config';
     saving: boolean;
-    serverError: null;
+    serverError: string | { message: string; id?: string } | null;
     confirmNeededId: string;
     showConfirmId: string;
     clientWarning: string | boolean;
@@ -77,6 +77,17 @@ const LDAPWizard = (props: Props) => {
         showConfirmId: '',
         clientWarning: '',
     });
+
+    React.useEffect(() => {
+        if (props.config && schema) {
+            const initialStateFromConfig = SchemaAdminSettings.getStateFromConfig(props.config, schema, props.roles);
+            setState(prevState => ({
+                ...prevState,
+                ...initialStateFromConfig,
+                prevSchemaId: schema.id,
+            }));
+        }
+    }, []);
 
     const [saveActions, setSaveActions] = useState<Array<() => Promise<{error?: {message?: string}}>>>([]);
 
@@ -311,6 +322,7 @@ const LDAPWizard = (props: Props) => {
                 confirmNeededId: '',
                 showConfirmId: '',
                 clientWarning: '',
+                serverError: null,
             }));
         }
     };

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_wizard.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_wizard.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useCallback, useState} from 'react';
-import type {IntlShape, MessageDescriptor, WrappedComponentProps} from 'react-intl';
+import type {MessageDescriptor, WrappedComponentProps} from 'react-intl';
 import {FormattedMessage} from 'react-intl';
 
 import type {CloudState} from '@mattermost/types/cloud';
@@ -36,8 +36,6 @@ import type {AdminDefinitionSetting, AdminDefinitionSettingButton, AdminDefiniti
 export type GeneralSettingProps = {
     setting: AdminDefinitionSetting;
     schema: AdminDefinitionSubSectionSchema | null;
-    config: Partial<AdminConfig>;
-    intl: IntlShape;
 }
 
 type Props = {
@@ -56,7 +54,7 @@ type Props = {
 } & WrappedComponentProps
 
 type State = {
-    [x: string]: any;
+    [x: string]: unknown;
     saveNeeded: false | 'both' | 'permissions' | 'config';
     saving: boolean;
     serverError: string | { message: string; id?: string } | null;
@@ -87,14 +85,14 @@ const LDAPWizard = (props: Props) => {
                 prevSchemaId: schema.id,
             }));
         }
-    }, []);
+    }, [props.config, props.roles, schema]);
 
     const [saveActions, setSaveActions] = useState<Array<() => Promise<{error?: {message?: string}}>>>([]);
 
     const buildTextSetting = (setting: AdminDefinitionSetting) => {
         return (
             <LDAPTextSetting
-                {...props}
+                config={props.config}
                 key={schema.id + '_text_' + setting.key}
                 state={state}
                 onChange={handleChange}
@@ -109,9 +107,8 @@ const LDAPWizard = (props: Props) => {
     const buildBoolSetting = (setting: AdminDefinitionSetting) => {
         return (
             <LDAPBooleanSetting
-                {...props}
                 key={schema.id + '_bool_' + setting.key}
-                value={state[setting.key!] || false}
+                value={state[setting.key!] as boolean || false}
                 onChange={handleChange}
                 schema={schema}
                 disabled={isDisabled(setting)}
@@ -124,7 +121,9 @@ const LDAPWizard = (props: Props) => {
     const buildDropdownSetting = (setting: AdminDefinitionSetting) => {
         return (
             <LDAPDropdownSetting
-                {...props}
+                config={props.config}
+                license={props.license}
+                enterpriseReady={props.enterpriseReady}
                 key={schema.id + '_dropdown_' + setting.key}
                 state={state}
                 onChange={handleChange}
@@ -139,7 +138,6 @@ const LDAPWizard = (props: Props) => {
     const buildButtonSetting = (setting: AdminDefinitionSetting) => {
         return (
             <LDAPButtonSetting
-                {...props}
                 key={schema.id + '_button_' + setting.key}
                 onChange={handleChange}
                 saveNeeded={false}
@@ -153,7 +151,6 @@ const LDAPWizard = (props: Props) => {
     const buildJobsTableSetting = (setting: AdminDefinitionSetting) => {
         return (
             <LDAPJobsTableSetting
-                {...props}
                 key={schema.id + '_jobstable_' + setting.key}
                 schema={schema}
                 disabled={isDisabled(setting)}
@@ -173,9 +170,8 @@ const LDAPWizard = (props: Props) => {
     const buildFileUploadSetting = (setting: AdminDefinitionSetting) => {
         return (
             <LDAPFileUploadSetting
-                {...props}
                 key={schema.id + '_fileupload_' + setting.key}
-                value={state[setting.key!]}
+                value={state[setting.key!] as string}
                 onChange={handleChange}
                 fileUploadSetstate={fileUploadSetstate}
                 schema={schema}
@@ -189,7 +185,8 @@ const LDAPWizard = (props: Props) => {
     const buildCustomSetting = (setting: AdminDefinitionSetting) => {
         return (
             <LDAPCustomSetting
-                {...props}
+                config={props.config}
+                license={props.license}
                 key={schema.id + '_custom_' + setting.key}
                 schema={schema}
                 setting={setting}
@@ -327,7 +324,7 @@ const LDAPWizard = (props: Props) => {
         }
     };
 
-    const handleChange = (id: string, value: any, confirm = false, shouldSubmit = false, warning = false) => {
+    const handleChange = (id: string, value: unknown, confirm = false, shouldSubmit = false, warning = false) => {
         let saveNeeded: State['saveNeeded'] = state.saveNeeded === 'permissions' ? 'both' : 'config';
 
         // Exception: Since OpenId-Custom is treated as feature discovery for Cloud Starter licenses, save button is disabled.

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
@@ -86,7 +86,7 @@ export function unescapePathPart(pathPart: string) {
     return pathPart.replace(/\+/g, '.');
 }
 
-function descriptorOrStringToString(text: string | MessageDescriptor | undefined, intl: IntlShape, values?: {[key: string]: any}): string | undefined {
+export function descriptorOrStringToString(text: string | MessageDescriptor | undefined, intl: IntlShape, values?: {[key: string]: any}): string | undefined {
     if (!text) {
         return undefined;
     }
@@ -204,46 +204,6 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
         }
     };
 
-    getConfigFromState(config: Partial<AdminConfig>) {
-        const schema = this.props.schema;
-
-        if (schema) {
-            let settings: AdminDefinitionSetting[] = [];
-
-            if ('settings' in schema && schema.settings) {
-                settings = schema.settings;
-            } else if ('sections' in schema && schema.sections) {
-                schema.sections.map((section) => section.settings).forEach((sectionSettings) => settings.push(...sectionSettings));
-            }
-
-            settings.forEach((setting) => {
-                if (!setting.key) {
-                    return;
-                }
-
-                if (setting.type === Constants.SettingsTypes.TYPE_PERMISSION) {
-                    this.setConfigValue(config, setting.key, null);
-                    return;
-                }
-
-                let value = this.getSettingValue(setting);
-                const previousValue = SchemaAdminSettings.getConfigValue(config, setting.key);
-
-                if ('onConfigSave' in setting && setting.onConfigSave) {
-                    value = setting.onConfigSave(value, previousValue);
-                }
-
-                this.setConfigValue(config, setting.key, value);
-            });
-
-            if ('onConfigSave' in schema && schema.onConfigSave) {
-                return schema.onConfigSave(config);
-            }
-        }
-
-        return config;
-    }
-
     static getStateFromConfig(config: Partial<AdminConfig>, schema: AdminDefinitionSubSectionSchema, roles?: Record<string, Role>) {
         let state: Partial<State> = {};
 
@@ -303,24 +263,6 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
         return null;
     }
 
-    getSettingValue(setting: AdminDefinitionSetting) {
-        // Force boolean values to false when disabled.
-        if (setting.type === Constants.SettingsTypes.TYPE_BOOL) {
-            if (this.isDisabled(setting)) {
-                return false;
-            }
-        }
-        if (!setting.key) {
-            return undefined;
-        }
-
-        if (setting.type === Constants.SettingsTypes.TYPE_TEXT && setting.dynamic_value) {
-            return setting.dynamic_value(this.state[setting.key], this.props.config, this.state);
-        }
-
-        return this.state[setting.key];
-    }
-
     renderTitle = () => {
         if (!this.props.schema) {
             return '';
@@ -376,59 +318,6 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
                 values={setting.label_values}
             />
         );
-    };
-
-    renderSettingHelpText = (setting: AdminDefinitionSetting) => {
-        if (!this.props.schema || setting.type === 'banner' || !setting.help_text) {
-            return <span>{''}</span>;
-        }
-
-        let helpText;
-        let isMarkdown;
-        let helpTextValues;
-        if ('disabled_help_text' in setting && setting.disabled_help_text && this.isDisabled(setting)) {
-            helpText = setting.disabled_help_text;
-            isMarkdown = setting.disabled_help_text_markdown;
-            helpTextValues = setting.disabled_help_text_values;
-        } else {
-            helpText = setting.help_text;
-            isMarkdown = setting.help_text_markdown;
-            helpTextValues = setting.help_text_values;
-        }
-
-        return (
-            <SchemaText
-                isMarkdown={isMarkdown}
-                text={helpText}
-                textValues={helpTextValues}
-            />
-        );
-    };
-
-    renderDropdownOptionHelpText = (option: AdminDefinitionSettingDropdownOption) => {
-        if (!option.help_text) {
-            return <span>{''}</span>;
-        }
-
-        return (
-            <SchemaText
-                isMarkdown={option.help_text_markdown}
-                text={option.help_text}
-                textValues={option.help_text_values}
-            />
-        );
-    };
-
-    renderLabel = (setting: AdminDefinitionSetting) => {
-        if (!this.props.schema || !setting.label) {
-            return '';
-        }
-
-        if (typeof setting.label === 'string') {
-            return setting.label;
-        }
-
-        return this.props.intl.formatMessage(setting.label);
     };
 
     isDisabled = (setting: AdminDefinitionSetting) => {
@@ -494,14 +383,17 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
             setting.action(successCallback, error, this.state[sourceUrlKey]);
         };
 
+        const helpText = renderSettingHelpText(setting, this.props.schema, this.isDisabled(setting));
+        const label = renderLabel(setting, this.props.schema, this.props.intl);
+
         return (
             <RequestButton
                 id={setting.key}
                 key={this.props.schema.id + '_text_' + setting.key}
                 requestAction={handleRequestAction}
-                helpText={this.renderSettingHelpText(setting)}
+                helpText={helpText}
                 loadingText={descriptorOrStringToString(setting.loading, this.props.intl)}
-                buttonText={<span>{this.renderLabel(setting)}</span>}
+                buttonText={<span>{label}</span>}
                 showSuccessMessage={Boolean(setting.success_message)}
                 includeDetailedError={true}
                 disabled={this.isDisabled(setting)}
@@ -543,18 +435,21 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
             ) : footer;
         }
 
+        const label = renderLabel(setting, this.props.schema, this.props.intl);
+        const helpText = renderSettingHelpText(setting, this.props.schema, this.isDisabled(setting));
+
         return (
             <TextSetting
                 key={this.props.schema.id + '_text_' + setting.key}
                 id={setting.key}
                 multiple={setting.multiple}
                 type={inputType}
-                label={this.renderLabel(setting)}
-                helpText={this.renderSettingHelpText(setting)}
+                label={label}
+                helpText={helpText}
                 placeholder={descriptorOrStringToString(setting.placeholder, this.props.intl, setting.placeholder_values)}
                 value={value}
                 disabled={this.isDisabled(setting)}
-                setByEnv={this.isSetByEnv(setting.key)}
+                setByEnv={isSetByEnv(setting.key, this.props.environmentConfig)}
                 onChange={this.handleChange}
                 maxLength={setting.max_length}
                 footer={footer}
@@ -566,12 +461,16 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
         if (!this.props.schema || !setting.key || setting.type !== 'color') {
             return (<></>);
         }
+
+        const label = renderLabel(setting, this.props.schema, this.props.intl);
+        const helpText = renderSettingHelpText(setting, this.props.schema, this.isDisabled(setting));
+
         return (
             <ColorSetting
                 key={this.props.schema.id + '_text_' + setting.key}
                 id={setting.key}
-                label={this.renderLabel(setting)}
-                helpText={this.renderSettingHelpText(setting)}
+                label={label}
+                helpText={helpText}
                 value={this.state[setting.key] || ''}
                 disabled={this.isDisabled(setting)}
                 onChange={this.handleChange}
@@ -584,15 +483,18 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
             return (<></>);
         }
 
+        const label = renderLabel(setting, this.props.schema, this.props.intl);
+        const helpText = renderSettingHelpText(setting, this.props.schema, this.isDisabled(setting));
+
         return (
             <BooleanSetting
                 key={this.props.schema.id + '_bool_' + setting.key}
                 id={setting.key}
-                label={this.renderLabel(setting)}
-                helpText={this.renderSettingHelpText(setting)}
+                label={label}
+                helpText={helpText}
                 value={this.state[setting.key] ?? (setting.default || false)}
                 disabled={this.isDisabled(setting)}
-                setByEnv={this.isSetByEnv(setting.key)}
+                setByEnv={isSetByEnv(setting.key, this.props.environmentConfig)}
                 onChange={this.handleChange}
             />
         );
@@ -603,15 +505,18 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
             return (<></>);
         }
 
+        const label = renderLabel(setting, this.props.schema, this.props.intl);
+        const helpText = renderSettingHelpText(setting, this.props.schema, this.isDisabled(setting));
+
         return (
             <BooleanSetting
                 key={this.props.schema.id + '_bool_' + setting.key}
                 id={setting.key}
-                label={this.renderLabel(setting)}
-                helpText={this.renderSettingHelpText(setting)}
+                label={label}
+                helpText={helpText}
                 value={this.state[setting.key] || false}
                 disabled={this.isDisabled(setting)}
-                setByEnv={this.isSetByEnv(setting.key)}
+                setByEnv={isSetByEnv(setting.key, this.props.environmentConfig)}
                 onChange={this.handlePermissionChange}
             />
         );
@@ -650,20 +555,22 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
             }
         }
 
+        const label = renderLabel(setting, this.props.schema, this.props.intl);
+
         let helpText: string | JSX.Element = '';
         if (!hideHelp) {
-            helpText = selectedOptionForHelpText ? this.renderDropdownOptionHelpText(selectedOptionForHelpText) : this.renderSettingHelpText(setting);
+            helpText = selectedOptionForHelpText ? renderDropdownOptionHelpText(selectedOptionForHelpText) : renderSettingHelpText(setting, this.props.schema, this.isDisabled(setting));
         }
         return (
             <DropdownSetting
                 key={this.props.schema.id + '_dropdown_' + setting.key}
                 id={setting.key}
                 values={values}
-                label={this.renderLabel(setting)}
+                label={label}
                 helpText={helpText}
                 value={selectedValue}
                 disabled={this.isDisabled(setting)}
-                setByEnv={this.isSetByEnv(setting.key)}
+                setByEnv={isSetByEnv(setting.key, this.props.environmentConfig)}
                 onChange={this.handleChange}
             />
         );
@@ -682,20 +589,24 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
             };
         });
 
+        const label = renderLabel(setting, this.props.schema, this.props.intl);
+        const helpText = renderSettingHelpText(setting, this.props.schema, this.isDisabled(setting));
+
         if (setting.multiple) {
             const noOptionsMessage = typeof setting.no_result === 'object' ? (
                 <FormattedMessage {...setting.no_result}/>
             ) : setting.no_result;
+
             return (
                 <MultiSelectSetting
                     key={this.props.schema.id + '_language_' + setting.key}
                     id={setting.key}
-                    label={this.renderLabel(setting)}
                     values={values}
-                    helpText={this.renderSettingHelpText(setting)}
+                    label={label}
+                    helpText={helpText}
                     selected={(this.state[setting.key] || emptyList)}
                     disabled={this.isDisabled(setting)}
-                    setByEnv={this.isSetByEnv(setting.key)}
+                    setByEnv={isSetByEnv(setting.key, this.props.environmentConfig)}
                     onChange={this.handleChange}
                     noOptionsMessage={noOptionsMessage}
                 />
@@ -705,12 +616,12 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
             <DropdownSetting
                 key={this.props.schema.id + '_language_' + setting.key}
                 id={setting.key}
-                label={this.renderLabel(setting)}
                 values={values}
-                helpText={this.renderSettingHelpText(setting)}
+                label={label}
+                helpText={helpText}
                 value={this.state[setting.key] ?? values[0].value}
                 disabled={this.isDisabled(setting)}
-                setByEnv={this.isSetByEnv(setting.key)}
+                setByEnv={isSetByEnv(setting.key, this.props.environmentConfig)}
                 onChange={this.handleChange}
             />
         );
@@ -727,17 +638,20 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
         }
         values.sort((a, b) => a.order - b.order);
 
+        const label = renderLabel(setting, this.props.schema, this.props.intl);
+        const helpText = renderSettingHelpText(setting, this.props.schema, this.isDisabled(setting));
+
         if (setting.multiple) {
             return (
                 <MultiSelectSetting
                     key={this.props.schema.id + '_language_' + setting.key}
                     id={setting.key}
-                    label={this.renderLabel(setting)}
+                    label={label}
                     values={values}
-                    helpText={this.renderSettingHelpText(setting)}
+                    helpText={helpText}
                     selected={(this.state[setting.key] && this.state[setting.key].split(',')) || []}
                     disabled={this.isDisabled(setting)}
-                    setByEnv={this.isSetByEnv(setting.key)}
+                    setByEnv={isSetByEnv(setting.key, this.props.environmentConfig)}
                     onChange={(changedId, value) => this.handleChange(changedId, value.join(','))}
                     noOptionsMessage={descriptorOrStringToString(setting.no_result, this.props.intl)}
                 />
@@ -747,12 +661,12 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
             <DropdownSetting
                 key={this.props.schema.id + '_language_' + setting.key}
                 id={setting.key}
-                label={this.renderLabel(setting)}
+                label={label}
                 values={values}
-                helpText={this.renderSettingHelpText(setting)}
+                helpText={helpText}
                 value={this.state[setting.key] ?? values[0].value}
                 disabled={this.isDisabled(setting)}
-                setByEnv={this.isSetByEnv(setting.key)}
+                setByEnv={isSetByEnv(setting.key, this.props.environmentConfig)}
                 onChange={this.handleChange}
             />
         );
@@ -767,16 +681,19 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
         const values = options.map((o) => ({value: o.value, text: descriptorOrStringToString(o.display_name, this.props.intl)!}));
         const defaultOption = values.find((v) => v.value === setting.default)?.value || values[0].value;
 
+        const label = renderLabel(setting, this.props.schema, this.props.intl);
+        const helpText = renderSettingHelpText(setting, this.props.schema, this.isDisabled(setting));
+
         return (
             <RadioSetting
                 key={this.props.schema.id + '_radio_' + setting.key}
                 id={setting.key}
                 values={values}
-                label={this.renderLabel(setting)}
-                helpText={this.renderSettingHelpText(setting)}
+                label={label}
+                helpText={helpText}
                 value={this.state[setting.key] ?? defaultOption}
                 disabled={this.isDisabled(setting)}
-                setByEnv={this.isSetByEnv(setting.key)}
+                setByEnv={isSetByEnv(setting.key, this.props.environmentConfig)}
                 onChange={this.handleChange}
             />
         );
@@ -794,7 +711,7 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
             >
                 <div className='banner__content'>
                     <span>
-                        { setting.banner_type === 'warning' ? <WarningIcon additionalClassName='banner__icon'/> : null}
+                        {setting.banner_type === 'warning' ? <WarningIcon additionalClassName='banner__icon'/> : null}
                         {this.renderBanner(setting)}
                     </span>
                 </div>
@@ -807,17 +724,20 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
             return (<></>);
         }
 
+        const label = renderLabel(setting, this.props.schema, this.props.intl);
+        const helpText = renderSettingHelpText(setting, this.props.schema, this.isDisabled(setting));
+
         return (
             <GeneratedSetting
                 key={this.props.schema.id + '_generated_' + setting.key}
                 id={setting.key}
-                label={this.renderLabel(setting)}
-                helpText={this.renderSettingHelpText(setting)}
+                label={label}
+                helpText={helpText}
                 regenerateHelpText={setting.regenerate_help_text}
                 placeholder={descriptorOrStringToString(setting.placeholder, this.props.intl)}
                 value={this.state[setting.key] ?? (setting.default || '')}
                 disabled={this.isDisabled(setting)}
-                setByEnv={this.isSetByEnv(setting.key)}
+                setByEnv={isSetByEnv(setting.key, this.props.environmentConfig)}
                 onChange={this.handleGeneratedChange}
             />
         );
@@ -875,12 +795,15 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
             return (<></>);
         }
 
+        const label = renderLabel(setting, this.props.schema, this.props.intl);
+        const helpText = renderSettingHelpText(setting, this.props.schema, this.isDisabled(setting));
+
         return (
             <UserAutocompleteSetting
                 key={this.props.schema.id + '_userautocomplete_' + setting.key}
                 id={setting.key}
-                label={this.renderLabel(setting)}
-                helpText={this.renderSettingHelpText(setting)}
+                label={label}
+                helpText={helpText}
                 placeholder={setting.placeholder}
                 value={this.state[setting.key] ?? (setting.default || '')}
                 disabled={this.isDisabled(setting)}
@@ -894,6 +817,8 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
             return (<></>);
         }
 
+        const helpText = renderSettingHelpText(setting, this.props.schema, this.isDisabled(setting));
+
         return (
             <JobsTable
                 key={this.props.schema.id + '_jobstable_' + setting.key}
@@ -901,7 +826,7 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
                 getExtraInfoText={setting.render_job}
                 disabled={this.isDisabled(setting)}
                 createJobButtonText={descriptorOrStringToString(setting.label, this.props.intl)}
-                createJobHelpText={this.renderSettingHelpText(setting)}
+                createJobHelpText={helpText}
             />
         );
     };
@@ -923,18 +848,22 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
                 };
                 setting.remove_action(successCallback, errorCallback);
             };
+
+            const label = renderLabel(setting, this.props.schema, this.props.intl);
+            const helpText = renderSettingHelpText(setting, this.props.schema, this.isDisabled(setting));
+
             return (
                 <RemoveFileSetting
                     id={this.props.schema.id}
                     key={this.props.schema.id + '_fileupload_' + setting.key}
-                    label={this.renderLabel(setting)}
-                    helpText={descriptorOrStringToString(setting.remove_help_text, this.props.intl)}
+                    label={label}
+                    helpText={helpText}
                     removeButtonText={descriptorOrStringToString(setting.remove_button_text, this.props.intl)}
                     removingText={descriptorOrStringToString(setting.removing_text, this.props.intl)}
                     fileName={this.state[setting.key]}
                     onSubmit={removeFile}
                     disabled={this.isDisabled(setting)}
-                    setByEnv={this.isSetByEnv(setting.key)}
+                    setByEnv={isSetByEnv(setting.key, this.props.environmentConfig)}
                 />
             );
         }
@@ -954,12 +883,15 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
             setting.upload_action(file, successCallback, errorCallback);
         };
 
+        const label = renderLabel(setting, this.props.schema, this.props.intl);
+        const helpText = renderSettingHelpText(setting, this.props.schema, this.isDisabled(setting));
+
         return (
             <FileUploadSetting
                 id={setting.key}
                 key={this.props.schema.id + '_fileupload_' + setting.key}
-                label={this.renderLabel(setting)}
-                helpText={this.renderSettingHelpText(setting)}
+                label={label}
+                helpText={helpText}
                 uploadingText={descriptorOrStringToString(setting.uploading_text, this.props.intl)}
                 disabled={this.isDisabled(setting)}
                 fileType={setting.fileType}
@@ -974,19 +906,22 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
             return (<></>);
         }
 
+        const label = renderLabel(setting, this.props.schema, this.props.intl);
+        const helpText = renderSettingHelpText(setting, this.props.schema, this.isDisabled(setting));
+
         const CustomComponent = setting.component;
 
         const componentInstance = (
             <CustomComponent
                 key={this.props.schema.id + '_custom_' + setting.key}
                 id={setting.key}
-                label={this.renderLabel(setting)}
-                helpText={this.renderSettingHelpText(setting)}
+                label={label}
+                helpText={helpText}
                 value={this.state[setting.key]}
                 disabled={this.isDisabled(setting)}
                 config={this.props.config}
                 license={this.props.license}
-                setByEnv={this.isSetByEnv(setting.key)}
+                setByEnv={isSetByEnv(setting.key, this.props.environmentConfig)}
                 onChange={this.handleChange}
                 registerSaveAction={this.registerSaveAction}
                 setSaveNeeded={this.setSaveNeeded}
@@ -1178,7 +1113,7 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
 
         // clone config so that we aren't modifying data in the stores
         let config = JSON.parse(JSON.stringify(this.props.config));
-        config = this.getConfigFromState(config);
+        config = getConfigFromState(config, this.state, this.props.schema, this.isDisabled);
 
         const {error} = await this.props.patchConfig(config);
         if (error) {
@@ -1224,24 +1159,6 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
         }, config);
     }
 
-    setConfigValue(config: any, path: string, value: any) {
-        function setValue(obj: any, pathParts: string[]) {
-            const part = unescapePathPart(pathParts[0]);
-
-            if (pathParts.length === 1) {
-                obj[part] = value;
-            } else {
-                if (obj[part] == null) {
-                    obj[part] = {};
-                }
-
-                setValue(obj[part], pathParts.slice(1));
-            }
-        }
-
-        setValue(config, path.split('.'));
-    }
-
     isSetByEnv = (path: string) => {
         return Boolean(SchemaAdminSettings.getConfigValue(this.props.environmentConfig, path));
     };
@@ -1273,7 +1190,7 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
             }
 
             // don't validate elements set by env.
-            if (this.isSetByEnv(setting.key)) {
+            if (isSetByEnv(setting.key, this.props.environmentConfig)) {
                 continue;
             }
 
@@ -1395,5 +1312,154 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
         );
     };
 }
+
+export const renderLabel = (
+    setting: AdminDefinitionSetting,
+    schema: AdminDefinitionSubSectionSchema | null,
+    intl: IntlShape,
+) => {
+    if (!schema || !setting.label) {
+        return '';
+    }
+
+    if (typeof setting.label === 'string') {
+        return setting.label;
+    }
+
+    return intl.formatMessage(setting.label);
+};
+
+export const renderSettingHelpText = (
+    setting: AdminDefinitionSetting,
+    schema: AdminDefinitionSubSectionSchema | null,
+    isDisabled: boolean,
+) => {
+    if (!schema || setting.type === 'banner' || !setting.help_text) {
+        return <span>{''}</span>;
+    }
+
+    let helpText;
+    let isMarkdown;
+    let helpTextValues;
+    if ('disabled_help_text' in setting && setting.disabled_help_text && isDisabled) {
+        helpText = setting.disabled_help_text;
+        isMarkdown = setting.disabled_help_text_markdown;
+        helpTextValues = setting.disabled_help_text_values;
+    } else {
+        helpText = setting.help_text;
+        isMarkdown = setting.help_text_markdown;
+        helpTextValues = setting.help_text_values;
+    }
+
+    return (
+        <SchemaText
+            isMarkdown={isMarkdown}
+            text={helpText}
+            textValues={helpTextValues}
+        />
+    );
+};
+
+export const isSetByEnv = (path: string, environmentConfig: Partial<EnvironmentConfig>) => {
+    return Boolean(SchemaAdminSettings.getConfigValue(environmentConfig, path));
+};
+
+export const renderDropdownOptionHelpText = (option: AdminDefinitionSettingDropdownOption) => {
+    if (!option.help_text) {
+        return <span>{''}</span>;
+    }
+
+    return (
+        <SchemaText
+            isMarkdown={option.help_text_markdown}
+            text={option.help_text}
+            textValues={option.help_text_values}
+        />
+    );
+};
+
+export const setConfigValue = (config: any, path: string, value: any) => {
+    function setValue(obj: any, pathParts: string[]) {
+        const part = unescapePathPart(pathParts[0]);
+
+        if (pathParts.length === 1) {
+            obj[part] = value;
+        } else {
+            if (obj[part] == null) {
+                obj[part] = {};
+            }
+
+            setValue(obj[part], pathParts.slice(1));
+        }
+    }
+
+    setValue(config, path.split('.'));
+};
+
+export const getSettingValue = (
+    setting: AdminDefinitionSetting,
+    state: any,
+    config: Partial<AdminConfig>,
+    isDisabled: (setting: AdminDefinitionSetting) => boolean,
+) => {
+    // Force boolean values to false when disabled.
+    if (setting.type === Constants.SettingsTypes.TYPE_BOOL) {
+        if (isDisabled(setting)) {
+            return false;
+        }
+    }
+    if (!setting.key) {
+        return undefined;
+    }
+
+    if (setting.type === Constants.SettingsTypes.TYPE_TEXT && setting.dynamic_value) {
+        return setting.dynamic_value(state[setting.key], config, state);
+    }
+
+    return state[setting.key];
+};
+
+export const getConfigFromState = (
+    config: Partial<AdminConfig>,
+    state: any,
+    schema: AdminDefinitionSubSectionSchema,
+    isDisabled: (setting: AdminDefinitionSetting) => boolean,
+) => {
+    if (schema) {
+        let settings: AdminDefinitionSetting[] = [];
+
+        if ('settings' in schema && schema.settings) {
+            settings = schema.settings;
+        } else if ('sections' in schema && schema.sections) {
+            schema.sections.map((section) => section.settings).forEach((sectionSettings) => settings.push(...sectionSettings));
+        }
+
+        settings.forEach((setting) => {
+            if (!setting.key) {
+                return;
+            }
+
+            if (setting.type === Constants.SettingsTypes.TYPE_PERMISSION) {
+                setConfigValue(config, setting.key, null);
+                return;
+            }
+
+            let value = getSettingValue(setting, state, config, isDisabled);
+            const previousValue = SchemaAdminSettings.getConfigValue(config, setting.key);
+
+            if ('onConfigSave' in setting && setting.onConfigSave) {
+                value = setting.onConfigSave(value, previousValue);
+            }
+
+            setConfigValue(config, setting.key, value);
+        });
+
+        if ('onConfigSave' in schema && schema.onConfigSave) {
+            return schema.onConfigSave(config);
+        }
+    }
+
+    return config;
+};
 
 export default injectIntl(SchemaAdminSettings);

--- a/webapp/channels/src/components/admin_console/types.ts
+++ b/webapp/channels/src/components/admin_console/types.ts
@@ -99,7 +99,7 @@ type AdminDefinitionSettingDropdown = AdminDefinitionSettingBase & {
     isHelpHidden?: Check;
 }
 
-type AdminDefinitionSettingFileUpload = AdminDefinitionSettingBase & {
+export type AdminDefinitionSettingFileUpload = AdminDefinitionSettingBase & {
     type: 'fileupload';
     remove_help_text: string | MessageDescriptor;
     remove_button_text: string | MessageDescriptor;
@@ -124,7 +124,7 @@ type AdminDefinitionSettingLanguage = AdminDefinitionSettingBase & {
     no_result?: string | MessageDescriptor;
 }
 
-type AdminDefinitionSettingButton = AdminDefinitionSettingBase & {
+export type AdminDefinitionSettingButton = AdminDefinitionSettingBase & {
     type: 'button';
     action: (success: (data?: any) => void, error: (error: {message: string; detailed_error?: string}) => void, siteUrl: string) => void;
     loading?: string | MessageDescriptor;

--- a/webapp/channels/src/components/form_error.tsx
+++ b/webapp/channels/src/components/form_error.tsx
@@ -3,8 +3,8 @@
 
 import React from 'react';
 
-const TYPE_MODAL = 'modal';
-const TYPE_BACKSTAGE = 'backstage';
+export const TYPE_MODAL = 'modal';
+export const TYPE_BACKSTAGE = 'backstage';
 
 // accepts either a single error or an array of errors
 type Props = {

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -1495,8 +1495,6 @@
   "admin.ldap.queryDesc": "The timeout value for queries to the AD/LDAP server. Increase if you are getting timeout errors caused by a slow AD/LDAP server.",
   "admin.ldap.queryEx": "E.g.: \"60\"",
   "admin.ldap.queryTitle": "Query Timeout (seconds):",
-  "admin.ldap.reAddRemovedMembersDesc": "When enabled, members who were previously removed from group-synced teams or channels will be re-added during LDAP synchronization if they are still a member of the LDAP group.",
-  "admin.ldap.reAddRemovedMembersTitle": "Re-add removed members on sync:",
   "admin.ldap.remove.privKey": "Remove TLS Certificate Private Key",
   "admin.ldap.remove.sp_certificate": "Remove Service Provider Certificate",
   "admin.ldap.removing.certificate": "Removing Certificate...",

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -377,6 +377,7 @@
   "admin.authentication.gitlab": "GitLab",
   "admin.authentication.guest_access": "Guest Access",
   "admin.authentication.ldap": "AD/LDAP",
+  "admin.authentication.ldap.wizard": "AD/LDAP Wizard",
   "admin.authentication.mfa": "Multi-factor Authentication",
   "admin.authentication.oauth": "OAuth 2.0",
   "admin.authentication.openid": "OpenID Connect",

--- a/webapp/channels/src/utils/admin_console_index.test.tsx
+++ b/webapp/channels/src/utils/admin_console_index.test.tsx
@@ -20,10 +20,10 @@ describe('AdminConsoleIndex.generateIndex', () => {
         expect(idx.search('ldap')).toEqual([
             'environment/session_lengths',
             'authentication/mfa',
-            'authentication/ldap',
             'authentication/saml',
             'experimental/features',
             'authentication/email',
+            'authentication/ldap',
             'authentication/guest_access',
         ]);
         expect(idx.search('saml')).toEqual([


### PR DESCRIPTION
#### Summary
- Initial commit on a feature-branch for the new LDAP Wizard
- Purpose of this PR is to move over the rendering of the AD/LDAP page to a new `LDAPWizard` component. This will allow us to control state across the whole page, including:
  - error states (and help icons with hover states) on components that are related to other state on the page
  - new autocomplete components (that get their state from the server based on the state of the LDAP Wizard's connection)
  - log components (state from the server based on LDAP Wizard's state)
  - buttons that need to use input from fields that haven't been saved to the config yet
- Could this have been done using the admin definition? Possibly, and I initially tried. But I backtracked after it became too complicated. It would require adding a bunch of complicated callbacks, and would ruin the benefit of the admin definition (declarative state for the common use cases).
- I am keeping the admin definitions for the AD/LDAP page for now, as the basis for the LDAP Wizard. This will allow us to keep as much of the old (battle-tested) logic as possible, and I'll only modify or remove those fields when I absolutely have to.
- Maybe we'll end up back with the definition in the end, I don't know.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-63717
- Designs (this is what we're working towards, what the `LDAPWizard` component will let us do): https://www.figma.com/design/ss8JccFIG9ICsIyX1YwxAA/LDAP-Wizard?node-id=5720-5888&m=dev

#### Screenshots
- AD/LDAP admin screen looks the same as before.

#### Release Note
```release-note
NONE
```

