### PR TITLE
MM-64313: Replace Link with BlockableLink in backstage navbar

### DIFF
--- a/webapp/channels/src/components/backstage/components/backstage_navbar.tsx
+++ b/webapp/channels/src/components/backstage/components/backstage_navbar.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
-import {Link} from 'react-router-dom';
+import BlockableLink from 'components/admin_console/blockable_link';
 
 import type {Team} from '@mattermost/types/teams';
 
@@ -19,7 +19,7 @@ const BackstageNavbar = ({team, siteName}: Props) => {
 
     return (
         <div className='backstage-navbar'>
-            <Link
+            <BlockableLink
                 className='backstage-navbar__back'
                 to={`/${teamExists ? team?.name : ''}`}
             >
@@ -38,7 +38,7 @@ const BackstageNavbar = ({team, siteName}: Props) => {
                         />
                     )}
                 </span>
-            </Link>
+            </BlockableLink>
         </div>
     );
 };


### PR DESCRIPTION
#### Summary

Replace the standard react-router-dom `Link` component with `BlockableLink` in the backstage navbar ("< Back to (sitename)") to call `getNavigationBlocked`.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-64313

#### Screenshots

*n/a* (You now see the **Discard Changes?** dialog when clicking the "< Back to xxx" link at the top of the page)

#### Release Note

```release-note
NONE
```
