### PR TITLE
[CLD-9535] [CLD-9352] Adjust useOpenSalesLink bases its query parameters on useExternalLink

### DIFF
--- a/webapp/channels/src/components/common/hooks/use_external_link.ts
+++ b/webapp/channels/src/components/common/hooks/use_external_link.ts
@@ -49,10 +49,6 @@ export function useExternalLink(href: string, location: string = '', overwriteQu
             utmMedium = 'in-product-cloud';
         }
 
-        console.log('isCloudPreview', isCloudPreview);
-        console.log('isCloud', isCloud);
-        console.log('utmMedium', utmMedium);
-
         const existingURLSearchParams = parsedUrl.searchParams;
         const existingQueryParamsObj = Object.fromEntries(existingURLSearchParams.entries());
         const queryParams = {

--- a/webapp/channels/src/components/common/hooks/use_external_link.ts
+++ b/webapp/channels/src/components/common/hooks/use_external_link.ts
@@ -49,6 +49,10 @@ export function useExternalLink(href: string, location: string = '', overwriteQu
             utmMedium = 'in-product-cloud';
         }
 
+        console.log('isCloudPreview', isCloudPreview);
+        console.log('isCloud', isCloud);
+        console.log('utmMedium', utmMedium);
+
         const existingURLSearchParams = parsedUrl.searchParams;
         const existingQueryParamsObj = Object.fromEntries(existingURLSearchParams.entries());
         const queryParams = {


### PR DESCRIPTION
#### Summary
useOpenSalesLink was skipping logic in useExternalLink around utm and other marketing parameters (and their adjustments for Cloud and Cloud Preview environments). This PR makes useOpenSalesLink base its query parameters off of useExternalLink first, then adds in the sales-form autofill specific fields after. 

This also fixed CLD-9352 - it won't send the sales-form specific fields in the event of a Cloud Preview, since the logged in user is a dummy pre seeded one.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-9353
https://mattermost.atlassian.net/browse/CLD-9352
#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
None
```
