### PR TITLE
Update go toolchain version in FIPS 10.8

### DIFF
--- a/server/build/Dockerfile.buildenv
+++ b/server/build/Dockerfile.buildenv
@@ -1,4 +1,4 @@
-FROM golang:1.23.7-bullseye@sha256:8731dcb40a7b879ccb493fa4fa38e83d9f33ca24ab60bec02e98d5af7e962cac
+FROM golang:1.23.9-bullseye@sha256:7f69bed02602c0d4e06a1598b690bb05f8114d788788f2eab72fec80b82c9224
 
 RUN apt-get update && apt-get install -y make git apt-transport-https ca-certificates curl software-properties-common build-essential zip xmlsec1 jq pgloader
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -2,7 +2,7 @@ module github.com/mattermost/mattermost/server/v8
 
 go 1.23.0
 
-toolchain go1.23.7
+toolchain go1.23.9
 
 require (
 	code.sajari.com/docconv/v2 v2.0.0-pre.4

--- a/server/public/go.mod
+++ b/server/public/go.mod
@@ -2,7 +2,7 @@ module github.com/mattermost/mattermost/server/public
 
 go 1.23.0
 
-toolchain go1.23.7
+toolchain go1.23.9
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
#### Summary
Update go toolchain version in FIPS 10.8

#### Release Note
```release-note
NONE
```