### PR TITLE
MM-64880 Revert change to border colour in list modals and remove a few things from applyTheme

### DIFF
--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -2255,9 +2255,14 @@
     }
 
     &.post--comment {
+        .post__body {
+            border-color: rgba(var(--button-bg-rgb), 0.24);
+        }
+
         &.other--root {
             .post-comment {
                 border-color: rgba(var(--center-channel-color-rgb), 0.1);
+                background-color: rgba(var(--center-channel-color-rgb), 0.05);
             }
         }
     }

--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -2253,4 +2253,12 @@
             }
         }
     }
+
+    &.post--comment {
+        &.other--root {
+            .post-comment {
+                border-color: rgba(var(--center-channel-color-rgb), 0.1);
+            }
+        }
+    }
 }

--- a/webapp/channels/src/sass/responsive/_mobile.scss
+++ b/webapp/channels/src/sass/responsive/_mobile.scss
@@ -817,6 +817,12 @@
             .post__link {
                 margin: 0 0 8px;
             }
+
+            &:hover {
+                .post__body {
+                    background: transparent;
+                }
+            }
         }
 
         .post__header {
@@ -1860,21 +1866,21 @@
             .modal-header {
                 min-height: unset;
                 box-shadow: none;
-            
+
                 .GenericModal__header__text_container .GenericModal__header {
                     flex-direction: column;
                     align-items: flex-start;
-    
+
                     button {
                         margin-top: 16px;
                     }
                 }
             }
-    
+
             .more-modal__dropdown {
                 flex-direction: column;
                 align-items: flex-start;
-    
+
                 #modalPreferenceContainer #menuWrapper {
                     padding-left: 0;
                 }

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -380,7 +380,7 @@ export function applyTheme(theme: Theme) {
         changeCss('.app__body .search-item-container', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.1));
         changeCss('.app__body .modal .custom-textarea:focus', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.3));
         changeCss('.app__body .channel-intro, .app__body hr, .app__body .modal .settings-modal .settings-table .settings-content .appearance-section .theme-elements__header, .app__body .user-settings .authorized-app:not(:last-child)', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
-        changeCss('.app__body .post.post--comment.other--root.current--user .post-comment, .app__body pre', 'background:' + changeOpacity(theme.centerChannelColor, 0.05));
+        changeCss('.app__body pre', 'background:' + changeOpacity(theme.centerChannelColor, 0.05));
         changeCss('.app__body .more-modal__list .more-modal__row, .app__body .member-div:first-child, .app__body .member-div, .app__body .access-history__table .access__report, .app__body .activity-log__table', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.1));
         changeCss('@media(max-width: 1800px){.app__body .inner-wrap.move--left .post.post--comment.same--root', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.07));
         changeCss('.app__body .post.post--hovered', 'background:' + changeOpacity(theme.centerChannelColor, 0.08));
@@ -388,7 +388,6 @@ export function applyTheme(theme: Theme) {
         changeCss('.app__body .attachment__body__wrap.btn-close', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('@media(min-width: 768px){.app__body .post.a11y--active, .app__body .modal .settings-modal .settings-table .settings-content .section-min:hover', 'background:' + changeOpacity(theme.centerChannelColor, 0.04));
         changeCss('@media(min-width: 768px){.app__body .post.post--editing', 'background:' + changeOpacity(theme.buttonBg, 0.08));
-        changeCss('@media(min-width: 768px){.app__body .post.current--user:hover .post__body ', 'background: transparent;');
         changeCss('.app__body .more-modal__row.more-modal__row--selected, .app__body .date-separator.hovered--before:after, .app__body .date-separator.hovered--after:before, .app__body .new-separator.hovered--after:before, .app__body .new-separator.hovered--before:after', 'background:' + changeOpacity(theme.centerChannelColor, 0.07));
         changeCss('@media(min-width: 768px){.app__body .dropdown-menu>li>a:focus, .app__body .dropdown-menu>li>a:hover', 'background:' + changeOpacity(theme.centerChannelColor, 0.15));
         changeCss('.app__body .form-control[disabled], .app__body .form-control[readonly], .app__body fieldset[disabled] .form-control', 'background:' + changeOpacity(theme.centerChannelColor, 0.1));
@@ -397,7 +396,6 @@ export function applyTheme(theme: Theme) {
         changeCss('body', 'scrollbar-arrow-color:' + theme.centerChannelColor);
         changeCss('.app__body .post.post--compact .post-image__column .post-image__details svg, .app__body .modal .about-modal .about-modal__logo svg, .app__body .status svg, .app__body .edit-post__actions .icon svg', 'fill:' + theme.centerChannelColor);
         changeCss('.app__body .post-list__new-messages-below', 'background:' + changeColor(theme.centerChannelColor, 0.5));
-        changeCss('.app__body .post.post--comment.current--user .post__body', 'border-color:' + changeOpacity(theme.buttonBg, 0.24));
         changeCss('.app__body .emoji-picker', 'color:' + theme.centerChannelColor);
         changeCss('.app__body .emoji-picker', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('.app__body .emoji-picker__search-icon', 'color:' + changeOpacity(theme.centerChannelColor, 0.4));

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -381,7 +381,7 @@ export function applyTheme(theme: Theme) {
         changeCss('.app__body .modal .custom-textarea:focus', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.3));
         changeCss('.app__body .channel-intro, .app__body hr, .app__body .modal .settings-modal .settings-table .settings-content .appearance-section .theme-elements__header, .app__body .user-settings .authorized-app:not(:last-child)', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('.app__body .post.post--comment.other--root.current--user .post-comment, .app__body pre', 'background:' + changeOpacity(theme.centerChannelColor, 0.05));
-        changeCss('.app__body .post.post--comment.other--root.current--user .post-comment, .app__body .more-modal__list .more-modal__row, .app__body .member-div:first-child, .app__body .member-div, .app__body .access-history__table .access__report, .app__body .activity-log__table', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.4));
+        changeCss('.app__body .more-modal__list .more-modal__row, .app__body .member-div:first-child, .app__body .member-div, .app__body .access-history__table .access__report, .app__body .activity-log__table', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.1));
         changeCss('@media(max-width: 1800px){.app__body .inner-wrap.move--left .post.post--comment.same--root', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.07));
         changeCss('.app__body .post.post--hovered', 'background:' + changeOpacity(theme.centerChannelColor, 0.08));
         changeCss('.app__body .attachment__body__wrap.btn-close', 'background:' + changeOpacity(theme.centerChannelColor, 0.08));


### PR DESCRIPTION
#### Summary
[One of the changes](https://github.com/mattermost/mattermost/pull/31008/files#diff-d6177135b34f4a9fb6057af1f126076a8f1c8359374fd435cdcaaf6cd5d21d5bR384) in https://github.com/mattermost/mattermost/pull/31008 accidentally affected more than it should have because those lines style way too much at once. I moved the intentional change from that into the CSS, and I reverted that change for the unintentional ones

While I was in there, I also took the opportunity to chip away a bit at moving the rest of that to use CSS variables

#### Ticket Link
MM-64880

#### Screenshots
Before|After
-|-
<img width="602" height="567" alt="Screenshot 2025-07-21 at 9 57 39 AM" src="https://github.com/user-attachments/assets/f9f99af1-ff58-4f6d-9e8e-00263c2b511f" />|<img width="602" height="567" alt="Screenshot 2025-07-21 at 9 59 48 AM" src="https://github.com/user-attachments/assets/2e3f55fd-7d1d-4cf5-a365-26bc9ef2ae15" />
<img width="602" height="567" alt="Screenshot 2025-07-21 at 9 57 56 AM" src="https://github.com/user-attachments/assets/8a2f7705-a9cd-49ef-8b0a-d215f026561c" />|<img width="602" height="567" alt="Screenshot 2025-07-21 at 9 59 54 AM" src="https://github.com/user-attachments/assets/ce49f2ed-1947-46f4-ba97-ad3a24b71cb6" />


#### Release Note
```release-note
Fixed colour of borders in Browse Channels and Direct Messages modals
```
