### PR TITLE
[MM-62987] Fix timestamp not actually being read

### DIFF
--- a/webapp/channels/src/components/threading/global_threads/thread_item/__snapshots__/thread_item.test.tsx.snap
+++ b/webapp/channels/src/components/threading/global_threads/thread_item/__snapshots__/thread_item.test.tsx.snap
@@ -126,7 +126,6 @@ exports[`components/threading/global_threads/thread_item should report total num
         id="threading.threadItem.timestamp"
       />
       <MockTimestamp
-        className="alt-hidden"
         day="numeric"
         units={
           Array [
@@ -279,7 +278,6 @@ exports[`components/threading/global_threads/thread_item should report unread me
         id="threading.threadItem.timestamp"
       />
       <MockTimestamp
-        className="alt-hidden"
         day="numeric"
         units={
           Array [
@@ -430,7 +428,6 @@ exports[`components/threading/global_threads/thread_item should report unread me
         id="threading.threadItem.timestamp"
       />
       <MockTimestamp
-        className="alt-hidden"
         day="numeric"
         units={
           Array [

--- a/webapp/channels/src/components/threading/global_threads/thread_item/thread_item.tsx
+++ b/webapp/channels/src/components/threading/global_threads/thread_item/thread_item.tsx
@@ -335,7 +335,6 @@ function ThreadItem({
                     />
                     <Timestamp
                         {...THREADING_TIME}
-                        className='alt-hidden'
                         value={lastReplyAt}
                     />
                 </span>


### PR DESCRIPTION
#### Summary
For some reason an extra class was added that stopped the `Timestamp` component from being read. This PR removes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62987

```release-note
NONE
```
