### PR TITLE
Always require signatures for prepackaged plugins

### DIFF
--- a/server/channels/api4/apitestlib.go
+++ b/server/channels/api4/apitestlib.go
@@ -127,6 +127,11 @@ func setupTestHelper(tb testing.TB, dbStore store.Store, sqlSettings *model.SqlS
 		updateConfig(memoryConfig)
 	}
 	memoryStore.Set(memoryConfig)
+	for _, signaturePublicKeyFile := range memoryConfig.PluginSettings.SignaturePublicKeyFiles {
+		signaturePublicKey, err := os.ReadFile(signaturePublicKeyFile)
+		require.NoError(tb, err, "failed to read signature public key file %s", signaturePublicKeyFile)
+		memoryStore.SetFile(signaturePublicKeyFile, signaturePublicKey)
+	}
 
 	configStore, err := config.NewStoreFromBacking(memoryStore, nil, false)
 	require.NoError(tb, err)

--- a/server/channels/api4/apitestlib.go
+++ b/server/channels/api4/apitestlib.go
@@ -128,7 +128,8 @@ func setupTestHelper(tb testing.TB, dbStore store.Store, sqlSettings *model.SqlS
 	}
 	memoryStore.Set(memoryConfig)
 	for _, signaturePublicKeyFile := range memoryConfig.PluginSettings.SignaturePublicKeyFiles {
-		signaturePublicKey, err := os.ReadFile(signaturePublicKeyFile)
+		var signaturePublicKey []byte
+		signaturePublicKey, err = os.ReadFile(signaturePublicKeyFile)
 		require.NoError(tb, err, "failed to read signature public key file %s", signaturePublicKeyFile)
 		memoryStore.SetFile(signaturePublicKeyFile, signaturePublicKey)
 	}

--- a/server/channels/api4/plugin_test.go
+++ b/server/channels/api4/plugin_test.go
@@ -1832,10 +1832,7 @@ func TestInstallMarketplacePluginPrepackagedDisabled(t *testing.T) {
 		defer th.TearDown()
 
 		th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
-			pluginSignatureFile, err := os.Open(filepath.Join(path, "testplugin.tar.gz.asc"))
-			require.NoError(t, err)
-			pluginSignatureData, err := io.ReadAll(pluginSignatureFile)
-			require.NoError(t, err)
+			expectedSignaturePath := filepath.Join(prepackagedPluginsDir, "testplugin.tar.gz.sig")
 
 			testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 				serverVersion := req.URL.Query().Get("server_version")
@@ -1881,7 +1878,7 @@ func TestInstallMarketplacePluginPrepackagedDisabled(t *testing.T) {
 				plugins := env.PrepackagedPlugins()
 				require.Len(t, plugins, 1)
 				require.Equal(t, "testplugin", plugins[0].Manifest.Id)
-				require.Equal(t, pluginSignatureData, plugins[0].Signature)
+				require.Equal(t, expectedSignaturePath, plugins[0].SignaturePath)
 
 				pluginsResp, _, err = client.GetPlugins(context.Background())
 				require.NoError(t, err)

--- a/server/channels/api4/plugin_test.go
+++ b/server/channels/api4/plugin_test.go
@@ -1406,16 +1406,18 @@ func TestGetPrepackagedPlaybooksPluginIn(t *testing.T) {
 }
 
 func TestInstallMarketplacePlugin(t *testing.T) {
-	th := Setup(t).InitBasic()
-	defer th.TearDown()
+	path, _ := fileutils.FindDir("tests")
 
-	th.App.UpdateConfig(func(cfg *model.Config) {
+	th := SetupConfig(t, func(cfg *model.Config) {
 		*cfg.PluginSettings.Enable = true
 		*cfg.PluginSettings.EnableUploads = true
 		*cfg.PluginSettings.EnableMarketplace = false
-	})
+		cfg.PluginSettings.SignaturePublicKeyFiles = []string{
+			filepath.Join(path, "development-private-key.asc"),
+		}
+	}).InitBasic()
+	defer th.TearDown()
 
-	path, _ := fileutils.FindDir("tests")
 	signatureFilename := "testplugin2.tar.gz.sig"
 	signatureFileReader, err := os.Open(filepath.Join(path, signatureFilename))
 	require.NoError(t, err)
@@ -1581,11 +1583,6 @@ func TestInstallMarketplacePlugin(t *testing.T) {
 			*cfg.PluginSettings.MarketplaceURL = testServer.URL
 		})
 
-		key, err := os.Open(filepath.Join(path, "development-private-key.asc"))
-		require.NoError(t, err)
-		appErr := th.App.AddPublicKey("pub_key", key)
-		require.Nil(t, appErr)
-
 		pRequest := &model.InstallMarketplacePluginRequest{Id: "testplugin2"}
 		manifest, _, err := client.InstallMarketplacePlugin(context.Background(), pRequest)
 		require.NoError(t, err)
@@ -1626,11 +1623,6 @@ func TestInstallMarketplacePlugin(t *testing.T) {
 			*cfg.PluginSettings.EnableRemoteMarketplace = true
 			*cfg.PluginSettings.MarketplaceURL = testServer.URL
 		})
-
-		key, err := os.Open(filepath.Join(path, "development-private-key.asc"))
-		require.NoError(t, err)
-		appErr := th.App.AddPublicKey("pub_key", key)
-		require.Nil(t, appErr)
 
 		pRequest := &model.InstallMarketplacePluginRequest{Id: "testplugin2", Version: "9.9.9"}
 		manifest, _, err := client.InstallMarketplacePlugin(context.Background(), pRequest)
@@ -1833,6 +1825,9 @@ func TestInstallMarketplacePluginPrepackagedDisabled(t *testing.T) {
 		th := SetupConfig(t, func(cfg *model.Config) {
 			// Disable auto-installing prepackaged plugins
 			*cfg.PluginSettings.AutomaticPrepackagedPlugins = false
+			cfg.PluginSettings.SignaturePublicKeyFiles = []string{
+				filepath.Join(path, "development-private-key.asc"),
+			}
 		}).InitBasic()
 		defer th.TearDown()
 
@@ -1841,16 +1836,6 @@ func TestInstallMarketplacePluginPrepackagedDisabled(t *testing.T) {
 			require.NoError(t, err)
 			pluginSignatureData, err := io.ReadAll(pluginSignatureFile)
 			require.NoError(t, err)
-
-			key, err := os.Open(filepath.Join(path, "development-private-key.asc"))
-			require.NoError(t, err)
-			appErr := th.App.AddPublicKey("pub_key", key)
-			require.Nil(t, appErr)
-
-			t.Cleanup(func() {
-				appErr = th.App.DeletePublicKey("pub_key")
-				require.Nil(t, appErr)
-			})
 
 			testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 				serverVersion := req.URL.Query().Get("server_version")
@@ -1956,7 +1941,7 @@ func TestInstallMarketplacePluginPrepackagedDisabled(t *testing.T) {
 				assert.Equal(t, "0.0.1", manifest.Version)
 			})
 
-			t.Run("Install both a prepacked and a Marketplace plugin", func(t *testing.T) {
+			t.Run("Install both a prepackaged and a Marketplace plugin", func(t *testing.T) {
 				pRequest := &model.InstallMarketplacePluginRequest{Id: "testplugin"}
 				manifest1, _, err := client.InstallMarketplacePlugin(context.Background(), pRequest)
 				require.NoError(t, err)
@@ -1993,9 +1978,6 @@ func TestInstallMarketplacePluginPrepackagedDisabled(t *testing.T) {
 					},
 				})
 			})
-
-			appErr = th.App.DeletePublicKey("pub_key")
-			require.Nil(t, appErr)
 		})
 	})
 
@@ -2016,15 +1998,13 @@ func TestInstallMarketplacePluginPrepackagedDisabled(t *testing.T) {
 		th := SetupConfig(t, func(cfg *model.Config) {
 			// Disable auto-installing prepackaged plugins
 			*cfg.PluginSettings.AutomaticPrepackagedPlugins = false
+			cfg.PluginSettings.SignaturePublicKeyFiles = []string{
+				filepath.Join(path, "development-private-key.asc"),
+			}
 		}).InitBasic()
 		defer th.TearDown()
 
 		th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
-			key, err := os.Open(filepath.Join(path, "development-private-key.asc"))
-			require.NoError(t, err)
-			appErr := th.App.AddPublicKey("pub_key", key)
-			require.Nil(t, appErr)
-
 			testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 				serverVersion := req.URL.Query().Get("server_version")
 				require.NotEmpty(t, serverVersion)
@@ -2050,9 +2030,7 @@ func TestInstallMarketplacePluginPrepackagedDisabled(t *testing.T) {
 
 			env := th.App.GetPluginsEnvironment()
 			plugins := env.PrepackagedPlugins()
-			require.Len(t, plugins, 1)
-			require.Equal(t, "testplugin", plugins[0].Manifest.Id)
-			require.Empty(t, plugins[0].Signature)
+			require.Len(t, plugins, 0)
 
 			pluginsResp, _, err := client.GetPlugins(context.Background())
 			require.NoError(t, err)
@@ -2080,10 +2058,6 @@ func TestInstallMarketplacePluginPrepackagedDisabled(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, pluginsResp.Active, 0)
 			require.Len(t, pluginsResp.Inactive, 0)
-
-			// Clean up
-			appErr = th.App.DeletePublicKey("pub_key")
-			require.Nil(t, appErr)
 		})
 	})
 }

--- a/server/channels/app/helper_test.go
+++ b/server/channels/app/helper_test.go
@@ -84,7 +84,8 @@ func setupTestHelper(dbStore store.Store, sqlStore *sqlstore.SqlStore, sqlSettin
 	}
 
 	for _, signaturePublicKeyFile := range memoryConfig.PluginSettings.SignaturePublicKeyFiles {
-		signaturePublicKey, err := os.ReadFile(signaturePublicKeyFile)
+		var signaturePublicKey []byte
+		signaturePublicKey, err = os.ReadFile(signaturePublicKeyFile)
 		require.NoError(tb, err, "failed to read signature public key file %s", signaturePublicKeyFile)
 		configStore.SetFile(signaturePublicKeyFile, signaturePublicKey)
 	}

--- a/server/channels/app/helper_test.go
+++ b/server/channels/app/helper_test.go
@@ -82,6 +82,12 @@ func setupTestHelper(dbStore store.Store, sqlStore *sqlstore.SqlStore, sqlSettin
 	if updateConfig != nil {
 		updateConfig(memoryConfig)
 	}
+
+	for _, signaturePublicKeyFile := range memoryConfig.PluginSettings.SignaturePublicKeyFiles {
+		signaturePublicKey, err := os.ReadFile(signaturePublicKeyFile)
+		require.NoError(tb, err, "failed to read signature public key file %s", signaturePublicKeyFile)
+		configStore.SetFile(signaturePublicKeyFile, signaturePublicKey)
+	}
 	configStore.Set(memoryConfig)
 
 	buffer := &mlog.Buffer{}

--- a/server/channels/app/plugin_install.go
+++ b/server/channels/app/plugin_install.go
@@ -123,6 +123,11 @@ func (ch *Channels) installPluginFromClusterMessage(pluginID string) {
 		return
 	}
 
+	logger = logger.With(
+		mlog.String("bundle_path", plugin.bundlePath),
+		mlog.String("signature_path", plugin.signaturePath),
+	)
+
 	bundle, appErr := ch.srv.fileReader(plugin.bundlePath)
 	if appErr != nil {
 		logger.Error("Failed to open plugin bundle from file store.", mlog.Err(appErr))
@@ -139,7 +144,7 @@ func (ch *Channels) installPluginFromClusterMessage(pluginID string) {
 		}
 		defer signature.Close()
 
-		if err := ch.verifyPlugin(bundle, signature); err != nil {
+		if err := ch.verifyPlugin(logger, bundle, signature); err != nil {
 			logger.Error("Failed to validate plugin signature.", mlog.Err(appErr))
 			return
 		}
@@ -270,7 +275,11 @@ func (ch *Channels) installPluginToFilestore(manifest *model.Manifest, bundle, s
 // plugin bundle from the prepackaged folder, if available, or remotely if EnableRemoteMarketplace
 // is true.
 func (ch *Channels) InstallMarketplacePlugin(request *model.InstallMarketplacePluginRequest) (*model.Manifest, *model.AppError) {
-	logger := ch.srv.Log().With(mlog.String("plugin_id", request.Id))
+	logger := ch.srv.Log().With(
+		mlog.String("plugin_id", request.Id),
+		mlog.String("requested_version", request.Version),
+	)
+	logger.Info("Installing plugin from marketplace")
 
 	var pluginFile, signatureFile io.ReadSeeker
 
@@ -287,6 +296,7 @@ func (ch *Channels) InstallMarketplacePlugin(request *model.InstallMarketplacePl
 
 		pluginFile = fileReader
 		signatureFile = bytes.NewReader(prepackagedPlugin.Signature)
+		logger.Debug("Found matching pre-packaged plugin", mlog.String("bundle_path", prepackagedPlugin.Path))
 	}
 
 	if *ch.cfgSvc.Config().PluginSettings.EnableRemoteMarketplace {
@@ -313,6 +323,8 @@ func (ch *Channels) InstallMarketplacePlugin(request *model.InstallMarketplacePl
 			}
 
 			if prepackagedVersion.LT(marketplaceVersion) { // Always true if no prepackaged plugin was found
+				logger.Debug("Found upgraded plugin from remote marketplace", mlog.String("version", plugin.Manifest.Version), mlog.String("download_url", plugin.DownloadURL))
+
 				downloadedPluginBytes, err := ch.srv.downloadFromURL(plugin.DownloadURL)
 				if err != nil {
 					return nil, model.NewAppError("InstallMarketplacePlugin", "app.plugin.install_marketplace_plugin.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -323,6 +335,8 @@ func (ch *Channels) InstallMarketplacePlugin(request *model.InstallMarketplacePl
 				}
 				pluginFile = bytes.NewReader(downloadedPluginBytes)
 				signatureFile = signature
+			} else {
+				logger.Debug("Preferring pre-packaged plugin over version in remote marketplace", mlog.String("version", plugin.Manifest.Version), mlog.String("download_url", plugin.DownloadURL))
 			}
 		}
 	}
@@ -334,7 +348,7 @@ func (ch *Channels) InstallMarketplacePlugin(request *model.InstallMarketplacePl
 		return nil, model.NewAppError("InstallMarketplacePlugin", "app.plugin.marketplace_plugins.signature_not_found.app_error", nil, "", http.StatusInternalServerError)
 	}
 
-	appErr = ch.verifyPlugin(pluginFile, signatureFile)
+	appErr = ch.verifyPlugin(logger, pluginFile, signatureFile)
 	if appErr != nil {
 		return nil, appErr
 	}

--- a/server/channels/app/plugin_install.go
+++ b/server/channels/app/plugin_install.go
@@ -294,9 +294,15 @@ func (ch *Channels) InstallMarketplacePlugin(request *model.InstallMarketplacePl
 		}
 		defer fileReader.Close()
 
+		signatureReader, err := os.Open(prepackagedPlugin.SignaturePath)
+		if err != nil {
+			return nil, model.NewAppError("InstallMarketplacePlugin", "app.plugin.install_marketplace_plugin.app_error", nil, fmt.Sprintf("failed to open prepackaged plugin signature %s", prepackagedPlugin.SignaturePath), http.StatusInternalServerError).Wrap(err)
+		}
+		defer signatureReader.Close()
+
 		pluginFile = fileReader
-		signatureFile = bytes.NewReader(prepackagedPlugin.Signature)
-		logger.Debug("Found matching pre-packaged plugin", mlog.String("bundle_path", prepackagedPlugin.Path))
+		signatureFile = signatureReader
+		logger.Debug("Found matching pre-packaged plugin", mlog.String("bundle_path", prepackagedPlugin.Path), mlog.String("signature_path", prepackagedPlugin.SignaturePath))
 	}
 
 	if *ch.cfgSvc.Config().PluginSettings.EnableRemoteMarketplace {

--- a/server/channels/app/plugin_prepackaged_test.go
+++ b/server/channels/app/plugin_prepackaged_test.go
@@ -58,7 +58,7 @@ func TestBuildPrepackagedPlugin(t *testing.T) {
 		// Verify plugin fields
 		assert.NotNil(t, plugin.Manifest)
 		assert.Equal(t, pluginPath.bundlePath, plugin.Path)
-		assert.NotEmpty(t, plugin.Signature)
+		assert.Equal(t, pluginPath.signaturePath, plugin.SignaturePath)
 		assert.Equal(t, "testplugin", plugin.Manifest.Id)
 
 		// Verify plugin has icon data loaded
@@ -112,7 +112,7 @@ func TestBuildPrepackagedPlugin(t *testing.T) {
 		require.Nil(t, plugin)
 		require.Empty(t, pluginDir)
 
-		assert.Contains(t, err.Error(), "Failed to read prepackaged plugin signature")
+		assert.Contains(t, err.Error(), "Failed to open prepackaged plugin signature")
 	})
 
 	t.Run("empty signature file", func(t *testing.T) {

--- a/server/channels/app/plugin_prepackaged_test.go
+++ b/server/channels/app/plugin_prepackaged_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/v8/channels/utils/fileutils"
+)
+
+func TestBuildPrepackagedPlugin(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	testsPath, found := fileutils.FindDir("tests")
+	require.True(t, found, "tests directory not found")
+
+	// Read public key file once for all subtests
+	publicKeyData, err := os.ReadFile(filepath.Join(testsPath, "development-public-key.asc"))
+	require.NoError(t, err)
+
+	t.Run("valid plugin with signature and icon data", func(t *testing.T) {
+		th := Setup(t)
+		defer th.TearDown()
+
+		// Import development public key for signature verification
+		appErr := th.App.AddPublicKey("development-public-key.asc", bytes.NewBuffer(publicKeyData))
+		require.Nil(t, appErr)
+
+		// Create test plugin path
+		pluginPath := &pluginSignaturePath{
+			pluginID:      "testplugin",
+			bundlePath:    filepath.Join(testsPath, "testplugin.tar.gz"),
+			signaturePath: filepath.Join(testsPath, "testplugin.tar.gz.sig"),
+		}
+
+		// Open plugin file
+		pluginFile, err := os.Open(pluginPath.bundlePath)
+		require.NoError(t, err)
+		defer pluginFile.Close()
+
+		// Create logger
+		logger := mlog.CreateConsoleTestLogger(t)
+
+		// Test buildPrepackagedPlugin
+		plugin, pluginDir, err := th.App.ch.buildPrepackagedPlugin(logger, pluginPath, pluginFile, t.TempDir())
+		require.NoError(t, err)
+		require.NotNil(t, plugin)
+		require.NotEmpty(t, pluginDir)
+
+		// Verify plugin fields
+		assert.NotNil(t, plugin.Manifest)
+		assert.Equal(t, pluginPath.bundlePath, plugin.Path)
+		assert.NotEmpty(t, plugin.Signature)
+		assert.Equal(t, "testplugin", plugin.Manifest.Id)
+
+		// Verify plugin has icon data loaded
+		assert.Equal(t, "assets/icon.svg", plugin.Manifest.IconPath)
+		assert.NotEmpty(t, plugin.IconData, "Plugin should have icon data loaded")
+	})
+
+	t.Run("missing signature file", func(t *testing.T) {
+		th := Setup(t)
+		defer th.TearDown()
+
+		// Create plugin path with empty signature path
+		pluginPath := &pluginSignaturePath{
+			pluginID:      "testplugin",
+			bundlePath:    filepath.Join(testsPath, "testplugin.tar.gz"),
+			signaturePath: "", // Empty signature path
+		}
+
+		pluginFile, err := os.Open(pluginPath.bundlePath)
+		require.NoError(t, err)
+		defer pluginFile.Close()
+
+		logger := mlog.CreateConsoleTestLogger(t)
+
+		plugin, pluginDir, err := th.App.ch.buildPrepackagedPlugin(logger, pluginPath, pluginFile, t.TempDir())
+		require.Error(t, err)
+		require.Nil(t, plugin)
+		require.Empty(t, pluginDir)
+
+		assert.Contains(t, err.Error(), "Prepackaged plugin missing required signature file")
+	})
+
+	t.Run("nonexistent signature file", func(t *testing.T) {
+		th := Setup(t)
+		defer th.TearDown()
+
+		pluginPath := &pluginSignaturePath{
+			pluginID:      "testplugin",
+			bundlePath:    filepath.Join(testsPath, "testplugin.tar.gz"),
+			signaturePath: "/nonexistent/signature.sig",
+		}
+
+		pluginFile, err := os.Open(pluginPath.bundlePath)
+		require.NoError(t, err)
+		defer pluginFile.Close()
+
+		logger := mlog.CreateConsoleTestLogger(t)
+
+		plugin, pluginDir, err := th.App.ch.buildPrepackagedPlugin(logger, pluginPath, pluginFile, t.TempDir())
+		require.Error(t, err)
+		require.Nil(t, plugin)
+		require.Empty(t, pluginDir)
+
+		assert.Contains(t, err.Error(), "Failed to read prepackaged plugin signature")
+	})
+
+	t.Run("empty signature file", func(t *testing.T) {
+		th := Setup(t)
+		defer th.TearDown()
+
+		// Import development public key
+		appErr := th.App.AddPublicKey("development-public-key.asc", bytes.NewBuffer(publicKeyData))
+		require.Nil(t, appErr)
+
+		// Create empty signature file
+		tmpSig, err := os.CreateTemp("", "*.sig")
+		require.NoError(t, err)
+		tmpSig.Close()
+		defer os.Remove(tmpSig.Name())
+
+		pluginPath := &pluginSignaturePath{
+			pluginID:      "testplugin",
+			bundlePath:    filepath.Join(testsPath, "testplugin.tar.gz"),
+			signaturePath: tmpSig.Name(),
+		}
+
+		pluginFile, err := os.Open(pluginPath.bundlePath)
+		require.NoError(t, err)
+		defer pluginFile.Close()
+
+		logger := mlog.CreateConsoleTestLogger(t)
+
+		plugin, pluginDir, err := th.App.ch.buildPrepackagedPlugin(logger, pluginPath, pluginFile, t.TempDir())
+		require.Error(t, err)
+		require.Nil(t, plugin)
+		require.Empty(t, pluginDir)
+
+		assert.Contains(t, err.Error(), "Prepackaged plugin signature verification failed")
+	})
+
+	t.Run("signature verification failure", func(t *testing.T) {
+		th := Setup(t)
+		defer th.TearDown()
+
+		// Use mismatched plugin and signature (testplugin.tar.gz with testplugin2.tar.gz.sig)
+		pluginPath := &pluginSignaturePath{
+			pluginID:      "testplugin",
+			bundlePath:    filepath.Join(testsPath, "testplugin.tar.gz"),
+			signaturePath: filepath.Join(testsPath, "testplugin2.tar.gz.sig"),
+		}
+
+		pluginFile, err := os.Open(pluginPath.bundlePath)
+		require.NoError(t, err)
+		defer pluginFile.Close()
+
+		logger := mlog.CreateConsoleTestLogger(t)
+
+		plugin, pluginDir, err := th.App.ch.buildPrepackagedPlugin(logger, pluginPath, pluginFile, t.TempDir())
+		require.Error(t, err)
+		require.Nil(t, plugin)
+		require.Empty(t, pluginDir)
+
+		assert.Contains(t, err.Error(), "Prepackaged plugin signature verification failed")
+	})
+}

--- a/server/channels/app/plugin_test.go
+++ b/server/channels/app/plugin_test.go
@@ -895,7 +895,7 @@ func TestProcessPrepackagedPlugins(t *testing.T) {
 		t.Helper()
 
 		require.Equal(t, pluginID, actual.Manifest.Id)
-		require.NotEmpty(t, actual.Signature, "testplugin has no signature")
+		require.NotEmpty(t, actual.SignaturePath, "testplugin has no signature")
 		require.Equal(t, version, actual.Manifest.Version)
 	}
 

--- a/server/channels/app/plugin_test.go
+++ b/server/channels/app/plugin_test.go
@@ -478,7 +478,13 @@ func TestGetPluginStatuses(t *testing.T) {
 
 func TestPluginSync(t *testing.T) {
 	mainHelper.Parallel(t)
-	th := Setup(t)
+	path, _ := fileutils.FindDir("tests")
+
+	th := SetupConfig(t, func(cfg *model.Config) {
+		cfg.PluginSettings.SignaturePublicKeyFiles = []string{
+			filepath.Join(path, "development-private-key.asc"),
+		}
+	})
 	defer th.TearDown()
 
 	testCases := []struct {
@@ -526,8 +532,6 @@ func TestPluginSync(t *testing.T) {
 
 			env := th.App.GetPluginsEnvironment()
 			require.NotNil(t, env)
-
-			path, _ := fileutils.FindDir("tests")
 
 			t.Run("new bundle in the file store", func(t *testing.T) {
 				th.App.UpdateConfig(func(cfg *model.Config) {
@@ -610,15 +614,10 @@ func TestPluginSync(t *testing.T) {
 					*cfg.PluginSettings.RequirePluginSignature = true
 				})
 
-				key, err := os.Open(filepath.Join(path, "development-private-key.asc"))
-				require.NoError(t, err)
-				appErr := th.App.AddPublicKey("pub_key", key)
-				checkNoError(t, appErr)
-
 				signatureFileReader, err := os.Open(filepath.Join(path, "testplugin.tar.gz.sig"))
 				require.NoError(t, err)
 				defer signatureFileReader.Close()
-				_, appErr = th.App.WriteFile(signatureFileReader, getSignatureStorePath("testplugin"))
+				_, appErr := th.App.WriteFile(signatureFileReader, getSignatureStorePath("testplugin"))
 				checkNoError(t, appErr)
 
 				appErr = th.App.SyncPlugins()
@@ -832,13 +831,17 @@ func (a pluginStatusById) Less(i, j int) bool { return a[i].PluginId < a[j].Plug
 
 func TestProcessPrepackagedPlugins(t *testing.T) {
 	mainHelper.Parallel(t)
-	// Find the tests folder before we change directories to the temporary workspace.
-	testsPath, _ := fileutils.FindDir("tests")
+	testsPath, found := fileutils.FindDir("tests")
+	require.True(t, found, "failed to find tests directory")
 
 	setup := func(t *testing.T) *TestHelper {
 		t.Helper()
 
-		th := Setup(t)
+		th := SetupConfig(t, func(cfg *model.Config) {
+			cfg.PluginSettings.SignaturePublicKeyFiles = []string{
+				filepath.Join(testsPath, "development-private-key.asc"),
+			}
+		})
 		t.Cleanup(th.TearDown)
 
 		// Make a prepackaged_plugins directory for use with the tests.

--- a/server/public/plugin/environment.go
+++ b/server/public/plugin/environment.go
@@ -38,10 +38,10 @@ type registeredPlugin struct {
 
 // PrepackagedPlugin is a plugin prepackaged with the server and found on startup.
 type PrepackagedPlugin struct {
-	Path      string
-	IconData  string
-	Manifest  *model.Manifest
-	Signature []byte
+	Path          string
+	IconData      string
+	Manifest      *model.Manifest
+	SignaturePath string
 }
 
 // Environment represents the execution environment of active plugins.


### PR DESCRIPTION
#### Summary
We have always required signatures for packages installed via the marketplace -- whether remotely satisfied, or sourced from the prepackaged plugin cache.

However, prepackaged plugins discovered and automatically installed on startup did not require a valid signature. Since we already ship signatures for all Mattermost-authored prepackaged plugins, it's easy to simply start requiring this.

Distributions of Mattermost that bundle their own prepackaged plugins will have to include their own signatures. This in turn requires distributing and configuring Mattermost with a custom public key via `PluginSettings.SignaturePublicKeyFiles`.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-64627

#### Release Note
```release-note
Always validate signatures for pre-packaged plugins.
```