### PR TITLE
[MM-63579] Missing status indicator in compact display mode

### DIFF
--- a/webapp/channels/src/components/post_profile_picture/post_profile_picture.tsx
+++ b/webapp/channels/src/components/post_profile_picture/post_profile_picture.tsx
@@ -100,7 +100,7 @@ export default class PostProfilePicture extends React.PureComponent<Props> {
 
         return (
             <ProfilePicture
-                size='md'
+                size={this.props.compactDisplay ? 'inherit' : 'md'}
                 src={src}
                 profileSrc={profileSrc}
                 isEmoji={isEmoji}

--- a/webapp/channels/src/components/profile_picture/index.tsx
+++ b/webapp/channels/src/components/profile_picture/index.tsx
@@ -53,8 +53,8 @@ function ProfilePicture(props: Props) {
                 triggerComponentAs='button'
                 triggerComponentStyle={{
                     borderRadius: '50%',
-                    width: `${getAvatarWidth(props?.size ?? 'md')}px`,
-                    height: `${getAvatarWidth(props?.size ?? 'md')}px`,
+                    width: getAvatarWidth(props?.size ?? 'md'),
+                    height: getAvatarWidth(props?.size ?? 'md'),
                 }}
             >
                 <>

--- a/webapp/channels/src/components/widgets/users/avatar/avatar.tsx
+++ b/webapp/channels/src/components/widgets/users/avatar/avatar.tsx
@@ -12,30 +12,30 @@ import BotDefaultIcon from 'images/bot_default_icon.png';
 
 import './avatar.scss';
 
-export type TAvatarSizeToken = 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xl-custom-GM' | 'xl-custom-DM' | 'xxl';
+export type TAvatarSizeToken = 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xl-custom-GM' | 'xl-custom-DM' | 'xxl' | 'inherit';
 
 export const getAvatarWidth = (size: TAvatarSizeToken) => {
     switch (size) {
     case 'xxs':
-        return 16;
+        return '16px';
     case 'xs':
-        return 20;
+        return '20px';
     case 'sm':
-        return 24;
+        return '24px';
     case 'md':
-        return 32;
+        return '32px';
     case 'lg':
-        return 36;
+        return '36px';
     case 'xl':
-        return 50;
+        return '50px';
     case 'xl-custom-GM':
-        return 72;
+        return '72px';
     case 'xl-custom-DM':
-        return 96;
+        return '96px';
     case 'xxl':
-        return 128;
+        return '128px';
     }
-    return 0;
+    return 'inherit';
 };
 
 type Props = {

--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -805,11 +805,9 @@
         }
 
         .status-wrapper {
-            height: 14px;
-
             .status {
                 position: relative;
-                top: -3px;
+                top: 1px;
                 right: auto;
                 bottom: auto;
                 left: -2px;

--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -749,10 +749,8 @@
 
         .post__img {
             width: 16px;
-            padding-top: 1px;
 
-            img,
-            button {
+            .profile-icon {
                 display: none;
             }
         }
@@ -811,7 +809,7 @@
 
             .status {
                 position: relative;
-                top: auto;
+                top: -3px;
                 right: auto;
                 bottom: auto;
                 left: -2px;


### PR DESCRIPTION
#### Summary
- Remove padding from status and adjust its position in compact mode

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63579


#### Screenshots

|  before  |  after  |
|----|----|
| <img width="1384" height="784" alt="CleanShot 2025-08-11 at 8  33 06@2x" src="https://github.com/user-attachments/assets/a68ae5ad-a306-4f32-a45e-c3ad1bfe3f5d" /> | <img width="1384" height="784" alt="CleanShot 2025-08-11 at 8  33 40@2x" src="https://github.com/user-attachments/assets/89fa6d20-9157-42a5-a99c-1468a3e6d7c3" /> |



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
