### PR TITLE
[MM-64332] If the attributes do not exist, it means we should deny with 403

### DIFF
--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -1677,7 +1677,7 @@ func (a *App) addUserToChannel(c request.CTX, user *model.User, channel *model.C
 				s, err := a.Srv().Store().Attributes().GetSubject(c, user.Id, groupID)
 				if err != nil {
 					return nil, model.NewAppError("AddUserToChannel", "api.channel.add_user.to.channel.failed.app_error", nil,
-						fmt.Sprintf("failed to get subject: %v, user_id: %s, channel_id: %s", err, user.Id, channel.Id), http.StatusNotFound)
+						fmt.Sprintf("failed to get subject: %v, user_id: %s, channel_id: %s", err, user.Id, channel.Id), http.StatusForbidden)
 				}
 
 				decision, evalErr := acs.AccessEvaluation(c, model.AccessRequest{


### PR DESCRIPTION


#### Summary
The `404` is not an actionable error, in fact, the response should be `403` because the error is simply needs to be forbidden in case the subject does not even exist (ie. User doesn't have any attributes at all).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64332


#### Release Note

```release-note
NONE
```
