### PR TITLE
avoid SELECT * in channel_store_categories.go

### DIFF
--- a/server/channels/store/sqlstore/channel_store_categories.go
+++ b/server/channels/store/sqlstore/channel_store_categories.go
@@ -16,12 +16,6 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 )
 
-// dbSelecter is an interface used to enable some internal store methods
-// using both transaction and normal queries.
-type dbSelecter interface {
-	Select(i any, query string, args ...any) error
-}
-
 func (s SqlChannelStore) CreateInitialSidebarCategories(c request.CTX, userId string, opts *store.SidebarCategorySearchOpts) (_ *model.OrderedSidebarCategories, err error) {
 	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
@@ -420,7 +414,7 @@ func (s SqlChannelStore) CreateSidebarCategory(userId, teamId string, newCategor
 	return result, nil
 }
 
-func (s SqlChannelStore) completePopulatingCategoryChannelsT(db dbSelecter, category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error) {
+func (s SqlChannelStore) completePopulatingCategoryChannelsT(db sqlxExecutor, category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error) {
 	if category.Type == model.SidebarCategoryCustom || category.Type == model.SidebarCategoryFavorites {
 		return category, nil
 	}
@@ -501,7 +495,7 @@ func (s SqlChannelStore) GetSidebarCategory(categoryId string) (*model.SidebarCa
 	return s.getSidebarCategoryT(s.GetReplica(), categoryId)
 }
 
-func (s SqlChannelStore) getSidebarCategoryT(db dbSelecter, categoryId string) (*model.SidebarCategoryWithChannels, error) {
+func (s SqlChannelStore) getSidebarCategoryT(db sqlxExecutor, categoryId string) (*model.SidebarCategoryWithChannels, error) {
 	query := s.sidebarCategorySelectQuery.
 		Columns("SidebarChannels.ChannelId").
 		LeftJoin("SidebarChannels ON SidebarChannels.CategoryId=SidebarCategories.Id").
@@ -534,7 +528,7 @@ func (s SqlChannelStore) getSidebarCategoryT(db dbSelecter, categoryId string) (
 	return s.completePopulatingCategoryChannelsT(db, result)
 }
 
-func (s SqlChannelStore) getSidebarCategoriesT(db dbSelecter, userId string, opts *store.SidebarCategorySearchOpts) (*model.OrderedSidebarCategories, error) {
+func (s SqlChannelStore) getSidebarCategoriesT(db sqlxExecutor, userId string, opts *store.SidebarCategorySearchOpts) (*model.OrderedSidebarCategories, error) {
 	oc := model.OrderedSidebarCategories{
 		Categories: make(model.SidebarCategoriesWithChannels, 0),
 		Order:      make([]string, 0),
@@ -620,23 +614,19 @@ func (s SqlChannelStore) GetSidebarCategoryOrder(userId, teamId string) ([]strin
 	return s.getSidebarCategoryOrderT(s.GetReplica(), userId, teamId)
 }
 
-func (s SqlChannelStore) getSidebarCategoryOrderT(db dbSelecter, userId, teamId string) ([]string, error) {
+func (s SqlChannelStore) getSidebarCategoryOrderT(db sqlxExecutor, userId, teamId string) ([]string, error) {
 	ids := []string{}
 
-	sql, args, err := s.getQueryBuilder().
+	query := s.getQueryBuilder().
 		Select("Id").
 		From("SidebarCategories").
 		Where(sq.And{
 			sq.Eq{"UserId": userId},
 			sq.Eq{"TeamId": teamId},
 		}).
-		OrderBy("SidebarCategories.SortOrder ASC").ToSql()
+		OrderBy("SidebarCategories.SortOrder ASC")
 
-	if err != nil {
-		return nil, errors.Wrap(err, "sidebar_category_tosql")
-	}
-
-	if err := db.Select(&ids, sql, args...); err != nil {
+	if err := db.SelectBuilder(&ids, query); err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("failed to get category order for userId=%s, teamId=%s", userId, teamId))
 	}
 
@@ -1129,7 +1119,8 @@ func (s SqlChannelStore) DeleteSidebarCategory(categoryId string) (err error) {
 
 	// Ensure that we're deleting a custom category
 	var category model.SidebarCategory
-	if err = transaction.Get(&category, "SELECT * FROM SidebarCategories WHERE Id = ?", categoryId); err != nil {
+	query := s.sidebarCategorySelectQuery.Where(sq.Eq{"Id": categoryId})
+	if err = transaction.GetBuilder(&category, query); err != nil {
 		return errors.Wrapf(err, "failed to find SidebarCategories with id=%s", categoryId)
 	}
 
@@ -1143,24 +1134,18 @@ func (s SqlChannelStore) DeleteSidebarCategory(categoryId string) (err error) {
 	// operating on the tables in reverse order.
 
 	// Delete the category itself
-	query, args, err := s.getQueryBuilder().
+	deleteCategoryQuery := s.getQueryBuilder().
 		Delete("SidebarCategories").
-		Where(sq.Eq{"Id": categoryId}).ToSql()
-	if err != nil {
-		return errors.Wrap(err, "delete_sidebar_category_tosql")
-	}
-	if _, err = transaction.Exec(query, args...); err != nil {
+		Where(sq.Eq{"Id": categoryId})
+	if _, err = transaction.ExecBuilder(deleteCategoryQuery); err != nil {
 		return errors.Wrap(err, "failed to delete SidebarCategory")
 	}
 
 	// Delete the channels in the category
-	query, args, err = s.getQueryBuilder().
+	deleteCategoryChannelsQuery := s.getQueryBuilder().
 		Delete("SidebarChannels").
-		Where(sq.Eq{"CategoryId": categoryId}).ToSql()
-	if err != nil {
-		return errors.Wrap(err, "delete_sidebar_category_tosql")
-	}
-	if _, err = transaction.Exec(query, args...); err != nil {
+		Where(sq.Eq{"CategoryId": categoryId})
+	if _, err = transaction.ExecBuilder(deleteCategoryChannelsQuery); err != nil {
 		return errors.Wrap(err, "failed to delete SidebarChannel")
 	}
 
@@ -1177,7 +1162,6 @@ func (s SqlChannelStore) DeleteAllSidebarChannelForChannel(channelID string) err
 		Where(sq.Eq{
 			"ChannelId": channelID,
 		}).ToSql()
-
 	if err != nil {
 		return errors.Wrap(err, "delete_all_sidebar_channel_for_channel_to_sql")
 	}


### PR DESCRIPTION
#### Summary
Avoid `SELECT *` in `channel_store_categories.go`. While we're in here, adopt the `*Builder` pattern a bit more aggressively to clean up some ancillary code.

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-62110

#### Release Note
```release-note
NONE
```
