### PR TITLE
Mm 48048 html lang tag set to default server locale

### DIFF
--- a/server/channels/web/static.go
+++ b/server/channels/web/static.go
@@ -96,9 +96,7 @@ func root(c *Context, w http.ResponseWriter, r *http.Request) {
 	defaultEnglishHtmlTag  := fmt.Sprintf(htmlTagWithLangTemplate, "en")
 	if bytes.Contains(contents, []byte(defaultEnglishHtmlTag )) {
 		contents = bytes.ReplaceAll(contents, []byte(defaultEnglishHtmlTag ), []byte(localizedHtmlTag))
-	} else if bytes.Contains(contents, []byte("<html>")) {
-		contents = bytes.ReplaceAll(contents, []byte("<html>"), []byte(localizedHtmlTag))
-	}
+	} 
 
 	titleTemplate := "<title>%s</title>"
 	originalHTML := fmt.Sprintf(titleTemplate, html.EscapeString(model.TeamSettingsDefaultSiteName))

--- a/server/channels/web/static.go
+++ b/server/channels/web/static.go
@@ -89,7 +89,13 @@ func root(c *Context, w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-
+	
+	defaultLocale := *c.App.Srv().Config().LocalizationSettings.DefaultServerLocale
+	contents = bytes.ReplaceAll(
+		contents,
+		[]byte(`<html lang="en">`),
+		[]byte(fmt.Sprintf(`<html lang="%s">`, defaultLocale)),
+	)
 	titleTemplate := "<title>%s</title>"
 	originalHTML := fmt.Sprintf(titleTemplate, html.EscapeString(model.TeamSettingsDefaultSiteName))
 	modifiedHTML := getOpenGraphMetaTags(c)

--- a/server/channels/web/static.go
+++ b/server/channels/web/static.go
@@ -91,11 +91,15 @@ func root(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 	
 	defaultLocale := *c.App.Srv().Config().LocalizationSettings.DefaultServerLocale
-	contents = bytes.ReplaceAll(
-		contents,
-		[]byte(`<html lang="en">`),
-		[]byte(fmt.Sprintf(`<html lang="%s">`, defaultLocale)),
-	)
+	htmlTagWithLangTemplate := `<html lang="%s">`
+	localizedHtmlTag  := fmt.Sprintf(htmlTagWithLangTemplate, html.EscapeString(defaultLocale))
+	defaultEnglishHtmlTag  := fmt.Sprintf(htmlTagWithLangTemplate, "en")
+	if bytes.Contains(contents, []byte(defaultEnglishHtmlTag )) {
+		contents = bytes.ReplaceAll(contents, []byte(defaultEnglishHtmlTag ), []byte(localizedHtmlTag))
+	} else if bytes.Contains(contents, []byte("<html>")) {
+		contents = bytes.ReplaceAll(contents, []byte("<html>"), []byte(localizedHtmlTag))
+	}
+
 	titleTemplate := "<title>%s</title>"
 	originalHTML := fmt.Sprintf(titleTemplate, html.EscapeString(model.TeamSettingsDefaultSiteName))
 	modifiedHTML := getOpenGraphMetaTags(c)

--- a/server/channels/web/static.go
+++ b/server/channels/web/static.go
@@ -89,14 +89,13 @@ func root(c *Context, w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	
 	defaultLocale := *c.App.Srv().Config().LocalizationSettings.DefaultServerLocale
 	htmlTagWithLangTemplate := `<html lang="%s">`
-	localizedHtmlTag  := fmt.Sprintf(htmlTagWithLangTemplate, html.EscapeString(defaultLocale))
-	defaultEnglishHtmlTag  := fmt.Sprintf(htmlTagWithLangTemplate, "en")
-	if bytes.Contains(contents, []byte(defaultEnglishHtmlTag )) {
-		contents = bytes.ReplaceAll(contents, []byte(defaultEnglishHtmlTag ), []byte(localizedHtmlTag))
-	} 
+	localizedHtmlTag := fmt.Sprintf(htmlTagWithLangTemplate, html.EscapeString(defaultLocale))
+	defaultEnglishHtmlTag := fmt.Sprintf(htmlTagWithLangTemplate, "en")
+	if bytes.Contains(contents, []byte(defaultEnglishHtmlTag)) {
+		contents = bytes.ReplaceAll(contents, []byte(defaultEnglishHtmlTag), []byte(localizedHtmlTag))
+	}
 
 	titleTemplate := "<title>%s</title>"
 	originalHTML := fmt.Sprintf(titleTemplate, html.EscapeString(model.TeamSettingsDefaultSiteName))


### PR DESCRIPTION
#### Summary
<!--

-->
This code looks for the <html lang="en"> tag and replaces it with the default server locale. This will then trigger browser's translate function (assuming user's browser translates settings set) and allow a better user experience when joining servers of different languages. 
#### Ticket Link
<!--

-->
Fixes https://github.com/mattermost/mattermost/issues/26672
Jira https://mattermost.atlassian.net/browse/MM-48048
```release-note
None
```
