### PR TITLE
[MM-64663] Fix potential panic in `mmctl ldap job show` command

### DIFF
--- a/server/cmd/mmctl/commands/ldap.go
+++ b/server/cmd/mmctl/commands/ldap.go
@@ -26,7 +26,7 @@ func newLDAPSyncCmd() *cobra.Command {
 		Use:     "sync",
 		Short:   "Synchronize now",
 		Long:    "Synchronize all LDAP users and groups now.",
-		Example: "  ldap sync",
+		Example: "mmctl ldap sync",
 		RunE:    withClient(ldapSyncCmdF),
 	}
 
@@ -48,7 +48,7 @@ var LdapIDMigrate = &cobra.Command{
 2. Run the command "mmctl ldap idmigrate objectGUID".
 3. Update the config within the System Console to the new value "objectGUID".
 4. Restart the Mattermost server.`,
-	Example: "  ldap idmigrate objectGUID",
+	Example: "mmctl ldap idmigrate objectGUID",
 	Args:    cobra.ExactArgs(1),
 	RunE:    withClient(ldapIDMigrateCmdF),
 }
@@ -60,7 +60,7 @@ var LdapJobCmd = &cobra.Command{
 
 var LdapJobListCmd = &cobra.Command{
 	Use:     "list",
-	Example: "  ldap job list",
+	Example: "mmctl ldap job list",
 	Short:   "List LDAP sync jobs",
 	// Alisases cause error in zsh. Supposedly, completion V2 will fix that: https://github.com/spf13/cobra/pull/1146
 	// https://mattermost.atlassian.net/browse/MM-57062
@@ -72,7 +72,7 @@ var LdapJobListCmd = &cobra.Command{
 
 var LdapJobShowCmd = &cobra.Command{
 	Use:               "show [ldapJobID]",
-	Example:           " import ldap show f3d68qkkm7n8xgsfxwuo498rah",
+	Example:           "mmctl ldap show f3d68qkkm7n8xgsfxwuo498rah",
 	Short:             "Show LDAP sync job",
 	Args:              cobra.MinimumNArgs(1),
 	ValidArgsFunction: validateArgsWithClient(ldapJobShowCompletionF),

--- a/server/cmd/mmctl/commands/ldap.go
+++ b/server/cmd/mmctl/commands/ldap.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -73,6 +74,7 @@ var LdapJobShowCmd = &cobra.Command{
 	Use:               "show [ldapJobID]",
 	Example:           " import ldap show f3d68qkkm7n8xgsfxwuo498rah",
 	Short:             "Show LDAP sync job",
+	Args:              cobra.MinimumNArgs(1),
 	ValidArgsFunction: validateArgsWithClient(ldapJobShowCompletionF),
 	RunE:              withClient(ldapJobShowCmdF),
 }
@@ -140,6 +142,10 @@ func ldapJobListCmdF(c client.Client, command *cobra.Command, args []string) err
 }
 
 func ldapJobShowCmdF(c client.Client, command *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return errors.New("expected at least one argument (ldapJobID). See help text for details")
+	}
+
 	job, _, err := c.GetJob(context.TODO(), args[0])
 	if err != nil {
 		return fmt.Errorf("failed to get LDAP sync job: %w", err)

--- a/server/cmd/mmctl/commands/ldap_e2e_test.go
+++ b/server/cmd/mmctl/commands/ldap_e2e_test.go
@@ -213,6 +213,15 @@ func (s *MmctlE2ETestSuite) TestLdapJobShowCmdF() {
 		s.Require().Empty(printer.GetErrorLines())
 	})
 
+	s.RunForSystemAdminAndLocal("no args", func(c client.Client) {
+		printer.Clean()
+
+		err := ldapJobShowCmdF(c, &cobra.Command{}, []string{})
+		s.Require().EqualError(err, "expected at least one argument (ldapJobID). See help text for details")
+		s.Require().Empty(printer.GetLines())
+		s.Require().Empty(printer.GetErrorLines())
+	})
+
 	s.RunForSystemAdminAndLocal("not found", func(c client.Client) {
 		printer.Clean()
 

--- a/server/cmd/mmctl/docs/mmctl_ldap_idmigrate.rst
+++ b/server/cmd/mmctl/docs/mmctl_ldap_idmigrate.rst
@@ -25,7 +25,7 @@ Examples
 
 ::
 
-    ldap idmigrate objectGUID
+  mmctl ldap idmigrate objectGUID
 
 Options
 ~~~~~~~

--- a/server/cmd/mmctl/docs/mmctl_ldap_job_list.rst
+++ b/server/cmd/mmctl/docs/mmctl_ldap_job_list.rst
@@ -20,7 +20,7 @@ Examples
 
 ::
 
-    ldap job list
+  mmctl ldap job list
 
 Options
 ~~~~~~~

--- a/server/cmd/mmctl/docs/mmctl_ldap_job_show.rst
+++ b/server/cmd/mmctl/docs/mmctl_ldap_job_show.rst
@@ -20,7 +20,7 @@ Examples
 
 ::
 
-   import ldap show f3d68qkkm7n8xgsfxwuo498rah
+  mmctl ldap show f3d68qkkm7n8xgsfxwuo498rah
 
 Options
 ~~~~~~~

--- a/server/cmd/mmctl/docs/mmctl_ldap_sync.rst
+++ b/server/cmd/mmctl/docs/mmctl_ldap_sync.rst
@@ -20,7 +20,7 @@ Examples
 
 ::
 
-    ldap sync
+  mmctl ldap sync
 
 Options
 ~~~~~~~


### PR DESCRIPTION
#### Summary

Fixes https://github.com/mattermost/mattermost/issues/31894

@cpoile Let me know if there's more to consider regarding autocompletion logic.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-64663

#### Release Note

```release-note
Fixed potential panic when running the `mmctl ldap job show` without the required argument.
```
