### PR TITLE
[MM-64639] Fix styling on thread item header

### DIFF
--- a/webapp/channels/src/components/threading/global_threads/thread_item/thread_item.scss
+++ b/webapp/channels/src/components/threading/global_threads/thread_item/thread_item.scss
@@ -105,7 +105,7 @@
         place-content: center;
     }
 
-    > header {
+    > .thread-item-header {
         position: relative;
         display: grid;
         margin: 0 0 6px;


### PR DESCRIPTION
#### Summary
The styling on the thread item broke as I missed changing the styling on the `thread_item` header. This PR switches to using the class instead of the element name.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64639

```release-note
NONE
```
