### PR TITLE
MM-62978 Remove alt text from profile picture in File Preview modal

### DIFF
--- a/webapp/channels/src/components/file_preview_modal/file_preview_modal_info/file_preview_modal_info.tsx
+++ b/webapp/channels/src/components/file_preview_modal/file_preview_modal_info/file_preview_modal_info.tsx
@@ -79,6 +79,7 @@ const FilePreviewModalInfo: React.FC<Props> = (props: Props) => {
                     username={user?.username}
                     url={imageURLForUser(props.post.user_id, user?.last_picture_update)}
                     className='file-preview-modal__avatar'
+                    alt=''
                 />
             }
 

--- a/webapp/channels/src/components/widgets/users/avatar/avatar.tsx
+++ b/webapp/channels/src/components/widgets/users/avatar/avatar.tsx
@@ -43,6 +43,14 @@ type Props = {
     username?: string;
     size?: TAvatarSizeToken;
     text?: string;
+
+    /**
+     * Override the default alt text for the image.
+     *
+     * If this Avatar is accompanied in the DOM by the user's name, this should be set to the empty string to prevent
+     * screen readers from repeating the user's name multiple times.
+     */
+    alt?: string;
 };
 
 type Attrs = HTMLAttributes<HTMLElement>;
@@ -55,6 +63,7 @@ const Avatar = forwardRef<HTMLElement, Props & Attrs>(({
     username,
     size = 'md',
     text,
+    alt,
     ...attrs
 }, ref) => {
     const {formatMessage} = useIntl();
@@ -85,7 +94,7 @@ const Avatar = forwardRef<HTMLElement, Props & Attrs>(({
             {...attrs}
             ref={ref as RefObject<HTMLImageElement>}
             className={classes}
-            alt={formatMessage({id: 'avatar.alt', defaultMessage: '{username} profile image'}, {
+            alt={alt ?? formatMessage({id: 'avatar.alt', defaultMessage: '{username} profile image'}, {
                 username: username || 'user',
             })}
             src={url}


### PR DESCRIPTION
#### Summary
This duplicates some work from https://github.com/mattermost/mattermost/pull/33553, but hopefully it shouldn't conflict because the changes are identical.

#### Ticket Link
MM-62978

#### Release Note
```release-note
NONE
```