### PR TITLE
Fix PostgreSQL SSL connection issue with sslmode=require in distroless images

### DIFF
--- a/server/build/Dockerfile
+++ b/server/build/Dockerfile
@@ -31,6 +31,10 @@ RUN mkdir -p /mattermost/data /mattermost/plugins /mattermost/client/plugins \
   && curl -L $MM_PACKAGE | tar -xvz \
   && chown -R mattermost:mattermost /mattermost /mattermost/data /mattermost/plugins /mattermost/client/plugins
 
+# Create PostgreSQL client SSL directory structure for ssl_mode=require
+RUN mkdir -p /mattermost/.postgresql \
+  && chmod 700 /mattermost/.postgresql
+
 # Final stage using distroless for minimal attack surface
 FROM gcr.io/distroless/base-debian12
 
@@ -41,7 +45,7 @@ ENV MM_SERVICESETTINGS_ENABLELOCALMODE="true"
 # Copy over metadata files needed by runtime
 COPY --from=builder /etc/mime.types /etc
 
-# Copy CA certificates for SSL/TLS validation with proper ownership - required for ssl_mode=require database connections
+# Copy CA certificates for SSL/TLS validation with proper ownership
 COPY --from=builder --chown=2000:2000 /etc/ssl/certs /etc/ssl/certs
 
 # Copy document processing utilities and necessary support files

--- a/server/build/Dockerfile
+++ b/server/build/Dockerfile
@@ -41,6 +41,9 @@ ENV MM_SERVICESETTINGS_ENABLELOCALMODE="true"
 # Copy over metadata files needed by runtime
 COPY --from=builder /etc/mime.types /etc
 
+# Copy CA certificates for SSL/TLS validation with proper ownership - required for ssl_mode=require database connections
+COPY --from=builder --chown=2000:2000 /etc/ssl/certs /etc/ssl/certs
+
 # Copy document processing utilities and necessary support files
 COPY --from=builder /usr/bin/pdftotext /usr/bin/pdftotext
 COPY --from=builder /usr/bin/wvText /usr/bin/wvText
@@ -57,7 +60,7 @@ COPY --from=builder /usr/lib/libwv.so* /usr/lib/
 COPY --from=builder /usr/lib/libtidy.so* /usr/lib/
 COPY --from=builder /usr/lib/libfontconfig.so* /usr/lib/
 
-# Copy mattermost from builder stage 
+# Copy mattermost from builder stage
 COPY --from=builder --chown=2000:2000 /mattermost /mattermost
 
 # Copy passwd including mattermost user

--- a/server/build/passwd
+++ b/server/build/passwd
@@ -1,4 +1,4 @@
 root:x:0:0:root:/root:/sbin/nologin
 nobody:x:65534:65534:nobody:/nonexistent:/sbin/nologin
 nonroot:x:65532:65532:nonroot:/home/nonroot:/sbin/nologin
-mattermost:x:2000:2000:nonroot:/home/nonroot:/sbin/nologin
+mattermost:x:2000:2000:mattermost:/mattermost:/sbin/nologin


### PR DESCRIPTION
#### Summary
**Problem**
When using sslmode=require in PostgreSQL connection strings, Mattermost containers based on distroless images were failing with: `error setting up connections: stat /home/nonroot/.postgresql/postgresql.crt: permission denied`

**Root Cause**
The PostgreSQL client library expects to find a `~/.postgresql/` directory in the user's home directory for SSL configuration. In distroless images:
* The mattermost user's home directory was set to `/home/nonroot` (owned by distroless nonroot user)
* The mattermost user (UID 2000) couldn't access `/home/nonroot` (owned by UID 65532)
* The `~/.postgresql/` directory didn't exist

**Changes**
* Dockerfile changes: Create `/mattermost/.postgresql/` directory with proper permissions (700)
* passwd changes: Change mattermost user's home directory from `/home/nonroot` to `/mattermost`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64860

#### Release Note
```release-note
NONE
```
