### PR TITLE
[MM-63417] remove second password eye icon for edge

### DIFF
--- a/webapp/channels/src/components/login/login.scss
+++ b/webapp/channels/src/components/login/login.scss
@@ -137,6 +137,7 @@
 
                     .login-body-card-form-password-input {
                         margin-top: 24px;
+                        input::-ms-reveal { display: none; }
                     }
 
                     .login-body-card-form-link {


### PR DESCRIPTION
#### Summary

When using Microsoft edge browser there is two eye balls to show the password this is because of the built in show password feature in Edge.


#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/30446
Jira https://mattermost.atlassian.net/browse/MM-63417



