### PR TITLE
MM-62745: [Shared Channels] Fix duplicate mentioning - local user with the same username as someone on the remote server - Part2initial checkin

### DIFF
--- a/server/channels/app/command.go
+++ b/server/channels/app/command.go
@@ -6,6 +6,7 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -239,6 +240,7 @@ func (a *App) MentionsToTeamMembers(c request.CTX, message, teamID string) model
 	}
 
 	possibleMentions := possibleAtMentions(message)
+	a.PostDebugToTownSquare(c, fmt.Sprintf("MentionsToTeamMembers: ENTRY - message='%s', teamID='%s', possibleMentions=%v", message, teamID, possibleMentions))
 	mentionChan := make(chan *mentionMapItem, len(possibleMentions))
 
 	var wg sync.WaitGroup
@@ -246,11 +248,20 @@ func (a *App) MentionsToTeamMembers(c request.CTX, message, teamID string) model
 		wg.Add(1)
 		go func(mention string) {
 			defer wg.Done()
+			a.PostDebugToTownSquare(c, fmt.Sprintf("MentionsToTeamMembers: Processing mention='%s'", mention))
 			user, nErr := a.Srv().Store().User().GetByUsername(mention)
+
+			// Debug: Also check if there are any users with this mention as part of a remote username
+			if remoteUsers, err := a.Srv().Store().User().GetProfilesByUsernames([]string{mention + ":org1", mention + ":org2", mention + ":remote1", mention + ":remote2"}, nil); err == nil {
+				for _, remoteUser := range remoteUsers {
+					a.PostDebugToTownSquare(c, fmt.Sprintf("MentionsToTeamMembers: Found potential remote user - Username=%s, ID=%s, RemoteId='%s'", remoteUser.Username, remoteUser.Id, remoteUser.GetRemoteID()))
+				}
+			}
 
 			var nfErr *store.ErrNotFound
 			if nErr != nil && !errors.As(nErr, &nfErr) {
 				c.Logger().Warn("Failed to retrieve user @"+mention, mlog.Err(nErr))
+				a.PostDebugToTownSquare(c, fmt.Sprintf("MentionsToTeamMembers: Failed to get user '%s': %v", mention, nErr))
 				return
 			}
 
@@ -281,12 +292,16 @@ func (a *App) MentionsToTeamMembers(c request.CTX, message, teamID string) model
 				return
 			}
 
+			a.PostDebugToTownSquare(c, fmt.Sprintf("MentionsToTeamMembers: Found user for mention='%s' - ID=%s, Username=%s, RemoteId='%s', Email=%s", mention, user.Id, user.Username, user.GetRemoteID(), user.Email))
+
 			_, err := a.GetTeamMember(c, teamID, user.Id)
 			if err != nil {
 				// The user is not in the team, so we should ignore it
+				a.PostDebugToTownSquare(c, fmt.Sprintf("MentionsToTeamMembers: User '%s' (ID=%s) is not a team member: %v", mention, user.Id, err))
 				return
 			}
 
+			a.PostDebugToTownSquare(c, fmt.Sprintf("MentionsToTeamMembers: Adding mention='%s' -> userID='%s' to map", mention, user.Id))
 			mentionChan <- &mentionMapItem{mention, user.Id}
 		}(mention)
 	}

--- a/server/channels/app/platform/shared_channel_service_iface.go
+++ b/server/channels/app/platform/shared_channel_service_iface.go
@@ -5,6 +5,7 @@ package platform
 
 import (
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/platform/services/sharedchannel"
 )
 
@@ -24,6 +25,7 @@ type SharedChannelServiceIFace interface {
 	CheckChannelIsShared(channelID string) error
 	CheckCanInviteToSharedChannel(channelId string) error
 	HandleMembershipChange(channelID, userID string, isAdd bool, remoteID string)
+	TransformMentionsOnReceiveForTesting(ctx request.CTX, post *model.Post, targetChannel *model.Channel, rc *model.RemoteCluster, syncMsgUsers map[string]*model.User, mentionTransforms map[string]string)
 }
 
 type MockOptionSharedChannelService func(service *mockSharedChannelService)
@@ -80,5 +82,9 @@ func (mrcs *mockSharedChannelService) NumInvitations() int {
 }
 
 func (mrcs *mockSharedChannelService) HandleMembershipChange(channelID, userID string, isAdd bool, remoteID string) {
+	// This is a mock implementation - it doesn't need to do anything
+}
+
+func (mrcs *mockSharedChannelService) TransformMentionsOnReceiveForTesting(ctx request.CTX, post *model.Post, targetChannel *model.Channel, rc *model.RemoteCluster, syncMsgUsers map[string]*model.User, mentionTransforms map[string]string) {
 	// This is a mock implementation - it doesn't need to do anything
 }

--- a/server/channels/app/shared_channel_service_iface.go
+++ b/server/channels/app/shared_channel_service_iface.go
@@ -6,6 +6,7 @@ package app
 // TODO: platform: remove this and use from platform package
 import (
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/platform/services/sharedchannel"
 )
 
@@ -27,6 +28,7 @@ type SharedChannelServiceIFace interface {
 	CheckChannelIsShared(channelID string) error
 	CheckCanInviteToSharedChannel(channelId string) error
 	HandleMembershipChange(channelID, userID string, isAdd bool, remoteID string)
+	TransformMentionsOnReceiveForTesting(ctx request.CTX, post *model.Post, targetChannel *model.Channel, rc *model.RemoteCluster, syncMsgUsers map[string]*model.User, mentionTransforms map[string]string)
 }
 
 func NewMockSharedChannelService(service SharedChannelServiceIFace) *mockSharedChannelService {

--- a/server/channels/app/shared_channel_test.go
+++ b/server/channels/app/shared_channel_test.go
@@ -4,6 +4,9 @@
 package app
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -22,6 +25,7 @@ func setupSharedChannels(tb testing.TB) *TestHelper {
 		*cfg.ConnectedWorkspacesSettings.EnableRemoteClusterService = true
 		*cfg.ConnectedWorkspacesSettings.EnableSharedChannels = true
 		cfg.FeatureFlags.EnableSharedChannelsMemberSync = true
+		cfg.ClusterSettings.ClusterName = model.NewPointer("test-remote")
 	})
 }
 
@@ -555,4 +559,356 @@ func TestSyncMessageErrChannelNotSharedResponse(t *testing.T) {
 		}
 	}
 	require.NotNil(t, systemPost, "System message should be posted when channel becomes unshared")
+}
+
+// PostTrackingSyncHandler extends the utilities handler to track received posts for testing
+type PostTrackingSyncHandler struct {
+	*SelfReferentialSyncHandler
+	receivedPosts []*model.Post // Track received posts for validation
+}
+
+// NewPostTrackingSyncHandler creates a new handler that tracks received posts
+func NewPostTrackingSyncHandler(t *testing.T, service *sharedchannel.Service, selfCluster *model.RemoteCluster) *PostTrackingSyncHandler {
+	baseHandler := NewSelfReferentialSyncHandler(t, service, selfCluster)
+	return &PostTrackingSyncHandler{
+		SelfReferentialSyncHandler: baseHandler,
+		receivedPosts:              make([]*model.Post, 0),
+	}
+}
+
+// HandleRequest extends the base handler to also track posts
+func (h *PostTrackingSyncHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/api/v4/remotecluster/msg" {
+		// Read and capture posts before delegating to base handler
+		body, _ := io.ReadAll(r.Body)
+		var frame model.RemoteClusterFrame
+		if json.Unmarshal(body, &frame) == nil {
+			var syncMsg model.SyncMsg
+			if json.Unmarshal(frame.Msg.Payload, &syncMsg) == nil {
+				// Track received posts for validation
+				h.receivedPosts = append(h.receivedPosts, syncMsg.Posts...)
+
+				// Debug mention transforms received
+				h.t.Logf("PostTrackingSyncHandler: Received SyncMsg with %d posts and %d mention transforms", len(syncMsg.Posts), len(syncMsg.MentionTransforms))
+				for mention, userID := range syncMsg.MentionTransforms {
+					h.t.Logf("PostTrackingSyncHandler: MentionTransform - '%s' -> '%s'", mention, userID)
+				}
+				for i, post := range syncMsg.Posts {
+					h.t.Logf("PostTrackingSyncHandler: Post[%d] - ID=%s, Message='%s'", i, post.Id, post.Message)
+				}
+			}
+		}
+
+		// Create a new request with the body content for the base handler
+		r.Body = io.NopCloser(bytes.NewReader(body))
+	}
+
+	// Delegate to base handler
+	h.SelfReferentialSyncHandler.HandleRequest(w, r)
+}
+
+// GetReceivedPosts returns the posts received by this handler
+func (h *PostTrackingSyncHandler) GetReceivedPosts() []*model.Post {
+	return h.receivedPosts
+}
+
+// ResetReceivedPosts clears the received posts list for testing
+func (h *PostTrackingSyncHandler) ResetReceivedPosts() {
+	h.receivedPosts = make([]*model.Post, 0)
+}
+
+// TestTransformMentionsOnReceive provides comprehensive unit testing for the mention transformation logic
+// using explicit mentionTransforms. This tests ONLY the receiver-side transformation logic
+// without requiring complex end-to-end cross-cluster setup.
+func TestTransformMentionsOnReceive(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := setupSharedChannels(t).InitBasic()
+
+	// Setup shared channel
+	sharedChannel := th.CreateChannel(th.Context, th.BasicTeam)
+	sc := &model.SharedChannel{
+		ChannelId: sharedChannel.Id,
+		TeamId:    th.BasicTeam.Id,
+		Home:      true,
+		ShareName: "testchannel",
+		CreatorId: th.BasicUser.Id,
+	}
+	_, err := th.App.ShareChannel(th.Context, sc)
+	require.NoError(t, err)
+
+	// Setup remote cluster representing the sender
+	remoteCluster := &model.RemoteCluster{
+		RemoteId:    model.NewId(),
+		Name:        "remote1",
+		DisplayName: "Remote 1",
+		SiteURL:     "http://remote1.example.com",
+		Token:       model.NewId(),
+		CreatorId:   th.BasicUser.Id,
+		CreateAt:    model.GetMillis(),
+		LastPingAt:  model.GetMillis(),
+	}
+	savedRemoteCluster, appErr := th.App.AddRemoteCluster(remoteCluster)
+	require.Nil(t, appErr)
+
+	// Get shared channel service
+	scs := th.App.Srv().Platform().GetSharedChannelService()
+	require.NotNil(t, scs)
+	concreteScs, ok := scs.(*sharedchannel.Service)
+	require.True(t, ok)
+
+	// Helper to create test users
+	createUser := func(username string, remoteId *string) *model.User {
+		user := th.CreateUser()
+		user.Username = username
+		if remoteId != nil {
+			user.RemoteId = remoteId
+		}
+		user, updateErr := th.App.UpdateUser(th.Context, user, false)
+		require.Nil(t, updateErr)
+		th.LinkUserToTeam(user, th.BasicTeam)
+		th.AddUserToChannel(user, sharedChannel)
+		return user
+	}
+
+	// Helper to test transformation
+	testTransformation := func(originalMessage string, mentionTransforms map[string]string, expectedMessage string, description string) {
+		post := &model.Post{
+			Id:        model.NewId(),
+			ChannelId: sharedChannel.Id,
+			UserId:    th.BasicUser.Id,
+			Message:   originalMessage,
+		}
+
+		t.Logf("Testing: %s", description)
+		t.Logf("  Original: %s", originalMessage)
+		t.Logf("  Transforms: %v", mentionTransforms)
+
+		// Call the transformation function directly
+		concreteScs.TransformMentionsOnReceiveForTesting(th.Context, post, sharedChannel, savedRemoteCluster, make(map[string]*model.User), mentionTransforms)
+
+		t.Logf("  Result: %s", post.Message)
+		t.Logf("  Expected: %s", expectedMessage)
+
+		require.Equal(t, expectedMessage, post.Message, description)
+	}
+
+	t.Run("Scenario 1.1: Remote mentions local user (simple mention)", func(t *testing.T) {
+		// Create remote user that was synced to receiver
+		remoteUser := createUser("admin:remote1", &savedRemoteCluster.RemoteId)
+
+		// Scenario: remote1 mentions "@admin" (their local user) → sent to receiver
+		// mentionTransforms["admin"] = remote1AdminUserId
+		mentionTransforms := map[string]string{
+			"admin": remoteUser.Id,
+		}
+
+		testTransformation(
+			"Hello @admin, can you help?",
+			mentionTransforms,
+			"Hello @admin:remote1, can you help?", // Use synced username
+			"Simple mention of synced remote user should use synced username",
+		)
+	})
+
+	t.Run("Scenario 1.2: Remote mentions local user (different username)", func(t *testing.T) {
+		// Create remote user that was synced to receiver
+		remoteUser := createUser("user:remote1", &savedRemoteCluster.RemoteId)
+
+		mentionTransforms := map[string]string{
+			"user": remoteUser.Id,
+		}
+
+		testTransformation(
+			"Hello @user, can you help?",
+			mentionTransforms,
+			"Hello @user:remote1, can you help?",
+			"Simple mention of different synced remote user should use synced username",
+		)
+	})
+
+	t.Run("Scenario 2.1: Remote mentions with colon (local user)", func(t *testing.T) {
+		// Create local user on receiver
+		localUser := createUser("admin", nil)
+
+		// Scenario: remote2 mentions "@admin:remote1" → sent to remote1
+		// mentionTransforms["admin:remote1"] = remote1AdminUserId
+		mentionTransforms := map[string]string{
+			"admin:remote1": localUser.Id,
+		}
+
+		testTransformation(
+			"Hello @admin:remote1, can you help?",
+			mentionTransforms,
+			"Hello @admin, can you help?", // Strip suffix for local user
+			"Colon mention of local user should strip cluster suffix",
+		)
+	})
+
+	t.Run("Scenario 2.2: Remote mentions with colon (different local user)", func(t *testing.T) {
+		// Create local user on receiver
+		localUser := createUser("user", nil)
+
+		mentionTransforms := map[string]string{
+			"user:remote1": localUser.Id,
+		}
+
+		testTransformation(
+			"Hello @user:remote1, can you help?",
+			mentionTransforms,
+			"Hello @user, can you help?",
+			"Colon mention of different local user should strip cluster suffix",
+		)
+	})
+
+	t.Run("Scenario A1: Name clash - remote user mention, local user exists", func(t *testing.T) {
+		// Create local user with same name
+		_ = createUser("alice", nil) // Create name clash scenario
+		// Create remote user that was synced
+		remoteUser := createUser("alice:remote1", &savedRemoteCluster.RemoteId)
+
+		// When remote1 mentions "@alice" (their local user), receiver gets explicit transform
+		mentionTransforms := map[string]string{
+			"alice": remoteUser.Id, // Points to synced remote user, not local user
+		}
+
+		testTransformation(
+			"Hello @alice, can you help?",
+			mentionTransforms,
+			"Hello @alice:remote1, can you help?",
+			"Matrix A1: Remote user mention with local name clash should add cluster suffix",
+		)
+	})
+
+	t.Run("Scenario A2: Same user - previously synced", func(t *testing.T) {
+		// Create user that was synced from sender
+		syncedUser := createUser("bob:remote1", &savedRemoteCluster.RemoteId)
+
+		mentionTransforms := map[string]string{
+			"bob": syncedUser.Id,
+		}
+
+		testTransformation(
+			"Hello @bob, can you help?",
+			mentionTransforms,
+			"Hello @bob:remote1, can you help?",
+			"Matrix A2: Previously synced user should display synced username",
+		)
+	})
+
+	t.Run("Scenario A3: No user exists on receiver", func(t *testing.T) {
+		// Use non-existent user ID
+		nonExistentUserId := model.NewId()
+
+		mentionTransforms := map[string]string{
+			"charlie": nonExistentUserId,
+		}
+
+		testTransformation(
+			"Hello @charlie, can you help?",
+			mentionTransforms,
+			"Hello @charlie:remote1, can you help?",
+			"Matrix A3: Unknown user should get cluster suffix",
+		)
+	})
+
+	t.Run("Scenario B1: User exists on origin with same ID", func(t *testing.T) {
+		// Create local user (representing user on their home cluster)
+		localUser := createUser("dave", nil)
+
+		// Remote mentions "@dave:remote1" pointing to local user ID
+		mentionTransforms := map[string]string{
+			"dave:remote1": localUser.Id,
+		}
+
+		testTransformation(
+			"Hello @dave:remote1, can you help?",
+			mentionTransforms,
+			"Hello @dave, can you help?",
+			"Matrix B1: Remote mention of local user should strip cluster suffix",
+		)
+	})
+
+	t.Run("Scenario B2: User does not exist on origin", func(t *testing.T) {
+		// Use non-existent user ID
+		nonExistentUserId := model.NewId()
+
+		mentionTransforms := map[string]string{
+			"eve:remote1": nonExistentUserId,
+		}
+
+		testTransformation(
+			"Hello @eve:remote1, can you help?",
+			mentionTransforms,
+			"Hello @eve:remote1, can you help?",
+			"Matrix B2: Unknown colon mention should remain unchanged",
+		)
+	})
+
+	t.Run("Empty mentionTransforms", func(t *testing.T) {
+		// No transforms provided
+		mentionTransforms := map[string]string{}
+
+		testTransformation(
+			"Hello @anyone, can you help?",
+			mentionTransforms,
+			"Hello @anyone, can you help?",
+			"Message without transforms should remain unchanged",
+		)
+	})
+
+	t.Run("Mixed scenarios in single message", func(t *testing.T) {
+		// Setup users
+		localUser := createUser("frank", nil)
+		remoteUser := createUser("george:remote1", &savedRemoteCluster.RemoteId)
+
+		// Multiple transforms in one message
+		mentionTransforms := map[string]string{
+			"frank:remote1": localUser.Id,  // Colon mention → strip suffix
+			"george":        remoteUser.Id, // Simple mention → use synced username
+		}
+
+		testTransformation(
+			"Hello @frank:remote1 and @george, let's collaborate!",
+			mentionTransforms,
+			"Hello @frank and @george:remote1, let's collaborate!",
+			"Mixed mention types should transform correctly",
+		)
+	})
+
+	t.Run("Colon mention of remote user", func(t *testing.T) {
+		// Create remote user that was synced
+		remoteUser := createUser("guest:remote1", &savedRemoteCluster.RemoteId)
+
+		// Colon mention pointing to remote user (edge case)
+		mentionTransforms := map[string]string{
+			"guest:remote1": remoteUser.Id,
+		}
+
+		testTransformation(
+			"Hello @guest:remote1, welcome!",
+			mentionTransforms,
+			"Hello @guest:remote1, welcome!",
+			"Colon mention of remote user should use synced username",
+		)
+	})
+
+	t.Run("Performance: Large message with many mentions", func(t *testing.T) {
+		// Create users for performance test
+		user1 := createUser("user1:remote1", &savedRemoteCluster.RemoteId)
+		user2 := createUser("user2:remote1", &savedRemoteCluster.RemoteId)
+		user3 := createUser("user3:remote1", &savedRemoteCluster.RemoteId)
+
+		mentionTransforms := map[string]string{
+			"user1": user1.Id,
+			"user2": user2.Id,
+			"user3": user3.Id,
+		}
+
+		testTransformation(
+			"Meeting with @user1, @user2, and @user3 about @user1's proposal. @user2 will present, @user3 will take notes.",
+			mentionTransforms,
+			"Meeting with @user1:remote1, @user2:remote1, and @user3:remote1 about @user1:remote1's proposal. @user2:remote1 will present, @user3:remote1 will take notes.",
+			"Multiple mentions should transform efficiently",
+		)
+	})
 }

--- a/server/platform/services/sharedchannel/mock_AppIface_test.go
+++ b/server/platform/services/sharedchannel/mock_AppIface_test.go
@@ -560,6 +560,11 @@ func (_m *MockAppIface) PermanentDeleteChannel(c request.CTX, channel *model.Cha
 	return r0
 }
 
+// PostDebugToTownSquare provides a mock function with given fields: c, message
+func (_m *MockAppIface) PostDebugToTownSquare(c request.CTX, message string) {
+	_m.Called(c, message)
+}
+
 // PreparePostForClient provides a mock function with given fields: c, post, isNewPost, includeDeleted, includePriority
 func (_m *MockAppIface) PreparePostForClient(c request.CTX, post *model.Post, isNewPost bool, includeDeleted bool, includePriority bool) *model.Post {
 	ret := _m.Called(c, post, isNewPost, includeDeleted, includePriority)

--- a/server/platform/services/sharedchannel/service.go
+++ b/server/platform/services/sharedchannel/service.go
@@ -84,6 +84,7 @@ type AppIface interface {
 	SaveAcknowledgementsForPost(c request.CTX, postID string, userIDs []string) ([]*model.PostAcknowledgement, *model.AppError)
 	GetAcknowledgementsForPost(postID string) ([]*model.PostAcknowledgement, *model.AppError)
 	PreparePostForClient(c request.CTX, post *model.Post, isNewPost, includeDeleted, includePriority bool) *model.Post
+	PostDebugToTownSquare(c request.CTX, message string)
 }
 
 // errNotFound allows checking against Store.ErrNotFound errors without making Store a dependency.
@@ -379,4 +380,9 @@ func (scs *Service) OnReceiveSyncMessageForTesting(msg model.RemoteClusterMsg, r
 // HandleChannelNotSharedErrorForTesting is a wrapper to expose handleChannelNotSharedError for testing purposes
 func (scs *Service) HandleChannelNotSharedErrorForTesting(msg *model.SyncMsg, rc *model.RemoteCluster) {
 	scs.handleChannelNotSharedError(msg, rc)
+}
+
+// TransformMentionsOnReceiveForTesting allows testing the full mention transformation flow
+func (scs *Service) TransformMentionsOnReceiveForTesting(ctx request.CTX, post *model.Post, targetChannel *model.Channel, rc *model.RemoteCluster, syncMsgUsers map[string]*model.User, mentionTransforms map[string]string) {
+	scs.transformMentionsOnReceive(ctx, post, targetChannel, rc, syncMsgUsers, mentionTransforms)
 }

--- a/server/platform/services/sharedchannel/sync_send_remote.go
+++ b/server/platform/services/sharedchannel/sync_send_remote.go
@@ -32,13 +32,14 @@ type syncData struct {
 	rc   *model.RemoteCluster
 	scr  *model.SharedChannelRemote
 
-	users            map[string]*model.User
-	profileImages    map[string]*model.User
-	posts            []*model.Post
-	reactions        []*model.Reaction
-	acknowledgements []*model.PostAcknowledgement
-	statuses         []*model.Status
-	attachments      []attachment
+	users             map[string]*model.User
+	profileImages     map[string]*model.User
+	posts             []*model.Post
+	reactions         []*model.Reaction
+	acknowledgements  []*model.PostAcknowledgement
+	statuses          []*model.Status
+	attachments       []attachment
+	mentionTransforms map[string]string
 
 	resultRepeat                bool
 	resultNextCursor            model.GetPostsSinceForSyncCursor
@@ -47,11 +48,12 @@ type syncData struct {
 
 func newSyncData(task syncTask, rc *model.RemoteCluster, scr *model.SharedChannelRemote) *syncData {
 	return &syncData{
-		task:          task,
-		rc:            rc,
-		scr:           scr,
-		users:         make(map[string]*model.User),
-		profileImages: make(map[string]*model.User),
+		task:              task,
+		rc:                rc,
+		scr:               scr,
+		users:             make(map[string]*model.User),
+		profileImages:     make(map[string]*model.User),
+		mentionTransforms: make(map[string]string),
 		resultNextCursor: model.GetPostsSinceForSyncCursor{
 			LastPostUpdateAt: scr.LastPostUpdateAt, LastPostUpdateID: scr.LastPostUpdateID,
 			LastPostCreateAt: scr.LastPostCreateAt, LastPostCreateID: scr.LastPostCreateID,
@@ -444,9 +446,6 @@ func (scs *Service) fetchPostUsersForSync(sd *syncData) error {
 	}
 
 	for _, post := range sd.posts {
-		// add author
-		userIDs[post.UserId] = p2mm{}
-
 		// get mentions and users for each mention
 		mentionMap := scs.app.MentionsToTeamMembers(request.EmptyContext(scs.server.Log()), post.Message, sc.TeamId)
 
@@ -458,10 +457,19 @@ func (scs *Service) fetchPostUsersForSync(sd *syncData) error {
 			}
 
 			// Skip remote users unless mention contains a colon (@username:remote)
-			if user.RemoteId != nil && !strings.Contains(mention, ":") {
+			if user.IsRemote() && !strings.Contains(mention, ":") {
 				continue
 			}
+		}
 
+		// add author with post and mentionMap so transformations can be applied
+		userIDs[post.UserId] = p2mm{
+			post:       post,
+			mentionMap: mentionMap,
+		}
+
+		// Add all mentioned users
+		for _, userID := range mentionMap {
 			userIDs[userID] = p2mm{
 				post:       post,
 				mentionMap: mentionMap,
@@ -470,7 +478,6 @@ func (scs *Service) fetchPostUsersForSync(sd *syncData) error {
 	}
 
 	merr := merror.New()
-
 	for userID, v := range userIDs {
 		user, err := scs.server.GetStore().User().Get(context.Background(), userID)
 		if err != nil {
@@ -480,7 +487,7 @@ func (scs *Service) fetchPostUsersForSync(sd *syncData) error {
 
 		sync, syncImage, err2 := scs.shouldUserSync(user, sd.task.channelID, sd.rc)
 		if err2 != nil {
-			merr.Append(fmt.Errorf("could not check should sync user %s: %w", userID, err))
+			merr.Append(fmt.Errorf("could not check should sync user %s: %w", userID, err2))
 			continue
 		}
 
@@ -492,9 +499,19 @@ func (scs *Service) fetchPostUsersForSync(sd *syncData) error {
 			sd.profileImages[user.Id] = user
 		}
 
-		// Transform @username:remote to @username when sending to a user's home cluster
-		if v.post != nil && user.RemoteId != nil && *user.RemoteId == sd.rc.RemoteId {
-			fixMention(v.post, v.mentionMap, user)
+		// Collect mention transforms for all mentioned users
+		if v.mentionMap != nil {
+			rctx := request.EmptyContext(scs.server.Log())
+			scs.app.PostDebugToTownSquare(rctx, fmt.Sprintf("fetchPostUsersForSync: Processing mention map - Remote=%s, UserID=%s, Username=%s, UserRemoteId=%s, MentionCount=%d", sd.rc.Name, userID, user.Username, user.GetRemoteID(), len(v.mentionMap)))
+			for mention, mentionUserID := range v.mentionMap {
+				scs.app.PostDebugToTownSquare(rctx, fmt.Sprintf("fetchPostUsersForSync: Processing mention='%s' -> mentionUserID='%s', currentUserID='%s'", mention, mentionUserID, userID))
+				if mentionUserID == userID {
+					// Always add the mention transform - let receiver decide how to display
+					// The sender should NOT modify the message, only provide the mapping
+					scs.app.PostDebugToTownSquare(rctx, fmt.Sprintf("fetchPostUsersForSync: Adding mention transform - Remote=%s, Mention='%s', UserID=%s", sd.rc.Name, mention, userID))
+					sd.mentionTransforms[mention] = userID
+				}
+			}
 		}
 	}
 	return merr.ErrorOrNil()
@@ -690,6 +707,11 @@ func (scs *Service) sendPostSyncData(sd *syncData) error {
 
 	msg := model.NewSyncMsg(sd.task.channelID)
 	msg.Posts = sd.posts
+	msg.MentionTransforms = sd.mentionTransforms
+
+	// Debug mention transforms being sent
+	rctx := request.EmptyContext(scs.server.Log())
+	scs.app.PostDebugToTownSquare(rctx, fmt.Sprintf("sendPostSyncData: Sending mention transforms - Remote=%s, ChannelID=%s, TransformCount=%d, Transforms=%v", sd.rc.Name, sd.task.channelID, len(sd.mentionTransforms), sd.mentionTransforms))
 
 	return scs.sendSyncMsgToRemote(msg, sd.rc, func(syncResp model.SyncResponse, errResp error) {
 		if len(syncResp.PostErrors) != 0 {

--- a/server/public/model/shared_channel.go
+++ b/server/public/model/shared_channel.go
@@ -292,6 +292,7 @@ type SyncMsg struct {
 	Statuses          []*Status              `json:"statuses,omitempty"`
 	MembershipChanges []*MembershipChangeMsg `json:"membership_changes,omitempty"`
 	Acknowledgements  []*PostAcknowledgement `json:"acknowledgements,omitempty"`
+	MentionTransforms map[string]string      `json:"mention_transforms,omitempty"`
 }
 
 func NewSyncMsg(channelID string) *SyncMsg {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
