### PR TITLE
MM-64713 - channel invite modal in abac channel should keep filtered list of users

### DIFF
--- a/webapp/channels/src/components/channel_invite_modal/channel_invite_modal.tsx
+++ b/webapp/channels/src/components/channel_invite_modal/channel_invite_modal.tsx
@@ -100,6 +100,7 @@ const ChannelInviteModalComponent = (props: Props) => {
     const [groupAndUserOptions, setGroupAndUserOptions] = useState<Array<UserProfileValue | GroupValue>>([]);
     const [inviteError, setInviteError] = useState<string | undefined>(undefined);
     const [pageCursors, setPageCursors] = useState<{[page: number]: string}>({});
+    const [abacFilteredUsers, setAbacFilteredUsers] = useState<UserProfile[]>([]);
 
     const searchTimeoutId = useRef<number>(0);
     const selectedItemRef = useRef<HTMLDivElement>(null);
@@ -183,18 +184,18 @@ const ChannelInviteModalComponent = (props: Props) => {
 
         let users: UserProfileValue[];
         if (props.channel.policy_enforced) {
-        // When ABAC is enabled, only use the ABAC-filtered profilesNotInCurrentChannel
-            const filteredUsers = filterProfilesStartingWithTerm(props.profilesNotInCurrentChannel, term);
+            // ABAC mode: Use local state with fresh API data, completely bypass Redux
+            const filteredUsers = filterProfilesStartingWithTerm(abacFilteredUsers, term);
             users = filterOutDeletedAndExcludedAndNotInTeamUsers(filteredUsers, excludedAndNotInTeamUserIds);
         } else {
-        // When ABAC is not enabled, use the current logic
+            // Non-ABAC mode: existing logic
             const filteredUsers = filterProfilesStartingWithTerm(props.profilesNotInCurrentChannel.concat(props.profilesInCurrentChannel), term);
             users = filterOutDeletedAndExcludedAndNotInTeamUsers(filteredUsers, excludedAndNotInTeamUserIds);
-        }
 
-        // Only include explicitly added users if ABAC is not enabled
-        if (props.includeUsers && !props.channel.policy_enforced) {
-            users = [...users, ...Object.values(props.includeUsers)];
+            // Only include explicitly added users if ABAC is not enabled
+            if (props.includeUsers) {
+                users = [...users, ...Object.values(props.includeUsers)];
+            }
         }
 
         const groupsAndUsers = [
@@ -218,6 +219,7 @@ const ChannelInviteModalComponent = (props: Props) => {
         props.channel.policy_enforced,
         excludedUsers,
         filterOutDeletedAndExcludedAndNotInTeamUsers,
+        abacFilteredUsers,
     ]);
 
     // Handle modal hide
@@ -246,6 +248,24 @@ const ChannelInviteModalComponent = (props: Props) => {
     const setUsersLoadingState = useCallback((loadingState: boolean) => {
         setLoadingUsers(loadingState);
     }, []);
+
+    // Custom function to fetch ABAC users without polluting Redux store
+    const fetchAbacUsers = useCallback(async (page = 0, perPage = USERS_PER_PAGE, cursorId = '') => {
+        try {
+            const profiles = await Client4.getProfilesNotInChannel(
+                props.channel.team_id,
+                props.channel.id,
+                props.channel.group_constrained,
+                page,
+                perPage,
+                cursorId,
+            );
+            setAbacFilteredUsers(profiles);
+            return {data: profiles};
+        } catch (error) {
+            return {error};
+        }
+    }, [props.channel.team_id, props.channel.id, props.channel.group_constrained]);
 
     // Handle page change with cursor-based pagination
     const handlePageChange = useCallback((page: number, prevPage: number) => {
@@ -439,9 +459,24 @@ const ChannelInviteModalComponent = (props: Props) => {
 
     // Initial data loading - only run when channel changes or component mounts
     useEffect(() => {
-        props.actions.getProfilesNotInChannel(props.channel.team_id, props.channel.id, props.channel.group_constrained, 0, USERS_PER_PAGE).then(() => {
-            setUsersLoadingState(false);
-        });
+        if (props.channel.policy_enforced) {
+            // For ABAC channels, use custom function to avoid Redux store pollution
+            fetchAbacUsers().then(() => {
+                setUsersLoadingState(false);
+            });
+        } else {
+            // For non-ABAC channels, use normal Redux actions
+            props.actions.getProfilesNotInChannel(
+                props.channel.team_id,
+                props.channel.id,
+                props.channel.group_constrained,
+                0,
+                USERS_PER_PAGE,
+            ).then(() => {
+                setUsersLoadingState(false);
+            });
+        }
+
         props.actions.getProfilesInChannel(props.channel.id, 0, USERS_PER_PAGE, '', {active: true});
         props.actions.getTeamStats(props.channel.team_id);
         props.actions.loadStatusesForProfilesList(props.profilesNotInCurrentChannel);
@@ -450,7 +485,9 @@ const ChannelInviteModalComponent = (props: Props) => {
         props.channel.id,
         props.channel.team_id,
         props.channel.group_constrained,
+        props.channel.policy_enforced,
         props.actions,
+        fetchAbacUsers,
 
         // Removing these dependencies as they cause an infinite loop
         // These profiles are updated by the actions above, which triggers the effect again
@@ -468,6 +505,8 @@ const ChannelInviteModalComponent = (props: Props) => {
         props.groups,
         props.profilesNotInCurrentTeam,
         props.excludeUsers,
+        props.channel.policy_enforced, // Add this to trigger recomputation when ABAC mode changes
+        abacFilteredUsers, // Add local ABAC state
     ]);
 
     // Update team members when options change


### PR DESCRIPTION
#### Summary
The initial work for filter user list in abac invite channel https://github.com/mattermost/mattermost/pull/31219 missed a part where the channel invite component in abac channel was still grabbing the global state list of users, so initially it was just going to populate this with the results of the search api call, and it was doing this correctly, but as soon as user interacts with other part of the app that would populate the state with the full list of users (i.e tagging users), that would cause the invite modal list to show the full list of users. This PR makes sure that the abac channels will only rely in the component state and the fetched user list from the api.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64713

#### Screenshots

Before:

https://github.com/user-attachments/assets/28a8d3bc-3074-43bb-9019-7ef1f4d079ec



After:

https://github.com/user-attachments/assets/a2f1a4c2-161c-4756-8dd1-252a0c04d9bf


#### Release Note
```release-note
NONE
```
