### PR TITLE
Replace SELECT * with explicit column lists in sqlstore

### DIFF
--- a/server/channels/app/user_test.go
+++ b/server/channels/app/user_test.go
@@ -1248,12 +1248,12 @@ func TestPermanentDeleteUser(t *testing.T) {
 	})
 	assert.Nil(t, err)
 
-	bots1 := []*model.Bot{}
-	bots2 := []*model.Bot{}
+	var botCount1 int
+	var botCount2 int
 
-	err1 := th.SQLStore.GetMaster().Select(&bots1, "SELECT * FROM Bots")
+	err1 := th.SQLStore.GetMaster().Get(&botCount1, "SELECT COUNT(*) FROM Bots")
 	assert.NoError(t, err1)
-	assert.Equal(t, 1, len(bots1))
+	assert.Equal(t, 1, botCount1)
 
 	// test that bot is deleted from bots table
 	retUser1, err := th.App.GetUser(bot.UserId)
@@ -1262,9 +1262,9 @@ func TestPermanentDeleteUser(t *testing.T) {
 	err = th.App.PermanentDeleteUser(th.Context, retUser1)
 	assert.Nil(t, err)
 
-	err1 = th.SQLStore.GetMaster().Select(&bots2, "SELECT * FROM Bots")
+	err1 = th.SQLStore.GetMaster().Get(&botCount2, "SELECT COUNT(*) FROM Bots")
 	assert.NoError(t, err1)
-	assert.Equal(t, 0, len(bots2))
+	assert.Equal(t, 0, botCount2)
 
 	scheduledPost1 := &model.ScheduledPost{
 		Draft: model.Draft{


### PR DESCRIPTION
## Summary

Migrates away from `SELECT *` patterns to explicit column lists in the SQL store layer for better performance, maintainability, and schema safety. This follows the pattern established in PR #31356.

### Changes Made

**channels/store/sqlstore/channel_store.go:**
- Replace `GetPinnedPosts` raw SQL with query builder using `postSliceColumns()` + ReplyCount subquery
- Replace `"cc.*"` in group channel search with `channelSliceColumns()` while preserving existing PolicyEnforced behavior
- Replace `GetChannelsBatchForIndexing` raw SQL with query builder using `channelSliceColumns(false)` (no PolicyEnforced needed for indexing)
- Replace channel member and team queries with respective column helper functions (`channelMemberSliceColumns()`, `teamSliceColumns()`)
- Use `SelectBuilder` helper instead of manual `ToSql()` calls

**channels/app/user_test.go:**
- Replace unnecessary `SELECT * FROM Bots` with `SELECT COUNT(*) FROM Bots` in `TestPermanentDeleteUser`

### Test Plan
- [x] All existing tests pass
- [x] `go fmt` and `go vet` pass
- [x] Verified functional equivalence by ensuring tests pass
- [x] Manual verification that no `SELECT *` patterns remain in modified files

### Benefits
- **Performance**: Reduces data transfer by only selecting needed columns
- **Maintainability**: Explicit column lists make schema dependencies clear
- **Schema Safety**: Changes to table structure won't break queries unexpectedly
- **Consistency**: Follows established patterns in the codebase

### Ticket Link
Related to the ongoing SELECT * migration effort referenced in PR #31356

### Release Note
```release-note
NONE
```