### PR TITLE
MM-59260 Add direct and group channel delete functionality

### DIFF
--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -1379,8 +1379,8 @@ func deleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.AddEventPriorState(channel)
 	defer c.LogAuditRec(auditRec)
 
-	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
-		c.Err = model.NewAppError("deleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
+	if (channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup) && !c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), channel.Id, model.PermissionDeletePrivateChannel) {
+		c.SetPermissionError(model.PermissionDeletePrivateChannel)
 		return
 	}
 

--- a/server/channels/api4/channel_local.go
+++ b/server/channels/api4/channel_local.go
@@ -422,8 +422,8 @@ func localDeleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.AddEventPriorState(channel)
 	audit.AddEventParameter(auditRec, "channel_id", c.Params.ChannelId)
 
-	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
-		c.Err = model.NewAppError("localDeleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
+	if (channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup) && !c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), channel.Id, model.PermissionDeletePrivateChannel) {
+		c.SetPermissionError(model.PermissionDeletePrivateChannel)
 		return
 	}
 

--- a/server/channels/api4/channel_local.go
+++ b/server/channels/api4/channel_local.go
@@ -422,8 +422,8 @@ func localDeleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.AddEventPriorState(channel)
 	audit.AddEventParameter(auditRec, "channel_id", c.Params.ChannelId)
 
-	if (channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup) && !c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), channel.Id, model.PermissionDeletePrivateChannel) {
-		c.SetPermissionError(model.PermissionDeletePrivateChannel)
+	if (channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup) && !c.Params.Permanent {
+		c.Err = model.NewAppError("deleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
 		return
 	}
 

--- a/server/channels/api4/channel_test.go
+++ b/server/channels/api4/channel_test.go
@@ -1352,7 +1352,7 @@ func TestDeleteDirectChannel(t *testing.T) {
 	require.NotNil(t, rgc, "should have created a direct channel")
 
 	_, err = client.DeleteChannel(context.Background(), rgc.Id)
-	CheckErrorID(t, err, "api.channel.delete_channel.type.invalid")
+	require.NoError(t, err)
 }
 
 func TestCreateGroupChannel(t *testing.T) {
@@ -1496,13 +1496,22 @@ func TestDeleteGroupChannel(t *testing.T) {
 
 	userIds := []string{user.Id, user2.Id, user3.Id}
 
-	th.TestForAllClients(t, func(t *testing.T, client *model.Client4) {
+	t.Run("Delete group channel for normal client", func(t *testing.T) {
 		rgc, resp, err := th.Client.CreateGroupChannel(context.Background(), userIds)
 		require.NoError(t, err)
 		CheckCreatedStatus(t, resp)
 		require.NotNil(t, rgc, "should have created a group channel")
-		_, err = client.DeleteChannel(context.Background(), rgc.Id)
-		CheckErrorID(t, err, "api.channel.delete_channel.type.invalid")
+		_, err = th.Client.DeleteChannel(context.Background(), rgc.Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete group channel for system admin client", func(t *testing.T) {
+		rgc, resp, err := th.SystemAdminClient.CreateGroupChannel(context.Background(), userIds)
+		require.NoError(t, err)
+		CheckCreatedStatus(t, resp)
+		require.NotNil(t, rgc, "should have created a group channel")
+		_, err = th.SystemAdminClient.DeleteChannel(context.Background(), rgc.Id)
+		require.NoError(t, err)
 	})
 }
 

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -397,7 +397,7 @@
   },
   {
     "id": "api.channel.delete_channel.type.invalid",
-    "translation": "Unable to delete direct or group message channels"
+    "translation": "Unable to soft delete direct or group message channels"
   },
   {
     "id": "api.channel.get_channel_moderations.license.error",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Added direct and group channel delete functionality in this PR. Updated the corresponding tests as well.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/27489
Jira https://mattermost.atlassian.net/browse/MM-59260

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
