### PR TITLE
remove spurious user limits log

### DIFF
--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -335,7 +335,7 @@ func (a *App) createUserOrGuest(c request.CTX, user *model.User, guest bool) (*m
 		// So, we log the error, not return
 		c.Logger().Error("Error fetching user limits in createUserOrGuest", mlog.Err(limitErr))
 	} else {
-		if userLimits.ActiveUserCount > userLimits.MaxUsersLimit {
+		if userLimits.MaxUsersLimit > 0 && userLimits.ActiveUserCount > userLimits.MaxUsersLimit {
 			// Use different warning messages based on whether server is licensed
 			if a.License() != nil {
 				c.Logger().Warn("ERROR_LICENSED_USERS_LIMIT_EXCEEDED: Created user exceeds the maximum licensed users.", mlog.Int("user_limit", userLimits.MaxUsersLimit))


### PR DESCRIPTION
#### Summary
Only log a warning when the created user exceeds the `MaxUserLimits` if `MaxUsersLimit > 0`. This was showing up spuriously on licensed servers for which no actual limit applied.

Note that this is distinct from blocking user creation past `MaxHardUsersLimit` -- the log exists to warn users about the intermediate state between soft and hard user limits.

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
