### PR TITLE
[MM-63038] Allow Invite Modal to scroll under very small screen sizes

### DIFF
--- a/webapp/channels/src/components/invitation_modal/invitation_modal.scss
+++ b/webapp/channels/src/components/invitation_modal/invitation_modal.scss
@@ -23,8 +23,8 @@
     }
 
     @media screen and (max-width: 768px) {
-        max-height: 100%;
         display: flex;
+        max-height: 100%;
 
         .modal-body {
             overflow-y: auto !important;


### PR DESCRIPTION
#### Summary
The Invite Modal has inaccessible controls under very small screen sizes (320x256). This PR allows it to scroll under those very small sizes if needed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63038

```release-note
NONE
```
