### PR TITLE
MM-64544 Fix width of threads textbox at all screen sizes

### DIFF
--- a/webapp/channels/src/components/threading/global_threads/global_threads.scss
+++ b/webapp/channels/src/components/threading/global_threads/global_threads.scss
@@ -65,7 +65,7 @@
 
     /* === Responsiveness === */
     --list: minmax(min-content, 300px);
-    --pane: minmax(min-content, auto);
+    --pane: auto;
 
     display: grid;
     overflow: hidden;


### PR DESCRIPTION
#### Summary
I'm not entirely sure why this only occurred at certain screen sizes, but this stops the thread pane from compressing the thread list

#### Ticket Link
MM-64544

#### Screenshots
Before|After
-|-
![Screenshot 2025-06-10 at 10 06 04 AM](https://github.com/user-attachments/assets/3feb42c1-b04a-4506-938d-30ab2a80a344)![Screenshot 2025-06-10 at 10 06 10 AM](https://github.com/user-attachments/assets/d5a9d08f-1ab2-4880-9f28-50c2b532de48)|![Screenshot 2025-06-10 at 10 07 06 AM](https://github.com/user-attachments/assets/ea3a3038-fdac-41f0-9690-21eb93a2bb3a)![Screenshot 2025-06-10 at 10 07 12 AM](https://github.com/user-attachments/assets/d36bed24-61ed-435c-93e6-391d0ddb2f94)

Wider monitors and mobile view were unchanged when I tested

#### Release Note
```release-note
Fixed the Threads textbox changing width when a message is typed on certain screen 
```
