### PR TITLE
[MM-64402] Improve validation of imported attachments

### DIFF
--- a/server/channels/app/import.go
+++ b/server/channels/app/import.go
@@ -101,7 +101,11 @@ func processAttachments(c request.CTX, line *imports.LineImportData, basePath st
 		}
 	case "user":
 		if line.User.ProfileImage != nil {
-			path := filepath.Join(basePath, *line.User.ProfileImage)
+			path, valid := imports.ValidateAttachmentPathForImport(*line.User.ProfileImage, basePath)
+			if !valid {
+				return fmt.Errorf("invalid profile image path %q", *line.User.ProfileImage)
+			}
+
 			*line.User.ProfileImage = path
 			if len(filesMap) > 0 {
 				if line.User.ProfileImageData, ok = filesMap[path]; !ok {
@@ -111,7 +115,11 @@ func processAttachments(c request.CTX, line *imports.LineImportData, basePath st
 		}
 	case "bot":
 		if line.Bot.ProfileImage != nil {
-			path := filepath.Join(basePath, *line.Bot.ProfileImage)
+			path, valid := imports.ValidateAttachmentPathForImport(*line.Bot.ProfileImage, basePath)
+			if !valid {
+				return fmt.Errorf("invalid bot profile image path %q", *line.Bot.ProfileImage)
+			}
+
 			*line.Bot.ProfileImage = path
 			if len(filesMap) > 0 {
 				if line.Bot.ProfileImageData, ok = filesMap[path]; !ok {
@@ -121,7 +129,11 @@ func processAttachments(c request.CTX, line *imports.LineImportData, basePath st
 		}
 	case "emoji":
 		if line.Emoji.Image != nil {
-			path := filepath.Join(basePath, *line.Emoji.Image)
+			path, valid := imports.ValidateAttachmentPathForImport(*line.Emoji.Image, basePath)
+			if !valid {
+				return fmt.Errorf("invalid emoji image path %q", *line.Emoji.Image)
+			}
+
 			*line.Emoji.Image = path
 			if len(filesMap) > 0 {
 				if line.Emoji.Data, ok = filesMap[path]; !ok {

--- a/server/channels/app/import_functions.go
+++ b/server/channels/app/import_functions.go
@@ -193,7 +193,6 @@ func (a *App) importTeam(rctx request.CTX, data *imports.TeamImportData, dryRun 
 
 	var team *model.Team
 	team, err := a.Srv().Store().Team().GetByName(teamName)
-
 	if err != nil {
 		team = &model.Team{
 			Name: teamName,
@@ -2063,6 +2062,7 @@ func (a *App) updateFileInfoWithPostId(rctx request.CTX, post *model.Post) {
 		}
 	}
 }
+
 func (a *App) importDirectChannel(rctx request.CTX, data *imports.DirectChannelImportData, dryRun bool) *model.AppError {
 	var err *model.AppError
 	if err = imports.ValidateDirectChannelImportData(data); err != nil {
@@ -2117,7 +2117,7 @@ func (a *App) importDirectChannel(rctx request.CTX, data *imports.DirectChannelI
 		return model.NewAppError("BulkImport", "app.import.import_direct_channel.get_channel_members.error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
 
-	var ems = make([]model.ChannelMember, 0, totalMembers)
+	ems := make([]model.ChannelMember, 0, totalMembers)
 	var page int
 
 	for int64(len(ems)) < totalMembers {

--- a/server/channels/app/import_test.go
+++ b/server/channels/app/import_test.go
@@ -231,6 +231,54 @@ func TestImportBulkImport(t *testing.T) {
 		require.Nil(t, err, "BulkImport should have succeeded")
 		require.Equal(t, 0, line, "BulkImport line should be 0")
 	})
+
+	t.Run("Invalid post attachment path", func(t *testing.T) {
+		data7 := `{"type": "version", "version": 1}
+{"type": "team", "team": {"type": "O", "display_name": "lskmw2d7a5ao7ppwqh5ljchvr4", "name": "` + teamName + `"}}
+{"type": "channel", "channel": {"type": "O", "display_name": "xr6m6udffngark2uekvr3hoeny", "team": "` + teamName + `", "name": "` + channelName + `"}}
+{"type": "user", "user": {"username": "` + username + `", "email": "` + username + `@example.com", "teams": [{"name": "` + teamName + `","theme": "` + teamTheme1 + `", "channels": [{"name": "` + channelName + `"}]}]}}
+{"type": "user", "user": {"username": "` + username2 + `", "email": "` + username2 + `@example.com", "teams": [{"name": "` + teamName + `","theme": "` + teamTheme2 + `", "channels": [{"name": "` + channelName + `"}]}]}}
+{"type": "user", "user": {"username": "` + username3 + `", "email": "` + username3 + `@example.com", "teams": [{"name": "` + teamName + `", "channels": [{"name": "` + channelName + `"}], "delete_at": 123456789016}]}}
+{"type": "post", "post": {"team": "` + teamName + `", "channel": "` + channelName + `", "user": "` + username + `", "message": "Hello World", "create_at": 123456789012, "attachments":[{"path": "` + testImage + `"}]}}
+{"type": "post", "post": {"team": "` + teamName + `", "channel": "` + channelName + `", "user": "` + username3 + `", "message": "Hey Everyone!", "create_at": 123456789013, "attachments":[{"path": "../` + testImage + `"}]}}`
+
+		line, err := th.App.BulkImport(th.Context, strings.NewReader(data7), nil, false, 2)
+		require.NotNil(t, err, "Should have failed due to invalid attachment path on line 8.")
+		require.Equal(t, "app.import.validate_post_import_data.attachment.error", err.Id)
+		require.Equal(t, 8, line, "Should have failed due to invalid type on line 8.")
+	})
+
+	t.Run("Invalid reply attachment path", func(t *testing.T) {
+		data8 := `{"type": "version", "version": 1}
+{"type": "team", "team": {"type": "O", "display_name": "lskmw2d7a5ao7ppwqh5ljchvr4", "name": "` + teamName + `"}}
+{"type": "channel", "channel": {"type": "O", "display_name": "xr6m6udffngark2uekvr3hoeny", "team": "` + teamName + `", "name": "` + channelName + `"}}
+{"type": "user", "user": {"username": "` + username + `", "email": "` + username + `@example.com", "teams": [{"name": "` + teamName + `","theme": "` + teamTheme1 + `", "channels": [{"name": "` + channelName + `"}]}]}}
+{"type": "user", "user": {"username": "` + username2 + `", "email": "` + username2 + `@example.com", "teams": [{"name": "` + teamName + `","theme": "` + teamTheme2 + `", "channels": [{"name": "` + channelName + `"}]}]}}
+{"type": "user", "user": {"username": "` + username3 + `", "email": "` + username3 + `@example.com", "teams": [{"name": "` + teamName + `", "channels": [{"name": "` + channelName + `"}], "delete_at": 123456789016}]}}
+{"type": "post", "post": {"team": "` + teamName + `", "channel": "` + channelName + `", "user": "` + username + `", "message": "Hello World", "create_at": 123456789012, "attachments":[{"path": "` + testImage + `"}]}}
+{"type": "post", "post": {"team": "` + teamName + `", "channel": "` + channelName + `", "user": "` + username3 + `", "message": "Hey Everyone!", "create_at": 123456789013, "replies": [{"create_at": 123456789015, "user": "` + username + `", "message": "reply", "attachments":[{"path": "../` + testImage + `"}]}]}}`
+
+		line, err := th.App.BulkImport(th.Context, strings.NewReader(data8), nil, false, 2)
+		require.NotNil(t, err, "Should have failed due to invalid attachment path on line 8.")
+		require.Equal(t, "app.import.validate_reply_import_data.attachment.error", err.Id)
+		require.Equal(t, 8, line, "Should have failed due to invalid type on line 8.")
+	})
+
+	t.Run("Invalid direct post attachment path", func(t *testing.T) {
+		data9 := `{"type": "version", "version": 1}
+{"type": "team", "team": {"type": "O", "display_name": "lskmw2d7a5ao7ppwqh5ljchvr4", "name": "` + teamName + `"}}
+{"type": "channel", "channel": {"type": "O", "display_name": "xr6m6udffngark2uekvr3hoeny", "team": "` + teamName + `", "name": "` + channelName + `"}}
+{"type": "user", "user": {"username": "` + username + `", "email": "` + username + `@example.com", "teams": [{"name": "` + teamName + `","theme": "` + teamTheme1 + `", "channels": [{"name": "` + channelName + `"}]}]}}
+{"type": "user", "user": {"username": "` + username2 + `", "email": "` + username2 + `@example.com", "teams": [{"name": "` + teamName + `","theme": "` + teamTheme2 + `", "channels": [{"name": "` + channelName + `"}]}]}}
+{"type": "user", "user": {"username": "` + username3 + `", "email": "` + username3 + `@example.com", "teams": [{"name": "` + teamName + `", "channels": [{"name": "` + channelName + `"}], "delete_at": 123456789016}]}}
+{"type": "direct_channel", "direct_channel": {"members": ["` + username + `", "` + username + `"]}}
+{"type": "direct_post", "direct_post": {"channel_members": ["` + username + `", "` + username + `"], "user": "` + username + `", "message": "Hello Direct Channel to myself", "create_at": 123456789014, "attachments":[{"path": "../` + testImage + `"}]}}`
+
+		line, err := th.App.BulkImport(th.Context, strings.NewReader(data9), nil, false, 2)
+		require.NotNil(t, err, "Should have failed due to invalid attachment path on line 8.")
+		require.Equal(t, "app.import.validate_direct_post_import_data.attachment.error", err.Id)
+		require.Equal(t, 8, line, "Should have failed due to invalid type on line 8.")
+	})
 }
 
 func TestImportProcessImportDataFileVersionLine(t *testing.T) {
@@ -273,6 +321,133 @@ func AssertFileIdsInPost(files []*model.FileInfo, th *TestHelper, t *testing.T) 
 	for _, file := range files {
 		assert.Contains(t, posts[0].FileIds, file.Id)
 	}
+}
+
+func TestProcessAttachmentPaths(t *testing.T) {
+	c := request.TestContext(t)
+
+	t.Run("nil attachments", func(t *testing.T) {
+		err := processAttachmentPaths(c, nil, "", nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("missing file in map", func(t *testing.T) {
+		attachments := &[]imports.AttachmentImportData{
+			{
+				Path: model.NewPointer("file.jpg"),
+			},
+		}
+
+		filesMap := map[string]*zip.File{
+			"./import/other-file.jpg": nil,
+		}
+
+		err := processAttachmentPaths(c, attachments, "", filesMap)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not found in map")
+	})
+
+	t.Run("valid paths", func(t *testing.T) {
+		attachments := &[]imports.AttachmentImportData{
+			{
+				Path: model.NewPointer("file.jpg"),
+			},
+			{
+				Path: model.NewPointer("somedir/file.jpg"),
+			},
+			{
+				Path: model.NewPointer("./someotherdir/file.jpg"),
+			},
+		}
+
+		expected := &[]imports.AttachmentImportData{
+			{
+				Path: model.NewPointer("data/file.jpg"),
+			},
+			{
+				Path: model.NewPointer("data/somedir/file.jpg"),
+			},
+			{
+				Path: model.NewPointer("data/someotherdir/file.jpg"),
+			},
+		}
+
+		err := processAttachmentPaths(c, attachments, model.ExportDataDir, nil)
+		require.NoError(t, err)
+		require.Equal(t, expected, attachments)
+	})
+
+	t.Run("uncleaned paths", func(t *testing.T) {
+		attachments := &[]imports.AttachmentImportData{
+			{
+				Path: model.NewPointer("../dir/invalid.txt"),
+			},
+			{
+				Path: model.NewPointer("somedir/./normal-file.jpg"),
+			},
+		}
+
+		expected := &[]imports.AttachmentImportData{
+			{
+				Path: model.NewPointer("/path/to/import/dir/invalid.txt"),
+			},
+			{
+				Path: model.NewPointer("/path/to/import/dir/somedir/normal-file.jpg"),
+			},
+		}
+
+		err := processAttachmentPaths(c, attachments, "/path/to/import/dir", nil)
+		require.NoError(t, err)
+		require.Equal(t, expected, attachments)
+	})
+
+	t.Run("paths outside base path", func(t *testing.T) {
+		attachments := &[]imports.AttachmentImportData{
+			{
+				Path: model.NewPointer("../../invalid.txt"),
+			},
+			{
+				Path: model.NewPointer("../../../invalid.txt"),
+			},
+		}
+
+		expected := &[]imports.AttachmentImportData{
+			{
+				Path: model.NewPointer(""),
+			},
+			{
+				Path: model.NewPointer(""),
+			},
+		}
+
+		err := processAttachmentPaths(c, attachments, "data", nil)
+		require.EqualError(t, err, "2 errors occurred:\n\t* invalid attachment path \"../../invalid.txt\"\n\t* invalid attachment path \"../../../invalid.txt\"\n\n")
+		require.Equal(t, expected, attachments)
+	})
+
+	t.Run("mix of valid and invalid paths", func(t *testing.T) {
+		attachments := &[]imports.AttachmentImportData{
+			{
+				Path: model.NewPointer("../../invalid.txt"),
+			},
+			{
+				Path: model.NewPointer("valid/path/to/file"),
+			},
+		}
+
+		expected := &[]imports.AttachmentImportData{
+			{
+				Path: model.NewPointer(""),
+			},
+			{
+				Path: model.NewPointer("data/valid/path/to/file"),
+			},
+		}
+
+		err := processAttachmentPaths(c, attachments, "data", nil)
+		require.EqualError(t, err, "1 error occurred:\n\t* invalid attachment path \"../../invalid.txt\"\n\n")
+		require.Equal(t, expected, attachments)
+	})
 }
 
 func TestProcessAttachments(t *testing.T) {

--- a/server/channels/app/import_test.go
+++ b/server/channels/app/import_test.go
@@ -239,13 +239,13 @@ func TestImportBulkImport(t *testing.T) {
 {"type": "user", "user": {"username": "` + username + `", "email": "` + username + `@example.com", "teams": [{"name": "` + teamName + `","theme": "` + teamTheme1 + `", "channels": [{"name": "` + channelName + `"}]}]}}
 {"type": "user", "user": {"username": "` + username2 + `", "email": "` + username2 + `@example.com", "teams": [{"name": "` + teamName + `","theme": "` + teamTheme2 + `", "channels": [{"name": "` + channelName + `"}]}]}}
 {"type": "user", "user": {"username": "` + username3 + `", "email": "` + username3 + `@example.com", "teams": [{"name": "` + teamName + `", "channels": [{"name": "` + channelName + `"}], "delete_at": 123456789016}]}}
-{"type": "post", "post": {"team": "` + teamName + `", "channel": "` + channelName + `", "user": "` + username + `", "message": "Hello World", "create_at": 123456789012, "attachments":[{"path": "` + testImage + `"}]}}
-{"type": "post", "post": {"team": "` + teamName + `", "channel": "` + channelName + `", "user": "` + username3 + `", "message": "Hey Everyone!", "create_at": 123456789013, "attachments":[{"path": "../` + testImage + `"}]}}`
+{"type": "post", "post": {"team": "` + teamName + `", "channel": "` + channelName + `", "user": "` + username + `", "message": "Hello World", "create_at": 123456789012, "attachments":[{"path": "test.png"}]}}
+{"type": "post", "post": {"team": "` + teamName + `", "channel": "` + channelName + `", "user": "` + username3 + `", "message": "Hey Everyone!", "create_at": 123456789013, "attachments":[{"path": "../test.png"}]}}`
 
-		line, err := th.App.BulkImport(th.Context, strings.NewReader(data7), nil, false, 2)
-		require.NotNil(t, err, "Should have failed due to invalid attachment path on line 8.")
-		require.Equal(t, "app.import.validate_post_import_data.attachment.error", err.Id)
-		require.Equal(t, 8, line, "Should have failed due to invalid type on line 8.")
+		// Import should not fail for a single invalid attachment path.
+		line, err := th.App.BulkImportWithPath(th.Context, strings.NewReader(data7), nil, false, false, 2, testsDir)
+		require.Nil(t, err, "BulkImport should have succeeded")
+		require.Equal(t, 0, line, "BulkImport line should be 0")
 	})
 
 	t.Run("Invalid reply attachment path", func(t *testing.T) {
@@ -255,13 +255,13 @@ func TestImportBulkImport(t *testing.T) {
 {"type": "user", "user": {"username": "` + username + `", "email": "` + username + `@example.com", "teams": [{"name": "` + teamName + `","theme": "` + teamTheme1 + `", "channels": [{"name": "` + channelName + `"}]}]}}
 {"type": "user", "user": {"username": "` + username2 + `", "email": "` + username2 + `@example.com", "teams": [{"name": "` + teamName + `","theme": "` + teamTheme2 + `", "channels": [{"name": "` + channelName + `"}]}]}}
 {"type": "user", "user": {"username": "` + username3 + `", "email": "` + username3 + `@example.com", "teams": [{"name": "` + teamName + `", "channels": [{"name": "` + channelName + `"}], "delete_at": 123456789016}]}}
-{"type": "post", "post": {"team": "` + teamName + `", "channel": "` + channelName + `", "user": "` + username + `", "message": "Hello World", "create_at": 123456789012, "attachments":[{"path": "` + testImage + `"}]}}
-{"type": "post", "post": {"team": "` + teamName + `", "channel": "` + channelName + `", "user": "` + username3 + `", "message": "Hey Everyone!", "create_at": 123456789013, "replies": [{"create_at": 123456789015, "user": "` + username + `", "message": "reply", "attachments":[{"path": "../` + testImage + `"}]}]}}`
+{"type": "post", "post": {"team": "` + teamName + `", "channel": "` + channelName + `", "user": "` + username + `", "message": "Hello World", "create_at": 123456789012, "attachments":[{"path": "test.png"}]}}
+{"type": "post", "post": {"team": "` + teamName + `", "channel": "` + channelName + `", "user": "` + username3 + `", "message": "Hey Everyone!", "create_at": 123456789013, "replies": [{"create_at": 123456789015, "user": "` + username + `", "message": "reply", "attachments":[{"path": "../test.png"}]}]}}`
 
-		line, err := th.App.BulkImport(th.Context, strings.NewReader(data8), nil, false, 2)
-		require.NotNil(t, err, "Should have failed due to invalid attachment path on line 8.")
-		require.Equal(t, "app.import.validate_reply_import_data.attachment.error", err.Id)
-		require.Equal(t, 8, line, "Should have failed due to invalid type on line 8.")
+		// Import should not fail for a single invalid attachment path.
+		line, err := th.App.BulkImportWithPath(th.Context, strings.NewReader(data8), nil, false, false, 2, testsDir)
+		require.Nil(t, err, "BulkImport should have succeeded")
+		require.Equal(t, 0, line, "BulkImport line should be 0")
 	})
 
 	t.Run("Invalid direct post attachment path", func(t *testing.T) {
@@ -272,12 +272,12 @@ func TestImportBulkImport(t *testing.T) {
 {"type": "user", "user": {"username": "` + username2 + `", "email": "` + username2 + `@example.com", "teams": [{"name": "` + teamName + `","theme": "` + teamTheme2 + `", "channels": [{"name": "` + channelName + `"}]}]}}
 {"type": "user", "user": {"username": "` + username3 + `", "email": "` + username3 + `@example.com", "teams": [{"name": "` + teamName + `", "channels": [{"name": "` + channelName + `"}], "delete_at": 123456789016}]}}
 {"type": "direct_channel", "direct_channel": {"members": ["` + username + `", "` + username + `"]}}
-{"type": "direct_post", "direct_post": {"channel_members": ["` + username + `", "` + username + `"], "user": "` + username + `", "message": "Hello Direct Channel to myself", "create_at": 123456789014, "attachments":[{"path": "../` + testImage + `"}]}}`
+{"type": "direct_post", "direct_post": {"channel_members": ["` + username + `", "` + username + `"], "user": "` + username + `", "message": "Hello Direct Channel to myself", "create_at": 123456789014, "attachments":[{"path": "../test.png"}]}}`
 
-		line, err := th.App.BulkImport(th.Context, strings.NewReader(data9), nil, false, 2)
-		require.NotNil(t, err, "Should have failed due to invalid attachment path on line 8.")
-		require.Equal(t, "app.import.validate_direct_post_import_data.attachment.error", err.Id)
-		require.Equal(t, 8, line, "Should have failed due to invalid type on line 8.")
+		// Import should not fail for a single invalid attachment path.
+		line, err := th.App.BulkImportWithPath(th.Context, strings.NewReader(data9), nil, false, false, 2, testsDir)
+		require.Nil(t, err, "BulkImport should have succeeded")
+		require.Equal(t, 0, line, "BulkImport line should be 0")
 	})
 }
 
@@ -344,7 +344,7 @@ func TestProcessAttachmentPaths(t *testing.T) {
 
 		err := processAttachmentPaths(c, attachments, "", filesMap)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "not found in map")
+		require.EqualError(t, err, "attachment \"file.jpg\" not found in map")
 	})
 
 	t.Run("valid paths", func(t *testing.T) {

--- a/server/channels/app/import_test.go
+++ b/server/channels/app/import_test.go
@@ -515,35 +515,35 @@ func TestProcessAttachments(t *testing.T) {
 	t.Run("valid path", func(t *testing.T) {
 		expected := &[]imports.AttachmentImportData{
 			{
-				Path: model.NewPointer("/tmp/file.jpg"),
+				Path: model.NewPointer("tmp/file.jpg"),
 			},
 			{
-				Path: model.NewPointer("/tmp/somedir/file.jpg"),
+				Path: model.NewPointer("tmp/somedir/file.jpg"),
 			},
 		}
 
 		t.Run("post attachments", func(t *testing.T) {
-			err := processAttachments(c, &line, "/tmp", nil)
+			err := processAttachments(c, &line, "tmp", nil)
 			require.NoError(t, err)
 			require.Equal(t, expected, line.Post.Attachments)
 		})
 
 		t.Run("direct post attachments", func(t *testing.T) {
-			err := processAttachments(c, &line2, "/tmp", nil)
+			err := processAttachments(c, &line2, "tmp", nil)
 			require.NoError(t, err)
 			require.Equal(t, expected, line2.DirectPost.Attachments)
 		})
 
 		t.Run("profile image", func(t *testing.T) {
-			expected := "/tmp/profile.jpg"
-			err := processAttachments(c, &userLine, "/tmp", nil)
+			expected := "tmp/profile.jpg"
+			err := processAttachments(c, &userLine, "tmp", nil)
 			require.NoError(t, err)
 			require.Equal(t, expected, *userLine.User.ProfileImage)
 		})
 
 		t.Run("emoji", func(t *testing.T) {
-			expected := "/tmp/emoji.png"
-			err := processAttachments(c, &emojiLine, "/tmp", nil)
+			expected := "tmp/emoji.png"
+			err := processAttachments(c, &emojiLine, "tmp", nil)
 			require.NoError(t, err)
 			require.Equal(t, expected, *emojiLine.Emoji.Image)
 		})
@@ -581,7 +581,7 @@ func TestProcessAttachments(t *testing.T) {
 			err := processAttachments(c, &userLine, "", filesMap)
 			require.Error(t, err)
 
-			filesMap["/tmp/profile.jpg"] = nil
+			filesMap["tmp/profile.jpg"] = nil
 			err = processAttachments(c, &userLine, "", filesMap)
 			require.NoError(t, err)
 		})
@@ -593,7 +593,7 @@ func TestProcessAttachments(t *testing.T) {
 			err := processAttachments(c, &emojiLine, "", filesMap)
 			require.Error(t, err)
 
-			filesMap["/tmp/emoji.png"] = nil
+			filesMap["tmp/emoji.png"] = nil
 			err = processAttachments(c, &emojiLine, "", filesMap)
 			require.NoError(t, err)
 		})

--- a/server/channels/app/import_test.go
+++ b/server/channels/app/import_test.go
@@ -421,7 +421,7 @@ func TestProcessAttachmentPaths(t *testing.T) {
 		}
 
 		err := processAttachmentPaths(c, attachments, "data", nil)
-		require.EqualError(t, err, "2 errors occurred:\n\t* invalid attachment path \"../../invalid.txt\"\n\t* invalid attachment path \"../../../invalid.txt\"\n\n")
+		require.EqualError(t, err, "invalid attachment path \"../../invalid.txt\"\ninvalid attachment path \"../../../invalid.txt\"")
 		require.Equal(t, expected, attachments)
 	})
 
@@ -445,7 +445,7 @@ func TestProcessAttachmentPaths(t *testing.T) {
 		}
 
 		err := processAttachmentPaths(c, attachments, "data", nil)
-		require.EqualError(t, err, "1 error occurred:\n\t* invalid attachment path \"../../invalid.txt\"\n\n")
+		require.EqualError(t, err, "invalid attachment path \"../../invalid.txt\"")
 		require.Equal(t, expected, attachments)
 	})
 }

--- a/server/channels/app/import_test.go
+++ b/server/channels/app/import_test.go
@@ -552,24 +552,24 @@ func TestProcessAttachments(t *testing.T) {
 	t.Run("with filesMap", func(t *testing.T) {
 		t.Run("post attachments", func(t *testing.T) {
 			filesMap := map[string]*zip.File{
-				"/tmp/file.jpg": nil,
+				"tmp/file.jpg": nil,
 			}
 			err := processAttachments(c, &line, "", filesMap)
 			require.Error(t, err)
 
-			filesMap["/tmp/somedir/file.jpg"] = nil
+			filesMap["tmp/somedir/file.jpg"] = nil
 			err = processAttachments(c, &line, "", filesMap)
 			require.NoError(t, err)
 		})
 
 		t.Run("direct post attachments", func(t *testing.T) {
 			filesMap := map[string]*zip.File{
-				"/tmp/file.jpg": nil,
+				"tmp/file.jpg": nil,
 			}
 			err := processAttachments(c, &line2, "", filesMap)
 			require.Error(t, err)
 
-			filesMap["/tmp/somedir/file.jpg"] = nil
+			filesMap["tmp/somedir/file.jpg"] = nil
 			err = processAttachments(c, &line2, "", filesMap)
 			require.NoError(t, err)
 		})

--- a/server/channels/app/import_test.go
+++ b/server/channels/app/import_test.go
@@ -157,7 +157,7 @@ func TestImportBulkImport(t *testing.T) {
 	username3 := model.NewUsername()
 	emojiName := model.NewId()
 	testsDir, _ := fileutils.FindDir("tests")
-	testImage := filepath.Join(testsDir, "test.png")
+	testImage := "test.png"
 	teamTheme1 := `{\"awayIndicator\":\"#DBBD4E\",\"buttonBg\":\"#23A1FF\",\"buttonColor\":\"#FFFFFF\",\"centerChannelBg\":\"#ffffff\",\"centerChannelColor\":\"#333333\",\"codeTheme\":\"github\",\"image\":\"/static/files/a4a388b38b32678e83823ef1b3e17766.png\",\"linkColor\":\"#2389d7\",\"mentionBg\":\"#2389d7\",\"mentionColor\":\"#ffffff\",\"mentionHighlightBg\":\"#fff2bb\",\"mentionHighlightLink\":\"#2f81b7\",\"newMessageSeparator\":\"#FF8800\",\"onlineIndicator\":\"#7DBE00\",\"sidebarBg\":\"#fafafa\",\"sidebarHeaderBg\":\"#3481B9\",\"sidebarHeaderTextColor\":\"#ffffff\",\"sidebarText\":\"#333333\",\"sidebarTextActiveBorder\":\"#378FD2\",\"sidebarTextActiveColor\":\"#111111\",\"sidebarTextHoverBg\":\"#e6f2fa\",\"sidebarUnreadText\":\"#333333\",\"type\":\"Mattermost\"}`
 	teamTheme2 := `{\"awayIndicator\":\"#DBBD4E\",\"buttonBg\":\"#23A100\",\"buttonColor\":\"#EEEEEE\",\"centerChannelBg\":\"#ffffff\",\"centerChannelColor\":\"#333333\",\"codeTheme\":\"github\",\"image\":\"/static/files/a4a388b38b32678e83823ef1b3e17766.png\",\"linkColor\":\"#2389d7\",\"mentionBg\":\"#2389d7\",\"mentionColor\":\"#ffffff\",\"mentionHighlightBg\":\"#fff2bb\",\"mentionHighlightLink\":\"#2f81b7\",\"newMessageSeparator\":\"#FF8800\",\"onlineIndicator\":\"#7DBE00\",\"sidebarBg\":\"#fafafa\",\"sidebarHeaderBg\":\"#3481B9\",\"sidebarHeaderTextColor\":\"#ffffff\",\"sidebarText\":\"#333333\",\"sidebarTextActiveBorder\":\"#378FD2\",\"sidebarTextActiveColor\":\"#222222\",\"sidebarTextHoverBg\":\"#e6f2fa\",\"sidebarUnreadText\":\"#444444\",\"type\":\"Mattermost\"}`
 
@@ -178,13 +178,13 @@ func TestImportBulkImport(t *testing.T) {
 {"type": "direct_post", "direct_post": {"channel_members": ["` + username + `", "` + username2 + `", "` + username3 + `"], "user": "` + username + `", "message": "Hello Group Channel", "create_at": 123456789015}}
 {"type": "emoji", "emoji": {"name": "` + emojiName + `", "image": "` + testImage + `"}}`
 
-	line, err := th.App.BulkImport(th.Context, strings.NewReader(data1), nil, false, 2)
+	line, err := th.App.BulkImportWithPath(th.Context, strings.NewReader(data1), nil, false, false, 2, testsDir)
 	require.Nil(t, err, "BulkImport should have succeeded")
 	require.Equal(t, 0, line, "BulkImport line should be 0")
 
 	// Run bulk import using a string that contains a line with invalid json.
 	data2 := `{"type": "version", "version": 1`
-	line, err = th.App.BulkImport(th.Context, strings.NewReader(data2), nil, false, 2)
+	line, err = th.App.BulkImportWithPath(th.Context, strings.NewReader(data2), nil, false, false, 2, testsDir)
 	require.NotNil(t, err, "Should have failed due to invalid JSON on line 1.")
 	require.Equal(t, 1, line, "Should have failed due to invalid JSON on line 1.")
 
@@ -193,7 +193,7 @@ func TestImportBulkImport(t *testing.T) {
 {"type": "channel", "channel": {"type": "O", "display_name": "xr6m6udffngark2uekvr3hoeny", "team": "` + teamName + `", "name": "` + channelName + `"}}
 {"type": "user", "user": {"username": "kufjgnkxkrhhfgbrip6qxkfsaa", "email": "kufjgnkxkrhhfgbrip6qxkfsaa@example.com"}}
 {"type": "user", "user": {"username": "bwshaim6qnc2ne7oqkd5b2s2rq", "email": "bwshaim6qnc2ne7oqkd5b2s2rq@example.com", "teams": [{"name": "` + teamName + `", "channels": [{"name": "` + channelName + `"}]}]}}`
-	line, err = th.App.BulkImport(th.Context, strings.NewReader(data3), nil, false, 2)
+	line, err = th.App.BulkImportWithPath(th.Context, strings.NewReader(data3), nil, false, false, 2, testsDir)
 	require.NotNil(t, err, "Should have failed due to missing version line on line 1.")
 	require.Equal(t, 1, line, "Should have failed due to missing version line on line 1.")
 

--- a/server/channels/app/imports/import_validators.go
+++ b/server/channels/app/imports/import_validators.go
@@ -784,10 +784,9 @@ func ValidateAttachmentPathForImport(path, basePath string) (string, bool) {
 	}
 
 	joined := filepath.Join(basePath, path)
-	cleanJoined := filepath.Clean(joined)
 
-	// Check if cleanJoined is within basePath
-	rel, err := filepath.Rel(basePath, cleanJoined)
+	// Check if the resolved joined path is within basePath
+	rel, err := filepath.Rel(basePath, joined)
 	if err != nil {
 		return "", false
 	}
@@ -795,7 +794,7 @@ func ValidateAttachmentPathForImport(path, basePath string) (string, bool) {
 		return "", false
 	}
 
-	return cleanJoined, true
+	return joined, true
 }
 
 func ValidateAttachmentImportData(data *AttachmentImportData) *model.AppError {

--- a/server/channels/app/imports/import_validators.go
+++ b/server/channels/app/imports/import_validators.go
@@ -192,6 +192,10 @@ func ValidateChannelImportData(data *ChannelImportData) *model.AppError {
 
 func ValidateUserImportData(data *UserImportData) *model.AppError {
 	if data.ProfileImage != nil && data.ProfileImageData == nil {
+		// Check if the resolved path is within the expected base path.
+		if _, valid := ValidateAttachmentPathForImport(*data.ProfileImage, model.ExportDataDir); !valid {
+			return model.NewAppError("BulkImport", "app.import.validate_user_import_data.invalid_image_path.error", map[string]any{"Path": *data.ProfileImage}, "", http.StatusBadRequest)
+		}
 		if _, err := os.Stat(*data.ProfileImage); os.IsNotExist(err) {
 			return model.NewAppError("BulkImport", "app.import.validate_user_import_data.profile_image.error", nil, "", http.StatusNotFound).Wrap(err)
 		} else if err != nil {
@@ -321,6 +325,11 @@ func ValidateUserImportData(data *UserImportData) *model.AppError {
 
 func ValidateBotImportData(data *BotImportData) *model.AppError {
 	if data.ProfileImage != nil && data.ProfileImageData == nil {
+		// Check if the resolved path is within the expected base path.
+		if _, valid := ValidateAttachmentPathForImport(*data.ProfileImage, model.ExportDataDir); !valid {
+			return model.NewAppError("BulkImport", "app.import.validate_user_import_data.invalid_image_path.error", map[string]any{"Path": *data.ProfileImage}, "", http.StatusBadRequest)
+		}
+
 		if _, err := os.Stat(*data.ProfileImage); os.IsNotExist(err) {
 			return model.NewAppError("BulkImport", "app.import.validate_user_import_data.profile_image.error", nil, "", http.StatusNotFound).Wrap(err)
 		} else if err != nil {
@@ -694,6 +703,11 @@ func ValidateEmojiImportData(data *EmojiImportData) *model.AppError {
 
 	if data.Image == nil || *data.Image == "" {
 		return model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.image_missing.error", nil, "", http.StatusBadRequest)
+	}
+
+	// Check if the resolved path is within the expected base path.
+	if _, valid := ValidateAttachmentPathForImport(*data.Image, model.ExportDataDir); !valid {
+		return model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.invalid_image_path.error", map[string]any{"Path": *data.Image}, "", http.StatusBadRequest)
 	}
 
 	if err := model.IsValidEmojiName(*data.Name); err != nil {

--- a/server/channels/app/imports/import_validators_test.go
+++ b/server/channels/app/imports/import_validators_test.go
@@ -499,6 +499,12 @@ func TestImportValidateUserImportData(t *testing.T) {
 	err = ValidateUserImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to not existing profile image file.")
 
+	// Invalid image path
+	data.ProfileImage = model.NewPointer("../invalid/path/file.jpg")
+	err = ValidateUserImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to invalid profile image file path.")
+	require.Equal(t, "app.import.validate_user_import_data.invalid_image_path.error", err.Id)
+
 	data.ProfileImage = nil
 
 	// Invalid Emails
@@ -731,6 +737,12 @@ func TestImportValidateBotImportData(t *testing.T) {
 	data.Owner = model.NewPointer(strings.Repeat("abcdefghij", 7))
 	err = ValidateBotImportData(&data)
 	require.NotNil(t, err, "Should have failed due to too long OwnerID.")
+
+	// Invalid profile image path
+	data.ProfileImage = model.NewPointer("../invalid/path/file.jpg")
+	err = ValidateBotImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid profile image file path.")
+	require.Equal(t, "app.import.validate_user_import_data.invalid_image_path.error", err.Id)
 }
 
 func TestImportValidateUserTeamsImportData(t *testing.T) {
@@ -1508,6 +1520,7 @@ func TestImportValidateEmojiImportData(t *testing.T) {
 		{"nil name", nil, model.NewPointer("/path/to/image"), true, false},
 		{"nil image", model.NewPointer("parrot2"), nil, true, false},
 		{"nil name and image", nil, nil, true, false},
+		{"invalid image path", model.NewPointer("parrot2"), model.NewPointer("../invalid/path/to/emoji.png"), true, false},
 	}
 
 	for _, tc := range testCases {

--- a/server/cmd/mmctl/commands/import_test.go
+++ b/server/cmd/mmctl/commands/import_test.go
@@ -475,4 +475,64 @@ func (s *MmctlUnitTestSuite) TestImportValidateCmdF() {
 		s.Require().Empty(res.Errors)
 		s.Equal("Validation complete\n", printer.GetLines()[2])
 	})
+
+	s.Run("invalid file attachment path", func() {
+		file, err := os.Create(importFilePath)
+		s.Require().NoError(err)
+
+		zipWr := zip.NewWriter(file)
+		wr, err := zipWr.Create("import.jsonl")
+		s.Require().NoError(err)
+
+		_, err = wr.Write([]byte(importBase))
+		s.Require().NoError(err)
+
+		_, err = wr.Write([]byte(`
+{"type":"post","post":{"team":"ad-1","channel":"iusto-9","user":"ashley.berry","message":"message","props":{},"create_at":1603398068740,"reactions":null,"replies":null,"attachments":[{"path": "data/../../invalid.jpg"}]}}`))
+		s.Require().NoError(err)
+
+		err = zipWr.Close()
+		s.Require().NoError(err)
+
+		err = file.Close()
+		s.Require().NoError(err)
+
+		printer.Clean()
+
+		s.client.
+			EXPECT().
+			GetUsers(context.TODO(), 0, 200, "").
+			Return(nil, &model.Response{}, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetAllTeams(context.TODO(), "", 0, 200).
+			Return(nil, &model.Response{}, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetOldClientConfig(context.TODO(), "").
+			Return(map[string]string{
+				"MaxPostSize": fmt.Sprintf("%d", model.PostMessageMaxRunesV2*2),
+			}, &model.Response{}, nil).
+			Times(1)
+
+		err = importValidateCmdF(s.client, ImportValidateCmd, []string{importFilePath})
+		s.Require().Nil(err)
+
+		s.Empty(printer.GetErrorLines())
+		s.Equal(Statistics{
+			Teams:          2,
+			Channels:       1,
+			DirectChannels: 1,
+			Users:          1,
+			Posts:          1,
+		}, printer.GetLines()[0].(Statistics))
+		res := printer.GetLines()[1].(ImportValidationResult)
+		s.Require().Len(res.Errors, 2)
+		s.Require().Equal("app.import.validate_post_import_data.attachment.error", res.Errors[0].Err.(*model.AppError).Id)
+		s.Equal("Validation complete\n", printer.GetLines()[2])
+	})
 }

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -5615,6 +5615,10 @@
     "translation": "Failed to read profile image data."
   },
   {
+    "id": "app.import.validate_attachment_import_data.invalid_path.error",
+    "translation": "Failed to validate attachment import data. Invalid path: \"{{.Path}}\""
+  },
+  {
     "id": "app.import.validate_bot_import_data.owner_missing.error",
     "translation": "Bot owner is missing"
   },
@@ -5679,6 +5683,10 @@
     "translation": "Direct channel can only be favorited by members. \"{{.Username}}\" is not a member."
   },
   {
+    "id": "app.import.validate_direct_post_import_data.attachment.error",
+    "translation": "Failed to validate direct post attachment data."
+  },
+  {
     "id": "app.import.validate_direct_post_import_data.channel_members_required.error",
     "translation": "Missing required direct post property: channel_members"
   },
@@ -5725,6 +5733,10 @@
   {
     "id": "app.import.validate_emoji_import_data.name_missing.error",
     "translation": "Import emoji name field missing or blank."
+  },
+  {
+    "id": "app.import.validate_post_import_data.attachment.error",
+    "translation": "Failed to validate post attachment data."
   },
   {
     "id": "app.import.validate_post_import_data.channel_missing.error",
@@ -5781,6 +5793,10 @@
   {
     "id": "app.import.validate_reaction_import_data.user_missing.error",
     "translation": "Missing required Reaction property: User."
+  },
+  {
+    "id": "app.import.validate_reply_import_data.attachment.error",
+    "translation": "Failed to validate reply attachment data."
   },
   {
     "id": "app.import.validate_reply_import_data.create_at_missing.error",

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -5731,6 +5731,10 @@
     "translation": "Import emoji image field missing or blank."
   },
   {
+    "id": "app.import.validate_emoji_import_data.invalid_image_path.error",
+    "translation": "Import emoji image field has an invalid path: \"{{.Path}}\""
+  },
+  {
     "id": "app.import.validate_emoji_import_data.name_missing.error",
     "translation": "Import emoji name field missing or blank."
   },
@@ -5961,6 +5965,10 @@
   {
     "id": "app.import.validate_user_import_data.guest_roles_conflict.error",
     "translation": "User roles are not consistent with guest status."
+  },
+  {
+    "id": "app.import.validate_user_import_data.invalid_image_path.error",
+    "translation": "User profile image path is invalid: \"{{.Path}}\""
   },
   {
     "id": "app.import.validate_user_import_data.last_name_length.error",


### PR DESCRIPTION
#### Summary

PR implements some extra validation on the paths used to import file attachments.

We implement a `ValidateAttachmentImportData` util function called by validators on parent structures (namely `PostImportData`, `ReplyImportData`, and `DirectPostImportData`), which returns an error during initial validation in case of invalid paths. At the same time, we add some additional protection to `processAttachmentPaths`, which is called as part of the bulk import logic.

One thing I am omitting for now is any validation on the base path used, noticing that [we default](https://github.com/mattermost/mattermost/blob/62bd9d917d3906a02a2b670254fbfb4bc672a2ca/server/channels/jobs/import_process/worker.go#L128) to the `model.ExportDataDir` constant when running import jobs.

Changes should be fully backward compatible. We are planning some manual QA to ensure that functionality has remained the same.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-64402

#### Release Note

```release-note
NONE
```
