### PR TITLE
MM-64336: simplify doc extractor

### DIFF
--- a/server/platform/services/docextractor/archive.go
+++ b/server/platform/services/docextractor/archive.go
@@ -39,6 +39,7 @@ func getExtAlsoTarGz(name string) string {
 func (ae *archiveExtractor) Extract(name string, r io.ReadSeeker) (string, error) {
 	ext := getExtAlsoTarGz(name)
 
+	// Create a temporary file, using `*` control the random component while preserving the extension.
 	f, err := os.CreateTemp("", "archiver-*"+ext)
 	if err != nil {
 		return "", fmt.Errorf("error creating temporary file: %v", err)

--- a/server/platform/services/docextractor/archive.go
+++ b/server/platform/services/docextractor/archive.go
@@ -27,17 +27,24 @@ func (ae *archiveExtractor) Match(filename string) bool {
 	return err == nil
 }
 
+// getExtAlsoTarGz returns the extension of the given file name, special casing .tar.gz.
+func getExtAlsoTarGz(name string) string {
+	if strings.HasSuffix(name, ".tar.gz") {
+		return ".tar.gz"
+	}
+
+	return filepath.Ext(name)
+}
+
 func (ae *archiveExtractor) Extract(name string, r io.ReadSeeker) (string, error) {
-	dir, err := os.MkdirTemp(os.TempDir(), "archiver")
+	ext := getExtAlsoTarGz(name)
+
+	f, err := os.CreateTemp("", "archiver-*"+ext)
 	if err != nil {
 		return "", fmt.Errorf("error creating temporary file: %v", err)
 	}
-	defer os.RemoveAll(dir)
+	defer os.Remove(f.Name())
 
-	f, err := os.Create(filepath.Join(dir, name))
-	if err != nil {
-		return "", fmt.Errorf("error copying data into temporary file: %v", err)
-	}
 	_, err = io.Copy(f, r)
 	f.Close()
 	if err != nil {


### PR DESCRIPTION
#### Summary
Avoid creating a whole temporary directory when a single temporary file suffices.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-64337

#### Release Note
```release-note
NONE
```
