### PR TITLE
MM-64372 Fix onboarding checklist being rendered behind team sidebar

### DIFF
--- a/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist_popover.tsx
+++ b/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist_popover.tsx
@@ -1,11 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {FloatingPortal} from '@floating-ui/react';
 import type {Placement} from '@floating-ui/react-dom';
 import {useFloating, offset as floatingOffset, autoUpdate} from '@floating-ui/react-dom';
 import React, {useLayoutEffect} from 'react';
 import {CSSTransition} from 'react-transition-group';
 import styled from 'styled-components';
+
+import {RootHtmlPortalId} from 'utils/constants';
 
 const Overlay = styled.div`
     background-color: rgba(0, 0, 0, 0.5);
@@ -86,7 +89,7 @@ export const TaskListPopover = ({
         },
     };
     return (
-        <>
+        <FloatingPortal id={RootHtmlPortalId}>
             <CSSTransition
                 timeout={150}
                 classNames='fade'
@@ -104,7 +107,7 @@ export const TaskListPopover = ({
             >
                 {children}
             </div>
-        </>
+        </FloatingPortal>
     );
 };
 


### PR DESCRIPTION
#### Summary
The checklist used Floating UI to position itself, but it still rendered as part of the rest of the app which caused it to get cut off by `overflow:hidden`. Portalling it up to the root of the DOM where other popovers are rendered prevents that

#### Ticket Link
MM-64372

#### Screenshots
![Screenshot 2025-06-10 at 9 46 14 AM](https://github.com/user-attachments/assets/9ae31afa-71d1-40dd-9540-45e53159246f)

#### Release Note
```release-note
Fixed onboarding checklist being cut off when on multiple teams
```
