### PR TITLE
Updated minimum supported Edge and Chrome versions

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10850,11 +10850,11 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "Version 134+"
+    "translation": "Version 138+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "Version 134+"
+    "translation": "Version 138+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",


### PR DESCRIPTION
Desktop app v5.13 will include Electron 37.2.2 which supports Chrome 138+.

```release-note
Updated minimum Edge and Chrome versions to 138+.
```
