### PR TITLE
MM-64987: Remove all prepackaged plugins

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -164,26 +164,8 @@ MMCTL_PACKAGES=$(shell $(GO) list ./... | grep -E 'server/v8/cmd/mmctl')
 
 TEMPLATES_DIR=templates
 
-# Plugins Packages
-PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.7.1
-PLUGIN_PACKAGES += mattermost-plugin-github-v2.3.0
-PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.9.1
-PLUGIN_PACKAGES += mattermost-plugin-jira-v4.2.1
-# We need to prepackage both versions of playbooks and install the correct one based on the server license. See MM-60025.
-PLUGIN_PACKAGES += mattermost-plugin-playbooks-v1.41.0
-PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.2.0
-PLUGIN_PACKAGES += mattermost-plugin-nps-v1.3.3
-PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.3.4
-PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.8.0
-PLUGIN_PACKAGES += mattermost-plugin-ai-v1.1.1
-PLUGIN_PACKAGES += mattermost-plugin-boards-v9.1.1
-PLUGIN_PACKAGES += mattermost-plugin-msteams-v2.2.1
-PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
-PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.3.4
-PLUGIN_PACKAGES += mattermost-plugin-msteams-meetings-v2.2.0
-PLUGIN_PACKAGES += mattermost-plugin-metrics-v0.6.0
-PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.2.1
+# Explicitly remove all prepackaged plugins
+undefine PLUGIN_PACKAGES
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)
 


### PR DESCRIPTION
#### Summary
Explicitly remove all prepackaged plugins by `undefine`ing the variable.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64987

#### Screenshots

#### Release Note
```release-note
NONE
```