### PR TITLE
[MM-56322] Document GetUsers plugin API limitation

### DIFF
--- a/server/public/plugin/api.go
+++ b/server/public/plugin/api.go
@@ -132,6 +132,8 @@ type API interface {
 
 	// GetUsers a list of users based on search options.
 	//
+	// Not all fields in UserGetOptions are supported by this API.
+	//
 	// @tag User
 	// Minimum server version: 5.10
 	GetUsers(options *model.UserGetOptions) ([]*model.User, *model.AppError)


### PR DESCRIPTION
#### Summary
The `GetUsers` API doesn't respect all of the parameters provided by `UserGetOptions`. For now instead of fixing it we'll simply document it so that plugin developers know.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56322

```release-note
NONE
```
