### PR TITLE
feat: mage package for plugins

### DIFF
--- a/server/public/pluginmage/README.md
+++ b/server/public/pluginmage/README.md
@@ -1,0 +1,127 @@
+# Plugin Magefile Package
+
+This package provides a comprehensive set of [Mage](https://magefile.org/) targets for building, developing, and deploying Mattermost plugins. It replaces the traditional Makefile-based build system with a more flexible and maintainable Go-based solution.
+
+## Features
+
+- 🔨 **Build System**
+  - Server binary compilation with multi-platform support
+  - Webapp (React/TypeScript) building and watching
+  - Plugin bundle creation
+  - Dependency management
+
+- 🚀 **Development Tools**
+  - Hot-reload capability with `Watch` target
+  - Debug mode support via `MM_DEBUG`
+  - Custom logging with namespace support
+  - Local and remote deployment options
+
+- 🛠️ **Deployment**
+  - Plugin upload via Mattermost API
+  - Enable/disable plugin management
+  - Support for both local socket and HTTP API connections
+
+## Usage
+
+### Basic Commands
+
+```bash
+# Show all available commands
+mage
+# Build everything (server, webapp, bundle)
+mage build:all
+# Watch webapp for changes (hot-reload)
+mage webapp:watch
+# Deploy to local Mattermost server
+mage pluginctl:deploy
+```
+
+### Environment Variables
+
+- `MM_DEBUG`: Enable debug mode for both Go and webapp builds
+- `MM_SERVICESETTINGS_SITEURL`: Mattermost server URL for deployment
+- `MM_ADMIN_TOKEN`: Admin access token for deployment
+- `MM_ADMIN_USERNAME`/`MM_ADMIN_PASSWORD`: Alternative authentication for deployment
+- `MM_LOCALSOCKETPATH`: Unix socket path for local mode deployment
+- `GO_BUILD_FLAGS`: Additional Go build flags
+- `ASSETS_DIR`: Custom assets directory path
+
+### Development Workflow
+
+1. Install dependencies:
+   ```bash
+   mage webapp:dependencies
+   ```
+
+2. Start development mode:
+   ```bash
+   mage webapp:watch
+   ```
+
+3. Deploy changes:
+   ```bash
+   mage pluginctl:deploy
+   ```
+
+## Customizing
+
+### Build more golang binaries
+
+You can register additional binaries to build by calling `RegisterBinary` in a new file in the `magefiles` directory:
+
+```go
+// magefiles/binaries.go
+func init() {
+    // Register additional binaries to build
+    plugin_magefile.RegisterBinary(plugin_magefile.BinaryBuildConfig{
+        BinaryName: "custom-tool",
+        PackagePath: "./tools/custom",
+        OutputPath: "./dist/tools",
+        Platforms: []plugin_magefile.BuildPlatform{
+            {GOOS: "linux", GOARCH: "amd64"},
+        },
+    })
+}
+```
+
+## Architecture
+
+### Package Structure
+
+- `build.go`: Build configuration and binary building logic
+- `webapp.go`: Webapp building and development tools
+- `dist.go`: Bundle creation and packaging
+- `pluginctl.go`: Deployment and plugin management
+- `server.go`: Server binary compilation
+- `cmd.go`: Command execution utilities
+- `log.go`: Custom logging implementation
+- `types.go`: Core types and configuration
+- `init.go`: Package initialization and environment setup
+- `assets/`: Embedded assets handling
+
+### Logging
+
+We include a custom logging output implementation that allows to easily spot the namespace and target of the log line by using the `namespace` and `target` as attributes:
+
+```go
+	Logger.Info("Info",
+		"namespace", "my namespace",
+		"target", "my target")
+```
+
+### Running commands
+
+We include a custom command runner that allows to run commands with the correct namespace and target:
+
+```go
+cmd := NewCmd("my namespace", "my target", map[string]string{
+    "ENV_VAR": "value",
+})
+if err := cmd.Run("npm", "run", "build"); err != nil {
+    return fmt.Errorf("failed to build webapp: %w", err)
+}
+```
+
+# More information
+
+- [Error codes](ERROR_CODES.md)

--- a/server/public/pluginmage/assets/.editorconfig
+++ b/server/public/pluginmage/assets/.editorconfig
@@ -1,0 +1,27 @@
+# http://editorconfig.org/
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+
+[*.{js,jsx,ts,tsx,json,html}]
+indent_style = space
+indent_size = 4
+
+[webapp/package.json]
+indent_size = 2
+
+[{Makefile,*.mk}]
+indent_style = tab
+
+[*.md]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = false

--- a/server/public/pluginmage/assets/.github/workflows/ci.yml
+++ b/server/public/pluginmage/assets/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: ci
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  IS_CI: true
+
+jobs:
+  plugin-ci:
+    uses: mattermost/actions-workflows/.github/workflows/plugin-ci.yml@mage
+    secrets: inherit
+    with:
+      mage-version: v1.15.0

--- a/server/public/pluginmage/assets/.golangci.yml
+++ b/server/public/pluginmage/assets/.golangci.yml
@@ -1,0 +1,48 @@
+run:
+  timeout: 5m
+  modules-download-mode: readonly
+
+linters-settings:
+  gofmt:
+    simplify: true
+  goimports:
+    local-prefixes: github.com/mattermost/mattermost-starter-template
+  govet:
+    check-shadowing: true
+    enable-all: true
+    disable:
+      - fieldalignment
+  misspell:
+    locale: US
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - errcheck
+    - gocritic
+    - gofmt
+    - goimports
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - revive
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unused
+    - whitespace
+
+issues:
+  exclude-rules:
+    - path: server/configuration.go
+      linters:
+        - unused
+    - path: _test\.go
+      linters:
+        - bodyclose
+        - scopelint # https://github.com/kyoh86/scopelint/issues/4

--- a/server/public/pluginmage/assets/assets.go
+++ b/server/public/pluginmage/assets/assets.go
@@ -1,0 +1,6 @@
+package assets
+
+import "embed"
+
+//go:embed *.yml **/*/*.yml .editorconfig
+var Assets embed.FS

--- a/server/public/pluginmage/assets/magefiles/magefile.go
+++ b/server/public/pluginmage/assets/magefiles/magefile.go
@@ -1,0 +1,12 @@
+//go:build mage
+// +build mage
+
+// This file is maintained by the plugin sdk tooling.
+// Please do not make changes to this file.
+
+package main
+
+import (
+	//mage:import
+	_ "github.com/mattermost/mattermost/server/public/pluginmage"
+)

--- a/server/public/pluginmage/build.go
+++ b/server/public/pluginmage/build.go
@@ -1,0 +1,162 @@
+package pluginmage
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"text/template"
+
+	"github.com/magefile/mage/mg"
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// Build namespace for all build-related targets
+type Build mg.Namespace
+
+// BinaryBuildConfig defines the configuration for building a binary.
+// This is used to build additional binaries in addition to the main server binary.
+type BinaryBuildConfig struct {
+	Name             string            // Friendly name for the binary
+	PackagePath      string            // Path to the source directory containing go.mod
+	OutputPath       string            // Destination path for the binary
+	BinaryNameFormat string            // Format of the output binary
+	BuildFlags       []string          // Additional build flags
+	CGOEnabled       bool              // Whether to enable CGO
+	Environment      map[string]string // Additional environment variables
+	Platforms        []BuildPlatform   // Target platforms
+	GoBuildFlags     string            // Optional build flags
+	GcFlags          string            // Optional gcflags
+	WorkingDir       string            // Working directory for the build
+}
+
+// GetBinaryName returns the binary name for a given platform using `BinaryFormat`
+func (c *BinaryBuildConfig) GetBinaryName(goos, goarch string) (string, error) {
+	tmpl, err := template.New("binary").Parse(c.BinaryNameFormat)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse binary format: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, struct {
+		Manifest *model.Manifest
+		GOOS     string
+		GOARCH   string
+	}{
+		Manifest: info.Manifest,
+		GOOS:     goos,
+		GOARCH:   goarch,
+	}); err != nil {
+		return "", fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// IsValid checks if the binary build configuration is valid
+func (c *BinaryBuildConfig) IsValid() error {
+	if c.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+
+	if c.BinaryNameFormat == "" {
+		return fmt.Errorf("binary format is required")
+	}
+
+	if c.OutputPath == "" {
+		return fmt.Errorf("output path is required")
+	}
+
+	// Validate each platform has required fields
+	for i, platform := range c.Platforms {
+		if platform.GOOS == "" {
+			return fmt.Errorf("GOOS is required for platform %d", i)
+		}
+		if platform.GOARCH == "" {
+			return fmt.Errorf("GOARCH is required for platform %d", i)
+		}
+	}
+
+	return nil
+}
+
+// Defaults sets up default values for required fields if they are empty
+func (c *BinaryBuildConfig) Defaults() *BinaryBuildConfig {
+	// Set default platforms if none specified
+	if len(c.Platforms) == 0 {
+		if info.EnableDeveloperMode {
+			c.Platforms = []BuildPlatform{
+				{GOOS: runtime.GOOS, GOARCH: runtime.GOARCH},
+			}
+		} else {
+			c.Platforms = DefaultPlatforms
+		}
+	}
+
+	// Initialize environment map if nil
+	if c.Environment == nil {
+		c.Environment = make(map[string]string)
+	}
+
+	if c.CGOEnabled {
+		c.Environment["CGO_ENABLED"] = "1"
+	} else {
+		c.Environment["CGO_ENABLED"] = "0"
+	}
+
+	return c
+}
+
+type BuildPlatform struct {
+	GOOS   string
+	GOARCH string
+}
+
+var (
+	// DefaultPlatforms defines the standard platforms to build for
+	DefaultPlatforms = []BuildPlatform{
+		{GOOS: "linux", GOARCH: "amd64"},
+		{GOOS: "linux", GOARCH: "arm64"},
+	}
+
+	// AllBinaries holds all binaries that need to be built
+	AllBinaries []BinaryBuildConfig
+
+	// DefaultBuildFlags are the default build flags for all binaries
+	DefaultBuildFlags = []string{"-trimpath"}
+)
+
+// RegisterBinary adds a new binary configuration to be built during the build process
+func RegisterBinary(config BinaryBuildConfig) {
+	AllBinaries = append(AllBinaries, *config.Defaults())
+}
+
+// setupPluginBinary configures the main plugin binary to be built during the build process
+func setupPluginBinary() {
+	// Configure the main plugin binary
+	pluginBinary := BinaryBuildConfig{
+		Name:             "plugin",
+		BinaryNameFormat: "plugin-{{.GOOS}}-{{.GOARCH}}",
+		PackagePath:      "./server",
+		OutputPath:       "./server/dist",
+		Environment: map[string]string{
+			"CGO_ENABLED": "0",
+		},
+	}
+
+	// Set build flags if configured
+	if info.GoBuildFlags != "" {
+		pluginBinary.GoBuildFlags = info.GoBuildFlags
+	}
+	if info.GoBuildGcflags != "" {
+		pluginBinary.GcFlags = info.GoBuildGcflags
+	}
+
+	// Add plugin binary as first element with defaults
+	AllBinaries = append([]BinaryBuildConfig{*pluginBinary.Defaults()}, AllBinaries...)
+}
+
+// All builds both server, additional binaries, and webapp
+func (Build) All() error {
+	mg.Deps(Build.Server, Build.AdditionalBinaries, Build.Webapp)
+	return nil
+}

--- a/server/public/pluginmage/cmd.go
+++ b/server/public/pluginmage/cmd.go
@@ -1,0 +1,105 @@
+package pluginmage
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/magefile/mage/sh"
+)
+
+// Cmd represents a command to be executed
+type Cmd struct {
+	env            map[string]string
+	namespace      string
+	target         string
+	workingDir     string
+	beforeCommands []string // Commands to run before the main command
+	disableLogging bool
+}
+
+// NewCmd creates a new command with the given namespace and target
+func NewCmd(namespace, target string, env map[string]string) *Cmd {
+	if env == nil {
+		env = make(map[string]string)
+	}
+	return &Cmd{
+		env:       env,
+		namespace: namespace,
+		target:    target,
+	}
+}
+
+// WorkingDir sets the working directory for the command
+func (c *Cmd) WorkingDir(dir string) *Cmd {
+	c.workingDir = dir
+	return c
+}
+
+// RunBefore adds a command to be executed before the main command
+func (c *Cmd) RunBefore(command string) *Cmd {
+	c.beforeCommands = append(c.beforeCommands, command)
+	return c
+}
+
+func (c *Cmd) DisableLogging() *Cmd {
+	c.disableLogging = true
+	return c
+}
+
+// Run executes the command with the given arguments
+func (c *Cmd) Run(cmd string, args ...string) error {
+	// Build shell command that includes before commands and cd
+	var commands []string
+	if c.workingDir != "" {
+		commands = append([]string{fmt.Sprintf("cd %q", c.workingDir)}, commands...)
+	}
+
+	// Add any before commands
+	commands = append(commands, c.beforeCommands...)
+
+	// Add the main command with proper shell escaping
+	quotedArgs := make([]string, len(args))
+	for i, arg := range args {
+		quotedArgs[i] = fmt.Sprintf("%q", arg)
+	}
+	commands = append(commands, fmt.Sprintf("%q %s", cmd, strings.Join(quotedArgs, " ")))
+
+	// Join all commands with &&
+	shellCmd := strings.Join(commands, " && ")
+
+	// Use user's default shell or fallback to sh
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "sh"
+	}
+
+	var stdout, stderr io.Writer
+	if !c.disableLogging {
+		Logger.Debug("Running command",
+			"namespace", c.namespace,
+			"target", c.target,
+			"command", shellCmd)
+
+		stdout = NewLogWriter(c.namespace, c.target, slog.LevelDebug)
+		stderr = NewLogWriter(c.namespace, c.target, slog.LevelError)
+	}
+
+	ok, err := sh.Exec(c.env, stdout, stderr, shell, "-c", shellCmd)
+
+	if err != nil || !ok {
+		return fmt.Errorf("command failed: %w", err)
+	}
+
+	return nil
+}
+
+// CheckCommand checks if a command exists on the system
+func CheckCommand(name string) bool {
+	cmd := NewCmd("", "", nil)
+	cmd.DisableLogging()
+	// Use command -v which is POSIX compliant
+	return cmd.Run("command", "-v", name) == nil
+}

--- a/server/public/pluginmage/deploy.go
+++ b/server/public/pluginmage/deploy.go
@@ -1,0 +1,14 @@
+package pluginmage
+
+import (
+	"github.com/magefile/mage/mg"
+)
+
+type Deploy mg.Namespace
+
+// Upload builds and installs the plugin to a server
+func (Deploy) Upload() error {
+	mg.SerialDeps(Build.All, Build.Bundle, Pluginctl.Deploy)
+
+	return nil
+}

--- a/server/public/pluginmage/dist.go
+++ b/server/public/pluginmage/dist.go
@@ -1,0 +1,86 @@
+package pluginmage
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+)
+
+// Bundle creates a distributable bundle of the plugin
+func (Build) Bundle() error {
+	mg.Deps(Build.Server, Build.Webapp)
+
+	// Clean dist directory
+	if err := sh.Rm("dist"); err != nil {
+		return fmt.Errorf("failed to clean dist directory: %w", err)
+	}
+
+	// Create dist directory and plugin subdirectory
+	pluginDir := filepath.Join("dist", info.Manifest.Id)
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		return fmt.Errorf("failed to create plugin directory: %w", err)
+	}
+
+	// Copy plugin.json to dist/plugin_id/
+	if err := sh.Copy(filepath.Join(pluginDir, "plugin.json"), "plugin.json"); err != nil {
+		return fmt.Errorf("failed to copy plugin.json: %w", err)
+	}
+
+	// Copy server files if they exist
+	if info.Manifest.HasServer() {
+		if err := copyDir(filepath.Join("server", "dist"), filepath.Join(pluginDir, "server", "dist")); err != nil {
+			return fmt.Errorf("failed to copy server files: %w", err)
+		}
+	}
+
+	// Copy webapp files if they exist
+	if info.Manifest.HasWebapp() {
+		if err := copyDir(filepath.Join("webapp", "dist"), filepath.Join(pluginDir, "webapp", "dist")); err != nil {
+			return fmt.Errorf("failed to copy webapp files: %w", err)
+		}
+	}
+
+	// Copy assets if directory is set and exists
+	if info.AssetsDir != "" {
+		if err := copyDir(info.AssetsDir, filepath.Join(pluginDir, "assets")); err != nil {
+			return fmt.Errorf("failed to copy assets: %w", err)
+		}
+	}
+
+	// Create the bundle in dist directory
+	bundleName := fmt.Sprintf("%s-%s.tar.gz", info.Manifest.Id, info.Manifest.Version)
+	cmd := NewCmd("dist", "bundle", nil)
+	if err := cmd.Run("tar", "-C", "dist", "-czf", filepath.Join("dist", bundleName), info.Manifest.Id); err != nil {
+		return fmt.Errorf("failed to create bundle: %w", err)
+	}
+
+	Logger.Info("Plugin built",
+		"namespace", "dist",
+		"target", "bundle",
+		"path", fmt.Sprintf("dist/%s", bundleName))
+
+	return nil
+}
+
+// copyDir copies a directory from src to dst, creating dst if it doesn't exist
+func copyDir(src, dst string) error {
+	if _, err := os.Stat(src); os.IsNotExist(err) {
+		return nil // Source doesn't exist, skip copying
+	}
+
+	if err := os.MkdirAll(dst, 0755); err != nil {
+		return err
+	}
+
+	writer := NewLogWriter("dist", "copy", slog.LevelDebug)
+	ok, err := sh.Exec(nil, writer, writer, "cp", "-R", src+"/.", dst)
+	if err != nil || !ok {
+		return fmt.Errorf("failed to copy directory: %w", err)
+	}
+
+	return nil
+}

--- a/server/public/pluginmage/dummy.go
+++ b/server/public/pluginmage/dummy.go
@@ -1,0 +1,18 @@
+package pluginmage
+
+import "time"
+
+// Dummy prints a hello message and plugin info
+func Dummy() error {
+	// The plugin info is already initialized via init() when this runs
+	Logger.Debug("Debug")
+	Logger.Info("Info")
+	Logger.Warn("Warn")
+	Logger.Error("Error")
+	time.Sleep(1 * time.Second)
+	Logger.Info("Plugin info",
+		"id", info.Manifest.Id,
+		"version", info.Manifest.Version,
+		"name", info.Manifest.Name)
+	return nil
+}

--- a/server/public/pluginmage/init.go
+++ b/server/public/pluginmage/init.go
@@ -1,0 +1,141 @@
+package pluginmage
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/mattermost/mattermost/server/public/pluginmage/assets"
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+var (
+	info   *pluginInfo
+	Logger *slog.Logger
+
+	DefaultAliases = map[string]interface{}{
+		"server":   Build.Server,
+		"binaries": Build.AdditionalBinaries,
+		"webapp":   Webapp.Watch,
+		"dist":     Build.All,
+		"bundle":   Build.Bundle,
+		"deploy":   Deploy.Upload,
+	}
+)
+
+// initializeEnvironment performs all the setup checks previously done in setup.mk
+func initializeEnvironment() error {
+	// Check if go is installed
+	if !CheckCommand("go") {
+		return fmt.Errorf("go is not available: see https://golang.org/doc/install")
+	}
+
+	// Check if tar is GNU tar
+	cmd := exec.Command("tar", "--version")
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("tar is not available")
+	}
+	if !strings.Contains(string(output), "GNU tar") {
+		return fmt.Errorf("GNU tar is required but system tar is not GNU compatible. Please install GNU tar on your system")
+	}
+
+	// Initialize plugin info
+	info = &pluginInfo{}
+	info.Init()
+	info.Defaults()
+
+	// Parse plugin.json
+	manifestBytes, err := os.ReadFile("plugin.json")
+	if err != nil {
+		return fmt.Errorf("failed to read plugin.json: %w", err)
+	}
+
+	info.Manifest = &model.Manifest{}
+	if err := json.Unmarshal(manifestBytes, info.Manifest); err != nil {
+		return fmt.Errorf("failed to parse plugin.json: %w", err)
+	}
+
+	// Check if webapp is defined
+	if info.Manifest.HasWebapp() {
+		// If webapp exists, verify npm is installed
+		if _, err := exec.LookPath("npm"); err != nil {
+			return fmt.Errorf("npm is not available: see https://www.npmjs.com/get-npm")
+		}
+	}
+
+	// Setup the plugin binary configuration in the build pipeline
+	setupPluginBinary()
+
+	return nil
+}
+
+// initializeAssets extracts all the assets from the embedded assets and writes them to the appropriate location in the repo
+func initializeAssets() error {
+	// Walk through all files in the embedded assets
+	err := fs.WalkDir(assets.Assets, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip directories, only process files
+		if d.IsDir() {
+			return nil
+		}
+
+		// Read the file content from embedded assets
+		content, err := assets.Assets.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read embedded asset %s: %w", path, err)
+		}
+
+		currentDir, err := filepath.Abs(".")
+		if err != nil {
+			return fmt.Errorf("failed to get absolute path for %s: %w", currentDir, err)
+		}
+
+		// Create the destination path in the repo root
+		destDir := filepath.Join(currentDir, filepath.Dir(path))
+
+		// Ensure the directory exists
+		if err := os.MkdirAll(destDir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", destDir, err)
+		}
+
+		destPath := filepath.Join(currentDir, path)
+
+		// Write the file to the destination
+		if err := os.WriteFile(destPath, content, 0600); err != nil {
+			return fmt.Errorf("failed to write file %s: %w", destPath, err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to extract assets: %w", err)
+	}
+
+	return nil
+}
+
+// init runs the initialization when the package is imported
+func init() {
+	// Initialize logger with custom handler
+	Logger = slog.New(NewCustomHandler(os.Stdout))
+
+	if err := initializeEnvironment(); err != nil {
+		Logger.Error("Error initializing environment", "error", err)
+		os.Exit(1)
+	}
+
+	if err := initializeAssets(); err != nil {
+		Logger.Error("Error initializing assets", "error", err)
+		os.Exit(1)
+	}
+}

--- a/server/public/pluginmage/log.go
+++ b/server/public/pluginmage/log.go
@@ -1,0 +1,177 @@
+package pluginmage
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"text/template"
+	"time"
+)
+
+const (
+	underline = "\x1b[4m"
+	reset     = "\x1b[0m"
+
+	// Colors for different log levels
+	colorDebug = "\x1b[36m" // Cyan
+	colorInfo  = "\x1b[32m" // Green
+	colorWarn  = "\x1b[33m" // Yellow
+	colorError = "\x1b[31m" // Red
+
+	// Log line template
+	logTmpl = `{{.Time}} {{if .NSTarget}}{{.NSTarget}} {{end}}{{if .UseColors}}{{.Underline}}{{.LevelColor}}{{end}}{{.Level}}{{if .UseColors}}{{.Reset}}{{.Reset}}{{end}} {{.Message}}{{if .Attrs}} {{.Attrs}}{{end}}`
+)
+
+type logLine struct {
+	Time       string
+	NSTarget   string
+	Level      string
+	Message    string
+	Attrs      []string
+	UseColors  bool
+	Underline  string
+	Reset      string
+	LevelColor string
+}
+
+var tmpl = template.Must(template.New("log").Parse(logTmpl))
+
+type customHandler struct {
+	out       io.Writer
+	startTime time.Time
+	useColors bool
+}
+
+func (h *customHandler) Enabled(_ context.Context, _ slog.Level) bool {
+	return true
+}
+
+func (h *customHandler) Handle(_ context.Context, r slog.Record) error {
+	// Get relative time since handler creation with fixed width (7 columns)
+	timeStr := fmt.Sprintf("%7.2fs", r.Time.Sub(h.startTime).Seconds())
+
+	// Extract namespace and target if present
+	var namespace, target string
+	attrs := make([]string, 0, r.NumAttrs())
+	r.Attrs(func(a slog.Attr) bool {
+		switch a.Key {
+		case "namespace":
+			namespace = a.Value.String()
+		case "target":
+			target = a.Value.String()
+		default:
+			if h.useColors {
+				// Format the key-value without brackets: underlined key = value + reset
+				attrs = append(attrs, fmt.Sprintf("%s%s%s=%v", underline, a.Key, reset, a.Value))
+			} else {
+				// Format the key-value without brackets: key = value
+				attrs = append(attrs, fmt.Sprintf("%s=%v", a.Key, a.Value))
+			}
+		}
+		return true
+	})
+
+	// Format namespace and target if present
+	nsTarget := ""
+	if namespace != "" && target != "" {
+		nsTarget = fmt.Sprintf("(%s:%s)", namespace, target)
+	} else if target != "" {
+		nsTarget = fmt.Sprintf("(%s)", target)
+	}
+
+	// Get color for log level
+	var levelColor string
+	if h.useColors {
+		switch r.Level {
+		case slog.LevelDebug:
+			levelColor = colorDebug
+		case slog.LevelInfo:
+			levelColor = colorInfo
+		case slog.LevelWarn:
+			levelColor = colorWarn
+		case slog.LevelError:
+			levelColor = colorError
+		}
+	}
+
+	// Prepare log line data
+	line := logLine{
+		Time:       timeStr,
+		NSTarget:   nsTarget,
+		Level:      r.Level.String(),
+		Message:    r.Message,
+		Attrs:      attrs,
+		UseColors:  h.useColors,
+		Underline:  underline,
+		Reset:      reset,
+		LevelColor: levelColor,
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, line); err != nil {
+		return err
+	}
+	buf.WriteByte('\n') // Add explicit newline after template execution
+
+	_, err := h.out.Write(buf.Bytes())
+	return err
+}
+
+func (h *customHandler) WithAttrs(_ []slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *customHandler) WithGroup(_ string) slog.Handler {
+	return h
+}
+
+// NewCustomHandler creates a new handler with our custom format
+func NewCustomHandler(out io.Writer) slog.Handler {
+	// Check if we're writing to a terminal
+	useColors := false
+	if f, ok := out.(*os.File); ok {
+		fileInfo, _ := f.Stat()
+		useColors = (fileInfo.Mode() & os.ModeCharDevice) != 0
+	}
+
+	return &customHandler{
+		out:       out,
+		startTime: time.Now(),
+		useColors: useColors,
+	}
+}
+
+// logWriter implements io.Writer to redirect output to logger. This is used to redirect the output
+// from commands to the logger so we can add namespace and target to the logs for easier debugging.
+type logWriter struct {
+	namespace string
+	target    string
+	level     slog.Level
+}
+
+// NewLogWriter creates a new logWriter with the given namespace, target and level
+func NewLogWriter(namespace, target string, level slog.Level) io.Writer {
+	return &logWriter{
+		namespace: namespace,
+		target:    target,
+		level:     level,
+	}
+}
+
+func (l *logWriter) Write(p []byte) (n int, err error) {
+	lines := bytes.Split(bytes.TrimSpace(p), []byte("\n"))
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+
+		Logger.Log(context.Background(), l.level, string(line),
+			"namespace", l.namespace,
+			"target", l.target)
+	}
+
+	return len(p), nil
+}

--- a/server/public/pluginmage/pluginctl.go
+++ b/server/public/pluginmage/pluginctl.go
@@ -1,0 +1,167 @@
+package pluginmage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/magefile/mage/mg"
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+type Pluginctl mg.Namespace
+
+const commandTimeout = 120 * time.Second
+
+// Deploy uploads and enables a plugin via the Client4 API
+func (Pluginctl) Deploy() error {
+	bundleName := fmt.Sprintf("%s-%s.tar.gz", info.Manifest.Id, info.Manifest.Version)
+	bundlePath := filepath.Join("dist", bundleName)
+
+	// Check if the bundle exists and is accessible
+	fileInfo, err := os.Stat(bundlePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("plugin bundle not found at %s - did you run 'make dist' first?", bundlePath)
+		}
+		return fmt.Errorf("failed to access plugin bundle at %s: %w", bundlePath, err)
+	}
+
+	// Validate the file size
+	if fileInfo.Size() == 0 {
+		return fmt.Errorf("plugin bundle at %s is empty", bundlePath)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	pluginBundle, err := os.Open(bundlePath)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", bundlePath, err)
+	}
+	defer pluginBundle.Close()
+
+	Logger.Info("Uploading plugin via API")
+	_, _, err = client.UploadPluginForced(ctx, pluginBundle)
+	if err != nil {
+		return fmt.Errorf("failed to upload plugin bundle: %w", err)
+	}
+
+	Logger.Info("Enabling plugin")
+	_, err = client.EnablePlugin(ctx, info.Manifest.Id)
+	if err != nil {
+		return fmt.Errorf("failed to enable plugin: %w", err)
+	}
+
+	return nil
+}
+
+// Disable disables a plugin via the Client4 API
+func (Pluginctl) Disable() error {
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	Logger.Info("Disabling plugin")
+	_, err = client.DisablePlugin(ctx, info.Manifest.Id)
+	if err != nil {
+		return fmt.Errorf("failed to disable plugin: %w", err)
+	}
+
+	return nil
+}
+
+// Enable enables a plugin via the Client4 API
+func (Pluginctl) Enable() error {
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	Logger.Info("Enabling plugin")
+	_, err = client.EnablePlugin(ctx, info.Manifest.Id)
+	if err != nil {
+		return fmt.Errorf("failed to enable plugin: %w", err)
+	}
+
+	return nil
+}
+
+// Reset disables and re-enables a plugin via the Client4 API
+func (Pluginctl) Reset() error {
+	mg.SerialDeps(Pluginctl.Disable, Pluginctl.Enable)
+	return nil
+}
+
+// getClient returns a Client4 instance configured for local or remote connection
+func getClient(ctx context.Context) (*model.Client4, error) {
+	socketPath := os.Getenv("MM_LOCALSOCKETPATH")
+	if socketPath == "" {
+		socketPath = model.LocalModeSocketPath
+	}
+
+	client, connected := getUnixClient(socketPath)
+	if connected {
+		Logger.Info("Connecting using local mode", "socket", socketPath)
+		return client, nil
+	}
+
+	if os.Getenv("MM_LOCALSOCKETPATH") != "" {
+		Logger.Info("No socket found for local mode deployment, attempting to authenticate with credentials", "socket", socketPath)
+	}
+
+	siteURL := os.Getenv("MM_SERVICESETTINGS_SITEURL")
+	adminToken := os.Getenv("MM_ADMIN_TOKEN")
+	adminUsername := os.Getenv("MM_ADMIN_USERNAME")
+	adminPassword := os.Getenv("MM_ADMIN_PASSWORD")
+
+	if siteURL == "" {
+		return nil, errors.New("MM_SERVICESETTINGS_SITEURL is not set")
+	}
+
+	client = model.NewAPIv4Client(siteURL)
+
+	if adminToken != "" {
+		Logger.Info("Authenticating using token", "url", siteURL)
+		client.SetToken(adminToken)
+		return client, nil
+	}
+
+	if adminUsername != "" && adminPassword != "" {
+		client := model.NewAPIv4Client(siteURL)
+		Logger.Info("Authenticating with credentials", "username", adminUsername, "url", siteURL)
+		_, _, err := client.Login(ctx, adminUsername, adminPassword)
+		if err != nil {
+			return nil, fmt.Errorf("failed to login as %s: %w", adminUsername, err)
+		}
+
+		return client, nil
+	}
+
+	return nil, errors.New("one of MM_ADMIN_TOKEN or MM_ADMIN_USERNAME/MM_ADMIN_PASSWORD must be defined")
+}
+
+func getUnixClient(socketPath string) (*model.Client4, bool) {
+	_, err := net.Dial("unix", socketPath)
+	if err != nil {
+		return nil, false
+	}
+
+	return model.NewAPIv4SocketClient(socketPath), true
+}

--- a/server/public/pluginmage/server.go
+++ b/server/public/pluginmage/server.go
@@ -1,0 +1,112 @@
+package pluginmage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/magefile/mage/sh"
+)
+
+// Build builds the server if it exists
+func (Build) Server() error {
+	if !info.Manifest.HasServer() {
+		return nil
+	}
+
+	// Validate all binary configurations before starting the build
+	for _, config := range AllBinaries {
+		if err := config.IsValid(); err != nil {
+			return fmt.Errorf("invalid build configuration for binary '%s': %w", config.Name, err)
+		}
+	}
+
+	// Clean dist directory before creating it
+	if err := sh.Rm(filepath.Join("server", "dist")); err != nil {
+		return fmt.Errorf("failed to clean server/dist directory: %w", err)
+	}
+
+	// Create dist directory if it doesn't exist
+	if err := os.MkdirAll(filepath.Join("server", "dist"), 0755); err != nil {
+		return fmt.Errorf("failed to create server/dist directory: %w", err)
+	}
+
+	pluginBinary := AllBinaries[0]
+
+	for _, platform := range pluginBinary.Platforms {
+		if err := buildBinary(pluginBinary, platform); err != nil {
+			return fmt.Errorf("failed to build %s for %s/%s: %w",
+				pluginBinary.Name, platform.GOOS, platform.GOARCH, err)
+		}
+	}
+
+	return nil
+}
+
+// AdditionalBinaries builds all additional binaries if set up by the plugin developers
+func (Build) AdditionalBinaries() error {
+	for _, config := range AllBinaries[1:] {
+		for _, platform := range config.Platforms {
+			if err := buildBinary(config, platform); err != nil {
+				return fmt.Errorf("failed to build %s for %s/%s: %w",
+					config.Name, platform.GOOS, platform.GOARCH, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func buildBinary(config BinaryBuildConfig, platform BuildPlatform) error {
+	Logger.Info("Building binary",
+		"namespace", "build",
+		"target", "server",
+		"binary", config.Name,
+		"GOOS", platform.GOOS,
+		"GOARCH", platform.GOARCH)
+
+	// Prepare build args
+	buildArgs := append([]string{"build"}, DefaultBuildFlags...)
+
+	// Add build flags if set
+	if config.GoBuildFlags != "" {
+		buildArgs = append(buildArgs, config.GoBuildFlags)
+	}
+
+	// Add gcflags if set
+	if config.GcFlags != "" {
+		buildArgs = append(buildArgs, "-gcflags", config.GcFlags)
+	}
+
+	binaryName, err := config.GetBinaryName(platform.GOOS, platform.GOARCH)
+	if err != nil {
+		return fmt.Errorf("failed to get binary name for %s/%s: %w",
+			platform.GOOS, platform.GOARCH, err)
+	}
+
+	buildArgs = append(buildArgs,
+		"-o", filepath.Join(config.OutputPath, binaryName),
+		config.PackagePath,
+	)
+
+	// Set up environment
+	env := map[string]string{
+		"GOOS":   platform.GOOS,
+		"GOARCH": platform.GOARCH,
+	}
+	// Merge with config environment
+	for k, v := range config.Environment {
+		env[k] = v
+	}
+
+	cmd := NewCmd("server", "build", env)
+	if config.WorkingDir != "" {
+		cmd.WorkingDir(config.WorkingDir)
+	}
+
+	if err := cmd.Run("go", buildArgs...); err != nil {
+		return fmt.Errorf("failed to build: %w", err)
+	}
+
+	return nil
+}

--- a/server/public/pluginmage/types.go
+++ b/server/public/pluginmage/types.go
@@ -1,0 +1,103 @@
+package pluginmage
+
+import (
+	"os"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+const (
+	// defaultUtilitiesDir is the default path to mattermost-utilities directory
+	// Override with MM_UTILITIES_DIR environment variable
+	defaultUtilitiesDir = "../mattermost-utilities"
+
+	// defaultAssetsDir is the default path to assets directory
+	// Override with ASSETS_DIR environment variable
+	defaultAssetsDir = "assets"
+
+	// defaultGoTestFlags are the default flags used for go test
+	// Override with GO_TEST_FLAGS environment variable
+	defaultGoTestFlags = "-race"
+
+	// defaultGoBuildFlags are the default flags used for go build
+	// Override with GO_BUILD_FLAGS environment variable
+	defaultGoBuildFlags = ""
+
+	// defaultGoBuildGcflags are the default flags used for go build -gcflags
+	// Override with GO_BUILD_GCFLAGS environment variable
+	defaultGoBuildGcflags = ""
+)
+
+// pluginInfo holds all the information needed by magefile targets
+type pluginInfo struct {
+	Manifest            *model.Manifest
+	HasPublic           bool
+	HasUtilities        bool
+	UtilitiesDir        string
+	AssetsDir           string
+	GoTestFlags         string
+	GoBuildFlags        string
+	GoBuildGcflags      string
+	EnableDeveloperMode bool
+}
+
+// Init initializes values from environment variables and checks for existence of directories
+func (i *pluginInfo) Init() {
+	// Set utilities dir from environment if available
+	if mmUtilitiesDir := os.Getenv("MM_UTILITIES_DIR"); mmUtilitiesDir != "" {
+		i.UtilitiesDir = mmUtilitiesDir
+	}
+
+	// Set assets dir from environment if available
+	if assetsDir := os.Getenv("ASSETS_DIR"); assetsDir != "" {
+		i.AssetsDir = assetsDir
+	}
+
+	// Set go test flags from environment if available
+	if goTestFlags := os.Getenv("GO_TEST_FLAGS"); goTestFlags != "" {
+		i.GoTestFlags = goTestFlags
+	}
+
+	// Set go build flags from environment if available
+	if goBuildFlags := os.Getenv("GO_BUILD_FLAGS"); goBuildFlags != "" {
+		i.GoBuildFlags = goBuildFlags
+	}
+
+	// Check if public folder exists
+	if _, err := os.Stat("public"); err == nil {
+		i.HasPublic = true
+	}
+
+	// Check if mattermost-utilities exists
+	if _, err := os.Stat(i.UtilitiesDir); err == nil {
+		i.HasUtilities = true
+	}
+
+	if os.Getenv("MM_SERVICESETTINGS_ENABLEDEVELOPER") != "" {
+		i.EnableDeveloperMode = true
+	}
+
+	if os.Getenv("MM_DEBUG") != "" {
+		Logger.Info("MM_DEBUG is set, setting Go build gcflags to -gcflags all=-N -l. To disable, unset MM_DEBUG.")
+		i.GoBuildGcflags = "-gcflags all=-N -l"
+	}
+}
+
+// Defaults sets the default values for pluginInfo if they are not already set
+func (i *pluginInfo) Defaults() {
+	if i.UtilitiesDir == "" {
+		i.UtilitiesDir = defaultUtilitiesDir
+	}
+	if i.AssetsDir == "" {
+		i.AssetsDir = defaultAssetsDir
+	}
+	if i.GoTestFlags == "" {
+		i.GoTestFlags = defaultGoTestFlags
+	}
+	if i.GoBuildFlags == "" {
+		i.GoBuildFlags = defaultGoBuildFlags
+	}
+	if i.GoBuildGcflags == "" {
+		i.GoBuildGcflags = defaultGoBuildGcflags
+	}
+}

--- a/server/public/pluginmage/webapp.go
+++ b/server/public/pluginmage/webapp.go
@@ -1,0 +1,101 @@
+package pluginmage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+	"github.com/magefile/mage/target"
+)
+
+type Webapp mg.Namespace
+
+// Dependencies installs webapp dependencies using npm
+func (Webapp) Dependencies() error {
+	if !info.Manifest.HasWebapp() {
+		return nil
+	}
+
+	nodeModulesPath := filepath.Join("webapp", "node_modules")
+	packageJSONPath := filepath.Join("webapp", "package.json")
+
+	// Check if node_modules is newer than package.json
+	newer, err := target.Path(nodeModulesPath, packageJSONPath)
+	if err != nil {
+		return fmt.Errorf("failed to check dependencies: %w", err)
+	}
+	if !newer {
+		return nil // node_modules is up to date
+	}
+
+	Logger.Info("Installing webapp dependencies",
+		"namespace", "webapp",
+		"target", "dependencies")
+
+	cmd := NewCmd("webapp", "installdeps", nil)
+	if err := cmd.WorkingDir("webapp").Run("npm", "install"); err != nil {
+		return fmt.Errorf("failed to install webapp dependencies: %w", err)
+	}
+
+	return nil
+}
+
+// Build builds the webapp if it exists
+func (Build) Webapp() error {
+	mg.Deps(Webapp.Dependencies)
+
+	if !info.Manifest.HasWebapp() {
+		return nil
+	}
+
+	cmd := NewCmd("build", "webapp", nil)
+
+	// Clean dist directory before creating it
+	if err := sh.Rm(filepath.Join("webapp", "dist")); err != nil {
+		return fmt.Errorf("failed to clean webapp/dist directory: %w", err)
+	}
+
+	// Create dist directory if it doesn't exist
+	if err := os.MkdirAll(filepath.Join("webapp", "dist"), 0755); err != nil {
+		return fmt.Errorf("failed to create webapp/dist directory: %w", err)
+	}
+
+	Logger.Info("Building webapp",
+		"namespace", "build",
+		"target", "webapp")
+
+	if err := cmd.WorkingDir("webapp").Run("npm", "run", "build"); err != nil {
+		return fmt.Errorf("failed to build webapp: %w", err)
+	}
+
+	return nil
+}
+
+// Watch builds and watches the webapp for changes, rebuilding automatically
+func (Webapp) Watch() error {
+	mg.Deps(Webapp.Dependencies, Build.Server)
+	mg.SerialDeps(Build.Bundle)
+
+	if !info.Manifest.HasWebapp() {
+		return nil
+	}
+
+	cmd := NewCmd("webapp", "watch", nil)
+	npmCmd := "build:watch"
+	if os.Getenv("MM_DEBUG") != "" {
+		npmCmd = "debug:watch"
+	}
+
+	Logger.Info("Watching webapp for changes",
+		"namespace", "webapp",
+		"target", "watch",
+		"mode", npmCmd)
+
+	if err := cmd.WorkingDir("webapp").Run("npm", "run", npmCmd); err != nil {
+		return fmt.Errorf("failed to watch webapp: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Summary

- Adds a `pluginmage` package that can be used from plugins to maintain the toolkit up to date.
- Make targets migrated: `server`, `proceesor`, `webapp`, `webapp/node_modules`, `deploy`, `dist`, `bundle`, `watch`
- `Makefile` now calls `mage` on the migrated targets.
- PluginCTL logic has been migrated to mage directly by calling `mage pluginctl:(command)` and it's available to other targets as well.

### Improvements
- Can run dependendant targets in parallel (server and webapp for a build).
- Friendly error codes for checks (do you have Go? Do you have NPM? Do you have GNU's Tar?) with links to documentation
- Allow the plugin developers to specify other binaries to be built in their `magefiles`, there's an example in this plugin with the processor.
- Common asset management for plugins is centralized. No more copying and pasting configuration for the editor, golangci lint, github workflows, ...

### `pluginmage`

All logic is bundled to this package which is the one we can move to the public package in the mattermost server for distribution.

```
$ mage
Targets:
  build:additionalBinaries    builds all additional binaries if set up by the plugin developers
  build:all                   builds both server, additional binaries, and webapp
  build:bundle                creates a distributable bundle of the plugin
  build:server                Build builds the server if it exists
  build:webapp                Build builds the webapp if it exists
  deploy:upload               builds and installs the plugin to a server
  dummy                       prints a hello message and plugin info
  pluginctl:deploy            uploads and enables a plugin via the Client4 API
  pluginctl:disable           disables a plugin via the Client4 API
  pluginctl:enable            enables a plugin via the Client4 API
  pluginctl:reset             disables and re-enables a plugin via the Client4 API
  webapp:dependencies         installs webapp dependencies using npm
  webapp:watch                builds and watches the webapp for changes, rebuilding automatically
```

Check the included README.md in the package.

Requires https://github.com/mattermost/actions-workflows/pull/53

#### Ticket Link


#### Screenshots
--

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Adds new package with plugin tooling
```
