### PR TITLE
Fix undefined variable 'opts' in getSidebarCategoriesT function

### DIFF
--- a/server/channels/store/sqlstore/channel_store_categories.go
+++ b/server/channels/store/sqlstore/channel_store_categories.go
@@ -568,7 +568,7 @@ func (s SqlChannelStore) getSidebarCategoriesT(db sqlxExecutor, userId, teamId s
 		}
 	}
 
-	if _, err := s.completePopulatingCategoriesT(db, userId, opts.TeamID, oc.Categories); err != nil {
+	if _, err := s.completePopulatingCategoriesT(db, userId, teamId, oc.Categories); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
#### Summary

Fixes a compilation error in the `getSidebarCategoriesT` function where an undefined variable `opts` was being referenced. The function was trying to use `opts.TeamID` but `opts` was not defined in the function scope. Changed it to use the `teamId` parameter which is properly defined in the function signature.

This fix resolves the broken master branch build that was failing with:
```
channels/store/sqlstore/channel_store_categories.go:571:59: undefined: opts
```

#### Ticket Link

This fixes the broken master branch build.

#### Release Note

```release-note
NONE
```