### PR TITLE
Introduce build-server-image-fips

### DIFF
--- a/.github/workflows/build-server-image.yml
+++ b/.github/workflows/build-server-image.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - server/build/Dockerfile.buildenv
+      - server/build/Dockerfile.buildenv-fips
       - .github/workflows/build-server-image.yml
 
 jobs:
@@ -34,3 +35,29 @@ jobs:
           push: true
           pull: true
           tags: mattermostdevelopment/mattermost-build-server:${{ steps.go.outputs.GO_VERSION }}
+
+  build-image-fips:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: buildenv/checkout-repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: buildenv/calculate-golang-version
+        working-directory: server/
+        id: go
+        run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
+
+      - name: buildenv/docker-login
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: buildenv/build-and-push
+        uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
+        with:
+          provenance: false
+          file: server/build/Dockerfile.buildenv-fips
+          push: true
+          pull: true
+          tags: mattermost/mattermost-build-server-fips:${{ steps.go.outputs.GO_VERSION }}

--- a/.github/workflows/dispatch-server-builder-image.yml
+++ b/.github/workflows/dispatch-server-builder-image.yml
@@ -5,10 +5,10 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Git branch or PR ref to build'
+        description: "Git branch or PR ref to build"
         required: true
       tag:
-        description: 'Docker image tag (e.g. v1.2.3 or latest)'
+        description: "Docker image tag (e.g. v1.2.3 or latest)"
         required: true
 
 jobs:
@@ -56,3 +56,32 @@ jobs:
             --tag mattermost/mattermost-build-server:"${IMAGE_TAG}" \
             --push \
             -f server/build/Dockerfile.buildenv .
+
+  build-and-push-fips:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Set up QEMU (optional, for multi-arch)
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca
+
+      - name: Login to DockerHub (production repo)
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build & push production image
+        run: |
+          docker buildx build \
+            --tag mattermost/mattermost-build-server-fips:${{ github.event.inputs.tag }} \
+            --push \
+            -f server/build/Dockerfile.buildenv-fips .

--- a/server/build/Dockerfile.buildenv-fips
+++ b/server/build/Dockerfile.buildenv-fips
@@ -1,0 +1,5 @@
+FROM cgr.dev/mattermost.com/go-msft-fips:1.24.5-dev@sha256:d7b2872c129277c01447903b7fde7a186fe211b59613172a7e40a3cc0dc5f126
+
+RUN apk add curl ca-certificates mailcap unrtf wv poppler-utils tzdata
+
+RUN git config --global --add safe.directory /mattermost


### PR DESCRIPTION
#### Summary
This is a variant of the existing [mattermost/mattermost-build-server](https://hub.docker.com/repository/docker/mattermost/mattermost-build-server) and [mattermostdevelopment/mattermost-build-server](https://hub.docker.com/repository/docker/mattermostdevelopment/mattermost-build-server/general) that starts from a Chainguard, install the requisite development packages, and publishes the resulting artifacts to a private DockerHub repository at mattermost/mattermost-build-server-fips.

We might come back and consolidate on a single, private repository for both images and just distinguish with `-fips` tags instead. Since both the existing repositories are public, this is a simple first step.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-65018

#### Release Note
```release-note
NONE
```
