### PR TITLE
Increase line height in RHS header

### DIFF
--- a/webapp/channels/src/sass/layout/_sidebar-right.scss
+++ b/webapp/channels/src/sass/layout/_sidebar-right.scss
@@ -129,7 +129,6 @@
         font-family: Metropolis, sans-serif;
         font-size: 1.6rem;
         font-weight: 600;
-        line-height: 1;
 
         @include mixins.clearfix;
         h2 {
@@ -137,7 +136,6 @@
             font-family: inherit;
             font-size: inherit;
             font-weight: inherit;
-            line-height: inherit;
         }
     }
 


### PR DESCRIPTION
#### Summary

The line height here caused some accents in Vietnamese to be cut off. Removing the `line-height` fixes the accent being cut off, but it also slightly changes the vertical position of that text if that's a concern

Issue reported here: https://community.mattermost.com/core/pl/skakydy4gpfwmjhzukjc3sizge

#### Screenshots
In Firefox:
|  before  |  after  |
|----|----|
|<img width="413" alt="Screenshot 2025-06-23 at 2 37 16 PM" src="https://github.com/user-attachments/assets/84dba4b4-eb17-4d73-b38f-a96c34dff228" />|<img width="413" alt="Screenshot 2025-06-23 at 2 37 19 PM" src="https://github.com/user-attachments/assets/de07773d-42a3-416f-a212-1da62ca18a94" />
<img width="194" alt="Screenshot 2025-06-23 at 2 39 23 PM" src="https://github.com/user-attachments/assets/943576b6-1a49-4097-8ccc-184370356172" />|<img width="194" alt="Screenshot 2025-06-23 at 2 39 26 PM" src="https://github.com/user-attachments/assets/576f31f8-7cc3-44cb-b4a6-96d83698dd1e" />


#### Release Note
```release-note
Fix accents 
```
