### PR TITLE
[MM-64748] Prepackage Calls v1.9.2 to 10.5

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -144,7 +144,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.7.1
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.9.2
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.3.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.9.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.2.1


### PR DESCRIPTION
#### Summary
- Prepackage calls v1.9.2 to 10.5 to resolve a customer's crash

- @amyblais Can you assign to the correct milestone and let me know the correct cherry pick command (if needed)?  Thank you!

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-64748


#### Release Note
```release-note
Prepackage Calls v1.9.2
```

