### PR TITLE
Fixes an authentication loop bug where users with a valid MMAUTHTOKEN cookie but missing/invalid MMCSRF

### DIFF
--- a/server/channels/web/handlers_test.go
+++ b/server/channels/web/handlers_test.go
@@ -667,8 +667,7 @@ func TestCheckCSRFToken(t *testing.T) {
 			},
 		}
 
-		w := httptest.NewRecorder()
-		checked, passed := h.checkCSRFToken(c, w, r, token, tokenLocation, session)
+		checked, passed := h.checkCSRFToken(c, r, tokenLocation, session)
 
 		assert.True(t, checked)
 		assert.True(t, passed)
@@ -699,12 +698,11 @@ func TestCheckCSRFToken(t *testing.T) {
 			},
 		}
 
-		w := httptest.NewRecorder()
-		checked, passed := h.checkCSRFToken(c, w, r, token, tokenLocation, session)
+		checked, passed := h.checkCSRFToken(c, r, tokenLocation, session)
 
 		assert.True(t, checked)
 		assert.False(t, passed)
-		assert.NotNil(t, c.Err)
+		assert.Nil(t, c.Err)
 	})
 
 	t.Run("should not allow a POST request without either header", func(t *testing.T) {
@@ -729,12 +727,11 @@ func TestCheckCSRFToken(t *testing.T) {
 			},
 		}
 
-		w := httptest.NewRecorder()
-		checked, passed := h.checkCSRFToken(c, w, r, token, tokenLocation, session)
+		checked, passed := h.checkCSRFToken(c, r, tokenLocation, session)
 
 		assert.True(t, checked)
 		assert.False(t, passed)
-		assert.NotNil(t, c.Err)
+		assert.Nil(t, c.Err)
 	})
 
 	t.Run("should not check GET requests", func(t *testing.T) {
@@ -759,8 +756,7 @@ func TestCheckCSRFToken(t *testing.T) {
 			},
 		}
 
-		w := httptest.NewRecorder()
-		checked, passed := h.checkCSRFToken(c, w, r, token, tokenLocation, session)
+		checked, passed := h.checkCSRFToken(c, r, tokenLocation, session)
 
 		assert.False(t, checked)
 		assert.False(t, passed)
@@ -789,8 +785,7 @@ func TestCheckCSRFToken(t *testing.T) {
 			},
 		}
 
-		w := httptest.NewRecorder()
-		checked, passed := h.checkCSRFToken(c, w, r, token, tokenLocation, session)
+		checked, passed := h.checkCSRFToken(c, r, tokenLocation, session)
 
 		assert.False(t, checked)
 		assert.False(t, passed)
@@ -815,8 +810,7 @@ func TestCheckCSRFToken(t *testing.T) {
 		r, _ := http.NewRequest(http.MethodPost, "", nil)
 		r.Header.Set(model.HeaderCsrfToken, token)
 
-		w := httptest.NewRecorder()
-		checked, passed := h.checkCSRFToken(c, w, r, token, tokenLocation, nil)
+		checked, passed := h.checkCSRFToken(c, r, tokenLocation, nil)
 
 		assert.False(t, checked)
 		assert.False(t, passed)
@@ -846,8 +840,7 @@ func TestCheckCSRFToken(t *testing.T) {
 			},
 		}
 
-		w := httptest.NewRecorder()
-		checked, passed := h.checkCSRFToken(c, w, r, token, tokenLocation, session)
+		checked, passed := h.checkCSRFToken(c, r, tokenLocation, session)
 
 		assert.True(t, checked)
 		assert.True(t, passed)


### PR DESCRIPTION
#### Summary
Fixes an authentication loop bug where users with a valid MMAUTHTOKEN cookie but a missing/invalid MMCSRF cookie get stuck in an unrecoverable login state. When CSRF validation fails, the server now properly clears the MMAUTHTOKEN cookie, allowing users to attempt login again with a clean authentication state.

#### Problem description
Users can become stuck in a state where they have a valid `MMAUTHTOKEN` cookie but no corresponding `MMCSRF` cookie. This might typically occur during:
- Account creation interruptions (browser cache, network issues)
- Manually deleting the cookies from the browser dev tool. etc.

In this state:
- User has `MMAUTHTOKEN` → triggers CSRF validation
- Missing/invalid `MMCSRF` → CSRF check fails with 401 Unauthorised
- Session gets invalidated, but `MMAUTHTOKEN` cookie persists
- Subsequent login attempts repeat this cycle indefinitely
- User cannot recover without manually clearing browser cookies

#### Solution
If the CSRF validation fails, clearing the `MMAUTHTOKEN` cookie by calling `c.RemoveSessionCookie(w, r)`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64984

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
