### PR TITLE
[MM-64893] Account for extra whitespace when replacing date on search hint

### DIFF
--- a/webapp/channels/src/components/new_search/search_box.tsx
+++ b/webapp/channels/src/components/new_search/search_box.tsx
@@ -175,7 +175,7 @@ const SearchBox = forwardRef(
                 }
 
                 setSearchTerms(
-                    searchTerms.slice(0, caretPosition).replace(new RegExp(escapedMatchedPretext + '$', 'i'), '').trimEnd() +
+                    searchTerms.slice(0, caretPosition).trimEnd().replace(new RegExp(escapedMatchedPretext + '$', 'i'), '').trimEnd() +
                     val +
                     extraSpace +
                     searchTerms.slice(caretPosition),


### PR DESCRIPTION
#### Summary
The search hint box uses some replacement techniques when replacing the date. However, there's a situation where you can click the date, and then press Enter afterwards, which ended up adding the date twice, and this was caused because the search box adds some extra whitespace after adding the date.

This PR just trims the trailing whitespace when matching so that it accurately matches the date and replaces it instead of adding it a second time.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64893

```release-note
Fixed an issue where replacing the date on a search hint could just add the date a second time
```
