### PR TITLE
Fix flaky test for TestLeaveChannel

### DIFF
--- a/server/channels/app/channel_test.go
+++ b/server/channels/app/channel_test.go
@@ -901,8 +901,8 @@ func TestLeaveChannel(t *testing.T) {
 	t.Run("can leave private channel as last member", func(t *testing.T) {
 		channel := th.createChannel(th.Context, th.BasicTeam, model.ChannelTypePrivate)
 
-		count, appErr := th.App.GetChannelMemberCount(th.Context, th.BasicChannel.Id)
-		require.Nil(t, appErr, "It should remove channel membership")
+		count, appErr := th.App.GetChannelMemberCount(th.Context, channel.Id)
+		require.Nil(t, appErr, "It should get the channel member count")
 		require.Equal(t, int64(1), count)
 
 		appErr = th.App.LeaveChannel(th.Context, channel.Id, th.BasicUser.Id)


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost/pull/30746

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
