### PR TITLE
Increase pbkdf2 rounds to OWASP recommendation

### DIFF
--- a/server/public/model/remote_cluster.go
+++ b/server/public/model/remote_cluster.go
@@ -406,7 +406,7 @@ func (rci *RemoteClusterInvite) Encrypt(password string) ([]byte, error) {
 	var key []byte
 	if rci.Version >= 3 {
 		// Use PBKDF2 for version 3 and above
-		key = pbkdf2.Key([]byte(password), salt, 100000, 32, sha256.New)
+		key = pbkdf2.Key([]byte(password), salt, 600000, 32, sha256.New)
 	} else {
 		// Use scrypt for older versions
 		key, err = scrypt.Key([]byte(password), salt, 32768, 8, 1, 32)
@@ -461,7 +461,7 @@ func (rci *RemoteClusterInvite) tryDecrypt(encrypted []byte, password string, sa
 
 	if usePBKDF2 {
 		// Use PBKDF2 for version 3 and above
-		key = pbkdf2.Key([]byte(password), salt, 100000, 32, sha256.New)
+		key = pbkdf2.Key([]byte(password), salt, 600000, 32, sha256.New)
 	} else {
 		// Use scrypt for older versions
 		key, err = scrypt.Key([]byte(password), salt, 32768, 8, 1, 32)


### PR DESCRIPTION
#### Summary
Increases rounds from 100K to 600K in PBKDF2 for shared channel encryption key
https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2

#### Release Note
```release-note
NONE
```
