### PR TITLE
Mm 64299 disable guest invite in abac channels

### DIFF
--- a/server/channels/app/team.go
+++ b/server/channels/app/team.go
@@ -1503,7 +1503,19 @@ func (a *App) prepareInviteGuestsToChannels(teamID string, guestsInvite *model.G
 		if channel.TeamId != teamID {
 			return nil, nil, nil, model.NewAppError("prepareInviteGuestsToChannels", "api.team.invite_guests.channel_in_invalid_team.app_error", nil, "", http.StatusBadRequest)
 		}
+
+		// Check if the channel has access control policy
+		ctx := request.EmptyContext(a.Log())
+		isControlled, err := a.ChannelAccessControlled(ctx, channel.Id)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		if isControlled {
+			return nil, nil, nil, model.NewAppError("prepareInviteGuestsToChannels", "api.team.invite_guests.policy_enforced_channel.app_error", nil, "", http.StatusBadRequest)
+		}
 	}
+
 	return user, team, channels, nil
 }
 

--- a/webapp/channels/src/components/channel_invite_modal/channel_invite_modal.test.tsx
+++ b/webapp/channels/src/components/channel_invite_modal/channel_invite_modal.test.tsx
@@ -589,4 +589,31 @@ describe('components/channel_invite_modal', () => {
         // Check that no tags are shown
         expect(wrapper.find('AlertTag').exists()).toBe(false);
     });
+
+    test('should hide the invite as guest link when channel has policy_enforced', () => {
+        const channelWithPolicy = {
+            ...channel,
+            policy_enforced: true,
+        };
+
+        const props = {
+            ...baseProps,
+            channel: channelWithPolicy,
+            canInviteGuests: true,
+            emailInvitationsEnabled: true,
+        };
+
+        const wrapper = shallowWithIntl(
+            <ChannelInviteModal {...props}/>,
+        );
+
+        // Check that the invite as guest link is not shown
+        const invitationLinks = wrapper.find('InviteModalLink');
+
+        // There should be no InviteModalLink with inviteAsGuest=true
+        const guestInviteLinks = invitationLinks.findWhere(
+            (node) => node.prop('inviteAsGuest') === true,
+        );
+        expect(guestInviteLinks).toHaveLength(0);
+    });
 });

--- a/webapp/channels/src/components/channel_invite_modal/channel_invite_modal.tsx
+++ b/webapp/channels/src/components/channel_invite_modal/channel_invite_modal.tsx
@@ -611,7 +611,7 @@ const ChannelInviteModalComponent = (props: Props) => {
                         teamId={channel.team_id}
                         users={usersNotInTeam}
                     />
-                    {(props.emailInvitationsEnabled && props.canInviteGuests) && inviteGuestLink}
+                    {(props.emailInvitationsEnabled && props.canInviteGuests && !channel.policy_enforced) && inviteGuestLink}
                 </div>
             </div>
         </GenericModal>


### PR DESCRIPTION
#### Summary
This PR makes sure that in abac enforced channels the CTA option to invite guests is not present. Also filters out any abac controlled channels from the channel invite list from the invitation modal when inviting guest.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64299

#### Screenshots
Before:

After:

#### Release Note
```release-note
NONE
```
