### PR TITLE
MM-64340 E2E/Fix Custom status expiry spec

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/custom_status/custom_status_expiry/custom_status_expiry_2_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/custom_status/custom_status_expiry/custom_status_expiry_2_spec.ts
@@ -12,19 +12,23 @@
 import dayjs from 'dayjs';
 
 describe('MM-T4064 Status expiry visibility', () => {
-    before(() => {
-        cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
-
-        // # Login as test user and visit channel
-        cy.apiInitSetup({loginAfter: true}).then(({channelUrl}) => {
-            cy.visit(channelUrl);
-        });
-    });
     const waitingTime = 60; //minutes
     let expiresAt = dayjs();
     const expiryTimeFormat = 'h:mm A';
 
-    it.skip('MM-T4064_6 should show expiry time in the tooltip of custom status emoji in the post header', () => {
+    beforeEach(() => {
+        cy.apiAdminLogin().apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
+
+        // # Login as test user and visit channel
+        cy.apiInitSetup({loginAfter: true}).then(({channelUrl}) => {
+            cy.visit(channelUrl);
+
+            // # Post a message in the channel
+            cy.postMessage('Hello World!');
+        });
+    });
+
+    it('MM-T4064_6 should show expiry time in the tooltip of custom status emoji in the post header', () => {
         // # Open the user account menu
         cy.uiOpenUserMenu('Set custom status');
 
@@ -44,9 +48,6 @@ describe('MM-T4064 Status expiry visibility', () => {
         // # Note that we need to be flexible around accepted values, as this calculation and the server-side one may differ slightly
         expiresAt = dayjs().add(waitingTime, 'minute');
 
-        // # Post a message in the channel
-        cy.postMessage('Hello World!');
-
         // # Get the last post
         cy.getLastPostId().then((postId) => {
             // # Hover on the custom status emoji present in the post header
@@ -59,7 +60,37 @@ describe('MM-T4064 Status expiry visibility', () => {
         });
     });
 
-    it.skip('MM-T4064_7 should show custom status expiry time in the user popover', () => {
+    it('MM-T4064_7 should show custom status expiry time in the user popover', () => {
+        // # Open the user account menu
+        cy.uiOpenUserMenu('Set custom status');
+
+        // * Verify that the custom status modal opens
+        cy.findByRole('dialog', {name: 'Set a status'}).should('exist').within(() => {
+            // # Select a custom status from the suggestions
+            cy.get('.statusSuggestion__row').first().click();
+
+            // # Click on the Set Status button
+            cy.findByText('Set Status').click();
+        });
+
+        // * Modal should be closed
+        cy.get('#custom_status_modal').should('not.exist');
+
+        // # Setting the time at which the custom status should be expired
+        // # Note that we need to be flexible around accepted values, as this calculation and the server-side one may differ slightly
+        expiresAt = dayjs().add(waitingTime, 'minute');
+
+        // # Get the last post
+        cy.getLastPostId().then((postId) => {
+            // # Hover on the custom status emoji present in the post header
+            cy.get(`#post_${postId}`).find('.emoticon').should('exist').trigger('mouseenter');
+
+            // * Custom status tooltip should be visible and contain the correct custom status expiry time
+            cy.findByRole('tooltip').should('exist').and('contain.text', expiresAt.format(expiryTimeFormat));
+
+            cy.get(`#post_${postId}`).find('.emoticon').trigger('mouseleave');
+        });
+
         // # Click on the post header of the last post by the current user and open profile popover
         cy.get('.post.current--user .post__header .user-popover').first().click();
         cy.get('div.user-profile-popover').should('exist');


### PR DESCRIPTION
#### Summary
- Fixed custom status expiry spec by making test not dependent to each other

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64340

#### Screenshots
<img width="801" alt="Screenshot 2025-06-10 at 1 01 54 PM" src="https://github.com/user-attachments/assets/f6aa9784-a9d1-493d-b1ba-1dc717eafce7" />

#### Release Note
```release-note
NONE
```
