### PR TITLE
[MM-64683] Implement property field limit enforcement and counting functionality in Plugin API

### DIFF
--- a/server/channels/app/properties/property_field.go
+++ b/server/channels/app/properties/property_field.go
@@ -29,6 +29,10 @@ func (ps *PropertyService) CountActivePropertyFieldsForGroup(groupID string) (in
 	return ps.fieldStore.CountForGroup(groupID, false)
 }
 
+func (ps *PropertyService) CountAllPropertyFieldsForGroup(groupID string) (int64, error) {
+	return ps.fieldStore.CountForGroup(groupID, false)
+}
+
 func (ps *PropertyService) SearchPropertyFields(groupID, targetID string, opts model.PropertyFieldSearchOpts) ([]*model.PropertyField, error) {
 	// groupID and targetID are part of the search method signature to
 	// incentivize the use of the database indexes in searches

--- a/server/channels/app/properties/property_field_test.go
+++ b/server/channels/app/properties/property_field_test.go
@@ -1,0 +1,198 @@
+package properties
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// mockPropertyFieldStore is a mock implementation of PropertyFieldStore interface
+type mockPropertyFieldStore struct {
+	mock.Mock
+}
+
+func (m *mockPropertyFieldStore) Create(field *model.PropertyField) (*model.PropertyField, error) {
+	args := m.Called(field)
+	return args.Get(0).(*model.PropertyField), args.Error(1)
+}
+
+func (m *mockPropertyFieldStore) Get(groupID, id string) (*model.PropertyField, error) {
+	args := m.Called(groupID, id)
+	return args.Get(0).(*model.PropertyField), args.Error(1)
+}
+
+func (m *mockPropertyFieldStore) GetMany(groupID string, ids []string) ([]*model.PropertyField, error) {
+	args := m.Called(groupID, ids)
+	return args.Get(0).([]*model.PropertyField), args.Error(1)
+}
+
+func (m *mockPropertyFieldStore) GetFieldByName(groupID, targetID, name string) (*model.PropertyField, error) {
+	args := m.Called(groupID, targetID, name)
+	return args.Get(0).(*model.PropertyField), args.Error(1)
+}
+
+func (m *mockPropertyFieldStore) CountForGroup(groupID string, includeDeleted bool) (int64, error) {
+	args := m.Called(groupID, includeDeleted)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *mockPropertyFieldStore) SearchPropertyFields(opts model.PropertyFieldSearchOpts) ([]*model.PropertyField, error) {
+	args := m.Called(opts)
+	return args.Get(0).([]*model.PropertyField), args.Error(1)
+}
+
+func (m *mockPropertyFieldStore) Update(groupID string, fields []*model.PropertyField) ([]*model.PropertyField, error) {
+	args := m.Called(groupID, fields)
+	return args.Get(0).([]*model.PropertyField), args.Error(1)
+}
+
+func (m *mockPropertyFieldStore) Delete(groupID string, id string) error {
+	args := m.Called(groupID, id)
+	return args.Error(0)
+}
+
+func TestPropertyService_CountActivePropertyFieldsForGroup(t *testing.T) {
+	t.Run("should return count of active property fields for a group", func(t *testing.T) {
+		// Create a mock store
+		mockStore := &mockPropertyFieldStore{}
+		mockStore.On("CountForGroup", "group1", false).Return(int64(5), nil)
+
+		// Create the service
+		service := &PropertyService{
+			fieldStore: mockStore,
+		}
+
+		// Call the method
+		count, err := service.CountActivePropertyFieldsForGroup("group1")
+
+		// Verify the results
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), count)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("should return error when store fails", func(t *testing.T) {
+		// Create a mock store
+		mockStore := &mockPropertyFieldStore{}
+		mockStore.On("CountForGroup", "group1", false).Return(int64(0), model.NewAppError("test", "test.error", nil, "", 500))
+
+		// Create the service
+		service := &PropertyService{
+			fieldStore: mockStore,
+		}
+
+		// Call the method
+		count, err := service.CountActivePropertyFieldsForGroup("group1")
+
+		// Verify the results
+		require.Error(t, err)
+		assert.Equal(t, int64(0), count)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("should return 0 for empty group", func(t *testing.T) {
+		// Create a mock store
+		mockStore := &mockPropertyFieldStore{}
+		mockStore.On("CountForGroup", "empty-group", false).Return(int64(0), nil)
+
+		// Create the service
+		service := &PropertyService{
+			fieldStore: mockStore,
+		}
+
+		// Call the method
+		count, err := service.CountActivePropertyFieldsForGroup("empty-group")
+
+		// Verify the results
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), count)
+		mockStore.AssertExpectations(t)
+	})
+}
+
+func TestPropertyService_CountAllPropertyFieldsForGroup(t *testing.T) {
+	t.Run("should return count of all property fields including deleted for a group", func(t *testing.T) {
+		// Create a mock store
+		mockStore := &mockPropertyFieldStore{}
+		mockStore.On("CountForGroup", "group1", true).Return(int64(8), nil)
+
+		// Create the service
+		service := &PropertyService{
+			fieldStore: mockStore,
+		}
+
+		// Call the method
+		count, err := service.CountAllPropertyFieldsForGroup("group1")
+
+		// Verify the results
+		require.NoError(t, err)
+		assert.Equal(t, int64(8), count)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("should return error when store fails", func(t *testing.T) {
+		// Create a mock store
+		mockStore := &mockPropertyFieldStore{}
+		mockStore.On("CountForGroup", "group1", true).Return(int64(0), model.NewAppError("test", "test.error", nil, "", 500))
+
+		// Create the service
+		service := &PropertyService{
+			fieldStore: mockStore,
+		}
+
+		// Call the method
+		count, err := service.CountAllPropertyFieldsForGroup("group1")
+
+		// Verify the results
+		require.Error(t, err)
+		assert.Equal(t, int64(0), count)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("should return 0 for empty group", func(t *testing.T) {
+		// Create a mock store
+		mockStore := &mockPropertyFieldStore{}
+		mockStore.On("CountForGroup", "empty-group", true).Return(int64(0), nil)
+
+		// Create the service
+		service := &PropertyService{
+			fieldStore: mockStore,
+		}
+
+		// Call the method
+		count, err := service.CountAllPropertyFieldsForGroup("empty-group")
+
+		// Verify the results
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), count)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("should return higher count than active fields when there are deleted fields", func(t *testing.T) {
+		// Create a mock store
+		mockStore := &mockPropertyFieldStore{}
+		mockStore.On("CountForGroup", "group1", false).Return(int64(5), nil)
+		mockStore.On("CountForGroup", "group1", true).Return(int64(8), nil)
+
+		// Create the service
+		service := &PropertyService{
+			fieldStore: mockStore,
+		}
+
+		// Call both methods
+		activeCount, err := service.CountActivePropertyFieldsForGroup("group1")
+		require.NoError(t, err)
+		
+		allCount, err := service.CountAllPropertyFieldsForGroup("group1")
+		require.NoError(t, err)
+
+		// Verify that all count is higher than active count
+		assert.Equal(t, int64(5), activeCount)
+		assert.Equal(t, int64(8), allCount)
+		assert.True(t, allCount > activeCount)
+		mockStore.AssertExpectations(t)
+	})
+}

--- a/server/public/plugin/api.go
+++ b/server/public/plugin/api.go
@@ -1449,6 +1449,12 @@ type API interface {
 	// Minimum server version: 10.10
 	SearchPropertyFields(groupID, targetID string, opts model.PropertyFieldSearchOpts) ([]*model.PropertyField, error)
 
+	// CountPropertyFields counts property fields for a group.
+	//
+	// @tag PropertyField
+	// Minimum server version: 10.10
+	CountPropertyFields(groupID string, includeDeleted bool) (int64, error)
+
 	// CreatePropertyValue creates a new property value.
 	//
 	// @tag PropertyValue

--- a/server/public/plugin/api_timer_layer_generated.go
+++ b/server/public/plugin/api_timer_layer_generated.go
@@ -1541,6 +1541,13 @@ func (api *apiTimerLayer) SearchPropertyFields(groupID, targetID string, opts mo
 	return _returnsA, _returnsB
 }
 
+func (api *apiTimerLayer) CountPropertyFields(groupID string, includeDeleted bool) (int64, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := api.apiImpl.CountPropertyFields(groupID, includeDeleted)
+	api.recordTime(startTime, "CountPropertyFields", _returnsB == nil)
+	return _returnsA, _returnsB
+}
+
 func (api *apiTimerLayer) CreatePropertyValue(value *model.PropertyValue) (*model.PropertyValue, error) {
 	startTime := timePkg.Now()
 	_returnsA, _returnsB := api.apiImpl.CreatePropertyValue(value)

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -7354,6 +7354,37 @@ func (s *apiRPCServer) SearchPropertyFields(args *Z_SearchPropertyFieldsArgs, re
 	return nil
 }
 
+type Z_CountPropertyFieldsArgs struct {
+	A string
+	B bool
+}
+
+type Z_CountPropertyFieldsReturns struct {
+	A int64
+	B error
+}
+
+func (g *apiRPCClient) CountPropertyFields(groupID string, includeDeleted bool) (int64, error) {
+	_args := &Z_CountPropertyFieldsArgs{groupID, includeDeleted}
+	_returns := &Z_CountPropertyFieldsReturns{}
+	if err := g.client.Call("Plugin.CountPropertyFields", _args, _returns); err != nil {
+		log.Printf("RPC call to CountPropertyFields API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) CountPropertyFields(args *Z_CountPropertyFieldsArgs, returns *Z_CountPropertyFieldsReturns) error {
+	if hook, ok := s.impl.(interface {
+		CountPropertyFields(groupID string, includeDeleted bool) (int64, error)
+	}); ok {
+		returns.A, returns.B = hook.CountPropertyFields(args.A, args.B)
+		returns.B = encodableError(returns.B)
+	} else {
+		return encodableError(fmt.Errorf("API CountPropertyFields called but not implemented."))
+	}
+	return nil
+}
+
 type Z_CreatePropertyValueArgs struct {
 	A *model.PropertyValue
 }

--- a/server/public/plugin/plugintest/api.go
+++ b/server/public/plugin/plugintest/api.go
@@ -148,6 +148,34 @@ func (_m *API) CopyFileInfos(userID string, fileIds []string) ([]string, *model.
 	return r0, r1
 }
 
+// CountPropertyFields provides a mock function with given fields: groupID, includeDeleted
+func (_m *API) CountPropertyFields(groupID string, includeDeleted bool) (int64, error) {
+	ret := _m.Called(groupID, includeDeleted)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountPropertyFields")
+	}
+
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, bool) (int64, error)); ok {
+		return rf(groupID, includeDeleted)
+	}
+	if rf, ok := ret.Get(0).(func(string, bool) int64); ok {
+		r0 = rf(groupID, includeDeleted)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	if rf, ok := ret.Get(1).(func(string, bool) error); ok {
+		r1 = rf(groupID, includeDeleted)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CreateBot provides a mock function with given fields: bot
 func (_m *API) CreateBot(bot *model.Bot) (*model.Bot, *model.AppError) {
 	ret := _m.Called(bot)

--- a/server/public/pluginapi/property.go
+++ b/server/public/pluginapi/property.go
@@ -52,6 +52,13 @@ func (p *PropertyService) SearchPropertyFields(groupID, targetID string, opts mo
 	return p.api.SearchPropertyFields(groupID, targetID, opts)
 }
 
+// CountPropertyFields counts property fields for a group.
+//
+// Minimum server version: 10.10
+func (p *PropertyService) CountPropertyFields(groupID string, includeDeleted bool) (int64, error) {
+	return p.api.CountPropertyFields(groupID, includeDeleted)
+}
+
 // CreatePropertyValue creates a new property value.
 //
 // Minimum server version: 10.10

--- a/server/public/pluginapi/property_test.go
+++ b/server/public/pluginapi/property_test.go
@@ -172,6 +172,44 @@ func TestPropertyFieldAPI(t *testing.T) {
 		assert.Equal(t, fields, result)
 		api.AssertExpectations(t)
 	})
+
+	t.Run("CountPropertyFields", func(t *testing.T) {
+		// Setup
+		api := &plugintest.API{}
+
+		// Mock the API call for active fields only
+		api.On("CountPropertyFields", "group1", false).Return(int64(5), nil)
+
+		// Create the client
+		client := NewClient(api, nil)
+
+		// Call the method
+		result, err := client.Property.CountPropertyFields("group1", false)
+
+		// Verify the results
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), result)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("CountPropertyFields with deleted", func(t *testing.T) {
+		// Setup
+		api := &plugintest.API{}
+
+		// Mock the API call for all fields including deleted
+		api.On("CountPropertyFields", "group1", true).Return(int64(8), nil)
+
+		// Create the client
+		client := NewClient(api, nil)
+
+		// Call the method
+		result, err := client.Property.CountPropertyFields("group1", true)
+
+		// Verify the results
+		require.NoError(t, err)
+		assert.Equal(t, int64(8), result)
+		api.AssertExpectations(t)
+	})
 }
 
 func TestPropertyValueAPI(t *testing.T) {


### PR DESCRIPTION
#### Summary
- Added a limit of 20 property fields per group in the CreatePropertyField method.
- Introduced CountPropertyFields method to count active and all property fields, including deleted ones.
- Enhanced tests to validate the new property field limit and counting behavior.
- Updated related API and service methods to support the new functionality.


#### Ticket Link
[MM-64683](https://mattermost.atlassian.net/browse/MM-64683)
#### Release Note
```release-note
Added a limit of 20 property fields per group in the CreatePropertyField method.
```
