### PR TITLE
Skip code coverage generation on cherry-pick PRs

### DIFF
--- a/.github/workflows/server-ci-template.yml
+++ b/.github/workflows/server-ci-template.yml
@@ -265,6 +265,8 @@ jobs:
       drivername: mysql
       logsartifact: mysql-server-test-logs
   test-coverage:
+    # Skip coverage generation for cherry-pick PRs into release branches.
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.event.pull_request.base.ref, 'release-') }}
     name: Generate Test Coverage
     needs: check-mattermost-vet
     uses: ./.github/workflows/server-test-template.yml

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -78,6 +78,7 @@ jobs:
             $BUILD_IMAGE \
             make test-server$RACE_MODE BUILD_NUMBER=$GITHUB_HEAD_REF-$GITHUB_RUN_ID
       - name: Upload coverage to Codecov
+        if: ${{ inputs.enablecoverage }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/webapp-ci-template.yml
+++ b/.github/workflows/webapp-ci-template.yml
@@ -79,6 +79,8 @@ jobs:
         run: |
           npm run test-ci
       - name: Upload coverage to Codecov
+        # Skip coverage upload for cherry-pick PRs into release branches.
+        if: ${{ github.event_name != 'pull_request' || !startsWith(github.event.pull_request.base.ref, 'release-') }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
#### Summary

Generating coverage on cherry-picked PRs isn't very valuable, so we skip the job in such a case.

#### Release Note

```release-note
NONE
```

