### PR TITLE
MM-13657: Set ExperimentalStrictCSRFEnforcement to true by default

### DIFF
--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -858,7 +858,7 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 	}
 
 	if s.ExperimentalStrictCSRFEnforcement == nil {
-		s.ExperimentalStrictCSRFEnforcement = NewPointer(false)
+		s.ExperimentalStrictCSRFEnforcement = NewPointer(true)
 	}
 
 	if s.DisableBotsWhenOwnerIsDeactivated == nil {


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/MM-13657
```release-note
We change ServiceSettings.ExperimentalStrictCSRFEnforcement to be
true by default for new installations. For existing installations,
the value will remain unchanged.
```
