### PR TITLE
Remove unused invalid CSS

### DIFF
--- a/webapp/channels/src/sass/responsive/_mobile.scss
+++ b/webapp/channels/src/sass/responsive/_mobile.scss
@@ -72,16 +72,6 @@
                     min-height: 100%;
                 }
 
-                .nav-pills {
-                    > &__tab {
-                        &:hover {
-                            a {
-                                background: transparent !important;
-                            }
-                        }
-                    }
-                }
-
                 &.display--content {
                     .modal-header {
                         display: none;


### PR DESCRIPTION
#### Summary
This was invalid CSS, but it didn't have any effect because we changed the settings sidebar to be a series of buttons instead of a list of `li`s containing links.

#### Release Note
```release-note
NONE
```
