### PR TITLE
MM-64874 E2E/Cypress: Fix accessibility_modals_dialog_spec

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/enterprise/accessibility/accessibility_modals_dialogs_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/enterprise/accessibility/accessibility_modals_dialogs_spec.ts
@@ -30,7 +30,7 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
             testChannel = channel;
             testUser = user;
 
-            cy.apiCreateUser().then(({user: newUser}) => {
+            cy.apiCreateUser({prefix: 'user000b'}).then(({user: newUser}) => {
                 cy.apiAddUserToTeam(testTeam.id, newUser.id).then(() => {
                     cy.apiAddUserToChannel(testChannel.id, newUser.id);
                 });
@@ -167,9 +167,9 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
                 wait(TIMEOUTS.HALF_SEC).
                 typeWithForce('u').
                 wait(TIMEOUTS.HALF_SEC).
-                typeWithForce('{downarrow}{downarrow}{downarrow}{uparrow}');
+                typeWithForce('{downarrow}{downarrow}{downarrow}{downarrow}{uparrow}');
             cy.get('#multiSelectList').
-                children().eq(1).
+                children().eq(2).
                 should('have.class', 'more-modal__row--selected').
                 within(() => {
                     cy.get('.more-modal__name').invoke('text').then((user) => {


### PR DESCRIPTION
#### Summary
Reason:
- The test failed due to second user that's added to channel are getting selected randomly.

Fix:
- Fixed second user position on dropdown by setting "prefix" to username so that the second user is always positioned on second row. Then on test, adjust the selection to select the third row (or 2nd index).

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-64874

#### Screenshots
<img width="816" height="259" alt="Screenshot 2025-07-21 at 1 22 57 PM" src="https://github.com/user-attachments/assets/3563c872-1793-43ed-83d4-ad4f5cc5cebe" />

#### Release Note
```release-note
NONE
```
