### PR TITLE
Reduce Codecov spam

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,7 +1,8 @@
 comment:
-  layout: "diff, flags, files"
+  layout: "condensed_header, condensed_files, condensed_footer"
   behavior: default
-  require_changes: false  # if true: only post the comment if coverage changes
+  require_changes: "uncovered_patch" # only post comment if the patch has uncovered lines
+  hide_project_coverage: true # only show coverage on the git diff
 coverage:
   status:
     changes: false


### PR DESCRIPTION
#### Summary

We are tweaking the commenting options slightly to only post on uncovered patch lines and hide the project coverage. This will hopefully limit the times the comment is edited in place, although that shouldn't be causing extra notifications, according to the [documentation](https://docs.codecov.com/docs/pull-request-comments#behavior).

#### Release Note

```release-note
NONE
```
