### PR TITLE
E2E/Cypress: Skip flaky tests

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/archived_channel/archive_channel_operations_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/archived_channel/archive_channel_operations_spec.ts
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @channels @channel
 
 import {getRandomId} from '../../../utils';
@@ -41,7 +40,7 @@ describe('Leave an archived channel', () => {
         });
     });
 
-    it('MM-T1704 Archived channels appear in channel switcher after refresh', () => {
+    it.skip('MM-T1704 Archived channels appear in channel switcher after refresh', () => {
         // # Archive the channel
         cy.apiLogin(testUser);
         cy.uiArchiveChannel();

--- a/e2e-tests/cypress/tests/integration/channels/collapsed_reply_threads/unread_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/collapsed_reply_threads/unread_spec.ts
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @channels @collapsed_reply_threads
 
 import {Channel} from '@mattermost/types/channels';
@@ -97,7 +96,7 @@ describe('Collapsed Reply Threads', () => {
         });
     });
 
-    it('MM-T5671 should handle mention counts correctly when marking a thread as unread and unfollowing it', () => {
+    it.skip('MM-T5671 should handle mention counts correctly when marking a thread as unread and unfollowing it', () => {
         // # Post a root post as current user
         cy.postMessageAs({
             sender: otherUser,

--- a/e2e-tests/cypress/tests/integration/channels/custom_status/custom_status_expiry/custom_status_expiry_2_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/custom_status/custom_status_expiry/custom_status_expiry_2_spec.ts
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @channels @custom_status
 
 import dayjs from 'dayjs';
@@ -25,7 +24,7 @@ describe('MM-T4064 Status expiry visibility', () => {
     let expiresAt = dayjs();
     const expiryTimeFormat = 'h:mm A';
 
-    it('MM-T4064_6 should show expiry time in the tooltip of custom status emoji in the post header', () => {
+    it.skip('MM-T4064_6 should show expiry time in the tooltip of custom status emoji in the post header', () => {
         // # Open the user account menu
         cy.uiOpenUserMenu('Set custom status');
 
@@ -60,7 +59,7 @@ describe('MM-T4064 Status expiry visibility', () => {
         });
     });
 
-    it('MM-T4064_7 should show custom status expiry time in the user popover', () => {
+    it.skip('MM-T4064_7 should show custom status expiry time in the user popover', () => {
         // # Click on the post header of the last post by the current user and open profile popover
         cy.get('.post.current--user .post__header .user-popover').first().click();
         cy.get('div.user-profile-popover').should('exist');

--- a/e2e-tests/cypress/tests/integration/channels/messaging/message_reaction_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/message_reaction_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod @smoke
 // Group: @channels @messaging
 
 describe('Emoji reactions to posts/messages', () => {
@@ -67,7 +66,7 @@ describe('Emoji reactions to posts/messages', () => {
         });
     });
 
-    it('another user adding to existing reaction increases reaction count', () => {
+    it.skip('another user adding to existing reaction increases reaction count', () => {
         cy.getLastPostId().then((postId) => {
             // # Click on the "slightly_frowning_face" emoji
             cy.get(`#postReaction-${postId}-slightly_frowning_face`).click();
@@ -79,7 +78,7 @@ describe('Emoji reactions to posts/messages', () => {
         });
     });
 
-    it('a reaction added by current user has highlighted background color', () => {
+    it.skip('a reaction added by current user has highlighted background color', () => {
         cy.getLastPostId().then((postId) => {
             // # The "slightly_frowning_face" emoji of the last post and the background color changes
             cy.get(`#postReaction-${postId}-slightly_frowning_face`).
@@ -89,7 +88,7 @@ describe('Emoji reactions to posts/messages', () => {
         });
     });
 
-    it("can click another user's reaction to detract from it", () => {
+    it.skip("can click another user's reaction to detract from it", () => {
         cy.getLastPostId().then((postId) => {
             // * The number shown on the "slightly_frowning_face" reaction is currently at 2
             cy.get(`#postReaction-${postId}-slightly_frowning_face .Reaction__number--display`).
@@ -106,7 +105,7 @@ describe('Emoji reactions to posts/messages', () => {
         });
     });
 
-    it('can add a reaction to a post with an existing reaction', () => {
+    it.skip('can add a reaction to a post with an existing reaction', () => {
         cy.getLastPostId().then((postId) => {
             // # Click on the + icon
             cy.get(`#addReaction-${postId}`).click({force: true});
@@ -125,7 +124,7 @@ describe('Emoji reactions to posts/messages', () => {
         });
     });
 
-    it('can remove a reaction to a post with an existing reaction', () => {
+    it.skip('can remove a reaction to a post with an existing reaction', () => {
         cy.getLastPostId().then((postId) => {
             // * The "sweat_smile" should exist on the post
             cy.get(`#postReaction-${postId}-sweat_smile`).should('be.visible');

--- a/e2e-tests/cypress/tests/integration/channels/notifications/message_posted_while_scrolled_up_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/notifications/message_posted_while_scrolled_up_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @channels @notifications
 
 import {getRandomId} from '../../../utils';
@@ -29,7 +28,7 @@ describe('Notifications', () => {
         });
     });
 
-    it('MM-T562 New message bar - Message posted while scrolled up in same channel', () => {
+    it.skip('MM-T562 New message bar - Message posted while scrolled up in same channel', () => {
         // # Post 30 random messages from the 'otherUser' account in off-topic
         Cypress._.times(numberOfPosts, (num) => {
             cy.postMessageAs({sender: otherUser, message: `${num} ${getRandomId()}`, channelId: offTopicChannelId});


### PR DESCRIPTION
#### Summary
Skipped flaky tests from:
- `channels/archived_channel/archive_channel_operations_spec.ts` - https://mattermost.atlassian.net/browse/MM-64342
- `channels/collapsed_reply_threads/unread_spec.ts` - https://mattermost.atlassian.net/browse/MM-64339
- `channels/custom_status/custom_status_expiry/custom_status_expiry_2_spec.ts` - https://mattermost.atlassian.net/browse/MM-64340
- `channels/messaging/message_reaction_spec.js` - https://mattermost.atlassian.net/browse/MM-64338
- `channels/notifications/message_posted_while_scrolled_up_spec.js` - https://mattermost.atlassian.net/browse/MM-64341

Note: next step to remove test in Cypress then migrate to Playwright

#### Ticket Link
See above

#### Release Note
```release-note
NONE
```
