### PR TITLE
[MM-64858] Generate Support Packet in memory instead of writing it to the file store first

### DIFF
--- a/server/channels/app/file.go
+++ b/server/channels/app/file.go
@@ -15,8 +15,6 @@ import (
 	"math"
 	"net/http"
 	"net/url"
-	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -1405,32 +1403,14 @@ func (a *App) CopyFileInfos(rctx request.CTX, userID string, fileIDs []string) (
 	return newFileIds, nil
 }
 
-// This function zip's up all the files in fileDatas array and then saves it to the directory specified with the specified zip file name
-// Ensure the zip file name ends with a .zip
-func (a *App) CreateZipFileAndAddFiles(fileBackend filestore.FileBackend, fileDatas []model.FileData, zipFileName, directory string) error {
-	// Create Zip File (temporarily stored on disk)
-	conglomerateZipFile, err := os.Create(zipFileName)
-	if err != nil {
-		return fmt.Errorf("failed to create temporary zip file %q: %w", zipFileName, err)
-	}
-	defer os.Remove(zipFileName)
+// WriteZipFile writes a zip file to the provided writer from the provided file data.
+func (a *App) WriteZipFile(w io.Writer, fileDatas []model.FileData) error {
+	zipWriter := zip.NewWriter(w)
 
-	// Create a new zip archive.
-	zipFileWriter := zip.NewWriter(conglomerateZipFile)
-
-	// Populate Zip file with File Datas array
-	err = populateZipfile(zipFileWriter, fileDatas)
+	// Populate zip file with file data
+	err := populateZipfile(zipWriter, fileDatas)
 	if err != nil {
-		return err
-	}
-
-	_, err = conglomerateZipFile.Seek(0, 0)
-	if err != nil {
-		return fmt.Errorf("failed to seek to beginning of zip file %q: %w", conglomerateZipFile.Name(), err)
-	}
-	_, err = fileBackend.WriteFile(conglomerateZipFile, path.Join(directory, zipFileName))
-	if err != nil {
-		return fmt.Errorf("failed to write zip file to file backend at path %s: %w", path.Join(directory, zipFileName), err)
+		return fmt.Errorf("failed to populate zip file: %w", err)
 	}
 
 	return nil

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -3855,10 +3855,6 @@
     "translation": "Error creating zip file."
   },
   {
-    "id": "api.unable_to_read_file_from_backend",
-    "translation": "Error reading file from backend"
-  },
-  {
     "id": "api.unmarshal_error",
     "translation": "Failed to unmarshal."
   },


### PR DESCRIPTION
#### Summary
When generating a Support Packet, Mattermost writes it to the file store first and then rereads the file to send it back over the wire. If there is an issue with the file store, creating the support packet will fail, locking us from debugging the problem with the customer.

Instead, the Support Packet should be generated in memory.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64858


#### Release Note
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.ai/code)