### PR TITLE
Fix: exclude deactivated users from mention autocomplete

### DIFF
--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -2831,6 +2831,122 @@ func TestUpdateUserActive(t *testing.T) {
 		})
 	})
 
+	t.Run("search index behavior on user deactivation", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		user := th.BasicUser2
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.EnableUserDeactivation = true })
+
+		// Verify user is initially active
+		activeUser, appErr := th.App.GetUser(user.Id)
+		require.Nil(t, appErr)
+		require.Equal(t, int64(0), activeUser.DeleteAt, "user should be active initially")
+
+		// Deactivate user
+		_, err := th.SystemAdminClient.UpdateUserActive(context.Background(), user.Id, false)
+		require.NoError(t, err)
+
+		// Verify user is now deactivated
+		deactivatedUser, appErr := th.App.GetUser(user.Id)
+		require.Nil(t, appErr)
+		require.NotEqual(t, int64(0), deactivatedUser.DeleteAt, "user should be deactivated")
+
+		// Reactivate user
+		_, err = th.SystemAdminClient.UpdateUserActive(context.Background(), user.Id, true)
+		require.NoError(t, err)
+
+		// Verify user is active again
+		reactivatedUser, appErr := th.App.GetUser(user.Id)
+		require.Nil(t, appErr)
+		require.Equal(t, int64(0), reactivatedUser.DeleteAt, "user should be active again")
+	})
+
+	t.Run("mention autocomplete excludes deactivated users", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		user := th.BasicUser2
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.EnableUserDeactivation = true })
+
+		// Add user to channel
+		th.LinkUserToTeam(user, th.BasicTeam)
+		th.AddUserToChannel(user, th.BasicChannel)
+
+		// Before user deactivation: verify user appears in autocomplete
+		rusers, _, err := th.Client.AutocompleteUsersInChannel(
+			context.Background(),
+			th.BasicTeam.Id,
+			th.BasicChannel.Id,
+			user.Username[:3], // Search using first 3 characters of username
+			model.UserSearchDefaultLimit,
+			"",
+		)
+		require.NoError(t, err)
+
+		// Before deactivation: verify user is included in results
+		found := false
+		for _, u := range rusers.Users {
+			if u.Id == user.Id {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "active user should appear in autocomplete results")
+
+		// Deactivate user
+		_, err = th.SystemAdminClient.UpdateUserActive(context.Background(), user.Id, false)
+		require.NoError(t, err)
+
+		// After deactivation: verify user does not appear in autocomplete
+		rusers, _, err = th.Client.AutocompleteUsersInChannel(
+			context.Background(),
+			th.BasicTeam.Id,
+			th.BasicChannel.Id,
+			user.Username[:3],
+			model.UserSearchDefaultLimit,
+			"",
+		)
+		require.NoError(t, err)
+
+		// After deactivation: verify user is not included in results
+		found = false
+		for _, u := range rusers.Users {
+			if u.Id == user.Id {
+				found = true
+				break
+			}
+		}
+		require.False(t, found, "deactivated user should not appear in autocomplete results")
+
+		// Reactivate user
+		_, err = th.SystemAdminClient.UpdateUserActive(context.Background(), user.Id, true)
+		require.NoError(t, err)
+
+		// After reactivation: verify user appears in autocomplete again
+		rusers, _, err = th.Client.AutocompleteUsersInChannel(
+			context.Background(),
+			th.BasicTeam.Id,
+			th.BasicChannel.Id,
+			user.Username[:3],
+			model.UserSearchDefaultLimit,
+			"",
+		)
+		require.NoError(t, err)
+
+		// After reactivation: verify user is included in results
+		found = false
+		for _, u := range rusers.Users {
+			if u.Id == user.Id {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "reactivated user should appear in autocomplete results again")
+	})
+
 	t.Run("websocket events", func(t *testing.T) {
 		mainHelper.Parallel(t)
 		th := Setup(t).InitBasic()

--- a/server/channels/store/searchlayer/layer.go
+++ b/server/channels/store/searchlayer/layer.go
@@ -76,6 +76,11 @@ func (s *SearchStore) indexUserFromID(rctx request.CTX, userId string) {
 }
 
 func (s *SearchStore) indexUser(rctx request.CTX, user *model.User) {
+	if user.DeleteAt != 0 {
+		s.user.deleteUserIndex(rctx, user)
+		return
+	}
+
 	for _, engine := range s.searchEngine.GetActiveEngines() {
 		if engine.IsIndexingEnabled() {
 			runIndexFn(rctx, engine, func(engineCopy searchengine.SearchEngineInterface) {


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

This pull request fixes an issue where deactivated users were still appearing in mention autocomplete suggestions. The fix ensures that when a user is deactivated (DeleteAt != 0), they are removed from the Bleve search index, preventing them from showing up in @mention autocomplete results.


#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

https://github.com/mattermost/mattermost/issues/31289

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

**Prepare:**
1. Choose an existing active user(brian.kelly) and verify they appear in mention autocomplete
2. Deactivate User A through System Console or API

**Before:**
User(brian.kelly) appears in @mention autocomplete suggestions even after being deactivated
<img width="385" alt="スクリーンショット 2025-06-05 15 10 37" src="https://github.com/user-attachments/assets/3e76ce9e-5548-4706-8057-9b0e6489bc72" />


**After:**
User(brian.kelly) no longer appears in @mention autocomplete suggestions once deactivated
<img width="472" alt="スクリーンショット 2025-06-04 11 52 37" src="https://github.com/user-attachments/assets/d87b9028-2c0b-445f-ba6a-7ba3561eb4b5" />

|  Before (Bug)  |  After (Fixed)  |
|----|----| 
| Deactivated users appear in autocomplete | Deactivated users are excluded from autocomplete |

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Fixed an issue where deactivated users were still appearing in mention autocomplete suggestions.
```
