### PR TITLE
MM-62158: Final migration for GetMemberUsersNotInChannel and GetMemberUsersInTeam

### DIFF
--- a/server/channels/store/sqlstore/group_store.go
+++ b/server/channels/store/sqlstore/group_store.go
@@ -614,32 +614,34 @@ func (s *SqlGroupStore) GetMemberUsersInTeam(groupID string, teamID string) ([]*
 func (s *SqlGroupStore) GetMemberUsersNotInChannel(groupID string, channelID string) ([]*model.User, error) {
 	groupMembers := []*model.User{}
 
-	query := `
-		SELECT
-			Users.*
-		FROM
-			GroupMembers
-			JOIN Users ON Users.Id = GroupMembers.UserId
-		WHERE
-			GroupId = ?
-			AND GroupMembers.UserId NOT IN (
-				SELECT ChannelMembers.UserId
-				FROM ChannelMembers
-				WHERE ChannelMembers.ChannelId = ?
-			)
-			AND GroupMembers.UserId IN (
-				SELECT TeamMembers.UserId
-				FROM TeamMembers
-				JOIN Channels ON Channels.Id = ?
-				JOIN Teams ON Teams.Id = Channels.TeamId
-				WHERE TeamMembers.TeamId = Teams.Id
-				AND TeamMembers.DeleteAt = 0
-			)
-			AND GroupMembers.DeleteAt = 0
-			AND Users.DeleteAt = 0
-		`
+	query := s.groupMemberUsersSelectQuery.
+		Where(sq.Eq{
+			"GroupMembers.GroupId": groupID,
+		}).
+		Where(sq.NotEq{
+			"GroupMembers.UserId": s.getQueryBuilder().
+				Select("ChannelMembers.UserId").
+				From("ChannelMembers").
+				Where(sq.Eq{
+					"ChannelMembers.ChannelId": channelID,
+				}),
+		}).
+		Where(sq.Eq{
+			"GroupMembers.UserId": s.getQueryBuilder().
+				Select("TeamMembers.UserId").
+				From("Channels").
+				Join("TeamMembers ON TeamMembers.TeamId = Channels.TeamId").
+				Where(sq.Eq{
+					"Channels.Id":          channelID,
+					"TeamMembers.DeleteAt": 0,
+				}),
+		}).
+		Where(sq.Eq{
+			"GroupMembers.DeleteAt": 0,
+			"Users.DeleteAt":        0,
+		})
 
-	if err := s.GetReplica().Select(&groupMembers, query, groupID, channelID, channelID); err != nil {
+	if err := s.GetReplica().SelectBuilder(&groupMembers, query); err != nil {
 		return nil, errors.Wrapf(err, "failed to member Users for groupId=%s and channelId!=%s", groupID, channelID)
 	}
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/mattermost/mattermost/server/public v0.1.12
 	github.com/mattermost/morph v1.1.0
 	github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0
-	github.com/mattermost/squirrel v0.4.0
+	github.com/mattermost/squirrel v0.5.0
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/minio/minio-go/v7 v7.0.91

--- a/server/go.sum
+++ b/server/go.sum
@@ -382,8 +382,8 @@ github.com/mattermost/morph v1.1.0 h1:Q9vrJbeM3s2jfweGheq12EFIzdNp9a/6IovcbvOQ6C
 github.com/mattermost/morph v1.1.0/go.mod h1:gD+EaqX2UMyyuzmF4PFh4r33XneQ8Nzi+0E8nXjMa3A=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0 h1:G9tL6JXRBMzjuD1kkBtcnd42kUiT6QDwxfFYu7adM6o=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
-github.com/mattermost/squirrel v0.4.0 h1:azf9LZ+8JUTAvwt/njB1utkPqWQ6e7Rje2ya5N0P2i4=
-github.com/mattermost/squirrel v0.4.0/go.mod h1:NPPtk+CdpWre4GxMGoOpzEVFVc0ZoEFyJBZGCtn9nSU=
+github.com/mattermost/squirrel v0.5.0 h1:81QPS0aA+inQbpA7Pzmv6O9sWwB6VaBh/VYw3oJf8ZY=
+github.com/mattermost/squirrel v0.5.0/go.mod h1:NPPtk+CdpWre4GxMGoOpzEVFVc0ZoEFyJBZGCtn9nSU=
 github.com/mattermost/xml-roundtrip-validator v0.1.0 h1:RXbVD2UAl7A7nOTR4u7E3ILa4IbtvKBHw64LDsmu9hU=
 github.com/mattermost/xml-roundtrip-validator v0.1.0/go.mod h1:qccnGMcpgwcNaBnxqpJpWWUiPNr5H3O8eDgGV9gT5To=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=


### PR DESCRIPTION
#### Summary
Completed the final migrations for MM-62158 to avoid SELECT * queries in group_store.go:
- Migrated `GetMemberUsersNotInChannel` to specify explicit columns
- Migrated `GetMemberUsersInTeam` to specify explicit columns  
- Upgraded mattermost/squirrel dependency

This completes the work to eliminate SELECT * queries from group_store.go, improving database performance and query specificity.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-62158

#### Screenshots
N/A - Backend database optimization only

```release-note
NONE
```