### PR TITLE
Disable retries for Cypress interactive mode

### DIFF
--- a/e2e-tests/cypress/cypress.config.ts
+++ b/e2e-tests/cypress/cypress.config.ts
@@ -9,7 +9,14 @@ export default defineConfig({
     downloadsFolder: 'tests/downloads',
     fixturesFolder: 'tests/fixtures',
     numTestsKeptInMemory: 0,
-    retries: 2,
+    retries: {
+
+        // 2 retrues for cypress:run
+        runMode: 2,
+
+        // No retries for cypress:open
+        openMode: 0,
+    },
     screenshotsFolder: 'tests/screenshots',
     taskTimeout: 60000,
     video: true,


### PR DESCRIPTION
#### Summary
Configures Cypress to disable test retries when running in interactive mode (`cypress:open`) while keeping retries enabled for headless mode (`cypress:run`). This improves the development experience by allowing developers to see test failures immediately without automatic retries when debugging locally.

#### Release Note
```release-note
NONE
```