### PR TITLE
Use chainctl for fips build images

### DIFF
--- a/.github/workflows/build-server-image.yml
+++ b/.github/workflows/build-server-image.yml
@@ -9,6 +9,9 @@ on:
       - server/build/Dockerfile.buildenv-fips
       - .github/workflows/build-server-image.yml
 
+env:
+  CHAINCTL_IDENTITY: ee399b4c72dd4e58e3d617f78fc47b74733c9557/922f2d48307d6f5f
+
 jobs:
   build-image:
     runs-on: ubuntu-22.04
@@ -39,6 +42,9 @@ jobs:
   build-image-fips:
     runs-on: ubuntu-22.04
     steps:
+      - uses: chainguard-dev/setup-chainctl@f4ed65b781b048c44d4f033ae854c025c5531c19 # v0.3.2
+        with:
+          identity: ${{ env.CHAINCTL_IDENTITY }}
       - name: buildenv/checkout-repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/dispatch-server-builder-image.yml
+++ b/.github/workflows/dispatch-server-builder-image.yml
@@ -11,6 +11,9 @@ on:
         description: "Docker image tag (e.g. v1.2.3 or latest)"
         required: true
 
+env:
+  CHAINCTL_IDENTITY: ee399b4c72dd4e58e3d617f78fc47b74733c9557/922f2d48307d6f5f
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -61,6 +64,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: chainguard-dev/setup-chainctl@f4ed65b781b048c44d4f033ae854c025c5531c19 # v0.3.2
+        with:
+          identity: ${{ env.CHAINCTL_IDENTITY }}
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
         with:


### PR DESCRIPTION
#### Summary
We need to identify ourselves to Chainguard for pulling images during build steps. Note that the identity value is not a secret, at least in so far as we're already using it this way over at
https://github.com/mattermost/mattermost/pull/33549/files.

This should fix the build failure: 
<img width="2552" height="360" alt="CleanShot 2025-08-13 at 15 55 35@2x" src="https://github.com/user-attachments/assets/272b85bb-3bf4-4ce0-8d54-a04131d004c3" />

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-65018

#### Release Note
```release-note
NONE
```
