### PR TITLE
MM-64656 E2E/Playwright: quick fix on test

### DIFF
--- a/e2e-tests/playwright/specs/functional/channels/threads/threads_list.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/threads/threads_list.spec.ts
@@ -3,7 +3,7 @@
 
 import {test} from '@mattermost/playwright-lib';
 
-test.fixme('Should be able to change threads with arrow keys', async ({pw}, testInfo) => {
+test('Should be able to change threads with arrow keys', async ({pw}, testInfo) => {
     test.skip(testInfo.project.name === 'ipad');
 
     const {team, user} = await pw.initSetup();
@@ -42,14 +42,14 @@ test.fixme('Should be able to change threads with arrow keys', async ({pw}, test
 
     // * Ensure the latest thread was selected
     await threadsPage.toHaveThreadSelected();
-    (await threadsPage.getLastPost()).toContainText('ccc reply');
+    await (await threadsPage.getLastPost()).toContainText('ccc reply');
 
     // # Press the down arrow again
     await page.keyboard.press('ArrowDown');
 
     // * Ensure the latest thread was selected
     await threadsPage.toHaveThreadSelected();
-    (await threadsPage.getLastPost()).toContainText('bbb reply');
+    await (await threadsPage.getLastPost()).toContainText('bbb reply');
 
     await threadsPage.threadsList.focus();
 
@@ -58,19 +58,19 @@ test.fixme('Should be able to change threads with arrow keys', async ({pw}, test
 
     // * Ensure the latest thread was selected
     await threadsPage.toHaveThreadSelected();
-    (await threadsPage.getLastPost()).toContainText('aaa reply');
+    await (await threadsPage.getLastPost()).toContainText('aaa reply');
 
     // # Press the up arrow
     await page.keyboard.press('ArrowUp');
 
     // * Ensure the latest thread was selected
     await threadsPage.toHaveThreadSelected();
-    (await threadsPage.getLastPost()).toContainText('bbb reply');
+    await (await threadsPage.getLastPost()).toContainText('bbb reply');
 
     // # Press the up arrow
     await page.keyboard.press('ArrowUp');
 
     // * Ensure the latest thread was selected
     await threadsPage.toHaveThreadSelected();
-    (await threadsPage.getLastPost()).toContainText('ccc reply');
+    await (await threadsPage.getLastPost()).toContainText('ccc reply');
 });


### PR DESCRIPTION
#### Summary
- nit: added await for calling [`toContainText`](https://github.com/mattermost/mattermost/blob/7a8ed33260dfe6747346409ee9bf310a80c33e66/e2e-tests/playwright/lib/src/ui/components/channels/post.ts#L85)

#### Release Note
```release-note
NONE
```
