### PR TITLE
Remove leftover mysql apt-key

### DIFF
--- a/server/build/docker-preview/Dockerfile
+++ b/server/build/docker-preview/Dockerfile
@@ -2,7 +2,6 @@
 # See License.txt for license information.
 FROM postgres:13
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
 RUN apt-get update && apt-get install -y ca-certificates
 
 ARG MATTERMOST_VERSION


### PR DESCRIPTION
#### Summary
Removed the key which was originally intended for MySQL but missed to remove upon switching to Postgres.

#### Ticket Link
None, see failed job at https://github.com/mattermost/delivery-platform/actions/runs/16929012677/job/47970305769

#### Screenshots
Tested and passed

<img width="981" height="649" alt="Screenshot 2025-08-14 at 1 20 21 PM" src="https://github.com/user-attachments/assets/ac6b41ea-1cc7-48bb-9109-f4369bd2e983" />
<img width="607" height="597" alt="Screenshot 2025-08-14 at 1 20 35 PM" src="https://github.com/user-attachments/assets/ebedef62-fc81-49ca-b0a7-ea2646db4914" />


#### Release Note
```release-note
NONE
```