### PR TITLE
gosec-g304: localstore os.root

### DIFF
--- a/server/platform/shared/filestore/filesstore_test.go
+++ b/server/platform/shared/filestore/filesstore_test.go
@@ -127,9 +127,9 @@ func (s *FileBackendTestSuite) SetupTest() {
 	err = s.backend.TestConnection()
 	if _, ok := err.(*S3FileBackendNoBucketError); ok {
 		s3Backend := s.backend.(*S3FileBackend)
-		s.NoError(s3Backend.MakeBucket())
+		s.Require().NoError(s3Backend.MakeBucket())
 	} else {
-		s.NoError(err)
+		s.Require().NoError(err)
 	}
 }
 
@@ -142,12 +142,12 @@ func (s *FileBackendTestSuite) TestReadWriteFile() {
 	path := "tests/" + randomString()
 
 	written, err := s.backend.WriteFile(bytes.NewReader(b), path)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
 	defer s.backend.RemoveFile(path)
 
 	read, err := s.backend.ReadFile(path)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	readString := string(read)
 	s.EqualValues(readString, "test")
@@ -174,12 +174,12 @@ func (s *FileBackendTestSuite) TestReadWriteFileContext() {
 		} else {
 			written, err = s.backend.WriteFile(strings.NewReader(data), path)
 		}
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.EqualValues(len(data), written, "expected given number of bytes to have been written")
 		defer s.backend.RemoveFile(path)
 
 		read, err := s.backend.ReadFile(path)
-		s.NoError(err)
+		s.Require().NoError(err)
 
 		readString := string(read)
 		s.Equal(readString, data)
@@ -200,12 +200,12 @@ func (s *FileBackendTestSuite) TestReadWriteFileContext() {
 		} else {
 			written, err = s.backend.WriteFile(strings.NewReader(data), path)
 		}
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.EqualValues(len(data), written, "expected given number of bytes to have been written")
 		defer s.backend.RemoveFile(path)
 
 		read, err := s.backend.ReadFile(path)
-		s.NoError(err)
+		s.Require().NoError(err)
 
 		readString := string(read)
 		s.Equal(readString, data)
@@ -243,12 +243,12 @@ func (s *FileBackendTestSuite) TestReadWriteFileImage() {
 	path := "tests/" + randomString() + ".png"
 
 	written, err := s.backend.WriteFile(bytes.NewReader(b), path)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
 	defer s.backend.RemoveFile(path)
 
 	read, err := s.backend.ReadFile(path)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	readString := string(read)
 	s.EqualValues(readString, "testimage")
@@ -259,15 +259,15 @@ func (s *FileBackendTestSuite) TestFileExists() {
 	path := "tests/" + randomString() + ".png"
 
 	_, err := s.backend.WriteFile(bytes.NewReader(b), path)
-	s.NoError(err)
+	s.Require().NoError(err)
 	defer s.backend.RemoveFile(path)
 
 	res, err := s.backend.FileExists(path)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.True(res)
 
 	res, err = s.backend.FileExists("tests/idontexist.png")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.False(res)
 }
 
@@ -277,19 +277,19 @@ func (s *FileBackendTestSuite) TestCopyFile() {
 	path2 := "tests/" + randomString()
 
 	written, err := s.backend.WriteFile(bytes.NewReader(b), path1)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
 	defer s.backend.RemoveFile(path1)
 
 	err = s.backend.CopyFile(path1, path2)
-	s.NoError(err)
+	s.Require().NoError(err)
 	defer s.backend.RemoveFile(path2)
 
 	data1, err := s.backend.ReadFile(path1)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	data2, err := s.backend.ReadFile(path2)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal(b, data1)
 	s.Equal(b, data2)
@@ -301,19 +301,19 @@ func (s *FileBackendTestSuite) TestCopyFileToDirectoryThatDoesntExist() {
 	path2 := "tests/newdirectory/" + randomString()
 
 	written, err := s.backend.WriteFile(bytes.NewReader(b), path1)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
 	defer s.backend.RemoveFile(path1)
 
 	err = s.backend.CopyFile(path1, path2)
-	s.NoError(err)
+	s.Require().NoError(err)
 	defer s.backend.RemoveFile(path2)
 
 	_, err = s.backend.ReadFile(path1)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	_, err = s.backend.ReadFile(path2)
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func (s *FileBackendTestSuite) TestMoveFile() {
@@ -322,7 +322,7 @@ func (s *FileBackendTestSuite) TestMoveFile() {
 	path2 := "tests/" + randomString()
 
 	written, err := s.backend.WriteFile(bytes.NewReader(b), path1)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
 	defer s.backend.RemoveFile(path1)
 
@@ -333,7 +333,7 @@ func (s *FileBackendTestSuite) TestMoveFile() {
 	s.Error(err)
 
 	data, err := s.backend.ReadFile(path2)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal(b, data)
 }
@@ -343,7 +343,7 @@ func (s *FileBackendTestSuite) TestRemoveFile() {
 	path := "tests/" + randomString()
 
 	written, err := s.backend.WriteFile(bytes.NewReader(b), path)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
 	s.Nil(s.backend.RemoveFile(path))
 
@@ -351,15 +351,15 @@ func (s *FileBackendTestSuite) TestRemoveFile() {
 	s.Error(err)
 
 	written, err = s.backend.WriteFile(bytes.NewReader(b), "tests2/foo")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
 
 	written, err = s.backend.WriteFile(bytes.NewReader(b), "tests2/bar")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
 
 	written, err = s.backend.WriteFile(bytes.NewReader(b), "tests2/asdf")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
 
 	s.Nil(s.backend.RemoveDirectory("tests2"))
@@ -371,35 +371,35 @@ func (s *FileBackendTestSuite) TestListDirectory() {
 	path2 := "19800101/" + randomString()
 
 	paths, err := s.backend.ListDirectory("19700101")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(paths, 0)
 
 	written, err := s.backend.WriteFile(bytes.NewReader(b), path1)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
 
 	written, err = s.backend.WriteFile(bytes.NewReader(b), path2)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
 
 	paths, err = s.backend.ListDirectory("19700101")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(paths, 1)
 	s.Equal(path1, (paths)[0])
 
 	paths, err = s.backend.ListDirectory("19800101/")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(paths, 1)
 	s.Equal(path2, (paths)[0])
 
 	if s.settings.DriverName == driverLocal {
 		paths, err = s.backend.ListDirectory("19800102")
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.Len(paths, 0)
 	}
 
 	paths, err = s.backend.ListDirectory("")
-	s.NoError(err)
+	s.Require().NoError(err)
 	found1 := false
 	found2 := false
 	for _, path := range paths {
@@ -423,39 +423,39 @@ func (s *FileBackendTestSuite) TestListDirectoryRecursively() {
 	longPath := "19800102" + strings.Repeat("/toomuch", MaxRecursionDepth+1) + randomString()
 
 	paths, err := s.backend.ListDirectoryRecursively("19700101")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(paths, 0)
 
 	written, err := s.backend.WriteFile(bytes.NewReader(b), path1)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
 
 	written, err = s.backend.WriteFile(bytes.NewReader(b), path2)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
 
 	written, err = s.backend.WriteFile(bytes.NewReader(b), longPath)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
 
 	paths, err = s.backend.ListDirectoryRecursively("19700101")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(paths, 1)
 	s.Equal(path1, (paths)[0])
 
 	paths, err = s.backend.ListDirectoryRecursively("19800101/")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(paths, 1)
 	s.Equal(path2, (paths)[0])
 
 	if s.settings.DriverName == driverLocal {
 		paths, err = s.backend.ListDirectory("19800102")
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.Len(paths, 1)
 	}
 
 	paths, err = s.backend.ListDirectoryRecursively("")
-	s.NoError(err)
+	s.Require().NoError(err)
 	found1 := false
 	found2 := false
 	found3 := false
@@ -483,15 +483,15 @@ func (s *FileBackendTestSuite) TestRemoveDirectory() {
 	b := []byte("test")
 
 	written, err := s.backend.WriteFile(bytes.NewReader(b), "tests2/foo")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
 
 	written, err = s.backend.WriteFile(bytes.NewReader(b), "tests2/bar")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
 
 	written, err = s.backend.WriteFile(bytes.NewReader(b), "tests2/aaa")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
 
 	s.Nil(s.backend.RemoveDirectory("tests2"))
@@ -520,7 +520,7 @@ func (s *FileBackendTestSuite) TestAppendFile() {
 		path := "tests/" + randomString()
 
 		written, err := s.backend.WriteFile(bytes.NewReader(b), path)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.EqualValues(len(b), written)
 		defer s.backend.RemoveFile(path)
 
@@ -530,11 +530,11 @@ func (s *FileBackendTestSuite) TestAppendFile() {
 		}
 
 		written, err = s.backend.AppendFile(bytes.NewReader(b2), path)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.EqualValues(int64(len(b2)), written)
 
 		read, err := s.backend.ReadFile(path)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.EqualValues(len(b)+len(b2), len(read))
 		s.True(bytes.Equal(append(b, b2...), read))
 
@@ -544,11 +544,11 @@ func (s *FileBackendTestSuite) TestAppendFile() {
 		}
 
 		written, err = s.backend.AppendFile(bytes.NewReader(b3), path)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.EqualValues(int64(len(b3)), written)
 
 		read, err = s.backend.ReadFile(path)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.EqualValues(len(b)+len(b2)+len(b3), len(read))
 		s.True(bytes.Equal(append(append(b, b2...), b3...), read))
 	})
@@ -566,12 +566,12 @@ func (s *FileBackendTestSuite) TestFileSize() {
 		path := "tests/" + randomString()
 
 		written, err := s.backend.WriteFile(bytes.NewReader(data), path)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.EqualValues(len(data), written)
 		defer s.backend.RemoveFile(path)
 
 		size, err := s.backend.FileSize(path)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.Equal(int64(len(data)), size)
 	})
 }
@@ -588,12 +588,12 @@ func (s *FileBackendTestSuite) TestFileModTime() {
 		data := []byte("some data")
 
 		written, err := s.backend.WriteFile(bytes.NewReader(data), path)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.EqualValues(len(data), written)
 		defer s.backend.RemoveFile(path)
 
 		modTime, err := s.backend.FileModTime(path)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.NotEmpty(modTime)
 
 		// We wait 1 second so that the times will differ enough to be testable.
@@ -601,12 +601,12 @@ func (s *FileBackendTestSuite) TestFileModTime() {
 
 		path2 := "tests/" + randomString()
 		written, err = s.backend.WriteFile(bytes.NewReader(data), path2)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.EqualValues(len(data), written)
 		defer s.backend.RemoveFile(path2)
 
 		modTime2, err := s.backend.FileModTime(path2)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.NotEmpty(modTime2)
 		s.True(modTime2.After(modTime))
 	})
@@ -1025,7 +1025,7 @@ func (s *FileBackendTestSuite) TestZipReaderSingleFile() {
 	path := "tests/" + randomString() + ".txt"
 
 	written, err := s.backend.WriteFile(bytes.NewReader(b), path)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written)
 	defer s.backend.RemoveFile(path)
 
@@ -1034,22 +1034,22 @@ func (s *FileBackendTestSuite) TestZipReaderSingleFile() {
 	path2 := "tests/" + randomString() + ".txt"
 
 	written, err = s.backend.WriteFile(bytes.NewReader(b2), path2)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b2), written)
 	defer s.backend.RemoveFile(path2)
 
 	// Test without compression
 	reader, err := s.backend.ZipReader(path, false)
-	s.NoError(err)
+	s.Require().NoError(err)
 	defer reader.Close()
 
 	// Read the zip file
 	zipBytes, err := io.ReadAll(reader)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	zipReader, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
-	s.NoError(err)
-	s.Len(zipReader.File, 1)
+	s.Require().NoError(err)
+	s.Require().Len(zipReader.File, 1)
 
 	// Verify file contents
 	zf := zipReader.File[0]
@@ -1057,11 +1057,11 @@ func (s *FileBackendTestSuite) TestZipReaderSingleFile() {
 	s.Equal(zip.Store, zf.Method)
 
 	rc, err := zf.Open()
-	s.NoError(err)
+	s.Require().NoError(err)
 	defer rc.Close()
 
 	content, err := io.ReadAll(rc)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(b, content)
 }
 
@@ -1071,7 +1071,7 @@ func (s *FileBackendTestSuite) TestZipReaderSingleFileCompressed() {
 	path := "tests/" + randomString() + ".txt"
 
 	written, err := s.backend.WriteFile(bytes.NewReader(b), path)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b), written)
 	defer s.backend.RemoveFile(path)
 
@@ -1080,31 +1080,31 @@ func (s *FileBackendTestSuite) TestZipReaderSingleFileCompressed() {
 	path2 := "tests/" + randomString() + ".txt"
 
 	written, err = s.backend.WriteFile(bytes.NewReader(b2), path2)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.EqualValues(len(b2), written)
 	defer s.backend.RemoveFile(path2)
 
 	reader, err := s.backend.ZipReader(path, true)
-	s.NoError(err)
+	s.Require().NoError(err)
 	defer reader.Close()
 
 	zipBytes, err := io.ReadAll(reader)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	zipReader, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
-	s.NoError(err)
-	s.Len(zipReader.File, 1)
+	s.Require().NoError(err)
+	s.Require().Len(zipReader.File, 1)
 
 	zf := zipReader.File[0]
 	s.Equal(filepath.Base(path), zf.Name)
 	s.Equal(zip.Deflate, zf.Method)
 
 	rc, err := zf.Open()
-	s.NoError(err)
+	s.Require().NoError(err)
 	defer rc.Close()
 
 	content, err := io.ReadAll(rc)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(b, content)
 }
 
@@ -1121,22 +1121,22 @@ func (s *FileBackendTestSuite) TestZipReaderDirectory() {
 	for path, content := range files {
 		fullPath := filepath.Join(dirPath, path)
 		written, err := s.backend.WriteFile(bytes.NewReader(content), fullPath)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.EqualValues(len(content), written)
 		defer s.backend.RemoveFile(fullPath)
 	}
 
 	// Test without compression
 	reader, err := s.backend.ZipReader(dirPath, false)
-	s.NoError(err)
+	s.Require().NoError(err)
 	defer reader.Close()
 
 	// Read and verify zip contents
 	zipBytes, err := io.ReadAll(reader)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	zipReader, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	// Verify each file
 	foundFiles := make(map[string]bool)
@@ -1146,10 +1146,10 @@ func (s *FileBackendTestSuite) TestZipReaderDirectory() {
 		delete(files, zf.Name)
 
 		rc, err := zf.Open()
-		s.NoError(err)
+		s.Require().NoError(err)
 
 		content, err := io.ReadAll(rc)
-		s.NoError(err)
+		s.Require().NoError(err)
 		rc.Close()
 
 		s.Equal(expectedContent, content)
@@ -1174,22 +1174,22 @@ func (s *FileBackendTestSuite) TestZipReaderDirectoryCompressed() {
 	for path, content := range files {
 		fullPath := filepath.Join(dirPath, path)
 		written, err := s.backend.WriteFile(bytes.NewReader(content), fullPath)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.EqualValues(len(content), written)
 		defer s.backend.RemoveFile(fullPath)
 	}
 
 	// Test with compression
 	reader, err := s.backend.ZipReader(dirPath, true)
-	s.NoError(err)
+	s.Require().NoError(err)
 	defer reader.Close()
 
 	// Read and verify zip contents
 	zipBytes, err := io.ReadAll(reader)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	zipReader, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	// Verify each file
 	foundFiles := make(map[string]bool)
@@ -1200,10 +1200,10 @@ func (s *FileBackendTestSuite) TestZipReaderDirectoryCompressed() {
 		delete(files, zf.Name)
 
 		rc, err := zf.Open()
-		s.NoError(err)
+		s.Require().NoError(err)
 
 		content, err := io.ReadAll(rc)
-		s.NoError(err)
+		s.Require().NoError(err)
 		rc.Close()
 
 		s.Equal(expectedContent, content)
@@ -1223,25 +1223,25 @@ func (s *FileBackendTestSuite) TestZipReaderErrors() {
 		s.Error(err)
 		s.Nil(reader)
 	} else {
-		s.NoError(err)
+		s.Require().NoError(err)
 		defer reader.Close()
 		var content []byte
 		content, err = io.ReadAll(reader)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.assertEmptyZip(content)
 	}
 
 	// Test empty directory
 	emptyDir := "tests/empty_" + randomString()
 	err = os.MkdirAll(filepath.Join(s.settings.Directory, emptyDir), 0750)
-	s.NoError(err)
+	s.Require().NoError(err)
 	defer os.RemoveAll(filepath.Join(s.settings.Directory, emptyDir))
 
 	reader, err = s.backend.ZipReader(emptyDir, false)
-	s.NoError(err)
+	s.Require().NoError(err)
 	defer reader.Close()
 	content, err := io.ReadAll(reader)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.assertEmptyZip(content)
 }
 
@@ -1253,25 +1253,25 @@ func (s *FileBackendTestSuite) TestZipReaderErrorsCompressed() {
 		s.Error(err)
 		s.Nil(reader)
 	} else {
-		s.NoError(err)
+		s.Require().NoError(err)
 		defer reader.Close()
 		var content []byte
 		content, err = io.ReadAll(reader)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.assertEmptyZip(content)
 	}
 
 	// Test empty directory with compression
 	emptyDir := "tests/empty_" + randomString()
 	err = os.MkdirAll(filepath.Join(s.settings.Directory, emptyDir), 0750)
-	s.NoError(err)
+	s.Require().NoError(err)
 	defer os.RemoveAll(filepath.Join(s.settings.Directory, emptyDir))
 
 	reader, err = s.backend.ZipReader(emptyDir, true)
-	s.NoError(err)
+	s.Require().NoError(err)
 	defer reader.Close()
 	content, err := io.ReadAll(reader)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.assertEmptyZip(content)
 }
 
@@ -1280,6 +1280,6 @@ func (s *FileBackendTestSuite) assertEmptyZip(content []byte) {
 
 	// Verify it's a valid but empty zip
 	zipReader, err := zip.NewReader(bytes.NewReader(content), int64(len(content)))
-	s.NoError(err)
-	s.Len(zipReader.File, 0)
+	s.Require().NoError(err)
+	s.Require().Len(zipReader.File, 0)
 }

--- a/server/platform/shared/filestore/localstore.go
+++ b/server/platform/shared/filestore/localstore.go
@@ -7,17 +7,20 @@ import (
 	"archive/zip"
 	"bytes"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/utils"
 )
 
 const (
-	TestFilePath      = "/testfile"
+	TestFilePath      = "testfile"
 	MaxRecursionDepth = 50
 )
 
@@ -38,6 +41,7 @@ func copyFile(src, dst string) (err error) {
 	if err = os.MkdirAll(filepath.Dir(dst), os.ModePerm); err != nil {
 		return
 	}
+
 	out, err := os.Create(dst)
 	if err != nil {
 		return
@@ -70,13 +74,28 @@ func copyFile(src, dst string) (err error) {
 	return
 }
 
+func mkdirAll(root *os.Root, path string, perm os.FileMode) error {
+	return os.MkdirAll(utils.SafeJoin(root.Name(), path), perm)
+}
+
+func rename(root *os.Root, oldPath, newPath string) error {
+	return os.Rename(
+		utils.SafeJoin(root.Name(), oldPath),
+		utils.SafeJoin(root.Name(), newPath),
+	)
+}
+
+func removeAll(root *os.Root, path string) error {
+	return os.RemoveAll(utils.SafeJoin(root.Name(), path))
+}
+
 func (b *LocalFileBackend) DriverName() string {
 	return driverLocal
 }
 
 func (b *LocalFileBackend) TestConnection() error {
 	f := bytes.NewReader([]byte("testingwrite"))
-	if _, err := writeFileLocally(f, filepath.Join(b.directory, TestFilePath)); err != nil {
+	if _, err := b.WriteFile(f, TestFilePath); err != nil {
 		return errors.Wrap(err, "unable to write to the local filesystem storage")
 	}
 	os.Remove(filepath.Join(b.directory, TestFilePath))
@@ -85,7 +104,7 @@ func (b *LocalFileBackend) TestConnection() error {
 }
 
 func (b *LocalFileBackend) Reader(path string) (ReadCloseSeeker, error) {
-	f, err := os.Open(filepath.Join(b.directory, path))
+	f, err := os.OpenInRoot(b.directory, path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to open file %s", path)
 	}
@@ -93,7 +112,14 @@ func (b *LocalFileBackend) Reader(path string) (ReadCloseSeeker, error) {
 }
 
 func (b *LocalFileBackend) ReadFile(path string) ([]byte, error) {
-	f, err := os.ReadFile(filepath.Join(b.directory, path))
+	file, err := os.OpenInRoot(b.directory, path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to open file %s", path)
+	}
+	defer file.Close()
+
+	// TODO: Consider replacing with Root.ReadFile with go1.25.
+	f, err := io.ReadAll(file)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to read file %s", path)
 	}
@@ -101,7 +127,13 @@ func (b *LocalFileBackend) ReadFile(path string) ([]byte, error) {
 }
 
 func (b *LocalFileBackend) FileExists(path string) (bool, error) {
-	_, err := os.Stat(filepath.Join(b.directory, path))
+	root, err := os.OpenRoot(b.directory)
+	if err != nil {
+		return false, errors.Wrapf(err, "unable to open root directory %q", b.directory)
+	}
+	defer root.Close()
+
+	_, err = root.Stat(path)
 
 	if os.IsNotExist(err) {
 		return false, nil
@@ -114,7 +146,13 @@ func (b *LocalFileBackend) FileExists(path string) (bool, error) {
 }
 
 func (b *LocalFileBackend) FileSize(path string) (int64, error) {
-	info, err := os.Stat(filepath.Join(b.directory, path))
+	root, err := os.OpenRoot(b.directory)
+	if err != nil {
+		return 0, errors.Wrapf(err, "unable to open root directory %q", b.directory)
+	}
+	defer root.Close()
+
+	info, err := root.Stat(path)
 	if err != nil {
 		return 0, errors.Wrapf(err, "unable to get file size for %s", path)
 	}
@@ -122,7 +160,13 @@ func (b *LocalFileBackend) FileSize(path string) (int64, error) {
 }
 
 func (b *LocalFileBackend) FileModTime(path string) (time.Time, error) {
-	info, err := os.Stat(filepath.Join(b.directory, path))
+	root, err := os.OpenRoot(b.directory)
+	if err != nil {
+		return time.Time{}, errors.Wrapf(err, "unable to open root directory %q", b.directory)
+	}
+	defer root.Close()
+
+	info, err := root.Stat(path)
 	if err != nil {
 		return time.Time{}, errors.Wrapf(err, "unable to get modification time for file %s", path)
 	}
@@ -130,18 +174,24 @@ func (b *LocalFileBackend) FileModTime(path string) (time.Time, error) {
 }
 
 func (b *LocalFileBackend) CopyFile(oldPath, newPath string) error {
-	if err := copyFile(filepath.Join(b.directory, oldPath), filepath.Join(b.directory, newPath)); err != nil {
+	if err := copyFile(utils.SafeJoin(b.directory, oldPath), utils.SafeJoin(b.directory, newPath)); err != nil {
 		return errors.Wrapf(err, "unable to copy file from %s to %s", oldPath, newPath)
 	}
 	return nil
 }
 
 func (b *LocalFileBackend) MoveFile(oldPath, newPath string) error {
-	if err := os.MkdirAll(filepath.Dir(filepath.Join(b.directory, newPath)), 0750); err != nil {
+	root, err := os.OpenRoot(b.directory)
+	if err != nil {
+		return errors.Wrapf(err, "unable to open root directory %q", b.directory)
+	}
+	defer root.Close()
+
+	if err := mkdirAll(root, filepath.Dir(newPath), 0750); err != nil {
 		return errors.Wrapf(err, "unable to create the new destination directory %s", filepath.Dir(newPath))
 	}
 
-	if err := os.Rename(filepath.Join(b.directory, oldPath), filepath.Join(b.directory, newPath)); err != nil {
+	if err := rename(root, oldPath, newPath); err != nil {
 		return errors.Wrapf(err, "unable to move the file to %s to the destination directory", newPath)
 	}
 
@@ -149,15 +199,18 @@ func (b *LocalFileBackend) MoveFile(oldPath, newPath string) error {
 }
 
 func (b *LocalFileBackend) WriteFile(fr io.Reader, path string) (int64, error) {
-	return writeFileLocally(fr, filepath.Join(b.directory, path))
-}
+	root, err := os.OpenRoot(b.directory)
+	if err != nil {
+		return 0, errors.Wrapf(err, "unable to open root directory %q", b.directory)
+	}
+	defer root.Close()
 
-func writeFileLocally(fr io.Reader, path string) (int64, error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+	if err := mkdirAll(root, filepath.Dir(path), 0750); err != nil {
 		directory, _ := filepath.Abs(filepath.Dir(path))
 		return 0, errors.Wrapf(err, "unable to create the directory %s for the file %s", directory, path)
 	}
-	fw, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+
+	fw, err := root.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return 0, errors.Wrapf(err, "unable to open the file %s to write the data", path)
 	}
@@ -170,11 +223,17 @@ func writeFileLocally(fr io.Reader, path string) (int64, error) {
 }
 
 func (b *LocalFileBackend) AppendFile(fr io.Reader, path string) (int64, error) {
-	fp := filepath.Join(b.directory, path)
-	if _, err := os.Stat(fp); err != nil {
+	root, err := os.OpenRoot(b.directory)
+	if err != nil {
+		return 0, errors.Wrapf(err, "unable to open root directory %q", b.directory)
+	}
+	defer root.Close()
+
+	if _, err := root.Stat(path); err != nil {
 		return 0, errors.Wrapf(err, "unable to find the file %s to append the data", path)
 	}
-	fw, err := os.OpenFile(fp, os.O_WRONLY|os.O_APPEND, 0600)
+
+	fw, err := root.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		return 0, errors.Wrapf(err, "unable to open the file %s to append the data", path)
 	}
@@ -187,18 +246,39 @@ func (b *LocalFileBackend) AppendFile(fr io.Reader, path string) (int64, error) 
 }
 
 func (b *LocalFileBackend) RemoveFile(path string) error {
-	if err := os.Remove(filepath.Join(b.directory, path)); err != nil {
+	root, err := os.OpenRoot(b.directory)
+	if err != nil {
+		return errors.Wrapf(err, "unable to open root directory %q", b.directory)
+	}
+	defer root.Close()
+
+	if err := root.Remove(path); err != nil {
 		return errors.Wrapf(err, "unable to remove the file %s", path)
 	}
 	return nil
 }
 
+// fixPathForRoot is a helper function to work around percularities with os.Root:
+func fixPathForRoot(path string) string {
+	// os.Root.FS().ReadDir doesn't handle trailing slashes correctly, so trim first.
+	path = strings.TrimSuffix(path, string(filepath.Separator))
+
+	// Similarly, an empty string isn't just handled as the root.
+	if path == "" {
+		path = "."
+	}
+
+	return path
+}
+
 // basePath: path to get to the file but won't be added to the end result
 // path: basePath+path current directory we are looking at
 // maxDepth: parameter to prevent infinite recursion, once this is reached we won't look any further
-func appendRecursively(basePath, path string, maxDepth int) ([]string, error) {
+func appendRecursively(root *os.Root, path string, maxDepth int) ([]string, error) {
+	path = fixPathForRoot(path)
+
 	results := []string{}
-	dirEntries, err := os.ReadDir(filepath.Join(basePath, path))
+	dirEntries, err := fs.ReadDir(root.FS(), path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return results, nil
@@ -217,7 +297,7 @@ func appendRecursively(basePath, path string, maxDepth int) ([]string, error) {
 				results = append(results, entryPath)
 				continue // we'll ignore it if max depth is reached.
 			}
-			nestedResults, err := appendRecursively(basePath, entryPath, maxDepth-1)
+			nestedResults, err := appendRecursively(root, entryPath, maxDepth-1)
 			if err != nil {
 				return results, err
 			}
@@ -231,7 +311,15 @@ func appendRecursively(basePath, path string, maxDepth int) ([]string, error) {
 
 func (b *LocalFileBackend) ListDirectory(path string) ([]string, error) {
 	results := []string{}
-	dirEntries, err := os.ReadDir(filepath.Join(b.directory, path))
+	root, err := os.OpenRoot(b.directory)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to open root directory %q", b.directory)
+	}
+	defer root.Close()
+
+	path = fixPathForRoot(path)
+
+	dirEntries, err := fs.ReadDir(root.FS(), path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// ideally os.ErrNotExist should've been returned but to keep the
@@ -249,11 +337,23 @@ func (b *LocalFileBackend) ListDirectory(path string) ([]string, error) {
 }
 
 func (b *LocalFileBackend) ListDirectoryRecursively(path string) ([]string, error) {
-	return appendRecursively(b.directory, path, MaxRecursionDepth)
+	root, err := os.OpenRoot(b.directory)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to open root directory %q", b.directory)
+	}
+	defer root.Close()
+
+	return appendRecursively(root, path, MaxRecursionDepth)
 }
 
 func (b *LocalFileBackend) RemoveDirectory(path string) error {
-	if err := os.RemoveAll(filepath.Join(b.directory, path)); err != nil {
+	root, err := os.OpenRoot(b.directory)
+	if err != nil {
+		return errors.Wrapf(err, "unable to open root directory %q", b.directory)
+	}
+	defer root.Close()
+
+	if err := removeAll(root, path); err != nil {
 		return errors.Wrapf(err, "unable to remove the directory %s", path)
 	}
 	return nil
@@ -267,9 +367,17 @@ func (b *LocalFileBackend) ZipReader(path string, deflate bool) (io.ReadCloser, 
 		deflateMethod = zip.Deflate
 	}
 
-	fullPath := filepath.Join(b.directory, path)
-	baseInfo, err := os.Stat(fullPath)
+	root, err := os.OpenRoot(b.directory)
 	if err != nil {
+		return nil, errors.Wrapf(err, "unable to open root directory %q", b.directory)
+	}
+
+	// We don't defer root.Close() here because we want to keep the root open until
+	// the pipe is closed.
+
+	baseInfo, err := root.Stat(path)
+	if err != nil {
+		root.Close()
 		return nil, errors.Wrapf(err, "unable to stat path %s", path)
 	}
 
@@ -277,17 +385,23 @@ func (b *LocalFileBackend) ZipReader(path string, deflate bool) (io.ReadCloser, 
 
 	go func() {
 		defer pw.Close()
+		defer root.Close()
 
 		zipWriter := zip.NewWriter(pw)
 		defer zipWriter.Close()
 
-		err = filepath.Walk(fullPath, func(filePath string, info os.FileInfo, err error) error {
+		err = fs.WalkDir(root.FS(), path, func(filePath string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
 
+			info, err := d.Info()
+			if err != nil {
+				return errors.Wrapf(err, "unable to call Info() for %s", filePath)
+			}
+
 			// Handle single file case
-			baseDir := fullPath
+			baseDir := path
 			if !baseInfo.IsDir() {
 				baseDir = filepath.Dir(baseDir)
 			}
@@ -325,7 +439,7 @@ func (b *LocalFileBackend) ZipReader(path string, deflate bool) (io.ReadCloser, 
 				return errors.Wrapf(err, "unable to create zip entry for %s", relPath)
 			}
 
-			file, err := os.Open(filePath)
+			file, err := root.Open(filePath)
 			if err != nil {
 				return errors.Wrapf(err, "unable to open file %s", filePath)
 			}
@@ -337,7 +451,6 @@ func (b *LocalFileBackend) ZipReader(path string, deflate bool) (io.ReadCloser, 
 
 			return nil
 		})
-
 		if err != nil {
 			pw.CloseWithError(errors.Wrap(err, "error walking directory"))
 		}

--- a/server/public/utils/filepath.go
+++ b/server/public/utils/filepath.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package utils
+
+import (
+	"path/filepath"
+)
+
+// SafeJoin lexically joins a trusted base path with an untrusted
+// path, ensuring the result is anchored at or below the base path.
+func SafeJoin(base string, elem ...string) string {
+	// The idea is to clean the untrusted path relative to '/', an
+	// only then join with the trusted base path. Any ../ attempts
+	// relative to `/` will efectively be ignored.
+	return filepath.Join(
+		base,
+		filepath.Join(
+			"/",
+			filepath.Join(elem...),
+		),
+	)
+}

--- a/server/public/utils/filepath_test.go
+++ b/server/public/utils/filepath_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeJoin(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     string
+		elem     []string
+		expected string
+	}{
+		{
+			name:     "empty base path",
+			base:     "",
+			elem:     []string{"folder", "file.txt"},
+			expected: "/folder/file.txt",
+		},
+		{
+			name:     "no elements",
+			base:     "/home/user",
+			elem:     []string{},
+			expected: "/home/user",
+		},
+		{
+			name:     "single file",
+			base:     "/tmp",
+			elem:     []string{"file.txt"},
+			expected: "/tmp/file.txt",
+		},
+		{
+			name:     "nested file",
+			base:     "/var/www",
+			elem:     []string{"html", "index.html"},
+			expected: "/var/www/html/index.html",
+		},
+		{
+			name:     "path traversal into parent directory",
+			base:     "/var/www",
+			elem:     []string{"../etc/passwd"},
+			expected: "/var/www/etc/passwd",
+		},
+		{
+			name:     "path traversal into ancestor directory",
+			base:     "/var/www",
+			elem:     []string{"../../etc/passwd"},
+			expected: "/var/www/etc/passwd",
+		},
+		{
+			name:     "path traversal into parent directory, multiple elements",
+			base:     "/app/data",
+			elem:     []string{"../", "etc", "passwd"},
+			expected: "/app/data/etc/passwd",
+		},
+		{
+			name:     "path traversal into ancestor directory, multiple elements",
+			base:     "/app/data",
+			elem:     []string{"../", "../", "etc", "passwd"},
+			expected: "/app/data/etc/passwd",
+		},
+		{
+			name:     "path traversal within base directory",
+			base:     "/uploads",
+			elem:     []string{"user123", "../admin", "config.json"},
+			expected: "/uploads/admin/config.json",
+		},
+		{
+			name:     "absolute path treated as relative",
+			base:     "/safe/dir",
+			elem:     []string{"/etc/passwd"},
+			expected: "/safe/dir/etc/passwd",
+		},
+		{
+			name:     "current directory references",
+			base:     "/project",
+			elem:     []string{".", "src", "main.go"},
+			expected: "/project/src/main.go",
+		},
+		{
+			name:     "empty base path",
+			base:     "",
+			elem:     []string{"folder", "file.txt"},
+			expected: "/folder/file.txt",
+		},
+		{
+			name:     "null byte should not break security",
+			base:     "/tmp",
+			elem:     []string{"file.txt\x00../../../etc/passwd"},
+			expected: "/tmp/etc/passwd",
+		},
+		{
+			name:     "windows style path separators",
+			base:     "/base",
+			elem:     []string{"..\\..\\windows\\system32"},
+			expected: "/base/..\\..\\windows\\system32",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SafeJoin(tt.base, tt.elem...)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
We begin adopting the new go1.24 support for `os.Root` by leveraging it in the localstore. This PR also includes `utils.SafeJoin` for use when `os.Root` isn't suitable.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-64667

#### Release Note
```release-note
NONE
```