### PR TITLE
Consistent use of uppercase LDAP tag

### DIFF
--- a/api/v4/source/ldap.yaml
+++ b/api/v4/source/ldap.yaml
@@ -47,7 +47,7 @@
   /api/v4/ldap/groups:
     get:
       tags:
-        - ldap
+        - LDAP
       summary: Returns a list of LDAP groups
       description: >
         ##### Permissions
@@ -94,7 +94,7 @@
   /api/v4/ldap/groups/{remote_id}/link:
     post:
       tags:
-        - ldap
+        - LDAP
       summary: Link a LDAP group
       description: >
         ##### Permissions


### PR DESCRIPTION
#### Summary

The tag `LDAP` is inconsistently used in upper-case and lower-case styles.
This PR corrects the lower-case occurrences to upper-case.