### PR TITLE
Mm 64925 -  prevent slack import email auto validation for non admin users

### DIFF
--- a/server/channels/app/slack.go
+++ b/server/channels/app/slack.go
@@ -49,7 +49,15 @@ func (a *App) SlackImport(c request.CTX, fileData multipart.File, fileSize int64
 		},
 	}
 
-	importer := slackimport.New(a.Srv().Store(), actions, a.Config())
+	// Get the importing user from the context for enhanced security controls
+	var importingUser *model.User
+	if c.Session() != nil && c.Session().UserId != "" {
+		if user, err := a.GetUser(c.Session().UserId); err == nil {
+			importingUser = user
+		}
+	}
+
+	importer := slackimport.NewWithImportingUser(a.Srv().Store(), actions, a.Config(), importingUser)
 	return importer.SlackImport(c, fileData, fileSize, teamID)
 }
 

--- a/server/platform/services/slackimport/slackimport.go
+++ b/server/platform/services/slackimport/slackimport.go
@@ -718,9 +718,7 @@ func (si *SlackImporter) oldImportUser(rctx request.CTX, team *model.Team, user 
 		return nil
 	}
 
-	if _, err := si.store.User().VerifyEmail(ruser.Id, ruser.Email); err != nil {
-		rctx.Logger().Warn("Failed to set email verified.", mlog.Err(err))
-	}
+	// Users must verify their emails through the standard verification process
 
 	if _, err := si.actions.JoinUserToTeam(team, user, ""); err != nil {
 		rctx.Logger().Warn("Failed to join team when importing.", mlog.Err(err))

--- a/server/platform/services/slackimport/slackimport.go
+++ b/server/platform/services/slackimport/slackimport.go
@@ -100,9 +100,10 @@ type Actions struct {
 
 // SlackImporter is a service that allows to import slack dumps into mattermost
 type SlackImporter struct {
-	store   store.Store
-	actions Actions
-	config  *model.Config
+	store         store.Store
+	actions       Actions
+	config        *model.Config
+	importingUser *model.User
 }
 
 // New creates a new SlackImporter service instance. It receive a store, a set of actions and the current config.
@@ -112,6 +113,17 @@ func New(store store.Store, actions Actions, config *model.Config) *SlackImporte
 		store:   store,
 		actions: actions,
 		config:  config,
+	}
+}
+
+// NewWithImportingUser creates a new SlackImporter service instance with information about the user performing the import.
+// This allows for enhanced security controls based on the importing user's role.
+func NewWithImportingUser(store store.Store, actions Actions, config *model.Config, importingUser *model.User) *SlackImporter {
+	return &SlackImporter{
+		store:         store,
+		actions:       actions,
+		config:        config,
+		importingUser: importingUser,
 	}
 }
 
@@ -718,7 +730,16 @@ func (si *SlackImporter) oldImportUser(rctx request.CTX, team *model.Team, user 
 		return nil
 	}
 
-	// Users must verify their emails through the standard verification process
+	// Only system admins can automatically verify emails during import
+	if si.importingUser != nil && si.importingUser.IsSystemAdmin() {
+		if _, err := si.store.User().VerifyEmail(ruser.Id, ruser.Email); err != nil {
+			rctx.Logger().Warn("Failed to set email verified for admin import.", mlog.Err(err))
+		}
+	} else {
+		// Non-admin users: emails remain unverified
+		rctx.Logger().Debug("Email verification skipped for non-admin import.",
+			mlog.String("user_email", ruser.Email))
+	}
 
 	if _, err := si.actions.JoinUserToTeam(team, user, ""); err != nil {
 		rctx.Logger().Warn("Failed to join team when importing.", mlog.Err(err))


### PR DESCRIPTION
#### Summary
This PR enhances the Slack import functionality to implement role-based email verification controls. Email addresses are now automatically verified only when system administrators perform the import, while regular users must complete standard email verification processes.

#### Ticket Link
n/a

#### Screenshots

https://github.com/user-attachments/assets/7306595f-f9a8-4aa6-9ccd-44c6b5e5cc70



#### Release Note
```release-note
NONE
```
