### PR TITLE
MM-64957 - fix autoscroll not working

### DIFF
--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -862,7 +862,7 @@
         }
 
         .post__body {
-            padding: 2px 0;
+            padding: 2px 0 0 0;
             background: transparent !important;
             line-height: 1.5;
 
@@ -1384,7 +1384,7 @@
 
     .post__body {
         width: 100%;
-        padding: 0.2em 0;
+        padding: 0 0 0.2em;
         word-wrap: break-word;
 
         &-reactions-acks {


### PR DESCRIPTION
#### Summary
There was an issue with the dynamic list calculation where it was failing to measure the new post heigh due to some css changes to the post paddings. This PR correctly adds those css padding back so the issue with the autoscrolling is fixed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64957

#### Screenshots
Before:

https://github.com/user-attachments/assets/28a93ab7-ce6c-4afc-8d2d-a5593e6dc28f



After:

https://github.com/user-attachments/assets/a8435db4-2ab5-41bc-b1be-532394bead46




#### Release Note
```release-note
NONE
```
