### PR TITLE
enforce License.IsSeatCountEnforced if set

### DIFF
--- a/server/channels/app/limits.go
+++ b/server/channels/app/limits.go
@@ -6,8 +6,6 @@ package app
 import (
 	"net/http"
 
-	"github.com/mattermost/mattermost/server/public/shared/mlog"
-
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
@@ -17,36 +15,37 @@ const (
 )
 
 func (a *App) GetServerLimits() (*model.ServerLimits, *model.AppError) {
-	var limits = &model.ServerLimits{}
+	limits := &model.ServerLimits{}
+	license := a.License()
 
-	if a.shouldShowUserLimits() {
-		activeUserCount, appErr := a.Srv().Store().User().Count(model.UserCountOptions{})
-		if appErr != nil {
-			mlog.Error("Failed to get active user count from database", mlog.String("error", appErr.Error()))
-			return nil, model.NewAppError("GetServerLimits", "app.limits.get_app_limits.user_count.store_error", nil, "", http.StatusInternalServerError).Wrap(appErr)
-		}
-
-		limits.ActiveUserCount = activeUserCount
+	if license == nil && maxUsersLimit > 0 {
+		// Enforce hard-coded limits for unlicensed servers.
 		limits.MaxUsersLimit = maxUsersLimit
 		limits.MaxUsersHardLimit = maxUsersHardLimit
+	} else if license.IsSeatCountEnforced && license.Features != nil && license.Features.Users != nil {
+		// Enforce license limits as required by the license.
+		limits.MaxUsersLimit = int64(*license.Features.Users)
+		limits.MaxUsersHardLimit = int64(*license.Features.Users)
 	}
+
+	activeUserCount, appErr := a.Srv().Store().User().Count(model.UserCountOptions{})
+	if appErr != nil {
+		return nil, model.NewAppError("GetServerLimits", "app.limits.get_app_limits.user_count.store_error", nil, "", http.StatusInternalServerError).Wrap(appErr)
+	}
+	limits.ActiveUserCount = activeUserCount
 
 	return limits, nil
 }
 
-func (a *App) shouldShowUserLimits() bool {
-	if maxUsersLimit == 0 {
-		return false
-	}
-
-	return a.License() == nil
-}
-
-func (a *App) isHardUserLimitExceeded() (bool, *model.AppError) {
+func (a *App) isAtUserLimit() (bool, *model.AppError) {
 	userLimits, appErr := a.GetServerLimits()
 	if appErr != nil {
 		return false, appErr
 	}
 
-	return userLimits.ActiveUserCount > userLimits.MaxUsersHardLimit, appErr
+	if userLimits.MaxUsersHardLimit == 0 {
+		return false, nil
+	}
+
+	return userLimits.ActiveUserCount >= userLimits.MaxUsersHardLimit, appErr
 }

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -236,12 +236,12 @@ func (a *App) CreateGuest(c request.CTX, user *model.User) (*model.User, *model.
 }
 
 func (a *App) createUserOrGuest(c request.CTX, user *model.User, guest bool) (*model.User, *model.AppError) {
-	exceeded, limitErr := a.isHardUserLimitExceeded()
+	atUserLimit, limitErr := a.isAtUserLimit()
 	if limitErr != nil {
 		return nil, limitErr
 	}
 
-	if exceeded {
+	if atUserLimit {
 		return nil, model.NewAppError("createUserOrGuest", "api.user.create_user.user_limits.exceeded", nil, "", http.StatusBadRequest)
 	}
 
@@ -1013,12 +1013,12 @@ func (a *App) invalidateUserChannelMembersCaches(c request.CTX, userID string) *
 
 func (a *App) UpdateActive(c request.CTX, user *model.User, active bool) (*model.User, *model.AppError) {
 	if active {
-		exceeded, appErr := a.isHardUserLimitExceeded()
+		atUserLimit, appErr := a.isAtUserLimit()
 		if appErr != nil {
 			return nil, appErr
 		}
 
-		if exceeded {
+		if atUserLimit {
 			return nil, model.NewAppError("UpdateActive", "app.user.update_active.user_limit.exceeded", nil, "", http.StatusBadRequest)
 		}
 	}

--- a/server/channels/app/user_limits_test.go
+++ b/server/channels/app/user_limits_test.go
@@ -1,0 +1,468 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	storemocks "github.com/mattermost/mattermost/server/v8/channels/store/storetest/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateActiveWithUserLimits(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	t.Run("unlicensed server", func(t *testing.T) {
+		t.Run("reactivation allowed below hard limit", func(t *testing.T) {
+			th := Setup(t).InitBasic()
+			defer th.TearDown()
+
+			th.App.Srv().SetLicense(nil)
+
+			// Deactivate user
+			deactivatedUser, appErr := th.App.UpdateActive(th.Context, th.BasicUser, false)
+			require.Nil(t, appErr)
+			require.NotEqual(t, 0, deactivatedUser.DeleteAt)
+
+			// Reactivate user (should succeed - below hard limit)
+			updatedUser, appErr := th.App.UpdateActive(th.Context, th.BasicUser, true)
+			require.Nil(t, appErr)
+			require.Equal(t, int64(0), updatedUser.DeleteAt)
+		})
+
+		t.Run("reactivation blocked at hard limit", func(t *testing.T) {
+			th := SetupWithStoreMock(t)
+			defer th.TearDown()
+
+			th.App.Srv().SetLicense(nil)
+
+			// Mock user count at hard limit
+			mockUserStore := storemocks.UserStore{}
+			mockUserStore.On("Count", mock.Anything).Return(int64(5000), nil) // At 5000 hard limit
+			mockStore := th.App.Srv().Store().(*storemocks.Store)
+			mockStore.On("User").Return(&mockUserStore)
+
+			user := &model.User{
+				Id:       model.NewId(),
+				Email:    "test@example.com",
+				Username: "testuser",
+				DeleteAt: model.GetMillis(),
+			}
+
+			// Try to reactivate user (should fail)
+			updatedUser, appErr := th.App.UpdateActive(th.Context, user, true)
+			require.NotNil(t, appErr)
+			require.Nil(t, updatedUser)
+			require.Equal(t, "app.user.update_active.user_limit.exceeded", appErr.Id)
+		})
+
+		t.Run("reactivation blocked above hard limit", func(t *testing.T) {
+			th := SetupWithStoreMock(t)
+			defer th.TearDown()
+
+			th.App.Srv().SetLicense(nil)
+
+			// Mock user count to exceed hard limit
+			mockUserStore := storemocks.UserStore{}
+			mockUserStore.On("Count", mock.Anything).Return(int64(6000), nil) // Over 5000 hard limit
+			mockStore := th.App.Srv().Store().(*storemocks.Store)
+			mockStore.On("User").Return(&mockUserStore)
+
+			user := &model.User{
+				Id:       model.NewId(),
+				Email:    "test@example.com",
+				Username: "testuser",
+				DeleteAt: model.GetMillis(),
+			}
+
+			// Try to reactivate user (should fail)
+			updatedUser, appErr := th.App.UpdateActive(th.Context, user, true)
+			require.NotNil(t, appErr)
+			require.Nil(t, updatedUser)
+			require.Equal(t, "app.user.update_active.user_limit.exceeded", appErr.Id)
+		})
+	})
+
+	t.Run("licensed server with seat count enforcement", func(t *testing.T) {
+		t.Run("reactivation allowed below limit", func(t *testing.T) {
+			th := Setup(t).InitBasic()
+			defer th.TearDown()
+
+			userLimit := 100
+			license := model.NewTestLicense("")
+			license.IsSeatCountEnforced = true
+			license.Features.Users = &userLimit
+			th.App.Srv().SetLicense(license)
+
+			// Deactivate user
+			_, appErr := th.App.UpdateActive(th.Context, th.BasicUser, false)
+			require.Nil(t, appErr)
+
+			// Reactivate user (should succeed - below limit)
+			updatedUser, appErr := th.App.UpdateActive(th.Context, th.BasicUser, true)
+			require.Nil(t, appErr)
+			require.Equal(t, int64(0), updatedUser.DeleteAt)
+		})
+
+		t.Run("reactivation blocked at limit", func(t *testing.T) {
+			th := SetupWithStoreMock(t)
+			defer th.TearDown()
+
+			userLimit := 100
+			license := model.NewTestLicense("")
+			license.IsSeatCountEnforced = true
+			license.Features.Users = &userLimit
+			th.App.Srv().SetLicense(license)
+
+			// Mock user count at seat limit
+			mockUserStore := storemocks.UserStore{}
+			mockUserStore.On("Count", mock.Anything).Return(int64(100), nil) // At limit
+			mockStore := th.App.Srv().Store().(*storemocks.Store)
+			mockStore.On("User").Return(&mockUserStore)
+
+			user := &model.User{
+				Id:       model.NewId(),
+				Email:    "test@example.com",
+				Username: "testuser",
+				DeleteAt: model.GetMillis(),
+			}
+
+			// Try to reactivate user (should fail)
+			updatedUser, appErr := th.App.UpdateActive(th.Context, user, true)
+			require.NotNil(t, appErr)
+			require.Nil(t, updatedUser)
+			require.Equal(t, "app.user.update_active.user_limit.exceeded", appErr.Id)
+		})
+
+		t.Run("reactivation blocked above limit", func(t *testing.T) {
+			th := SetupWithStoreMock(t)
+			defer th.TearDown()
+
+			userLimit := 100
+			license := model.NewTestLicense("")
+			license.IsSeatCountEnforced = true
+			license.Features.Users = &userLimit
+			th.App.Srv().SetLicense(license)
+
+			// Mock user count above seat limit
+			mockUserStore := storemocks.UserStore{}
+			mockUserStore.On("Count", mock.Anything).Return(int64(150), nil) // Above limit
+			mockStore := th.App.Srv().Store().(*storemocks.Store)
+			mockStore.On("User").Return(&mockUserStore)
+
+			user := &model.User{
+				Id:       model.NewId(),
+				Email:    "test@example.com",
+				Username: "testuser",
+				DeleteAt: model.GetMillis(),
+			}
+
+			// Try to reactivate user (should fail)
+			updatedUser, appErr := th.App.UpdateActive(th.Context, user, true)
+			require.NotNil(t, appErr)
+			require.Nil(t, updatedUser)
+			require.Equal(t, "app.user.update_active.user_limit.exceeded", appErr.Id)
+		})
+	})
+
+	t.Run("licensed server without seat count enforcement", func(t *testing.T) {
+		t.Run("reactivation allowed below unenforced limit", func(t *testing.T) {
+			th := Setup(t).InitBasic()
+			defer th.TearDown()
+
+			userLimit := 5
+			license := model.NewTestLicense("")
+			license.IsSeatCountEnforced = false
+			license.Features.Users = &userLimit
+			th.App.Srv().SetLicense(license)
+
+			// Create 2 additional users to have 3 total (below limit of 5)
+			th.CreateUser()
+			th.CreateUser()
+
+			// Deactivate user
+			_, appErr := th.App.UpdateActive(th.Context, th.BasicUser, false)
+			require.Nil(t, appErr)
+
+			// Reactivate user (should succeed - enforcement disabled and below limit)
+			updatedUser, appErr := th.App.UpdateActive(th.Context, th.BasicUser, true)
+			require.Nil(t, appErr)
+			require.Equal(t, int64(0), updatedUser.DeleteAt)
+		})
+
+		t.Run("reactivation allowed at unenforced limit", func(t *testing.T) {
+			th := Setup(t).InitBasic()
+			defer th.TearDown()
+
+			userLimit := 5
+			license := model.NewTestLicense("")
+			license.IsSeatCountEnforced = false
+			license.Features.Users = &userLimit
+			th.App.Srv().SetLicense(license)
+
+			// Create 4 additional users to have 5 total (at limit of 5)
+			th.CreateUser()
+			th.CreateUser()
+			th.CreateUser()
+			th.CreateUser()
+
+			// Create a user and then deactivate them
+			testUser := th.CreateUser()
+			_, appErr := th.App.UpdateActive(th.Context, testUser, false)
+			require.Nil(t, appErr)
+
+			// Reactivate user (should succeed - enforcement disabled)
+			updatedUser, appErr := th.App.UpdateActive(th.Context, testUser, true)
+			require.Nil(t, appErr)
+			require.Equal(t, int64(0), updatedUser.DeleteAt)
+		})
+
+		t.Run("reactivation allowed above unenforced limit", func(t *testing.T) {
+			th := Setup(t).InitBasic()
+			defer th.TearDown()
+
+			userLimit := 5
+			license := model.NewTestLicense("")
+			license.IsSeatCountEnforced = false
+			license.Features.Users = &userLimit
+			th.App.Srv().SetLicense(license)
+
+			// Create 5 additional users to have 6 total (above limit of 5)
+			th.CreateUser()
+			th.CreateUser()
+			th.CreateUser()
+			th.CreateUser()
+			th.CreateUser()
+
+			// Create a user and then deactivate them
+			testUser := th.CreateUser()
+			_, appErr := th.App.UpdateActive(th.Context, testUser, false)
+			require.Nil(t, appErr)
+
+			// Reactivate user (should succeed - enforcement disabled)
+			updatedUser, appErr := th.App.UpdateActive(th.Context, testUser, true)
+			require.Nil(t, appErr)
+			require.Equal(t, int64(0), updatedUser.DeleteAt)
+		})
+	})
+}
+
+func TestCreateUserOrGuestSeatCountEnforcement(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	t.Run("seat count enforced - allows user creation when under limit", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		userLimit := 5
+		license := model.NewTestLicense("")
+		license.IsSeatCountEnforced = true
+		license.Features.Users = &userLimit
+		th.App.Srv().SetLicense(license)
+
+		// InitBasic creates 3 users, so we're under the limit of 5
+		user := &model.User{
+			Email:         "TestCreateUserOrGuest@example.com",
+			Username:      "username_123",
+			Password:      "Password1",
+			EmailVerified: true,
+		}
+
+		createdUser, appErr := th.App.createUserOrGuest(th.Context, user, false)
+		require.Nil(t, appErr)
+		require.NotNil(t, createdUser)
+		require.Equal(t, "username_123", createdUser.Username)
+	})
+
+	t.Run("seat count enforced - blocks user creation when at limit", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		userLimit := 5
+		license := model.NewTestLicense("")
+		license.IsSeatCountEnforced = true
+		license.Features.Users = &userLimit
+		th.App.Srv().SetLicense(license)
+
+		// Create 2 additional users to reach the limit of 5 (3 from InitBasic + 2)
+		th.CreateUser()
+		th.CreateUser()
+
+		// Now at limit - attempting to create another user should fail
+		user := &model.User{
+			Email:         "TestSeatCount@example.com",
+			Username:      "seat_test_user",
+			Password:      "Password1",
+			EmailVerified: true,
+		}
+
+		createdUser, appErr := th.App.createUserOrGuest(th.Context, user, false)
+		require.NotNil(t, appErr)
+		require.Nil(t, createdUser)
+		require.Equal(t, "api.user.create_user.user_limits.exceeded", appErr.Id)
+	})
+
+	t.Run("seat count enforced - blocks user creation when over limit", func(t *testing.T) {
+		// Use mocks for this test since we can't actually create users beyond the safety limit
+		th := SetupWithStoreMock(t)
+		defer th.TearDown()
+
+		userLimit := 5
+		currentUserCount := int64(6) // Over limit
+
+		mockUserStore := storemocks.UserStore{}
+		mockUserStore.On("Count", mock.Anything).Return(currentUserCount, nil)
+		mockUserStore.On("IsEmpty", true).Return(false, nil)
+
+		mockGroupStore := storemocks.GroupStore{}
+		mockGroupStore.On("GetByName", "seat_test_user", mock.Anything).Return(nil, nil)
+
+		mockStore := th.App.Srv().Store().(*storemocks.Store)
+		mockStore.On("User").Return(&mockUserStore)
+		mockStore.On("Group").Return(&mockGroupStore)
+
+		license := model.NewTestLicense("")
+		license.IsSeatCountEnforced = true
+		license.Features.Users = &userLimit
+		th.App.Srv().SetLicense(license)
+
+		user := &model.User{
+			Email:         "TestSeatCount@example.com",
+			Username:      "seat_test_user",
+			Password:      "Password1",
+			EmailVerified: true,
+		}
+
+		createdUser, appErr := th.App.createUserOrGuest(th.Context, user, false)
+		require.NotNil(t, appErr)
+		require.Nil(t, createdUser)
+		require.Equal(t, "api.user.create_user.user_limits.exceeded", appErr.Id)
+	})
+
+	t.Run("seat count not enforced - allows user creation even when over limit", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		userLimit := 5
+		license := model.NewTestLicense("")
+		license.IsSeatCountEnforced = false
+		license.Features.Users = &userLimit
+		th.App.Srv().SetLicense(license)
+
+		// Create additional users to exceed the limit (3 from InitBasic + 3 = 6, over limit of 5)
+		th.CreateUser()
+		th.CreateUser()
+		th.CreateUser()
+
+		// Should still allow creation since enforcement is disabled
+		user := &model.User{
+			Email:         "TestSeatCount@example.com",
+			Username:      "seat_test_user",
+			Password:      "Password1",
+			EmailVerified: true,
+		}
+
+		createdUser, appErr := th.App.createUserOrGuest(th.Context, user, false)
+		require.Nil(t, appErr)
+		require.NotNil(t, createdUser)
+		require.Equal(t, "seat_test_user", createdUser.Username)
+	})
+
+	t.Run("no license - uses existing hard limit logic", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		th.App.Srv().SetLicense(nil)
+
+		// Should allow creation under hard limit
+		user := &model.User{
+			Email:         "TestSeatCount@example.com",
+			Username:      "seat_test_user",
+			Password:      "Password1",
+			EmailVerified: true,
+		}
+
+		createdUser, appErr := th.App.createUserOrGuest(th.Context, user, false)
+		require.Nil(t, appErr)
+		require.NotNil(t, createdUser)
+		require.Equal(t, "seat_test_user", createdUser.Username)
+	})
+
+	t.Run("license without Users feature - no seat count enforcement", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		license := model.NewTestLicense("")
+		license.IsSeatCountEnforced = true
+		license.Features.Users = nil
+		th.App.Srv().SetLicense(license)
+
+		// Should allow creation since Users feature is nil
+		user := &model.User{
+			Email:         "TestSeatCount@example.com",
+			Username:      "seat_test_user",
+			Password:      "Password1",
+			EmailVerified: true,
+		}
+
+		createdUser, appErr := th.App.createUserOrGuest(th.Context, user, false)
+		require.Nil(t, appErr)
+		require.NotNil(t, createdUser)
+		require.Equal(t, "seat_test_user", createdUser.Username)
+	})
+
+	t.Run("guest creation with seat count enforcement - blocks when at limit", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		userLimit := 5
+		license := model.NewTestLicense("")
+		license.IsSeatCountEnforced = true
+		license.Features.Users = &userLimit
+		th.App.Srv().SetLicense(license)
+
+		// Create 2 additional users to reach the limit of 5 (3 from InitBasic + 2)
+		th.CreateUser()
+		th.CreateUser()
+
+		// Now at limit - attempting to create a guest should fail
+		user := &model.User{
+			Email:         "TestSeatCountGuest@example.com",
+			Username:      "seat_test_guest",
+			Password:      "Password1",
+			EmailVerified: true,
+		}
+
+		createdUser, appErr := th.App.createUserOrGuest(th.Context, user, true)
+		require.NotNil(t, appErr)
+		require.Nil(t, createdUser)
+		require.Equal(t, "api.user.create_user.user_limits.exceeded", appErr.Id)
+	})
+
+	t.Run("guest creation with seat count enforcement - allows when under limit", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		userLimit := 5
+		license := model.NewTestLicense("")
+		license.IsSeatCountEnforced = true
+		license.Features.Users = &userLimit
+		th.App.Srv().SetLicense(license)
+
+		// InitBasic creates 3 users, so we're under the limit of 5
+		user := &model.User{
+			Email:         "TestSeatCountGuest@example.com",
+			Username:      "seat_test_guest",
+			Password:      "Password1",
+			EmailVerified: true,
+		}
+
+		createdUser, appErr := th.App.createUserOrGuest(th.Context, user, true)
+		require.Nil(t, appErr)
+		require.NotNil(t, createdUser)
+		require.Equal(t, "seat_test_guest", createdUser.Username)
+	})
+}

--- a/server/public/model/license.go
+++ b/server/public/model/license.go
@@ -57,17 +57,18 @@ type LicenseRecord struct {
 }
 
 type License struct {
-	Id           string    `json:"id"`
-	IssuedAt     int64     `json:"issued_at"`
-	StartsAt     int64     `json:"starts_at"`
-	ExpiresAt    int64     `json:"expires_at"`
-	Customer     *Customer `json:"customer"`
-	Features     *Features `json:"features"`
-	SkuName      string    `json:"sku_name"`
-	SkuShortName string    `json:"sku_short_name"`
-	IsTrial      bool      `json:"is_trial"`
-	IsGovSku     bool      `json:"is_gov_sku"`
-	SignupJWT    *string   `json:"signup_jwt"`
+	Id                  string    `json:"id"`
+	IssuedAt            int64     `json:"issued_at"`
+	StartsAt            int64     `json:"starts_at"`
+	ExpiresAt           int64     `json:"expires_at"`
+	Customer            *Customer `json:"customer"`
+	Features            *Features `json:"features"`
+	SkuName             string    `json:"sku_name"`
+	SkuShortName        string    `json:"sku_short_name"`
+	IsTrial             bool      `json:"is_trial"`
+	IsGovSku            bool      `json:"is_gov_sku"`
+	IsSeatCountEnforced bool      `json:"is_seat_count_enforced"`
+	SignupJWT           *string   `json:"signup_jwt"`
 }
 
 type Customer struct {


### PR DESCRIPTION
#### Summary
If a license sets `IsSeatCountEnforced`, enforce the user limit therein as a hard cap.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/CLD-9260

#### Release Note
```release-note
Support licenses that enforce seat counts.
```
