### PR TITLE
Improve HTTP service IP and host validation error messages

### DIFF
--- a/server/channels/app/post_metadata_test.go
+++ b/server/channels/app/post_metadata_test.go
@@ -2590,7 +2590,7 @@ func TestGetLinkMetadata(t *testing.T) {
 		assert.Nil(t, img)
 		assert.Error(t, err)
 		assert.IsType(t, &url.Error{}, err)
-		assert.Equal(t, httpservice.ErrAddressForbidden, err.(*url.Error).Err)
+		assert.ErrorContains(t, err, httpservice.ErrAddressForbidden.Error())
 
 		requestURL = th.App.GetSiteURL() + "/api/v4/image?url=" + url.QueryEscape(requestURL)
 

--- a/server/public/shared/httpservice/client.go
+++ b/server/public/shared/httpservice/client.go
@@ -147,7 +147,7 @@ func dialContextFilter(dial DialContextFunction, allowHost func(host string) boo
 			}
 
 			if allowIP == nil {
-				forbiddenReasons = append(forbiddenReasons, fmt.Sprintf("IP %s is not allowed", ip.String()))
+				forbiddenReasons = append(forbiddenReasons, fmt.Sprintf("IP %s is not allowed", ip))
 				continue
 			}
 
@@ -181,7 +181,7 @@ func getProxyFn() func(r *http.Request) (*url.URL, error) {
 		// TODO: Consider removing this code once MM-61938 is fixed upstream.
 		if r.URL != nil {
 			if addr, err := netip.ParseAddr(r.URL.Hostname()); err == nil && addr.Is6() && addr.Zone() != "" {
-				return nil, fmt.Errorf("invalid IPv6 address in URL: %q", addr.String())
+				return nil, fmt.Errorf("invalid IPv6 address in URL: %q", addr)
 			}
 		}
 

--- a/server/public/shared/httpservice/client.go
+++ b/server/public/shared/httpservice/client.go
@@ -147,7 +147,7 @@ func dialContextFilter(dial DialContextFunction, allowHost func(host string) boo
 			}
 
 			if allowIP == nil {
-				forbiddenReasons = append(forbiddenReasons, "IP "+ip.String()+" is not allowed")
+				forbiddenReasons = append(forbiddenReasons, fmt.Sprintf("IP %s is not allowed", ip.String()))
 				continue
 			}
 

--- a/server/public/shared/httpservice/client.go
+++ b/server/public/shared/httpservice/client.go
@@ -165,7 +165,7 @@ func dialContextFilter(dial DialContextFunction, allowHost func(host string) boo
 			}
 		}
 		if firstDialErr == nil {
-			// If we didn't found an allowed IP address, return a error explaining why
+			// If we didn't find an allowed IP address, return an error explaining why
 			if len(forbiddenReasons) > 0 {
 				return nil, fmt.Errorf("%s: %s", ErrAddressForbidden.Error(), strings.Join(forbiddenReasons, "; "))
 			}

--- a/server/public/shared/httpservice/client_test.go
+++ b/server/public/shared/httpservice/client_test.go
@@ -60,13 +60,13 @@ func TestHTTPClient(t *testing.T) {
 	t.Run("checks", func(t *testing.T) {
 		allowHost := func(_ string) bool { return true }
 		rejectHost := func(_ string) bool { return false }
-		allowIP := func(_ net.IP) bool { return true }
-		rejectIP := func(_ net.IP) bool { return false }
+		allowIP := func(_ net.IP) error { return nil }
+		rejectIP := func(_ net.IP) error { return fmt.Errorf("IP not allowed") }
 
 		testCases := []struct {
 			description     string
 			allowHost       func(string) bool
-			allowIP         func(net.IP) bool
+			allowIP         func(net.IP) error
 			expectedAllowed bool
 		}{
 			{"allow with no checks", nil, nil, true},
@@ -88,7 +88,7 @@ func TestHTTPClient(t *testing.T) {
 					require.NoError(t, err)
 				} else {
 					require.IsType(t, &url.Error{}, err)
-					require.Equal(t, ErrAddressForbidden, err.(*url.Error).Err)
+					require.Contains(t, err.(*url.Error).Err.Error(), "address forbidden")
 				}
 			})
 		}
@@ -156,7 +156,12 @@ func TestDialContextFilter(t *testing.T) {
 		filter := dialContextFilter(func(ctx context.Context, network, addr string) (net.Conn, error) {
 			didDial = true
 			return nil, nil
-		}, func(host string) bool { return host == "10.0.0.1" }, func(ip net.IP) bool { return !IsReservedIP(ip) })
+		}, func(host string) bool { return host == "10.0.0.1" }, func(ip net.IP) error {
+			if IsReservedIP(ip) {
+				return fmt.Errorf("IP %s is reserved", ip.String())
+			}
+			return nil
+		})
 		_, err := filter(context.Background(), "", tc.Addr)
 
 		if tc.IsValid {
@@ -164,7 +169,7 @@ func TestDialContextFilter(t *testing.T) {
 			require.True(t, didDial)
 		} else {
 			require.Error(t, err)
-			require.Equal(t, err, ErrAddressForbidden)
+			require.Contains(t, err.Error(), "address forbidden")
 			require.False(t, didDial)
 		}
 	}

--- a/server/public/shared/httpservice/client_test.go
+++ b/server/public/shared/httpservice/client_test.go
@@ -158,7 +158,7 @@ func TestDialContextFilter(t *testing.T) {
 			return nil, nil
 		}, func(host string) bool { return host == "10.0.0.1" }, func(ip net.IP) error {
 			if IsReservedIP(ip) {
-				return fmt.Errorf("IP %s is reserved", ip.String())
+				return fmt.Errorf("IP %s is reserved", ip)
 			}
 			return nil
 		})
@@ -231,8 +231,9 @@ func TestIsOwnIP(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _ := IsOwnIP(tt.ip)
-			assert.Equalf(t, tt.want, got, "IsOwnIP() = %v, want %v for IP %s", got, tt.want, tt.ip.String())
+			got, err := IsOwnIP(tt.ip)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/server/public/shared/httpservice/httpservice.go
+++ b/server/public/shared/httpservice/httpservice.go
@@ -104,7 +104,7 @@ func (h *HTTPServiceImpl) MakeTransport(trustURLs bool) *MattermostTransport {
 		}
 
 		// In the case it's the self-assigned IP, enforce that it needs to be explicitly added to the AllowedUntrustedInternalConnections
-		for _, allowed := range strings.FieldsFunc(*h.configService.Config().ServiceSettings.AllowedUntrustedInternalConnections, splitFields) {
+		for _, allowed := range strings.FieldsFunc(model.SafeDereference(h.configService.Config().ServiceSettings.AllowedUntrustedInternalConnections), splitFields) {
 			if _, ipRange, err := net.ParseCIDR(allowed); err == nil && ipRange.Contains(ip) {
 				return nil
 			}

--- a/server/public/shared/httpservice/httpservice.go
+++ b/server/public/shared/httpservice/httpservice.go
@@ -111,9 +111,9 @@ func (h *HTTPServiceImpl) MakeTransport(trustURLs bool) *MattermostTransport {
 		}
 
 		if reservedIP {
-			return fmt.Errorf("IP %s is in a reserved range and not in AllowedUntrustedInternalConnections", ip.String())
+			return fmt.Errorf("IP %s is in a reserved range and not in AllowedUntrustedInternalConnections", ip)
 		}
-		return fmt.Errorf("IP %s is a self-assigned IP and not in AllowedUntrustedInternalConnections", ip.String())
+		return fmt.Errorf("IP %s is a self-assigned IP and not in AllowedUntrustedInternalConnections", ip)
 	}
 
 	return NewTransport(insecure, allowHost, allowIP)

--- a/server/public/shared/httpservice/httpservice.go
+++ b/server/public/shared/httpservice/httpservice.go
@@ -103,14 +103,6 @@ func (h *HTTPServiceImpl) MakeTransport(trustURLs bool) *MattermostTransport {
 			return nil
 		}
 
-		if h.configService.Config().ServiceSettings.AllowedUntrustedInternalConnections == nil {
-			if reservedIP {
-				return fmt.Errorf("IP %s is in a reserved range and AllowedUntrustedInternalConnections is not configured", ip.String())
-			} else {
-				return fmt.Errorf("IP %s is a self-assigned IP and AllowedUntrustedInternalConnections is not configured", ip.String())
-			}
-		}
-
 		// In the case it's the self-assigned IP, enforce that it needs to be explicitly added to the AllowedUntrustedInternalConnections
 		for _, allowed := range strings.FieldsFunc(*h.configService.Config().ServiceSettings.AllowedUntrustedInternalConnections, splitFields) {
 			if _, ipRange, err := net.ParseCIDR(allowed); err == nil && ipRange.Contains(ip) {
@@ -120,9 +112,8 @@ func (h *HTTPServiceImpl) MakeTransport(trustURLs bool) *MattermostTransport {
 
 		if reservedIP {
 			return fmt.Errorf("IP %s is in a reserved range and not in AllowedUntrustedInternalConnections", ip.String())
-		} else {
-			return fmt.Errorf("IP %s is a self-assigned IP and not in AllowedUntrustedInternalConnections", ip.String())
 		}
+		return fmt.Errorf("IP %s is a self-assigned IP and not in AllowedUntrustedInternalConnections", ip.String())
 	}
 
 	return NewTransport(insecure, allowHost, allowIP)


### PR DESCRIPTION
## Summary
A customer was running into an issue where Mattermost didn't fetch the post metadata for internal links, as they were blocked. It took a long time to debug why mattermost didn't fetch the data. This PR improves the error message for blocked outgoing traffic. 

- Updated IP validation function to return detailed error messages instead of just a boolean
- Enhanced error messages to explain specific reasons for rejection (reserved IP, self-assigned IP, not in AllowedUntrustedInternalConnections)
- Updated transport layer to aggregate and display detailed error messages


#### Release Note
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.ai/code)