### PR TITLE
MM-43114: Fix OAuth redirect URL missing subpath for email -> SSO

### DIFF
--- a/server/channels/web/oauth.go
+++ b/server/channels/web/oauth.go
@@ -16,7 +16,6 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/i18n"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
-	"github.com/mattermost/mattermost/server/v8/channels/app"
 	"github.com/mattermost/mattermost/server/v8/channels/utils"
 	"github.com/mattermost/mattermost/server/v8/channels/utils/fileutils"
 )
@@ -342,7 +341,7 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	if action == model.OAuthActionEmailToSSO {
 		redirectURL = c.GetSiteURLHeader() + "/login?extra=signin_change"
 	} else if action == model.OAuthActionSSOToEmail {
-		redirectURL = app.GetProtocol(r) + "://" + r.Host + "/claim?email=" + url.QueryEscape(props["email"])
+		redirectURL = c.GetSiteURLHeader() + "/claim?email=" + url.QueryEscape(props["email"])
 	} else {
 		desktopToken := ""
 		if val, ok := props["desktop_token"]; ok {


### PR DESCRIPTION
#### Summary
When switching from SSO to email/password login on a server with subpath, the redirect URL was constructed using app.GetProtocol + r.Host which doesn't include the subpath, causing 404 errors. Changed to use c.GetSiteURLHeader() which properly includes the subpath.

I evaluated adding unit tests in `oauth_test.go`, but found the existing tests to be mostly not really testing anything. After trying 10x the time it took to fix the bug, I've opted to just merge the fix that should hopefully appear self-evident as far as a resolution.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-43114

#### Release Note
```release-note
NONE
```