### PR TITLE
[MM-64437] Hotfix on attribute view creation error

### DIFF
--- a/server/channels/db/migrations/postgres/000136_create_attribute_view.up.sql
+++ b/server/channels/db/migrations/postgres/000136_create_attribute_view.up.sql
@@ -17,7 +17,7 @@ BEGIN
                     WHERE options.id = pv.Value #>> ''{}''
                     LIMIT 1
                 )
-                WHEN pf.Type = ''multiselect'' THEN (
+                WHEN pf.Type = ''multiselect'' AND jsonb_typeof(pv.Value) = ''array'' THEN (
                     SELECT jsonb_agg(option_names.name)
                     FROM jsonb_array_elements_text(pv.Value) AS option_id
                     JOIN jsonb_to_recordset(pf.Attrs->''options'') AS option_names(id text, name text)
@@ -27,7 +27,7 @@ BEGIN
             END
         ) AS Attributes    FROM PropertyValues pv
     LEFT JOIN PropertyFields pf ON pf.ID = pv.FieldID
-    WHERE pv.DeleteAt = 0 OR pv.DeleteAt IS NULL
+    WHERE (pv.DeleteAt = 0 OR pv.DeleteAt IS NULL) AND (pf.DeleteAt = 0 OR pf.DeleteAt IS NULL)
     GROUP BY pv.GroupID, pv.TargetID, pv.TargetType
         ';
 END;


### PR DESCRIPTION


#### Summary
Kind of edge case but we are strengthening the view query to ensure `multiselect` values should be arrays all the time. This was discovered while trying to update a QA test server and the possible sequence happened in this order:

- Create text type field and crate a CPA 
- Convert field to `multiselect`
- Try to create or refresh attribute view

Since we are here, we should also filter out deleted property fields.

Note: Ideally we should never touch migration files after merged. But I think we can do that becasue:
- It's not a schema change, a refinement on existing query
- It's not released yet
- It can cause issues while trying to update

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64437

#### Screenshots
<img width="1040" alt="image" src="https://github.com/user-attachments/assets/ab2ca2c7-7a98-4297-8eb9-c03675220bf9" />

On the screenshot 2 values sharing the same fieldID but the value types are different. That was the root cause.

#### Release Note

```release-note
NONE
```
