### PR TITLE
Explicitly list exports from mattermost-redux

### DIFF
--- a/webapp/platform/mattermost-redux/package.json
+++ b/webapp/platform/mattermost-redux/package.json
@@ -12,10 +12,18 @@
     "lib"
   ],
   "exports": {
-    "./*": [
-      "./lib/*/index.js",
-      "./lib/*.js"
-    ]
+    "./action_types": "./lib/action_types/index.js",
+    "./actions": "./lib/actions/index.js",
+    "./client": "./lib/client/index.js",
+    "./constants": "./lib/constants/index.js",
+    "./reducers": "./lib/reducers/index.js",
+    "./reducers/entities": "./lib/reducers/entities/index.js",
+    "./reducers/entities/threads": "./lib/reducers/entities/threads/index.js",
+    "./reducers/errors": "./lib/reducers/errors/index.js",
+    "./reducers/requests": "./lib/reducers/requests/index.js",
+    "./selectors/create_selector": "./lib/selectors/create_selector/index.js",
+    "./store": "./lib/store/index.js",
+    "./*": "./lib/*.js"
   },
   "typesVersions": {
     ">=3.1": {


### PR DESCRIPTION
#### Summary
In https://github.com/mattermost/mattermost/pull/30675, we found that we need to change how we specify exports so that we can actually import `index.js` files in newer versions of Webpack because they decided to match Node.js's method of resolving imports for things specified in the `exports` field of the `package.json`.

The way that Webpack/Node now work is that, when resolving an import from a `node_modules` package, they return the first valid file path that matches the given import path without hitting the disk. Previously, Webpack would check to see if the file existed, so we were able to tell it to look for an `index.js` file if one exists before falling back to a file with a matching name, but that's no longer possible. Instead, we have to manually tell it which index files exist which is a bit tedious, but generally workable.

In the future, we might need to get rid of `index.js` files entirely for things like this because the ES Modules spec requires file extensions in import paths and it doesn't automatically resolve index files, so none of this will work then, but we'll deal with that problem when we get to it

#### Ticket Link
MM-64393

#### Release Note
```release-note
NONE
```
