### PR TITLE
Prepackage Calls v1.8.0 (`release-10.9`)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -136,7 +136,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.7.1
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.8.0
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.3.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.9.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.2.1


### PR DESCRIPTION
#### Summary

Prepackage [Calls v1.8.0](https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v1.8.0) to `release-10.9`.

#### Ticket

https://mattermost.atlassian.net/browse/MM-63789

#### Release Note

```release-note
Prepackage Calls v1.8.0
```
