### PR TITLE
[MM-64512] - Test user filters UI

### DIFF
--- a/api/v4/source/definitions.yaml
+++ b/api/v4/source/definitions.yaml
@@ -1364,9 +1364,6 @@ components:
         filter_value:
           type: string
           description: The actual filter string used
-        success:
-          type: boolean
-          description: Whether the filter test succeeded
         total_count:
           type: integer
           description: Number of entries found by the filter

--- a/api/v4/source/definitions.yaml
+++ b/api/v4/source/definitions.yaml
@@ -1367,7 +1367,7 @@ components:
         success:
           type: boolean
           description: Whether the filter test succeeded
-        result_count:
+        total_count:
           type: integer
           description: Number of entries found by the filter
         message:

--- a/server/public/model/ldap.go
+++ b/server/public/model/ldap.go
@@ -13,10 +13,9 @@ const (
 type LdapFilterTestResult struct {
 	FilterName    string            `json:"filter_name"`
 	FilterValue   string            `json:"filter_value"`
-	Success       bool              `json:"success"`
 	TotalCount    int               `json:"total_count"`
 	Message       string            `json:"message,omitempty"`
-	Error         string            `json:"error,omitempty"`
+	Error         string            `json:"error"`
 	SampleResults []LdapSampleEntry `json:"sample_results"`
 }
 

--- a/server/public/model/ldap.go
+++ b/server/public/model/ldap.go
@@ -14,7 +14,7 @@ type LdapFilterTestResult struct {
 	FilterName    string            `json:"filter_name"`
 	FilterValue   string            `json:"filter_value"`
 	Success       bool              `json:"success"`
-	ResultCount   int               `json:"result_count"`
+	TotalCount    int               `json:"total_count"`
 	Message       string            `json:"message,omitempty"`
 	Error         string            `json:"error,omitempty"`
 	SampleResults []LdapSampleEntry `json:"sample_results"`

--- a/webapp/channels/src/components/admin_console/admin_definition_ldap_wizard.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition_ldap_wizard.tsx
@@ -348,7 +348,7 @@ export const ldapWizardAdminDefinition: LDAPAdminDefinitionConfigSchemaSettings 
                 key: 'LdapSettings.TestFilters',
                 label: defineMessage({id: 'admin.ldap.testFiltersTitle', defaultMessage: 'Test Filters'}),
                 help_text_markdown: false,
-                error_message: defineMessage({id: 'admin.ldap.testFiltersFailure', defaultMessage: 'We failed to apply some filters.'}),
+                error_message: defineMessage({id: 'admin.ldap.testFiltersFailure', defaultMessage: 'We failed to apply some filters: {error}'}),
                 success_message: defineMessage({id: 'admin.ldap.testFiltersSuccess', defaultMessage: 'Test Successful'}),
                 isDisabled: it.any(
                     it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_button_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_button_setting.tsx
@@ -40,11 +40,11 @@ const LDAPButtonSetting = (props: Props) => {
             if (props.setting.key === 'LdapSettings.TestFilters' && props.onFilterTestResults && data) {
                 props.onFilterTestResults(data);
 
-                const allTestsPassed = Array.isArray(data) && data.every((result) => result.success === true);
+                const allTestsPassed = Array.isArray(data) && data.every((result) => result.error === '');
                 if (allTestsPassed) {
                     success?.();
                 } else {
-                    const failedCount = data.filter((result) => result.success === false).length;
+                    const failedCount = data.filter((result) => result.error !== '').length;
                     const totalCount = data.length;
 
                     error({

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_text_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_text_setting.tsx
@@ -75,8 +75,8 @@ const LDAPTextSetting = (props: TextSettingProps) => {
     const showFilterIcon = hasContent && props.filterResult != null; // loose equality operator is intentional
 
     // Determine icon type and content - three states
-    const isSuccess = props.filterResult?.success === true && (props.filterResult?.total_count || 0) > 0;
-    const isWarning = props.filterResult?.success === true && (props.filterResult?.total_count || 0) === 0;
+    const isSuccess = props.filterResult?.error === '' && (props.filterResult?.total_count || 0) > 0;
+    const isWarning = props.filterResult?.error === '' && (props.filterResult?.total_count || 0) === 0;
 
     const getIconClass = () => {
         if (isSuccess) {

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_text_setting.tsx
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_text_setting.tsx
@@ -5,10 +5,12 @@ import React from 'react';
 import type {MessageDescriptor} from 'react-intl';
 import {useIntl} from 'react-intl';
 
+import type {LdapFilterTestResult} from '@mattermost/types/admin';
 import type {AdminConfig} from '@mattermost/types/config';
 
 import TextSetting from 'components/admin_console/text_setting';
 import FormError, {TYPE_BACKSTAGE} from 'components/form_error';
+import WithTooltip from 'components/with_tooltip';
 
 import Constants from 'utils/constants';
 
@@ -24,6 +26,7 @@ type TextSettingProps = {
     onChange(id: string, value: any): void;
     disabled: boolean;
     setByEnv: boolean;
+    filterResult?: LdapFilterTestResult | null;
 } & GeneralSettingProps
 
 const LDAPTextSetting = (props: TextSettingProps) => {
@@ -67,22 +70,85 @@ const LDAPTextSetting = (props: TextSettingProps) => {
     const label = renderLabel(props.setting, props.schema, intl);
     const helpText = renderLDAPSettingHelpText(props.setting, props.schema, Boolean(props.disabled));
 
+    // Show icon only when input has content and there's a filter result
+    const hasContent = value.trim() !== '';
+    const showFilterIcon = hasContent && props.filterResult != null; // loose equality operator is intentional
+
+    // Determine icon type and content - three states
+    const isSuccess = props.filterResult?.success === true && (props.filterResult?.total_count || 0) > 0;
+    const isWarning = props.filterResult?.success === true && (props.filterResult?.total_count || 0) === 0;
+
+    const getIconClass = () => {
+        if (isSuccess) {
+            return 'icon icon-check-circle';
+        }
+        return 'icon icon-alert-outline'; // Used for both warning and failure
+    };
+
+    const getIconCssClass = () => {
+        if (isSuccess) {
+            return 'ldap-text-setting__filter-icon--success';
+        }
+        if (isWarning) {
+            return 'ldap-text-setting__filter-icon--warning';
+        }
+        return 'ldap-text-setting__filter-icon--error';
+    };
+
+    const iconClass = getIconClass();
+    const iconCssClass = getIconCssClass();
+
+    const getTooltipContent = () => {
+        if (!props.filterResult) {
+            return '';
+        }
+
+        if (isSuccess) {
+            const count = props.filterResult.total_count || 0;
+            return `Test successful: ${count} result${count === 1 ? '' : 's'} found`;
+        }
+
+        if (isWarning) {
+            return 'Test successful but no results found. Your filter may be too restrictive.';
+        }
+
+        // For failed tests, combine message and error if both are available
+        const message = props.filterResult.message;
+        const error = props.filterResult.error;
+
+        if (message && error) {
+            return `${message}: ${error}`;
+        }
+
+        return message || error || 'Filter test failed';
+    };
+
     return (
-        <TextSetting
-            key={props.schema.id + '_text_' + props.setting.key}
-            id={props.setting.key}
-            multiple={props.setting.multiple}
-            type={inputType}
-            label={label}
-            helpText={helpText}
-            placeholder={props.setting.placeholder}
-            value={value}
-            disabled={props.disabled}
-            setByEnv={props.setByEnv}
-            onChange={props.onChange}
-            maxLength={props.setting.max_length}
-            footer={footer}
-        />
+        <div style={{position: 'relative'}}>
+            <TextSetting
+                key={props.schema.id + '_text_' + props.setting.key}
+                id={props.setting.key}
+                multiple={props.setting.multiple}
+                type={inputType}
+                label={label}
+                helpText={helpText}
+                placeholder={props.setting.placeholder}
+                value={value}
+                disabled={props.disabled}
+                setByEnv={props.setByEnv}
+                onChange={props.onChange}
+                maxLength={props.setting.max_length}
+                footer={footer}
+            />
+            {showFilterIcon && (
+                <WithTooltip
+                    title={getTooltipContent()}
+                    forcedPlacement='top'
+                >
+                    <i className={`${iconClass} ldap-text-setting__filter-icon ${iconCssClass}`}/>
+                </WithTooltip>
+            )}
+        </div>
     );
 };
 

--- a/webapp/channels/src/components/admin_console/ldap_wizard/ldap_wizard.scss
+++ b/webapp/channels/src/components/admin_console/ldap_wizard/ldap_wizard.scss
@@ -145,3 +145,24 @@
     text-align: left; // Left-align for better readability of longer text
     white-space: pre-line; // Preserve line breaks in help text
 }
+
+.ldap-text-setting__filter-icon {
+    position: absolute;
+    top: 10px;
+    right: 36px;
+    cursor: pointer;
+    font-size: 16px;
+    pointer-events: all;
+
+    &--success {
+        color: rgba(var(--semantic-color-success), 1);
+    }
+
+    &--warning {
+        color: rgba(var(--semantic-color-warning), 1);
+    }
+
+    &--error {
+        color: rgba(var(--semantic-color-danger), 1);
+    }
+}

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
@@ -216,7 +216,21 @@ export class SchemaAdminSettings extends React.PureComponent<Props, State> {
                 schema.sections.map((section) => section.settings).forEach((sectionSettings) => settings.push(...sectionSettings));
             }
 
-            settings.forEach((setting) => {
+            // Recursively collect settings from expandable settings
+            const collectSettingsRecursively = (settingsArray: AdminDefinitionSetting[]): AdminDefinitionSetting[] => {
+                const allSettings: AdminDefinitionSetting[] = [];
+                settingsArray.forEach((setting) => {
+                    allSettings.push(setting);
+                    if (setting.type === Constants.SettingsTypes.TYPE_EXPANDABLE_SETTING && setting.settings) {
+                        allSettings.push(...collectSettingsRecursively(setting.settings));
+                    }
+                });
+                return allSettings;
+            };
+
+            const allSettings = collectSettingsRecursively(settings);
+
+            allSettings.forEach((setting) => {
                 if (!setting.key) {
                     return;
                 }
@@ -1434,7 +1448,21 @@ export const getConfigFromState = (
             schema.sections.map((section) => section.settings).forEach((sectionSettings) => settings.push(...sectionSettings));
         }
 
-        settings.forEach((setting) => {
+        // Recursively collect settings from expandable settings
+        const collectSettingsRecursively = (settingsArray: AdminDefinitionSetting[]): AdminDefinitionSetting[] => {
+            const allSettings: AdminDefinitionSetting[] = [];
+            settingsArray.forEach((setting) => {
+                allSettings.push(setting);
+                if (setting.type === Constants.SettingsTypes.TYPE_EXPANDABLE_SETTING && setting.settings) {
+                    allSettings.push(...collectSettingsRecursively(setting.settings));
+                }
+            });
+            return allSettings;
+        };
+
+        const allSettings = collectSettingsRecursively(settings);
+
+        allSettings.forEach((setting) => {
             if (!setting.key) {
                 return;
             }

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -1524,6 +1524,7 @@
   "admin.ldap.testConnectionTitle": "Test Connection",
   "admin.ldap.testFailure": "AD/LDAP Test Failure: {error}",
   "admin.ldap.testFiltersFailure": "We failed to apply some filters.",
+  "admin.ldap.testFiltersPartialFailure": "{failedCount, number} of {totalCount, number} filter test{totalCount, plural, one {} other {s}} failed. Check the highlighted fields for details.",
   "admin.ldap.testFiltersSuccess": "Test Successful",
   "admin.ldap.testFiltersTitle": "Test Filters",
   "admin.ldap.testHelpText": "Tests if the Mattermost server can connect to the AD/LDAP server specified. Please review \"System Console > Logs\" and <link>documentation</link> to troubleshoot errors.",

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -1523,7 +1523,7 @@
   "admin.ldap.testConnectionSuccess": "Test Connection Successful",
   "admin.ldap.testConnectionTitle": "Test Connection",
   "admin.ldap.testFailure": "AD/LDAP Test Failure: {error}",
-  "admin.ldap.testFiltersFailure": "We failed to apply some filters.",
+  "admin.ldap.testFiltersFailure": "We failed to apply some filters: {error}",
   "admin.ldap.testFiltersPartialFailure": "{failedCount, number} of {totalCount, number} filter test{totalCount, plural, one {} other {s}} failed. Check the highlighted fields for details.",
   "admin.ldap.testFiltersSuccess": "Test Successful",
   "admin.ldap.testFiltersTitle": "Test Filters",

--- a/webapp/platform/types/src/admin.ts
+++ b/webapp/platform/types/src/admin.ts
@@ -158,7 +158,6 @@ export type LdapSampleEntry = {
 export type LdapFilterTestResult = {
     filter_name: string;
     filter_value: string;
-    success: boolean;
     total_count: number;
     message?: string;
     error?: string;

--- a/webapp/platform/types/src/admin.ts
+++ b/webapp/platform/types/src/admin.ts
@@ -161,7 +161,7 @@ export type LdapFilterTestResult = {
     success: boolean;
     total_count: number;
     message?: string;
-    error?: any;
+    error?: string;
     sample_results: LdapSampleEntry[];
 };
 

--- a/webapp/platform/types/src/admin.ts
+++ b/webapp/platform/types/src/admin.ts
@@ -143,3 +143,26 @@ export type SupportPacketContent = {
     selected: boolean;
     mandatory: boolean;
 }
+
+export type LdapSampleEntry = {
+    dn: string;
+    username?: string;
+    email?: string;
+    first_name?: string;
+    last_name?: string;
+    id?: string;
+    display_name?: string;
+    available_attributes?: Record<string, string>;
+};
+
+export type LdapFilterTestResult = {
+    filter_name: string;
+    filter_value: string;
+    success: boolean;
+    total_count: number;
+    message?: string;
+    error?: any;
+    sample_results: LdapSampleEntry[];
+};
+
+export type TestLdapFiltersResponse = LdapFilterTestResult[];


### PR DESCRIPTION
#### Summary
- This is the UI component of https://github.com/mattermost/mattermost/pull/31312 and https://github.com/mattermost/enterprise/pull/1934
- @asaadmahmood I kept to most of the design, except for autocomplete (that's complicated for LDAP, but maybe possible -- I'll leave to an enhancement nice to have). I also didn't do the full log with table -- I'm going to do that as a separate PR. I'm putting diagnostic info into the tooltips as the designs suggest, let me know if it looks good to you -- we can control the text and the amount of info, but it's somewhat constrained by the i18n templating system.
- Added three states:
  - success (tells you how many records returned)
  - warning (successfully parsed the filter, but no results returned)
  - error (error in the filter)
- Sister PR here: https://github.com/mattermost/enterprise/pull/1938

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-64512

#### Screenshots

(having trouble capturing the tooltips -- they're normal in real usage)

|    |   |
|----|----|
| ![CleanShot 2025-06-09 at 20 20 51@2x](https://github.com/user-attachments/assets/051a754a-1fe3-4026-89f0-0b40fccce439) | ![CleanShot 2025-06-09 at 20 21 22@2x](https://github.com/user-attachments/assets/4a0e3a79-00e8-4114-8545-848eb425a445) |
| ![CleanShot 2025-06-09 at 20 22 11@2x](https://github.com/user-attachments/assets/bbe8f876-dd2a-46cf-9eca-82ba6ff4501b) | |

#### Release Note
```release-note
LDAP Wizard: Added Test Filters button with feedback on failure
```
