### PR TITLE
MM-64316 Fix icon_emoji not working on webhook posts

### DIFF
--- a/server/channels/app/webhook.go
+++ b/server/channels/app/webhook.go
@@ -344,7 +344,7 @@ func (a *App) CreateWebhookPost(c request.CTX, userID string, channel *model.Cha
 			post.AddProp(model.PostPropsOverrideIconURL, overrideIconURL)
 		}
 		if overrideIconEmoji != "" {
-			post.AddProp(model.PostPropsOverrideIconURL, overrideIconEmoji)
+			post.AddProp(model.PostPropsOverrideIconEmoji, overrideIconEmoji)
 		}
 	}
 

--- a/server/channels/app/webhook_test.go
+++ b/server/channels/app/webhook_test.go
@@ -394,6 +394,92 @@ Date:   Thu Mar 1 19:46:48 2018 +0300
 	})
 }
 
+func TestCreateWebhookPostWithOverriddenIcon(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ServiceSettings.EnableIncomingWebhooks = true
+		*cfg.ServiceSettings.EnablePostIconOverride = true
+	})
+
+	hook, appErr := th.App.CreateIncomingWebhookForChannel(th.BasicUser.Id, th.BasicChannel, &model.IncomingWebhook{ChannelId: th.BasicChannel.Id})
+	require.Nil(t, appErr)
+	defer func() {
+		appErr = th.App.DeleteIncomingWebhook(hook.Id)
+		require.Nil(t, appErr, "Error cleaning up webhook")
+	}()
+
+	t.Run("should set props based on icon_url", func(t *testing.T) {
+		post, appErr := th.App.CreateWebhookPost(
+			th.Context,
+			hook.UserId,
+			th.BasicChannel,
+			"test post",
+			"",
+			"https://example.com/icon.png",
+			"",
+			nil,
+			"",
+			"",
+			nil,
+		)
+
+		require.Nil(t, appErr)
+		assert.Equal(t, "https://example.com/icon.png", post.GetProp(model.PostPropsOverrideIconURL))
+
+		clientPost := th.App.PreparePostForClient(th.Context, post, true, false, false)
+
+		assert.Equal(t, "https://example.com/icon.png", clientPost.GetProp(model.PostPropsOverrideIconURL))
+	})
+
+	t.Run("should set props based on icon_emoji", func(t *testing.T) {
+		post, appErr := th.App.CreateWebhookPost(
+			th.Context,
+			hook.UserId,
+			th.BasicChannel,
+			"test post",
+			"",
+			"",
+			"smile",
+			nil,
+			"",
+			"",
+			nil,
+		)
+
+		require.Nil(t, appErr)
+		assert.Equal(t, "smile", post.GetProp(model.PostPropsOverrideIconEmoji))
+
+		clientPost := th.App.PreparePostForClient(th.Context, post, true, false, false)
+
+		assert.Equal(t, "/static/emoji/1f604.png", clientPost.GetProp(model.PostPropsOverrideIconURL))
+	})
+
+	t.Run("should set props based on icon_emoji (with colons around emoji name)", func(t *testing.T) {
+		post, appErr := th.App.CreateWebhookPost(
+			th.Context,
+			hook.UserId,
+			th.BasicChannel,
+			"test post",
+			"",
+			"",
+			":smile:",
+			nil,
+			"",
+			"",
+			nil,
+		)
+
+		require.Nil(t, appErr)
+		assert.Equal(t, ":smile:", post.GetProp(model.PostPropsOverrideIconEmoji))
+
+		clientPost := th.App.PreparePostForClient(th.Context, post, true, false, false)
+
+		assert.Equal(t, "/static/emoji/1f604.png", clientPost.GetProp(model.PostPropsOverrideIconURL))
+	})
+}
+
 func TestCreateWebhookPostWithPriority(t *testing.T) {
 	testCluster := &testlib.FakeClusterInterface{}
 	th := SetupWithClusterMock(t, testCluster).InitBasic()

--- a/server/channels/app/webhook_test.go
+++ b/server/channels/app/webhook_test.go
@@ -456,6 +456,31 @@ func TestCreateWebhookPostWithOverriddenIcon(t *testing.T) {
 		assert.Equal(t, "/static/emoji/1f604.png", clientPost.GetProp(model.PostPropsOverrideIconURL))
 	})
 
+	t.Run("should set props based on icon_emoji (using a custom emoji)", func(t *testing.T) {
+		emoji := th.CreateEmoji()
+
+		post, appErr := th.App.CreateWebhookPost(
+			th.Context,
+			hook.UserId,
+			th.BasicChannel,
+			"test post",
+			"",
+			"",
+			emoji.Name,
+			nil,
+			"",
+			"",
+			nil,
+		)
+
+		require.Nil(t, appErr)
+		assert.Equal(t, emoji.Name, post.GetProp(model.PostPropsOverrideIconEmoji))
+
+		clientPost := th.App.PreparePostForClient(th.Context, post, true, false, false)
+
+		assert.Equal(t, fmt.Sprintf("/api/v4/emoji/%s/image", emoji.Id), clientPost.GetProp(model.PostPropsOverrideIconURL))
+	})
+
 	t.Run("should set props based on icon_emoji (with colons around emoji name)", func(t *testing.T) {
 		post, appErr := th.App.CreateWebhookPost(
 			th.Context,


### PR DESCRIPTION
#### Summary
This was broken by a small typo in https://github.com/mattermost/mattermost/pull/30180

#### Ticket Link
MM-64316

#### Release Note
```release-note
Fixed icon_emoji property not working for webhook posts
```
