### PR TITLE
Fix broken Makefile

### DIFF
--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -71,7 +71,7 @@ dist: node_modules ## Builds all web app packages
 
 node_modules: package.json $(wildcard package-lock.json)
 	@echo Getting dependencies using npm
-
+	
 ifeq ($(CI),false)
 	CPPFLAGS="$(CPPFLAGS)" npm install
 else


### PR DESCRIPTION
#### Summary

This Makefile hasn't been valid for several releases now. Including blank lines in targets is a bad idea in general, but at least if they are blank they *must* start with a tab, not be completely blank. Completely blank lines end the recipe entirely, meaning these lines are not even part of the expected target.

#### Release Note

```release-note
Fix invalid syntax in Makefile causing `make node_modules` target to not function
```
