### PR TITLE
[MM-64894] Check for non-primitive fields using DeepEqual

### DIFF
--- a/server/public/model/slack_attachment.go
+++ b/server/public/model/slack_attachment.go
@@ -219,7 +219,7 @@ func (s *SlackAttachmentField) Equals(input *SlackAttachmentField) bool {
 		return false
 	}
 
-	if reflect.ValueOf(input.Value).Type().Comparable() && reflect.ValueOf(s.Value).Type().Comparable() {
+	if reflect.ValueOf(input.Value).Type().Comparable() && reflect.ValueOf(s.Value).Type().Comparable() && reflect.ValueOf(input.Value).Type() == reflect.ValueOf(s.Value).Type() {
 		if s.Value != input.Value {
 			return false
 		}

--- a/server/public/model/slack_attachment.go
+++ b/server/public/model/slack_attachment.go
@@ -5,6 +5,7 @@ package model
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"slices"
 
@@ -218,8 +219,15 @@ func (s *SlackAttachmentField) Equals(input *SlackAttachmentField) bool {
 		return false
 	}
 
-	if s.Value != input.Value {
-		return false
+	switch s.Value.(type) {
+	case string, bool, int, float64:
+		if s.Value != input.Value {
+			return false
+		}
+	default:
+		if !reflect.DeepEqual(s.Value, input.Value) {
+			return false
+		}
 	}
 
 	if s.Short != input.Short {

--- a/server/public/model/slack_attachment.go
+++ b/server/public/model/slack_attachment.go
@@ -230,11 +230,7 @@ func (s *SlackAttachmentField) Equals(input *SlackAttachmentField) bool {
 		}
 	}
 
-	if s.Short != input.Short {
-		return false
-	}
-
-	return true
+	return s.Short == input.Short
 }
 
 func StringifySlackFieldValue(a []*SlackAttachment) []*SlackAttachment {

--- a/server/public/model/slack_attachment.go
+++ b/server/public/model/slack_attachment.go
@@ -219,12 +219,11 @@ func (s *SlackAttachmentField) Equals(input *SlackAttachmentField) bool {
 		return false
 	}
 
-	switch s.Value.(type) {
-	case string, bool, int, float64:
+	if reflect.ValueOf(input.Value).Type().Comparable() && reflect.ValueOf(s.Value).Type().Comparable() {
 		if s.Value != input.Value {
 			return false
 		}
-	default:
+	} else {
 		if !reflect.DeepEqual(s.Value, input.Value) {
 			return false
 		}

--- a/server/public/model/slack_attachment_test.go
+++ b/server/public/model/slack_attachment_test.go
@@ -229,7 +229,7 @@ func TestSlackAttachment_Equals_PrimitiveAndNonPrimitiveField(t *testing.T) {
 		Fields: []*SlackAttachmentField{
 			{
 				Title: "Field1",
-				Value: []interface{}{"value", 2},
+				Value: []any{"value", 2},
 				Short: true,
 			},
 		},
@@ -238,7 +238,7 @@ func TestSlackAttachment_Equals_PrimitiveAndNonPrimitiveField(t *testing.T) {
 		Fields: []*SlackAttachmentField{
 			{
 				Title: "Field1",
-				Value: []interface{}{"value", 2},
+				Value: []any{"value", 2},
 				Short: true,
 			},
 		},

--- a/server/public/model/slack_attachment_test.go
+++ b/server/public/model/slack_attachment_test.go
@@ -201,3 +201,47 @@ func TestParseSlackAttachment(t *testing.T) {
 		assert.Equal(t, expectedPost, post)
 	})
 }
+
+func TestSlackAttachment_Equals_PrimitiveAndNonPrimitiveField(t *testing.T) {
+	// Field with primitive type (string)
+	attachment1 := &SlackAttachment{
+		Fields: []*SlackAttachmentField{
+			{
+				Title: "Field1",
+				Value: "value",
+				Short: true,
+			},
+		},
+	}
+	attachment2 := &SlackAttachment{
+		Fields: []*SlackAttachmentField{
+			{
+				Title: "Field1",
+				Value: "value",
+				Short: true,
+			},
+		},
+	}
+	assert.True(t, attachment1.Equals(attachment2), "Attachments with identical primitive field values should be equal")
+
+	// Field with non-primitive type ([]interface{})
+	attachment3 := &SlackAttachment{
+		Fields: []*SlackAttachmentField{
+			{
+				Title: "Field1",
+				Value: []interface{}{"value", 2},
+				Short: true,
+			},
+		},
+	}
+	attachment4 := &SlackAttachment{
+		Fields: []*SlackAttachmentField{
+			{
+				Title: "Field1",
+				Value: []interface{}{"value", 2},
+				Short: true,
+			},
+		},
+	}
+	assert.True(t, attachment3.Equals(attachment4), "Attachments with identical non-primitive ([]interface{}) field values should be equal")
+}


### PR DESCRIPTION
#### Summary
Attachments fields of type `any` were not being checked for their ability to be an `interface{}` type, which would require `reflect.DeepEqual`. This PR makes that check.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64894

```release-note
Fixed a potential crash in UpdatePost
```
