### PR TITLE
Relax post action requirements to allow undefined name

### DIFF
--- a/webapp/channels/src/components/post_view/message_attachments/action_button/action_button.tsx
+++ b/webapp/channels/src/components/post_view/message_attachments/action_button/action_button.tsx
@@ -56,6 +56,8 @@ const ActionButton = ({
             (action.style.match('^#(?:[0-9a-fA-F]{3}){1,2}$') && action.style);
     }
 
+    const name = action.name || action.id;
+
     return (
         <ActionBtn
             data-action-id={action.id}
@@ -71,7 +73,7 @@ const ActionButton = ({
                 text={actionExecutingMessage}
             >
                 <Markdown
-                    message={action.name}
+                    message={name}
                     options={markdownOptions}
                 />
             </LoadingWrapper>

--- a/webapp/channels/src/components/post_view/message_attachments/action_menu/action_menu.tsx
+++ b/webapp/channels/src/components/post_view/message_attachments/action_menu/action_menu.tsx
@@ -99,6 +99,7 @@ export default class ActionMenu extends React.PureComponent<Props, State> {
 
     render() {
         const {action, disabled} = this.props;
+        const name = action.name || action.id;
 
         return (
             <PostContext.Consumer>
@@ -106,7 +107,7 @@ export default class ActionMenu extends React.PureComponent<Props, State> {
                     <AutocompleteSelector
                         providers={this.providers}
                         onSelected={this.handleSelected}
-                        placeholder={action.name}
+                        placeholder={name}
                         inputClassName='post-attachment-dropdown'
                         value={this.state.value}
                         toggleFocus={handlePopupOpened}

--- a/webapp/channels/src/components/post_view/message_attachments/message_attachment/message_attachment.tsx
+++ b/webapp/channels/src/components/post_view/message_attachments/message_attachment/message_attachment.tsx
@@ -145,7 +145,7 @@ export default class MessageAttachment extends React.PureComponent<Props, State>
         const content = [] as JSX.Element[];
 
         actions.forEach((action: PostAction) => {
-            if (!action.id) {
+            if (!action.id || !action.name) {
                 return;
             }
 

--- a/webapp/channels/src/components/post_view/message_attachments/message_attachment/message_attachment.tsx
+++ b/webapp/channels/src/components/post_view/message_attachments/message_attachment/message_attachment.tsx
@@ -145,7 +145,7 @@ export default class MessageAttachment extends React.PureComponent<Props, State>
         const content = [] as JSX.Element[];
 
         actions.forEach((action: PostAction) => {
-            if (!action.id || !action.name) {
+            if (!action.id) {
                 return;
             }
 

--- a/webapp/platform/types/src/integration_actions.ts
+++ b/webapp/platform/types/src/integration_actions.ts
@@ -6,7 +6,7 @@ import {isArrayOf} from './utilities';
 export type PostAction = {
     id: string;
     type?: string;
-    name: string;
+    name?: string;
     disabled?: boolean;
     style?: string;
     data_source?: string;
@@ -28,11 +28,7 @@ export function isPostAction(v: unknown): v is PostAction {
         return false;
     }
 
-    if (!('name' in v)) {
-        return false;
-    }
-
-    if (typeof v.name !== 'string') {
+    if ('name' in v && typeof v.name !== 'string') {
         return false;
     }
 


### PR DESCRIPTION
#### Summary
We were considering actions without names on post attachments to be invalid, rendering the whole post attachment invalid.

We have relaxed this, and default the name to the id.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64626

#### Release Note
```release-note
Fix issue where some webhooks may not show
```
