### PR TITLE
[MM-64360] Data retention: optionally preserve pinned posts

### DIFF
--- a/server/channels/app/syncables_test.go
+++ b/server/channels/app/syncables_test.go
@@ -302,9 +302,15 @@ func TestCreateDefaultMemberships(t *testing.T) {
 
 	timeAfterLeaving := model.GetMillis() + 1
 
+	retentionPolicyBatchConfigs := model.RetentionPolicyBatchConfigs{
+		Now:                 0,
+		GlobalPolicyEndTime: timeBeforeLeaving,
+		Limit:               1000,
+	}
+
 	// Purging channelmemberhistory doesn't re-add user to channel
 	deletedCount, _, nErr := th.App.Srv().Store().ChannelMemberHistory().PermanentDeleteBatchForRetentionPolicies(
-		0, timeBeforeLeaving, 1000, model.RetentionPolicyCursor{})
+		retentionPolicyBatchConfigs, model.RetentionPolicyCursor{})
 	if nErr != nil {
 		t.Errorf("error permanently deleting channelmemberhistory: %s", nErr.Error())
 	}
@@ -320,9 +326,15 @@ func TestCreateDefaultMemberships(t *testing.T) {
 		t.Error("Expected channel member to remain deleted")
 	}
 
+	retentionPolicyBatchConfigs = model.RetentionPolicyBatchConfigs{
+		Now:                 0,
+		GlobalPolicyEndTime: timeAfterLeaving,
+		Limit:               1000,
+	}
+
 	// Purging channelmemberhistory doesn't re-add user to channel
 	deletedCount, _, nErr = th.App.Srv().Store().ChannelMemberHistory().PermanentDeleteBatchForRetentionPolicies(
-		0, timeAfterLeaving, 1000, model.RetentionPolicyCursor{})
+		retentionPolicyBatchConfigs, model.RetentionPolicyCursor{})
 	if nErr != nil {
 		t.Errorf("error permanently deleting channelmemberhistory: %s", nErr.Error())
 	}

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -3656,11 +3656,11 @@ func (s *RetryLayerChannelMemberHistoryStore) PermanentDeleteBatch(endTime int64
 
 }
 
-func (s *RetryLayerChannelMemberHistoryStore) PermanentDeleteBatchForRetentionPolicies(now int64, globalPolicyEndTime int64, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
+func (s *RetryLayerChannelMemberHistoryStore) PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
 
 	tries := 0
 	for {
-		result, resultVar1, err := s.ChannelMemberHistoryStore.PermanentDeleteBatchForRetentionPolicies(now, globalPolicyEndTime, limit, cursor)
+		result, resultVar1, err := s.ChannelMemberHistoryStore.PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs, cursor)
 		if err == nil {
 			return result, resultVar1, nil
 		}
@@ -8360,11 +8360,11 @@ func (s *RetryLayerPostStore) PermanentDeleteBatch(endTime int64, limit int64) (
 
 }
 
-func (s *RetryLayerPostStore) PermanentDeleteBatchForRetentionPolicies(now int64, globalPolicyEndTime int64, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
+func (s *RetryLayerPostStore) PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
 
 	tries := 0
 	for {
-		result, resultVar1, err := s.PostStore.PermanentDeleteBatchForRetentionPolicies(now, globalPolicyEndTime, limit, cursor)
+		result, resultVar1, err := s.PostStore.PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs, cursor)
 		if err == nil {
 			return result, resultVar1, nil
 		}
@@ -13796,11 +13796,11 @@ func (s *RetryLayerThreadStore) MarkAsRead(userID string, threadID string, times
 
 }
 
-func (s *RetryLayerThreadStore) PermanentDeleteBatchForRetentionPolicies(now int64, globalPolicyEndTime int64, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
+func (s *RetryLayerThreadStore) PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
 
 	tries := 0
 	for {
-		result, resultVar1, err := s.ThreadStore.PermanentDeleteBatchForRetentionPolicies(now, globalPolicyEndTime, limit, cursor)
+		result, resultVar1, err := s.ThreadStore.PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs, cursor)
 		if err == nil {
 			return result, resultVar1, nil
 		}
@@ -13817,11 +13817,11 @@ func (s *RetryLayerThreadStore) PermanentDeleteBatchForRetentionPolicies(now int
 
 }
 
-func (s *RetryLayerThreadStore) PermanentDeleteBatchThreadMembershipsForRetentionPolicies(now int64, globalPolicyEndTime int64, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
+func (s *RetryLayerThreadStore) PermanentDeleteBatchThreadMembershipsForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
 
 	tries := 0
 	for {
-		result, resultVar1, err := s.ThreadStore.PermanentDeleteBatchThreadMembershipsForRetentionPolicies(now, globalPolicyEndTime, limit, cursor)
+		result, resultVar1, err := s.ThreadStore.PermanentDeleteBatchThreadMembershipsForRetentionPolicies(retentionPolicyBatchConfigs, cursor)
 		if err == nil {
 			return result, resultVar1, nil
 		}

--- a/server/channels/store/sqlstore/channel_member_history_store.go
+++ b/server/channels/store/sqlstore/channel_member_history_store.go
@@ -229,7 +229,7 @@ func (s SqlChannelMemberHistoryStore) getFromChannelMembersTable(startTime int64
 // PermanentDeleteBatchForRetentionPolicies deletes a batch of records which are affected by
 // the global or a granular retention policy.
 // See `genericPermanentDeleteBatchForRetentionPolicies` for details.
-func (s SqlChannelMemberHistoryStore) PermanentDeleteBatchForRetentionPolicies(now, globalPolicyEndTime, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
+func (s SqlChannelMemberHistoryStore) PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
 	builder := s.getQueryBuilder().
 		Select("ChannelMemberHistory.ChannelId, ChannelMemberHistory.UserId, ChannelMemberHistory.JoinTime").
 		From("ChannelMemberHistory")
@@ -239,9 +239,9 @@ func (s SqlChannelMemberHistoryStore) PermanentDeleteBatchForRetentionPolicies(n
 		TimeColumn:          "LeaveTime",
 		PrimaryKeys:         []string{"ChannelId", "UserId", "JoinTime"},
 		ChannelIDTable:      "ChannelMemberHistory",
-		NowMillis:           now,
-		GlobalPolicyEndTime: globalPolicyEndTime,
-		Limit:               limit,
+		NowMillis:           retentionPolicyBatchConfigs.Now,
+		GlobalPolicyEndTime: retentionPolicyBatchConfigs.GlobalPolicyEndTime,
+		Limit:               retentionPolicyBatchConfigs.Limit,
 		StoreDeletedIds:     false,
 	}, s.SqlStore, cursor)
 }

--- a/server/channels/store/sqlstore/post_store.go
+++ b/server/channels/store/sqlstore/post_store.go
@@ -2666,19 +2666,30 @@ func (s *SqlPostStore) GetPostsBatchForIndexing(startTime int64, startPostID str
 // PermanentDeleteBatchForRetentionPolicies deletes a batch of records which are affected by
 // the global or a granular retention policy.
 // See `genericPermanentDeleteBatchForRetentionPolicies` for details.
-func (s *SqlPostStore) PermanentDeleteBatchForRetentionPolicies(now, globalPolicyEndTime, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
+func (s *SqlPostStore) PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
 	builder := s.getQueryBuilder().
 		Select("Posts.Id").
 		From("Posts")
+
+	if retentionPolicyBatchConfigs.PreservePinnedPosts {
+		builder = builder.Where(sq.Or{
+			sq.Eq{"Posts.IsPinned": false},
+			sq.And{
+				sq.Eq{"Posts.IsPinned": true},
+				sq.Gt{"Posts.DeleteAt": 0},
+			},
+		})
+	}
+
 	return genericPermanentDeleteBatchForRetentionPolicies(RetentionPolicyBatchDeletionInfo{
 		BaseBuilder:         builder,
 		Table:               "Posts",
 		TimeColumn:          "CreateAt",
 		PrimaryKeys:         []string{"Id"},
 		ChannelIDTable:      "Posts",
-		NowMillis:           now,
-		GlobalPolicyEndTime: globalPolicyEndTime,
-		Limit:               limit,
+		NowMillis:           retentionPolicyBatchConfigs.Now,
+		GlobalPolicyEndTime: retentionPolicyBatchConfigs.GlobalPolicyEndTime,
+		Limit:               retentionPolicyBatchConfigs.Limit,
 		StoreDeletedIds:     true,
 	}, s.SqlStore, cursor)
 }

--- a/server/channels/store/sqlstore/thread_store.go
+++ b/server/channels/store/sqlstore/thread_store.go
@@ -987,7 +987,7 @@ func (s *SqlThreadStore) maintainMembershipTx(trx *sqlxTxWrapper, userID, postID
 // PermanentDeleteBatchForRetentionPolicies deletes a batch of records which are affected by
 // the global or a granular retention policy.
 // See `genericPermanentDeleteBatchForRetentionPolicies` for details.
-func (s *SqlThreadStore) PermanentDeleteBatchForRetentionPolicies(now, globalPolicyEndTime, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
+func (s *SqlThreadStore) PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
 	builder := s.getQueryBuilder().
 		Select("Threads.PostId").
 		From("Threads")
@@ -997,9 +997,9 @@ func (s *SqlThreadStore) PermanentDeleteBatchForRetentionPolicies(now, globalPol
 		TimeColumn:          "LastReplyAt",
 		PrimaryKeys:         []string{"PostId"},
 		ChannelIDTable:      "Threads",
-		NowMillis:           now,
-		GlobalPolicyEndTime: globalPolicyEndTime,
-		Limit:               limit,
+		NowMillis:           retentionPolicyBatchConfigs.Now,
+		GlobalPolicyEndTime: retentionPolicyBatchConfigs.GlobalPolicyEndTime,
+		Limit:               retentionPolicyBatchConfigs.Limit,
 		StoreDeletedIds:     false,
 	}, s.SqlStore, cursor)
 }
@@ -1007,7 +1007,7 @@ func (s *SqlThreadStore) PermanentDeleteBatchForRetentionPolicies(now, globalPol
 // PermanentDeleteBatchThreadMembershipsForRetentionPolicies deletes a batch of records
 // which are affected by the global or a granular retention policy.
 // See `genericPermanentDeleteBatchForRetentionPolicies` for details.
-func (s *SqlThreadStore) PermanentDeleteBatchThreadMembershipsForRetentionPolicies(now, globalPolicyEndTime, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
+func (s *SqlThreadStore) PermanentDeleteBatchThreadMembershipsForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
 	builder := s.getQueryBuilder().
 		Select("ThreadMemberships.PostId").
 		From("ThreadMemberships").
@@ -1018,9 +1018,9 @@ func (s *SqlThreadStore) PermanentDeleteBatchThreadMembershipsForRetentionPolici
 		TimeColumn:          "LastUpdated",
 		PrimaryKeys:         []string{"PostId"},
 		ChannelIDTable:      "Threads",
-		NowMillis:           now,
-		GlobalPolicyEndTime: globalPolicyEndTime,
-		Limit:               limit,
+		NowMillis:           retentionPolicyBatchConfigs.Now,
+		GlobalPolicyEndTime: retentionPolicyBatchConfigs.GlobalPolicyEndTime,
+		Limit:               retentionPolicyBatchConfigs.Limit,
 		StoreDeletedIds:     false,
 	}, s.SqlStore, cursor)
 }

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -327,7 +327,7 @@ type ChannelMemberHistoryStore interface {
 	LogLeaveEvent(userID string, channelID string, leaveTime int64) error
 	GetUsersInChannelDuring(startTime int64, endTime int64, channelID []string) ([]*model.ChannelMemberHistoryResult, error)
 	GetChannelsWithActivityDuring(startTime int64, endTime int64) ([]string, error)
-	PermanentDeleteBatchForRetentionPolicies(now, globalPolicyEndTime, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)
+	PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)
 	DeleteOrphanedRows(limit int) (deleted int64, err error)
 	PermanentDeleteBatch(endTime int64, limit int64) (int64, error)
 	GetChannelsLeftSince(userID string, since int64) ([]string, error)
@@ -355,8 +355,8 @@ type ThreadStore interface {
 	GetMembershipForUser(userID, postID string) (*model.ThreadMembership, error)
 	DeleteMembershipForUser(userID, postID string) error
 	MaintainMembership(userID, postID string, opts ThreadMembershipOpts) (*model.ThreadMembership, error)
-	PermanentDeleteBatchForRetentionPolicies(now, globalPolicyEndTime, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)
-	PermanentDeleteBatchThreadMembershipsForRetentionPolicies(now, globalPolicyEndTime, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)
+	PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)
+	PermanentDeleteBatchThreadMembershipsForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)
 	DeleteOrphanedRows(limit int) (deleted int64, err error)
 	GetThreadUnreadReplyCount(threadMembership *model.ThreadMembership) (int64, error)
 	DeleteMembershipsForChannel(userID, channelID string) error
@@ -401,7 +401,7 @@ type PostStore interface {
 	GetPostsByIds(postIds []string) ([]*model.Post, error)
 	GetEditHistoryForPost(postID string) ([]*model.Post, error)
 	GetPostsBatchForIndexing(startTime int64, startPostID string, limit int) ([]*model.PostForIndexing, error)
-	PermanentDeleteBatchForRetentionPolicies(now, globalPolicyEndTime, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)
+	PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)
 	PermanentDeleteBatch(endTime int64, limit int64) (int64, error)
 	GetOldest() (*model.Post, error)
 	GetMaxPostSize() int

--- a/server/channels/store/storetest/channel_member_history_store.go
+++ b/server/channels/store/storetest/channel_member_history_store.go
@@ -358,8 +358,11 @@ func testGetUsersInChannelAtChannelMembers(t *testing.T, rctx request.CTX, ss st
 	tableDataTruncated := false
 	for !tableDataTruncated {
 		var count int64
-		count, _, err = ss.ChannelMemberHistory().PermanentDeleteBatchForRetentionPolicies(
-			0, model.GetMillis(), 1000, model.RetentionPolicyCursor{})
+		count, _, err = ss.ChannelMemberHistory().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+			Now:                 0,
+			GlobalPolicyEndTime: model.GetMillis(),
+			Limit:               1000,
+		}, model.RetentionPolicyCursor{})
 		require.NoError(t, err, "Failed to truncate ChannelMemberHistory contents")
 		tableDataTruncated = count == int64(0)
 	}
@@ -493,8 +496,11 @@ func testPermanentDeleteBatch(t *testing.T, rctx request.CTX, ss store.Store) {
 	assert.Len(t, channelMembers, 2)
 
 	// the permanent delete should delete at least one record
-	rowsDeleted, _, err := ss.ChannelMemberHistory().PermanentDeleteBatchForRetentionPolicies(
-		0, leaveTime+1, math.MaxInt64, model.RetentionPolicyCursor{})
+	rowsDeleted, _, err := ss.ChannelMemberHistory().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+		Now:                 0,
+		GlobalPolicyEndTime: leaveTime + 1,
+		Limit:               math.MaxInt64,
+	}, model.RetentionPolicyCursor{})
 	require.NoError(t, err)
 	assert.NotEqual(t, int64(0), rowsDeleted)
 
@@ -540,8 +546,11 @@ func testPermanentDeleteBatchForRetentionPolicies(t *testing.T, rctx request.CTX
 	require.NoError(t, err)
 
 	nowMillis := leaveTime + *channelPolicy.PostDurationDays*model.DayInMilliseconds + 1
-	_, _, err = ss.ChannelMemberHistory().PermanentDeleteBatchForRetentionPolicies(
-		nowMillis, 0, limit, model.RetentionPolicyCursor{})
+	_, _, err = ss.ChannelMemberHistory().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+		Now:                 nowMillis,
+		GlobalPolicyEndTime: 0,
+		Limit:               limit,
+	}, model.RetentionPolicyCursor{})
 	require.NoError(t, err)
 	result, err := ss.ChannelMemberHistory().GetUsersInChannelDuring(joinTime, leaveTime, []string{channel.Id})
 	require.NoError(t, err)

--- a/server/channels/store/storetest/group_store.go
+++ b/server/channels/store/storetest/group_store.go
@@ -2345,8 +2345,11 @@ func testChannelMembersToAdd(t *testing.T, rctx request.CTX, ss store.Store) {
 	require.Empty(t, channelMembers)
 
 	// Purging ChannelMemberHistory re-returns the result
-	_, _, nErr = ss.ChannelMemberHistory().PermanentDeleteBatchForRetentionPolicies(
-		0, model.GetMillis()+1, 100, model.RetentionPolicyCursor{})
+	_, _, nErr = ss.ChannelMemberHistory().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+		Now:                 0,
+		GlobalPolicyEndTime: model.GetMillis() + 1,
+		Limit:               100,
+	}, model.RetentionPolicyCursor{})
 	require.NoError(t, nErr)
 	channelMembers, err = ss.Group().ChannelMembersToAdd(0, nil, false)
 	require.NoError(t, err)

--- a/server/channels/store/storetest/mocks/ChannelMemberHistoryStore.go
+++ b/server/channels/store/storetest/mocks/ChannelMemberHistoryStore.go
@@ -196,9 +196,9 @@ func (_m *ChannelMemberHistoryStore) PermanentDeleteBatch(endTime int64, limit i
 	return r0, r1
 }
 
-// PermanentDeleteBatchForRetentionPolicies provides a mock function with given fields: now, globalPolicyEndTime, limit, cursor
-func (_m *ChannelMemberHistoryStore) PermanentDeleteBatchForRetentionPolicies(now int64, globalPolicyEndTime int64, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
-	ret := _m.Called(now, globalPolicyEndTime, limit, cursor)
+// PermanentDeleteBatchForRetentionPolicies provides a mock function with given fields: retentionPolicyBatchConfigs, cursor
+func (_m *ChannelMemberHistoryStore) PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
+	ret := _m.Called(retentionPolicyBatchConfigs, cursor)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PermanentDeleteBatchForRetentionPolicies")
@@ -207,23 +207,23 @@ func (_m *ChannelMemberHistoryStore) PermanentDeleteBatchForRetentionPolicies(no
 	var r0 int64
 	var r1 model.RetentionPolicyCursor
 	var r2 error
-	if rf, ok := ret.Get(0).(func(int64, int64, int64, model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)); ok {
-		return rf(now, globalPolicyEndTime, limit, cursor)
+	if rf, ok := ret.Get(0).(func(model.RetentionPolicyBatchConfigs, model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)); ok {
+		return rf(retentionPolicyBatchConfigs, cursor)
 	}
-	if rf, ok := ret.Get(0).(func(int64, int64, int64, model.RetentionPolicyCursor) int64); ok {
-		r0 = rf(now, globalPolicyEndTime, limit, cursor)
+	if rf, ok := ret.Get(0).(func(model.RetentionPolicyBatchConfigs, model.RetentionPolicyCursor) int64); ok {
+		r0 = rf(retentionPolicyBatchConfigs, cursor)
 	} else {
 		r0 = ret.Get(0).(int64)
 	}
 
-	if rf, ok := ret.Get(1).(func(int64, int64, int64, model.RetentionPolicyCursor) model.RetentionPolicyCursor); ok {
-		r1 = rf(now, globalPolicyEndTime, limit, cursor)
+	if rf, ok := ret.Get(1).(func(model.RetentionPolicyBatchConfigs, model.RetentionPolicyCursor) model.RetentionPolicyCursor); ok {
+		r1 = rf(retentionPolicyBatchConfigs, cursor)
 	} else {
 		r1 = ret.Get(1).(model.RetentionPolicyCursor)
 	}
 
-	if rf, ok := ret.Get(2).(func(int64, int64, int64, model.RetentionPolicyCursor) error); ok {
-		r2 = rf(now, globalPolicyEndTime, limit, cursor)
+	if rf, ok := ret.Get(2).(func(model.RetentionPolicyBatchConfigs, model.RetentionPolicyCursor) error); ok {
+		r2 = rf(retentionPolicyBatchConfigs, cursor)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/server/channels/store/storetest/mocks/PostStore.go
+++ b/server/channels/store/storetest/mocks/PostStore.go
@@ -1120,9 +1120,9 @@ func (_m *PostStore) PermanentDeleteBatch(endTime int64, limit int64) (int64, er
 	return r0, r1
 }
 
-// PermanentDeleteBatchForRetentionPolicies provides a mock function with given fields: now, globalPolicyEndTime, limit, cursor
-func (_m *PostStore) PermanentDeleteBatchForRetentionPolicies(now int64, globalPolicyEndTime int64, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
-	ret := _m.Called(now, globalPolicyEndTime, limit, cursor)
+// PermanentDeleteBatchForRetentionPolicies provides a mock function with given fields: retentionPolicyBatchConfigs, cursor
+func (_m *PostStore) PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
+	ret := _m.Called(retentionPolicyBatchConfigs, cursor)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PermanentDeleteBatchForRetentionPolicies")
@@ -1131,23 +1131,23 @@ func (_m *PostStore) PermanentDeleteBatchForRetentionPolicies(now int64, globalP
 	var r0 int64
 	var r1 model.RetentionPolicyCursor
 	var r2 error
-	if rf, ok := ret.Get(0).(func(int64, int64, int64, model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)); ok {
-		return rf(now, globalPolicyEndTime, limit, cursor)
+	if rf, ok := ret.Get(0).(func(model.RetentionPolicyBatchConfigs, model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)); ok {
+		return rf(retentionPolicyBatchConfigs, cursor)
 	}
-	if rf, ok := ret.Get(0).(func(int64, int64, int64, model.RetentionPolicyCursor) int64); ok {
-		r0 = rf(now, globalPolicyEndTime, limit, cursor)
+	if rf, ok := ret.Get(0).(func(model.RetentionPolicyBatchConfigs, model.RetentionPolicyCursor) int64); ok {
+		r0 = rf(retentionPolicyBatchConfigs, cursor)
 	} else {
 		r0 = ret.Get(0).(int64)
 	}
 
-	if rf, ok := ret.Get(1).(func(int64, int64, int64, model.RetentionPolicyCursor) model.RetentionPolicyCursor); ok {
-		r1 = rf(now, globalPolicyEndTime, limit, cursor)
+	if rf, ok := ret.Get(1).(func(model.RetentionPolicyBatchConfigs, model.RetentionPolicyCursor) model.RetentionPolicyCursor); ok {
+		r1 = rf(retentionPolicyBatchConfigs, cursor)
 	} else {
 		r1 = ret.Get(1).(model.RetentionPolicyCursor)
 	}
 
-	if rf, ok := ret.Get(2).(func(int64, int64, int64, model.RetentionPolicyCursor) error); ok {
-		r2 = rf(now, globalPolicyEndTime, limit, cursor)
+	if rf, ok := ret.Get(2).(func(model.RetentionPolicyBatchConfigs, model.RetentionPolicyCursor) error); ok {
+		r2 = rf(retentionPolicyBatchConfigs, cursor)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/server/channels/store/storetest/mocks/ThreadStore.go
+++ b/server/channels/store/storetest/mocks/ThreadStore.go
@@ -591,9 +591,9 @@ func (_m *ThreadStore) MarkAsRead(userID string, threadID string, timestamp int6
 	return r0
 }
 
-// PermanentDeleteBatchForRetentionPolicies provides a mock function with given fields: now, globalPolicyEndTime, limit, cursor
-func (_m *ThreadStore) PermanentDeleteBatchForRetentionPolicies(now int64, globalPolicyEndTime int64, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
-	ret := _m.Called(now, globalPolicyEndTime, limit, cursor)
+// PermanentDeleteBatchForRetentionPolicies provides a mock function with given fields: retentionPolicyBatchConfigs, cursor
+func (_m *ThreadStore) PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
+	ret := _m.Called(retentionPolicyBatchConfigs, cursor)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PermanentDeleteBatchForRetentionPolicies")
@@ -602,23 +602,23 @@ func (_m *ThreadStore) PermanentDeleteBatchForRetentionPolicies(now int64, globa
 	var r0 int64
 	var r1 model.RetentionPolicyCursor
 	var r2 error
-	if rf, ok := ret.Get(0).(func(int64, int64, int64, model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)); ok {
-		return rf(now, globalPolicyEndTime, limit, cursor)
+	if rf, ok := ret.Get(0).(func(model.RetentionPolicyBatchConfigs, model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)); ok {
+		return rf(retentionPolicyBatchConfigs, cursor)
 	}
-	if rf, ok := ret.Get(0).(func(int64, int64, int64, model.RetentionPolicyCursor) int64); ok {
-		r0 = rf(now, globalPolicyEndTime, limit, cursor)
+	if rf, ok := ret.Get(0).(func(model.RetentionPolicyBatchConfigs, model.RetentionPolicyCursor) int64); ok {
+		r0 = rf(retentionPolicyBatchConfigs, cursor)
 	} else {
 		r0 = ret.Get(0).(int64)
 	}
 
-	if rf, ok := ret.Get(1).(func(int64, int64, int64, model.RetentionPolicyCursor) model.RetentionPolicyCursor); ok {
-		r1 = rf(now, globalPolicyEndTime, limit, cursor)
+	if rf, ok := ret.Get(1).(func(model.RetentionPolicyBatchConfigs, model.RetentionPolicyCursor) model.RetentionPolicyCursor); ok {
+		r1 = rf(retentionPolicyBatchConfigs, cursor)
 	} else {
 		r1 = ret.Get(1).(model.RetentionPolicyCursor)
 	}
 
-	if rf, ok := ret.Get(2).(func(int64, int64, int64, model.RetentionPolicyCursor) error); ok {
-		r2 = rf(now, globalPolicyEndTime, limit, cursor)
+	if rf, ok := ret.Get(2).(func(model.RetentionPolicyBatchConfigs, model.RetentionPolicyCursor) error); ok {
+		r2 = rf(retentionPolicyBatchConfigs, cursor)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -626,9 +626,9 @@ func (_m *ThreadStore) PermanentDeleteBatchForRetentionPolicies(now int64, globa
 	return r0, r1, r2
 }
 
-// PermanentDeleteBatchThreadMembershipsForRetentionPolicies provides a mock function with given fields: now, globalPolicyEndTime, limit, cursor
-func (_m *ThreadStore) PermanentDeleteBatchThreadMembershipsForRetentionPolicies(now int64, globalPolicyEndTime int64, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
-	ret := _m.Called(now, globalPolicyEndTime, limit, cursor)
+// PermanentDeleteBatchThreadMembershipsForRetentionPolicies provides a mock function with given fields: retentionPolicyBatchConfigs, cursor
+func (_m *ThreadStore) PermanentDeleteBatchThreadMembershipsForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
+	ret := _m.Called(retentionPolicyBatchConfigs, cursor)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PermanentDeleteBatchThreadMembershipsForRetentionPolicies")
@@ -637,23 +637,23 @@ func (_m *ThreadStore) PermanentDeleteBatchThreadMembershipsForRetentionPolicies
 	var r0 int64
 	var r1 model.RetentionPolicyCursor
 	var r2 error
-	if rf, ok := ret.Get(0).(func(int64, int64, int64, model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)); ok {
-		return rf(now, globalPolicyEndTime, limit, cursor)
+	if rf, ok := ret.Get(0).(func(model.RetentionPolicyBatchConfigs, model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)); ok {
+		return rf(retentionPolicyBatchConfigs, cursor)
 	}
-	if rf, ok := ret.Get(0).(func(int64, int64, int64, model.RetentionPolicyCursor) int64); ok {
-		r0 = rf(now, globalPolicyEndTime, limit, cursor)
+	if rf, ok := ret.Get(0).(func(model.RetentionPolicyBatchConfigs, model.RetentionPolicyCursor) int64); ok {
+		r0 = rf(retentionPolicyBatchConfigs, cursor)
 	} else {
 		r0 = ret.Get(0).(int64)
 	}
 
-	if rf, ok := ret.Get(1).(func(int64, int64, int64, model.RetentionPolicyCursor) model.RetentionPolicyCursor); ok {
-		r1 = rf(now, globalPolicyEndTime, limit, cursor)
+	if rf, ok := ret.Get(1).(func(model.RetentionPolicyBatchConfigs, model.RetentionPolicyCursor) model.RetentionPolicyCursor); ok {
+		r1 = rf(retentionPolicyBatchConfigs, cursor)
 	} else {
 		r1 = ret.Get(1).(model.RetentionPolicyCursor)
 	}
 
-	if rf, ok := ret.Get(2).(func(int64, int64, int64, model.RetentionPolicyCursor) error); ok {
-		r2 = rf(now, globalPolicyEndTime, limit, cursor)
+	if rf, ok := ret.Get(2).(func(model.RetentionPolicyBatchConfigs, model.RetentionPolicyCursor) error); ok {
+		r2 = rf(retentionPolicyBatchConfigs, cursor)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/server/channels/store/storetest/post_store.go
+++ b/server/channels/store/storetest/post_store.go
@@ -4466,6 +4466,151 @@ func testPostStorePermanentDeleteBatch(t *testing.T, rctx request.CTX, ss store.
 			require.Equal(t, int64(0), deleted)
 		}
 	})
+
+	t.Run("with preserve pinned posts true", func(t *testing.T) {
+		p1 := &model.Post{}
+		p1.ChannelId = channel.Id
+		p1.UserId = model.NewId()
+		p1.IsPinned = false
+		p1.Message = NewTestID()
+		p1.CreateAt = 1000
+		p1, err = ss.Post().Save(rctx, p1)
+		require.NoError(t, err)
+
+		p2 := &model.Post{}
+		p2.ChannelId = channel.Id
+		p2.UserId = model.NewId()
+		p2.IsPinned = false
+		p2.Message = NewTestID()
+		p2.CreateAt = 1000
+		p2, err = ss.Post().Save(rctx, p2)
+		require.NoError(t, err)
+
+		p3 := &model.Post{}
+		p3.ChannelId = channel.Id
+		p3.UserId = model.NewId()
+		p3.IsPinned = false
+		p3.Message = NewTestID()
+		p3.CreateAt = 1000
+		p3, err = ss.Post().Save(rctx, p3)
+		require.NoError(t, err)
+
+		np3 := p3.Clone()
+		np3.IsPinned = true
+
+		np3, err = ss.Post().Update(rctx, np3, p3)
+
+		deleted, _, err := ss.Post().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+			Now:                 0,
+			GlobalPolicyEndTime: 2000,
+			Limit:               1000,
+			PreservePinnedPosts: true,
+		}, model.RetentionPolicyCursor{})
+		require.NoError(t, err)
+		require.Equal(t, int64(3), deleted)
+
+		_, err = ss.Post().Get(context.Background(), p1.Id, model.GetPostsOptions{}, "", map[string]bool{})
+		require.Error(t, err, "Should have not found post 1 after purge")
+
+		_, err = ss.Post().Get(context.Background(), p2.Id, model.GetPostsOptions{}, "", map[string]bool{})
+		require.Error(t, err, "Should have not found post 2 after purge")
+
+		_, err = ss.Post().Get(context.Background(), p3.Id, model.GetPostsOptions{}, "", map[string]bool{})
+		require.Error(t, err, "Should have not found post 3 before update after purge")
+
+		_, err = ss.Post().Get(context.Background(), np3.Id, model.GetPostsOptions{}, "", map[string]bool{})
+		require.NoError(t, err, "Should have found updated post 3 after purge")
+
+		rows, err := ss.RetentionPolicy().GetIdsForDeletionByTableName("Posts", 1000)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(rows))
+		require.Equal(t, 3, len(rows[0].Ids))
+		// Clean up retention ids table
+		deleted, err = ss.Reaction().DeleteOrphanedRowsByIds(rows[0])
+		require.NoError(t, err)
+		require.Equal(t, int64(0), deleted)
+
+		// Clean up pinned post
+		_, _, err = ss.Post().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+			Now:                 0,
+			GlobalPolicyEndTime: 2000,
+			Limit:               1000,
+			PreservePinnedPosts: false,
+		}, model.RetentionPolicyCursor{})
+		require.NoError(t, err)
+
+		rows, err = ss.RetentionPolicy().GetIdsForDeletionByTableName("Posts", 1000)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(rows))
+
+		// Clean up retention ids table
+		deleted, err = ss.Reaction().DeleteOrphanedRowsByIds(rows[0])
+		require.NoError(t, err)
+	})
+
+	t.Run("with preserve pinned posts false", func(t *testing.T) {
+		p1 := &model.Post{}
+		p1.ChannelId = channel.Id
+		p1.UserId = model.NewId()
+		p1.IsPinned = false
+		p1.Message = NewTestID()
+		p1.CreateAt = 1000
+		p1, err = ss.Post().Save(rctx, p1)
+		require.NoError(t, err)
+
+		p2 := &model.Post{}
+		p2.ChannelId = channel.Id
+		p2.UserId = model.NewId()
+		p2.IsPinned = false
+		p2.Message = NewTestID()
+		p2.CreateAt = 1000
+		p2, err = ss.Post().Save(rctx, p2)
+		require.NoError(t, err)
+
+		p3 := &model.Post{}
+		p3.ChannelId = channel.Id
+		p3.UserId = model.NewId()
+		p3.IsPinned = false
+		p3.Message = NewTestID()
+		p3.CreateAt = 1000
+		p3, err = ss.Post().Save(rctx, p3)
+		require.NoError(t, err)
+
+		np3 := p3.Clone()
+		np3.IsPinned = true
+
+		np3, err = ss.Post().Update(rctx, np3, p3)
+
+		deleted, _, err := ss.Post().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+			Now:                 0,
+			GlobalPolicyEndTime: 2000,
+			Limit:               1000,
+			PreservePinnedPosts: false,
+		}, model.RetentionPolicyCursor{})
+		require.NoError(t, err)
+		require.Equal(t, int64(4), deleted)
+
+		_, err = ss.Post().Get(context.Background(), p1.Id, model.GetPostsOptions{}, "", map[string]bool{})
+		require.Error(t, err, "Should have not found post 1 after purge")
+
+		_, err = ss.Post().Get(context.Background(), p2.Id, model.GetPostsOptions{}, "", map[string]bool{})
+		require.Error(t, err, "Should have not found post 2 after purge")
+
+		_, err = ss.Post().Get(context.Background(), p3.Id, model.GetPostsOptions{}, "", map[string]bool{})
+		require.Error(t, err, "Should have not found post 3 before update after purge")
+
+		_, err = ss.Post().Get(context.Background(), np3.Id, model.GetPostsOptions{}, "", map[string]bool{})
+		require.Error(t, err, "Should have not found updated post 3 after purge")
+
+		rows, err := ss.RetentionPolicy().GetIdsForDeletionByTableName("Posts", 1000)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(rows))
+		require.Equal(t, 4, len(rows[0].Ids))
+		// Clean up retention ids table
+		deleted, err = ss.Reaction().DeleteOrphanedRowsByIds(rows[0])
+		require.NoError(t, err)
+		require.Equal(t, int64(0), deleted)
+	})
 }
 
 func testPostStoreGetOldest(t *testing.T, rctx request.CTX, ss store.Store) {

--- a/server/channels/store/storetest/post_store.go
+++ b/server/channels/store/storetest/post_store.go
@@ -4446,7 +4446,7 @@ func testPostStorePermanentDeleteBatch(t *testing.T, rctx request.CTX, ss store.
 		require.NoError(t, err2)
 
 		nowMillis := int64(1 + 30*model.DayInMilliseconds + 1)
-		deleted, _, err2 := ss.Post().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+		deleted, _, err2 = ss.Post().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
 			Now:                 nowMillis,
 			GlobalPolicyEndTime: 2,
 			Limit:               1000,
@@ -4521,7 +4521,7 @@ func testPostStorePermanentDeleteBatch(t *testing.T, rctx request.CTX, ss store.
 		_, err = ss.Post().Get(context.Background(), np3.Id, model.GetPostsOptions{}, "", map[string]bool{})
 		require.NoError(t, err, "Should have found updated post 3 after purge")
 
-		rows, err := ss.RetentionPolicy().GetIdsForDeletionByTableName("Posts", 1000)
+		rows, err = ss.RetentionPolicy().GetIdsForDeletionByTableName("Posts", 1000)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(rows))
 		require.Equal(t, 3, len(rows[0].Ids))
@@ -4581,7 +4581,7 @@ func testPostStorePermanentDeleteBatch(t *testing.T, rctx request.CTX, ss store.
 
 		np3, err = ss.Post().Update(rctx, np3, p3)
 
-		deleted, _, err := ss.Post().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+		deleted, _, err = ss.Post().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
 			Now:                 0,
 			GlobalPolicyEndTime: 2000,
 			Limit:               1000,
@@ -4602,7 +4602,7 @@ func testPostStorePermanentDeleteBatch(t *testing.T, rctx request.CTX, ss store.
 		_, err = ss.Post().Get(context.Background(), np3.Id, model.GetPostsOptions{}, "", map[string]bool{})
 		require.Error(t, err, "Should have not found updated post 3 after purge")
 
-		rows, err := ss.RetentionPolicy().GetIdsForDeletionByTableName("Posts", 1000)
+		rows, err = ss.RetentionPolicy().GetIdsForDeletionByTableName("Posts", 1000)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(rows))
 		require.Equal(t, 4, len(rows[0].Ids))

--- a/server/channels/store/storetest/post_store.go
+++ b/server/channels/store/storetest/post_store.go
@@ -4500,7 +4500,7 @@ func testPostStorePermanentDeleteBatch(t *testing.T, rctx request.CTX, ss store.
 
 		np3, err = ss.Post().Update(rctx, np3, p3)
 
-		deleted, _, err := ss.Post().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+		deleted, _, err = ss.Post().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
 			Now:                 0,
 			GlobalPolicyEndTime: 2000,
 			Limit:               1000,
@@ -4544,7 +4544,7 @@ func testPostStorePermanentDeleteBatch(t *testing.T, rctx request.CTX, ss store.
 		require.Equal(t, 1, len(rows))
 
 		// Clean up retention ids table
-		deleted, err = ss.Reaction().DeleteOrphanedRowsByIds(rows[0])
+		_, err = ss.Reaction().DeleteOrphanedRowsByIds(rows[0])
 		require.NoError(t, err)
 	})
 

--- a/server/channels/store/storetest/preference_store.go
+++ b/server/channels/store/storetest/preference_store.go
@@ -448,7 +448,11 @@ func testPreferenceDeleteOrphanedRows(t *testing.T, rctx request.CTX, ss store.S
 	nErr := ss.Preference().Save(model.Preferences{preference1, preference2})
 	require.NoError(t, nErr)
 
-	_, _, nErr = ss.Post().PermanentDeleteBatchForRetentionPolicies(0, 2000, limit, model.RetentionPolicyCursor{})
+	_, _, nErr = ss.Post().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+		Now:                 0,
+		GlobalPolicyEndTime: 2000,
+		Limit:               limit,
+	}, model.RetentionPolicyCursor{})
 	assert.NoError(t, nErr)
 
 	rows, err := ss.RetentionPolicy().GetIdsForDeletionByTableName("Posts", 1000)

--- a/server/channels/store/storetest/reaction_store.go
+++ b/server/channels/store/storetest/reaction_store.go
@@ -710,7 +710,11 @@ func testReactionStorePermanentDeleteBatch(t *testing.T, rctx request.CTX, ss st
 		require.NoError(t, err)
 	}
 
-	_, _, err = ss.Post().PermanentDeleteBatchForRetentionPolicies(0, 2000, limit, model.RetentionPolicyCursor{})
+	_, _, err = ss.Post().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+		Now:                 0,
+		GlobalPolicyEndTime: 2000,
+		Limit:               limit,
+	}, model.RetentionPolicyCursor{})
 	require.NoError(t, err)
 
 	rows, err := ss.RetentionPolicy().GetIdsForDeletionByTableName("Posts", 1000)

--- a/server/channels/store/storetest/thread_store.go
+++ b/server/channels/store/storetest/thread_store.go
@@ -530,7 +530,11 @@ func testThreadStorePermanentDeleteBatchForRetentionPolicies(t *testing.T, rctx 
 	require.NoError(t, err)
 
 	nowMillis := thread.LastReplyAt + *channelPolicy.PostDurationDays*model.DayInMilliseconds + 1
-	_, _, err = ss.Thread().PermanentDeleteBatchForRetentionPolicies(nowMillis, 0, limit, model.RetentionPolicyCursor{})
+	_, _, err = ss.Thread().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+		Now:                 nowMillis,
+		GlobalPolicyEndTime: 0,
+		Limit:               limit,
+	}, model.RetentionPolicyCursor{})
 	require.NoError(t, err)
 	thread, err = ss.Thread().Get(post.Id)
 	assert.NoError(t, err)
@@ -552,7 +556,11 @@ func testThreadStorePermanentDeleteBatchForRetentionPolicies(t *testing.T, rctx 
 	require.NoError(t, err)
 
 	nowMillis = thread.LastReplyAt + *teamPolicy.PostDurationDays*model.DayInMilliseconds + 1
-	_, _, err = ss.Thread().PermanentDeleteBatchForRetentionPolicies(nowMillis, 0, limit, model.RetentionPolicyCursor{})
+	_, _, err = ss.Thread().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+		Now:                 nowMillis,
+		GlobalPolicyEndTime: 0,
+		Limit:               limit,
+	}, model.RetentionPolicyCursor{})
 	require.NoError(t, err)
 	_, err = ss.Thread().Get(post.Id)
 	require.NoError(t, err, "channel policy should have overridden team policy")
@@ -560,7 +568,11 @@ func testThreadStorePermanentDeleteBatchForRetentionPolicies(t *testing.T, rctx 
 	// Delete channel policy and re-run team policy
 	err = ss.RetentionPolicy().Delete(channelPolicy.ID)
 	require.NoError(t, err)
-	_, _, err = ss.Thread().PermanentDeleteBatchForRetentionPolicies(nowMillis, 0, limit, model.RetentionPolicyCursor{})
+	_, _, err = ss.Thread().PermanentDeleteBatchForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+		Now:                 nowMillis,
+		GlobalPolicyEndTime: 0,
+		Limit:               limit,
+	}, model.RetentionPolicyCursor{})
 	require.NoError(t, err)
 	thread, err = ss.Thread().Get(post.Id)
 	assert.NoError(t, err)
@@ -617,7 +629,11 @@ func testThreadStorePermanentDeleteBatchThreadMembershipsForRetentionPolicies(t 
 	require.NoError(t, err)
 
 	nowMillis := threadMembership.LastUpdated + *channelPolicy.PostDurationDays*model.DayInMilliseconds + 1
-	_, _, err = ss.Thread().PermanentDeleteBatchThreadMembershipsForRetentionPolicies(nowMillis, 0, limit, model.RetentionPolicyCursor{})
+	_, _, err = ss.Thread().PermanentDeleteBatchThreadMembershipsForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+		Now:                 nowMillis,
+		GlobalPolicyEndTime: 0,
+		Limit:               limit,
+	}, model.RetentionPolicyCursor{})
 	require.NoError(t, err)
 	_, err = ss.Thread().GetMembershipForUser(userID, post.Id)
 	require.Error(t, err, "thread membership should have been deleted by channel policy")
@@ -636,7 +652,11 @@ func testThreadStorePermanentDeleteBatchThreadMembershipsForRetentionPolicies(t 
 	require.NoError(t, err)
 
 	nowMillis = threadMembership.LastUpdated + *teamPolicy.PostDurationDays*model.DayInMilliseconds + 1
-	_, _, err = ss.Thread().PermanentDeleteBatchThreadMembershipsForRetentionPolicies(nowMillis, 0, limit, model.RetentionPolicyCursor{})
+	_, _, err = ss.Thread().PermanentDeleteBatchThreadMembershipsForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+		Now:                 nowMillis,
+		GlobalPolicyEndTime: 0,
+		Limit:               limit,
+	}, model.RetentionPolicyCursor{})
 	require.NoError(t, err)
 	_, err = ss.Thread().GetMembershipForUser(userID, post.Id)
 	require.NoError(t, err, "channel policy should have overridden team policy")
@@ -644,7 +664,11 @@ func testThreadStorePermanentDeleteBatchThreadMembershipsForRetentionPolicies(t 
 	// Delete channel policy and re-run team policy
 	err = ss.RetentionPolicy().Delete(channelPolicy.ID)
 	require.NoError(t, err)
-	_, _, err = ss.Thread().PermanentDeleteBatchThreadMembershipsForRetentionPolicies(nowMillis, 0, limit, model.RetentionPolicyCursor{})
+	_, _, err = ss.Thread().PermanentDeleteBatchThreadMembershipsForRetentionPolicies(model.RetentionPolicyBatchConfigs{
+		Now:                 nowMillis,
+		GlobalPolicyEndTime: 0,
+		Limit:               limit,
+	}, model.RetentionPolicyCursor{})
 	require.NoError(t, err)
 	_, err = ss.Thread().GetMembershipForUser(userID, post.Id)
 	require.Error(t, err, "thread membership should have been deleted by team policy")

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -3002,10 +3002,10 @@ func (s *TimerLayerChannelMemberHistoryStore) PermanentDeleteBatch(endTime int64
 	return result, err
 }
 
-func (s *TimerLayerChannelMemberHistoryStore) PermanentDeleteBatchForRetentionPolicies(now int64, globalPolicyEndTime int64, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
+func (s *TimerLayerChannelMemberHistoryStore) PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
 	start := time.Now()
 
-	result, resultVar1, err := s.ChannelMemberHistoryStore.PermanentDeleteBatchForRetentionPolicies(now, globalPolicyEndTime, limit, cursor)
+	result, resultVar1, err := s.ChannelMemberHistoryStore.PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs, cursor)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -6661,10 +6661,10 @@ func (s *TimerLayerPostStore) PermanentDeleteBatch(endTime int64, limit int64) (
 	return result, err
 }
 
-func (s *TimerLayerPostStore) PermanentDeleteBatchForRetentionPolicies(now int64, globalPolicyEndTime int64, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
+func (s *TimerLayerPostStore) PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
 	start := time.Now()
 
-	result, resultVar1, err := s.PostStore.PermanentDeleteBatchForRetentionPolicies(now, globalPolicyEndTime, limit, cursor)
+	result, resultVar1, err := s.PostStore.PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs, cursor)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -10835,10 +10835,10 @@ func (s *TimerLayerThreadStore) MarkAsRead(userID string, threadID string, times
 	return err
 }
 
-func (s *TimerLayerThreadStore) PermanentDeleteBatchForRetentionPolicies(now int64, globalPolicyEndTime int64, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
+func (s *TimerLayerThreadStore) PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
 	start := time.Now()
 
-	result, resultVar1, err := s.ThreadStore.PermanentDeleteBatchForRetentionPolicies(now, globalPolicyEndTime, limit, cursor)
+	result, resultVar1, err := s.ThreadStore.PermanentDeleteBatchForRetentionPolicies(retentionPolicyBatchConfigs, cursor)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -10851,10 +10851,10 @@ func (s *TimerLayerThreadStore) PermanentDeleteBatchForRetentionPolicies(now int
 	return result, resultVar1, err
 }
 
-func (s *TimerLayerThreadStore) PermanentDeleteBatchThreadMembershipsForRetentionPolicies(now int64, globalPolicyEndTime int64, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
+func (s *TimerLayerThreadStore) PermanentDeleteBatchThreadMembershipsForRetentionPolicies(retentionPolicyBatchConfigs model.RetentionPolicyBatchConfigs, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error) {
 	start := time.Now()
 
-	result, resultVar1, err := s.ThreadStore.PermanentDeleteBatchThreadMembershipsForRetentionPolicies(now, globalPolicyEndTime, limit, cursor)
+	result, resultVar1, err := s.ThreadStore.PermanentDeleteBatchThreadMembershipsForRetentionPolicies(retentionPolicyBatchConfigs, cursor)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -3114,6 +3114,7 @@ type DataRetentionSettings struct {
 	BatchSize                      *int    `access:"compliance_data_retention_policy"`
 	TimeBetweenBatchesMilliseconds *int    `access:"compliance_data_retention_policy"`
 	RetentionIdsBatchSize          *int    `access:"compliance_data_retention_policy"`
+	PreservePinnedPosts            *bool   `access:"compliance_data_retention_policy"`
 }
 
 func (s *DataRetentionSettings) SetDefaults() {
@@ -3162,6 +3163,10 @@ func (s *DataRetentionSettings) SetDefaults() {
 	}
 	if s.RetentionIdsBatchSize == nil {
 		s.RetentionIdsBatchSize = NewPointer(DataRetentionSettingsDefaultRetentionIdsBatchSize)
+	}
+
+	if s.PreservePinnedPosts == nil {
+		s.PreservePinnedPosts = NewPointer(false)
 	}
 }
 

--- a/server/public/model/data_retention_policy.go
+++ b/server/public/model/data_retention_policy.go
@@ -91,6 +91,13 @@ type RetentionIdsForDeletion struct {
 	Ids       []string
 }
 
+type RetentionPolicyBatchConfigs struct {
+	Now                 int64
+	GlobalPolicyEndTime int64
+	Limit               int64
+	PreservePinnedPosts bool
+}
+
 func (r *RetentionIdsForDeletion) PreSave() {
 	if r.Id == "" {
 		r.Id = NewId()

--- a/webapp/channels/src/components/error_page/error_message.tsx
+++ b/webapp/channels/src/components/error_page/error_message.tsx
@@ -60,6 +60,16 @@ const ErrorMessage: React.FC<Props> = ({type, message, service, isGuest}: Props)
                 </p>
             );
             break;
+        case ErrorPageTypes.POST_NOT_FOUND:
+            errorMessage = (
+                <p>
+                    <FormattedMessage
+                        id='post.error.access'
+                        defaultMessage="The post you're requesting is private or does not exist."
+                    />
+                </p>
+            );
+            break;
         case ErrorPageTypes.CLOUD_ARCHIVED:
             errorMessage = (
                 <p>

--- a/webapp/channels/src/components/error_page/error_title.tsx
+++ b/webapp/channels/src/components/error_page/error_title.tsx
@@ -31,6 +31,14 @@ const ErrorTitle: React.FC<Props> = ({type, title}: Props) => {
                 />
             );
             break;
+        case ErrorPageTypes.POST_NOT_FOUND:
+            errorTitle = (
+                <FormattedMessage
+                    id='post.error.title'
+                    defaultMessage='Post Not Found'
+                />
+            );
+            break;
         case ErrorPageTypes.CLOUD_ARCHIVED:
             errorTitle = (
                 <FormattedMessage

--- a/webapp/channels/src/components/permalink_view/actions.ts
+++ b/webapp/channels/src/components/permalink_view/actions.ts
@@ -52,6 +52,11 @@ function focusReplyPost(post: Post, channel: Channel, teamId: string, returnTo: 
     return async (dispatch, getState) => {
         const {data} = await dispatch(getPostThread(post.root_id));
 
+        if (!data) {
+            getHistory().replace(`/error?type=${ErrorPageTypes.POST_NOT_FOUND}&returnTo=${returnTo}`);
+            return {data: false};
+        }
+
         if (data!.first_inaccessible_post_time) {
             getHistory().replace(`/error?type=${ErrorPageTypes.CLOUD_ARCHIVED}&returnTo=${returnTo}`);
             return {data: false};

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -4981,6 +4981,8 @@
   "post.ariaLabel.reaction": ", 1 reaction",
   "post.ariaLabel.reactionMultiple": ", {reactionCount} reactions",
   "post.ariaLabel.replyMessage": "At {time} {date}, {authorName} replied, {message}",
+  "post.error.access": "The post you're requesting is private or does not exist.",
+  "post.error.title": "Post Not Found",
   "post.reminder.acknowledgement": "You will be reminded at {reminderTime}, {reminderDate} about this message from {username}: {permaLink}",
   "post.reminder.systemBot": "Hi there, here's your reminder about this message from {username}: {permaLink}",
   "post.renderError.message": "An error occurred while rendering this post.",

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -925,6 +925,7 @@ export const ErrorPageTypes = {
     PERMALINK_NOT_FOUND: 'permalink_not_found',
     TEAM_NOT_FOUND: 'team_not_found',
     CHANNEL_NOT_FOUND: 'channel_not_found',
+    POST_NOT_FOUND: 'post_not_found',
     CLOUD_ARCHIVED: 'cloud_archived',
 };
 


### PR DESCRIPTION
#### Summary
Added a new global config, `PreservePinnedPosts`, that controls whether data retention should delete pinned posts or not. This config applies to all policies, including channel and team policies. It cannot be configured per policy.

When you pin a post it marks the old post entry as deleted and creates a new post with `IsPinned` set to true. It has the same behaviour when you unpin a post. This means the where clause looks like this:

```sql
WHERE (
	Posts.IsPinned = false 
	OR (
		Posts.IsPinned = true 
		AND Posts.DeleteAt > 0
	)
)...
```

I did an EXPLAIN ANALYZE on the queries in Postgres and MySQL, the cost is slightly higher with the new filter but it's not much.

**Postgres:**
Preserve pinned posts:
```sql
EXPLAIN ANALYZE DELETE FROM Posts
WHERE (Id)
	IN(
		SELECT
			Posts.Id FROM Posts
			INNER JOIN Channels ON Posts.ChannelId = Channels.Id
			LEFT JOIN RetentionPoliciesChannels ON Posts.ChannelId = RetentionPoliciesChannels.ChannelId
			LEFT JOIN RetentionPoliciesTeams ON Channels.TeamId = RetentionPoliciesTeams.TeamId
			LEFT JOIN RetentionPolicies ON RetentionPoliciesChannels.PolicyId = RetentionPolicies.Id
		WHERE (Posts.IsPinned = FALSE
			OR(Posts.IsPinned = TRUE
				AND Posts.DeleteAt > 0))
		AND(RetentionPoliciesChannels.PolicyId IS NULL
			AND RetentionPoliciesTeams.PolicyId IS NULL)
		AND Posts.CreateAt < 1687165598826
	LIMIT 3000)
RETURNING
	Posts.Id;
```
```
Delete on posts  (cost=21409.30..21434.51 rows=3 width=57) (actual time=14.607..68.865 rows=3000 loops=1)
  ->  Nested Loop  (cost=21409.30..21434.51 rows=3 width=57) (actual time=14.551..67.386 rows=3000 loops=1)
        ->  HashAggregate  (cost=21408.74..21408.77 rows=3 width=78) (actual time=14.528..15.180 rows=3000 loops=1)
              Group Key: ("ANY_subquery".id)::text
              Batches: 1  Memory Usage: 649kB
              ->  Subquery Scan on "ANY_subquery"  (cost=42.46..21408.73 rows=3 width=78) (actual time=0.224..13.337 rows=3000 loops=1)
                    ->  Limit  (cost=42.46..21408.70 rows=3 width=27) (actual time=0.200..12.838 rows=3000 loops=1)
                          ->  Hash Left Join  (cost=42.46..21408.70 rows=3 width=27) (actual time=0.199..12.641 rows=3000 loops=1)
                                Hash Cond: ((channels.teamid)::text = (retentionpoliciesteams.teamid)::text)
                                Filter: (retentionpoliciesteams.policyid IS NULL)
                                ->  Nested Loop  (cost=21.66..21386.29 rows=608 width=30) (actual time=0.171..12.148 rows=3000 loops=1)
                                      ->  Hash Left Join  (cost=21.24..18483.06 rows=608 width=54) (actual time=0.091..2.605 rows=3000 loops=1)
                                            Hash Cond: ((posts_1.channelid)::text = (retentionpolicieschannels.channelid)::text)
                                            Filter: (retentionpolicieschannels.policyid IS NULL)
                                            ->  Index Scan using idx_posts_create_at on posts posts_1  (cost=0.44..18142.34 rows=121688 width=54) (actual time=0.058..2.088 rows=3000 loops=1)
                                                  Index Cond: (createat < '1687165598826'::bigint)
                                                  Filter: ((NOT ispinned) OR (ispinned AND (deleteat > 0)))
                                            ->  Hash  (cost=14.80..14.80 rows=480 width=140) (actual time=0.005..0.005 rows=0 loops=1)
                                                  Buckets: 1024  Batches: 1  Memory Usage: 8kB
                                                  ->  Seq Scan on retentionpolicieschannels  (cost=0.00..14.80 rows=480 width=140) (actual time=0.004..0.004 rows=0 loops=1)
                                      ->  Index Scan using channels_pkey on channels  (cost=0.42..4.78 rows=1 width=30) (actual time=0.003..0.003 rows=1 loops=3000)
                                            Index Cond: ((id)::text = (posts_1.channelid)::text)
                                ->  Hash  (cost=14.80..14.80 rows=480 width=140) (actual time=0.002..0.003 rows=0 loops=1)
                                      Buckets: 1024  Batches: 1  Memory Usage: 8kB
                                      ->  Seq Scan on retentionpoliciesteams  (cost=0.00..14.80 rows=480 width=140) (actual time=0.002..0.002 rows=0 loops=1)
        ->  Index Scan using posts_pkey on posts  (cost=0.56..8.58 rows=1 width=33) (actual time=0.017..0.017 rows=1 loops=3000)
              Index Cond: ((id)::text = ("ANY_subquery".id)::text)
Planning Time: 1.441 ms
Execution Time: 69.045 ms
```
Delete pinned posts:
```sql
EXPLAIN ANALYZE DELETE FROM Posts
WHERE (Id)
	IN(
		SELECT
			Posts.Id FROM Posts
			INNER JOIN Channels ON Posts.ChannelId = Channels.Id
			LEFT JOIN RetentionPoliciesChannels ON Posts.ChannelId = RetentionPoliciesChannels.ChannelId
			LEFT JOIN RetentionPoliciesTeams ON Channels.TeamId = RetentionPoliciesTeams.TeamId
			LEFT JOIN RetentionPolicies ON RetentionPoliciesChannels.PolicyId = RetentionPolicies.Id
		WHERE (RetentionPoliciesChannels.PolicyId IS NULL
			AND RetentionPoliciesTeams.PolicyId IS NULL)
		AND Posts.CreateAt < 1687165598826
	LIMIT 3000)
RETURNING
	Posts.Id;
```
```
Delete on posts  (cost=19598.29..19623.50 rows=3 width=57) (actual time=37.514..465.732 rows=3000 loops=1)
  ->  Nested Loop  (cost=19598.29..19623.50 rows=3 width=57) (actual time=37.484..463.349 rows=3000 loops=1)
        ->  HashAggregate  (cost=19597.73..19597.76 rows=3 width=78) (actual time=37.290..38.081 rows=3000 loops=1)
              Group Key: ("ANY_subquery".id)::text
              Batches: 1  Memory Usage: 649kB
              ->  Subquery Scan on "ANY_subquery"  (cost=42.46..19597.72 rows=3 width=78) (actual time=0.265..36.127 rows=3000 loops=1)
                    ->  Limit  (cost=42.46..19597.69 rows=3 width=27) (actual time=0.258..35.503 rows=3000 loops=1)
                          ->  Hash Left Join  (cost=42.46..19597.69 rows=3 width=27) (actual time=0.257..35.301 rows=3000 loops=1)
                                Hash Cond: ((channels.teamid)::text = (retentionpoliciesteams.teamid)::text)
                                Filter: (retentionpoliciesteams.policyid IS NULL)
                                ->  Nested Loop  (cost=21.66..19575.40 rows=564 width=30) (actual time=0.247..34.764 rows=3000 loops=1)
                                      ->  Hash Left Join  (cost=21.24..16881.24 rows=564 width=54) (actual time=0.188..4.073 rows=3000 loops=1)
                                            Hash Cond: ((posts_1.channelid)::text = (retentionpolicieschannels.channelid)::text)
                                            Filter: (retentionpolicieschannels.policyid IS NULL)
                                            ->  Index Scan using idx_posts_create_at on posts posts_1  (cost=0.44..16563.81 rows=112830 width=54) (actual time=0.171..3.356 rows=3000 loops=1)
                                                  Index Cond: (createat < '1687165598826'::bigint)
                                            ->  Hash  (cost=14.80..14.80 rows=480 width=140) (actual time=0.004..0.005 rows=0 loops=1)
                                                  Buckets: 1024  Batches: 1  Memory Usage: 8kB
                                                  ->  Seq Scan on retentionpolicieschannels  (cost=0.00..14.80 rows=480 width=140) (actual time=0.004..0.004 rows=0 loops=1)
                                      ->  Index Scan using channels_pkey on channels  (cost=0.42..4.78 rows=1 width=30) (actual time=0.010..0.010 rows=1 loops=3000)
                                            Index Cond: ((id)::text = (posts_1.channelid)::text)
                                ->  Hash  (cost=14.80..14.80 rows=480 width=140) (actual time=0.002..0.003 rows=0 loops=1)
                                      Buckets: 1024  Batches: 1  Memory Usage: 8kB
                                      ->  Seq Scan on retentionpoliciesteams  (cost=0.00..14.80 rows=480 width=140) (actual time=0.002..0.002 rows=0 loops=1)
        ->  Index Scan using posts_pkey on posts  (cost=0.56..8.58 rows=1 width=33) (actual time=0.141..0.141 rows=1 loops=3000)
              Index Cond: ((id)::text = ("ANY_subquery".id)::text)
Planning Time: 2.853 ms
Execution Time: 465.999 ms
```

**MYSQL:**
Preserve pinned posts:
```
-> Limit: 3000 row(s)  (cost=1.41 rows=1) (actual time=0.041..0.041 rows=0 loops=1)
    -> Nested loop left join  (cost=1.41 rows=1) (actual time=0.040..0.040 rows=0 loops=1)
        -> Filter: (RetentionPoliciesTeams.PolicyId is null)  (cost=1.24 rows=1) (actual time=0.040..0.040 rows=0 loops=1)
            -> Nested loop left join  (cost=1.24 rows=1) (actual time=0.039..0.039 rows=0 loops=1)
                -> Filter: (RetentionPoliciesChannels.PolicyId is null)  (cost=1.06 rows=1) (actual time=0.039..0.039 rows=0 loops=1)
                    -> Nested loop left join  (cost=1.06 rows=1) (actual time=0.039..0.039 rows=0 loops=1)
                        -> Nested loop inner join  (cost=0.89 rows=1) (actual time=0.039..0.039 rows=0 loops=1)
                            -> Filter: (((Posts.IsPinned = false) or ((Posts.IsPinned = true) and (Posts.DeleteAt > 0))) and (Posts.ChannelId is not null))  (cost=0.71 rows=1) (actual time=0.039..0.039 rows=0 loops=1)
                                -> Index range scan on Posts using idx_posts_create_at over (NULL < CreateAt < 1684872360000), with index condition: (Posts.CreateAt < 1684872360000)  (cost=0.71 rows=1) (actual time=0.033..0.037 rows=1 loops=1)
                            -> Single-row index lookup on Channels using PRIMARY (Id=Posts.ChannelId)  (cost=0.45 rows=1) (never executed)
                        -> Single-row index lookup on RetentionPoliciesChannels using PRIMARY (ChannelId=Posts.ChannelId)  (cost=0.45 rows=1) (never executed)
                -> Single-row index lookup on RetentionPoliciesTeams using PRIMARY (TeamId=Channels.TeamId)  (cost=0.45 rows=1) (never executed)
        -> Single-row covering index lookup on RetentionPolicies using PRIMARY (Id=RetentionPoliciesChannels.PolicyId)  (cost=0.45 rows=1) (never executed)
```
Delete pinned posts:
```
-> Limit: 3000 row(s)  (cost=2.11 rows=1) (actual time=0.231..0.239 rows=1 loops=1)
    -> Nested loop left join  (cost=2.11 rows=1) (actual time=0.229..0.237 rows=1 loops=1)
        -> Filter: (RetentionPoliciesTeams.PolicyId is null)  (cost=1.76 rows=1) (actual time=0.205..0.213 rows=1 loops=1)
            -> Nested loop left join  (cost=1.76 rows=1) (actual time=0.205..0.212 rows=1 loops=1)
                -> Filter: (RetentionPoliciesChannels.PolicyId is null)  (cost=1.41 rows=1) (actual time=0.167..0.175 rows=1 loops=1)
                    -> Nested loop left join  (cost=1.41 rows=1) (actual time=0.167..0.174 rows=1 loops=1)
                        -> Nested loop inner join  (cost=1.06 rows=1) (actual time=0.078..0.085 rows=1 loops=1)
                            -> Filter: (Posts.ChannelId is not null)  (cost=0.71 rows=1) (actual time=0.055..0.062 rows=1 loops=1)
                                -> Index range scan on Posts using idx_posts_create_at over (NULL < CreateAt < 1684872360000), with index condition: (Posts.CreateAt < 1684872360000)  (cost=0.71 rows=1) (actual time=0.053..0.060 rows=1 loops=1)
                            -> Single-row index lookup on Channels using PRIMARY (Id=Posts.ChannelId)  (cost=0.35 rows=1) (actual time=0.021..0.021 rows=1 loops=1)
                        -> Single-row index lookup on RetentionPoliciesChannels using PRIMARY (ChannelId=Posts.ChannelId)  (cost=0.35 rows=1) (actual time=0.087..0.087 rows=0 loops=1)
                -> Single-row index lookup on RetentionPoliciesTeams using PRIMARY (TeamId=Channels.TeamId)  (cost=0.35 rows=1) (actual time=0.037..0.037 rows=0 loops=1)
        -> Single-row covering index lookup on RetentionPolicies using PRIMARY (Id=RetentionPoliciesChannels.PolicyId)  (cost=0.35 rows=1) (actual time=0.022..0.022 rows=0 loops=1)
```
#### Related PR
https://github.com/mattermost/enterprise/pull/1927

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64360

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
New config for DataRetentionSettings called PreservePinnedPosts. If it's set to true, pinned posts will not be deleted by data retention.
```
