### PR TITLE
Fix webapp code coverage tracking

### DIFF
--- a/.github/workflows/webapp-ci-template.yml
+++ b/.github/workflows/webapp-ci-template.yml
@@ -4,6 +4,9 @@
 name: Web App CI Template
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: true
 
 jobs:
   check-lint:

--- a/webapp/channels/jest.config.js
+++ b/webapp/channels/jest.config.js
@@ -12,7 +12,7 @@ const config = {
     ],
     coveragePathIgnorePatterns: [
         '/node_modules/',
-        'packages/mattermost-redux/src/selectors/create_selector',
+        'mattermost-redux/src/selectors/create_selector',
     ],
     coverageReporters: ['lcov', 'text-summary'],
     fakeTimers: {


### PR DESCRIPTION
#### Summary

Take 2. The workflow was actually [invalid](https://github.com/mattermost/mattermost/actions/runs/15552370899), but I failed to spot it because the error did not surface.

It's now running, so we should be able to validate it e2e.

#### Release Note

```release-note
NONE
```

