### PR TITLE
[MM-64959] Styling for 'Request acknowledgement' in the message input box is gone

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/priority_labels/priority_labels.scss
+++ b/webapp/channels/src/components/advanced_text_editor/priority_labels/priority_labels.scss
@@ -10,6 +10,15 @@
         }
     }
 
+    .priorityLabelsAcknowledgements {
+        display: flex;
+        align-items: center;
+        color: var(--online-indicator);
+        font-size: 11px;
+        font-weight: 600;
+        line-height: 16px;
+    }
+
     .priorityLabelsClose {
         display: flex;
         align-items: center;


### PR DESCRIPTION
#### Summary
Add styles for priority labels acknowledgements in the advanced text editor

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-64959


#### Screenshots

|  before  |  after  |
|----|----|
| <img width="1384" height="344" alt="CleanShot 2025-08-12 at 2  24 46@2x" src="https://github.com/user-attachments/assets/3eac125d-d2bc-4743-b8c9-313de08b20bc" /> | <img width="1384" height="344" alt="CleanShot 2025-08-12 at 2  24 03@2x" src="https://github.com/user-attachments/assets/ef83b161-7627-4adc-a2f0-591544cb2b2d" /> |




#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
