### PR TITLE
feat(root_portal): migrate RootPortal to a function component

### DIFF
--- a/webapp/channels/src/components/root_portal.tsx
+++ b/webapp/channels/src/components/root_portal.tsx
@@ -1,38 +1,40 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
 import ReactDOM from 'react-dom';
 
 interface Props {
     children: React.ReactNode | React.ReactNodeArray;
 }
-export default class RootPortal extends React.PureComponent<Props> {
-    private el: HTMLDivElement;
 
-    constructor(props: Props) {
-        super(props);
-        this.el = document.createElement('div');
-    }
+const div = document.createElement('div');
 
-    componentDidMount() {
+const RootPortal = ({children}: Props) => {
+    const el = useRef<HTMLDivElement>(div);
+
+    useEffect(() => {
+        const element = el.current;
+
         const rootPortal = document.getElementById('root-portal');
-        if (rootPortal) {
-            rootPortal.appendChild(this.el);
-        }
-    }
 
-    componentWillUnmount() {
-        const rootPortal = document.getElementById('root-portal');
         if (rootPortal) {
-            rootPortal.removeChild(this.el);
+            rootPortal.appendChild(element);
         }
-    }
 
-    render() {
-        return ReactDOM.createPortal(
-            this.props.children,
-            this.el,
-        );
-    }
-}
+        return () => {
+            const rootPortal = document.getElementById('root-portal');
+
+            if (rootPortal) {
+                rootPortal.removeChild(element);
+            }
+        };
+    }, []);
+
+    return ReactDOM.createPortal(
+        children,
+        el.current,
+    );
+};
+
+export default React.memo(RootPortal);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This pull request migrates `RootPortal` from a class component to a function component.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
N/A

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
