### PR TITLE
MM-64869 Prevent space from selecting emojis in emoji picker

### DIFF
--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_search.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_search.tsx
@@ -108,13 +108,6 @@ const EmojiPickerSearch = forwardRef<HTMLInputElement, Props>(({value, cursorCat
                 onKeyDown(NavigationDirection.NextEmojiRow);
             }
             break;
-        case KeyCodes.SPACE[0]: {
-            event.stopPropagation();
-            event.preventDefault();
-
-            onEnter();
-            break;
-        }
         case KeyCodes.ENTER[0]: {
             event.stopPropagation();
             event.preventDefault();


### PR DESCRIPTION
#### Summary
When improving the keyboard support for the emoji picker in https://github.com/mattermost/mattermost/pull/29629, we changed it so that it selected emojis when pressing space. Unfortunately, that causes people (me at least) to accidentally select emojis when trying to search "thumbs up" or something similar with a space.

While the space bar selects items in some cases, the combobox pattern in the APG doesn't actually include selecting things by pressing space, so it seemed simplest to just remove that instead of trying to make the space bar only select emojis in certain cases.

#### Ticket Link
MM-64869

#### Release Note
```release-note
Prevented emoji picker items from being selected by pressing the space bar
```
