### PR TITLE
[MM-64696] LDAP Wizard: Add help text for slow LDAP queries

### DIFF
--- a/webapp/channels/src/components/admin_console/admin_definition_ldap_wizard.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition_ldap_wizard.tsx
@@ -366,7 +366,8 @@ export const ldapWizardAdminDefinition: LDAPAdminDefinitionConfigSchemaSettings 
                     ),
                 ),
                 label: defineMessage({id: 'admin.ldap.testFiltersTitle', defaultMessage: 'Test Filters'}),
-                help_text_markdown: false,
+                help_text: defineMessage({id: 'admin.ldap.testFiltersHelpText', defaultMessage: '**Note**: This test is similar in scope to an LDAP sync and may take time depending on the size of the LDAP Server, hardware, or network conditions.'}),
+                help_text_markdown: true,
                 error_message: defineMessage({id: 'admin.ldap.testFiltersFailure', defaultMessage: 'We failed to apply some filters: {error}'}),
                 success_message: defineMessage({id: 'admin.ldap.testFiltersSuccess', defaultMessage: 'Test Successful'}),
             },
@@ -526,7 +527,9 @@ export const ldapWizardAdminDefinition: LDAPAdminDefinitionConfigSchemaSettings 
                 type: 'button',
                 action: ldapTestAttributes,
                 key: 'LdapSettings.TestAttributes',
-                help_text_markdown: false,
+                label: defineMessage({id: 'admin.ldap.testAttributesTitle', defaultMessage: 'Test Attributes'}),
+                help_text: defineMessage({id: 'admin.ldap.testFiltersHelpText', defaultMessage: '**Note**: This test is similar in scope to an LDAP sync and may take time depending on the size of the LDAP Server, hardware, or network conditions.'}),
+                help_text_markdown: true,
                 isDisabled: it.any(
                     it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
                     it.all(
@@ -534,7 +537,6 @@ export const ldapWizardAdminDefinition: LDAPAdminDefinitionConfigSchemaSettings 
                         it.stateIsFalse('LdapSettings.EnableSync'),
                     ),
                 ),
-                label: defineMessage({id: 'admin.ldap.testAttributesTitle', defaultMessage: 'Test Attributes'}),
                 error_message: defineMessage({id: 'admin.ldap.testAttributesFailure', defaultMessage: 'We failed to find some attributes: {error}'}),
                 success_message: defineMessage({id: 'admin.ldap.testAttributesSuccess', defaultMessage: 'Test Successful'}),
             },
@@ -583,7 +585,9 @@ export const ldapWizardAdminDefinition: LDAPAdminDefinitionConfigSchemaSettings 
                 type: 'button',
                 action: ldapTestGroupAttributes,
                 key: 'LdapSettings.TestGroupAttributes',
-                help_text_markdown: false,
+                label: defineMessage({id: 'admin.ldap.testGroupAttributesTitle', defaultMessage: 'Test Group Attributes'}),
+                help_text: defineMessage({id: 'admin.ldap.testFiltersHelpText', defaultMessage: '**Note**: This test is similar in scope to an LDAP sync and may take time depending on the size of the LDAP Server, hardware, or network conditions.'}),
+                help_text_markdown: true,
                 isDisabled: it.any(
                     it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.LDAP)),
                     it.all(
@@ -591,7 +595,6 @@ export const ldapWizardAdminDefinition: LDAPAdminDefinitionConfigSchemaSettings 
                         it.stateIsFalse('LdapSettings.EnableSync'),
                     ),
                 ),
-                label: defineMessage({id: 'admin.ldap.testGroupAttributesTitle', defaultMessage: 'Test Group Attributes'}),
                 error_message: defineMessage({id: 'admin.ldap.testGroupAttributesFailure', defaultMessage: 'We failed to find some attributes: {error}'}),
                 success_message: defineMessage({id: 'admin.ldap.testGroupAttributesSuccess', defaultMessage: 'Test Successful'}),
             },

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -1542,6 +1542,7 @@
   "admin.ldap.testConnectionSuccess": "Test Connection Successful",
   "admin.ldap.testConnectionTitle": "Test Connection",
   "admin.ldap.testFiltersFailure": "We failed to apply some filters: {error}",
+  "admin.ldap.testFiltersHelpText": "**Note**: This test is similar in scope to an LDAP sync and may take time depending on the size of the LDAP Server, hardware, or network conditions.",
   "admin.ldap.testFiltersPartialFailure": "{failedCount, number} of {totalCount, number} filter test{totalCount, plural, one {} other {s}} failed. Check the highlighted fields for details.",
   "admin.ldap.testFiltersSuccess": "Test Successful",
   "admin.ldap.testFiltersTitle": "Test Filters",


### PR DESCRIPTION
#### Summary
- Benchmarking shows that some customers with very large LDAP servers (100k+ users) may experience wait times after pressing the `Test Filters` and `Test Attributes` buttons (and to a much lesser extent, the `Test Group Attributes` button). 
- The Test buttons do get replaced by a `Loading` spinner, so that's good. I want to also add some help text to explain what's happening, so that the users don't feel like something is broken.
- @cwarnermm @asaadmahmood Please advise on wording if you anything better and I'll make the change. Thanks!

/cc @amyblais If possible, I'd like to get this in for 10.10 given the very little core code impact

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-64696

#### Screenshots

|  before  |  after  | after pressing |
|----|----|----|
| ![CleanShot 2025-06-26 at 15 11 39](https://github.com/user-attachments/assets/08484632-c375-4c80-82ef-b460e78dac64) |  ![CleanShot 2025-06-26 at 15 08 27](https://github.com/user-attachments/assets/480e4e62-3be0-4208-81c2-56cf0333908a) | ![CleanShot 2025-06-26 at 15 08 55](https://github.com/user-attachments/assets/a25c973d-f77b-44bb-a66e-796627444383) |


#### Release Note

```release-note
LDAP Wizard: Add help text explaining the possible delay when running tests on large LDAP servers.
```
