### PR TITLE
MM-64522: Use PBKDF2 as the new key derivation for remote cluster invitation

### DIFF
--- a/server/channels/app/remote_cluster.go
+++ b/server/channels/app/remote_cluster.go
@@ -202,7 +202,7 @@ func (a *App) CreateRemoteClusterInvite(remoteId, siteURL, token, password strin
 		RemoteId: remoteId,
 		SiteURL:  siteURL,
 		Token:    token,
-		Version:  2,
+		Version:  3,
 	}
 
 	if err := invite.IsValid(); err != nil {

--- a/server/platform/services/remotecluster/invitation.go
+++ b/server/platform/services/remotecluster/invitation.go
@@ -80,7 +80,7 @@ func makeConfirmFrame(rc *model.RemoteCluster, siteURL string) (*model.RemoteClu
 		SiteURL:        siteURL,
 		Token:          rc.Token,
 		RefreshedToken: rc.RemoteToken,
-		Version:        2,
+		Version:        3,
 	}
 	confirmRaw, err := json.Marshal(confirm)
 	if err != nil {


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/MM-64522

```release-note
NONE
```
