### PR TITLE
Fix OpenAPI schema for custom profile attributes

### DIFF
--- a/api/v4/source/custom_profile_attributes.yaml
+++ b/api/v4/source/custom_profile_attributes.yaml
@@ -53,7 +53,36 @@
                 type:
                   type: string
                 attrs:
-                  type: string
+                  type: object
+                  properties:
+                    visibility:
+                      type: string
+                      description: "Visibility of the attribute"
+                      enum: ["hidden", "when_set", "always"]
+                      default: "when_set"
+                    sort_order:
+                      type: number
+                      description: "Sort order for displaying this attribute"
+                    options:
+                      type: array
+                      description: "Options for select/multiselect fields"
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          color:
+                            type: string
+                    value_type:
+                      type: string
+                      description: "Type of text value"
+                      enum: ["email", "url", "phone"]
+                    ldap:
+                      type: string
+                      description: "LDAP attribute for syncing"
+                    saml:
+                      type: string
+                      description: "SAML attribute for syncing"
       responses:
         "201":
           description: Custom Profile Attribute field creation successful
@@ -106,7 +135,38 @@
                 type:
                   type: string
                 attrs:
-                  type: string
+                  type: object
+                  properties:
+                    visibility:
+                      type: string
+                      description: "Visibility of the attribute"
+                      enum: ["hidden", "when_set", "always"]
+                      default: "when_set"
+                    sort_order:
+                      type: number
+                      description: "Sort order for displaying this attribute"
+                    options:
+                      type: array
+                      description: "Options for select/multiselect fields"
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          color:
+                            type: string
+                    value_type:
+                      type: string
+                      description: "Type of text value"
+                      enum: ["email", "url", "phone"]
+                    ldap:
+                      type: string
+                      description: "LDAP attribute for syncing"
+                    saml:
+                      type: string
+                      description: "SAML attribute for syncing"
       responses:
         "200":
           description: Custom Profile Attribute field patch successful


### PR DESCRIPTION
#### Summary
- Update the 'attrs' field definition from string to object with proper properties in OpenAPI schema
- Remove 'id' property from options array in the POST endpoint as it's auto-generated by the server
- Add enum values for 'value_type' and 'visibility' fields

#### Ticket Link
Fixes mattermost/mattermost#7955

#### Related Pull Requests
- None

#### Screenshots
- None

```release-note
NONE
```