### PR TITLE
MM-64537 E2E/Fix DM category spec

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/channel_sidebar/dm_category_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/channel_sidebar/dm_category_spec.ts
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @channels @dm_category
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
@@ -64,7 +63,7 @@ describe('MM-T3156 DM category', () => {
     it('MM-T3156_3 should order DMs alphabetically ', () => {
         // # Hover over DIRECT MESSAGES and click channel options
         cy.get('.SidebarChannelGroupHeader:contains(DIRECT MESSAGES) .SidebarMenu').invoke('show').
-            get('.SidebarChannelGroupHeader:contains(DIRECT MESSAGES) .SidebarMenu_menuButton').should('be.visible').click();
+            get('.SidebarChannelGroupHeader:contains(DIRECT MESSAGES) .SidebarMenu_menuButton').should('be.visible').click({force: true});
 
         // # Change sorting to be alphabetical
         cy.findByText('Sort').trigger('mouseover');


### PR DESCRIPTION
#### Summary
- Fixed DM category spec by forcing click to the submenu item due to menuitem transition
- Demoted from prod to monitor stability

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64537

#### Screenshots
<img width="802" alt="Screenshot 2025-06-10 at 1 15 45 PM" src="https://github.com/user-attachments/assets/43196b0f-d705-4474-ab01-4d153f052486" />

#### Release Note
```release-note
NONE
```
