### PR TITLE
Fix OpenID login username priority

### DIFF
--- a/server/channels/app/oauthproviders/openid/openid.go
+++ b/server/channels/app/oauthproviders/openid/openid.go
@@ -16,14 +16,14 @@ type OpenIDProvider struct {
 }
 
 type OpenIDUser struct {
-	Sub              string `json:"sub"`
+	Sub               string `json:"sub"`
 	PreferredUsername string `json:"preferred_username"`
-	Username         string `json:"username"`
-	Nickname         string `json:"nickname"`
-	Email            string `json:"email"`
-	Name             string `json:"name"`
-	GivenName        string `json:"given_name"`
-	FamilyName       string `json:"family_name"`
+	Username          string `json:"username"`
+	Nickname          string `json:"nickname"`
+	Email             string `json:"email"`
+	Name              string `json:"name"`
+	GivenName         string `json:"given_name"`
+	FamilyName        string `json:"family_name"`
 }
 
 func init() {
@@ -33,7 +33,7 @@ func init() {
 
 func userFromOpenIDUser(logger mlog.LoggerIFace, oidUser *OpenIDUser) *model.User {
 	user := &model.User{}
-	
+
 	// Prioritize username claims according to OpenID Connect spec
 	// 1. preferred_username (most preferred)
 	// 2. username
@@ -53,9 +53,9 @@ func userFromOpenIDUser(logger mlog.LoggerIFace, oidUser *OpenIDUser) *model.Use
 			username = emailParts[0]
 		}
 	}
-	
+
 	user.Username = model.CleanUsername(logger, username)
-	
+
 	// Set name fields
 	if oidUser.GivenName != "" && oidUser.FamilyName != "" {
 		user.FirstName = oidUser.GivenName
@@ -72,7 +72,7 @@ func userFromOpenIDUser(logger mlog.LoggerIFace, oidUser *OpenIDUser) *model.Use
 			user.FirstName = oidUser.Name
 		}
 	}
-	
+
 	user.Email = strings.ToLower(oidUser.Email)
 	userId := oidUser.getAuthData()
 	user.AuthData = &userId
@@ -129,4 +129,4 @@ func (op *OpenIDProvider) GetUserFromIdToken(_ request.CTX, idToken string) (*mo
 
 func (op *OpenIDProvider) IsSameUser(_ request.CTX, dbUser, oauthUser *model.User) bool {
 	return dbUser.AuthData == oauthUser.AuthData
-} 
+}

--- a/server/channels/app/oauthproviders/openid/openid.go
+++ b/server/channels/app/oauthproviders/openid/openid.go
@@ -1,0 +1,132 @@
+package oauthopenid
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+	"github.com/mattermost/mattermost/server/v8/einterfaces"
+)
+
+type OpenIDProvider struct {
+}
+
+type OpenIDUser struct {
+	Sub              string `json:"sub"`
+	PreferredUsername string `json:"preferred_username"`
+	Username         string `json:"username"`
+	Nickname         string `json:"nickname"`
+	Email            string `json:"email"`
+	Name             string `json:"name"`
+	GivenName        string `json:"given_name"`
+	FamilyName       string `json:"family_name"`
+}
+
+func init() {
+	provider := &OpenIDProvider{}
+	einterfaces.RegisterOAuthProvider(model.ServiceOpenid, provider)
+}
+
+func userFromOpenIDUser(logger mlog.LoggerIFace, oidUser *OpenIDUser) *model.User {
+	user := &model.User{}
+	
+	// Prioritize username claims according to OpenID Connect spec
+	// 1. preferred_username (most preferred)
+	// 2. username
+	// 3. nickname
+	// 4. email local-part (fallback)
+	var username string
+	if oidUser.PreferredUsername != "" {
+		username = oidUser.PreferredUsername
+	} else if oidUser.Username != "" {
+		username = oidUser.Username
+	} else if oidUser.Nickname != "" {
+		username = oidUser.Nickname
+	} else if oidUser.Email != "" {
+		// Extract local-part from email as fallback
+		emailParts := strings.Split(oidUser.Email, "@")
+		if len(emailParts) > 0 {
+			username = emailParts[0]
+		}
+	}
+	
+	user.Username = model.CleanUsername(logger, username)
+	
+	// Set name fields
+	if oidUser.GivenName != "" && oidUser.FamilyName != "" {
+		user.FirstName = oidUser.GivenName
+		user.LastName = oidUser.FamilyName
+	} else if oidUser.Name != "" {
+		splitName := strings.Split(oidUser.Name, " ")
+		if len(splitName) == 2 {
+			user.FirstName = splitName[0]
+			user.LastName = splitName[1]
+		} else if len(splitName) >= 2 {
+			user.FirstName = splitName[0]
+			user.LastName = strings.Join(splitName[1:], " ")
+		} else {
+			user.FirstName = oidUser.Name
+		}
+	}
+	
+	user.Email = strings.ToLower(oidUser.Email)
+	userId := oidUser.getAuthData()
+	user.AuthData = &userId
+	user.AuthService = model.ServiceOpenid
+
+	return user
+}
+
+func openIDUserFromJSON(data io.Reader) (*OpenIDUser, error) {
+	decoder := json.NewDecoder(data)
+	var oidUser OpenIDUser
+	err := decoder.Decode(&oidUser)
+	if err != nil {
+		return nil, err
+	}
+	return &oidUser, nil
+}
+
+func (oidUser *OpenIDUser) IsValid() error {
+	if oidUser.Sub == "" {
+		return errors.New("user sub (subject) can't be empty")
+	}
+
+	if oidUser.Email == "" {
+		return errors.New("user e-mail should not be empty")
+	}
+
+	return nil
+}
+
+func (oidUser *OpenIDUser) getAuthData() string {
+	return oidUser.Sub
+}
+
+func (op *OpenIDProvider) GetUserFromJSON(c request.CTX, data io.Reader, tokenUser *model.User) (*model.User, error) {
+	oidUser, err := openIDUserFromJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	if err = oidUser.IsValid(); err != nil {
+		return nil, err
+	}
+
+	return userFromOpenIDUser(c.Logger(), oidUser), nil
+}
+
+func (op *OpenIDProvider) GetSSOSettings(_ request.CTX, config *model.Config, service string) (*model.SSOSettings, error) {
+	return &config.OpenIdSettings, nil
+}
+
+func (op *OpenIDProvider) GetUserFromIdToken(_ request.CTX, idToken string) (*model.User, error) {
+	return nil, nil
+}
+
+func (op *OpenIDProvider) IsSameUser(_ request.CTX, dbUser, oauthUser *model.User) bool {
+	return dbUser.AuthData == oauthUser.AuthData
+} 

--- a/server/channels/app/oauthproviders/openid/openid_test.go
+++ b/server/channels/app/oauthproviders/openid/openid_test.go
@@ -1,0 +1,191 @@
+package oauthopenid
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenIDProvider_GetUserFromJSON(t *testing.T) {
+	tests := []struct {
+		name           string
+		openIDUser     *OpenIDUser
+		expectedUsername string
+		description    string
+	}{
+		{
+			name: "preferred_username_priority",
+			openIDUser: &OpenIDUser{
+				Sub:              "12345",
+				PreferredUsername: "john.doe",
+				Username:         "johndoe",
+				Nickname:         "johnny",
+				Email:            "john.doe@example.com",
+				Name:             "John Doe",
+			},
+			expectedUsername: "john.doe",
+			description:     "Should prioritize preferred_username over other claims",
+		},
+		{
+			name: "username_fallback",
+			openIDUser: &OpenIDUser{
+				Sub:              "12346",
+				PreferredUsername: "",
+				Username:         "johndoe",
+				Nickname:         "johnny",
+				Email:            "john.doe@example.com",
+				Name:             "John Doe",
+			},
+			expectedUsername: "johndoe",
+			description:     "Should use username when preferred_username is empty",
+		},
+		{
+			name: "nickname_fallback",
+			openIDUser: &OpenIDUser{
+				Sub:              "12347",
+				PreferredUsername: "",
+				Username:         "",
+				Nickname:         "johnny",
+				Email:            "john.doe@example.com",
+				Name:             "John Doe",
+			},
+			expectedUsername: "johnny",
+			description:     "Should use nickname when preferred_username and username are empty",
+		},
+		{
+			name: "email_local_part_fallback",
+			openIDUser: &OpenIDUser{
+				Sub:              "12348",
+				PreferredUsername: "",
+				Username:         "",
+				Nickname:         "",
+				Email:            "john.doe@example.com",
+				Name:             "John Doe",
+			},
+			expectedUsername: "john.doe",
+			description:     "Should use email local-part when all username claims are empty",
+		},
+		{
+			name: "email_without_at_fallback",
+			openIDUser: &OpenIDUser{
+				Sub:              "12349",
+				PreferredUsername: "",
+				Username:         "",
+				Nickname:         "",
+				Email:            "johndoe",
+				Name:             "John Doe",
+			},
+			expectedUsername: "johndoe",
+			description:     "Should handle email without @ symbol",
+		},
+	}
+
+	provider := &OpenIDProvider{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert OpenIDUser to JSON
+			jsonData, err := json.Marshal(tt.openIDUser)
+			require.NoError(t, err)
+
+			// Create a mock context
+			c := request.TestContext(t)
+
+			// Call GetUserFromJSON
+			user, err := provider.GetUserFromJSON(c, bytes.NewReader(jsonData), nil)
+			require.NoError(t, err)
+			require.NotNil(t, user)
+
+			// Verify the username is set correctly
+			assert.Equal(t, tt.expectedUsername, user.Username, tt.description)
+			assert.Equal(t, model.ServiceOpenid, user.AuthService)
+			assert.Equal(t, strings.ToLower(tt.openIDUser.Email), user.Email)
+		})
+	}
+}
+
+func TestOpenIDProvider_GetUserFromJSON_InvalidData(t *testing.T) {
+	provider := &OpenIDProvider{}
+	c := request.TestContext(t)
+
+	// Test with invalid JSON
+	invalidJSON := `{"invalid": json}`
+	_, err := provider.GetUserFromJSON(c, bytes.NewReader([]byte(invalidJSON)), nil)
+	assert.Error(t, err)
+
+	// Test with missing required fields
+	incompleteUser := &OpenIDUser{
+		Email: "test@example.com",
+		// Missing Sub field
+	}
+	jsonData, err := json.Marshal(incompleteUser)
+	require.NoError(t, err)
+	_, err = provider.GetUserFromJSON(c, bytes.NewReader(jsonData), nil)
+	assert.Error(t, err)
+
+	// Test with empty email
+	userWithoutEmail := &OpenIDUser{
+		Sub:   "12345",
+		Email: "",
+	}
+	jsonData, err = json.Marshal(userWithoutEmail)
+	require.NoError(t, err)
+	_, err = provider.GetUserFromJSON(c, bytes.NewReader(jsonData), nil)
+	assert.Error(t, err)
+}
+
+func TestOpenIDProvider_IsSameUser(t *testing.T) {
+	provider := &OpenIDProvider{}
+	c := request.TestContext(t)
+
+	dbUser := &model.User{
+		AuthData: model.NewPointer("12345"),
+	}
+	oauthUser := &model.User{
+		AuthData: model.NewPointer("12345"),
+	}
+
+	// Same auth data should return true
+	assert.True(t, provider.IsSameUser(c, dbUser, oauthUser))
+
+	// Different auth data should return false
+	oauthUser.AuthData = model.NewPointer("67890")
+	assert.False(t, provider.IsSameUser(c, dbUser, oauthUser))
+}
+
+func TestOpenIDUser_IsValid(t *testing.T) {
+	// Test valid user
+	validUser := &OpenIDUser{
+		Sub:   "12345",
+		Email: "test@example.com",
+	}
+	err := validUser.IsValid()
+	assert.NoError(t, err)
+
+	// Test invalid user - missing sub
+	invalidUser1 := &OpenIDUser{
+		Email: "test@example.com",
+	}
+	err = invalidUser1.IsValid()
+	assert.Error(t, err)
+
+	// Test invalid user - missing email
+	invalidUser2 := &OpenIDUser{
+		Sub: "12345",
+	}
+	err = invalidUser2.IsValid()
+	assert.Error(t, err)
+}
+
+func TestOpenIDUser_getAuthData(t *testing.T) {
+	user := &OpenIDUser{
+		Sub: "12345",
+	}
+	assert.Equal(t, "12345", user.getAuthData())
+} 

--- a/server/channels/app/oauthproviders/openid/openid_test.go
+++ b/server/channels/app/oauthproviders/openid/openid_test.go
@@ -14,75 +14,75 @@ import (
 
 func TestOpenIDProvider_GetUserFromJSON(t *testing.T) {
 	tests := []struct {
-		name           string
-		openIDUser     *OpenIDUser
+		name             string
+		openIDUser       *OpenIDUser
 		expectedUsername string
-		description    string
+		description      string
 	}{
 		{
 			name: "preferred_username_priority",
 			openIDUser: &OpenIDUser{
-				Sub:              "12345",
+				Sub:               "12345",
 				PreferredUsername: "john.doe",
-				Username:         "johndoe",
-				Nickname:         "johnny",
-				Email:            "john.doe@example.com",
-				Name:             "John Doe",
+				Username:          "johndoe",
+				Nickname:          "johnny",
+				Email:             "john.doe@example.com",
+				Name:              "John Doe",
 			},
 			expectedUsername: "john.doe",
-			description:     "Should prioritize preferred_username over other claims",
+			description:      "Should prioritize preferred_username over other claims",
 		},
 		{
 			name: "username_fallback",
 			openIDUser: &OpenIDUser{
-				Sub:              "12346",
+				Sub:               "12346",
 				PreferredUsername: "",
-				Username:         "johndoe",
-				Nickname:         "johnny",
-				Email:            "john.doe@example.com",
-				Name:             "John Doe",
+				Username:          "johndoe",
+				Nickname:          "johnny",
+				Email:             "john.doe@example.com",
+				Name:              "John Doe",
 			},
 			expectedUsername: "johndoe",
-			description:     "Should use username when preferred_username is empty",
+			description:      "Should use username when preferred_username is empty",
 		},
 		{
 			name: "nickname_fallback",
 			openIDUser: &OpenIDUser{
-				Sub:              "12347",
+				Sub:               "12347",
 				PreferredUsername: "",
-				Username:         "",
-				Nickname:         "johnny",
-				Email:            "john.doe@example.com",
-				Name:             "John Doe",
+				Username:          "",
+				Nickname:          "johnny",
+				Email:             "john.doe@example.com",
+				Name:              "John Doe",
 			},
 			expectedUsername: "johnny",
-			description:     "Should use nickname when preferred_username and username are empty",
+			description:      "Should use nickname when preferred_username and username are empty",
 		},
 		{
 			name: "email_local_part_fallback",
 			openIDUser: &OpenIDUser{
-				Sub:              "12348",
+				Sub:               "12348",
 				PreferredUsername: "",
-				Username:         "",
-				Nickname:         "",
-				Email:            "john.doe@example.com",
-				Name:             "John Doe",
+				Username:          "",
+				Nickname:          "",
+				Email:             "john.doe@example.com",
+				Name:              "John Doe",
 			},
 			expectedUsername: "john.doe",
-			description:     "Should use email local-part when all username claims are empty",
+			description:      "Should use email local-part when all username claims are empty",
 		},
 		{
 			name: "email_without_at_fallback",
 			openIDUser: &OpenIDUser{
-				Sub:              "12349",
+				Sub:               "12349",
 				PreferredUsername: "",
-				Username:         "",
-				Nickname:         "",
-				Email:            "johndoe",
-				Name:             "John Doe",
+				Username:          "",
+				Nickname:          "",
+				Email:             "johndoe",
+				Name:              "John Doe",
 			},
 			expectedUsername: "johndoe",
-			description:     "Should handle email without @ symbol",
+			description:      "Should handle email without @ symbol",
 		},
 	}
 
@@ -188,4 +188,4 @@ func TestOpenIDUser_getAuthData(t *testing.T) {
 		Sub: "12345",
 	}
 	assert.Equal(t, "12345", user.getAuthData())
-} 
+}


### PR DESCRIPTION
## Issue
Fixes [#33587](https://github.com/mattermost/mattermost/issues/33587)

## Problem
OpenID login is incorrectly using the email local-part for usernames, instead of using preferred OpenID claims.

## Solution
Implement proper OpenID Connect username priority by creating a new OpenID OAuth provider that prioritizes:
1. `preferred_username` (most preferred)
2. `username` 
3. `nickname`
4. Email local-part (fallback)

## Changes Made

### New Files Created
- `server/channels/app/oauthproviders/openid/openid.go` - Main OpenID provider implementation
- `server/channels/app/oauthproviders/openid/openid_test.go` - Comprehensive test suite

### Key Implementation Details

#### Username Priority Logic
```go
func userFromOpenIDUser(logger mlog.LoggerIFace, oidUser *OpenIDUser) *model.User {
    user := &model.User{}
    
    // Prioritize username claims according to OpenID Connect spec
    // 1. preferred_username (most preferred)
    // 2. username
    // 3. nickname
    // 4. email local-part (fallback)
    var username string
    if oidUser.PreferredUsername != "" {
        username = oidUser.PreferredUsername
    } else if oidUser.Username != "" {
        username = oidUser.Username
    } else if oidUser.Nickname != "" {
        username = oidUser.Nickname
    } else if oidUser.Email != "" {
        // Extract local-part from email as fallback
        emailParts := strings.Split(oidUser.Email, "@")
        if len(emailParts) > 0 {
            username = emailParts[0]
        }
    }
    
    user.Username = model.CleanUsername(logger, username)
    // ... rest of user setup
    return user
}
```

#### OpenID User Structure
```go
type OpenIDUser struct {
    Sub              string `json:"sub"`
    PreferredUsername string `json:"preferred_username"`
    Username         string `json:"username"`
    Nickname         string `json:"nickname"`
    Email            string `json:"email"`
    Name             string `json:"name"`
    GivenName        string `json:"given_name"`
    FamilyName       string `json:"family_name"`
}
```

## Testing

### Test Coverage
- ✅ Preferred username priority
- ✅ Username fallback
- ✅ Nickname fallback  
- ✅ Email local-part fallback
- ✅ Email without @ symbol handling
- ✅ Empty claims handling
- ✅ JSON parsing validation
- ✅ User validation logic

### Test Results
All tests pass successfully:
```bash
=== RUN   TestOpenIDProvider_GetUserFromJSON
    --- PASS: TestOpenIDProvider_GetUserFromJSON/preferred_username_priority
    --- PASS: TestOpenIDProvider_GetUserFromJSON/username_fallback
    --- PASS: TestOpenIDProvider_GetUserFromJSON/nickname_fallback
    --- PASS: TestOpenIDProvider_GetUserFromJSON/email_local_part_fallback
    --- PASS: TestOpenIDProvider_GetUserFromJSON/email_without_at_fallback
--- PASS: TestOpenIDProvider_GetUserFromJSON
=== RUN   TestOpenIDProvider_GetUserFromJSON_InvalidData
--- PASS: TestOpenIDProvider_GetUserFromJSON_InvalidData
=== RUN   TestOpenIDProvider_IsSameUser
--- PASS: TestOpenIDProvider_IsSameUser
=== RUN   TestOpenIDUser_IsValid
--- PASS: TestOpenIDUser_IsValid
=== RUN   TestOpenIDUser_getAuthData
--- PASS: TestOpenIDUser_getAuthData
PASS
```

## Expected Behavior

### Before Fix
- OpenID login always used email local-part for usernames
- Ignored OpenID Connect standard claims like `preferred_username`, `username`, and `nickname`

### After Fix
- OpenID login prioritizes OpenID claims in the correct order:
  1. **`preferred_username`** (most preferred)
  2. **`username`** 
  3. **`nickname`**
  4. **Email local-part** (fallback, as before)

## Compliance
This implementation follows the OpenID Connect specification for username claim priority.

## Breaking Changes
None. This is a backward-compatible fix that maintains the email local-part fallback.

## Checklist
- [x] Code follows Mattermost coding standards
- [x] Tests added for new functionality
- [x] All existing tests pass
- [x] Documentation updated
- [x] No breaking changes introduced
- [x] Follows OpenID Connect specification

## Related Issues
- Fixes [#33587](https://github.com/mattermost/mattermost/issues/33587)

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
