### PR TITLE
MM-51230 Remove unused react-contextmenu dependency

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -9986,41 +9986,6 @@ SOFTWARE.
 
 ---
 
-## react-contextmenu
-
-This product contains 'react-contextmenu' by Vivek Kumar Bansal.
-
-Context Menu implemented in React
-
-* HOMEPAGE:
-  * https://github.com/vkbansal/react-contextmenu
-
-* LICENSE: MIT
-
-The MIT License (MIT)
-
-Copyright (c) 2015 Vivek Kumar Bansal
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
 ## react-custom-scrollbars
 
 This product contains 'react-custom-scrollbars' by Malte Wessel.

--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -64,7 +64,6 @@
     "react-beautiful-dnd": "13.1.1",
     "react-bootstrap": "github:mattermost/react-bootstrap#d821e2b1db1059bd36112d7587fd1b0912b27626",
     "react-color": "2.19.3",
-    "react-contextmenu": "2.14.0",
     "react-custom-scrollbars": "4.2.1",
     "react-day-picker": "8.3.6",
     "react-dom": "17.0.2",

--- a/webapp/channels/src/sass/layout/_markdown.scss
+++ b/webapp/channels/src/sass/layout/_markdown.scss
@@ -221,29 +221,6 @@ h6.markdown__heading {
     }
 }
 
-.post-code__context-menu {
-    &.react-contextmenu {
-        background-color: variables.$white;
-    }
-
-    .react-contextmenu-item {
-        .span {
-            display: inline-block;
-            padding: 3px 0;
-        }
-
-        &.react-contextmenu-item--divider {
-            border-top: 1px solid rgba(63, 67, 80, 0.16);
-            margin: 5px 15px;
-        }
-
-        &.react-contextmenu-item--divider:hover {
-            background: unset;
-            color: unset;
-        }
-    }
-}
-
 .post-code__overlay {
     position: absolute;
     z-index: 5;
@@ -419,7 +396,7 @@ blockquote {
     &:first-child {
         margin-top: 0;
     }
-    
+
     +p {
         margin-top: 6px;
 

--- a/webapp/channels/src/sass/layout/_sidebar-left.scss
+++ b/webapp/channels/src/sass/layout/_sidebar-left.scss
@@ -1308,32 +1308,6 @@ $sidebarOpacityAnimationDuration: 0.15s;
     }
 }
 
-/* context menu shown when right-clicking on a channel in the LHS when using the desktop app */
-.react-contextmenu--visible {
-    z-index: 100;
-    padding: 2px 0;
-    border: 1px solid #c6c6c6;
-    border-radius: 5px;
-    background: #f0f0f0;
-    color: black;
-    cursor: pointer;
-}
-
-.react-contextmenu-item {
-    padding: 0 22px;
-    margin: 1px 0;
-
-    &:hover {
-        background: #489dfe;
-        color: variables.$white;
-    }
-
-    &:focus,
-    span {
-        outline: none;
-    }
-}
-
 // global header style adjustments
 @media screen and (min-width: 769px) {
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -118,7 +118,6 @@
         "react-beautiful-dnd": "13.1.1",
         "react-bootstrap": "github:mattermost/react-bootstrap#d821e2b1db1059bd36112d7587fd1b0912b27626",
         "react-color": "2.19.3",
-        "react-contextmenu": "2.14.0",
         "react-custom-scrollbars": "4.2.1",
         "react-day-picker": "8.3.6",
         "react-dom": "17.0.2",
@@ -450,20 +449,6 @@
       },
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "channels/node_modules/react-contextmenu": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/react-contextmenu/-/react-contextmenu-2.14.0.tgz",
-      "integrity": "sha512-ktqMOuad6sCFNJs/ltEwppN8F0YeXmqoZfwycgtZR/MxOXMYx1xgYC44SzWH259HdGyshk1/7sXGuIRwj9hzbw==",
-      "dependencies": {
-        "classnames": "^2.2.5",
-        "object-assign": "^4.1.0"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.0.0",
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.1",
-        "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.1"
       }
     },
     "channels/node_modules/react-custom-scrollbars": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -80,10 +80,6 @@
       "react": "17.0.2",
       "react-dom": "17.0.2"
     },
-    "react-contextmenu": {
-      "react": "17.0.2",
-      "react-dom": "17.0.2"
-    },
     "react-custom-scrollbars": {
       "react": "17.0.2",
       "react-dom": "17.0.2"


### PR DESCRIPTION
#### Summary
This is one of the dependencies that would've needed to be updated to support React 18, but it turns out that it's not actually used as of https://github.com/mattermost/mattermost/pull/26856, so we can just remove it instead.

#### Ticket Link
MM-51230

#### Release Note
```release-note
NONE
```
