### PR TITLE
[MM-64708] Fix custom data retention policy navigation

### DIFF
--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -5449,7 +5449,7 @@ const AdminDefinition: AdminDefinitionType = {
                 url: `compliance/data_retention_settings/custom_policy/:policy_id(${ID_PATH_PATTERN})`,
                 isHidden: it.any(
                     it.not(it.licensedForFeature('DataRetention')),
-                    it.not(it.userHasReadPermissionOnSomeResources(RESOURCE_KEYS.COMPLIANCE.DATA_RETENTION_POLICY)),
+                    it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.COMPLIANCE.DATA_RETENTION_POLICY)),
                 ),
                 isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.COMPLIANCE.DATA_RETENTION_POLICY)),
                 schema: {
@@ -5462,7 +5462,7 @@ const AdminDefinition: AdminDefinitionType = {
                 url: 'compliance/data_retention_settings/custom_policy',
                 isHidden: it.any(
                     it.not(it.licensedForFeature('DataRetention')),
-                    it.not(it.userHasReadPermissionOnSomeResources(RESOURCE_KEYS.COMPLIANCE.DATA_RETENTION_POLICY)),
+                    it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.COMPLIANCE.DATA_RETENTION_POLICY)),
                 ),
                 isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.COMPLIANCE.DATA_RETENTION_POLICY)),
                 schema: {


### PR DESCRIPTION
## Summary

Fix navigation regression where the "Add Policy" button in System Console > Compliance > Data Retention Policies changed the URL but didn't navigate to the custom policy form.

## Root Cause

During the ABAC Phase 1 implementation (commit `a344b3225b`), the permission checking logic for custom data retention policy routes was incorrectly changed from `userHasReadPermissionOnResource()` to `userHasReadPermissionOnSomeResources()` without updating the parameter type. This caused the routes to be filtered out as "hidden" due to failed permission checks.

## Changes

- Fixed `custom_policy_form` route permission checking
- Fixed `custom_policy_form_edit` route permission checking  
- Both now use `userHasReadPermissionOnResource()` consistently with other working data retention routes

## Test Plan

- [x] Navigate to System Console > Compliance > Data Retention Policies
- [x] Click "Add Policy" button - should navigate to custom policy form
- [x] Navigate directly to `/admin_console/compliance/data_retention_settings/custom_policy` - should work
- [x] Edit existing custom policies - should work

🤖 Generated with [Claude Code](https://claude.ai/code)

### Ticket
- https://mattermost.atlassian.net/browse/MM-64708

### Release Note

```release-note
NONE
```

### Additional notes
- I checked the other permissions in the admin_definition and the ldap's admin_definition, looks like nothing else got broken in a similar way.