### PR TITLE
[MM-64288] Enable Attribte Based Access Control FF by default

### DIFF
--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -83,7 +83,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.NotificationMonitoring = true
 	f.ExperimentalAuditSettingsSystemConsoleUI = false
 	f.CustomProfileAttributes = true
-	f.AttributeBasedAccessControl = false
+	f.AttributeBasedAccessControl = true
 }
 
 // ToMap returns the feature flags as a map[string]string


### PR DESCRIPTION
#### Summary
Enables Attribte Based Access Control Feature Flag by default.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64288

#### Release Note

```release-note
Attribute-Based Access: Define policies that automatically grant channel memberships based on user attributes. Membership updates happen automatically when user attributes change — no need for manual role adjustments.
Policy Management UI & API: Easily create and manage attribute-based rules via an admin interface.
```
