### PR TITLE
Adds a feature flag and the logic to hide plugin interactions on shared channels

### DIFF
--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -22,6 +22,9 @@ type FeatureFlags struct {
 	// Enable DMs and GMs for shared channels.
 	EnableSharedChannelsDMs bool
 
+	// Enable plugins in shared channels.
+	EnableSharedChannelsPlugins bool
+
 	// AppsEnabled toggles the Apps framework functionalities both in server and client side
 	AppsEnabled bool
 
@@ -66,6 +69,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.TestBoolFeature = false
 	f.EnableRemoteClusterService = false
 	f.EnableSharedChannelsDMs = false
+	f.EnableSharedChannelsPlugins = false
 	f.AppsEnabled = false
 	f.NormalizeLdapDNs = false
 	f.DeprecateCloudFree = false

--- a/webapp/channels/src/components/actions_menu/actions_menu.tsx
+++ b/webapp/channels/src/components/actions_menu/actions_menu.tsx
@@ -48,6 +48,8 @@ export type Props = {
     post: Post;
     teamId: string;
     canOpenMarketplace: boolean;
+    channelIsShared?: boolean;
+    sharedChannelsPluginsEnabled?: boolean;
 
     /**
      * Components for overriding provided by plugins
@@ -269,7 +271,8 @@ export class ActionMenuClass extends React.PureComponent<Props, State> {
             return null;
         }
 
-        const pluginItems = this.props.pluginMenuItems?.
+        const pluginItemsVisible = !this.props.channelIsShared || this.props.sharedChannelsPluginsEnabled;
+        const pluginItems = pluginItemsVisible ? this.props.pluginMenuItems?.
             filter((item) => {
                 return item.filter ? item.filter(this.props.post.id) : item;
             }).
@@ -298,7 +301,7 @@ export class ActionMenuClass extends React.PureComponent<Props, State> {
                         }}
                     />
                 );
-            }) || [];
+            }) || [] : [];
 
         let appBindings = [] as JSX.Element[];
         if (this.props.appsEnabled && this.state.appBindings) {
@@ -344,7 +347,7 @@ export class ActionMenuClass extends React.PureComponent<Props, State> {
 
         let menuItems;
         const hasApps = Boolean(appBindings.length);
-        const hasPluggables = Boolean(this.props.pluginMenuItemComponents?.length);
+        const hasPluggables = pluginItemsVisible && Boolean(this.props.pluginMenuItemComponents?.length);
         const hasPluginItems = Boolean(pluginItems?.length);
 
         const hasPluginMenuItems = hasPluginItems || hasApps || hasPluggables;

--- a/webapp/channels/src/components/actions_menu/index.ts
+++ b/webapp/channels/src/components/actions_menu/index.ts
@@ -12,7 +12,8 @@ import type {Post} from '@mattermost/types/posts';
 import {Permissions} from 'mattermost-redux/constants';
 import {AppBindingLocations} from 'mattermost-redux/constants/apps';
 import {appsEnabled} from 'mattermost-redux/selectors/entities/apps';
-import {isMarketplaceEnabled} from 'mattermost-redux/selectors/entities/general';
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import {isMarketplaceEnabled, getFeatureFlagValue} from 'mattermost-redux/selectors/entities/general';
 import {haveICurrentTeamPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
@@ -47,6 +48,8 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
     const {post} = ownProps;
 
     const systemMessage = isSystemMessage(post);
+    const channel = getChannel(state, post.channel_id);
+    const sharedChannelsPluginsEnabled = getFeatureFlagValue(state, 'EnableSharedChannelsPlugins') === 'true';
 
     const apps = appsEnabled(state);
     const showBindings = apps && !systemMessage && !isCombinedUserActivityPost(post.id);
@@ -65,6 +68,8 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
         pluginMenuItems: state.plugins.components.PostDropdownMenu,
         teamId: getCurrentTeamId(state),
         isMobileView: getIsMobileView(state),
+        channelIsShared: channel?.shared,
+        sharedChannelsPluginsEnabled,
         canOpenMarketplace: (
             isMarketplaceEnabled(state) &&
             haveICurrentTeamPermission(state, Permissions.SYSCONSOLE_WRITE_PLUGINS)

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -307,7 +307,7 @@ const AdvancedTextEditor = ({
     }, [dispatch, currentUserId, getFormattingBarPreferenceName, isFormattingBarHidden]);
 
     useOrientationHandler(textboxRef, rootId);
-    const pluginItems = usePluginItems(draft, textboxRef, handleDraftChange);
+    const pluginItems = usePluginItems(draft, textboxRef, handleDraftChange, isChannelShared);
     const focusTextbox = useTextboxFocus(textboxRef, channelId, isRHS, canPost);
     const [attachmentPreview, fileUploadJSX] = useUploadFiles(
         draft,

--- a/webapp/channels/src/components/advanced_text_editor/use_plugin_items.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_plugin_items.tsx
@@ -4,6 +4,7 @@
 import React, {useCallback, useMemo} from 'react';
 import {useSelector} from 'react-redux';
 
+import {usePluginVisibilityInSharedChannel} from 'components/common/hooks/usePluginVisibilityInSharedChannel';
 import type TextboxClass from 'components/textbox/textbox';
 
 import type {GlobalState} from 'types/store';
@@ -13,8 +14,11 @@ const usePluginItems = (
     draft: PostDraft,
     textboxRef: React.RefObject<TextboxClass>,
     handleDraftChange: (draft: PostDraft) => void,
+    channelIsShared?: boolean,
 ) => {
     const postEditorActions = useSelector((state: GlobalState) => state.plugins.components.PostEditorAction);
+    const isSharedChannel = channelIsShared || false;
+    const pluginItemsVisible = usePluginVisibilityInSharedChannel(isSharedChannel);
 
     const getSelectedText = useCallback(() => {
         const input = textboxRef.current?.getInputBox();
@@ -34,21 +38,27 @@ const usePluginItems = (
         // Missing setting the state eventually?
     }, [handleDraftChange, draft]);
 
-    const items = useMemo(() => postEditorActions?.map((item) => {
-        if (!item.component) {
-            return null;
+    const items = useMemo(() => {
+        if (!pluginItemsVisible) {
+            return [];
         }
 
-        const Component = item.component as any;
-        return (
-            <Component
-                key={item.id}
-                draft={draft}
-                getSelectedText={getSelectedText}
-                updateText={updateText}
-            />
-        );
-    }), [postEditorActions, draft, getSelectedText, updateText]);
+        return postEditorActions?.map((item) => {
+            if (!item.component) {
+                return null;
+            }
+
+            const Component = item.component as any;
+            return (
+                <Component
+                    key={item.id}
+                    draft={draft}
+                    getSelectedText={getSelectedText}
+                    updateText={updateText}
+                />
+            );
+        });
+    }, [postEditorActions, draft, getSelectedText, updateText, pluginItemsVisible]);
 
     return items;
 };

--- a/webapp/channels/src/components/channel_header/channel_header.tsx
+++ b/webapp/channels/src/components/channel_header/channel_header.tsx
@@ -370,11 +370,15 @@ class ChannelHeader extends React.PureComponent<Props> {
                             </div>
                         </div>
                     </div>
-                    <ChannelHeaderPlug
-                        channel={channel}
-                        channelMember={channelMember}
-                    />
-                    <CallButton/>
+                    {!channel.shared && (
+                        <>
+                            <ChannelHeaderPlug
+                                channel={channel}
+                                channelMember={channelMember}
+                            />
+                            <CallButton/>
+                        </>
+                    )}
                     <ChannelInfoButton channel={channel}/>
                 </div>
             </div>

--- a/webapp/channels/src/components/channel_header_menu/channel_header_menu.tsx
+++ b/webapp/channels/src/components/channel_header_menu/channel_header_menu.tsx
@@ -86,7 +86,9 @@ export default function ChannelHeaderMenu({dmUser, gmMembers, isMobile, archived
         channelTitle = <ChannelHeaderTitleGroup gmMembers={gmMembers}/>;
     }
 
-    const pluginItems = pluginMenuItems.map((item) => {
+    const isSharedChannel = channel?.shared || false;
+
+    const pluginItems = isSharedChannel ? [] : pluginMenuItems.map((item) => {
         const handlePluginItemClick = () => {
             if (item.action) {
                 item.action(channel.id);
@@ -183,4 +185,3 @@ export default function ChannelHeaderMenu({dmUser, gmMembers, isMobile, archived
         </Menu.Container>
     );
 }
-

--- a/webapp/channels/src/components/code_block/code_block.tsx
+++ b/webapp/channels/src/components/code_block/code_block.tsx
@@ -4,6 +4,7 @@
 import React, {useCallback, useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
 
+import {usePluginVisibilityInSharedChannel} from 'components/common/hooks/usePluginVisibilityInSharedChannel';
 import CopyButton from 'components/copy_button';
 
 import * as SyntaxHighlighting from 'utils/syntax_highlighting';
@@ -15,9 +16,10 @@ type Props = {
     code: string;
     language: string;
     searchedContent?: string;
+    channelIsShared?: boolean;
 }
 
-const CodeBlock: React.FC<Props> = ({code, language, searchedContent}: Props) => {
+const CodeBlock: React.FC<Props> = ({code, language, searchedContent, channelIsShared}: Props) => {
     const getUsedLanguage = useCallback(() => {
         let usedLanguage = language || '';
         usedLanguage = usedLanguage.toLowerCase();
@@ -82,7 +84,11 @@ const CodeBlock: React.FC<Props> = ({code, language, searchedContent}: Props) =>
     }
 
     const codeBlockActions = useSelector((state: GlobalState) => state.plugins.components.CodeBlockAction);
-    const pluginItems = codeBlockActions?.
+
+    const isSharedChannel = channelIsShared || false;
+    const pluginItemsVisible = usePluginVisibilityInSharedChannel(isSharedChannel);
+
+    const pluginItems = pluginItemsVisible ? codeBlockActions?.
         map((item) => {
             if (!item.component) {
                 return null;
@@ -95,7 +101,7 @@ const CodeBlock: React.FC<Props> = ({code, language, searchedContent}: Props) =>
                     code={code}
                 />
             );
-        });
+        }) : [];
 
     return (
         <div className={className}>

--- a/webapp/channels/src/components/common/hooks/usePluginVisibilityInSharedChannel.ts
+++ b/webapp/channels/src/components/common/hooks/usePluginVisibilityInSharedChannel.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {useSelector} from 'react-redux';
+
+import {getFeatureFlagValue} from 'mattermost-redux/selectors/entities/general';
+
+import type {GlobalState} from 'types/store';
+
+/**
+ * Custom hook to determine if plugin components should be visible in a shared channel.
+ *
+ * @param isSharedChannel - Whether the current channel is a shared channel
+ * @returns true if plugins should be visible, false otherwise
+ *
+ * Plugins are visible when:
+ * - The channel is not shared, OR
+ * - The channel is shared AND the EnableSharedChannelsPlugins feature flag is enabled
+ */
+export function usePluginVisibilityInSharedChannel(isSharedChannel: boolean): boolean {
+    const sharedChannelsPluginsEnabled = useSelector((state: GlobalState) =>
+        getFeatureFlagValue(state, 'EnableSharedChannelsPlugins') === 'true',
+    );
+
+    return !isSharedChannel || sharedChannelsPluginsEnabled;
+}

--- a/webapp/channels/src/components/file_attachment/file_attachment.tsx
+++ b/webapp/channels/src/components/file_attachment/file_attachment.tsx
@@ -10,6 +10,7 @@ import type {FileInfo} from '@mattermost/types/files';
 
 import {getFileThumbnailUrl, getFileUrl} from 'mattermost-redux/utils/file_utils';
 
+import {usePluginVisibilityInSharedChannel} from 'components/common/hooks/usePluginVisibilityInSharedChannel';
 import GetPublicModal from 'components/get_public_link_modal';
 import Menu from 'components/widgets/menu/menu';
 import MenuWrapper from 'components/widgets/menu/menu_wrapper';
@@ -68,6 +69,9 @@ export default function FileAttachment(props: Props) {
     const [showTooltip, setShowTooltip] = useState(true);
 
     const buttonRef = useRef<HTMLButtonElement | null>(null);
+
+    const isSharedChannel = props.currentChannel?.shared || false;
+    const pluginItemsVisible = usePluginVisibilityInSharedChannel(isSharedChannel);
 
     const handleImageLoaded = () => {
         if (mounted.current) {
@@ -195,7 +199,7 @@ export default function FileAttachment(props: Props) {
             );
         }
 
-        const pluginItems = pluginMenuItems?.filter((item) => item?.match(fileInfo)).map((item) => {
+        const pluginItems = pluginItemsVisible ? pluginMenuItems?.filter((item) => item?.match(fileInfo)).map((item) => {
             return (
                 <Menu.ItemAction
                     id={item.id + '_pluginmenuitem'}
@@ -204,7 +208,7 @@ export default function FileAttachment(props: Props) {
                     text={item.text}
                 />
             );
-        });
+        }) : [];
 
         const isMenuVisible = defaultItems?.length || pluginItems?.length;
         if (!isMenuVisible) {

--- a/webapp/channels/src/components/file_attachment/index.ts
+++ b/webapp/channels/src/components/file_attachment/index.ts
@@ -6,6 +6,7 @@ import type {ConnectedProps} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
+import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {openModal} from 'actions/views/modals';
@@ -29,6 +30,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
         enableSVGs: config.EnableSVGs === 'true',
         enablePublicLink: config.EnablePublicLink === 'true',
         pluginMenuItems: getFilesDropdownPluginMenuItems(state),
+        currentChannel: getCurrentChannel(state),
     };
 }
 

--- a/webapp/channels/src/components/file_search_results/file_search_result_item.tsx
+++ b/webapp/channels/src/components/file_search_results/file_search_result_item.tsx
@@ -58,7 +58,13 @@ export default class FileSearchResultItem extends React.PureComponent<Props, Sta
     };
 
     private renderPluginItems = () => {
-        const {fileInfo} = this.props;
+        const {fileInfo, channel, enableSharedChannelsPlugins} = this.props;
+        const isSharedChannel = channel?.shared || false;
+
+        if (isSharedChannel && !enableSharedChannelsPlugins) {
+            return null;
+        }
+
         const pluginItems = this.props.pluginMenuItems?.filter((item) => item?.match(fileInfo)).map((item) => {
             return (
                 <Menu.ItemAction

--- a/webapp/channels/src/components/file_search_results/index.tsx
+++ b/webapp/channels/src/components/file_search_results/index.tsx
@@ -9,6 +9,7 @@ import type {Dispatch} from 'redux';
 import type {FileInfo} from '@mattermost/types/files';
 
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getFeatureFlagValue} from 'mattermost-redux/selectors/entities/general';
 
 import {openModal} from 'actions/views/modals';
 
@@ -26,10 +27,13 @@ export type OwnProps = {
 
 function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     const channel = getChannel(state, ownProps.channelId);
+    const enableSharedChannelsPlugins = getFeatureFlagValue(state, 'EnableSharedChannelsPlugins') === 'true';
 
     return {
         channelDisplayName: '',
         channelType: channel?.type,
+        channel,
+        enableSharedChannelsPlugins,
     };
 }
 

--- a/webapp/channels/src/components/post/index.tsx
+++ b/webapp/channels/src/components/post/index.tsx
@@ -176,6 +176,7 @@ function makeMapStateToProps() {
             canReply,
             pluginPostTypes: state.plugins.postTypes,
             channelIsArchived: isArchivedChannel(channel),
+            channelIsShared: channel?.shared,
             isConsecutivePost: isConsecutivePost(state, ownProps),
             previousPostIsComment,
             isFlagged: isPostFlagged(state, post.id),

--- a/webapp/channels/src/components/post/post_component.tsx
+++ b/webapp/channels/src/components/post/post_component.tsx
@@ -69,6 +69,7 @@ export type Props = {
     isReadOnly?: boolean;
     pluginPostTypes?: {[postType: string]: PostPluginComponent};
     channelIsArchived?: boolean;
+    channelIsShared?: boolean;
     isConsecutivePost?: boolean;
     isLastPost?: boolean;
     recentEmojis: Emoji[];

--- a/webapp/channels/src/components/post/post_options.tsx
+++ b/webapp/channels/src/components/post/post_options.tsx
@@ -14,6 +14,7 @@ import {isPostEphemeral} from 'mattermost-redux/utils/post_utils';
 
 import ActionsMenu from 'components/actions_menu';
 import CommentIcon from 'components/common/comment_icon';
+import {usePluginVisibilityInSharedChannel} from 'components/common/hooks/usePluginVisibilityInSharedChannel';
 import DotMenu from 'components/dot_menu';
 import PostFlagIcon from 'components/post_view/post_flag_icon';
 import PostReaction from 'components/post_view/post_reaction';
@@ -32,6 +33,7 @@ type Props = {
     enableEmojiPicker?: boolean;
     isReadOnly?: boolean;
     channelIsArchived?: boolean;
+    channelIsShared?: boolean;
     handleCommentClick?: (e: React.MouseEvent) => void;
     handleJumpClick?: (e: React.MouseEvent) => void;
     handleDropdownOpened?: (e: boolean) => void;
@@ -200,7 +202,10 @@ const PostOptions = (props: Props): JSX.Element => {
     );
 
     let pluginItems: ReactNode = null;
-    if ((!isEphemeral && !post.failed && !systemMessage) && hoverLocal) {
+    const isSharedChannel = props.channelIsShared || false;
+    const pluginItemsVisible = usePluginVisibilityInSharedChannel(isSharedChannel);
+
+    if ((!isEphemeral && !post.failed && !systemMessage) && hoverLocal && pluginItemsVisible) {
         pluginItems = props.pluginActions?.
             map((item) => {
                 if (item.component) {

--- a/webapp/channels/src/components/post_view/channel_intro_message/pluggable_intro_buttons/pluggable_intro_buttons.tsx
+++ b/webapp/channels/src/components/post_view/channel_intro_message/pluggable_intro_buttons/pluggable_intro_buttons.tsx
@@ -5,6 +5,8 @@ import React from 'react';
 
 import type {Channel, ChannelMembership} from '@mattermost/types/channels';
 
+import {usePluginVisibilityInSharedChannel} from 'components/common/hooks/usePluginVisibilityInSharedChannel';
+
 import type {ChannelIntroButtonAction} from 'types/store/plugins';
 
 type Props = {
@@ -19,7 +21,10 @@ const PluggableIntroButtons = React.memo(({
     channelMember,
 }: Props) => {
     const channelIsArchived = channel.delete_at !== 0;
-    if (channelIsArchived || pluginButtons.length === 0 || !channelMember) {
+    const isSharedChannel = channel.shared || false;
+    const pluginItemsVisible = usePluginVisibilityInSharedChannel(isSharedChannel);
+
+    if (channelIsArchived || pluginButtons.length === 0 || !channelMember || !pluginItemsVisible) {
         return null;
     }
 

--- a/webapp/channels/src/components/post_view/post_message_view/post_message_view.tsx
+++ b/webapp/channels/src/components/post_view/post_message_view/post_message_view.tsx
@@ -7,8 +7,11 @@ import {FormattedMessage} from 'react-intl';
 import type {Post} from '@mattermost/types/posts';
 
 import {Posts} from 'mattermost-redux/constants';
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import type {Theme} from 'mattermost-redux/selectors/entities/preferences';
 import {isPostEphemeral} from 'mattermost-redux/utils/post_utils';
+
+import store from 'stores/redux_store';
 
 import PostMarkdown from 'components/post_markdown';
 import ShowMore from 'components/post_view/show_more';
@@ -142,6 +145,10 @@ export default class PostMessageView extends React.PureComponent<Props, State> {
 
         const id = isRHS ? `rhsPostMessageText_${post.id}` : `postMessageText_${post.id}`;
 
+        // Check if channel is shared
+        const channel = getChannel(store.getState(), post.channel_id);
+        const isSharedChannel = channel?.shared || false;
+
         return (
             <ShowMore
                 checkOverflow={this.state.checkOverflow}
@@ -164,11 +171,13 @@ export default class PostMessageView extends React.PureComponent<Props, State> {
                         showPostEditedIndicator={this.props.showPostEditedIndicator}
                     />
                 </div>
-                <Pluggable
-                    pluggableName='PostMessageAttachment'
-                    postId={post.id}
-                    onHeightChange={this.handleHeightReceived}
-                />
+                {!isSharedChannel && (
+                    <Pluggable
+                        pluggableName='PostMessageAttachment'
+                        postId={post.id}
+                        onHeightChange={this.handleHeightReceived}
+                    />
+                )}
             </ShowMore>
         );
     }

--- a/webapp/channels/src/components/profile_popover/profile_popover.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover.tsx
@@ -4,6 +4,7 @@
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentChannelId, getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 import {getFeatureFlagValue} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentRelativeTeamUrl, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
@@ -16,6 +17,8 @@ import {closeModal} from 'actions/views/modals';
 import {getMembershipForEntities} from 'actions/views/profile_popover';
 import {getSelectedPost} from 'selectors/rhs';
 import {getIsMobileView} from 'selectors/views/browser';
+
+import {usePluginVisibilityInSharedChannel} from 'components/common/hooks/usePluginVisibilityInSharedChannel';
 
 import Pluggable from 'plugins/pluggable';
 import {getHistory} from 'utils/browser_history';
@@ -73,6 +76,9 @@ const ProfilePopover = ({
     const user = useSelector((state: GlobalState) => getUser(state, userId));
     const currentTeamId = useSelector((state: GlobalState) => getCurrentTeamId(state));
     const channelId = useSelector((state: GlobalState) => (channelIdProp || getDefaultChannelId(state)));
+    const channel = useSelector((state: GlobalState) => getChannel(state, channelId));
+    const isSharedChannel = channel?.shared || false;
+    const pluginItemsVisible = usePluginVisibilityInSharedChannel(isSharedChannel);
     const isMobileView = useSelector(getIsMobileView);
     const teamUrl = useSelector(getCurrentRelativeTeamUrl);
     const modals = useSelector((state: GlobalState) => state.views.modals);
@@ -182,15 +188,17 @@ const ProfilePopover = ({
                     haveOverrideProp={haveOverrideProp}
                     isBot={user.is_bot}
                 />
-                <div className='user-profile-popover-pluggables'>
-                    <Pluggable
-                        pluggableName={PLUGGABLE_COMPONENT_NAME_PROFILE_POPOVER}
-                        user={user}
-                        hide={hide}
-                        status={hideStatus ? null : status}
-                        fromWebhook={fromWebhook}
-                    />
-                </div>
+                {pluginItemsVisible && (
+                    <div className='user-profile-popover-pluggables'>
+                        <Pluggable
+                            pluggableName={PLUGGABLE_COMPONENT_NAME_PROFILE_POPOVER}
+                            user={user}
+                            hide={hide}
+                            status={hideStatus ? null : status}
+                            fromWebhook={fromWebhook}
+                        />
+                    </div>
+                )}
 
                 {enableCustomProfileAttributes && !user.is_bot && (
                     <ProfilePopoverCustomAttributes
@@ -238,12 +246,14 @@ const ProfilePopover = ({
                     user={user}
                     hide={hide}
                 />
-                <Pluggable
-                    pluggableName='PopoverUserActions'
-                    user={user}
-                    hide={hide}
-                    status={hideStatus ? null : status}
-                />
+                {pluginItemsVisible && (
+                    <Pluggable
+                        pluggableName='PopoverUserActions'
+                        user={user}
+                        hide={hide}
+                        status={hideStatus ? null : status}
+                    />
+                )}
             </div>
         </div>
     );

--- a/webapp/channels/src/utils/message_html_to_component.tsx
+++ b/webapp/channels/src/utils/message_html_to_component.tsx
@@ -36,6 +36,7 @@ export type Options = Partial<{
     images: boolean;
     atPlanMentions: boolean;
     channelId: string;
+    channelIsShared: boolean;
 
     /**
      * Whether or not the AtMention component should attempt to fetch at-mentioned users if none can be found for
@@ -267,6 +268,7 @@ export default function messageHtmlToComponent(html: string, options: Options = 
                         code={node.attribs['data-codeblock-code']}
                         language={node.attribs['data-codeblock-language']}
                         searchedContent={node.attribs['data-codeblock-searchedcontent']}
+                        channelIsShared={options.channelIsShared}
                     />
                 );
             },


### PR DESCRIPTION
#### Summary
These changes avoid rendering plugin registered components for user interactions when in the context of a shared channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64308

#### Release Note
```release-note
* Hide plugin components in Shared Channels, and provide a EnableSharedChannelsPlugins to reenable them.
```
