### PR TITLE
Ensures new CPA fields are created without DeleteAt set

### DIFF
--- a/server/channels/app/custom_profile_attributes.go
+++ b/server/channels/app/custom_profile_attributes.go
@@ -95,6 +95,7 @@ func (a *App) CreateCPAField(field *model.CPAField) (*model.PropertyField, *mode
 	}
 
 	field.GroupID = groupID
+	field.DeleteAt = 0
 
 	if appErr := field.SanitizeAndValidate(); appErr != nil {
 		return nil, appErr


### PR DESCRIPTION
#### Summary
This PR overwrites `DeleteAt` when creating a new CPA field. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62713

#### Release Note
```release-note
NONE
```