### PR TITLE
[MM-64833] Convert multiselect attribute types to CEL canonically

### DIFF
--- a/server/public/model/cel.go
+++ b/server/public/model/cel.go
@@ -21,6 +21,8 @@ type Condition struct {
 	Value any `json:"value"`
 	// Type of the Value (LiteralValue or AttributeValue). Needed for comparisons like user.attr1 == user.attr2.
 	ValueType ValueType `json:"value_type"`
+	// Type of the Attribute (e.g., "text", "select", "multiselect").
+	AttributeType string `json:"attribute_type"`
 }
 
 // VisualExpression represents a series of conditions combined with logical AND.

--- a/webapp/channels/src/components/admin_console/access_control/editors/table_editor/table_editor.test.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/editors/table_editor/table_editor.test.tsx
@@ -14,6 +14,7 @@ describe('parseExpression', () => {
                     operator: '==',
                     value: 'Engineering',
                     value_type: 0,
+                    attribute_type: 'text',
                 },
             ],
         };
@@ -23,6 +24,7 @@ describe('parseExpression', () => {
                 attribute: 'department',
                 operator: 'is',
                 values: ['Engineering'],
+                attribute_type: 'text',
             },
         ]);
     });
@@ -35,6 +37,7 @@ describe('parseExpression', () => {
                     operator: 'in',
                     value: ['US', 'CA'],
                     value_type: 0,
+                    attribute_type: 'text',
                 },
             ],
         };
@@ -44,6 +47,7 @@ describe('parseExpression', () => {
                 attribute: 'location',
                 operator: 'in',
                 values: ['US', 'CA'],
+                attribute_type: 'text',
             },
         ]);
     });
@@ -56,6 +60,7 @@ describe('parseExpression', () => {
                     operator: '!=',
                     value: 'guest',
                     value_type: 0,
+                    attribute_type: 'text',
                 },
             ],
         };
@@ -77,6 +82,7 @@ describe('parseExpression', () => {
                     operator: 'startsWith',
                     value: 'admin',
                     value_type: 0,
+                    attribute_type: 'text',
                 },
             ],
         };
@@ -86,6 +92,7 @@ describe('parseExpression', () => {
                 attribute: 'email',
                 operator: 'starts with',
                 values: ['admin'],
+                attribute_type: 'text',
             },
         ]);
     });
@@ -98,12 +105,14 @@ describe('parseExpression', () => {
                     operator: 'startsWith',
                     value: 'admin',
                     value_type: 0,
+                    attribute_type: 'text',
                 },
                 {
                     attribute: 'user.attributes.department',
                     operator: '==',
                     value: 'Engineering',
                     value_type: 0,
+                    attribute_type: 'text',
                 },
             ],
         };
@@ -113,11 +122,13 @@ describe('parseExpression', () => {
                 attribute: 'email',
                 operator: 'starts with',
                 values: ['admin'],
+                attribute_type: 'text',
             },
             {
                 attribute: 'department',
                 operator: 'is',
                 values: ['Engineering'],
+                attribute_type: 'text',
             },
         ]);
     });
@@ -130,6 +141,7 @@ describe('parseExpression', () => {
                     operator: 'unknownOp',
                     value: 'foo',
                     value_type: 0,
+                    attribute_type: 'text',
                 },
             ],
         };
@@ -139,7 +151,14 @@ describe('parseExpression', () => {
                 attribute: 'department',
                 operator: 'is',
                 values: ['foo'],
+                attribute_type: 'text',
             },
         ]);
+    });
+
+    test('handles empty or null AST', () => {
+        expect(parseExpression(null as any)).toEqual([]);
+        expect(parseExpression(undefined as any)).toEqual([]);
+        expect(parseExpression({conditions: []})).toEqual([]);
     });
 });

--- a/webapp/channels/src/components/admin_console/access_control/editors/table_editor/table_editor.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/editors/table_editor/table_editor.tsx
@@ -69,6 +69,7 @@ export const parseExpression = (visualAST: AccessControlVisualAST): TableRow[] =
             attribute: attr,
             operator: op,
             values,
+            attribute_type: node.attribute_type,
         });
     }
 
@@ -125,15 +126,28 @@ function TableEditor({
             const attributeExpr = `user.attributes.${row.attribute}`;
             const config = OPERATOR_CONFIG[row.operator];
 
+            // Find the attribute object to check its type
+            const attributeObj = userAttributes.find((attr) => attr.name === row.attribute);
+
             if (!config) {
                 // Fallback for unknown operators, defaulting to 'in' logic
                 // This handles cases where row.operator might be an unexpected string.
                 const valuesStr = row.values.map((val: string) => `"${val}"`).join(', ');
+
+                // For multiselect, reverse the order since multiselect attributes can contain multiple values
+                if (attributeObj?.type === 'multiselect') {
+                    return `[${valuesStr}] in ${attributeExpr}`;
+                }
                 return `${attributeExpr} in [${valuesStr}]`;
             }
 
             if (config.type === 'list') { // Handles 'in'
                 const valuesStr = row.values.map((val: string) => `"${val}"`).join(', ');
+
+                // For multiselect, reverse the order since multiselect attributes can contain multiple values
+                if (attributeObj?.type === 'multiselect') {
+                    return `[${valuesStr}] ${config.celOp} ${attributeExpr}`;
+                }
                 return `${attributeExpr} ${config.celOp} [${valuesStr}]`;
             }
 
@@ -154,7 +168,7 @@ function TableEditor({
             // (e.g. no rows, or rows without attributes yet), it's valid from table perspective.
             onValidate(expr === '' || rowsThatCanFormExpressions.length > 0);
         }
-    }, [onChange, onValidate]);
+    }, [onChange, onValidate, userAttributes]);
 
     // Row Manipulation Handlers
     const addRow = useCallback(() => {
@@ -166,6 +180,7 @@ function TableEditor({
                 attribute: userAttributes[0]?.name || '', // Default to the first available attribute
                 operator: OperatorLabel.IS, // Default operator
                 values: [],
+                attribute_type: userAttributes[0]?.type || '',
             };
             const newRows = [...currentRows, newRow];
             updateExpression(newRows); // Ensure expression is updated immediately

--- a/webapp/channels/src/components/admin_console/access_control/editors/table_editor/value_selector_menu.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/editors/table_editor/value_selector_menu.tsx
@@ -12,6 +12,7 @@ export interface TableRow {
     attribute: string;
     operator: string;
     values: string[];
+    attribute_type: string;
 }
 
 export interface ValueSelectorMenuProps {

--- a/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.tsx
@@ -98,10 +98,12 @@ function PolicyDetails({
 
         // Expression is simple if it only contains user.attributes.X == "Y" or user.attributes.X in ["Y", "Z"]
         // or user.attributes.X.startsWith/endsWith/contains("Y")
+        // or ["Y", "Z"] in user.attributes.X (for multiselect attributes)
         return expr.split('&&').every((condition) => {
             const trimmed = condition.trim();
             return trimmed.match(/^user\.attributes\.\w+\s*(==|!=)\s*['"][^'"]*['"]$/) ||
                    trimmed.match(/^user\.attributes\.\w+\s+in\s+\[.*?\]$/) ||
+                   trimmed.match(/^((\[.*?\])||['"][^'"]*['"].*?)\s+in\s+user\.attributes\.\w+$/) ||
                    trimmed.match(/^user\.attributes\.\w+\.startsWith\(['"][^'"]*['"].*?\)$/) ||
                    trimmed.match(/^user\.attributes\.\w+\.endsWith\(['"][^'"]*['"].*?\)$/) ||
                    trimmed.match(/^user\.attributes\.\w+\.contains\(['"][^'"]*['"].*?\)$/);

--- a/webapp/platform/types/src/access_control.ts
+++ b/webapp/platform/types/src/access_control.ts
@@ -67,6 +67,7 @@ export type AccessControlVisualASTNode = {
     operator: string;
     value: any;
     value_type: number;
+    attribute_type: string;
 }
 
 /**


### PR DESCRIPTION

#### Summary
As the title suggest, we need to interpret `multiselect` type differently (with the order of operands).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64833


#### Release Note

```release-note
NONE
```
