### PR TITLE
setup permissions for chainguard-dev/setup-chainctl

### DIFF
--- a/.github/workflows/build-server-image.yml
+++ b/.github/workflows/build-server-image.yml
@@ -12,6 +12,11 @@ on:
 env:
   CHAINCTL_IDENTITY: ee399b4c72dd4e58e3d617f78fc47b74733c9557/922f2d48307d6f5f
 
+# Permissions required for chainguard-dev/setup-chainctl
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-image:
     runs-on: ubuntu-22.04

--- a/.github/workflows/dispatch-server-builder-image.yml
+++ b/.github/workflows/dispatch-server-builder-image.yml
@@ -14,6 +14,11 @@ on:
 env:
   CHAINCTL_IDENTITY: ee399b4c72dd4e58e3d617f78fc47b74733c9557/922f2d48307d6f5f
 
+# Permissions required for chainguard-dev/setup-chainctl
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Summary
Setting `id-token: write` allows the workflow to request and use a JSON Web Token (JWT) from GitHub's OIDC provider. This JWT can then be exchanged with an external service -- in this case, ChainGuard -- to obtain short-lived credentials for authenticating and performing actions on that service.

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-65018

#### Release Note
```release-note
NONE
```
