### PR TITLE
Fix spurious error log re: initializing Access Control

### DIFF
--- a/server/channels/app/channels.go
+++ b/server/channels/app/channels.go
@@ -145,7 +145,7 @@ func NewChannels(s *Server) (*Channels, error) {
 
 		app.AddLicenseListener(func(newCfg, old *model.License) {
 			if ch.AccessControl != nil {
-				if appErr := ch.AccessControl.Init(request.EmptyContext(s.Log())); appErr != nil {
+				if appErr := ch.AccessControl.Init(request.EmptyContext(s.Log())); appErr != nil && appErr.StatusCode != http.StatusNotImplemented {
 					s.Log().Error("An error occurred while initializing Access Control", mlog.Err(appErr))
 				}
 			}


### PR DESCRIPTION
#### Summary

This PR fixes a spurious error log that was being generated when initializing Access Control. The error occurs when Access Control returns a "Not Implemented" status (HTTP 501), which is expected behavior and should not be logged as an error.

The fix adds a condition to only log errors when the status code is not `http.StatusNotImplemented`, preventing unnecessary error logs in scenarios where Access Control functionality is intentionally not implemented.

#### Release Note

```release-note
NONE
```