### PR TITLE
consolidate go version computation

### DIFF
--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -31,15 +31,6 @@ jobs:
         run: |
           echo "${{ inputs.name }}" > server/test-name
           echo "${{ github.event.pull_request.number }}" > server/pr-number
-      - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: ${{ inputs.go-version }}
-          cache-dependency-path: server/go.sum
-      - name: Run setup-go-work
-        run: |
-          cd server
-          make setup-go-work
       - name: Setup needed prepackaged plugins
         run: |
           cd server

--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -14,6 +14,9 @@ on:
       logsartifact:
         required: true
         type: string
+      go-version:
+        required: true
+        type: string
 
 jobs:
   test:
@@ -24,10 +27,6 @@ jobs:
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Calculate Golang Version
-        id: go
-        working-directory: ./server
-        run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
       - name: Store required variables for publishing results
         run: |
           echo "${{ inputs.name }}" > server/test-name
@@ -35,7 +34,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ steps.go.outputs.GO_VERSION }}
+          go-version: ${{ inputs.go-version }}
           cache-dependency-path: server/go.sum
       - name: Run setup-go-work
         run: |
@@ -56,7 +55,7 @@ jobs:
           docker compose --ansi never ps
       - name: Run mmctl Tests
         env:
-          BUILD_IMAGE: mattermostdevelopment/mattermost-build-server:${{ steps.go.outputs.GO_VERSION }}
+          BUILD_IMAGE: mattermostdevelopment/mattermost-build-server:${{ inputs.go-version }}
         run: |
           if [[ ${{ github.ref_name }} == 'master' ]]; then
             export TESTFLAGS="-timeout 90m -race"

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -17,22 +17,32 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  go:
+    name: Compute Go Version
+    runs-on: ubuntu-22.04
+    outputs:
+      version: ${{ steps.calculate.outputs.GO_VERSION }}
+    steps:
+      - name: Checkout mattermost project
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Calculate version
+        id: calculate
+        working-directory: server/
+        run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
   check-mocks:
     name: Check mocks
     runs-on: ubuntu-22.04
+    needs: go
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Calculate Golang Version
-        id: go
-        run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ steps.go.outputs.GO_VERSION }}
+          go-version: ${{ needs.go.outputs.version }}
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
@@ -45,19 +55,17 @@ jobs:
   check-go-mod-tidy:
     name: Check go mod tidy
     runs-on: ubuntu-22.04
+    needs: go
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Calculate Golang Version
-        id: go
-        run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ steps.go.outputs.GO_VERSION }}
+          go-version: ${{ needs.go.outputs.version }}
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
@@ -70,19 +78,17 @@ jobs:
   golangci:
     name: golangci-lint
     runs-on: ubuntu-22.04
+    needs: go
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Calculate Golang Version
-        id: go
-        run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ steps.go.outputs.GO_VERSION }}
+          go-version: ${{ needs.go.outputs.version }}
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
@@ -93,19 +99,17 @@ jobs:
   check-gen-serialized:
     name: Check serialization methods for hot structs
     runs-on: ubuntu-22.04
+    needs: go
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Calculate Golang Version
-        id: go
-        run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ steps.go.outputs.GO_VERSION }}
+          go-version: ${{ needs.go.outputs.version }}
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
@@ -118,19 +122,17 @@ jobs:
   check-mattermost-vet:
     name: Check style
     runs-on: ubuntu-22.04
+    needs: go
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Calculate Golang Version
-        id: go
-        run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ steps.go.outputs.GO_VERSION }}
+          go-version: ${{ needs.go.outputs.version }}
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
@@ -145,19 +147,17 @@ jobs:
   check-mattermost-vet-api:
     name: Vet API
     runs-on: ubuntu-22.04
+    needs: go
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Calculate Golang Version
-        id: go
-        run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ steps.go.outputs.GO_VERSION }}
+          go-version: ${{ needs.go.outputs.version }}
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
@@ -168,6 +168,7 @@ jobs:
   check-migrations:
     name: Check migration files
     runs-on: ubuntu-22.04
+    needs: go
     defaults:
       run:
         working-directory: server
@@ -181,6 +182,7 @@ jobs:
   check-email-templates:
     name: Generate email templates
     runs-on: ubuntu-22.04
+    needs: go
     defaults:
       run:
         working-directory: server
@@ -196,19 +198,17 @@ jobs:
   check-store-layers:
     name: Check store layers
     runs-on: ubuntu-22.04
+    needs: go
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Calculate Golang Version
-        id: go
-        run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ steps.go.outputs.GO_VERSION }}
+          go-version: ${{ needs.go.outputs.version }}
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
@@ -221,19 +221,17 @@ jobs:
   check-mmctl-docs:
     name: Check mmctl docs
     runs-on: ubuntu-22.04
+    needs: go
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout mattermost-server
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Calculate Golang Version
-        id: go
-        run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ steps.go.outputs.GO_VERSION }}
+          go-version: ${{ needs.go.outputs.version }}
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum
@@ -247,7 +245,9 @@ jobs:
   test-postgres-binary:
     if: github.ref_name != 'master' # Do not run postgres binary tests on master
     name: Postgres with binary parameters
-    needs: check-mattermost-vet
+    needs:
+      - go
+      - check-mattermost-vet
     uses: ./.github/workflows/server-test-template.yml
     secrets: inherit
     with:
@@ -255,9 +255,12 @@ jobs:
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10&binary_parameters=yes
       drivername: postgres
       logsartifact: postgres-binary-server-test-logs
+      go-version: ${{ needs.go.outputs.version }}
   test-postgres-normal:
     name: Postgres
-    needs: check-mattermost-vet
+    needs:
+      - go
+      - check-mattermost-vet
     uses: ./.github/workflows/server-test-template.yml
     secrets: inherit
     with:
@@ -265,11 +268,14 @@ jobs:
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
       drivername: postgres
       logsartifact: postgres-server-test-logs
+      go-version: ${{ needs.go.outputs.version }}
   test-coverage:
     # Skip coverage generation for cherry-pick PRs into release branches.
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.event.pull_request.base.ref, 'release-') }}
     name: Generate Test Coverage
-    needs: check-mattermost-vet
+    needs:
+      - go
+      - check-mattermost-vet
     uses: ./.github/workflows/server-test-template.yml
     secrets: inherit
     with:
@@ -279,9 +285,12 @@ jobs:
       logsartifact: coverage-server-test-logs
       fullyparallel: true
       enablecoverage: true
+      go-version: ${{ needs.go.outputs.version }}
   test-mmctl:
     name: Run mmctl tests
-    needs: check-mattermost-vet
+    needs:
+      - check-mattermost-vet
+      - go
     uses: ./.github/workflows/mmctl-test-template.yml
     secrets: inherit
     with:
@@ -289,23 +298,23 @@ jobs:
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
       drivername: postgres
       logsartifact: mmctl-test-logs
+      go-version: ${{ needs.go.outputs.version }}
   build-mattermost-server:
     name: Build mattermost server app
     runs-on: ubuntu-22.04
+    needs:
+      - go
+      - check-mattermost-vet
     defaults:
       run:
         working-directory: server
-    needs: check-mattermost-vet
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Calculate Golang Version
-        id: go
-        run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ steps.go.outputs.GO_VERSION }}
+          go-version: ${{ needs.go.outputs.version }}
           cache-dependency-path: |
             server/go.sum
             server/public/go.sum

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -159,7 +159,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Generate email templates
         run: |
-          sudo npm install -g mjml@4.9.0
+          npm install -g mjml@4.9.0
           make build-templates
       - name: Check generated email templates
         run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the email templates using `make build-templates`"; exit 1; fi

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -199,7 +199,7 @@ jobs:
           make mmctl-docs
           if [[ -n $(git status --porcelain) ]]; then echo "Please update the mmctl docs using make mmctl-docs"; exit 1; fi
   test-postgres-binary:
-    if: github.ref_name != 'master' # Do not run postgres binary tests on master
+    if: github.event_name == 'push' # Only run postgres binary tests on master/release pushes: odds are low this regresses, so save the cycles for pull requests.
     name: Postgres with binary parameters
     needs:
       - go

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -71,6 +71,8 @@ jobs:
     defaults:
       run:
         working-directory: server
+    env:
+      GOFLAGS: -buildvcs=false # TODO: work around "error obtaining VCS status: exit status 128" in a container
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -263,6 +265,8 @@ jobs:
     defaults:
       run:
         working-directory: server
+    env:
+      GOFLAGS: -buildvcs=false # TODO: work around "error obtaining VCS status: exit status 128" in a container
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -31,21 +31,15 @@ jobs:
         run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
   check-mocks:
     name: Check mocks
-    runs-on: ubuntu-22.04
     needs: go
+    runs-on: ubuntu-22.04
+    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: ${{ needs.go.outputs.version }}
-          cache-dependency-path: |
-            server/go.sum
-            server/public/go.sum
       - name: Run setup-go-work
         run: make setup-go-work
       - name: Generate mocks
@@ -54,21 +48,15 @@ jobs:
         run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the mocks using `make mocks`"; exit 1; fi
   check-go-mod-tidy:
     name: Check go mod tidy
-    runs-on: ubuntu-22.04
     needs: go
+    runs-on: ubuntu-22.04
+    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: ${{ needs.go.outputs.version }}
-          cache-dependency-path: |
-            server/go.sum
-            server/public/go.sum
       - name: Run setup-go-work
         run: make setup-go-work
       - name: Run go mod tidy
@@ -77,42 +65,30 @@ jobs:
         run: if [[ -n $(git status --porcelain) ]]; then echo "Please tidy up the Go modules using make modules-tidy"; git diff; exit 1; fi
   golangci:
     name: golangci-lint
-    runs-on: ubuntu-22.04
     needs: go
+    runs-on: ubuntu-22.04
+    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: ${{ needs.go.outputs.version }}
-          cache-dependency-path: |
-            server/go.sum
-            server/public/go.sum
       - name: Run setup-go-work
         run: make setup-go-work
       - name: Run golangci
         run: make golangci-lint
   check-gen-serialized:
     name: Check serialization methods for hot structs
-    runs-on: ubuntu-22.04
     needs: go
+    runs-on: ubuntu-22.04
+    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: ${{ needs.go.outputs.version }}
-          cache-dependency-path: |
-            server/go.sum
-            server/public/go.sum
       - name: Run setup-go-work
         run: make setup-go-work
       - name: Run make-gen-serialized
@@ -121,21 +97,15 @@ jobs:
         run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the serialized files using 'make gen-serialized'"; exit 1; fi
   check-mattermost-vet:
     name: Check style
-    runs-on: ubuntu-22.04
     needs: go
+    runs-on: ubuntu-22.04
+    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: ${{ needs.go.outputs.version }}
-          cache-dependency-path: |
-            server/go.sum
-            server/public/go.sum
       - name: Run setup-go-work
         run: make setup-go-work
       - name: Reset config
@@ -146,29 +116,24 @@ jobs:
         run: make vet BUILD_NUMBER='${GITHUB_HEAD_REF}'
   check-mattermost-vet-api:
     name: Vet API
-    runs-on: ubuntu-22.04
     needs: go
+    runs-on: ubuntu-22.04
+    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: ${{ needs.go.outputs.version }}
-          cache-dependency-path: |
-            server/go.sum
-            server/public/go.sum
       - name: Run setup-go-work
         run: make setup-go-work
       - name: Run mattermost-vet-api
         run: make vet-api
   check-migrations:
     name: Check migration files
-    runs-on: ubuntu-22.04
     needs: go
+    runs-on: ubuntu-22.04
+    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
@@ -181,8 +146,9 @@ jobs:
         run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the migrations using make migrations-extract"; exit 1; fi
   check-email-templates:
     name: Generate email templates
-    runs-on: ubuntu-22.04
     needs: go
+    runs-on: ubuntu-22.04
+    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
@@ -197,21 +163,15 @@ jobs:
         run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the email templates using `make build-templates`"; exit 1; fi
   check-store-layers:
     name: Check store layers
-    runs-on: ubuntu-22.04
     needs: go
+    runs-on: ubuntu-22.04
+    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: ${{ needs.go.outputs.version }}
-          cache-dependency-path: |
-            server/go.sum
-            server/public/go.sum
       - name: Run setup-go-work
         run: make setup-go-work
       - name: Generate store layers
@@ -220,21 +180,15 @@ jobs:
         run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the store layers using make store-layers"; exit 1; fi
   check-mmctl-docs:
     name: Check mmctl docs
-    runs-on: ubuntu-22.04
     needs: go
+    runs-on: ubuntu-22.04
+    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout mattermost-server
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: ${{ needs.go.outputs.version }}
-          cache-dependency-path: |
-            server/go.sum
-            server/public/go.sum
       - name: Run setup-go-work
         run: make setup-go-work
       - name: Check docs
@@ -301,23 +255,17 @@ jobs:
       go-version: ${{ needs.go.outputs.version }}
   build-mattermost-server:
     name: Build mattermost server app
-    runs-on: ubuntu-22.04
     needs:
       - go
       - check-mattermost-vet
+    runs-on: ubuntu-22.04
+    container: mattermostdevelopment/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: ${{ needs.go.outputs.version }}
-          cache-dependency-path: |
-            server/go.sum
-            server/public/go.sum
       - name: ci/setup-node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         id: setup_node

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -22,6 +22,9 @@ on:
         required: false
         type: boolean
         default: false
+      go-version:
+        required: true
+        type: string
 
 jobs:
   test:
@@ -33,14 +36,10 @@ jobs:
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Calculate Golang Version
-        id: go
-        working-directory: ./server
-        run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ steps.go.outputs.GO_VERSION }}
+          go-version: ${{ inputs.go-version }}
           cache-dependency-path: server/go.sum
       - name: Store required variables for publishing results
         run: |
@@ -57,7 +56,7 @@ jobs:
           docker compose --ansi never ps
       - name: Run Tests
         env:
-          BUILD_IMAGE: mattermostdevelopment/mattermost-build-server:${{ steps.go.outputs.GO_VERSION }}
+          BUILD_IMAGE: mattermostdevelopment/mattermost-build-server:${{ inputs.go-version }}
         run: |
           if [[ ${{ github.ref_name }} == 'master' && ${{ inputs.fullyparallel }} != true ]]; then
             export RACE_MODE="-race"

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -36,11 +36,6 @@ jobs:
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: ${{ inputs.go-version }}
-          cache-dependency-path: server/go.sum
       - name: Store required variables for publishing results
         run: |
           echo "${{ inputs.name }}" > server/test-name

--- a/server/Makefile
+++ b/server/Makefile
@@ -521,28 +521,28 @@ inject-test-data: # add test data to the local instance.
 test-mmctl-unit: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)
 test-mmctl-unit: export GOTESTSUM_JUNITFILE := $(GOTESTSUM_JUNITFILE)
 test-mmctl-unit: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
-test-mmctl-unit: gotestsum
+test-mmctl-unit: check-prereqs-enterprise gotestsum
 	@echo Running mmctl unit tests
 	$(GOBIN)/gotestsum --packages="$(MMCTL_PACKAGES)" -- -tags 'unit $(MMCTL_BUILD_TAGS)' $(MMCTL_TESTFLAGS)
 
 test-mmctl-e2e: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)
 test-mmctl-e2e: export GOTESTSUM_JUNITFILE := $(GOTESTSUM_JUNITFILE)
 test-mmctl-e2e: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
-test-mmctl-e2e: gotestsum start-docker
+test-mmctl-e2e: check-prereqs-enterprise gotestsum start-docker
 	@echo Running mmctl e2e tests
 	$(GOBIN)/gotestsum --packages="$(MMCTL_PACKAGES)" -- -tags 'e2e $(MMCTL_BUILD_TAGS)' $(MMCTL_TESTFLAGS)
 
 test-mmctl: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)
 test-mmctl: export GOTESTSUM_JUNITFILE := $(GOTESTSUM_JUNITFILE)
 test-mmctl: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
-test-mmctl: gotestsum start-docker
+test-mmctl: check-prereqs-enterprise gotestsum start-docker
 	@echo Running all mmctl tests
 	$(GOBIN)/gotestsum --packages="$(MMCTL_PACKAGES)" -- -tags 'unit e2e $(MMCTL_BUILD_TAGS)' $(MMCTL_TESTFLAGS)
 
 test-mmctl-coverage: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)
 test-mmctl-coverage: export GOTESTSUM_JUNITFILE := $(GOTESTSUM_JUNITFILE)
 test-mmctl-coverage: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
-test-mmctl-coverage: gotestsum start-docker
+test-mmctl-coverage: check-prereqs-enterprise gotestsum start-docker
 	@echo Running all mmctl tests with coverage
 	$(GOBIN)/gotestsum --packages="$(MMCTL_PACKAGES)" -- -tags 'unit e2e $(MMCTL_BUILD_TAGS)' -coverprofile=mmctlcover.out $(MMCTL_TESTFLAGS)
 	$(GO) tool cover -html=mmctlcover.out

--- a/server/Makefile
+++ b/server/Makefile
@@ -705,7 +705,7 @@ config-openid: ## Configures OpenID.
 config-reset: ## Resets the config/config.json file to the default production values.
 	@echo Resetting configuration to production default
 	rm -f config/config.json
-	OUTPUT_CONFIG=$(PWD)/config/config.json $(GO) $(GOFLAGS) run -tags production ./scripts/config_generator
+	OUTPUT_CONFIG=$(PWD)/config/config.json $(GO) run $(GOFLAGS) -tags production ./scripts/config_generator
 
 diff-config: ## Compares default configuration between two mattermost versions
 	@./scripts/diff-config.sh


### PR DESCRIPTION
#### Summary
Consistently use the mattermost-build-server image instead of sometimes building on ubuntu. This unlocks the next change in which we can switch to using the FIPS container image seamlessly.

Broken down into detailed commits for your reviewing ease!
- [`7d84996`](https://github.com/mattermost/mattermost/pull/33679/commits/7d84996) - compute the Go version more centrally
- [`17a3481`](https://github.com/mattermost/mattermost/pull/33679/commits/17a3481) - use the mattermost-build-server instead of setting up Go manually
- [`9c92ada`](https://github.com/mattermost/mattermost/pull/33679/commits/9c92ada) - work around "error obtaining VCS status: exit status 128" in a container"
- [`98c516d`](https://github.com/mattermost/mattermost/pull/33679/commits/98c516d) - no longer require sudo since now installing in a container
- [`48888ff`](https://github.com/mattermost/mattermost/pull/33679/commits/48888ff) - GOFLAGS for `make config-reset` was broken (out of order)
- [`1f01bed`](https://github.com/mattermost/mattermost/pull/33679/commits/1f01bed) - only test-postgres-binary on master/release
- [`00f3f0a`](https://github.com/mattermost/mattermost/pull/33679/commits/00f3f0a86b117416fe4740c6a068fced33f5c878) - fix a `go.work` dependency check in the `test-mmctl*` commands

Note that [`1f01bed`](https://github.com/mattermost/mattermost/pull/33679/commits/1f01bed) is somewhat unrelated, but I took the opportunity to remove a step from PRs (which run far more often) and lift this check to non-pull requests (aka `master` and `release` branches). If this regresses, we'll still catch it, but we'll save a lot of time in interating.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-65021

#### Release Note
```release-note
NONE
```