### PR TITLE
Cherry-pick: Bump prepackage Jira plugin version to 4.3.0

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -139,7 +139,7 @@ PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
 PLUGIN_PACKAGES += mattermost-plugin-calls-v1.8.0
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.3.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.9.1
-PLUGIN_PACKAGES += mattermost-plugin-jira-v4.2.1
+PLUGIN_PACKAGES += mattermost-plugin-jira-v4.3.0
 # We need to prepackage both versions of playbooks and install the correct one based on the server license. See MM-60025.
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v1.41.0
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.2.0


### PR DESCRIPTION
#### Summary
Cherry-pick https://github.com/mattermost/mattermost/pull/31098 which bumps the Jira prepackage version to v4.3

#### Ticket Link
NONE

#### Screenshots

#### Release Note
```release-note
Prepackage Jira plugin version [v4.3.0](https://github.com/mattermost/mattermost-plugin-jira/releases/tag/v4.3.0).
```
