### PR TITLE
Add data-testid for App forms select fields

### DIFF
--- a/webapp/channels/src/components/apps_form/apps_form_field/apps_form_field.tsx
+++ b/webapp/channels/src/components/apps_form/apps_form_field/apps_form_field.tsx
@@ -146,6 +146,7 @@ export default class AppsFormField extends React.PureComponent<Props> {
             return (
                 <AppsFormSelectField
                     {...this.props}
+                    id={name}
                     teammateNameDisplay={this.props.teammateNameDisplay}
                     field={field}
                     label={displayNameContent}

--- a/webapp/channels/src/components/apps_form/apps_form_field/apps_form_select_field.tsx
+++ b/webapp/channels/src/components/apps_form/apps_form_field/apps_form_select_field.tsx
@@ -21,6 +21,7 @@ import {SelectChannelOption} from './select_channel_option';
 import {SelectUserOption} from './select_user_option';
 
 export type Props = {
+    id: string;
     field: AppField;
     label: React.ReactNode;
     helpText: React.ReactNode;
@@ -226,6 +227,7 @@ export default class AppsFormSelectField extends React.PureComponent<Props, Stat
 
         return (
             <div
+                data-testid={this.props.id}
                 className='form-group'
             >
                 {label && (


### PR DESCRIPTION
#### Summary
The [migrations from Interactive Dialog to App forms](https://github.com/mattermost/mattermost/pull/31821) made some Playbooks e2e tests break because the Select fields do not have a `data-testid` set, but the interactive dialog did set one. This PR rights this wrong by adding a `data-testid`, mimicking the way it's done for the `Text` fields.

#### Ticket Link
N/A

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```
