### PR TITLE
[MM-54600] Add date separator components for search results, remove as part of post component

### DIFF
--- a/webapp/channels/src/components/post/post_component.tsx
+++ b/webapp/channels/src/components/post/post_component.tsx
@@ -26,7 +26,6 @@ import PriorityLabel from 'components/post_priority/post_priority_label';
 import PostProfilePicture from 'components/post_profile_picture';
 import PostAcknowledgements from 'components/post_view/acknowledgements';
 import CommentedOn from 'components/post_view/commented_on/commented_on';
-import DateSeparator from 'components/post_view/date_separator';
 import FailedPostOptions from 'components/post_view/failed_post_options';
 import PostAriaLabelDiv from 'components/post_view/post_aria_label_div';
 import PostBodyAdditionalContent from 'components/post_view/post_body_additional_content';
@@ -45,7 +44,7 @@ import Constants, {A11yCustomEventTypes, AppEvents, Locations} from 'utils/const
 import type {A11yFocusEventDetail} from 'utils/constants';
 import {isKeyPressed} from 'utils/keyboard';
 import * as PostUtils from 'utils/post_utils';
-import {getDateForUnixTicks, makeIsEligibleForClick} from 'utils/utils';
+import {makeIsEligibleForClick} from 'utils/utils';
 
 import type {PostActionComponent, PostPluginComponent} from 'types/store/plugins';
 
@@ -481,7 +480,6 @@ function PostComponent(props: Props) {
             replyClick={handleThreadClick}
         />
     ) : null;
-    const currentPostDay = getDateForUnixTicks(post.create_at);
     const channelDisplayName = getChannelName();
     const showReactions = props.location !== Locations.SEARCH || props.isPinnedPosts || props.isFlaggedPosts;
 
@@ -522,7 +520,6 @@ function PostComponent(props: Props) {
 
     return (
         <>
-            {(isSearchResultItem || (props.location !== Locations.CENTER && (props.isPinnedPosts || props.isFlaggedPosts))) && <DateSeparator date={currentPostDay}/>}
             <PostAriaLabelDiv
                 ref={postRef}
                 id={getTestId()}

--- a/webapp/channels/src/components/search_results/index.tsx
+++ b/webapp/channels/src/components/search_results/index.tsx
@@ -11,6 +11,7 @@ import {getSearchFilesResults} from 'mattermost-redux/selectors/entities/files';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getSearchMatches, getSearchResults} from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+import {makeAddDateSeparatorsForSearchResults} from 'mattermost-redux/utils/post_list';
 
 import {
     getSearchResultsTerms,
@@ -33,7 +34,7 @@ function makeMapStateToProps() {
     let files: FileSearchResultItem[] = [];
     let posts: Post[];
 
-    return function mapStateToProps(state: GlobalState) {
+    return function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
         const config = getConfig(state);
 
         const viewArchivedChannels = config.ExperimentalViewArchivedChannels === 'true';
@@ -80,8 +81,15 @@ function makeMapStateToProps() {
         const currentSearch = (getCurrentSearchForSearchTeam(state) as unknown as Record<string, any>) || {};
         const currentTeamName = getCurrentTeam(state)?.name ?? '';
 
+        if (ownProps.isPinnedPosts) {
+            results = results.sort((postA: Post|FileSearchResultItem, postB: Post|FileSearchResultItem) => postB.create_at - postA.create_at);
+        }
+
+        const addDateSeparatorsForSearchResults = makeAddDateSeparatorsForSearchResults();
+        const resultsWithDateSeparators = addDateSeparatorsForSearchResults(state, results);
+
         return {
-            results: posts,
+            results: resultsWithDateSeparators,
             fileResults: files,
             matches: getSearchMatches(state),
             searchTerms: getSearchResultsTerms(state),

--- a/webapp/channels/src/components/search_results/types.ts
+++ b/webapp/channels/src/components/search_results/types.ts
@@ -34,7 +34,7 @@ export type OwnProps = {
 };
 
 export type StateProps = {
-    results: Post[];
+    results: Array<Post|string>;
     fileResults: FileInfo[];
     matches: Record<string, string[]>;
     searchTerms: string;

--- a/webapp/channels/src/packages/mattermost-redux/src/utils/post_list.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/utils/post_list.ts
@@ -5,6 +5,7 @@ import moment from 'moment-timezone';
 
 import type {ActivityEntry, Post} from '@mattermost/types/posts';
 import type {GlobalState} from '@mattermost/types/store';
+import type {UserProfile} from '@mattermost/types/users';
 import {isStringArray, isArrayOf} from '@mattermost/types/utilities';
 
 import {Posts} from 'mattermost-redux/constants';
@@ -78,23 +79,7 @@ export function makeFilterPostsAndAddSeparators() {
                     continue;
                 }
 
-                // Push on a date header if the last post was on a different day than the current one
-                const postDate = new Date(post.create_at);
-                const currentOffset = postDate.getTimezoneOffset() * 60 * 1000;
-                const timezone = getUserCurrentTimezone(currentUser.timezone);
-                if (timezone) {
-                    const zone = moment.tz.zone(timezone);
-                    if (zone) {
-                        const timezoneOffset = zone.utcOffset(postDate.getTime()) * 60 * 1000;
-                        postDate.setTime(postDate.getTime() + (currentOffset - timezoneOffset));
-                    }
-                }
-
-                if (!lastDate || lastDate.toDateString() !== postDate.toDateString()) {
-                    out.push(DATE_LINE + postDate.getTime());
-
-                    lastDate = postDate;
-                }
+                lastDate = pushPostDateIfNeeded(post, currentUser, out, lastDate);
 
                 if (
                     lastViewedAt &&
@@ -112,6 +97,52 @@ export function makeFilterPostsAndAddSeparators() {
 
             // Flip it back to newest to oldest
             return out.reverse();
+        },
+    );
+}
+
+function pushPostDateIfNeeded(post: Post, currentUser: UserProfile, out: Array<Post|string>, lastDate?: Date) {
+    // Push on a date header if the last post was on a different day than the current one
+    const postDate = new Date(post.create_at);
+    const currentOffset = postDate.getTimezoneOffset() * 60 * 1000;
+    const timezone = getUserCurrentTimezone(currentUser.timezone);
+    if (timezone) {
+        const zone = moment.tz.zone(timezone);
+        if (zone) {
+            const timezoneOffset = zone.utcOffset(postDate.getTime()) * 60 * 1000;
+            postDate.setTime(postDate.getTime() + (currentOffset - timezoneOffset));
+        }
+    }
+
+    if (!lastDate || lastDate.toDateString() !== postDate.toDateString()) {
+        out.push(DATE_LINE + postDate.getTime());
+
+        return postDate;
+    }
+
+    return lastDate;
+}
+
+export function makeAddDateSeparatorsForSearchResults() {
+    return createIdsSelector(
+        'makeAddDateSeparatorsForSearchResults',
+        (state: GlobalState, posts: Post[]) => posts,
+        getCurrentUser,
+        (posts, currentUser) => {
+            if (posts.length === 0 || !currentUser) {
+                return [];
+            }
+
+            const out: Array<Post|string> = [];
+            let lastDate;
+
+            for (const post of posts) {
+                lastDate = pushPostDateIfNeeded(post, currentUser, out, lastDate);
+
+                out.push(post);
+            }
+
+            return out;
         },
     );
 }


### PR DESCRIPTION
#### Summary
Our search results were dependent on the `PostComponent` to show date separators when we loaded the components there. However, this meant that each post would show its own date separator, despite the fact that previous posts would be on the same day, which was unnecessary.

This PR instead uses the same methodology as the `PostList`, injecting `DateSeparator` components intelligently between posts when needed, such that we are only seeing separation once per day rather than multiple times.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54600

```release-note
Fixed an issue where extra date separators were added in search results, pinned posts and saved messages.
```
