### PR TITLE
Disable `-race` mode when running fully parallel tests

### DIFF
--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -59,7 +59,7 @@ jobs:
         env:
           BUILD_IMAGE: mattermostdevelopment/mattermost-build-server:${{ steps.go.outputs.GO_VERSION }}
         run: |
-          if [[ ${{ github.ref_name }} == 'master' ]]; then
+          if [[ ${{ github.ref_name }} == 'master' && ${{ inputs.fullyparallel }} != true ]]; then
             export RACE_MODE="-race"
           fi
           docker run --net ghactions_mm-test \


### PR DESCRIPTION
#### Summary

We are not quite ready yet to use `-race` when running the suite through full parallelism. These are the results for the latest run on `master`:

```
2025-05-30T12:38:17.5785836Z DONE 2 runs, 15732 tests, 59 skipped, 14 failures in 2078.385s
```

https://github.com/mattermost/mattermost/actions/runs/15346258508/job/43183233772

We disable it for now since we are mainly interested in generating coverage, plus we already run with `-race` in the existing jobs (Postgres and MySQL).

#### Release Note

```release-note
NONE
```
