### PR TITLE
Inline annotations

### DIFF
--- a/.github/workflows/server-ci-report.yml
+++ b/.github/workflows/server-ci-report.yml
@@ -55,7 +55,8 @@ jobs:
         if: github.event.workflow_run.name == 'Server CI PR'
         id: incoming-pr
         run: echo "NUMBER=$(cat ${{ matrix.test.artifact }}/pr-number)" >> ${GITHUB_OUTPUT}
-      - name: Publish test report
+      - name: Publish test report (forked branches, write access disabled)
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
         id: report
         uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857 # v5.5.1
         with:

--- a/.github/workflows/server-ci-report.yml
+++ b/.github/workflows/server-ci-report.yml
@@ -21,7 +21,7 @@ jobs:
           github-token: ${{ github.token }}
           pattern: "*-test-logs"
           path: reports
-      
+
       - name: report/generate-report-matrix
         id: report
         run: |
@@ -31,11 +31,11 @@ jobs:
             echo "{\"artifact\": \"$folder\", \"name\": \"$test_name\"}"
           done | jq -s '{ "test": . }' | tee /tmp/report-matrix
           echo REPORT_MATRIX=$(cat /tmp/report-matrix | jq --compact-output --monochrome-output) >> ${GITHUB_OUTPUT}
-      
+
   publish-report:
     runs-on: ubuntu-22.04
     name: Publish Report ${{ matrix.test.name }}
-    needs: 
+    needs:
       - generate-report-matrix
     permissions:
       pull-requests: write

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -87,6 +87,28 @@ jobs:
         run: |
           cd server/build
           docker compose --ansi never stop
+      - name: Annotate test failures (local branches, requires write access)
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        id: report-local
+        uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857 # v5.5.1
+        with:
+          report_paths: server/report.xml
+          check_name: ${{ inputs.name }} (Results)
+          annotate_only: false
+          require_tests: true
+          check_retries: true
+          flaky_summary: true
+          include_passed: true
+          check_annotations: true
+      - name: Annotate test failures (forked branches, write access denied)
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        id: report-forked
+        uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857 # v5.5.1
+        with:
+          report_paths: server/report.xml
+          annotate_only: true
+          require_tests: true
+          check_retries: true
       - name: Archive logs
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -88,7 +88,7 @@ jobs:
           cd server/build
           docker compose --ansi never stop
       - name: Annotate test failures (local branches, requires write access)
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
         id: report-local
         uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857 # v5.5.1
         with:
@@ -101,7 +101,7 @@ jobs:
           include_passed: true
           check_annotations: true
       - name: Annotate test failures (forked branches, write access denied)
-        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        if: ${{ always() && github.event.pull_request.head.repo.full_name != github.repository }}
         id: report-forked
         uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857 # v5.5.1
         with:

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -93,7 +93,6 @@ jobs:
         uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857 # v5.5.1
         with:
           report_paths: server/report.xml
-          check_name: ${{ inputs.name }} (Results)
           annotate_only: false
           require_tests: true
           check_retries: true

--- a/server/Makefile
+++ b/server/Makefile
@@ -452,7 +452,7 @@ test-server: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)
 test-server: export GOTESTSUM_JUNITFILE := $(GOTESTSUM_JUNITFILE)
 test-server: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
 test-server: test-server-pre
-	$(GOBIN)/gotestsum --rerun-fails=3 --packages="$(TE_PACKAGES) $(EE_PACKAGES)" -- $(GOFLAGS) -timeout=90m $(COVERAGE_FLAG)
+	$(GOBIN)/gotestsum --rerun-fails=3 --packages="github.com/mattermost/mattermost/server/v8/platform/services/marketplace" -- $(GOFLAGS) -timeout=90m $(COVERAGE_FLAG)
 ifneq ($(IS_CI),true)
   ifneq ($(MM_NO_DOCKER),true)
     ifneq ($(TEMP_DOCKER_SERVICES),)

--- a/server/platform/services/marketplace/client_test.go
+++ b/server/platform/services/marketplace/client_test.go
@@ -30,7 +30,7 @@ func TestBuildURL(t *testing.T) {
 		"Base url without trailing slash and path without leading slash": {
 			base:     "https://api.integrations.mattermost.com",
 			path:     "api/v1/plugins",
-			expected: "https://api.integrations.mattermost.com/api/v1/plugins",
+			expected: "https://api.integrations.mattermost.com/api/v1/plugins2",
 		},
 	}
 


### PR DESCRIPTION
#### Summary
A work-in-progress branch to lift annotations out of a hard-to-find "(Results)" job and directly into the failing run -- at least for branches within the repository. (Forked branches are subject to the same split, but we still capture annotations there as well.)

#### Ticket Link
None

#### Screenshots
TODO

#### Release Note
```release-note
NONE
```
