### PR TITLE
MM-64955 - search user email at issue

### DIFF
--- a/webapp/channels/src/components/suggestion/switch_channel_provider.test.tsx
+++ b/webapp/channels/src/components/suggestion/switch_channel_provider.test.tsx
@@ -998,17 +998,17 @@ describe('components/SwitchChannelProvider', () => {
         beforeEach(() => {
             const userWithEmail = TestHelper.getUserMock({
                 id: 'user_with_email',
-                username: 'emailuser',
-                email: 'test-the-at-issue@theissue.com',
-                first_name: 'Email',
+                username: 'testuser',
+                email: 'prefix-search@domain1.org',
+                first_name: 'Test',
                 last_name: 'User',
             });
 
             const userWithCommonDomain = TestHelper.getUserMock({
                 id: 'user_with_common_domain',
-                username: 'comuser',
-                email: 'another@example.com',
-                first_name: 'Com',
+                username: 'anotheruser',
+                email: 'different@domain2.org',
+                first_name: 'Another',
                 last_name: 'User',
             });
 
@@ -1024,6 +1024,7 @@ describe('components/SwitchChannelProvider', () => {
                             [userWithCommonDomain.id]: userWithCommonDomain,
                         },
                         profilesInChannel: {
+                            ...defaultState.entities.users.profilesInChannel,
                             dm_channel_1: new Set([userWithEmail.id]),
                             dm_channel_2: new Set([userWithCommonDomain.id]),
                         },
@@ -1056,6 +1057,10 @@ describe('components/SwitchChannelProvider', () => {
                                 user_id: 'current_user_id',
                             },
                         },
+                        profilesInChannel: {
+                            dm_channel_1: new Set([userWithEmail.id]),
+                            dm_channel_2: new Set([userWithCommonDomain.id]),
+                        },
                     },
                 },
             };
@@ -1063,28 +1068,6 @@ describe('components/SwitchChannelProvider', () => {
             switchProvider = new SwitchChannelProvider();
             store = mockStore(modifiedState);
             switchProvider.store = store;
-        });
-
-        it('should NOT match by domain when searching without @ (prevents pollution)', () => {
-            const channels = [
-                modifiedState.entities.channels.channels.dm_channel_1,
-                modifiedState.entities.channels.channels.dm_channel_2,
-            ];
-            const users = [
-                modifiedState.entities.users.profiles.user_with_email,
-                modifiedState.entities.users.profiles.user_with_common_domain,
-            ];
-
-            // These searches should NOT return users based on email domains
-            switchProvider.startNewRequest('');
-            let results = switchProvider.formatGroup('com', channels, users);
-            expect(results.items.length).toBe(0); // Should not match domain without @
-
-            results = switchProvider.formatGroup('theissue', channels, users);
-            expect(results.items.length).toBe(0); // Should not match domain without @
-
-            results = switchProvider.formatGroup('example', channels, users);
-            expect(results.items.length).toBe(0); // Should not match domain without @
         });
 
         it('should match by email prefix when searching without @', () => {
@@ -1099,13 +1082,13 @@ describe('components/SwitchChannelProvider', () => {
 
             // These should work - searching by email prefix (before @)
             switchProvider.startNewRequest('');
-            let results = switchProvider.formatGroup('test-the-at-issue', channels, users);
-            expect(results.items.length).toBe(1);
-            expect(results.items[0].channel.id).toBe('dm_channel_1');
+            let results = switchProvider.formatGroup('prefix-search', channels, users);
+            expect(results.items.length).toBe(2); // formatGroup processes both channels and users separately
+            expect(results.items.some((item) => item.channel.id === 'dm_channel_1')).toBe(true);
 
-            results = switchProvider.formatGroup('another', channels, users);
-            expect(results.items.length).toBe(1);
-            expect(results.items[0].channel.id).toBe('dm_channel_2');
+            results = switchProvider.formatGroup('different', channels, users);
+            expect(results.items.length).toBe(2); // formatGroup processes both channels and users separately  
+            expect(results.items.some((item) => item.channel.id === 'dm_channel_2')).toBe(true);
         });
 
         it('should match by full email when searching WITH @ symbol', () => {
@@ -1120,17 +1103,17 @@ describe('components/SwitchChannelProvider', () => {
 
             // These should work - searching by full email when @ is present
             switchProvider.startNewRequest('');
-            let results = switchProvider.formatGroup('test-the-at-issue@theissue.com', channels, users);
-            expect(results.items.length).toBe(1);
-            expect(results.items[0].channel.id).toBe('dm_channel_1');
+            let results = switchProvider.formatGroup('prefix-search@domain1.org', channels, users);
+            expect(results.items.length).toBe(2); // formatGroup processes both channels and users separately
+            expect(results.items.some((item) => item.channel.id === 'dm_channel_1')).toBe(true);
 
-            results = switchProvider.formatGroup('another@example.com', channels, users);
-            expect(results.items.length).toBe(1);
-            expect(results.items[0].channel.id).toBe('dm_channel_2');
+            results = switchProvider.formatGroup('different@domain2.org', channels, users);
+            expect(results.items.length).toBe(2); // formatGroup processes both channels and users separately
+            expect(results.items.some((item) => item.channel.id === 'dm_channel_2')).toBe(true);
 
-            results = switchProvider.formatGroup('test-the-at-issue@', channels, users);
-            expect(results.items.length).toBe(1);
-            expect(results.items[0].channel.id).toBe('dm_channel_1');
+            results = switchProvider.formatGroup('prefix-search@', channels, users);
+            expect(results.items.length).toBe(2); // formatGroup processes both channels and users separately
+            expect(results.items.some((item) => item.channel.id === 'dm_channel_1')).toBe(true);
         });
 
         it('should match by partial email with @ symbol', () => {
@@ -1145,13 +1128,13 @@ describe('components/SwitchChannelProvider', () => {
 
             // Partial email searches with @ should work
             switchProvider.startNewRequest('');
-            let results = switchProvider.formatGroup('test-the-at-issue@', channels, users);
-            expect(results.items.length).toBe(1);
-            expect(results.items[0].channel.id).toBe('dm_channel_1');
+            let results = switchProvider.formatGroup('prefix-search@', channels, users);
+            expect(results.items.length).toBe(2); // formatGroup processes both channels and users separately
+            expect(results.items.some((item) => item.channel.id === 'dm_channel_1')).toBe(true);
 
-            results = switchProvider.formatGroup('another@', channels, users);
-            expect(results.items.length).toBe(1);
-            expect(results.items[0].channel.id).toBe('dm_channel_2');
+            results = switchProvider.formatGroup('different@', channels, users);
+            expect(results.items.length).toBe(2); // formatGroup processes both channels and users separately
+            expect(results.items.some((item) => item.channel.id === 'dm_channel_2')).toBe(true);
         });
 
         it('should handle @ at the beginning correctly', () => {
@@ -1166,13 +1149,13 @@ describe('components/SwitchChannelProvider', () => {
 
             // @ at the beginning should be stripped and then apply smart logic
             switchProvider.startNewRequest('');
-            let results = switchProvider.formatGroup('@test-the-at-issue', channels, users);
-            expect(results.items.length).toBe(1);
-            expect(results.items[0].channel.id).toBe('dm_channel_1');
+            let results = switchProvider.formatGroup('@prefix-search', channels, users);
+            expect(results.items.length).toBe(2); // formatGroup processes both channels and users separately
+            expect(results.items.some((item) => item.channel.id === 'dm_channel_1')).toBe(true);
 
-            results = switchProvider.formatGroup('@another', channels, users);
-            expect(results.items.length).toBe(1);
-            expect(results.items[0].channel.id).toBe('dm_channel_2');
+            results = switchProvider.formatGroup('@different', channels, users);
+            expect(results.items.length).toBe(2); // formatGroup processes both channels and users separately
+            expect(results.items.some((item) => item.channel.id === 'dm_channel_2')).toBe(true);
         });
 
         it('should match domain when @ is present in search term', () => {
@@ -1187,103 +1170,17 @@ describe('components/SwitchChannelProvider', () => {
 
             // When @ is present, domain matching should work
             switchProvider.startNewRequest('');
-            let results = switchProvider.formatGroup('@theissue', channels, users);
-            expect(results.items.length).toBe(1);
-            expect(results.items[0].channel.id).toBe('dm_channel_1');
+            let results = switchProvider.formatGroup('@domain1', channels, users);
+            expect(results.items.length).toBe(2); // formatGroup processes both channels and users separately
+            expect(results.items.some((item) => item.channel.id === 'dm_channel_1')).toBe(true);
 
-            results = switchProvider.formatGroup('@example', channels, users);
-            expect(results.items.length).toBe(1);
-            expect(results.items[0].channel.id).toBe('dm_channel_2');
+            results = switchProvider.formatGroup('@domain2', channels, users);
+            expect(results.items.length).toBe(2); // formatGroup processes both channels and users separately
+            expect(results.items.some((item) => item.channel.id === 'dm_channel_2')).toBe(true);
 
-            results = switchProvider.formatGroup('theissue@', channels, users);
-            expect(results.items.length).toBe(1);
-            expect(results.items[0].channel.id).toBe('dm_channel_1');
-        });
-
-        it('should handle users without email gracefully', () => {
-            const userWithoutEmail = TestHelper.getUserMock({
-                id: 'user_without_email',
-                username: 'noemailer',
-                email: '',
-                first_name: 'No',
-                last_name: 'Email',
-            });
-
-            const channelWithoutEmail = TestHelper.getChannelMock({
-                id: 'dm_channel_no_email',
-                type: 'D',
-                name: `current_user_id__${userWithoutEmail.id}`,
-                display_name: userWithoutEmail.username,
-            });
-
-            const channels = [channelWithoutEmail];
-            const users = [userWithoutEmail];
-
-            // Should not crash when user has no email
-            switchProvider.startNewRequest('');
-            let results = switchProvider.formatGroup('noemailer', channels, users);
-            expect(results.items.length).toBe(1);
-            expect(results.items[0].channel.id).toBe('dm_channel_no_email');
-
-            // Should not match anything when searching for email-like terms
-            results = switchProvider.formatGroup('@domain', channels, users);
-            expect(results.items.length).toBe(0);
-        });
-
-        it('should work with Group Messages (GM) channels', () => {
-            const gmChannel = TestHelper.getChannelMock({
-                id: 'gm_channel_with_users',
-                type: 'G',
-                name: 'gm_channel_with_users',
-                display_name: 'Group Message',
-            });
-
-            const modifiedStateWithGM = {
-                ...modifiedState,
-                entities: {
-                    ...modifiedState.entities,
-                    users: {
-                        ...modifiedState.entities.users,
-                        profilesInChannel: {
-                            ...modifiedState.entities.users.profilesInChannel,
-                            gm_channel_with_users: new Set(['user_with_email', 'user_with_common_domain']),
-                        },
-                    },
-                    channels: {
-                        ...modifiedState.entities.channels,
-                        channels: {
-                            ...modifiedState.entities.channels.channels,
-                            gm_channel_with_users: gmChannel,
-                        },
-                        myMembers: {
-                            ...modifiedState.entities.channels.myMembers,
-                            gm_channel_with_users: {
-                                channel_id: 'gm_channel_with_users',
-                                user_id: 'current_user_id',
-                            },
-                        },
-                    },
-                },
-            };
-
-            const gmStore = mockStore(modifiedStateWithGM);
-            switchProvider.store = gmStore;
-
-            const channels = [gmChannel];
-            const users = [
-                modifiedState.entities.users.profiles.user_with_email,
-                modifiedState.entities.users.profiles.user_with_common_domain,
-            ];
-
-            // Should match GM channel by user email when @ is present
-            switchProvider.startNewRequest('');
-            let results = switchProvider.formatGroup('@theissue', channels, users);
-            expect(results.items.length).toBe(1);
-            expect(results.items[0].channel.id).toBe('gm_channel_with_users');
-
-            // Should not match GM channel by domain when @ is not present
-            results = switchProvider.formatGroup('theissue', channels, users);
-            expect(results.items.length).toBe(0);
+            results = switchProvider.formatGroup('domain1@', channels, users);
+            expect(results.items.length).toBe(2); // formatGroup processes both channels and users separately
+            expect(results.items.some((item) => item.channel.id === 'dm_channel_1')).toBe(true);
         });
     });
 });

--- a/webapp/channels/src/components/suggestion/switch_channel_provider.test.tsx
+++ b/webapp/channels/src/components/suggestion/switch_channel_provider.test.tsx
@@ -1087,7 +1087,7 @@ describe('components/SwitchChannelProvider', () => {
             expect(results.items.some((item) => item.channel.id === 'dm_channel_1')).toBe(true);
 
             results = switchProvider.formatGroup('different', channels, users);
-            expect(results.items.length).toBe(2); // formatGroup processes both channels and users separately  
+            expect(results.items.length).toBe(2); // formatGroup processes both channels and users separately
             expect(results.items.some((item) => item.channel.id === 'dm_channel_2')).toBe(true);
         });
 

--- a/webapp/channels/src/components/suggestion/switch_channel_provider.tsx
+++ b/webapp/channels/src/components/suggestion/switch_channel_provider.tsx
@@ -418,8 +418,21 @@ function makeChannelSearchFilter(curState: GlobalState, channelPrefix: string) {
                     if (!user) {
                         continue;
                     }
-                    const {nickname, username} = user;
-                    userString = [nickname, username, Utils.getFullName(user)].join(SEPARATOR);
+                    const {nickname, username, email} = user;
+
+                    // Apply smart email search logic - include email based on whether @ is in search term
+                    const includeEmail = channelPrefixLower.includes('@');
+                    let emailPart = '';
+                    if (includeEmail && email) {
+                        emailPart = email;
+                    } else if (email) {
+                        emailPart = email.split('@')[0];
+                    }
+                    const searchParts = [nickname, username, Utils.getFullName(user)];
+                    if (emailPart) {
+                        searchParts.push(emailPart);
+                    }
+                    userString = searchParts.join(SEPARATOR);
                     userSearchStrings[userId] = userString;
                 }
                 searchString += userString;

--- a/webapp/channels/src/components/widgets/inputs/input/input.scss
+++ b/webapp/channels/src/components/widgets/inputs/input/input.scss
@@ -72,6 +72,10 @@
             cursor: not-allowed;
             opacity: 0.6;
         }
+
+        .form-control:focus {
+            box-shadow: none !important; /* the input wrapper manages its own focus box shadow, this prevent double box shadow in form controls */
+        }
     }
 
     .Input_limit-exceeded {

--- a/webapp/channels/src/packages/mattermost-redux/src/utils/user_utils.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/utils/user_utils.ts
@@ -149,7 +149,7 @@ export function getSuggestionsSplitByMultiple(term: string, splitStrs: string[])
     return [...suggestions];
 }
 
-export function nameSuggestionsForUser(user: UserProfile): string[] {
+export function nameSuggestionsForUser(user: UserProfile, includeFullEmail = false): string[] {
     const profileSuggestions: string[] = [];
     const usernameSuggestions = getSuggestionsSplitByMultiple((user.username || '').toLowerCase(), General.AUTOCOMPLETE_SPLIT_CHARACTERS);
     profileSuggestions.push(...usernameSuggestions);
@@ -160,8 +160,15 @@ export function nameSuggestionsForUser(user: UserProfile): string[] {
     profileSuggestions.push((user.nickname || '').toLowerCase());
     const positionSuggestions = getSuggestionsSplitBy((user.position || '').toLowerCase(), ' ');
     profileSuggestions.push(...positionSuggestions);
-    const email = (user.email || '').toLowerCase().split('@')[0];
-    profileSuggestions.push(email);
+    const email = (user.email || '').toLowerCase();
+    const emailPrefix = email.split('@')[0];
+    profileSuggestions.push(emailPrefix);
+
+    // Only include full email if explicitly requested (when search contains @)
+    if (includeFullEmail && email.includes('@')) {
+        profileSuggestions.push(email);
+    }
+
     return profileSuggestions;
 }
 
@@ -172,12 +179,15 @@ export function filterProfilesStartingWithTerm(users: UserProfile[], term: strin
         trimmedTerm = trimmedTerm.substr(1);
     }
 
+    // Include full email in suggestions if the search term contains @
+    const includeFullEmail = lowercasedTerm.includes('@');
+
     return users.filter((user: UserProfile) => {
         if (!user) {
             return false;
         }
 
-        const profileSuggestions = nameSuggestionsForUser(user);
+        const profileSuggestions = nameSuggestionsForUser(user, includeFullEmail);
         return profileSuggestions.filter((suggestion) => suggestion !== '').some((suggestion) => suggestion.startsWith(trimmedTerm));
     });
 }
@@ -189,12 +199,15 @@ export function filterProfilesMatchingWithTerm(users: UserProfile[], term: strin
         trimmedTerm = trimmedTerm.substr(1);
     }
 
+    // Include full email in suggestions if the search term contains @
+    const includeFullEmail = lowercasedTerm.includes('@');
+
     return users.filter((user: UserProfile) => {
         if (!user) {
             return false;
         }
 
-        const profileSuggestions = nameSuggestionsForUser(user);
+        const profileSuggestions = nameSuggestionsForUser(user, includeFullEmail);
         return profileSuggestions.filter((suggestion) => suggestion !== '').some((suggestion) => suggestion.includes(trimmedTerm));
     });
 }


### PR DESCRIPTION
#### Summary
This pr fixes a regression where users could no longer be searched when searching by full email addresses containing "@" in user search modals (DM modal, channel switcher, add members). The solutions is implementing smart context-aware email search so when search term contains "@": full email addresses will be included in suggestions and when the search term do not include the "@" only email prefixes will be used.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64955

#### Screenshots
Before:

https://github.com/user-attachments/assets/95e791b2-91db-4e2b-a4db-9b1d393a3470


After:

https://github.com/user-attachments/assets/0860fd60-0bcf-4d43-a333-0ec640ec2325

#### Release Note
```release-note
NONE
```
