### PR TITLE
MM-64438: skip flaky: testGetNthRecentPostTime

### DIFF
--- a/server/channels/store/storetest/post_store.go
+++ b/server/channels/store/storetest/post_store.go
@@ -5279,6 +5279,8 @@ func getPostIds(posts []*model.Post, morePosts ...*model.Post) []string {
 }
 
 func testGetNthRecentPostTime(t *testing.T, rctx request.CTX, ss store.Store) {
+	t.Skip("https://mattermost.atlassian.net/browse/MM-64438")
+
 	_, err := ss.Post().GetNthRecentPostTime(0)
 	assert.Error(t, err)
 	_, err = ss.Post().GetNthRecentPostTime(-1)


### PR DESCRIPTION
#### Summary
As of https://github.com/mattermost/mattermost/pull/30735, `GetNthRecentPostTime` is flaky:

![image](https://github.com/user-attachments/assets/ae1b2add-a01c-40c7-892a-4f3afd074c67)

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-64438

#### Release Note
```release-note
NONE
```
