### PR TITLE
[MM-62991] Ensure extra content is also accounted for in the focus order

### DIFF
--- a/webapp/channels/src/components/setting_item_max.tsx
+++ b/webapp/channels/src/components/setting_item_max.tsx
@@ -216,6 +216,7 @@ export default class SettingItemMax extends React.PureComponent<Props> {
         return (
             <section
                 className={`section-max form-horizontal ${this.props.containerStyle}`}
+                ref={this.settingList}
             >
                 {title}
                 {this.props.extraContentBeforeSettingList}
@@ -227,7 +228,6 @@ export default class SettingItemMax extends React.PureComponent<Props> {
                 >
                     <div
                         tabIndex={-1}
-                        ref={this.settingList}
                         className='setting-list'
                     >
                         {listContent}


### PR DESCRIPTION
#### Summary
The auto focus code was not accounting for the `extraContentBeforeSettingList` section, which could contain focusable elements. This PR moves the ref so that we check the whole section for focusable elements.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62991

```release-note
Ensure extra content is also accounted for in the focus order
```
