### PR TITLE
Fixed width of edit scheduled post UI

### DIFF
--- a/webapp/channels/src/components/drafts/scheduled_post_list/scheduled_post_list.scss
+++ b/webapp/channels/src/components/drafts/scheduled_post_list/scheduled_post_list.scss
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 .ScheduledPostList {
+    width: 100%;
     height: 100%;
 
     &.nonVirtualizedScheduledPostList {

--- a/webapp/channels/src/components/edit_scheduled_post/edit_post.tsx
+++ b/webapp/channels/src/components/edit_scheduled_post/edit_post.tsx
@@ -262,6 +262,7 @@ const EditPost = ({editingPost, actions, canEditPost, config, channelId, draft, 
     const handleEdit = async () => {
         if (scheduledPost) {
             await handleEditScheduledPost();
+            afterSave?.();
             return;
         }
 


### PR DESCRIPTION
#### Summary
1. Fixed width of edit schedule post UI.
2. Fixed a bug where clicking on `Save` button on edit scheduled post without any change did nothing, and didn't even close the edit.

This got broken in https://github.com/mattermost/mattermost/pull/30563

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-64363

#### Screenshots
![Screenshot 2025-05-27 at 3 45 16 PM](https://github.com/user-attachments/assets/f595492b-c07e-42ce-a94c-6d1e45688093)

#### Release Note
```release-note
None
```
