### PR TITLE
[MM-64630] Fix an issue where multiple channels can't be removed from policies

### DIFF
--- a/server/channels/app/access_control.go
+++ b/server/channels/app/access_control.go
@@ -183,7 +183,7 @@ func (a *App) UnassignPoliciesFromChannels(rctx request.CTX, policyID string, ch
 	cps, _, err := a.Srv().Store().AccessControlPolicy().SearchPolicies(rctx, model.AccessControlPolicySearch{
 		Type:     model.AccessControlPolicyTypeChannel,
 		ParentID: policyID,
-		Limit:    len(channelIDs),
+		Limit:    1000,
 	})
 	if err != nil {
 		return model.NewAppError("UnassignPoliciesFromChannels", "app.pap.unassign_access_control_policy_from_channels.app_error", nil, err.Error(), http.StatusInternalServerError)

--- a/server/channels/app/access_control.go
+++ b/server/channels/app/access_control.go
@@ -183,13 +183,24 @@ func (a *App) UnassignPoliciesFromChannels(rctx request.CTX, policyID string, ch
 	cps, _, err := a.Srv().Store().AccessControlPolicy().SearchPolicies(rctx, model.AccessControlPolicySearch{
 		Type:     model.AccessControlPolicyTypeChannel,
 		ParentID: policyID,
+		Limit:    len(channelIDs),
 	})
 	if err != nil {
 		return model.NewAppError("UnassignPoliciesFromChannels", "app.pap.unassign_access_control_policy_from_channels.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
-	for _, cp := range cps {
-		appErr := acs.DeletePolicy(rctx, cp.ID)
+	childPolicies := make(map[string]bool)
+	for _, p := range cps {
+		childPolicies[p.ID] = true
+	}
+
+	for _, channelID := range channelIDs {
+		if _, ok := childPolicies[channelID]; !ok {
+			mlog.Warn("Policy is not assigned to the parent policy", mlog.String("channel_id", channelID), mlog.String("parent_policy_id", policyID))
+			continue
+		}
+
+		appErr := acs.DeletePolicy(rctx, channelID)
 		if appErr != nil {
 			return appErr
 		}

--- a/server/channels/app/access_control.go
+++ b/server/channels/app/access_control.go
@@ -188,18 +188,8 @@ func (a *App) UnassignPoliciesFromChannels(rctx request.CTX, policyID string, ch
 		return model.NewAppError("UnassignPoliciesFromChannels", "app.pap.unassign_access_control_policy_from_channels.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
-	childPolicies := make(map[string]bool)
-	for _, p := range cps {
-		childPolicies[p.ID] = true
-	}
-
-	for _, channelID := range channelIDs {
-		if _, ok := childPolicies[channelID]; !ok {
-			mlog.Warn("Policy is not assigned to the parent policy", mlog.String("channel_id", channelID), mlog.String("parent_policy_id", policyID))
-			continue
-		}
-
-		appErr := acs.DeletePolicy(rctx, channelID)
+	for _, cp := range cps {
+		appErr := acs.DeletePolicy(rctx, cp.ID)
 		if appErr != nil {
 			return appErr
 		}

--- a/server/channels/app/access_control_test.go
+++ b/server/channels/app/access_control_test.go
@@ -341,7 +341,7 @@ func TestAssignAccessControlPolicyToChannels(t *testing.T) {
 	})
 }
 
-func TestUnAssignPoliciesFromChannels(t *testing.T) {
+func TestUnassignPoliciesFromChannels(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 

--- a/webapp/channels/src/components/admin_console/access_control/policy_details/__snapshots__/policy_details.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/access_control/policy_details/__snapshots__/policy_details.test.tsx.snap
@@ -142,7 +142,6 @@ exports[`components/admin_console/access_control/policy_details/PolicyDetails sh
             channelsToAdd={Object {}}
             channelsToRemove={Object {}}
             onRemoveCallback={[Function]}
-            onUndoRemoveCallback={[Function]}
             policyId="policy1"
           />
         </CardBody>
@@ -346,7 +345,6 @@ exports[`components/admin_console/access_control/policy_details/PolicyDetails sh
             channelsToAdd={Object {}}
             channelsToRemove={Object {}}
             onRemoveCallback={[Function]}
-            onUndoRemoveCallback={[Function]}
             policyId=""
           />
         </CardBody>

--- a/webapp/channels/src/components/admin_console/access_control/policy_details/channel_list/channel_list.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/policy_details/channel_list/channel_list.tsx
@@ -30,7 +30,6 @@ type Props = {
     filters: ChannelSearchOpts;
     policyId?: string;
     onRemoveCallback: (channel: ChannelWithTeamData) => void;
-    onUndoRemoveCallback: (channel: ChannelWithTeamData) => void;
     channelsToRemove: Record<string, ChannelWithTeamData>;
     channelsToAdd: Record<string, ChannelWithTeamData>;
     actions: {
@@ -196,15 +195,8 @@ export default class ChannelList extends React.PureComponent<Props, State> {
     };
 
     private removeChannel = (channel: ChannelWithTeamData) => {
-        const {channelsToRemove, onRemoveCallback, onUndoRemoveCallback} = this.props;
+        const {onRemoveCallback} = this.props;
         const {page} = this.state;
-
-        // Toggle between adding and removing the channel
-        if (channelsToRemove[channel.id] === channel) {
-            // If the channel is already marked for removal, undo it
-            onUndoRemoveCallback(channel);
-            return;
-        }
 
         // If the channel is not marked for removal, mark it
         onRemoveCallback(channel);

--- a/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.tsx
@@ -285,33 +285,13 @@ function PolicyDetails({
 
             channels.forEach((channel) => {
                 if (isAdding) {
-                    if (newChanges.removed[channel.id]) {
-                        delete newChanges.removed[channel.id];
-                        newChanges.removedCount--;
-                    } else {
-                        newChanges.added[channel.id] = channel;
-                    }
-                } else if (newChanges.added[channel.id]) {
-                    delete newChanges.added[channel.id];
-                } else if (!newChanges.removed[channel.id]) {
+                    newChanges.added[channel.id] = channel;
+                } else {
                     newChanges.removedCount++;
                     newChanges.removed[channel.id] = channel;
                 }
             });
 
-            return newChanges;
-        });
-        setSaveNeeded(true);
-        actions.setNavigationBlocked(true);
-    };
-
-    const handleUndoRemove = (channel: ChannelWithTeamData) => {
-        setChannelChanges((prev) => {
-            const newChanges = cloneDeep(prev);
-            if (newChanges.removed[channel.id]) {
-                delete newChanges.removed[channel.id];
-                newChanges.removedCount--;
-            }
             return newChanges;
         });
         setSaveNeeded(true);
@@ -519,7 +499,6 @@ function PolicyDetails({
                         <Card.Body expanded={true}>
                             <ChannelList
                                 onRemoveCallback={(channel) => handleChannelChanges([channel], false)}
-                                onUndoRemoveCallback={handleUndoRemove}
                                 channelsToRemove={channelChanges.removed}
                                 channelsToAdd={channelChanges.added}
                                 policyId={policyId}


### PR DESCRIPTION


#### Summary
While we are here, we also remove the unnecessary logic for "to be removed" logic. The actual bug about not being able to unassign multiple policies was related to map iteration.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64630



#### Release Note

```release-note
NONE
```
