### PR TITLE
[MM-64255] Fix height of automatic replies textarea

### DIFF
--- a/webapp/channels/src/components/user_settings/notifications/manage_auto_responder/__snapshots__/manage_auto_responder.test.tsx.snap
+++ b/webapp/channels/src/components/user_settings/notifications/manage_auto_responder/__snapshots__/manage_auto_responder.test.tsx.snap
@@ -229,6 +229,7 @@ exports[`components/user_settings/notifications/ManageAutoResponder should match
               rows={5}
               style={
                 Object {
+                  "height": "auto",
                   "resize": "none",
                 }
               }
@@ -327,6 +328,7 @@ exports[`components/user_settings/notifications/ManageAutoResponder should match
                   rows={5}
                   style={
                     Object {
+                      "height": "auto",
                       "resize": "none",
                     }
                   }
@@ -341,6 +343,7 @@ exports[`components/user_settings/notifications/ManageAutoResponder should match
                     rows={5}
                     style={
                       Object {
+                        "height": "auto",
                         "resize": "none",
                       }
                     }

--- a/webapp/channels/src/components/user_settings/notifications/manage_auto_responder/manage_auto_responder.tsx
+++ b/webapp/channels/src/components/user_settings/notifications/manage_auto_responder/manage_auto_responder.tsx
@@ -70,7 +70,7 @@ export default class ManageAutoResponder extends React.PureComponent<Props> {
             >
                 <div className='pt-2'>
                     <LocalizedPlaceholderTextarea
-                        style={{resize: 'none'}}
+                        style={{resize: 'none', height: 'auto'}}
                         id='autoResponderMessageInput'
                         className='form-control'
                         rows={5}


### PR DESCRIPTION
#### Summary
Converting the user settings modal to `GenericModal` caused some unwanted side effects in styling. One of these was forcing any `form-control` classed element to be 40px.

It's likely we should audit the `GenericModal` CSS to see how opinionated it really should be on sub element styling, but for this PR the easy fix is to force the height back to `auto`, in order to prevent any other unwanted side effects.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64255

```release-note
Fix height of automatic replies textarea
```
