### PR TITLE
[MM-62983] Add aria-live region for updating the file preview modal carousel position

### DIFF
--- a/webapp/channels/src/components/file_preview_modal/file_preview_modal_main_nav/__snapshots__/file_preview_modal_main_nav.test.tsx.snap
+++ b/webapp/channels/src/components/file_preview_modal/file_preview_modal_main_nav/__snapshots__/file_preview_modal_main_nav.test.tsx.snap
@@ -24,6 +24,8 @@ exports[`components/file_preview_modal/file_preview_modal_main_nav/FilePreviewMo
     </button>
   </WithTooltip>
   <span
+    aria-atomic="true"
+    aria-live="polite"
     className="modal-bar-file-count"
   >
     <MemoizedFormattedMessage

--- a/webapp/channels/src/components/file_preview_modal/file_preview_modal_main_nav/file_preview_modal_main_nav.tsx
+++ b/webapp/channels/src/components/file_preview_modal/file_preview_modal_main_nav/file_preview_modal_main_nav.tsx
@@ -58,7 +58,11 @@ const FilePreviewModalMainNav: React.FC<Props> = (props: Props) => {
     return (
         <div className='file_preview_modal_main_nav'>
             {leftArrow}
-            <span className='modal-bar-file-count'>
+            <span
+                className='modal-bar-file-count'
+                aria-live='polite'
+                aria-atomic='true'
+            >
                 <FormattedMessage
                     id='file_preview_modal_main_nav.file'
                     defaultMessage='{count, number} of {total, number}'


### PR DESCRIPTION
#### Summary
The file preview modal gave no indication to screen reader users when they moved to the next position in the carousel, this PR adds an aria-live region to read out the position when it changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62983

```release-note
Add aria-live region for updating the file preview modal carousel position
```
