### PR TITLE
[MM-62409] Fix webapp coverage upload for master runs

### DIFF
--- a/.github/workflows/webapp-ci-master.yml
+++ b/.github/workflows/webapp-ci-master.yml
@@ -8,3 +8,4 @@ on:
 jobs:
   master-ci:
     uses: ./.github/workflows/webapp-ci-template.yml
+    secrets: inherit


### PR DESCRIPTION
#### Summary

Small follow-up on https://github.com/mattermost/mattermost/pull/31144. We need to forward the secrets to the template or the upload step (below) will fail, missing the token.

https://github.com/mattermost/mattermost/blob/f3d20cfc1514d22b4da16e6e6a707e3795a85d45/.github/workflows/webapp-ci-template.yml#L81-L83

![image](https://github.com/user-attachments/assets/7fe8e925-36ea-4fbe-ae16-f372ffe3692b)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-62409

#### Release Note

```release-note
NONE
```

