### PR TITLE
[MM-64883] Don't show unreads from muted channels in the favicon/desktop app

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channels.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channels.test.ts
@@ -2255,6 +2255,35 @@ describe('Selectors.Channels.getUnreadStatus', () => {
 
         expect(Selectors.getUnreadStatus(newState)).toBe(1);
     });
+
+    it('should not count unreads and mentions from a muted channel', () => {
+        const mutedChannelId = channel2.id;
+        const newMyMembers = {
+            ...testState.entities.channels.myMembers,
+            [mutedChannelId]: {
+                ...testState.entities.channels.myMembers[mutedChannelId],
+                notify_props: {
+                    ...testState.entities.channels.myMembers[mutedChannelId].notify_props,
+                    mark_unread: 'mention',
+                },
+                mention_count: 3,
+                msg_count: 10,
+            },
+        };
+
+        const newState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    myMembers: newMyMembers,
+                },
+            },
+        };
+
+        expect(Selectors.getUnreadStatus(newState)).toBe(1);
+    });
 });
 
 describe('Selectors.Channels.getUnreadStatus', () => {

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channels.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channels.ts
@@ -642,8 +642,12 @@ export const getUnreadStatus: (state: GlobalState) => BasicUnreadStatus = create
                 return counts;
             }
 
+            if (isChannelMuted(membership)) {
+                return counts;
+            }
+
             const mentions = collapsedThreads ? membership.mention_count_root : membership.mention_count;
-            if (mentions && !isChannelMuted(membership)) {
+            if (mentions) {
                 counts.mentions += mentions;
             }
 


### PR DESCRIPTION
#### Summary
Our unreads code was not accounting for muted channels when counting unreads, adding a dot when a user had unread mentions in the app.

This PR makes sure we don't count anything from a channel where it is muted.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64883

```release-note
Don't show unreads from muted channels in the favicon/desktop app
```
