### PR TITLE
[MM-64612] Update Calls to v1.10.0

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -142,7 +142,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.9.1
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.10.0
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.10.0
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.3.0


### PR DESCRIPTION
#### Summary
- Update prepackaged Calls to v1.10.0

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-64612


#### Release Note
```release-note
Mattermost Calls was updated to v1.10.0, bringing stability and performance improvements.
```
