### PR TITLE
Use a new Sentry key for v11+

### DIFF
--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -85,12 +85,7 @@ const (
 	debugScheduledPostJobInterval = 2 * time.Second
 )
 
-var SentryDSN = "https://9d7c9cccf549479799f880bcf4f26323@o94110.ingest.sentry.io/5212327"
-
-// This is a placeholder to allow the existing release pipelines to run without failing to insert
-// the key that's now hard-coded above. Remove this once we converge on the unified delivery
-// pipeline in GitHub.
-var _ = "placeholder_sentry_dsn"
+var SentryDSN = "https://eaf281226106b5bba68694d1316da21c@o94110.ingest.us.sentry.io/5212327"
 
 type Server struct {
 	// RootRouter is the starting point for all HTTP requests to the server.
@@ -1413,7 +1408,7 @@ func (s *Server) doLicenseExpirationCheck() {
 		})
 	}
 
-	//remove the license
+	// remove the license
 	if appErr := s.RemoveLicense(); appErr != nil {
 		mlog.Error("Error while removing the license.", mlog.Err(appErr))
 	}


### PR DESCRIPTION
#### Summary
This will allow us to eventually rotate out the older key and deprecate reports from older Mattermost server versions.

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
