### PR TITLE
[AI Assisted] Add missing shadows to the access control policies page

### DIFF
--- a/webapp/channels/src/components/admin_console/schema_admin_settings.scss
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.scss
@@ -2,6 +2,7 @@
     border-radius: 4px;
     margin-top: 20px;
     background: white;
+    box-shadow: 0 2px 3px rgba(0, 0, 0, 0.08);
 
     .admin-console__wrapper {
         padding: 0;


### PR DESCRIPTION


#### Summary

- The attribute-based access page uses schema-based admin settings which wrap sections in `.config-section` divs
- The .`config-section` class has styling for background, border-radius, and margins, but is missing the box-shadow

#### Screenshots
<img width="947" alt="resim" src="https://github.com/user-attachments/assets/c03f27bd-3dca-4fdf-8614-37314e124758" />
<img width="950" alt="resim" src="https://github.com/user-attachments/assets/a6498206-29a2-487b-8380-5fc9d1ecd472" />


#### Release Note

```release-note
NONE
```
