### PR TITLE
Fix delete button aria-label on User Groups list modal

### DIFF
--- a/webapp/channels/src/components/view_user_group_modal/view_user_group_list_item/view_user_group_list_item.tsx
+++ b/webapp/channels/src/components/view_user_group_modal/view_user_group_list_item/view_user_group_list_item.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useCallback} from 'react';
+import {useIntl} from 'react-intl';
 import {useSelector} from 'react-redux';
 
 import type {Group} from '@mattermost/types/groups';
@@ -31,6 +32,7 @@ export type Props = {
 }
 
 const ViewUserGroupListItem = (props: Props) => {
+    const {formatMessage} = useIntl();
     const {
         user,
         group,
@@ -76,10 +78,14 @@ const ViewUserGroupListItem = (props: Props) => {
                 <button
                     type='button'
                     className='remove-group-member btn btn-icon btn-xs'
-                    aria-label='Close'
+                    aria-label={formatMessage({
+                        id: 'view_user_group_list_item.removeUserFromGroup',
+                        defaultMessage: 'Remove {user} from group',
+                    }, {user: Utils.getFullName(user)})}
                     onClick={removeUserFromGroup}
                 >
                     <i
+                        aria-hidden='true'
                         className='icon icon-trash-can-outline'
                     />
                 </button>

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -6280,6 +6280,7 @@
   "view_image.zoom_out": "Zoom Out",
   "view_image.zoom_reset": "Reset Zoom",
   "view_user_group_header_sub_menu.menuAriaLabel": "User group actions",
+  "view_user_group_list_item.removeUserFromGroup": "Remove {user} from group",
   "view_user_group_modal.ldapSynced": "AD/LDAP SYNCED",
   "view_user_group_modal.memberCount": "{member_count} {member_count, plural, one {Member} other {Members}}",
   "view_user_group_modal.pluginSynced": "Plugin SYNCED",


### PR DESCRIPTION
#### Summary
The Delete button per user on the User Groups modal was using a completely wrong `aria-label`. This PR adds one that is much more descriptive.

```release-note
Fix delete button aria-label on User Groups list modal
```
