### PR TITLE
[MM-64685] Show back button on desktop external login redirect page

### DIFF
--- a/webapp/channels/src/components/login/login.tsx
+++ b/webapp/channels/src/components/login/login.tsx
@@ -446,11 +446,11 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
     useEffect(() => {
         if (onCustomizeHeader) {
             onCustomizeHeader({
-                onBackButtonClick: showMfa ? handleHeaderBackButtonOnClick : undefined,
+                onBackButtonClick: (showMfa || desktopLoginLink) ? handleHeaderBackButtonOnClick : undefined,
                 alternateLink: isMobileView ? getAlternateLink() : undefined,
             });
         }
-    }, [onCustomizeHeader, search, showMfa, isMobileView, getAlternateLink]);
+    }, [onCustomizeHeader, search, showMfa, desktopLoginLink, isMobileView, getAlternateLink]);
 
     useEffect(() => {
         // We don't want to redirect outside of this route if we're doing Desktop App auth


### PR DESCRIPTION
#### Summary
There are cases where a user might miss redirecting to the browser to login from the Desktop App and need to restart the process. The current workaround was to refresh the page, but that's not an ideal UX.

This PR adds the back button like other login pages have to bring the user back to the login screen where they can just try again.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64685

```release-note
Show back button on desktop external login redirect page
```
