### PR TITLE
Standardize request.CTX parameter naming to rctx

### DIFF
--- a/server/channels/app/authorization.go
+++ b/server/channels/app/authorization.go
@@ -63,7 +63,7 @@ func (a *App) SessionHasPermissionToTeam(session model.Session, teamID string, p
 }
 
 // SessionHasPermissionToTeams returns true only if user has access to all teams.
-func (a *App) SessionHasPermissionToTeams(c request.CTX, session model.Session, teamIDs []string, permission *model.Permission) bool {
+func (a *App) SessionHasPermissionToTeams(rctx request.CTX, session model.Session, teamIDs []string, permission *model.Permission) bool {
 	if len(teamIDs) == 0 {
 		return true
 	}
@@ -91,16 +91,16 @@ func (a *App) SessionHasPermissionToTeams(c request.CTX, session model.Session, 
 	return true
 }
 
-func (a *App) SessionHasPermissionToChannel(c request.CTX, session model.Session, channelID string, permission *model.Permission) bool {
+func (a *App) SessionHasPermissionToChannel(rctx request.CTX, session model.Session, channelID string, permission *model.Permission) bool {
 	if channelID == "" {
 		return false
 	}
 
-	channel, appErr := a.GetChannel(c, channelID)
+	channel, appErr := a.GetChannel(rctx, channelID)
 	if appErr != nil && appErr.StatusCode == http.StatusNotFound {
 		return false
 	} else if appErr != nil {
-		c.Logger().Warn("Failed to get channel", mlog.String("channel_id", channelID), mlog.Err(appErr))
+		rctx.Logger().Warn("Failed to get channel", mlog.String("channel_id", channelID), mlog.Err(appErr))
 	}
 
 	if session.IsUnrestricted() || a.RolesGrantPermission(session.GetUserRoles(), model.PermissionManageSystem.Id) {
@@ -111,7 +111,7 @@ func (a *App) SessionHasPermissionToChannel(c request.CTX, session model.Session
 		return false
 	}
 
-	ids, err := a.Srv().Store().Channel().GetAllChannelMembersForUser(c, session.UserId, true, true)
+	ids, err := a.Srv().Store().Channel().GetAllChannelMembersForUser(rctx, session.UserId, true, true)
 	var channelRoles []string
 	if err == nil {
 		if roles, ok := ids[channelID]; ok {
@@ -130,7 +130,7 @@ func (a *App) SessionHasPermissionToChannel(c request.CTX, session model.Session
 }
 
 // SessionHasPermissionToChannels returns true only if user has access to all channels.
-func (a *App) SessionHasPermissionToChannels(c request.CTX, session model.Session, channelIDs []string, permission *model.Permission) bool {
+func (a *App) SessionHasPermissionToChannels(rctx request.CTX, session model.Session, channelIDs []string, permission *model.Permission) bool {
 	if len(channelIDs) == 0 {
 		return true
 	}
@@ -146,7 +146,7 @@ func (a *App) SessionHasPermissionToChannels(c request.CTX, session model.Sessio
 
 		// make sure all channels exist, otherwise return false.
 		for _, channelID := range channelIDs {
-			channel, appErr := a.GetChannel(c, channelID)
+			channel, appErr := a.GetChannel(rctx, channelID)
 			if appErr != nil {
 				return false
 			}
@@ -164,7 +164,7 @@ func (a *App) SessionHasPermissionToChannels(c request.CTX, session model.Sessio
 		return true
 	}
 
-	ids, err := a.Srv().Store().Channel().GetAllChannelMembersForUser(c, session.UserId, true, true)
+	ids, err := a.Srv().Store().Channel().GetAllChannelMembersForUser(rctx, session.UserId, true, true)
 	var channelRoles []string
 	for _, channelID := range channelIDs {
 		if err == nil {
@@ -221,11 +221,11 @@ func (a *App) SessionHasPermissionToChannelByPost(session model.Session, postID 
 	return a.SessionHasPermissionTo(session, permission)
 }
 
-func (a *App) SessionHasPermissionToCategory(c request.CTX, session model.Session, userID, teamID, categoryId string) bool {
+func (a *App) SessionHasPermissionToCategory(rctx request.CTX, session model.Session, userID, teamID, categoryId string) bool {
 	if a.SessionHasPermissionTo(session, model.PermissionEditOtherUsers) {
 		return true
 	}
-	category, err := a.GetSidebarCategory(c, categoryId)
+	category, err := a.GetSidebarCategory(rctx, categoryId)
 	return err == nil && category != nil && category.UserId == session.UserId && category.UserId == userID && category.TeamId == teamID
 }
 
@@ -285,11 +285,11 @@ func (a *App) HasPermissionTo(askingUserId string, permission *model.Permission)
 	return a.RolesGrantPermission(roles, permission.Id)
 }
 
-func (a *App) HasPermissionToTeam(c request.CTX, askingUserId string, teamID string, permission *model.Permission) bool {
+func (a *App) HasPermissionToTeam(rctx request.CTX, askingUserId string, teamID string, permission *model.Permission) bool {
 	if teamID == "" || askingUserId == "" {
 		return false
 	}
-	teamMember, _ := a.GetTeamMember(c, teamID, askingUserId)
+	teamMember, _ := a.GetTeamMember(rctx, teamID, askingUserId)
 	if teamMember != nil && teamMember.DeleteAt == 0 {
 		if a.RolesGrantPermission(teamMember.GetRoles(), permission.Id) {
 			return true
@@ -298,7 +298,7 @@ func (a *App) HasPermissionToTeam(c request.CTX, askingUserId string, teamID str
 	return a.HasPermissionTo(askingUserId, permission)
 }
 
-func (a *App) HasPermissionToChannel(c request.CTX, askingUserId string, channelID string, permission *model.Permission) bool {
+func (a *App) HasPermissionToChannel(rctx request.CTX, askingUserId string, channelID string, permission *model.Permission) bool {
 	if channelID == "" || askingUserId == "" {
 		return false
 	}
@@ -306,7 +306,7 @@ func (a *App) HasPermissionToChannel(c request.CTX, askingUserId string, channel
 	// We call GetAllChannelMembersForUser instead of just getting
 	// a single member from the DB, because it's cache backed
 	// and this is a very frequent call.
-	ids, err := a.Srv().Store().Channel().GetAllChannelMembersForUser(c, askingUserId, true, true)
+	ids, err := a.Srv().Store().Channel().GetAllChannelMembersForUser(rctx, askingUserId, true, true)
 	var channelRoles []string
 	if err == nil {
 		if roles, ok := ids[channelID]; ok {
@@ -317,15 +317,15 @@ func (a *App) HasPermissionToChannel(c request.CTX, askingUserId string, channel
 		}
 	}
 
-	channel, appErr := a.GetChannel(c, channelID)
+	channel, appErr := a.GetChannel(rctx, channelID)
 	if appErr == nil && channel.TeamId != "" {
-		return a.HasPermissionToTeam(c, askingUserId, channel.TeamId, permission)
+		return a.HasPermissionToTeam(rctx, askingUserId, channel.TeamId, permission)
 	}
 
 	return a.HasPermissionTo(askingUserId, permission)
 }
 
-func (a *App) HasPermissionToChannelByPost(c request.CTX, askingUserId string, postID string, permission *model.Permission) bool {
+func (a *App) HasPermissionToChannelByPost(rctx request.CTX, askingUserId string, postID string, permission *model.Permission) bool {
 	if channelMember, err := a.Srv().Store().Channel().GetMemberForPost(postID, askingUserId, *a.Config().TeamSettings.ExperimentalViewArchivedChannels); err == nil {
 		if a.RolesGrantPermission(channelMember.GetRoles(), permission.Id) {
 			return true
@@ -333,7 +333,7 @@ func (a *App) HasPermissionToChannelByPost(c request.CTX, askingUserId string, p
 	}
 
 	if channel, err := a.Srv().Store().Channel().GetForPost(postID); err == nil {
-		return a.HasPermissionToTeam(c, askingUserId, channel.TeamId, permission)
+		return a.HasPermissionToTeam(rctx, askingUserId, channel.TeamId, permission)
 	}
 
 	return a.HasPermissionTo(askingUserId, permission)
@@ -411,39 +411,39 @@ func (a *App) SessionHasPermissionToManageBot(rctx request.CTX, session model.Se
 	return nil
 }
 
-func (a *App) SessionHasPermissionToReadChannel(c request.CTX, session model.Session, channel *model.Channel) bool {
+func (a *App) SessionHasPermissionToReadChannel(rctx request.CTX, session model.Session, channel *model.Channel) bool {
 	if session.IsUnrestricted() {
 		return true
 	}
 
-	return a.HasPermissionToReadChannel(c, session.UserId, channel)
+	return a.HasPermissionToReadChannel(rctx, session.UserId, channel)
 }
 
-func (a *App) HasPermissionToReadChannel(c request.CTX, userID string, channel *model.Channel) bool {
+func (a *App) HasPermissionToReadChannel(rctx request.CTX, userID string, channel *model.Channel) bool {
 	if a.isChannelArchivedAndHidden(channel) {
 		return false
 	}
-	if a.HasPermissionToChannel(c, userID, channel.Id, model.PermissionReadChannelContent) {
+	if a.HasPermissionToChannel(rctx, userID, channel.Id, model.PermissionReadChannelContent) {
 		return true
 	}
 
 	if channel.Type == model.ChannelTypeOpen && !*a.Config().ComplianceSettings.Enable {
-		return a.HasPermissionToTeam(c, userID, channel.TeamId, model.PermissionReadPublicChannel)
+		return a.HasPermissionToTeam(rctx, userID, channel.TeamId, model.PermissionReadPublicChannel)
 	}
 
 	return false
 }
 
-func (a *App) HasPermissionToChannelMemberCount(c request.CTX, userID string, channel *model.Channel) bool {
+func (a *App) HasPermissionToChannelMemberCount(rctx request.CTX, userID string, channel *model.Channel) bool {
 	if a.isChannelArchivedAndHidden(channel) {
 		return false
 	}
-	if a.HasPermissionToChannel(c, userID, channel.Id, model.PermissionReadChannelContent) {
+	if a.HasPermissionToChannel(rctx, userID, channel.Id, model.PermissionReadChannelContent) {
 		return true
 	}
 
 	if channel.Type == model.ChannelTypeOpen {
-		return a.HasPermissionToTeam(c, userID, channel.TeamId, model.PermissionListTeamChannels)
+		return a.HasPermissionToTeam(rctx, userID, channel.TeamId, model.PermissionListTeamChannels)
 	}
 
 	return false

--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -39,7 +39,7 @@ const (
 // 'off-topic' and be included in the return results in addition to 'town-square'. For example:
 //
 //	['town-square', 'game-of-thrones', 'wow']
-func (a *App) DefaultChannelNames(c request.CTX) []string {
+func (a *App) DefaultChannelNames(rctx request.CTX) []string {
 	names := []string{"town-square"}
 
 	if len(a.Config().TeamSettings.ExperimentalDefaultChannels) == 0 {
@@ -57,7 +57,7 @@ func (a *App) DefaultChannelNames(c request.CTX) []string {
 	return names
 }
 
-func (a *App) JoinDefaultChannels(c request.CTX, teamID string, user *model.User, shouldBeAdmin bool, userRequestorId string) *model.AppError {
+func (a *App) JoinDefaultChannels(rctx request.CTX, teamID string, user *model.User, shouldBeAdmin bool, userRequestorId string) *model.AppError {
 	var requestor *model.User
 	var nErr error
 	if userRequestorId != "" {
@@ -73,10 +73,10 @@ func (a *App) JoinDefaultChannels(c request.CTX, teamID string, user *model.User
 		}
 	}
 
-	for _, channelName := range a.DefaultChannelNames(c) {
+	for _, channelName := range a.DefaultChannelNames(rctx) {
 		channel, channelErr := a.Srv().Store().Channel().GetByName(teamID, channelName, true)
 		if channelErr != nil {
-			c.Logger().Warn("No default channel with this name", mlog.String("channelName", channelName), mlog.String("teamID", teamID), mlog.Err(channelErr))
+			rctx.Logger().Warn("No default channel with this name", mlog.String("channelName", channelName), mlog.String("teamID", teamID), mlog.Err(channelErr))
 			continue
 		}
 
@@ -93,14 +93,14 @@ func (a *App) JoinDefaultChannels(c request.CTX, teamID string, user *model.User
 			NotifyProps: model.GetDefaultChannelNotifyProps(),
 		}
 
-		_, nErr = a.Srv().Store().Channel().SaveMember(c, cm)
+		_, nErr = a.Srv().Store().Channel().SaveMember(rctx, cm)
 		if histErr := a.Srv().Store().ChannelMemberHistory().LogJoinEvent(user.Id, channel.Id, model.GetMillis()); histErr != nil {
 			return model.NewAppError("JoinDefaultChannels", "app.channel_member_history.log_join_event.internal_error", nil, "", http.StatusInternalServerError).Wrap(histErr)
 		}
 
 		if *a.Config().ServiceSettings.ExperimentalEnableDefaultChannelLeaveJoinMessages {
-			if aErr := a.postJoinMessageForDefaultChannel(c, user, requestor, channel); aErr != nil {
-				c.Logger().Warn("Failed to post join/leave message", mlog.Err(aErr))
+			if aErr := a.postJoinMessageForDefaultChannel(rctx, user, requestor, channel); aErr != nil {
+				rctx.Logger().Warn("Failed to post join/leave message", mlog.Err(aErr))
 			}
 		}
 
@@ -130,24 +130,24 @@ func (a *App) JoinDefaultChannels(c request.CTX, teamID string, user *model.User
 	return nil
 }
 
-func (a *App) postJoinMessageForDefaultChannel(c request.CTX, user *model.User, requestor *model.User, channel *model.Channel) *model.AppError {
+func (a *App) postJoinMessageForDefaultChannel(rctx request.CTX, user *model.User, requestor *model.User, channel *model.Channel) *model.AppError {
 	if channel.Name == model.DefaultChannelName {
 		if requestor == nil {
-			if err := a.postJoinTeamMessage(c, user, channel); err != nil {
+			if err := a.postJoinTeamMessage(rctx, user, channel); err != nil {
 				return err
 			}
 		} else {
-			if err := a.postAddToTeamMessage(c, requestor, user, channel, ""); err != nil {
+			if err := a.postAddToTeamMessage(rctx, requestor, user, channel, ""); err != nil {
 				return err
 			}
 		}
 	} else {
 		if requestor == nil {
-			if err := a.postJoinChannelMessage(c, user, channel); err != nil {
+			if err := a.postJoinChannelMessage(rctx, user, channel); err != nil {
 				return err
 			}
 		} else {
-			if err := a.PostAddToChannelMessage(c, requestor, user, channel, ""); err != nil {
+			if err := a.PostAddToChannelMessage(rctx, requestor, user, channel, ""); err != nil {
 				return err
 			}
 		}
@@ -156,7 +156,7 @@ func (a *App) postJoinMessageForDefaultChannel(c request.CTX, user *model.User, 
 	return nil
 }
 
-func (a *App) CreateChannelWithUser(c request.CTX, channel *model.Channel, userID string) (*model.Channel, *model.AppError) {
+func (a *App) CreateChannelWithUser(rctx request.CTX, channel *model.Channel, userID string) (*model.Channel, *model.AppError) {
 	if channel.IsGroupOrDirect() {
 		return nil, model.NewAppError("CreateChannelWithUser", "api.channel.create_channel.direct_channel.app_error", nil, "", http.StatusBadRequest)
 	}
@@ -166,7 +166,7 @@ func (a *App) CreateChannelWithUser(c request.CTX, channel *model.Channel, userI
 	}
 
 	// Get total number of channels on current team
-	count, err := a.GetNumberOfChannelsOnTeam(c, channel.TeamId)
+	count, err := a.GetNumberOfChannelsOnTeam(rctx, channel.TeamId)
 	if err != nil {
 		return nil, err
 	}
@@ -177,19 +177,19 @@ func (a *App) CreateChannelWithUser(c request.CTX, channel *model.Channel, userI
 
 	channel.CreatorId = userID
 
-	rchannel, err := a.CreateChannel(c, channel, true)
+	rchannel, err := a.CreateChannel(rctx, channel, true)
 	if err != nil {
 		return nil, err
 	}
 
-	a.addChannelToDefaultCategory(c, userID, channel)
+	a.addChannelToDefaultCategory(rctx, userID, channel)
 
 	var user *model.User
 	if user, err = a.GetUser(userID); err != nil {
 		return nil, err
 	}
 
-	if err = a.postJoinChannelMessage(c, user, channel); err != nil {
+	if err = a.postJoinChannelMessage(rctx, user, channel); err != nil {
 		return nil, err
 	}
 
@@ -202,7 +202,7 @@ func (a *App) CreateChannelWithUser(c request.CTX, channel *model.Channel, userI
 }
 
 // RenameChannel is used to rename the channel Name and the DisplayName fields
-func (a *App) RenameChannel(c request.CTX, channel *model.Channel, newChannelName string, newDisplayName string) (*model.Channel, *model.AppError) {
+func (a *App) RenameChannel(rctx request.CTX, channel *model.Channel, newChannelName string, newDisplayName string) (*model.Channel, *model.AppError) {
 	if channel.Type == model.ChannelTypeDirect {
 		return nil, model.NewAppError("RenameChannel", "api.channel.rename_channel.cant_rename_direct_messages.app_error", nil, "", http.StatusBadRequest)
 	}
@@ -220,7 +220,7 @@ func (a *App) RenameChannel(c request.CTX, channel *model.Channel, newChannelNam
 		channel.DisplayName = newDisplayName
 	}
 
-	newChannel, err := a.UpdateChannel(c, channel)
+	newChannel, err := a.UpdateChannel(rctx, channel)
 	if err != nil {
 		return nil, err
 	}
@@ -228,11 +228,11 @@ func (a *App) RenameChannel(c request.CTX, channel *model.Channel, newChannelNam
 	return newChannel, nil
 }
 
-func (a *App) CreateChannel(c request.CTX, channel *model.Channel, addMember bool) (*model.Channel, *model.AppError) {
+func (a *App) CreateChannel(rctx request.CTX, channel *model.Channel, addMember bool) (*model.Channel, *model.AppError) {
 	a.handleChannelCategoryName(channel)
 
 	channel.DisplayName = strings.TrimSpace(channel.DisplayName)
-	sc, nErr := a.Srv().Store().Channel().Save(c, channel, *a.Config().TeamSettings.MaxChannelsPerTeam)
+	sc, nErr := a.Srv().Store().Channel().Save(rctx, channel, *a.Config().TeamSettings.MaxChannelsPerTeam)
 	if nErr != nil {
 		var invErr *store.ErrInvalidInput
 		var cErr *store.ErrConflict
@@ -280,7 +280,7 @@ func (a *App) CreateChannel(c request.CTX, channel *model.Channel, addMember boo
 			NotifyProps: model.GetDefaultChannelNotifyProps(),
 		}
 
-		if _, nErr := a.Srv().Store().Channel().SaveMember(c, cm); nErr != nil {
+		if _, nErr := a.Srv().Store().Channel().SaveMember(rctx, cm); nErr != nil {
 			var appErr *model.AppError
 			var cErr *store.ErrConflict
 			switch {
@@ -304,7 +304,7 @@ func (a *App) CreateChannel(c request.CTX, channel *model.Channel, addMember boo
 	}
 
 	a.Srv().Go(func() {
-		pluginContext := pluginContext(c)
+		pluginContext := pluginContext(rctx)
 		a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 			hooks.ChannelHasBeenCreated(pluginContext, sc)
 			return true
@@ -314,8 +314,8 @@ func (a *App) CreateChannel(c request.CTX, channel *model.Channel, addMember boo
 	return sc, nil
 }
 
-func (a *App) GetOrCreateDirectChannel(c request.CTX, userID, otherUserID string, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError) {
-	channel, nErr := a.getDirectChannel(c, userID, otherUserID)
+func (a *App) GetOrCreateDirectChannel(rctx request.CTX, userID, otherUserID string, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError) {
+	channel, nErr := a.getDirectChannel(rctx, userID, otherUserID)
 	if nErr != nil {
 		return nil, nErr
 	}
@@ -325,7 +325,7 @@ func (a *App) GetOrCreateDirectChannel(c request.CTX, userID, otherUserID string
 	}
 
 	if *a.Config().TeamSettings.RestrictDirectMessage == model.DirectMessageTeam &&
-		!a.SessionHasPermissionTo(*c.Session(), model.PermissionManageSystem) {
+		!a.SessionHasPermissionTo(*rctx.Session(), model.PermissionManageSystem) {
 		users, err := a.GetUsersByIds([]string{userID, otherUserID}, &store.UserGetByIdsOpts{})
 		if err != nil {
 			return nil, err
@@ -349,7 +349,7 @@ func (a *App) GetOrCreateDirectChannel(c request.CTX, userID, otherUserID string
 		}
 	}
 
-	channel, err := a.createDirectChannel(c, userID, otherUserID, channelOptions...)
+	channel, err := a.createDirectChannel(rctx, userID, otherUserID, channelOptions...)
 	if err != nil {
 		if err.Id == store.ChannelExistsError {
 			return channel, nil
@@ -357,12 +357,12 @@ func (a *App) GetOrCreateDirectChannel(c request.CTX, userID, otherUserID string
 		return nil, err
 	}
 
-	a.handleCreationEvent(c, userID, otherUserID, channel)
+	a.handleCreationEvent(rctx, userID, otherUserID, channel)
 	return channel, nil
 }
 
-func (a *App) getOrCreateDirectChannelWithUser(c request.CTX, user, otherUser *model.User) (*model.Channel, *model.AppError) {
-	channel, nErr := a.getDirectChannel(c, user.Id, otherUser.Id)
+func (a *App) getOrCreateDirectChannelWithUser(rctx request.CTX, user, otherUser *model.User) (*model.Channel, *model.AppError) {
+	channel, nErr := a.getDirectChannel(rctx, user.Id, otherUser.Id)
 	if nErr != nil {
 		return nil, nErr
 	}
@@ -371,7 +371,7 @@ func (a *App) getOrCreateDirectChannelWithUser(c request.CTX, user, otherUser *m
 		return channel, nil
 	}
 
-	channel, err := a.createDirectChannelWithUser(c, user, otherUser)
+	channel, err := a.createDirectChannelWithUser(rctx, user, otherUser)
 	if err != nil {
 		if err.Id == store.ChannelExistsError {
 			return channel, nil
@@ -379,16 +379,16 @@ func (a *App) getOrCreateDirectChannelWithUser(c request.CTX, user, otherUser *m
 		return nil, err
 	}
 
-	a.handleCreationEvent(c, user.Id, otherUser.Id, channel)
+	a.handleCreationEvent(rctx, user.Id, otherUser.Id, channel)
 	return channel, nil
 }
 
-func (a *App) handleCreationEvent(c request.CTX, userID, otherUserID string, channel *model.Channel) {
+func (a *App) handleCreationEvent(rctx request.CTX, userID, otherUserID string, channel *model.Channel) {
 	a.Srv().Platform().InvalidateChannelCacheForUser(userID)
 	a.Srv().Platform().InvalidateChannelCacheForUser(otherUserID)
 
 	a.Srv().Go(func() {
-		pluginContext := pluginContext(c)
+		pluginContext := pluginContext(rctx)
 		a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 			hooks.ChannelHasBeenCreated(pluginContext, channel)
 			return true
@@ -401,7 +401,7 @@ func (a *App) handleCreationEvent(c request.CTX, userID, otherUserID string, cha
 	a.Publish(message)
 }
 
-func (a *App) createDirectChannel(c request.CTX, userID string, otherUserID string, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError) {
+func (a *App) createDirectChannel(rctx request.CTX, userID string, otherUserID string, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError) {
 	users, err := a.Srv().Store().User().GetMany(context.Background(), []string{userID, otherUserID})
 	if err != nil {
 		return nil, model.NewAppError("CreateDirectChannel", "api.channel.create_direct_channel.invalid_user.app_error", nil, "", http.StatusBadRequest).Wrap(err)
@@ -431,15 +431,15 @@ func (a *App) createDirectChannel(c request.CTX, userID string, otherUserID stri
 		user = users[1]
 		otherUser = users[0]
 	}
-	return a.createDirectChannelWithUser(c, user, otherUser, channelOptions...)
+	return a.createDirectChannelWithUser(rctx, user, otherUser, channelOptions...)
 }
 
-func (a *App) createDirectChannelWithUser(c request.CTX, user, otherUser *model.User, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError) {
+func (a *App) createDirectChannelWithUser(rctx request.CTX, user, otherUser *model.User, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError) {
 	if !a.Config().FeatureFlags.EnableSharedChannelsDMs && (user.IsRemote() || otherUser.IsRemote()) {
 		return nil, model.NewAppError("createDirectChannelWithUser", "api.channel.create_channel.direct_channel.remote_restricted.app_error", nil, "", http.StatusForbidden)
 	}
 
-	channel, nErr := a.Srv().Store().Channel().CreateDirectChannel(c, user, otherUser, channelOptions...)
+	channel, nErr := a.Srv().Store().Channel().CreateDirectChannel(rctx, user, otherUser, channelOptions...)
 	if nErr != nil {
 		var invErr *store.ErrInvalidInput
 		var cErr *store.ErrConflict
@@ -496,16 +496,16 @@ func (a *App) createDirectChannelWithUser(c request.CTX, user, otherUser *model.
 			Type:             channel.Type,
 		}
 
-		if _, err := a.ShareChannel(c, sc); err != nil {
-			c.Logger().Error("Failed to share newly created direct channel", mlog.String("channel_id", channel.Id), mlog.Err(err))
+		if _, err := a.ShareChannel(rctx, sc); err != nil {
+			rctx.Logger().Error("Failed to share newly created direct channel", mlog.String("channel_id", channel.Id), mlog.Err(err))
 		}
 	}
 
 	return channel, nil
 }
 
-func (a *App) CreateGroupChannel(c request.CTX, userIDs []string, creatorId string, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError) {
-	channel, err := a.createGroupChannel(c, userIDs, creatorId, channelOptions...)
+func (a *App) CreateGroupChannel(rctx request.CTX, userIDs []string, creatorId string, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError) {
+	channel, err := a.createGroupChannel(rctx, userIDs, creatorId, channelOptions...)
 	if err != nil {
 		if err.Id == store.ChannelExistsError {
 			return channel, nil
@@ -529,7 +529,7 @@ func (a *App) CreateGroupChannel(c request.CTX, userIDs []string, creatorId stri
 // shared channel record attached. It can be empty if the caller
 // doesn't know who the creator is (e.g. the import process) and the
 // resulting group channel will not be shared
-func (a *App) createGroupChannel(c request.CTX, userIDs []string, creatorID string, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError) {
+func (a *App) createGroupChannel(rctx request.CTX, userIDs []string, creatorID string, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError) {
 	if len(userIDs) > model.ChannelGroupMaxUsers || len(userIDs) < model.ChannelGroupMinUsers {
 		return nil, model.NewAppError("CreateGroupChannel", "api.channel.create_group.bad_size.app_error", nil, "", http.StatusBadRequest)
 	}
@@ -537,7 +537,7 @@ func (a *App) createGroupChannel(c request.CTX, userIDs []string, creatorID stri
 	// we skip cache and use master when fetching profiles to avoid
 	// issues in shared channels and HA, when users are created from a
 	// shared channels GM invite right before creating the GM
-	ctx := sqlstore.RequestContextWithMaster(c).Context()
+	ctx := sqlstore.RequestContextWithMaster(rctx).Context()
 	users, err := a.Srv().Store().User().GetProfileByIds(ctx, userIDs, nil, false)
 	if err != nil {
 		return nil, model.NewAppError("createGroupChannel", "app.user.get_profiles.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -576,7 +576,7 @@ func (a *App) createGroupChannel(c request.CTX, userIDs []string, creatorID stri
 		Shared:      model.NewPointer(channelIsShared),
 	}
 
-	channel, nErr := a.Srv().Store().Channel().Save(c, group, *a.Config().TeamSettings.MaxChannelsPerTeam, channelOptions...)
+	channel, nErr := a.Srv().Store().Channel().Save(rctx, group, *a.Config().TeamSettings.MaxChannelsPerTeam, channelOptions...)
 	if nErr != nil {
 		var invErr *store.ErrInvalidInput
 		var cErr *store.ErrConflict
@@ -612,7 +612,7 @@ func (a *App) createGroupChannel(c request.CTX, userIDs []string, creatorID stri
 			SchemeUser:  !user.IsGuest(),
 		}
 
-		if _, nErr = a.Srv().Store().Channel().SaveMember(c, cm); nErr != nil {
+		if _, nErr = a.Srv().Store().Channel().SaveMember(rctx, cm); nErr != nil {
 			var appErr *model.AppError
 			var cErr *store.ErrConflict
 			switch {
@@ -649,8 +649,8 @@ func (a *App) createGroupChannel(c request.CTX, userIDs []string, creatorID stri
 			Type:             channel.Type,
 		}
 
-		if _, err := a.ShareChannel(c, sc); err != nil {
-			c.Logger().Error("Failed to share newly created group channel", mlog.String("channel_id", channel.Id), mlog.Err(err))
+		if _, err := a.ShareChannel(rctx, sc); err != nil {
+			rctx.Logger().Error("Failed to share newly created group channel", mlog.String("channel_id", channel.Id), mlog.Err(err))
 		} else {
 			// if we could successfully share the channel, we invite
 			// the remotes involved to it
@@ -658,7 +658,7 @@ func (a *App) createGroupChannel(c request.CTX, userIDs []string, creatorID stri
 				for remoteID := range remoteIDs {
 					rc, err := a.Srv().Store().RemoteCluster().Get(remoteID, false)
 					if err != nil {
-						c.Logger().Error("Failed to send invite to group message channel, can't retrieve remote cluster", mlog.String("channel_id", channel.Id), mlog.String("remote_id", remoteID), mlog.Err(err))
+						rctx.Logger().Error("Failed to send invite to group message channel, can't retrieve remote cluster", mlog.String("channel_id", channel.Id), mlog.String("remote_id", remoteID), mlog.Err(err))
 						continue
 					}
 
@@ -667,7 +667,7 @@ func (a *App) createGroupChannel(c request.CTX, userIDs []string, creatorID stri
 						opts = append(opts, sharedchannel.WithDirectParticipant(user, remoteID))
 					}
 					if err := sc.SendChannelInvite(channel, creatorID, rc, opts...); err != nil {
-						c.Logger().Error("Failed to send invite to group message channel, error sending the invite", mlog.String("channel_id", channel.Id), mlog.String("remote_id", remoteID), mlog.Err(err))
+						rctx.Logger().Error("Failed to send invite to group message channel, error sending the invite", mlog.String("channel_id", channel.Id), mlog.String("remote_id", remoteID), mlog.Err(err))
 					}
 				}
 			}
@@ -675,7 +675,7 @@ func (a *App) createGroupChannel(c request.CTX, userIDs []string, creatorID stri
 	}
 
 	a.Srv().Go(func() {
-		pluginContext := pluginContext(c)
+		pluginContext := pluginContext(rctx)
 		a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 			hooks.ChannelHasBeenCreated(pluginContext, channel)
 			return true
@@ -685,7 +685,7 @@ func (a *App) createGroupChannel(c request.CTX, userIDs []string, creatorID stri
 	return channel, nil
 }
 
-func (a *App) GetGroupChannel(c request.CTX, userIDs []string) (*model.Channel, *model.AppError) {
+func (a *App) GetGroupChannel(rctx request.CTX, userIDs []string) (*model.Channel, *model.AppError) {
 	if len(userIDs) > model.ChannelGroupMaxUsers || len(userIDs) < model.ChannelGroupMinUsers {
 		return nil, model.NewAppError("GetGroupChannel", "api.channel.create_group.bad_size.app_error", nil, "", http.StatusBadRequest)
 	}
@@ -699,7 +699,7 @@ func (a *App) GetGroupChannel(c request.CTX, userIDs []string) (*model.Channel, 
 		return nil, model.NewAppError("GetGroupChannel", "api.channel.create_group.bad_user.app_error", nil, "user_ids="+model.ArrayToJSON(userIDs), http.StatusBadRequest)
 	}
 
-	channel, appErr := a.GetChannelByName(c, model.GetGroupNameFromUserIds(userIDs), "", true)
+	channel, appErr := a.GetChannelByName(rctx, model.GetGroupNameFromUserIds(userIDs), "", true)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -708,8 +708,8 @@ func (a *App) GetGroupChannel(c request.CTX, userIDs []string) (*model.Channel, 
 }
 
 // UpdateChannel updates a given channel by its Id. It also publishes the CHANNEL_UPDATED event.
-func (a *App) UpdateChannel(c request.CTX, channel *model.Channel) (*model.Channel, *model.AppError) {
-	ok, appErr := a.ChannelAccessControlled(c, channel.Id)
+func (a *App) UpdateChannel(rctx request.CTX, channel *model.Channel) (*model.Channel, *model.AppError) {
+	ok, appErr := a.ChannelAccessControlled(rctx, channel.Id)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -717,7 +717,7 @@ func (a *App) UpdateChannel(c request.CTX, channel *model.Channel) (*model.Chann
 		return nil, model.NewAppError("UpdateChannel", "api.channel.update_channel.not_allowed.app_error", nil, "", http.StatusForbidden)
 	}
 
-	_, err := a.Srv().Store().Channel().Update(c, channel)
+	_, err := a.Srv().Store().Channel().Update(rctx, channel)
 	if err != nil {
 		var appErr *model.AppError
 		var uniqueConstraintErr *store.ErrUniqueConstraint
@@ -748,7 +748,7 @@ func (a *App) UpdateChannel(c request.CTX, channel *model.Channel) (*model.Chann
 }
 
 // CreateChannelScheme creates a new Scheme of scope channel and assigns it to the channel.
-func (a *App) CreateChannelScheme(c request.CTX, channel *model.Channel) (*model.Scheme, *model.AppError) {
+func (a *App) CreateChannelScheme(rctx request.CTX, channel *model.Channel) (*model.Scheme, *model.AppError) {
 	scheme, err := a.CreateScheme(&model.Scheme{
 		Name:        model.NewId(),
 		DisplayName: model.NewId(),
@@ -759,42 +759,42 @@ func (a *App) CreateChannelScheme(c request.CTX, channel *model.Channel) (*model
 	}
 
 	channel.SchemeId = &scheme.Id
-	if _, err := a.UpdateChannelScheme(c, channel); err != nil {
+	if _, err := a.UpdateChannelScheme(rctx, channel); err != nil {
 		return nil, err
 	}
 	return scheme, nil
 }
 
 // DeleteChannelScheme deletes a channels scheme and sets its SchemeId to nil.
-func (a *App) DeleteChannelScheme(c request.CTX, channel *model.Channel) (*model.Channel, *model.AppError) {
+func (a *App) DeleteChannelScheme(rctx request.CTX, channel *model.Channel) (*model.Channel, *model.AppError) {
 	if channel.SchemeId != nil && *channel.SchemeId != "" {
 		if _, err := a.DeleteScheme(*channel.SchemeId); err != nil {
 			return nil, err
 		}
 	}
 	channel.SchemeId = nil
-	return a.UpdateChannelScheme(c, channel)
+	return a.UpdateChannelScheme(rctx, channel)
 }
 
 // UpdateChannelScheme saves the new SchemeId of the channel passed.
-func (a *App) UpdateChannelScheme(c request.CTX, channel *model.Channel) (*model.Channel, *model.AppError) {
+func (a *App) UpdateChannelScheme(rctx request.CTX, channel *model.Channel) (*model.Channel, *model.AppError) {
 	var oldChannel *model.Channel
 	var err *model.AppError
-	if oldChannel, err = a.GetChannel(c, channel.Id); err != nil {
+	if oldChannel, err = a.GetChannel(rctx, channel.Id); err != nil {
 		return nil, err
 	}
 
 	oldChannel.SchemeId = channel.SchemeId
-	return a.UpdateChannel(c, oldChannel)
+	return a.UpdateChannel(rctx, oldChannel)
 }
 
-func (a *App) UpdateChannelPrivacy(c request.CTX, oldChannel *model.Channel, user *model.User) (*model.Channel, *model.AppError) {
-	channel, err := a.UpdateChannel(c, oldChannel)
+func (a *App) UpdateChannelPrivacy(rctx request.CTX, oldChannel *model.Channel, user *model.User) (*model.Channel, *model.AppError) {
+	channel, err := a.UpdateChannel(rctx, oldChannel)
 	if err != nil {
 		return channel, err
 	}
 
-	postErr := a.postChannelPrivacyMessage(c, user, channel)
+	postErr := a.postChannelPrivacyMessage(rctx, user, channel)
 	if postErr != nil {
 		if channel.Type == model.ChannelTypeOpen {
 			channel.Type = model.ChannelTypePrivate
@@ -802,7 +802,7 @@ func (a *App) UpdateChannelPrivacy(c request.CTX, oldChannel *model.Channel, use
 			channel.Type = model.ChannelTypeOpen
 		}
 		// revert to previous channel privacy
-		if _, err = a.UpdateChannel(c, channel); err != nil {
+		if _, err = a.UpdateChannel(rctx, channel); err != nil {
 			a.Log().Error("Failed to revert channel privacy after posting an update message failed", mlog.Err(err))
 		}
 		return channel, postErr
@@ -817,14 +817,14 @@ func (a *App) UpdateChannelPrivacy(c request.CTX, oldChannel *model.Channel, use
 	return channel, nil
 }
 
-func (a *App) postChannelPrivacyMessage(c request.CTX, user *model.User, channel *model.Channel) *model.AppError {
+func (a *App) postChannelPrivacyMessage(rctx request.CTX, user *model.User, channel *model.Channel) *model.AppError {
 	var authorId string
 	var authorUsername string
 	if user != nil {
 		authorId = user.Id
 		authorUsername = user.Username
 	} else {
-		systemBot, err := a.GetSystemBot(c)
+		systemBot, err := a.GetSystemBot(rctx)
 		if err != nil {
 			return model.NewAppError("postChannelPrivacyMessage", "api.channel.post_channel_privacy_message.error", nil, "", http.StatusInternalServerError).Wrap(err)
 		}
@@ -847,14 +847,14 @@ func (a *App) postChannelPrivacyMessage(c request.CTX, user *model.User, channel
 		},
 	}
 
-	if _, err := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
+	if _, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
 		return model.NewAppError("postChannelPrivacyMessage", "api.channel.post_channel_privacy_message.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	return nil
 }
 
-func (a *App) RestoreChannel(c request.CTX, channel *model.Channel, userID string) (*model.Channel, *model.AppError) {
+func (a *App) RestoreChannel(rctx request.CTX, channel *model.Channel, userID string) (*model.Channel, *model.AppError) {
 	if channel.DeleteAt == 0 {
 		return nil, model.NewAppError("restoreChannel", "api.channel.restore_channel.restored.app_error", nil, "", http.StatusBadRequest)
 	}
@@ -902,14 +902,14 @@ func (a *App) RestoreChannel(c request.CTX, channel *model.Channel, userID strin
 			},
 		}
 
-		if _, err := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
-			c.Logger().Warn("Failed to post unarchive message", mlog.Err(err))
+		if _, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
+			rctx.Logger().Warn("Failed to post unarchive message", mlog.Err(err))
 		}
 	} else {
 		a.Srv().Go(func() {
-			systemBot, err := a.GetSystemBot(c)
+			systemBot, err := a.GetSystemBot(rctx)
 			if err != nil {
-				c.Logger().Error("Failed to post unarchive message", mlog.Err(err))
+				rctx.Logger().Error("Failed to post unarchive message", mlog.Err(err))
 				return
 			}
 
@@ -923,8 +923,8 @@ func (a *App) RestoreChannel(c request.CTX, channel *model.Channel, userID strin
 				},
 			}
 
-			if _, err := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
-				c.Logger().Error("Failed to post unarchive message", mlog.Err(err))
+			if _, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
+				rctx.Logger().Error("Failed to post unarchive message", mlog.Err(err))
 			}
 		})
 	}
@@ -932,35 +932,35 @@ func (a *App) RestoreChannel(c request.CTX, channel *model.Channel, userID strin
 	return channel, nil
 }
 
-func (a *App) PatchChannel(c request.CTX, channel *model.Channel, patch *model.ChannelPatch, userID string) (*model.Channel, *model.AppError) {
+func (a *App) PatchChannel(rctx request.CTX, channel *model.Channel, patch *model.ChannelPatch, userID string) (*model.Channel, *model.AppError) {
 	oldChannelDisplayName := channel.DisplayName
 	oldChannelHeader := channel.Header
 	oldChannelPurpose := channel.Purpose
 
 	channel.Patch(patch)
 	a.handleChannelCategoryName(channel)
-	channel, err := a.UpdateChannel(c, channel)
+	channel, err := a.UpdateChannel(rctx, channel)
 	if err != nil {
 		return nil, err
 	}
 
-	a.addChannelToDefaultCategory(c, userID, channel)
+	a.addChannelToDefaultCategory(rctx, userID, channel)
 
 	if oldChannelDisplayName != channel.DisplayName {
-		if err = a.PostUpdateChannelDisplayNameMessage(c, userID, channel, oldChannelDisplayName, channel.DisplayName); err != nil {
-			c.Logger().Warn(err.Error())
+		if err = a.PostUpdateChannelDisplayNameMessage(rctx, userID, channel, oldChannelDisplayName, channel.DisplayName); err != nil {
+			rctx.Logger().Warn(err.Error())
 		}
 	}
 
 	if channel.Header != oldChannelHeader {
-		if err = a.PostUpdateChannelHeaderMessage(c, userID, channel, oldChannelHeader, channel.Header); err != nil {
-			c.Logger().Warn(err.Error())
+		if err = a.PostUpdateChannelHeaderMessage(rctx, userID, channel, oldChannelHeader, channel.Header); err != nil {
+			rctx.Logger().Warn(err.Error())
 		}
 	}
 
 	if channel.Purpose != oldChannelPurpose {
-		if err = a.PostUpdateChannelPurposeMessage(c, userID, channel, oldChannelPurpose, channel.Purpose); err != nil {
-			c.Logger().Warn(err.Error())
+		if err = a.PostUpdateChannelPurposeMessage(rctx, userID, channel, oldChannelPurpose, channel.Purpose); err != nil {
+			rctx.Logger().Warn(err.Error())
 		}
 	}
 
@@ -968,8 +968,8 @@ func (a *App) PatchChannel(c request.CTX, channel *model.Channel, patch *model.C
 }
 
 // GetSchemeRolesForChannel Checks if a channel or its team has an override scheme for channel roles and returns the scheme roles or default channel roles.
-func (a *App) GetSchemeRolesForChannel(c request.CTX, channelID string) (guestRoleName, userRoleName, adminRoleName string, err *model.AppError) {
-	channel, err := a.GetChannel(c, channelID)
+func (a *App) GetSchemeRolesForChannel(rctx request.CTX, channelID string) (guestRoleName, userRoleName, adminRoleName string, err *model.AppError) {
+	channel, err := a.GetChannel(rctx, channelID)
 	if err != nil {
 		return
 	}
@@ -988,11 +988,11 @@ func (a *App) GetSchemeRolesForChannel(c request.CTX, channelID string) (guestRo
 		return
 	}
 
-	return a.GetTeamSchemeChannelRoles(c, channel.TeamId)
+	return a.GetTeamSchemeChannelRoles(rctx, channel.TeamId)
 }
 
 // GetTeamSchemeChannelRoles Checks if a team has an override scheme and returns the scheme channel role names or default channel role names.
-func (a *App) GetTeamSchemeChannelRoles(c request.CTX, teamID string) (guestRoleName, userRoleName, adminRoleName string, err *model.AppError) {
+func (a *App) GetTeamSchemeChannelRoles(rctx request.CTX, teamID string) (guestRoleName, userRoleName, adminRoleName string, err *model.AppError) {
 	team, err := a.GetTeam(teamID)
 	if err != nil {
 		return
@@ -1018,8 +1018,8 @@ func (a *App) GetTeamSchemeChannelRoles(c request.CTX, teamID string) (guestRole
 }
 
 // GetChannelModerationsForChannel Gets a channels ChannelModerations from either the higherScoped roles or from the channel scheme roles.
-func (a *App) GetChannelModerationsForChannel(c request.CTX, channel *model.Channel) ([]*model.ChannelModeration, *model.AppError) {
-	guestRoleName, memberRoleName, _, err := a.GetSchemeRolesForChannel(c, channel.Id)
+func (a *App) GetChannelModerationsForChannel(rctx request.CTX, channel *model.Channel) ([]*model.ChannelModeration, *model.AppError) {
+	guestRoleName, memberRoleName, _, err := a.GetSchemeRolesForChannel(rctx, channel.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -1037,7 +1037,7 @@ func (a *App) GetChannelModerationsForChannel(c request.CTX, channel *model.Chan
 		}
 	}
 
-	higherScopedGuestRoleName, higherScopedMemberRoleName, _, err := a.GetTeamSchemeChannelRoles(c, channel.TeamId)
+	higherScopedGuestRoleName, higherScopedMemberRoleName, _, err := a.GetTeamSchemeChannelRoles(rctx, channel.TeamId)
 	if err != nil {
 		return nil, err
 	}
@@ -1054,12 +1054,12 @@ func (a *App) GetChannelModerationsForChannel(c request.CTX, channel *model.Chan
 		}
 	}
 
-	return buildChannelModerations(c, channel.Type, memberRole, guestRole, higherScopedMemberRole, higherScopedGuestRole), nil
+	return buildChannelModerations(rctx, channel.Type, memberRole, guestRole, higherScopedMemberRole, higherScopedGuestRole), nil
 }
 
 // PatchChannelModerationsForChannel Updates a channels scheme roles based on a given ChannelModerationPatch, if the permissions match the higher scoped role the scheme is deleted.
-func (a *App) PatchChannelModerationsForChannel(c request.CTX, channel *model.Channel, channelModerationsPatch []*model.ChannelModerationPatch) ([]*model.ChannelModeration, *model.AppError) {
-	higherScopedGuestRoleName, higherScopedMemberRoleName, _, err := a.GetTeamSchemeChannelRoles(c, channel.TeamId)
+func (a *App) PatchChannelModerationsForChannel(rctx request.CTX, channel *model.Channel, channelModerationsPatch []*model.ChannelModerationPatch) ([]*model.ChannelModeration, *model.AppError) {
+	higherScopedGuestRoleName, higherScopedMemberRoleName, _, err := a.GetTeamSchemeChannelRoles(rctx, channel.TeamId)
 	if err != nil {
 		return nil, err
 	}
@@ -1097,7 +1097,7 @@ func (a *App) PatchChannelModerationsForChannel(c request.CTX, channel *model.Ch
 	var scheme *model.Scheme
 	// Channel has no scheme so create one
 	if channel.SchemeId == nil || *channel.SchemeId == "" {
-		scheme, err = a.CreateChannelScheme(c, channel)
+		scheme, err = a.CreateChannelScheme(rctx, channel)
 		if err != nil {
 			return nil, err
 		}
@@ -1114,7 +1114,7 @@ func (a *App) PatchChannelModerationsForChannel(c request.CTX, channel *model.Ch
 
 		message := model.NewWebSocketEvent(model.WebsocketEventChannelSchemeUpdated, "", channel.Id, "", nil, "")
 		a.Publish(message)
-		c.Logger().Info("Permission scheme created.", mlog.String("channel_id", channel.Id), mlog.String("channel_name", channel.Name))
+		rctx.Logger().Info("Permission scheme created.", mlog.String("channel_id", channel.Id), mlog.String("channel_name", channel.Name))
 	} else {
 		scheme, err = a.GetScheme(*channel.SchemeId)
 		if err != nil {
@@ -1147,17 +1147,17 @@ func (a *App) PatchChannelModerationsForChannel(c request.CTX, channel *model.Ch
 		permissionModified := *channelModerationPatch.Name
 		if channelModerationPatch.Roles.Guests != nil && slices.Contains(model.ChannelModeratedPermissionsChangedByPatch(guestRole, guestRolePatch), permissionModified) {
 			if *channelModerationPatch.Roles.Guests {
-				c.Logger().Info("Permission enabled for guests.", mlog.String("permission", permissionModified), mlog.String("channel_id", channel.Id), mlog.String("channel_name", channel.Name))
+				rctx.Logger().Info("Permission enabled for guests.", mlog.String("permission", permissionModified), mlog.String("channel_id", channel.Id), mlog.String("channel_name", channel.Name))
 			} else {
-				c.Logger().Info("Permission disabled for guests.", mlog.String("permission", permissionModified), mlog.String("channel_id", channel.Id), mlog.String("channel_name", channel.Name))
+				rctx.Logger().Info("Permission disabled for guests.", mlog.String("permission", permissionModified), mlog.String("channel_id", channel.Id), mlog.String("channel_name", channel.Name))
 			}
 		}
 
 		if channelModerationPatch.Roles.Members != nil && slices.Contains(model.ChannelModeratedPermissionsChangedByPatch(memberRole, memberRolePatch), permissionModified) {
 			if *channelModerationPatch.Roles.Members {
-				c.Logger().Info("Permission enabled for members.", mlog.String("permission", permissionModified), mlog.String("channel_id", channel.Id), mlog.String("channel_name", channel.Name))
+				rctx.Logger().Info("Permission enabled for members.", mlog.String("permission", permissionModified), mlog.String("channel_id", channel.Id), mlog.String("channel_name", channel.Name))
 			} else {
-				c.Logger().Info("Permission disabled for members.", mlog.String("permission", permissionModified), mlog.String("channel_id", channel.Id), mlog.String("channel_name", channel.Name))
+				rctx.Logger().Info("Permission disabled for members.", mlog.String("permission", permissionModified), mlog.String("channel_id", channel.Id), mlog.String("channel_name", channel.Name))
 			}
 		}
 	}
@@ -1166,7 +1166,7 @@ func (a *App) PatchChannelModerationsForChannel(c request.CTX, channel *model.Ch
 	guestRolePermissionsUnmodified := len(model.ChannelModeratedPermissionsChangedByPatch(higherScopedGuestRole, guestRolePatch)) == 0
 	if memberRolePermissionsUnmodified && guestRolePermissionsUnmodified {
 		// The channel scheme matches the permissions of its higherScoped scheme so delete the scheme
-		if _, err = a.DeleteChannelScheme(c, channel); err != nil {
+		if _, err = a.DeleteChannelScheme(rctx, channel); err != nil {
 			return nil, err
 		}
 
@@ -1175,7 +1175,7 @@ func (a *App) PatchChannelModerationsForChannel(c request.CTX, channel *model.Ch
 
 		memberRole = higherScopedMemberRole
 		guestRole = higherScopedGuestRole
-		c.Logger().Info("Permission scheme deleted.", mlog.String("channel_id", channel.Id), mlog.String("channel_name", channel.Name))
+		rctx.Logger().Info("Permission scheme deleted.", mlog.String("channel_id", channel.Id), mlog.String("channel_name", channel.Name))
 	} else {
 		memberRole, err = a.PatchRole(memberRole, memberRolePatch)
 		if err != nil {
@@ -1187,7 +1187,7 @@ func (a *App) PatchChannelModerationsForChannel(c request.CTX, channel *model.Ch
 		}
 	}
 
-	cErr := a.forEachChannelMember(c, channel.Id, func(channelMember model.ChannelMember) error {
+	cErr := a.forEachChannelMember(rctx, channel.Id, func(channelMember model.ChannelMember) error {
 		a.Srv().Store().Channel().InvalidateAllChannelMembersForUser(channelMember.UserId)
 
 		evt := model.NewWebSocketEvent(model.WebsocketEventChannelMemberUpdated, "", "", channelMember.UserId, nil, "")
@@ -1204,10 +1204,10 @@ func (a *App) PatchChannelModerationsForChannel(c request.CTX, channel *model.Ch
 		return nil, model.NewAppError("PatchChannelModerationsForChannel", "api.channel.patch_channel_moderations.cache_invalidation.error", nil, "", http.StatusInternalServerError).Wrap(cErr)
 	}
 
-	return buildChannelModerations(c, channel.Type, memberRole, guestRole, higherScopedMemberRole, higherScopedGuestRole), nil
+	return buildChannelModerations(rctx, channel.Type, memberRole, guestRole, higherScopedMemberRole, higherScopedGuestRole), nil
 }
 
-func buildChannelModerations(c request.CTX, channelType model.ChannelType, memberRole *model.Role, guestRole *model.Role, higherScopedMemberRole *model.Role, higherScopedGuestRole *model.Role) []*model.ChannelModeration {
+func buildChannelModerations(rctx request.CTX, channelType model.ChannelType, memberRole *model.Role, guestRole *model.Role, higherScopedMemberRole *model.Role, higherScopedGuestRole *model.Role) []*model.ChannelModeration {
 	var memberPermissions, guestPermissions, higherScopedMemberPermissions, higherScopedGuestPermissions map[string]bool
 	if memberRole != nil {
 		memberPermissions = memberRole.GetChannelModeratedPermissions(channelType)
@@ -1251,14 +1251,14 @@ func buildChannelModerations(c request.CTX, channelType model.ChannelType, membe
 	return channelModerations
 }
 
-func (a *App) UpdateChannelMemberRoles(c request.CTX, channelID string, userID string, newRoles string) (*model.ChannelMember, *model.AppError) {
+func (a *App) UpdateChannelMemberRoles(rctx request.CTX, channelID string, userID string, newRoles string) (*model.ChannelMember, *model.AppError) {
 	var member *model.ChannelMember
 	var err *model.AppError
-	if member, err = a.GetChannelMember(c, channelID, userID); err != nil {
+	if member, err = a.GetChannelMember(rctx, channelID, userID); err != nil {
 		return nil, err
 	}
 
-	schemeGuestRole, schemeUserRole, schemeAdminRole, err := a.GetSchemeRolesForChannel(c, channelID)
+	schemeGuestRole, schemeUserRole, schemeAdminRole, err := a.GetSchemeRolesForChannel(rctx, channelID)
 	if err != nil {
 		return nil, err
 	}
@@ -1307,11 +1307,11 @@ func (a *App) UpdateChannelMemberRoles(c request.CTX, channelID string, userID s
 
 	member.ExplicitRoles = strings.Join(newExplicitRoles, " ")
 
-	return a.updateChannelMember(c, member)
+	return a.updateChannelMember(rctx, member)
 }
 
-func (a *App) UpdateChannelMemberSchemeRoles(c request.CTX, channelID string, userID string, isSchemeGuest bool, isSchemeUser bool, isSchemeAdmin bool) (*model.ChannelMember, *model.AppError) {
-	member, err := a.GetChannelMember(c, channelID, userID)
+func (a *App) UpdateChannelMemberSchemeRoles(rctx request.CTX, channelID string, userID string, isSchemeGuest bool, isSchemeUser bool, isSchemeAdmin bool) (*model.ChannelMember, *model.AppError) {
+	member, err := a.GetChannelMember(rctx, channelID, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -1337,10 +1337,10 @@ func (a *App) UpdateChannelMemberSchemeRoles(c request.CTX, channelID string, us
 		member.ExplicitRoles = removeRoles([]string{model.ChannelGuestRoleId, model.ChannelUserRoleId, model.ChannelAdminRoleId}, member.ExplicitRoles)
 	}
 
-	return a.updateChannelMember(c, member)
+	return a.updateChannelMember(rctx, member)
 }
 
-func (a *App) UpdateChannelMemberNotifyProps(c request.CTX, data map[string]string, channelID string, userID string) (*model.ChannelMember, *model.AppError) {
+func (a *App) UpdateChannelMemberNotifyProps(rctx request.CTX, data map[string]string, channelID string, userID string) (*model.ChannelMember, *model.AppError) {
 	filteredProps := make(map[string]string)
 
 	// update whichever notify properties have been provided, but don't change the others
@@ -1413,7 +1413,7 @@ func (a *App) UpdateChannelMemberNotifyProps(c request.CTX, data map[string]stri
 	return member, nil
 }
 
-func (a *App) PatchChannelMembersNotifyProps(c request.CTX, members []*model.ChannelMemberIdentifier, notifyProps map[string]string) ([]*model.ChannelMember, *model.AppError) {
+func (a *App) PatchChannelMembersNotifyProps(rctx request.CTX, members []*model.ChannelMemberIdentifier, notifyProps map[string]string) ([]*model.ChannelMember, *model.AppError) {
 	if len(members) > UpdateMultipleMaximum {
 		return nil, model.NewAppError("PatchChannelMembersNotifyProps", "app.channel.patch_channel_members_notify_props.too_many", map[string]any{"Max": UpdateMultipleMaximum}, "", http.StatusBadRequest)
 	}
@@ -1448,7 +1448,7 @@ func (a *App) PatchChannelMembersNotifyProps(c request.CTX, members []*model.Cha
 	for _, member := range updated {
 		err := a.sendUpdateChannelMemberEvent(member)
 		if err != nil {
-			c.Logger().Warn("Failed to send WebSocket event for updated channel member notify props", mlog.Err(err))
+			rctx.Logger().Warn("Failed to send WebSocket event for updated channel member notify props", mlog.Err(err))
 		}
 	}
 
@@ -1467,8 +1467,8 @@ func (a *App) sendUpdateChannelMemberEvent(member *model.ChannelMember) error {
 	return nil
 }
 
-func (a *App) updateChannelMember(c request.CTX, member *model.ChannelMember) (*model.ChannelMember, *model.AppError) {
-	member, err := a.Srv().Store().Channel().UpdateMember(c, member)
+func (a *App) updateChannelMember(rctx request.CTX, member *model.ChannelMember) (*model.ChannelMember, *model.AppError) {
+	member, err := a.Srv().Store().Channel().UpdateMember(rctx, member)
 	if err != nil {
 		var appErr *model.AppError
 		var nfErr *store.ErrNotFound
@@ -1496,7 +1496,7 @@ func (a *App) updateChannelMember(c request.CTX, member *model.ChannelMember) (*
 	return member, nil
 }
 
-func (a *App) DeleteChannel(c request.CTX, channel *model.Channel, userID string) *model.AppError {
+func (a *App) DeleteChannel(rctx request.CTX, channel *model.Channel, userID string) *model.AppError {
 	ihc := make(chan store.StoreResult[[]*model.IncomingWebhook], 1)
 	ohc := make(chan store.StoreResult[[]*model.OutgoingWebhook], 1)
 
@@ -1560,13 +1560,13 @@ func (a *App) DeleteChannel(c request.CTX, channel *model.Channel, userID string
 			},
 		}
 
-		if _, err := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
-			c.Logger().Warn("Failed to post archive message", mlog.Err(err))
+		if _, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
+			rctx.Logger().Warn("Failed to post archive message", mlog.Err(err))
 		}
 	} else {
-		systemBot, err := a.GetSystemBot(c)
+		systemBot, err := a.GetSystemBot(rctx)
 		if err != nil {
-			c.Logger().Warn("Failed to post archive message", mlog.Err(err))
+			rctx.Logger().Warn("Failed to post archive message", mlog.Err(err))
 		} else {
 			post := &model.Post{
 				ChannelId: channel.Id,
@@ -1578,8 +1578,8 @@ func (a *App) DeleteChannel(c request.CTX, channel *model.Channel, userID string
 				},
 			}
 
-			if _, err := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
-				c.Logger().Warn("Failed to post archive message", mlog.Err(err))
+			if _, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
+				rctx.Logger().Warn("Failed to post archive message", mlog.Err(err))
 			}
 		}
 	}
@@ -1587,14 +1587,14 @@ func (a *App) DeleteChannel(c request.CTX, channel *model.Channel, userID string
 	now := model.GetMillis()
 	for _, hook := range ihcresult.Data {
 		if err := a.Srv().Store().Webhook().DeleteIncoming(hook.Id, now); err != nil {
-			c.Logger().Warn("Encountered error deleting incoming webhook", mlog.String("hook_id", hook.Id), mlog.Err(err))
+			rctx.Logger().Warn("Encountered error deleting incoming webhook", mlog.String("hook_id", hook.Id), mlog.Err(err))
 		}
 		a.Srv().Platform().InvalidateCacheForWebhook(hook.Id)
 	}
 
 	for _, hook := range ohcresult.Data {
 		if err := a.Srv().Store().Webhook().DeleteOutgoing(hook.Id, now); err != nil {
-			c.Logger().Warn("Encountered error deleting outgoing webhook", mlog.String("hook_id", hook.Id), mlog.Err(err))
+			rctx.Logger().Warn("Encountered error deleting outgoing webhook", mlog.String("hook_id", hook.Id), mlog.Err(err))
 		}
 	}
 
@@ -1623,7 +1623,7 @@ func (a *App) DeleteChannel(c request.CTX, channel *model.Channel, userID string
 	return nil
 }
 
-func (a *App) addUserToChannel(c request.CTX, user *model.User, channel *model.Channel) (*model.ChannelMember, *model.AppError) {
+func (a *App) addUserToChannel(rctx request.CTX, user *model.User, channel *model.Channel) (*model.ChannelMember, *model.AppError) {
 	if channel.Type != model.ChannelTypeOpen && channel.Type != model.ChannelTypePrivate {
 		return nil, model.NewAppError("AddUserToChannel", "api.channel.add_user_to_channel.type.app_error", nil, "", http.StatusBadRequest)
 	}
@@ -1666,7 +1666,7 @@ func (a *App) addUserToChannel(c request.CTX, user *model.User, channel *model.C
 	}
 
 	if channel.Type == model.ChannelTypePrivate {
-		if ok, appErr := a.ChannelAccessControlled(c, channel.Id); ok {
+		if ok, appErr := a.ChannelAccessControlled(rctx, channel.Id); ok {
 			if acs := a.Srv().Channels().AccessControl; acs != nil {
 				groupID, err := a.CpaGroupID()
 				if err != nil {
@@ -1674,13 +1674,13 @@ func (a *App) addUserToChannel(c request.CTX, user *model.User, channel *model.C
 						fmt.Sprintf("failed to get group: %v, user_id: %s, channel_id: %s", err, user.Id, channel.Id), http.StatusInternalServerError)
 				}
 
-				s, err := a.Srv().Store().Attributes().GetSubject(c, user.Id, groupID)
+				s, err := a.Srv().Store().Attributes().GetSubject(rctx, user.Id, groupID)
 				if err != nil {
 					return nil, model.NewAppError("AddUserToChannel", "api.channel.add_user.to.channel.failed.app_error", nil,
 						fmt.Sprintf("failed to get subject: %v, user_id: %s, channel_id: %s", err, user.Id, channel.Id), http.StatusNotFound)
 				}
 
-				decision, evalErr := acs.AccessEvaluation(c, model.AccessRequest{
+				decision, evalErr := acs.AccessEvaluation(rctx, model.AccessRequest{
 					Subject: *s,
 					Resource: model.Resource{
 						Type: model.AccessControlPolicyTypeChannel,
@@ -1699,7 +1699,7 @@ func (a *App) addUserToChannel(c request.CTX, user *model.User, channel *model.C
 		}
 	}
 
-	newMember, nErr = a.Srv().Store().Channel().SaveMember(c, newMember)
+	newMember, nErr = a.Srv().Store().Channel().SaveMember(rctx, newMember)
 	if nErr != nil {
 		return nil, model.NewAppError("AddUserToChannel", "api.channel.add_user.to.channel.failed.app_error", nil,
 			fmt.Sprintf("failed to add member: %v, user_id: %s, channel_id: %s", nErr, user.Id, channel.Id), http.StatusInternalServerError)
@@ -1730,9 +1730,9 @@ func (a *App) addUserToChannel(c request.CTX, user *model.User, channel *model.C
 }
 
 // AddUserToChannel adds a user to a given channel.
-func (a *App) AddUserToChannel(c request.CTX, user *model.User, channel *model.Channel, skipTeamMemberIntegrityCheck bool) (*model.ChannelMember, *model.AppError) {
+func (a *App) AddUserToChannel(rctx request.CTX, user *model.User, channel *model.Channel, skipTeamMemberIntegrityCheck bool) (*model.ChannelMember, *model.AppError) {
 	if !skipTeamMemberIntegrityCheck {
-		teamMember, nErr := a.Srv().Store().Team().GetMember(c, channel.TeamId, user.Id)
+		teamMember, nErr := a.Srv().Store().Team().GetMember(rctx, channel.TeamId, user.Id)
 		if nErr != nil {
 			var nfErr *store.ErrNotFound
 			switch {
@@ -1748,12 +1748,12 @@ func (a *App) AddUserToChannel(c request.CTX, user *model.User, channel *model.C
 		}
 	}
 
-	newMember, err := a.addUserToChannel(c, user, channel)
+	newMember, err := a.addUserToChannel(rctx, user, channel)
 	if err != nil {
 		return nil, err
 	}
 
-	a.addChannelToDefaultCategory(c, user.Id, channel)
+	a.addChannelToDefaultCategory(rctx, user.Id, channel)
 
 	// We are sending separate websocket events to the user added and to the channel
 	// This is to get around potential cluster syncing issues where other nodes may not receive the most up to date channel members
@@ -1781,7 +1781,7 @@ type ChannelMemberOpts struct {
 }
 
 // AddChannelMember adds a user to a channel. It is a wrapper over AddUserToChannel.
-func (a *App) AddChannelMember(c request.CTX, userID string, channel *model.Channel, opts ChannelMemberOpts) (*model.ChannelMember, *model.AppError) {
+func (a *App) AddChannelMember(rctx request.CTX, userID string, channel *model.Channel, opts ChannelMemberOpts) (*model.ChannelMember, *model.AppError) {
 	if member, err := a.Srv().Store().Channel().GetMember(context.Background(), channel.Id, userID); err != nil {
 		var nfErr *store.ErrNotFound
 		if !errors.As(err, &nfErr) {
@@ -1809,13 +1809,13 @@ func (a *App) AddChannelMember(c request.CTX, userID string, channel *model.Chan
 		}
 	}
 
-	cm, err := a.AddUserToChannel(c, user, channel, opts.SkipTeamMemberIntegrityCheck)
+	cm, err := a.AddUserToChannel(rctx, user, channel, opts.SkipTeamMemberIntegrityCheck)
 	if err != nil {
 		return nil, err
 	}
 
 	a.Srv().Go(func() {
-		pluginContext := pluginContext(c)
+		pluginContext := pluginContext(rctx)
 		a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 			hooks.UserHasJoinedChannel(pluginContext, cm, userRequestor)
 			return true
@@ -1823,13 +1823,13 @@ func (a *App) AddChannelMember(c request.CTX, userID string, channel *model.Chan
 	})
 
 	if opts.UserRequestorID == "" || userID == opts.UserRequestorID {
-		if err := a.postJoinChannelMessage(c, user, channel); err != nil {
+		if err := a.postJoinChannelMessage(rctx, user, channel); err != nil {
 			return nil, err
 		}
 	} else {
 		a.Srv().Go(func() {
-			if err := a.PostAddToChannelMessage(c, userRequestor, user, channel, opts.PostRootID); err != nil {
-				c.Logger().Error("Failed to post AddToChannel message", mlog.Err(err))
+			if err := a.PostAddToChannelMessage(rctx, userRequestor, user, channel, opts.PostRootID); err != nil {
+				rctx.Logger().Error("Failed to post AddToChannel message", mlog.Err(err))
 			}
 		})
 	}
@@ -1837,7 +1837,7 @@ func (a *App) AddChannelMember(c request.CTX, userID string, channel *model.Chan
 	return cm, nil
 }
 
-func (a *App) AddDirectChannels(c request.CTX, teamID string, user *model.User) *model.AppError {
+func (a *App) AddDirectChannels(rctx request.CTX, teamID string, user *model.User) *model.AppError {
 	var profiles []*model.User
 	options := &model.UserGetOptions{InTeamId: teamID, Page: 0, PerPage: 100}
 	profiles, err := a.Srv().Store().User().GetProfiles(options)
@@ -1873,7 +1873,7 @@ func (a *App) AddDirectChannels(c request.CTX, teamID string, user *model.User) 
 	return nil
 }
 
-func (a *App) PostUpdateChannelHeaderMessage(c request.CTX, userID string, channel *model.Channel, oldChannelHeader, newChannelHeader string) *model.AppError {
+func (a *App) PostUpdateChannelHeaderMessage(rctx request.CTX, userID string, channel *model.Channel, oldChannelHeader, newChannelHeader string) *model.AppError {
 	user, err := a.Srv().Store().User().Get(context.Background(), userID)
 	if err != nil {
 		return model.NewAppError("PostUpdateChannelHeaderMessage", "api.channel.post_update_channel_header_message_and_forget.retrieve_user.error", nil, "", http.StatusBadRequest).Wrap(err)
@@ -1900,14 +1900,14 @@ func (a *App) PostUpdateChannelHeaderMessage(c request.CTX, userID string, chann
 		},
 	}
 
-	if _, err := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
+	if _, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
 		return model.NewAppError("", "api.channel.post_update_channel_header_message_and_forget.post.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	return nil
 }
 
-func (a *App) PostUpdateChannelPurposeMessage(c request.CTX, userID string, channel *model.Channel, oldChannelPurpose string, newChannelPurpose string) *model.AppError {
+func (a *App) PostUpdateChannelPurposeMessage(rctx request.CTX, userID string, channel *model.Channel, oldChannelPurpose string, newChannelPurpose string) *model.AppError {
 	user, err := a.Srv().Store().User().Get(context.Background(), userID)
 	if err != nil {
 		return model.NewAppError("PostUpdateChannelPurposeMessage", "app.channel.post_update_channel_purpose_message.retrieve_user.error", nil, "", http.StatusBadRequest).Wrap(err)
@@ -1933,14 +1933,14 @@ func (a *App) PostUpdateChannelPurposeMessage(c request.CTX, userID string, chan
 			"new_purpose": newChannelPurpose,
 		},
 	}
-	if _, err := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
+	if _, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
 		return model.NewAppError("", "app.channel.post_update_channel_purpose_message.post.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	return nil
 }
 
-func (a *App) PostUpdateChannelDisplayNameMessage(c request.CTX, userID string, channel *model.Channel, oldChannelDisplayName, newChannelDisplayName string) *model.AppError {
+func (a *App) PostUpdateChannelDisplayNameMessage(rctx request.CTX, userID string, channel *model.Channel, oldChannelDisplayName, newChannelDisplayName string) *model.AppError {
 	user, err := a.Srv().Store().User().Get(context.Background(), userID)
 	if err != nil {
 		return model.NewAppError("PostUpdateChannelDisplayNameMessage", "api.channel.post_update_channel_displayname_message_and_forget.retrieve_user.error", nil, "", http.StatusBadRequest).Wrap(err)
@@ -1960,18 +1960,18 @@ func (a *App) PostUpdateChannelDisplayNameMessage(c request.CTX, userID string, 
 		},
 	}
 
-	if _, err := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
+	if _, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
 		return model.NewAppError("PostUpdateChannelDisplayNameMessage", "api.channel.post_update_channel_displayname_message_and_forget.create_post.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	return nil
 }
 
-func (a *App) GetChannel(c request.CTX, channelID string) (*model.Channel, *model.AppError) {
-	return a.Srv().getChannel(c, channelID)
+func (a *App) GetChannel(rctx request.CTX, channelID string) (*model.Channel, *model.AppError) {
+	return a.Srv().getChannel(rctx, channelID)
 }
 
-func (s *Server) getChannel(c request.CTX, channelID string) (*model.Channel, *model.AppError) {
+func (s *Server) getChannel(rctx request.CTX, channelID string) (*model.Channel, *model.AppError) {
 	channel, err := s.Store().Channel().Get(channelID, true)
 	if err != nil {
 		errCtx := map[string]any{"channel_id": channelID}
@@ -1986,7 +1986,7 @@ func (s *Server) getChannel(c request.CTX, channelID string) (*model.Channel, *m
 	return channel, nil
 }
 
-func (a *App) GetChannels(c request.CTX, channelIDs []string) ([]*model.Channel, *model.AppError) {
+func (a *App) GetChannels(rctx request.CTX, channelIDs []string) ([]*model.Channel, *model.AppError) {
 	channels, err := a.Srv().Store().Channel().GetMany(channelIDs, true)
 	if err != nil {
 		errCtx := map[string]any{"channel_id": channelIDs}
@@ -2001,7 +2001,7 @@ func (a *App) GetChannels(c request.CTX, channelIDs []string) ([]*model.Channel,
 	return channels, nil
 }
 
-func (a *App) GetChannelsMemberCount(c request.CTX, channelIDs []string) (map[string]int64, *model.AppError) {
+func (a *App) GetChannelsMemberCount(rctx request.CTX, channelIDs []string) (map[string]int64, *model.AppError) {
 	channelsCount, err := a.Srv().Store().Channel().GetChannelsMemberCount(channelIDs)
 	if err != nil {
 		var nfErr *store.ErrNotFound
@@ -2015,7 +2015,7 @@ func (a *App) GetChannelsMemberCount(c request.CTX, channelIDs []string) (map[st
 	return channelsCount, nil
 }
 
-func (a *App) GetChannelByName(c request.CTX, channelName, teamID string, includeDeleted bool) (*model.Channel, *model.AppError) {
+func (a *App) GetChannelByName(rctx request.CTX, channelName, teamID string, includeDeleted bool) (*model.Channel, *model.AppError) {
 	var channel *model.Channel
 	var err error
 
@@ -2038,7 +2038,7 @@ func (a *App) GetChannelByName(c request.CTX, channelName, teamID string, includ
 	return channel, nil
 }
 
-func (a *App) GetChannelsByNames(c request.CTX, channelNames []string, teamID string) ([]*model.Channel, *model.AppError) {
+func (a *App) GetChannelsByNames(rctx request.CTX, channelNames []string, teamID string) ([]*model.Channel, *model.AppError) {
 	channels, err := a.Srv().Store().Channel().GetByNames(teamID, channelNames, true)
 	if err != nil {
 		return nil, model.NewAppError("GetChannelsByNames", "app.channel.get_by_name.existing.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -2046,7 +2046,7 @@ func (a *App) GetChannelsByNames(c request.CTX, channelNames []string, teamID st
 	return channels, nil
 }
 
-func (a *App) GetChannelByNameForTeamName(c request.CTX, channelName, teamName string, includeDeleted bool) (*model.Channel, *model.AppError) {
+func (a *App) GetChannelByNameForTeamName(rctx request.CTX, channelName, teamName string, includeDeleted bool) (*model.Channel, *model.AppError) {
 	var team *model.Team
 
 	team, err := a.Srv().Store().Team().GetByName(teamName)
@@ -2082,7 +2082,7 @@ func (a *App) GetChannelByNameForTeamName(c request.CTX, channelName, teamName s
 	return result, nil
 }
 
-func (s *Server) getChannelsForTeamForUser(c request.CTX, teamID string, userID string, opts *model.ChannelSearchOpts) (model.ChannelList, *model.AppError) {
+func (s *Server) getChannelsForTeamForUser(rctx request.CTX, teamID string, userID string, opts *model.ChannelSearchOpts) (model.ChannelList, *model.AppError) {
 	list, err := s.Store().Channel().GetChannels(teamID, userID, opts)
 	if err != nil {
 		var nfErr *store.ErrNotFound
@@ -2097,11 +2097,11 @@ func (s *Server) getChannelsForTeamForUser(c request.CTX, teamID string, userID 
 	return list, nil
 }
 
-func (a *App) GetChannelsForTeamForUser(c request.CTX, teamID string, userID string, opts *model.ChannelSearchOpts) (model.ChannelList, *model.AppError) {
-	return a.Srv().getChannelsForTeamForUser(c, teamID, userID, opts)
+func (a *App) GetChannelsForTeamForUser(rctx request.CTX, teamID string, userID string, opts *model.ChannelSearchOpts) (model.ChannelList, *model.AppError) {
+	return a.Srv().getChannelsForTeamForUser(rctx, teamID, userID, opts)
 }
 
-func (a *App) GetChannelsForUser(c request.CTX, userID string, includeDeleted bool, lastDeleteAt, pageSize int, fromChannelID string) (model.ChannelList, *model.AppError) {
+func (a *App) GetChannelsForUser(rctx request.CTX, userID string, includeDeleted bool, lastDeleteAt, pageSize int, fromChannelID string) (model.ChannelList, *model.AppError) {
 	list, err := a.Srv().Store().Channel().GetChannelsByUser(userID, includeDeleted, lastDeleteAt, pageSize, fromChannelID)
 	if err != nil {
 		var nfErr *store.ErrNotFound
@@ -2116,9 +2116,9 @@ func (a *App) GetChannelsForUser(c request.CTX, userID string, includeDeleted bo
 	return list, nil
 }
 
-func (a *App) GetAllChannels(c request.CTX, page, perPage int, opts model.ChannelSearchOpts) (model.ChannelListWithTeamData, *model.AppError) {
+func (a *App) GetAllChannels(rctx request.CTX, page, perPage int, opts model.ChannelSearchOpts) (model.ChannelListWithTeamData, *model.AppError) {
 	if opts.ExcludeDefaultChannels {
-		opts.ExcludeChannelNames = a.DefaultChannelNames(c)
+		opts.ExcludeChannelNames = a.DefaultChannelNames(rctx)
 	}
 	storeOpts := store.ChannelSearchOpts{
 		NotAssociatedToGroup:               opts.NotAssociatedToGroup,
@@ -2139,9 +2139,9 @@ func (a *App) GetAllChannels(c request.CTX, page, perPage int, opts model.Channe
 	return channels, nil
 }
 
-func (a *App) GetAllChannelsCount(c request.CTX, opts model.ChannelSearchOpts) (int64, *model.AppError) {
+func (a *App) GetAllChannelsCount(rctx request.CTX, opts model.ChannelSearchOpts) (int64, *model.AppError) {
 	if opts.ExcludeDefaultChannels {
-		opts.ExcludeChannelNames = a.DefaultChannelNames(c)
+		opts.ExcludeChannelNames = a.DefaultChannelNames(rctx)
 	}
 	storeOpts := store.ChannelSearchOpts{
 		NotAssociatedToGroup:     opts.NotAssociatedToGroup,
@@ -2160,7 +2160,7 @@ func (a *App) GetAllChannelsCount(c request.CTX, opts model.ChannelSearchOpts) (
 	return count, nil
 }
 
-func (a *App) GetDeletedChannels(c request.CTX, teamID string, offset int, limit int, userID string, skipTeamMembershipCheck bool) (model.ChannelList, *model.AppError) {
+func (a *App) GetDeletedChannels(rctx request.CTX, teamID string, offset int, limit int, userID string, skipTeamMembershipCheck bool) (model.ChannelList, *model.AppError) {
 	list, err := a.Srv().Store().Channel().GetDeleted(teamID, offset, limit, userID, skipTeamMembershipCheck)
 	if err != nil {
 		var nfErr *store.ErrNotFound
@@ -2175,7 +2175,7 @@ func (a *App) GetDeletedChannels(c request.CTX, teamID string, offset int, limit
 	return list, nil
 }
 
-func (a *App) GetChannelsUserNotIn(c request.CTX, teamID string, userID string, offset int, limit int) (model.ChannelList, *model.AppError) {
+func (a *App) GetChannelsUserNotIn(rctx request.CTX, teamID string, userID string, offset int, limit int) (model.ChannelList, *model.AppError) {
 	channels, err := a.Srv().Store().Channel().GetMoreChannels(teamID, userID, offset, limit)
 	if err != nil {
 		return nil, model.NewAppError("GetChannelsUserNotIn", "app.channel.get_more_channels.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -2183,7 +2183,7 @@ func (a *App) GetChannelsUserNotIn(c request.CTX, teamID string, userID string, 
 	return channels, nil
 }
 
-func (a *App) GetPublicChannelsByIdsForTeam(c request.CTX, teamID string, channelIDs []string) (model.ChannelList, *model.AppError) {
+func (a *App) GetPublicChannelsByIdsForTeam(rctx request.CTX, teamID string, channelIDs []string) (model.ChannelList, *model.AppError) {
 	list, err := a.Srv().Store().Channel().GetPublicChannelsByIdsForTeam(teamID, channelIDs)
 	if err != nil {
 		var nfErr *store.ErrNotFound
@@ -2198,7 +2198,7 @@ func (a *App) GetPublicChannelsByIdsForTeam(c request.CTX, teamID string, channe
 	return list, nil
 }
 
-func (a *App) GetPublicChannelsForTeam(c request.CTX, teamID string, offset int, limit int) (model.ChannelList, *model.AppError) {
+func (a *App) GetPublicChannelsForTeam(rctx request.CTX, teamID string, offset int, limit int) (model.ChannelList, *model.AppError) {
 	list, err := a.Srv().Store().Channel().GetPublicChannelsForTeam(teamID, offset, limit)
 	if err != nil {
 		return nil, model.NewAppError("GetPublicChannelsForTeam", "app.channel.get_public_channels.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -2207,7 +2207,7 @@ func (a *App) GetPublicChannelsForTeam(c request.CTX, teamID string, offset int,
 	return list, nil
 }
 
-func (a *App) GetPrivateChannelsForTeam(c request.CTX, teamID string, offset int, limit int) (model.ChannelList, *model.AppError) {
+func (a *App) GetPrivateChannelsForTeam(rctx request.CTX, teamID string, offset int, limit int) (model.ChannelList, *model.AppError) {
 	list, err := a.Srv().Store().Channel().GetPrivateChannelsForTeam(teamID, offset, limit)
 	if err != nil {
 		return nil, model.NewAppError("GetPrivateChannelsForTeam", "app.channel.get_private_channels.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -2216,12 +2216,12 @@ func (a *App) GetPrivateChannelsForTeam(c request.CTX, teamID string, offset int
 	return list, nil
 }
 
-func (a *App) GetChannelMember(c request.CTX, channelID string, userID string) (*model.ChannelMember, *model.AppError) {
-	return a.Srv().getChannelMember(c, channelID, userID)
+func (a *App) GetChannelMember(rctx request.CTX, channelID string, userID string) (*model.ChannelMember, *model.AppError) {
+	return a.Srv().getChannelMember(rctx, channelID, userID)
 }
 
-func (s *Server) getChannelMember(c request.CTX, channelID string, userID string) (*model.ChannelMember, *model.AppError) {
-	channelMember, err := s.Store().Channel().GetMember(c.Context(), channelID, userID)
+func (s *Server) getChannelMember(rctx request.CTX, channelID string, userID string) (*model.ChannelMember, *model.AppError) {
+	channelMember, err := s.Store().Channel().GetMember(rctx.Context(), channelID, userID)
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -2235,8 +2235,8 @@ func (s *Server) getChannelMember(c request.CTX, channelID string, userID string
 	return channelMember, nil
 }
 
-func (s *Server) getChannelMemberLastViewedAt(c request.CTX, channelID string, userID string) (int64, *model.AppError) {
-	lastViewedAt, err := s.Store().Channel().GetMemberLastViewedAt(c.Context(), channelID, userID)
+func (s *Server) getChannelMemberLastViewedAt(rctx request.CTX, channelID string, userID string) (int64, *model.AppError) {
+	lastViewedAt, err := s.Store().Channel().GetMemberLastViewedAt(rctx.Context(), channelID, userID)
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -2250,7 +2250,7 @@ func (s *Server) getChannelMemberLastViewedAt(c request.CTX, channelID string, u
 	return lastViewedAt, nil
 }
 
-func (a *App) GetChannelMembersPage(c request.CTX, channelID string, page, perPage int) (model.ChannelMembers, *model.AppError) {
+func (a *App) GetChannelMembersPage(rctx request.CTX, channelID string, page, perPage int) (model.ChannelMembers, *model.AppError) {
 	opts := model.ChannelMembersGetOptions{
 		ChannelID: channelID,
 		Offset:    page * perPage,
@@ -2264,7 +2264,7 @@ func (a *App) GetChannelMembersPage(c request.CTX, channelID string, page, perPa
 	return channelMembers, nil
 }
 
-func (a *App) GetChannelMembersTimezones(c request.CTX, channelID string) ([]string, *model.AppError) {
+func (a *App) GetChannelMembersTimezones(rctx request.CTX, channelID string) ([]string, *model.AppError) {
 	membersTimezones, err := a.Srv().Store().Channel().GetChannelMembersTimezones(channelID)
 	if err != nil {
 		return nil, model.NewAppError("GetChannelMembersTimezones", "app.channel.get_members.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -2281,7 +2281,7 @@ func (a *App) GetChannelMembersTimezones(c request.CTX, channelID string) ([]str
 	return model.RemoveDuplicateStrings(timezones), nil
 }
 
-func (a *App) GetChannelMembersByIds(c request.CTX, channelID string, userIDs []string) (model.ChannelMembers, *model.AppError) {
+func (a *App) GetChannelMembersByIds(rctx request.CTX, channelID string, userIDs []string) (model.ChannelMembers, *model.AppError) {
 	members, err := a.Srv().Store().Channel().GetMembersByIds(channelID, userIDs)
 	if err != nil {
 		return nil, model.NewAppError("GetChannelMembersByIds", "app.channel.get_members_by_ids.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -2290,7 +2290,7 @@ func (a *App) GetChannelMembersByIds(c request.CTX, channelID string, userIDs []
 	return members, nil
 }
 
-func (a *App) GetChannelMembersForUser(c request.CTX, teamID string, userID string) (model.ChannelMembers, *model.AppError) {
+func (a *App) GetChannelMembersForUser(rctx request.CTX, teamID string, userID string) (model.ChannelMembers, *model.AppError) {
 	channelMembers, err := a.Srv().Store().Channel().GetMembersForUser(teamID, userID)
 	if err != nil {
 		return nil, model.NewAppError("GetChannelMembersForUser", "app.channel.get_members.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -2299,7 +2299,7 @@ func (a *App) GetChannelMembersForUser(c request.CTX, teamID string, userID stri
 	return channelMembers, nil
 }
 
-func (a *App) GetChannelMembersForUserWithPagination(c request.CTX, userID string, page, perPage int) ([]*model.ChannelMember, *model.AppError) {
+func (a *App) GetChannelMembersForUserWithPagination(rctx request.CTX, userID string, page, perPage int) ([]*model.ChannelMember, *model.AppError) {
 	m, err := a.Srv().Store().Channel().GetMembersForUserWithPagination(userID, page, perPage)
 	if err != nil {
 		return nil, model.NewAppError("GetChannelMembersForUserWithPagination", "app.channel.get_members.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -2313,7 +2313,7 @@ func (a *App) GetChannelMembersForUserWithPagination(c request.CTX, userID strin
 	return members, nil
 }
 
-func (a *App) GetChannelMembersWithTeamDataForUserWithPagination(c request.CTX, userID string, cursor *model.ChannelMemberCursor) (model.ChannelMembersWithTeamData, *model.AppError) {
+func (a *App) GetChannelMembersWithTeamDataForUserWithPagination(rctx request.CTX, userID string, cursor *model.ChannelMemberCursor) (model.ChannelMembersWithTeamData, *model.AppError) {
 	var m model.ChannelMembersWithTeamData
 	var err error
 	var method string
@@ -2337,7 +2337,7 @@ func (a *App) GetChannelMembersWithTeamDataForUserWithPagination(c request.CTX, 
 	return m, nil
 }
 
-func (a *App) GetChannelMemberCount(c request.CTX, channelID string) (int64, *model.AppError) {
+func (a *App) GetChannelMemberCount(rctx request.CTX, channelID string) (int64, *model.AppError) {
 	count, err := a.Srv().Store().Channel().GetMemberCount(channelID, true)
 	if err != nil {
 		return 0, model.NewAppError("GetChannelMemberCount", "app.channel.get_member_count.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -2346,7 +2346,7 @@ func (a *App) GetChannelMemberCount(c request.CTX, channelID string) (int64, *mo
 	return count, nil
 }
 
-func (a *App) GetChannelFileCount(c request.CTX, channelID string) (int64, *model.AppError) {
+func (a *App) GetChannelFileCount(rctx request.CTX, channelID string) (int64, *model.AppError) {
 	count, err := a.Srv().Store().Channel().GetFileCount(channelID)
 	if err != nil {
 		return 0, model.NewAppError("SqlChannelStore.GetFileCount", "app.channel.get_file_count.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -2355,7 +2355,7 @@ func (a *App) GetChannelFileCount(c request.CTX, channelID string) (int64, *mode
 	return count, nil
 }
 
-func (a *App) GetChannelGuestCount(c request.CTX, channelID string) (int64, *model.AppError) {
+func (a *App) GetChannelGuestCount(rctx request.CTX, channelID string) (int64, *model.AppError) {
 	count, err := a.Srv().Store().Channel().GetGuestCount(channelID, true)
 	if err != nil {
 		return 0, model.NewAppError("SqlChannelStore.GetGuestCount", "app.channel.get_member_count.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -2364,7 +2364,7 @@ func (a *App) GetChannelGuestCount(c request.CTX, channelID string) (int64, *mod
 	return count, nil
 }
 
-func (a *App) GetChannelPinnedPostCount(c request.CTX, channelID string) (int64, *model.AppError) {
+func (a *App) GetChannelPinnedPostCount(rctx request.CTX, channelID string) (int64, *model.AppError) {
 	count, err := a.Srv().Store().Channel().GetPinnedPostCount(channelID, true)
 	if err != nil {
 		return 0, model.NewAppError("GetChannelPinnedPostCount", "app.channel.get_pinnedpost_count.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -2373,7 +2373,7 @@ func (a *App) GetChannelPinnedPostCount(c request.CTX, channelID string) (int64,
 	return count, nil
 }
 
-func (a *App) GetChannelCounts(c request.CTX, teamID string, userID string) (*model.ChannelCounts, *model.AppError) {
+func (a *App) GetChannelCounts(rctx request.CTX, teamID string, userID string) (*model.ChannelCounts, *model.AppError) {
 	counts, err := a.Srv().Store().Channel().GetChannelCounts(teamID, userID)
 	if err != nil {
 		return nil, model.NewAppError("SqlChannelStore.GetChannelCounts", "app.channel.get_channel_counts.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -2382,7 +2382,7 @@ func (a *App) GetChannelCounts(c request.CTX, teamID string, userID string) (*mo
 	return counts, nil
 }
 
-func (a *App) GetChannelUnread(c request.CTX, channelID, userID string) (*model.ChannelUnread, *model.AppError) {
+func (a *App) GetChannelUnread(rctx request.CTX, channelID, userID string) (*model.ChannelUnread, *model.AppError) {
 	channelUnread, err := a.Srv().Store().Channel().GetChannelUnread(channelID, userID)
 	if err != nil {
 		var nfErr *store.ErrNotFound
@@ -2401,7 +2401,7 @@ func (a *App) GetChannelUnread(c request.CTX, channelID, userID string) (*model.
 	return channelUnread, nil
 }
 
-func (a *App) JoinChannel(c request.CTX, channel *model.Channel, userID string) *model.AppError {
+func (a *App) JoinChannel(rctx request.CTX, channel *model.Channel, userID string) *model.AppError {
 	userChan := make(chan store.StoreResult[*model.User], 1)
 	memberChan := make(chan store.StoreResult[*model.ChannelMember], 1)
 	go func() {
@@ -2438,27 +2438,27 @@ func (a *App) JoinChannel(c request.CTX, channel *model.Channel, userID string) 
 		return model.NewAppError("JoinChannel", "api.channel.join_channel.permissions.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	cm, err := a.AddUserToChannel(c, user, channel, false)
+	cm, err := a.AddUserToChannel(rctx, user, channel, false)
 	if err != nil {
 		return err
 	}
 
 	a.Srv().Go(func() {
-		pluginContext := pluginContext(c)
+		pluginContext := pluginContext(rctx)
 		a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 			hooks.UserHasJoinedChannel(pluginContext, cm, nil)
 			return true
 		}, plugin.UserHasJoinedChannelID)
 	})
 
-	if err := a.postJoinChannelMessage(c, user, channel); err != nil {
+	if err := a.postJoinChannelMessage(rctx, user, channel); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (a *App) postJoinChannelMessage(c request.CTX, user *model.User, channel *model.Channel) *model.AppError {
+func (a *App) postJoinChannelMessage(rctx request.CTX, user *model.User, channel *model.Channel) *model.AppError {
 	message := fmt.Sprintf(i18n.T("api.channel.join_channel.post_and_forget"), user.Username)
 	postType := model.PostTypeJoinChannel
 
@@ -2477,14 +2477,14 @@ func (a *App) postJoinChannelMessage(c request.CTX, user *model.User, channel *m
 		},
 	}
 
-	if _, err := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
+	if _, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
 		return model.NewAppError("postJoinChannelMessage", "api.channel.post_user_add_remove_message_and_forget.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	return nil
 }
 
-func (a *App) postJoinTeamMessage(c request.CTX, user *model.User, channel *model.Channel) *model.AppError {
+func (a *App) postJoinTeamMessage(rctx request.CTX, user *model.User, channel *model.Channel) *model.AppError {
 	post := &model.Post{
 		ChannelId: channel.Id,
 		Message:   fmt.Sprintf(i18n.T("api.team.join_team.post_and_forget"), user.Username),
@@ -2495,14 +2495,14 @@ func (a *App) postJoinTeamMessage(c request.CTX, user *model.User, channel *mode
 		},
 	}
 
-	if _, err := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
+	if _, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
 		return model.NewAppError("postJoinTeamMessage", "api.channel.post_user_add_remove_message_and_forget.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	return nil
 }
 
-func (a *App) LeaveChannel(c request.CTX, channelID string, userID string) *model.AppError {
+func (a *App) LeaveChannel(rctx request.CTX, channelID string, userID string) *model.AppError {
 	sc := make(chan store.StoreResult[*model.Channel], 1)
 	go func() {
 		channel, err := a.Srv().Store().Channel().Get(channelID, true)
@@ -2547,7 +2547,7 @@ func (a *App) LeaveChannel(c request.CTX, channelID string, userID string) *mode
 		return err
 	}
 
-	if err := a.removeUserFromChannel(c, userID, userID, channel); err != nil {
+	if err := a.removeUserFromChannel(rctx, userID, userID, channel); err != nil {
 		return err
 	}
 
@@ -2556,15 +2556,15 @@ func (a *App) LeaveChannel(c request.CTX, channelID string, userID string) *mode
 	}
 
 	a.Srv().Go(func() {
-		if err := a.postLeaveChannelMessage(c, user, channel); err != nil {
-			c.Logger().Error("Failed to post LeaveChannel message", mlog.Err(err))
+		if err := a.postLeaveChannelMessage(rctx, user, channel); err != nil {
+			rctx.Logger().Error("Failed to post LeaveChannel message", mlog.Err(err))
 		}
 	})
 
 	return nil
 }
 
-func (a *App) postLeaveChannelMessage(c request.CTX, user *model.User, channel *model.Channel) *model.AppError {
+func (a *App) postLeaveChannelMessage(rctx request.CTX, user *model.User, channel *model.Channel) *model.AppError {
 	post := &model.Post{
 		ChannelId: channel.Id,
 		// Message here embeds `@username`, not just `username`, to ensure that mentions
@@ -2578,14 +2578,14 @@ func (a *App) postLeaveChannelMessage(c request.CTX, user *model.User, channel *
 		},
 	}
 
-	if _, err := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
+	if _, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
 		return model.NewAppError("postLeaveChannelMessage", "api.channel.post_user_add_remove_message_and_forget.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	return nil
 }
 
-func (a *App) PostAddToChannelMessage(c request.CTX, user *model.User, addedUser *model.User, channel *model.Channel, postRootId string) *model.AppError {
+func (a *App) PostAddToChannelMessage(rctx request.CTX, user *model.User, addedUser *model.User, channel *model.Channel, postRootId string) *model.AppError {
 	message := fmt.Sprintf(i18n.T("api.channel.add_member.added"), addedUser.Username, user.Username)
 	postType := model.PostTypeAddToChannel
 
@@ -2607,14 +2607,14 @@ func (a *App) PostAddToChannelMessage(c request.CTX, user *model.User, addedUser
 		},
 	}
 
-	if _, err := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
+	if _, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
 		return model.NewAppError("postAddToChannelMessage", "api.channel.post_user_add_remove_message_and_forget.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	return nil
 }
 
-func (a *App) postAddToTeamMessage(c request.CTX, user *model.User, addedUser *model.User, channel *model.Channel, postRootId string) *model.AppError {
+func (a *App) postAddToTeamMessage(rctx request.CTX, user *model.User, addedUser *model.User, channel *model.Channel, postRootId string) *model.AppError {
 	post := &model.Post{
 		ChannelId: channel.Id,
 		Message:   fmt.Sprintf(i18n.T("api.team.add_user_to_team.added"), addedUser.Username, user.Username),
@@ -2629,17 +2629,17 @@ func (a *App) postAddToTeamMessage(c request.CTX, user *model.User, addedUser *m
 		},
 	}
 
-	if _, err := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
+	if _, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
 		return model.NewAppError("postAddToTeamMessage", "api.channel.post_user_add_remove_message_and_forget.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	return nil
 }
 
-func (a *App) postRemoveFromChannelMessage(c request.CTX, removerUserId string, removedUser *model.User, channel *model.Channel) *model.AppError {
+func (a *App) postRemoveFromChannelMessage(rctx request.CTX, removerUserId string, removedUser *model.User, channel *model.Channel) *model.AppError {
 	messageUserId := removerUserId
 	if messageUserId == "" {
-		systemBot, err := a.GetSystemBot(c)
+		systemBot, err := a.GetSystemBot(rctx)
 		if err != nil {
 			return model.NewAppError("postRemoveFromChannelMessage", "api.channel.post_user_add_remove_message_and_forget.error", nil, "", http.StatusInternalServerError).Wrap(err)
 		}
@@ -2661,14 +2661,14 @@ func (a *App) postRemoveFromChannelMessage(c request.CTX, removerUserId string, 
 		},
 	}
 
-	if _, err := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
+	if _, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
 		return model.NewAppError("postRemoveFromChannelMessage", "api.channel.post_user_add_remove_message_and_forget.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	return nil
 }
 
-func (a *App) removeUserFromChannel(c request.CTX, userIDToRemove string, removerUserId string, channel *model.Channel) *model.AppError {
+func (a *App) removeUserFromChannel(rctx request.CTX, userIDToRemove string, removerUserId string, channel *model.Channel) *model.AppError {
 	user, nErr := a.Srv().Store().User().Get(context.Background(), userIDToRemove)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
@@ -2697,12 +2697,12 @@ func (a *App) removeUserFromChannel(c request.CTX, userIDToRemove string, remove
 		}
 	}
 
-	cm, err := a.GetChannelMember(c, channel.Id, userIDToRemove)
+	cm, err := a.GetChannelMember(rctx, channel.Id, userIDToRemove)
 	if err != nil {
 		return err
 	}
 
-	if err := a.Srv().Store().Channel().RemoveMember(c, channel.Id, userIDToRemove); err != nil {
+	if err := a.Srv().Store().Channel().RemoveMember(rctx, channel.Id, userIDToRemove); err != nil {
 		return model.NewAppError("removeUserFromChannel", "app.channel.remove_member.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	if err := a.Srv().Store().ChannelMemberHistory().LogLeaveEvent(userIDToRemove, channel.Id, model.GetMillis()); err != nil {
@@ -2713,21 +2713,21 @@ func (a *App) removeUserFromChannel(c request.CTX, userIDToRemove string, remove
 	}
 
 	if isGuest {
-		currentMembers, err := a.GetChannelMembersForUser(c, channel.TeamId, userIDToRemove)
+		currentMembers, err := a.GetChannelMembersForUser(rctx, channel.TeamId, userIDToRemove)
 		if err != nil {
 			return err
 		}
 		if len(currentMembers) == 0 {
-			teamMember, err := a.GetTeamMember(c, channel.TeamId, userIDToRemove)
+			teamMember, err := a.GetTeamMember(rctx, channel.TeamId, userIDToRemove)
 			if err != nil {
 				return model.NewAppError("removeUserFromChannel", "api.team.remove_user_from_team.missing.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 			}
 
-			if err := a.ch.srv.teamService.RemoveTeamMember(c, teamMember); err != nil {
+			if err := a.ch.srv.teamService.RemoveTeamMember(rctx, teamMember); err != nil {
 				return model.NewAppError("removeUserFromChannel", "api.team.remove_user_from_team.missing.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 			}
 
-			if err = a.postProcessTeamMemberLeave(c, teamMember, removerUserId); err != nil {
+			if err = a.postProcessTeamMemberLeave(rctx, teamMember, removerUserId); err != nil {
 				return err
 			}
 		}
@@ -2742,7 +2742,7 @@ func (a *App) removeUserFromChannel(c request.CTX, userIDToRemove string, remove
 	}
 
 	a.Srv().Go(func() {
-		pluginContext := pluginContext(c)
+		pluginContext := pluginContext(rctx)
 		a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 			hooks.UserHasLeftChannel(pluginContext, cm, actorUser)
 			return true
@@ -2771,10 +2771,10 @@ func (a *App) removeUserFromChannel(c request.CTX, userIDToRemove string, remove
 	return nil
 }
 
-func (a *App) RemoveUserFromChannel(c request.CTX, userIDToRemove string, removerUserId string, channel *model.Channel) *model.AppError {
+func (a *App) RemoveUserFromChannel(rctx request.CTX, userIDToRemove string, removerUserId string, channel *model.Channel) *model.AppError {
 	var err *model.AppError
 
-	if err = a.removeUserFromChannel(c, userIDToRemove, removerUserId, channel); err != nil {
+	if err = a.removeUserFromChannel(rctx, userIDToRemove, removerUserId, channel); err != nil {
 		return err
 	}
 
@@ -2784,19 +2784,19 @@ func (a *App) RemoveUserFromChannel(c request.CTX, userIDToRemove string, remove
 	}
 
 	if userIDToRemove == removerUserId {
-		if err := a.postLeaveChannelMessage(c, user, channel); err != nil {
+		if err := a.postLeaveChannelMessage(rctx, user, channel); err != nil {
 			return err
 		}
 	} else {
-		if err := a.postRemoveFromChannelMessage(c, removerUserId, user, channel); err != nil {
-			c.Logger().Error("Failed to post user removal message", mlog.Err(err))
+		if err := a.postRemoveFromChannelMessage(rctx, removerUserId, user, channel); err != nil {
+			rctx.Logger().Error("Failed to post user removal message", mlog.Err(err))
 		}
 	}
 
 	return nil
 }
 
-func (a *App) GetNumberOfChannelsOnTeam(c request.CTX, teamID string) (int, *model.AppError) {
+func (a *App) GetNumberOfChannelsOnTeam(rctx request.CTX, teamID string) (int, *model.AppError) {
 	// Get total number of channels on current team
 	list, err := a.Srv().Store().Channel().GetTeamChannels(teamID)
 	if err != nil {
@@ -2811,7 +2811,7 @@ func (a *App) GetNumberOfChannelsOnTeam(c request.CTX, teamID string) (int, *mod
 	return len(list), nil
 }
 
-func (a *App) SetActiveChannel(c request.CTX, userID string, channelID string) *model.AppError {
+func (a *App) SetActiveChannel(rctx request.CTX, userID string, channelID string) *model.AppError {
 	status, err := a.Srv().Platform().GetStatus(userID)
 
 	oldStatus := model.StatusOffline
@@ -2867,7 +2867,7 @@ func (a *App) SetActiveChannel(c request.CTX, userID string, channelID string) *
 	return nil
 }
 
-func (a *App) IsCRTEnabledForUser(c request.CTX, userID string) bool {
+func (a *App) IsCRTEnabledForUser(rctx request.CTX, userID string) bool {
 	appCRT := *a.Config().ServiceSettings.CollapsedThreads
 	if appCRT == model.CollapsedThreadsDisabled {
 		return false
@@ -2884,33 +2884,33 @@ func (a *App) IsCRTEnabledForUser(c request.CTX, userID string) bool {
 }
 
 // ValidateUserPermissionsOnChannels filters channelIds based on whether userId is authorized to manage channel members. Unauthorized channels are removed from the returned list.
-func (a *App) ValidateUserPermissionsOnChannels(c request.CTX, userId string, channelIds []string) []string {
+func (a *App) ValidateUserPermissionsOnChannels(rctx request.CTX, userId string, channelIds []string) []string {
 	var allowedChannelIds []string
 
 	for _, channelId := range channelIds {
-		channel, err := a.GetChannel(c, channelId)
+		channel, err := a.GetChannel(rctx, channelId)
 		if err != nil {
-			c.Logger().Info("Invite users to team - couldn't get channel " + channelId)
+			rctx.Logger().Info("Invite users to team - couldn't get channel " + channelId)
 			continue
 		}
 
-		if channel.Type == model.ChannelTypePrivate && a.HasPermissionToChannel(c, userId, channelId, model.PermissionManagePrivateChannelMembers) {
+		if channel.Type == model.ChannelTypePrivate && a.HasPermissionToChannel(rctx, userId, channelId, model.PermissionManagePrivateChannelMembers) {
 			allowedChannelIds = append(allowedChannelIds, channelId)
-		} else if channel.Type == model.ChannelTypeOpen && a.HasPermissionToChannel(c, userId, channelId, model.PermissionManagePublicChannelMembers) {
+		} else if channel.Type == model.ChannelTypeOpen && a.HasPermissionToChannel(rctx, userId, channelId, model.PermissionManagePublicChannelMembers) {
 			allowedChannelIds = append(allowedChannelIds, channelId)
 		} else {
-			c.Logger().Info("Invite users to team - no permission to add members to that channel. UserId: " + userId + " ChannelId: " + channelId)
+			rctx.Logger().Info("Invite users to team - no permission to add members to that channel. UserId: " + userId + " ChannelId: " + channelId)
 		}
 	}
 	return allowedChannelIds
 }
 
 // MarkChanelAsUnreadFromPost will take a post and set the channel as unread from that one.
-func (a *App) MarkChannelAsUnreadFromPost(c request.CTX, postID string, userID string, collapsedThreadsSupported bool) (*model.ChannelUnreadAt, *model.AppError) {
-	if !collapsedThreadsSupported || !a.IsCRTEnabledForUser(c, userID) {
-		return a.markChannelAsUnreadFromPostCRTUnsupported(c, postID, userID)
+func (a *App) MarkChannelAsUnreadFromPost(rctx request.CTX, postID string, userID string, collapsedThreadsSupported bool) (*model.ChannelUnreadAt, *model.AppError) {
+	if !collapsedThreadsSupported || !a.IsCRTEnabledForUser(rctx, userID) {
+		return a.markChannelAsUnreadFromPostCRTUnsupported(rctx, postID, userID)
 	}
-	post, err := a.GetSinglePost(c, postID, false)
+	post, err := a.GetSinglePost(rctx, postID, false)
 	if err != nil {
 		return nil, err
 	}
@@ -2920,7 +2920,7 @@ func (a *App) MarkChannelAsUnreadFromPost(c request.CTX, postID string, userID s
 		return nil, err
 	}
 
-	unreadMentions, unreadMentionsRoot, urgentMentions, err := a.countMentionsFromPost(c, user, post)
+	unreadMentions, unreadMentionsRoot, urgentMentions, err := a.countMentionsFromPost(rctx, user, post)
 	if err != nil {
 		return nil, err
 	}
@@ -2930,14 +2930,14 @@ func (a *App) MarkChannelAsUnreadFromPost(c request.CTX, postID string, userID s
 		return channelUnread, model.NewAppError("MarkChannelAsUnreadFromPost", "app.channel.update_last_viewed_at_post.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)
 	}
 
-	a.sendWebSocketPostUnreadEvent(c, channelUnread, postID)
+	a.sendWebSocketPostUnreadEvent(rctx, channelUnread, postID)
 	a.UpdateMobileAppBadge(userID)
 
 	return channelUnread, nil
 }
 
-func (a *App) markChannelAsUnreadFromPostCRTUnsupported(c request.CTX, postID string, userID string) (*model.ChannelUnreadAt, *model.AppError) {
-	post, appErr := a.GetSinglePost(c, postID, false)
+func (a *App) markChannelAsUnreadFromPostCRTUnsupported(rctx request.CTX, postID string, userID string) (*model.ChannelUnreadAt, *model.AppError) {
+	post, appErr := a.GetSinglePost(rctx, postID, false)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -2952,7 +2952,7 @@ func (a *App) markChannelAsUnreadFromPostCRTUnsupported(c request.CTX, postID st
 		threadId = post.Id
 	}
 
-	unreadMentions, unreadMentionsRoot, urgentMentions, appErr := a.countMentionsFromPost(c, user, post)
+	unreadMentions, unreadMentionsRoot, urgentMentions, appErr := a.countMentionsFromPost(rctx, user, post)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -2966,7 +2966,7 @@ func (a *App) markChannelAsUnreadFromPostCRTUnsupported(c request.CTX, postID st
 			return channelUnread, model.NewAppError("MarkChannelAsUnreadFromPost", "app.channel.update_last_viewed_at_post.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)
 		}
 
-		a.sendWebSocketPostUnreadEvent(c, channelUnread, postID)
+		a.sendWebSocketPostUnreadEvent(rctx, channelUnread, postID)
 		a.UpdateMobileAppBadge(userID)
 		return channelUnread, nil
 	}
@@ -2976,7 +2976,7 @@ func (a *App) markChannelAsUnreadFromPostCRTUnsupported(c request.CTX, postID st
 	//                          If there are replies with mentions below the marked reply in the thread, then sum the mentions for the threads mention badge.
 	// In CRT Unsupported Client: Channel is marked as unread and new messages line inserted above the marked post.
 	//                            Badge on channel sums mentions in all posts (root & replies) including and below the post that was marked unread.
-	rootPost, appErr := a.GetSinglePost(c, post.RootId, false)
+	rootPost, appErr := a.GetSinglePost(rctx, post.RootId, false)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -3009,7 +3009,7 @@ func (a *App) markChannelAsUnreadFromPostCRTUnsupported(c request.CTX, postID st
 		// If threadmembership already exists but user had previously unfollowed the thread, then follow the thread again.
 		threadMembership.Following = true
 		threadMembership.LastViewed = post.CreateAt - 1
-		threadMembership.UnreadMentions, appErr = a.countThreadMentions(c, user, rootPost, channel.TeamId, post.CreateAt-1)
+		threadMembership.UnreadMentions, appErr = a.countThreadMentions(rctx, user, rootPost, channel.TeamId, post.CreateAt-1)
 		if appErr != nil {
 			return nil, appErr
 		}
@@ -3024,7 +3024,7 @@ func (a *App) markChannelAsUnreadFromPostCRTUnsupported(c request.CTX, postID st
 		a.sanitizeProfiles(thread.Participants, false)
 		thread.Post.SanitizeProps()
 
-		if a.IsCRTEnabledForUser(c, userID) {
+		if a.IsCRTEnabledForUser(rctx, userID) {
 			payload, jsonErr := json.Marshal(thread)
 			if jsonErr != nil {
 				return nil, model.NewAppError("MarkChannelAsUnreadFromPost", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(jsonErr)
@@ -3039,12 +3039,12 @@ func (a *App) markChannelAsUnreadFromPostCRTUnsupported(c request.CTX, postID st
 	if nErr != nil {
 		return channelUnread, model.NewAppError("MarkChannelAsUnreadFromPost", "app.channel.update_last_viewed_at_post.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)
 	}
-	a.sendWebSocketPostUnreadEvent(c, channelUnread, postID)
+	a.sendWebSocketPostUnreadEvent(rctx, channelUnread, postID)
 	a.UpdateMobileAppBadge(userID)
 	return channelUnread, nil
 }
 
-func (a *App) sendWebSocketPostUnreadEvent(c request.CTX, channelUnread *model.ChannelUnreadAt, postID string) {
+func (a *App) sendWebSocketPostUnreadEvent(rctx request.CTX, channelUnread *model.ChannelUnreadAt, postID string) {
 	message := model.NewWebSocketEvent(model.WebsocketEventPostUnread, channelUnread.TeamId, channelUnread.ChannelId, channelUnread.UserId, nil, "")
 	message.Add("msg_count", channelUnread.MsgCount)
 	message.Add("msg_count_root", channelUnread.MsgCountRoot)
@@ -3056,7 +3056,7 @@ func (a *App) sendWebSocketPostUnreadEvent(c request.CTX, channelUnread *model.C
 	a.Publish(message)
 }
 
-func (a *App) AutocompleteChannels(c request.CTX, userID, term string) (model.ChannelListWithTeamData, *model.AppError) {
+func (a *App) AutocompleteChannels(rctx request.CTX, userID, term string) (model.ChannelListWithTeamData, *model.AppError) {
 	includeDeleted := *a.Config().TeamSettings.ExperimentalViewArchivedChannels
 	term = strings.TrimSpace(term)
 
@@ -3065,7 +3065,7 @@ func (a *App) AutocompleteChannels(c request.CTX, userID, term string) (model.Ch
 		return nil, appErr
 	}
 
-	channelList, err := a.Srv().Store().Channel().Autocomplete(c, userID, term, includeDeleted, user.IsGuest())
+	channelList, err := a.Srv().Store().Channel().Autocomplete(rctx, userID, term, includeDeleted, user.IsGuest())
 	if err != nil {
 		return nil, model.NewAppError("AutocompleteChannels", "app.channel.search.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -3073,7 +3073,7 @@ func (a *App) AutocompleteChannels(c request.CTX, userID, term string) (model.Ch
 	return channelList, nil
 }
 
-func (a *App) AutocompleteChannelsForTeam(c request.CTX, teamID, userID, term string) (model.ChannelList, *model.AppError) {
+func (a *App) AutocompleteChannelsForTeam(rctx request.CTX, teamID, userID, term string) (model.ChannelList, *model.AppError) {
 	includeDeleted := *a.Config().TeamSettings.ExperimentalViewArchivedChannels
 	term = strings.TrimSpace(term)
 
@@ -3082,7 +3082,7 @@ func (a *App) AutocompleteChannelsForTeam(c request.CTX, teamID, userID, term st
 		return nil, appErr
 	}
 
-	channelList, err := a.Srv().Store().Channel().AutocompleteInTeam(c, teamID, userID, term, includeDeleted, user.IsGuest())
+	channelList, err := a.Srv().Store().Channel().AutocompleteInTeam(rctx, teamID, userID, term, includeDeleted, user.IsGuest())
 	if err != nil {
 		return nil, model.NewAppError("AutocompleteChannels", "app.channel.search.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -3090,7 +3090,7 @@ func (a *App) AutocompleteChannelsForTeam(c request.CTX, teamID, userID, term st
 	return channelList, nil
 }
 
-func (a *App) AutocompleteChannelsForSearch(c request.CTX, teamID string, userID string, term string) (model.ChannelList, *model.AppError) {
+func (a *App) AutocompleteChannelsForSearch(rctx request.CTX, teamID string, userID string, term string) (model.ChannelList, *model.AppError) {
 	includeDeleted := *a.Config().TeamSettings.ExperimentalViewArchivedChannels
 
 	term = strings.TrimSpace(term)
@@ -3104,9 +3104,9 @@ func (a *App) AutocompleteChannelsForSearch(c request.CTX, teamID string, userID
 }
 
 // SearchAllChannels returns a list of channels, the total count of the results of the search (if the paginate search option is true), and an error.
-func (a *App) SearchAllChannels(c request.CTX, term string, opts model.ChannelSearchOpts) (model.ChannelListWithTeamData, int64, *model.AppError) {
+func (a *App) SearchAllChannels(rctx request.CTX, term string, opts model.ChannelSearchOpts) (model.ChannelListWithTeamData, int64, *model.AppError) {
 	if opts.ExcludeDefaultChannels {
-		opts.ExcludeChannelNames = a.DefaultChannelNames(c)
+		opts.ExcludeChannelNames = a.DefaultChannelNames(rctx)
 	}
 	storeOpts := store.ChannelSearchOpts{
 		ExcludeChannelNames:                opts.ExcludeChannelNames,
@@ -3140,7 +3140,7 @@ func (a *App) SearchAllChannels(c request.CTX, term string, opts model.ChannelSe
 	return channelList, totalCount, nil
 }
 
-func (a *App) SearchChannels(c request.CTX, teamID string, term string) (model.ChannelList, *model.AppError) {
+func (a *App) SearchChannels(rctx request.CTX, teamID string, term string) (model.ChannelList, *model.AppError) {
 	includeDeleted := *a.Config().TeamSettings.ExperimentalViewArchivedChannels
 
 	term = strings.TrimSpace(term)
@@ -3153,7 +3153,7 @@ func (a *App) SearchChannels(c request.CTX, teamID string, term string) (model.C
 	return channelList, nil
 }
 
-func (a *App) SearchArchivedChannels(c request.CTX, teamID string, term string, userID string) (model.ChannelList, *model.AppError) {
+func (a *App) SearchArchivedChannels(rctx request.CTX, teamID string, term string, userID string) (model.ChannelList, *model.AppError) {
 	term = strings.TrimSpace(term)
 
 	channelList, err := a.Srv().Store().Channel().SearchArchivedInTeam(teamID, term, userID)
@@ -3164,7 +3164,7 @@ func (a *App) SearchArchivedChannels(c request.CTX, teamID string, term string, 
 	return channelList, nil
 }
 
-func (a *App) SearchChannelsForUser(c request.CTX, userID, teamID, term string) (model.ChannelList, *model.AppError) {
+func (a *App) SearchChannelsForUser(rctx request.CTX, userID, teamID, term string) (model.ChannelList, *model.AppError) {
 	includeDeleted := *a.Config().TeamSettings.ExperimentalViewArchivedChannels
 
 	term = strings.TrimSpace(term)
@@ -3177,7 +3177,7 @@ func (a *App) SearchChannelsForUser(c request.CTX, userID, teamID, term string) 
 	return channelList, nil
 }
 
-func (a *App) SearchGroupChannels(c request.CTX, userID, term string) (model.ChannelList, *model.AppError) {
+func (a *App) SearchGroupChannels(rctx request.CTX, userID, term string) (model.ChannelList, *model.AppError) {
 	if term == "" {
 		return model.ChannelList{}, nil
 	}
@@ -3189,7 +3189,7 @@ func (a *App) SearchGroupChannels(c request.CTX, userID, term string) (model.Cha
 	return channelList, nil
 }
 
-func (a *App) SearchChannelsUserNotIn(c request.CTX, teamID string, userID string, term string) (model.ChannelList, *model.AppError) {
+func (a *App) SearchChannelsUserNotIn(rctx request.CTX, teamID string, userID string, term string) (model.ChannelList, *model.AppError) {
 	term = strings.TrimSpace(term)
 	channelList, err := a.Srv().Store().Channel().SearchMore(userID, teamID, term)
 	if err != nil {
@@ -3199,16 +3199,16 @@ func (a *App) SearchChannelsUserNotIn(c request.CTX, teamID string, userID strin
 	return channelList, nil
 }
 
-func (a *App) MarkChannelsAsViewed(c request.CTX, channelIDs []string, userID string, currentSessionId string, collapsedThreadsSupported, isCRTEnabled bool) (map[string]int64, *model.AppError) {
+func (a *App) MarkChannelsAsViewed(rctx request.CTX, channelIDs []string, userID string, currentSessionId string, collapsedThreadsSupported, isCRTEnabled bool) (map[string]int64, *model.AppError) {
 	var err error
 
-	user, err := a.Srv().Store().User().Get(c.Context(), userID)
+	user, err := a.Srv().Store().User().Get(rctx.Context(), userID)
 	if err != nil {
 		return nil, model.NewAppError("MarkChannelsAsViewed", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	// We use channelsToView to later only update those, or early return if no channel is to be read
-	channelsToView, channelsToClearPushNotifications, times, err := a.Srv().Store().Channel().GetChannelsWithUnreadsAndWithMentions(c.Context(), channelIDs, userID, user.NotifyProps)
+	channelsToView, channelsToClearPushNotifications, times, err := a.Srv().Store().Channel().GetChannelsWithUnreadsAndWithMentions(rctx.Context(), channelIDs, userID, user.NotifyProps)
 	if err != nil {
 		return nil, model.NewAppError("MarkChannelsAsViewed", "app.channel.get_channels_with_unreads_and_with_mentions.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -3258,8 +3258,8 @@ func (a *App) MarkChannelsAsViewed(c request.CTX, channelIDs []string, userID st
 	return times, nil
 }
 
-func (a *App) ViewChannel(c request.CTX, view *model.ChannelView, userID string, currentSessionId string, collapsedThreadsSupported bool) (map[string]int64, *model.AppError) {
-	if err := a.SetActiveChannel(c, userID, view.ChannelId); err != nil {
+func (a *App) ViewChannel(rctx request.CTX, view *model.ChannelView, userID string, currentSessionId string, collapsedThreadsSupported bool) (map[string]int64, *model.AppError) {
+	if err := a.SetActiveChannel(rctx, userID, view.ChannelId); err != nil {
 		return nil, err
 	}
 
@@ -3277,15 +3277,15 @@ func (a *App) ViewChannel(c request.CTX, view *model.ChannelView, userID string,
 		return map[string]int64{}, nil
 	}
 
-	return a.MarkChannelsAsViewed(c, channelIDs, userID, currentSessionId, collapsedThreadsSupported, a.IsCRTEnabledForUser(c, userID))
+	return a.MarkChannelsAsViewed(rctx, channelIDs, userID, currentSessionId, collapsedThreadsSupported, a.IsCRTEnabledForUser(rctx, userID))
 }
 
-func (a *App) PermanentDeleteChannel(c request.CTX, channel *model.Channel) *model.AppError {
-	if err := a.Srv().Store().Post().PermanentDeleteByChannel(c, channel.Id); err != nil {
+func (a *App) PermanentDeleteChannel(rctx request.CTX, channel *model.Channel) *model.AppError {
+	if err := a.Srv().Store().Post().PermanentDeleteByChannel(rctx, channel.Id); err != nil {
 		return model.NewAppError("PermanentDeleteChannel", "app.post.permanent_delete_by_channel.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
-	if err := a.Srv().Store().Channel().PermanentDeleteMembersByChannel(c, channel.Id); err != nil {
+	if err := a.Srv().Store().Channel().PermanentDeleteMembersByChannel(rctx, channel.Id); err != nil {
 		return model.NewAppError("PermanentDeleteChannel", "app.channel.remove_member.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
@@ -3303,7 +3303,7 @@ func (a *App) PermanentDeleteChannel(c request.CTX, channel *model.Channel) *mod
 
 	deleteAt := model.GetMillis()
 
-	if nErr := a.Srv().Store().Channel().PermanentDelete(c, channel.Id); nErr != nil {
+	if nErr := a.Srv().Store().Channel().PermanentDelete(rctx, channel.Id); nErr != nil {
 		return model.NewAppError("PermanentDeleteChannel", "app.channel.permanent_delete.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)
 	}
 
@@ -3322,8 +3322,8 @@ func (a *App) PermanentDeleteChannel(c request.CTX, channel *model.Channel) *mod
 	return nil
 }
 
-func (a *App) RemoveAllDeactivatedMembersFromChannel(c request.CTX, channel *model.Channel) *model.AppError {
-	err := a.Srv().Store().Channel().RemoveAllDeactivatedMembers(c, channel.Id)
+func (a *App) RemoveAllDeactivatedMembersFromChannel(rctx request.CTX, channel *model.Channel) *model.AppError {
+	err := a.Srv().Store().Channel().RemoveAllDeactivatedMembers(rctx, channel.Id)
 	if err != nil {
 		return model.NewAppError("RemoveAllDeactivatedMembersFromChannel", "app.channel.remove_all_deactivated_members.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -3333,9 +3333,9 @@ func (a *App) RemoveAllDeactivatedMembersFromChannel(c request.CTX, channel *mod
 
 // MoveChannel method is prone to data races if someone joins to channel during the move process. However this
 // function is only exposed to sysadmins and the possibility of this edge case is relatively small.
-func (a *App) MoveChannel(c request.CTX, team *model.Team, channel *model.Channel, user *model.User) *model.AppError {
+func (a *App) MoveChannel(rctx request.CTX, team *model.Team, channel *model.Channel, user *model.User) *model.AppError {
 	// Check that all channel members are in the destination team.
-	channelMembers, err := a.GetChannelMembersPage(c, channel.Id, 0, 10000000)
+	channelMembers, err := a.GetChannelMembersPage(rctx, channel.Id, 0, 10000000)
 	if err != nil {
 		return err
 	}
@@ -3358,7 +3358,7 @@ func (a *App) MoveChannel(c request.CTX, team *model.Team, channel *model.Channe
 			}
 			for _, channelMember := range channelMembers {
 				if _, ok := teamMembersMap[channelMember.UserId]; !ok {
-					c.Logger().Warn("Not member of the target team", mlog.String("userId", channelMember.UserId))
+					rctx.Logger().Warn("Not member of the target team", mlog.String("userId", channelMember.UserId))
 				}
 			}
 			return model.NewAppError("MoveChannel", "app.channel.move_channel.members_do_not_match.error", nil, "", http.StatusInternalServerError)
@@ -3382,7 +3382,7 @@ func (a *App) MoveChannel(c request.CTX, team *model.Team, channel *model.Channe
 	}
 
 	channel.TeamId = team.Id
-	if _, err := a.Srv().Store().Channel().Update(c, channel); err != nil {
+	if _, err := a.Srv().Store().Channel().Update(rctx, channel); err != nil {
 		var appErr *model.AppError
 		var uniqueConstraintErr *store.ErrUniqueConstraint
 		var invErr *store.ErrInvalidInput
@@ -3399,26 +3399,26 @@ func (a *App) MoveChannel(c request.CTX, team *model.Team, channel *model.Channe
 	}
 
 	if incomingWebhooks, err := a.GetIncomingWebhooksForTeamPage(previousTeam.Id, 0, 10000000); err != nil {
-		c.Logger().Warn("Failed to get incoming webhooks", mlog.Err(err))
+		rctx.Logger().Warn("Failed to get incoming webhooks", mlog.Err(err))
 	} else {
 		for _, webhook := range incomingWebhooks {
 			if webhook.ChannelId == channel.Id {
 				webhook.TeamId = team.Id
 				if _, err := a.Srv().Store().Webhook().UpdateIncoming(webhook); err != nil {
-					c.Logger().Warn("Failed to move incoming webhook to new team", mlog.String("webhook id", webhook.Id))
+					rctx.Logger().Warn("Failed to move incoming webhook to new team", mlog.String("webhook id", webhook.Id))
 				}
 			}
 		}
 	}
 
 	if outgoingWebhooks, err := a.GetOutgoingWebhooksForTeamPage(previousTeam.Id, 0, 10000000); err != nil {
-		c.Logger().Warn("Failed to get outgoing webhooks", mlog.Err(err))
+		rctx.Logger().Warn("Failed to get outgoing webhooks", mlog.Err(err))
 	} else {
 		for _, webhook := range outgoingWebhooks {
 			if webhook.ChannelId == channel.Id {
 				webhook.TeamId = team.Id
 				if _, err := a.Srv().Store().Webhook().UpdateOutgoing(webhook); err != nil {
-					c.Logger().Warn("Failed to move outgoing webhook to new team.", mlog.String("webhook id", webhook.Id))
+					rctx.Logger().Warn("Failed to move outgoing webhook to new team.", mlog.String("webhook id", webhook.Id))
 				}
 			}
 		}
@@ -3426,23 +3426,23 @@ func (a *App) MoveChannel(c request.CTX, team *model.Team, channel *model.Channe
 
 	// Update the threads within this channel to the new team
 	if err := a.Srv().Store().Thread().UpdateTeamIdForChannelThreads(channel.Id, team.Id); err != nil {
-		c.Logger().Warn("error while updating threads after channel move", mlog.Err(err))
+		rctx.Logger().Warn("error while updating threads after channel move", mlog.Err(err))
 	}
 
-	if err := a.RemoveUsersFromChannelNotMemberOfTeam(c, user, channel, team); err != nil {
-		c.Logger().Warn("error while removing non-team member users", mlog.Err(err))
+	if err := a.RemoveUsersFromChannelNotMemberOfTeam(rctx, user, channel, team); err != nil {
+		rctx.Logger().Warn("error while removing non-team member users", mlog.Err(err))
 	}
 
 	if user != nil {
-		if err := a.postChannelMoveMessage(c, user, channel, previousTeam); err != nil {
-			c.Logger().Warn("error while posting move channel message", mlog.Err(err))
+		if err := a.postChannelMoveMessage(rctx, user, channel, previousTeam); err != nil {
+			rctx.Logger().Warn("error while posting move channel message", mlog.Err(err))
 		}
 	}
 
 	return nil
 }
 
-func (a *App) postChannelMoveMessage(c request.CTX, user *model.User, channel *model.Channel, previousTeam *model.Team) *model.AppError {
+func (a *App) postChannelMoveMessage(rctx request.CTX, user *model.User, channel *model.Channel, previousTeam *model.Team) *model.AppError {
 	post := &model.Post{
 		ChannelId: channel.Id,
 		Message:   fmt.Sprintf(i18n.T("api.team.move_channel.success"), previousTeam.Name),
@@ -3453,15 +3453,15 @@ func (a *App) postChannelMoveMessage(c request.CTX, user *model.User, channel *m
 		},
 	}
 
-	if _, err := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
+	if _, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
 		return model.NewAppError("postChannelMoveMessage", "api.team.move_channel.post.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	return nil
 }
 
-func (a *App) RemoveUsersFromChannelNotMemberOfTeam(c request.CTX, remover *model.User, channel *model.Channel, team *model.Team) *model.AppError {
-	channelMembers, err := a.GetChannelMembersPage(c, channel.Id, 0, 10000000)
+func (a *App) RemoveUsersFromChannelNotMemberOfTeam(rctx request.CTX, remover *model.User, channel *model.Channel, team *model.Team) *model.AppError {
+	channelMembers, err := a.GetChannelMembersPage(rctx, channel.Id, 0, 10000000)
 	if err != nil {
 		return err
 	}
@@ -3489,7 +3489,7 @@ func (a *App) RemoveUsersFromChannelNotMemberOfTeam(c request.CTX, remover *mode
 				removerId = remover.Id
 			}
 			for userID := range channelMemberMap {
-				if err := a.removeUserFromChannel(c, userID, removerId, channel); err != nil {
+				if err := a.removeUserFromChannel(rctx, userID, removerId, channel); err != nil {
 					return err
 				}
 			}
@@ -3499,7 +3499,7 @@ func (a *App) RemoveUsersFromChannelNotMemberOfTeam(c request.CTX, remover *mode
 	return nil
 }
 
-func (a *App) GetPinnedPosts(c request.CTX, channelID string) (*model.PostList, *model.AppError) {
+func (a *App) GetPinnedPosts(rctx request.CTX, channelID string) (*model.PostList, *model.AppError) {
 	posts, err := a.Srv().Store().Channel().GetPinnedPosts(channelID)
 	if err != nil {
 		return nil, model.NewAppError("GetPinnedPosts", "app.channel.pinned_posts.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -3512,7 +3512,7 @@ func (a *App) GetPinnedPosts(c request.CTX, channelID string) (*model.PostList, 
 	return posts, nil
 }
 
-func (a *App) ToggleMuteChannel(c request.CTX, channelID, userID string) (*model.ChannelMember, *model.AppError) {
+func (a *App) ToggleMuteChannel(rctx request.CTX, channelID, userID string) (*model.ChannelMember, *model.AppError) {
 	member, nErr := a.Srv().Store().Channel().GetMember(context.Background(), channelID, userID)
 	if nErr != nil {
 		var appErr *model.AppError
@@ -3529,7 +3529,7 @@ func (a *App) ToggleMuteChannel(c request.CTX, channelID, userID string) (*model
 
 	member.SetChannelMuted(!member.IsChannelMuted())
 
-	member, err := a.updateChannelMember(c, member)
+	member, err := a.updateChannelMember(rctx, member)
 	if err != nil {
 		return nil, err
 	}
@@ -3539,7 +3539,7 @@ func (a *App) ToggleMuteChannel(c request.CTX, channelID, userID string) (*model
 	return member, nil
 }
 
-func (a *App) setChannelsMuted(c request.CTX, channelIDs []string, userID string, muted bool) ([]*model.ChannelMember, *model.AppError) {
+func (a *App) setChannelsMuted(rctx request.CTX, channelIDs []string, userID string, muted bool) ([]*model.ChannelMember, *model.AppError) {
 	members, err := a.Srv().Store().Channel().GetMembersByChannelIds(channelIDs, userID)
 	if err != nil {
 		var appErr *model.AppError
@@ -3598,11 +3598,11 @@ func (a *App) setChannelsMuted(c request.CTX, channelIDs []string, userID string
 	return updated, nil
 }
 
-func (a *App) FillInChannelProps(c request.CTX, channel *model.Channel) *model.AppError {
-	return a.FillInChannelsProps(c, model.ChannelList{channel})
+func (a *App) FillInChannelProps(rctx request.CTX, channel *model.Channel) *model.AppError {
+	return a.FillInChannelsProps(rctx, model.ChannelList{channel})
 }
 
-func (a *App) FillInChannelsProps(c request.CTX, channelList model.ChannelList) *model.AppError {
+func (a *App) FillInChannelsProps(rctx request.CTX, channelList model.ChannelList) *model.AppError {
 	// Group the channels by team and call GetChannelsByNames just once per team.
 	channelsByTeam := make(map[string]model.ChannelList)
 	for _, channel := range channelList {
@@ -3628,7 +3628,7 @@ func (a *App) FillInChannelsProps(c request.CTX, channelList model.ChannelList) 
 		}
 
 		if len(allChannelMentionNames) > 0 {
-			mentionedChannels, err := a.GetChannelsByNames(c, allChannelMentionNames, teamID)
+			mentionedChannels, err := a.GetChannelsByNames(rctx, allChannelMentionNames, teamID)
 			if err != nil {
 				return err
 			}
@@ -3662,7 +3662,7 @@ func (a *App) FillInChannelsProps(c request.CTX, channelList model.ChannelList) 
 	return nil
 }
 
-func (a *App) forEachChannelMember(c request.CTX, channelID string, f func(model.ChannelMember) error) error {
+func (a *App) forEachChannelMember(rctx request.CTX, channelID string, f func(model.ChannelMember) error) error {
 	perPage := 100
 	page := 0
 
@@ -3694,7 +3694,7 @@ func (a *App) forEachChannelMember(c request.CTX, channelID string, f func(model
 	return nil
 }
 
-func (a *App) ClearChannelMembersCache(c request.CTX, channelID string) error {
+func (a *App) ClearChannelMembersCache(rctx request.CTX, channelID string) error {
 	clearSessionCache := func(channelMember model.ChannelMember) error {
 		a.ClearSessionCacheForUser(channelMember.UserId)
 		message := model.NewWebSocketEvent(model.WebsocketEventChannelMemberUpdated, "", "", channelMember.UserId, nil, "")
@@ -3706,7 +3706,7 @@ func (a *App) ClearChannelMembersCache(c request.CTX, channelID string) error {
 		a.Publish(message)
 		return nil
 	}
-	if err := a.forEachChannelMember(c, channelID, clearSessionCache); err != nil {
+	if err := a.forEachChannelMember(rctx, channelID, clearSessionCache); err != nil {
 		return fmt.Errorf("error clearing cache for channel members: channel_id: %s, error: %w", channelID, err)
 	}
 	return nil
@@ -3721,12 +3721,12 @@ func (a *App) GetMemberCountsByGroup(rctx request.CTX, channelID string, include
 	return channelMemberCounts, nil
 }
 
-func (a *App) getDirectChannel(c request.CTX, userID, otherUserID string) (*model.Channel, *model.AppError) {
-	return a.Srv().getDirectChannel(c, userID, otherUserID)
+func (a *App) getDirectChannel(rctx request.CTX, userID, otherUserID string) (*model.Channel, *model.AppError) {
+	return a.Srv().getDirectChannel(rctx, userID, otherUserID)
 }
 
-func (a *App) GetGroupMessageMembersCommonTeams(c request.CTX, channelID string) ([]*model.Team, *model.AppError) {
-	channel, appErr := a.GetChannel(c, channelID)
+func (a *App) GetGroupMessageMembersCommonTeams(rctx request.CTX, channelID string) ([]*model.Team, *model.AppError) {
+	channel, appErr := a.GetChannel(rctx, channelID)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -3761,13 +3761,13 @@ func (a *App) GetGroupMessageMembersCommonTeams(c request.CTX, channelID string)
 	return teams, appErr
 }
 
-func (a *App) ConvertGroupMessageToChannel(c request.CTX, convertedByUserId string, gmConversionRequest *model.GroupMessageConversionRequestBody) (*model.Channel, *model.AppError) {
-	originalChannel, appErr := a.GetChannel(c, gmConversionRequest.ChannelID)
+func (a *App) ConvertGroupMessageToChannel(rctx request.CTX, convertedByUserId string, gmConversionRequest *model.GroupMessageConversionRequestBody) (*model.Channel, *model.AppError) {
+	originalChannel, appErr := a.GetChannel(rctx, gmConversionRequest.ChannelID)
 	if appErr != nil {
 		return nil, appErr
 	}
 
-	appErr = a.validateForConvertGroupMessageToChannel(c, convertedByUserId, originalChannel, gmConversionRequest)
+	appErr = a.validateForConvertGroupMessageToChannel(rctx, convertedByUserId, originalChannel, gmConversionRequest)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -3778,7 +3778,7 @@ func (a *App) ConvertGroupMessageToChannel(c request.CTX, convertedByUserId stri
 	toUpdate.Name = gmConversionRequest.Name
 	toUpdate.DisplayName = gmConversionRequest.DisplayName
 
-	updatedChannel, appErr := a.UpdateChannel(c, toUpdate)
+	updatedChannel, appErr := a.UpdateChannel(rctx, toUpdate)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -3794,11 +3794,11 @@ func (a *App) ConvertGroupMessageToChannel(c request.CTX, convertedByUserId stri
 		return nil, appErr
 	}
 
-	_ = a.setSidebarCategoriesForConvertedGroupMessage(c, gmConversionRequest, users)
-	_ = a.postMessageForConvertGroupMessageToChannel(c, gmConversionRequest.ChannelID, convertedByUserId, users)
+	_ = a.setSidebarCategoriesForConvertedGroupMessage(rctx, gmConversionRequest, users)
+	_ = a.postMessageForConvertGroupMessageToChannel(rctx, gmConversionRequest.ChannelID, convertedByUserId, users)
 
 	// the user conversion the GM becomes the channel admin.
-	_, appErr = a.UpdateChannelMemberSchemeRoles(c, gmConversionRequest.ChannelID, convertedByUserId, false, true, true)
+	_, appErr = a.UpdateChannelMemberSchemeRoles(rctx, gmConversionRequest.ChannelID, convertedByUserId, false, true, true)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -3806,7 +3806,7 @@ func (a *App) ConvertGroupMessageToChannel(c request.CTX, convertedByUserId stri
 	return updatedChannel, nil
 }
 
-func (a *App) setSidebarCategoriesForConvertedGroupMessage(c request.CTX, gmConversionRequest *model.GroupMessageConversionRequestBody, channelUsers []*model.User) *model.AppError {
+func (a *App) setSidebarCategoriesForConvertedGroupMessage(rctx request.CTX, gmConversionRequest *model.GroupMessageConversionRequestBody, channelUsers []*model.User) *model.AppError {
 	// First we'll delete channel from everyone's sidebar. Only the members of GM
 	// can have it in sidebar, so we can delete the channel from all SidebarChannels entries.
 	err := a.Srv().Store().Channel().DeleteAllSidebarChannelForChannel(gmConversionRequest.ChannelID)
@@ -3823,10 +3823,10 @@ func (a *App) setSidebarCategoriesForConvertedGroupMessage(c request.CTX, gmConv
 	// Now that we've deleted existing entries, we can set the channel in default "Channels" category
 	// for all GM members
 	for _, user := range channelUsers {
-		categories, appErr := a.GetSidebarCategories(c, user.Id, gmConversionRequest.TeamID)
+		categories, appErr := a.GetSidebarCategories(rctx, user.Id, gmConversionRequest.TeamID)
 
 		if appErr != nil {
-			c.Logger().Error("Failed to search sidebar categories for user for adding converted GM")
+			rctx.Logger().Error("Failed to search sidebar categories for user for adding converted GM")
 			continue
 		}
 
@@ -3843,17 +3843,17 @@ func (a *App) setSidebarCategoriesForConvertedGroupMessage(c request.CTX, gmConv
 		// So what we do is fetch the category, so we get an auto-filled data,
 		// then call update category to persist the data and send the websocket events.
 		channelsCategory := categories.Categories[0]
-		_, appErr = a.UpdateSidebarCategories(c, user.Id, gmConversionRequest.TeamID, []*model.SidebarCategoryWithChannels{channelsCategory})
+		_, appErr = a.UpdateSidebarCategories(rctx, user.Id, gmConversionRequest.TeamID, []*model.SidebarCategoryWithChannels{channelsCategory})
 		if appErr != nil {
-			c.Logger().Error("Failed to add converted GM to default sidebar category for user", mlog.String("user_id", user.Id), mlog.Err(err))
+			rctx.Logger().Error("Failed to add converted GM to default sidebar category for user", mlog.String("user_id", user.Id), mlog.Err(err))
 		}
 	}
 
 	return nil
 }
 
-func (a *App) validateForConvertGroupMessageToChannel(c request.CTX, convertedByUserId string, originalChannel *model.Channel, gmConversionRequest *model.GroupMessageConversionRequestBody) *model.AppError {
-	commonTeams, appErr := a.GetGroupMessageMembersCommonTeams(c, originalChannel.Id)
+func (a *App) validateForConvertGroupMessageToChannel(rctx request.CTX, convertedByUserId string, originalChannel *model.Channel, gmConversionRequest *model.GroupMessageConversionRequestBody) *model.AppError {
+	commonTeams, appErr := a.GetGroupMessageMembersCommonTeams(rctx, originalChannel.Id)
 	if appErr != nil {
 		return appErr
 	}
@@ -3886,7 +3886,7 @@ func (a *App) validateForConvertGroupMessageToChannel(c request.CTX, convertedBy
 		)
 	}
 
-	channelMember, appErr := a.GetChannelMember(c, gmConversionRequest.ChannelID, convertedByUserId)
+	channelMember, appErr := a.GetChannelMember(rctx, gmConversionRequest.ChannelID, convertedByUserId)
 	if appErr != nil {
 		return appErr
 	}
@@ -3903,7 +3903,7 @@ func (a *App) validateForConvertGroupMessageToChannel(c request.CTX, convertedBy
 	return clone.IsValid()
 }
 
-func (a *App) postMessageForConvertGroupMessageToChannel(c request.CTX, channelID, convertedByUserId string, channelUsers []*model.User) *model.AppError {
+func (a *App) postMessageForConvertGroupMessageToChannel(rctx request.CTX, channelID, convertedByUserId string, channelUsers []*model.User) *model.AppError {
 	convertedByUser, appErr := a.GetUser(convertedByUserId)
 	if appErr != nil {
 		return appErr
@@ -3934,13 +3934,13 @@ func (a *App) postMessageForConvertGroupMessageToChannel(c request.CTX, channelI
 	post.AddProp("convertedByUserId", convertedByUser.Id)
 	post.AddProp("gmMembersDuringConversionIDs", userIDs)
 
-	channel, appErr := a.GetChannel(c, channelID)
+	channel, appErr := a.GetChannel(rctx, channelID)
 	if appErr != nil {
 		return appErr
 	}
 
-	if _, appErr := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); appErr != nil {
-		c.Logger().Error("Failed to create post for notifying about GM converted to private channel", mlog.Err(appErr))
+	if _, appErr := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); appErr != nil {
+		rctx.Logger().Error("Failed to create post for notifying about GM converted to private channel", mlog.Err(appErr))
 
 		return model.NewAppError(
 			"postMessageForConvertGroupMessageToChannel",
@@ -3954,7 +3954,7 @@ func (a *App) postMessageForConvertGroupMessageToChannel(c request.CTX, channelI
 	return nil
 }
 
-func (s *Server) getDirectChannel(c request.CTX, userID, otherUserID string) (*model.Channel, *model.AppError) {
+func (s *Server) getDirectChannel(rctx request.CTX, userID, otherUserID string) (*model.Channel, *model.AppError) {
 	channel, nErr := s.Store().Channel().GetByName("", model.GetDMNameFromIds(userID, otherUserID), true)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
@@ -3968,7 +3968,7 @@ func (s *Server) getDirectChannel(c request.CTX, userID, otherUserID string) (*m
 	return channel, nil
 }
 
-func (a *App) ChannelAccessControlled(c request.CTX, channelID string) (bool, *model.AppError) {
+func (a *App) ChannelAccessControlled(rctx request.CTX, channelID string) (bool, *model.AppError) {
 	if l := a.License(); !model.MinimumEnterpriseAdvancedLicense(l) || !*a.Config().AccessControlSettings.EnableAttributeBasedAccessControl {
 		return false, nil
 	}
@@ -3992,11 +3992,11 @@ func (a *App) handleChannelCategoryName(channel *model.Channel) {
 	}
 }
 
-func (a *App) addChannelToDefaultCategory(c request.CTX, userID string, channel *model.Channel) {
+func (a *App) addChannelToDefaultCategory(rctx request.CTX, userID string, channel *model.Channel) {
 	// Add channel to default category if specified
 	if channel.DefaultCategoryName != "" && *a.Config().ExperimentalSettings.ExperimentalChannelCategorySorting {
 		// Get user's categories for this team
-		categories, err := a.GetSidebarCategoriesForTeamForUser(c, userID, channel.TeamId)
+		categories, err := a.GetSidebarCategoriesForTeamForUser(rctx, userID, channel.TeamId)
 		if err != nil {
 			mlog.Error("Failed to get sidebar categories", mlog.String("user_id", userID), mlog.String("team_id", channel.TeamId), mlog.Err(err))
 			return
@@ -4022,14 +4022,14 @@ func (a *App) addChannelToDefaultCategory(c request.CTX, userID string, channel 
 				},
 				Channels: []string{channel.Id},
 			}
-			_, err = a.CreateSidebarCategory(c, userID, channel.TeamId, targetCategory)
+			_, err = a.CreateSidebarCategory(rctx, userID, channel.TeamId, targetCategory)
 			if err != nil {
 				mlog.Error("Failed to create default category", mlog.String("user_id", userID), mlog.String("team_id", channel.TeamId), mlog.String("category_name", channel.DefaultCategoryName), mlog.Err(err))
 			}
 		} else {
 			// Add channel to existing category
 			targetCategory.Channels = append([]string{channel.Id}, targetCategory.Channels...)
-			_, err = a.UpdateSidebarCategories(c, userID, channel.TeamId, []*model.SidebarCategoryWithChannels{targetCategory})
+			_, err = a.UpdateSidebarCategories(rctx, userID, channel.TeamId, []*model.SidebarCategoryWithChannels{targetCategory})
 			if err != nil {
 				mlog.Error("Failed to update default category", mlog.String("user_id", userID), mlog.String("team_id", channel.TeamId), mlog.String("category_name", channel.DefaultCategoryName), mlog.Err(err))
 			}

--- a/server/channels/app/channel_bookmark.go
+++ b/server/channels/app/channel_bookmark.go
@@ -31,8 +31,8 @@ func (a *App) GetBookmark(bookmarkId string, includeDeleted bool) (*model.Channe
 	return bookmark, nil
 }
 
-func (a *App) CreateChannelBookmark(c request.CTX, newBookmark *model.ChannelBookmark, connectionId string) (*model.ChannelBookmarkWithFileInfo, *model.AppError) {
-	newBookmark.OwnerId = c.Session().UserId //ensure that the bookmark is being created by the user who owns the session
+func (a *App) CreateChannelBookmark(rctx request.CTX, newBookmark *model.ChannelBookmark, connectionId string) (*model.ChannelBookmarkWithFileInfo, *model.AppError) {
+	newBookmark.OwnerId = rctx.Session().UserId //ensure that the bookmark is being created by the user who owns the session
 	newBookmark.Id = ""                      // ensure that creating a new bookmark generates a new ID
 	bookmark, err := a.Srv().Store().ChannelBookmark().Save(newBookmark, true)
 	if err != nil {
@@ -49,9 +49,9 @@ func (a *App) CreateChannelBookmark(c request.CTX, newBookmark *model.ChannelBoo
 	return bookmark, nil
 }
 
-func (a *App) UpdateChannelBookmark(c request.CTX, updateBookmark *model.ChannelBookmarkWithFileInfo, connectionId string) (*model.UpdateChannelBookmarkResponse, *model.AppError) {
+func (a *App) UpdateChannelBookmark(rctx request.CTX, updateBookmark *model.ChannelBookmarkWithFileInfo, connectionId string) (*model.UpdateChannelBookmarkResponse, *model.AppError) {
 	response := &model.UpdateChannelBookmarkResponse{}
-	if updateBookmark.OwnerId == c.Session().UserId {
+	if updateBookmark.OwnerId == rctx.Session().UserId {
 		isAnotherFile := updateBookmark.FileInfo != nil && updateBookmark.FileId != "" && updateBookmark.FileId != updateBookmark.FileInfo.Id
 
 		if isAnotherFile {
@@ -84,7 +84,7 @@ func (a *App) UpdateChannelBookmark(c request.CTX, updateBookmark *model.Channel
 			return nil, model.NewAppError("UpdateChannelBookmark", "app.channel.bookmark.delete.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 		}
 
-		newBookmark := updateBookmark.SetOriginal(c.Session().UserId)
+		newBookmark := updateBookmark.SetOriginal(rctx.Session().UserId)
 		bookmark, err := a.Srv().Store().ChannelBookmark().Save(newBookmark, false)
 		if err != nil {
 			return nil, model.NewAppError("UpdateChannelBookmark", "app.channel.bookmark.save.app_error", nil, "", http.StatusInternalServerError).Wrap(err)

--- a/server/channels/app/channel_category.go
+++ b/server/channels/app/channel_category.go
@@ -14,8 +14,8 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 )
 
-func (a *App) createInitialSidebarCategories(c request.CTX, userID string, teamID string) (*model.OrderedSidebarCategories, *model.AppError) {
-	categories, nErr := a.Srv().Store().Channel().CreateInitialSidebarCategories(c, userID, teamID)
+func (a *App) createInitialSidebarCategories(rctx request.CTX, userID string, teamID string) (*model.OrderedSidebarCategories, *model.AppError) {
+	categories, nErr := a.Srv().Store().Channel().CreateInitialSidebarCategories(rctx, userID, teamID)
 	if nErr != nil {
 		return nil, model.NewAppError("createInitialSidebarCategories", "app.channel.create_initial_sidebar_categories.internal_error", nil, "", http.StatusInternalServerError).Wrap(nErr)
 	}
@@ -23,12 +23,12 @@ func (a *App) createInitialSidebarCategories(c request.CTX, userID string, teamI
 	return categories, nil
 }
 
-func (a *App) GetSidebarCategoriesForTeamForUser(c request.CTX, userID, teamID string) (*model.OrderedSidebarCategories, *model.AppError) {
+func (a *App) GetSidebarCategoriesForTeamForUser(rctx request.CTX, userID, teamID string) (*model.OrderedSidebarCategories, *model.AppError) {
 	var appErr *model.AppError
 	categories, err := a.Srv().Store().Channel().GetSidebarCategoriesForTeamForUser(userID, teamID)
 	if err == nil && len(categories.Categories) == 0 {
 		// A user must always have categories, so migration must not have happened yet, and we should run it ourselves
-		categories, appErr = a.createInitialSidebarCategories(c, userID, teamID)
+		categories, appErr = a.createInitialSidebarCategories(rctx, userID, teamID)
 		if appErr != nil {
 			return nil, appErr
 		}
@@ -47,12 +47,12 @@ func (a *App) GetSidebarCategoriesForTeamForUser(c request.CTX, userID, teamID s
 	return categories, nil
 }
 
-func (a *App) GetSidebarCategories(c request.CTX, userID string, teamID string) (*model.OrderedSidebarCategories, *model.AppError) {
+func (a *App) GetSidebarCategories(rctx request.CTX, userID string, teamID string) (*model.OrderedSidebarCategories, *model.AppError) {
 	var appErr *model.AppError
 	categories, err := a.Srv().Store().Channel().GetSidebarCategories(userID, teamID)
 	if err == nil && len(categories.Categories) == 0 {
 		// A user must always have categories, so migration must not have happened yet, and we should run it ourselves
-		categories, appErr = a.createInitialSidebarCategories(c, userID, teamID)
+		categories, appErr = a.createInitialSidebarCategories(rctx, userID, teamID)
 		if appErr != nil {
 			return nil, appErr
 		}
@@ -71,7 +71,7 @@ func (a *App) GetSidebarCategories(c request.CTX, userID string, teamID string) 
 	return categories, nil
 }
 
-func (a *App) GetSidebarCategoryOrder(c request.CTX, userID, teamID string) ([]string, *model.AppError) {
+func (a *App) GetSidebarCategoryOrder(rctx request.CTX, userID, teamID string) ([]string, *model.AppError) {
 	categories, err := a.Srv().Store().Channel().GetSidebarCategoryOrder(userID, teamID)
 	if err != nil {
 		var nfErr *store.ErrNotFound
@@ -86,7 +86,7 @@ func (a *App) GetSidebarCategoryOrder(c request.CTX, userID, teamID string) ([]s
 	return categories, nil
 }
 
-func (a *App) GetSidebarCategory(c request.CTX, categoryId string) (*model.SidebarCategoryWithChannels, *model.AppError) {
+func (a *App) GetSidebarCategory(rctx request.CTX, categoryId string) (*model.SidebarCategoryWithChannels, *model.AppError) {
 	category, err := a.Srv().Store().Channel().GetSidebarCategory(categoryId)
 	if err != nil {
 		var nfErr *store.ErrNotFound
@@ -101,7 +101,7 @@ func (a *App) GetSidebarCategory(c request.CTX, categoryId string) (*model.Sideb
 	return category, nil
 }
 
-func (a *App) CreateSidebarCategory(c request.CTX, userID, teamID string, newCategory *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, *model.AppError) {
+func (a *App) CreateSidebarCategory(rctx request.CTX, userID, teamID string, newCategory *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, *model.AppError) {
 	category, err := a.Srv().Store().Channel().CreateSidebarCategory(userID, teamID, newCategory)
 	if err != nil {
 		var nfErr *store.ErrNotFound
@@ -118,7 +118,7 @@ func (a *App) CreateSidebarCategory(c request.CTX, userID, teamID string, newCat
 	return category, nil
 }
 
-func (a *App) UpdateSidebarCategoryOrder(c request.CTX, userID, teamID string, categoryOrder []string) *model.AppError {
+func (a *App) UpdateSidebarCategoryOrder(rctx request.CTX, userID, teamID string, categoryOrder []string) *model.AppError {
 	err := a.Srv().Store().Channel().UpdateSidebarCategoryOrder(userID, teamID, categoryOrder)
 	if err != nil {
 		var nfErr *store.ErrNotFound
@@ -138,7 +138,7 @@ func (a *App) UpdateSidebarCategoryOrder(c request.CTX, userID, teamID string, c
 	return nil
 }
 
-func (a *App) UpdateSidebarCategories(c request.CTX, userID, teamID string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, *model.AppError) {
+func (a *App) UpdateSidebarCategories(rctx request.CTX, userID, teamID string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, *model.AppError) {
 	updatedCategories, originalCategories, err := a.Srv().Store().Channel().UpdateSidebarCategories(userID, teamID, categories)
 	if err != nil {
 		return nil, model.NewAppError("UpdateSidebarCategories", "app.channel.sidebar_categories.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -155,12 +155,12 @@ func (a *App) UpdateSidebarCategories(c request.CTX, userID, teamID string, cate
 
 	a.Publish(message)
 
-	a.muteChannelsForUpdatedCategories(c, userID, updatedCategories, originalCategories)
+	a.muteChannelsForUpdatedCategories(rctx, userID, updatedCategories, originalCategories)
 
 	return updatedCategories, nil
 }
 
-func (a *App) muteChannelsForUpdatedCategories(c request.CTX, userID string, updatedCategories []*model.SidebarCategoryWithChannels, originalCategories []*model.SidebarCategoryWithChannels) {
+func (a *App) muteChannelsForUpdatedCategories(rctx request.CTX, userID string, updatedCategories []*model.SidebarCategoryWithChannels, originalCategories []*model.SidebarCategoryWithChannels) {
 	var channelsToMute []string
 	var channelsToUnmute []string
 
@@ -208,9 +208,9 @@ func (a *App) muteChannelsForUpdatedCategories(c request.CTX, userID string, upd
 	}
 
 	if len(channelsToMute) > 0 {
-		_, err := a.setChannelsMuted(c, channelsToMute, userID, true)
+		_, err := a.setChannelsMuted(rctx, channelsToMute, userID, true)
 		if err != nil {
-			c.Logger().Error(
+			rctx.Logger().Error(
 				"Failed to mute channels to match category",
 				mlog.String("user_id", userID),
 				mlog.Err(err),
@@ -219,9 +219,9 @@ func (a *App) muteChannelsForUpdatedCategories(c request.CTX, userID string, upd
 	}
 
 	if len(channelsToUnmute) > 0 {
-		_, err := a.setChannelsMuted(c, channelsToUnmute, userID, false)
+		_, err := a.setChannelsMuted(rctx, channelsToUnmute, userID, false)
 		if err != nil {
-			c.Logger().Error(
+			rctx.Logger().Error(
 				"Failed to unmute channels to match category",
 				mlog.String("user_id", userID),
 				mlog.Err(err),
@@ -265,7 +265,7 @@ func diffChannelsBetweenCategories(updatedCategories []*model.SidebarCategoryWit
 	return channelsDiff
 }
 
-func (a *App) DeleteSidebarCategory(c request.CTX, userID, teamID, categoryId string) *model.AppError {
+func (a *App) DeleteSidebarCategory(rctx request.CTX, userID, teamID, categoryId string) *model.AppError {
 	err := a.Srv().Store().Channel().DeleteSidebarCategory(categoryId)
 	if err != nil {
 		var invErr *store.ErrInvalidInput

--- a/server/channels/app/command.go
+++ b/server/channels/app/command.go
@@ -33,7 +33,7 @@ var atMentionRegexp = regexp.MustCompile(`\B@[[:alnum:]][[:alnum:]\.\-_:]*`)
 type CommandProvider interface {
 	GetTrigger() string
 	GetCommand(a *App, T i18n.TranslateFunc) *model.Command
-	DoCommand(a *App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse
+	DoCommand(a *App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse
 }
 
 var commandProviders = make(map[string]CommandProvider)
@@ -51,7 +51,7 @@ func GetCommandProvider(name string) CommandProvider {
 	return nil
 }
 
-func (a *App) CreateCommandPost(c request.CTX, post *model.Post, teamID string, response *model.CommandResponse, skipSlackParsing bool) (*model.Post, *model.AppError) {
+func (a *App) CreateCommandPost(rctx request.CTX, post *model.Post, teamID string, response *model.CommandResponse, skipSlackParsing bool) (*model.Post, *model.AppError) {
 	if skipSlackParsing {
 		post.Message = response.Text
 	} else {
@@ -70,11 +70,11 @@ func (a *App) CreateCommandPost(c request.CTX, post *model.Post, teamID string, 
 	}
 
 	if response.ResponseType == model.CommandResponseTypeInChannel {
-		return a.CreatePostMissingChannel(c, post, true, true)
+		return a.CreatePostMissingChannel(rctx, post, true, true)
 	}
 
 	if (response.ResponseType == "" || response.ResponseType == model.CommandResponseTypeEphemeral) && (response.Text != "" || response.Attachments != nil) {
-		a.SendEphemeralPost(c, post.UserId, post)
+		a.SendEphemeralPost(rctx, post.UserId, post)
 	}
 
 	return post, nil
@@ -177,7 +177,7 @@ func (a *App) ListAllCommands(teamID string, T i18n.TranslateFunc) ([]*model.Com
 	return commands, nil
 }
 
-func (a *App) ExecuteCommand(c request.CTX, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+func (a *App) ExecuteCommand(rctx request.CTX, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
 	trigger := ""
 	message := ""
 	index := strings.IndexFunc(args.Command, unicode.IsSpace)
@@ -195,32 +195,32 @@ func (a *App) ExecuteCommand(c request.CTX, args *model.CommandArgs) (*model.Com
 
 	clientTriggerId, triggerId, appErr := model.GenerateTriggerId(args.UserId, a.AsymmetricSigningKey())
 	if appErr != nil {
-		c.Logger().Warn("error occurred in generating trigger Id for a user ", mlog.Err(appErr))
+		rctx.Logger().Warn("error occurred in generating trigger Id for a user ", mlog.Err(appErr))
 	}
 
 	args.TriggerId = triggerId
 
 	// Plugins can override built in and custom commands
-	cmd, response, appErr := a.tryExecutePluginCommand(c, args)
+	cmd, response, appErr := a.tryExecutePluginCommand(rctx, args)
 	if appErr != nil {
 		return nil, appErr
 	} else if cmd != nil && response != nil {
 		response.TriggerId = clientTriggerId
-		return a.HandleCommandResponse(c, cmd, args, response, true)
+		return a.HandleCommandResponse(rctx, cmd, args, response, true)
 	}
 
 	// Custom commands can override built ins
-	cmd, response, appErr = a.tryExecuteCustomCommand(c, args, trigger, message)
+	cmd, response, appErr = a.tryExecuteCustomCommand(rctx, args, trigger, message)
 	if appErr != nil {
 		return nil, appErr
 	} else if cmd != nil && response != nil {
 		response.TriggerId = clientTriggerId
-		return a.HandleCommandResponse(c, cmd, args, response, false)
+		return a.HandleCommandResponse(rctx, cmd, args, response, false)
 	}
 
-	cmd, response = a.tryExecuteBuiltInCommand(c, args, trigger, message)
+	cmd, response = a.tryExecuteBuiltInCommand(rctx, args, trigger, message)
 	if cmd != nil && response != nil {
-		return a.HandleCommandResponse(c, cmd, args, response, true)
+		return a.HandleCommandResponse(rctx, cmd, args, response, true)
 	}
 
 	if len(trigger) > maxTriggerLen {
@@ -232,7 +232,7 @@ func (a *App) ExecuteCommand(c request.CTX, args *model.CommandArgs) (*model.Com
 
 // MentionsToTeamMembers returns all the @ mentions found in message that
 // belong to users in the specified team, linking them to their users
-func (a *App) MentionsToTeamMembers(c request.CTX, message, teamID string) model.UserMentionMap {
+func (a *App) MentionsToTeamMembers(rctx request.CTX, message, teamID string) model.UserMentionMap {
 	type mentionMapItem struct {
 		Name string
 		Id   string
@@ -250,7 +250,7 @@ func (a *App) MentionsToTeamMembers(c request.CTX, message, teamID string) model
 
 			var nfErr *store.ErrNotFound
 			if nErr != nil && !errors.As(nErr, &nfErr) {
-				c.Logger().Warn("Failed to retrieve user @"+mention, mlog.Err(nErr))
+				rctx.Logger().Warn("Failed to retrieve user @"+mention, mlog.Err(nErr))
 				return
 			}
 
@@ -268,7 +268,7 @@ func (a *App) MentionsToTeamMembers(c request.CTX, message, teamID string) model
 						continue
 					}
 
-					_, err := a.GetTeamMember(c, teamID, userFromTrimmed.Id)
+					_, err := a.GetTeamMember(rctx, teamID, userFromTrimmed.Id)
 					if err != nil {
 						// The user is not in the team, so we should ignore it
 						return
@@ -281,7 +281,7 @@ func (a *App) MentionsToTeamMembers(c request.CTX, message, teamID string) model
 				return
 			}
 
-			_, err := a.GetTeamMember(c, teamID, user.Id)
+			_, err := a.GetTeamMember(rctx, teamID, user.Id)
 			if err != nil {
 				// The user is not in the team, so we should ignore it
 				return
@@ -304,7 +304,7 @@ func (a *App) MentionsToTeamMembers(c request.CTX, message, teamID string) model
 
 // MentionsToPublicChannels returns all the mentions to public channels,
 // linking them to their channels
-func (a *App) MentionsToPublicChannels(c request.CTX, message, teamID string) model.ChannelMentionMap {
+func (a *App) MentionsToPublicChannels(rctx request.CTX, message, teamID string) model.ChannelMentionMap {
 	type mentionMapItem struct {
 		Name string
 		Id   string
@@ -318,7 +318,7 @@ func (a *App) MentionsToPublicChannels(c request.CTX, message, teamID string) mo
 		wg.Add(1)
 		go func(channelName string) {
 			defer wg.Done()
-			channel, err := a.GetChannelByName(c, channelName, teamID, false)
+			channel, err := a.GetChannelByName(rctx, channelName, teamID, false)
 			if err != nil {
 				return
 			}
@@ -344,7 +344,7 @@ func (a *App) MentionsToPublicChannels(c request.CTX, message, teamID string) mo
 
 // tryExecuteBuiltInCommand attempts to run a built in command based on the given arguments. If no such command can be
 // found, returns nil for all arguments.
-func (a *App) tryExecuteBuiltInCommand(c request.CTX, args *model.CommandArgs, trigger string, message string) (*model.Command, *model.CommandResponse) {
+func (a *App) tryExecuteBuiltInCommand(rctx request.CTX, args *model.CommandArgs, trigger string, message string) (*model.Command, *model.CommandResponse) {
 	provider := GetCommandProvider(trigger)
 	if provider == nil {
 		return nil, nil
@@ -355,12 +355,12 @@ func (a *App) tryExecuteBuiltInCommand(c request.CTX, args *model.CommandArgs, t
 		return nil, nil
 	}
 
-	return cmd, provider.DoCommand(a, c, args, message)
+	return cmd, provider.DoCommand(a, rctx, args, message)
 }
 
 // tryExecuteCustomCommand attempts to run a custom command based on the given arguments. If no such command can be
 // found, returns nil for all arguments.
-func (a *App) tryExecuteCustomCommand(c request.CTX, args *model.CommandArgs, trigger string, message string) (*model.Command, *model.CommandResponse, *model.AppError) {
+func (a *App) tryExecuteCustomCommand(rctx request.CTX, args *model.CommandArgs, trigger string, message string) (*model.Command, *model.CommandResponse, *model.AppError) {
 	// Handle custom commands
 	if !*a.Config().ServiceSettings.EnableCommands {
 		return nil, nil, model.NewAppError("ExecuteCommand", "api.command.disabled.app_error", nil, "", http.StatusNotImplemented)
@@ -441,7 +441,7 @@ func (a *App) tryExecuteCustomCommand(c request.CTX, args *model.CommandArgs, tr
 		return nil, nil, nil
 	}
 
-	c.Logger().Debug("Executing command", mlog.String("command", trigger), mlog.String("user_id", args.UserId))
+	rctx.Logger().Debug("Executing command", mlog.String("command", trigger), mlog.String("user_id", args.UserId))
 
 	p := url.Values{}
 	p.Set("token", cmd.Token)
@@ -460,12 +460,12 @@ func (a *App) tryExecuteCustomCommand(c request.CTX, args *model.CommandArgs, tr
 
 	p.Set("trigger_id", args.TriggerId)
 
-	userMentionMap := a.MentionsToTeamMembers(c, message, team.Id)
+	userMentionMap := a.MentionsToTeamMembers(rctx, message, team.Id)
 	for key, values := range userMentionMap.ToURLValues() {
 		p[key] = values
 	}
 
-	channelMentionMap := a.MentionsToPublicChannels(c, message, team.Id)
+	channelMentionMap := a.MentionsToPublicChannels(rctx, message, team.Id)
 	for key, values := range channelMentionMap.ToURLValues() {
 		p[key] = values
 	}
@@ -476,7 +476,7 @@ func (a *App) tryExecuteCustomCommand(c request.CTX, args *model.CommandArgs, tr
 	}
 	p.Set("response_url", args.SiteURL+"/hooks/commands/"+hook.Id)
 
-	return a.DoCommandRequest(c, cmd, p)
+	return a.DoCommandRequest(rctx, cmd, p)
 }
 
 func (a *App) DoCommandRequest(rctx request.CTX, cmd *model.Command, p url.Values) (*model.Command, *model.CommandResponse, *model.AppError) {
@@ -563,7 +563,7 @@ func (a *App) DoCommandRequest(rctx request.CTX, cmd *model.Command, p url.Value
 	return cmd, response, nil
 }
 
-func (a *App) HandleCommandResponse(c request.CTX, command *model.Command, args *model.CommandArgs, response *model.CommandResponse, builtIn bool) (*model.CommandResponse, *model.AppError) {
+func (a *App) HandleCommandResponse(rctx request.CTX, command *model.Command, args *model.CommandArgs, response *model.CommandResponse, builtIn bool) (*model.CommandResponse, *model.AppError) {
 	trigger := ""
 	if args.Command != "" {
 		parts := strings.Split(args.Command, " ")
@@ -572,19 +572,19 @@ func (a *App) HandleCommandResponse(c request.CTX, command *model.Command, args 
 	}
 
 	var lastError *model.AppError
-	_, err := a.HandleCommandResponsePost(c, command, args, response, builtIn)
+	_, err := a.HandleCommandResponsePost(rctx, command, args, response, builtIn)
 
 	if err != nil {
-		c.Logger().Debug("Error occurred in handling command response post", mlog.Err(err))
+		rctx.Logger().Debug("Error occurred in handling command response post", mlog.Err(err))
 		lastError = err
 	}
 
 	if response.ExtraResponses != nil {
 		for _, resp := range response.ExtraResponses {
-			_, err := a.HandleCommandResponsePost(c, command, args, resp, builtIn)
+			_, err := a.HandleCommandResponsePost(rctx, command, args, resp, builtIn)
 
 			if err != nil {
-				c.Logger().Debug("Error occurred in handling command response post", mlog.Err(err))
+				rctx.Logger().Debug("Error occurred in handling command response post", mlog.Err(err))
 				lastError = err
 			}
 		}
@@ -597,7 +597,7 @@ func (a *App) HandleCommandResponse(c request.CTX, command *model.Command, args 
 	return response, nil
 }
 
-func (a *App) HandleCommandResponsePost(c request.CTX, command *model.Command, args *model.CommandArgs, response *model.CommandResponse, builtIn bool) (*model.Post, *model.AppError) {
+func (a *App) HandleCommandResponsePost(rctx request.CTX, command *model.Command, args *model.CommandArgs, response *model.CommandResponse, builtIn bool) (*model.Post, *model.AppError) {
 	post := &model.Post{}
 	post.ChannelId = args.ChannelId
 	post.RootId = args.RootId
@@ -606,7 +606,7 @@ func (a *App) HandleCommandResponsePost(c request.CTX, command *model.Command, a
 	post.SetProps(response.Props)
 
 	if response.ChannelId != "" {
-		_, err := a.GetChannelMember(c, response.ChannelId, args.UserId)
+		_, err := a.GetChannelMember(rctx, response.ChannelId, args.UserId)
 		if err != nil {
 			err = model.NewAppError("HandleCommandResponsePost", "api.command.command_post.forbidden.app_error", nil, "", http.StatusForbidden).Wrap(err)
 			return nil, err
@@ -648,7 +648,7 @@ func (a *App) HandleCommandResponsePost(c request.CTX, command *model.Command, a
 		response.Attachments = a.ProcessSlackAttachments(response.Attachments)
 	}
 
-	if _, err := a.CreateCommandPost(c, post, args.TeamId, response, response.SkipSlackParsing); err != nil {
+	if _, err := a.CreateCommandPost(rctx, post, args.TeamId, response, response.SkipSlackParsing); err != nil {
 		return post, err
 	}
 

--- a/server/channels/app/command_autocomplete_test.go
+++ b/server/channels/app/command_autocomplete_test.go
@@ -663,14 +663,14 @@ func (p *testCommandProvider) GetCommand(a *App, T i18n.TranslateFunc) *model.Co
 	}
 }
 
-func (p *testCommandProvider) DoCommand(a *App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (p *testCommandProvider) DoCommand(a *App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	return &model.CommandResponse{
 		Text:         "I do nothing!",
 		ResponseType: model.CommandResponseTypeEphemeral,
 	}
 }
 
-func (p *testCommandProvider) GetAutoCompleteListItems(c request.CTX, a *App, commandArgs *model.CommandArgs, arg *model.AutocompleteArg, parsed, toBeParsed string) ([]model.AutocompleteListItem, error) {
+func (p *testCommandProvider) GetAutoCompleteListItems(rctx request.CTX, a *App, commandArgs *model.CommandArgs, arg *model.AutocompleteArg, parsed, toBeParsed string) ([]model.AutocompleteListItem, error) {
 	if arg.Name == "dynaArg" {
 		return []model.AutocompleteListItem{
 			{Item: "item1", Hint: "this is hint 1", HelpText: "This is help text 1."},

--- a/server/channels/app/context.go
+++ b/server/channels/app/context.go
@@ -10,17 +10,17 @@ import (
 )
 
 // RequestContextWithMaster adds the context value that master DB should be selected for this request.
-func RequestContextWithMaster(c request.CTX) request.CTX {
-	return sqlstore.RequestContextWithMaster(c)
+func RequestContextWithMaster(rctx request.CTX) request.CTX {
+	return sqlstore.RequestContextWithMaster(rctx)
 }
 
-func pluginContext(c request.CTX) *plugin.Context {
+func pluginContext(rctx request.CTX) *plugin.Context {
 	context := &plugin.Context{
-		RequestId:      c.RequestId(),
-		SessionId:      c.Session().Id,
-		IPAddress:      c.IPAddress(),
-		AcceptLanguage: c.AcceptLanguage(),
-		UserAgent:      c.UserAgent(),
+		RequestId:      rctx.RequestId(),
+		SessionId:      rctx.Session().Id,
+		IPAddress:      rctx.IPAddress(),
+		AcceptLanguage: rctx.AcceptLanguage(),
+		UserAgent:      rctx.UserAgent(),
 	}
 	return context
 }

--- a/server/channels/app/file.go
+++ b/server/channels/app/file.go
@@ -592,12 +592,12 @@ func GeneratePublicLinkHash(fileID, salt string) string {
 }
 
 // UploadFile uploads a single file in form of a completely constructed byte array for a channel.
-func (a *App) UploadFile(c request.CTX, data []byte, channelID string, filename string) (*model.FileInfo, *model.AppError) {
-	return a.UploadFileForUserAndTeam(c, data, channelID, filename, "", "")
+func (a *App) UploadFile(rctx request.CTX, data []byte, channelID string, filename string) (*model.FileInfo, *model.AppError) {
+	return a.UploadFileForUserAndTeam(rctx, data, channelID, filename, "", "")
 }
 
-func (a *App) UploadFileForUserAndTeam(c request.CTX, data []byte, channelID string, filename string, rawUserId string, rawTeamId string) (*model.FileInfo, *model.AppError) {
-	_, err := a.GetChannel(c, channelID)
+func (a *App) UploadFileForUserAndTeam(rctx request.CTX, data []byte, channelID string, filename string, rawUserId string, rawTeamId string) (*model.FileInfo, *model.AppError) {
+	_, err := a.GetChannel(rctx, channelID)
 	if err != nil && channelID != "" {
 		return nil, model.NewAppError("UploadFile", "api.file.upload_file.incorrect_channelId.app_error",
 			map[string]any{"channelId": channelID}, "", http.StatusBadRequest)
@@ -613,7 +613,7 @@ func (a *App) UploadFileForUserAndTeam(c request.CTX, data []byte, channelID str
 		teamId = "noteam"
 	}
 
-	info, _, appError := a.DoUploadFileExpectModification(c, time.Now(), teamId, channelID, userId, filename, data, true)
+	info, _, appError := a.DoUploadFileExpectModification(rctx, time.Now(), teamId, channelID, userId, filename, data, true)
 	if appError != nil {
 		return nil, appError
 	}
@@ -623,14 +623,14 @@ func (a *App) UploadFileForUserAndTeam(c request.CTX, data []byte, channelID str
 		thumbnailPathList := []string{info.ThumbnailPath}
 		imageDataList := [][]byte{data}
 
-		a.HandleImages(c, previewPathList, thumbnailPathList, imageDataList)
+		a.HandleImages(rctx, previewPathList, thumbnailPathList, imageDataList)
 	}
 
 	return info, nil
 }
 
-func (a *App) DoUploadFile(c request.CTX, now time.Time, rawTeamId string, rawChannelId string, rawUserId string, rawFilename string, data []byte, extractContent bool) (*model.FileInfo, *model.AppError) {
-	info, _, err := a.DoUploadFileExpectModification(c, now, rawTeamId, rawChannelId, rawUserId, rawFilename, data, extractContent)
+func (a *App) DoUploadFile(rctx request.CTX, now time.Time, rawTeamId string, rawChannelId string, rawUserId string, rawFilename string, data []byte, extractContent bool) (*model.FileInfo, *model.AppError) {
+	info, _, err := a.DoUploadFileExpectModification(rctx, now, rawTeamId, rawChannelId, rawUserId, rawFilename, data, extractContent)
 	return info, err
 }
 
@@ -769,11 +769,11 @@ func (t *UploadFileTask) init(a *App) {
 // returns a filled-out FileInfo and an optional error. A plugin may reject the
 // upload, returning a rejection error. In this case FileInfo would have
 // contained the last "good" FileInfo before the execution of that plugin.
-func (a *App) UploadFileX(c request.CTX, channelID, name string, input io.Reader,
+func (a *App) UploadFileX(rctx request.CTX, channelID, name string, input io.Reader,
 	opts ...func(*UploadFileTask),
 ) (*model.FileInfo, *model.AppError) {
 	t := &UploadFileTask{
-		Logger:         c.Logger(),
+		Logger:         rctx.Logger(),
 		ChannelId:      filepath.Base(channelID),
 		Name:           filepath.Base(name),
 		Input:          input,
@@ -787,7 +787,7 @@ func (a *App) UploadFileX(c request.CTX, channelID, name string, input io.Reader
 		o(t)
 	}
 
-	c = c.WithLogger(c.Logger().With(
+	rctx = rctx.WithLogger(rctx.Logger().With(
 		mlog.String("file_name", name),
 		mlog.String("channel_id", channelID),
 		mlog.String("user_id", t.UserId),
@@ -817,7 +817,7 @@ func (a *App) UploadFileX(c request.CTX, channelID, name string, input io.Reader
 
 	if written > t.maxFileSize {
 		if fileErr := a.RemoveFile(t.fileinfo.Path); fileErr != nil {
-			c.Logger().Error("Failed to remove file", mlog.Err(fileErr))
+			rctx.Logger().Error("Failed to remove file", mlog.Err(fileErr))
 		}
 		return nil, t.newAppError("api.file.upload_file.too_large_detailed.app_error", http.StatusRequestEntityTooLarge, "Length", t.ContentLength, "Limit", t.maxFileSize)
 	}
@@ -830,7 +830,7 @@ func (a *App) UploadFileX(c request.CTX, channelID, name string, input io.Reader
 	}
 	defer file.Close()
 
-	aerr = a.runPluginsHook(c, t.fileinfo, file)
+	aerr = a.runPluginsHook(rctx, t.fileinfo, file)
 	if aerr != nil {
 		return nil, aerr
 	}
@@ -844,7 +844,7 @@ func (a *App) UploadFileX(c request.CTX, channelID, name string, input io.Reader
 		t.postprocessImage(file)
 	}
 
-	if _, err := t.saveToDatabase(c, t.fileinfo); err != nil {
+	if _, err := t.saveToDatabase(rctx, t.fileinfo); err != nil {
 		var appErr *model.AppError
 		switch {
 		case errors.As(err, &appErr):
@@ -857,9 +857,9 @@ func (a *App) UploadFileX(c request.CTX, channelID, name string, input io.Reader
 	if *a.Config().FileSettings.ExtractContent && t.ExtractContent {
 		infoCopy := *t.fileinfo
 		a.Srv().GoBuffered(func() {
-			err := a.ExtractContentFromFileInfo(c, &infoCopy)
+			err := a.ExtractContentFromFileInfo(rctx, &infoCopy)
 			if err != nil {
-				c.Logger().Error("Failed to extract file content", mlog.Err(err), mlog.String("fileInfoId", infoCopy.Id))
+				rctx.Logger().Error("Failed to extract file content", mlog.Err(err), mlog.String("fileInfoId", infoCopy.Id))
 			}
 		})
 	}
@@ -1038,7 +1038,7 @@ func (t UploadFileTask) newAppError(id string, httpStatus int, extra ...any) *mo
 	return model.NewAppError("uploadFileTask", id, params, "", httpStatus)
 }
 
-func (a *App) DoUploadFileExpectModification(c request.CTX, now time.Time, rawTeamId string, rawChannelId string, rawUserId string, rawFilename string, data []byte, extractContent bool) (*model.FileInfo, []byte, *model.AppError) {
+func (a *App) DoUploadFileExpectModification(rctx request.CTX, now time.Time, rawTeamId string, rawChannelId string, rawUserId string, rawFilename string, data []byte, extractContent bool) (*model.FileInfo, []byte, *model.AppError) {
 	filename := filepath.Base(rawFilename)
 	teamID := filepath.Base(rawTeamId)
 	channelID := filepath.Base(rawChannelId)
@@ -1057,7 +1057,7 @@ func (a *App) DoUploadFileExpectModification(c request.CTX, now time.Time, rawTe
 			orientation == imaging.RotatedCW) {
 		info.Width, info.Height = info.Height, info.Width
 	} else if err != nil {
-		c.Logger().Warn("Failed to get image orientation", mlog.Err(err))
+		rctx.Logger().Warn("Failed to get image orientation", mlog.Err(err))
 	}
 
 	info.Id = model.NewId()
@@ -1082,7 +1082,7 @@ func (a *App) DoUploadFileExpectModification(c request.CTX, now time.Time, rawTe
 	}
 
 	var rejectionError *model.AppError
-	pluginContext := pluginContext(c)
+	pluginContext := pluginContext(rctx)
 	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 		var newBytes bytes.Buffer
 		replacementInfo, rejectionReason := hooks.FileWillBeUploaded(pluginContext, info, bytes.NewReader(data), &newBytes)
@@ -1108,7 +1108,7 @@ func (a *App) DoUploadFileExpectModification(c request.CTX, now time.Time, rawTe
 		return nil, data, err
 	}
 
-	if _, err := a.Srv().Store().FileInfo().Save(c, info); err != nil {
+	if _, err := a.Srv().Store().FileInfo().Save(rctx, info); err != nil {
 		var appErr *model.AppError
 		switch {
 		case errors.As(err, &appErr):
@@ -1124,9 +1124,9 @@ func (a *App) DoUploadFileExpectModification(c request.CTX, now time.Time, rawTe
 	if *a.Config().FileSettings.ExtractContent && extractContent {
 		infoCopy := *info
 		a.Srv().GoBuffered(func() {
-			err := a.ExtractContentFromFileInfo(c, &infoCopy)
+			err := a.ExtractContentFromFileInfo(rctx, &infoCopy)
 			if err != nil {
-				c.Logger().Error("Failed to extract file content", mlog.Err(err), mlog.String("fileInfoId", infoCopy.Id))
+				rctx.Logger().Error("Failed to extract file content", mlog.Err(err), mlog.String("fileInfoId", infoCopy.Id))
 			}
 		})
 	}
@@ -1458,7 +1458,7 @@ func populateZipfile(w *zip.Writer, fileDatas []model.FileData) error {
 	return nil
 }
 
-func (a *App) SearchFilesInTeamForUser(c request.CTX, terms string, userId string, teamId string, isOrSearch bool, includeDeletedChannels bool, timeZoneOffset int, page, perPage int) (*model.FileInfoList, *model.AppError) {
+func (a *App) SearchFilesInTeamForUser(rctx request.CTX, terms string, userId string, teamId string, isOrSearch bool, includeDeletedChannels bool, timeZoneOffset int, page, perPage int) (*model.FileInfoList, *model.AppError) {
 	paramsList := model.ParseSearchParams(strings.TrimSpace(terms), timeZoneOffset)
 	includeDeleted := includeDeletedChannels && *a.Config().TeamSettings.ExperimentalViewArchivedChannels
 
@@ -1474,12 +1474,12 @@ func (a *App) SearchFilesInTeamForUser(c request.CTX, terms string, userId strin
 		// Don't allow users to search for "*"
 		if params.Terms != "*" {
 			// Convert channel names to channel IDs
-			params.InChannels = a.convertChannelNamesToChannelIds(c, params.InChannels, userId, teamId, includeDeletedChannels)
-			params.ExcludedChannels = a.convertChannelNamesToChannelIds(c, params.ExcludedChannels, userId, teamId, includeDeletedChannels)
+			params.InChannels = a.convertChannelNamesToChannelIds(rctx, params.InChannels, userId, teamId, includeDeletedChannels)
+			params.ExcludedChannels = a.convertChannelNamesToChannelIds(rctx, params.ExcludedChannels, userId, teamId, includeDeletedChannels)
 
 			// Convert usernames to user IDs
-			params.FromUsers = a.convertUserNameToUserIds(c, params.FromUsers)
-			params.ExcludedUsers = a.convertUserNameToUserIds(c, params.ExcludedUsers)
+			params.FromUsers = a.convertUserNameToUserIds(rctx, params.FromUsers)
+			params.ExcludedUsers = a.convertUserNameToUserIds(rctx, params.ExcludedUsers)
 
 			finalParamsList = append(finalParamsList, params)
 		}
@@ -1490,7 +1490,7 @@ func (a *App) SearchFilesInTeamForUser(c request.CTX, terms string, userId strin
 		return model.NewFileInfoList(), nil
 	}
 
-	fileInfoSearchResults, nErr := a.Srv().Store().FileInfo().Search(c, finalParamsList, userId, teamId, page, perPage)
+	fileInfoSearchResults, nErr := a.Srv().Store().FileInfo().Search(rctx, finalParamsList, userId, teamId, page, perPage)
 	if nErr != nil {
 		var appErr *model.AppError
 		switch {

--- a/server/channels/app/helper_test.go
+++ b/server/channels/app/helper_test.go
@@ -438,15 +438,15 @@ func WithCreateAt(v int64) ChannelOption {
 	}
 }
 
-func (th *TestHelper) CreateChannel(c request.CTX, team *model.Team, options ...ChannelOption) *model.Channel {
-	return th.createChannel(c, team, model.ChannelTypeOpen, options...)
+func (th *TestHelper) CreateChannel(rctx request.CTX, team *model.Team, options ...ChannelOption) *model.Channel {
+	return th.createChannel(rctx, team, model.ChannelTypeOpen, options...)
 }
 
-func (th *TestHelper) CreatePrivateChannel(c request.CTX, team *model.Team, options ...ChannelOption) *model.Channel {
-	return th.createChannel(c, team, model.ChannelTypePrivate, options...)
+func (th *TestHelper) CreatePrivateChannel(rctx request.CTX, team *model.Team, options ...ChannelOption) *model.Channel {
+	return th.createChannel(rctx, team, model.ChannelTypePrivate, options...)
 }
 
-func (th *TestHelper) createChannel(c request.CTX, team *model.Team, channelType model.ChannelType, options ...ChannelOption) *model.Channel {
+func (th *TestHelper) createChannel(rctx request.CTX, team *model.Team, channelType model.ChannelType, options ...ChannelOption) *model.Channel {
 	id := model.NewId()
 
 	channel := &model.Channel{
@@ -468,7 +468,7 @@ func (th *TestHelper) createChannel(c request.CTX, team *model.Team, channelType
 
 	if channel.IsShared() {
 		id := model.NewId()
-		_, err := th.App.ShareChannel(c, &model.SharedChannel{
+		_, err := th.App.ShareChannel(rctx, &model.SharedChannel{
 			ChannelId:        channel.Id,
 			TeamId:           channel.TeamId,
 			Home:             false,
@@ -494,10 +494,10 @@ func (th *TestHelper) CreateDmChannel(user *model.User) *model.Channel {
 	return channel
 }
 
-func (th *TestHelper) CreateGroupChannel(c request.CTX, user1 *model.User, user2 *model.User) *model.Channel {
+func (th *TestHelper) CreateGroupChannel(rctx request.CTX, user1 *model.User, user2 *model.User) *model.Channel {
 	var err *model.AppError
 	var channel *model.Channel
-	if channel, err = th.App.CreateGroupChannel(c, []string{th.BasicUser.Id, user1.Id, user2.Id}, th.BasicUser.Id); err != nil {
+	if channel, err = th.App.CreateGroupChannel(rctx, []string{th.BasicUser.Id, user1.Id, user2.Id}, th.BasicUser.Id); err != nil {
 		panic(err)
 	}
 	return channel

--- a/server/channels/app/import.go
+++ b/server/channels/app/import.go
@@ -29,20 +29,20 @@ const (
 	statusUpdateAfterLines       = 8192
 )
 
-func stopOnError(c request.CTX, err imports.LineImportWorkerError) bool {
+func stopOnError(rctx request.CTX, err imports.LineImportWorkerError) bool {
 	switch err.Error.Id {
 	case "api.file.upload_file.large_image.app_error":
-		c.Logger().Warn("Large image import error", mlog.Err(err.Error))
+		rctx.Logger().Warn("Large image import error", mlog.Err(err.Error))
 		return false
 	case "app.import.validate_direct_channel_import_data.members_too_few.error", "app.import.validate_direct_channel_import_data.members_too_many.error":
-		c.Logger().Warn("Invalid direct channel import data", mlog.Err(err.Error))
+		rctx.Logger().Warn("Invalid direct channel import data", mlog.Err(err.Error))
 		return false
 	default:
 		return true
 	}
 }
 
-func processAttachmentPaths(c request.CTX, files *[]imports.AttachmentImportData, basePath string, filesMap map[string]*zip.File) error {
+func processAttachmentPaths(rctx request.CTX, files *[]imports.AttachmentImportData, basePath string, filesMap map[string]*zip.File) error {
 	if files == nil {
 		return nil
 	}
@@ -74,20 +74,20 @@ func processAttachmentPaths(c request.CTX, files *[]imports.AttachmentImportData
 	return errors.Join(errs...)
 }
 
-func processAttachments(c request.CTX, line *imports.LineImportData, basePath string, filesMap map[string]*zip.File) error {
+func processAttachments(rctx request.CTX, line *imports.LineImportData, basePath string, filesMap map[string]*zip.File) error {
 	var ok bool
 	switch line.Type {
 	case "post", "direct_post":
 		var replies []imports.ReplyImportData
 		if line.Type == "direct_post" {
-			if err := processAttachmentPaths(c, line.DirectPost.Attachments, basePath, filesMap); err != nil {
+			if err := processAttachmentPaths(rctx, line.DirectPost.Attachments, basePath, filesMap); err != nil {
 				return err
 			}
 			if line.DirectPost.Replies != nil {
 				replies = *line.DirectPost.Replies
 			}
 		} else {
-			if err := processAttachmentPaths(c, line.Post.Attachments, basePath, filesMap); err != nil {
+			if err := processAttachmentPaths(rctx, line.Post.Attachments, basePath, filesMap); err != nil {
 				return err
 			}
 			if line.Post.Replies != nil {
@@ -95,7 +95,7 @@ func processAttachments(c request.CTX, line *imports.LineImportData, basePath st
 			}
 		}
 		for _, reply := range replies {
-			if err := processAttachmentPaths(c, reply.Attachments, basePath, filesMap); err != nil {
+			if err := processAttachmentPaths(rctx, reply.Attachments, basePath, filesMap); err != nil {
 				return err
 			}
 		}
@@ -146,14 +146,14 @@ func processAttachments(c request.CTX, line *imports.LineImportData, basePath st
 	return nil
 }
 
-func (a *App) bulkImportWorker(c request.CTX, dryRun, extractContent bool, wg *sync.WaitGroup, lines <-chan imports.LineImportWorkerData, errors chan<- imports.LineImportWorkerError) {
+func (a *App) bulkImportWorker(rctx request.CTX, dryRun, extractContent bool, wg *sync.WaitGroup, lines <-chan imports.LineImportWorkerData, errors chan<- imports.LineImportWorkerError) {
 	workerID := model.NewId()
 	processedLines := uint64(0)
 
-	c.Logger().Info("Started new bulk import worker", mlog.String("bulk_import_worker_id", workerID))
+	rctx.Logger().Info("Started new bulk import worker", mlog.String("bulk_import_worker_id", workerID))
 	defer func() {
 		wg.Done()
-		c.Logger().Info("Bulk import worker finished", mlog.String("bulk_import_worker_id", workerID), mlog.Uint("processed_lines", processedLines))
+		rctx.Logger().Info("Bulk import worker finished", mlog.String("bulk_import_worker_id", workerID), mlog.Uint("processed_lines", processedLines))
 	}()
 
 	postLines := []imports.LineImportWorkerData{}
@@ -166,7 +166,7 @@ func (a *App) bulkImportWorker(c request.CTX, dryRun, extractContent bool, wg *s
 				errors <- imports.LineImportWorkerError{Error: model.NewAppError("BulkImport", "app.import.import_line.null_post.error", nil, "", http.StatusBadRequest), LineNumber: line.LineNumber}
 			}
 			if len(postLines) >= importMultiplePostsThreshold {
-				if errLine, err := a.importMultiplePostLines(c, postLines, dryRun, extractContent); err != nil {
+				if errLine, err := a.importMultiplePostLines(rctx, postLines, dryRun, extractContent); err != nil {
 					errors <- imports.LineImportWorkerError{Error: err, LineNumber: errLine}
 				}
 				postLines = []imports.LineImportWorkerData{}
@@ -177,48 +177,48 @@ func (a *App) bulkImportWorker(c request.CTX, dryRun, extractContent bool, wg *s
 				errors <- imports.LineImportWorkerError{Error: model.NewAppError("BulkImport", "app.import.import_line.null_direct_post.error", nil, "", http.StatusBadRequest), LineNumber: line.LineNumber}
 			}
 			if len(directPostLines) >= importMultiplePostsThreshold {
-				if errLine, err := a.importMultipleDirectPostLines(c, directPostLines, dryRun, extractContent); err != nil {
+				if errLine, err := a.importMultipleDirectPostLines(rctx, directPostLines, dryRun, extractContent); err != nil {
 					errors <- imports.LineImportWorkerError{Error: err, LineNumber: errLine}
 				}
 				directPostLines = []imports.LineImportWorkerData{}
 			}
 		default:
-			if err := a.importLine(c, line.LineImportData, dryRun); err != nil {
+			if err := a.importLine(rctx, line.LineImportData, dryRun); err != nil {
 				errors <- imports.LineImportWorkerError{Error: err, LineNumber: line.LineNumber}
 			}
 		}
 
 		processedLines++
 		if processedLines%statusUpdateAfterLines == 0 {
-			c.Logger().Info("Worker progress", mlog.String("bulk_import_worker_id", workerID), mlog.Uint("processed_lines", processedLines))
+			rctx.Logger().Info("Worker progress", mlog.String("bulk_import_worker_id", workerID), mlog.Uint("processed_lines", processedLines))
 		}
 	}
 
 	if len(postLines) > 0 {
-		if errLine, err := a.importMultiplePostLines(c, postLines, dryRun, extractContent); err != nil {
+		if errLine, err := a.importMultiplePostLines(rctx, postLines, dryRun, extractContent); err != nil {
 			errors <- imports.LineImportWorkerError{Error: err, LineNumber: errLine}
 		}
 	}
 	if len(directPostLines) > 0 {
-		if errLine, err := a.importMultipleDirectPostLines(c, directPostLines, dryRun, extractContent); err != nil {
+		if errLine, err := a.importMultipleDirectPostLines(rctx, directPostLines, dryRun, extractContent); err != nil {
 			errors <- imports.LineImportWorkerError{Error: err, LineNumber: errLine}
 		}
 	}
 }
 
-func (a *App) BulkImport(c request.CTX, jsonlReader io.Reader, attachmentsReader *zip.Reader, dryRun bool, workers int) (int, *model.AppError) {
-	return a.bulkImport(c, jsonlReader, attachmentsReader, dryRun, true, workers, "")
+func (a *App) BulkImport(rctx request.CTX, jsonlReader io.Reader, attachmentsReader *zip.Reader, dryRun bool, workers int) (int, *model.AppError) {
+	return a.bulkImport(rctx, jsonlReader, attachmentsReader, dryRun, true, workers, "")
 }
 
-func (a *App) BulkImportWithPath(c request.CTX, jsonlReader io.Reader, attachmentsReader *zip.Reader, dryRun, extractContent bool, workers int, importPath string) (int, *model.AppError) {
-	return a.bulkImport(c, jsonlReader, attachmentsReader, dryRun, extractContent, workers, importPath)
+func (a *App) BulkImportWithPath(rctx request.CTX, jsonlReader io.Reader, attachmentsReader *zip.Reader, dryRun, extractContent bool, workers int, importPath string) (int, *model.AppError) {
+	return a.bulkImport(rctx, jsonlReader, attachmentsReader, dryRun, extractContent, workers, importPath)
 }
 
 // bulkImport will extract attachments from attachmentsReader if it is
 // not nil. If it is nil, it will look for attachments on the
 // filesystem in the locations specified by the JSONL file according
 // to the older behavior
-func (a *App) bulkImport(c request.CTX, jsonlReader io.Reader, attachmentsReader *zip.Reader, dryRun, extractContent bool, workers int, importPath string) (int, *model.AppError) {
+func (a *App) bulkImport(rctx request.CTX, jsonlReader io.Reader, attachmentsReader *zip.Reader, dryRun, extractContent bool, workers int, importPath string) (int, *model.AppError) {
 	scanner := bufio.NewScanner(jsonlReader)
 	buf := make([]byte, 0, 64*1024)
 	scanner.Buffer(buf, maxScanTokenSize)
@@ -244,7 +244,7 @@ func (a *App) bulkImport(c request.CTX, jsonlReader io.Reader, attachmentsReader
 	for scanner.Scan() {
 		lineNumber++
 		if lineNumber%statusUpdateAfterLines == 0 {
-			c.Logger().Info("Reader progress", mlog.Int("processed_lines", lineNumber))
+			rctx.Logger().Info("Reader progress", mlog.Int("processed_lines", lineNumber))
 		}
 
 		var line imports.LineImportData
@@ -252,8 +252,8 @@ func (a *App) bulkImport(c request.CTX, jsonlReader io.Reader, attachmentsReader
 			return lineNumber, model.NewAppError("BulkImport", "app.import.bulk_import.json_decode.error", nil, "", http.StatusBadRequest).Wrap(err)
 		}
 
-		if err := processAttachments(c, &line, importPath, attachedFiles); err != nil {
-			c.Logger().Warn("Error while processing import attachments. Objects might be broken.", mlog.Err(err))
+		if err := processAttachments(rctx, &line, importPath, attachedFiles); err != nil {
+			rctx.Logger().Warn("Error while processing import attachments. Objects might be broken.", mlog.Err(err))
 		}
 
 		if lineNumber == 1 {
@@ -272,7 +272,7 @@ func (a *App) bulkImport(c request.CTX, jsonlReader io.Reader, attachmentsReader
 		if line.Type != lastLineType {
 			// Only clear the worker queue if is not the first data entry
 			if lineNumber != 2 {
-				c.Logger().Info(
+				rctx.Logger().Info(
 					"Finished parsing segment, waiting for workers to finish",
 					mlog.String("old_segment", lastLineType),
 					mlog.String("new_segment", line.Type),
@@ -285,13 +285,13 @@ func (a *App) bulkImport(c request.CTX, jsonlReader io.Reader, attachmentsReader
 				// Check no errors occurred while waiting for the queue to empty.
 				if len(errorsChan) != 0 {
 					err := <-errorsChan
-					if stopOnError(c, err) {
+					if stopOnError(rctx, err) {
 						return err.LineNumber, err.Error
 					}
 				}
 			}
 
-			c.Logger().Info(
+			rctx.Logger().Info(
 				"Starting workers for new segment",
 				mlog.String("old_segment", lastLineType),
 				mlog.String("new_segment", line.Type),
@@ -303,14 +303,14 @@ func (a *App) bulkImport(c request.CTX, jsonlReader io.Reader, attachmentsReader
 			linesChan = make(chan imports.LineImportWorkerData, workers)
 			for i := 0; i < workers; i++ {
 				wg.Add(1)
-				go a.bulkImportWorker(c, dryRun, extractContent, &wg, linesChan, errorsChan)
+				go a.bulkImportWorker(rctx, dryRun, extractContent, &wg, linesChan, errorsChan)
 			}
 		}
 
 		select {
 		case linesChan <- imports.LineImportWorkerData{LineImportData: line, LineNumber: lineNumber}:
 		case err := <-errorsChan:
-			if stopOnError(c, err) {
+			if stopOnError(rctx, err) {
 				close(linesChan)
 				wg.Wait()
 				return err.LineNumber, err.Error
@@ -327,7 +327,7 @@ func (a *App) bulkImport(c request.CTX, jsonlReader io.Reader, attachmentsReader
 	// Check no errors occurred while waiting for the queue to empty.
 	if len(errorsChan) != 0 {
 		err := <-errorsChan
-		if stopOnError(c, err) {
+		if stopOnError(rctx, err) {
 			return err.LineNumber, err.Error
 		}
 	}
@@ -347,48 +347,48 @@ func processImportDataFileVersionLine(line imports.LineImportData) (int, *model.
 	return *line.Version, nil
 }
 
-func (a *App) importLine(c request.CTX, line imports.LineImportData, dryRun bool) *model.AppError {
+func (a *App) importLine(rctx request.CTX, line imports.LineImportData, dryRun bool) *model.AppError {
 	switch {
 	case line.Type == "role":
 		if line.Role == nil {
 			return model.NewAppError("BulkImport", "app.import.import_line.null_role.error", nil, "", http.StatusBadRequest)
 		}
-		return a.importRole(c, line.Role, dryRun)
+		return a.importRole(rctx, line.Role, dryRun)
 	case line.Type == "scheme":
 		if line.Scheme == nil {
 			return model.NewAppError("BulkImport", "app.import.import_line.null_scheme.error", nil, "", http.StatusBadRequest)
 		}
-		return a.importScheme(c, line.Scheme, dryRun)
+		return a.importScheme(rctx, line.Scheme, dryRun)
 	case line.Type == "team":
 		if line.Team == nil {
 			return model.NewAppError("BulkImport", "app.import.import_line.null_team.error", nil, "", http.StatusBadRequest)
 		}
-		return a.importTeam(c, line.Team, dryRun)
+		return a.importTeam(rctx, line.Team, dryRun)
 	case line.Type == "channel":
 		if line.Channel == nil {
 			return model.NewAppError("BulkImport", "app.import.import_line.null_channel.error", nil, "", http.StatusBadRequest)
 		}
-		return a.importChannel(c, line.Channel, dryRun)
+		return a.importChannel(rctx, line.Channel, dryRun)
 	case line.Type == "user":
 		if line.User == nil {
 			return model.NewAppError("BulkImport", "app.import.import_line.null_user.error", nil, "", http.StatusBadRequest)
 		}
-		return a.importUser(c, line.User, dryRun)
+		return a.importUser(rctx, line.User, dryRun)
 	case line.Type == "bot":
 		if line.Bot == nil {
 			return model.NewAppError("BulkImport", "app.import.import_line.null_bot.error", nil, "", http.StatusBadRequest)
 		}
-		return a.importBot(c, line.Bot, dryRun)
+		return a.importBot(rctx, line.Bot, dryRun)
 	case line.Type == "direct_channel":
 		if line.DirectChannel == nil {
 			return model.NewAppError("BulkImport", "app.import.import_line.null_direct_channel.error", nil, "", http.StatusBadRequest)
 		}
-		return a.importDirectChannel(c, line.DirectChannel, dryRun)
+		return a.importDirectChannel(rctx, line.DirectChannel, dryRun)
 	case line.Type == "emoji":
 		if line.Emoji == nil {
 			return model.NewAppError("BulkImport", "app.import.import_line.null_emoji.error", nil, "", http.StatusBadRequest)
 		}
-		return a.importEmoji(c, line.Emoji, dryRun)
+		return a.importEmoji(rctx, line.Emoji, dryRun)
 	default:
 		return model.NewAppError("BulkImport", "app.import.import_line.unknown_line_type.error", map[string]any{"Type": line.Type}, "", http.StatusBadRequest)
 	}

--- a/server/channels/app/integration_action.go
+++ b/server/channels/app/integration_action.go
@@ -39,7 +39,7 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/utils"
 )
 
-func (a *App) DoPostActionWithCookie(c request.CTX, postID, actionId, userID, selectedOption string, cookie *model.PostActionCookie) (string, *model.AppError) {
+func (a *App) DoPostActionWithCookie(rctx request.CTX, postID, actionId, userID, selectedOption string, cookie *model.PostActionCookie) (string, *model.AppError) {
 	// PostAction may result in the original post being updated. For the
 	// updated post, we need to unconditionally preserve the original
 	// IsPinned and HasReaction attributes, and preserve its entire
@@ -67,7 +67,7 @@ func (a *App) DoPostActionWithCookie(c request.CTX, postID, actionId, userID, se
 	// Start all queries here for parallel execution
 	pchan := make(chan store.StoreResult[*model.Post], 1)
 	go func() {
-		post, err := a.Srv().Store().Post().GetSingle(c, postID, false)
+		post, err := a.Srv().Store().Post().GetSingle(rctx, postID, false)
 		pchan <- store.StoreResult[*model.Post]{Data: post, NErr: err}
 		close(pchan)
 	}()
@@ -235,7 +235,7 @@ func (a *App) DoPostActionWithCookie(c request.CTX, postID, actionId, userID, se
 	}
 
 	// Log request, regardless of whether destination is internal or external
-	c.Logger().Info("DoPostActionWithCookie POST request, through DoActionRequest",
+	rctx.Logger().Info("DoPostActionWithCookie POST request, through DoActionRequest",
 		mlog.String("url", upstreamURL),
 		mlog.String("user_id", upstreamRequest.UserId),
 		mlog.String("post_id", upstreamRequest.PostId),
@@ -245,7 +245,7 @@ func (a *App) DoPostActionWithCookie(c request.CTX, postID, actionId, userID, se
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*a.Config().ServiceSettings.OutgoingIntegrationRequestsTimeout)*time.Second)
 	defer cancel()
-	resp, appErr := a.DoActionRequest(c.WithContext(ctx), upstreamURL, requestJSON)
+	resp, appErr := a.DoActionRequest(rctx.WithContext(ctx), upstreamURL, requestJSON)
 	if appErr != nil {
 		return "", appErr
 	}
@@ -280,7 +280,7 @@ func (a *App) DoPostActionWithCookie(c request.CTX, postID, actionId, userID, se
 		response.Update.IsPinned = originalIsPinned
 		response.Update.HasReactions = originalHasReactions
 
-		if _, appErr = a.UpdatePost(c, response.Update, &model.UpdatePostOptions{SafeUpdate: false}); appErr != nil {
+		if _, appErr = a.UpdatePost(rctx, response.Update, &model.UpdatePostOptions{SafeUpdate: false}); appErr != nil {
 			return "", appErr
 		}
 	}
@@ -300,7 +300,7 @@ func (a *App) DoPostActionWithCookie(c request.CTX, postID, actionId, userID, se
 		for key, value := range retain {
 			ephemeralPost.AddProp(key, value)
 		}
-		a.SendEphemeralPost(c, userID, ephemeralPost)
+		a.SendEphemeralPost(rctx, userID, ephemeralPost)
 	}
 
 	return clientTriggerId, nil
@@ -309,7 +309,7 @@ func (a *App) DoPostActionWithCookie(c request.CTX, postID, actionId, userID, se
 // DoActionRequest performs an HTTP POST request to an integration's action endpoint.
 // Caller must consume and close returned http.Response as necessary.
 // For internal requests, requests are routed directly to a plugin ServerHTTP hook
-func (a *App) DoActionRequest(c request.CTX, rawURL string, body []byte) (*http.Response, *model.AppError) {
+func (a *App) DoActionRequest(rctx request.CTX, rawURL string, body []byte) (*http.Response, *model.AppError) {
 	inURL, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, model.NewAppError("DoActionRequest", "api.post.do_action.action_integration.app_error", nil, "", http.StatusBadRequest).Wrap(err)
@@ -317,13 +317,13 @@ func (a *App) DoActionRequest(c request.CTX, rawURL string, body []byte) (*http.
 
 	rawURLPath := path.Clean(rawURL)
 	if strings.HasPrefix(rawURLPath, "/plugins/") || strings.HasPrefix(rawURLPath, "plugins/") {
-		return a.DoLocalRequest(c, rawURLPath, body)
+		return a.DoLocalRequest(rctx, rawURLPath, body)
 	}
 
-	req, err := http.NewRequestWithContext(c.Context(), "POST", rawURL, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(rctx.Context(), "POST", rawURL, bytes.NewReader(body))
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			c.Logger().Info("Outgoing Integration Action request timed out. Consider increasing ServiceSettings.OutgoingIntegrationRequestsTimeout.")
+			rctx.Logger().Info("Outgoing Integration Action request timed out. Consider increasing ServiceSettings.OutgoingIntegrationRequestsTimeout.")
 		}
 		return nil, model.NewAppError("DoActionRequest", "api.post.do_action.action_integration.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
@@ -335,7 +335,7 @@ func (a *App) DoActionRequest(c request.CTX, rawURL string, body []byte) (*http.
 	subpath, _ := utils.GetSubpathFromConfig(a.Config())
 	siteURL, _ := url.Parse(*a.Config().ServiceSettings.SiteURL)
 	if inURL.Hostname() == siteURL.Hostname() && strings.HasPrefix(inURL.Path, path.Join(subpath, "plugins")) {
-		req.Header.Set(model.HeaderAuth, "Bearer "+c.Session().Token)
+		req.Header.Set(model.HeaderAuth, "Bearer "+rctx.Session().Token)
 		httpClient = a.HTTPService().MakeClient(true)
 	} else {
 		httpClient = a.HTTPService().MakeClient(false)
@@ -376,11 +376,11 @@ func (w *LocalResponseWriter) WriteHeader(statusCode int) {
 	w.status = statusCode
 }
 
-func (a *App) doPluginRequest(c request.CTX, method, rawURL string, values url.Values, body []byte) (*http.Response, *model.AppError) {
-	return a.ch.doPluginRequest(c, method, rawURL, values, body)
+func (a *App) doPluginRequest(rctx request.CTX, method, rawURL string, values url.Values, body []byte) (*http.Response, *model.AppError) {
+	return a.ch.doPluginRequest(rctx, method, rawURL, values, body)
 }
 
-func (ch *Channels) doPluginRequest(c request.CTX, method, rawURL string, values url.Values, body []byte) (*http.Response, *model.AppError) {
+func (ch *Channels) doPluginRequest(rctx request.CTX, method, rawURL string, values url.Values, body []byte) (*http.Response, *model.AppError) {
 	rawURL = strings.TrimPrefix(rawURL, "/")
 	inURL, err := url.Parse(rawURL)
 	if err != nil {
@@ -423,8 +423,8 @@ func (ch *Channels) doPluginRequest(c request.CTX, method, rawURL string, values
 	if err != nil {
 		return nil, model.NewAppError("doPluginRequest", "api.post.do_action.action_integration.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
-	r.Header.Set("Mattermost-User-Id", c.Session().UserId)
-	r.Header.Set(model.HeaderAuth, "Bearer "+c.Session().Token)
+	r.Header.Set("Mattermost-User-Id", rctx.Session().UserId)
+	r.Header.Set(model.HeaderAuth, "Bearer "+rctx.Session().Token)
 	params := make(map[string]string)
 	params["plugin_id"] = pluginID
 	r = mux.SetURLVars(r, params)
@@ -459,11 +459,11 @@ func (mlc *MailToLinkContent) ToJSON() string {
 	return string(b)
 }
 
-func (a *App) DoLocalRequest(c request.CTX, rawURL string, body []byte) (*http.Response, *model.AppError) {
-	return a.doPluginRequest(c, "POST", rawURL, nil, body)
+func (a *App) DoLocalRequest(rctx request.CTX, rawURL string, body []byte) (*http.Response, *model.AppError) {
+	return a.doPluginRequest(rctx, "POST", rawURL, nil, body)
 }
 
-func (a *App) OpenInteractiveDialog(c request.CTX, request model.OpenDialogRequest) *model.AppError {
+func (a *App) OpenInteractiveDialog(rctx request.CTX, request model.OpenDialogRequest) *model.AppError {
 	timeout := time.Duration(*a.Config().ServiceSettings.OutgoingIntegrationRequestsTimeout) * time.Second
 	clientTriggerId, userID, appErr := request.DecodeAndVerifyTriggerId(a.AsymmetricSigningKey(), timeout)
 	if appErr != nil {
@@ -471,7 +471,7 @@ func (a *App) OpenInteractiveDialog(c request.CTX, request model.OpenDialogReque
 	}
 
 	if dialogErr := request.IsValid(); dialogErr != nil {
-		c.Logger().Warn("Interactive dialog is invalid", mlog.Err(dialogErr))
+		rctx.Logger().Warn("Interactive dialog is invalid", mlog.Err(dialogErr))
 	}
 
 	request.TriggerId = clientTriggerId
@@ -488,7 +488,7 @@ func (a *App) OpenInteractiveDialog(c request.CTX, request model.OpenDialogReque
 	return nil
 }
 
-func (a *App) SubmitInteractiveDialog(c request.CTX, request model.SubmitDialogRequest) (*model.SubmitDialogResponse, *model.AppError) {
+func (a *App) SubmitInteractiveDialog(rctx request.CTX, request model.SubmitDialogRequest) (*model.SubmitDialogResponse, *model.AppError) {
 	url := request.URL
 	request.URL = ""
 	request.Type = "dialog_submission"
@@ -499,7 +499,7 @@ func (a *App) SubmitInteractiveDialog(c request.CTX, request model.SubmitDialogR
 	}
 
 	// Log request, regardless of whether destination is internal or external
-	c.Logger().Info("SubmitInteractiveDialog POST request, through DoActionRequest",
+	rctx.Logger().Info("SubmitInteractiveDialog POST request, through DoActionRequest",
 		mlog.String("url", url),
 		mlog.String("user_id", request.UserId),
 		mlog.String("channel_id", request.ChannelId),
@@ -508,7 +508,7 @@ func (a *App) SubmitInteractiveDialog(c request.CTX, request model.SubmitDialogR
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*a.Config().ServiceSettings.OutgoingIntegrationRequestsTimeout)*time.Second)
 	defer cancel()
-	resp, appErr := a.DoActionRequest(c.WithContext(ctx), url, b)
+	resp, appErr := a.DoActionRequest(rctx.WithContext(ctx), url, b)
 	if appErr != nil {
 		return nil, appErr
 	}

--- a/server/channels/app/ip_filtering.go
+++ b/server/channels/app/ip_filtering.go
@@ -10,12 +10,12 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/request"
 )
 
-func (a *App) SendIPFiltersChangedEmail(c request.CTX, userID string) error {
+func (a *App) SendIPFiltersChangedEmail(rctx request.CTX, userID string) error {
 	cloudWorkspaceOwnerEmailAddress := ""
 	if a.License().IsCloud() {
 		portalUserCustomer, cErr := a.Cloud().GetCloudCustomer(userID)
 		if cErr != nil {
-			c.Logger().Error("Failed to get portal user customer", mlog.Err(cErr))
+			rctx.Logger().Error("Failed to get portal user customer", mlog.Err(cErr))
 		}
 		if cErr == nil && portalUserCustomer != nil {
 			cloudWorkspaceOwnerEmailAddress = portalUserCustomer.Email
@@ -24,17 +24,17 @@ func (a *App) SendIPFiltersChangedEmail(c request.CTX, userID string) error {
 
 	initiatingUser, err := a.Srv().Store().User().GetProfileByIds(context.Background(), []string{userID}, nil, true)
 	if err != nil {
-		c.Logger().Error("Failed to get initiating user", mlog.Err(err))
+		rctx.Logger().Error("Failed to get initiating user", mlog.Err(err))
 	}
 
 	users, err := a.Srv().Store().User().GetSystemAdminProfiles()
 	if err != nil {
-		c.Logger().Error("Failed to get system admins", mlog.Err(err))
+		rctx.Logger().Error("Failed to get system admins", mlog.Err(err))
 	}
 
 	for _, user := range users {
 		if err = a.Srv().EmailService.SendIPFiltersChangedEmail(user.Email, initiatingUser[0], *a.Config().ServiceSettings.SiteURL, *a.Config().CloudSettings.CWSURL, user.Locale, cloudWorkspaceOwnerEmailAddress == user.Email); err != nil {
-			c.Logger().Error("Error while sending IP filters changed email", mlog.Err(err))
+			rctx.Logger().Error("Error while sending IP filters changed email", mlog.Err(err))
 		}
 	}
 

--- a/server/channels/app/job.go
+++ b/server/channels/app/job.go
@@ -12,8 +12,8 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 )
 
-func (a *App) GetJob(c request.CTX, id string) (*model.Job, *model.AppError) {
-	job, err := a.Srv().Store().Job().Get(c, id)
+func (a *App) GetJob(rctx request.CTX, id string) (*model.Job, *model.AppError) {
+	job, err := a.Srv().Store().Job().Get(rctx, id)
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -27,44 +27,44 @@ func (a *App) GetJob(c request.CTX, id string) (*model.Job, *model.AppError) {
 	return job, nil
 }
 
-func (a *App) GetJobsByTypePage(c request.CTX, jobType string, page int, perPage int) ([]*model.Job, *model.AppError) {
-	jobs, err := a.Srv().Store().Job().GetAllByTypePage(c, jobType, page, perPage)
+func (a *App) GetJobsByTypePage(rctx request.CTX, jobType string, page int, perPage int) ([]*model.Job, *model.AppError) {
+	jobs, err := a.Srv().Store().Job().GetAllByTypePage(rctx, jobType, page, perPage)
 	if err != nil {
 		return nil, model.NewAppError("GetJobsByType", "app.job.get_all.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	return jobs, nil
 }
 
-func (a *App) GetJobsByTypesPage(c request.CTX, jobType []string, page int, perPage int) ([]*model.Job, *model.AppError) {
-	jobs, err := a.Srv().Store().Job().GetAllByTypesPage(c, jobType, page, perPage)
+func (a *App) GetJobsByTypesPage(rctx request.CTX, jobType []string, page int, perPage int) ([]*model.Job, *model.AppError) {
+	jobs, err := a.Srv().Store().Job().GetAllByTypesPage(rctx, jobType, page, perPage)
 	if err != nil {
 		return nil, model.NewAppError("GetJobsByType", "app.job.get_all.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	return jobs, nil
 }
 
-func (a *App) GetJobsByTypesAndStatuses(c request.CTX, jobTypes []string, status []string, page int, perPage int) ([]*model.Job, *model.AppError) {
-	jobs, err := a.Srv().Store().Job().GetAllByTypesAndStatusesPage(c, jobTypes, status, page*perPage, perPage)
+func (a *App) GetJobsByTypesAndStatuses(rctx request.CTX, jobTypes []string, status []string, page int, perPage int) ([]*model.Job, *model.AppError) {
+	jobs, err := a.Srv().Store().Job().GetAllByTypesAndStatusesPage(rctx, jobTypes, status, page*perPage, perPage)
 	if err != nil {
 		return nil, model.NewAppError("GetAllByTypesAndStatusesPage", "app.job.get_all.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	return jobs, nil
 }
 
-func (a *App) CreateJob(c request.CTX, job *model.Job) (*model.Job, *model.AppError) {
-	return a.Srv().Jobs.CreateJob(c, job.Type, job.Data)
+func (a *App) CreateJob(rctx request.CTX, job *model.Job) (*model.Job, *model.AppError) {
+	return a.Srv().Jobs.CreateJob(rctx, job.Type, job.Data)
 }
 
-func (a *App) CancelJob(c request.CTX, jobId string) *model.AppError {
-	return a.Srv().Jobs.RequestCancellation(c, jobId)
+func (a *App) CancelJob(rctx request.CTX, jobId string) *model.AppError {
+	return a.Srv().Jobs.RequestCancellation(rctx, jobId)
 }
 
-func (a *App) UpdateJobStatus(c request.CTX, job *model.Job, newStatus string) *model.AppError {
+func (a *App) UpdateJobStatus(rctx request.CTX, job *model.Job, newStatus string) *model.AppError {
 	switch newStatus {
 	case model.JobStatusPending:
 		return a.Srv().Jobs.SetJobPending(job)
 	case model.JobStatusCancelRequested:
-		return a.Srv().Jobs.RequestCancellation(c, job.Id)
+		return a.Srv().Jobs.RequestCancellation(rctx, job.Id)
 	case model.JobStatusCanceled:
 		return a.Srv().Jobs.SetJobCanceled(job)
 	default:

--- a/server/channels/app/ldap.go
+++ b/server/channels/app/ldap.go
@@ -17,21 +17,21 @@ import (
 // SyncLdap starts an LDAP sync job.
 // If reAddRemovedMembers is true, then members who left or were removed from a team/channel will
 // be re-added; otherwise, they will not be re-added.
-func (a *App) SyncLdap(c request.CTX, reAddRemovedMembers *bool) {
+func (a *App) SyncLdap(rctx request.CTX, reAddRemovedMembers *bool) {
 	a.Srv().Go(func() {
 		if license := a.Srv().License(); license != nil && *license.Features.LDAP {
 			if !*a.Config().LdapSettings.EnableSync {
-				c.Logger().Error("LdapSettings.EnableSync is set to false. Skipping LDAP sync.")
+				rctx.Logger().Error("LdapSettings.EnableSync is set to false. Skipping LDAP sync.")
 				return
 			}
 
 			ldapI := a.Ldap()
 			if ldapI == nil {
-				c.Logger().Error("Not executing ldap sync because ldap is not available")
+				rctx.Logger().Error("Not executing ldap sync because ldap is not available")
 				return
 			}
-			if _, appErr := ldapI.StartSynchronizeJob(c, false, reAddRemovedMembers); appErr != nil {
-				c.Logger().Error("Failed to start LDAP sync job")
+			if _, appErr := ldapI.StartSynchronizeJob(rctx, false, reAddRemovedMembers); appErr != nil {
+				rctx.Logger().Error("Failed to start LDAP sync job")
 			}
 		}
 	})
@@ -112,7 +112,7 @@ func (a *App) GetAllLdapGroupsPage(rctx request.CTX, page int, perPage int, opts
 	return groups, total, nil
 }
 
-func (a *App) SwitchEmailToLdap(c request.CTX, email, password, code, ldapLoginId, ldapPassword string) (string, *model.AppError) {
+func (a *App) SwitchEmailToLdap(rctx request.CTX, email, password, code, ldapLoginId, ldapPassword string) (string, *model.AppError) {
 	if a.Srv().License() != nil && !*a.Config().ServiceSettings.ExperimentalEnableAuthenticationTransfer {
 		return "", model.NewAppError("emailToLdap", "api.user.email_to_ldap.not_available.app_error", nil, "", http.StatusForbidden)
 	}
@@ -122,11 +122,11 @@ func (a *App) SwitchEmailToLdap(c request.CTX, email, password, code, ldapLoginI
 		return "", err
 	}
 
-	if err := a.CheckPasswordAndAllCriteria(c, user.Id, password, code); err != nil {
+	if err := a.CheckPasswordAndAllCriteria(rctx, user.Id, password, code); err != nil {
 		return "", err
 	}
 
-	if err := a.RevokeAllSessions(c, user.Id); err != nil {
+	if err := a.RevokeAllSessions(rctx, user.Id); err != nil {
 		return "", err
 	}
 
@@ -135,20 +135,20 @@ func (a *App) SwitchEmailToLdap(c request.CTX, email, password, code, ldapLoginI
 		return "", model.NewAppError("SwitchEmailToLdap", "api.user.email_to_ldap.not_available.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	if err := ldapInterface.SwitchToLdap(c, user.Id, ldapLoginId, ldapPassword); err != nil {
+	if err := ldapInterface.SwitchToLdap(rctx, user.Id, ldapLoginId, ldapPassword); err != nil {
 		return "", err
 	}
 
 	a.Srv().Go(func() {
 		if err := a.Srv().EmailService.SendSignInChangeEmail(user.Email, "AD/LDAP", user.Locale, a.GetSiteURL()); err != nil {
-			c.Logger().Error("Could not send sign in method changed e-mail", mlog.Err(err))
+			rctx.Logger().Error("Could not send sign in method changed e-mail", mlog.Err(err))
 		}
 	})
 
 	return "/login?extra=signin_change", nil
 }
 
-func (a *App) SwitchLdapToEmail(c request.CTX, ldapPassword, code, email, newPassword string) (string, *model.AppError) {
+func (a *App) SwitchLdapToEmail(rctx request.CTX, ldapPassword, code, email, newPassword string) (string, *model.AppError) {
 	if a.Srv().License() != nil && !*a.Config().ServiceSettings.ExperimentalEnableAuthenticationTransfer {
 		return "", model.NewAppError("ldapToEmail", "api.user.ldap_to_email.not_available.app_error", nil, "", http.StatusForbidden)
 	}
@@ -175,16 +175,16 @@ func (a *App) SwitchLdapToEmail(c request.CTX, ldapPassword, code, email, newPas
 		return "", model.NewAppError("SwitchLdapToEmail", "api.user.ldap_to_email.not_available.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	user, err = a.checkLdapUserPasswordAndAllCriteria(c, user, ldapPassword, code)
+	user, err = a.checkLdapUserPasswordAndAllCriteria(rctx, user, ldapPassword, code)
 	if err != nil {
 		return "", err
 	}
 
-	if err := a.UpdatePassword(c, user, newPassword); err != nil {
+	if err := a.UpdatePassword(rctx, user, newPassword); err != nil {
 		return "", err
 	}
 
-	if err := a.RevokeAllSessions(c, user.Id); err != nil {
+	if err := a.RevokeAllSessions(rctx, user.Id); err != nil {
 		return "", err
 	}
 
@@ -192,16 +192,16 @@ func (a *App) SwitchLdapToEmail(c request.CTX, ldapPassword, code, email, newPas
 
 	a.Srv().Go(func() {
 		if err := a.Srv().EmailService.SendSignInChangeEmail(user.Email, T("api.templates.signin_change_email.body.method_email"), user.Locale, a.GetSiteURL()); err != nil {
-			c.Logger().Error("Could not send sign in method changed e-mail", mlog.Err(err))
+			rctx.Logger().Error("Could not send sign in method changed e-mail", mlog.Err(err))
 		}
 	})
 
 	return "/login?extra=signin_change", nil
 }
 
-func (a *App) MigrateIdLDAP(c request.CTX, toAttribute string) *model.AppError {
+func (a *App) MigrateIdLDAP(rctx request.CTX, toAttribute string) *model.AppError {
 	if ldapI := a.Ldap(); ldapI != nil {
-		if err := ldapI.MigrateIDAttribute(c, toAttribute); err != nil {
+		if err := ldapI.MigrateIDAttribute(rctx, toAttribute); err != nil {
 			switch err := err.(type) {
 			case *model.AppError:
 				return err

--- a/server/channels/app/migrations.go
+++ b/server/channels/app/migrations.go
@@ -582,7 +582,7 @@ func (s *Server) doPostPriorityConfigDefaultTrueMigration() error {
 	return nil
 }
 
-func (s *Server) doCloudS3PathMigrations(c request.CTX) error {
+func (s *Server) doCloudS3PathMigrations(rctx request.CTX) error {
 	// This migration is only applicable for cloud environments
 	if os.Getenv("MM_CLOUD_FILESTORE_BIFROST") == "" {
 		return nil
@@ -595,7 +595,7 @@ func (s *Server) doCloudS3PathMigrations(c request.CTX) error {
 
 	// If there is a job already pending, no need to schedule again.
 	// This is possible if the pod was rolled over.
-	jobs, err := s.Store().Job().GetAllByTypeAndStatus(c, model.JobTypeS3PathMigration, model.JobStatusPending)
+	jobs, err := s.Store().Job().GetAllByTypeAndStatus(rctx, model.JobTypeS3PathMigration, model.JobStatusPending)
 	if err != nil {
 		return fmt.Errorf("failed to get jobs by type and status: %w", err)
 	}
@@ -603,20 +603,20 @@ func (s *Server) doCloudS3PathMigrations(c request.CTX) error {
 		return nil
 	}
 
-	if _, appErr := s.Jobs.CreateJobOnce(c, model.JobTypeS3PathMigration, nil); appErr != nil {
+	if _, appErr := s.Jobs.CreateJobOnce(rctx, model.JobTypeS3PathMigration, nil); appErr != nil {
 		return fmt.Errorf("failed to start job for migrating s3 file paths: %w", appErr)
 	}
 
 	return nil
 }
 
-func (s *Server) doDeleteEmptyDraftsMigration(c request.CTX) error {
+func (s *Server) doDeleteEmptyDraftsMigration(rctx request.CTX) error {
 	// If the migration is already marked as completed, don't do it again.
 	if _, err := s.Store().System().GetByName(model.MigrationKeyDeleteEmptyDrafts); err == nil {
 		return nil
 	}
 
-	jobs, err := s.Store().Job().GetAllByTypeAndStatus(c, model.JobTypeDeleteEmptyDraftsMigration, model.JobStatusPending)
+	jobs, err := s.Store().Job().GetAllByTypeAndStatus(rctx, model.JobTypeDeleteEmptyDraftsMigration, model.JobStatusPending)
 	if err != nil {
 		return fmt.Errorf("failed to get jobs by type and status: %w", err)
 	}
@@ -624,20 +624,20 @@ func (s *Server) doDeleteEmptyDraftsMigration(c request.CTX) error {
 		return nil
 	}
 
-	if _, appErr := s.Jobs.CreateJobOnce(c, model.JobTypeDeleteEmptyDraftsMigration, nil); appErr != nil {
+	if _, appErr := s.Jobs.CreateJobOnce(rctx, model.JobTypeDeleteEmptyDraftsMigration, nil); appErr != nil {
 		return fmt.Errorf("failed to start job for deleting empty drafts: %w", appErr)
 	}
 
 	return nil
 }
 
-func (s *Server) doDeleteOrphanDraftsMigration(c request.CTX) error {
+func (s *Server) doDeleteOrphanDraftsMigration(rctx request.CTX) error {
 	// If the migration is already marked as completed, don't do it again.
 	if _, err := s.Store().System().GetByName(model.MigrationKeyDeleteOrphanDrafts); err == nil {
 		return nil
 	}
 
-	jobs, err := s.Store().Job().GetAllByTypeAndStatus(c, model.JobTypeDeleteOrphanDraftsMigration, model.JobStatusPending)
+	jobs, err := s.Store().Job().GetAllByTypeAndStatus(rctx, model.JobTypeDeleteOrphanDraftsMigration, model.JobStatusPending)
 	if err != nil {
 		return fmt.Errorf("failed to get jobs by type and status: %w", err)
 	}
@@ -645,20 +645,20 @@ func (s *Server) doDeleteOrphanDraftsMigration(c request.CTX) error {
 		return nil
 	}
 
-	if _, appErr := s.Jobs.CreateJobOnce(c, model.JobTypeDeleteOrphanDraftsMigration, nil); appErr != nil {
+	if _, appErr := s.Jobs.CreateJobOnce(rctx, model.JobTypeDeleteOrphanDraftsMigration, nil); appErr != nil {
 		return fmt.Errorf("failed to start job for deleting orphan drafts: %w", appErr)
 	}
 
 	return nil
 }
 
-func (s *Server) doDeleteDmsPreferencesMigration(c request.CTX) error {
+func (s *Server) doDeleteDmsPreferencesMigration(rctx request.CTX) error {
 	// If the migration is already marked as completed, don't do it again.
 	if _, err := s.Store().System().GetByName(model.MigrationKeyDeleteDmsPreferences); err == nil {
 		return nil
 	}
 
-	jobs, err := s.Store().Job().GetAllByTypeAndStatus(c, model.JobTypeDeleteDmsPreferencesMigration, model.JobStatusPending)
+	jobs, err := s.Store().Job().GetAllByTypeAndStatus(rctx, model.JobTypeDeleteDmsPreferencesMigration, model.JobStatusPending)
 	if err != nil {
 		return fmt.Errorf("failed to get jobs by type and status: %w", err)
 	}
@@ -666,7 +666,7 @@ func (s *Server) doDeleteDmsPreferencesMigration(c request.CTX) error {
 		return nil
 	}
 
-	if _, appErr := s.Jobs.CreateJobOnce(c, model.JobTypeDeleteDmsPreferencesMigration, nil); appErr != nil {
+	if _, appErr := s.Jobs.CreateJobOnce(rctx, model.JobTypeDeleteDmsPreferencesMigration, nil); appErr != nil {
 		return fmt.Errorf("failed to start job for deleting dm preferences: %w", appErr)
 	}
 
@@ -718,9 +718,9 @@ func (s *Server) doAppMigrations() {
 		{"Delete Invalid Dms Preferences Migration", s.doDeleteDmsPreferencesMigration},
 	}
 
-	c := request.EmptyContext(s.Log())
+	rctx := request.EmptyContext(s.Log())
 	for i := range m2 {
-		err := m2[i].handler(c)
+		err := m2[i].handler(rctx)
 		if err != nil {
 			mlog.Fatal("Failed to run app migration",
 				mlog.String("migration", m2[i].name),

--- a/server/channels/app/notification_push.go
+++ b/server/channels/app/notification_push.go
@@ -67,12 +67,12 @@ type PushNotification struct {
 	replyToThreadType  string
 }
 
-func (a *App) sendPushNotificationSync(c request.CTX, post *model.Post, user *model.User, channel *model.Channel, channelName string, senderName string,
+func (a *App) sendPushNotificationSync(rctx request.CTX, post *model.Post, user *model.User, channel *model.Channel, channelName string, senderName string,
 	explicitMention bool, channelWideMention bool, replyToThreadType string,
 ) *model.AppError {
 	cfg := a.Config()
 	msg, appErr := a.BuildPushNotificationMessage(
-		c,
+		rctx,
 		*cfg.EmailSettings.PushNotificationContents,
 		post,
 		user,
@@ -87,7 +87,7 @@ func (a *App) sendPushNotificationSync(c request.CTX, post *model.Post, user *mo
 		return appErr
 	}
 
-	return a.sendPushNotificationToAllSessions(c, msg, user.Id, "")
+	return a.sendPushNotificationToAllSessions(rctx, msg, user.Id, "")
 }
 
 func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.PushNotification, userID string, skipSessionId string) *model.AppError {
@@ -328,8 +328,8 @@ func (a *App) getUserBadgeCount(userID string, isCRTEnabled bool) (int, *model.A
 	return badgeCount, nil
 }
 
-func (a *App) clearPushNotificationSync(c request.CTX, currentSessionId, userID, channelID, rootID string) *model.AppError {
-	isCRTEnabled := a.IsCRTEnabledForUser(c, userID)
+func (a *App) clearPushNotificationSync(rctx request.CTX, currentSessionId, userID, channelID, rootID string) *model.AppError {
+	isCRTEnabled := a.IsCRTEnabledForUser(rctx, userID)
 
 	badgeCount, err := a.getUserBadgeCount(userID, isCRTEnabled)
 	if err != nil {
@@ -346,7 +346,7 @@ func (a *App) clearPushNotificationSync(c request.CTX, currentSessionId, userID,
 		IsCRTEnabled:     isCRTEnabled,
 	}
 
-	return a.sendPushNotificationToAllSessions(c, msg, userID, currentSessionId)
+	return a.sendPushNotificationToAllSessions(rctx, msg, userID, currentSessionId)
 }
 
 func (a *App) clearPushNotification(currentSessionId, userID, channelID, rootID string) {
@@ -363,8 +363,8 @@ func (a *App) clearPushNotification(currentSessionId, userID, channelID, rootID 
 	}
 }
 
-func (a *App) updateMobileAppBadgeSync(c request.CTX, userID string) *model.AppError {
-	badgeCount, err := a.getUserBadgeCount(userID, a.IsCRTEnabledForUser(c, userID))
+func (a *App) updateMobileAppBadgeSync(rctx request.CTX, userID string) *model.AppError {
+	badgeCount, err := a.getUserBadgeCount(userID, a.IsCRTEnabledForUser(rctx, userID))
 	if err != nil {
 		return model.NewAppError("updateMobileAppBadgeSync", "app.user.get_badge_count.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -376,7 +376,7 @@ func (a *App) updateMobileAppBadgeSync(c request.CTX, userID string) *model.AppE
 		ContentAvailable: 1,
 		Badge:            badgeCount,
 	}
-	return a.sendPushNotificationToAllSessions(c, msg, userID, "")
+	return a.sendPushNotificationToAllSessions(rctx, msg, userID, "")
 }
 
 func (a *App) UpdateMobileAppBadge(userID string) {
@@ -390,7 +390,7 @@ func (a *App) UpdateMobileAppBadge(userID string) {
 	}
 }
 
-func (s *Server) createPushNotificationsHub(c request.CTX) {
+func (s *Server) createPushNotificationsHub(rctx request.CTX) {
 	buffer := *s.platform.Config().EmailSettings.PushNotificationBuffer
 	hub := PushNotificationsHub{
 		notificationsChan: make(chan PushNotification, buffer),
@@ -401,11 +401,11 @@ func (s *Server) createPushNotificationsHub(c request.CTX) {
 		stopChan:          make(chan struct{}),
 		buffer:            buffer,
 	}
-	go hub.start(c)
+	go hub.start(rctx)
 	s.PushNotificationsHub = hub
 }
 
-func (hub *PushNotificationsHub) start(c request.CTX) {
+func (hub *PushNotificationsHub) start(rctx request.CTX) {
 	hub.wg.Add(1)
 	defer hub.wg.Done()
 	for {
@@ -432,10 +432,10 @@ func (hub *PushNotificationsHub) start(c request.CTX) {
 				var err *model.AppError
 				switch notification.notificationType {
 				case notificationTypeClear:
-					err = hub.app.clearPushNotificationSync(c, notification.currentSessionId, notification.userID, notification.channelID, notification.rootID)
+					err = hub.app.clearPushNotificationSync(rctx, notification.currentSessionId, notification.userID, notification.channelID, notification.rootID)
 				case notificationTypeMessage:
 					err = hub.app.sendPushNotificationSync(
-						c,
+						rctx,
 						notification.post,
 						notification.user,
 						notification.channel,
@@ -446,13 +446,13 @@ func (hub *PushNotificationsHub) start(c request.CTX) {
 						notification.replyToThreadType,
 					)
 				case notificationTypeUpdateBadge:
-					err = hub.app.updateMobileAppBadgeSync(c, notification.userID)
+					err = hub.app.updateMobileAppBadgeSync(rctx, notification.userID)
 				default:
-					c.Logger().Debug("Invalid notification type", mlog.String("notification_type", notification.notificationType))
+					rctx.Logger().Debug("Invalid notification type", mlog.String("notification_type", notification.notificationType))
 				}
 
 				if err != nil {
-					c.Logger().Error("Unable to send push notification", mlog.String("notification_type", notification.notificationType), mlog.Err(err))
+					rctx.Logger().Error("Unable to send push notification", mlog.String("notification_type", notification.notificationType), mlog.Err(err))
 				}
 			}(notification)
 		case <-hub.stopChan:
@@ -701,7 +701,7 @@ func doesStatusAllowPushNotification(userNotifyProps model.StringMap, status *mo
 	return model.NotificationReasonUserIsActive
 }
 
-func (a *App) BuildPushNotificationMessage(c request.CTX, contentsConfig string, post *model.Post, user *model.User, channel *model.Channel, channelName string, senderName string,
+func (a *App) BuildPushNotificationMessage(rctx request.CTX, contentsConfig string, post *model.Post, user *model.User, channel *model.Channel, channelName string, senderName string,
 	explicitMention bool, channelWideMention bool, replyToThreadType string,
 ) (*model.PushNotification, *model.AppError) {
 	var msg *model.PushNotification
@@ -712,12 +712,12 @@ func (a *App) BuildPushNotificationMessage(c request.CTX, contentsConfig string,
 	}
 
 	if contentsConfig == model.IdLoadedNotification {
-		msg = a.buildIdLoadedPushNotificationMessage(c, channel, post, user)
+		msg = a.buildIdLoadedPushNotificationMessage(rctx, channel, post, user)
 	} else {
-		msg = a.buildFullPushNotificationMessage(c, contentsConfig, post, user, channel, channelName, senderName, explicitMention, channelWideMention, replyToThreadType)
+		msg = a.buildFullPushNotificationMessage(rctx, contentsConfig, post, user, channel, channelName, senderName, explicitMention, channelWideMention, replyToThreadType)
 	}
 
-	badgeCount, err := a.getUserBadgeCount(user.Id, a.IsCRTEnabledForUser(c, user.Id))
+	badgeCount, err := a.getUserBadgeCount(user.Id, a.IsCRTEnabledForUser(rctx, user.Id))
 	if err != nil {
 		return nil, model.NewAppError("BuildPushNotificationMessage", "app.user.get_badge_count.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -777,13 +777,13 @@ func (a *App) SendTestPushNotification(deviceID string) string {
 	return "true"
 }
 
-func (a *App) buildIdLoadedPushNotificationMessage(c request.CTX, channel *model.Channel, post *model.Post, user *model.User) *model.PushNotification {
+func (a *App) buildIdLoadedPushNotificationMessage(rctx request.CTX, channel *model.Channel, post *model.Post, user *model.User) *model.PushNotification {
 	userLocale := i18n.GetUserTranslations(user.Locale)
 	msg := &model.PushNotification{
 		PostId:       post.Id,
 		ChannelId:    post.ChannelId,
 		RootId:       post.RootId,
-		IsCRTEnabled: a.IsCRTEnabledForUser(c, user.Id),
+		IsCRTEnabled: a.IsCRTEnabledForUser(rctx, user.Id),
 		Category:     model.CategoryCanReply,
 		Version:      model.PushMessageV2,
 		TeamId:       channel.TeamId,
@@ -796,7 +796,7 @@ func (a *App) buildIdLoadedPushNotificationMessage(c request.CTX, channel *model
 	return msg
 }
 
-func (a *App) buildFullPushNotificationMessage(c request.CTX, contentsConfig string, post *model.Post, user *model.User, channel *model.Channel, channelName string, senderName string,
+func (a *App) buildFullPushNotificationMessage(rctx request.CTX, contentsConfig string, post *model.Post, user *model.User, channel *model.Channel, channelName string, senderName string,
 	explicitMention bool, channelWideMention bool, replyToThreadType string,
 ) *model.PushNotification {
 	msg := &model.PushNotification{
@@ -818,7 +818,7 @@ func (a *App) buildFullPushNotificationMessage(c request.CTX, contentsConfig str
 		msg.ChannelName = channelName
 	}
 
-	if a.IsCRTEnabledForUser(c, user.Id) {
+	if a.IsCRTEnabledForUser(rctx, user.Id) {
 		msg.IsCRTEnabled = true
 		if post.RootId != "" {
 			if contentsConfig != model.GenericNoChannelNotification {
@@ -849,7 +849,7 @@ func (a *App) buildFullPushNotificationMessage(c request.CTX, contentsConfig str
 	postMessage := post.Message
 	stripped, err := utils.StripMarkdown(postMessage)
 	if err != nil {
-		c.Logger().Warn("Failed parse to markdown", mlog.String("post_id", post.Id), mlog.Err(err))
+		rctx.Logger().Warn("Failed parse to markdown", mlog.String("post_id", post.Id), mlog.Err(err))
 	} else {
 		postMessage = stripped
 	}

--- a/server/channels/app/oauthproviders/gitlab/gitlab.go
+++ b/server/channels/app/oauthproviders/gitlab/gitlab.go
@@ -84,7 +84,7 @@ func (glu *GitLabUser) getAuthData() string {
 	return strconv.FormatInt(glu.Id, 10)
 }
 
-func (gp *GitLabProvider) GetUserFromJSON(c request.CTX, data io.Reader, tokenUser *model.User) (*model.User, error) {
+func (gp *GitLabProvider) GetUserFromJSON(rctx request.CTX, data io.Reader, tokenUser *model.User) (*model.User, error) {
 	glu, err := gitLabUserFromJSON(data)
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func (gp *GitLabProvider) GetUserFromJSON(c request.CTX, data io.Reader, tokenUs
 		return nil, err
 	}
 
-	return userFromGitLabUser(c.Logger(), glu), nil
+	return userFromGitLabUser(rctx.Logger(), glu), nil
 }
 
 func (gp *GitLabProvider) GetSSOSettings(_ request.CTX, config *model.Config, service string) (*model.SSOSettings, error) {

--- a/server/channels/app/platform/helper_test.go
+++ b/server/channels/app/platform/helper_test.go
@@ -57,11 +57,11 @@ func (ms *mockSuite) GetSession(token string) (*model.Session, *model.AppError) 
 	return &model.Session{}, nil
 }
 func (ms *mockSuite) RolesGrantPermission(roleNames []string, permissionId string) bool { return true }
-func (ms *mockSuite) UserCanSeeOtherUser(c request.CTX, userID string, otherUserId string) (bool, *model.AppError) {
+func (ms *mockSuite) UserCanSeeOtherUser(rctx request.CTX, userID string, otherUserId string) (bool, *model.AppError) {
 	return true, nil
 }
 
-func (ms *mockSuite) HasPermissionToReadChannel(c request.CTX, userID string, channel *model.Channel) bool {
+func (ms *mockSuite) HasPermissionToReadChannel(rctx request.CTX, userID string, channel *model.Channel) bool {
 	return true
 }
 

--- a/server/channels/app/platform/mocks/SuiteIFace.go
+++ b/server/channels/app/platform/mocks/SuiteIFace.go
@@ -48,9 +48,9 @@ func (_m *SuiteIFace) GetSession(token string) (*model.Session, *model.AppError)
 	return r0, r1
 }
 
-// HasPermissionToReadChannel provides a mock function with given fields: c, userID, channel
-func (_m *SuiteIFace) HasPermissionToReadChannel(c request.CTX, userID string, channel *model.Channel) bool {
-	ret := _m.Called(c, userID, channel)
+// HasPermissionToReadChannel provides a mock function with given fields: rctx, userID, channel
+func (_m *SuiteIFace) HasPermissionToReadChannel(rctx request.CTX, userID string, channel *model.Channel) bool {
+	ret := _m.Called(rctx, userID, channel)
 
 	if len(ret) == 0 {
 		panic("no return value specified for HasPermissionToReadChannel")
@@ -58,7 +58,7 @@ func (_m *SuiteIFace) HasPermissionToReadChannel(c request.CTX, userID string, c
 
 	var r0 bool
 	if rf, ok := ret.Get(0).(func(request.CTX, string, *model.Channel) bool); ok {
-		r0 = rf(c, userID, channel)
+		r0 = rf(rctx, userID, channel)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
@@ -84,9 +84,9 @@ func (_m *SuiteIFace) RolesGrantPermission(roleNames []string, permissionId stri
 	return r0
 }
 
-// UserCanSeeOtherUser provides a mock function with given fields: c, userID, otherUserId
-func (_m *SuiteIFace) UserCanSeeOtherUser(c request.CTX, userID string, otherUserId string) (bool, *model.AppError) {
-	ret := _m.Called(c, userID, otherUserId)
+// UserCanSeeOtherUser provides a mock function with given fields: rctx, userID, otherUserId
+func (_m *SuiteIFace) UserCanSeeOtherUser(rctx request.CTX, userID string, otherUserId string) (bool, *model.AppError) {
+	ret := _m.Called(rctx, userID, otherUserId)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UserCanSeeOtherUser")
@@ -95,16 +95,16 @@ func (_m *SuiteIFace) UserCanSeeOtherUser(c request.CTX, userID string, otherUse
 	var r0 bool
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string) (bool, *model.AppError)); ok {
-		return rf(c, userID, otherUserId)
+		return rf(rctx, userID, otherUserId)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string) bool); ok {
-		r0 = rf(c, userID, otherUserId)
+		r0 = rf(rctx, userID, otherUserId)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, string) *model.AppError); ok {
-		r1 = rf(c, userID, otherUserId)
+		r1 = rf(rctx, userID, otherUserId)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)

--- a/server/channels/app/platform/shared_channel_service_iface.go
+++ b/server/channels/app/platform/shared_channel_service_iface.go
@@ -25,7 +25,7 @@ type SharedChannelServiceIFace interface {
 	CheckChannelIsShared(channelID string) error
 	CheckCanInviteToSharedChannel(channelId string) error
 	HandleMembershipChange(channelID, userID string, isAdd bool, remoteID string)
-	TransformMentionsOnReceiveForTesting(ctx request.CTX, post *model.Post, targetChannel *model.Channel, rc *model.RemoteCluster, mentionTransforms map[string]string)
+	TransformMentionsOnReceiveForTesting(rctx request.CTX, post *model.Post, targetChannel *model.Channel, rc *model.RemoteCluster, mentionTransforms map[string]string)
 }
 
 type MockOptionSharedChannelService func(service *mockSharedChannelService)
@@ -85,6 +85,6 @@ func (mrcs *mockSharedChannelService) HandleMembershipChange(channelID, userID s
 	// This is a mock implementation - it doesn't need to do anything
 }
 
-func (mrcs *mockSharedChannelService) TransformMentionsOnReceiveForTesting(ctx request.CTX, post *model.Post, targetChannel *model.Channel, rc *model.RemoteCluster, mentionTransforms map[string]string) {
+func (mrcs *mockSharedChannelService) TransformMentionsOnReceiveForTesting(rctx request.CTX, post *model.Post, targetChannel *model.Channel, rc *model.RemoteCluster, mentionTransforms map[string]string) {
 	// This is a mock implementation - it doesn't need to do anything
 }

--- a/server/channels/app/platform/web_hub.go
+++ b/server/channels/app/platform/web_hub.go
@@ -28,8 +28,8 @@ const (
 type SuiteIFace interface {
 	GetSession(token string) (*model.Session, *model.AppError)
 	RolesGrantPermission(roleNames []string, permissionId string) bool
-	HasPermissionToReadChannel(c request.CTX, userID string, channel *model.Channel) bool
-	UserCanSeeOtherUser(c request.CTX, userID string, otherUserId string) (bool, *model.AppError)
+	HasPermissionToReadChannel(rctx request.CTX, userID string, channel *model.Channel) bool
+	UserCanSeeOtherUser(rctx request.CTX, userID string, otherUserId string) (bool, *model.AppError)
 }
 
 type webConnActivityMessage struct {

--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -162,15 +162,15 @@ func (ch *Channels) syncPluginsActiveState() {
 	}
 }
 
-func (a *App) NewPluginAPI(c request.CTX, manifest *model.Manifest) plugin.API {
-	return NewPluginAPI(a, c, manifest)
+func (a *App) NewPluginAPI(rctx request.CTX, manifest *model.Manifest) plugin.API {
+	return NewPluginAPI(a, rctx, manifest)
 }
 
-func (a *App) InitPlugins(c request.CTX, pluginDir, webappPluginDir string) {
-	a.ch.initPlugins(c, pluginDir, webappPluginDir)
+func (a *App) InitPlugins(rctx request.CTX, pluginDir, webappPluginDir string) {
+	a.ch.initPlugins(rctx, pluginDir, webappPluginDir)
 }
 
-func (ch *Channels) initPlugins(c request.CTX, pluginDir, webappPluginDir string) {
+func (ch *Channels) initPlugins(rctx request.CTX, pluginDir, webappPluginDir string) {
 	// Acquiring lock manually, as plugins might be disabled. See GetPluginsEnvironment.
 	defer func() {
 		ch.srv.Platform().SetPluginsEnvironment(ch)
@@ -200,7 +200,7 @@ func (ch *Channels) initPlugins(c request.CTX, pluginDir, webappPluginDir string
 	}
 
 	newAPIFunc := func(manifest *model.Manifest) plugin.API {
-		return New(ServerConnector(ch)).NewPluginAPI(c, manifest)
+		return New(ServerConnector(ch)).NewPluginAPI(rctx, manifest)
 	}
 
 	env, err := plugin.NewEnvironment(

--- a/server/channels/app/plugin_api.go
+++ b/server/channels/app/plugin_api.go
@@ -29,11 +29,11 @@ type PluginAPI struct {
 	manifest *model.Manifest
 }
 
-func NewPluginAPI(a *App, c request.CTX, manifest *model.Manifest) *PluginAPI {
+func NewPluginAPI(a *App, rctx request.CTX, manifest *model.Manifest) *PluginAPI {
 	return &PluginAPI{
 		id:       manifest.Id,
 		manifest: manifest,
-		ctx:      c,
+		ctx:      rctx,
 		app:      a,
 		logger:   a.Log().Sugar(mlog.String("plugin_id", manifest.Id)),
 	}

--- a/server/channels/app/plugin_api_test.go
+++ b/server/channels/app/plugin_api_test.go
@@ -70,7 +70,7 @@ func setDefaultPluginConfig(th *TestHelper, pluginID string) {
 	})
 }
 
-func setupMultiPluginAPITest(t *testing.T, pluginCodes []string, pluginManifests []string, pluginIDs []string, asMain bool, app *App, c request.CTX) string {
+func setupMultiPluginAPITest(t *testing.T, pluginCodes []string, pluginManifests []string, pluginIDs []string, asMain bool, app *App, rctx request.CTX) string {
 	pluginDir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -90,7 +90,7 @@ func setupMultiPluginAPITest(t *testing.T, pluginCodes []string, pluginManifests
 	})
 
 	newPluginAPI := func(manifest *model.Manifest) plugin.API {
-		return app.NewPluginAPI(c, manifest)
+		return app.NewPluginAPI(rctx, manifest)
 	}
 
 	env, err := plugin.NewEnvironment(newPluginAPI, NewDriverImpl(app.Srv()), pluginDir, webappPluginDir, app.Log(), nil)
@@ -126,11 +126,11 @@ func setupMultiPluginAPITest(t *testing.T, pluginCodes []string, pluginManifests
 	return pluginDir
 }
 
-func setupPluginAPITest(t *testing.T, pluginCode string, pluginManifest string, pluginID string, app *App, c request.CTX) string {
+func setupPluginAPITest(t *testing.T, pluginCode string, pluginManifest string, pluginID string, app *App, rctx request.CTX) string {
 	asMain := pluginID != "test_db_driver"
 	return setupMultiPluginAPITest(t,
 		[]string{pluginCode}, []string{pluginManifest}, []string{pluginID},
-		asMain, app, c)
+		asMain, app, rctx)
 }
 
 func TestPublicFilesPathConfiguration(t *testing.T) {
@@ -1058,7 +1058,7 @@ func TestInstallPlugin(t *testing.T) {
 	// we need a modified version of setupPluginAPITest() because it wasn't possible to use it directly here
 	// since it removes plugin dirs right after it returns, does not update App configs with the plugin
 	// dirs and this behavior tends to break this test as a result.
-	setupTest := func(t *testing.T, pluginCode string, pluginManifest string, pluginID string, app *App, c request.CTX) (func(), string) {
+	setupTest := func(t *testing.T, pluginCode string, pluginManifest string, pluginID string, app *App, rctx request.CTX) (func(), string) {
 		pluginDir, err := os.MkdirTemp("", "")
 		require.NoError(t, err)
 		webappPluginDir, err := os.MkdirTemp("", "")
@@ -1070,7 +1070,7 @@ func TestInstallPlugin(t *testing.T) {
 		})
 
 		newPluginAPI := func(manifest *model.Manifest) plugin.API {
-			return app.NewPluginAPI(c, manifest)
+			return app.NewPluginAPI(rctx, manifest)
 		}
 
 		env, err := plugin.NewEnvironment(newPluginAPI, NewDriverImpl(app.Srv()), pluginDir, webappPluginDir, app.Log(), nil)
@@ -2080,7 +2080,7 @@ func (*MockSlashCommandProvider) GetCommand(a *App, T i18n.TranslateFunc) *model
 	}
 }
 
-func (mscp *MockSlashCommandProvider) DoCommand(a *App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (mscp *MockSlashCommandProvider) DoCommand(a *App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	mscp.Args = args
 	mscp.Message = message
 	return &model.CommandResponse{

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -35,7 +35,7 @@ const (
 
 var atMentionPattern = regexp.MustCompile(`\B@`)
 
-func (a *App) CreatePostAsUser(c request.CTX, post *model.Post, currentSessionId string, setOnline bool) (*model.Post, *model.AppError) {
+func (a *App) CreatePostAsUser(rctx request.CTX, post *model.Post, currentSessionId string, setOnline bool) (*model.Post, *model.AppError) {
 	// Check that channel has not been deleted
 	channel, errCh := a.Srv().Store().Channel().Get(post.ChannelId, true)
 	if errCh != nil {
@@ -53,7 +53,7 @@ func (a *App) CreatePostAsUser(c request.CTX, post *model.Post, currentSessionId
 		return nil, err
 	}
 
-	rp, err := a.CreatePost(c, post, channel, model.CreatePostFlags{TriggerWebhooks: true, SetOnline: setOnline})
+	rp, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{TriggerWebhooks: true, SetOnline: setOnline})
 	if err != nil {
 		if err.Id == "api.post.create_post.root_id.app_error" ||
 			err.Id == "api.post.create_post.channel_root_id.app_error" {
@@ -69,11 +69,11 @@ func (a *App) CreatePostAsUser(c request.CTX, post *model.Post, currentSessionId
 	// the post is NOT a reply post with CRT enabled
 	_, fromWebhook := post.GetProps()[model.PostPropsFromWebhook]
 	_, fromBot := post.GetProps()[model.PostPropsFromBot]
-	isCRTEnabled := a.IsCRTEnabledForUser(c, post.UserId)
+	isCRTEnabled := a.IsCRTEnabledForUser(rctx, post.UserId)
 	isCRTReply := post.RootId != "" && isCRTEnabled
 	if !fromWebhook && !fromBot && !isCRTReply {
-		if _, err := a.MarkChannelsAsViewed(c, []string{post.ChannelId}, post.UserId, currentSessionId, true, isCRTEnabled); err != nil {
-			c.Logger().Warn(
+		if _, err := a.MarkChannelsAsViewed(rctx, []string{post.ChannelId}, post.UserId, currentSessionId, true, isCRTEnabled); err != nil {
+			rctx.Logger().Warn(
 				"Encountered error updating last viewed",
 				mlog.String("channel_id", post.ChannelId),
 				mlog.String("user_id", post.UserId),
@@ -116,7 +116,7 @@ func (a *App) CreatePostAsUser(c request.CTX, post *model.Post, currentSessionId
 	return rp, nil
 }
 
-func (a *App) CreatePostMissingChannel(c request.CTX, post *model.Post, triggerWebhooks bool, setOnline bool) (*model.Post, *model.AppError) {
+func (a *App) CreatePostMissingChannel(rctx request.CTX, post *model.Post, triggerWebhooks bool, setOnline bool) (*model.Post, *model.AppError) {
 	channel, err := a.Srv().Store().Channel().Get(post.ChannelId, true)
 	if err != nil {
 		errCtx := map[string]any{"channel_id": post.ChannelId}
@@ -129,7 +129,7 @@ func (a *App) CreatePostMissingChannel(c request.CTX, post *model.Post, triggerW
 		}
 	}
 
-	return a.CreatePost(c, post, channel, model.CreatePostFlags{TriggerWebhooks: triggerWebhooks, SetOnline: setOnline})
+	return a.CreatePost(rctx, post, channel, model.CreatePostFlags{TriggerWebhooks: triggerWebhooks, SetOnline: setOnline})
 }
 
 // deduplicateCreatePost attempts to make posting idempotent within a caching window.
@@ -179,12 +179,12 @@ func (a *App) deduplicateCreatePost(rctx request.CTX, post *model.Post) (foundPo
 	return actualPost, nil
 }
 
-func (a *App) CreatePost(c request.CTX, post *model.Post, channel *model.Channel, flags model.CreatePostFlags) (savedPost *model.Post, err *model.AppError) {
+func (a *App) CreatePost(rctx request.CTX, post *model.Post, channel *model.Channel, flags model.CreatePostFlags) (savedPost *model.Post, err *model.AppError) {
 	if !a.Config().FeatureFlags.EnableSharedChannelsDMs && channel.IsShared() && (channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup) {
 		return nil, model.NewAppError("CreatePost", "app.post.create_post.shared_dm_or_gm.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	foundPost, err := a.deduplicateCreatePost(c, post)
+	foundPost, err := a.deduplicateCreatePost(rctx, post)
 	if err != nil {
 		return nil, err
 	}
@@ -257,12 +257,12 @@ func (a *App) CreatePost(c request.CTX, post *model.Post, channel *model.Channel
 		post.AddProp(model.PostPropsForceNotification, model.NewId())
 	}
 
-	if c.Session().IsOAuth {
+	if rctx.Session().IsOAuth {
 		post.AddProp(model.PostPropsFromOAuthApp, "true")
 	}
 
 	var ephemeralPost *model.Post
-	if post.Type == "" && !a.HasPermissionToChannel(c, user.Id, channel.Id, model.PermissionUseChannelMentions) {
+	if post.Type == "" && !a.HasPermissionToChannel(rctx, user.Id, channel.Id, model.PermissionUseChannelMentions) {
 		mention := post.DisableMentionHighlights()
 		if mention != "" {
 			T := i18n.GetUserTranslations(user.Locale)
@@ -296,7 +296,7 @@ func (a *App) CreatePost(c request.CTX, post *model.Post, channel *model.Channel
 
 	post.Hashtags, _ = model.ParseHashtags(post.Message)
 
-	if err = a.FillInPostProps(c, post, channel); err != nil {
+	if err = a.FillInPostProps(rctx, post, channel); err != nil {
 		return nil, err
 	}
 
@@ -309,7 +309,7 @@ func (a *App) CreatePost(c request.CTX, post *model.Post, channel *model.Channel
 			post.AddProp(model.PostPropsAttachments, attachmentsInterface)
 		}
 		if err != nil {
-			c.Logger().Warn("Could not convert post attachments to map interface.", mlog.Err(err))
+			rctx.Logger().Warn("Could not convert post attachments to map interface.", mlog.Err(err))
 		}
 	}
 
@@ -318,7 +318,7 @@ func (a *App) CreatePost(c request.CTX, post *model.Post, channel *model.Channel
 		metadata = post.Metadata.Copy()
 	}
 	var rejectionError *model.AppError
-	pluginContext := pluginContext(c)
+	pluginContext := pluginContext(rctx)
 	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 		replacementPost, rejectionReason := hooks.MessageWillBePosted(pluginContext, post.ForPlugin())
 		if rejectionReason != "" {
@@ -350,13 +350,13 @@ func (a *App) CreatePost(c request.CTX, post *model.Post, channel *model.Channel
 		post.CreateAt = model.GetMillis()
 	}
 
-	post = a.getEmbedsAndImages(c, post, true)
+	post = a.getEmbedsAndImages(rctx, post, true)
 	previewPost := post.GetPreviewPost()
 	if previewPost != nil {
 		post.AddProp(model.PostPropsPreviewedPost, previewPost.PostID)
 	}
 
-	rpost, nErr := a.Srv().Store().Post().Save(c, post)
+	rpost, nErr := a.Srv().Store().Post().Save(rctx, post)
 	if nErr != nil {
 		var appErr *model.AppError
 		var invErr *store.ErrInvalidInput
@@ -381,8 +381,8 @@ func (a *App) CreatePost(c request.CTX, post *model.Post, channel *model.Channel
 	}
 
 	if len(post.FileIds) > 0 {
-		if err = a.attachFilesToPost(c, post); err != nil {
-			c.Logger().Warn("Encountered error attaching files to post", mlog.String("post_id", post.Id), mlog.Array("file_ids", post.FileIds), mlog.Err(err))
+		if err = a.attachFilesToPost(rctx, post); err != nil {
+			rctx.Logger().Warn("Encountered error attaching files to post", mlog.String("post_id", post.Id), mlog.Array("file_ids", post.FileIds), mlog.Err(err))
 		}
 
 		if a.Metrics() != nil {
@@ -404,12 +404,12 @@ func (a *App) CreatePost(c request.CTX, post *model.Post, channel *model.Channel
 	// to be done when we send the post over the websocket in handlePostEvents
 	// PS: we don't want to include PostPriority from the db to avoid the replica lag,
 	// so we just return the one that was passed with post
-	rpost = a.PreparePostForClient(c, rpost, true, false, false)
+	rpost = a.PreparePostForClient(rctx, rpost, true, false, false)
 
 	a.applyPostWillBeConsumedHook(&rpost)
 
 	if rpost.RootId != "" {
-		if appErr := a.ResolvePersistentNotification(c, parentPostList.Posts[post.RootId], rpost.UserId); appErr != nil {
+		if appErr := a.ResolvePersistentNotification(rctx, parentPostList.Posts[post.RootId], rpost.UserId); appErr != nil {
 			a.CountNotificationReason(model.NotificationStatusError, model.NotificationTypeWebsocket, model.NotificationReasonResolvePersistentNotificationError, model.NotificationNoPlatform)
 			a.NotificationsLog().Error("Error resolving persistent notification",
 				mlog.String("sender_id", rpost.UserId),
@@ -429,20 +429,20 @@ func (a *App) CreatePost(c request.CTX, post *model.Post, channel *model.Channel
 			UpdateFollowing: true,
 		})
 		if err != nil {
-			c.Logger().Warn("Failed to update thread membership", mlog.Err(err))
+			rctx.Logger().Warn("Failed to update thread membership", mlog.Err(err))
 		}
 	}
 
-	if err := a.handlePostEvents(c, rpost, user, channel, flags.TriggerWebhooks, parentPostList, flags.SetOnline); err != nil {
-		c.Logger().Warn("Failed to handle post events", mlog.Err(err))
+	if err := a.handlePostEvents(rctx, rpost, user, channel, flags.TriggerWebhooks, parentPostList, flags.SetOnline); err != nil {
+		rctx.Logger().Warn("Failed to handle post events", mlog.Err(err))
 	}
 
 	// Send any ephemeral posts after the post is created to ensure it shows up after the latest post created
 	if ephemeralPost != nil {
-		a.SendEphemeralPost(c, post.UserId, ephemeralPost)
+		a.SendEphemeralPost(rctx, post.UserId, ephemeralPost)
 	}
 
-	rpost, err = a.SanitizePostMetadataForUser(c, rpost, c.Session().UserId)
+	rpost, err = a.SanitizePostMetadataForUser(rctx, rpost, rctx.Session().UserId)
 	if err != nil {
 		return nil, err
 	}
@@ -494,7 +494,7 @@ func (a *App) attachFileIDsToPost(rctx request.CTX, postID, channelID, userID st
 // channel_mentions.
 //
 // If channel is nil, FillInPostProps will look up the channel corresponding to the post.
-func (a *App) FillInPostProps(c request.CTX, post *model.Post, channel *model.Channel) *model.AppError {
+func (a *App) FillInPostProps(rctx request.CTX, post *model.Post, channel *model.Channel) *model.AppError {
 	channelMentions := post.ChannelMentions()
 	channelMentionsProp := make(map[string]any)
 
@@ -507,7 +507,7 @@ func (a *App) FillInPostProps(c request.CTX, post *model.Post, channel *model.Ch
 			channel = postChannel
 		}
 
-		mentionedChannels, err := a.GetChannelsByNames(c, channelMentions, channel.TeamId)
+		mentionedChannels, err := a.GetChannelsByNames(rctx, channelMentions, channel.TeamId)
 		if err != nil {
 			return err
 		}
@@ -516,7 +516,7 @@ func (a *App) FillInPostProps(c request.CTX, post *model.Post, channel *model.Ch
 			if mentioned.Type == model.ChannelTypeOpen {
 				team, err := a.Srv().Store().Team().Get(mentioned.TeamId)
 				if err != nil {
-					c.Logger().Warn("Failed to get team of the channel mention", mlog.String("team_id", channel.TeamId), mlog.String("channel_id", channel.Id), mlog.Err(err))
+					rctx.Logger().Warn("Failed to get team of the channel mention", mlog.String("team_id", channel.TeamId), mlog.String("channel_id", channel.Id), mlog.Err(err))
 					continue
 				}
 				channelMentionsProp[mentioned.Name] = map[string]any{
@@ -534,14 +534,14 @@ func (a *App) FillInPostProps(c request.CTX, post *model.Post, channel *model.Ch
 	}
 
 	matched := atMentionPattern.MatchString(post.Message)
-	if a.Srv().License() != nil && *a.Srv().License().Features.LDAPGroups && matched && !a.HasPermissionToChannel(c, post.UserId, post.ChannelId, model.PermissionUseGroupMentions) {
+	if a.Srv().License() != nil && *a.Srv().License().Features.LDAPGroups && matched && !a.HasPermissionToChannel(rctx, post.UserId, post.ChannelId, model.PermissionUseGroupMentions) {
 		post.AddProp(model.PostPropsGroupHighlightDisabled, true)
 	}
 
 	return nil
 }
 
-func (a *App) handlePostEvents(c request.CTX, post *model.Post, user *model.User, channel *model.Channel, triggerWebhooks bool, parentPostList *model.PostList, setOnline bool) error {
+func (a *App) handlePostEvents(rctx request.CTX, post *model.Post, user *model.User, channel *model.Channel, triggerWebhooks bool, parentPostList *model.PostList, setOnline bool) error {
 	var team *model.Team
 	if channel.TeamId != "" {
 		t, err := a.Srv().Store().Team().Get(channel.TeamId)
@@ -567,23 +567,23 @@ func (a *App) handlePostEvents(c request.CTX, post *model.Post, user *model.User
 	}
 	a.Srv().Store().Post().InvalidateLastPostTimeCache(channel.Id)
 
-	if _, err := a.SendNotifications(c, post, team, channel, user, parentPostList, setOnline); err != nil {
+	if _, err := a.SendNotifications(rctx, post, team, channel, user, parentPostList, setOnline); err != nil {
 		return err
 	}
 
 	if post.Type != model.PostTypeAutoResponder { // don't respond to an auto-responder
 		a.Srv().Go(func() {
-			_, err := a.SendAutoResponseIfNecessary(c, channel, user, post)
+			_, err := a.SendAutoResponseIfNecessary(rctx, channel, user, post)
 			if err != nil {
-				c.Logger().Error("Failed to send auto response", mlog.String("user_id", user.Id), mlog.String("post_id", post.Id), mlog.Err(err))
+				rctx.Logger().Error("Failed to send auto response", mlog.String("user_id", user.Id), mlog.String("post_id", post.Id), mlog.Err(err))
 			}
 		})
 	}
 
 	if triggerWebhooks {
 		a.Srv().Go(func() {
-			if err := a.handleWebhookEvents(c, post, team, channel, user); err != nil {
-				c.Logger().Error("Failed to handle webhook event", mlog.String("user_id", user.Id), mlog.String("post_id", post.Id), mlog.Err(err))
+			if err := a.handleWebhookEvents(rctx, post, team, channel, user); err != nil {
+				rctx.Logger().Error("Failed to handle webhook event", mlog.String("user_id", user.Id), mlog.String("post_id", post.Id), mlog.Err(err))
 			}
 		})
 	}
@@ -591,7 +591,7 @@ func (a *App) handlePostEvents(c request.CTX, post *model.Post, user *model.User
 	return nil
 }
 
-func (a *App) SendEphemeralPost(c request.CTX, userID string, post *model.Post) *model.Post {
+func (a *App) SendEphemeralPost(rctx request.CTX, userID string, post *model.Post) *model.Post {
 	post.Type = model.PostTypeEphemeral
 
 	// fill in fields which haven't been specified which have sensible defaults
@@ -607,12 +607,12 @@ func (a *App) SendEphemeralPost(c request.CTX, userID string, post *model.Post) 
 
 	post.GenerateActionIds()
 	message := model.NewWebSocketEvent(model.WebsocketEventEphemeralMessage, "", post.ChannelId, userID, nil, "")
-	post = a.PreparePostForClientWithEmbedsAndImages(c, post, true, false, true)
+	post = a.PreparePostForClientWithEmbedsAndImages(rctx, post, true, false, true)
 	post = model.AddPostActionCookies(post, a.PostActionCookieSecret())
 
-	sanitizedPost, appErr := a.SanitizePostMetadataForUser(c, post, userID)
+	sanitizedPost, appErr := a.SanitizePostMetadataForUser(rctx, post, userID)
 	if appErr != nil {
-		c.Logger().Error("Failed to sanitize post metadata for user", mlog.String("user_id", userID), mlog.Err(appErr))
+		rctx.Logger().Error("Failed to sanitize post metadata for user", mlog.String("user_id", userID), mlog.Err(appErr))
 
 		// If we failed to sanitize the post, we still want to remove the metadata.
 		sanitizedPost = post.Clone()
@@ -623,7 +623,7 @@ func (a *App) SendEphemeralPost(c request.CTX, userID string, post *model.Post) 
 
 	postJSON, jsonErr := post.ToJSON()
 	if jsonErr != nil {
-		c.Logger().Warn("Failed to encode post to JSON", mlog.Err(jsonErr))
+		rctx.Logger().Warn("Failed to encode post to JSON", mlog.Err(jsonErr))
 	}
 	message.Add("post", postJSON)
 	a.Publish(message)
@@ -631,7 +631,7 @@ func (a *App) SendEphemeralPost(c request.CTX, userID string, post *model.Post) 
 	return post
 }
 
-func (a *App) UpdateEphemeralPost(c request.CTX, userID string, post *model.Post) *model.Post {
+func (a *App) UpdateEphemeralPost(rctx request.CTX, userID string, post *model.Post) *model.Post {
 	post.Type = model.PostTypeEphemeral
 
 	post.UpdateAt = model.GetMillis()
@@ -641,12 +641,12 @@ func (a *App) UpdateEphemeralPost(c request.CTX, userID string, post *model.Post
 
 	post.GenerateActionIds()
 	message := model.NewWebSocketEvent(model.WebsocketEventPostEdited, "", post.ChannelId, userID, nil, "")
-	post = a.PreparePostForClientWithEmbedsAndImages(c, post, true, false, true)
+	post = a.PreparePostForClientWithEmbedsAndImages(rctx, post, true, false, true)
 	post = model.AddPostActionCookies(post, a.PostActionCookieSecret())
 
-	sanitizedPost, appErr := a.SanitizePostMetadataForUser(c, post, userID)
+	sanitizedPost, appErr := a.SanitizePostMetadataForUser(rctx, post, userID)
 	if appErr != nil {
-		c.Logger().Error("Failed to sanitize post metadata for user", mlog.String("user_id", userID), mlog.Err(appErr))
+		rctx.Logger().Error("Failed to sanitize post metadata for user", mlog.String("user_id", userID), mlog.Err(appErr))
 
 		// If we failed to sanitize the post, we still want to remove the metadata.
 		sanitizedPost = post.Clone()
@@ -657,7 +657,7 @@ func (a *App) UpdateEphemeralPost(c request.CTX, userID string, post *model.Post
 
 	postJSON, jsonErr := post.ToJSON()
 	if jsonErr != nil {
-		c.Logger().Warn("Failed to encode post to JSON", mlog.Err(jsonErr))
+		rctx.Logger().Warn("Failed to encode post to JSON", mlog.Err(jsonErr))
 	}
 	message.Add("post", postJSON)
 	a.Publish(message)
@@ -683,7 +683,7 @@ func (a *App) DeleteEphemeralPost(rctx request.CTX, userID, postID string) {
 	a.Publish(message)
 }
 
-func (a *App) UpdatePost(c request.CTX, receivedUpdatedPost *model.Post, updatePostOptions *model.UpdatePostOptions) (*model.Post, *model.AppError) {
+func (a *App) UpdatePost(rctx request.CTX, receivedUpdatedPost *model.Post, updatePostOptions *model.UpdatePostOptions) (*model.Post, *model.AppError) {
 	if updatePostOptions == nil {
 		updatePostOptions = model.DefaultUpdatePostOptions()
 	}
@@ -721,7 +721,7 @@ func (a *App) UpdatePost(c request.CTX, receivedUpdatedPost *model.Post, updateP
 		return nil, appErr
 	}
 
-	channel, appErr := a.GetChannel(c, oldPost.ChannelId)
+	channel, appErr := a.GetChannel(rctx, oldPost.ChannelId)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -744,7 +744,7 @@ func (a *App) UpdatePost(c request.CTX, receivedUpdatedPost *model.Post, updateP
 		newPost.SetProps(receivedUpdatedPost.GetProps())
 
 		var fileIds []string
-		fileIds, appErr = a.processPostFileChanges(c, receivedUpdatedPost, oldPost, updatePostOptions)
+		fileIds, appErr = a.processPostFileChanges(rctx, receivedUpdatedPost, oldPost, updatePostOptions)
 		if appErr != nil {
 			return nil, appErr
 		}
@@ -756,7 +756,7 @@ func (a *App) UpdatePost(c request.CTX, receivedUpdatedPost *model.Post, updateP
 		newPost.EditAt = model.GetMillis()
 	}
 
-	if appErr = a.FillInPostProps(c, newPost, nil); appErr != nil {
+	if appErr = a.FillInPostProps(rctx, newPost, nil); appErr != nil {
 		return nil, appErr
 	}
 
@@ -765,7 +765,7 @@ func (a *App) UpdatePost(c request.CTX, receivedUpdatedPost *model.Post, updateP
 	}
 
 	var rejectionReason string
-	pluginContext := pluginContext(c)
+	pluginContext := pluginContext(rctx)
 	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 		newPost, rejectionReason = hooks.MessageWillBeUpdated(pluginContext, newPost.ForPlugin(), oldPost.ForPlugin())
 		return newPost != nil
@@ -782,7 +782,7 @@ func (a *App) UpdatePost(c request.CTX, receivedUpdatedPost *model.Post, updateP
 		newPost.Metadata = oldPost.Metadata
 	}
 
-	rpost, nErr := a.Srv().Store().Post().Update(c, newPost, oldPost)
+	rpost, nErr := a.Srv().Store().Post().Update(rctx, newPost, oldPost)
 	if nErr != nil {
 		switch {
 		case errors.As(nErr, &appErr):
@@ -801,29 +801,29 @@ func (a *App) UpdatePost(c request.CTX, receivedUpdatedPost *model.Post, updateP
 		}, plugin.MessageHasBeenUpdatedID)
 	})
 
-	rpost = a.PreparePostForClientWithEmbedsAndImages(c, rpost, false, true, true)
+	rpost = a.PreparePostForClientWithEmbedsAndImages(rctx, rpost, false, true, true)
 
 	// Ensure IsFollowing is nil since this updated post will be broadcast to all users
 	// and we don't want to have to populate it for every single user and broadcast to each
 	// individually.
 	rpost.IsFollowing = nil
 
-	rpost, nErr = a.addPostPreviewProp(c, rpost)
+	rpost, nErr = a.addPostPreviewProp(rctx, rpost)
 	if nErr != nil {
 		return nil, model.NewAppError("UpdatePost", "app.post.update.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)
 	}
 
 	message := model.NewWebSocketEvent(model.WebsocketEventPostEdited, "", rpost.ChannelId, "", nil, "")
 
-	appErr = a.publishWebsocketEventForPost(c, rpost, message)
+	appErr = a.publishWebsocketEventForPost(rctx, rpost, message)
 	if appErr != nil {
 		return nil, appErr
 	}
 
 	a.invalidateCacheForChannelPosts(rpost.ChannelId)
 
-	userID := c.Session().UserId
-	sanitizedPost, appErr := a.SanitizePostMetadataForUser(c, rpost, userID)
+	userID := rctx.Session().UserId
+	sanitizedPost, appErr := a.SanitizePostMetadataForUser(rctx, rpost, userID)
 	if appErr != nil {
 		mlog.Error("Failed to sanitize post metadata for user", mlog.String("user_id", userID), mlog.Err(appErr))
 
@@ -952,17 +952,17 @@ func (a *App) setupBroadcastHookForPermalink(rctx request.CTX, post *model.Post,
 	return nil
 }
 
-func (a *App) PatchPost(c request.CTX, postID string, patch *model.PostPatch, patchPostOptions *model.UpdatePostOptions) (*model.Post, *model.AppError) {
+func (a *App) PatchPost(rctx request.CTX, postID string, patch *model.PostPatch, patchPostOptions *model.UpdatePostOptions) (*model.Post, *model.AppError) {
 	if patchPostOptions == nil {
 		patchPostOptions = model.DefaultUpdatePostOptions()
 	}
 
-	post, err := a.GetSinglePost(c, postID, false)
+	post, err := a.GetSinglePost(rctx, postID, false)
 	if err != nil {
 		return nil, err
 	}
 
-	channel, err := a.GetChannel(c, post.ChannelId)
+	channel, err := a.GetChannel(rctx, post.ChannelId)
 	if err != nil {
 		return nil, err
 	}
@@ -972,14 +972,14 @@ func (a *App) PatchPost(c request.CTX, postID string, patch *model.PostPatch, pa
 		return nil, err
 	}
 
-	if !a.HasPermissionToChannel(c, post.UserId, post.ChannelId, model.PermissionUseChannelMentions) {
+	if !a.HasPermissionToChannel(rctx, post.UserId, post.ChannelId, model.PermissionUseChannelMentions) {
 		patch.DisableMentionHighlights()
 	}
 
 	post.Patch(patch)
 
 	patchPostOptions.SafeUpdate = false
-	updatedPost, err := a.UpdatePost(c, post, patchPostOptions)
+	updatedPost, err := a.UpdatePost(rctx, post, patchPostOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -1151,7 +1151,7 @@ func (a *App) GetFlaggedPostsForChannel(userID, channelID string, offset int, li
 	return postList, nil
 }
 
-func (a *App) GetPermalinkPost(c request.CTX, postID string, userID string) (*model.PostList, *model.AppError) {
+func (a *App) GetPermalinkPost(rctx request.CTX, postID string, userID string) (*model.PostList, *model.AppError) {
 	list, nErr := a.Srv().Store().Post().Get(context.Background(), postID, model.GetPostsOptions{}, userID, a.Config().GetSanitizeOptions())
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
@@ -1171,12 +1171,12 @@ func (a *App) GetPermalinkPost(c request.CTX, postID string, userID string) (*mo
 	}
 	post := list.Posts[list.Order[0]]
 
-	channel, err := a.GetChannel(c, post.ChannelId)
+	channel, err := a.GetChannel(rctx, post.ChannelId)
 	if err != nil {
 		return nil, err
 	}
 
-	if err = a.JoinChannel(c, channel, userID); err != nil {
+	if err = a.JoinChannel(rctx, channel, userID); err != nil {
 		return nil, err
 	}
 
@@ -1390,10 +1390,10 @@ func (a *App) AddCursorIdsForPostList(originalList *model.PostList, afterPost, b
 	originalList.PrevPostId = prevPostId
 }
 
-func (a *App) GetPostsForChannelAroundLastUnread(c request.CTX, channelID, userID string, limitBefore, limitAfter int, skipFetchThreads bool, collapsedThreads, collapsedThreadsExtended bool) (*model.PostList, *model.AppError) {
+func (a *App) GetPostsForChannelAroundLastUnread(rctx request.CTX, channelID, userID string, limitBefore, limitAfter int, skipFetchThreads bool, collapsedThreads, collapsedThreadsExtended bool) (*model.PostList, *model.AppError) {
 	var lastViewedAt int64
 	var err *model.AppError
-	if lastViewedAt, err = a.Srv().getChannelMemberLastViewedAt(c, channelID, userID); err != nil {
+	if lastViewedAt, err = a.Srv().getChannelMemberLastViewedAt(rctx, channelID, userID); err != nil {
 		return nil, err
 	} else if lastViewedAt == 0 {
 		return model.NewPostList(), nil
@@ -1482,27 +1482,27 @@ func (a *App) DeletePost(rctx request.CTX, postID, deleteByID string) (*model.Po
 	return post, nil
 }
 
-func (a *App) deleteDraftsAssociatedWithPost(c request.CTX, channel *model.Channel, post *model.Post) {
+func (a *App) deleteDraftsAssociatedWithPost(rctx request.CTX, channel *model.Channel, post *model.Post) {
 	if err := a.Srv().Store().Draft().DeleteDraftsAssociatedWithPost(channel.Id, post.Id); err != nil {
-		c.Logger().Error("Failed to delete drafts associated with post when deleting post", mlog.Err(err))
+		rctx.Logger().Error("Failed to delete drafts associated with post when deleting post", mlog.Err(err))
 		return
 	}
 }
 
-func (a *App) deleteFlaggedPosts(c request.CTX, postID string) {
+func (a *App) deleteFlaggedPosts(rctx request.CTX, postID string) {
 	if err := a.Srv().Store().Preference().DeleteCategoryAndName(model.PreferenceCategoryFlaggedPost, postID); err != nil {
-		c.Logger().Warn("Unable to delete flagged post preference when deleting post.", mlog.Err(err))
+		rctx.Logger().Warn("Unable to delete flagged post preference when deleting post.", mlog.Err(err))
 		return
 	}
 }
 
-func (a *App) deletePostFiles(c request.CTX, postID string) {
-	if _, err := a.Srv().Store().FileInfo().DeleteForPost(c, postID); err != nil {
-		c.Logger().Warn("Encountered error when deleting files for post", mlog.String("post_id", postID), mlog.Err(err))
+func (a *App) deletePostFiles(rctx request.CTX, postID string) {
+	if _, err := a.Srv().Store().FileInfo().DeleteForPost(rctx, postID); err != nil {
+		rctx.Logger().Warn("Encountered error when deleting files for post", mlog.String("post_id", postID), mlog.Err(err))
 	}
 }
 
-func (a *App) parseAndFetchChannelIdByNameFromInFilter(c request.CTX, channelName, userID, teamID string, includeDeleted bool) (*model.Channel, error) {
+func (a *App) parseAndFetchChannelIdByNameFromInFilter(rctx request.CTX, channelName, userID, teamID string, includeDeleted bool) (*model.Channel, error) {
 	cleanChannelName := strings.TrimLeft(channelName, "~")
 
 	if strings.HasPrefix(cleanChannelName, "@") && strings.Contains(cleanChannelName, ",") {
@@ -1515,7 +1515,7 @@ func (a *App) parseAndFetchChannelIdByNameFromInFilter(c request.CTX, channelNam
 			userIDs = append(userIDs, user.Id)
 		}
 
-		channel, err := a.GetGroupChannel(c, userIDs)
+		channel, err := a.GetGroupChannel(rctx, userIDs)
 		if err != nil {
 			return nil, err
 		}
@@ -1527,14 +1527,14 @@ func (a *App) parseAndFetchChannelIdByNameFromInFilter(c request.CTX, channelNam
 		if err != nil {
 			return nil, err
 		}
-		channel, err := a.GetOrCreateDirectChannel(c, userID, user.Id)
+		channel, err := a.GetOrCreateDirectChannel(rctx, userID, user.Id)
 		if err != nil {
 			return nil, err
 		}
 		return channel, nil
 	}
 
-	channel, err := a.GetChannelByName(c, cleanChannelName, teamID, includeDeleted)
+	channel, err := a.GetChannelByName(rctx, cleanChannelName, teamID, includeDeleted)
 	if err != nil {
 		return nil, err
 	}
@@ -1582,11 +1582,11 @@ func (a *App) searchPostsInTeam(teamID string, userID string, paramsList []*mode
 	return posts, nil
 }
 
-func (a *App) convertChannelNamesToChannelIds(c request.CTX, channels []string, userID string, teamID string, includeDeletedChannels bool) []string {
+func (a *App) convertChannelNamesToChannelIds(rctx request.CTX, channels []string, userID string, teamID string, includeDeletedChannels bool) []string {
 	for idx, channelName := range channels {
-		channel, err := a.parseAndFetchChannelIdByNameFromInFilter(c, channelName, userID, teamID, includeDeletedChannels)
+		channel, err := a.parseAndFetchChannelIdByNameFromInFilter(rctx, channelName, userID, teamID, includeDeletedChannels)
 		if err != nil {
-			c.Logger().Warn("error getting channel id by name from in filter", mlog.Err(err))
+			rctx.Logger().Warn("error getting channel id by name from in filter", mlog.Err(err))
 			continue
 		}
 		channels[idx] = channel.Id
@@ -1594,11 +1594,11 @@ func (a *App) convertChannelNamesToChannelIds(c request.CTX, channels []string, 
 	return channels
 }
 
-func (a *App) convertUserNameToUserIds(c request.CTX, usernames []string) []string {
+func (a *App) convertUserNameToUserIds(rctx request.CTX, usernames []string) []string {
 	for idx, username := range usernames {
 		user, err := a.GetUserByUsername(strings.TrimLeft(username, "@"))
 		if err != nil {
-			c.Logger().Warn("error getting user by username", mlog.String("user_name", username), mlog.Err(err))
+			rctx.Logger().Warn("error getting user by username", mlog.String("user_name", username), mlog.Err(err))
 			continue
 		}
 		usernames[idx] = user.Id
@@ -1713,7 +1713,7 @@ func (a *App) SearchPostsInTeam(teamID string, paramsList []*model.SearchParams)
 	})
 }
 
-func (a *App) SearchPostsForUser(c request.CTX, terms string, userID string, teamID string, isOrSearch bool, includeDeletedChannels bool, timeZoneOffset int, page, perPage int) (*model.PostSearchResults, *model.AppError) {
+func (a *App) SearchPostsForUser(rctx request.CTX, terms string, userID string, teamID string, isOrSearch bool, includeDeletedChannels bool, timeZoneOffset int, page, perPage int) (*model.PostSearchResults, *model.AppError) {
 	var postSearchResults *model.PostSearchResults
 	paramsList := model.ParseSearchParams(strings.TrimSpace(terms), timeZoneOffset)
 	includeDeleted := includeDeletedChannels && *a.Config().TeamSettings.ExperimentalViewArchivedChannels
@@ -1733,12 +1733,12 @@ func (a *App) SearchPostsForUser(c request.CTX, terms string, userID string, tea
 			// from the front-end. Otherwise it's not possible to distinguish
 			// from just the channel name at a cross-team level.
 			// Convert channel names to channel IDs
-			params.InChannels = a.convertChannelNamesToChannelIds(c, params.InChannels, userID, teamID, includeDeletedChannels)
-			params.ExcludedChannels = a.convertChannelNamesToChannelIds(c, params.ExcludedChannels, userID, teamID, includeDeletedChannels)
+			params.InChannels = a.convertChannelNamesToChannelIds(rctx, params.InChannels, userID, teamID, includeDeletedChannels)
+			params.ExcludedChannels = a.convertChannelNamesToChannelIds(rctx, params.ExcludedChannels, userID, teamID, includeDeletedChannels)
 
 			// Convert usernames to user IDs
-			params.FromUsers = a.convertUserNameToUserIds(c, params.FromUsers)
-			params.ExcludedUsers = a.convertUserNameToUserIds(c, params.ExcludedUsers)
+			params.FromUsers = a.convertUserNameToUserIds(rctx, params.FromUsers)
+			params.ExcludedUsers = a.convertUserNameToUserIds(rctx, params.ExcludedUsers)
 
 			finalParamsList = append(finalParamsList, params)
 		}
@@ -1749,7 +1749,7 @@ func (a *App) SearchPostsForUser(c request.CTX, terms string, userID string, tea
 		return model.MakePostSearchResults(model.NewPostList(), nil), nil
 	}
 
-	postSearchResults, err := a.Srv().Store().Post().SearchPostsForUser(c, finalParamsList, userID, teamID, page, perPage)
+	postSearchResults, err := a.Srv().Store().Post().SearchPostsForUser(rctx, finalParamsList, userID, teamID, page, perPage)
 	if err != nil {
 		var appErr *model.AppError
 		switch {
@@ -1868,8 +1868,8 @@ func (a *App) MaxPostSize() int {
 }
 
 // countThreadMentions returns the number of times the user is mentioned in a specified thread after the timestamp.
-func (a *App) countThreadMentions(c request.CTX, user *model.User, post *model.Post, teamID string, timestamp int64) (int64, *model.AppError) {
-	channel, err := a.GetChannel(c, post.ChannelId)
+func (a *App) countThreadMentions(rctx request.CTX, user *model.User, post *model.Post, teamID string, timestamp int64) (int64, *model.AppError) {
+	channel, err := a.GetChannel(rctx, post.ChannelId)
 	if err != nil {
 		return 0, err
 	}
@@ -1930,8 +1930,8 @@ func (a *App) countThreadMentions(c request.CTX, user *model.User, post *model.P
 
 // countMentionsFromPost returns the number of posts in the post's channel that mention the user after and including the
 // given post.
-func (a *App) countMentionsFromPost(c request.CTX, user *model.User, post *model.Post) (int, int, int, *model.AppError) {
-	channel, appErr := a.GetChannel(c, post.ChannelId)
+func (a *App) countMentionsFromPost(rctx request.CTX, user *model.User, post *model.Post) (int, int, int, *model.AppError) {
+	channel, appErr := a.GetChannel(rctx, post.ChannelId)
 	if appErr != nil {
 		return 0, 0, 0, appErr
 	}
@@ -2116,18 +2116,18 @@ func (a *App) GetThreadMembershipsForUser(userID, teamID string) ([]*model.Threa
 	return a.Srv().Store().Thread().GetMembershipsForUser(userID, teamID)
 }
 
-func (a *App) GetPostIfAuthorized(c request.CTX, postID string, session *model.Session, includeDeleted bool) (*model.Post, *model.AppError) {
-	post, err := a.GetSinglePost(c, postID, includeDeleted)
+func (a *App) GetPostIfAuthorized(rctx request.CTX, postID string, session *model.Session, includeDeleted bool) (*model.Post, *model.AppError) {
+	post, err := a.GetSinglePost(rctx, postID, includeDeleted)
 	if err != nil {
 		return nil, err
 	}
 
-	channel, err := a.GetChannel(c, post.ChannelId)
+	channel, err := a.GetChannel(rctx, post.ChannelId)
 	if err != nil {
 		return nil, err
 	}
 
-	if !a.SessionHasPermissionToReadChannel(c, *session, channel) {
+	if !a.SessionHasPermissionToReadChannel(rctx, *session, channel) {
 		if channel.Type == model.ChannelTypeOpen && !*a.Config().ComplianceSettings.Enable {
 			if !a.SessionHasPermissionToTeam(*session, channel.TeamId, model.PermissionReadPublicChannel) {
 				return nil, model.MakePermissionError(session, []*model.Permission{model.PermissionReadPublicChannel})
@@ -2327,14 +2327,14 @@ func (a *App) CheckPostReminders(rctx request.CTX) {
 	}
 }
 
-func (a *App) GetPostInfo(c request.CTX, postID string) (*model.PostInfo, *model.AppError) {
-	userID := c.Session().UserId
-	post, appErr := a.GetSinglePost(c, postID, false)
+func (a *App) GetPostInfo(rctx request.CTX, postID string) (*model.PostInfo, *model.AppError) {
+	userID := rctx.Session().UserId
+	post, appErr := a.GetSinglePost(rctx, postID, false)
 	if appErr != nil {
 		return nil, appErr
 	}
 
-	channel, appErr := a.GetChannel(c, post.ChannelId)
+	channel, appErr := a.GetChannel(rctx, post.ChannelId)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -2349,7 +2349,7 @@ func (a *App) GetPostInfo(c request.CTX, postID string) (*model.PostInfo, *model
 			return nil, appErr
 		}
 
-		teamMember, appErr := a.GetTeamMember(c, channel.TeamId, userID)
+		teamMember, appErr := a.GetTeamMember(rctx, channel.TeamId, userID)
 		if appErr != nil && appErr.StatusCode != http.StatusNotFound {
 			return nil, appErr
 		}
@@ -2362,9 +2362,9 @@ func (a *App) GetPostInfo(c request.CTX, postID string) (*model.PostInfo, *model
 
 		if !hasPermissionToAccessTeam {
 			if team.AllowOpenInvite {
-				hasPermissionToAccessTeam = a.HasPermissionToTeam(c, userID, team.Id, model.PermissionJoinPublicTeams)
+				hasPermissionToAccessTeam = a.HasPermissionToTeam(rctx, userID, team.Id, model.PermissionJoinPublicTeams)
 			} else {
-				hasPermissionToAccessTeam = a.HasPermissionToTeam(c, userID, team.Id, model.PermissionJoinPrivateTeams)
+				hasPermissionToAccessTeam = a.HasPermissionToTeam(rctx, userID, team.Id, model.PermissionJoinPrivateTeams)
 			}
 		}
 	} else {
@@ -2378,7 +2378,7 @@ func (a *App) GetPostInfo(c request.CTX, postID string) (*model.PostInfo, *model
 
 	hasPermissionToAccessChannel := false
 
-	_, channelMemberErr := a.GetChannelMember(c, channel.Id, userID)
+	_, channelMemberErr := a.GetChannelMember(rctx, channel.Id, userID)
 
 	if channelMemberErr == nil {
 		hasPermissionToAccessChannel = true
@@ -2388,9 +2388,9 @@ func (a *App) GetPostInfo(c request.CTX, postID string) (*model.PostInfo, *model
 		if channel.Type == model.ChannelTypeOpen {
 			hasPermissionToAccessChannel = true
 		} else if channel.Type == model.ChannelTypePrivate {
-			hasPermissionToAccessChannel = a.HasPermissionToChannel(c, userID, channel.Id, model.PermissionManagePrivateChannelMembers)
+			hasPermissionToAccessChannel = a.HasPermissionToChannel(rctx, userID, channel.Id, model.PermissionManagePrivateChannelMembers)
 		} else if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
-			hasPermissionToAccessChannel = a.HasPermissionToChannel(c, userID, channel.Id, model.PermissionReadChannelContent)
+			hasPermissionToAccessChannel = a.HasPermissionToChannel(rctx, userID, channel.Id, model.PermissionReadChannelContent)
 		}
 	}
 
@@ -2405,7 +2405,7 @@ func (a *App) GetPostInfo(c request.CTX, postID string) (*model.PostInfo, *model
 		HasJoinedChannel:   channelMemberErr == nil,
 	}
 	if team != nil {
-		teamMember, teamMemberErr := a.GetTeamMember(c, team.Id, userID)
+		teamMember, teamMemberErr := a.GetTeamMember(rctx, team.Id, userID)
 
 		teamType := model.TeamInvite
 		if team.AllowOpenInvite {
@@ -2460,7 +2460,7 @@ func makePostLink(siteURL, teamName, postID string) string {
 // validateMoveOrCopy performs validation on a provided post list to determine
 // if all permissions are in place to allow the for the posts to be moved or
 // copied.
-func (a *App) ValidateMoveOrCopy(c request.CTX, wpl *model.WranglerPostList, originalChannel *model.Channel, targetChannel *model.Channel, user *model.User) error {
+func (a *App) ValidateMoveOrCopy(rctx request.CTX, wpl *model.WranglerPostList, originalChannel *model.Channel, targetChannel *model.Channel, user *model.User) error {
 	if wpl.NumPosts() == 0 {
 		return errors.New("The wrangler post list contains no posts")
 	}
@@ -2494,12 +2494,12 @@ func (a *App) ValidateMoveOrCopy(c request.CTX, wpl *model.WranglerPostList, ori
 		return fmt.Errorf("the thread is %d posts long, but this command is configured to only move threads of up to %d posts", wpl.NumPosts(), *config.MoveThreadMaxCount)
 	}
 
-	_, appErr := a.GetChannelMember(c, targetChannel.Id, user.Id)
+	_, appErr := a.GetChannelMember(rctx, targetChannel.Id, user.Id)
 	if appErr != nil {
 		return fmt.Errorf("channel with ID %s doesn't exist or you are not a member", targetChannel.Id)
 	}
 
-	_, appErr = a.GetChannelMember(c, originalChannel.Id, user.Id)
+	_, appErr = a.GetChannelMember(rctx, originalChannel.Id, user.Id)
 	if appErr != nil {
 		return fmt.Errorf("channel with ID %s doesn't exist or you are not a member", originalChannel.Id)
 	}
@@ -2507,7 +2507,7 @@ func (a *App) ValidateMoveOrCopy(c request.CTX, wpl *model.WranglerPostList, ori
 	return nil
 }
 
-func (a *App) CopyWranglerPostlist(c request.CTX, wpl *model.WranglerPostList, targetChannel *model.Channel) (*model.Post, *model.AppError) {
+func (a *App) CopyWranglerPostlist(rctx request.CTX, wpl *model.WranglerPostList, targetChannel *model.Channel) (*model.Post, *model.AppError) {
 	var appErr *model.AppError
 	var newRootPost *model.Post
 
@@ -2516,7 +2516,7 @@ func (a *App) CopyWranglerPostlist(c request.CTX, wpl *model.WranglerPostList, t
 		// thread, the files will have to be re-uploaded. This is completed
 		// before any messages are moved.
 		// TODO: check number of files that need to be re-uploaded or file size?
-		c.Logger().Info("Wrangler is re-uploading file attachments",
+		rctx.Logger().Info("Wrangler is re-uploading file attachments",
 			mlog.String("file_count", fmt.Sprintf("%d", wpl.FileAttachmentCount)),
 		)
 
@@ -2525,15 +2525,15 @@ func (a *App) CopyWranglerPostlist(c request.CTX, wpl *model.WranglerPostList, t
 			var fileBytes []byte
 			var oldFileInfo, newFileInfo *model.FileInfo
 			for _, fileID := range post.FileIds {
-				oldFileInfo, appErr = a.GetFileInfo(c, fileID)
+				oldFileInfo, appErr = a.GetFileInfo(rctx, fileID)
 				if appErr != nil {
 					return nil, appErr
 				}
-				fileBytes, appErr = a.GetFile(c, fileID)
+				fileBytes, appErr = a.GetFile(rctx, fileID)
 				if appErr != nil {
 					return nil, appErr
 				}
-				newFileInfo, appErr = a.UploadFile(c, fileBytes, targetChannel.Id, oldFileInfo.Name)
+				newFileInfo, appErr = a.UploadFile(rctx, fileBytes, targetChannel.Id, oldFileInfo.Name)
 				if appErr != nil {
 					return nil, appErr
 				}
@@ -2552,7 +2552,7 @@ func (a *App) CopyWranglerPostlist(c request.CTX, wpl *model.WranglerPostList, t
 		reactions, appErr = a.GetReactionsForPost(post.Id)
 		if appErr != nil {
 			// Reaction-based errors are logged, but do not abort
-			c.Logger().Error("Failed to get reactions on original post")
+			rctx.Logger().Error("Failed to get reactions on original post")
 		}
 
 		newPost := post.Clone()
@@ -2560,14 +2560,14 @@ func (a *App) CopyWranglerPostlist(c request.CTX, wpl *model.WranglerPostList, t
 		newPost.ChannelId = targetChannel.Id
 
 		if i == 0 {
-			newPost, appErr = a.CreatePost(c, newPost, targetChannel, model.CreatePostFlags{})
+			newPost, appErr = a.CreatePost(rctx, newPost, targetChannel, model.CreatePostFlags{})
 			if appErr != nil {
 				return nil, appErr
 			}
 			newRootPost = newPost.Clone()
 		} else {
 			newPost.RootId = newRootPost.Id
-			newPost, appErr = a.CreatePost(c, newPost, targetChannel, model.CreatePostFlags{})
+			newPost, appErr = a.CreatePost(rctx, newPost, targetChannel, model.CreatePostFlags{})
 			if appErr != nil {
 				return nil, appErr
 			}
@@ -2575,10 +2575,10 @@ func (a *App) CopyWranglerPostlist(c request.CTX, wpl *model.WranglerPostList, t
 
 		for _, reaction := range reactions {
 			reaction.PostId = newPost.Id
-			_, appErr = a.SaveReactionForPost(c, reaction)
+			_, appErr = a.SaveReactionForPost(rctx, reaction)
 			if appErr != nil {
 				// Reaction-based errors are logged, but do not abort
-				c.Logger().Error("Failed to reapply reactions to post")
+				rctx.Logger().Error("Failed to reapply reactions to post")
 			}
 		}
 	}
@@ -2586,23 +2586,23 @@ func (a *App) CopyWranglerPostlist(c request.CTX, wpl *model.WranglerPostList, t
 	return newRootPost, nil
 }
 
-func (a *App) MoveThread(c request.CTX, postID string, sourceChannelID, channelID string, user *model.User) *model.AppError {
+func (a *App) MoveThread(rctx request.CTX, postID string, sourceChannelID, channelID string, user *model.User) *model.AppError {
 	postListResponse, appErr := a.GetPostThread(postID, model.GetPostsOptions{}, user.Id)
 	if appErr != nil {
 		return model.NewAppError("getPostThread", "app.post.move_thread_command.error", nil, "postID="+postID+", "+"UserId="+user.Id+"", http.StatusBadRequest).Wrap(appErr)
 	}
 	wpl := postListResponse.BuildWranglerPostList()
 
-	originalChannel, appErr := a.GetChannel(c, sourceChannelID)
+	originalChannel, appErr := a.GetChannel(rctx, sourceChannelID)
 	if appErr != nil {
 		return appErr
 	}
-	targetChannel, appErr := a.GetChannel(c, channelID)
+	targetChannel, appErr := a.GetChannel(rctx, channelID)
 	if appErr != nil {
 		return appErr
 	}
 
-	err := a.ValidateMoveOrCopy(c, wpl, originalChannel, targetChannel, user)
+	err := a.ValidateMoveOrCopy(rctx, wpl, originalChannel, targetChannel, user)
 	if err != nil {
 		return model.NewAppError("validateMoveOrCopy", "app.post.move_thread_command.error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
@@ -2625,11 +2625,11 @@ func (a *App) MoveThread(c request.CTX, postID string, sourceChannelID, channelI
 	}
 
 	// Begin creating the new thread.
-	c.Logger().Info("Wrangler is moving a thread", mlog.String("user_id", user.Id), mlog.String("original_post_id", wpl.RootPost().Id), mlog.String("original_channel_id", originalChannel.Id))
+	rctx.Logger().Info("Wrangler is moving a thread", mlog.String("user_id", user.Id), mlog.String("original_post_id", wpl.RootPost().Id), mlog.String("original_channel_id", originalChannel.Id))
 
 	// To simulate the move, we first copy the original messages(s) to the
 	// new channel and later delete the original messages(s).
-	newRootPost, appErr := a.CopyWranglerPostlist(c, wpl, targetChannel)
+	newRootPost, appErr := a.CopyWranglerPostlist(rctx, wpl, targetChannel)
 	if appErr != nil {
 		return appErr
 	}
@@ -2642,7 +2642,7 @@ func (a *App) MoveThread(c request.CTX, postID string, sourceChannelID, channelI
 	ephemeralPostProps := model.StringInterface{
 		"TranslationID": "app.post.move_thread.from_another_channel",
 	}
-	_, appErr = a.CreatePost(c, &model.Post{
+	_, appErr = a.CreatePost(rctx, &model.Post{
 		UserId:    user.Id,
 		Type:      model.PostTypeWrangler,
 		RootId:    newRootPost.Id,
@@ -2655,12 +2655,12 @@ func (a *App) MoveThread(c request.CTX, postID string, sourceChannelID, channelI
 	}
 	// Cleanup is handled by simply deleting the root post. Any comments/replies
 	// are automatically marked as deleted for us.
-	_, appErr = a.DeletePost(c, wpl.RootPost().Id, user.Id)
+	_, appErr = a.DeletePost(rctx, wpl.RootPost().Id, user.Id)
 	if appErr != nil {
 		return appErr
 	}
 
-	c.Logger().Info("Wrangler thread move complete", mlog.String("user_id", user.Id), mlog.String("new_post_id", newRootPost.Id), mlog.String("channel_id", channelID))
+	rctx.Logger().Info("Wrangler thread move complete", mlog.String("user_id", user.Id), mlog.String("new_post_id", newRootPost.Id), mlog.String("channel_id", channelID))
 
 	// Translate to the system locale, webapp will attempt to render in each user's specific locale (based on the TranslationID prop) before falling back on the initiating user's locale
 	ephemeralPostProps = model.StringInterface{}
@@ -2690,7 +2690,7 @@ func (a *App) MoveThread(c request.CTX, postID string, sourceChannelID, channelI
 
 	ephemeralPostProps["NumMessages"] = wpl.NumPosts()
 
-	_, appErr = a.CreatePost(c, &model.Post{
+	_, appErr = a.CreatePost(rctx, &model.Post{
 		UserId:    user.Id,
 		Type:      model.PostTypeWrangler,
 		ChannelId: originalChannel.Id,
@@ -2701,7 +2701,7 @@ func (a *App) MoveThread(c request.CTX, postID string, sourceChannelID, channelI
 		return appErr
 	}
 
-	c.Logger().Info(msg)
+	rctx.Logger().Info(msg)
 	return nil
 }
 
@@ -2731,14 +2731,14 @@ func (a *App) PermanentDeletePost(rctx request.CTX, postID, deleteByID string) *
 	return nil
 }
 
-func (a *App) CleanUpAfterPostDeletion(c request.CTX, post *model.Post, deleteByID string) *model.AppError {
-	channel, appErr := a.GetChannel(c, post.ChannelId)
+func (a *App) CleanUpAfterPostDeletion(rctx request.CTX, post *model.Post, deleteByID string) *model.AppError {
+	channel, appErr := a.GetChannel(rctx, post.ChannelId)
 	if appErr != nil {
 		return appErr
 	}
 
 	if post.RootId == "" {
-		if appErr := a.DeletePersistentNotification(c, post); appErr != nil {
+		if appErr := a.DeletePersistentNotification(rctx, post); appErr != nil {
 			return appErr
 		}
 	}
@@ -2760,11 +2760,11 @@ func (a *App) CleanUpAfterPostDeletion(c request.CTX, post *model.Post, deleteBy
 	a.Publish(adminMessage)
 
 	a.Srv().Go(func() {
-		a.deleteFlaggedPosts(c, post.Id)
+		a.deleteFlaggedPosts(rctx, post.Id)
 	})
 
 	pluginPost := post.ForPlugin()
-	pluginContext := pluginContext(c)
+	pluginContext := pluginContext(rctx)
 	a.Srv().Go(func() {
 		a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 			hooks.MessageHasBeenDeleted(pluginContext, pluginPost)
@@ -2773,14 +2773,14 @@ func (a *App) CleanUpAfterPostDeletion(c request.CTX, post *model.Post, deleteBy
 	})
 
 	a.Srv().Go(func() {
-		if err = a.RemoveNotifications(c, post, channel); err != nil {
-			c.Logger().Error("DeletePost failed to delete notification", mlog.Err(err))
+		if err = a.RemoveNotifications(rctx, post, channel); err != nil {
+			rctx.Logger().Error("DeletePost failed to delete notification", mlog.Err(err))
 		}
 	})
 
 	// delete drafts associated with the post when deleting the post
 	a.Srv().Go(func() {
-		a.deleteDraftsAssociatedWithPost(c, channel, post)
+		a.deleteDraftsAssociatedWithPost(rctx, channel, post)
 	})
 
 	a.invalidateCacheForChannelPosts(post.ChannelId)
@@ -2788,13 +2788,13 @@ func (a *App) CleanUpAfterPostDeletion(c request.CTX, post *model.Post, deleteBy
 	return nil
 }
 
-func (a *App) SendTestMessage(c request.CTX, userID string) (*model.Post, *model.AppError) {
-	bot, err := a.GetSystemBot(c)
+func (a *App) SendTestMessage(rctx request.CTX, userID string) (*model.Post, *model.AppError) {
+	bot, err := a.GetSystemBot(rctx)
 	if err != nil {
 		return nil, model.NewAppError("SendTestMessage", "app.notifications.send_test_message.errors.no_bot", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
-	channel, err := a.GetOrCreateDirectChannel(c, userID, bot.UserId)
+	channel, err := a.GetOrCreateDirectChannel(rctx, userID, bot.UserId)
 	if err != nil {
 		return nil, model.NewAppError("SendTestMessage", "app.notifications.send_test_message.errors.no_channel", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -2811,7 +2811,7 @@ func (a *App) SendTestMessage(c request.CTX, userID string) (*model.Post, *model
 		UserId:    bot.UserId,
 	}
 
-	post, err = a.CreatePost(c, post, channel, model.CreatePostFlags{ForceNotification: true})
+	post, err = a.CreatePost(rctx, post, channel, model.CreatePostFlags{ForceNotification: true})
 	if err != nil {
 		return nil, model.NewAppError("SendTestMessage", "app.notifications.send_test_message.errors.create_post", nil, "", http.StatusInternalServerError).Wrap(err)
 	}

--- a/server/channels/app/post_acknowledgements.go
+++ b/server/channels/app/post_acknowledgements.go
@@ -14,23 +14,23 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 )
 
-func (a *App) SaveAcknowledgementForPost(c request.CTX, postID, userID string) (*model.PostAcknowledgement, *model.AppError) {
-	return a.saveAcknowledgementForPostWithPost(c, nil, userID, postID)
+func (a *App) SaveAcknowledgementForPost(rctx request.CTX, postID, userID string) (*model.PostAcknowledgement, *model.AppError) {
+	return a.saveAcknowledgementForPostWithPost(rctx, nil, userID, postID)
 }
 
-func (a *App) saveAcknowledgementForPostWithPost(c request.CTX, post *model.Post, userID string, postID ...string) (*model.PostAcknowledgement, *model.AppError) {
+func (a *App) saveAcknowledgementForPostWithPost(rctx request.CTX, post *model.Post, userID string, postID ...string) (*model.PostAcknowledgement, *model.AppError) {
 	if post == nil {
 		if len(postID) == 0 {
 			return nil, model.NewAppError("SaveAcknowledgementForPost", "app.acknowledgement.save.missing_post.app_error", nil, "", http.StatusBadRequest)
 		}
 		var err *model.AppError
-		post, err = a.GetSinglePost(c, postID[0], false)
+		post, err = a.GetSinglePost(rctx, postID[0], false)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	channel, err := a.GetChannel(c, post.ChannelId)
+	channel, err := a.GetChannel(rctx, post.ChannelId)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (a *App) saveAcknowledgementForPostWithPost(c request.CTX, post *model.Post
 		}
 	}
 
-	if appErr := a.ResolvePersistentNotification(c, post, userID); appErr != nil {
+	if appErr := a.ResolvePersistentNotification(rctx, post, userID); appErr != nil {
 		a.CountNotificationReason(model.NotificationStatusError, model.NotificationTypeWebsocket, model.NotificationReasonResolvePersistentNotificationError, model.NotificationNoPlatform)
 		a.NotificationsLog().Error("Error resolving persistent notification",
 			mlog.String("sender_id", userID),
@@ -72,31 +72,31 @@ func (a *App) saveAcknowledgementForPostWithPost(c request.CTX, post *model.Post
 	// The post is always modified since the UpdateAt always changes
 	a.Srv().Store().Post().InvalidateLastPostTimeCache(channel.Id)
 
-	a.sendAcknowledgementEvent(c, model.WebsocketEventAcknowledgementAdded, savedAck, post)
+	a.sendAcknowledgementEvent(rctx, model.WebsocketEventAcknowledgementAdded, savedAck, post)
 
 	// Trigger post updated event to ensure shared channel sync
-	a.sendPostUpdateEvent(c, post)
+	a.sendPostUpdateEvent(rctx, post)
 
 	return savedAck, nil
 }
 
-func (a *App) DeleteAcknowledgementForPost(c request.CTX, postID, userID string) *model.AppError {
-	return a.deleteAcknowledgementForPostWithPost(c, nil, userID, postID)
+func (a *App) DeleteAcknowledgementForPost(rctx request.CTX, postID, userID string) *model.AppError {
+	return a.deleteAcknowledgementForPostWithPost(rctx, nil, userID, postID)
 }
 
-func (a *App) deleteAcknowledgementForPostWithPost(c request.CTX, post *model.Post, userID string, postID ...string) *model.AppError {
+func (a *App) deleteAcknowledgementForPostWithPost(rctx request.CTX, post *model.Post, userID string, postID ...string) *model.AppError {
 	if post == nil {
 		if len(postID) == 0 {
 			return model.NewAppError("DeleteAcknowledgementForPost", "app.acknowledgement.delete.missing_post.app_error", nil, "", http.StatusBadRequest)
 		}
 		var err *model.AppError
-		post, err = a.GetSinglePost(c, postID[0], false)
+		post, err = a.GetSinglePost(rctx, postID[0], false)
 		if err != nil {
 			return err
 		}
 	}
 
-	channel, err := a.GetChannel(c, post.ChannelId)
+	channel, err := a.GetChannel(rctx, post.ChannelId)
 	if err != nil {
 		return err
 	}
@@ -129,10 +129,10 @@ func (a *App) deleteAcknowledgementForPostWithPost(c request.CTX, post *model.Po
 	// The post is always modified since the UpdateAt always changes
 	a.Srv().Store().Post().InvalidateLastPostTimeCache(channel.Id)
 
-	a.sendAcknowledgementEvent(c, model.WebsocketEventAcknowledgementRemoved, oldAck, post)
+	a.sendAcknowledgementEvent(rctx, model.WebsocketEventAcknowledgementRemoved, oldAck, post)
 
 	// Trigger post updated event to ensure shared channel sync
-	a.sendPostUpdateEvent(c, post)
+	a.sendPostUpdateEvent(rctx, post)
 
 	return nil
 }
@@ -163,17 +163,17 @@ func (a *App) GetAcknowledgementsForPostList(postList *model.PostList) (map[stri
 }
 
 // SaveAcknowledgementsForPost saves multiple acknowledgements for a post in a single operation.
-func (a *App) SaveAcknowledgementsForPost(c request.CTX, postID string, userIDs []string) ([]*model.PostAcknowledgement, *model.AppError) {
+func (a *App) SaveAcknowledgementsForPost(rctx request.CTX, postID string, userIDs []string) ([]*model.PostAcknowledgement, *model.AppError) {
 	if len(userIDs) == 0 {
 		return []*model.PostAcknowledgement{}, nil
 	}
 
-	post, err := a.GetSinglePost(c, postID, false)
+	post, err := a.GetSinglePost(rctx, postID, false)
 	if err != nil {
 		return nil, err
 	}
 
-	channel, err := a.GetChannel(c, post.ChannelId)
+	channel, err := a.GetChannel(rctx, post.ChannelId)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +209,7 @@ func (a *App) SaveAcknowledgementsForPost(c request.CTX, postID string, userIDs 
 
 	// Resolve persistent notifications for each user
 	for _, userID := range userIDs {
-		if appErr := a.ResolvePersistentNotification(c, post, userID); appErr != nil {
+		if appErr := a.ResolvePersistentNotification(rctx, post, userID); appErr != nil {
 			a.CountNotificationReason(model.NotificationStatusError, model.NotificationTypeWebsocket, model.NotificationReasonResolvePersistentNotificationError, model.NotificationNoPlatform)
 			a.NotificationsLog().Error("Error resolving persistent notification",
 				mlog.String("sender_id", userID),
@@ -227,11 +227,11 @@ func (a *App) SaveAcknowledgementsForPost(c request.CTX, postID string, userIDs 
 
 	// Send WebSocket events for each acknowledgement
 	for _, ack := range savedAcks {
-		a.sendAcknowledgementEvent(c, model.WebsocketEventAcknowledgementAdded, ack, post)
+		a.sendAcknowledgementEvent(rctx, model.WebsocketEventAcknowledgementAdded, ack, post)
 	}
 
 	// Trigger post updated event to ensure shared channel sync
-	a.sendPostUpdateEvent(c, post)
+	a.sendPostUpdateEvent(rctx, post)
 
 	return savedAcks, nil
 }
@@ -248,14 +248,14 @@ func (a *App) sendAcknowledgementEvent(rctx request.CTX, event model.WebsocketEv
 	a.Publish(message)
 }
 
-func (a *App) SaveAcknowledgementForPostWithModel(c request.CTX, acknowledgement *model.PostAcknowledgement) (*model.PostAcknowledgement, *model.AppError) {
+func (a *App) SaveAcknowledgementForPostWithModel(rctx request.CTX, acknowledgement *model.PostAcknowledgement) (*model.PostAcknowledgement, *model.AppError) {
 	// Get the post to verify it exists and get the channel
-	post, err := a.GetSinglePost(c, acknowledgement.PostId, false)
+	post, err := a.GetSinglePost(rctx, acknowledgement.PostId, false)
 	if err != nil {
 		return nil, err
 	}
 
-	channel, err := a.GetChannel(c, post.ChannelId)
+	channel, err := a.GetChannel(rctx, post.ChannelId)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +280,7 @@ func (a *App) SaveAcknowledgementForPostWithModel(c request.CTX, acknowledgement
 		}
 	}
 
-	if appErr := a.ResolvePersistentNotification(c, post, acknowledgement.UserId); appErr != nil {
+	if appErr := a.ResolvePersistentNotification(rctx, post, acknowledgement.UserId); appErr != nil {
 		a.CountNotificationReason(model.NotificationStatusError, model.NotificationTypeWebsocket, model.NotificationReasonResolvePersistentNotificationError, model.NotificationNoPlatform)
 		a.NotificationsLog().Error("Error resolving persistent notification",
 			mlog.String("sender_id", acknowledgement.UserId),
@@ -295,22 +295,22 @@ func (a *App) SaveAcknowledgementForPostWithModel(c request.CTX, acknowledgement
 	// The post is always modified since the UpdateAt always changes
 	a.Srv().Store().Post().InvalidateLastPostTimeCache(channel.Id)
 
-	a.sendAcknowledgementEvent(c, model.WebsocketEventAcknowledgementAdded, savedAck, post)
+	a.sendAcknowledgementEvent(rctx, model.WebsocketEventAcknowledgementAdded, savedAck, post)
 
 	// Trigger post updated event to ensure shared channel sync
-	a.sendPostUpdateEvent(c, post)
+	a.sendPostUpdateEvent(rctx, post)
 
 	return savedAck, nil
 }
 
-func (a *App) DeleteAcknowledgementForPostWithModel(c request.CTX, acknowledgement *model.PostAcknowledgement) *model.AppError {
+func (a *App) DeleteAcknowledgementForPostWithModel(rctx request.CTX, acknowledgement *model.PostAcknowledgement) *model.AppError {
 	// Get the post to verify it exists and get the channel
-	post, err := a.GetSinglePost(c, acknowledgement.PostId, false)
+	post, err := a.GetSinglePost(rctx, acknowledgement.PostId, false)
 	if err != nil {
 		return err
 	}
 
-	channel, err := a.GetChannel(c, post.ChannelId)
+	channel, err := a.GetChannel(rctx, post.ChannelId)
 	if err != nil {
 		return err
 	}
@@ -327,17 +327,17 @@ func (a *App) DeleteAcknowledgementForPostWithModel(c request.CTX, acknowledgeme
 	// The post is always modified since the UpdateAt always changes
 	a.Srv().Store().Post().InvalidateLastPostTimeCache(channel.Id)
 
-	a.sendAcknowledgementEvent(c, model.WebsocketEventAcknowledgementRemoved, acknowledgement, post)
+	a.sendAcknowledgementEvent(rctx, model.WebsocketEventAcknowledgementRemoved, acknowledgement, post)
 
 	// Trigger post updated event to ensure shared channel sync
-	a.sendPostUpdateEvent(c, post)
+	a.sendPostUpdateEvent(rctx, post)
 
 	return nil
 }
 
-func (a *App) sendPostUpdateEvent(c request.CTX, post *model.Post) {
+func (a *App) sendPostUpdateEvent(rctx request.CTX, post *model.Post) {
 	if post == nil {
-		c.Logger().Warn("sendPostUpdateEvent called with nil post")
+		rctx.Logger().Warn("sendPostUpdateEvent called with nil post")
 		return
 	}
 
@@ -345,9 +345,9 @@ func (a *App) sendPostUpdateEvent(c request.CTX, post *model.Post) {
 	message := model.NewWebSocketEvent(model.WebsocketEventPostEdited, "", post.ChannelId, "", nil, "")
 
 	// Prepare the post with metadata for the event
-	preparedPost := a.PreparePostForClient(c, post, false, true, true)
+	preparedPost := a.PreparePostForClient(rctx, post, false, true, true)
 
-	if appErr := a.publishWebsocketEventForPost(c, preparedPost, message); appErr != nil {
-		c.Logger().Warn("Failed to send post update event for acknowledgement sync", mlog.String("post_id", post.Id), mlog.Err(appErr))
+	if appErr := a.publishWebsocketEventForPost(rctx, preparedPost, message); appErr != nil {
+		rctx.Logger().Warn("Failed to send post update event for acknowledgement sync", mlog.String("post_id", post.Id), mlog.Err(appErr))
 	}
 }

--- a/server/channels/app/post_metadata.go
+++ b/server/channels/app/post_metadata.go
@@ -52,7 +52,7 @@ func (s *Server) initPostMetadata() {
 	})
 }
 
-func (a *App) PreparePostListForClient(c request.CTX, originalList *model.PostList) *model.PostList {
+func (a *App) PreparePostListForClient(rctx request.CTX, originalList *model.PostList) *model.PostList {
 	list := &model.PostList{
 		Posts:                     make(map[string]*model.Post, len(originalList.Posts)),
 		Order:                     originalList.Order,
@@ -63,7 +63,7 @@ func (a *App) PreparePostListForClient(c request.CTX, originalList *model.PostLi
 	}
 
 	for id, originalPost := range originalList.Posts {
-		post := a.PreparePostForClientWithEmbedsAndImages(c, originalPost, false, false, false)
+		post := a.PreparePostForClientWithEmbedsAndImages(rctx, originalPost, false, false, false)
 
 		list.Posts[id] = post
 	}
@@ -87,7 +87,7 @@ func (a *App) PreparePostListForClient(c request.CTX, originalList *model.PostLi
 
 // OverrideIconURLIfEmoji changes the post icon override URL prop, if it has an emoji icon,
 // so that it points to the URL (relative) of the emoji - static if emoji is default, /api if custom.
-func (a *App) OverrideIconURLIfEmoji(c request.CTX, post *model.Post) {
+func (a *App) OverrideIconURLIfEmoji(rctx request.CTX, post *model.Post) {
 	prop, ok := post.GetProps()[model.PostPropsOverrideIconEmoji]
 	if !ok || prop == nil {
 		return
@@ -104,20 +104,20 @@ func (a *App) OverrideIconURLIfEmoji(c request.CTX, post *model.Post) {
 
 	emojiName = strings.ReplaceAll(emojiName, ":", "")
 
-	if emojiURL, err := a.GetEmojiStaticURL(c, emojiName); err == nil {
+	if emojiURL, err := a.GetEmojiStaticURL(rctx, emojiName); err == nil {
 		post.AddProp(model.PostPropsOverrideIconURL, emojiURL)
 	} else {
-		c.Logger().Warn("Failed to retrieve URL for overridden profile icon (emoji)", mlog.String("emojiName", emojiName), mlog.Err(err))
+		rctx.Logger().Warn("Failed to retrieve URL for overridden profile icon (emoji)", mlog.String("emojiName", emojiName), mlog.Err(err))
 	}
 }
 
-func (a *App) PreparePostForClient(c request.CTX, originalPost *model.Post, isNewPost, isEditPost, includePriority bool) *model.Post {
+func (a *App) PreparePostForClient(rctx request.CTX, originalPost *model.Post, isNewPost, isEditPost, includePriority bool) *model.Post {
 	post := originalPost.Clone()
 
 	// Proxy image links before constructing metadata so that requests go through the proxy
 	post = a.PostWithProxyAddedToImageURLs(post)
 
-	a.OverrideIconURLIfEmoji(c, post)
+	a.OverrideIconURLIfEmoji(rctx, post)
 	if post.Metadata == nil {
 		post.Metadata = &model.PostMetadata{}
 	}
@@ -130,16 +130,16 @@ func (a *App) PreparePostForClient(c request.CTX, originalPost *model.Post, isNe
 	}
 
 	// Emojis and reaction counts
-	if emojis, reactions, err := a.getEmojisAndReactionsForPost(c, post); err != nil {
-		c.Logger().Warn("Failed to get emojis and reactions for a post", mlog.String("post_id", post.Id), mlog.Err(err))
+	if emojis, reactions, err := a.getEmojisAndReactionsForPost(rctx, post); err != nil {
+		rctx.Logger().Warn("Failed to get emojis and reactions for a post", mlog.String("post_id", post.Id), mlog.Err(err))
 	} else {
 		post.Metadata.Emojis = emojis
 		post.Metadata.Reactions = reactions
 	}
 
 	// Files
-	if fileInfos, _, err := a.getFileMetadataForPost(c, post, isNewPost || isEditPost); err != nil {
-		c.Logger().Warn("Failed to get files for a post", mlog.String("post_id", post.Id), mlog.Err(err))
+	if fileInfos, _, err := a.getFileMetadataForPost(rctx, post, isNewPost || isEditPost); err != nil {
+		rctx.Logger().Warn("Failed to get files for a post", mlog.String("post_id", post.Id), mlog.Err(err))
 	} else {
 		post.Metadata.Files = fileInfos
 	}
@@ -147,14 +147,14 @@ func (a *App) PreparePostForClient(c request.CTX, originalPost *model.Post, isNe
 	if includePriority && a.IsPostPriorityEnabled() && post.RootId == "" {
 		// Post's Priority if any
 		if priority, err := a.GetPriorityForPost(post.Id); err != nil {
-			c.Logger().Warn("Failed to get post priority for a post", mlog.String("post_id", post.Id), mlog.Err(err))
+			rctx.Logger().Warn("Failed to get post priority for a post", mlog.String("post_id", post.Id), mlog.Err(err))
 		} else {
 			post.Metadata.Priority = priority
 		}
 
 		// Post's acknowledgements if any
 		if acknowledgements, err := a.GetAcknowledgementsForPost(post.Id); err != nil {
-			c.Logger().Warn("Failed to get post acknowledgements for a post", mlog.String("post_id", post.Id), mlog.Err(err))
+			rctx.Logger().Warn("Failed to get post acknowledgements for a post", mlog.String("post_id", post.Id), mlog.Err(err))
 		} else {
 			post.Metadata.Acknowledgements = acknowledgements
 		}
@@ -163,13 +163,13 @@ func (a *App) PreparePostForClient(c request.CTX, originalPost *model.Post, isNe
 	return post
 }
 
-func (a *App) PreparePostForClientWithEmbedsAndImages(c request.CTX, originalPost *model.Post, isNewPost, isEditPost, includePriority bool) *model.Post {
-	post := a.PreparePostForClient(c, originalPost, isNewPost, isEditPost, includePriority)
-	post = a.getEmbedsAndImages(c, post, isNewPost)
+func (a *App) PreparePostForClientWithEmbedsAndImages(rctx request.CTX, originalPost *model.Post, isNewPost, isEditPost, includePriority bool) *model.Post {
+	post := a.PreparePostForClient(rctx, originalPost, isNewPost, isEditPost, includePriority)
+	post = a.getEmbedsAndImages(rctx, post, isNewPost)
 	return post
 }
 
-func (a *App) getEmbedsAndImages(c request.CTX, post *model.Post, isNewPost bool) *model.Post {
+func (a *App) getEmbedsAndImages(rctx request.CTX, post *model.Post, isNewPost bool) *model.Post {
 	if post.Metadata == nil {
 		post.Metadata = &model.PostMetadata{}
 	}
@@ -179,7 +179,7 @@ func (a *App) getEmbedsAndImages(c request.CTX, post *model.Post, isNewPost bool
 	}
 
 	// Embeds and image dimensions
-	firstLink, images := a.getFirstLinkAndImages(c, post.Message)
+	firstLink, images := a.getFirstLinkAndImages(rctx, post.Message)
 
 	if unsafeLinksProp := post.GetProp(model.PostPropsUnsafeLinks); unsafeLinksProp != nil {
 		if prop, ok := unsafeLinksProp.(string); ok && prop == "true" {
@@ -190,17 +190,17 @@ func (a *App) getEmbedsAndImages(c request.CTX, post *model.Post, isNewPost bool
 		}
 	}
 
-	if embed, err := a.getEmbedForPost(c, post, firstLink, isNewPost); err != nil {
+	if embed, err := a.getEmbedForPost(rctx, post, firstLink, isNewPost); err != nil {
 		appErr, ok := err.(*model.AppError)
 		isNotFound := ok && appErr.StatusCode == http.StatusNotFound
 		// Ignore NotFound errors.
 		if !isNotFound {
-			c.Logger().Debug("Failed to get embedded content for a post", mlog.String("post_id", post.Id), mlog.Err(err))
+			rctx.Logger().Debug("Failed to get embedded content for a post", mlog.String("post_id", post.Id), mlog.Err(err))
 		}
 	} else if embed != nil {
 		post.Metadata.Embeds = append(post.Metadata.Embeds, embed)
 	}
-	post.Metadata.Images = a.getImagesForPost(c, post, images, isNewPost)
+	post.Metadata.Images = a.getImagesForPost(rctx, post, images, isNewPost)
 	return post
 }
 
@@ -227,19 +227,19 @@ func removeEmbeddedPostsFromMetadata(post *model.Post) {
 	post.Metadata.Embeds = newEmbeds
 }
 
-func (a *App) sanitizePostMetadataForUserAndChannel(c request.CTX, post *model.Post, previewedPost *model.PreviewPost, previewedChannel *model.Channel, userID string) *model.Post {
+func (a *App) sanitizePostMetadataForUserAndChannel(rctx request.CTX, post *model.Post, previewedPost *model.PreviewPost, previewedChannel *model.Channel, userID string) *model.Post {
 	if post.Metadata == nil || len(post.Metadata.Embeds) == 0 || previewedPost == nil {
 		return post
 	}
 
-	if previewedChannel != nil && !a.HasPermissionToReadChannel(c, userID, previewedChannel) {
+	if previewedChannel != nil && !a.HasPermissionToReadChannel(rctx, userID, previewedChannel) {
 		removePermalinkMetadataFromPost(post)
 	}
 
 	return post
 }
 
-func (a *App) SanitizePostMetadataForUser(c request.CTX, post *model.Post, userID string) (*model.Post, *model.AppError) {
+func (a *App) SanitizePostMetadataForUser(rctx request.CTX, post *model.Post, userID string) (*model.Post, *model.AppError) {
 	if post.Metadata == nil || len(post.Metadata.Embeds) == 0 {
 		return post, nil
 	}
@@ -249,22 +249,22 @@ func (a *App) SanitizePostMetadataForUser(c request.CTX, post *model.Post, userI
 		return post, nil
 	}
 
-	previewedChannel, err := a.GetChannel(c, previewPost.Post.ChannelId)
+	previewedChannel, err := a.GetChannel(rctx, previewPost.Post.ChannelId)
 	if err != nil {
 		return nil, err
 	}
 
-	if previewedChannel != nil && !a.HasPermissionToReadChannel(c, userID, previewedChannel) {
+	if previewedChannel != nil && !a.HasPermissionToReadChannel(rctx, userID, previewedChannel) {
 		removePermalinkMetadataFromPost(post)
 	}
 
 	return post, nil
 }
 
-func (a *App) SanitizePostListMetadataForUser(c request.CTX, postList *model.PostList, userID string) (*model.PostList, *model.AppError) {
+func (a *App) SanitizePostListMetadataForUser(rctx request.CTX, postList *model.PostList, userID string) (*model.PostList, *model.AppError) {
 	clonedPostList := postList.Clone()
 	for postID, post := range clonedPostList.Posts {
-		sanitizedPost, err := a.SanitizePostMetadataForUser(c, post, userID)
+		sanitizedPost, err := a.SanitizePostMetadataForUser(rctx, post, userID)
 		if err != nil {
 			return nil, err
 		}
@@ -281,7 +281,7 @@ func (a *App) getFileMetadataForPost(rctx request.CTX, post *model.Post, fromMas
 	return a.GetFileInfosForPost(rctx, post.Id, fromMaster, false)
 }
 
-func (a *App) getEmojisAndReactionsForPost(c request.CTX, post *model.Post) ([]*model.Emoji, []*model.Reaction, *model.AppError) {
+func (a *App) getEmojisAndReactionsForPost(rctx request.CTX, post *model.Post) ([]*model.Emoji, []*model.Reaction, *model.AppError) {
 	var reactions []*model.Reaction
 	if post.HasReactions {
 		var err *model.AppError
@@ -291,7 +291,7 @@ func (a *App) getEmojisAndReactionsForPost(c request.CTX, post *model.Post) ([]*
 		}
 	}
 
-	emojis, err := a.getCustomEmojisForPost(c, post, reactions)
+	emojis, err := a.getCustomEmojisForPost(rctx, post, reactions)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -299,7 +299,7 @@ func (a *App) getEmojisAndReactionsForPost(c request.CTX, post *model.Post) ([]*
 	return emojis, reactions, nil
 }
 
-func (a *App) getEmbedForPost(c request.CTX, post *model.Post, firstLink string, isNewPost bool) (*model.PostEmbed, error) {
+func (a *App) getEmbedForPost(rctx request.CTX, post *model.Post, firstLink string, isNewPost bool) (*model.PostEmbed, error) {
 	if _, ok := post.GetProps()[model.PostPropsAttachments]; ok {
 		return &model.PostEmbed{
 			Type: model.PostEmbedMessageAttachment,
@@ -322,7 +322,7 @@ func (a *App) getEmbedForPost(c request.CTX, post *model.Post, firstLink string,
 		return nil, nil
 	}
 
-	og, image, permalink, err := a.getLinkMetadata(c, firstLink, post.CreateAt, isNewPost, post.GetPreviewedPostProp())
+	og, image, permalink, err := a.getLinkMetadata(rctx, firstLink, post.CreateAt, isNewPost, post.GetPreviewedPostProp())
 	if err != nil {
 		return nil, err
 	}
@@ -357,7 +357,7 @@ func (a *App) getEmbedForPost(c request.CTX, post *model.Post, firstLink string,
 	}, nil
 }
 
-func (a *App) getImagesForPost(c request.CTX, post *model.Post, imageURLs []string, isNewPost bool) map[string]*model.PostImage {
+func (a *App) getImagesForPost(rctx request.CTX, post *model.Post, imageURLs []string, isNewPost bool) map[string]*model.PostImage {
 	images := map[string]*model.PostImage{}
 
 	for _, embed := range post.Metadata.Embeds {
@@ -367,12 +367,12 @@ func (a *App) getImagesForPost(c request.CTX, post *model.Post, imageURLs []stri
 			imageURLs = append(imageURLs, embed.URL)
 
 		case model.PostEmbedMessageAttachment:
-			imageURLs = append(imageURLs, a.getImagesInMessageAttachments(c, post)...)
+			imageURLs = append(imageURLs, a.getImagesInMessageAttachments(rctx, post)...)
 
 		case model.PostEmbedOpengraph:
 			openGraph, ok := embed.Data.(*opengraph.OpenGraph)
 			if !ok {
-				c.Logger().Warn("Could not read the image data: the data could not be casted to OpenGraph",
+				rctx.Logger().Warn("Could not read the image data: the data could not be casted to OpenGraph",
 					mlog.String("post_id", post.Id),
 					mlog.String("data type", fmt.Sprintf("%t", embed.Data)),
 				)
@@ -407,12 +407,12 @@ func (a *App) getImagesForPost(c request.CTX, post *model.Post, imageURLs []stri
 			continue
 		}
 
-		if _, image, _, err := a.getLinkMetadata(c, imageURL, post.CreateAt, isNewPost, post.GetPreviewedPostProp()); err != nil {
+		if _, image, _, err := a.getLinkMetadata(rctx, imageURL, post.CreateAt, isNewPost, post.GetPreviewedPostProp()); err != nil {
 			appErr, ok := err.(*model.AppError)
 			isNotFound := ok && appErr.StatusCode == http.StatusNotFound
 			// Ignore NotFound errors.
 			if !isNotFound {
-				c.Logger().Debug("Failed to get dimensions of an image in a post",
+				rctx.Logger().Debug("Failed to get dimensions of an image in a post",
 					mlog.String("post_id", post.Id),
 					mlog.String("image_url", imageURL),
 					mlog.Err(err),
@@ -475,7 +475,7 @@ func getEmojiNamesForPost(post *model.Post, reactions []*model.Reaction) []strin
 	return names
 }
 
-func (a *App) getCustomEmojisForPost(c request.CTX, post *model.Post, reactions []*model.Reaction) ([]*model.Emoji, *model.AppError) {
+func (a *App) getCustomEmojisForPost(rctx request.CTX, post *model.Post, reactions []*model.Reaction) ([]*model.Emoji, *model.AppError) {
 	if !*a.Config().ServiceSettings.EnableCustomEmoji {
 		// Only custom emoji are returned
 		return []*model.Emoji{}, nil
@@ -486,7 +486,7 @@ func (a *App) getCustomEmojisForPost(c request.CTX, post *model.Post, reactions 
 		return []*model.Emoji{}, nil
 	}
 
-	return a.GetMultipleEmojiByName(c, names)
+	return a.GetMultipleEmojiByName(rctx, names)
 }
 
 func (a *App) isLinkAllowedForPreview(rctx request.CTX, link string) bool {
@@ -531,22 +531,22 @@ func normalizeDomains(domains string) []string {
 // Given a string, returns the first autolinked URL in the string as well as an array of all Markdown
 // images of the form ![alt text](image url). Note that this does not return Markdown links of the
 // form [text](url).
-func (a *App) getFirstLinkAndImages(c request.CTX, str string) (string, []string) {
+func (a *App) getFirstLinkAndImages(rctx request.CTX, str string) (string, []string) {
 	firstLink := ""
 	images := []string{}
 
 	markdown.Inspect(str, func(blockOrInline any) bool {
 		switch v := blockOrInline.(type) {
 		case *markdown.Autolink:
-			if link := v.Destination(); firstLink == "" && a.isLinkAllowedForPreview(c, link) {
+			if link := v.Destination(); firstLink == "" && a.isLinkAllowedForPreview(rctx, link) {
 				firstLink = link
 			}
 		case *markdown.InlineImage:
-			if link := v.Destination(); a.isLinkAllowedForPreview(c, link) {
+			if link := v.Destination(); a.isLinkAllowedForPreview(rctx, link) {
 				images = append(images, link)
 			}
 		case *markdown.ReferenceImage:
-			if link := v.ReferenceDefinition.Destination(); a.isLinkAllowedForPreview(c, link) {
+			if link := v.ReferenceDefinition.Destination(); a.isLinkAllowedForPreview(rctx, link) {
 				images = append(images, link)
 			}
 		}
@@ -618,7 +618,7 @@ func (a *App) containsPermalink(rctx request.CTX, post *model.Post) bool {
 	return looksLikeAPermalink(link, a.GetSiteURL())
 }
 
-func (a *App) getLinkMetadata(c request.CTX, requestURL string, timestamp int64, isNewPost bool, previewedPostPropVal string) (*opengraph.OpenGraph, *model.PostImage, *model.Permalink, error) {
+func (a *App) getLinkMetadata(rctx request.CTX, requestURL string, timestamp int64, isNewPost bool, previewedPostPropVal string) (*opengraph.OpenGraph, *model.PostImage, *model.Permalink, error) {
 	requestURL = resolveMetadataURL(requestURL, a.GetSiteURL())
 
 	// If it's an embedded image, nothing to do.
@@ -642,21 +642,21 @@ func (a *App) getLinkMetadata(c request.CTX, requestURL string, timestamp int64,
 	if !isNewPost {
 		og, image, ok = a.getLinkMetadataFromDatabase(requestURL, timestamp)
 		if ok && previewedPostPropVal == "" {
-			cacheLinkMetadata(c, requestURL, timestamp, og, image, nil)
+			cacheLinkMetadata(rctx, requestURL, timestamp, og, image, nil)
 			return og, image, nil, nil
 		}
 	}
 
 	var err error
 	if looksLikeAPermalink(requestURL, a.GetSiteURL()) && *a.Config().ServiceSettings.EnablePermalinkPreviews {
-		permalink, err = a.getLinkMetadataForPermalink(c, requestURL)
+		permalink, err = a.getLinkMetadataForPermalink(rctx, requestURL)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 	} else if oEmbedProvider := oembed.FindEndpointForURL(requestURL); oEmbedProvider != nil {
-		og, err = a.getLinkMetadataFromOEmbed(c, requestURL, oEmbedProvider)
+		og, err = a.getLinkMetadataFromOEmbed(rctx, requestURL, oEmbedProvider)
 	} else {
-		og, image, err = a.getLinkMetadataForURL(c, requestURL)
+		og, image, err = a.getLinkMetadataForURL(rctx, requestURL)
 
 		// We intentionally don't return early on an error because we want to save that there is no metadata for this link
 
@@ -664,21 +664,21 @@ func (a *App) getLinkMetadata(c request.CTX, requestURL string, timestamp int64,
 	}
 
 	// Write back to cache and database, even if there was an error and the results are nil
-	cacheLinkMetadata(c, requestURL, timestamp, og, image, permalink)
+	cacheLinkMetadata(rctx, requestURL, timestamp, og, image, permalink)
 
 	return og, image, permalink, err
 }
 
-func (a *App) getLinkMetadataForPermalink(c request.CTX, requestURL string) (*model.Permalink, error) {
+func (a *App) getLinkMetadataForPermalink(rctx request.CTX, requestURL string) (*model.Permalink, error) {
 	referencedPostID := requestURL[len(requestURL)-26:]
 
-	referencedPost, appErr := a.GetSinglePost(c, referencedPostID, false)
+	referencedPost, appErr := a.GetSinglePost(rctx, referencedPostID, false)
 	// TODO: Look into saving a value in the LinkMetadata.Data field to prevent perpetually re-querying for the deleted post.
 	if appErr != nil {
 		return nil, appErr
 	}
 
-	referencedChannel, appErr := a.GetChannel(c, referencedPost.ChannelId)
+	referencedChannel, appErr := a.GetChannel(rctx, referencedPost.ChannelId)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -695,19 +695,19 @@ func (a *App) getLinkMetadataForPermalink(c request.CTX, requestURL string) (*mo
 
 	// Get metadata for embedded post
 	var permalink *model.Permalink
-	if a.containsPermalink(c, referencedPost) {
+	if a.containsPermalink(rctx, referencedPost) {
 		// referencedPost contains a permalink: we don't get its metadata
 		permalink = &model.Permalink{PreviewPost: model.NewPreviewPost(referencedPost, referencedTeam, referencedChannel)}
 	} else {
 		// referencedPost does not contain a permalink: we get its metadata
-		referencedPostWithMetadata := a.PreparePostForClientWithEmbedsAndImages(c, referencedPost, false, false, false)
+		referencedPostWithMetadata := a.PreparePostForClientWithEmbedsAndImages(rctx, referencedPost, false, false, false)
 		permalink = &model.Permalink{PreviewPost: model.NewPreviewPost(referencedPostWithMetadata, referencedTeam, referencedChannel)}
 	}
 
 	return permalink, nil
 }
 
-func (a *App) getLinkMetadataFromOEmbed(c request.CTX, requestURL string, provider *oembed.ProviderEndpoint) (*opengraph.OpenGraph, error) {
+func (a *App) getLinkMetadataFromOEmbed(rctx request.CTX, requestURL string, provider *oembed.ProviderEndpoint) (*opengraph.OpenGraph, error) {
 	request, err := http.NewRequest("GET", provider.GetProviderURL(requestURL), nil)
 	if err != nil {
 		return nil, err
@@ -721,13 +721,13 @@ func (a *App) getLinkMetadataFromOEmbed(c request.CTX, requestURL string, provid
 
 	res, err := client.Do(request)
 	if err != nil {
-		c.Logger().Warn("error fetching oEmbed data", mlog.Err(err))
+		rctx.Logger().Warn("error fetching oEmbed data", mlog.Err(err))
 		return nil, errors.Wrap(err, "getLinkMetadataFromOEmbed: Unable to get oEmbed data")
 	}
 
 	defer func() {
 		if _, err = io.Copy(io.Discard, res.Body); err != nil {
-			c.Logger().Warn("error discarding oEmbed response body", mlog.Err(err))
+			rctx.Logger().Warn("error discarding oEmbed response body", mlog.Err(err))
 		}
 		res.Body.Close()
 	}()
@@ -735,7 +735,7 @@ func (a *App) getLinkMetadataFromOEmbed(c request.CTX, requestURL string, provid
 	return a.parseOpenGraphFromOEmbed(requestURL, res.Body)
 }
 
-func (a *App) getLinkMetadataForURL(c request.CTX, requestURL string) (*opengraph.OpenGraph, *model.PostImage, error) {
+func (a *App) getLinkMetadataForURL(rctx request.CTX, requestURL string) (*opengraph.OpenGraph, *model.PostImage, error) {
 	var request *http.Request
 	// Make request for a web page or an image
 	request, err := http.NewRequest("GET", requestURL, nil)
@@ -760,7 +760,7 @@ func (a *App) getLinkMetadataForURL(c request.CTX, requestURL string) (*opengrap
 		var res *http.Response
 		res, err = client.Do(request)
 		if err != nil {
-			c.Logger().Warn("error fetching OG image data", mlog.Err(err))
+			rctx.Logger().Warn("error fetching OG image data", mlog.Err(err))
 		}
 
 		if res != nil {
@@ -772,7 +772,7 @@ func (a *App) getLinkMetadataForURL(c request.CTX, requestURL string) (*opengrap
 	if body != nil {
 		defer func() {
 			if _, err = io.Copy(io.Discard, body); err != nil {
-				c.Logger().Warn("error discarding OG image response body", mlog.Err(err))
+				rctx.Logger().Warn("error discarding OG image response body", mlog.Err(err))
 			}
 			body.Close()
 		}()
@@ -783,7 +783,7 @@ func (a *App) getLinkMetadataForURL(c request.CTX, requestURL string) (*opengrap
 
 	if err == nil {
 		// Parse the data
-		og, image, err = a.parseLinkMetadata(c, requestURL, body, contentType)
+		og, image, err = a.parseLinkMetadata(rctx, requestURL, body, contentType)
 	}
 	og = model.TruncateOpenGraph(og) // remove unwanted length of texts
 

--- a/server/channels/app/post_permission_utils.go
+++ b/server/channels/app/post_permission_utils.go
@@ -97,13 +97,13 @@ func postHardenedModeCheck(hardenedModeEnabled, isIntegration bool, props model.
 	return nil
 }
 
-func userCreatePostPermissionCheckWithApp(c request.CTX, a *App, userId, channelId string) *model.AppError {
+func userCreatePostPermissionCheckWithApp(rctx request.CTX, a *App, userId, channelId string) *model.AppError {
 	hasPermission := false
-	if a.HasPermissionToChannel(c, userId, channelId, model.PermissionCreatePost) {
+	if a.HasPermissionToChannel(rctx, userId, channelId, model.PermissionCreatePost) {
 		hasPermission = true
-	} else if channel, err := a.GetChannel(c, channelId); err == nil {
+	} else if channel, err := a.GetChannel(rctx, channelId); err == nil {
 		// Temporary permission check method until advanced permissions, please do not copy
-		if channel.Type == model.ChannelTypeOpen && a.HasPermissionToTeam(c, userId, channel.TeamId, model.PermissionCreatePostPublic) {
+		if channel.Type == model.ChannelTypeOpen && a.HasPermissionToTeam(rctx, userId, channel.TeamId, model.PermissionCreatePostPublic) {
 			hasPermission = true
 		}
 	}

--- a/server/channels/app/post_restore.go
+++ b/server/channels/app/post_restore.go
@@ -13,8 +13,8 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/request"
 )
 
-func (a *App) RestorePostVersion(c request.CTX, userID, postID, restoreVersionID string) (*model.Post, *model.AppError) {
-	toRestorePostVersion, err := a.Srv().Store().Post().GetSingle(c, restoreVersionID, true)
+func (a *App) RestorePostVersion(rctx request.CTX, userID, postID, restoreVersionID string) (*model.Post, *model.AppError) {
+	toRestorePostVersion, err := a.Srv().Store().Post().GetSingle(rctx, restoreVersionID, true)
 	if err != nil {
 		var statusCode int
 		var notFoundErr *store.ErrNotFound
@@ -54,5 +54,5 @@ func (a *App) RestorePostVersion(c request.CTX, userID, postID, restoreVersionID
 		IsRestorePost: true,
 	}
 
-	return a.PatchPost(c, postID, postPatch, patchPostOptions)
+	return a.PatchPost(rctx, postID, postPatch, patchPostOptions)
 }

--- a/server/channels/app/preference.go
+++ b/server/channels/app/preference.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/request"
 )
 
-func (a *App) GetPreferencesForUser(c request.CTX, userID string) (model.Preferences, *model.AppError) {
+func (a *App) GetPreferencesForUser(rctx request.CTX, userID string) (model.Preferences, *model.AppError) {
 	preferences, err := a.Srv().Store().Preference().GetAll(userID)
 	if err != nil {
 		return nil, model.NewAppError("GetPreferencesForUser", "app.preference.get_all.app_error", nil, "", http.StatusBadRequest).Wrap(err)
@@ -21,7 +21,7 @@ func (a *App) GetPreferencesForUser(c request.CTX, userID string) (model.Prefere
 	return preferences, nil
 }
 
-func (a *App) GetPreferenceByCategoryForUser(c request.CTX, userID string, category string) (model.Preferences, *model.AppError) {
+func (a *App) GetPreferenceByCategoryForUser(rctx request.CTX, userID string, category string) (model.Preferences, *model.AppError) {
 	preferences, err := a.Srv().Store().Preference().GetCategory(userID, category)
 	if err != nil {
 		return nil, model.NewAppError("GetPreferenceByCategoryForUser", "app.preference.get_category.app_error", nil, "", http.StatusBadRequest).Wrap(err)
@@ -33,7 +33,7 @@ func (a *App) GetPreferenceByCategoryForUser(c request.CTX, userID string, categ
 	return preferences, nil
 }
 
-func (a *App) GetPreferenceByCategoryAndNameForUser(c request.CTX, userID string, category string, preferenceName string) (*model.Preference, *model.AppError) {
+func (a *App) GetPreferenceByCategoryAndNameForUser(rctx request.CTX, userID string, category string, preferenceName string) (*model.Preference, *model.AppError) {
 	res, err := a.Srv().Store().Preference().Get(userID, category, preferenceName)
 	if err != nil {
 		return nil, model.NewAppError("GetPreferenceByCategoryAndNameForUser", "app.preference.get.app_error", nil, "", http.StatusBadRequest).Wrap(err)
@@ -41,7 +41,7 @@ func (a *App) GetPreferenceByCategoryAndNameForUser(c request.CTX, userID string
 	return res, nil
 }
 
-func (a *App) UpdatePreferences(c request.CTX, userID string, preferences model.Preferences) *model.AppError {
+func (a *App) UpdatePreferences(rctx request.CTX, userID string, preferences model.Preferences) *model.AppError {
 	for _, preference := range preferences {
 		if userID != preference.UserId {
 			return model.NewAppError("savePreferences", "api.preference.update_preferences.set.app_error", nil,
@@ -75,7 +75,7 @@ func (a *App) UpdatePreferences(c request.CTX, userID string, preferences model.
 	message.Add("preferences", string(prefsJSON))
 	a.Publish(message)
 
-	pluginContext := pluginContext(c)
+	pluginContext := pluginContext(rctx)
 	a.Srv().Go(func() {
 		a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 			hooks.PreferencesHaveChanged(pluginContext, preferences)
@@ -86,7 +86,7 @@ func (a *App) UpdatePreferences(c request.CTX, userID string, preferences model.
 	return nil
 }
 
-func (a *App) DeletePreferences(c request.CTX, userID string, preferences model.Preferences) *model.AppError {
+func (a *App) DeletePreferences(rctx request.CTX, userID string, preferences model.Preferences) *model.AppError {
 	for _, preference := range preferences {
 		if userID != preference.UserId {
 			err := model.NewAppError("DeletePreferences", "api.preference.delete_preferences.delete.app_error", nil,

--- a/server/channels/app/product_notices.go
+++ b/server/channels/app/product_notices.go
@@ -52,11 +52,11 @@ func noticeMatchesConditions(config *model.Config, preferences store.PreferenceS
 	}
 
 	for _, v := range clientVersions {
-		c, err2 := semver.NewConstraint(v)
+		rctx, err2 := semver.NewConstraint(v)
 		if err2 != nil {
 			return false, errors.Wrapf(err2, "Cannot parse version range %s", v)
 		}
-		if !c.Check(clientVersionParsed) {
+		if !rctx.Check(clientVersionParsed) {
 			return false, nil
 		}
 	}
@@ -65,11 +65,11 @@ func noticeMatchesConditions(config *model.Config, preferences store.PreferenceS
 	if cnd.DisplayDate != nil {
 		y, m, d := time.Now().UTC().Date()
 		trunc := time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
-		c, err2 := date_constraints.NewConstraint(*cnd.DisplayDate)
+		rctx, err2 := date_constraints.NewConstraint(*cnd.DisplayDate)
 		if err2 != nil {
 			return false, errors.Wrapf(err2, "Cannot parse date range %s", *cnd.DisplayDate)
 		}
-		if !c.Check(&trunc) {
+		if !rctx.Check(&trunc) {
 			return false, nil
 		}
 	}
@@ -82,11 +82,11 @@ func noticeMatchesConditions(config *model.Config, preferences store.PreferenceS
 			return false, nil
 		}
 		for _, v := range cnd.ServerVersion {
-			c, err := semver.NewConstraint(v)
+			rctx, err := semver.NewConstraint(v)
 			if err != nil {
 				return false, errors.Wrapf(err, "Cannot parse version range %s", v)
 			}
-			if !c.Check(serverVersionSemver) {
+			if !rctx.Check(serverVersionSemver) {
 				return false, nil
 			}
 		}
@@ -210,9 +210,9 @@ func validateConfigEntry(conf *model.Config, path string, expectedValue any) boo
 }
 
 // GetProductNotices is called from the frontend to fetch the product notices that are relevant to the caller
-func (a *App) GetProductNotices(c request.CTX, userID, teamID string, client model.NoticeClientType, clientVersion string, locale string) (model.NoticeMessages, *model.AppError) {
-	isSystemAdmin := a.SessionHasPermissionTo(*c.Session(), model.PermissionManageSystem)
-	isTeamAdmin := a.SessionHasPermissionToTeam(*c.Session(), teamID, model.PermissionManageTeam)
+func (a *App) GetProductNotices(rctx request.CTX, userID, teamID string, client model.NoticeClientType, clientVersion string, locale string) (model.NoticeMessages, *model.AppError) {
+	isSystemAdmin := a.SessionHasPermissionTo(*rctx.Session(), model.PermissionManageSystem)
+	isTeamAdmin := a.SessionHasPermissionToTeam(*rctx.Session(), teamID, model.PermissionManageTeam)
 
 	// check if notices for regular users are disabled
 	if !*a.Config().AnnouncementSettings.UserNoticesEnabled && !isSystemAdmin {

--- a/server/channels/app/reaction.go
+++ b/server/channels/app/reaction.go
@@ -14,15 +14,15 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/request"
 )
 
-func (a *App) SaveReactionForPost(c request.CTX, reaction *model.Reaction) (*model.Reaction, *model.AppError) {
-	post, err := a.GetSinglePost(c, reaction.PostId, false)
+func (a *App) SaveReactionForPost(rctx request.CTX, reaction *model.Reaction) (*model.Reaction, *model.AppError) {
+	post, err := a.GetSinglePost(rctx, reaction.PostId, false)
 	if err != nil {
 		return nil, err
 	}
 
 	// Check whether this is a valid emoji
 	if _, ok := model.GetSystemEmojiId(reaction.EmojiName); !ok {
-		if _, emojiErr := a.GetEmojiByName(c, reaction.EmojiName); emojiErr != nil {
+		if _, emojiErr := a.GetEmojiByName(rctx, reaction.EmojiName); emojiErr != nil {
 			return nil, emojiErr
 		}
 	}
@@ -44,7 +44,7 @@ func (a *App) SaveReactionForPost(c request.CTX, reaction *model.Reaction) (*mod
 		}
 	}
 
-	channel, err := a.GetChannel(c, post.ChannelId)
+	channel, err := a.GetChannel(rctx, post.ChannelId)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (a *App) SaveReactionForPost(c request.CTX, reaction *model.Reaction) (*mod
 	}
 
 	if post.RootId == "" {
-		if appErr := a.ResolvePersistentNotification(c, post, reaction.UserId); appErr != nil {
+		if appErr := a.ResolvePersistentNotification(rctx, post, reaction.UserId); appErr != nil {
 			a.CountNotificationReason(model.NotificationStatusError, model.NotificationTypeAll, model.NotificationReasonResolvePersistentNotificationError, model.NotificationNoPlatform)
 			a.NotificationsLog().Error("Error resolving persistent notification",
 				mlog.String("sender_id", reaction.UserId),
@@ -82,7 +82,7 @@ func (a *App) SaveReactionForPost(c request.CTX, reaction *model.Reaction) (*mod
 	// The post is always modified since the UpdateAt always changes
 	a.Srv().Store().Post().InvalidateLastPostTimeCache(channel.Id)
 
-	pluginContext := pluginContext(c)
+	pluginContext := pluginContext(rctx)
 	a.Srv().Go(func() {
 		a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 			hooks.ReactionHasBeenAdded(pluginContext, reaction)
@@ -90,7 +90,7 @@ func (a *App) SaveReactionForPost(c request.CTX, reaction *model.Reaction) (*mod
 		}, plugin.ReactionHasBeenAddedID)
 	})
 
-	a.sendReactionEvent(c, model.WebsocketEventReactionAdded, reaction, post)
+	a.sendReactionEvent(rctx, model.WebsocketEventReactionAdded, reaction, post)
 
 	return reaction, nil
 }
@@ -131,13 +131,13 @@ func populateEmptyReactions(postIDs []string, reactions map[string][]*model.Reac
 	return reactions
 }
 
-func (a *App) DeleteReactionForPost(c request.CTX, reaction *model.Reaction) *model.AppError {
-	post, err := a.GetSinglePost(c, reaction.PostId, false)
+func (a *App) DeleteReactionForPost(rctx request.CTX, reaction *model.Reaction) *model.AppError {
+	post, err := a.GetSinglePost(rctx, reaction.PostId, false)
 	if err != nil {
 		return err
 	}
 
-	channel, err := a.GetChannel(c, post.ChannelId)
+	channel, err := a.GetChannel(rctx, post.ChannelId)
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func (a *App) DeleteReactionForPost(c request.CTX, reaction *model.Reaction) *mo
 	// The post is always modified since the UpdateAt always changes
 	a.Srv().Store().Post().InvalidateLastPostTimeCache(channel.Id)
 
-	pluginContext := pluginContext(c)
+	pluginContext := pluginContext(rctx)
 	a.Srv().Go(func() {
 		a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 			hooks.ReactionHasBeenRemoved(pluginContext, reaction)
@@ -161,7 +161,7 @@ func (a *App) DeleteReactionForPost(c request.CTX, reaction *model.Reaction) *mo
 		}, plugin.ReactionHasBeenRemovedID)
 	})
 
-	a.sendReactionEvent(c, model.WebsocketEventReactionRemoved, reaction, post)
+	a.sendReactionEvent(rctx, model.WebsocketEventReactionRemoved, reaction, post)
 
 	return nil
 }

--- a/server/channels/app/saml.go
+++ b/server/channels/app/saml.go
@@ -24,13 +24,13 @@ const (
 	SamlIdpCertificateName    = "saml-idp.crt"
 )
 
-func (a *App) GetSamlMetadata(c request.CTX) (string, *model.AppError) {
+func (a *App) GetSamlMetadata(rctx request.CTX) (string, *model.AppError) {
 	if a.Saml() == nil {
 		err := model.NewAppError("GetSamlMetadata", "api.admin.saml.not_available.app_error", nil, "", http.StatusNotImplemented)
 		return "", err
 	}
 
-	result, err := a.Saml().GetMetadata(c)
+	result, err := a.Saml().GetMetadata(rctx)
 	if err != nil {
 		return "", model.NewAppError("GetSamlMetadata", "api.admin.saml.metadata.app_error", nil, "", err.StatusCode).Wrap(err)
 	}

--- a/server/channels/app/searchengine.go
+++ b/server/channels/app/searchengine.go
@@ -36,7 +36,7 @@ func (a *App) SetSearchEngine(se *searchengine.Broker) {
 	a.ch.srv.platform.SearchEngine = se
 }
 
-func (a *App) PurgeElasticsearchIndexes(c request.CTX, indexes []string) *model.AppError {
+func (a *App) PurgeElasticsearchIndexes(rctx request.CTX, indexes []string) *model.AppError {
 	engine := a.SearchEngine().ElasticsearchEngine
 	if engine == nil {
 		err := model.NewAppError("PurgeElasticsearchIndexes", "ent.elasticsearch.test_config.license.error", nil, "", http.StatusNotImplemented)
@@ -45,21 +45,21 @@ func (a *App) PurgeElasticsearchIndexes(c request.CTX, indexes []string) *model.
 
 	var appErr *model.AppError
 	if len(indexes) > 0 {
-		appErr = engine.PurgeIndexList(c, indexes)
+		appErr = engine.PurgeIndexList(rctx, indexes)
 	} else {
-		appErr = engine.PurgeIndexes(c)
+		appErr = engine.PurgeIndexes(rctx)
 	}
 
 	return appErr
 }
 
-func (a *App) PurgeBleveIndexes(c request.CTX) *model.AppError {
+func (a *App) PurgeBleveIndexes(rctx request.CTX) *model.AppError {
 	engine := a.SearchEngine().BleveEngine
 	if engine == nil {
 		err := model.NewAppError("PurgeBleveIndexes", "searchengine.bleve.disabled.error", nil, "", http.StatusNotImplemented)
 		return err
 	}
-	if err := engine.PurgeIndexes(c); err != nil {
+	if err := engine.PurgeIndexes(rctx); err != nil {
 		return err
 	}
 	return nil

--- a/server/channels/app/session.go
+++ b/server/channels/app/session.go
@@ -21,8 +21,8 @@ import (
 // maxSessionsLimit prevents a potential DOS caused by creating an unbounded number of sessions; MM-55320
 const maxSessionsLimit = 500
 
-func (a *App) CreateSession(c request.CTX, session *model.Session) (*model.Session, *model.AppError) {
-	if appErr := a.limitNumberOfSessions(c, session.UserId); appErr != nil {
+func (a *App) CreateSession(rctx request.CTX, session *model.Session) (*model.Session, *model.AppError) {
+	if appErr := a.limitNumberOfSessions(rctx, session.UserId); appErr != nil {
 		return nil, appErr
 	}
 
@@ -37,7 +37,7 @@ func (a *App) CreateSession(c request.CTX, session *model.Session) (*model.Sessi
 		return nil, model.NewAppError("login", "api.user.login.remote_users.login.error", nil, "", http.StatusUnauthorized)
 	}
 
-	session, err := a.ch.srv.platform.CreateSession(c, session)
+	session, err := a.ch.srv.platform.CreateSession(rctx, session)
 	if err != nil {
 		var invErr *store.ErrInvalidInput
 		switch {
@@ -84,26 +84,26 @@ func (a *App) GetRemoteClusterSession(token string, remoteId string) (*model.Ses
 func (a *App) GetSession(token string) (*model.Session, *model.AppError) {
 	// Create a context as GetSession is used in a lot of places where no context is current present.
 	// Once more of the codebase is migrated to use a context, GetSession should accept one.
-	c := request.EmptyContext(a.Log())
+	rctx := request.EmptyContext(a.Log())
 
 	var session *model.Session
 	// We intentionally skip the error check here, we only want to check if the token is valid.
 	// If we don't have the session we are going to create one with the token eventually.
-	if session, _ = a.ch.srv.platform.GetSession(c, token); session != nil {
+	if session, _ = a.ch.srv.platform.GetSession(rctx, token); session != nil {
 		if session.Token != token {
 			return nil, model.NewAppError("GetSession", "api.context.invalid_token.error", map[string]any{"Token": token, "Error": ""}, "session token is different from the one in DB", http.StatusUnauthorized)
 		}
 
 		if !session.IsExpired() {
 			if err := a.ch.srv.platform.AddSessionToCache(session); err != nil {
-				c.Logger().Error("Failed to add session to cache", mlog.Err(err))
+				rctx.Logger().Error("Failed to add session to cache", mlog.Err(err))
 			}
 		}
 	}
 
 	var appErr *model.AppError
 	if session == nil || session.Id == "" {
-		session, appErr = a.createSessionForUserAccessToken(c, token)
+		session, appErr = a.createSessionForUserAccessToken(rctx, token)
 		if appErr != nil {
 			detailedError := ""
 			statusCode := http.StatusUnauthorized
@@ -111,7 +111,7 @@ func (a *App) GetSession(token string) (*model.Session, *model.AppError) {
 				detailedError = appErr.Error()
 				statusCode = appErr.StatusCode
 			} else {
-				c.Logger().Warn("Error while creating session for user access token", mlog.Err(appErr))
+				rctx.Logger().Warn("Error while creating session for user access token", mlog.Err(appErr))
 			}
 			return nil, model.NewAppError("GetSession", "api.context.invalid_token.error", map[string]any{"Token": token, "Error": detailedError}, "", statusCode)
 		}
@@ -135,9 +135,9 @@ func (a *App) GetSession(token string) (*model.Session, *model.AppError) {
 			// gets called from (*WebConn).isMemberOfTeam and revoking a session involves
 			// clearing the webconn cache, which needs the hub again.
 			a.Srv().Go(func() {
-				err := a.RevokeSessionById(c, session.Id)
+				err := a.RevokeSessionById(rctx, session.Id)
 				if err != nil {
-					c.Logger().Warn("Error while revoking session", mlog.Err(err))
+					rctx.Logger().Warn("Error while revoking session", mlog.Err(err))
 				}
 			})
 			return nil, model.NewAppError("GetSession", "api.context.invalid_token.error", map[string]any{"Token": token, "Error": ""}, "idle timeout", http.StatusUnauthorized)
@@ -147,8 +147,8 @@ func (a *App) GetSession(token string) (*model.Session, *model.AppError) {
 	return session, nil
 }
 
-func (a *App) GetSessions(c request.CTX, userID string) ([]*model.Session, *model.AppError) {
-	sessions, err := a.ch.srv.platform.GetSessions(c, userID)
+func (a *App) GetSessions(rctx request.CTX, userID string) ([]*model.Session, *model.AppError) {
+	sessions, err := a.ch.srv.platform.GetSessions(rctx, userID)
 	if err != nil {
 		return nil, model.NewAppError("GetSessions", "app.session.get_sessions.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -158,20 +158,20 @@ func (a *App) GetSessions(c request.CTX, userID string) ([]*model.Session, *mode
 
 // limitNumberOfSessions revokes userId's least recently used sessions to keep the number below
 // maxSessionsLimit; MM-55320
-func (a *App) limitNumberOfSessions(c request.CTX, userId string) *model.AppError {
+func (a *App) limitNumberOfSessions(rctx request.CTX, userId string) *model.AppError {
 	const returnLimit = 100
-	sessions, appErr := a.GetLRUSessions(c, userId, returnLimit, maxSessionsLimit-1)
+	sessions, appErr := a.GetLRUSessions(rctx, userId, returnLimit, maxSessionsLimit-1)
 	if appErr != nil {
 		return model.NewAppError("limitNumberOfSessions", "app.session.save.app_error", nil, "", http.StatusInternalServerError).Wrap(appErr)
 	}
 
 	// Revoke any sessions over the limit to make room for new sessions
 	for _, sess := range sessions {
-		if err := a.RevokeSession(c, sess); err != nil {
+		if err := a.RevokeSession(rctx, sess); err != nil {
 			return model.NewAppError("limitNumberOfSessions", "app.session.save.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 		}
 
-		c.Logger().Debug("Session revoked; user's number of sessions were over the maxSessionsLimit",
+		rctx.Logger().Debug("Session revoked; user's number of sessions were over the maxSessionsLimit",
 			mlog.String("user_id", userId),
 			mlog.String("session_id", sess.Id))
 	}
@@ -181,8 +181,8 @@ func (a *App) limitNumberOfSessions(c request.CTX, userId string) *model.AppErro
 
 // GetLRUSessions returns the Least Recently Used sessions for userID, skipping over the newest 'offset'
 // number of sessions. E.g., if userID has 100 sessions, offset 98 will return the oldest 2 sessions.
-func (a *App) GetLRUSessions(c request.CTX, userID string, limit uint64, offset uint64) ([]*model.Session, *model.AppError) {
-	sessions, err := a.ch.srv.platform.GetLRUSessions(c, userID, limit, offset)
+func (a *App) GetLRUSessions(rctx request.CTX, userID string, limit uint64, offset uint64) ([]*model.Session, *model.AppError) {
+	sessions, err := a.ch.srv.platform.GetLRUSessions(rctx, userID, limit, offset)
 	if err != nil {
 		return nil, model.NewAppError("GetLRUSessions", "app.session.get_lru_sessions.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -190,8 +190,8 @@ func (a *App) GetLRUSessions(c request.CTX, userID string, limit uint64, offset 
 	return sessions, nil
 }
 
-func (a *App) RevokeAllSessions(c request.CTX, userID string) *model.AppError {
-	if err := a.ch.srv.platform.RevokeAllSessions(c, userID); err != nil {
+func (a *App) RevokeAllSessions(rctx request.CTX, userID string) *model.AppError {
+	if err := a.ch.srv.platform.RevokeAllSessions(rctx, userID); err != nil {
 		switch {
 		case errors.Is(err, platform.GetSessionError):
 			return model.NewAppError("RevokeAllSessions", "app.session.get_sessions.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -244,16 +244,16 @@ func (a *App) ClearSessionCacheForAllUsersSkipClusterSend() {
 	a.Srv().Platform().ClearSessionCacheForAllUsersSkipClusterSend()
 }
 
-func (a *App) RevokeSessionsForDeviceId(c request.CTX, userID string, deviceID string, currentSessionId string) *model.AppError {
-	if err := a.ch.srv.platform.RevokeSessionsForDeviceId(c, userID, deviceID, currentSessionId); err != nil {
+func (a *App) RevokeSessionsForDeviceId(rctx request.CTX, userID string, deviceID string, currentSessionId string) *model.AppError {
+	if err := a.ch.srv.platform.RevokeSessionsForDeviceId(rctx, userID, deviceID, currentSessionId); err != nil {
 		return model.NewAppError("RevokeSessionsForDeviceId", "app.session.get_sessions.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	return nil
 }
 
-func (a *App) GetSessionById(c request.CTX, sessionID string) (*model.Session, *model.AppError) {
-	session, err := a.ch.srv.platform.GetSessionByID(c, sessionID)
+func (a *App) GetSessionById(rctx request.CTX, sessionID string) (*model.Session, *model.AppError) {
+	session, err := a.ch.srv.platform.GetSessionByID(rctx, sessionID)
 	if err != nil {
 		return nil, model.NewAppError("GetSessionById", "app.session.get.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
@@ -261,17 +261,17 @@ func (a *App) GetSessionById(c request.CTX, sessionID string) (*model.Session, *
 	return session, nil
 }
 
-func (a *App) RevokeSessionById(c request.CTX, sessionID string) *model.AppError {
-	session, err := a.GetSessionById(c, sessionID)
+func (a *App) RevokeSessionById(rctx request.CTX, sessionID string) *model.AppError {
+	session, err := a.GetSessionById(rctx, sessionID)
 	if err != nil {
 		return model.NewAppError("RevokeSessionById", "app.session.get.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
 
-	return a.RevokeSession(c, session)
+	return a.RevokeSession(rctx, session)
 }
 
-func (a *App) RevokeSession(c request.CTX, session *model.Session) *model.AppError {
-	if err := a.ch.srv.platform.RevokeSession(c, session); err != nil {
+func (a *App) RevokeSession(rctx request.CTX, session *model.Session) *model.AppError {
+	if err := a.ch.srv.platform.RevokeSession(rctx, session); err != nil {
 		switch {
 		case errors.Is(err, platform.DeleteSessionError):
 			return model.NewAppError("RevokeSession", "app.session.remove.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -432,7 +432,7 @@ func (a *App) CreateUserAccessToken(rctx request.CTX, token *model.UserAccessTok
 	return token, nil
 }
 
-func (a *App) createSessionForUserAccessToken(c request.CTX, tokenString string) (*model.Session, *model.AppError) {
+func (a *App) createSessionForUserAccessToken(rctx request.CTX, tokenString string) (*model.Session, *model.AppError) {
 	token, nErr := a.Srv().Store().UserAccessToken().GetByToken(tokenString)
 	if nErr != nil {
 		return nil, model.NewAppError("createSessionForUserAccessToken", "app.user_access_token.invalid_or_missing", nil, "", http.StatusUnauthorized).Wrap(nErr)
@@ -442,7 +442,7 @@ func (a *App) createSessionForUserAccessToken(c request.CTX, tokenString string)
 		return nil, model.NewAppError("createSessionForUserAccessToken", "app.user_access_token.invalid_or_missing", nil, "inactive_token", http.StatusUnauthorized)
 	}
 
-	user, nErr := a.Srv().Store().User().Get(c.Context(), token.UserId)
+	user, nErr := a.Srv().Store().User().Get(rctx.Context(), token.UserId)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -461,7 +461,7 @@ func (a *App) createSessionForUserAccessToken(c request.CTX, tokenString string)
 		return nil, model.NewAppError("createSessionForUserAccessToken", "app.user_access_token.invalid_or_missing", nil, "inactive_user_id="+user.Id, http.StatusUnauthorized)
 	}
 
-	if appErr := a.limitNumberOfSessions(c, user.Id); appErr != nil {
+	if appErr := a.limitNumberOfSessions(rctx, user.Id); appErr != nil {
 		return nil, appErr
 	}
 
@@ -484,7 +484,7 @@ func (a *App) createSessionForUserAccessToken(c request.CTX, tokenString string)
 	}
 	a.ch.srv.platform.SetSessionExpireInHours(session, model.SessionUserAccessTokenExpiryHours)
 
-	session, nErr = a.Srv().Store().Session().Save(c, session)
+	session, nErr = a.Srv().Store().Session().Save(rctx, session)
 	if nErr != nil {
 		var invErr *store.ErrInvalidInput
 		switch {
@@ -502,9 +502,9 @@ func (a *App) createSessionForUserAccessToken(c request.CTX, tokenString string)
 	return session, nil
 }
 
-func (a *App) RevokeUserAccessToken(c request.CTX, token *model.UserAccessToken) *model.AppError {
+func (a *App) RevokeUserAccessToken(rctx request.CTX, token *model.UserAccessToken) *model.AppError {
 	var session *model.Session
-	session, _ = a.ch.srv.platform.GetSessionContext(c, token.Token)
+	session, _ = a.ch.srv.platform.GetSessionContext(rctx, token.Token)
 
 	if err := a.Srv().Store().UserAccessToken().Delete(token.Id); err != nil {
 		return model.NewAppError("RevokeUserAccessToken", "app.user_access_token.delete.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -514,12 +514,12 @@ func (a *App) RevokeUserAccessToken(c request.CTX, token *model.UserAccessToken)
 		return nil
 	}
 
-	return a.RevokeSession(c, session)
+	return a.RevokeSession(rctx, session)
 }
 
-func (a *App) DisableUserAccessToken(c request.CTX, token *model.UserAccessToken) *model.AppError {
+func (a *App) DisableUserAccessToken(rctx request.CTX, token *model.UserAccessToken) *model.AppError {
 	var session *model.Session
-	session, _ = a.ch.srv.platform.GetSessionContext(c, token.Token)
+	session, _ = a.ch.srv.platform.GetSessionContext(rctx, token.Token)
 
 	if err := a.Srv().Store().UserAccessToken().UpdateTokenDisable(token.Id); err != nil {
 		return model.NewAppError("DisableUserAccessToken", "app.user_access_token.update_token_disable.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -529,12 +529,12 @@ func (a *App) DisableUserAccessToken(c request.CTX, token *model.UserAccessToken
 		return nil
 	}
 
-	return a.RevokeSession(c, session)
+	return a.RevokeSession(rctx, session)
 }
 
-func (a *App) EnableUserAccessToken(c request.CTX, token *model.UserAccessToken) *model.AppError {
+func (a *App) EnableUserAccessToken(rctx request.CTX, token *model.UserAccessToken) *model.AppError {
 	var session *model.Session
-	session, _ = a.ch.srv.platform.GetSessionContext(c, token.Token)
+	session, _ = a.ch.srv.platform.GetSessionContext(rctx, token.Token)
 
 	err := a.Srv().Store().UserAccessToken().UpdateTokenEnable(token.Id)
 	if err != nil {

--- a/server/channels/app/shared_channel.go
+++ b/server/channels/app/shared_channel.go
@@ -29,9 +29,9 @@ func (a *App) getSharedChannelsService(ensureIsActive bool) (SharedChannelServic
 	return scService, nil
 }
 
-func (a *App) checkChannelNotShared(c request.CTX, channelId string) error {
+func (a *App) checkChannelNotShared(rctx request.CTX, channelId string) error {
 	// check that channel exists.
-	if _, appErr := a.GetChannel(c, channelId); appErr != nil {
+	if _, appErr := a.GetChannel(rctx, channelId); appErr != nil {
 		return fmt.Errorf("cannot find channel: %w", appErr)
 	}
 
@@ -64,7 +64,7 @@ func (a *App) CheckCanInviteToSharedChannel(channelId string) error {
 
 // SharedChannels
 
-func (a *App) ShareChannel(c request.CTX, sc *model.SharedChannel) (*model.SharedChannel, error) {
+func (a *App) ShareChannel(rctx request.CTX, sc *model.SharedChannel) (*model.SharedChannel, error) {
 	scService, err := a.getSharedChannelsService(false)
 	if err != nil {
 		return nil, err

--- a/server/channels/app/shared_channel_service_iface.go
+++ b/server/channels/app/shared_channel_service_iface.go
@@ -29,7 +29,7 @@ type SharedChannelServiceIFace interface {
 	CheckCanInviteToSharedChannel(channelId string) error
 	HandleMembershipChange(channelID, userID string, isAdd bool, remoteID string)
 	IsRemoteClusterDirectlyConnected(remoteId string) bool
-	TransformMentionsOnReceiveForTesting(ctx request.CTX, post *model.Post, targetChannel *model.Channel, rc *model.RemoteCluster, mentionTransforms map[string]string)
+	TransformMentionsOnReceiveForTesting(rctx request.CTX, post *model.Post, targetChannel *model.Channel, rc *model.RemoteCluster, mentionTransforms map[string]string)
 }
 
 func NewMockSharedChannelService(service SharedChannelServiceIFace) *mockSharedChannelService {

--- a/server/channels/app/slack.go
+++ b/server/channels/app/slack.go
@@ -19,29 +19,29 @@ import (
 	"github.com/mattermost/mattermost/server/v8/platform/services/slackimport"
 )
 
-func (a *App) SlackImport(c request.CTX, fileData multipart.File, fileSize int64, teamID string) (*model.AppError, *bytes.Buffer) {
+func (a *App) SlackImport(rctx request.CTX, fileData multipart.File, fileSize int64, teamID string) (*model.AppError, *bytes.Buffer) {
 	actions := slackimport.Actions{
 		UpdateActive: func(user *model.User, active bool) (*model.User, *model.AppError) {
-			return a.UpdateActive(c, user, active)
+			return a.UpdateActive(rctx, user, active)
 		},
 		AddUserToChannel: a.AddUserToChannel,
 		JoinUserToTeam: func(team *model.Team, user *model.User, userRequestorId string) (*model.TeamMember, *model.AppError) {
-			return a.JoinUserToTeam(c, team, user, userRequestorId)
+			return a.JoinUserToTeam(rctx, team, user, userRequestorId)
 		},
 		CreateDirectChannel: a.createDirectChannel,
 		CreateGroupChannel:  a.createGroupChannel,
 		CreateChannel: func(channel *model.Channel, addMember bool) (*model.Channel, *model.AppError) {
-			return a.CreateChannel(c, channel, addMember)
+			return a.CreateChannel(rctx, channel, addMember)
 		},
 		DoUploadFile: func(now time.Time, rawTeamId string, rawChannelId string, rawUserId string, rawFilename string, data []byte) (*model.FileInfo, *model.AppError) {
-			return a.DoUploadFile(c, now, rawTeamId, rawChannelId, rawUserId, rawFilename, data, true)
+			return a.DoUploadFile(rctx, now, rawTeamId, rawChannelId, rawUserId, rawFilename, data, true)
 		},
 		GenerateThumbnailImage: a.generateThumbnailImage,
 		GeneratePreviewImage:   a.generatePreviewImage,
 		InvalidateAllCaches:    func() *model.AppError { return a.ch.srv.platform.InvalidateAllCaches() },
 		MaxPostSize:            func() int { return a.ch.srv.platform.MaxPostSize() },
 		PrepareImage: func(fileData []byte) (image.Image, string, func(), error) {
-			img, imgType, release, err := prepareImage(c, a.ch.imgDecoder, bytes.NewReader(fileData))
+			img, imgType, release, err := prepareImage(rctx, a.ch.imgDecoder, bytes.NewReader(fileData))
 			if err != nil {
 				return nil, "", nil, err
 			}
@@ -50,7 +50,7 @@ func (a *App) SlackImport(c request.CTX, fileData multipart.File, fileSize int64
 	}
 
 	importer := slackimport.New(a.Srv().Store(), actions, a.Config())
-	return importer.SlackImport(c, fileData, fileSize, teamID)
+	return importer.SlackImport(rctx, fileData, fileSize, teamID)
 }
 
 func (a *App) ProcessSlackText(text string) string {

--- a/server/channels/app/slashcommands/auto_channels.go
+++ b/server/channels/app/slashcommands/auto_channels.go
@@ -38,7 +38,7 @@ func NewAutoChannelCreator(a *app.App, team *model.Team, userID string) *AutoCha
 	}
 }
 
-func (cfg *AutoChannelCreator) createRandomChannel(c request.CTX) (*model.Channel, error) {
+func (cfg *AutoChannelCreator) createRandomChannel(rctx request.CTX) (*model.Channel, error) {
 	var displayName string
 	if cfg.Fuzzy {
 		displayName = utils.FuzzName()
@@ -56,20 +56,20 @@ func (cfg *AutoChannelCreator) createRandomChannel(c request.CTX) (*model.Channe
 		CreateAt:    cfg.CreateTime,
 	}
 
-	channel, err := cfg.a.CreateChannel(c, channel, true)
+	channel, err := cfg.a.CreateChannel(rctx, channel, true)
 	if err != nil {
 		return nil, err
 	}
 	return channel, nil
 }
 
-func (cfg *AutoChannelCreator) CreateTestChannels(c request.CTX, num utils.Range) ([]*model.Channel, error) {
+func (cfg *AutoChannelCreator) CreateTestChannels(rctx request.CTX, num utils.Range) ([]*model.Channel, error) {
 	numChannels := utils.RandIntFromRange(num)
 	channels := make([]*model.Channel, numChannels)
 
 	for i := 0; i < numChannels; i++ {
 		var err error
-		channels[i], err = cfg.createRandomChannel(c)
+		channels[i], err = cfg.createRandomChannel(rctx)
 		if err != nil {
 			return nil, err
 		}

--- a/server/channels/app/slashcommands/auto_environment.go
+++ b/server/channels/app/slashcommands/auto_environment.go
@@ -19,7 +19,7 @@ type TestEnvironment struct {
 	Environments []TeamEnvironment
 }
 
-func CreateTestEnvironmentWithTeams(a *app.App, c request.CTX, client *model.Client4, rangeTeams utils.Range, rangeChannels utils.Range, rangeUsers utils.Range, rangePosts utils.Range, fuzzy bool) (TestEnvironment, error) {
+func CreateTestEnvironmentWithTeams(a *app.App, rctx request.CTX, client *model.Client4, rangeTeams utils.Range, rangeChannels utils.Range, rangeUsers utils.Range, rangePosts utils.Range, fuzzy bool) (TestEnvironment, error) {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	teamCreator := NewAutoTeamCreator(client)
@@ -34,7 +34,7 @@ func CreateTestEnvironmentWithTeams(a *app.App, c request.CTX, client *model.Cli
 	for i, team := range teams {
 		userCreator := NewAutoUserCreator(a, client, team)
 		userCreator.Fuzzy = fuzzy
-		randomUser, err := userCreator.createRandomUser(c)
+		randomUser, err := userCreator.createRandomUser(rctx)
 		if err != nil {
 			return TestEnvironment{}, err
 		}
@@ -42,7 +42,7 @@ func CreateTestEnvironmentWithTeams(a *app.App, c request.CTX, client *model.Cli
 		if err != nil {
 			return TestEnvironment{}, err
 		}
-		teamEnvironment, err := CreateTestEnvironmentInTeam(a, c, client, team, rangeChannels, rangeUsers, rangePosts, fuzzy)
+		teamEnvironment, err := CreateTestEnvironmentInTeam(a, rctx, client, team, rangeChannels, rangeUsers, rangePosts, fuzzy)
 		if err != nil {
 			return TestEnvironment{}, err
 		}
@@ -52,7 +52,7 @@ func CreateTestEnvironmentWithTeams(a *app.App, c request.CTX, client *model.Cli
 	return environment, nil
 }
 
-func CreateTestEnvironmentInTeam(a *app.App, c request.CTX, client *model.Client4, team *model.Team, rangeChannels utils.Range, rangeUsers utils.Range, rangePosts utils.Range, fuzzy bool) (TeamEnvironment, error) {
+func CreateTestEnvironmentInTeam(a *app.App, rctx request.CTX, client *model.Client4, team *model.Team, rangeChannels utils.Range, rangeUsers utils.Range, rangePosts utils.Range, fuzzy bool) (TeamEnvironment, error) {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	// We need to create at least one user
@@ -62,7 +62,7 @@ func CreateTestEnvironmentInTeam(a *app.App, c request.CTX, client *model.Client
 
 	userCreator := NewAutoUserCreator(a, client, team)
 	userCreator.Fuzzy = fuzzy
-	users, err := userCreator.CreateTestUsers(c, rangeUsers)
+	users, err := userCreator.CreateTestUsers(rctx, rangeUsers)
 	if err != nil {
 		return TeamEnvironment{}, err
 	}
@@ -73,7 +73,7 @@ func CreateTestEnvironmentInTeam(a *app.App, c request.CTX, client *model.Client
 
 	channelCreator := NewAutoChannelCreator(a, team, users[0].Id)
 	channelCreator.Fuzzy = fuzzy
-	channels, err := channelCreator.CreateTestChannels(c, rangeChannels)
+	channels, err := channelCreator.CreateTestChannels(rctx, rangeChannels)
 	if err != nil {
 		return TeamEnvironment{}, err
 	}
@@ -107,7 +107,7 @@ func CreateTestEnvironmentInTeam(a *app.App, c request.CTX, client *model.Client
 			postCreator.HasImage = i < numImages
 			postCreator.Users = usernames
 			postCreator.Fuzzy = fuzzy
-			_, err := postCreator.CreateRandomPost(c)
+			_, err := postCreator.CreateRandomPost(rctx)
 			if err != nil {
 				return TeamEnvironment{}, err
 			}

--- a/server/channels/app/slashcommands/auto_posts.go
+++ b/server/channels/app/slashcommands/auto_posts.go
@@ -51,7 +51,7 @@ func NewAutoPostCreator(a *app.App, channelid, userid string) *AutoPostCreator {
 	}
 }
 
-func (cfg *AutoPostCreator) UploadTestFile(c request.CTX) ([]string, error) {
+func (cfg *AutoPostCreator) UploadTestFile(rctx request.CTX) ([]string, error) {
 	filename := cfg.ImageFilenames[utils.RandIntFromRange(utils.Range{Begin: 0, End: len(cfg.ImageFilenames) - 1})]
 
 	path, _ := fileutils.FindDir("tests")
@@ -67,7 +67,7 @@ func (cfg *AutoPostCreator) UploadTestFile(c request.CTX) ([]string, error) {
 		return nil, err
 	}
 
-	fileResp, err2 := cfg.a.UploadFile(c, data.Bytes(), cfg.channelid, filename)
+	fileResp, err2 := cfg.a.UploadFile(rctx, data.Bytes(), cfg.channelid, filename)
 	if err2 != nil {
 		return nil, err2
 	}
@@ -75,15 +75,15 @@ func (cfg *AutoPostCreator) UploadTestFile(c request.CTX) ([]string, error) {
 	return []string{fileResp.Id}, nil
 }
 
-func (cfg *AutoPostCreator) CreateRandomPost(c request.CTX) (*model.Post, error) {
-	return cfg.CreateRandomPostNested(c, "")
+func (cfg *AutoPostCreator) CreateRandomPost(rctx request.CTX) (*model.Post, error) {
+	return cfg.CreateRandomPostNested(rctx, "")
 }
 
-func (cfg *AutoPostCreator) CreateRandomPostNested(c request.CTX, rootID string) (*model.Post, error) {
+func (cfg *AutoPostCreator) CreateRandomPostNested(rctx request.CTX, rootID string) (*model.Post, error) {
 	var fileIDs []string
 	if cfg.HasImage {
 		var err error
-		fileIDs, err = cfg.UploadTestFile(c)
+		fileIDs, err = cfg.UploadTestFile(rctx)
 		if err != nil {
 			return nil, err
 		}
@@ -114,7 +114,7 @@ func (cfg *AutoPostCreator) CreateRandomPostNested(c request.CTX, rootID string)
 			post.UserId = cfg.UsersToPostFrom[i]
 		}
 	}
-	rpost, err := cfg.a.CreatePostMissingChannel(c, post, true, true)
+	rpost, err := cfg.a.CreatePostMissingChannel(rctx, post, true, true)
 	if err != nil {
 		return nil, err
 	}

--- a/server/channels/app/slashcommands/auto_users.go
+++ b/server/channels/app/slashcommands/auto_users.go
@@ -81,7 +81,7 @@ func CreateBasicUser(rctx request.CTX, a *app.App, client *model.Client4) error 
 	return nil
 }
 
-func (cfg *AutoUserCreator) createRandomUser(c request.CTX) (*model.User, error) {
+func (cfg *AutoUserCreator) createRandomUser(rctx request.CTX) (*model.User, error) {
 	var userEmail string
 	var userName string
 	if cfg.Fuzzy {
@@ -99,7 +99,7 @@ func (cfg *AutoUserCreator) createRandomUser(c request.CTX) (*model.User, error)
 		CreateAt: cfg.JoinTime,
 	}
 
-	ruser, appErr := cfg.app.CreateUserWithInviteId(c, user, cfg.team.InviteId, "")
+	ruser, appErr := cfg.app.CreateUserWithInviteId(rctx, user, cfg.team.InviteId, "")
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -122,12 +122,12 @@ func (cfg *AutoUserCreator) createRandomUser(c request.CTX) (*model.User, error)
 	}
 
 	if cfg.JoinTime != 0 {
-		teamMember, appErr := cfg.app.GetTeamMember(c, cfg.team.Id, ruser.Id)
+		teamMember, appErr := cfg.app.GetTeamMember(rctx, cfg.team.Id, ruser.Id)
 		if appErr != nil {
 			return nil, appErr
 		}
 		teamMember.CreateAt = cfg.JoinTime
-		_, err := cfg.app.Srv().Store().Team().UpdateMember(c, teamMember)
+		_, err := cfg.app.Srv().Store().Team().UpdateMember(rctx, teamMember)
 		if err != nil {
 			return nil, err
 		}
@@ -136,13 +136,13 @@ func (cfg *AutoUserCreator) createRandomUser(c request.CTX) (*model.User, error)
 	return ruser, nil
 }
 
-func (cfg *AutoUserCreator) CreateTestUsers(c request.CTX, num utils.Range) ([]*model.User, error) {
+func (cfg *AutoUserCreator) CreateTestUsers(rctx request.CTX, num utils.Range) ([]*model.User, error) {
 	numUsers := utils.RandIntFromRange(num)
 	users := make([]*model.User, numUsers)
 
 	for i := 0; i < numUsers; i++ {
 		var err error
-		users[i], err = cfg.createRandomUser(c)
+		users[i], err = cfg.createRandomUser(rctx)
 		if err != nil {
 			return nil, err
 		}

--- a/server/channels/app/slashcommands/command_channel_header.go
+++ b/server/channels/app/slashcommands/command_channel_header.go
@@ -35,8 +35,8 @@ func (*HeaderProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Comma
 	}
 }
 
-func (*HeaderProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
-	channel, err := a.GetChannel(c, args.ChannelId)
+func (*HeaderProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+	channel, err := a.GetChannel(rctx, args.ChannelId)
 	if err != nil {
 		return &model.CommandResponse{
 			Text:         args.T("api.command_channel_header.channel.app_error"),
@@ -46,7 +46,7 @@ func (*HeaderProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandA
 
 	switch channel.Type {
 	case model.ChannelTypeOpen:
-		if !a.HasPermissionToChannel(c, args.UserId, args.ChannelId, model.PermissionManagePublicChannelProperties) {
+		if !a.HasPermissionToChannel(rctx, args.UserId, args.ChannelId, model.PermissionManagePublicChannelProperties) {
 			return &model.CommandResponse{
 				Text:         args.T("api.command_channel_header.permission.app_error"),
 				ResponseType: model.CommandResponseTypeEphemeral,
@@ -54,7 +54,7 @@ func (*HeaderProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandA
 		}
 
 	case model.ChannelTypePrivate:
-		if !a.HasPermissionToChannel(c, args.UserId, args.ChannelId, model.PermissionManagePrivateChannelProperties) {
+		if !a.HasPermissionToChannel(rctx, args.UserId, args.ChannelId, model.PermissionManagePrivateChannelProperties) {
 			return &model.CommandResponse{
 				Text:         args.T("api.command_channel_header.permission.app_error"),
 				ResponseType: model.CommandResponseTypeEphemeral,
@@ -64,7 +64,7 @@ func (*HeaderProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandA
 	case model.ChannelTypeGroup, model.ChannelTypeDirect:
 		// Modifying the header is not linked to any specific permission for group/dm channels, so just check for membership.
 		var channelMember *model.ChannelMember
-		channelMember, err = a.GetChannelMember(c, args.ChannelId, args.UserId)
+		channelMember, err = a.GetChannelMember(rctx, args.ChannelId, args.UserId)
 		if err != nil || channelMember == nil {
 			return &model.CommandResponse{
 				Text:         args.T("api.command_channel_header.permission.app_error"),
@@ -91,7 +91,7 @@ func (*HeaderProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandA
 	}
 	*patch.Header = message
 
-	_, err = a.PatchChannel(c, channel, patch, args.UserId)
+	_, err = a.PatchChannel(rctx, channel, patch, args.UserId)
 	if err != nil {
 		text := args.T("api.command_channel_header.update_channel.app_error")
 		if err.Id == "model.channel.is_valid.header.app_error" {

--- a/server/channels/app/slashcommands/command_channel_purpose.go
+++ b/server/channels/app/slashcommands/command_channel_purpose.go
@@ -35,8 +35,8 @@ func (*PurposeProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Comm
 	}
 }
 
-func (*PurposeProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
-	channel, err := a.GetChannel(c, args.ChannelId)
+func (*PurposeProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+	channel, err := a.GetChannel(rctx, args.ChannelId)
 	if err != nil {
 		return &model.CommandResponse{
 			Text:         args.T("api.command_channel_purpose.channel.app_error"),
@@ -46,14 +46,14 @@ func (*PurposeProvider) DoCommand(a *app.App, c request.CTX, args *model.Command
 
 	switch channel.Type {
 	case model.ChannelTypeOpen:
-		if !a.HasPermissionToChannel(c, args.UserId, args.ChannelId, model.PermissionManagePublicChannelProperties) {
+		if !a.HasPermissionToChannel(rctx, args.UserId, args.ChannelId, model.PermissionManagePublicChannelProperties) {
 			return &model.CommandResponse{
 				Text:         args.T("api.command_channel_purpose.permission.app_error"),
 				ResponseType: model.CommandResponseTypeEphemeral,
 			}
 		}
 	case model.ChannelTypePrivate:
-		if !a.HasPermissionToChannel(c, args.UserId, args.ChannelId, model.PermissionManagePrivateChannelProperties) {
+		if !a.HasPermissionToChannel(rctx, args.UserId, args.ChannelId, model.PermissionManagePrivateChannelProperties) {
 			return &model.CommandResponse{
 				Text:         args.T("api.command_channel_purpose.permission.app_error"),
 				ResponseType: model.CommandResponseTypeEphemeral,
@@ -78,7 +78,7 @@ func (*PurposeProvider) DoCommand(a *app.App, c request.CTX, args *model.Command
 	}
 	*patch.Purpose = message
 
-	_, err = a.PatchChannel(c, channel, patch, args.UserId)
+	_, err = a.PatchChannel(rctx, channel, patch, args.UserId)
 	if err != nil {
 		text := args.T("api.command_channel_purpose.update_channel.app_error")
 		if err.Id == "model.channel.is_valid.purpose.app_error" {

--- a/server/channels/app/slashcommands/command_channel_rename.go
+++ b/server/channels/app/slashcommands/command_channel_rename.go
@@ -38,8 +38,8 @@ func (*RenameProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Comma
 	}
 }
 
-func (*RenameProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
-	channel, err := a.GetChannel(c, args.ChannelId)
+func (*RenameProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+	channel, err := a.GetChannel(rctx, args.ChannelId)
 	if err != nil {
 		return &model.CommandResponse{
 			Text:         args.T("api.command_channel_rename.channel.app_error"),
@@ -49,14 +49,14 @@ func (*RenameProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandA
 
 	switch channel.Type {
 	case model.ChannelTypeOpen:
-		if !a.HasPermissionToChannel(c, args.UserId, args.ChannelId, model.PermissionManagePublicChannelProperties) {
+		if !a.HasPermissionToChannel(rctx, args.UserId, args.ChannelId, model.PermissionManagePublicChannelProperties) {
 			return &model.CommandResponse{
 				Text:         args.T("api.command_channel_rename.permission.app_error"),
 				ResponseType: model.CommandResponseTypeEphemeral,
 			}
 		}
 	case model.ChannelTypePrivate:
-		if !a.HasPermissionToChannel(c, args.UserId, args.ChannelId, model.PermissionManagePrivateChannelProperties) {
+		if !a.HasPermissionToChannel(rctx, args.UserId, args.ChannelId, model.PermissionManagePrivateChannelProperties) {
 			return &model.CommandResponse{
 				Text:         args.T("api.command_channel_rename.permission.app_error"),
 				ResponseType: model.CommandResponseTypeEphemeral,
@@ -92,7 +92,7 @@ func (*RenameProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandA
 	}
 	*patch.DisplayName = message
 
-	_, err = a.PatchChannel(c, channel, patch, args.UserId)
+	_, err = a.PatchChannel(rctx, channel, patch, args.UserId)
 	if err != nil {
 		return &model.CommandResponse{
 			Text:         args.T("api.command_channel_rename.update_channel.app_error"),

--- a/server/channels/app/slashcommands/command_code.go
+++ b/server/channels/app/slashcommands/command_code.go
@@ -37,7 +37,7 @@ func (*CodeProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Command
 	}
 }
 
-func (*CodeProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (*CodeProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	if message == "" {
 		return &model.CommandResponse{Text: args.T("api.command_code.message.app_error"), ResponseType: model.CommandResponseTypeEphemeral}
 	}

--- a/server/channels/app/slashcommands/command_custom_status.go
+++ b/server/channels/app/slashcommands/command_custom_status.go
@@ -40,15 +40,15 @@ func (*CustomStatusProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model
 	}
 }
 
-func (*CustomStatusProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (*CustomStatusProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	if !*a.Config().TeamSettings.EnableCustomUserStatuses {
 		return nil
 	}
 
 	message = strings.TrimSpace(message)
 	if message == CmdCustomStatusClear {
-		if err := a.RemoveCustomStatus(c, args.UserId); err != nil {
-			c.Logger().Debug(err.Error())
+		if err := a.RemoveCustomStatus(rctx, args.UserId); err != nil {
+			rctx.Logger().Debug(err.Error())
 			return &model.CommandResponse{Text: args.T("api.command_custom_status.clear.app_error"), ResponseType: model.CommandResponseTypeEphemeral}
 		}
 
@@ -60,8 +60,8 @@ func (*CustomStatusProvider) DoCommand(a *app.App, c request.CTX, args *model.Co
 
 	customStatus := GetCustomStatus(message)
 	customStatus.PreSave()
-	if err := a.SetCustomStatus(c, args.UserId, customStatus); err != nil {
-		c.Logger().Debug(err.Error())
+	if err := a.SetCustomStatus(rctx, args.UserId, customStatus); err != nil {
+		rctx.Logger().Debug(err.Error())
 		return &model.CommandResponse{Text: args.T("api.command_custom_status.app_error"), ResponseType: model.CommandResponseTypeEphemeral}
 	}
 

--- a/server/channels/app/slashcommands/command_dnd.go
+++ b/server/channels/app/slashcommands/command_dnd.go
@@ -34,7 +34,7 @@ func (*DndProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Command 
 	}
 }
 
-func (*DndProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (*DndProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	a.SetStatusDoNotDisturb(args.UserId)
 
 	return &model.CommandResponse{ResponseType: model.CommandResponseTypeEphemeral, Text: args.T("api.command_dnd.success")}

--- a/server/channels/app/slashcommands/command_echo.go
+++ b/server/channels/app/slashcommands/command_echo.go
@@ -42,7 +42,7 @@ func (*EchoProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Command
 	}
 }
 
-func (*EchoProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (*EchoProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	if message == "" {
 		return &model.CommandResponse{Text: args.T("api.command_echo.message.app_error"), ResponseType: model.CommandResponseTypeEphemeral}
 	}
@@ -89,8 +89,8 @@ func (*EchoProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArg
 
 		time.Sleep(time.Duration(delay) * time.Second)
 
-		if _, err := a.CreatePostMissingChannel(c, post, true, true); err != nil {
-			c.Logger().Error("Unable to create /echo post.", mlog.Err(err))
+		if _, err := a.CreatePostMissingChannel(rctx, post, true, true); err != nil {
+			rctx.Logger().Error("Unable to create /echo post.", mlog.Err(err))
 		}
 	})
 

--- a/server/channels/app/slashcommands/command_expand_collapse.go
+++ b/server/channels/app/slashcommands/command_expand_collapse.go
@@ -55,11 +55,11 @@ func (*CollapseProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Com
 	}
 }
 
-func (*ExpandProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (*ExpandProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	return setCollapsePreference(a, args, false)
 }
 
-func (*CollapseProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (*CollapseProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	return setCollapsePreference(a, args, true)
 }
 

--- a/server/channels/app/slashcommands/command_exportlink.go
+++ b/server/channels/app/slashcommands/command_exportlink.go
@@ -58,8 +58,8 @@ func (*ExportLinkProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.C
 	}
 }
 
-func (*ExportLinkProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
-	if !a.SessionHasPermissionTo(*c.Session(), model.PermissionManageSystem) {
+func (*ExportLinkProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+	if !a.SessionHasPermissionTo(*rctx.Session(), model.PermissionManageSystem) {
 		return &model.CommandResponse{ResponseType: model.CommandResponseTypeEphemeral, Text: args.T("api.command_exportlink.permission.app_error")}
 	}
 
@@ -86,7 +86,7 @@ func (*ExportLinkProvider) DoCommand(a *app.App, c request.CTX, args *model.Comm
 			}
 			t, err := b.FileModTime(f)
 			if err != nil {
-				c.Logger().Warn("Failed to get file mod time", mlog.String("file", f), mlog.Err(err))
+				rctx.Logger().Warn("Failed to get file mod time", mlog.String("file", f), mlog.Err(err))
 				continue
 			}
 			if t.After(latestFound) {

--- a/server/channels/app/slashcommands/command_help.go
+++ b/server/channels/app/slashcommands/command_help.go
@@ -34,7 +34,7 @@ func (h *HelpProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Comma
 	}
 }
 
-func (h *HelpProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (h *HelpProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	helpLink := *a.Config().SupportSettings.HelpLink
 
 	if helpLink == "" {

--- a/server/channels/app/slashcommands/command_invite.go
+++ b/server/channels/app/slashcommands/command_invite.go
@@ -49,27 +49,27 @@ func (*InviteProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Comma
 	}
 }
 
-func (i *InviteProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (i *InviteProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	return &model.CommandResponse{
-		Text:         i.doCommand(a, c, args, message),
+		Text:         i.doCommand(a, rctx, args, message),
 		ResponseType: model.CommandResponseTypeEphemeral,
 	}
 }
 
-func (i *InviteProvider) doCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) string {
+func (i *InviteProvider) doCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) string {
 	if message == "" {
 		return args.T("api.command_invite.missing_message.app_error")
 	}
 
 	resps := &[]string{}
 
-	targetUsers, targetChannels, resp := i.parseMessage(a, c, args, resps, message)
+	targetUsers, targetChannels, resp := i.parseMessage(a, rctx, args, resps, message)
 	if resp != "" {
 		return resp
 	}
 
 	// Verify that the inviter has permissions to invite users to the every channel.
-	targetChannels = i.checkPermissions(a, c, args, resps, targetUsers[0], targetChannels)
+	targetChannels = i.checkPermissions(a, rctx, args, resps, targetUsers[0], targetChannels)
 
 	// track errors returned for various users.
 	differentChannels := make(map[string][]string)
@@ -81,7 +81,7 @@ func (i *InviteProvider) doCommand(a *app.App, c request.CTX, args *model.Comman
 	for _, targetChannel := range targetChannels {
 		var targetTeamDisplay string
 		for _, targetUser := range targetUsers {
-			userError := i.addUserToChannel(a, c, args, targetUser, targetChannel)
+			userError := i.addUserToChannel(a, rctx, args, targetUser, targetChannel)
 			if userError == NoError {
 				if args.ChannelId != targetChannel.Id {
 					differentChannels[targetChannel.Name] = append(differentChannels[targetChannel.Name], targetUser.Username)
@@ -205,7 +205,7 @@ func (i *InviteProvider) getUsersFromMentionName(a *app.App, mentionName string)
 	return members, group
 }
 
-func (i *InviteProvider) parseMessage(a *app.App, c request.CTX, args *model.CommandArgs, resps *[]string, message string) ([]*model.User, []*model.Channel, string) {
+func (i *InviteProvider) parseMessage(a *app.App, rctx request.CTX, args *model.CommandArgs, resps *[]string, message string) ([]*model.User, []*model.Channel, string) {
 	splitMessage := strings.Split(message, " ")
 
 	targetUsers := make([]*model.User, 0, 1)
@@ -223,7 +223,7 @@ func (i *InviteProvider) parseMessage(a *app.App, c request.CTX, args *model.Com
 				a.Srv().GetTelemetryService().SendTelemetryForFeature(
 					telemetry.TrackGroupsFeature,
 					"invite_group_to_channel__command",
-					map[string]any{telemetry.TrackPropertyUser: c.Session().UserId, telemetry.TrackPropertyGroup: group.Id},
+					map[string]any{telemetry.TrackPropertyUser: rctx.Session().UserId, telemetry.TrackPropertyGroup: group.Id},
 				)
 			}
 			if len(users) == 0 {
@@ -235,7 +235,7 @@ func (i *InviteProvider) parseMessage(a *app.App, c request.CTX, args *model.Com
 			targetUsers = append(targetUsers, users...)
 		} else {
 			targetChannelName := strings.TrimPrefix(msg, "~")
-			channelToJoin, err := a.GetChannelByName(c, targetChannelName, args.TeamId, false)
+			channelToJoin, err := a.GetChannelByName(rctx, targetChannelName, args.TeamId, false)
 			if err != nil {
 				*resps = append(*resps, args.T("api.command_invite.channel.error", map[string]any{
 					"Channel": targetChannelName,
@@ -258,7 +258,7 @@ func (i *InviteProvider) parseMessage(a *app.App, c request.CTX, args *model.Com
 			return nil, nil, strings.Join(*resps, "\n")
 		}
 
-		channelToJoin, err := a.GetChannel(c, args.ChannelId)
+		channelToJoin, err := a.GetChannel(rctx, args.ChannelId)
 		if err != nil {
 			return nil, nil, args.T("api.command_invite.channel.app_error")
 		}
@@ -268,13 +268,13 @@ func (i *InviteProvider) parseMessage(a *app.App, c request.CTX, args *model.Com
 	return targetUsers, targetChannels, ""
 }
 
-func (i *InviteProvider) checkPermissions(a *app.App, c request.CTX, args *model.CommandArgs, resps *[]string, targetUser *model.User, targetChannels []*model.Channel) []*model.Channel {
+func (i *InviteProvider) checkPermissions(a *app.App, rctx request.CTX, args *model.CommandArgs, resps *[]string, targetUser *model.User, targetChannels []*model.Channel) []*model.Channel {
 	var err *model.AppError
 	validChannels := make([]*model.Channel, 0, len(targetChannels))
 	for _, targetChannel := range targetChannels {
 		switch targetChannel.Type {
 		case model.ChannelTypeOpen:
-			if !a.HasPermissionToChannel(c, args.UserId, targetChannel.Id, model.PermissionManagePublicChannelMembers) {
+			if !a.HasPermissionToChannel(rctx, args.UserId, targetChannel.Id, model.PermissionManagePublicChannelMembers) {
 				*resps = append(*resps, args.T("api.command_invite.permission.app_error", map[string]any{
 					"User":    targetUser.Username,
 					"Channel": targetChannel.Name,
@@ -282,8 +282,8 @@ func (i *InviteProvider) checkPermissions(a *app.App, c request.CTX, args *model
 				continue
 			}
 		case model.ChannelTypePrivate:
-			if !a.HasPermissionToChannel(c, args.UserId, targetChannel.Id, model.PermissionManagePrivateChannelMembers) {
-				if _, err = a.GetChannelMember(c, targetChannel.Id, args.UserId); err == nil {
+			if !a.HasPermissionToChannel(rctx, args.UserId, targetChannel.Id, model.PermissionManagePrivateChannelMembers) {
+				if _, err = a.GetChannelMember(rctx, targetChannel.Id, args.UserId); err == nil {
 					// User doing the inviting is a member of the channel.
 					*resps = append(*resps, args.T("api.command_invite.permission.app_error", map[string]any{
 						"User":    targetUser.Username,
@@ -306,21 +306,21 @@ func (i *InviteProvider) checkPermissions(a *app.App, c request.CTX, args *model
 	return validChannels
 }
 
-func (i *InviteProvider) addUserToChannel(a *app.App, c request.CTX, args *model.CommandArgs, userProfile *model.User, channelToJoin *model.Channel) UserError {
+func (i *InviteProvider) addUserToChannel(a *app.App, rctx request.CTX, args *model.CommandArgs, userProfile *model.User, channelToJoin *model.Channel) UserError {
 	// Check if user is already in the channel
-	_, err := a.GetChannelMember(c, channelToJoin.Id, userProfile.Id)
+	_, err := a.GetChannelMember(rctx, channelToJoin.Id, userProfile.Id)
 	if err == nil {
 		return UserInChannel
 	}
 
-	if _, err = a.AddChannelMember(c, userProfile.Id, channelToJoin, app.ChannelMemberOpts{UserRequestorID: args.UserId}); err != nil {
+	if _, err = a.AddChannelMember(rctx, userProfile.Id, channelToJoin, app.ChannelMemberOpts{UserRequestorID: args.UserId}); err != nil {
 		if err.Id == "api.channel.add_members.user_denied" {
 			return IsConstrained
 		} else if err.Id == "app.team.get_member.missing.app_error" ||
 			err.Id == "api.channel.add_user.to.channel.failed.deleted.app_error" {
 			return UserNotInTeam
 		}
-		c.Logger().Warn("addUserToChannel had unexpected error.", mlog.String("UserId", userProfile.Id), mlog.Err(err))
+		rctx.Logger().Warn("addUserToChannel had unexpected error.", mlog.String("UserId", userProfile.Id), mlog.Err(err))
 		return Unknown
 	}
 

--- a/server/channels/app/slashcommands/command_invite_people.go
+++ b/server/channels/app/slashcommands/command_invite_people.go
@@ -41,12 +41,12 @@ func (*InvitePeopleProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model
 	}
 }
 
-func (*InvitePeopleProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
-	if !a.HasPermissionToTeam(c, args.UserId, args.TeamId, model.PermissionInviteUser) {
+func (*InvitePeopleProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+	if !a.HasPermissionToTeam(rctx, args.UserId, args.TeamId, model.PermissionInviteUser) {
 		return &model.CommandResponse{Text: args.T("api.command_invite_people.permission.app_error"), ResponseType: model.CommandResponseTypeEphemeral}
 	}
 
-	if !a.HasPermissionToTeam(c, args.UserId, args.TeamId, model.PermissionAddUserToTeam) {
+	if !a.HasPermissionToTeam(rctx, args.UserId, args.TeamId, model.PermissionAddUserToTeam) {
 		return &model.CommandResponse{Text: args.T("api.command_invite_people.permission.app_error"), ResponseType: model.CommandResponseTypeEphemeral}
 	}
 
@@ -75,8 +75,8 @@ func (*InvitePeopleProvider) DoCommand(a *app.App, c request.CTX, args *model.Co
 		return &model.CommandResponse{ResponseType: model.CommandResponseTypeEphemeral, Text: args.T("api.command.invite_people.no_email")}
 	}
 
-	if err := a.InviteNewUsersToTeam(c, emailList, args.TeamId, args.UserId); err != nil {
-		c.Logger().Error(err.Error())
+	if err := a.InviteNewUsersToTeam(rctx, emailList, args.TeamId, args.UserId); err != nil {
+		rctx.Logger().Error(err.Error())
 		return &model.CommandResponse{ResponseType: model.CommandResponseTypeEphemeral, Text: args.T("api.command.invite_people.fail")}
 	}
 

--- a/server/channels/app/slashcommands/command_join.go
+++ b/server/channels/app/slashcommands/command_join.go
@@ -37,7 +37,7 @@ func (*JoinProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Command
 	}
 }
 
-func (*JoinProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (*JoinProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	channelName := strings.ToLower(message)
 
 	if strings.HasPrefix(message, "~") {
@@ -55,18 +55,18 @@ func (*JoinProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArg
 
 	switch channel.Type {
 	case model.ChannelTypeOpen:
-		if !a.HasPermissionToChannel(c, args.UserId, channel.Id, model.PermissionJoinPublicChannels) {
+		if !a.HasPermissionToChannel(rctx, args.UserId, channel.Id, model.PermissionJoinPublicChannels) {
 			return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.CommandResponseTypeEphemeral}
 		}
 	case model.ChannelTypePrivate:
-		if !a.HasPermissionToChannel(c, args.UserId, channel.Id, model.PermissionReadChannel) {
+		if !a.HasPermissionToChannel(rctx, args.UserId, channel.Id, model.PermissionReadChannel) {
 			return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.CommandResponseTypeEphemeral}
 		}
 	default:
 		return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.CommandResponseTypeEphemeral}
 	}
 
-	if appErr := a.JoinChannel(c, channel, args.UserId); appErr != nil {
+	if appErr := a.JoinChannel(rctx, channel, args.UserId); appErr != nil {
 		return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.CommandResponseTypeEphemeral}
 	}
 

--- a/server/channels/app/slashcommands/command_leave.go
+++ b/server/channels/app/slashcommands/command_leave.go
@@ -34,10 +34,10 @@ func (*LeaveProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Comman
 	}
 }
 
-func (*LeaveProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (*LeaveProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	var channel *model.Channel
 	var noChannelErr *model.AppError
-	if channel, noChannelErr = a.GetChannel(c, args.ChannelId); noChannelErr != nil {
+	if channel, noChannelErr = a.GetChannel(rctx, args.ChannelId); noChannelErr != nil {
 		return &model.CommandResponse{Text: args.T("api.command_leave.fail.app_error"), ResponseType: model.CommandResponseTypeEphemeral}
 	}
 
@@ -46,7 +46,7 @@ func (*LeaveProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandAr
 		return &model.CommandResponse{Text: args.T("api.command_leave.fail.app_error"), ResponseType: model.CommandResponseTypeEphemeral}
 	}
 
-	err = a.LeaveChannel(c, args.ChannelId, args.UserId)
+	err = a.LeaveChannel(rctx, args.ChannelId, args.UserId)
 	if err != nil {
 		if channel.Name == model.DefaultChannelName {
 			return &model.CommandResponse{Text: args.T("api.channel.leave.default.app_error", map[string]any{"Channel": model.DefaultChannelName}), ResponseType: model.CommandResponseTypeEphemeral}
@@ -54,7 +54,7 @@ func (*LeaveProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandAr
 		return &model.CommandResponse{Text: args.T("api.command_leave.fail.app_error"), ResponseType: model.CommandResponseTypeEphemeral}
 	}
 
-	member, err := a.GetTeamMember(c, team.Id, args.UserId)
+	member, err := a.GetTeamMember(rctx, team.Id, args.UserId)
 	if err != nil || member.DeleteAt != 0 {
 		return &model.CommandResponse{GotoLocation: args.SiteURL + "/"}
 	}
@@ -65,11 +65,11 @@ func (*LeaveProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandAr
 	}
 
 	if user.IsGuest() {
-		members, err := a.GetChannelMembersForUser(c, team.Id, args.UserId)
+		members, err := a.GetChannelMembersForUser(rctx, team.Id, args.UserId)
 		if err != nil || len(members) == 0 {
 			return &model.CommandResponse{Text: args.T("api.command_leave.fail.app_error"), ResponseType: model.CommandResponseTypeEphemeral}
 		}
-		channel, err := a.GetChannel(c, members[0].ChannelId)
+		channel, err := a.GetChannel(rctx, members[0].ChannelId)
 		if err != nil {
 			return &model.CommandResponse{Text: args.T("api.command_leave.fail.app_error"), ResponseType: model.CommandResponseTypeEphemeral}
 		}

--- a/server/channels/app/slashcommands/command_loadtest.go
+++ b/server/channels/app/slashcommands/command_loadtest.go
@@ -139,63 +139,63 @@ func (*LoadTestProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Com
 	}
 }
 
-func (lt *LoadTestProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
-	commandResponse, err := lt.doCommand(a, c, args, message)
+func (lt *LoadTestProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+	commandResponse, err := lt.doCommand(a, rctx, args, message)
 	if err != nil {
-		c.Logger().Error("failed command /"+CmdTest, mlog.Err(err))
+		rctx.Logger().Error("failed command /"+CmdTest, mlog.Err(err))
 	}
 
 	return commandResponse
 }
 
-func (lt *LoadTestProvider) doCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
+func (lt *LoadTestProvider) doCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
 	//This command is only available when EnableTesting is true
 	if !*a.Config().ServiceSettings.EnableTesting {
 		return &model.CommandResponse{}, nil
 	}
 
 	if strings.HasPrefix(message, "setup") {
-		return lt.SetupCommand(a, c, args, message)
+		return lt.SetupCommand(a, rctx, args, message)
 	}
 
 	if strings.HasPrefix(message, "users") {
-		return lt.UsersCommand(a, c, args, message)
+		return lt.UsersCommand(a, rctx, args, message)
 	}
 
 	if strings.HasPrefix(message, "activate_user") {
-		return lt.ActivateUserCommand(a, c, args, message)
+		return lt.ActivateUserCommand(a, rctx, args, message)
 	}
 
 	if strings.HasPrefix(message, "deactivate_user") {
-		return lt.DeActivateUserCommand(a, c, args, message)
+		return lt.DeActivateUserCommand(a, rctx, args, message)
 	}
 
 	if strings.HasPrefix(message, "channels") {
-		return lt.ChannelsCommand(a, c, args, message)
+		return lt.ChannelsCommand(a, rctx, args, message)
 	}
 
 	if strings.HasPrefix(message, "dms") {
-		return lt.DMsCommand(a, c, args, message)
+		return lt.DMsCommand(a, rctx, args, message)
 	}
 
 	if strings.HasPrefix(message, "posts") {
-		return lt.PostsCommand(a, c, args, message)
+		return lt.PostsCommand(a, rctx, args, message)
 	}
 
 	if strings.HasPrefix(message, "post") {
-		return lt.PostCommand(a, c, args, message)
+		return lt.PostCommand(a, rctx, args, message)
 	}
 
 	if strings.HasPrefix(message, "threaded_post") {
-		return lt.ThreadedPostCommand(a, c, args, message)
+		return lt.ThreadedPostCommand(a, rctx, args, message)
 	}
 
 	if strings.HasPrefix(message, "url") {
-		return lt.URLCommand(a, c, args, message)
+		return lt.URLCommand(a, rctx, args, message)
 	}
 
 	if strings.HasPrefix(message, "json") {
-		return lt.JSONCommand(a, c, args, message)
+		return lt.JSONCommand(a, rctx, args, message)
 	}
 
 	return lt.HelpCommand(args, message), nil
@@ -294,25 +294,25 @@ func (*LoadTestProvider) SetupCommand(a *app.App, rctx request.CTX, args *model.
 	return &model.CommandResponse{Text: "Created environment", ResponseType: model.CommandResponseTypeEphemeral}, nil
 }
 
-func (*LoadTestProvider) ActivateUserCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
+func (*LoadTestProvider) ActivateUserCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
 	userID := strings.TrimSpace(strings.TrimPrefix(message, "activate_user"))
-	if err := a.UpdateUserActive(c, userID, true); err != nil {
+	if err := a.UpdateUserActive(rctx, userID, true); err != nil {
 		return &model.CommandResponse{Text: "Failed to activate user", ResponseType: model.CommandResponseTypeEphemeral}, err
 	}
 
 	return &model.CommandResponse{Text: "Activated user", ResponseType: model.CommandResponseTypeEphemeral}, nil
 }
 
-func (*LoadTestProvider) DeActivateUserCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
+func (*LoadTestProvider) DeActivateUserCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
 	userID := strings.TrimSpace(strings.TrimPrefix(message, "deactivate_user"))
-	if err := a.UpdateUserActive(c, userID, false); err != nil {
+	if err := a.UpdateUserActive(rctx, userID, false); err != nil {
 		return &model.CommandResponse{Text: "Failed to deactivate user", ResponseType: model.CommandResponseTypeEphemeral}, err
 	}
 
 	return &model.CommandResponse{Text: "DeActivated user", ResponseType: model.CommandResponseTypeEphemeral}, nil
 }
 
-func (*LoadTestProvider) UsersCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
+func (*LoadTestProvider) UsersCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
 	cmd := strings.TrimSpace(strings.TrimPrefix(message, "users"))
 
 	doFuzz := false
@@ -348,14 +348,14 @@ func (*LoadTestProvider) UsersCommand(a *app.App, c request.CTX, args *model.Com
 	userCreator := NewAutoUserCreator(a, client, team)
 	userCreator.Fuzzy = doFuzz
 	userCreator.JoinTime = time
-	if _, err := userCreator.CreateTestUsers(c, rng); err != nil {
+	if _, err := userCreator.CreateTestUsers(rctx, rng); err != nil {
 		return &model.CommandResponse{Text: "Failed to add users: " + err.Error(), ResponseType: model.CommandResponseTypeEphemeral}, err
 	}
 
 	return &model.CommandResponse{Text: "Added users", ResponseType: model.CommandResponseTypeEphemeral}, nil
 }
 
-func (*LoadTestProvider) ChannelsCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
+func (*LoadTestProvider) ChannelsCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
 	cmd := strings.TrimSpace(strings.TrimPrefix(message, "channels"))
 
 	doFuzz := false
@@ -403,14 +403,14 @@ func (*LoadTestProvider) ChannelsCommand(a *app.App, c request.CTX, args *model.
 	channelCreator.Fuzzy = doFuzz
 	channelCreator.CreateTime = time
 	channelCreator.ChannelType = typ
-	if _, err := channelCreator.CreateTestChannels(c, rng); err != nil {
+	if _, err := channelCreator.CreateTestChannels(rctx, rng); err != nil {
 		return &model.CommandResponse{Text: "Failed to create test channels: " + err.Error(), ResponseType: model.CommandResponseTypeEphemeral}, err
 	}
 
 	return &model.CommandResponse{Text: "Added channels", ResponseType: model.CommandResponseTypeEphemeral}, nil
 }
 
-func (*LoadTestProvider) DMsCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
+func (*LoadTestProvider) DMsCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
 	cmd := strings.TrimSpace(strings.TrimPrefix(message, "dms"))
 
 	var err error
@@ -439,14 +439,14 @@ func (*LoadTestProvider) DMsCommand(a *app.App, c request.CTX, args *model.Comma
 		}
 	}
 
-	channel, err := a.GetOrCreateDirectChannel(c, args.UserId, user.Id)
+	channel, err := a.GetOrCreateDirectChannel(rctx, args.UserId, user.Id)
 
 	postCreator := NewAutoPostCreator(a, channel.Id, args.UserId)
 	postCreator.CreateTime = time
 	postCreator.UsersToPostFrom = []string{user.Id}
 	numPosts := utils.RandIntFromRange(rng)
 	for i := 0; i < numPosts; i++ {
-		if _, err := postCreator.CreateRandomPost(c); err != nil {
+		if _, err := postCreator.CreateRandomPost(rctx); err != nil {
 			return &model.CommandResponse{Text: "Failed to create test DMs: " + err.Error(), ResponseType: model.CommandResponseTypeEphemeral}, err
 		}
 	}
@@ -454,7 +454,7 @@ func (*LoadTestProvider) DMsCommand(a *app.App, c request.CTX, args *model.Comma
 	return &model.CommandResponse{Text: "Added DMs", ResponseType: model.CommandResponseTypeEphemeral}, nil
 }
 
-func (*LoadTestProvider) ThreadedPostCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
+func (*LoadTestProvider) ThreadedPostCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
 	cmd := strings.TrimSpace(strings.TrimPrefix(message, "threaded_post"))
 
 	var err error
@@ -492,13 +492,13 @@ func (*LoadTestProvider) ThreadedPostCommand(a *app.App, c request.CTX, args *mo
 	testPoster.Fuzzy = true
 	testPoster.Users = usernames
 	testPoster.CreateTime = time
-	rpost, err2 := testPoster.CreateRandomPost(c)
+	rpost, err2 := testPoster.CreateRandomPost(rctx)
 	if err2 != nil {
 		return &model.CommandResponse{Text: "Failed to create a post", ResponseType: model.CommandResponseTypeEphemeral}, err2
 	}
 	numPosts := utils.RandIntFromRange(rng)
 	for i := 0; i < numPosts; i++ {
-		_, err = testPoster.CreateRandomPostNested(c, rpost.Id)
+		_, err = testPoster.CreateRandomPostNested(rctx, rpost.Id)
 		if err != nil {
 			return &model.CommandResponse{Text: "Failed to create nested post", ResponseType: model.CommandResponseTypeEphemeral}, err
 		}
@@ -507,7 +507,7 @@ func (*LoadTestProvider) ThreadedPostCommand(a *app.App, c request.CTX, args *mo
 	return &model.CommandResponse{Text: "Added threaded post", ResponseType: model.CommandResponseTypeEphemeral}, nil
 }
 
-func (*LoadTestProvider) PostsCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
+func (*LoadTestProvider) PostsCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
 	cmd := strings.TrimSpace(strings.TrimPrefix(message, "posts"))
 
 	doFuzz := false
@@ -563,7 +563,7 @@ func (*LoadTestProvider) PostsCommand(a *app.App, c request.CTX, args *model.Com
 	numPosts := utils.RandIntFromRange(rng)
 	for i := 0; i < numPosts; i++ {
 		testPoster.HasImage = (i < numImages)
-		_, err := testPoster.CreateRandomPost(c)
+		_, err := testPoster.CreateRandomPost(rctx)
 		if err != nil {
 			return &model.CommandResponse{Text: "Failed to add posts", ResponseType: model.CommandResponseTypeEphemeral}, err
 		}
@@ -580,7 +580,7 @@ func getMatch(re *regexp.Regexp, text string) string {
 	return ""
 }
 
-func (*LoadTestProvider) PostCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
+func (*LoadTestProvider) PostCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
 	textMessage := getMatch(messageRE, message)
 	if textMessage == "" {
 		return &model.CommandResponse{Text: "No message to post", ResponseType: model.CommandResponseTypeEphemeral}, nil
@@ -593,7 +593,7 @@ func (*LoadTestProvider) PostCommand(a *app.App, c request.CTX, args *model.Comm
 	}
 
 	channelName := getMatch(channelRE, message)
-	channel, err := a.GetChannelByName(c, channelName, team.Id, true)
+	channel, err := a.GetChannelByName(rctx, channelName, team.Id, true)
 	if err != nil {
 		return &model.CommandResponse{Text: "Failed to get a channel", ResponseType: model.CommandResponseTypeEphemeral}, err
 	}
@@ -623,7 +623,7 @@ func (*LoadTestProvider) PostCommand(a *app.App, c request.CTX, args *model.Comm
 	return &model.CommandResponse{Text: "Added a post to " + channel.DisplayName, ResponseType: model.CommandResponseTypeEphemeral}, nil
 }
 
-func (*LoadTestProvider) URLCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
+func (*LoadTestProvider) URLCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
 	url := strings.TrimSpace(strings.TrimPrefix(message, "url"))
 	if url == "" {
 		return &model.CommandResponse{Text: "Command must contain a url", ResponseType: model.CommandResponseTypeEphemeral}, nil
@@ -645,7 +645,7 @@ func (*LoadTestProvider) URLCommand(a *app.App, c request.CTX, args *model.Comma
 	defer func() {
 		_, err := io.Copy(io.Discard, r.Body)
 		if err != nil {
-			c.Logger().Warn("Error discarding request body", mlog.Err(err))
+			rctx.Logger().Warn("Error discarding request body", mlog.Err(err))
 		}
 		r.Body.Close()
 	}()
@@ -672,7 +672,7 @@ func (*LoadTestProvider) URLCommand(a *app.App, c request.CTX, args *model.Comma
 		post.ChannelId = args.ChannelId
 		post.UserId = args.UserId
 
-		if _, err := a.CreatePostMissingChannel(c, post, false, true); err != nil {
+		if _, err := a.CreatePostMissingChannel(rctx, post, false, true); err != nil {
 			return &model.CommandResponse{Text: "Unable to create post", ResponseType: model.CommandResponseTypeEphemeral}, err
 		}
 	}
@@ -680,7 +680,7 @@ func (*LoadTestProvider) URLCommand(a *app.App, c request.CTX, args *model.Comma
 	return &model.CommandResponse{Text: "Loaded data", ResponseType: model.CommandResponseTypeEphemeral}, nil
 }
 
-func (*LoadTestProvider) JSONCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
+func (*LoadTestProvider) JSONCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
 	url := strings.TrimSpace(strings.TrimPrefix(message, "json"))
 	if url == "" {
 		return &model.CommandResponse{Text: "Command must contain a url", ResponseType: model.CommandResponseTypeEphemeral}, nil
@@ -706,7 +706,7 @@ func (*LoadTestProvider) JSONCommand(a *app.App, c request.CTX, args *model.Comm
 	defer func() {
 		_, err := io.Copy(io.Discard, r.Body)
 		if err != nil {
-			c.Logger().Warn("Error discarding request body", mlog.Err(err))
+			rctx.Logger().Warn("Error discarding request body", mlog.Err(err))
 		}
 		r.Body.Close()
 	}()
@@ -721,7 +721,7 @@ func (*LoadTestProvider) JSONCommand(a *app.App, c request.CTX, args *model.Comm
 		post.Message = message
 	}
 
-	if _, err := a.CreatePostMissingChannel(c, &post, false, true); err != nil {
+	if _, err := a.CreatePostMissingChannel(rctx, &post, false, true); err != nil {
 		return &model.CommandResponse{Text: "Unable to create post", ResponseType: model.CommandResponseTypeEphemeral}, err
 	}
 

--- a/server/channels/app/slashcommands/command_marketplace.go
+++ b/server/channels/app/slashcommands/command_marketplace.go
@@ -40,7 +40,7 @@ func (h *MarketplaceProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *mode
 	}
 }
 
-func (h *MarketplaceProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (h *MarketplaceProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	// This command is handled client-side and shouldn't hit the server.
 	return &model.CommandResponse{
 		Text:         args.T("api.command_marketplace.unsupported.app_error"),

--- a/server/channels/app/slashcommands/command_me.go
+++ b/server/channels/app/slashcommands/command_me.go
@@ -35,7 +35,7 @@ func (*MeProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (*MeProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (*MeProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	return &model.CommandResponse{
 		ResponseType: model.CommandResponseTypeInChannel,
 		Type:         model.PostTypeMe,

--- a/server/channels/app/slashcommands/command_mute.go
+++ b/server/channels/app/slashcommands/command_mute.go
@@ -37,11 +37,11 @@ func (*MuteProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Command
 	}
 }
 
-func (*MuteProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (*MuteProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	var channel *model.Channel
 	var noChannelErr *model.AppError
 
-	if channel, noChannelErr = a.GetChannel(c, args.ChannelId); noChannelErr != nil {
+	if channel, noChannelErr = a.GetChannel(rctx, args.ChannelId); noChannelErr != nil {
 		return &model.CommandResponse{Text: args.T("api.command_mute.no_channel.error"), ResponseType: model.CommandResponseTypeEphemeral}
 	}
 
@@ -62,7 +62,7 @@ func (*MuteProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArg
 		}
 	}
 
-	channelMember, err := a.ToggleMuteChannel(c, channel.Id, args.UserId)
+	channelMember, err := a.ToggleMuteChannel(rctx, channel.Id, args.UserId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_mute.not_member.error", map[string]any{"Channel": channelName}), ResponseType: model.CommandResponseTypeEphemeral}
 	}

--- a/server/channels/app/slashcommands/command_offline.go
+++ b/server/channels/app/slashcommands/command_offline.go
@@ -34,7 +34,7 @@ func (*OfflineProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Comm
 	}
 }
 
-func (*OfflineProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (*OfflineProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	a.SetStatusOffline(args.UserId, true, false)
 
 	return &model.CommandResponse{ResponseType: model.CommandResponseTypeEphemeral, Text: args.T("api.command_offline.success")}

--- a/server/channels/app/slashcommands/command_online.go
+++ b/server/channels/app/slashcommands/command_online.go
@@ -34,7 +34,7 @@ func (*OnlineProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Comma
 	}
 }
 
-func (*OnlineProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (*OnlineProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	a.SetStatusOnline(args.UserId, true)
 
 	return &model.CommandResponse{ResponseType: model.CommandResponseTypeEphemeral, Text: args.T("api.command_online.success")}

--- a/server/channels/app/slashcommands/command_remote.go
+++ b/server/channels/app/slashcommands/command_remote.go
@@ -70,7 +70,7 @@ func (rp *RemoteProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Co
 	}
 }
 
-func (rp *RemoteProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (rp *RemoteProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	if !a.HasPermissionTo(args.UserId, model.PermissionManageSecureConnections) {
 		return response(args.T("api.command_remote.permission_required", map[string]any{"Permission": "manage_secure_connections"}))
 	}
@@ -95,7 +95,7 @@ func (rp *RemoteProvider) DoCommand(a *app.App, c request.CTX, args *model.Comma
 	return response(args.T("api.command_remote.unknown_action", map[string]any{"Action": action}))
 }
 
-func (rp *RemoteProvider) GetAutoCompleteListItems(c request.CTX, a *app.App, commandArgs *model.CommandArgs, arg *model.AutocompleteArg, parsed, toBeParsed string) ([]model.AutocompleteListItem, error) {
+func (rp *RemoteProvider) GetAutoCompleteListItems(rctx request.CTX, a *app.App, commandArgs *model.CommandArgs, arg *model.AutocompleteArg, parsed, toBeParsed string) ([]model.AutocompleteListItem, error) {
 	if !a.HasPermissionTo(commandArgs.UserId, model.PermissionManageSecureConnections) {
 		return nil, errors.New("You require `manage_secure_connections` permission to manage secure connections.")
 	}

--- a/server/channels/app/slashcommands/command_search.go
+++ b/server/channels/app/slashcommands/command_search.go
@@ -35,7 +35,7 @@ func (search *SearchProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *mode
 	}
 }
 
-func (search *SearchProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (search *SearchProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	// This command is handled client-side and shouldn't hit the server.
 	return &model.CommandResponse{
 		Text:         args.T("api.command_search.unsupported.app_error"),

--- a/server/channels/app/slashcommands/command_settings.go
+++ b/server/channels/app/slashcommands/command_settings.go
@@ -35,7 +35,7 @@ func (settings *SettingsProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *
 	}
 }
 
-func (settings *SettingsProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (settings *SettingsProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	// This command is handled client-side and shouldn't hit the server.
 	return &model.CommandResponse{
 		Text:         args.T("api.command_settings.unsupported.app_error"),

--- a/server/channels/app/slashcommands/command_shortcuts.go
+++ b/server/channels/app/slashcommands/command_shortcuts.go
@@ -35,7 +35,7 @@ func (*ShortcutsProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Co
 	}
 }
 
-func (*ShortcutsProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (*ShortcutsProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	// This command is handled client-side and shouldn't hit the server.
 	return &model.CommandResponse{
 		Text:         args.T("api.command_shortcuts.unsupported.app_error"),

--- a/server/channels/app/slashcommands/command_shrug.go
+++ b/server/channels/app/slashcommands/command_shrug.go
@@ -35,7 +35,7 @@ func (*ShrugProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Comman
 	}
 }
 
-func (*ShrugProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (*ShrugProvider) DoCommand(a *app.App, rctx request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	rmsg := `¯\\\_(ツ)\_/¯`
 	if message != "" {
 		rmsg = message + " " + rmsg

--- a/server/channels/app/support_packet.go
+++ b/server/channels/app/support_packet.go
@@ -20,7 +20,7 @@ import (
 )
 
 func (a *App) GenerateSupportPacket(rctx request.CTX, options *model.SupportPacketOptions) []model.FileData {
-	functions := map[string]func(c request.CTX) (*model.FileData, error){
+	functions := map[string]func(rctx request.CTX) (*model.FileData, error){
 		"metadata":    a.getSupportPacketMetadata,
 		"stats":       a.getSupportPacketStats,
 		"jobs":        a.getSupportPacketJobList,

--- a/server/channels/app/team.go
+++ b/server/channels/app/team.go
@@ -103,8 +103,8 @@ func (a *App) AdjustTeamsFromProductLimits(teamLimits *model.TeamsLimits) *model
 	return nil
 }
 
-func (a *App) CreateTeam(c request.CTX, team *model.Team) (*model.Team, *model.AppError) {
-	rteam, err := a.ch.srv.teamService.CreateTeam(c, team)
+func (a *App) CreateTeam(rctx request.CTX, team *model.Team) (*model.Team, *model.AppError) {
+	rteam, err := a.ch.srv.teamService.CreateTeam(rctx, team)
 	if err != nil {
 		var invErr *store.ErrInvalidInput
 
@@ -139,7 +139,7 @@ func (a *App) CreateTeam(c request.CTX, team *model.Team) (*model.Team, *model.A
 	return rteam, nil
 }
 
-func (a *App) CreateTeamWithUser(c request.CTX, team *model.Team, userID string) (*model.Team, *model.AppError) {
+func (a *App) CreateTeamWithUser(rctx request.CTX, team *model.Team, userID string) (*model.Team, *model.AppError) {
 	user, err := a.GetUser(userID)
 	if err != nil {
 		return nil, err
@@ -150,12 +150,12 @@ func (a *App) CreateTeamWithUser(c request.CTX, team *model.Team, userID string)
 		return nil, model.NewAppError("CreateTeamWithUser", "api.team.is_team_creation_allowed.domain.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	rteam, err := a.CreateTeam(c, team)
+	rteam, err := a.CreateTeam(rctx, team)
 	if err != nil {
 		return nil, err
 	}
 
-	if _, err := a.JoinUserToTeam(c, rteam, user, ""); err != nil {
+	if _, err := a.JoinUserToTeam(rctx, rteam, user, ""); err != nil {
 		return nil, err
 	}
 
@@ -392,8 +392,8 @@ func (a *App) GetSchemeRolesForTeam(teamID string) (string, string, string, *mod
 	return model.TeamGuestRoleId, model.TeamUserRoleId, model.TeamAdminRoleId, nil
 }
 
-func (a *App) UpdateTeamMemberRoles(c request.CTX, teamID string, userID string, newRoles string) (*model.TeamMember, *model.AppError) {
-	member, nErr := a.Srv().Store().Team().GetMember(c, teamID, userID)
+func (a *App) UpdateTeamMemberRoles(rctx request.CTX, teamID string, userID string, newRoles string) (*model.TeamMember, *model.AppError) {
+	member, nErr := a.Srv().Store().Team().GetMember(rctx, teamID, userID)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -456,7 +456,7 @@ func (a *App) UpdateTeamMemberRoles(c request.CTX, teamID string, userID string,
 
 	member.ExplicitRoles = strings.Join(newExplicitRoles, " ")
 
-	member, nErr = a.Srv().Store().Team().UpdateMember(c, member)
+	member, nErr = a.Srv().Store().Team().UpdateMember(rctx, member)
 	if nErr != nil {
 		var appErr *model.AppError
 		switch {
@@ -476,8 +476,8 @@ func (a *App) UpdateTeamMemberRoles(c request.CTX, teamID string, userID string,
 	return member, nil
 }
 
-func (a *App) UpdateTeamMemberSchemeRoles(c request.CTX, teamID string, userID string, isSchemeGuest bool, isSchemeUser bool, isSchemeAdmin bool) (*model.TeamMember, *model.AppError) {
-	member, err := a.GetTeamMember(c, teamID, userID)
+func (a *App) UpdateTeamMemberSchemeRoles(rctx request.CTX, teamID string, userID string, isSchemeGuest bool, isSchemeUser bool, isSchemeAdmin bool) (*model.TeamMember, *model.AppError) {
+	member, err := a.GetTeamMember(rctx, teamID, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -503,7 +503,7 @@ func (a *App) UpdateTeamMemberSchemeRoles(c request.CTX, teamID string, userID s
 		member.ExplicitRoles = removeRoles([]string{model.TeamGuestRoleId, model.TeamUserRoleId, model.TeamAdminRoleId}, member.ExplicitRoles)
 	}
 
-	member, nErr := a.Srv().Store().Team().UpdateMember(c, member)
+	member, nErr := a.Srv().Store().Team().UpdateMember(rctx, member)
 	if nErr != nil {
 		var appErr *model.AppError
 		switch {
@@ -534,7 +534,7 @@ func (a *App) sendUpdatedTeamMemberEvent(member *model.TeamMember) *model.AppErr
 	return nil
 }
 
-func (a *App) AddUserToTeam(c request.CTX, teamID string, userID string, userRequestorId string) (*model.Team, *model.TeamMember, *model.AppError) {
+func (a *App) AddUserToTeam(rctx request.CTX, teamID string, userID string, userRequestorId string) (*model.Team, *model.TeamMember, *model.AppError) {
 	tchan := make(chan store.StoreResult[*model.Team], 1)
 	go func() {
 		team, err := a.Srv().Store().Team().Get(teamID)
@@ -573,7 +573,7 @@ func (a *App) AddUserToTeam(c request.CTX, teamID string, userID string, userReq
 	}
 	user := userChanResult.Data
 
-	teamMember, err := a.JoinUserToTeam(c, team, user, userRequestorId)
+	teamMember, err := a.JoinUserToTeam(rctx, team, user, userRequestorId)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -581,7 +581,7 @@ func (a *App) AddUserToTeam(c request.CTX, teamID string, userID string, userReq
 	return team, teamMember, nil
 }
 
-func (a *App) AddUserToTeamByTeamId(c request.CTX, teamID string, user *model.User) *model.AppError {
+func (a *App) AddUserToTeamByTeamId(rctx request.CTX, teamID string, user *model.User) *model.AppError {
 	team, err := a.Srv().Store().Team().Get(teamID)
 	if err != nil {
 		var nfErr *store.ErrNotFound
@@ -593,13 +593,13 @@ func (a *App) AddUserToTeamByTeamId(c request.CTX, teamID string, user *model.Us
 		}
 	}
 
-	if _, err := a.JoinUserToTeam(c, team, user, ""); err != nil {
+	if _, err := a.JoinUserToTeam(rctx, team, user, ""); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (a *App) AddUserToTeamByToken(c request.CTX, userID string, tokenID string) (*model.Team, *model.TeamMember, *model.AppError) {
+func (a *App) AddUserToTeamByToken(rctx request.CTX, userID string, tokenID string) (*model.Team, *model.TeamMember, *model.AppError) {
 	token, err := a.Srv().Store().Token().GetByToken(tokenID)
 	if err != nil {
 		return nil, nil, model.NewAppError("AddUserToTeamByToken", "api.user.create_user.signup_link_invalid.app_error", nil, "", http.StatusBadRequest).Wrap(err)
@@ -611,7 +611,7 @@ func (a *App) AddUserToTeamByToken(c request.CTX, userID string, tokenID string)
 
 	if model.GetMillis()-token.CreateAt >= InvitationExpiryTime {
 		if err := a.DeleteToken(token); err != nil {
-			c.Logger().Warn("Error deleting expired team invitation token during team join", mlog.String("token_id", token.Token), mlog.String("token_type", token.Type), mlog.Err(err))
+			rctx.Logger().Warn("Error deleting expired team invitation token during team join", mlog.String("token_id", token.Token), mlog.String("token_type", token.Type), mlog.Err(err))
 		}
 		return nil, nil, model.NewAppError("AddUserToTeamByToken", "api.user.create_user.signup_link_expired.app_error", nil, "", http.StatusBadRequest)
 	}
@@ -667,7 +667,7 @@ func (a *App) AddUserToTeamByToken(c request.CTX, userID string, tokenID string)
 		return nil, nil, model.NewAppError("AddUserToTeamByToken", "api.user.create_user.invalid_invitation_type.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	teamMember, appErr := a.JoinUserToTeam(c, team, user, "")
+	teamMember, appErr := a.JoinUserToTeam(rctx, team, user, "")
 	if appErr != nil {
 		return nil, nil, appErr
 	}
@@ -679,21 +679,21 @@ func (a *App) AddUserToTeamByToken(c request.CTX, userID string, tokenID string)
 		}
 
 		for _, channel := range channels {
-			_, err := a.AddUserToChannel(c, user, channel, false)
+			_, err := a.AddUserToChannel(rctx, user, channel, false)
 			if err != nil {
-				c.Logger().Warn("Error adding user to channel", mlog.Err(err))
+				rctx.Logger().Warn("Error adding user to channel", mlog.Err(err))
 			}
 		}
 	}
 
 	if err := a.DeleteToken(token); err != nil {
-		c.Logger().Warn("Error while deleting token", mlog.Err(err))
+		rctx.Logger().Warn("Error while deleting token", mlog.Err(err))
 	}
 
 	return team, teamMember, nil
 }
 
-func (a *App) AddUserToTeamByInviteId(c request.CTX, inviteId string, userID string) (*model.Team, *model.TeamMember, *model.AppError) {
+func (a *App) AddUserToTeamByInviteId(rctx request.CTX, inviteId string, userID string) (*model.Team, *model.TeamMember, *model.AppError) {
 	tchan := make(chan store.StoreResult[*model.Team], 1)
 	go func() {
 		team, err := a.Srv().Store().Team().GetByInviteId(inviteId)
@@ -732,7 +732,7 @@ func (a *App) AddUserToTeamByInviteId(c request.CTX, inviteId string, userID str
 	}
 	user := userChanResult.Data
 
-	teamMember, err := a.JoinUserToTeam(c, team, user, "")
+	teamMember, err := a.JoinUserToTeam(rctx, team, user, "")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -740,8 +740,8 @@ func (a *App) AddUserToTeamByInviteId(c request.CTX, inviteId string, userID str
 	return team, teamMember, nil
 }
 
-func (a *App) JoinUserToTeam(c request.CTX, team *model.Team, user *model.User, userRequestorId string) (*model.TeamMember, *model.AppError) {
-	teamMember, alreadyAdded, err := a.ch.srv.teamService.JoinUserToTeam(c, team, user)
+func (a *App) JoinUserToTeam(rctx request.CTX, team *model.Team, user *model.User, userRequestorId string) (*model.TeamMember, *model.AppError) {
+	teamMember, alreadyAdded, err := a.ch.srv.teamService.JoinUserToTeam(rctx, team, user)
 	if err != nil {
 		var appErr *model.AppError
 		var conflictErr *store.ErrConflict
@@ -771,8 +771,8 @@ func (a *App) JoinUserToTeam(c request.CTX, team *model.Team, user *model.User, 
 		return nil, model.NewAppError("JoinUserToTeam", "app.user.update_update.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
-	if _, err := a.createInitialSidebarCategories(c, user.Id, team.Id); err != nil {
-		c.Logger().Warn(
+	if _, err := a.createInitialSidebarCategories(rctx, user.Id, team.Id); err != nil {
+		rctx.Logger().Warn(
 			"Encountered an issue creating default sidebar categories.",
 			mlog.String("user_id", user.Id),
 			mlog.String("team_id", team.Id),
@@ -784,8 +784,8 @@ func (a *App) JoinUserToTeam(c request.CTX, team *model.Team, user *model.User, 
 
 	if !user.IsGuest() {
 		// Soft error if there is an issue joining the default channels
-		if err := a.JoinDefaultChannels(c, team.Id, user, shouldBeAdmin, userRequestorId); err != nil {
-			c.Logger().Warn(
+		if err := a.JoinDefaultChannels(rctx, team.Id, user, shouldBeAdmin, userRequestorId); err != nil {
+			rctx.Logger().Warn(
 				"Encountered an issue joining default channels.",
 				mlog.String("user_id", user.Id),
 				mlog.String("team_id", team.Id),
@@ -804,7 +804,7 @@ func (a *App) JoinUserToTeam(c request.CTX, team *model.Team, user *model.User, 
 	}
 
 	a.Srv().Go(func() {
-		pluginContext := pluginContext(c)
+		pluginContext := pluginContext(rctx)
 		a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 			hooks.UserHasJoinedTeam(pluginContext, teamMember, actor)
 			return true
@@ -986,8 +986,8 @@ func (a *App) GetTeamMember(rctx request.CTX, teamID, userID string) (*model.Tea
 	return teamMember, nil
 }
 
-func (a *App) GetTeamMembersForUser(c request.CTX, userID string, excludeTeamID string, includeDeleted bool) ([]*model.TeamMember, *model.AppError) {
-	teamMembers, err := a.Srv().Store().Team().GetTeamsForUser(c, userID, excludeTeamID, includeDeleted)
+func (a *App) GetTeamMembersForUser(rctx request.CTX, userID string, excludeTeamID string, includeDeleted bool) ([]*model.TeamMember, *model.AppError) {
+	teamMembers, err := a.Srv().Store().Team().GetTeamsForUser(rctx, userID, excludeTeamID, includeDeleted)
 	if err != nil {
 		return nil, model.NewAppError("GetTeamMembersForUser", "app.team.get_members.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -1030,8 +1030,8 @@ func (a *App) GetCommonTeamIDsForTwoUsers(userID, otherUserID string) ([]string,
 	return teamIDs, nil
 }
 
-func (a *App) AddTeamMember(c request.CTX, teamID, userID string) (*model.TeamMember, *model.AppError) {
-	_, teamMember, err := a.AddUserToTeam(c, teamID, userID, "")
+func (a *App) AddTeamMember(rctx request.CTX, teamID, userID string) (*model.TeamMember, *model.AppError) {
+	_, teamMember, err := a.AddUserToTeam(rctx, teamID, userID, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1044,11 +1044,11 @@ func (a *App) AddTeamMember(c request.CTX, teamID, userID string) (*model.TeamMe
 	return teamMember, nil
 }
 
-func (a *App) AddTeamMembers(c request.CTX, teamID string, userIDs []string, userRequestorId string, graceful bool) ([]*model.TeamMemberWithError, *model.AppError) {
+func (a *App) AddTeamMembers(rctx request.CTX, teamID string, userIDs []string, userRequestorId string, graceful bool) ([]*model.TeamMemberWithError, *model.AppError) {
 	var membersWithErrors []*model.TeamMemberWithError
 
 	for _, userID := range userIDs {
-		_, teamMember, err := a.AddUserToTeam(c, teamID, userID, userRequestorId)
+		_, teamMember, err := a.AddUserToTeam(rctx, teamID, userID, userRequestorId)
 		if err != nil {
 			if graceful {
 				membersWithErrors = append(membersWithErrors, &model.TeamMemberWithError{
@@ -1074,8 +1074,8 @@ func (a *App) AddTeamMembers(c request.CTX, teamID string, userIDs []string, use
 	return membersWithErrors, nil
 }
 
-func (a *App) AddTeamMemberByToken(c request.CTX, userID, tokenID string) (*model.TeamMember, *model.AppError) {
-	_, teamMember, err := a.AddUserToTeamByToken(c, userID, tokenID)
+func (a *App) AddTeamMemberByToken(rctx request.CTX, userID, tokenID string) (*model.TeamMember, *model.AppError) {
+	_, teamMember, err := a.AddUserToTeamByToken(rctx, userID, tokenID)
 	if err != nil {
 		return nil, err
 	}
@@ -1083,8 +1083,8 @@ func (a *App) AddTeamMemberByToken(c request.CTX, userID, tokenID string) (*mode
 	return teamMember, nil
 }
 
-func (a *App) AddTeamMemberByInviteId(c request.CTX, inviteId, userID string) (*model.TeamMember, *model.AppError) {
-	team, teamMember, err := a.AddUserToTeamByInviteId(c, inviteId, userID)
+func (a *App) AddTeamMemberByInviteId(rctx request.CTX, inviteId, userID string) (*model.TeamMember, *model.AppError) {
+	team, teamMember, err := a.AddUserToTeamByInviteId(rctx, inviteId, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -1122,7 +1122,7 @@ func (a *App) GetTeamUnread(teamID, userID string) (*model.TeamUnread, *model.Ap
 	return teamUnread, nil
 }
 
-func (a *App) RemoveUserFromTeam(c request.CTX, teamID string, userID string, requestorId string) *model.AppError {
+func (a *App) RemoveUserFromTeam(rctx request.CTX, teamID string, userID string, requestorId string) *model.AppError {
 	tchan := make(chan store.StoreResult[*model.Team], 1)
 	go func() {
 		team, err := a.Srv().Store().Team().Get(teamID)
@@ -1161,21 +1161,21 @@ func (a *App) RemoveUserFromTeam(c request.CTX, teamID string, userID string, re
 	}
 	user := userChanResult.Data
 
-	if err := a.LeaveTeam(c, team, user, requestorId); err != nil {
+	if err := a.LeaveTeam(rctx, team, user, requestorId); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (a *App) postProcessTeamMemberLeave(c request.CTX, teamMember *model.TeamMember, requestorId string) *model.AppError {
+func (a *App) postProcessTeamMemberLeave(rctx request.CTX, teamMember *model.TeamMember, requestorId string) *model.AppError {
 	var actor *model.User
 	if requestorId != "" {
 		actor, _ = a.GetUser(requestorId)
 	}
 
 	a.Srv().Go(func() {
-		pluginContext := pluginContext(c)
+		pluginContext := pluginContext(rctx)
 		a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 			hooks.UserHasLeftTeam(pluginContext, teamMember, actor)
 			return true
@@ -1213,8 +1213,8 @@ func (a *App) postProcessTeamMemberLeave(c request.CTX, teamMember *model.TeamMe
 	return nil
 }
 
-func (a *App) LeaveTeam(c request.CTX, team *model.Team, user *model.User, requestorId string) *model.AppError {
-	teamMember, err := a.GetTeamMember(c, team.Id, user.Id)
+func (a *App) LeaveTeam(rctx request.CTX, team *model.Team, user *model.User, requestorId string) *model.AppError {
+	teamMember, err := a.GetTeamMember(rctx, team.Id, user.Id)
 	if err != nil {
 		return model.NewAppError("LeaveTeam", "api.team.remove_user_from_team.missing.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
@@ -1236,7 +1236,7 @@ func (a *App) LeaveTeam(c request.CTX, team *model.Team, user *model.User, reque
 	for _, channel := range channelList {
 		if !channel.IsGroupOrDirect() {
 			a.invalidateCacheForChannelMembers(channel.Id)
-			if nErr = a.Srv().Store().Channel().RemoveMember(c, channel.Id, user.Id); nErr != nil {
+			if nErr = a.Srv().Store().Channel().RemoveMember(rctx, channel.Id, user.Id); nErr != nil {
 				return model.NewAppError("LeaveTeam", "app.channel.remove_member.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)
 			}
 		}
@@ -1255,28 +1255,28 @@ func (a *App) LeaveTeam(c request.CTX, team *model.Team, user *model.User, reque
 		}
 
 		if requestorId == user.Id {
-			if err = a.postLeaveTeamMessage(c, user, channel); err != nil {
-				c.Logger().Warn("Failed to post join/leave message", mlog.Err(err))
+			if err = a.postLeaveTeamMessage(rctx, user, channel); err != nil {
+				rctx.Logger().Warn("Failed to post join/leave message", mlog.Err(err))
 			}
 		} else {
-			if err = a.postRemoveFromTeamMessage(c, user, channel); err != nil {
-				c.Logger().Warn("Failed to post join/leave message", mlog.Err(err))
+			if err = a.postRemoveFromTeamMessage(rctx, user, channel); err != nil {
+				rctx.Logger().Warn("Failed to post join/leave message", mlog.Err(err))
 			}
 		}
 	}
 
-	if err := a.ch.srv.teamService.RemoveTeamMember(c, teamMember); err != nil {
+	if err := a.ch.srv.teamService.RemoveTeamMember(rctx, teamMember); err != nil {
 		return model.NewAppError("RemoveTeamMemberFromTeam", "app.team.save_member.save.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
-	if err := a.postProcessTeamMemberLeave(c, teamMember, requestorId); err != nil {
+	if err := a.postProcessTeamMemberLeave(rctx, teamMember, requestorId); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (a *App) postLeaveTeamMessage(c request.CTX, user *model.User, channel *model.Channel) *model.AppError {
+func (a *App) postLeaveTeamMessage(rctx request.CTX, user *model.User, channel *model.Channel) *model.AppError {
 	post := &model.Post{
 		ChannelId: channel.Id,
 		Message:   fmt.Sprintf(i18n.T("api.team.leave.left"), user.Username),
@@ -1287,14 +1287,14 @@ func (a *App) postLeaveTeamMessage(c request.CTX, user *model.User, channel *mod
 		},
 	}
 
-	if _, err := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
+	if _, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
 		return model.NewAppError("postRemoveFromChannelMessage", "api.channel.post_user_add_remove_message_and_forget.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	return nil
 }
 
-func (a *App) postRemoveFromTeamMessage(c request.CTX, user *model.User, channel *model.Channel) *model.AppError {
+func (a *App) postRemoveFromTeamMessage(rctx request.CTX, user *model.User, channel *model.Channel) *model.AppError {
 	post := &model.Post{
 		ChannelId: channel.Id,
 		Message:   fmt.Sprintf(i18n.T("api.team.remove_user_from_team.removed"), user.Username),
@@ -1305,7 +1305,7 @@ func (a *App) postRemoveFromTeamMessage(c request.CTX, user *model.User, channel
 		},
 	}
 
-	if _, err := a.CreatePost(c, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
+	if _, err := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); err != nil {
 		return model.NewAppError("postRemoveFromTeamMessage", "api.channel.post_user_add_remove_message_and_forget.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
@@ -1729,16 +1729,16 @@ func (a *App) GetTeamsUnreadForUser(excludeTeamId string, userID string, include
 	return members, nil
 }
 
-func (a *App) PermanentDeleteTeamId(c request.CTX, teamID string) *model.AppError {
+func (a *App) PermanentDeleteTeamId(rctx request.CTX, teamID string) *model.AppError {
 	team, err := a.GetTeam(teamID)
 	if err != nil {
 		return err
 	}
 
-	return a.PermanentDeleteTeam(c, team)
+	return a.PermanentDeleteTeam(rctx, team)
 }
 
-func (a *App) PermanentDeleteTeam(c request.CTX, team *model.Team) *model.AppError {
+func (a *App) PermanentDeleteTeam(rctx request.CTX, team *model.Team) *model.AppError {
 	team.DeleteAt = model.GetMillis()
 	if _, err := a.Srv().Store().Team().Update(team); err != nil {
 		var invErr *store.ErrInvalidInput
@@ -1760,8 +1760,8 @@ func (a *App) PermanentDeleteTeam(c request.CTX, team *model.Team) *model.AppErr
 		}
 	} else {
 		for _, ch := range channels {
-			if err := a.PermanentDeleteChannel(c, ch); err != nil {
-				c.Logger().Warn("Error permanently deleting channel during team deletion", mlog.String("channel_id", ch.Id), mlog.String("team_id", team.Id), mlog.Err(err))
+			if err := a.PermanentDeleteChannel(rctx, ch); err != nil {
+				rctx.Logger().Warn("Error permanently deleting channel during team deletion", mlog.String("channel_id", ch.Id), mlog.String("team_id", team.Id), mlog.Err(err))
 			}
 		}
 	}
@@ -2049,33 +2049,33 @@ func (a *App) RemoveTeamIcon(teamID string) *model.AppError {
 	return nil
 }
 
-func (a *App) InvalidateAllEmailInvites(c request.CTX) *model.AppError {
+func (a *App) InvalidateAllEmailInvites(rctx request.CTX) *model.AppError {
 	if err := a.Srv().Store().Token().RemoveAllTokensByType(TokenTypeTeamInvitation); err != nil {
 		return model.NewAppError("InvalidateAllEmailInvites", "api.team.invalidate_all_email_invites.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	if err := a.Srv().Store().Token().RemoveAllTokensByType(TokenTypeGuestInvitation); err != nil {
 		return model.NewAppError("InvalidateAllEmailInvites", "api.team.invalidate_all_email_invites.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
-	if err := a.InvalidateAllResendInviteEmailJobs(c); err != nil {
+	if err := a.InvalidateAllResendInviteEmailJobs(rctx); err != nil {
 		return model.NewAppError("InvalidateAllEmailInvites", "api.team.invalidate_all_email_invites.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	return nil
 }
 
-func (a *App) InvalidateAllResendInviteEmailJobs(c request.CTX) *model.AppError {
-	jobs, appErr := a.Srv().Jobs.GetJobsByTypeAndStatus(c, model.JobTypeResendInvitationEmail, model.JobStatusPending)
+func (a *App) InvalidateAllResendInviteEmailJobs(rctx request.CTX) *model.AppError {
+	jobs, appErr := a.Srv().Jobs.GetJobsByTypeAndStatus(rctx, model.JobTypeResendInvitationEmail, model.JobStatusPending)
 	if appErr != nil {
 		return appErr
 	}
 
 	for _, j := range jobs {
 		if err := a.Srv().Jobs.SetJobCanceled(j); err != nil {
-			c.Logger().Warn("Error canceling resend invitation email job during team invitation invalidation", mlog.String("job_id", j.Id), mlog.Err(err))
+			rctx.Logger().Warn("Error canceling resend invitation email job during team invitation invalidation", mlog.String("job_id", j.Id), mlog.Err(err))
 		}
 		// clean up any system values this job was using
 		_, err := a.Srv().Store().System().PermanentDeleteByName(j.Id)
 		if err != nil {
-			c.Logger().Warn("Error deleting system values for resend invitation email job during team invitation invalidation", mlog.String("job_id", j.Id), mlog.Err(err))
+			rctx.Logger().Warn("Error deleting system values for resend invitation email job during team invitation invalidation", mlog.String("job_id", j.Id), mlog.Err(err))
 		}
 	}
 

--- a/server/channels/app/teams/teams.go
+++ b/server/channels/app/teams/teams.go
@@ -227,8 +227,8 @@ func (ts *TeamService) RemoveTeamMember(rctx request.CTX, teamMember *model.Team
 }
 
 // GetMember return the team member from the team.
-func (ts *TeamService) GetMember(c request.CTX, teamID string, userID string) (*model.TeamMember, error) {
-	member, err := ts.store.GetMember(c, teamID, userID)
+func (ts *TeamService) GetMember(rctx request.CTX, teamID string, userID string) (*model.TeamMember, error) {
+	member, err := ts.store.GetMember(rctx, teamID, userID)
 	if err != nil {
 		return nil, err
 	}

--- a/server/channels/app/upload.go
+++ b/server/channels/app/upload.go
@@ -48,7 +48,7 @@ func (a *App) genFileInfoFromReader(name string, file io.ReadSeeker, size int64)
 	return info, nil
 }
 
-func (a *App) runPluginsHook(c request.CTX, info *model.FileInfo, file io.Reader) *model.AppError {
+func (a *App) runPluginsHook(rctx request.CTX, info *model.FileInfo, file io.Reader) *model.AppError {
 	filePath := info.Path
 	// using a pipe to avoid loading the whole file content in memory.
 	r, w := io.Pipe()
@@ -61,7 +61,7 @@ func (a *App) runPluginsHook(c request.CTX, info *model.FileInfo, file io.Reader
 		defer close(errChan)
 		var rejErr *model.AppError
 		var once sync.Once
-		pluginContext := pluginContext(c)
+		pluginContext := pluginContext(rctx)
 		a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 			once.Do(func() {
 				hookHasRunCh <- struct{}{}
@@ -91,7 +91,7 @@ func (a *App) runPluginsHook(c request.CTX, info *model.FileInfo, file io.Reader
 	written, err := a.WriteFile(r, tmpPath)
 	if err != nil {
 		if fileErr := a.RemoveFile(tmpPath); fileErr != nil {
-			c.Logger().Warn("Failed to remove file", mlog.Err(fileErr))
+			rctx.Logger().Warn("Failed to remove file", mlog.Err(fileErr))
 		}
 		r.CloseWithError(err) // always returns nil
 		return err
@@ -99,10 +99,10 @@ func (a *App) runPluginsHook(c request.CTX, info *model.FileInfo, file io.Reader
 
 	if err = <-errChan; err != nil {
 		if fileErr := a.RemoveFile(info.Path); fileErr != nil {
-			c.Logger().Warn("Failed to remove file", mlog.Err(fileErr))
+			rctx.Logger().Warn("Failed to remove file", mlog.Err(fileErr))
 		}
 		if fileErr := a.RemoveFile(tmpPath); fileErr != nil {
-			c.Logger().Warn("Failed to remove file", mlog.Err(fileErr))
+			rctx.Logger().Warn("Failed to remove file", mlog.Err(fileErr))
 		}
 		return err
 	}
@@ -115,14 +115,14 @@ func (a *App) runPluginsHook(c request.CTX, info *model.FileInfo, file io.Reader
 		}
 	} else {
 		if fileErr := a.RemoveFile(tmpPath); fileErr != nil {
-			c.Logger().Warn("Failed to remove file", mlog.Err(fileErr))
+			rctx.Logger().Warn("Failed to remove file", mlog.Err(fileErr))
 		}
 	}
 
 	return nil
 }
 
-func (a *App) CreateUploadSession(c request.CTX, us *model.UploadSession) (*model.UploadSession, *model.AppError) {
+func (a *App) CreateUploadSession(rctx request.CTX, us *model.UploadSession) (*model.UploadSession, *model.AppError) {
 	us.FileOffset = 0
 	now := time.Now()
 	us.CreateAt = model.GetMillisForTime(now)
@@ -136,7 +136,7 @@ func (a *App) CreateUploadSession(c request.CTX, us *model.UploadSession) (*mode
 	}
 
 	if us.Type == model.UploadTypeAttachment {
-		channel, err := a.GetChannel(c, us.ChannelId)
+		channel, err := a.GetChannel(rctx, us.ChannelId)
 		if err != nil {
 			return nil, model.NewAppError("CreateUploadSession", "app.upload.create.incorrect_channel_id.app_error",
 				map[string]any{"channelId": us.ChannelId}, "", http.StatusBadRequest)
@@ -155,8 +155,8 @@ func (a *App) CreateUploadSession(c request.CTX, us *model.UploadSession) (*mode
 	return us, nil
 }
 
-func (a *App) GetUploadSession(c request.CTX, uploadId string) (*model.UploadSession, *model.AppError) {
-	us, err := a.Srv().Store().UploadSession().Get(c, uploadId)
+func (a *App) GetUploadSession(rctx request.CTX, uploadId string) (*model.UploadSession, *model.AppError) {
+	us, err := a.Srv().Store().UploadSession().Get(rctx, uploadId)
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -180,7 +180,7 @@ func (a *App) GetUploadSessionsForUser(userID string) ([]*model.UploadSession, *
 	return uss, nil
 }
 
-func (a *App) UploadData(c request.CTX, us *model.UploadSession, rd io.Reader) (*model.FileInfo, *model.AppError) {
+func (a *App) UploadData(rctx request.CTX, us *model.UploadSession, rd io.Reader) (*model.FileInfo, *model.AppError) {
 	// prevent more than one caller to upload data at the same time for a given upload session.
 	// This is to avoid possible inconsistencies.
 	a.ch.uploadLockMapMut.Lock()
@@ -203,8 +203,8 @@ func (a *App) UploadData(c request.CTX, us *model.UploadSession, rd io.Reader) (
 	}()
 
 	// fetch the session from store to check for inconsistencies.
-	c = c.With(RequestContextWithMaster)
-	if storedSession, err := a.GetUploadSession(c, us.Id); err != nil {
+	rctx = rctx.With(RequestContextWithMaster)
+	if storedSession, err := a.GetUploadSession(rctx, us.Id); err != nil {
 		return nil, err
 	} else if us.FileOffset != storedSession.FileOffset {
 		return nil, model.NewAppError("UploadData", "app.upload.upload_data.concurrent.app_error",
@@ -231,7 +231,7 @@ func (a *App) UploadData(c request.CTX, us *model.UploadSession, rd io.Reader) (
 		}
 		if written < minFirstPartSize && written != us.FileSize {
 			if fileErr := a.RemoveFile(uploadPath); fileErr != nil {
-				c.Logger().Warn("Failed to remove initial upload chunk that was too small",
+				rctx.Logger().Warn("Failed to remove initial upload chunk that was too small",
 					mlog.Err(fileErr),
 					mlog.String("upload_path", uploadPath),
 					mlog.String("upload_id", us.Id),
@@ -288,7 +288,7 @@ func (a *App) UploadData(c request.CTX, us *model.UploadSession, rd io.Reader) (
 	}
 
 	// run plugins upload hook
-	if err := a.runPluginsHook(c, info, file); err != nil {
+	if err := a.runPluginsHook(rctx, info, file); err != nil {
 		return nil, err
 	}
 
@@ -306,7 +306,7 @@ func (a *App) UploadData(c request.CTX, us *model.UploadSession, rd io.Reader) (
 		if fileErr != nil {
 			return nil, fileErr
 		}
-		a.HandleImages(c, []string{info.PreviewPath}, []string{info.ThumbnailPath}, [][]byte{imgData})
+		a.HandleImages(rctx, []string{info.PreviewPath}, []string{info.ThumbnailPath}, [][]byte{imgData})
 	}
 
 	if us.Type == model.UploadTypeImport {
@@ -316,7 +316,7 @@ func (a *App) UploadData(c request.CTX, us *model.UploadSession, rd io.Reader) (
 	}
 
 	var storeErr error
-	if info, storeErr = a.Srv().Store().FileInfo().Save(c, info); storeErr != nil {
+	if info, storeErr = a.Srv().Store().FileInfo().Save(rctx, info); storeErr != nil {
 		var appErr *model.AppError
 		switch {
 		case errors.As(storeErr, &appErr):
@@ -329,16 +329,16 @@ func (a *App) UploadData(c request.CTX, us *model.UploadSession, rd io.Reader) (
 	if *a.Config().FileSettings.ExtractContent {
 		infoCopy := *info
 		a.Srv().Go(func() {
-			err := a.ExtractContentFromFileInfo(c, &infoCopy)
+			err := a.ExtractContentFromFileInfo(rctx, &infoCopy)
 			if err != nil {
-				c.Logger().Error("Failed to extract file content", mlog.Err(err), mlog.String("fileInfoId", infoCopy.Id))
+				rctx.Logger().Error("Failed to extract file content", mlog.Err(err), mlog.String("fileInfoId", infoCopy.Id))
 			}
 		})
 	}
 
 	// delete upload session
 	if storeErr := a.Srv().Store().UploadSession().Delete(us.Id); storeErr != nil {
-		c.Logger().Warn("Failed to delete UploadSession", mlog.Err(storeErr))
+		rctx.Logger().Warn("Failed to delete UploadSession", mlog.Err(storeErr))
 	}
 
 	return info, nil

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -43,7 +43,7 @@ const (
 	ImageProfilePixelDimension = 128
 )
 
-func (a *App) CreateUserWithToken(c request.CTX, user *model.User, token *model.Token) (*model.User, *model.AppError) {
+func (a *App) CreateUserWithToken(rctx request.CTX, user *model.User, token *model.Token) (*model.User, *model.AppError) {
 	if err := a.IsUserSignUpAllowed(); err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func (a *App) CreateUserWithToken(c request.CTX, user *model.User, token *model.
 
 	if model.GetMillis()-token.CreateAt >= InvitationExpiryTime {
 		if appErr := a.DeleteToken(token); appErr != nil {
-			c.Logger().Warn("Error while deleting expired signup-invite token", mlog.Err(appErr))
+			rctx.Logger().Warn("Error while deleting expired signup-invite token", mlog.Err(appErr))
 		}
 		return nil, model.NewAppError("CreateUserWithToken", "api.user.create_user.signup_link_expired.app_error", nil, "", http.StatusBadRequest)
 	}
@@ -78,7 +78,7 @@ func (a *App) CreateUserWithToken(c request.CTX, user *model.User, token *model.
 	channelIds := strings.Split(tokenData["channels"], " ")
 
 	// filter the channels the original inviter has still permissions over
-	channelIds = a.ValidateUserPermissionsOnChannels(c, senderId, channelIds)
+	channelIds = a.ValidateUserPermissionsOnChannels(rctx, senderId, channelIds)
 
 	channels, nErr := a.Srv().Store().Channel().GetChannelsByIds(channelIds, false)
 	if nErr != nil {
@@ -96,39 +96,39 @@ func (a *App) CreateUserWithToken(c request.CTX, user *model.User, token *model.
 	var ruser *model.User
 	var err *model.AppError
 	if token.Type == TokenTypeTeamInvitation {
-		ruser, err = a.CreateUser(c, user)
+		ruser, err = a.CreateUser(rctx, user)
 	} else {
-		ruser, err = a.CreateGuest(c, user)
+		ruser, err = a.CreateGuest(rctx, user)
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	if _, err := a.JoinUserToTeam(c, team, ruser, ""); err != nil {
+	if _, err := a.JoinUserToTeam(rctx, team, ruser, ""); err != nil {
 		return nil, err
 	}
 
-	if appErr := a.AddDirectChannels(c, team.Id, ruser); appErr != nil {
+	if appErr := a.AddDirectChannels(rctx, team.Id, ruser); appErr != nil {
 		return nil, appErr
 	}
 
 	if token.Type == TokenTypeGuestInvitation || (token.Type == TokenTypeTeamInvitation && len(channels) > 0) {
 		for _, channel := range channels {
-			_, err := a.AddChannelMember(c, ruser.Id, channel, ChannelMemberOpts{})
+			_, err := a.AddChannelMember(rctx, ruser.Id, channel, ChannelMemberOpts{})
 			if err != nil {
-				c.Logger().Warn("Failed to add channel member", mlog.Err(err))
+				rctx.Logger().Warn("Failed to add channel member", mlog.Err(err))
 			}
 		}
 	}
 
 	if err := a.DeleteToken(token); err != nil {
-		c.Logger().Warn("Error while deleting token", mlog.Err(err))
+		rctx.Logger().Warn("Error while deleting token", mlog.Err(err))
 	}
 
 	return ruser, nil
 }
 
-func (a *App) CreateUserWithInviteId(c request.CTX, user *model.User, inviteId, redirect string) (*model.User, *model.AppError) {
+func (a *App) CreateUserWithInviteId(rctx request.CTX, user *model.User, inviteId, redirect string) (*model.User, *model.AppError) {
 	if err := a.IsUserSignUpAllowed(); err != nil {
 		return nil, err
 	}
@@ -154,40 +154,40 @@ func (a *App) CreateUserWithInviteId(c request.CTX, user *model.User, inviteId, 
 
 	user.EmailVerified = false
 
-	ruser, err := a.CreateUser(c, user)
+	ruser, err := a.CreateUser(rctx, user)
 	if err != nil {
 		return nil, err
 	}
 
-	if _, err := a.JoinUserToTeam(c, team, ruser, ""); err != nil {
+	if _, err := a.JoinUserToTeam(rctx, team, ruser, ""); err != nil {
 		return nil, err
 	}
 
-	if appErr := a.AddDirectChannels(c, team.Id, ruser); appErr != nil {
+	if appErr := a.AddDirectChannels(rctx, team.Id, ruser); appErr != nil {
 		return nil, appErr
 	}
 
 	if err := a.Srv().EmailService.SendWelcomeEmail(ruser.Id, ruser.Email, ruser.EmailVerified, ruser.DisableWelcomeEmail, ruser.Locale, a.GetSiteURL(), redirect); err != nil {
-		c.Logger().Warn("Failed to send welcome email on create user with inviteId", mlog.Err(err))
+		rctx.Logger().Warn("Failed to send welcome email on create user with inviteId", mlog.Err(err))
 	}
 
 	return ruser, nil
 }
 
-func (a *App) CreateUserAsAdmin(c request.CTX, user *model.User, redirect string) (*model.User, *model.AppError) {
-	ruser, err := a.CreateUser(c, user)
+func (a *App) CreateUserAsAdmin(rctx request.CTX, user *model.User, redirect string) (*model.User, *model.AppError) {
+	ruser, err := a.CreateUser(rctx, user)
 	if err != nil {
 		return nil, err
 	}
 
 	if err := a.Srv().EmailService.SendWelcomeEmail(ruser.Id, ruser.Email, ruser.EmailVerified, ruser.DisableWelcomeEmail, ruser.Locale, a.GetSiteURL(), redirect); err != nil {
-		c.Logger().Warn("Failed to send welcome email to the new user, created by system admin", mlog.Err(err))
+		rctx.Logger().Warn("Failed to send welcome email to the new user, created by system admin", mlog.Err(err))
 	}
 
 	return ruser, nil
 }
 
-func (a *App) CreateUserFromSignup(c request.CTX, user *model.User, redirect string) (*model.User, *model.AppError) {
+func (a *App) CreateUserFromSignup(rctx request.CTX, user *model.User, redirect string) (*model.User, *model.AppError) {
 	if err := a.IsUserSignUpAllowed(); err != nil {
 		return nil, err
 	}
@@ -199,13 +199,13 @@ func (a *App) CreateUserFromSignup(c request.CTX, user *model.User, redirect str
 
 	user.EmailVerified = false
 
-	ruser, err := a.CreateUser(c, user)
+	ruser, err := a.CreateUser(rctx, user)
 	if err != nil {
 		return nil, err
 	}
 
 	if err := a.Srv().EmailService.SendWelcomeEmail(ruser.Id, ruser.Email, ruser.EmailVerified, ruser.DisableWelcomeEmail, ruser.Locale, a.GetSiteURL(), redirect); err != nil {
-		c.Logger().Warn("Failed to send welcome email on create user from signup", mlog.Err(err))
+		rctx.Logger().Warn("Failed to send welcome email on create user from signup", mlog.Err(err))
 	}
 
 	return ruser, nil
@@ -225,17 +225,17 @@ func (a *App) IsFirstUserAccount() bool {
 
 // CreateUser creates a user and sets several fields of the returned User struct to
 // their zero values.
-func (a *App) CreateUser(c request.CTX, user *model.User) (*model.User, *model.AppError) {
-	return a.createUserOrGuest(c, user, false)
+func (a *App) CreateUser(rctx request.CTX, user *model.User) (*model.User, *model.AppError) {
+	return a.createUserOrGuest(rctx, user, false)
 }
 
 // CreateGuest creates a guest and sets several fields of the returned User struct to
 // their zero values.
-func (a *App) CreateGuest(c request.CTX, user *model.User) (*model.User, *model.AppError) {
-	return a.createUserOrGuest(c, user, true)
+func (a *App) CreateGuest(rctx request.CTX, user *model.User) (*model.User, *model.AppError) {
+	return a.createUserOrGuest(rctx, user, true)
 }
 
-func (a *App) createUserOrGuest(c request.CTX, user *model.User, guest bool) (*model.User, *model.AppError) {
+func (a *App) createUserOrGuest(rctx request.CTX, user *model.User, guest bool) (*model.User, *model.AppError) {
 	atUserLimit, limitErr := a.isAtUserLimit()
 	if limitErr != nil {
 		return nil, limitErr
@@ -254,7 +254,7 @@ func (a *App) createUserOrGuest(c request.CTX, user *model.User, guest bool) (*m
 		return nil, err
 	}
 
-	ruser, nErr := a.ch.srv.userService.CreateUser(c, user, users.UserCreateOptions{Guest: guest})
+	ruser, nErr := a.ch.srv.userService.CreateUser(rctx, user, users.UserCreateOptions{Guest: guest})
 	if nErr != nil {
 		var appErr *model.AppError
 		var invErr *store.ErrInvalidInput
@@ -311,7 +311,7 @@ func (a *App) createUserOrGuest(c request.CTX, user *model.User, guest bool) (*m
 
 	preferences := model.Preferences{recommendedNextStepsPref, tutorialStepPref, gmASdmPref}
 	if err := a.Srv().Store().Preference().Save(preferences); err != nil {
-		c.Logger().Warn("Encountered error saving user preferences", mlog.Err(err))
+		rctx.Logger().Warn("Encountered error saving user preferences", mlog.Err(err))
 	}
 
 	go a.UpdateViewedProductNoticesForNewUser(ruser.Id)
@@ -321,7 +321,7 @@ func (a *App) createUserOrGuest(c request.CTX, user *model.User, guest bool) (*m
 	message.Add("user_id", ruser.Id)
 	a.Publish(message)
 
-	pluginContext := pluginContext(c)
+	pluginContext := pluginContext(rctx)
 	a.Srv().Go(func() {
 		a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 			hooks.UserHasBeenCreated(pluginContext, ruser)
@@ -333,14 +333,14 @@ func (a *App) createUserOrGuest(c request.CTX, user *model.User, guest bool) (*m
 	if limitErr != nil {
 		// we don't want to break the create user flow just because of this.
 		// So, we log the error, not return
-		c.Logger().Error("Error fetching user limits in createUserOrGuest", mlog.Err(limitErr))
+		rctx.Logger().Error("Error fetching user limits in createUserOrGuest", mlog.Err(limitErr))
 	} else {
 		if userLimits.MaxUsersLimit > 0 && userLimits.ActiveUserCount > userLimits.MaxUsersLimit {
 			// Use different warning messages based on whether server is licensed
 			if a.License() != nil {
-				c.Logger().Warn("ERROR_LICENSED_USERS_LIMIT_EXCEEDED: Created user exceeds the maximum licensed users.", mlog.Int("user_limit", userLimits.MaxUsersLimit))
+				rctx.Logger().Warn("ERROR_LICENSED_USERS_LIMIT_EXCEEDED: Created user exceeds the maximum licensed users.", mlog.Int("user_limit", userLimits.MaxUsersLimit))
 			} else {
-				c.Logger().Warn("ERROR_SAFETY_LIMITS_EXCEEDED: Created user exceeds the total activated users limit.", mlog.Int("user_limit", userLimits.MaxUsersLimit))
+				rctx.Logger().Warn("ERROR_SAFETY_LIMITS_EXCEEDED: Created user exceeds the total activated users limit.", mlog.Int("user_limit", userLimits.MaxUsersLimit))
 			}
 		}
 	}
@@ -348,7 +348,7 @@ func (a *App) createUserOrGuest(c request.CTX, user *model.User, guest bool) (*m
 	return ruser, nil
 }
 
-func (a *App) CreateOAuthUser(c request.CTX, service string, userData io.Reader, teamID string, tokenUser *model.User) (*model.User, *model.AppError) {
+func (a *App) CreateOAuthUser(rctx request.CTX, service string, userData io.Reader, teamID string, tokenUser *model.User) (*model.User, *model.AppError) {
 	if !*a.Config().TeamSettings.EnableUserCreation {
 		return nil, model.NewAppError("CreateOAuthUser", "api.user.create_user.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
@@ -357,7 +357,7 @@ func (a *App) CreateOAuthUser(c request.CTX, service string, userData io.Reader,
 	if e != nil {
 		return nil, e
 	}
-	user, err1 := provider.GetUserFromJSON(c, userData, tokenUser)
+	user, err1 := provider.GetUserFromJSON(rctx, userData, tokenUser)
 	if err1 != nil {
 		return nil, model.NewAppError("CreateOAuthUser", "api.user.create_oauth_user.create.app_error", map[string]any{"Service": service}, "", http.StatusInternalServerError).Wrap(err1)
 	}
@@ -384,10 +384,10 @@ func (a *App) CreateOAuthUser(c request.CTX, service string, userData io.Reader,
 		if userByEmail.AuthService == "" {
 			return nil, model.NewAppError("CreateOAuthUser", "api.user.create_oauth_user.already_attached.app_error", map[string]any{"Service": service, "Auth": model.UserAuthServiceEmail}, "email="+user.Email, http.StatusBadRequest)
 		}
-		if provider.IsSameUser(c, userByEmail, user) {
+		if provider.IsSameUser(rctx, userByEmail, user) {
 			if _, err := a.Srv().Store().User().UpdateAuthData(userByEmail.Id, user.AuthService, user.AuthData, "", false); err != nil {
 				// if the user is not updated, write a warning to the log, but don't prevent user login
-				c.Logger().Warn("Error attempting to update user AuthData", mlog.Err(err))
+				rctx.Logger().Warn("Error attempting to update user AuthData", mlog.Err(err))
 			}
 			return userByEmail, nil
 		}
@@ -396,20 +396,20 @@ func (a *App) CreateOAuthUser(c request.CTX, service string, userData io.Reader,
 
 	user.EmailVerified = true
 
-	ruser, err := a.CreateUser(c, user)
+	ruser, err := a.CreateUser(rctx, user)
 	if err != nil {
 		return nil, err
 	}
 
 	if teamID != "" {
-		err = a.AddUserToTeamByTeamId(c, teamID, user)
+		err = a.AddUserToTeamByTeamId(rctx, teamID, user)
 		if err != nil {
 			return nil, err
 		}
 
-		err = a.AddDirectChannels(c, teamID, user)
+		err = a.AddDirectChannels(rctx, teamID, user)
 		if err != nil {
-			c.Logger().Warn("Failed to add direct channels", mlog.Err(err))
+			rctx.Logger().Warn("Failed to add direct channels", mlog.Err(err))
 		}
 	}
 
@@ -667,7 +667,7 @@ func (a *App) GetUsersNotInChannelPage(teamID string, channelID string, groupCon
 	return a.sanitizeProfiles(users, asAdmin), nil
 }
 
-func (a *App) GetUsersNotInAbacChannel(ctx request.CTX, teamID string, channelID string, groupConstrained bool, cursorID string, limit int, asAdmin bool, viewRestrictions *model.ViewUsersRestrictions) ([]*model.User, *model.AppError) {
+func (a *App) GetUsersNotInAbacChannel(rctx request.CTX, teamID string, channelID string, groupConstrained bool, cursorID string, limit int, asAdmin bool, viewRestrictions *model.ViewUsersRestrictions) ([]*model.User, *model.AppError) {
 	// Get the AccessControl service
 	acs := a.Srv().Channels().AccessControl
 	if acs == nil {
@@ -675,7 +675,7 @@ func (a *App) GetUsersNotInAbacChannel(ctx request.CTX, teamID string, channelID
 	}
 
 	// Use cursor-based pagination for ABAC channels
-	users, _, appErr := acs.QueryUsersForResource(ctx, channelID, "*", model.SubjectSearchOptions{
+	users, _, appErr := acs.QueryUsersForResource(rctx, channelID, "*", model.SubjectSearchOptions{
 		TeamID: teamID,
 		Limit:  limit,
 		Cursor: model.SubjectCursor{
@@ -736,8 +736,8 @@ func (a *App) GetUsersByIds(userIDs []string, options *store.UserGetByIdsOpts) (
 	return users, nil
 }
 
-func (a *App) GetUsersByGroupChannelIds(c request.CTX, channelIDs []string, asAdmin bool) (map[string][]*model.User, *model.AppError) {
-	usersByChannelId, err := a.Srv().Store().User().GetProfileByGroupChannelIdsForUser(c.Session().UserId, channelIDs)
+func (a *App) GetUsersByGroupChannelIds(rctx request.CTX, channelIDs []string, asAdmin bool) (map[string][]*model.User, *model.AppError) {
+	usersByChannelId, err := a.Srv().Store().User().GetProfileByGroupChannelIdsForUser(rctx.Session().UserId, channelIDs)
 	if err != nil {
 		return nil, model.NewAppError("GetUsersByGroupChannelIds", "app.user.get_profile_by_group_channel_ids_for_user.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -854,7 +854,7 @@ func (a *App) GetDefaultProfileImage(user *model.User) ([]byte, *model.AppError)
 	return a.ch.srv.GetDefaultProfileImage(user)
 }
 
-func (a *App) UpdateDefaultProfileImage(c request.CTX, user *model.User) *model.AppError {
+func (a *App) UpdateDefaultProfileImage(rctx request.CTX, user *model.User) *model.AppError {
 	img, appErr := a.GetDefaultProfileImage(user)
 	if appErr != nil {
 		return appErr
@@ -866,7 +866,7 @@ func (a *App) UpdateDefaultProfileImage(c request.CTX, user *model.User) *model.
 	}
 
 	if err := a.Srv().Store().User().ResetLastPictureUpdate(user.Id); err != nil {
-		c.Logger().Warn("Failed to reset last picture update", mlog.Err(err))
+		rctx.Logger().Warn("Failed to reset last picture update", mlog.Err(err))
 	}
 
 	a.InvalidateCacheForUser(user.Id)
@@ -874,15 +874,15 @@ func (a *App) UpdateDefaultProfileImage(c request.CTX, user *model.User) *model.
 	return nil
 }
 
-func (a *App) SetDefaultProfileImage(c request.CTX, user *model.User) *model.AppError {
-	if err := a.UpdateDefaultProfileImage(c, user); err != nil {
-		c.Logger().Error("Failed to update default profile image for user", mlog.String("user_id", user.Id), mlog.Err(err))
+func (a *App) SetDefaultProfileImage(rctx request.CTX, user *model.User) *model.AppError {
+	if err := a.UpdateDefaultProfileImage(rctx, user); err != nil {
+		rctx.Logger().Error("Failed to update default profile image for user", mlog.String("user_id", user.Id), mlog.Err(err))
 		return err
 	}
 
 	updatedUser, appErr := a.GetUser(user.Id)
 	if appErr != nil {
-		c.Logger().Warn("Error in getting users profile forcing logout", mlog.String("user_id", user.Id), mlog.Err(appErr))
+		rctx.Logger().Warn("Error in getting users profile forcing logout", mlog.String("user_id", user.Id), mlog.Err(appErr))
 		return nil
 	}
 
@@ -896,21 +896,21 @@ func (a *App) SetDefaultProfileImage(c request.CTX, user *model.User) *model.App
 	return nil
 }
 
-func (a *App) SetProfileImage(c request.CTX, userID string, imageData *multipart.FileHeader) *model.AppError {
+func (a *App) SetProfileImage(rctx request.CTX, userID string, imageData *multipart.FileHeader) *model.AppError {
 	file, err := imageData.Open()
 	if err != nil {
 		return model.NewAppError("SetProfileImage", "api.user.upload_profile_user.open.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
 	defer file.Close()
-	return a.SetProfileImageFromMultiPartFile(c, userID, file)
+	return a.SetProfileImageFromMultiPartFile(rctx, userID, file)
 }
 
-func (a *App) SetProfileImageFromMultiPartFile(c request.CTX, userID string, file multipart.File) *model.AppError {
+func (a *App) SetProfileImageFromMultiPartFile(rctx request.CTX, userID string, file multipart.File) *model.AppError {
 	if limitErr := checkImageLimits(file, *a.Config().FileSettings.MaxImageResolution); limitErr != nil {
 		return model.NewAppError("SetProfileImage", "api.user.upload_profile_user.check_image_limits.app_error", nil, "", http.StatusBadRequest).Wrap(limitErr)
 	}
 
-	return a.SetProfileImageFromFile(c, userID, file)
+	return a.SetProfileImageFromFile(rctx, userID, file)
 }
 
 func (a *App) AdjustImage(rctx request.CTX, file io.ReadSeeker) (*bytes.Buffer, *model.AppError) {
@@ -939,8 +939,8 @@ func (a *App) AdjustImage(rctx request.CTX, file io.ReadSeeker) (*bytes.Buffer, 
 	return buf, nil
 }
 
-func (a *App) SetProfileImageFromFile(c request.CTX, userID string, file io.ReadSeeker) *model.AppError {
-	buf, err := a.AdjustImage(c, file)
+func (a *App) SetProfileImageFromFile(rctx request.CTX, userID string, file io.ReadSeeker) *model.AppError {
+	buf, err := a.AdjustImage(rctx, file)
 	if err != nil {
 		return err
 	}
@@ -955,15 +955,15 @@ func (a *App) SetProfileImageFromFile(c request.CTX, userID string, file io.Read
 	}
 
 	if err := a.Srv().Store().User().UpdateLastPictureUpdate(userID); err != nil {
-		c.Logger().Warn("Error with updating last picture update", mlog.Err(err))
+		rctx.Logger().Warn("Error with updating last picture update", mlog.Err(err))
 	}
-	a.invalidateUserCacheAndPublish(c, userID)
+	a.invalidateUserCacheAndPublish(rctx, userID)
 	a.onUserProfileChange(userID)
 
 	return nil
 }
 
-func (a *App) UpdatePasswordAsUser(c request.CTX, userID, currentPassword, newPassword string) *model.AppError {
+func (a *App) UpdatePasswordAsUser(rctx request.CTX, userID, currentPassword, newPassword string) *model.AppError {
 	user, err := a.GetUser(userID)
 	if err != nil {
 		return err
@@ -977,7 +977,7 @@ func (a *App) UpdatePasswordAsUser(c request.CTX, userID, currentPassword, newPa
 		return model.NewAppError("updatePassword", "api.user.update_password.oauth.app_error", nil, "auth_service="+user.AuthService, http.StatusBadRequest)
 	}
 
-	if err := a.DoubleCheckPassword(c, user, currentPassword); err != nil {
+	if err := a.DoubleCheckPassword(rctx, user, currentPassword); err != nil {
 		if err.Id == "api.user.check_user_password.invalid.app_error" {
 			err = model.NewAppError("updatePassword", "api.user.update_password.incorrect.app_error", nil, "", http.StatusBadRequest)
 		}
@@ -986,10 +986,10 @@ func (a *App) UpdatePasswordAsUser(c request.CTX, userID, currentPassword, newPa
 
 	T := i18n.GetUserTranslations(user.Locale)
 
-	return a.UpdatePasswordSendEmail(c, user, newPassword, T("api.user.update_password.menu"))
+	return a.UpdatePasswordSendEmail(rctx, user, newPassword, T("api.user.update_password.menu"))
 }
 
-func (a *App) userDeactivated(c request.CTX, userID string) *model.AppError {
+func (a *App) userDeactivated(rctx request.CTX, userID string) *model.AppError {
 	a.SetStatusOffline(userID, false, true)
 
 	user, err := a.GetUser(userID)
@@ -1001,32 +1001,32 @@ func (a *App) userDeactivated(c request.CTX, userID string) *model.AppError {
 	// bots the user owns. Only notify once, when the user is the owner, not the
 	// owners bots
 	if !user.IsBot {
-		if appErr := a.notifySysadminsBotOwnerDeactivated(c, userID); appErr != nil {
-			c.Logger().Warn("Error while notifying the system admin that the owner of bot accounts got disabled", mlog.Err(appErr))
+		if appErr := a.notifySysadminsBotOwnerDeactivated(rctx, userID); appErr != nil {
+			rctx.Logger().Warn("Error while notifying the system admin that the owner of bot accounts got disabled", mlog.Err(appErr))
 		}
 	}
 
 	if *a.Config().ServiceSettings.DisableBotsWhenOwnerIsDeactivated {
-		if appErr := a.disableUserBots(c, userID); appErr != nil {
-			c.Logger().Warn("Error while disabling all bots owned by the deactivated user", mlog.Err(appErr))
+		if appErr := a.disableUserBots(rctx, userID); appErr != nil {
+			rctx.Logger().Warn("Error while disabling all bots owned by the deactivated user", mlog.Err(appErr))
 		}
 	}
 
 	if nErr := a.Srv().Store().OAuth().RemoveAuthDataByUserId(userID); nErr != nil {
-		c.Logger().Warn("unable to remove auth data by user id", mlog.Err(nErr))
+		rctx.Logger().Warn("unable to remove auth data by user id", mlog.Err(nErr))
 	}
 
 	return nil
 }
 
-func (a *App) invalidateUserChannelMembersCaches(c request.CTX, userID string) *model.AppError {
+func (a *App) invalidateUserChannelMembersCaches(rctx request.CTX, userID string) *model.AppError {
 	teamsForUser, err := a.GetTeamsForUser(userID)
 	if err != nil {
 		return err
 	}
 
 	for _, team := range teamsForUser {
-		channelsForUser, err := a.GetChannelsForTeamForUser(c, team.Id, userID, &model.ChannelSearchOpts{
+		channelsForUser, err := a.GetChannelsForTeamForUser(rctx, team.Id, userID, &model.ChannelSearchOpts{
 			IncludeDeleted: false,
 			LastDeleteAt:   0,
 		})
@@ -1042,7 +1042,7 @@ func (a *App) invalidateUserChannelMembersCaches(c request.CTX, userID string) *
 	return nil
 }
 
-func (a *App) UpdateActive(c request.CTX, user *model.User, active bool) (*model.User, *model.AppError) {
+func (a *App) UpdateActive(rctx request.CTX, user *model.User, active bool) (*model.User, *model.AppError) {
 	if active {
 		atUserLimit, appErr := a.isAtUserLimit()
 		if appErr != nil {
@@ -1065,7 +1065,7 @@ func (a *App) UpdateActive(c request.CTX, user *model.User, active bool) (*model
 		user.DeleteAt = user.UpdateAt
 	}
 
-	userUpdate, err := a.ch.srv.userService.UpdateUser(c, user, true)
+	userUpdate, err := a.ch.srv.userService.UpdateUser(rctx, user, true)
 	if err != nil {
 		var appErr *model.AppError
 		var invErr *store.ErrInvalidInput
@@ -1082,22 +1082,22 @@ func (a *App) UpdateActive(c request.CTX, user *model.User, active bool) (*model
 	a.InvalidateCacheForUser(user.Id)
 
 	if !active {
-		if err := a.RevokeAllSessions(c, ruser.Id); err != nil {
+		if err := a.RevokeAllSessions(rctx, ruser.Id); err != nil {
 			return nil, err
 		}
-		if err := a.userDeactivated(c, ruser.Id); err != nil {
+		if err := a.userDeactivated(rctx, ruser.Id); err != nil {
 			return nil, err
 		}
 	}
 
-	if appErr := a.invalidateUserChannelMembersCaches(c, user.Id); appErr != nil {
-		c.Logger().Warn("Error while invalidating user channel members caches", mlog.Err(appErr))
+	if appErr := a.invalidateUserChannelMembersCaches(rctx, user.Id); appErr != nil {
+		rctx.Logger().Warn("Error while invalidating user channel members caches", mlog.Err(appErr))
 	}
 	a.sendUpdatedUserEvent(ruser)
 
 	if !active && user.DeleteAt != 0 {
 		a.Srv().Go(func() {
-			pluginContext := pluginContext(c)
+			pluginContext := pluginContext(rctx)
 			a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 				hooks.UserHasBeenDeactivated(pluginContext, user)
 				return true
@@ -1108,14 +1108,14 @@ func (a *App) UpdateActive(c request.CTX, user *model.User, active bool) (*model
 	if active {
 		userLimits, appErr := a.GetServerLimits()
 		if appErr != nil {
-			c.Logger().Error("Error fetching user limits in UpdateActive", mlog.Err(appErr))
+			rctx.Logger().Error("Error fetching user limits in UpdateActive", mlog.Err(appErr))
 		} else {
 			if userLimits.ActiveUserCount > userLimits.MaxUsersLimit {
 				// Use different warning messages based on whether server is licensed
 				if a.License() != nil {
-					c.Logger().Warn("ERROR_LICENSED_USERS_LIMIT_EXCEEDED: Activated user exceeds the maximum licensed users.", mlog.Int("user_limit", userLimits.MaxUsersLimit))
+					rctx.Logger().Warn("ERROR_LICENSED_USERS_LIMIT_EXCEEDED: Activated user exceeds the maximum licensed users.", mlog.Int("user_limit", userLimits.MaxUsersLimit))
 				} else {
-					c.Logger().Warn("ERROR_SAFETY_LIMITS_EXCEEDED: Activated user exceeds the total active user limit.", mlog.Int("user_limit", userLimits.MaxUsersLimit))
+					rctx.Logger().Warn("ERROR_SAFETY_LIMITS_EXCEEDED: Activated user exceeds the total active user limit.", mlog.Int("user_limit", userLimits.MaxUsersLimit))
 				}
 			}
 		}
@@ -1124,20 +1124,20 @@ func (a *App) UpdateActive(c request.CTX, user *model.User, active bool) (*model
 	return ruser, nil
 }
 
-func (a *App) DeactivateGuests(c request.CTX) *model.AppError {
+func (a *App) DeactivateGuests(rctx request.CTX) *model.AppError {
 	userIDs, err := a.ch.srv.userService.DeactivateAllGuests()
 	if err != nil {
 		return model.NewAppError("DeactivateGuests", "app.user.update_active_for_multiple_users.updating.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	for _, userID := range userIDs {
-		if err := a.Srv().Platform().RevokeAllSessions(c, userID); err != nil {
+		if err := a.Srv().Platform().RevokeAllSessions(rctx, userID); err != nil {
 			return model.NewAppError("DeactivateGuests", "app.user.update_active_for_multiple_users.updating.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 		}
 	}
 
 	for _, userID := range userIDs {
-		if err := a.userDeactivated(c, userID); err != nil {
+		if err := a.userDeactivated(rctx, userID); err != nil {
 			return err
 		}
 	}
@@ -1161,8 +1161,8 @@ func (a *App) SanitizeProfile(user *model.User, asAdmin bool) {
 	user.SanitizeProfile(options, asAdmin)
 }
 
-func (a *App) UpdateUserAsUser(c request.CTX, user *model.User, asAdmin bool) (*model.User, *model.AppError) {
-	updatedUser, err := a.UpdateUser(c, user, true)
+func (a *App) UpdateUserAsUser(rctx request.CTX, user *model.User, asAdmin bool) (*model.User, *model.AppError) {
+	updatedUser, err := a.UpdateUser(rctx, user, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1173,7 +1173,7 @@ func (a *App) UpdateUserAsUser(c request.CTX, user *model.User, asAdmin bool) (*
 // CheckProviderAttributes returns the empty string if the patch can be applied without
 // overriding attributes set by the user's login provider; otherwise, the name of the offending
 // field is returned.
-func (a *App) CheckProviderAttributes(c request.CTX, user *model.User, patch *model.UserPatch) string {
+func (a *App) CheckProviderAttributes(rctx request.CTX, user *model.User, patch *model.UserPatch) string {
 	tryingToChange := func(userValue *string, patchValue *string) bool {
 		return patchValue != nil && *patchValue != *userValue
 	}
@@ -1189,9 +1189,9 @@ func (a *App) CheckProviderAttributes(c request.CTX, user *model.User, patch *mo
 	conflictField := ""
 	if a.Ldap() != nil &&
 		(user.IsLDAPUser() || (user.IsSAMLUser() && *SamlSettings.EnableSyncWithLdap)) {
-		conflictField = a.Ldap().CheckProviderAttributes(c, LdapSettings, user, patch)
+		conflictField = a.Ldap().CheckProviderAttributes(rctx, LdapSettings, user, patch)
 	} else if a.Saml() != nil && user.IsSAMLUser() {
-		conflictField = a.Saml().CheckProviderAttributes(c, SamlSettings, user, patch)
+		conflictField = a.Saml().CheckProviderAttributes(rctx, SamlSettings, user, patch)
 	} else if user.IsOAuthUser() {
 		if tryingToChange(&user.FirstName, patch.FirstName) || tryingToChange(&user.LastName, patch.LastName) {
 			conflictField = "full name"
@@ -1201,7 +1201,7 @@ func (a *App) CheckProviderAttributes(c request.CTX, user *model.User, patch *mo
 	return conflictField
 }
 
-func (a *App) PatchUser(c request.CTX, userID string, patch *model.UserPatch, asAdmin bool) (*model.User, *model.AppError) {
+func (a *App) PatchUser(rctx request.CTX, userID string, patch *model.UserPatch, asAdmin bool) (*model.User, *model.AppError) {
 	user, err := a.GetUser(userID)
 	if err != nil {
 		return nil, err
@@ -1209,7 +1209,7 @@ func (a *App) PatchUser(c request.CTX, userID string, patch *model.UserPatch, as
 
 	user.Patch(patch)
 
-	updatedUser, err := a.UpdateUser(c, user, true)
+	updatedUser, err := a.UpdateUser(rctx, user, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1217,7 +1217,7 @@ func (a *App) PatchUser(c request.CTX, userID string, patch *model.UserPatch, as
 	return updatedUser, nil
 }
 
-func (a *App) UpdateUserAuth(c request.CTX, userID string, userAuth *model.UserAuth) (*model.UserAuth, *model.AppError) {
+func (a *App) UpdateUserAuth(rctx request.CTX, userID string, userAuth *model.UserAuth) (*model.UserAuth, *model.AppError) {
 	if _, err := a.Srv().Store().User().UpdateAuthData(userID, userAuth.AuthService, userAuth.AuthData, "", false); err != nil {
 		var invErr *store.ErrInvalidInput
 		switch {
@@ -1278,7 +1278,7 @@ func (a *App) isUniqueToGroupNames(val string) *model.AppError {
 	return nil
 }
 
-func (a *App) UpdateUser(c request.CTX, user *model.User, sendNotifications bool) (*model.User, *model.AppError) {
+func (a *App) UpdateUser(rctx request.CTX, user *model.User, sendNotifications bool) (*model.User, *model.AppError) {
 	prev, err := a.ch.srv.userService.GetUser(user.Id)
 	if err != nil {
 		var nfErr *store.ErrNotFound
@@ -1333,7 +1333,7 @@ func (a *App) UpdateUser(c request.CTX, user *model.User, sendNotifications bool
 		}
 	}
 
-	userUpdate, err := a.ch.srv.userService.UpdateUser(c, user, false)
+	userUpdate, err := a.ch.srv.userService.UpdateUser(rctx, user, false)
 	if err != nil {
 		var appErr *model.AppError
 		var invErr *store.ErrInvalidInput
@@ -1357,13 +1357,13 @@ func (a *App) UpdateUser(c request.CTX, user *model.User, sendNotifications bool
 
 	if (newUser.Username != userUpdate.Old.Username) && (newUser.LastPictureUpdate <= 0) {
 		// When a username is updated and the profile is still using a default profile picture, generate a new one based on their username
-		if err := a.UpdateDefaultProfileImage(c, newUser); err != nil {
-			c.Logger().Warn("Error with updating default profile image", mlog.Err(err))
+		if err := a.UpdateDefaultProfileImage(rctx, newUser); err != nil {
+			rctx.Logger().Warn("Error with updating default profile image", mlog.Err(err))
 		}
 
 		tempUser, getUserErr := a.GetUser(user.Id)
 		if getUserErr != nil {
-			c.Logger().Warn("Error when retrieving user after profile picture update, avatar may fail to update automatically on client applications.", mlog.Err(getUserErr))
+			rctx.Logger().Warn("Error when retrieving user after profile picture update, avatar may fail to update automatically on client applications.", mlog.Err(getUserErr))
 		} else {
 			newUser = tempUser
 		}
@@ -1374,13 +1374,13 @@ func (a *App) UpdateUser(c request.CTX, user *model.User, sendNotifications bool
 			if *a.Config().EmailSettings.RequireEmailVerification {
 				a.Srv().Go(func() {
 					if err := a.SendEmailVerification(newUser, newEmail, ""); err != nil {
-						c.Logger().Error("Failed to send email verification", mlog.Err(err))
+						rctx.Logger().Error("Failed to send email verification", mlog.Err(err))
 					}
 				})
 			} else {
 				a.Srv().Go(func() {
 					if err := a.Srv().EmailService.SendEmailChangeEmail(userUpdate.Old.Email, newUser.Email, newUser.Locale, a.GetSiteURL()); err != nil {
-						c.Logger().Error("Failed to send email change email", mlog.Err(err))
+						rctx.Logger().Error("Failed to send email change email", mlog.Err(err))
 					}
 				})
 			}
@@ -1389,7 +1389,7 @@ func (a *App) UpdateUser(c request.CTX, user *model.User, sendNotifications bool
 		if newUser.Username != userUpdate.Old.Username {
 			a.Srv().Go(func() {
 				if err := a.Srv().EmailService.SendChangeUsernameEmail(newUser.Username, newUser.Email, newUser.Locale, a.GetSiteURL()); err != nil {
-					c.Logger().Error("Failed to send change username email", mlog.Err(err))
+					rctx.Logger().Error("Failed to send change username email", mlog.Err(err))
 				}
 			})
 		}
@@ -1404,12 +1404,12 @@ func (a *App) UpdateUser(c request.CTX, user *model.User, sendNotifications bool
 	return newUser, nil
 }
 
-func (a *App) UpdateUserActive(c request.CTX, userID string, active bool) *model.AppError {
+func (a *App) UpdateUserActive(rctx request.CTX, userID string, active bool) *model.AppError {
 	user, err := a.GetUser(userID)
 	if err != nil {
 		return err
 	}
-	if _, err = a.UpdateActive(c, user, active); err != nil {
+	if _, err = a.UpdateActive(rctx, user, active); err != nil {
 		return err
 	}
 
@@ -1434,7 +1434,7 @@ func (a *App) updateUserNotifyProps(userID string, props map[string]string) *mod
 	return nil
 }
 
-func (a *App) UpdateMfa(c request.CTX, activate bool, userID, token string) *model.AppError {
+func (a *App) UpdateMfa(rctx request.CTX, activate bool, userID, token string) *model.AppError {
 	if activate {
 		if err := a.ActivateMfa(userID, token); err != nil {
 			return err
@@ -1448,25 +1448,25 @@ func (a *App) UpdateMfa(c request.CTX, activate bool, userID, token string) *mod
 	a.Srv().Go(func() {
 		user, err := a.GetUser(userID)
 		if err != nil {
-			c.Logger().Error("Failed to get user", mlog.Err(err))
+			rctx.Logger().Error("Failed to get user", mlog.Err(err))
 			return
 		}
 
 		if err := a.Srv().EmailService.SendMfaChangeEmail(user.Email, activate, user.Locale, a.GetSiteURL()); err != nil {
-			c.Logger().Error("Failed to send mfa change email", mlog.Err(err))
+			rctx.Logger().Error("Failed to send mfa change email", mlog.Err(err))
 		}
 	})
 
 	return nil
 }
 
-func (a *App) UpdatePasswordByUserIdSendEmail(c request.CTX, userID, newPassword, method string) *model.AppError {
+func (a *App) UpdatePasswordByUserIdSendEmail(rctx request.CTX, userID, newPassword, method string) *model.AppError {
 	user, err := a.GetUser(userID)
 	if err != nil {
 		return err
 	}
 
-	return a.UpdatePasswordSendEmail(c, user, newPassword, method)
+	return a.UpdatePasswordSendEmail(rctx, user, newPassword, method)
 }
 
 func (a *App) UpdatePassword(rctx request.CTX, user *model.User, newPassword string) *model.AppError {
@@ -1519,14 +1519,14 @@ func (a *App) UpdatePassword(rctx request.CTX, user *model.User, newPassword str
 	return nil
 }
 
-func (a *App) UpdatePasswordSendEmail(c request.CTX, user *model.User, newPassword, method string) *model.AppError {
-	if err := a.UpdatePassword(c, user, newPassword); err != nil {
+func (a *App) UpdatePasswordSendEmail(rctx request.CTX, user *model.User, newPassword, method string) *model.AppError {
+	if err := a.UpdatePassword(rctx, user, newPassword); err != nil {
 		return err
 	}
 
 	a.Srv().Go(func() {
 		if err := a.Srv().EmailService.SendPasswordChangeEmail(user.Email, method, user.Locale, a.GetSiteURL()); err != nil {
-			c.Logger().Error("Failed to send password change email", mlog.Err(err))
+			rctx.Logger().Error("Failed to send password change email", mlog.Err(err))
 		}
 	})
 
@@ -1557,11 +1557,11 @@ func (a *App) UpdateHashedPassword(user *model.User, newHashedPassword string) *
 	return nil
 }
 
-func (a *App) ResetPasswordFromToken(c request.CTX, userSuppliedTokenString, newPassword string) *model.AppError {
-	return a.resetPasswordFromToken(c, userSuppliedTokenString, newPassword, model.GetMillis())
+func (a *App) ResetPasswordFromToken(rctx request.CTX, userSuppliedTokenString, newPassword string) *model.AppError {
+	return a.resetPasswordFromToken(rctx, userSuppliedTokenString, newPassword, model.GetMillis())
 }
 
-func (a *App) resetPasswordFromToken(c request.CTX, userSuppliedTokenString, newPassword string, nowMilli int64) *model.AppError {
+func (a *App) resetPasswordFromToken(rctx request.CTX, userSuppliedTokenString, newPassword string, nowMilli int64) *model.AppError {
 	token, err := a.GetPasswordRecoveryToken(userSuppliedTokenString)
 	if err != nil {
 		return err
@@ -1600,12 +1600,12 @@ func (a *App) resetPasswordFromToken(c request.CTX, userSuppliedTokenString, new
 
 	T := i18n.GetUserTranslations(user.Locale)
 
-	if err := a.UpdatePasswordSendEmail(c, user, newPassword, T("api.user.reset_password.method")); err != nil {
+	if err := a.UpdatePasswordSendEmail(rctx, user, newPassword, T("api.user.reset_password.method")); err != nil {
 		return err
 	}
 
 	if err := a.DeleteToken(token); err != nil {
-		c.Logger().Warn("Failed to delete token", mlog.Err(err))
+		rctx.Logger().Warn("Failed to delete token", mlog.Err(err))
 	}
 
 	return nil
@@ -1737,17 +1737,17 @@ func (a *App) DeleteToken(token *model.Token) *model.AppError {
 	return nil
 }
 
-func (a *App) UpdateUserRoles(c request.CTX, userID string, newRoles string, sendWebSocketEvent bool) (*model.User, *model.AppError) {
+func (a *App) UpdateUserRoles(rctx request.CTX, userID string, newRoles string, sendWebSocketEvent bool) (*model.User, *model.AppError) {
 	user, err := a.GetUser(userID)
 	if err != nil {
 		err.StatusCode = http.StatusBadRequest
 		return nil, err
 	}
 
-	return a.UpdateUserRolesWithUser(c, user, newRoles, sendWebSocketEvent)
+	return a.UpdateUserRolesWithUser(rctx, user, newRoles, sendWebSocketEvent)
 }
 
-func (a *App) UpdateUserRolesWithUser(c request.CTX, user *model.User, newRoles string, sendWebSocketEvent bool) (*model.User, *model.AppError) {
+func (a *App) UpdateUserRolesWithUser(rctx request.CTX, user *model.User, newRoles string, sendWebSocketEvent bool) (*model.User, *model.AppError) {
 	if err := a.CheckRolesExist(strings.Fields(newRoles)); err != nil {
 		return nil, err
 	}
@@ -1770,7 +1770,7 @@ func (a *App) UpdateUserRolesWithUser(c request.CTX, user *model.User, newRoles 
 	user.Roles = newRoles
 	uchan := make(chan store.StoreResult[*model.UserUpdate], 1)
 	go func() {
-		userUpdate, err := a.Srv().Store().User().Update(c, user, true)
+		userUpdate, err := a.Srv().Store().User().Update(rctx, user, true)
 		uchan <- store.StoreResult[*model.UserUpdate]{Data: userUpdate, NErr: err}
 		close(uchan)
 	}()
@@ -1799,7 +1799,7 @@ func (a *App) UpdateUserRolesWithUser(c request.CTX, user *model.User, newRoles 
 
 	if result := <-schan; result.NErr != nil {
 		// soft error since the user roles were still updated
-		c.Logger().Warn("Failed during updating user roles", mlog.Err(result.NErr))
+		rctx.Logger().Warn("Failed during updating user roles", mlog.Err(result.NErr))
 	}
 
 	a.InvalidateCacheForUser(user.Id)
@@ -1950,14 +1950,14 @@ func (a *App) PermanentDeleteUser(rctx request.CTX, user *model.User) *model.App
 	return nil
 }
 
-func (a *App) PermanentDeleteAllUsers(c request.CTX) *model.AppError {
+func (a *App) PermanentDeleteAllUsers(rctx request.CTX) *model.AppError {
 	users, err := a.Srv().Store().User().GetAll()
 	if err != nil {
 		return model.NewAppError("PermanentDeleteAllUsers", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	for _, user := range users {
-		if appErr := a.PermanentDeleteUser(c, user); appErr != nil {
-			c.Logger().Warn("Error while deleting user", mlog.Err(appErr))
+		if appErr := a.PermanentDeleteUser(rctx, user); appErr != nil {
+			rctx.Logger().Warn("Error while deleting user", mlog.Err(appErr))
 		}
 	}
 
@@ -1994,7 +1994,7 @@ func (a *App) SendEmailVerification(user *model.User, newEmail, redirect string)
 	return nil
 }
 
-func (a *App) VerifyEmailFromToken(c request.CTX, userSuppliedTokenString string) *model.AppError {
+func (a *App) VerifyEmailFromToken(rctx request.CTX, userSuppliedTokenString string) *model.AppError {
 	token, err := a.GetVerifyEmailToken(userSuppliedTokenString)
 	if err != nil {
 		return err
@@ -2026,13 +2026,13 @@ func (a *App) VerifyEmailFromToken(c request.CTX, userSuppliedTokenString string
 	if user.Email != tokenData.Email {
 		a.Srv().Go(func() {
 			if err := a.Srv().EmailService.SendEmailChangeEmail(user.Email, tokenData.Email, user.Locale, a.GetSiteURL()); err != nil {
-				c.Logger().Error("Failed to send email change email", mlog.Err(err))
+				rctx.Logger().Error("Failed to send email change email", mlog.Err(err))
 			}
 		})
 	}
 
 	if err := a.DeleteToken(token); err != nil {
-		c.Logger().Warn("Failed to delete token", mlog.Err(err))
+		rctx.Logger().Warn("Failed to delete token", mlog.Err(err))
 	}
 
 	return nil
@@ -2131,13 +2131,13 @@ func (a *App) SearchUsersInChannel(channelID string, term string, options *model
 func (a *App) SearchUsersNotInChannel(teamID string, channelID string, term string, options *model.UserSearchOptions) ([]*model.User, *model.AppError) {
 	term = strings.TrimSpace(term)
 
-	ctx := request.EmptyContext(a.Log())
-	if ok, err := a.ChannelAccessControlled(ctx, channelID); err != nil {
+	rctx := request.EmptyContext(a.Log())
+	if ok, err := a.ChannelAccessControlled(rctx, channelID); err != nil {
 		return nil, err
 	} else if ok {
 		acs := a.Srv().Channels().AccessControl
 		if acs != nil {
-			users, _, appErr := acs.QueryUsersForResource(ctx, channelID, "*", model.SubjectSearchOptions{
+			users, _, appErr := acs.QueryUsersForResource(rctx, channelID, "*", model.SubjectSearchOptions{
 				Term:   term,
 				TeamID: teamID,
 				Limit:  options.Limit,
@@ -2269,8 +2269,8 @@ func (a *App) AutocompleteUsersInTeam(rctx request.CTX, teamID string, term stri
 	return autocomplete, nil
 }
 
-func (a *App) UpdateOAuthUserAttrs(c request.CTX, userData io.Reader, user *model.User, provider einterfaces.OAuthProvider, service string, tokenUser *model.User) *model.AppError {
-	oauthUser, err1 := provider.GetUserFromJSON(c, userData, tokenUser)
+func (a *App) UpdateOAuthUserAttrs(rctx request.CTX, userData io.Reader, user *model.User, provider einterfaces.OAuthProvider, service string, tokenUser *model.User) *model.AppError {
+	oauthUser, err1 := provider.GetUserFromJSON(rctx, userData, tokenUser)
 	if err1 != nil {
 		return model.NewAppError("UpdateOAuthUserAttrs", "api.user.update_oauth_user_attrs.get_user.app_error", map[string]any{"Service": service}, "", http.StatusBadRequest).Wrap(err1)
 	}
@@ -2304,7 +2304,7 @@ func (a *App) UpdateOAuthUserAttrs(c request.CTX, userData io.Reader, user *mode
 	}
 
 	if userAttrsChanged {
-		users, err := a.Srv().Store().User().Update(c, user, true)
+		users, err := a.Srv().Store().User().Update(rctx, user, true)
 		if err != nil {
 			var appErr *model.AppError
 			var invErr *store.ErrInvalidInput
@@ -2325,8 +2325,8 @@ func (a *App) UpdateOAuthUserAttrs(c request.CTX, userData io.Reader, user *mode
 	return nil
 }
 
-func (a *App) RestrictUsersGetByPermissions(c request.CTX, userID string, options *model.UserGetOptions) (*model.UserGetOptions, *model.AppError) {
-	restrictions, err := a.GetViewUsersRestrictions(c, userID)
+func (a *App) RestrictUsersGetByPermissions(rctx request.CTX, userID string, options *model.UserGetOptions) (*model.UserGetOptions, *model.AppError) {
+	restrictions, err := a.GetViewUsersRestrictions(rctx, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -2381,8 +2381,8 @@ func (a *App) filterNonGroupUsers(userIDs []string, groupUsers []*model.User) ([
 	return nonMemberIds, nil
 }
 
-func (a *App) RestrictUsersSearchByPermissions(c request.CTX, userID string, options *model.UserSearchOptions) (*model.UserSearchOptions, *model.AppError) {
-	restrictions, err := a.GetViewUsersRestrictions(c, userID)
+func (a *App) RestrictUsersSearchByPermissions(rctx request.CTX, userID string, options *model.UserSearchOptions) (*model.UserSearchOptions, *model.AppError) {
+	restrictions, err := a.GetViewUsersRestrictions(rctx, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -2391,12 +2391,12 @@ func (a *App) RestrictUsersSearchByPermissions(c request.CTX, userID string, opt
 	return options, nil
 }
 
-func (a *App) UserCanSeeOtherUser(c request.CTX, userID string, otherUserId string) (bool, *model.AppError) {
+func (a *App) UserCanSeeOtherUser(rctx request.CTX, userID string, otherUserId string) (bool, *model.AppError) {
 	if userID == otherUserId {
 		return true, nil
 	}
 
-	restrictions, err := a.GetViewUsersRestrictions(c, userID)
+	restrictions, err := a.GetViewUsersRestrictions(rctx, userID)
 	if err != nil {
 		return false, err
 	}
@@ -2437,7 +2437,7 @@ func (a *App) userBelongsToChannels(userID string, channelIDs []string) (bool, *
 	return belongs, nil
 }
 
-func (a *App) GetViewUsersRestrictions(c request.CTX, userID string) (*model.ViewUsersRestrictions, *model.AppError) {
+func (a *App) GetViewUsersRestrictions(rctx request.CTX, userID string) (*model.ViewUsersRestrictions, *model.AppError) {
 	if a.HasPermissionTo(userID, model.PermissionViewMembers) {
 		return nil, nil
 	}
@@ -2449,12 +2449,12 @@ func (a *App) GetViewUsersRestrictions(c request.CTX, userID string) (*model.Vie
 
 	teamIDsWithPermission := []string{}
 	for _, teamID := range teamIDs {
-		if a.HasPermissionToTeam(c, userID, teamID, model.PermissionViewMembers) {
+		if a.HasPermissionToTeam(rctx, userID, teamID, model.PermissionViewMembers) {
 			teamIDsWithPermission = append(teamIDsWithPermission, teamID)
 		}
 	}
 
-	userChannelMembers, err := a.Srv().Store().Channel().GetAllChannelMembersForUser(c, userID, true, true)
+	userChannelMembers, err := a.Srv().Store().Channel().GetAllChannelMembersForUser(rctx, userID, true, true)
 	if err != nil {
 		return nil, model.NewAppError("GetViewUsersRestrictions", "app.channel.get_channels.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -2469,7 +2469,7 @@ func (a *App) GetViewUsersRestrictions(c request.CTX, userID string) (*model.Vie
 
 // PromoteGuestToUser Convert user's roles and all his membership's roles from
 // guest roles to regular user roles.
-func (a *App) PromoteGuestToUser(c request.CTX, user *model.User, requestorId string) *model.AppError {
+func (a *App) PromoteGuestToUser(rctx request.CTX, user *model.User, requestorId string) *model.AppError {
 	nErr := a.ch.srv.userService.PromoteGuestToUser(user)
 	a.InvalidateCacheForUser(user.Id)
 	if nErr != nil {
@@ -2482,34 +2482,34 @@ func (a *App) PromoteGuestToUser(c request.CTX, user *model.User, requestorId st
 
 	for _, team := range userTeams {
 		// Soft error if there is an issue joining the default channels
-		if err := a.JoinDefaultChannels(c, team.Id, user, false, requestorId); err != nil {
-			c.Logger().Warn("Failed to join default channels", mlog.String("user_id", user.Id), mlog.String("team_id", team.Id), mlog.String("requestor_id", requestorId), mlog.Err(err))
+		if err := a.JoinDefaultChannels(rctx, team.Id, user, false, requestorId); err != nil {
+			rctx.Logger().Warn("Failed to join default channels", mlog.String("user_id", user.Id), mlog.String("team_id", team.Id), mlog.String("requestor_id", requestorId), mlog.Err(err))
 		}
 	}
 
 	promotedUser, err := a.GetUser(user.Id)
 	if err != nil {
-		c.Logger().Warn("Failed to get user on promote guest to user", mlog.Err(err))
+		rctx.Logger().Warn("Failed to get user on promote guest to user", mlog.Err(err))
 	} else {
 		a.sendUpdatedUserEvent(promotedUser)
-		if uErr := a.ch.srv.platform.UpdateSessionsIsGuest(c, promotedUser, promotedUser.IsGuest()); uErr != nil {
-			c.Logger().Warn("Unable to update user sessions", mlog.String("user_id", promotedUser.Id), mlog.Err(uErr))
+		if uErr := a.ch.srv.platform.UpdateSessionsIsGuest(rctx, promotedUser, promotedUser.IsGuest()); uErr != nil {
+			rctx.Logger().Warn("Unable to update user sessions", mlog.String("user_id", promotedUser.Id), mlog.Err(uErr))
 		}
 	}
 
-	teamMembers, err := a.GetTeamMembersForUser(c, user.Id, "", true)
+	teamMembers, err := a.GetTeamMembersForUser(rctx, user.Id, "", true)
 	if err != nil {
-		c.Logger().Warn("Failed to get team members for user on promote guest to user", mlog.Err(err))
+		rctx.Logger().Warn("Failed to get team members for user on promote guest to user", mlog.Err(err))
 	}
 
 	for _, member := range teamMembers {
 		if appErr := a.sendUpdatedTeamMemberEvent(member); appErr != nil {
-			c.Logger().Warn("Error while sending updated team member event", mlog.Err(appErr))
+			rctx.Logger().Warn("Error while sending updated team member event", mlog.Err(appErr))
 		}
 
-		channelMembers, appErr := a.GetChannelMembersForUser(c, member.TeamId, user.Id)
+		channelMembers, appErr := a.GetChannelMembersForUser(rctx, member.TeamId, user.Id)
 		if appErr != nil {
-			c.Logger().Warn("Failed to get channel members for user on promote guest to user", mlog.Err(appErr))
+			rctx.Logger().Warn("Failed to get channel members for user on promote guest to user", mlog.Err(appErr))
 		}
 
 		for _, member := range channelMembers {
@@ -2531,7 +2531,7 @@ func (a *App) PromoteGuestToUser(c request.CTX, user *model.User, requestorId st
 
 // DemoteUserToGuest Convert user's roles and all his membership's roles from
 // regular user roles to guest roles.
-func (a *App) DemoteUserToGuest(c request.CTX, user *model.User) *model.AppError {
+func (a *App) DemoteUserToGuest(rctx request.CTX, user *model.User) *model.AppError {
 	demotedUser, nErr := a.ch.srv.userService.DemoteUserToGuest(user)
 	a.InvalidateCacheForUser(user.Id)
 	if nErr != nil {
@@ -2539,23 +2539,23 @@ func (a *App) DemoteUserToGuest(c request.CTX, user *model.User) *model.AppError
 	}
 
 	a.sendUpdatedUserEvent(demotedUser)
-	if uErr := a.ch.srv.platform.UpdateSessionsIsGuest(c, demotedUser, demotedUser.IsGuest()); uErr != nil {
-		c.Logger().Warn("Unable to update user sessions", mlog.String("user_id", demotedUser.Id), mlog.Err(uErr))
+	if uErr := a.ch.srv.platform.UpdateSessionsIsGuest(rctx, demotedUser, demotedUser.IsGuest()); uErr != nil {
+		rctx.Logger().Warn("Unable to update user sessions", mlog.String("user_id", demotedUser.Id), mlog.Err(uErr))
 	}
 
-	teamMembers, err := a.GetTeamMembersForUser(c, user.Id, "", true)
+	teamMembers, err := a.GetTeamMembersForUser(rctx, user.Id, "", true)
 	if err != nil {
-		c.Logger().Warn("Failed to get team members for users on demote user to guest", mlog.Err(err))
+		rctx.Logger().Warn("Failed to get team members for users on demote user to guest", mlog.Err(err))
 	}
 
 	for _, member := range teamMembers {
 		if appErr := a.sendUpdatedTeamMemberEvent(member); appErr != nil {
-			c.Logger().Warn("Error while sending updated team member event", mlog.Err(appErr))
+			rctx.Logger().Warn("Error while sending updated team member event", mlog.Err(appErr))
 		}
 
-		channelMembers, appErr := a.GetChannelMembersForUser(c, member.TeamId, user.Id)
+		channelMembers, appErr := a.GetChannelMembersForUser(rctx, member.TeamId, user.Id)
 		if appErr != nil {
-			c.Logger().Warn("Failed to get channel members for users on demote user to guest", mlog.Err(appErr))
+			rctx.Logger().Warn("Failed to get channel members for users on demote user to guest", mlog.Err(appErr))
 			continue
 		}
 
@@ -2619,8 +2619,8 @@ func (a *App) GetKnownUsers(userID string) ([]string, *model.AppError) {
 }
 
 // ConvertBotToUser converts a bot to user.
-func (a *App) ConvertBotToUser(c request.CTX, bot *model.Bot, userPatch *model.UserPatch, sysadmin bool) (*model.User, *model.AppError) {
-	user, nErr := a.Srv().Store().User().Get(c.Context(), bot.UserId)
+func (a *App) ConvertBotToUser(rctx request.CTX, bot *model.Bot, userPatch *model.UserPatch, sysadmin bool) (*model.User, *model.AppError) {
+	user, nErr := a.Srv().Store().User().Get(rctx.Context(), bot.UserId)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -2632,7 +2632,7 @@ func (a *App) ConvertBotToUser(c request.CTX, bot *model.Bot, userPatch *model.U
 	}
 
 	if sysadmin && !user.IsInRole(model.SystemAdminRoleId) {
-		_, appErr := a.UpdateUserRoles(c,
+		_, appErr := a.UpdateUserRoles(rctx,
 			user.Id,
 			fmt.Sprintf("%s %s", user.Roles, model.SystemAdminRoleId),
 			false)
@@ -2643,12 +2643,12 @@ func (a *App) ConvertBotToUser(c request.CTX, bot *model.Bot, userPatch *model.U
 
 	user.Patch(userPatch)
 
-	user, err := a.UpdateUser(c, user, false)
+	user, err := a.UpdateUser(rctx, user, false)
 	if err != nil {
 		return nil, err
 	}
 
-	err = a.UpdatePassword(c, user, *userPatch.Password)
+	err = a.UpdatePassword(rctx, user, *userPatch.Password)
 	if err != nil {
 		return nil, err
 	}
@@ -2815,7 +2815,7 @@ func (a *App) UpdateThreadFollowForUser(userID, teamID, threadID string, state b
 	return nil
 }
 
-func (a *App) UpdateThreadFollowForUserFromChannelAdd(c request.CTX, userID, teamID, threadID string) *model.AppError {
+func (a *App) UpdateThreadFollowForUserFromChannelAdd(rctx request.CTX, userID, teamID, threadID string) *model.AppError {
 	opts := store.ThreadMembershipOpts{
 		Following:             true,
 		IncrementMentions:     false,
@@ -2828,7 +2828,7 @@ func (a *App) UpdateThreadFollowForUserFromChannelAdd(c request.CTX, userID, tea
 		return model.NewAppError("UpdateThreadFollowForUserFromChannelAdd", "app.user.update_thread_follow_for_user.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
-	post, appErr := a.GetSinglePost(c, threadID, false)
+	post, appErr := a.GetSinglePost(rctx, threadID, false)
 	if appErr != nil {
 		return appErr
 	}
@@ -2836,7 +2836,7 @@ func (a *App) UpdateThreadFollowForUserFromChannelAdd(c request.CTX, userID, tea
 	if appErr != nil {
 		return appErr
 	}
-	tm.UnreadMentions, appErr = a.countThreadMentions(c, user, post, teamID, post.CreateAt-1)
+	tm.UnreadMentions, appErr = a.countThreadMentions(rctx, user, post, teamID, post.CreateAt-1)
 	if appErr != nil {
 		return appErr
 	}
@@ -2857,7 +2857,7 @@ func (a *App) UpdateThreadFollowForUserFromChannelAdd(c request.CTX, userID, tea
 	}
 	a.sanitizeProfiles(userThread.Participants, false)
 	userThread.Post.SanitizeProps()
-	sanitizedPost, appErr := a.SanitizePostMetadataForUser(c, userThread.Post, userID)
+	sanitizedPost, appErr := a.SanitizePostMetadataForUser(rctx, userThread.Post, userID)
 	if appErr != nil {
 		return appErr
 	}
@@ -2875,8 +2875,8 @@ func (a *App) UpdateThreadFollowForUserFromChannelAdd(c request.CTX, userID, tea
 	return nil
 }
 
-func (a *App) UpdateThreadReadForUserByPost(c request.CTX, currentSessionId, userID, teamID, threadID, postID string) (*model.ThreadResponse, *model.AppError) {
-	post, err := a.GetSinglePost(c, postID, false)
+func (a *App) UpdateThreadReadForUserByPost(rctx request.CTX, currentSessionId, userID, teamID, threadID, postID string) (*model.ThreadResponse, *model.AppError) {
+	post, err := a.GetSinglePost(rctx, postID, false)
 	if err != nil {
 		return nil, err
 	}
@@ -2885,10 +2885,10 @@ func (a *App) UpdateThreadReadForUserByPost(c request.CTX, currentSessionId, use
 		return nil, model.NewAppError("UpdateThreadReadForUser", "app.user.update_thread_read_for_user_by_post.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	return a.UpdateThreadReadForUser(c, currentSessionId, userID, teamID, threadID, post.CreateAt-1)
+	return a.UpdateThreadReadForUser(rctx, currentSessionId, userID, teamID, threadID, post.CreateAt-1)
 }
 
-func (a *App) UpdateThreadReadForUser(c request.CTX, currentSessionId, userID, teamID, threadID string, timestamp int64) (*model.ThreadResponse, *model.AppError) {
+func (a *App) UpdateThreadReadForUser(rctx request.CTX, currentSessionId, userID, teamID, threadID string, timestamp int64) (*model.ThreadResponse, *model.AppError) {
 	user, err := a.GetUser(userID)
 	if err != nil {
 		return nil, err
@@ -2906,11 +2906,11 @@ func (a *App) UpdateThreadReadForUser(c request.CTX, currentSessionId, userID, t
 		return nil, model.NewAppError("UpdateThreadReadForUser", "app.user.update_thread_read_for_user.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)
 	}
 
-	post, err := a.GetSinglePost(c, threadID, false)
+	post, err := a.GetSinglePost(rctx, threadID, false)
 	if err != nil {
 		return nil, err
 	}
-	membership.UnreadMentions, err = a.countThreadMentions(c, user, post, teamID, timestamp)
+	membership.UnreadMentions, err = a.countThreadMentions(rctx, user, post, teamID, timestamp)
 	if err != nil {
 		return nil, err
 	}
@@ -2931,7 +2931,7 @@ func (a *App) UpdateThreadReadForUser(c request.CTX, currentSessionId, userID, t
 	}
 
 	// Clear if user has read the messages
-	if thread.UnreadReplies == 0 && a.IsCRTEnabledForUser(c, userID) {
+	if thread.UnreadReplies == 0 && a.IsCRTEnabledForUser(rctx, userID) {
 		a.clearPushNotification(currentSessionId, userID, post.ChannelId, threadID)
 	}
 
@@ -2986,7 +2986,7 @@ func (a *App) UserIsFirstAdmin(rctx request.CTX, user *model.User) bool {
 	return true
 }
 
-func (a *App) ResetPasswordFailedAttempts(c request.CTX, user *model.User) *model.AppError {
+func (a *App) ResetPasswordFailedAttempts(rctx request.CTX, user *model.User) *model.AppError {
 	err := a.Srv().Store().User().UpdateFailedPasswordAttempts(user.Id, 0)
 	if err != nil {
 		return model.NewAppError("ResetPasswordFailedAttempts", "app.user.reset_password_failed_attempts.app_error", nil, "", http.StatusInternalServerError).Wrap(err)

--- a/server/channels/app/user_test.go
+++ b/server/channels/app/user_test.go
@@ -738,14 +738,14 @@ func getGitlabUserPayload(gitlabUser oauthgitlab.GitLabUser, t *testing.T) []byt
 	return payload
 }
 
-func createGitlabUser(t *testing.T, a *App, c request.CTX, id int64, username string, email string) (*model.User, oauthgitlab.GitLabUser) {
+func createGitlabUser(t *testing.T, a *App, rctx request.CTX, id int64, username string, email string) (*model.User, oauthgitlab.GitLabUser) {
 	gitlabUserObj := oauthgitlab.GitLabUser{Id: id, Username: username, Login: "user1", Email: email, Name: "Test User"}
 	gitlabUser := getGitlabUserPayload(gitlabUserObj, t)
 
 	var user *model.User
 	var err *model.AppError
 
-	user, err = a.CreateOAuthUser(c, "gitlab", bytes.NewReader(gitlabUser), "", nil)
+	user, err = a.CreateOAuthUser(rctx, "gitlab", bytes.NewReader(gitlabUser), "", nil)
 	require.Nil(t, err, "unable to create the user", err)
 
 	return user, gitlabUserObj

--- a/server/channels/app/webhook.go
+++ b/server/channels/app/webhook.go
@@ -32,7 +32,7 @@ const (
 
 var linkWithTextRegex = regexp.MustCompile(`<([^\n<\|>]+)\|([^\|\n>]+)>`)
 
-func (a *App) handleWebhookEvents(c request.CTX, post *model.Post, team *model.Team, channel *model.Channel, user *model.User) *model.AppError {
+func (a *App) handleWebhookEvents(rctx request.CTX, post *model.Post, team *model.Team, channel *model.Channel, user *model.User) *model.AppError {
 	if !*a.Config().ServiceSettings.EnableOutgoingWebhooks {
 		return nil
 	}
@@ -88,14 +88,14 @@ func (a *App) handleWebhookEvents(c request.CTX, post *model.Post, team *model.T
 			TriggerWord: triggerWord,
 			FileIds:     strings.Join(post.FileIds, ","),
 		}
-		a.TriggerWebhook(c, payload, hook, post, channel)
+		a.TriggerWebhook(rctx, payload, hook, post, channel)
 	}
 
 	return nil
 }
 
-func (a *App) TriggerWebhook(c request.CTX, payload *model.OutgoingWebhookPayload, hook *model.OutgoingWebhook, post *model.Post, channel *model.Channel) {
-	logger := c.Logger().With(mlog.String("outgoing_webhook_id", hook.Id), mlog.String("post_id", post.Id), mlog.String("channel_id", channel.Id), mlog.String("content_type", hook.ContentType))
+func (a *App) TriggerWebhook(rctx request.CTX, payload *model.OutgoingWebhookPayload, hook *model.OutgoingWebhook, post *model.Post, channel *model.Channel) {
+	logger := rctx.Logger().With(mlog.String("outgoing_webhook_id", hook.Id), mlog.String("post_id", post.Id), mlog.String("channel_id", channel.Id), mlog.String("content_type", hook.ContentType))
 
 	var jsonBytes []byte
 	var err error
@@ -130,14 +130,14 @@ func (a *App) TriggerWebhook(c request.CTX, payload *model.OutgoingWebhookPayloa
 
 			// Retrieve an access token from a connection if one exists to use for the webhook request
 			if a.Config().ServiceSettings.EnableOutgoingOAuthConnections != nil && *a.Config().ServiceSettings.EnableOutgoingOAuthConnections && a.OutgoingOAuthConnections() != nil {
-				connection, err := a.OutgoingOAuthConnections().GetConnectionForAudience(c, url)
+				connection, err := a.OutgoingOAuthConnections().GetConnectionForAudience(rctx, url)
 				if err != nil {
 					logger.Error("Failed to find an outgoing oauth connection for the webhook", mlog.Err(err))
 					return
 				}
 
 				if connection != nil {
-					accessToken, err = a.OutgoingOAuthConnections().RetrieveTokenForConnection(c, connection)
+					accessToken, err = a.OutgoingOAuthConnections().RetrieveTokenForConnection(rctx, connection)
 					if err != nil {
 						logger.Error("Failed to retrieve token for outgoing oauth connection", mlog.Err(err))
 						return
@@ -181,7 +181,7 @@ func (a *App) TriggerWebhook(c request.CTX, payload *model.OutgoingWebhookPayloa
 				if *a.Config().ServiceSettings.EnablePostIconOverride && hook.IconURL != "" && webhookResp.IconURL == "" {
 					webhookResp.IconURL = hook.IconURL
 				}
-				if _, err := a.CreateWebhookPost(c, hook.CreatorId, channel, text, webhookResp.Username, webhookResp.IconURL, "", webhookResp.Props, webhookResp.Type, postRootId, webhookResp.Priority); err != nil {
+				if _, err := a.CreateWebhookPost(rctx, hook.CreatorId, channel, text, webhookResp.Username, webhookResp.IconURL, "", webhookResp.Props, webhookResp.Type, postRootId, webhookResp.Priority); err != nil {
 					logger.Error("Failed to create response post.", mlog.Err(err))
 				}
 			}
@@ -305,7 +305,7 @@ func splitWebhookPost(post *model.Post, maxPostSize int) ([]*model.Post, *model.
 	return splits, nil
 }
 
-func (a *App) CreateWebhookPost(c request.CTX, userID string, channel *model.Channel, text, overrideUsername, overrideIconURL, overrideIconEmoji string, props model.StringInterface, postType string, postRootId string, priority *model.PostPriority) (*model.Post, *model.AppError) {
+func (a *App) CreateWebhookPost(rctx request.CTX, userID string, channel *model.Channel, text, overrideUsername, overrideIconURL, overrideIconEmoji string, props model.StringInterface, postType string, postRootId string, priority *model.PostPriority) (*model.Post, *model.AppError) {
 	// parse links into Markdown format
 	text = linkWithTextRegex.ReplaceAllString(text, "[${2}](${1})")
 
@@ -371,7 +371,7 @@ func (a *App) CreateWebhookPost(c request.CTX, userID string, channel *model.Cha
 	}
 
 	for _, split := range splits {
-		if _, err = a.CreatePost(c, split, channel, model.CreatePostFlags{}); err != nil {
+		if _, err = a.CreatePost(rctx, split, channel, model.CreatePostFlags{}); err != nil {
 			return nil, model.NewAppError("CreateWebhookPost", "api.post.create_webhook_post.creating.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 		}
 	}
@@ -585,13 +585,13 @@ func (a *App) CreateOutgoingWebhook(hook *model.OutgoingWebhook) (*model.Outgoin
 	return webhook, nil
 }
 
-func (a *App) UpdateOutgoingWebhook(c request.CTX, oldHook, updatedHook *model.OutgoingWebhook) (*model.OutgoingWebhook, *model.AppError) {
+func (a *App) UpdateOutgoingWebhook(rctx request.CTX, oldHook, updatedHook *model.OutgoingWebhook) (*model.OutgoingWebhook, *model.AppError) {
 	if !*a.Config().ServiceSettings.EnableOutgoingWebhooks {
 		return nil, model.NewAppError("UpdateOutgoingWebhook", "api.outgoing_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	if updatedHook.ChannelId != "" {
-		channel, err := a.GetChannel(c, updatedHook.ChannelId)
+		channel, err := a.GetChannel(rctx, updatedHook.ChannelId)
 		if err != nil {
 			return nil, err
 		}
@@ -728,7 +728,7 @@ func (a *App) RegenOutgoingWebhookToken(hook *model.OutgoingWebhook) (*model.Out
 	return webhook, nil
 }
 
-func (a *App) HandleIncomingWebhook(c request.CTX, hookID string, req *model.IncomingWebhookRequest) *model.AppError {
+func (a *App) HandleIncomingWebhook(rctx request.CTX, hookID string, req *model.IncomingWebhookRequest) *model.AppError {
 	if !*a.Config().ServiceSettings.EnableIncomingWebhooks {
 		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
@@ -789,7 +789,7 @@ func (a *App) HandleIncomingWebhook(c request.CTX, hookID string, req *model.Inc
 			if nErr != nil {
 				return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.user.app_error", map[string]any{"user": channelName[1:]}, "", http.StatusBadRequest).Wrap(nErr)
 			}
-			ch, err := a.GetOrCreateDirectChannel(c, hook.UserId, result.Id)
+			ch, err := a.GetOrCreateDirectChannel(rctx, hook.UserId, result.Id)
 			if err != nil {
 				return err
 			}
@@ -847,7 +847,7 @@ func (a *App) HandleIncomingWebhook(c request.CTX, hookID string, req *model.Inc
 		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.user.app_error", map[string]any{"user": hook.UserId}, "", http.StatusForbidden).Wrap(resultU.NErr)
 	}
 
-	if channel.Type != model.ChannelTypeOpen && !a.HasPermissionToChannel(c, hook.UserId, channel.Id, model.PermissionReadChannelContent) {
+	if channel.Type != model.ChannelTypeOpen && !a.HasPermissionToChannel(rctx, hook.UserId, channel.Id, model.PermissionReadChannelContent) {
 		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.permissions.app_error", map[string]any{"user": hook.UserId, "channel": channel.Id}, "", http.StatusForbidden)
 	}
 
@@ -861,7 +861,7 @@ func (a *App) HandleIncomingWebhook(c request.CTX, hookID string, req *model.Inc
 		overrideIconURL = req.IconURL
 	}
 
-	_, err := a.CreateWebhookPost(c, hook.UserId, channel, text, overrideUsername, overrideIconURL, req.IconEmoji, req.Props, webhookType, "", req.Priority)
+	_, err := a.CreateWebhookPost(rctx, hook.UserId, channel, text, overrideUsername, overrideIconURL, req.IconEmoji, req.Props, webhookType, "", req.Priority)
 	return err
 }
 
@@ -889,7 +889,7 @@ func (a *App) CreateCommandWebhook(commandID string, args *model.CommandArgs) (*
 	return savedHook, nil
 }
 
-func (a *App) HandleCommandWebhook(c request.CTX, hookID string, response *model.CommandResponse) *model.AppError {
+func (a *App) HandleCommandWebhook(rctx request.CTX, hookID string, response *model.CommandResponse) *model.AppError {
 	if response == nil {
 		return model.NewAppError("HandleCommandWebhook", "app.command_webhook.handle_command_webhook.parse", nil, "", http.StatusBadRequest)
 	}
@@ -933,6 +933,6 @@ func (a *App) HandleCommandWebhook(c request.CTX, hookID string, response *model
 		}
 	}
 
-	_, err := a.HandleCommandResponse(c, cmd, args, response, false)
+	_, err := a.HandleCommandResponse(rctx, cmd, args, response, false)
 	return err
 }

--- a/server/channels/jobs/base_schedulers.go
+++ b/server/channels/jobs/base_schedulers.go
@@ -39,8 +39,8 @@ func (scheduler *PeriodicScheduler) NextScheduleTime(_ *model.Config, _ time.Tim
 	return &nextTime
 }
 
-func (scheduler *PeriodicScheduler) ScheduleJob(c request.CTX, _ *model.Config /* pendingJobs */, _ bool /* lastSuccessfulJob */, _ *model.Job) (*model.Job, *model.AppError) {
-	return scheduler.jobs.CreateJob(c, scheduler.jobType, nil)
+func (scheduler *PeriodicScheduler) ScheduleJob(rctx request.CTX, _ *model.Config /* pendingJobs */, _ bool /* lastSuccessfulJob */, _ *model.Job) (*model.Job, *model.AppError) {
+	return scheduler.jobs.CreateJob(rctx, scheduler.jobType, nil)
 }
 
 type DailyScheduler struct {
@@ -74,8 +74,8 @@ func (scheduler *DailyScheduler) NextScheduleTime(cfg *model.Config, now time.Ti
 	return GenerateNextStartDateTime(now, *scheduledTime)
 }
 
-func (scheduler *DailyScheduler) ScheduleJob(c request.CTX, _ *model.Config /* pendingJobs */, _ bool /* lastSuccessfulJob */, _ *model.Job) (*model.Job, *model.AppError) {
-	return scheduler.jobs.CreateJob(c, scheduler.jobType, nil)
+func (scheduler *DailyScheduler) ScheduleJob(rctx request.CTX, _ *model.Config /* pendingJobs */, _ bool /* lastSuccessfulJob */, _ *model.Job) (*model.Job, *model.AppError) {
+	return scheduler.jobs.CreateJob(rctx, scheduler.jobType, nil)
 }
 
 const jitterRange = 2000 // milliseconds

--- a/server/channels/jobs/export_process/worker.go
+++ b/server/channels/jobs/export_process/worker.go
@@ -18,7 +18,7 @@ import (
 type AppIface interface {
 	configservice.ConfigService
 	WriteExportFileContext(ctx context.Context, fr io.Reader, path string) (int64, *model.AppError)
-	BulkExport(ctx request.CTX, writer io.Writer, outPath string, job *model.Job, opts model.BulkExportOpts) *model.AppError
+	BulkExport(rctx request.CTX, writer io.Writer, outPath string, job *model.Job, opts model.BulkExportOpts) *model.AppError
 	Log() *mlog.Logger
 }
 

--- a/server/channels/jobs/import_process/worker.go
+++ b/server/channels/jobs/import_process/worker.go
@@ -29,7 +29,7 @@ type AppIface interface {
 	FileExists(path string) (bool, *model.AppError)
 	FileSize(path string) (int64, *model.AppError)
 	FileReader(path string) (filestore.ReadCloseSeeker, *model.AppError)
-	BulkImportWithPath(c request.CTX, jsonlReader io.Reader, attachmentsReader *zip.Reader, dryRun, extractContent bool, workers int, importPath string) (int, *model.AppError)
+	BulkImportWithPath(rctx request.CTX, jsonlReader io.Reader, attachmentsReader *zip.Reader, dryRun, extractContent bool, workers int, importPath string) (int, *model.AppError)
 	Log() *mlog.Logger
 }
 

--- a/server/channels/jobs/migrations/migrations.go
+++ b/server/channels/jobs/migrations/migrations.go
@@ -26,12 +26,12 @@ func MakeMigrationsList() []string {
 	}
 }
 
-func GetMigrationState(c request.CTX, migration string, store store.Store) (string, *model.Job, *model.AppError) {
+func GetMigrationState(rctx request.CTX, migration string, store store.Store) (string, *model.Job, *model.AppError) {
 	if _, err := store.System().GetByName(migration); err == nil {
 		return MigrationStateCompleted, nil, nil
 	}
 
-	jobs, err := store.Job().GetAllByType(c, model.JobTypeMigrations)
+	jobs, err := store.Job().GetAllByType(rctx, model.JobTypeMigrations)
 	if err != nil {
 		return "", nil, model.NewAppError("GetMigrationState", "app.job.get_all.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}

--- a/server/channels/jobs/migrations/worker.go
+++ b/server/channels/jobs/migrations/worker.go
@@ -102,11 +102,11 @@ func (worker *Worker) DoJob(job *model.Job) {
 		return
 	}
 
-	var cancelContext request.CTX = request.EmptyContext(worker.logger)
+	var rctx request.CTX = request.EmptyContext(worker.logger)
 	cancelCtx, cancelCancelWatcher := context.WithCancel(context.Background())
 	cancelWatcherChan := make(chan struct{}, 1)
-	cancelContext = cancelContext.WithContext(cancelCtx)
-	go worker.jobServer.CancellationWatcher(cancelContext, job.Id, cancelWatcherChan)
+	rctx = rctx.WithContext(cancelCtx)
+	go worker.jobServer.CancellationWatcher(rctx, job.Id, cancelWatcherChan)
 	defer cancelCancelWatcher()
 
 	for {

--- a/server/channels/jobs/schedulers.go
+++ b/server/channels/jobs/schedulers.go
@@ -16,7 +16,7 @@ import (
 type Scheduler interface {
 	Enabled(cfg *model.Config) bool
 	NextScheduleTime(cfg *model.Config, now time.Time, pendingJobs bool, lastSuccessfulJob *model.Job) *time.Time
-	ScheduleJob(c request.CTX, cfg *model.Config, pendingJobs bool, lastSuccessfulJob *model.Job) (*model.Job, *model.AppError)
+	ScheduleJob(rctx request.CTX, cfg *model.Config, pendingJobs bool, lastSuccessfulJob *model.Job) (*model.Job, *model.AppError)
 }
 
 type Schedulers struct {
@@ -87,8 +87,8 @@ func (schedulers *Schedulers) Start() {
 						if scheduler == nil || !schedulers.isLeader || !scheduler.Enabled(cfg) {
 							continue
 						}
-						c := request.EmptyContext(schedulers.jobs.Logger())
-						if _, err := schedulers.scheduleJob(c, cfg, name, scheduler); err != nil {
+						rctx := request.EmptyContext(schedulers.jobs.Logger())
+						if _, err := schedulers.scheduleJob(rctx, cfg, name, scheduler); err != nil {
 							mlog.Error("Failed to schedule job", mlog.String("scheduler", name), mlog.Err(err))
 							continue
 						}
@@ -155,7 +155,7 @@ func (schedulers *Schedulers) setNextRunTime(cfg *model.Config, name string, now
 	mlog.Debug("Next run time for scheduler", mlog.String("scheduler_name", name), mlog.String("next_runtime", fmt.Sprintf("%v", schedulers.nextRunTimes[name])))
 }
 
-func (schedulers *Schedulers) scheduleJob(c request.CTX, cfg *model.Config, name string, scheduler Scheduler) (*model.Job, *model.AppError) {
+func (schedulers *Schedulers) scheduleJob(rctx request.CTX, cfg *model.Config, name string, scheduler Scheduler) (*model.Job, *model.AppError) {
 	pendingJobs, err := schedulers.jobs.CheckForPendingJobsByType(name)
 	if err != nil {
 		return nil, err
@@ -166,7 +166,7 @@ func (schedulers *Schedulers) scheduleJob(c request.CTX, cfg *model.Config, name
 		return nil, err
 	}
 
-	return scheduler.ScheduleJob(c, cfg, pendingJobs, lastSuccessfulJob)
+	return scheduler.ScheduleJob(rctx, cfg, pendingJobs, lastSuccessfulJob)
 }
 
 func (schedulers *Schedulers) handleConfigChange(_, newConfig *model.Config) {

--- a/server/channels/jobs/schedulers_test.go
+++ b/server/channels/jobs/schedulers_test.go
@@ -31,7 +31,7 @@ func (scheduler *MockScheduler) NextScheduleTime(cfg *model.Config, now time.Tim
 	return &nextTime
 }
 
-func (scheduler *MockScheduler) ScheduleJob(c request.CTX, cfg *model.Config, pendingJobs bool, lastSuccessfulJob *model.Job) (*model.Job, *model.AppError) {
+func (scheduler *MockScheduler) ScheduleJob(rctx request.CTX, cfg *model.Config, pendingJobs bool, lastSuccessfulJob *model.Job) (*model.Job, *model.AppError) {
 	return nil, nil
 }
 
@@ -181,8 +181,8 @@ func TestRandomDelay(t *testing.T) {
 	}
 
 	cases := []int64{5, 10, 100}
-	for _, c := range cases {
-		out := getRandomDelay(c)
-		require.Less(t, out.Milliseconds(), c)
+	for _, rctx := range cases {
+		out := getRandomDelay(rctx)
+		require.Less(t, out.Milliseconds(), rctx)
 	}
 }

--- a/server/channels/store/localcachelayer/channel_layer.go
+++ b/server/channels/store/localcachelayer/channel_layer.go
@@ -281,7 +281,7 @@ func (s LocalCacheChannelStore) GetMany(ids []string, allowFromCache bool) (mode
 	return append(foundChannels, channels...), nil
 }
 
-func (s LocalCacheChannelStore) GetAllChannelMembersForUser(ctx request.CTX, userId string, allowFromCache bool, includeDeleted bool) (map[string]string, error) {
+func (s LocalCacheChannelStore) GetAllChannelMembersForUser(rctx request.CTX, userId string, allowFromCache bool, includeDeleted bool) (map[string]string, error) {
 	cache_key := userId
 	if includeDeleted {
 		cache_key += "_deleted"
@@ -293,7 +293,7 @@ func (s LocalCacheChannelStore) GetAllChannelMembersForUser(ctx request.CTX, use
 		}
 	}
 
-	ids, err := s.ChannelStore.GetAllChannelMembersForUser(ctx, userId, allowFromCache, includeDeleted)
+	ids, err := s.ChannelStore.GetAllChannelMembersForUser(rctx, userId, allowFromCache, includeDeleted)
 	if err != nil {
 		return nil, err
 	}

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -551,11 +551,11 @@ func isRepeatableError(err error) bool {
 	return false
 }
 
-func (s *RetryLayerAccessControlPolicyStore) Delete(c request.CTX, id string) error {
+func (s *RetryLayerAccessControlPolicyStore) Delete(rctx request.CTX, id string) error {
 
 	tries := 0
 	for {
-		err := s.AccessControlPolicyStore.Delete(c, id)
+		err := s.AccessControlPolicyStore.Delete(rctx, id)
 		if err == nil {
 			return nil
 		}
@@ -572,11 +572,11 @@ func (s *RetryLayerAccessControlPolicyStore) Delete(c request.CTX, id string) er
 
 }
 
-func (s *RetryLayerAccessControlPolicyStore) Get(c request.CTX, id string) (*model.AccessControlPolicy, error) {
+func (s *RetryLayerAccessControlPolicyStore) Get(rctx request.CTX, id string) (*model.AccessControlPolicy, error) {
 
 	tries := 0
 	for {
-		result, err := s.AccessControlPolicyStore.Get(c, id)
+		result, err := s.AccessControlPolicyStore.Get(rctx, id)
 		if err == nil {
 			return result, nil
 		}
@@ -593,11 +593,11 @@ func (s *RetryLayerAccessControlPolicyStore) Get(c request.CTX, id string) (*mod
 
 }
 
-func (s *RetryLayerAccessControlPolicyStore) Save(c request.CTX, policy *model.AccessControlPolicy) (*model.AccessControlPolicy, error) {
+func (s *RetryLayerAccessControlPolicyStore) Save(rctx request.CTX, policy *model.AccessControlPolicy) (*model.AccessControlPolicy, error) {
 
 	tries := 0
 	for {
-		result, err := s.AccessControlPolicyStore.Save(c, policy)
+		result, err := s.AccessControlPolicyStore.Save(rctx, policy)
 		if err == nil {
 			return result, nil
 		}
@@ -635,11 +635,11 @@ func (s *RetryLayerAccessControlPolicyStore) SearchPolicies(rctx request.CTX, op
 
 }
 
-func (s *RetryLayerAccessControlPolicyStore) SetActiveStatus(c request.CTX, id string, active bool) (*model.AccessControlPolicy, error) {
+func (s *RetryLayerAccessControlPolicyStore) SetActiveStatus(rctx request.CTX, id string, active bool) (*model.AccessControlPolicy, error) {
 
 	tries := 0
 	for {
-		result, err := s.AccessControlPolicyStore.SetActiveStatus(c, id, active)
+		result, err := s.AccessControlPolicyStore.SetActiveStatus(rctx, id, active)
 		if err == nil {
 			return result, nil
 		}
@@ -1172,11 +1172,11 @@ func (s *RetryLayerChannelStore) CountUrgentPostsAfter(channelID string, timesta
 
 }
 
-func (s *RetryLayerChannelStore) CreateDirectChannel(ctx request.CTX, userID *model.User, otherUserID *model.User, channelOptions ...model.ChannelOption) (*model.Channel, error) {
+func (s *RetryLayerChannelStore) CreateDirectChannel(rctx request.CTX, userID *model.User, otherUserID *model.User, channelOptions ...model.ChannelOption) (*model.Channel, error) {
 
 	tries := 0
 	for {
-		result, err := s.ChannelStore.CreateDirectChannel(ctx, userID, otherUserID, channelOptions...)
+		result, err := s.ChannelStore.CreateDirectChannel(rctx, userID, otherUserID, channelOptions...)
 		if err == nil {
 			return result, nil
 		}
@@ -1193,11 +1193,11 @@ func (s *RetryLayerChannelStore) CreateDirectChannel(ctx request.CTX, userID *mo
 
 }
 
-func (s *RetryLayerChannelStore) CreateInitialSidebarCategories(c request.CTX, userID string, teamID string) (*model.OrderedSidebarCategories, error) {
+func (s *RetryLayerChannelStore) CreateInitialSidebarCategories(rctx request.CTX, userID string, teamID string) (*model.OrderedSidebarCategories, error) {
 
 	tries := 0
 	for {
-		result, err := s.ChannelStore.CreateInitialSidebarCategories(c, userID, teamID)
+		result, err := s.ChannelStore.CreateInitialSidebarCategories(rctx, userID, teamID)
 		if err == nil {
 			return result, nil
 		}
@@ -1382,11 +1382,11 @@ func (s *RetryLayerChannelStore) GetAllChannelMemberIdsByChannelId(id string) ([
 
 }
 
-func (s *RetryLayerChannelStore) GetAllChannelMembersForUser(ctx request.CTX, userID string, allowFromCache bool, includeDeleted bool) (map[string]string, error) {
+func (s *RetryLayerChannelStore) GetAllChannelMembersForUser(rctx request.CTX, userID string, allowFromCache bool, includeDeleted bool) (map[string]string, error) {
 
 	tries := 0
 	for {
-		result, err := s.ChannelStore.GetAllChannelMembersForUser(ctx, userID, allowFromCache, includeDeleted)
+		result, err := s.ChannelStore.GetAllChannelMembersForUser(rctx, userID, allowFromCache, includeDeleted)
 		if err == nil {
 			return result, nil
 		}
@@ -2669,11 +2669,11 @@ func (s *RetryLayerChannelStore) PatchMultipleMembersNotifyProps(members []*mode
 
 }
 
-func (s *RetryLayerChannelStore) PermanentDelete(ctx request.CTX, channelID string) error {
+func (s *RetryLayerChannelStore) PermanentDelete(rctx request.CTX, channelID string) error {
 
 	tries := 0
 	for {
-		err := s.ChannelStore.PermanentDelete(ctx, channelID)
+		err := s.ChannelStore.PermanentDelete(rctx, channelID)
 		if err == nil {
 			return nil
 		}
@@ -2711,11 +2711,11 @@ func (s *RetryLayerChannelStore) PermanentDeleteByTeam(teamID string) error {
 
 }
 
-func (s *RetryLayerChannelStore) PermanentDeleteMembersByChannel(ctx request.CTX, channelID string) error {
+func (s *RetryLayerChannelStore) PermanentDeleteMembersByChannel(rctx request.CTX, channelID string) error {
 
 	tries := 0
 	for {
-		err := s.ChannelStore.PermanentDeleteMembersByChannel(ctx, channelID)
+		err := s.ChannelStore.PermanentDeleteMembersByChannel(rctx, channelID)
 		if err == nil {
 			return nil
 		}
@@ -2732,11 +2732,11 @@ func (s *RetryLayerChannelStore) PermanentDeleteMembersByChannel(ctx request.CTX
 
 }
 
-func (s *RetryLayerChannelStore) PermanentDeleteMembersByUser(ctx request.CTX, userID string) error {
+func (s *RetryLayerChannelStore) PermanentDeleteMembersByUser(rctx request.CTX, userID string) error {
 
 	tries := 0
 	for {
-		err := s.ChannelStore.PermanentDeleteMembersByUser(ctx, userID)
+		err := s.ChannelStore.PermanentDeleteMembersByUser(rctx, userID)
 		if err == nil {
 			return nil
 		}
@@ -2753,11 +2753,11 @@ func (s *RetryLayerChannelStore) PermanentDeleteMembersByUser(ctx request.CTX, u
 
 }
 
-func (s *RetryLayerChannelStore) RemoveAllDeactivatedMembers(ctx request.CTX, channelID string) error {
+func (s *RetryLayerChannelStore) RemoveAllDeactivatedMembers(rctx request.CTX, channelID string) error {
 
 	tries := 0
 	for {
-		err := s.ChannelStore.RemoveAllDeactivatedMembers(ctx, channelID)
+		err := s.ChannelStore.RemoveAllDeactivatedMembers(rctx, channelID)
 		if err == nil {
 			return nil
 		}
@@ -2774,11 +2774,11 @@ func (s *RetryLayerChannelStore) RemoveAllDeactivatedMembers(ctx request.CTX, ch
 
 }
 
-func (s *RetryLayerChannelStore) RemoveMember(ctx request.CTX, channelID string, userID string) error {
+func (s *RetryLayerChannelStore) RemoveMember(rctx request.CTX, channelID string, userID string) error {
 
 	tries := 0
 	for {
-		err := s.ChannelStore.RemoveMember(ctx, channelID, userID)
+		err := s.ChannelStore.RemoveMember(rctx, channelID, userID)
 		if err == nil {
 			return nil
 		}
@@ -2795,11 +2795,11 @@ func (s *RetryLayerChannelStore) RemoveMember(ctx request.CTX, channelID string,
 
 }
 
-func (s *RetryLayerChannelStore) RemoveMembers(ctx request.CTX, channelID string, userIds []string) error {
+func (s *RetryLayerChannelStore) RemoveMembers(rctx request.CTX, channelID string, userIds []string) error {
 
 	tries := 0
 	for {
-		err := s.ChannelStore.RemoveMembers(ctx, channelID, userIds)
+		err := s.ChannelStore.RemoveMembers(rctx, channelID, userIds)
 		if err == nil {
 			return nil
 		}
@@ -2879,11 +2879,11 @@ func (s *RetryLayerChannelStore) Save(rctx request.CTX, channel *model.Channel, 
 
 }
 
-func (s *RetryLayerChannelStore) SaveDirectChannel(ctx request.CTX, channel *model.Channel, member1 *model.ChannelMember, member2 *model.ChannelMember) (*model.Channel, error) {
+func (s *RetryLayerChannelStore) SaveDirectChannel(rctx request.CTX, channel *model.Channel, member1 *model.ChannelMember, member2 *model.ChannelMember) (*model.Channel, error) {
 
 	tries := 0
 	for {
-		result, err := s.ChannelStore.SaveDirectChannel(ctx, channel, member1, member2)
+		result, err := s.ChannelStore.SaveDirectChannel(rctx, channel, member1, member2)
 		if err == nil {
 			return result, nil
 		}
@@ -3110,11 +3110,11 @@ func (s *RetryLayerChannelStore) SetShared(channelID string, shared bool) error 
 
 }
 
-func (s *RetryLayerChannelStore) Update(ctx request.CTX, channel *model.Channel) (*model.Channel, error) {
+func (s *RetryLayerChannelStore) Update(rctx request.CTX, channel *model.Channel) (*model.Channel, error) {
 
 	tries := 0
 	for {
-		result, err := s.ChannelStore.Update(ctx, channel)
+		result, err := s.ChannelStore.Update(rctx, channel)
 		if err == nil {
 			return result, nil
 		}
@@ -3173,11 +3173,11 @@ func (s *RetryLayerChannelStore) UpdateLastViewedAtPost(unreadPost *model.Post, 
 
 }
 
-func (s *RetryLayerChannelStore) UpdateMember(ctx request.CTX, member *model.ChannelMember) (*model.ChannelMember, error) {
+func (s *RetryLayerChannelStore) UpdateMember(rctx request.CTX, member *model.ChannelMember) (*model.ChannelMember, error) {
 
 	tries := 0
 	for {
-		result, err := s.ChannelStore.UpdateMember(ctx, member)
+		result, err := s.ChannelStore.UpdateMember(rctx, member)
 		if err == nil {
 			return result, nil
 		}
@@ -4124,11 +4124,11 @@ func (s *RetryLayerComplianceStore) GetAll(offset int, limit int) (model.Complia
 
 }
 
-func (s *RetryLayerComplianceStore) MessageExport(c request.CTX, cursor model.MessageExportCursor, limit int) ([]*model.MessageExport, model.MessageExportCursor, error) {
+func (s *RetryLayerComplianceStore) MessageExport(rctx request.CTX, cursor model.MessageExportCursor, limit int) ([]*model.MessageExport, model.MessageExportCursor, error) {
 
 	tries := 0
 	for {
-		result, resultVar1, err := s.ComplianceStore.MessageExport(c, cursor, limit)
+		result, resultVar1, err := s.ComplianceStore.MessageExport(rctx, cursor, limit)
 		if err == nil {
 			return result, resultVar1, nil
 		}
@@ -4502,11 +4502,11 @@ func (s *RetryLayerEmojiStore) Delete(emoji *model.Emoji, timestamp int64) error
 
 }
 
-func (s *RetryLayerEmojiStore) Get(c request.CTX, id string, allowFromCache bool) (*model.Emoji, error) {
+func (s *RetryLayerEmojiStore) Get(rctx request.CTX, id string, allowFromCache bool) (*model.Emoji, error) {
 
 	tries := 0
 	for {
-		result, err := s.EmojiStore.Get(c, id, allowFromCache)
+		result, err := s.EmojiStore.Get(rctx, id, allowFromCache)
 		if err == nil {
 			return result, nil
 		}
@@ -4523,11 +4523,11 @@ func (s *RetryLayerEmojiStore) Get(c request.CTX, id string, allowFromCache bool
 
 }
 
-func (s *RetryLayerEmojiStore) GetByName(c request.CTX, name string, allowFromCache bool) (*model.Emoji, error) {
+func (s *RetryLayerEmojiStore) GetByName(rctx request.CTX, name string, allowFromCache bool) (*model.Emoji, error) {
 
 	tries := 0
 	for {
-		result, err := s.EmojiStore.GetByName(c, name, allowFromCache)
+		result, err := s.EmojiStore.GetByName(rctx, name, allowFromCache)
 		if err == nil {
 			return result, nil
 		}
@@ -4565,11 +4565,11 @@ func (s *RetryLayerEmojiStore) GetList(offset int, limit int, sort string) ([]*m
 
 }
 
-func (s *RetryLayerEmojiStore) GetMultipleByName(c request.CTX, names []string) ([]*model.Emoji, error) {
+func (s *RetryLayerEmojiStore) GetMultipleByName(rctx request.CTX, names []string) ([]*model.Emoji, error) {
 
 	tries := 0
 	for {
-		result, err := s.EmojiStore.GetMultipleByName(c, names)
+		result, err := s.EmojiStore.GetMultipleByName(rctx, names)
 		if err == nil {
 			return result, nil
 		}
@@ -4628,11 +4628,11 @@ func (s *RetryLayerEmojiStore) Search(name string, prefixOnly bool, limit int) (
 
 }
 
-func (s *RetryLayerFileInfoStore) AttachToPost(c request.CTX, fileID string, postID string, channelID string, creatorID string) error {
+func (s *RetryLayerFileInfoStore) AttachToPost(rctx request.CTX, fileID string, postID string, channelID string, creatorID string) error {
 
 	tries := 0
 	for {
-		err := s.FileInfoStore.AttachToPost(c, fileID, postID, channelID, creatorID)
+		err := s.FileInfoStore.AttachToPost(rctx, fileID, postID, channelID, creatorID)
 		if err == nil {
 			return nil
 		}
@@ -4676,11 +4676,11 @@ func (s *RetryLayerFileInfoStore) CountAll() (int64, error) {
 
 }
 
-func (s *RetryLayerFileInfoStore) DeleteForPost(c request.CTX, postID string) (string, error) {
+func (s *RetryLayerFileInfoStore) DeleteForPost(rctx request.CTX, postID string) (string, error) {
 
 	tries := 0
 	for {
-		result, err := s.FileInfoStore.DeleteForPost(c, postID)
+		result, err := s.FileInfoStore.DeleteForPost(rctx, postID)
 		if err == nil {
 			return result, nil
 		}
@@ -4934,11 +4934,11 @@ func (s *RetryLayerFileInfoStore) InvalidateFileInfosForPostCache(postID string,
 
 }
 
-func (s *RetryLayerFileInfoStore) PermanentDelete(c request.CTX, fileID string) error {
+func (s *RetryLayerFileInfoStore) PermanentDelete(rctx request.CTX, fileID string) error {
 
 	tries := 0
 	for {
-		err := s.FileInfoStore.PermanentDelete(c, fileID)
+		err := s.FileInfoStore.PermanentDelete(rctx, fileID)
 		if err == nil {
 			return nil
 		}
@@ -4955,11 +4955,11 @@ func (s *RetryLayerFileInfoStore) PermanentDelete(c request.CTX, fileID string) 
 
 }
 
-func (s *RetryLayerFileInfoStore) PermanentDeleteBatch(ctx request.CTX, endTime int64, limit int64) (int64, error) {
+func (s *RetryLayerFileInfoStore) PermanentDeleteBatch(rctx request.CTX, endTime int64, limit int64) (int64, error) {
 
 	tries := 0
 	for {
-		result, err := s.FileInfoStore.PermanentDeleteBatch(ctx, endTime, limit)
+		result, err := s.FileInfoStore.PermanentDeleteBatch(rctx, endTime, limit)
 		if err == nil {
 			return result, nil
 		}
@@ -4976,11 +4976,11 @@ func (s *RetryLayerFileInfoStore) PermanentDeleteBatch(ctx request.CTX, endTime 
 
 }
 
-func (s *RetryLayerFileInfoStore) PermanentDeleteByUser(ctx request.CTX, userID string) (int64, error) {
+func (s *RetryLayerFileInfoStore) PermanentDeleteByUser(rctx request.CTX, userID string) (int64, error) {
 
 	tries := 0
 	for {
-		result, err := s.FileInfoStore.PermanentDeleteByUser(ctx, userID)
+		result, err := s.FileInfoStore.PermanentDeleteByUser(rctx, userID)
 		if err == nil {
 			return result, nil
 		}
@@ -5060,11 +5060,11 @@ func (s *RetryLayerFileInfoStore) RestoreForPostByIds(rctx request.CTX, postId s
 
 }
 
-func (s *RetryLayerFileInfoStore) Save(ctx request.CTX, info *model.FileInfo) (*model.FileInfo, error) {
+func (s *RetryLayerFileInfoStore) Save(rctx request.CTX, info *model.FileInfo) (*model.FileInfo, error) {
 
 	tries := 0
 	for {
-		result, err := s.FileInfoStore.Save(ctx, info)
+		result, err := s.FileInfoStore.Save(rctx, info)
 		if err == nil {
 			return result, nil
 		}
@@ -5081,11 +5081,11 @@ func (s *RetryLayerFileInfoStore) Save(ctx request.CTX, info *model.FileInfo) (*
 
 }
 
-func (s *RetryLayerFileInfoStore) Search(ctx request.CTX, paramsList []*model.SearchParams, userID string, teamID string, page int, perPage int) (*model.FileInfoList, error) {
+func (s *RetryLayerFileInfoStore) Search(rctx request.CTX, paramsList []*model.SearchParams, userID string, teamID string, page int, perPage int) (*model.FileInfoList, error) {
 
 	tries := 0
 	for {
-		result, err := s.FileInfoStore.Search(ctx, paramsList, userID, teamID, page, perPage)
+		result, err := s.FileInfoStore.Search(rctx, paramsList, userID, teamID, page, perPage)
 		if err == nil {
 			return result, nil
 		}
@@ -5102,11 +5102,11 @@ func (s *RetryLayerFileInfoStore) Search(ctx request.CTX, paramsList []*model.Se
 
 }
 
-func (s *RetryLayerFileInfoStore) SetContent(ctx request.CTX, fileID string, content string) error {
+func (s *RetryLayerFileInfoStore) SetContent(rctx request.CTX, fileID string, content string) error {
 
 	tries := 0
 	for {
-		err := s.FileInfoStore.SetContent(ctx, fileID, content)
+		err := s.FileInfoStore.SetContent(rctx, fileID, content)
 		if err == nil {
 			return nil
 		}
@@ -6320,11 +6320,11 @@ func (s *RetryLayerJobStore) Delete(id string) (string, error) {
 
 }
 
-func (s *RetryLayerJobStore) Get(c request.CTX, id string) (*model.Job, error) {
+func (s *RetryLayerJobStore) Get(rctx request.CTX, id string) (*model.Job, error) {
 
 	tries := 0
 	for {
-		result, err := s.JobStore.Get(c, id)
+		result, err := s.JobStore.Get(rctx, id)
 		if err == nil {
 			return result, nil
 		}
@@ -6341,11 +6341,11 @@ func (s *RetryLayerJobStore) Get(c request.CTX, id string) (*model.Job, error) {
 
 }
 
-func (s *RetryLayerJobStore) GetAllByStatus(c request.CTX, status string) ([]*model.Job, error) {
+func (s *RetryLayerJobStore) GetAllByStatus(rctx request.CTX, status string) ([]*model.Job, error) {
 
 	tries := 0
 	for {
-		result, err := s.JobStore.GetAllByStatus(c, status)
+		result, err := s.JobStore.GetAllByStatus(rctx, status)
 		if err == nil {
 			return result, nil
 		}
@@ -6362,11 +6362,11 @@ func (s *RetryLayerJobStore) GetAllByStatus(c request.CTX, status string) ([]*mo
 
 }
 
-func (s *RetryLayerJobStore) GetAllByType(c request.CTX, jobType string) ([]*model.Job, error) {
+func (s *RetryLayerJobStore) GetAllByType(rctx request.CTX, jobType string) ([]*model.Job, error) {
 
 	tries := 0
 	for {
-		result, err := s.JobStore.GetAllByType(c, jobType)
+		result, err := s.JobStore.GetAllByType(rctx, jobType)
 		if err == nil {
 			return result, nil
 		}
@@ -6383,11 +6383,11 @@ func (s *RetryLayerJobStore) GetAllByType(c request.CTX, jobType string) ([]*mod
 
 }
 
-func (s *RetryLayerJobStore) GetAllByTypeAndStatus(c request.CTX, jobType string, status string) ([]*model.Job, error) {
+func (s *RetryLayerJobStore) GetAllByTypeAndStatus(rctx request.CTX, jobType string, status string) ([]*model.Job, error) {
 
 	tries := 0
 	for {
-		result, err := s.JobStore.GetAllByTypeAndStatus(c, jobType, status)
+		result, err := s.JobStore.GetAllByTypeAndStatus(rctx, jobType, status)
 		if err == nil {
 			return result, nil
 		}
@@ -6404,11 +6404,11 @@ func (s *RetryLayerJobStore) GetAllByTypeAndStatus(c request.CTX, jobType string
 
 }
 
-func (s *RetryLayerJobStore) GetAllByTypePage(c request.CTX, jobType string, offset int, limit int) ([]*model.Job, error) {
+func (s *RetryLayerJobStore) GetAllByTypePage(rctx request.CTX, jobType string, offset int, limit int) ([]*model.Job, error) {
 
 	tries := 0
 	for {
-		result, err := s.JobStore.GetAllByTypePage(c, jobType, offset, limit)
+		result, err := s.JobStore.GetAllByTypePage(rctx, jobType, offset, limit)
 		if err == nil {
 			return result, nil
 		}
@@ -6425,11 +6425,11 @@ func (s *RetryLayerJobStore) GetAllByTypePage(c request.CTX, jobType string, off
 
 }
 
-func (s *RetryLayerJobStore) GetAllByTypesAndStatusesPage(c request.CTX, jobType []string, status []string, offset int, limit int) ([]*model.Job, error) {
+func (s *RetryLayerJobStore) GetAllByTypesAndStatusesPage(rctx request.CTX, jobType []string, status []string, offset int, limit int) ([]*model.Job, error) {
 
 	tries := 0
 	for {
-		result, err := s.JobStore.GetAllByTypesAndStatusesPage(c, jobType, status, offset, limit)
+		result, err := s.JobStore.GetAllByTypesAndStatusesPage(rctx, jobType, status, offset, limit)
 		if err == nil {
 			return result, nil
 		}
@@ -6446,11 +6446,11 @@ func (s *RetryLayerJobStore) GetAllByTypesAndStatusesPage(c request.CTX, jobType
 
 }
 
-func (s *RetryLayerJobStore) GetAllByTypesPage(c request.CTX, jobTypes []string, offset int, limit int) ([]*model.Job, error) {
+func (s *RetryLayerJobStore) GetAllByTypesPage(rctx request.CTX, jobTypes []string, offset int, limit int) ([]*model.Job, error) {
 
 	tries := 0
 	for {
-		result, err := s.JobStore.GetAllByTypesPage(c, jobTypes, offset, limit)
+		result, err := s.JobStore.GetAllByTypesPage(rctx, jobTypes, offset, limit)
 		if err == nil {
 			return result, nil
 		}
@@ -6635,11 +6635,11 @@ func (s *RetryLayerJobStore) UpdateStatusOptimistically(id string, currentStatus
 
 }
 
-func (s *RetryLayerLicenseStore) Get(c request.CTX, id string) (*model.LicenseRecord, error) {
+func (s *RetryLayerLicenseStore) Get(rctx request.CTX, id string) (*model.LicenseRecord, error) {
 
 	tries := 0
 	for {
-		result, err := s.LicenseStore.Get(c, id)
+		result, err := s.LicenseStore.Get(rctx, id)
 		if err == nil {
 			return result, nil
 		}
@@ -7286,11 +7286,11 @@ func (s *RetryLayerOAuthStore) UpdateApp(app *model.OAuthApp) (*model.OAuthApp, 
 
 }
 
-func (s *RetryLayerOutgoingOAuthConnectionStore) DeleteConnection(c request.CTX, id string) error {
+func (s *RetryLayerOutgoingOAuthConnectionStore) DeleteConnection(rctx request.CTX, id string) error {
 
 	tries := 0
 	for {
-		err := s.OutgoingOAuthConnectionStore.DeleteConnection(c, id)
+		err := s.OutgoingOAuthConnectionStore.DeleteConnection(rctx, id)
 		if err == nil {
 			return nil
 		}
@@ -7307,11 +7307,11 @@ func (s *RetryLayerOutgoingOAuthConnectionStore) DeleteConnection(c request.CTX,
 
 }
 
-func (s *RetryLayerOutgoingOAuthConnectionStore) GetConnection(c request.CTX, id string) (*model.OutgoingOAuthConnection, error) {
+func (s *RetryLayerOutgoingOAuthConnectionStore) GetConnection(rctx request.CTX, id string) (*model.OutgoingOAuthConnection, error) {
 
 	tries := 0
 	for {
-		result, err := s.OutgoingOAuthConnectionStore.GetConnection(c, id)
+		result, err := s.OutgoingOAuthConnectionStore.GetConnection(rctx, id)
 		if err == nil {
 			return result, nil
 		}
@@ -7328,11 +7328,11 @@ func (s *RetryLayerOutgoingOAuthConnectionStore) GetConnection(c request.CTX, id
 
 }
 
-func (s *RetryLayerOutgoingOAuthConnectionStore) GetConnections(c request.CTX, filters model.OutgoingOAuthConnectionGetConnectionsFilter) ([]*model.OutgoingOAuthConnection, error) {
+func (s *RetryLayerOutgoingOAuthConnectionStore) GetConnections(rctx request.CTX, filters model.OutgoingOAuthConnectionGetConnectionsFilter) ([]*model.OutgoingOAuthConnection, error) {
 
 	tries := 0
 	for {
-		result, err := s.OutgoingOAuthConnectionStore.GetConnections(c, filters)
+		result, err := s.OutgoingOAuthConnectionStore.GetConnections(rctx, filters)
 		if err == nil {
 			return result, nil
 		}
@@ -7349,11 +7349,11 @@ func (s *RetryLayerOutgoingOAuthConnectionStore) GetConnections(c request.CTX, f
 
 }
 
-func (s *RetryLayerOutgoingOAuthConnectionStore) SaveConnection(c request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error) {
+func (s *RetryLayerOutgoingOAuthConnectionStore) SaveConnection(rctx request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error) {
 
 	tries := 0
 	for {
-		result, err := s.OutgoingOAuthConnectionStore.SaveConnection(c, conn)
+		result, err := s.OutgoingOAuthConnectionStore.SaveConnection(rctx, conn)
 		if err == nil {
 			return result, nil
 		}
@@ -7370,11 +7370,11 @@ func (s *RetryLayerOutgoingOAuthConnectionStore) SaveConnection(c request.CTX, c
 
 }
 
-func (s *RetryLayerOutgoingOAuthConnectionStore) UpdateConnection(c request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error) {
+func (s *RetryLayerOutgoingOAuthConnectionStore) UpdateConnection(rctx request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error) {
 
 	tries := 0
 	for {
-		result, err := s.OutgoingOAuthConnectionStore.UpdateConnection(c, conn)
+		result, err := s.OutgoingOAuthConnectionStore.UpdateConnection(rctx, conn)
 		if err == nil {
 			return result, nil
 		}
@@ -11180,11 +11180,11 @@ func (s *RetryLayerSessionStore) Cleanup(expiryTime int64, batchSize int64) erro
 
 }
 
-func (s *RetryLayerSessionStore) Get(c request.CTX, sessionIDOrToken string) (*model.Session, error) {
+func (s *RetryLayerSessionStore) Get(rctx request.CTX, sessionIDOrToken string) (*model.Session, error) {
 
 	tries := 0
 	for {
-		result, err := s.SessionStore.Get(c, sessionIDOrToken)
+		result, err := s.SessionStore.Get(rctx, sessionIDOrToken)
 		if err == nil {
 			return result, nil
 		}
@@ -11201,11 +11201,11 @@ func (s *RetryLayerSessionStore) Get(c request.CTX, sessionIDOrToken string) (*m
 
 }
 
-func (s *RetryLayerSessionStore) GetLRUSessions(c request.CTX, userID string, limit uint64, offset uint64) ([]*model.Session, error) {
+func (s *RetryLayerSessionStore) GetLRUSessions(rctx request.CTX, userID string, limit uint64, offset uint64) ([]*model.Session, error) {
 
 	tries := 0
 	for {
-		result, err := s.SessionStore.GetLRUSessions(c, userID, limit, offset)
+		result, err := s.SessionStore.GetLRUSessions(rctx, userID, limit, offset)
 		if err == nil {
 			return result, nil
 		}
@@ -11243,11 +11243,11 @@ func (s *RetryLayerSessionStore) GetMobileSessionMetadata() ([]*model.MobileSess
 
 }
 
-func (s *RetryLayerSessionStore) GetSessions(c request.CTX, userID string) ([]*model.Session, error) {
+func (s *RetryLayerSessionStore) GetSessions(rctx request.CTX, userID string) ([]*model.Session, error) {
 
 	tries := 0
 	for {
-		result, err := s.SessionStore.GetSessions(c, userID)
+		result, err := s.SessionStore.GetSessions(rctx, userID)
 		if err == nil {
 			return result, nil
 		}
@@ -11369,11 +11369,11 @@ func (s *RetryLayerSessionStore) RemoveAllSessions() error {
 
 }
 
-func (s *RetryLayerSessionStore) Save(c request.CTX, session *model.Session) (*model.Session, error) {
+func (s *RetryLayerSessionStore) Save(rctx request.CTX, session *model.Session) (*model.Session, error) {
 
 	tries := 0
 	for {
-		result, err := s.SessionStore.Save(c, session)
+		result, err := s.SessionStore.Save(rctx, session)
 		if err == nil {
 			return result, nil
 		}
@@ -12845,11 +12845,11 @@ func (s *RetryLayerTeamStore) GetMany(ids []string) ([]*model.Team, error) {
 
 }
 
-func (s *RetryLayerTeamStore) GetMember(c request.CTX, teamID string, userID string) (*model.TeamMember, error) {
+func (s *RetryLayerTeamStore) GetMember(rctx request.CTX, teamID string, userID string) (*model.TeamMember, error) {
 
 	tries := 0
 	for {
-		result, err := s.TeamStore.GetMember(c, teamID, userID)
+		result, err := s.TeamStore.GetMember(rctx, teamID, userID)
 		if err == nil {
 			return result, nil
 		}
@@ -12971,11 +12971,11 @@ func (s *RetryLayerTeamStore) GetTeamsByUserId(userID string) ([]*model.Team, er
 
 }
 
-func (s *RetryLayerTeamStore) GetTeamsForUser(c request.CTX, userID string, excludeTeamID string, includeDeleted bool) ([]*model.TeamMember, error) {
+func (s *RetryLayerTeamStore) GetTeamsForUser(rctx request.CTX, userID string, excludeTeamID string, includeDeleted bool) ([]*model.TeamMember, error) {
 
 	tries := 0
 	for {
-		result, err := s.TeamStore.GetTeamsForUser(c, userID, excludeTeamID, includeDeleted)
+		result, err := s.TeamStore.GetTeamsForUser(rctx, userID, excludeTeamID, includeDeleted)
 		if err == nil {
 			return result, nil
 		}
@@ -13145,11 +13145,11 @@ func (s *RetryLayerTeamStore) RemoveAllMembersByTeam(teamID string) error {
 
 }
 
-func (s *RetryLayerTeamStore) RemoveAllMembersByUser(ctx request.CTX, userID string) error {
+func (s *RetryLayerTeamStore) RemoveAllMembersByUser(rctx request.CTX, userID string) error {
 
 	tries := 0
 	for {
-		err := s.TeamStore.RemoveAllMembersByUser(ctx, userID)
+		err := s.TeamStore.RemoveAllMembersByUser(rctx, userID)
 		if err == nil {
 			return nil
 		}
@@ -14264,11 +14264,11 @@ func (s *RetryLayerUploadSessionStore) Delete(id string) error {
 
 }
 
-func (s *RetryLayerUploadSessionStore) Get(c request.CTX, id string) (*model.UploadSession, error) {
+func (s *RetryLayerUploadSessionStore) Get(rctx request.CTX, id string) (*model.UploadSession, error) {
 
 	tries := 0
 	for {
-		result, err := s.UploadSessionStore.Get(c, id)
+		result, err := s.UploadSessionStore.Get(rctx, id)
 		if err == nil {
 			return result, nil
 		}

--- a/server/channels/store/sqlstore/channel_store_categories.go
+++ b/server/channels/store/sqlstore/channel_store_categories.go
@@ -16,7 +16,7 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 )
 
-func (s SqlChannelStore) CreateInitialSidebarCategories(c request.CTX, userId string, teamID string) (_ *model.OrderedSidebarCategories, err error) {
+func (s SqlChannelStore) CreateInitialSidebarCategories(rctx request.CTX, userId string, teamID string) (_ *model.OrderedSidebarCategories, err error) {
 	transaction, err := s.GetMaster().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "CreateInitialSidebarCategories: begin_transaction")

--- a/server/channels/store/sqlstore/compliance_store.go
+++ b/server/channels/store/sqlstore/compliance_store.go
@@ -301,7 +301,7 @@ func (s SqlComplianceStore) ComplianceExport(job *model.Compliance, cursor model
 	return append(channelPosts, directMessagePosts...), cursor, nil
 }
 
-func (s SqlComplianceStore) MessageExport(c request.CTX, cursor model.MessageExportCursor, limit int) ([]*model.MessageExport, model.MessageExportCursor, error) {
+func (s SqlComplianceStore) MessageExport(rctx request.CTX, cursor model.MessageExportCursor, limit int) ([]*model.MessageExport, model.MessageExportCursor, error) {
 	caseStmt, caseArgs, caseErr := sq.Case().
 		When(
 			sq.Eq{"Channels.Type": model.ChannelTypeDirect},
@@ -361,7 +361,7 @@ func (s SqlComplianceStore) MessageExport(c request.CTX, cursor model.MessageExp
 	}
 
 	cposts := []*model.MessageExport{}
-	if err := s.GetReplica().SelectBuilderCtx(c.Context(), &cposts, builder); err != nil {
+	if err := s.GetReplica().SelectBuilderCtx(rctx.Context(), &cposts, builder); err != nil {
 		return nil, cursor, errors.Wrap(err, "unable to export messages")
 	}
 	if len(cposts) > 0 {

--- a/server/channels/store/sqlstore/context.go
+++ b/server/channels/store/sqlstore/context.go
@@ -29,10 +29,10 @@ func WithMaster(ctx context.Context) context.Context {
 }
 
 // RequestContextWithMaster adds the context value that master DB should be selected for this request.
-func RequestContextWithMaster(c request.CTX) request.CTX {
-	ctx := WithMaster(c.Context())
-	c = c.WithContext(ctx)
-	return c
+func RequestContextWithMaster(rctx request.CTX) request.CTX {
+	ctx := WithMaster(rctx.Context())
+	rctx = rctx.WithContext(ctx)
+	return rctx
 }
 
 // HasMaster is a helper function to check whether master DB should be selected or not.

--- a/server/channels/store/sqlstore/emoji_store.go
+++ b/server/channels/store/sqlstore/emoji_store.go
@@ -52,19 +52,19 @@ func (es SqlEmojiStore) Save(emoji *model.Emoji) (*model.Emoji, error) {
 	return emoji, nil
 }
 
-func (es SqlEmojiStore) Get(c request.CTX, id string, allowFromCache bool) (*model.Emoji, error) {
-	return es.getBy(c, "Id", id)
+func (es SqlEmojiStore) Get(rctx request.CTX, id string, allowFromCache bool) (*model.Emoji, error) {
+	return es.getBy(rctx, "Id", id)
 }
 
-func (es SqlEmojiStore) GetByName(c request.CTX, name string, allowFromCache bool) (*model.Emoji, error) {
-	return es.getBy(c, "Name", name)
+func (es SqlEmojiStore) GetByName(rctx request.CTX, name string, allowFromCache bool) (*model.Emoji, error) {
+	return es.getBy(rctx, "Name", name)
 }
 
-func (es SqlEmojiStore) GetMultipleByName(c request.CTX, names []string) ([]*model.Emoji, error) {
+func (es SqlEmojiStore) GetMultipleByName(rctx request.CTX, names []string) ([]*model.Emoji, error) {
 	query := es.emojiSelectQuery.Where(sq.Eq{"Name": names})
 
 	emojis := []*model.Emoji{}
-	if err := es.DBXFromContext(c.Context()).SelectBuilder(&emojis, query); err != nil {
+	if err := es.DBXFromContext(rctx.Context()).SelectBuilder(&emojis, query); err != nil {
 		return nil, errors.Wrapf(err, "error getting emojis by names %v", names)
 	}
 
@@ -128,12 +128,12 @@ func (es SqlEmojiStore) Search(name string, prefixOnly bool, limit int) ([]*mode
 }
 
 // getBy returns one active (not deleted) emoji, found by any one column (what/key).
-func (es SqlEmojiStore) getBy(c request.CTX, what, key string) (*model.Emoji, error) {
+func (es SqlEmojiStore) getBy(rctx request.CTX, what, key string) (*model.Emoji, error) {
 	var emoji model.Emoji
 
 	query := es.emojiSelectQuery.Where(sq.Eq{what: key})
 
-	err := es.DBXFromContext(c.Context()).GetBuilder(&emoji, query)
+	err := es.DBXFromContext(rctx.Context()).GetBuilder(&emoji, query)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Emoji", fmt.Sprintf("%s=%s", what, key))

--- a/server/channels/store/sqlstore/integrity_test.go
+++ b/server/channels/store/sqlstore/integrity_test.go
@@ -317,10 +317,10 @@ func createScheme(ss store.Store) *model.Scheme {
 	return s
 }
 
-func createSession(c request.CTX, ss store.Store, userId string) *model.Session {
+func createSession(rctx request.CTX, ss store.Store, userId string) *model.Session {
 	m := model.Session{}
 	m.UserId = userId
-	s, _ := ss.Session().Save(c, &m)
+	s, _ := ss.Session().Save(rctx, &m)
 	return s
 }
 

--- a/server/channels/store/sqlstore/job_store.go
+++ b/server/channels/store/sqlstore/job_store.go
@@ -274,7 +274,7 @@ func (jss SqlJobStore) UpdateStatusOptimistically(id string, currentStatus strin
 	return job[0], nil
 }
 
-func (jss SqlJobStore) Get(c request.CTX, id string) (*model.Job, error) {
+func (jss SqlJobStore) Get(rctx request.CTX, id string) (*model.Job, error) {
 	query, args, err := jss.jobQuery.
 		Where(sq.Eq{"Id": id}).ToSql()
 	if err != nil {
@@ -292,7 +292,7 @@ func (jss SqlJobStore) Get(c request.CTX, id string) (*model.Job, error) {
 	return &status, nil
 }
 
-func (jss SqlJobStore) GetAllByTypesPage(c request.CTX, jobTypes []string, page int, perPage int) ([]*model.Job, error) {
+func (jss SqlJobStore) GetAllByTypesPage(rctx request.CTX, jobTypes []string, page int, perPage int) ([]*model.Job, error) {
 	offset := page * perPage
 	query, args, err := jss.jobQuery.
 		Where(sq.Eq{"Type": jobTypes}).
@@ -311,7 +311,7 @@ func (jss SqlJobStore) GetAllByTypesPage(c request.CTX, jobTypes []string, page 
 	return jobs, nil
 }
 
-func (jss SqlJobStore) GetAllByType(c request.CTX, jobType string) ([]*model.Job, error) {
+func (jss SqlJobStore) GetAllByType(rctx request.CTX, jobType string) ([]*model.Job, error) {
 	query, args, err := jss.jobQuery.
 		Where(sq.Eq{"Type": jobType}).
 		OrderBy("CreateAt DESC").ToSql()
@@ -327,7 +327,7 @@ func (jss SqlJobStore) GetAllByType(c request.CTX, jobType string) ([]*model.Job
 	return statuses, nil
 }
 
-func (jss SqlJobStore) GetAllByTypeAndStatus(c request.CTX, jobType string, status string) ([]*model.Job, error) {
+func (jss SqlJobStore) GetAllByTypeAndStatus(rctx request.CTX, jobType string, status string) ([]*model.Job, error) {
 	query, args, err := jss.jobQuery.
 		Where(sq.Eq{"Type": jobType, "Status": status}).
 		OrderBy("CreateAt DESC").ToSql()
@@ -343,7 +343,7 @@ func (jss SqlJobStore) GetAllByTypeAndStatus(c request.CTX, jobType string, stat
 	return jobs, nil
 }
 
-func (jss SqlJobStore) GetAllByTypePage(c request.CTX, jobType string, page int, perPage int) ([]*model.Job, error) {
+func (jss SqlJobStore) GetAllByTypePage(rctx request.CTX, jobType string, page int, perPage int) ([]*model.Job, error) {
 	offset := page * perPage
 	query, args, err := jss.jobQuery.
 		Where(sq.Eq{"Type": jobType}).
@@ -362,7 +362,7 @@ func (jss SqlJobStore) GetAllByTypePage(c request.CTX, jobType string, page int,
 	return statuses, nil
 }
 
-func (jss SqlJobStore) GetAllByStatus(c request.CTX, status string) ([]*model.Job, error) {
+func (jss SqlJobStore) GetAllByStatus(rctx request.CTX, status string) ([]*model.Job, error) {
 	statuses := []*model.Job{}
 	query, args, err := jss.jobQuery.
 		Where(sq.Eq{"Status": status}).
@@ -378,7 +378,7 @@ func (jss SqlJobStore) GetAllByStatus(c request.CTX, status string) ([]*model.Jo
 	return statuses, nil
 }
 
-func (jss SqlJobStore) GetAllByTypesAndStatusesPage(c request.CTX, jobType []string, status []string, offset int, limit int) ([]*model.Job, error) {
+func (jss SqlJobStore) GetAllByTypesAndStatusesPage(rctx request.CTX, jobType []string, status []string, offset int, limit int) ([]*model.Job, error) {
 	query, args, err := jss.jobQuery.
 		Where(sq.Eq{"Type": jobType, "Status": status}).
 		OrderBy("CreateAt DESC").

--- a/server/channels/store/sqlstore/license_store.go
+++ b/server/channels/store/sqlstore/license_store.go
@@ -57,7 +57,7 @@ func (ls SqlLicenseStore) Save(license *model.LicenseRecord) error {
 // Get obtains the license with the provided id parameter from the database.
 // If the license doesn't exist it returns a model.AppError with
 // http.StatusNotFound in the StatusCode field.
-func (ls SqlLicenseStore) Get(c request.CTX, id string) (*model.LicenseRecord, error) {
+func (ls SqlLicenseStore) Get(rctx request.CTX, id string) (*model.LicenseRecord, error) {
 	query := ls.getQueryBuilder().
 		Select("Id, CreateAt, Bytes").
 		From("Licenses").
@@ -69,7 +69,7 @@ func (ls SqlLicenseStore) Get(c request.CTX, id string) (*model.LicenseRecord, e
 	}
 
 	license := &model.LicenseRecord{}
-	if err := ls.DBXFromContext(c.Context()).Get(license, queryString, args...); err != nil {
+	if err := ls.DBXFromContext(rctx.Context()).Get(license, queryString, args...); err != nil {
 		return nil, store.NewErrNotFound("License", id)
 	}
 	return license, nil

--- a/server/channels/store/sqlstore/outgoing_oauth_connection_store.go
+++ b/server/channels/store/sqlstore/outgoing_oauth_connection_store.go
@@ -33,7 +33,7 @@ func newSqlOutgoingOAuthConnectionStore(sqlStore *SqlStore) store.OutgoingOAuthC
 	return &s
 }
 
-func (s *SqlOutgoingOAuthConnectionStore) SaveConnection(c request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error) {
+func (s *SqlOutgoingOAuthConnectionStore) SaveConnection(rctx request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error) {
 	if conn.Id != "" {
 		return nil, store.NewErrInvalidInput("OutgoingOAuthConnection", "Id", conn.Id)
 	}
@@ -52,7 +52,7 @@ func (s *SqlOutgoingOAuthConnectionStore) SaveConnection(c request.CTX, conn *mo
 	return conn, nil
 }
 
-func (s *SqlOutgoingOAuthConnectionStore) UpdateConnection(c request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error) {
+func (s *SqlOutgoingOAuthConnectionStore) UpdateConnection(rctx request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error) {
 	if conn.Id == "" {
 		return nil, store.NewErrInvalidInput("OutgoingOAuthConnection", "Id", conn.Id)
 	}
@@ -94,7 +94,7 @@ func (s *SqlOutgoingOAuthConnectionStore) UpdateConnection(c request.CTX, conn *
 	return conn, nil
 }
 
-func (s *SqlOutgoingOAuthConnectionStore) GetConnection(c request.CTX, id string) (*model.OutgoingOAuthConnection, error) {
+func (s *SqlOutgoingOAuthConnectionStore) GetConnection(rctx request.CTX, id string) (*model.OutgoingOAuthConnection, error) {
 	conn := &model.OutgoingOAuthConnection{}
 	query := s.tableSelectQuery.Where(sq.Eq{"Id": id})
 
@@ -107,7 +107,7 @@ func (s *SqlOutgoingOAuthConnectionStore) GetConnection(c request.CTX, id string
 	return conn, nil
 }
 
-func (s *SqlOutgoingOAuthConnectionStore) GetConnections(c request.CTX, filters model.OutgoingOAuthConnectionGetConnectionsFilter) ([]*model.OutgoingOAuthConnection, error) {
+func (s *SqlOutgoingOAuthConnectionStore) GetConnections(rctx request.CTX, filters model.OutgoingOAuthConnectionGetConnectionsFilter) ([]*model.OutgoingOAuthConnection, error) {
 	filters.SetDefaults()
 
 	conns := []*model.OutgoingOAuthConnection{}
@@ -121,14 +121,14 @@ func (s *SqlOutgoingOAuthConnectionStore) GetConnections(c request.CTX, filters 
 		query = query.Where(sq.Like{"Audiences": fmt.Sprint("%", filters.Audience, "%")})
 	}
 
-	if err := s.GetReplica().SelectBuilderCtx(c.Context(), &conns, query); err != nil {
+	if err := s.GetReplica().SelectBuilderCtx(rctx.Context(), &conns, query); err != nil {
 		return nil, errors.Wrap(err, "failed to get OutgoingOAuthConnections")
 	}
 
 	return conns, nil
 }
 
-func (s *SqlOutgoingOAuthConnectionStore) DeleteConnection(c request.CTX, id string) error {
+func (s *SqlOutgoingOAuthConnectionStore) DeleteConnection(rctx request.CTX, id string) error {
 	if _, err := s.GetMaster().Exec(`DELETE FROM OutgoingOAuthConnections WHERE Id=?`, id); err != nil {
 		return errors.Wrap(err, "failed to delete OutgoingOAuthConnection")
 	}

--- a/server/channels/store/sqlstore/team_store.go
+++ b/server/channels/store/sqlstore/team_store.go
@@ -1114,7 +1114,7 @@ func (s SqlTeamStore) GetMembersByIds(teamId string, userIds []string, restricti
 }
 
 // GetTeamsForUser returns a list of teams that the user is a member of. Expects userId to be passed as a parameter. It can also negative the teamID passed.
-func (s SqlTeamStore) GetTeamsForUser(ctx request.CTX, userId, excludeTeamID string, includeDeleted bool) ([]*model.TeamMember, error) {
+func (s SqlTeamStore) GetTeamsForUser(rctx request.CTX, userId, excludeTeamID string, includeDeleted bool) ([]*model.TeamMember, error) {
 	query := s.getTeamMembersWithSchemeSelectQuery().
 		Where(sq.Eq{"TeamMembers.UserId": userId})
 
@@ -1132,7 +1132,7 @@ func (s SqlTeamStore) GetTeamsForUser(ctx request.CTX, userId, excludeTeamID str
 	}
 
 	dbMembers := teamMemberWithSchemeRolesList{}
-	err = s.SqlStore.DBXFromContext(ctx.Context()).Select(&dbMembers, queryString, args...)
+	err = s.SqlStore.DBXFromContext(rctx.Context()).Select(&dbMembers, queryString, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find TeamMembers with userId=%s", userId)
 	}

--- a/server/channels/store/sqlstore/upload_session_store.go
+++ b/server/channels/store/sqlstore/upload_session_store.go
@@ -99,7 +99,7 @@ func (us SqlUploadSessionStore) Update(session *model.UploadSession) error {
 	return nil
 }
 
-func (us SqlUploadSessionStore) Get(c request.CTX, id string) (*model.UploadSession, error) {
+func (us SqlUploadSessionStore) Get(rctx request.CTX, id string) (*model.UploadSession, error) {
 	if !model.IsValidId(id) {
 		return nil, errors.New("SqlUploadSessionStore.Get: id is not valid")
 	}
@@ -110,7 +110,7 @@ func (us SqlUploadSessionStore) Get(c request.CTX, id string) (*model.UploadSess
 		return nil, errors.Wrap(err, "SqlUploadSessionStore.Get: failed to build query")
 	}
 	var session model.UploadSession
-	if err := us.DBXFromContext(c.Context()).Get(&session, query, args...); err != nil {
+	if err := us.DBXFromContext(rctx.Context()).Get(&session, query, args...); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("UploadSession", id)
 		}

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -147,19 +147,19 @@ type TeamStore interface {
 	SaveMember(rctx request.CTX, member *model.TeamMember, maxUsersPerTeam int) (*model.TeamMember, error)
 	UpdateMember(rctx request.CTX, member *model.TeamMember) (*model.TeamMember, error)
 	UpdateMultipleMembers(members []*model.TeamMember) ([]*model.TeamMember, error)
-	GetMember(c request.CTX, teamID string, userID string) (*model.TeamMember, error)
+	GetMember(rctx request.CTX, teamID string, userID string) (*model.TeamMember, error)
 	GetMembers(teamID string, offset int, limit int, teamMembersGetOptions *model.TeamMembersGetOptions) ([]*model.TeamMember, error)
 	GetMembersByIds(teamID string, userIds []string, restrictions *model.ViewUsersRestrictions) ([]*model.TeamMember, error)
 	GetTotalMemberCount(teamID string, restrictions *model.ViewUsersRestrictions) (int64, error)
 	GetActiveMemberCount(teamID string, restrictions *model.ViewUsersRestrictions) (int64, error)
-	GetTeamsForUser(c request.CTX, userID, excludeTeamID string, includeDeleted bool) ([]*model.TeamMember, error)
+	GetTeamsForUser(rctx request.CTX, userID, excludeTeamID string, includeDeleted bool) ([]*model.TeamMember, error)
 	GetTeamsForUserWithPagination(userID string, page, perPage int) ([]*model.TeamMember, error)
 	GetChannelUnreadsForAllTeams(excludeTeamID, userID string) ([]*model.ChannelUnread, error)
 	GetChannelUnreadsForTeam(teamID, userID string) ([]*model.ChannelUnread, error)
 	RemoveMember(rctx request.CTX, teamID string, userID string) error
 	RemoveMembers(rctx request.CTX, teamID string, userIds []string) error
 	RemoveAllMembersByTeam(teamID string) error
-	RemoveAllMembersByUser(ctx request.CTX, userID string) error
+	RemoveAllMembersByUser(rctx request.CTX, userID string) error
 	UpdateLastTeamIconUpdate(teamID string, curTime int64) error
 	GetTeamsByScheme(schemeID string, offset int, limit int) ([]*model.Team, error)
 	MigrateTeamMembers(fromTeamID string, fromUserID string) (map[string]string, error)
@@ -190,9 +190,9 @@ type TeamStore interface {
 
 type ChannelStore interface {
 	Save(rctx request.CTX, channel *model.Channel, maxChannelsPerTeam int64, channelOptions ...model.ChannelOption) (*model.Channel, error)
-	CreateDirectChannel(ctx request.CTX, userID *model.User, otherUserID *model.User, channelOptions ...model.ChannelOption) (*model.Channel, error)
-	SaveDirectChannel(ctx request.CTX, channel *model.Channel, member1 *model.ChannelMember, member2 *model.ChannelMember) (*model.Channel, error)
-	Update(ctx request.CTX, channel *model.Channel) (*model.Channel, error)
+	CreateDirectChannel(rctx request.CTX, userID *model.User, otherUserID *model.User, channelOptions ...model.ChannelOption) (*model.Channel, error)
+	SaveDirectChannel(rctx request.CTX, channel *model.Channel, member1 *model.ChannelMember, member2 *model.ChannelMember) (*model.Channel, error)
+	Update(rctx request.CTX, channel *model.Channel) (*model.Channel, error)
 	UpdateSidebarChannelCategoryOnMove(channel *model.Channel, newTeamID string) error
 	ClearSidebarOnTeamLeave(userID, teamID string) error
 	Get(id string, allowFromCache bool) (*model.Channel, error)
@@ -202,7 +202,7 @@ type ChannelStore interface {
 	Delete(channelID string, timestamp int64) error
 	Restore(channelID string, timestamp int64) error
 	SetDeleteAt(channelID string, deleteAt int64, updateAt int64) error
-	PermanentDelete(ctx request.CTX, channelID string) error
+	PermanentDelete(rctx request.CTX, channelID string) error
 	PermanentDeleteByTeam(teamID string) error
 	GetByName(teamID string, name string, allowFromCache bool) (*model.Channel, error)
 	GetByNames(teamID string, names []string, allowFromCache bool) ([]*model.Channel, error)
@@ -227,7 +227,7 @@ type ChannelStore interface {
 	GetForPost(postID string) (*model.Channel, error)
 	SaveMultipleMembers(members []*model.ChannelMember) ([]*model.ChannelMember, error)
 	SaveMember(rctx request.CTX, member *model.ChannelMember) (*model.ChannelMember, error)
-	UpdateMember(ctx request.CTX, member *model.ChannelMember) (*model.ChannelMember, error)
+	UpdateMember(rctx request.CTX, member *model.ChannelMember) (*model.ChannelMember, error)
 	UpdateMultipleMembers(members []*model.ChannelMember) ([]*model.ChannelMember, error)
 	// UpdateMemberNotifyProps patches the notifyProps field with the given props map.
 	// It replaces existing fields and creates new ones which don't exist.
@@ -237,7 +237,7 @@ type ChannelStore interface {
 	GetMember(ctx context.Context, channelID string, userID string) (*model.ChannelMember, error)
 	GetMemberLastViewedAt(ctx context.Context, channelID string, userID string) (int64, error)
 	GetChannelMembersTimezones(channelID string) ([]model.StringMap, error)
-	GetAllChannelMembersForUser(ctx request.CTX, userID string, allowFromCache bool, includeDeleted bool) (map[string]string, error)
+	GetAllChannelMembersForUser(rctx request.CTX, userID string, allowFromCache bool, includeDeleted bool) (map[string]string, error)
 	GetChannelsMemberCount(channelIDs []string) (map[string]int64, error)
 	InvalidateAllChannelMembersForUser(userID string)
 	GetAllChannelMembersNotifyPropsForChannel(channelID string, allowFromCache bool) (map[string]model.StringMap, error)
@@ -253,10 +253,10 @@ type ChannelStore interface {
 	InvalidateGuestCount(channelID string)
 	GetGuestCount(channelID string, allowFromCache bool) (int64, error)
 	GetPinnedPosts(channelID string) (*model.PostList, error)
-	RemoveMember(ctx request.CTX, channelID string, userID string) error
-	RemoveMembers(ctx request.CTX, channelID string, userIds []string) error
-	PermanentDeleteMembersByUser(ctx request.CTX, userID string) error
-	PermanentDeleteMembersByChannel(ctx request.CTX, channelID string) error
+	RemoveMember(rctx request.CTX, channelID string, userID string) error
+	RemoveMembers(rctx request.CTX, channelID string, userIds []string) error
+	PermanentDeleteMembersByUser(rctx request.CTX, userID string) error
+	PermanentDeleteMembersByChannel(rctx request.CTX, channelID string) error
 	UpdateLastViewedAt(channelIds []string, userID string) (map[string]int64, error)
 	UpdateLastViewedAtPost(unreadPost *model.Post, userID string, mentionCount, mentionCountRoot, urgentMentionCount int, setUnreadCountRoot bool) (*model.ChannelUnreadAt, error)
 	CountPostsAfter(channelID string, timestamp int64, excludedUserID string) (int, int, error)
@@ -289,7 +289,7 @@ type ChannelStore interface {
 	MigrateChannelMembers(fromChannelID string, fromUserID string) (map[string]string, error)
 	ResetAllChannelSchemes() error
 	ClearAllCustomRoleAssignments() error
-	CreateInitialSidebarCategories(c request.CTX, userID string, teamID string) (*model.OrderedSidebarCategories, error)
+	CreateInitialSidebarCategories(rctx request.CTX, userID string, teamID string) (*model.OrderedSidebarCategories, error)
 	GetSidebarCategoriesForTeamForUser(userID, teamID string) (*model.OrderedSidebarCategories, error)
 	GetSidebarCategories(userID string, teamID string) (*model.OrderedSidebarCategories, error)
 	GetSidebarCategory(categoryID string) (*model.SidebarCategoryWithChannels, error)
@@ -304,7 +304,7 @@ type ChannelStore interface {
 	GetAllChannelsForExportAfter(limit int, afterID string) ([]*model.ChannelForExport, error)
 	GetAllDirectChannelsForExportAfter(limit int, afterID string, includeArchivedChannels bool) ([]*model.DirectChannelForExport, error)
 	GetChannelMembersForExport(userID string, teamID string, includeArchivedChannel bool) ([]*model.ChannelMemberForExport, error)
-	RemoveAllDeactivatedMembers(ctx request.CTX, channelID string) error
+	RemoveAllDeactivatedMembers(rctx request.CTX, channelID string) error
 	GetChannelsBatchForIndexing(startTime int64, startChannelID string, limit int) ([]*model.Channel, error)
 	UserBelongsToChannels(userID string, channelIds []string) (bool, error)
 
@@ -519,10 +519,10 @@ type BotStore interface {
 }
 
 type SessionStore interface {
-	Get(c request.CTX, sessionIDOrToken string) (*model.Session, error)
-	Save(c request.CTX, session *model.Session) (*model.Session, error)
-	GetSessions(c request.CTX, userID string) ([]*model.Session, error)
-	GetLRUSessions(c request.CTX, userID string, limit uint64, offset uint64) ([]*model.Session, error)
+	Get(rctx request.CTX, sessionIDOrToken string) (*model.Session, error)
+	Save(rctx request.CTX, session *model.Session) (*model.Session, error)
+	GetSessions(rctx request.CTX, userID string) ([]*model.Session, error)
+	GetLRUSessions(rctx request.CTX, userID string, limit uint64, offset uint64) ([]*model.Session, error)
 	GetMobileSessionMetadata() ([]*model.MobileSessionMetadata, error)
 	GetSessionsWithActiveDeviceIds(userID string) ([]*model.Session, error)
 	GetSessionsExpired(thresholdMillis int64, mobileOnly bool, unnotifiedOnly bool) ([]*model.Session, error)
@@ -572,7 +572,7 @@ type ComplianceStore interface {
 	Get(id string) (*model.Compliance, error)
 	GetAll(offset, limit int) (model.Compliances, error)
 	ComplianceExport(compliance *model.Compliance, cursor model.ComplianceExportCursor, limit int) ([]*model.CompliancePost, model.ComplianceExportCursor, error)
-	MessageExport(c request.CTX, cursor model.MessageExportCursor, limit int) ([]*model.MessageExport, model.MessageExportCursor, error)
+	MessageExport(rctx request.CTX, cursor model.MessageExportCursor, limit int) ([]*model.MessageExport, model.MessageExportCursor, error)
 }
 
 type OAuthStore interface {
@@ -600,11 +600,11 @@ type OAuthStore interface {
 }
 
 type OutgoingOAuthConnectionStore interface {
-	SaveConnection(c request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error)
-	UpdateConnection(c request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error)
-	GetConnection(c request.CTX, id string) (*model.OutgoingOAuthConnection, error)
-	GetConnections(c request.CTX, filters model.OutgoingOAuthConnectionGetConnectionsFilter) ([]*model.OutgoingOAuthConnection, error)
-	DeleteConnection(c request.CTX, id string) error
+	SaveConnection(rctx request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error)
+	UpdateConnection(rctx request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error)
+	GetConnection(rctx request.CTX, id string) (*model.OutgoingOAuthConnection, error)
+	GetConnections(rctx request.CTX, filters model.OutgoingOAuthConnectionGetConnectionsFilter) ([]*model.OutgoingOAuthConnection, error)
+	DeleteConnection(rctx request.CTX, id string) error
 }
 
 type SystemStore interface {
@@ -685,7 +685,7 @@ type PreferenceStore interface {
 
 type LicenseStore interface {
 	Save(license *model.LicenseRecord) error
-	Get(c request.CTX, id string) (*model.LicenseRecord, error)
+	Get(rctx request.CTX, id string) (*model.LicenseRecord, error)
 	GetAll() ([]*model.LicenseRecord, error)
 }
 
@@ -708,9 +708,9 @@ type DesktopTokensStore interface {
 
 type EmojiStore interface {
 	Save(emoji *model.Emoji) (*model.Emoji, error)
-	Get(c request.CTX, id string, allowFromCache bool) (*model.Emoji, error)
-	GetByName(c request.CTX, name string, allowFromCache bool) (*model.Emoji, error)
-	GetMultipleByName(c request.CTX, names []string) ([]*model.Emoji, error)
+	Get(rctx request.CTX, id string, allowFromCache bool) (*model.Emoji, error)
+	GetByName(rctx request.CTX, name string, allowFromCache bool) (*model.Emoji, error)
+	GetMultipleByName(rctx request.CTX, names []string) ([]*model.Emoji, error)
 	GetList(offset, limit int, sort string) ([]*model.Emoji, error)
 	Delete(emoji *model.Emoji, timestamp int64) error
 	Search(name string, prefixOnly bool, limit int) ([]*model.Emoji, error)
@@ -728,7 +728,7 @@ type StatusStore interface {
 }
 
 type FileInfoStore interface {
-	Save(ctx request.CTX, info *model.FileInfo) (*model.FileInfo, error)
+	Save(rctx request.CTX, info *model.FileInfo) (*model.FileInfo, error)
 	Upsert(rctx request.CTX, info *model.FileInfo) (*model.FileInfo, error)
 	Get(id string) (*model.FileInfo, error)
 	GetFromMaster(id string) (*model.FileInfo, error)
@@ -738,16 +738,16 @@ type FileInfoStore interface {
 	GetForUser(userID string) ([]*model.FileInfo, error)
 	GetWithOptions(page, perPage int, opt *model.GetFileInfosOptions) ([]*model.FileInfo, error)
 	InvalidateFileInfosForPostCache(postID string, deleted bool)
-	AttachToPost(c request.CTX, fileID string, postID string, channelID, creatorID string) error
-	DeleteForPost(c request.CTX, postID string) (string, error)
+	AttachToPost(rctx request.CTX, fileID string, postID string, channelID, creatorID string) error
+	DeleteForPost(rctx request.CTX, postID string) (string, error)
 	DeleteForPostByIds(rctx request.CTX, postId string, fileIDs []string) error
 	RestoreForPostByIds(rctx request.CTX, postId string, fileIDs []string) error
 	PermanentDeleteForPost(rctx request.CTX, postID string) error
-	PermanentDelete(c request.CTX, fileID string) error
-	PermanentDeleteBatch(ctx request.CTX, endTime int64, limit int64) (int64, error)
-	PermanentDeleteByUser(ctx request.CTX, userID string) (int64, error)
-	SetContent(ctx request.CTX, fileID, content string) error
-	Search(ctx request.CTX, paramsList []*model.SearchParams, userID, teamID string, page, perPage int) (*model.FileInfoList, error)
+	PermanentDelete(rctx request.CTX, fileID string) error
+	PermanentDeleteBatch(rctx request.CTX, endTime int64, limit int64) (int64, error)
+	PermanentDeleteByUser(rctx request.CTX, userID string) (int64, error)
+	SetContent(rctx request.CTX, fileID, content string) error
+	Search(rctx request.CTX, paramsList []*model.SearchParams, userID, teamID string, page, perPage int) (*model.FileInfoList, error)
 	CountAll() (int64, error)
 	GetFilesBatchForIndexing(startTime int64, startFileID string, includeDeleted bool, limit int) ([]*model.FileForIndexing, error)
 	ClearCaches()
@@ -761,7 +761,7 @@ type FileInfoStore interface {
 type UploadSessionStore interface {
 	Save(session *model.UploadSession) (*model.UploadSession, error)
 	Update(session *model.UploadSession) error
-	Get(c request.CTX, id string) (*model.UploadSession, error)
+	Get(rctx request.CTX, id string) (*model.UploadSession, error)
 	GetForUser(userID string) ([]*model.UploadSession, error)
 	Delete(id string) error
 }
@@ -790,13 +790,13 @@ type JobStore interface {
 	UpdateOptimistically(job *model.Job, currentStatus string) (bool, error)
 	UpdateStatus(id string, status string) (*model.Job, error)
 	UpdateStatusOptimistically(id string, currentStatus string, newStatus string) (*model.Job, error)
-	Get(c request.CTX, id string) (*model.Job, error)
-	GetAllByType(c request.CTX, jobType string) ([]*model.Job, error)
-	GetAllByTypeAndStatus(c request.CTX, jobType string, status string) ([]*model.Job, error)
-	GetAllByTypePage(c request.CTX, jobType string, offset int, limit int) ([]*model.Job, error)
-	GetAllByTypesPage(c request.CTX, jobTypes []string, offset int, limit int) ([]*model.Job, error)
-	GetAllByStatus(c request.CTX, status string) ([]*model.Job, error)
-	GetAllByTypesAndStatusesPage(c request.CTX, jobType []string, status []string, offset int, limit int) ([]*model.Job, error)
+	Get(rctx request.CTX, id string) (*model.Job, error)
+	GetAllByType(rctx request.CTX, jobType string) ([]*model.Job, error)
+	GetAllByTypeAndStatus(rctx request.CTX, jobType string, status string) ([]*model.Job, error)
+	GetAllByTypePage(rctx request.CTX, jobType string, offset int, limit int) ([]*model.Job, error)
+	GetAllByTypesPage(rctx request.CTX, jobTypes []string, offset int, limit int) ([]*model.Job, error)
+	GetAllByStatus(rctx request.CTX, status string) ([]*model.Job, error)
+	GetAllByTypesAndStatusesPage(rctx request.CTX, jobType []string, status []string, offset int, limit int) ([]*model.Job, error)
 	GetNewestJobByStatusAndType(status string, jobType string) (*model.Job, error)
 	GetNewestJobByStatusesAndType(statuses []string, jobType string) (*model.Job, error)
 	GetCountByStatusAndType(status string, jobType string) (int64, error)
@@ -1125,10 +1125,10 @@ type PropertyValueStore interface {
 }
 
 type AccessControlPolicyStore interface {
-	Save(c request.CTX, policy *model.AccessControlPolicy) (*model.AccessControlPolicy, error)
-	Delete(c request.CTX, id string) error
-	SetActiveStatus(c request.CTX, id string, active bool) (*model.AccessControlPolicy, error)
-	Get(c request.CTX, id string) (*model.AccessControlPolicy, error)
+	Save(rctx request.CTX, policy *model.AccessControlPolicy) (*model.AccessControlPolicy, error)
+	Delete(rctx request.CTX, id string) error
+	SetActiveStatus(rctx request.CTX, id string, active bool) (*model.AccessControlPolicy, error)
+	Get(rctx request.CTX, id string) (*model.AccessControlPolicy, error)
 	SearchPolicies(rctx request.CTX, opts model.AccessControlPolicySearch) ([]*model.AccessControlPolicy, int64, error)
 }
 

--- a/server/channels/store/storetest/mocks/AccessControlPolicyStore.go
+++ b/server/channels/store/storetest/mocks/AccessControlPolicyStore.go
@@ -15,9 +15,9 @@ type AccessControlPolicyStore struct {
 	mock.Mock
 }
 
-// Delete provides a mock function with given fields: c, id
-func (_m *AccessControlPolicyStore) Delete(c request.CTX, id string) error {
-	ret := _m.Called(c, id)
+// Delete provides a mock function with given fields: rctx, id
+func (_m *AccessControlPolicyStore) Delete(rctx request.CTX, id string) error {
+	ret := _m.Called(rctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Delete")
@@ -25,7 +25,7 @@ func (_m *AccessControlPolicyStore) Delete(c request.CTX, id string) error {
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) error); ok {
-		r0 = rf(c, id)
+		r0 = rf(rctx, id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -33,9 +33,9 @@ func (_m *AccessControlPolicyStore) Delete(c request.CTX, id string) error {
 	return r0
 }
 
-// Get provides a mock function with given fields: c, id
-func (_m *AccessControlPolicyStore) Get(c request.CTX, id string) (*model.AccessControlPolicy, error) {
-	ret := _m.Called(c, id)
+// Get provides a mock function with given fields: rctx, id
+func (_m *AccessControlPolicyStore) Get(rctx request.CTX, id string) (*model.AccessControlPolicy, error) {
+	ret := _m.Called(rctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Get")
@@ -44,10 +44,10 @@ func (_m *AccessControlPolicyStore) Get(c request.CTX, id string) (*model.Access
 	var r0 *model.AccessControlPolicy
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) (*model.AccessControlPolicy, error)); ok {
-		return rf(c, id)
+		return rf(rctx, id)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string) *model.AccessControlPolicy); ok {
-		r0 = rf(c, id)
+		r0 = rf(rctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.AccessControlPolicy)
@@ -55,7 +55,7 @@ func (_m *AccessControlPolicyStore) Get(c request.CTX, id string) (*model.Access
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string) error); ok {
-		r1 = rf(c, id)
+		r1 = rf(rctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -63,9 +63,9 @@ func (_m *AccessControlPolicyStore) Get(c request.CTX, id string) (*model.Access
 	return r0, r1
 }
 
-// Save provides a mock function with given fields: c, policy
-func (_m *AccessControlPolicyStore) Save(c request.CTX, policy *model.AccessControlPolicy) (*model.AccessControlPolicy, error) {
-	ret := _m.Called(c, policy)
+// Save provides a mock function with given fields: rctx, policy
+func (_m *AccessControlPolicyStore) Save(rctx request.CTX, policy *model.AccessControlPolicy) (*model.AccessControlPolicy, error) {
+	ret := _m.Called(rctx, policy)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Save")
@@ -74,10 +74,10 @@ func (_m *AccessControlPolicyStore) Save(c request.CTX, policy *model.AccessCont
 	var r0 *model.AccessControlPolicy
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.AccessControlPolicy) (*model.AccessControlPolicy, error)); ok {
-		return rf(c, policy)
+		return rf(rctx, policy)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.AccessControlPolicy) *model.AccessControlPolicy); ok {
-		r0 = rf(c, policy)
+		r0 = rf(rctx, policy)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.AccessControlPolicy)
@@ -85,7 +85,7 @@ func (_m *AccessControlPolicyStore) Save(c request.CTX, policy *model.AccessCont
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.AccessControlPolicy) error); ok {
-		r1 = rf(c, policy)
+		r1 = rf(rctx, policy)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -130,9 +130,9 @@ func (_m *AccessControlPolicyStore) SearchPolicies(rctx request.CTX, opts model.
 	return r0, r1, r2
 }
 
-// SetActiveStatus provides a mock function with given fields: c, id, active
-func (_m *AccessControlPolicyStore) SetActiveStatus(c request.CTX, id string, active bool) (*model.AccessControlPolicy, error) {
-	ret := _m.Called(c, id, active)
+// SetActiveStatus provides a mock function with given fields: rctx, id, active
+func (_m *AccessControlPolicyStore) SetActiveStatus(rctx request.CTX, id string, active bool) (*model.AccessControlPolicy, error) {
+	ret := _m.Called(rctx, id, active)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SetActiveStatus")
@@ -141,10 +141,10 @@ func (_m *AccessControlPolicyStore) SetActiveStatus(c request.CTX, id string, ac
 	var r0 *model.AccessControlPolicy
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string, bool) (*model.AccessControlPolicy, error)); ok {
-		return rf(c, id, active)
+		return rf(rctx, id, active)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, bool) *model.AccessControlPolicy); ok {
-		r0 = rf(c, id, active)
+		r0 = rf(rctx, id, active)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.AccessControlPolicy)
@@ -152,7 +152,7 @@ func (_m *AccessControlPolicyStore) SetActiveStatus(c request.CTX, id string, ac
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, bool) error); ok {
-		r1 = rf(c, id, active)
+		r1 = rf(rctx, id, active)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/storetest/mocks/ChannelStore.go
+++ b/server/channels/store/storetest/mocks/ChannelStore.go
@@ -305,14 +305,14 @@ func (_m *ChannelStore) CountUrgentPostsAfter(channelID string, timestamp int64,
 	return r0, r1
 }
 
-// CreateDirectChannel provides a mock function with given fields: ctx, userID, otherUserID, channelOptions
-func (_m *ChannelStore) CreateDirectChannel(ctx request.CTX, userID *model.User, otherUserID *model.User, channelOptions ...model.ChannelOption) (*model.Channel, error) {
+// CreateDirectChannel provides a mock function with given fields: rctx, userID, otherUserID, channelOptions
+func (_m *ChannelStore) CreateDirectChannel(rctx request.CTX, userID *model.User, otherUserID *model.User, channelOptions ...model.ChannelOption) (*model.Channel, error) {
 	_va := make([]interface{}, len(channelOptions))
 	for _i := range channelOptions {
 		_va[_i] = channelOptions[_i]
 	}
 	var _ca []interface{}
-	_ca = append(_ca, ctx, userID, otherUserID)
+	_ca = append(_ca, rctx, userID, otherUserID)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
@@ -323,10 +323,10 @@ func (_m *ChannelStore) CreateDirectChannel(ctx request.CTX, userID *model.User,
 	var r0 *model.Channel
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.User, *model.User, ...model.ChannelOption) (*model.Channel, error)); ok {
-		return rf(ctx, userID, otherUserID, channelOptions...)
+		return rf(rctx, userID, otherUserID, channelOptions...)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.User, *model.User, ...model.ChannelOption) *model.Channel); ok {
-		r0 = rf(ctx, userID, otherUserID, channelOptions...)
+		r0 = rf(rctx, userID, otherUserID, channelOptions...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Channel)
@@ -334,7 +334,7 @@ func (_m *ChannelStore) CreateDirectChannel(ctx request.CTX, userID *model.User,
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.User, *model.User, ...model.ChannelOption) error); ok {
-		r1 = rf(ctx, userID, otherUserID, channelOptions...)
+		r1 = rf(rctx, userID, otherUserID, channelOptions...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -342,9 +342,9 @@ func (_m *ChannelStore) CreateDirectChannel(ctx request.CTX, userID *model.User,
 	return r0, r1
 }
 
-// CreateInitialSidebarCategories provides a mock function with given fields: c, userID, teamID
-func (_m *ChannelStore) CreateInitialSidebarCategories(c request.CTX, userID string, teamID string) (*model.OrderedSidebarCategories, error) {
-	ret := _m.Called(c, userID, teamID)
+// CreateInitialSidebarCategories provides a mock function with given fields: rctx, userID, teamID
+func (_m *ChannelStore) CreateInitialSidebarCategories(rctx request.CTX, userID string, teamID string) (*model.OrderedSidebarCategories, error) {
+	ret := _m.Called(rctx, userID, teamID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateInitialSidebarCategories")
@@ -353,10 +353,10 @@ func (_m *ChannelStore) CreateInitialSidebarCategories(c request.CTX, userID str
 	var r0 *model.OrderedSidebarCategories
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string) (*model.OrderedSidebarCategories, error)); ok {
-		return rf(c, userID, teamID)
+		return rf(rctx, userID, teamID)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string) *model.OrderedSidebarCategories); ok {
-		r0 = rf(c, userID, teamID)
+		r0 = rf(rctx, userID, teamID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.OrderedSidebarCategories)
@@ -364,7 +364,7 @@ func (_m *ChannelStore) CreateInitialSidebarCategories(c request.CTX, userID str
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, string) error); ok {
-		r1 = rf(c, userID, teamID)
+		r1 = rf(rctx, userID, teamID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -564,9 +564,9 @@ func (_m *ChannelStore) GetAllChannelMemberIdsByChannelId(id string) ([]string, 
 	return r0, r1
 }
 
-// GetAllChannelMembersForUser provides a mock function with given fields: ctx, userID, allowFromCache, includeDeleted
-func (_m *ChannelStore) GetAllChannelMembersForUser(ctx request.CTX, userID string, allowFromCache bool, includeDeleted bool) (map[string]string, error) {
-	ret := _m.Called(ctx, userID, allowFromCache, includeDeleted)
+// GetAllChannelMembersForUser provides a mock function with given fields: rctx, userID, allowFromCache, includeDeleted
+func (_m *ChannelStore) GetAllChannelMembersForUser(rctx request.CTX, userID string, allowFromCache bool, includeDeleted bool) (map[string]string, error) {
+	ret := _m.Called(rctx, userID, allowFromCache, includeDeleted)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllChannelMembersForUser")
@@ -575,10 +575,10 @@ func (_m *ChannelStore) GetAllChannelMembersForUser(ctx request.CTX, userID stri
 	var r0 map[string]string
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string, bool, bool) (map[string]string, error)); ok {
-		return rf(ctx, userID, allowFromCache, includeDeleted)
+		return rf(rctx, userID, allowFromCache, includeDeleted)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, bool, bool) map[string]string); ok {
-		r0 = rf(ctx, userID, allowFromCache, includeDeleted)
+		r0 = rf(rctx, userID, allowFromCache, includeDeleted)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]string)
@@ -586,7 +586,7 @@ func (_m *ChannelStore) GetAllChannelMembersForUser(ctx request.CTX, userID stri
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, bool, bool) error); ok {
-		r1 = rf(ctx, userID, allowFromCache, includeDeleted)
+		r1 = rf(rctx, userID, allowFromCache, includeDeleted)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2375,9 +2375,9 @@ func (_m *ChannelStore) PatchMultipleMembersNotifyProps(members []*model.Channel
 	return r0, r1
 }
 
-// PermanentDelete provides a mock function with given fields: ctx, channelID
-func (_m *ChannelStore) PermanentDelete(ctx request.CTX, channelID string) error {
-	ret := _m.Called(ctx, channelID)
+// PermanentDelete provides a mock function with given fields: rctx, channelID
+func (_m *ChannelStore) PermanentDelete(rctx request.CTX, channelID string) error {
+	ret := _m.Called(rctx, channelID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PermanentDelete")
@@ -2385,7 +2385,7 @@ func (_m *ChannelStore) PermanentDelete(ctx request.CTX, channelID string) error
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) error); ok {
-		r0 = rf(ctx, channelID)
+		r0 = rf(rctx, channelID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -2411,9 +2411,9 @@ func (_m *ChannelStore) PermanentDeleteByTeam(teamID string) error {
 	return r0
 }
 
-// PermanentDeleteMembersByChannel provides a mock function with given fields: ctx, channelID
-func (_m *ChannelStore) PermanentDeleteMembersByChannel(ctx request.CTX, channelID string) error {
-	ret := _m.Called(ctx, channelID)
+// PermanentDeleteMembersByChannel provides a mock function with given fields: rctx, channelID
+func (_m *ChannelStore) PermanentDeleteMembersByChannel(rctx request.CTX, channelID string) error {
+	ret := _m.Called(rctx, channelID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PermanentDeleteMembersByChannel")
@@ -2421,7 +2421,7 @@ func (_m *ChannelStore) PermanentDeleteMembersByChannel(ctx request.CTX, channel
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) error); ok {
-		r0 = rf(ctx, channelID)
+		r0 = rf(rctx, channelID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -2429,9 +2429,9 @@ func (_m *ChannelStore) PermanentDeleteMembersByChannel(ctx request.CTX, channel
 	return r0
 }
 
-// PermanentDeleteMembersByUser provides a mock function with given fields: ctx, userID
-func (_m *ChannelStore) PermanentDeleteMembersByUser(ctx request.CTX, userID string) error {
-	ret := _m.Called(ctx, userID)
+// PermanentDeleteMembersByUser provides a mock function with given fields: rctx, userID
+func (_m *ChannelStore) PermanentDeleteMembersByUser(rctx request.CTX, userID string) error {
+	ret := _m.Called(rctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PermanentDeleteMembersByUser")
@@ -2439,7 +2439,7 @@ func (_m *ChannelStore) PermanentDeleteMembersByUser(ctx request.CTX, userID str
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) error); ok {
-		r0 = rf(ctx, userID)
+		r0 = rf(rctx, userID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -2447,9 +2447,9 @@ func (_m *ChannelStore) PermanentDeleteMembersByUser(ctx request.CTX, userID str
 	return r0
 }
 
-// RemoveAllDeactivatedMembers provides a mock function with given fields: ctx, channelID
-func (_m *ChannelStore) RemoveAllDeactivatedMembers(ctx request.CTX, channelID string) error {
-	ret := _m.Called(ctx, channelID)
+// RemoveAllDeactivatedMembers provides a mock function with given fields: rctx, channelID
+func (_m *ChannelStore) RemoveAllDeactivatedMembers(rctx request.CTX, channelID string) error {
+	ret := _m.Called(rctx, channelID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RemoveAllDeactivatedMembers")
@@ -2457,7 +2457,7 @@ func (_m *ChannelStore) RemoveAllDeactivatedMembers(ctx request.CTX, channelID s
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) error); ok {
-		r0 = rf(ctx, channelID)
+		r0 = rf(rctx, channelID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -2465,9 +2465,9 @@ func (_m *ChannelStore) RemoveAllDeactivatedMembers(ctx request.CTX, channelID s
 	return r0
 }
 
-// RemoveMember provides a mock function with given fields: ctx, channelID, userID
-func (_m *ChannelStore) RemoveMember(ctx request.CTX, channelID string, userID string) error {
-	ret := _m.Called(ctx, channelID, userID)
+// RemoveMember provides a mock function with given fields: rctx, channelID, userID
+func (_m *ChannelStore) RemoveMember(rctx request.CTX, channelID string, userID string) error {
+	ret := _m.Called(rctx, channelID, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RemoveMember")
@@ -2475,7 +2475,7 @@ func (_m *ChannelStore) RemoveMember(ctx request.CTX, channelID string, userID s
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string) error); ok {
-		r0 = rf(ctx, channelID, userID)
+		r0 = rf(rctx, channelID, userID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -2483,9 +2483,9 @@ func (_m *ChannelStore) RemoveMember(ctx request.CTX, channelID string, userID s
 	return r0
 }
 
-// RemoveMembers provides a mock function with given fields: ctx, channelID, userIds
-func (_m *ChannelStore) RemoveMembers(ctx request.CTX, channelID string, userIds []string) error {
-	ret := _m.Called(ctx, channelID, userIds)
+// RemoveMembers provides a mock function with given fields: rctx, channelID, userIds
+func (_m *ChannelStore) RemoveMembers(rctx request.CTX, channelID string, userIds []string) error {
+	ret := _m.Called(rctx, channelID, userIds)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RemoveMembers")
@@ -2493,7 +2493,7 @@ func (_m *ChannelStore) RemoveMembers(ctx request.CTX, channelID string, userIds
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string, []string) error); ok {
-		r0 = rf(ctx, channelID, userIds)
+		r0 = rf(rctx, channelID, userIds)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -2574,9 +2574,9 @@ func (_m *ChannelStore) Save(rctx request.CTX, channel *model.Channel, maxChanne
 	return r0, r1
 }
 
-// SaveDirectChannel provides a mock function with given fields: ctx, channel, member1, member2
-func (_m *ChannelStore) SaveDirectChannel(ctx request.CTX, channel *model.Channel, member1 *model.ChannelMember, member2 *model.ChannelMember) (*model.Channel, error) {
-	ret := _m.Called(ctx, channel, member1, member2)
+// SaveDirectChannel provides a mock function with given fields: rctx, channel, member1, member2
+func (_m *ChannelStore) SaveDirectChannel(rctx request.CTX, channel *model.Channel, member1 *model.ChannelMember, member2 *model.ChannelMember) (*model.Channel, error) {
+	ret := _m.Called(rctx, channel, member1, member2)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SaveDirectChannel")
@@ -2585,10 +2585,10 @@ func (_m *ChannelStore) SaveDirectChannel(ctx request.CTX, channel *model.Channe
 	var r0 *model.Channel
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Channel, *model.ChannelMember, *model.ChannelMember) (*model.Channel, error)); ok {
-		return rf(ctx, channel, member1, member2)
+		return rf(rctx, channel, member1, member2)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Channel, *model.ChannelMember, *model.ChannelMember) *model.Channel); ok {
-		r0 = rf(ctx, channel, member1, member2)
+		r0 = rf(rctx, channel, member1, member2)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Channel)
@@ -2596,7 +2596,7 @@ func (_m *ChannelStore) SaveDirectChannel(ctx request.CTX, channel *model.Channe
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.Channel, *model.ChannelMember, *model.ChannelMember) error); ok {
-		r1 = rf(ctx, channel, member1, member2)
+		r1 = rf(rctx, channel, member1, member2)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2887,9 +2887,9 @@ func (_m *ChannelStore) SetShared(channelID string, shared bool) error {
 	return r0
 }
 
-// Update provides a mock function with given fields: ctx, channel
-func (_m *ChannelStore) Update(ctx request.CTX, channel *model.Channel) (*model.Channel, error) {
-	ret := _m.Called(ctx, channel)
+// Update provides a mock function with given fields: rctx, channel
+func (_m *ChannelStore) Update(rctx request.CTX, channel *model.Channel) (*model.Channel, error) {
+	ret := _m.Called(rctx, channel)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Update")
@@ -2898,10 +2898,10 @@ func (_m *ChannelStore) Update(ctx request.CTX, channel *model.Channel) (*model.
 	var r0 *model.Channel
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Channel) (*model.Channel, error)); ok {
-		return rf(ctx, channel)
+		return rf(rctx, channel)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Channel) *model.Channel); ok {
-		r0 = rf(ctx, channel)
+		r0 = rf(rctx, channel)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Channel)
@@ -2909,7 +2909,7 @@ func (_m *ChannelStore) Update(ctx request.CTX, channel *model.Channel) (*model.
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.Channel) error); ok {
-		r1 = rf(ctx, channel)
+		r1 = rf(rctx, channel)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2977,9 +2977,9 @@ func (_m *ChannelStore) UpdateLastViewedAtPost(unreadPost *model.Post, userID st
 	return r0, r1
 }
 
-// UpdateMember provides a mock function with given fields: ctx, member
-func (_m *ChannelStore) UpdateMember(ctx request.CTX, member *model.ChannelMember) (*model.ChannelMember, error) {
-	ret := _m.Called(ctx, member)
+// UpdateMember provides a mock function with given fields: rctx, member
+func (_m *ChannelStore) UpdateMember(rctx request.CTX, member *model.ChannelMember) (*model.ChannelMember, error) {
+	ret := _m.Called(rctx, member)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateMember")
@@ -2988,10 +2988,10 @@ func (_m *ChannelStore) UpdateMember(ctx request.CTX, member *model.ChannelMembe
 	var r0 *model.ChannelMember
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.ChannelMember) (*model.ChannelMember, error)); ok {
-		return rf(ctx, member)
+		return rf(rctx, member)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.ChannelMember) *model.ChannelMember); ok {
-		r0 = rf(ctx, member)
+		r0 = rf(rctx, member)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.ChannelMember)
@@ -2999,7 +2999,7 @@ func (_m *ChannelStore) UpdateMember(ctx request.CTX, member *model.ChannelMembe
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.ChannelMember) error); ok {
-		r1 = rf(ctx, member)
+		r1 = rf(rctx, member)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/storetest/mocks/ComplianceStore.go
+++ b/server/channels/store/storetest/mocks/ComplianceStore.go
@@ -112,9 +112,9 @@ func (_m *ComplianceStore) GetAll(offset int, limit int) (model.Compliances, err
 	return r0, r1
 }
 
-// MessageExport provides a mock function with given fields: c, cursor, limit
-func (_m *ComplianceStore) MessageExport(c request.CTX, cursor model.MessageExportCursor, limit int) ([]*model.MessageExport, model.MessageExportCursor, error) {
-	ret := _m.Called(c, cursor, limit)
+// MessageExport provides a mock function with given fields: rctx, cursor, limit
+func (_m *ComplianceStore) MessageExport(rctx request.CTX, cursor model.MessageExportCursor, limit int) ([]*model.MessageExport, model.MessageExportCursor, error) {
+	ret := _m.Called(rctx, cursor, limit)
 
 	if len(ret) == 0 {
 		panic("no return value specified for MessageExport")
@@ -124,10 +124,10 @@ func (_m *ComplianceStore) MessageExport(c request.CTX, cursor model.MessageExpo
 	var r1 model.MessageExportCursor
 	var r2 error
 	if rf, ok := ret.Get(0).(func(request.CTX, model.MessageExportCursor, int) ([]*model.MessageExport, model.MessageExportCursor, error)); ok {
-		return rf(c, cursor, limit)
+		return rf(rctx, cursor, limit)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, model.MessageExportCursor, int) []*model.MessageExport); ok {
-		r0 = rf(c, cursor, limit)
+		r0 = rf(rctx, cursor, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.MessageExport)
@@ -135,13 +135,13 @@ func (_m *ComplianceStore) MessageExport(c request.CTX, cursor model.MessageExpo
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, model.MessageExportCursor, int) model.MessageExportCursor); ok {
-		r1 = rf(c, cursor, limit)
+		r1 = rf(rctx, cursor, limit)
 	} else {
 		r1 = ret.Get(1).(model.MessageExportCursor)
 	}
 
 	if rf, ok := ret.Get(2).(func(request.CTX, model.MessageExportCursor, int) error); ok {
-		r2 = rf(c, cursor, limit)
+		r2 = rf(rctx, cursor, limit)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/server/channels/store/storetest/mocks/EmojiStore.go
+++ b/server/channels/store/storetest/mocks/EmojiStore.go
@@ -33,9 +33,9 @@ func (_m *EmojiStore) Delete(emoji *model.Emoji, timestamp int64) error {
 	return r0
 }
 
-// Get provides a mock function with given fields: c, id, allowFromCache
-func (_m *EmojiStore) Get(c request.CTX, id string, allowFromCache bool) (*model.Emoji, error) {
-	ret := _m.Called(c, id, allowFromCache)
+// Get provides a mock function with given fields: rctx, id, allowFromCache
+func (_m *EmojiStore) Get(rctx request.CTX, id string, allowFromCache bool) (*model.Emoji, error) {
+	ret := _m.Called(rctx, id, allowFromCache)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Get")
@@ -44,10 +44,10 @@ func (_m *EmojiStore) Get(c request.CTX, id string, allowFromCache bool) (*model
 	var r0 *model.Emoji
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string, bool) (*model.Emoji, error)); ok {
-		return rf(c, id, allowFromCache)
+		return rf(rctx, id, allowFromCache)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, bool) *model.Emoji); ok {
-		r0 = rf(c, id, allowFromCache)
+		r0 = rf(rctx, id, allowFromCache)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Emoji)
@@ -55,7 +55,7 @@ func (_m *EmojiStore) Get(c request.CTX, id string, allowFromCache bool) (*model
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, bool) error); ok {
-		r1 = rf(c, id, allowFromCache)
+		r1 = rf(rctx, id, allowFromCache)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -63,9 +63,9 @@ func (_m *EmojiStore) Get(c request.CTX, id string, allowFromCache bool) (*model
 	return r0, r1
 }
 
-// GetByName provides a mock function with given fields: c, name, allowFromCache
-func (_m *EmojiStore) GetByName(c request.CTX, name string, allowFromCache bool) (*model.Emoji, error) {
-	ret := _m.Called(c, name, allowFromCache)
+// GetByName provides a mock function with given fields: rctx, name, allowFromCache
+func (_m *EmojiStore) GetByName(rctx request.CTX, name string, allowFromCache bool) (*model.Emoji, error) {
+	ret := _m.Called(rctx, name, allowFromCache)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetByName")
@@ -74,10 +74,10 @@ func (_m *EmojiStore) GetByName(c request.CTX, name string, allowFromCache bool)
 	var r0 *model.Emoji
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string, bool) (*model.Emoji, error)); ok {
-		return rf(c, name, allowFromCache)
+		return rf(rctx, name, allowFromCache)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, bool) *model.Emoji); ok {
-		r0 = rf(c, name, allowFromCache)
+		r0 = rf(rctx, name, allowFromCache)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Emoji)
@@ -85,7 +85,7 @@ func (_m *EmojiStore) GetByName(c request.CTX, name string, allowFromCache bool)
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, bool) error); ok {
-		r1 = rf(c, name, allowFromCache)
+		r1 = rf(rctx, name, allowFromCache)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -123,9 +123,9 @@ func (_m *EmojiStore) GetList(offset int, limit int, sort string) ([]*model.Emoj
 	return r0, r1
 }
 
-// GetMultipleByName provides a mock function with given fields: c, names
-func (_m *EmojiStore) GetMultipleByName(c request.CTX, names []string) ([]*model.Emoji, error) {
-	ret := _m.Called(c, names)
+// GetMultipleByName provides a mock function with given fields: rctx, names
+func (_m *EmojiStore) GetMultipleByName(rctx request.CTX, names []string) ([]*model.Emoji, error) {
+	ret := _m.Called(rctx, names)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetMultipleByName")
@@ -134,10 +134,10 @@ func (_m *EmojiStore) GetMultipleByName(c request.CTX, names []string) ([]*model
 	var r0 []*model.Emoji
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, []string) ([]*model.Emoji, error)); ok {
-		return rf(c, names)
+		return rf(rctx, names)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, []string) []*model.Emoji); ok {
-		r0 = rf(c, names)
+		r0 = rf(rctx, names)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.Emoji)
@@ -145,7 +145,7 @@ func (_m *EmojiStore) GetMultipleByName(c request.CTX, names []string) ([]*model
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, []string) error); ok {
-		r1 = rf(c, names)
+		r1 = rf(rctx, names)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/storetest/mocks/FileInfoStore.go
+++ b/server/channels/store/storetest/mocks/FileInfoStore.go
@@ -15,9 +15,9 @@ type FileInfoStore struct {
 	mock.Mock
 }
 
-// AttachToPost provides a mock function with given fields: c, fileID, postID, channelID, creatorID
-func (_m *FileInfoStore) AttachToPost(c request.CTX, fileID string, postID string, channelID string, creatorID string) error {
-	ret := _m.Called(c, fileID, postID, channelID, creatorID)
+// AttachToPost provides a mock function with given fields: rctx, fileID, postID, channelID, creatorID
+func (_m *FileInfoStore) AttachToPost(rctx request.CTX, fileID string, postID string, channelID string, creatorID string) error {
+	ret := _m.Called(rctx, fileID, postID, channelID, creatorID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AttachToPost")
@@ -25,7 +25,7 @@ func (_m *FileInfoStore) AttachToPost(c request.CTX, fileID string, postID strin
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string, string, string) error); ok {
-		r0 = rf(c, fileID, postID, channelID, creatorID)
+		r0 = rf(rctx, fileID, postID, channelID, creatorID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -66,9 +66,9 @@ func (_m *FileInfoStore) CountAll() (int64, error) {
 	return r0, r1
 }
 
-// DeleteForPost provides a mock function with given fields: c, postID
-func (_m *FileInfoStore) DeleteForPost(c request.CTX, postID string) (string, error) {
-	ret := _m.Called(c, postID)
+// DeleteForPost provides a mock function with given fields: rctx, postID
+func (_m *FileInfoStore) DeleteForPost(rctx request.CTX, postID string) (string, error) {
+	ret := _m.Called(rctx, postID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteForPost")
@@ -77,16 +77,16 @@ func (_m *FileInfoStore) DeleteForPost(c request.CTX, postID string) (string, er
 	var r0 string
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) (string, error)); ok {
-		return rf(c, postID)
+		return rf(rctx, postID)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string) string); ok {
-		r0 = rf(c, postID)
+		r0 = rf(rctx, postID)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string) error); ok {
-		r1 = rf(c, postID)
+		r1 = rf(rctx, postID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -413,9 +413,9 @@ func (_m *FileInfoStore) InvalidateFileInfosForPostCache(postID string, deleted 
 	_m.Called(postID, deleted)
 }
 
-// PermanentDelete provides a mock function with given fields: c, fileID
-func (_m *FileInfoStore) PermanentDelete(c request.CTX, fileID string) error {
-	ret := _m.Called(c, fileID)
+// PermanentDelete provides a mock function with given fields: rctx, fileID
+func (_m *FileInfoStore) PermanentDelete(rctx request.CTX, fileID string) error {
+	ret := _m.Called(rctx, fileID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PermanentDelete")
@@ -423,7 +423,7 @@ func (_m *FileInfoStore) PermanentDelete(c request.CTX, fileID string) error {
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) error); ok {
-		r0 = rf(c, fileID)
+		r0 = rf(rctx, fileID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -431,9 +431,9 @@ func (_m *FileInfoStore) PermanentDelete(c request.CTX, fileID string) error {
 	return r0
 }
 
-// PermanentDeleteBatch provides a mock function with given fields: ctx, endTime, limit
-func (_m *FileInfoStore) PermanentDeleteBatch(ctx request.CTX, endTime int64, limit int64) (int64, error) {
-	ret := _m.Called(ctx, endTime, limit)
+// PermanentDeleteBatch provides a mock function with given fields: rctx, endTime, limit
+func (_m *FileInfoStore) PermanentDeleteBatch(rctx request.CTX, endTime int64, limit int64) (int64, error) {
+	ret := _m.Called(rctx, endTime, limit)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PermanentDeleteBatch")
@@ -442,16 +442,16 @@ func (_m *FileInfoStore) PermanentDeleteBatch(ctx request.CTX, endTime int64, li
 	var r0 int64
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, int64, int64) (int64, error)); ok {
-		return rf(ctx, endTime, limit)
+		return rf(rctx, endTime, limit)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, int64, int64) int64); ok {
-		r0 = rf(ctx, endTime, limit)
+		r0 = rf(rctx, endTime, limit)
 	} else {
 		r0 = ret.Get(0).(int64)
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, int64, int64) error); ok {
-		r1 = rf(ctx, endTime, limit)
+		r1 = rf(rctx, endTime, limit)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -459,9 +459,9 @@ func (_m *FileInfoStore) PermanentDeleteBatch(ctx request.CTX, endTime int64, li
 	return r0, r1
 }
 
-// PermanentDeleteByUser provides a mock function with given fields: ctx, userID
-func (_m *FileInfoStore) PermanentDeleteByUser(ctx request.CTX, userID string) (int64, error) {
-	ret := _m.Called(ctx, userID)
+// PermanentDeleteByUser provides a mock function with given fields: rctx, userID
+func (_m *FileInfoStore) PermanentDeleteByUser(rctx request.CTX, userID string) (int64, error) {
+	ret := _m.Called(rctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PermanentDeleteByUser")
@@ -470,16 +470,16 @@ func (_m *FileInfoStore) PermanentDeleteByUser(ctx request.CTX, userID string) (
 	var r0 int64
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) (int64, error)); ok {
-		return rf(ctx, userID)
+		return rf(rctx, userID)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string) int64); ok {
-		r0 = rf(ctx, userID)
+		r0 = rf(rctx, userID)
 	} else {
 		r0 = ret.Get(0).(int64)
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string) error); ok {
-		r1 = rf(ctx, userID)
+		r1 = rf(rctx, userID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -541,9 +541,9 @@ func (_m *FileInfoStore) RestoreForPostByIds(rctx request.CTX, postId string, fi
 	return r0
 }
 
-// Save provides a mock function with given fields: ctx, info
-func (_m *FileInfoStore) Save(ctx request.CTX, info *model.FileInfo) (*model.FileInfo, error) {
-	ret := _m.Called(ctx, info)
+// Save provides a mock function with given fields: rctx, info
+func (_m *FileInfoStore) Save(rctx request.CTX, info *model.FileInfo) (*model.FileInfo, error) {
+	ret := _m.Called(rctx, info)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Save")
@@ -552,10 +552,10 @@ func (_m *FileInfoStore) Save(ctx request.CTX, info *model.FileInfo) (*model.Fil
 	var r0 *model.FileInfo
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.FileInfo) (*model.FileInfo, error)); ok {
-		return rf(ctx, info)
+		return rf(rctx, info)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.FileInfo) *model.FileInfo); ok {
-		r0 = rf(ctx, info)
+		r0 = rf(rctx, info)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.FileInfo)
@@ -563,7 +563,7 @@ func (_m *FileInfoStore) Save(ctx request.CTX, info *model.FileInfo) (*model.Fil
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.FileInfo) error); ok {
-		r1 = rf(ctx, info)
+		r1 = rf(rctx, info)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -571,9 +571,9 @@ func (_m *FileInfoStore) Save(ctx request.CTX, info *model.FileInfo) (*model.Fil
 	return r0, r1
 }
 
-// Search provides a mock function with given fields: ctx, paramsList, userID, teamID, page, perPage
-func (_m *FileInfoStore) Search(ctx request.CTX, paramsList []*model.SearchParams, userID string, teamID string, page int, perPage int) (*model.FileInfoList, error) {
-	ret := _m.Called(ctx, paramsList, userID, teamID, page, perPage)
+// Search provides a mock function with given fields: rctx, paramsList, userID, teamID, page, perPage
+func (_m *FileInfoStore) Search(rctx request.CTX, paramsList []*model.SearchParams, userID string, teamID string, page int, perPage int) (*model.FileInfoList, error) {
+	ret := _m.Called(rctx, paramsList, userID, teamID, page, perPage)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Search")
@@ -582,10 +582,10 @@ func (_m *FileInfoStore) Search(ctx request.CTX, paramsList []*model.SearchParam
 	var r0 *model.FileInfoList
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, []*model.SearchParams, string, string, int, int) (*model.FileInfoList, error)); ok {
-		return rf(ctx, paramsList, userID, teamID, page, perPage)
+		return rf(rctx, paramsList, userID, teamID, page, perPage)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, []*model.SearchParams, string, string, int, int) *model.FileInfoList); ok {
-		r0 = rf(ctx, paramsList, userID, teamID, page, perPage)
+		r0 = rf(rctx, paramsList, userID, teamID, page, perPage)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.FileInfoList)
@@ -593,7 +593,7 @@ func (_m *FileInfoStore) Search(ctx request.CTX, paramsList []*model.SearchParam
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, []*model.SearchParams, string, string, int, int) error); ok {
-		r1 = rf(ctx, paramsList, userID, teamID, page, perPage)
+		r1 = rf(rctx, paramsList, userID, teamID, page, perPage)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -601,9 +601,9 @@ func (_m *FileInfoStore) Search(ctx request.CTX, paramsList []*model.SearchParam
 	return r0, r1
 }
 
-// SetContent provides a mock function with given fields: ctx, fileID, content
-func (_m *FileInfoStore) SetContent(ctx request.CTX, fileID string, content string) error {
-	ret := _m.Called(ctx, fileID, content)
+// SetContent provides a mock function with given fields: rctx, fileID, content
+func (_m *FileInfoStore) SetContent(rctx request.CTX, fileID string, content string) error {
+	ret := _m.Called(rctx, fileID, content)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SetContent")
@@ -611,7 +611,7 @@ func (_m *FileInfoStore) SetContent(ctx request.CTX, fileID string, content stri
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string) error); ok {
-		r0 = rf(ctx, fileID, content)
+		r0 = rf(rctx, fileID, content)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/server/channels/store/storetest/mocks/JobStore.go
+++ b/server/channels/store/storetest/mocks/JobStore.go
@@ -61,9 +61,9 @@ func (_m *JobStore) Delete(id string) (string, error) {
 	return r0, r1
 }
 
-// Get provides a mock function with given fields: c, id
-func (_m *JobStore) Get(c request.CTX, id string) (*model.Job, error) {
-	ret := _m.Called(c, id)
+// Get provides a mock function with given fields: rctx, id
+func (_m *JobStore) Get(rctx request.CTX, id string) (*model.Job, error) {
+	ret := _m.Called(rctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Get")
@@ -72,10 +72,10 @@ func (_m *JobStore) Get(c request.CTX, id string) (*model.Job, error) {
 	var r0 *model.Job
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) (*model.Job, error)); ok {
-		return rf(c, id)
+		return rf(rctx, id)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string) *model.Job); ok {
-		r0 = rf(c, id)
+		r0 = rf(rctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Job)
@@ -83,7 +83,7 @@ func (_m *JobStore) Get(c request.CTX, id string) (*model.Job, error) {
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string) error); ok {
-		r1 = rf(c, id)
+		r1 = rf(rctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -91,9 +91,9 @@ func (_m *JobStore) Get(c request.CTX, id string) (*model.Job, error) {
 	return r0, r1
 }
 
-// GetAllByStatus provides a mock function with given fields: c, status
-func (_m *JobStore) GetAllByStatus(c request.CTX, status string) ([]*model.Job, error) {
-	ret := _m.Called(c, status)
+// GetAllByStatus provides a mock function with given fields: rctx, status
+func (_m *JobStore) GetAllByStatus(rctx request.CTX, status string) ([]*model.Job, error) {
+	ret := _m.Called(rctx, status)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllByStatus")
@@ -102,10 +102,10 @@ func (_m *JobStore) GetAllByStatus(c request.CTX, status string) ([]*model.Job, 
 	var r0 []*model.Job
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) ([]*model.Job, error)); ok {
-		return rf(c, status)
+		return rf(rctx, status)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string) []*model.Job); ok {
-		r0 = rf(c, status)
+		r0 = rf(rctx, status)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.Job)
@@ -113,7 +113,7 @@ func (_m *JobStore) GetAllByStatus(c request.CTX, status string) ([]*model.Job, 
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string) error); ok {
-		r1 = rf(c, status)
+		r1 = rf(rctx, status)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -121,9 +121,9 @@ func (_m *JobStore) GetAllByStatus(c request.CTX, status string) ([]*model.Job, 
 	return r0, r1
 }
 
-// GetAllByType provides a mock function with given fields: c, jobType
-func (_m *JobStore) GetAllByType(c request.CTX, jobType string) ([]*model.Job, error) {
-	ret := _m.Called(c, jobType)
+// GetAllByType provides a mock function with given fields: rctx, jobType
+func (_m *JobStore) GetAllByType(rctx request.CTX, jobType string) ([]*model.Job, error) {
+	ret := _m.Called(rctx, jobType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllByType")
@@ -132,10 +132,10 @@ func (_m *JobStore) GetAllByType(c request.CTX, jobType string) ([]*model.Job, e
 	var r0 []*model.Job
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) ([]*model.Job, error)); ok {
-		return rf(c, jobType)
+		return rf(rctx, jobType)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string) []*model.Job); ok {
-		r0 = rf(c, jobType)
+		r0 = rf(rctx, jobType)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.Job)
@@ -143,7 +143,7 @@ func (_m *JobStore) GetAllByType(c request.CTX, jobType string) ([]*model.Job, e
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string) error); ok {
-		r1 = rf(c, jobType)
+		r1 = rf(rctx, jobType)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -151,9 +151,9 @@ func (_m *JobStore) GetAllByType(c request.CTX, jobType string) ([]*model.Job, e
 	return r0, r1
 }
 
-// GetAllByTypeAndStatus provides a mock function with given fields: c, jobType, status
-func (_m *JobStore) GetAllByTypeAndStatus(c request.CTX, jobType string, status string) ([]*model.Job, error) {
-	ret := _m.Called(c, jobType, status)
+// GetAllByTypeAndStatus provides a mock function with given fields: rctx, jobType, status
+func (_m *JobStore) GetAllByTypeAndStatus(rctx request.CTX, jobType string, status string) ([]*model.Job, error) {
+	ret := _m.Called(rctx, jobType, status)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllByTypeAndStatus")
@@ -162,10 +162,10 @@ func (_m *JobStore) GetAllByTypeAndStatus(c request.CTX, jobType string, status 
 	var r0 []*model.Job
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string) ([]*model.Job, error)); ok {
-		return rf(c, jobType, status)
+		return rf(rctx, jobType, status)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string) []*model.Job); ok {
-		r0 = rf(c, jobType, status)
+		r0 = rf(rctx, jobType, status)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.Job)
@@ -173,7 +173,7 @@ func (_m *JobStore) GetAllByTypeAndStatus(c request.CTX, jobType string, status 
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, string) error); ok {
-		r1 = rf(c, jobType, status)
+		r1 = rf(rctx, jobType, status)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -181,9 +181,9 @@ func (_m *JobStore) GetAllByTypeAndStatus(c request.CTX, jobType string, status 
 	return r0, r1
 }
 
-// GetAllByTypePage provides a mock function with given fields: c, jobType, offset, limit
-func (_m *JobStore) GetAllByTypePage(c request.CTX, jobType string, offset int, limit int) ([]*model.Job, error) {
-	ret := _m.Called(c, jobType, offset, limit)
+// GetAllByTypePage provides a mock function with given fields: rctx, jobType, offset, limit
+func (_m *JobStore) GetAllByTypePage(rctx request.CTX, jobType string, offset int, limit int) ([]*model.Job, error) {
+	ret := _m.Called(rctx, jobType, offset, limit)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllByTypePage")
@@ -192,10 +192,10 @@ func (_m *JobStore) GetAllByTypePage(c request.CTX, jobType string, offset int, 
 	var r0 []*model.Job
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string, int, int) ([]*model.Job, error)); ok {
-		return rf(c, jobType, offset, limit)
+		return rf(rctx, jobType, offset, limit)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, int, int) []*model.Job); ok {
-		r0 = rf(c, jobType, offset, limit)
+		r0 = rf(rctx, jobType, offset, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.Job)
@@ -203,7 +203,7 @@ func (_m *JobStore) GetAllByTypePage(c request.CTX, jobType string, offset int, 
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, int, int) error); ok {
-		r1 = rf(c, jobType, offset, limit)
+		r1 = rf(rctx, jobType, offset, limit)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -211,9 +211,9 @@ func (_m *JobStore) GetAllByTypePage(c request.CTX, jobType string, offset int, 
 	return r0, r1
 }
 
-// GetAllByTypesAndStatusesPage provides a mock function with given fields: c, jobType, status, offset, limit
-func (_m *JobStore) GetAllByTypesAndStatusesPage(c request.CTX, jobType []string, status []string, offset int, limit int) ([]*model.Job, error) {
-	ret := _m.Called(c, jobType, status, offset, limit)
+// GetAllByTypesAndStatusesPage provides a mock function with given fields: rctx, jobType, status, offset, limit
+func (_m *JobStore) GetAllByTypesAndStatusesPage(rctx request.CTX, jobType []string, status []string, offset int, limit int) ([]*model.Job, error) {
+	ret := _m.Called(rctx, jobType, status, offset, limit)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllByTypesAndStatusesPage")
@@ -222,10 +222,10 @@ func (_m *JobStore) GetAllByTypesAndStatusesPage(c request.CTX, jobType []string
 	var r0 []*model.Job
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, []string, []string, int, int) ([]*model.Job, error)); ok {
-		return rf(c, jobType, status, offset, limit)
+		return rf(rctx, jobType, status, offset, limit)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, []string, []string, int, int) []*model.Job); ok {
-		r0 = rf(c, jobType, status, offset, limit)
+		r0 = rf(rctx, jobType, status, offset, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.Job)
@@ -233,7 +233,7 @@ func (_m *JobStore) GetAllByTypesAndStatusesPage(c request.CTX, jobType []string
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, []string, []string, int, int) error); ok {
-		r1 = rf(c, jobType, status, offset, limit)
+		r1 = rf(rctx, jobType, status, offset, limit)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -241,9 +241,9 @@ func (_m *JobStore) GetAllByTypesAndStatusesPage(c request.CTX, jobType []string
 	return r0, r1
 }
 
-// GetAllByTypesPage provides a mock function with given fields: c, jobTypes, offset, limit
-func (_m *JobStore) GetAllByTypesPage(c request.CTX, jobTypes []string, offset int, limit int) ([]*model.Job, error) {
-	ret := _m.Called(c, jobTypes, offset, limit)
+// GetAllByTypesPage provides a mock function with given fields: rctx, jobTypes, offset, limit
+func (_m *JobStore) GetAllByTypesPage(rctx request.CTX, jobTypes []string, offset int, limit int) ([]*model.Job, error) {
+	ret := _m.Called(rctx, jobTypes, offset, limit)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllByTypesPage")
@@ -252,10 +252,10 @@ func (_m *JobStore) GetAllByTypesPage(c request.CTX, jobTypes []string, offset i
 	var r0 []*model.Job
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, []string, int, int) ([]*model.Job, error)); ok {
-		return rf(c, jobTypes, offset, limit)
+		return rf(rctx, jobTypes, offset, limit)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, []string, int, int) []*model.Job); ok {
-		r0 = rf(c, jobTypes, offset, limit)
+		r0 = rf(rctx, jobTypes, offset, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.Job)
@@ -263,7 +263,7 @@ func (_m *JobStore) GetAllByTypesPage(c request.CTX, jobTypes []string, offset i
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, []string, int, int) error); ok {
-		r1 = rf(c, jobTypes, offset, limit)
+		r1 = rf(rctx, jobTypes, offset, limit)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/storetest/mocks/LicenseStore.go
+++ b/server/channels/store/storetest/mocks/LicenseStore.go
@@ -15,9 +15,9 @@ type LicenseStore struct {
 	mock.Mock
 }
 
-// Get provides a mock function with given fields: c, id
-func (_m *LicenseStore) Get(c request.CTX, id string) (*model.LicenseRecord, error) {
-	ret := _m.Called(c, id)
+// Get provides a mock function with given fields: rctx, id
+func (_m *LicenseStore) Get(rctx request.CTX, id string) (*model.LicenseRecord, error) {
+	ret := _m.Called(rctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Get")
@@ -26,10 +26,10 @@ func (_m *LicenseStore) Get(c request.CTX, id string) (*model.LicenseRecord, err
 	var r0 *model.LicenseRecord
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) (*model.LicenseRecord, error)); ok {
-		return rf(c, id)
+		return rf(rctx, id)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string) *model.LicenseRecord); ok {
-		r0 = rf(c, id)
+		r0 = rf(rctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.LicenseRecord)
@@ -37,7 +37,7 @@ func (_m *LicenseStore) Get(c request.CTX, id string) (*model.LicenseRecord, err
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string) error); ok {
-		r1 = rf(c, id)
+		r1 = rf(rctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/storetest/mocks/OutgoingOAuthConnectionStore.go
+++ b/server/channels/store/storetest/mocks/OutgoingOAuthConnectionStore.go
@@ -15,9 +15,9 @@ type OutgoingOAuthConnectionStore struct {
 	mock.Mock
 }
 
-// DeleteConnection provides a mock function with given fields: c, id
-func (_m *OutgoingOAuthConnectionStore) DeleteConnection(c request.CTX, id string) error {
-	ret := _m.Called(c, id)
+// DeleteConnection provides a mock function with given fields: rctx, id
+func (_m *OutgoingOAuthConnectionStore) DeleteConnection(rctx request.CTX, id string) error {
+	ret := _m.Called(rctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteConnection")
@@ -25,7 +25,7 @@ func (_m *OutgoingOAuthConnectionStore) DeleteConnection(c request.CTX, id strin
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) error); ok {
-		r0 = rf(c, id)
+		r0 = rf(rctx, id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -33,9 +33,9 @@ func (_m *OutgoingOAuthConnectionStore) DeleteConnection(c request.CTX, id strin
 	return r0
 }
 
-// GetConnection provides a mock function with given fields: c, id
-func (_m *OutgoingOAuthConnectionStore) GetConnection(c request.CTX, id string) (*model.OutgoingOAuthConnection, error) {
-	ret := _m.Called(c, id)
+// GetConnection provides a mock function with given fields: rctx, id
+func (_m *OutgoingOAuthConnectionStore) GetConnection(rctx request.CTX, id string) (*model.OutgoingOAuthConnection, error) {
+	ret := _m.Called(rctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetConnection")
@@ -44,10 +44,10 @@ func (_m *OutgoingOAuthConnectionStore) GetConnection(c request.CTX, id string) 
 	var r0 *model.OutgoingOAuthConnection
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) (*model.OutgoingOAuthConnection, error)); ok {
-		return rf(c, id)
+		return rf(rctx, id)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string) *model.OutgoingOAuthConnection); ok {
-		r0 = rf(c, id)
+		r0 = rf(rctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.OutgoingOAuthConnection)
@@ -55,7 +55,7 @@ func (_m *OutgoingOAuthConnectionStore) GetConnection(c request.CTX, id string) 
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string) error); ok {
-		r1 = rf(c, id)
+		r1 = rf(rctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -63,9 +63,9 @@ func (_m *OutgoingOAuthConnectionStore) GetConnection(c request.CTX, id string) 
 	return r0, r1
 }
 
-// GetConnections provides a mock function with given fields: c, filters
-func (_m *OutgoingOAuthConnectionStore) GetConnections(c request.CTX, filters model.OutgoingOAuthConnectionGetConnectionsFilter) ([]*model.OutgoingOAuthConnection, error) {
-	ret := _m.Called(c, filters)
+// GetConnections provides a mock function with given fields: rctx, filters
+func (_m *OutgoingOAuthConnectionStore) GetConnections(rctx request.CTX, filters model.OutgoingOAuthConnectionGetConnectionsFilter) ([]*model.OutgoingOAuthConnection, error) {
+	ret := _m.Called(rctx, filters)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetConnections")
@@ -74,10 +74,10 @@ func (_m *OutgoingOAuthConnectionStore) GetConnections(c request.CTX, filters mo
 	var r0 []*model.OutgoingOAuthConnection
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, model.OutgoingOAuthConnectionGetConnectionsFilter) ([]*model.OutgoingOAuthConnection, error)); ok {
-		return rf(c, filters)
+		return rf(rctx, filters)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, model.OutgoingOAuthConnectionGetConnectionsFilter) []*model.OutgoingOAuthConnection); ok {
-		r0 = rf(c, filters)
+		r0 = rf(rctx, filters)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.OutgoingOAuthConnection)
@@ -85,7 +85,7 @@ func (_m *OutgoingOAuthConnectionStore) GetConnections(c request.CTX, filters mo
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, model.OutgoingOAuthConnectionGetConnectionsFilter) error); ok {
-		r1 = rf(c, filters)
+		r1 = rf(rctx, filters)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -93,9 +93,9 @@ func (_m *OutgoingOAuthConnectionStore) GetConnections(c request.CTX, filters mo
 	return r0, r1
 }
 
-// SaveConnection provides a mock function with given fields: c, conn
-func (_m *OutgoingOAuthConnectionStore) SaveConnection(c request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error) {
-	ret := _m.Called(c, conn)
+// SaveConnection provides a mock function with given fields: rctx, conn
+func (_m *OutgoingOAuthConnectionStore) SaveConnection(rctx request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error) {
+	ret := _m.Called(rctx, conn)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SaveConnection")
@@ -104,10 +104,10 @@ func (_m *OutgoingOAuthConnectionStore) SaveConnection(c request.CTX, conn *mode
 	var r0 *model.OutgoingOAuthConnection
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error)); ok {
-		return rf(c, conn)
+		return rf(rctx, conn)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.OutgoingOAuthConnection) *model.OutgoingOAuthConnection); ok {
-		r0 = rf(c, conn)
+		r0 = rf(rctx, conn)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.OutgoingOAuthConnection)
@@ -115,7 +115,7 @@ func (_m *OutgoingOAuthConnectionStore) SaveConnection(c request.CTX, conn *mode
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.OutgoingOAuthConnection) error); ok {
-		r1 = rf(c, conn)
+		r1 = rf(rctx, conn)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -123,9 +123,9 @@ func (_m *OutgoingOAuthConnectionStore) SaveConnection(c request.CTX, conn *mode
 	return r0, r1
 }
 
-// UpdateConnection provides a mock function with given fields: c, conn
-func (_m *OutgoingOAuthConnectionStore) UpdateConnection(c request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error) {
-	ret := _m.Called(c, conn)
+// UpdateConnection provides a mock function with given fields: rctx, conn
+func (_m *OutgoingOAuthConnectionStore) UpdateConnection(rctx request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error) {
+	ret := _m.Called(rctx, conn)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateConnection")
@@ -134,10 +134,10 @@ func (_m *OutgoingOAuthConnectionStore) UpdateConnection(c request.CTX, conn *mo
 	var r0 *model.OutgoingOAuthConnection
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error)); ok {
-		return rf(c, conn)
+		return rf(rctx, conn)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.OutgoingOAuthConnection) *model.OutgoingOAuthConnection); ok {
-		r0 = rf(c, conn)
+		r0 = rf(rctx, conn)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.OutgoingOAuthConnection)
@@ -145,7 +145,7 @@ func (_m *OutgoingOAuthConnectionStore) UpdateConnection(c request.CTX, conn *mo
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.OutgoingOAuthConnection) error); ok {
-		r1 = rf(c, conn)
+		r1 = rf(rctx, conn)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/storetest/mocks/SessionStore.go
+++ b/server/channels/store/storetest/mocks/SessionStore.go
@@ -61,9 +61,9 @@ func (_m *SessionStore) Cleanup(expiryTime int64, batchSize int64) error {
 	return r0
 }
 
-// Get provides a mock function with given fields: c, sessionIDOrToken
-func (_m *SessionStore) Get(c request.CTX, sessionIDOrToken string) (*model.Session, error) {
-	ret := _m.Called(c, sessionIDOrToken)
+// Get provides a mock function with given fields: rctx, sessionIDOrToken
+func (_m *SessionStore) Get(rctx request.CTX, sessionIDOrToken string) (*model.Session, error) {
+	ret := _m.Called(rctx, sessionIDOrToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Get")
@@ -72,10 +72,10 @@ func (_m *SessionStore) Get(c request.CTX, sessionIDOrToken string) (*model.Sess
 	var r0 *model.Session
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) (*model.Session, error)); ok {
-		return rf(c, sessionIDOrToken)
+		return rf(rctx, sessionIDOrToken)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string) *model.Session); ok {
-		r0 = rf(c, sessionIDOrToken)
+		r0 = rf(rctx, sessionIDOrToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Session)
@@ -83,7 +83,7 @@ func (_m *SessionStore) Get(c request.CTX, sessionIDOrToken string) (*model.Sess
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string) error); ok {
-		r1 = rf(c, sessionIDOrToken)
+		r1 = rf(rctx, sessionIDOrToken)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -91,9 +91,9 @@ func (_m *SessionStore) Get(c request.CTX, sessionIDOrToken string) (*model.Sess
 	return r0, r1
 }
 
-// GetLRUSessions provides a mock function with given fields: c, userID, limit, offset
-func (_m *SessionStore) GetLRUSessions(c request.CTX, userID string, limit uint64, offset uint64) ([]*model.Session, error) {
-	ret := _m.Called(c, userID, limit, offset)
+// GetLRUSessions provides a mock function with given fields: rctx, userID, limit, offset
+func (_m *SessionStore) GetLRUSessions(rctx request.CTX, userID string, limit uint64, offset uint64) ([]*model.Session, error) {
+	ret := _m.Called(rctx, userID, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetLRUSessions")
@@ -102,10 +102,10 @@ func (_m *SessionStore) GetLRUSessions(c request.CTX, userID string, limit uint6
 	var r0 []*model.Session
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string, uint64, uint64) ([]*model.Session, error)); ok {
-		return rf(c, userID, limit, offset)
+		return rf(rctx, userID, limit, offset)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, uint64, uint64) []*model.Session); ok {
-		r0 = rf(c, userID, limit, offset)
+		r0 = rf(rctx, userID, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.Session)
@@ -113,7 +113,7 @@ func (_m *SessionStore) GetLRUSessions(c request.CTX, userID string, limit uint6
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, uint64, uint64) error); ok {
-		r1 = rf(c, userID, limit, offset)
+		r1 = rf(rctx, userID, limit, offset)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -151,9 +151,9 @@ func (_m *SessionStore) GetMobileSessionMetadata() ([]*model.MobileSessionMetada
 	return r0, r1
 }
 
-// GetSessions provides a mock function with given fields: c, userID
-func (_m *SessionStore) GetSessions(c request.CTX, userID string) ([]*model.Session, error) {
-	ret := _m.Called(c, userID)
+// GetSessions provides a mock function with given fields: rctx, userID
+func (_m *SessionStore) GetSessions(rctx request.CTX, userID string) ([]*model.Session, error) {
+	ret := _m.Called(rctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetSessions")
@@ -162,10 +162,10 @@ func (_m *SessionStore) GetSessions(c request.CTX, userID string) ([]*model.Sess
 	var r0 []*model.Session
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) ([]*model.Session, error)); ok {
-		return rf(c, userID)
+		return rf(rctx, userID)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string) []*model.Session); ok {
-		r0 = rf(c, userID)
+		r0 = rf(rctx, userID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.Session)
@@ -173,7 +173,7 @@ func (_m *SessionStore) GetSessions(c request.CTX, userID string) ([]*model.Sess
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string) error); ok {
-		r1 = rf(c, userID)
+		r1 = rf(rctx, userID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -295,9 +295,9 @@ func (_m *SessionStore) RemoveAllSessions() error {
 	return r0
 }
 
-// Save provides a mock function with given fields: c, session
-func (_m *SessionStore) Save(c request.CTX, session *model.Session) (*model.Session, error) {
-	ret := _m.Called(c, session)
+// Save provides a mock function with given fields: rctx, session
+func (_m *SessionStore) Save(rctx request.CTX, session *model.Session) (*model.Session, error) {
+	ret := _m.Called(rctx, session)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Save")
@@ -306,10 +306,10 @@ func (_m *SessionStore) Save(c request.CTX, session *model.Session) (*model.Sess
 	var r0 *model.Session
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Session) (*model.Session, error)); ok {
-		return rf(c, session)
+		return rf(rctx, session)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Session) *model.Session); ok {
-		r0 = rf(c, session)
+		r0 = rf(rctx, session)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Session)
@@ -317,7 +317,7 @@ func (_m *SessionStore) Save(c request.CTX, session *model.Session) (*model.Sess
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.Session) error); ok {
-		r1 = rf(c, session)
+		r1 = rf(rctx, session)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/storetest/mocks/TeamStore.go
+++ b/server/channels/store/storetest/mocks/TeamStore.go
@@ -572,9 +572,9 @@ func (_m *TeamStore) GetMany(ids []string) ([]*model.Team, error) {
 	return r0, r1
 }
 
-// GetMember provides a mock function with given fields: c, teamID, userID
-func (_m *TeamStore) GetMember(c request.CTX, teamID string, userID string) (*model.TeamMember, error) {
-	ret := _m.Called(c, teamID, userID)
+// GetMember provides a mock function with given fields: rctx, teamID, userID
+func (_m *TeamStore) GetMember(rctx request.CTX, teamID string, userID string) (*model.TeamMember, error) {
+	ret := _m.Called(rctx, teamID, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetMember")
@@ -583,10 +583,10 @@ func (_m *TeamStore) GetMember(c request.CTX, teamID string, userID string) (*mo
 	var r0 *model.TeamMember
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string) (*model.TeamMember, error)); ok {
-		return rf(c, teamID, userID)
+		return rf(rctx, teamID, userID)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string) *model.TeamMember); ok {
-		r0 = rf(c, teamID, userID)
+		r0 = rf(rctx, teamID, userID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.TeamMember)
@@ -594,7 +594,7 @@ func (_m *TeamStore) GetMember(c request.CTX, teamID string, userID string) (*mo
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, string) error); ok {
-		r1 = rf(c, teamID, userID)
+		r1 = rf(rctx, teamID, userID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -752,9 +752,9 @@ func (_m *TeamStore) GetTeamsByUserId(userID string) ([]*model.Team, error) {
 	return r0, r1
 }
 
-// GetTeamsForUser provides a mock function with given fields: c, userID, excludeTeamID, includeDeleted
-func (_m *TeamStore) GetTeamsForUser(c request.CTX, userID string, excludeTeamID string, includeDeleted bool) ([]*model.TeamMember, error) {
-	ret := _m.Called(c, userID, excludeTeamID, includeDeleted)
+// GetTeamsForUser provides a mock function with given fields: rctx, userID, excludeTeamID, includeDeleted
+func (_m *TeamStore) GetTeamsForUser(rctx request.CTX, userID string, excludeTeamID string, includeDeleted bool) ([]*model.TeamMember, error) {
+	ret := _m.Called(rctx, userID, excludeTeamID, includeDeleted)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetTeamsForUser")
@@ -763,10 +763,10 @@ func (_m *TeamStore) GetTeamsForUser(c request.CTX, userID string, excludeTeamID
 	var r0 []*model.TeamMember
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string, bool) ([]*model.TeamMember, error)); ok {
-		return rf(c, userID, excludeTeamID, includeDeleted)
+		return rf(rctx, userID, excludeTeamID, includeDeleted)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string, bool) []*model.TeamMember); ok {
-		r0 = rf(c, userID, excludeTeamID, includeDeleted)
+		r0 = rf(rctx, userID, excludeTeamID, includeDeleted)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.TeamMember)
@@ -774,7 +774,7 @@ func (_m *TeamStore) GetTeamsForUser(c request.CTX, userID string, excludeTeamID
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, string, bool) error); ok {
-		r1 = rf(c, userID, excludeTeamID, includeDeleted)
+		r1 = rf(rctx, userID, excludeTeamID, includeDeleted)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -969,9 +969,9 @@ func (_m *TeamStore) RemoveAllMembersByTeam(teamID string) error {
 	return r0
 }
 
-// RemoveAllMembersByUser provides a mock function with given fields: ctx, userID
-func (_m *TeamStore) RemoveAllMembersByUser(ctx request.CTX, userID string) error {
-	ret := _m.Called(ctx, userID)
+// RemoveAllMembersByUser provides a mock function with given fields: rctx, userID
+func (_m *TeamStore) RemoveAllMembersByUser(rctx request.CTX, userID string) error {
+	ret := _m.Called(rctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RemoveAllMembersByUser")
@@ -979,7 +979,7 @@ func (_m *TeamStore) RemoveAllMembersByUser(ctx request.CTX, userID string) erro
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) error); ok {
-		r0 = rf(ctx, userID)
+		r0 = rf(rctx, userID)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/server/channels/store/storetest/mocks/UploadSessionStore.go
+++ b/server/channels/store/storetest/mocks/UploadSessionStore.go
@@ -33,9 +33,9 @@ func (_m *UploadSessionStore) Delete(id string) error {
 	return r0
 }
 
-// Get provides a mock function with given fields: c, id
-func (_m *UploadSessionStore) Get(c request.CTX, id string) (*model.UploadSession, error) {
-	ret := _m.Called(c, id)
+// Get provides a mock function with given fields: rctx, id
+func (_m *UploadSessionStore) Get(rctx request.CTX, id string) (*model.UploadSession, error) {
+	ret := _m.Called(rctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Get")
@@ -44,10 +44,10 @@ func (_m *UploadSessionStore) Get(c request.CTX, id string) (*model.UploadSessio
 	var r0 *model.UploadSession
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) (*model.UploadSession, error)); ok {
-		return rf(c, id)
+		return rf(rctx, id)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string) *model.UploadSession); ok {
-		r0 = rf(c, id)
+		r0 = rf(rctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.UploadSession)
@@ -55,7 +55,7 @@ func (_m *UploadSessionStore) Get(c request.CTX, id string) (*model.UploadSessio
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string) error); ok {
-		r1 = rf(c, id)
+		r1 = rf(rctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -531,10 +531,10 @@ type TimerLayerWebhookStore struct {
 	Root *TimerLayer
 }
 
-func (s *TimerLayerAccessControlPolicyStore) Delete(c request.CTX, id string) error {
+func (s *TimerLayerAccessControlPolicyStore) Delete(rctx request.CTX, id string) error {
 	start := time.Now()
 
-	err := s.AccessControlPolicyStore.Delete(c, id)
+	err := s.AccessControlPolicyStore.Delete(rctx, id)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -547,10 +547,10 @@ func (s *TimerLayerAccessControlPolicyStore) Delete(c request.CTX, id string) er
 	return err
 }
 
-func (s *TimerLayerAccessControlPolicyStore) Get(c request.CTX, id string) (*model.AccessControlPolicy, error) {
+func (s *TimerLayerAccessControlPolicyStore) Get(rctx request.CTX, id string) (*model.AccessControlPolicy, error) {
 	start := time.Now()
 
-	result, err := s.AccessControlPolicyStore.Get(c, id)
+	result, err := s.AccessControlPolicyStore.Get(rctx, id)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -563,10 +563,10 @@ func (s *TimerLayerAccessControlPolicyStore) Get(c request.CTX, id string) (*mod
 	return result, err
 }
 
-func (s *TimerLayerAccessControlPolicyStore) Save(c request.CTX, policy *model.AccessControlPolicy) (*model.AccessControlPolicy, error) {
+func (s *TimerLayerAccessControlPolicyStore) Save(rctx request.CTX, policy *model.AccessControlPolicy) (*model.AccessControlPolicy, error) {
 	start := time.Now()
 
-	result, err := s.AccessControlPolicyStore.Save(c, policy)
+	result, err := s.AccessControlPolicyStore.Save(rctx, policy)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -595,10 +595,10 @@ func (s *TimerLayerAccessControlPolicyStore) SearchPolicies(rctx request.CTX, op
 	return result, resultVar1, err
 }
 
-func (s *TimerLayerAccessControlPolicyStore) SetActiveStatus(c request.CTX, id string, active bool) (*model.AccessControlPolicy, error) {
+func (s *TimerLayerAccessControlPolicyStore) SetActiveStatus(rctx request.CTX, id string, active bool) (*model.AccessControlPolicy, error) {
 	start := time.Now()
 
-	result, err := s.AccessControlPolicyStore.SetActiveStatus(c, id, active)
+	result, err := s.AccessControlPolicyStore.SetActiveStatus(rctx, id, active)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -1025,10 +1025,10 @@ func (s *TimerLayerChannelStore) CountUrgentPostsAfter(channelID string, timesta
 	return result, err
 }
 
-func (s *TimerLayerChannelStore) CreateDirectChannel(ctx request.CTX, userID *model.User, otherUserID *model.User, channelOptions ...model.ChannelOption) (*model.Channel, error) {
+func (s *TimerLayerChannelStore) CreateDirectChannel(rctx request.CTX, userID *model.User, otherUserID *model.User, channelOptions ...model.ChannelOption) (*model.Channel, error) {
 	start := time.Now()
 
-	result, err := s.ChannelStore.CreateDirectChannel(ctx, userID, otherUserID, channelOptions...)
+	result, err := s.ChannelStore.CreateDirectChannel(rctx, userID, otherUserID, channelOptions...)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -1041,10 +1041,10 @@ func (s *TimerLayerChannelStore) CreateDirectChannel(ctx request.CTX, userID *mo
 	return result, err
 }
 
-func (s *TimerLayerChannelStore) CreateInitialSidebarCategories(c request.CTX, userID string, teamID string) (*model.OrderedSidebarCategories, error) {
+func (s *TimerLayerChannelStore) CreateInitialSidebarCategories(rctx request.CTX, userID string, teamID string) (*model.OrderedSidebarCategories, error) {
 	start := time.Now()
 
-	result, err := s.ChannelStore.CreateInitialSidebarCategories(c, userID, teamID)
+	result, err := s.ChannelStore.CreateInitialSidebarCategories(rctx, userID, teamID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -1185,10 +1185,10 @@ func (s *TimerLayerChannelStore) GetAllChannelMemberIdsByChannelId(id string) ([
 	return result, err
 }
 
-func (s *TimerLayerChannelStore) GetAllChannelMembersForUser(ctx request.CTX, userID string, allowFromCache bool, includeDeleted bool) (map[string]string, error) {
+func (s *TimerLayerChannelStore) GetAllChannelMembersForUser(rctx request.CTX, userID string, allowFromCache bool, includeDeleted bool) (map[string]string, error) {
 	start := time.Now()
 
-	result, err := s.ChannelStore.GetAllChannelMembersForUser(ctx, userID, allowFromCache, includeDeleted)
+	result, err := s.ChannelStore.GetAllChannelMembersForUser(rctx, userID, allowFromCache, includeDeleted)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -2250,10 +2250,10 @@ func (s *TimerLayerChannelStore) PatchMultipleMembersNotifyProps(members []*mode
 	return result, err
 }
 
-func (s *TimerLayerChannelStore) PermanentDelete(ctx request.CTX, channelID string) error {
+func (s *TimerLayerChannelStore) PermanentDelete(rctx request.CTX, channelID string) error {
 	start := time.Now()
 
-	err := s.ChannelStore.PermanentDelete(ctx, channelID)
+	err := s.ChannelStore.PermanentDelete(rctx, channelID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -2282,10 +2282,10 @@ func (s *TimerLayerChannelStore) PermanentDeleteByTeam(teamID string) error {
 	return err
 }
 
-func (s *TimerLayerChannelStore) PermanentDeleteMembersByChannel(ctx request.CTX, channelID string) error {
+func (s *TimerLayerChannelStore) PermanentDeleteMembersByChannel(rctx request.CTX, channelID string) error {
 	start := time.Now()
 
-	err := s.ChannelStore.PermanentDeleteMembersByChannel(ctx, channelID)
+	err := s.ChannelStore.PermanentDeleteMembersByChannel(rctx, channelID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -2298,10 +2298,10 @@ func (s *TimerLayerChannelStore) PermanentDeleteMembersByChannel(ctx request.CTX
 	return err
 }
 
-func (s *TimerLayerChannelStore) PermanentDeleteMembersByUser(ctx request.CTX, userID string) error {
+func (s *TimerLayerChannelStore) PermanentDeleteMembersByUser(rctx request.CTX, userID string) error {
 	start := time.Now()
 
-	err := s.ChannelStore.PermanentDeleteMembersByUser(ctx, userID)
+	err := s.ChannelStore.PermanentDeleteMembersByUser(rctx, userID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -2314,10 +2314,10 @@ func (s *TimerLayerChannelStore) PermanentDeleteMembersByUser(ctx request.CTX, u
 	return err
 }
 
-func (s *TimerLayerChannelStore) RemoveAllDeactivatedMembers(ctx request.CTX, channelID string) error {
+func (s *TimerLayerChannelStore) RemoveAllDeactivatedMembers(rctx request.CTX, channelID string) error {
 	start := time.Now()
 
-	err := s.ChannelStore.RemoveAllDeactivatedMembers(ctx, channelID)
+	err := s.ChannelStore.RemoveAllDeactivatedMembers(rctx, channelID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -2330,10 +2330,10 @@ func (s *TimerLayerChannelStore) RemoveAllDeactivatedMembers(ctx request.CTX, ch
 	return err
 }
 
-func (s *TimerLayerChannelStore) RemoveMember(ctx request.CTX, channelID string, userID string) error {
+func (s *TimerLayerChannelStore) RemoveMember(rctx request.CTX, channelID string, userID string) error {
 	start := time.Now()
 
-	err := s.ChannelStore.RemoveMember(ctx, channelID, userID)
+	err := s.ChannelStore.RemoveMember(rctx, channelID, userID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -2346,10 +2346,10 @@ func (s *TimerLayerChannelStore) RemoveMember(ctx request.CTX, channelID string,
 	return err
 }
 
-func (s *TimerLayerChannelStore) RemoveMembers(ctx request.CTX, channelID string, userIds []string) error {
+func (s *TimerLayerChannelStore) RemoveMembers(rctx request.CTX, channelID string, userIds []string) error {
 	start := time.Now()
 
-	err := s.ChannelStore.RemoveMembers(ctx, channelID, userIds)
+	err := s.ChannelStore.RemoveMembers(rctx, channelID, userIds)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -2410,10 +2410,10 @@ func (s *TimerLayerChannelStore) Save(rctx request.CTX, channel *model.Channel, 
 	return result, err
 }
 
-func (s *TimerLayerChannelStore) SaveDirectChannel(ctx request.CTX, channel *model.Channel, member1 *model.ChannelMember, member2 *model.ChannelMember) (*model.Channel, error) {
+func (s *TimerLayerChannelStore) SaveDirectChannel(rctx request.CTX, channel *model.Channel, member1 *model.ChannelMember, member2 *model.ChannelMember) (*model.Channel, error) {
 	start := time.Now()
 
-	result, err := s.ChannelStore.SaveDirectChannel(ctx, channel, member1, member2)
+	result, err := s.ChannelStore.SaveDirectChannel(rctx, channel, member1, member2)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -2586,10 +2586,10 @@ func (s *TimerLayerChannelStore) SetShared(channelID string, shared bool) error 
 	return err
 }
 
-func (s *TimerLayerChannelStore) Update(ctx request.CTX, channel *model.Channel) (*model.Channel, error) {
+func (s *TimerLayerChannelStore) Update(rctx request.CTX, channel *model.Channel) (*model.Channel, error) {
 	start := time.Now()
 
-	result, err := s.ChannelStore.Update(ctx, channel)
+	result, err := s.ChannelStore.Update(rctx, channel)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -2634,10 +2634,10 @@ func (s *TimerLayerChannelStore) UpdateLastViewedAtPost(unreadPost *model.Post, 
 	return result, err
 }
 
-func (s *TimerLayerChannelStore) UpdateMember(ctx request.CTX, member *model.ChannelMember) (*model.ChannelMember, error) {
+func (s *TimerLayerChannelStore) UpdateMember(rctx request.CTX, member *model.ChannelMember) (*model.ChannelMember, error) {
 	start := time.Now()
 
-	result, err := s.ChannelStore.UpdateMember(ctx, member)
+	result, err := s.ChannelStore.UpdateMember(rctx, member)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -3369,10 +3369,10 @@ func (s *TimerLayerComplianceStore) GetAll(offset int, limit int) (model.Complia
 	return result, err
 }
 
-func (s *TimerLayerComplianceStore) MessageExport(c request.CTX, cursor model.MessageExportCursor, limit int) ([]*model.MessageExport, model.MessageExportCursor, error) {
+func (s *TimerLayerComplianceStore) MessageExport(rctx request.CTX, cursor model.MessageExportCursor, limit int) ([]*model.MessageExport, model.MessageExportCursor, error) {
 	start := time.Now()
 
-	result, resultVar1, err := s.ComplianceStore.MessageExport(c, cursor, limit)
+	result, resultVar1, err := s.ComplianceStore.MessageExport(rctx, cursor, limit)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -3657,10 +3657,10 @@ func (s *TimerLayerEmojiStore) Delete(emoji *model.Emoji, timestamp int64) error
 	return err
 }
 
-func (s *TimerLayerEmojiStore) Get(c request.CTX, id string, allowFromCache bool) (*model.Emoji, error) {
+func (s *TimerLayerEmojiStore) Get(rctx request.CTX, id string, allowFromCache bool) (*model.Emoji, error) {
 	start := time.Now()
 
-	result, err := s.EmojiStore.Get(c, id, allowFromCache)
+	result, err := s.EmojiStore.Get(rctx, id, allowFromCache)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -3673,10 +3673,10 @@ func (s *TimerLayerEmojiStore) Get(c request.CTX, id string, allowFromCache bool
 	return result, err
 }
 
-func (s *TimerLayerEmojiStore) GetByName(c request.CTX, name string, allowFromCache bool) (*model.Emoji, error) {
+func (s *TimerLayerEmojiStore) GetByName(rctx request.CTX, name string, allowFromCache bool) (*model.Emoji, error) {
 	start := time.Now()
 
-	result, err := s.EmojiStore.GetByName(c, name, allowFromCache)
+	result, err := s.EmojiStore.GetByName(rctx, name, allowFromCache)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -3705,10 +3705,10 @@ func (s *TimerLayerEmojiStore) GetList(offset int, limit int, sort string) ([]*m
 	return result, err
 }
 
-func (s *TimerLayerEmojiStore) GetMultipleByName(c request.CTX, names []string) ([]*model.Emoji, error) {
+func (s *TimerLayerEmojiStore) GetMultipleByName(rctx request.CTX, names []string) ([]*model.Emoji, error) {
 	start := time.Now()
 
-	result, err := s.EmojiStore.GetMultipleByName(c, names)
+	result, err := s.EmojiStore.GetMultipleByName(rctx, names)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -3753,10 +3753,10 @@ func (s *TimerLayerEmojiStore) Search(name string, prefixOnly bool, limit int) (
 	return result, err
 }
 
-func (s *TimerLayerFileInfoStore) AttachToPost(c request.CTX, fileID string, postID string, channelID string, creatorID string) error {
+func (s *TimerLayerFileInfoStore) AttachToPost(rctx request.CTX, fileID string, postID string, channelID string, creatorID string) error {
 	start := time.Now()
 
-	err := s.FileInfoStore.AttachToPost(c, fileID, postID, channelID, creatorID)
+	err := s.FileInfoStore.AttachToPost(rctx, fileID, postID, channelID, creatorID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -3800,10 +3800,10 @@ func (s *TimerLayerFileInfoStore) CountAll() (int64, error) {
 	return result, err
 }
 
-func (s *TimerLayerFileInfoStore) DeleteForPost(c request.CTX, postID string) (string, error) {
+func (s *TimerLayerFileInfoStore) DeleteForPost(rctx request.CTX, postID string) (string, error) {
 	start := time.Now()
 
-	result, err := s.FileInfoStore.DeleteForPost(c, postID)
+	result, err := s.FileInfoStore.DeleteForPost(rctx, postID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -4007,10 +4007,10 @@ func (s *TimerLayerFileInfoStore) InvalidateFileInfosForPostCache(postID string,
 	}
 }
 
-func (s *TimerLayerFileInfoStore) PermanentDelete(c request.CTX, fileID string) error {
+func (s *TimerLayerFileInfoStore) PermanentDelete(rctx request.CTX, fileID string) error {
 	start := time.Now()
 
-	err := s.FileInfoStore.PermanentDelete(c, fileID)
+	err := s.FileInfoStore.PermanentDelete(rctx, fileID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -4023,10 +4023,10 @@ func (s *TimerLayerFileInfoStore) PermanentDelete(c request.CTX, fileID string) 
 	return err
 }
 
-func (s *TimerLayerFileInfoStore) PermanentDeleteBatch(ctx request.CTX, endTime int64, limit int64) (int64, error) {
+func (s *TimerLayerFileInfoStore) PermanentDeleteBatch(rctx request.CTX, endTime int64, limit int64) (int64, error) {
 	start := time.Now()
 
-	result, err := s.FileInfoStore.PermanentDeleteBatch(ctx, endTime, limit)
+	result, err := s.FileInfoStore.PermanentDeleteBatch(rctx, endTime, limit)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -4039,10 +4039,10 @@ func (s *TimerLayerFileInfoStore) PermanentDeleteBatch(ctx request.CTX, endTime 
 	return result, err
 }
 
-func (s *TimerLayerFileInfoStore) PermanentDeleteByUser(ctx request.CTX, userID string) (int64, error) {
+func (s *TimerLayerFileInfoStore) PermanentDeleteByUser(rctx request.CTX, userID string) (int64, error) {
 	start := time.Now()
 
-	result, err := s.FileInfoStore.PermanentDeleteByUser(ctx, userID)
+	result, err := s.FileInfoStore.PermanentDeleteByUser(rctx, userID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -4103,10 +4103,10 @@ func (s *TimerLayerFileInfoStore) RestoreForPostByIds(rctx request.CTX, postId s
 	return err
 }
 
-func (s *TimerLayerFileInfoStore) Save(ctx request.CTX, info *model.FileInfo) (*model.FileInfo, error) {
+func (s *TimerLayerFileInfoStore) Save(rctx request.CTX, info *model.FileInfo) (*model.FileInfo, error) {
 	start := time.Now()
 
-	result, err := s.FileInfoStore.Save(ctx, info)
+	result, err := s.FileInfoStore.Save(rctx, info)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -4119,10 +4119,10 @@ func (s *TimerLayerFileInfoStore) Save(ctx request.CTX, info *model.FileInfo) (*
 	return result, err
 }
 
-func (s *TimerLayerFileInfoStore) Search(ctx request.CTX, paramsList []*model.SearchParams, userID string, teamID string, page int, perPage int) (*model.FileInfoList, error) {
+func (s *TimerLayerFileInfoStore) Search(rctx request.CTX, paramsList []*model.SearchParams, userID string, teamID string, page int, perPage int) (*model.FileInfoList, error) {
 	start := time.Now()
 
-	result, err := s.FileInfoStore.Search(ctx, paramsList, userID, teamID, page, perPage)
+	result, err := s.FileInfoStore.Search(rctx, paramsList, userID, teamID, page, perPage)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -4135,10 +4135,10 @@ func (s *TimerLayerFileInfoStore) Search(ctx request.CTX, paramsList []*model.Se
 	return result, err
 }
 
-func (s *TimerLayerFileInfoStore) SetContent(ctx request.CTX, fileID string, content string) error {
+func (s *TimerLayerFileInfoStore) SetContent(rctx request.CTX, fileID string, content string) error {
 	start := time.Now()
 
-	err := s.FileInfoStore.SetContent(ctx, fileID, content)
+	err := s.FileInfoStore.SetContent(rctx, fileID, content)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -5063,10 +5063,10 @@ func (s *TimerLayerJobStore) Delete(id string) (string, error) {
 	return result, err
 }
 
-func (s *TimerLayerJobStore) Get(c request.CTX, id string) (*model.Job, error) {
+func (s *TimerLayerJobStore) Get(rctx request.CTX, id string) (*model.Job, error) {
 	start := time.Now()
 
-	result, err := s.JobStore.Get(c, id)
+	result, err := s.JobStore.Get(rctx, id)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -5079,10 +5079,10 @@ func (s *TimerLayerJobStore) Get(c request.CTX, id string) (*model.Job, error) {
 	return result, err
 }
 
-func (s *TimerLayerJobStore) GetAllByStatus(c request.CTX, status string) ([]*model.Job, error) {
+func (s *TimerLayerJobStore) GetAllByStatus(rctx request.CTX, status string) ([]*model.Job, error) {
 	start := time.Now()
 
-	result, err := s.JobStore.GetAllByStatus(c, status)
+	result, err := s.JobStore.GetAllByStatus(rctx, status)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -5095,10 +5095,10 @@ func (s *TimerLayerJobStore) GetAllByStatus(c request.CTX, status string) ([]*mo
 	return result, err
 }
 
-func (s *TimerLayerJobStore) GetAllByType(c request.CTX, jobType string) ([]*model.Job, error) {
+func (s *TimerLayerJobStore) GetAllByType(rctx request.CTX, jobType string) ([]*model.Job, error) {
 	start := time.Now()
 
-	result, err := s.JobStore.GetAllByType(c, jobType)
+	result, err := s.JobStore.GetAllByType(rctx, jobType)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -5111,10 +5111,10 @@ func (s *TimerLayerJobStore) GetAllByType(c request.CTX, jobType string) ([]*mod
 	return result, err
 }
 
-func (s *TimerLayerJobStore) GetAllByTypeAndStatus(c request.CTX, jobType string, status string) ([]*model.Job, error) {
+func (s *TimerLayerJobStore) GetAllByTypeAndStatus(rctx request.CTX, jobType string, status string) ([]*model.Job, error) {
 	start := time.Now()
 
-	result, err := s.JobStore.GetAllByTypeAndStatus(c, jobType, status)
+	result, err := s.JobStore.GetAllByTypeAndStatus(rctx, jobType, status)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -5127,10 +5127,10 @@ func (s *TimerLayerJobStore) GetAllByTypeAndStatus(c request.CTX, jobType string
 	return result, err
 }
 
-func (s *TimerLayerJobStore) GetAllByTypePage(c request.CTX, jobType string, offset int, limit int) ([]*model.Job, error) {
+func (s *TimerLayerJobStore) GetAllByTypePage(rctx request.CTX, jobType string, offset int, limit int) ([]*model.Job, error) {
 	start := time.Now()
 
-	result, err := s.JobStore.GetAllByTypePage(c, jobType, offset, limit)
+	result, err := s.JobStore.GetAllByTypePage(rctx, jobType, offset, limit)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -5143,10 +5143,10 @@ func (s *TimerLayerJobStore) GetAllByTypePage(c request.CTX, jobType string, off
 	return result, err
 }
 
-func (s *TimerLayerJobStore) GetAllByTypesAndStatusesPage(c request.CTX, jobType []string, status []string, offset int, limit int) ([]*model.Job, error) {
+func (s *TimerLayerJobStore) GetAllByTypesAndStatusesPage(rctx request.CTX, jobType []string, status []string, offset int, limit int) ([]*model.Job, error) {
 	start := time.Now()
 
-	result, err := s.JobStore.GetAllByTypesAndStatusesPage(c, jobType, status, offset, limit)
+	result, err := s.JobStore.GetAllByTypesAndStatusesPage(rctx, jobType, status, offset, limit)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -5159,10 +5159,10 @@ func (s *TimerLayerJobStore) GetAllByTypesAndStatusesPage(c request.CTX, jobType
 	return result, err
 }
 
-func (s *TimerLayerJobStore) GetAllByTypesPage(c request.CTX, jobTypes []string, offset int, limit int) ([]*model.Job, error) {
+func (s *TimerLayerJobStore) GetAllByTypesPage(rctx request.CTX, jobTypes []string, offset int, limit int) ([]*model.Job, error) {
 	start := time.Now()
 
-	result, err := s.JobStore.GetAllByTypesPage(c, jobTypes, offset, limit)
+	result, err := s.JobStore.GetAllByTypesPage(rctx, jobTypes, offset, limit)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -5303,10 +5303,10 @@ func (s *TimerLayerJobStore) UpdateStatusOptimistically(id string, currentStatus
 	return result, err
 }
 
-func (s *TimerLayerLicenseStore) Get(c request.CTX, id string) (*model.LicenseRecord, error) {
+func (s *TimerLayerLicenseStore) Get(rctx request.CTX, id string) (*model.LicenseRecord, error) {
 	start := time.Now()
 
-	result, err := s.LicenseStore.Get(c, id)
+	result, err := s.LicenseStore.Get(rctx, id)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -5799,10 +5799,10 @@ func (s *TimerLayerOAuthStore) UpdateApp(app *model.OAuthApp) (*model.OAuthApp, 
 	return result, err
 }
 
-func (s *TimerLayerOutgoingOAuthConnectionStore) DeleteConnection(c request.CTX, id string) error {
+func (s *TimerLayerOutgoingOAuthConnectionStore) DeleteConnection(rctx request.CTX, id string) error {
 	start := time.Now()
 
-	err := s.OutgoingOAuthConnectionStore.DeleteConnection(c, id)
+	err := s.OutgoingOAuthConnectionStore.DeleteConnection(rctx, id)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -5815,10 +5815,10 @@ func (s *TimerLayerOutgoingOAuthConnectionStore) DeleteConnection(c request.CTX,
 	return err
 }
 
-func (s *TimerLayerOutgoingOAuthConnectionStore) GetConnection(c request.CTX, id string) (*model.OutgoingOAuthConnection, error) {
+func (s *TimerLayerOutgoingOAuthConnectionStore) GetConnection(rctx request.CTX, id string) (*model.OutgoingOAuthConnection, error) {
 	start := time.Now()
 
-	result, err := s.OutgoingOAuthConnectionStore.GetConnection(c, id)
+	result, err := s.OutgoingOAuthConnectionStore.GetConnection(rctx, id)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -5831,10 +5831,10 @@ func (s *TimerLayerOutgoingOAuthConnectionStore) GetConnection(c request.CTX, id
 	return result, err
 }
 
-func (s *TimerLayerOutgoingOAuthConnectionStore) GetConnections(c request.CTX, filters model.OutgoingOAuthConnectionGetConnectionsFilter) ([]*model.OutgoingOAuthConnection, error) {
+func (s *TimerLayerOutgoingOAuthConnectionStore) GetConnections(rctx request.CTX, filters model.OutgoingOAuthConnectionGetConnectionsFilter) ([]*model.OutgoingOAuthConnection, error) {
 	start := time.Now()
 
-	result, err := s.OutgoingOAuthConnectionStore.GetConnections(c, filters)
+	result, err := s.OutgoingOAuthConnectionStore.GetConnections(rctx, filters)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -5847,10 +5847,10 @@ func (s *TimerLayerOutgoingOAuthConnectionStore) GetConnections(c request.CTX, f
 	return result, err
 }
 
-func (s *TimerLayerOutgoingOAuthConnectionStore) SaveConnection(c request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error) {
+func (s *TimerLayerOutgoingOAuthConnectionStore) SaveConnection(rctx request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error) {
 	start := time.Now()
 
-	result, err := s.OutgoingOAuthConnectionStore.SaveConnection(c, conn)
+	result, err := s.OutgoingOAuthConnectionStore.SaveConnection(rctx, conn)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -5863,10 +5863,10 @@ func (s *TimerLayerOutgoingOAuthConnectionStore) SaveConnection(c request.CTX, c
 	return result, err
 }
 
-func (s *TimerLayerOutgoingOAuthConnectionStore) UpdateConnection(c request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error) {
+func (s *TimerLayerOutgoingOAuthConnectionStore) UpdateConnection(rctx request.CTX, conn *model.OutgoingOAuthConnection) (*model.OutgoingOAuthConnection, error) {
 	start := time.Now()
 
-	result, err := s.OutgoingOAuthConnectionStore.UpdateConnection(c, conn)
+	result, err := s.OutgoingOAuthConnectionStore.UpdateConnection(rctx, conn)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -8821,10 +8821,10 @@ func (s *TimerLayerSessionStore) Cleanup(expiryTime int64, batchSize int64) erro
 	return err
 }
 
-func (s *TimerLayerSessionStore) Get(c request.CTX, sessionIDOrToken string) (*model.Session, error) {
+func (s *TimerLayerSessionStore) Get(rctx request.CTX, sessionIDOrToken string) (*model.Session, error) {
 	start := time.Now()
 
-	result, err := s.SessionStore.Get(c, sessionIDOrToken)
+	result, err := s.SessionStore.Get(rctx, sessionIDOrToken)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -8837,10 +8837,10 @@ func (s *TimerLayerSessionStore) Get(c request.CTX, sessionIDOrToken string) (*m
 	return result, err
 }
 
-func (s *TimerLayerSessionStore) GetLRUSessions(c request.CTX, userID string, limit uint64, offset uint64) ([]*model.Session, error) {
+func (s *TimerLayerSessionStore) GetLRUSessions(rctx request.CTX, userID string, limit uint64, offset uint64) ([]*model.Session, error) {
 	start := time.Now()
 
-	result, err := s.SessionStore.GetLRUSessions(c, userID, limit, offset)
+	result, err := s.SessionStore.GetLRUSessions(rctx, userID, limit, offset)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -8869,10 +8869,10 @@ func (s *TimerLayerSessionStore) GetMobileSessionMetadata() ([]*model.MobileSess
 	return result, err
 }
 
-func (s *TimerLayerSessionStore) GetSessions(c request.CTX, userID string) ([]*model.Session, error) {
+func (s *TimerLayerSessionStore) GetSessions(rctx request.CTX, userID string) ([]*model.Session, error) {
 	start := time.Now()
 
-	result, err := s.SessionStore.GetSessions(c, userID)
+	result, err := s.SessionStore.GetSessions(rctx, userID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -8965,10 +8965,10 @@ func (s *TimerLayerSessionStore) RemoveAllSessions() error {
 	return err
 }
 
-func (s *TimerLayerSessionStore) Save(c request.CTX, session *model.Session) (*model.Session, error) {
+func (s *TimerLayerSessionStore) Save(rctx request.CTX, session *model.Session) (*model.Session, error) {
 	start := time.Now()
 
-	result, err := s.SessionStore.Save(c, session)
+	result, err := s.SessionStore.Save(rctx, session)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -10100,10 +10100,10 @@ func (s *TimerLayerTeamStore) GetMany(ids []string) ([]*model.Team, error) {
 	return result, err
 }
 
-func (s *TimerLayerTeamStore) GetMember(c request.CTX, teamID string, userID string) (*model.TeamMember, error) {
+func (s *TimerLayerTeamStore) GetMember(rctx request.CTX, teamID string, userID string) (*model.TeamMember, error) {
 	start := time.Now()
 
-	result, err := s.TeamStore.GetMember(c, teamID, userID)
+	result, err := s.TeamStore.GetMember(rctx, teamID, userID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -10196,10 +10196,10 @@ func (s *TimerLayerTeamStore) GetTeamsByUserId(userID string) ([]*model.Team, er
 	return result, err
 }
 
-func (s *TimerLayerTeamStore) GetTeamsForUser(c request.CTX, userID string, excludeTeamID string, includeDeleted bool) ([]*model.TeamMember, error) {
+func (s *TimerLayerTeamStore) GetTeamsForUser(rctx request.CTX, userID string, excludeTeamID string, includeDeleted bool) ([]*model.TeamMember, error) {
 	start := time.Now()
 
-	result, err := s.TeamStore.GetTeamsForUser(c, userID, excludeTeamID, includeDeleted)
+	result, err := s.TeamStore.GetTeamsForUser(rctx, userID, excludeTeamID, includeDeleted)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -10339,10 +10339,10 @@ func (s *TimerLayerTeamStore) RemoveAllMembersByTeam(teamID string) error {
 	return err
 }
 
-func (s *TimerLayerTeamStore) RemoveAllMembersByUser(ctx request.CTX, userID string) error {
+func (s *TimerLayerTeamStore) RemoveAllMembersByUser(rctx request.CTX, userID string) error {
 	start := time.Now()
 
-	err := s.TeamStore.RemoveAllMembersByUser(ctx, userID)
+	err := s.TeamStore.RemoveAllMembersByUser(rctx, userID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -11202,10 +11202,10 @@ func (s *TimerLayerUploadSessionStore) Delete(id string) error {
 	return err
 }
 
-func (s *TimerLayerUploadSessionStore) Get(c request.CTX, id string) (*model.UploadSession, error) {
+func (s *TimerLayerUploadSessionStore) Get(rctx request.CTX, id string) (*model.UploadSession, error) {
 	start := time.Now()
 
-	result, err := s.UploadSessionStore.Get(c, id)
+	result, err := s.UploadSessionStore.Get(rctx, id)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {

--- a/server/channels/web/unsupported_browser.go
+++ b/server/channels/web/unsupported_browser.go
@@ -44,11 +44,11 @@ type SystemBrowser struct {
 	MakeDefaultString      string
 }
 
-func renderUnsupportedBrowser(ctx request.CTX, r *http.Request) templates.Data {
+func renderUnsupportedBrowser(rctx request.CTX, r *http.Request) templates.Data {
 	data := templates.Data{
 		Props: map[string]any{
-			"DownloadAppOrUpgradeBrowserString": ctx.T("web.error.unsupported_browser.download_app_or_upgrade_browser"),
-			"LearnMoreString":                   ctx.T("web.error.unsupported_browser.learn_more"),
+			"DownloadAppOrUpgradeBrowserString": rctx.T("web.error.unsupported_browser.download_app_or_upgrade_browser"),
+			"LearnMoreString":                   rctx.T("web.error.unsupported_browser.learn_more"),
 		},
 	}
 
@@ -61,98 +61,98 @@ func renderUnsupportedBrowser(ctx request.CTX, r *http.Request) templates.Data {
 
 	// Basic heading translations
 	if isSafari {
-		data.Props["NoLongerSupportString"] = ctx.T("web.error.unsupported_browser.no_longer_support_version")
+		data.Props["NoLongerSupportString"] = rctx.T("web.error.unsupported_browser.no_longer_support_version")
 	} else {
-		data.Props["NoLongerSupportString"] = ctx.T("web.error.unsupported_browser.no_longer_support")
+		data.Props["NoLongerSupportString"] = rctx.T("web.error.unsupported_browser.no_longer_support")
 	}
 
 	// Mattermost app version
 	if isWindows {
-		data.Props["App"] = renderMattermostAppWindows(ctx)
+		data.Props["App"] = renderMattermostAppWindows(rctx)
 	} else if isMacOSX {
-		data.Props["App"] = renderMattermostAppMac(ctx)
+		data.Props["App"] = renderMattermostAppMac(rctx)
 	}
 
 	// Browsers to download
 	// Show a link to Safari if you're using safari and it's outdated
 	// Can't show on Mac all the time because there's no way to open it via URI
-	browsers := []Browser{renderBrowserChrome(ctx), renderBrowserFirefox(ctx)}
+	browsers := []Browser{renderBrowserChrome(rctx), renderBrowserFirefox(rctx)}
 	if isSafari {
-		browsers = append(browsers, renderBrowserSafari(ctx))
+		browsers = append(browsers, renderBrowserSafari(rctx))
 	}
 	data.Props["Browsers"] = browsers
 
 	// If on Windows 10, show link to Edge
 	if isWindows10 {
-		data.Props["SystemBrowser"] = renderSystemBrowserEdge(ctx, r)
+		data.Props["SystemBrowser"] = renderSystemBrowserEdge(rctx, r)
 	}
 
 	return data
 }
 
-func renderMattermostAppMac(ctx request.CTX) MattermostApp {
+func renderMattermostAppMac(rctx request.CTX) MattermostApp {
 	return MattermostApp{
 		"/static/images/browser-icons/mac.png",
-		ctx.T("web.error.unsupported_browser.download_the_app"),
-		ctx.T("web.error.unsupported_browser.min_os_version.mac"),
-		ctx.T("web.error.unsupported_browser.download"),
+		rctx.T("web.error.unsupported_browser.download_the_app"),
+		rctx.T("web.error.unsupported_browser.min_os_version.mac"),
+		rctx.T("web.error.unsupported_browser.download"),
 		"https://mattermost.com/pl/download-apps",
-		ctx.T("web.error.unsupported_browser.install_guide.mac"),
+		rctx.T("web.error.unsupported_browser.install_guide.mac"),
 		"https://docs.mattermost.com/install/desktop.html#mac-os-x-10-9",
 	}
 }
 
-func renderMattermostAppWindows(ctx request.CTX) MattermostApp {
+func renderMattermostAppWindows(rctx request.CTX) MattermostApp {
 	return MattermostApp{
 		"/static/images/browser-icons/windows.svg",
-		ctx.T("web.error.unsupported_browser.download_the_app"),
-		ctx.T("web.error.unsupported_browser.min_os_version.windows"),
-		ctx.T("web.error.unsupported_browser.download"),
+		rctx.T("web.error.unsupported_browser.download_the_app"),
+		rctx.T("web.error.unsupported_browser.min_os_version.windows"),
+		rctx.T("web.error.unsupported_browser.download"),
 		"https://mattermost.com/pl/download-apps",
-		ctx.T("web.error.unsupported_browser.install_guide.windows"),
+		rctx.T("web.error.unsupported_browser.install_guide.windows"),
 		"https://docs.mattermost.com/install/desktop.html#windows-10-windows-8-1-windows-7",
 	}
 }
 
-func renderBrowserChrome(ctx request.CTX) Browser {
+func renderBrowserChrome(rctx request.CTX) Browser {
 	return Browser{
 		"/static/images/browser-icons/chrome.svg",
-		ctx.T("web.error.unsupported_browser.browser_title.chrome"),
-		ctx.T("web.error.unsupported_browser.min_browser_version.chrome"),
+		rctx.T("web.error.unsupported_browser.browser_title.chrome"),
+		rctx.T("web.error.unsupported_browser.min_browser_version.chrome"),
 		"http://www.google.com/chrome",
-		ctx.T("web.error.unsupported_browser.browser_get_latest.chrome"),
+		rctx.T("web.error.unsupported_browser.browser_get_latest.chrome"),
 	}
 }
 
-func renderBrowserFirefox(ctx request.CTX) Browser {
+func renderBrowserFirefox(rctx request.CTX) Browser {
 	return Browser{
 		"/static/images/browser-icons/firefox.svg",
-		ctx.T("web.error.unsupported_browser.browser_title.firefox"),
-		ctx.T("web.error.unsupported_browser.min_browser_version.firefox"),
+		rctx.T("web.error.unsupported_browser.browser_title.firefox"),
+		rctx.T("web.error.unsupported_browser.min_browser_version.firefox"),
 		"https://www.mozilla.org/firefox/new/",
-		ctx.T("web.error.unsupported_browser.browser_get_latest.firefox"),
+		rctx.T("web.error.unsupported_browser.browser_get_latest.firefox"),
 	}
 }
 
-func renderBrowserSafari(ctx request.CTX) Browser {
+func renderBrowserSafari(rctx request.CTX) Browser {
 	return Browser{
 		"/static/images/browser-icons/safari.svg",
-		ctx.T("web.error.unsupported_browser.browser_title.safari"),
-		ctx.T("web.error.unsupported_browser.min_browser_version.safari"),
+		rctx.T("web.error.unsupported_browser.browser_title.safari"),
+		rctx.T("web.error.unsupported_browser.min_browser_version.safari"),
 		"macappstore://showUpdatesPage",
-		ctx.T("web.error.unsupported_browser.browser_get_latest.safari"),
+		rctx.T("web.error.unsupported_browser.browser_get_latest.safari"),
 	}
 }
 
-func renderSystemBrowserEdge(ctx request.CTX, r *http.Request) SystemBrowser {
+func renderSystemBrowserEdge(rctx request.CTX, r *http.Request) SystemBrowser {
 	return SystemBrowser{
 		"/static/images/browser-icons/edge.svg",
-		ctx.T("web.error.unsupported_browser.browser_title.edge"),
-		ctx.T("web.error.unsupported_browser.min_browser_version.edge"),
-		ctx.T("web.error.unsupported_browser.open_system_browser.edge"),
+		rctx.T("web.error.unsupported_browser.browser_title.edge"),
+		rctx.T("web.error.unsupported_browser.min_browser_version.edge"),
+		rctx.T("web.error.unsupported_browser.open_system_browser.edge"),
 		"microsoft-edge:http://" + r.Host + r.RequestURI, //TODO: Can we get HTTP or HTTPS? If someone's server doesn't have a redirect this won't work
 		"ms-settings:defaultapps",
-		ctx.T("web.error.unsupported_browser.system_browser_or"),
-		ctx.T("web.error.unsupported_browser.system_browser_make_default"),
+		rctx.T("web.error.unsupported_browser.system_browser_or"),
+		rctx.T("web.error.unsupported_browser.system_browser_make_default"),
 	}
 }

--- a/server/einterfaces/account_migration.go
+++ b/server/einterfaces/account_migration.go
@@ -9,6 +9,6 @@ import (
 )
 
 type AccountMigrationInterface interface {
-	MigrateToLdap(c request.CTX, fromAuthService string, foreignUserFieldNameToMatch string, force bool, dryRun bool) *model.AppError
-	MigrateToSaml(c request.CTX, fromAuthService string, usersMap map[string]string, auto bool, dryRun bool) *model.AppError
+	MigrateToLdap(rctx request.CTX, fromAuthService string, foreignUserFieldNameToMatch string, force bool, dryRun bool) *model.AppError
+	MigrateToSaml(rctx request.CTX, fromAuthService string, usersMap map[string]string, auto bool, dryRun bool) *model.AppError
 }

--- a/server/einterfaces/cluster.go
+++ b/server/einterfaces/cluster.go
@@ -26,7 +26,7 @@ type ClusterInterface interface {
 	SendClusterMessageToNode(nodeID string, msg *model.ClusterMessage) error
 	NotifyMsg(buf []byte)
 	GetClusterStats(rctx request.CTX) ([]*model.ClusterStats, *model.AppError)
-	GetLogs(ctx request.CTX, page, perPage int) ([]string, *model.AppError)
+	GetLogs(rctx request.CTX, page, perPage int) ([]string, *model.AppError)
 	QueryLogs(rctx request.CTX, page, perPage int) (map[string][]string, *model.AppError)
 	GenerateSupportPacket(rctx request.CTX, options *model.SupportPacketOptions) (map[string][]model.FileData, error)
 	GetPluginStatuses() (model.PluginStatuses, *model.AppError)

--- a/server/einterfaces/jobs/scheduler.go
+++ b/server/einterfaces/jobs/scheduler.go
@@ -13,5 +13,5 @@ import (
 type Scheduler interface {
 	Enabled(cfg *model.Config) bool
 	NextScheduleTime(cfg *model.Config, now time.Time, pendingJobs bool, lastSuccessfulJob *model.Job) *time.Time
-	ScheduleJob(c request.CTX, cfg *model.Config, pendingJobs bool, lastSuccessfulJob *model.Job) (*model.Job, *model.AppError)
+	ScheduleJob(rctx request.CTX, cfg *model.Config, pendingJobs bool, lastSuccessfulJob *model.Job) (*model.Job, *model.AppError)
 }

--- a/server/einterfaces/ldap.go
+++ b/server/einterfaces/ldap.go
@@ -9,18 +9,18 @@ import (
 )
 
 type LdapInterface interface {
-	DoLogin(c request.CTX, id string, password string) (*model.User, *model.AppError)
-	GetUser(c request.CTX, id string) (*model.User, *model.AppError)
+	DoLogin(rctx request.CTX, id string, password string) (*model.User, *model.AppError)
+	GetUser(rctx request.CTX, id string) (*model.User, *model.AppError)
 	GetLDAPUserForMMUser(rctx request.CTX, mmUser *model.User) (*model.User, string, *model.AppError)
 	GetUserAttributes(rctx request.CTX, id string, attributes []string) (map[string]string, *model.AppError)
-	CheckProviderAttributes(c request.CTX, LS *model.LdapSettings, ouser *model.User, patch *model.UserPatch) string
-	SwitchToLdap(c request.CTX, userID, ldapID, ldapPassword string) *model.AppError
-	StartSynchronizeJob(c request.CTX, waitForJobToFinish bool, reAddRemovedMembers *bool) (*model.Job, *model.AppError)
-	GetAllLdapUsers(c request.CTX) ([]*model.User, *model.AppError)
-	MigrateIDAttribute(c request.CTX, toAttribute string) error
+	CheckProviderAttributes(rctx request.CTX, LS *model.LdapSettings, ouser *model.User, patch *model.UserPatch) string
+	SwitchToLdap(rctx request.CTX, userID, ldapID, ldapPassword string) *model.AppError
+	StartSynchronizeJob(rctx request.CTX, waitForJobToFinish bool, reAddRemovedMembers *bool) (*model.Job, *model.AppError)
+	GetAllLdapUsers(rctx request.CTX) ([]*model.User, *model.AppError)
+	MigrateIDAttribute(rctx request.CTX, toAttribute string) error
 	GetGroup(rctx request.CTX, groupUID string) (*model.Group, *model.AppError)
 	GetAllGroupsPage(rctx request.CTX, page int, perPage int, opts model.LdapGroupSearchOpts) ([]*model.Group, int, *model.AppError)
-	FirstLoginSync(c request.CTX, user *model.User) *model.AppError
+	FirstLoginSync(rctx request.CTX, user *model.User) *model.AppError
 	UpdateProfilePictureIfNecessary(request.CTX, model.User, model.Session)
 }
 

--- a/server/einterfaces/mocks/AccountMigrationInterface.go
+++ b/server/einterfaces/mocks/AccountMigrationInterface.go
@@ -15,9 +15,9 @@ type AccountMigrationInterface struct {
 	mock.Mock
 }
 
-// MigrateToLdap provides a mock function with given fields: c, fromAuthService, foreignUserFieldNameToMatch, force, dryRun
-func (_m *AccountMigrationInterface) MigrateToLdap(c request.CTX, fromAuthService string, foreignUserFieldNameToMatch string, force bool, dryRun bool) *model.AppError {
-	ret := _m.Called(c, fromAuthService, foreignUserFieldNameToMatch, force, dryRun)
+// MigrateToLdap provides a mock function with given fields: rctx, fromAuthService, foreignUserFieldNameToMatch, force, dryRun
+func (_m *AccountMigrationInterface) MigrateToLdap(rctx request.CTX, fromAuthService string, foreignUserFieldNameToMatch string, force bool, dryRun bool) *model.AppError {
+	ret := _m.Called(rctx, fromAuthService, foreignUserFieldNameToMatch, force, dryRun)
 
 	if len(ret) == 0 {
 		panic("no return value specified for MigrateToLdap")
@@ -25,7 +25,7 @@ func (_m *AccountMigrationInterface) MigrateToLdap(c request.CTX, fromAuthServic
 
 	var r0 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string, bool, bool) *model.AppError); ok {
-		r0 = rf(c, fromAuthService, foreignUserFieldNameToMatch, force, dryRun)
+		r0 = rf(rctx, fromAuthService, foreignUserFieldNameToMatch, force, dryRun)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.AppError)
@@ -35,9 +35,9 @@ func (_m *AccountMigrationInterface) MigrateToLdap(c request.CTX, fromAuthServic
 	return r0
 }
 
-// MigrateToSaml provides a mock function with given fields: c, fromAuthService, usersMap, auto, dryRun
-func (_m *AccountMigrationInterface) MigrateToSaml(c request.CTX, fromAuthService string, usersMap map[string]string, auto bool, dryRun bool) *model.AppError {
-	ret := _m.Called(c, fromAuthService, usersMap, auto, dryRun)
+// MigrateToSaml provides a mock function with given fields: rctx, fromAuthService, usersMap, auto, dryRun
+func (_m *AccountMigrationInterface) MigrateToSaml(rctx request.CTX, fromAuthService string, usersMap map[string]string, auto bool, dryRun bool) *model.AppError {
+	ret := _m.Called(rctx, fromAuthService, usersMap, auto, dryRun)
 
 	if len(ret) == 0 {
 		panic("no return value specified for MigrateToSaml")
@@ -45,7 +45,7 @@ func (_m *AccountMigrationInterface) MigrateToSaml(c request.CTX, fromAuthServic
 
 	var r0 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, string, map[string]string, bool, bool) *model.AppError); ok {
-		r0 = rf(c, fromAuthService, usersMap, auto, dryRun)
+		r0 = rf(rctx, fromAuthService, usersMap, auto, dryRun)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.AppError)

--- a/server/einterfaces/mocks/ClusterInterface.go
+++ b/server/einterfaces/mocks/ClusterInterface.go
@@ -148,9 +148,9 @@ func (_m *ClusterInterface) GetClusterStats(rctx request.CTX) ([]*model.ClusterS
 	return r0, r1
 }
 
-// GetLogs provides a mock function with given fields: ctx, page, perPage
-func (_m *ClusterInterface) GetLogs(ctx request.CTX, page int, perPage int) ([]string, *model.AppError) {
-	ret := _m.Called(ctx, page, perPage)
+// GetLogs provides a mock function with given fields: rctx, page, perPage
+func (_m *ClusterInterface) GetLogs(rctx request.CTX, page int, perPage int) ([]string, *model.AppError) {
+	ret := _m.Called(rctx, page, perPage)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetLogs")
@@ -159,10 +159,10 @@ func (_m *ClusterInterface) GetLogs(ctx request.CTX, page int, perPage int) ([]s
 	var r0 []string
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, int, int) ([]string, *model.AppError)); ok {
-		return rf(ctx, page, perPage)
+		return rf(rctx, page, perPage)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, int, int) []string); ok {
-		r0 = rf(ctx, page, perPage)
+		r0 = rf(rctx, page, perPage)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
@@ -170,7 +170,7 @@ func (_m *ClusterInterface) GetLogs(ctx request.CTX, page int, perPage int) ([]s
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, int, int) *model.AppError); ok {
-		r1 = rf(ctx, page, perPage)
+		r1 = rf(rctx, page, perPage)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)

--- a/server/einterfaces/mocks/LdapInterface.go
+++ b/server/einterfaces/mocks/LdapInterface.go
@@ -15,9 +15,9 @@ type LdapInterface struct {
 	mock.Mock
 }
 
-// CheckProviderAttributes provides a mock function with given fields: c, LS, ouser, patch
-func (_m *LdapInterface) CheckProviderAttributes(c request.CTX, LS *model.LdapSettings, ouser *model.User, patch *model.UserPatch) string {
-	ret := _m.Called(c, LS, ouser, patch)
+// CheckProviderAttributes provides a mock function with given fields: rctx, LS, ouser, patch
+func (_m *LdapInterface) CheckProviderAttributes(rctx request.CTX, LS *model.LdapSettings, ouser *model.User, patch *model.UserPatch) string {
+	ret := _m.Called(rctx, LS, ouser, patch)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CheckProviderAttributes")
@@ -25,7 +25,7 @@ func (_m *LdapInterface) CheckProviderAttributes(c request.CTX, LS *model.LdapSe
 
 	var r0 string
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.LdapSettings, *model.User, *model.UserPatch) string); ok {
-		r0 = rf(c, LS, ouser, patch)
+		r0 = rf(rctx, LS, ouser, patch)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
@@ -33,9 +33,9 @@ func (_m *LdapInterface) CheckProviderAttributes(c request.CTX, LS *model.LdapSe
 	return r0
 }
 
-// DoLogin provides a mock function with given fields: c, id, password
-func (_m *LdapInterface) DoLogin(c request.CTX, id string, password string) (*model.User, *model.AppError) {
-	ret := _m.Called(c, id, password)
+// DoLogin provides a mock function with given fields: rctx, id, password
+func (_m *LdapInterface) DoLogin(rctx request.CTX, id string, password string) (*model.User, *model.AppError) {
+	ret := _m.Called(rctx, id, password)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DoLogin")
@@ -44,10 +44,10 @@ func (_m *LdapInterface) DoLogin(c request.CTX, id string, password string) (*mo
 	var r0 *model.User
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string) (*model.User, *model.AppError)); ok {
-		return rf(c, id, password)
+		return rf(rctx, id, password)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string) *model.User); ok {
-		r0 = rf(c, id, password)
+		r0 = rf(rctx, id, password)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.User)
@@ -55,7 +55,7 @@ func (_m *LdapInterface) DoLogin(c request.CTX, id string, password string) (*mo
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, string) *model.AppError); ok {
-		r1 = rf(c, id, password)
+		r1 = rf(rctx, id, password)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -65,9 +65,9 @@ func (_m *LdapInterface) DoLogin(c request.CTX, id string, password string) (*mo
 	return r0, r1
 }
 
-// FirstLoginSync provides a mock function with given fields: c, user
-func (_m *LdapInterface) FirstLoginSync(c request.CTX, user *model.User) *model.AppError {
-	ret := _m.Called(c, user)
+// FirstLoginSync provides a mock function with given fields: rctx, user
+func (_m *LdapInterface) FirstLoginSync(rctx request.CTX, user *model.User) *model.AppError {
+	ret := _m.Called(rctx, user)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FirstLoginSync")
@@ -75,7 +75,7 @@ func (_m *LdapInterface) FirstLoginSync(c request.CTX, user *model.User) *model.
 
 	var r0 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.User) *model.AppError); ok {
-		r0 = rf(c, user)
+		r0 = rf(rctx, user)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.AppError)
@@ -124,9 +124,9 @@ func (_m *LdapInterface) GetAllGroupsPage(rctx request.CTX, page int, perPage in
 	return r0, r1, r2
 }
 
-// GetAllLdapUsers provides a mock function with given fields: c
-func (_m *LdapInterface) GetAllLdapUsers(c request.CTX) ([]*model.User, *model.AppError) {
-	ret := _m.Called(c)
+// GetAllLdapUsers provides a mock function with given fields: rctx
+func (_m *LdapInterface) GetAllLdapUsers(rctx request.CTX) ([]*model.User, *model.AppError) {
+	ret := _m.Called(rctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllLdapUsers")
@@ -135,10 +135,10 @@ func (_m *LdapInterface) GetAllLdapUsers(c request.CTX) ([]*model.User, *model.A
 	var r0 []*model.User
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX) ([]*model.User, *model.AppError)); ok {
-		return rf(c)
+		return rf(rctx)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX) []*model.User); ok {
-		r0 = rf(c)
+		r0 = rf(rctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.User)
@@ -146,7 +146,7 @@ func (_m *LdapInterface) GetAllLdapUsers(c request.CTX) ([]*model.User, *model.A
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX) *model.AppError); ok {
-		r1 = rf(c)
+		r1 = rf(rctx)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -227,9 +227,9 @@ func (_m *LdapInterface) GetLDAPUserForMMUser(rctx request.CTX, mmUser *model.Us
 	return r0, r1, r2
 }
 
-// GetUser provides a mock function with given fields: c, id
-func (_m *LdapInterface) GetUser(c request.CTX, id string) (*model.User, *model.AppError) {
-	ret := _m.Called(c, id)
+// GetUser provides a mock function with given fields: rctx, id
+func (_m *LdapInterface) GetUser(rctx request.CTX, id string) (*model.User, *model.AppError) {
+	ret := _m.Called(rctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUser")
@@ -238,10 +238,10 @@ func (_m *LdapInterface) GetUser(c request.CTX, id string) (*model.User, *model.
 	var r0 *model.User
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, string) (*model.User, *model.AppError)); ok {
-		return rf(c, id)
+		return rf(rctx, id)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string) *model.User); ok {
-		r0 = rf(c, id)
+		r0 = rf(rctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.User)
@@ -249,7 +249,7 @@ func (_m *LdapInterface) GetUser(c request.CTX, id string) (*model.User, *model.
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string) *model.AppError); ok {
-		r1 = rf(c, id)
+		r1 = rf(rctx, id)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -291,9 +291,9 @@ func (_m *LdapInterface) GetUserAttributes(rctx request.CTX, id string, attribut
 	return r0, r1
 }
 
-// MigrateIDAttribute provides a mock function with given fields: c, toAttribute
-func (_m *LdapInterface) MigrateIDAttribute(c request.CTX, toAttribute string) error {
-	ret := _m.Called(c, toAttribute)
+// MigrateIDAttribute provides a mock function with given fields: rctx, toAttribute
+func (_m *LdapInterface) MigrateIDAttribute(rctx request.CTX, toAttribute string) error {
+	ret := _m.Called(rctx, toAttribute)
 
 	if len(ret) == 0 {
 		panic("no return value specified for MigrateIDAttribute")
@@ -301,7 +301,7 @@ func (_m *LdapInterface) MigrateIDAttribute(c request.CTX, toAttribute string) e
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) error); ok {
-		r0 = rf(c, toAttribute)
+		r0 = rf(rctx, toAttribute)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -309,9 +309,9 @@ func (_m *LdapInterface) MigrateIDAttribute(c request.CTX, toAttribute string) e
 	return r0
 }
 
-// StartSynchronizeJob provides a mock function with given fields: c, waitForJobToFinish, reAddRemovedMembers
-func (_m *LdapInterface) StartSynchronizeJob(c request.CTX, waitForJobToFinish bool, reAddRemovedMembers *bool) (*model.Job, *model.AppError) {
-	ret := _m.Called(c, waitForJobToFinish, reAddRemovedMembers)
+// StartSynchronizeJob provides a mock function with given fields: rctx, waitForJobToFinish, reAddRemovedMembers
+func (_m *LdapInterface) StartSynchronizeJob(rctx request.CTX, waitForJobToFinish bool, reAddRemovedMembers *bool) (*model.Job, *model.AppError) {
+	ret := _m.Called(rctx, waitForJobToFinish, reAddRemovedMembers)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StartSynchronizeJob")
@@ -320,10 +320,10 @@ func (_m *LdapInterface) StartSynchronizeJob(c request.CTX, waitForJobToFinish b
 	var r0 *model.Job
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, bool, *bool) (*model.Job, *model.AppError)); ok {
-		return rf(c, waitForJobToFinish, reAddRemovedMembers)
+		return rf(rctx, waitForJobToFinish, reAddRemovedMembers)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, bool, *bool) *model.Job); ok {
-		r0 = rf(c, waitForJobToFinish, reAddRemovedMembers)
+		r0 = rf(rctx, waitForJobToFinish, reAddRemovedMembers)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Job)
@@ -331,7 +331,7 @@ func (_m *LdapInterface) StartSynchronizeJob(c request.CTX, waitForJobToFinish b
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, bool, *bool) *model.AppError); ok {
-		r1 = rf(c, waitForJobToFinish, reAddRemovedMembers)
+		r1 = rf(rctx, waitForJobToFinish, reAddRemovedMembers)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -341,9 +341,9 @@ func (_m *LdapInterface) StartSynchronizeJob(c request.CTX, waitForJobToFinish b
 	return r0, r1
 }
 
-// SwitchToLdap provides a mock function with given fields: c, userID, ldapID, ldapPassword
-func (_m *LdapInterface) SwitchToLdap(c request.CTX, userID string, ldapID string, ldapPassword string) *model.AppError {
-	ret := _m.Called(c, userID, ldapID, ldapPassword)
+// SwitchToLdap provides a mock function with given fields: rctx, userID, ldapID, ldapPassword
+func (_m *LdapInterface) SwitchToLdap(rctx request.CTX, userID string, ldapID string, ldapPassword string) *model.AppError {
+	ret := _m.Called(rctx, userID, ldapID, ldapPassword)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SwitchToLdap")
@@ -351,7 +351,7 @@ func (_m *LdapInterface) SwitchToLdap(c request.CTX, userID string, ldapID strin
 
 	var r0 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string, string) *model.AppError); ok {
-		r0 = rf(c, userID, ldapID, ldapPassword)
+		r0 = rf(rctx, userID, ldapID, ldapPassword)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.AppError)

--- a/server/einterfaces/mocks/NotificationInterface.go
+++ b/server/einterfaces/mocks/NotificationInterface.go
@@ -35,9 +35,9 @@ func (_m *NotificationInterface) CheckLicense() *model.AppError {
 	return r0
 }
 
-// GetNotificationMessage provides a mock function with given fields: c, ack, userID
-func (_m *NotificationInterface) GetNotificationMessage(c request.CTX, ack *model.PushNotificationAck, userID string) (*model.PushNotification, *model.AppError) {
-	ret := _m.Called(c, ack, userID)
+// GetNotificationMessage provides a mock function with given fields: rctx, ack, userID
+func (_m *NotificationInterface) GetNotificationMessage(rctx request.CTX, ack *model.PushNotificationAck, userID string) (*model.PushNotification, *model.AppError) {
+	ret := _m.Called(rctx, ack, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetNotificationMessage")
@@ -46,10 +46,10 @@ func (_m *NotificationInterface) GetNotificationMessage(c request.CTX, ack *mode
 	var r0 *model.PushNotification
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.PushNotificationAck, string) (*model.PushNotification, *model.AppError)); ok {
-		return rf(c, ack, userID)
+		return rf(rctx, ack, userID)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.PushNotificationAck, string) *model.PushNotification); ok {
-		r0 = rf(c, ack, userID)
+		r0 = rf(rctx, ack, userID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.PushNotification)
@@ -57,7 +57,7 @@ func (_m *NotificationInterface) GetNotificationMessage(c request.CTX, ack *mode
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.PushNotificationAck, string) *model.AppError); ok {
-		r1 = rf(c, ack, userID)
+		r1 = rf(rctx, ack, userID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)

--- a/server/einterfaces/mocks/OAuthProvider.go
+++ b/server/einterfaces/mocks/OAuthProvider.go
@@ -18,9 +18,9 @@ type OAuthProvider struct {
 	mock.Mock
 }
 
-// GetSSOSettings provides a mock function with given fields: c, config, service
-func (_m *OAuthProvider) GetSSOSettings(c request.CTX, config *model.Config, service string) (*model.SSOSettings, error) {
-	ret := _m.Called(c, config, service)
+// GetSSOSettings provides a mock function with given fields: rctx, config, service
+func (_m *OAuthProvider) GetSSOSettings(rctx request.CTX, config *model.Config, service string) (*model.SSOSettings, error) {
+	ret := _m.Called(rctx, config, service)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetSSOSettings")
@@ -29,10 +29,10 @@ func (_m *OAuthProvider) GetSSOSettings(c request.CTX, config *model.Config, ser
 	var r0 *model.SSOSettings
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Config, string) (*model.SSOSettings, error)); ok {
-		return rf(c, config, service)
+		return rf(rctx, config, service)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Config, string) *model.SSOSettings); ok {
-		r0 = rf(c, config, service)
+		r0 = rf(rctx, config, service)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.SSOSettings)
@@ -40,7 +40,7 @@ func (_m *OAuthProvider) GetSSOSettings(c request.CTX, config *model.Config, ser
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.Config, string) error); ok {
-		r1 = rf(c, config, service)
+		r1 = rf(rctx, config, service)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -48,9 +48,9 @@ func (_m *OAuthProvider) GetSSOSettings(c request.CTX, config *model.Config, ser
 	return r0, r1
 }
 
-// GetUserFromIdToken provides a mock function with given fields: c, idToken
-func (_m *OAuthProvider) GetUserFromIdToken(c request.CTX, idToken string) (*model.User, error) {
-	ret := _m.Called(c, idToken)
+// GetUserFromIdToken provides a mock function with given fields: rctx, idToken
+func (_m *OAuthProvider) GetUserFromIdToken(rctx request.CTX, idToken string) (*model.User, error) {
+	ret := _m.Called(rctx, idToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserFromIdToken")
@@ -59,10 +59,10 @@ func (_m *OAuthProvider) GetUserFromIdToken(c request.CTX, idToken string) (*mod
 	var r0 *model.User
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, string) (*model.User, error)); ok {
-		return rf(c, idToken)
+		return rf(rctx, idToken)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string) *model.User); ok {
-		r0 = rf(c, idToken)
+		r0 = rf(rctx, idToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.User)
@@ -70,7 +70,7 @@ func (_m *OAuthProvider) GetUserFromIdToken(c request.CTX, idToken string) (*mod
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string) error); ok {
-		r1 = rf(c, idToken)
+		r1 = rf(rctx, idToken)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -78,9 +78,9 @@ func (_m *OAuthProvider) GetUserFromIdToken(c request.CTX, idToken string) (*mod
 	return r0, r1
 }
 
-// GetUserFromJSON provides a mock function with given fields: c, data, tokenUser
-func (_m *OAuthProvider) GetUserFromJSON(c request.CTX, data io.Reader, tokenUser *model.User) (*model.User, error) {
-	ret := _m.Called(c, data, tokenUser)
+// GetUserFromJSON provides a mock function with given fields: rctx, data, tokenUser
+func (_m *OAuthProvider) GetUserFromJSON(rctx request.CTX, data io.Reader, tokenUser *model.User) (*model.User, error) {
+	ret := _m.Called(rctx, data, tokenUser)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserFromJSON")
@@ -89,10 +89,10 @@ func (_m *OAuthProvider) GetUserFromJSON(c request.CTX, data io.Reader, tokenUse
 	var r0 *model.User
 	var r1 error
 	if rf, ok := ret.Get(0).(func(request.CTX, io.Reader, *model.User) (*model.User, error)); ok {
-		return rf(c, data, tokenUser)
+		return rf(rctx, data, tokenUser)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, io.Reader, *model.User) *model.User); ok {
-		r0 = rf(c, data, tokenUser)
+		r0 = rf(rctx, data, tokenUser)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.User)
@@ -100,7 +100,7 @@ func (_m *OAuthProvider) GetUserFromJSON(c request.CTX, data io.Reader, tokenUse
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, io.Reader, *model.User) error); ok {
-		r1 = rf(c, data, tokenUser)
+		r1 = rf(rctx, data, tokenUser)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -108,9 +108,9 @@ func (_m *OAuthProvider) GetUserFromJSON(c request.CTX, data io.Reader, tokenUse
 	return r0, r1
 }
 
-// IsSameUser provides a mock function with given fields: c, dbUser, oAuthUser
-func (_m *OAuthProvider) IsSameUser(c request.CTX, dbUser *model.User, oAuthUser *model.User) bool {
-	ret := _m.Called(c, dbUser, oAuthUser)
+// IsSameUser provides a mock function with given fields: rctx, dbUser, oAuthUser
+func (_m *OAuthProvider) IsSameUser(rctx request.CTX, dbUser *model.User, oAuthUser *model.User) bool {
+	ret := _m.Called(rctx, dbUser, oAuthUser)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IsSameUser")
@@ -118,7 +118,7 @@ func (_m *OAuthProvider) IsSameUser(c request.CTX, dbUser *model.User, oAuthUser
 
 	var r0 bool
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.User, *model.User) bool); ok {
-		r0 = rf(c, dbUser, oAuthUser)
+		r0 = rf(rctx, dbUser, oAuthUser)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}

--- a/server/einterfaces/mocks/SamlInterface.go
+++ b/server/einterfaces/mocks/SamlInterface.go
@@ -17,9 +17,9 @@ type SamlInterface struct {
 	mock.Mock
 }
 
-// BuildRequest provides a mock function with given fields: c, relayState
-func (_m *SamlInterface) BuildRequest(c request.CTX, relayState string) (*model.SamlAuthRequest, *model.AppError) {
-	ret := _m.Called(c, relayState)
+// BuildRequest provides a mock function with given fields: rctx, relayState
+func (_m *SamlInterface) BuildRequest(rctx request.CTX, relayState string) (*model.SamlAuthRequest, *model.AppError) {
+	ret := _m.Called(rctx, relayState)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildRequest")
@@ -28,10 +28,10 @@ func (_m *SamlInterface) BuildRequest(c request.CTX, relayState string) (*model.
 	var r0 *model.SamlAuthRequest
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, string) (*model.SamlAuthRequest, *model.AppError)); ok {
-		return rf(c, relayState)
+		return rf(rctx, relayState)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string) *model.SamlAuthRequest); ok {
-		r0 = rf(c, relayState)
+		r0 = rf(rctx, relayState)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.SamlAuthRequest)
@@ -39,7 +39,7 @@ func (_m *SamlInterface) BuildRequest(c request.CTX, relayState string) (*model.
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string) *model.AppError); ok {
-		r1 = rf(c, relayState)
+		r1 = rf(rctx, relayState)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -49,9 +49,9 @@ func (_m *SamlInterface) BuildRequest(c request.CTX, relayState string) (*model.
 	return r0, r1
 }
 
-// CheckProviderAttributes provides a mock function with given fields: c, SS, ouser, patch
-func (_m *SamlInterface) CheckProviderAttributes(c request.CTX, SS *model.SamlSettings, ouser *model.User, patch *model.UserPatch) string {
-	ret := _m.Called(c, SS, ouser, patch)
+// CheckProviderAttributes provides a mock function with given fields: rctx, SS, ouser, patch
+func (_m *SamlInterface) CheckProviderAttributes(rctx request.CTX, SS *model.SamlSettings, ouser *model.User, patch *model.UserPatch) string {
+	ret := _m.Called(rctx, SS, ouser, patch)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CheckProviderAttributes")
@@ -59,7 +59,7 @@ func (_m *SamlInterface) CheckProviderAttributes(c request.CTX, SS *model.SamlSe
 
 	var r0 string
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.SamlSettings, *model.User, *model.UserPatch) string); ok {
-		r0 = rf(c, SS, ouser, patch)
+		r0 = rf(rctx, SS, ouser, patch)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
@@ -67,9 +67,9 @@ func (_m *SamlInterface) CheckProviderAttributes(c request.CTX, SS *model.SamlSe
 	return r0
 }
 
-// ConfigureSP provides a mock function with given fields: c
-func (_m *SamlInterface) ConfigureSP(c request.CTX) error {
-	ret := _m.Called(c)
+// ConfigureSP provides a mock function with given fields: rctx
+func (_m *SamlInterface) ConfigureSP(rctx request.CTX) error {
+	ret := _m.Called(rctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ConfigureSP")
@@ -77,7 +77,7 @@ func (_m *SamlInterface) ConfigureSP(c request.CTX) error {
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(request.CTX) error); ok {
-		r0 = rf(c)
+		r0 = rf(rctx)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -85,9 +85,9 @@ func (_m *SamlInterface) ConfigureSP(c request.CTX) error {
 	return r0
 }
 
-// DoLogin provides a mock function with given fields: c, encodedXML, relayState
-func (_m *SamlInterface) DoLogin(c request.CTX, encodedXML string, relayState map[string]string) (*model.User, *saml2.AssertionInfo, *model.AppError) {
-	ret := _m.Called(c, encodedXML, relayState)
+// DoLogin provides a mock function with given fields: rctx, encodedXML, relayState
+func (_m *SamlInterface) DoLogin(rctx request.CTX, encodedXML string, relayState map[string]string) (*model.User, *saml2.AssertionInfo, *model.AppError) {
+	ret := _m.Called(rctx, encodedXML, relayState)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DoLogin")
@@ -97,10 +97,10 @@ func (_m *SamlInterface) DoLogin(c request.CTX, encodedXML string, relayState ma
 	var r1 *saml2.AssertionInfo
 	var r2 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, string, map[string]string) (*model.User, *saml2.AssertionInfo, *model.AppError)); ok {
-		return rf(c, encodedXML, relayState)
+		return rf(rctx, encodedXML, relayState)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, map[string]string) *model.User); ok {
-		r0 = rf(c, encodedXML, relayState)
+		r0 = rf(rctx, encodedXML, relayState)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.User)
@@ -108,7 +108,7 @@ func (_m *SamlInterface) DoLogin(c request.CTX, encodedXML string, relayState ma
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, map[string]string) *saml2.AssertionInfo); ok {
-		r1 = rf(c, encodedXML, relayState)
+		r1 = rf(rctx, encodedXML, relayState)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*saml2.AssertionInfo)
@@ -116,7 +116,7 @@ func (_m *SamlInterface) DoLogin(c request.CTX, encodedXML string, relayState ma
 	}
 
 	if rf, ok := ret.Get(2).(func(request.CTX, string, map[string]string) *model.AppError); ok {
-		r2 = rf(c, encodedXML, relayState)
+		r2 = rf(rctx, encodedXML, relayState)
 	} else {
 		if ret.Get(2) != nil {
 			r2 = ret.Get(2).(*model.AppError)
@@ -126,9 +126,9 @@ func (_m *SamlInterface) DoLogin(c request.CTX, encodedXML string, relayState ma
 	return r0, r1, r2
 }
 
-// GetMetadata provides a mock function with given fields: c
-func (_m *SamlInterface) GetMetadata(c request.CTX) (string, *model.AppError) {
-	ret := _m.Called(c)
+// GetMetadata provides a mock function with given fields: rctx
+func (_m *SamlInterface) GetMetadata(rctx request.CTX) (string, *model.AppError) {
+	ret := _m.Called(rctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetMetadata")
@@ -137,16 +137,16 @@ func (_m *SamlInterface) GetMetadata(c request.CTX) (string, *model.AppError) {
 	var r0 string
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX) (string, *model.AppError)); ok {
-		return rf(c)
+		return rf(rctx)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX) string); ok {
-		r0 = rf(c)
+		r0 = rf(rctx)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX) *model.AppError); ok {
-		r1 = rf(c)
+		r1 = rf(rctx)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)

--- a/server/einterfaces/mocks/Scheduler.go
+++ b/server/einterfaces/mocks/Scheduler.go
@@ -55,9 +55,9 @@ func (_m *Scheduler) NextScheduleTime(cfg *model.Config, now time.Time, pendingJ
 	return r0
 }
 
-// ScheduleJob provides a mock function with given fields: c, cfg, pendingJobs, lastSuccessfulJob
-func (_m *Scheduler) ScheduleJob(c request.CTX, cfg *model.Config, pendingJobs bool, lastSuccessfulJob *model.Job) (*model.Job, *model.AppError) {
-	ret := _m.Called(c, cfg, pendingJobs, lastSuccessfulJob)
+// ScheduleJob provides a mock function with given fields: rctx, cfg, pendingJobs, lastSuccessfulJob
+func (_m *Scheduler) ScheduleJob(rctx request.CTX, cfg *model.Config, pendingJobs bool, lastSuccessfulJob *model.Job) (*model.Job, *model.AppError) {
+	ret := _m.Called(rctx, cfg, pendingJobs, lastSuccessfulJob)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ScheduleJob")
@@ -66,10 +66,10 @@ func (_m *Scheduler) ScheduleJob(c request.CTX, cfg *model.Config, pendingJobs b
 	var r0 *model.Job
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Config, bool, *model.Job) (*model.Job, *model.AppError)); ok {
-		return rf(c, cfg, pendingJobs, lastSuccessfulJob)
+		return rf(rctx, cfg, pendingJobs, lastSuccessfulJob)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Config, bool, *model.Job) *model.Job); ok {
-		r0 = rf(c, cfg, pendingJobs, lastSuccessfulJob)
+		r0 = rf(rctx, cfg, pendingJobs, lastSuccessfulJob)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Job)
@@ -77,7 +77,7 @@ func (_m *Scheduler) ScheduleJob(c request.CTX, cfg *model.Config, pendingJobs b
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.Config, bool, *model.Job) *model.AppError); ok {
-		r1 = rf(c, cfg, pendingJobs, lastSuccessfulJob)
+		r1 = rf(rctx, cfg, pendingJobs, lastSuccessfulJob)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)

--- a/server/einterfaces/notification.go
+++ b/server/einterfaces/notification.go
@@ -9,6 +9,6 @@ import (
 )
 
 type NotificationInterface interface {
-	GetNotificationMessage(c request.CTX, ack *model.PushNotificationAck, userID string) (*model.PushNotification, *model.AppError)
+	GetNotificationMessage(rctx request.CTX, ack *model.PushNotificationAck, userID string) (*model.PushNotification, *model.AppError)
 	CheckLicense() *model.AppError
 }

--- a/server/einterfaces/oauthproviders.go
+++ b/server/einterfaces/oauthproviders.go
@@ -11,10 +11,10 @@ import (
 )
 
 type OAuthProvider interface {
-	GetUserFromJSON(c request.CTX, data io.Reader, tokenUser *model.User) (*model.User, error)
-	GetSSOSettings(c request.CTX, config *model.Config, service string) (*model.SSOSettings, error)
-	GetUserFromIdToken(c request.CTX, idToken string) (*model.User, error)
-	IsSameUser(c request.CTX, dbUser, oAuthUser *model.User) bool
+	GetUserFromJSON(rctx request.CTX, data io.Reader, tokenUser *model.User) (*model.User, error)
+	GetSSOSettings(rctx request.CTX, config *model.Config, service string) (*model.SSOSettings, error)
+	GetUserFromIdToken(rctx request.CTX, idToken string) (*model.User, error)
+	IsSameUser(rctx request.CTX, dbUser, oAuthUser *model.User) bool
 }
 
 var oauthProviders = make(map[string]OAuthProvider)

--- a/server/einterfaces/saml.go
+++ b/server/einterfaces/saml.go
@@ -10,9 +10,9 @@ import (
 )
 
 type SamlInterface interface {
-	ConfigureSP(c request.CTX) error
-	BuildRequest(c request.CTX, relayState string) (*model.SamlAuthRequest, *model.AppError)
-	DoLogin(c request.CTX, encodedXML string, relayState map[string]string) (*model.User, *saml2.AssertionInfo, *model.AppError)
-	GetMetadata(c request.CTX) (string, *model.AppError)
-	CheckProviderAttributes(c request.CTX, SS *model.SamlSettings, ouser *model.User, patch *model.UserPatch) string
+	ConfigureSP(rctx request.CTX) error
+	BuildRequest(rctx request.CTX, relayState string) (*model.SamlAuthRequest, *model.AppError)
+	DoLogin(rctx request.CTX, encodedXML string, relayState map[string]string) (*model.User, *saml2.AssertionInfo, *model.AppError)
+	GetMetadata(rctx request.CTX) (string, *model.AppError)
+	CheckProviderAttributes(rctx request.CTX, SS *model.SamlSettings, ouser *model.User, patch *model.UserPatch) string
 }

--- a/server/platform/services/searchengine/bleveengine/indexer/indexing_job.go
+++ b/server/platform/services/searchengine/bleveengine/indexer/indexing_job.go
@@ -270,11 +270,11 @@ func (worker *BleveIndexerWorker) DoJob(job *model.Job) {
 		progress.TotalFilesCount = count
 	}
 
-	var cancelContext request.CTX = request.EmptyContext(worker.logger)
+	var rctx request.CTX = request.EmptyContext(worker.logger)
 	cancelCtx, cancelCancelWatcher := context.WithCancel(context.Background())
 	cancelWatcherChan := make(chan struct{}, 1)
-	cancelContext = cancelContext.WithContext(cancelCtx)
-	go worker.jobServer.CancellationWatcher(cancelContext, job.Id, cancelWatcherChan)
+	rctx = rctx.WithContext(cancelCtx)
+	go worker.jobServer.CancellationWatcher(rctx, job.Id, cancelWatcherChan)
 	defer cancelCancelWatcher()
 
 	for {

--- a/server/platform/services/sharedchannel/mock_AppIface_test.go
+++ b/server/platform/services/sharedchannel/mock_AppIface_test.go
@@ -18,9 +18,9 @@ type MockAppIface struct {
 	mock.Mock
 }
 
-// AddUserToChannel provides a mock function with given fields: c, user, channel, skipTeamMemberIntegrityCheck
-func (_m *MockAppIface) AddUserToChannel(c request.CTX, user *model.User, channel *model.Channel, skipTeamMemberIntegrityCheck bool) (*model.ChannelMember, *model.AppError) {
-	ret := _m.Called(c, user, channel, skipTeamMemberIntegrityCheck)
+// AddUserToChannel provides a mock function with given fields: rctx, user, channel, skipTeamMemberIntegrityCheck
+func (_m *MockAppIface) AddUserToChannel(rctx request.CTX, user *model.User, channel *model.Channel, skipTeamMemberIntegrityCheck bool) (*model.ChannelMember, *model.AppError) {
+	ret := _m.Called(rctx, user, channel, skipTeamMemberIntegrityCheck)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AddUserToChannel")
@@ -29,10 +29,10 @@ func (_m *MockAppIface) AddUserToChannel(c request.CTX, user *model.User, channe
 	var r0 *model.ChannelMember
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.User, *model.Channel, bool) (*model.ChannelMember, *model.AppError)); ok {
-		return rf(c, user, channel, skipTeamMemberIntegrityCheck)
+		return rf(rctx, user, channel, skipTeamMemberIntegrityCheck)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.User, *model.Channel, bool) *model.ChannelMember); ok {
-		r0 = rf(c, user, channel, skipTeamMemberIntegrityCheck)
+		r0 = rf(rctx, user, channel, skipTeamMemberIntegrityCheck)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.ChannelMember)
@@ -40,7 +40,7 @@ func (_m *MockAppIface) AddUserToChannel(c request.CTX, user *model.User, channe
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.User, *model.Channel, bool) *model.AppError); ok {
-		r1 = rf(c, user, channel, skipTeamMemberIntegrityCheck)
+		r1 = rf(rctx, user, channel, skipTeamMemberIntegrityCheck)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -50,9 +50,9 @@ func (_m *MockAppIface) AddUserToChannel(c request.CTX, user *model.User, channe
 	return r0, r1
 }
 
-// AddUserToTeamByTeamId provides a mock function with given fields: c, teamId, user
-func (_m *MockAppIface) AddUserToTeamByTeamId(c request.CTX, teamId string, user *model.User) *model.AppError {
-	ret := _m.Called(c, teamId, user)
+// AddUserToTeamByTeamId provides a mock function with given fields: rctx, teamId, user
+func (_m *MockAppIface) AddUserToTeamByTeamId(rctx request.CTX, teamId string, user *model.User) *model.AppError {
+	ret := _m.Called(rctx, teamId, user)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AddUserToTeamByTeamId")
@@ -60,7 +60,7 @@ func (_m *MockAppIface) AddUserToTeamByTeamId(c request.CTX, teamId string, user
 
 	var r0 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, string, *model.User) *model.AppError); ok {
-		r0 = rf(c, teamId, user)
+		r0 = rf(rctx, teamId, user)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.AppError)
@@ -70,9 +70,9 @@ func (_m *MockAppIface) AddUserToTeamByTeamId(c request.CTX, teamId string, user
 	return r0
 }
 
-// CreateChannelWithUser provides a mock function with given fields: c, channel, userId
-func (_m *MockAppIface) CreateChannelWithUser(c request.CTX, channel *model.Channel, userId string) (*model.Channel, *model.AppError) {
-	ret := _m.Called(c, channel, userId)
+// CreateChannelWithUser provides a mock function with given fields: rctx, channel, userId
+func (_m *MockAppIface) CreateChannelWithUser(rctx request.CTX, channel *model.Channel, userId string) (*model.Channel, *model.AppError) {
+	ret := _m.Called(rctx, channel, userId)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateChannelWithUser")
@@ -81,10 +81,10 @@ func (_m *MockAppIface) CreateChannelWithUser(c request.CTX, channel *model.Chan
 	var r0 *model.Channel
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Channel, string) (*model.Channel, *model.AppError)); ok {
-		return rf(c, channel, userId)
+		return rf(rctx, channel, userId)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Channel, string) *model.Channel); ok {
-		r0 = rf(c, channel, userId)
+		r0 = rf(rctx, channel, userId)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Channel)
@@ -92,7 +92,7 @@ func (_m *MockAppIface) CreateChannelWithUser(c request.CTX, channel *model.Chan
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.Channel, string) *model.AppError); ok {
-		r1 = rf(c, channel, userId)
+		r1 = rf(rctx, channel, userId)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -102,14 +102,14 @@ func (_m *MockAppIface) CreateChannelWithUser(c request.CTX, channel *model.Chan
 	return r0, r1
 }
 
-// CreateGroupChannel provides a mock function with given fields: c, userIDs, creatorId, channelOptions
-func (_m *MockAppIface) CreateGroupChannel(c request.CTX, userIDs []string, creatorId string, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError) {
+// CreateGroupChannel provides a mock function with given fields: rctx, userIDs, creatorId, channelOptions
+func (_m *MockAppIface) CreateGroupChannel(rctx request.CTX, userIDs []string, creatorId string, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError) {
 	_va := make([]interface{}, len(channelOptions))
 	for _i := range channelOptions {
 		_va[_i] = channelOptions[_i]
 	}
 	var _ca []interface{}
-	_ca = append(_ca, c, userIDs, creatorId)
+	_ca = append(_ca, rctx, userIDs, creatorId)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
@@ -120,10 +120,10 @@ func (_m *MockAppIface) CreateGroupChannel(c request.CTX, userIDs []string, crea
 	var r0 *model.Channel
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, []string, string, ...model.ChannelOption) (*model.Channel, *model.AppError)); ok {
-		return rf(c, userIDs, creatorId, channelOptions...)
+		return rf(rctx, userIDs, creatorId, channelOptions...)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, []string, string, ...model.ChannelOption) *model.Channel); ok {
-		r0 = rf(c, userIDs, creatorId, channelOptions...)
+		r0 = rf(rctx, userIDs, creatorId, channelOptions...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Channel)
@@ -131,7 +131,7 @@ func (_m *MockAppIface) CreateGroupChannel(c request.CTX, userIDs []string, crea
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, []string, string, ...model.ChannelOption) *model.AppError); ok {
-		r1 = rf(c, userIDs, creatorId, channelOptions...)
+		r1 = rf(rctx, userIDs, creatorId, channelOptions...)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -141,9 +141,9 @@ func (_m *MockAppIface) CreateGroupChannel(c request.CTX, userIDs []string, crea
 	return r0, r1
 }
 
-// CreatePost provides a mock function with given fields: c, post, channel, flags
-func (_m *MockAppIface) CreatePost(c request.CTX, post *model.Post, channel *model.Channel, flags model.CreatePostFlags) (*model.Post, *model.AppError) {
-	ret := _m.Called(c, post, channel, flags)
+// CreatePost provides a mock function with given fields: rctx, post, channel, flags
+func (_m *MockAppIface) CreatePost(rctx request.CTX, post *model.Post, channel *model.Channel, flags model.CreatePostFlags) (*model.Post, *model.AppError) {
+	ret := _m.Called(rctx, post, channel, flags)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreatePost")
@@ -152,10 +152,10 @@ func (_m *MockAppIface) CreatePost(c request.CTX, post *model.Post, channel *mod
 	var r0 *model.Post
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Post, *model.Channel, model.CreatePostFlags) (*model.Post, *model.AppError)); ok {
-		return rf(c, post, channel, flags)
+		return rf(rctx, post, channel, flags)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Post, *model.Channel, model.CreatePostFlags) *model.Post); ok {
-		r0 = rf(c, post, channel, flags)
+		r0 = rf(rctx, post, channel, flags)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Post)
@@ -163,7 +163,7 @@ func (_m *MockAppIface) CreatePost(c request.CTX, post *model.Post, channel *mod
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.Post, *model.Channel, model.CreatePostFlags) *model.AppError); ok {
-		r1 = rf(c, post, channel, flags)
+		r1 = rf(rctx, post, channel, flags)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -173,9 +173,9 @@ func (_m *MockAppIface) CreatePost(c request.CTX, post *model.Post, channel *mod
 	return r0, r1
 }
 
-// CreateUploadSession provides a mock function with given fields: c, us
-func (_m *MockAppIface) CreateUploadSession(c request.CTX, us *model.UploadSession) (*model.UploadSession, *model.AppError) {
-	ret := _m.Called(c, us)
+// CreateUploadSession provides a mock function with given fields: rctx, us
+func (_m *MockAppIface) CreateUploadSession(rctx request.CTX, us *model.UploadSession) (*model.UploadSession, *model.AppError) {
+	ret := _m.Called(rctx, us)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateUploadSession")
@@ -184,10 +184,10 @@ func (_m *MockAppIface) CreateUploadSession(c request.CTX, us *model.UploadSessi
 	var r0 *model.UploadSession
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.UploadSession) (*model.UploadSession, *model.AppError)); ok {
-		return rf(c, us)
+		return rf(rctx, us)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.UploadSession) *model.UploadSession); ok {
-		r0 = rf(c, us)
+		r0 = rf(rctx, us)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.UploadSession)
@@ -195,7 +195,7 @@ func (_m *MockAppIface) CreateUploadSession(c request.CTX, us *model.UploadSessi
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.UploadSession) *model.AppError); ok {
-		r1 = rf(c, us)
+		r1 = rf(rctx, us)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -205,9 +205,9 @@ func (_m *MockAppIface) CreateUploadSession(c request.CTX, us *model.UploadSessi
 	return r0, r1
 }
 
-// DeleteAcknowledgementForPostWithModel provides a mock function with given fields: c, acknowledgement
-func (_m *MockAppIface) DeleteAcknowledgementForPostWithModel(c request.CTX, acknowledgement *model.PostAcknowledgement) *model.AppError {
-	ret := _m.Called(c, acknowledgement)
+// DeleteAcknowledgementForPostWithModel provides a mock function with given fields: rctx, acknowledgement
+func (_m *MockAppIface) DeleteAcknowledgementForPostWithModel(rctx request.CTX, acknowledgement *model.PostAcknowledgement) *model.AppError {
+	ret := _m.Called(rctx, acknowledgement)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteAcknowledgementForPostWithModel")
@@ -215,7 +215,7 @@ func (_m *MockAppIface) DeleteAcknowledgementForPostWithModel(c request.CTX, ack
 
 	var r0 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.PostAcknowledgement) *model.AppError); ok {
-		r0 = rf(c, acknowledgement)
+		r0 = rf(rctx, acknowledgement)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.AppError)
@@ -225,9 +225,9 @@ func (_m *MockAppIface) DeleteAcknowledgementForPostWithModel(c request.CTX, ack
 	return r0
 }
 
-// DeletePost provides a mock function with given fields: c, postID, deleteByID
-func (_m *MockAppIface) DeletePost(c request.CTX, postID string, deleteByID string) (*model.Post, *model.AppError) {
-	ret := _m.Called(c, postID, deleteByID)
+// DeletePost provides a mock function with given fields: rctx, postID, deleteByID
+func (_m *MockAppIface) DeletePost(rctx request.CTX, postID string, deleteByID string) (*model.Post, *model.AppError) {
+	ret := _m.Called(rctx, postID, deleteByID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeletePost")
@@ -236,10 +236,10 @@ func (_m *MockAppIface) DeletePost(c request.CTX, postID string, deleteByID stri
 	var r0 *model.Post
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string) (*model.Post, *model.AppError)); ok {
-		return rf(c, postID, deleteByID)
+		return rf(rctx, postID, deleteByID)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string) *model.Post); ok {
-		r0 = rf(c, postID, deleteByID)
+		r0 = rf(rctx, postID, deleteByID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Post)
@@ -247,7 +247,7 @@ func (_m *MockAppIface) DeletePost(c request.CTX, postID string, deleteByID stri
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, string) *model.AppError); ok {
-		r1 = rf(c, postID, deleteByID)
+		r1 = rf(rctx, postID, deleteByID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -257,9 +257,9 @@ func (_m *MockAppIface) DeletePost(c request.CTX, postID string, deleteByID stri
 	return r0, r1
 }
 
-// DeleteReactionForPost provides a mock function with given fields: c, reaction
-func (_m *MockAppIface) DeleteReactionForPost(c request.CTX, reaction *model.Reaction) *model.AppError {
-	ret := _m.Called(c, reaction)
+// DeleteReactionForPost provides a mock function with given fields: rctx, reaction
+func (_m *MockAppIface) DeleteReactionForPost(rctx request.CTX, reaction *model.Reaction) *model.AppError {
+	ret := _m.Called(rctx, reaction)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteReactionForPost")
@@ -267,7 +267,7 @@ func (_m *MockAppIface) DeleteReactionForPost(c request.CTX, reaction *model.Rea
 
 	var r0 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Reaction) *model.AppError); ok {
-		r0 = rf(c, reaction)
+		r0 = rf(rctx, reaction)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.AppError)
@@ -341,14 +341,14 @@ func (_m *MockAppIface) GetAcknowledgementsForPost(postID string) ([]*model.Post
 	return r0, r1
 }
 
-// GetOrCreateDirectChannel provides a mock function with given fields: c, userId, otherUserId, channelOptions
-func (_m *MockAppIface) GetOrCreateDirectChannel(c request.CTX, userId string, otherUserId string, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError) {
+// GetOrCreateDirectChannel provides a mock function with given fields: rctx, userId, otherUserId, channelOptions
+func (_m *MockAppIface) GetOrCreateDirectChannel(rctx request.CTX, userId string, otherUserId string, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError) {
 	_va := make([]interface{}, len(channelOptions))
 	for _i := range channelOptions {
 		_va[_i] = channelOptions[_i]
 	}
 	var _ca []interface{}
-	_ca = append(_ca, c, userId, otherUserId)
+	_ca = append(_ca, rctx, userId, otherUserId)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
@@ -359,10 +359,10 @@ func (_m *MockAppIface) GetOrCreateDirectChannel(c request.CTX, userId string, o
 	var r0 *model.Channel
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string, ...model.ChannelOption) (*model.Channel, *model.AppError)); ok {
-		return rf(c, userId, otherUserId, channelOptions...)
+		return rf(rctx, userId, otherUserId, channelOptions...)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string, ...model.ChannelOption) *model.Channel); ok {
-		r0 = rf(c, userId, otherUserId, channelOptions...)
+		r0 = rf(rctx, userId, otherUserId, channelOptions...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Channel)
@@ -370,7 +370,7 @@ func (_m *MockAppIface) GetOrCreateDirectChannel(c request.CTX, userId string, o
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, string, ...model.ChannelOption) *model.AppError); ok {
-		r1 = rf(c, userId, otherUserId, channelOptions...)
+		r1 = rf(rctx, userId, otherUserId, channelOptions...)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -419,9 +419,9 @@ func (_m *MockAppIface) GetProfileImage(user *model.User) ([]byte, bool, *model.
 	return r0, r1, r2
 }
 
-// MentionsToTeamMembers provides a mock function with given fields: c, message, teamID
-func (_m *MockAppIface) MentionsToTeamMembers(c request.CTX, message string, teamID string) model.UserMentionMap {
-	ret := _m.Called(c, message, teamID)
+// MentionsToTeamMembers provides a mock function with given fields: rctx, message, teamID
+func (_m *MockAppIface) MentionsToTeamMembers(rctx request.CTX, message string, teamID string) model.UserMentionMap {
+	ret := _m.Called(rctx, message, teamID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for MentionsToTeamMembers")
@@ -429,7 +429,7 @@ func (_m *MockAppIface) MentionsToTeamMembers(c request.CTX, message string, tea
 
 	var r0 model.UserMentionMap
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string) model.UserMentionMap); ok {
-		r0 = rf(c, message, teamID)
+		r0 = rf(rctx, message, teamID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(model.UserMentionMap)
@@ -508,9 +508,9 @@ func (_m *MockAppIface) OnSharedChannelsSyncMsg(msg *model.SyncMsg, rc *model.Re
 	return r0, r1
 }
 
-// PatchChannelModerationsForChannel provides a mock function with given fields: c, channel, channelModerationsPatch
-func (_m *MockAppIface) PatchChannelModerationsForChannel(c request.CTX, channel *model.Channel, channelModerationsPatch []*model.ChannelModerationPatch) ([]*model.ChannelModeration, *model.AppError) {
-	ret := _m.Called(c, channel, channelModerationsPatch)
+// PatchChannelModerationsForChannel provides a mock function with given fields: rctx, channel, channelModerationsPatch
+func (_m *MockAppIface) PatchChannelModerationsForChannel(rctx request.CTX, channel *model.Channel, channelModerationsPatch []*model.ChannelModerationPatch) ([]*model.ChannelModeration, *model.AppError) {
+	ret := _m.Called(rctx, channel, channelModerationsPatch)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PatchChannelModerationsForChannel")
@@ -519,10 +519,10 @@ func (_m *MockAppIface) PatchChannelModerationsForChannel(c request.CTX, channel
 	var r0 []*model.ChannelModeration
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Channel, []*model.ChannelModerationPatch) ([]*model.ChannelModeration, *model.AppError)); ok {
-		return rf(c, channel, channelModerationsPatch)
+		return rf(rctx, channel, channelModerationsPatch)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Channel, []*model.ChannelModerationPatch) []*model.ChannelModeration); ok {
-		r0 = rf(c, channel, channelModerationsPatch)
+		r0 = rf(rctx, channel, channelModerationsPatch)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.ChannelModeration)
@@ -530,7 +530,7 @@ func (_m *MockAppIface) PatchChannelModerationsForChannel(c request.CTX, channel
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.Channel, []*model.ChannelModerationPatch) *model.AppError); ok {
-		r1 = rf(c, channel, channelModerationsPatch)
+		r1 = rf(rctx, channel, channelModerationsPatch)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -540,9 +540,9 @@ func (_m *MockAppIface) PatchChannelModerationsForChannel(c request.CTX, channel
 	return r0, r1
 }
 
-// PermanentDeleteChannel provides a mock function with given fields: c, channel
-func (_m *MockAppIface) PermanentDeleteChannel(c request.CTX, channel *model.Channel) *model.AppError {
-	ret := _m.Called(c, channel)
+// PermanentDeleteChannel provides a mock function with given fields: rctx, channel
+func (_m *MockAppIface) PermanentDeleteChannel(rctx request.CTX, channel *model.Channel) *model.AppError {
+	ret := _m.Called(rctx, channel)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PermanentDeleteChannel")
@@ -550,7 +550,7 @@ func (_m *MockAppIface) PermanentDeleteChannel(c request.CTX, channel *model.Cha
 
 	var r0 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Channel) *model.AppError); ok {
-		r0 = rf(c, channel)
+		r0 = rf(rctx, channel)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.AppError)
@@ -560,9 +560,9 @@ func (_m *MockAppIface) PermanentDeleteChannel(c request.CTX, channel *model.Cha
 	return r0
 }
 
-// PreparePostForClient provides a mock function with given fields: c, post, isNewPost, includeDeleted, includePriority
-func (_m *MockAppIface) PreparePostForClient(c request.CTX, post *model.Post, isNewPost bool, includeDeleted bool, includePriority bool) *model.Post {
-	ret := _m.Called(c, post, isNewPost, includeDeleted, includePriority)
+// PreparePostForClient provides a mock function with given fields: rctx, post, isNewPost, includeDeleted, includePriority
+func (_m *MockAppIface) PreparePostForClient(rctx request.CTX, post *model.Post, isNewPost bool, includeDeleted bool, includePriority bool) *model.Post {
+	ret := _m.Called(rctx, post, isNewPost, includeDeleted, includePriority)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PreparePostForClient")
@@ -570,7 +570,7 @@ func (_m *MockAppIface) PreparePostForClient(c request.CTX, post *model.Post, is
 
 	var r0 *model.Post
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Post, bool, bool, bool) *model.Post); ok {
-		r0 = rf(c, post, isNewPost, includeDeleted, includePriority)
+		r0 = rf(rctx, post, isNewPost, includeDeleted, includePriority)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Post)
@@ -585,9 +585,9 @@ func (_m *MockAppIface) Publish(message *model.WebSocketEvent) {
 	_m.Called(message)
 }
 
-// RemoveUserFromChannel provides a mock function with given fields: c, userID, removerUserId, channel
-func (_m *MockAppIface) RemoveUserFromChannel(c request.CTX, userID string, removerUserId string, channel *model.Channel) *model.AppError {
-	ret := _m.Called(c, userID, removerUserId, channel)
+// RemoveUserFromChannel provides a mock function with given fields: rctx, userID, removerUserId, channel
+func (_m *MockAppIface) RemoveUserFromChannel(rctx request.CTX, userID string, removerUserId string, channel *model.Channel) *model.AppError {
+	ret := _m.Called(rctx, userID, removerUserId, channel)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RemoveUserFromChannel")
@@ -595,7 +595,7 @@ func (_m *MockAppIface) RemoveUserFromChannel(c request.CTX, userID string, remo
 
 	var r0 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string, *model.Channel) *model.AppError); ok {
-		r0 = rf(c, userID, removerUserId, channel)
+		r0 = rf(rctx, userID, removerUserId, channel)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.AppError)
@@ -605,9 +605,9 @@ func (_m *MockAppIface) RemoveUserFromChannel(c request.CTX, userID string, remo
 	return r0
 }
 
-// SaveAcknowledgementForPostWithModel provides a mock function with given fields: c, acknowledgement
-func (_m *MockAppIface) SaveAcknowledgementForPostWithModel(c request.CTX, acknowledgement *model.PostAcknowledgement) (*model.PostAcknowledgement, *model.AppError) {
-	ret := _m.Called(c, acknowledgement)
+// SaveAcknowledgementForPostWithModel provides a mock function with given fields: rctx, acknowledgement
+func (_m *MockAppIface) SaveAcknowledgementForPostWithModel(rctx request.CTX, acknowledgement *model.PostAcknowledgement) (*model.PostAcknowledgement, *model.AppError) {
+	ret := _m.Called(rctx, acknowledgement)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SaveAcknowledgementForPostWithModel")
@@ -616,10 +616,10 @@ func (_m *MockAppIface) SaveAcknowledgementForPostWithModel(c request.CTX, ackno
 	var r0 *model.PostAcknowledgement
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.PostAcknowledgement) (*model.PostAcknowledgement, *model.AppError)); ok {
-		return rf(c, acknowledgement)
+		return rf(rctx, acknowledgement)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.PostAcknowledgement) *model.PostAcknowledgement); ok {
-		r0 = rf(c, acknowledgement)
+		r0 = rf(rctx, acknowledgement)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.PostAcknowledgement)
@@ -627,7 +627,7 @@ func (_m *MockAppIface) SaveAcknowledgementForPostWithModel(c request.CTX, ackno
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.PostAcknowledgement) *model.AppError); ok {
-		r1 = rf(c, acknowledgement)
+		r1 = rf(rctx, acknowledgement)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -637,9 +637,9 @@ func (_m *MockAppIface) SaveAcknowledgementForPostWithModel(c request.CTX, ackno
 	return r0, r1
 }
 
-// SaveAcknowledgementsForPost provides a mock function with given fields: c, postID, userIDs
-func (_m *MockAppIface) SaveAcknowledgementsForPost(c request.CTX, postID string, userIDs []string) ([]*model.PostAcknowledgement, *model.AppError) {
-	ret := _m.Called(c, postID, userIDs)
+// SaveAcknowledgementsForPost provides a mock function with given fields: rctx, postID, userIDs
+func (_m *MockAppIface) SaveAcknowledgementsForPost(rctx request.CTX, postID string, userIDs []string) ([]*model.PostAcknowledgement, *model.AppError) {
+	ret := _m.Called(rctx, postID, userIDs)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SaveAcknowledgementsForPost")
@@ -648,10 +648,10 @@ func (_m *MockAppIface) SaveAcknowledgementsForPost(c request.CTX, postID string
 	var r0 []*model.PostAcknowledgement
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, string, []string) ([]*model.PostAcknowledgement, *model.AppError)); ok {
-		return rf(c, postID, userIDs)
+		return rf(rctx, postID, userIDs)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, []string) []*model.PostAcknowledgement); ok {
-		r0 = rf(c, postID, userIDs)
+		r0 = rf(rctx, postID, userIDs)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.PostAcknowledgement)
@@ -659,7 +659,7 @@ func (_m *MockAppIface) SaveAcknowledgementsForPost(c request.CTX, postID string
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, []string) *model.AppError); ok {
-		r1 = rf(c, postID, userIDs)
+		r1 = rf(rctx, postID, userIDs)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -674,9 +674,9 @@ func (_m *MockAppIface) SaveAndBroadcastStatus(status *model.Status) {
 	_m.Called(status)
 }
 
-// SaveReactionForPost provides a mock function with given fields: c, reaction
-func (_m *MockAppIface) SaveReactionForPost(c request.CTX, reaction *model.Reaction) (*model.Reaction, *model.AppError) {
-	ret := _m.Called(c, reaction)
+// SaveReactionForPost provides a mock function with given fields: rctx, reaction
+func (_m *MockAppIface) SaveReactionForPost(rctx request.CTX, reaction *model.Reaction) (*model.Reaction, *model.AppError) {
+	ret := _m.Called(rctx, reaction)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SaveReactionForPost")
@@ -685,10 +685,10 @@ func (_m *MockAppIface) SaveReactionForPost(c request.CTX, reaction *model.React
 	var r0 *model.Reaction
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Reaction) (*model.Reaction, *model.AppError)); ok {
-		return rf(c, reaction)
+		return rf(rctx, reaction)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Reaction) *model.Reaction); ok {
-		r0 = rf(c, reaction)
+		r0 = rf(rctx, reaction)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Reaction)
@@ -696,7 +696,7 @@ func (_m *MockAppIface) SaveReactionForPost(c request.CTX, reaction *model.React
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.Reaction) *model.AppError); ok {
-		r1 = rf(c, reaction)
+		r1 = rf(rctx, reaction)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -706,9 +706,9 @@ func (_m *MockAppIface) SaveReactionForPost(c request.CTX, reaction *model.React
 	return r0, r1
 }
 
-// SendEphemeralPost provides a mock function with given fields: c, userId, post
-func (_m *MockAppIface) SendEphemeralPost(c request.CTX, userId string, post *model.Post) *model.Post {
-	ret := _m.Called(c, userId, post)
+// SendEphemeralPost provides a mock function with given fields: rctx, userId, post
+func (_m *MockAppIface) SendEphemeralPost(rctx request.CTX, userId string, post *model.Post) *model.Post {
+	ret := _m.Called(rctx, userId, post)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SendEphemeralPost")
@@ -716,7 +716,7 @@ func (_m *MockAppIface) SendEphemeralPost(c request.CTX, userId string, post *mo
 
 	var r0 *model.Post
 	if rf, ok := ret.Get(0).(func(request.CTX, string, *model.Post) *model.Post); ok {
-		r0 = rf(c, userId, post)
+		r0 = rf(rctx, userId, post)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Post)
@@ -726,9 +726,9 @@ func (_m *MockAppIface) SendEphemeralPost(c request.CTX, userId string, post *mo
 	return r0
 }
 
-// UpdatePost provides a mock function with given fields: c, post, updatePostOptions
-func (_m *MockAppIface) UpdatePost(c request.CTX, post *model.Post, updatePostOptions *model.UpdatePostOptions) (*model.Post, *model.AppError) {
-	ret := _m.Called(c, post, updatePostOptions)
+// UpdatePost provides a mock function with given fields: rctx, post, updatePostOptions
+func (_m *MockAppIface) UpdatePost(rctx request.CTX, post *model.Post, updatePostOptions *model.UpdatePostOptions) (*model.Post, *model.AppError) {
+	ret := _m.Called(rctx, post, updatePostOptions)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdatePost")
@@ -737,10 +737,10 @@ func (_m *MockAppIface) UpdatePost(c request.CTX, post *model.Post, updatePostOp
 	var r0 *model.Post
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Post, *model.UpdatePostOptions) (*model.Post, *model.AppError)); ok {
-		return rf(c, post, updatePostOptions)
+		return rf(rctx, post, updatePostOptions)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, *model.Post, *model.UpdatePostOptions) *model.Post); ok {
-		r0 = rf(c, post, updatePostOptions)
+		r0 = rf(rctx, post, updatePostOptions)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Post)
@@ -748,7 +748,7 @@ func (_m *MockAppIface) UpdatePost(c request.CTX, post *model.Post, updatePostOp
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, *model.Post, *model.UpdatePostOptions) *model.AppError); ok {
-		r1 = rf(c, post, updatePostOptions)
+		r1 = rf(rctx, post, updatePostOptions)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -758,9 +758,9 @@ func (_m *MockAppIface) UpdatePost(c request.CTX, post *model.Post, updatePostOp
 	return r0, r1
 }
 
-// UserCanSeeOtherUser provides a mock function with given fields: c, userID, otherUserId
-func (_m *MockAppIface) UserCanSeeOtherUser(c request.CTX, userID string, otherUserId string) (bool, *model.AppError) {
-	ret := _m.Called(c, userID, otherUserId)
+// UserCanSeeOtherUser provides a mock function with given fields: rctx, userID, otherUserId
+func (_m *MockAppIface) UserCanSeeOtherUser(rctx request.CTX, userID string, otherUserId string) (bool, *model.AppError) {
+	ret := _m.Called(rctx, userID, otherUserId)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UserCanSeeOtherUser")
@@ -769,16 +769,16 @@ func (_m *MockAppIface) UserCanSeeOtherUser(c request.CTX, userID string, otherU
 	var r0 bool
 	var r1 *model.AppError
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string) (bool, *model.AppError)); ok {
-		return rf(c, userID, otherUserId)
+		return rf(rctx, userID, otherUserId)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, string) bool); ok {
-		r0 = rf(c, userID, otherUserId)
+		r0 = rf(rctx, userID, otherUserId)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, string) *model.AppError); ok {
-		r1 = rf(c, userID, otherUserId)
+		r1 = rf(rctx, userID, otherUserId)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)

--- a/server/platform/services/sharedchannel/service.go
+++ b/server/platform/services/sharedchannel/service.go
@@ -54,36 +54,36 @@ type PlatformIface interface {
 }
 
 type AppIface interface {
-	SendEphemeralPost(c request.CTX, userId string, post *model.Post) *model.Post
-	CreateChannelWithUser(c request.CTX, channel *model.Channel, userId string) (*model.Channel, *model.AppError)
-	GetOrCreateDirectChannel(c request.CTX, userId, otherUserId string, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError)
-	CreateGroupChannel(c request.CTX, userIDs []string, creatorId string, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError)
-	UserCanSeeOtherUser(c request.CTX, userID string, otherUserId string) (bool, *model.AppError)
-	AddUserToChannel(c request.CTX, user *model.User, channel *model.Channel, skipTeamMemberIntegrityCheck bool) (*model.ChannelMember, *model.AppError)
-	AddUserToTeamByTeamId(c request.CTX, teamId string, user *model.User) *model.AppError
-	RemoveUserFromChannel(c request.CTX, userID string, removerUserId string, channel *model.Channel) *model.AppError
-	PermanentDeleteChannel(c request.CTX, channel *model.Channel) *model.AppError
-	CreatePost(c request.CTX, post *model.Post, channel *model.Channel, flags model.CreatePostFlags) (savedPost *model.Post, err *model.AppError)
-	UpdatePost(c request.CTX, post *model.Post, updatePostOptions *model.UpdatePostOptions) (*model.Post, *model.AppError)
-	DeletePost(c request.CTX, postID, deleteByID string) (*model.Post, *model.AppError)
-	SaveReactionForPost(c request.CTX, reaction *model.Reaction) (*model.Reaction, *model.AppError)
-	DeleteReactionForPost(c request.CTX, reaction *model.Reaction) *model.AppError
+	SendEphemeralPost(rctx request.CTX, userId string, post *model.Post) *model.Post
+	CreateChannelWithUser(rctx request.CTX, channel *model.Channel, userId string) (*model.Channel, *model.AppError)
+	GetOrCreateDirectChannel(rctx request.CTX, userId, otherUserId string, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError)
+	CreateGroupChannel(rctx request.CTX, userIDs []string, creatorId string, channelOptions ...model.ChannelOption) (*model.Channel, *model.AppError)
+	UserCanSeeOtherUser(rctx request.CTX, userID string, otherUserId string) (bool, *model.AppError)
+	AddUserToChannel(rctx request.CTX, user *model.User, channel *model.Channel, skipTeamMemberIntegrityCheck bool) (*model.ChannelMember, *model.AppError)
+	AddUserToTeamByTeamId(rctx request.CTX, teamId string, user *model.User) *model.AppError
+	RemoveUserFromChannel(rctx request.CTX, userID string, removerUserId string, channel *model.Channel) *model.AppError
+	PermanentDeleteChannel(rctx request.CTX, channel *model.Channel) *model.AppError
+	CreatePost(rctx request.CTX, post *model.Post, channel *model.Channel, flags model.CreatePostFlags) (savedPost *model.Post, err *model.AppError)
+	UpdatePost(rctx request.CTX, post *model.Post, updatePostOptions *model.UpdatePostOptions) (*model.Post, *model.AppError)
+	DeletePost(rctx request.CTX, postID, deleteByID string) (*model.Post, *model.AppError)
+	SaveReactionForPost(rctx request.CTX, reaction *model.Reaction) (*model.Reaction, *model.AppError)
+	DeleteReactionForPost(rctx request.CTX, reaction *model.Reaction) *model.AppError
 	SaveAndBroadcastStatus(status *model.Status)
-	PatchChannelModerationsForChannel(c request.CTX, channel *model.Channel, channelModerationsPatch []*model.ChannelModerationPatch) ([]*model.ChannelModeration, *model.AppError)
-	CreateUploadSession(c request.CTX, us *model.UploadSession) (*model.UploadSession, *model.AppError)
+	PatchChannelModerationsForChannel(rctx request.CTX, channel *model.Channel, channelModerationsPatch []*model.ChannelModerationPatch) ([]*model.ChannelModeration, *model.AppError)
+	CreateUploadSession(rctx request.CTX, us *model.UploadSession) (*model.UploadSession, *model.AppError)
 	FileReader(path string) (filestore.ReadCloseSeeker, *model.AppError)
-	MentionsToTeamMembers(c request.CTX, message, teamID string) model.UserMentionMap
+	MentionsToTeamMembers(rctx request.CTX, message, teamID string) model.UserMentionMap
 	GetProfileImage(user *model.User) ([]byte, bool, *model.AppError)
 	NotifySharedChannelUserUpdate(user *model.User)
 	OnSharedChannelsSyncMsg(msg *model.SyncMsg, rc *model.RemoteCluster) (model.SyncResponse, error)
 	OnSharedChannelsAttachmentSyncMsg(fi *model.FileInfo, post *model.Post, rc *model.RemoteCluster) error
 	OnSharedChannelsProfileImageSyncMsg(user *model.User, rc *model.RemoteCluster) error
 	Publish(message *model.WebSocketEvent)
-	SaveAcknowledgementForPostWithModel(c request.CTX, acknowledgement *model.PostAcknowledgement) (*model.PostAcknowledgement, *model.AppError)
-	DeleteAcknowledgementForPostWithModel(c request.CTX, acknowledgement *model.PostAcknowledgement) *model.AppError
-	SaveAcknowledgementsForPost(c request.CTX, postID string, userIDs []string) ([]*model.PostAcknowledgement, *model.AppError)
+	SaveAcknowledgementForPostWithModel(rctx request.CTX, acknowledgement *model.PostAcknowledgement) (*model.PostAcknowledgement, *model.AppError)
+	DeleteAcknowledgementForPostWithModel(rctx request.CTX, acknowledgement *model.PostAcknowledgement) *model.AppError
+	SaveAcknowledgementsForPost(rctx request.CTX, postID string, userIDs []string) ([]*model.PostAcknowledgement, *model.AppError)
 	GetAcknowledgementsForPost(postID string) ([]*model.PostAcknowledgement, *model.AppError)
-	PreparePostForClient(c request.CTX, post *model.Post, isNewPost, includeDeleted, includePriority bool) *model.Post
+	PreparePostForClient(rctx request.CTX, post *model.Post, isNewPost, includeDeleted, includePriority bool) *model.Post
 }
 
 // errNotFound allows checking against Store.ErrNotFound errors without making Store a dependency.
@@ -405,6 +405,6 @@ func (scs *Service) HandleChannelNotSharedErrorForTesting(msg *model.SyncMsg, rc
 }
 
 // TransformMentionsOnReceiveForTesting allows testing the full mention transformation flow
-func (scs *Service) TransformMentionsOnReceiveForTesting(ctx request.CTX, post *model.Post, targetChannel *model.Channel, rc *model.RemoteCluster, mentionTransforms map[string]string) {
-	scs.transformMentionsOnReceive(ctx, post, targetChannel, rc, mentionTransforms)
+func (scs *Service) TransformMentionsOnReceiveForTesting(rctx request.CTX, post *model.Post, targetChannel *model.Channel, rc *model.RemoteCluster, mentionTransforms map[string]string) {
+	scs.transformMentionsOnReceive(rctx, post, targetChannel, rc, mentionTransforms)
 }


### PR DESCRIPTION
## Summary
Standardizes all `request.CTX` parameter names to use consistent `rctx` naming across the codebase.

- **886 parameter renames** across **147 files**
- Migrated from inconsistent naming (`c`, `ctx`, `cancelContext`) to standardized `rctx`
- Updated both function signatures and function bodies
- Preserved underscore parameters unchanged (unused parameters)

## Changes Made
- `c` → `rctx`: 781 occurrences
- `ctx` → `rctx`: 99 occurrences  
- `cancelContext` → `rctx`: 6 occurrences
- Fixed method receiver context issue in `store.go`

## Test Plan
- [x] Code builds successfully (non-generated files)
- [x] All `request.CTX` parameters now consistently use `rctx` naming
- [x] Underscore parameters preserved as requested
- [x] Function bodies updated to reference new parameter names

Generated files (`timerlayer.go`, `retrylayer.go`) will be regenerated by the build system.

🤖 Generated with [Claude Code](https://claude.ai/code)