### PR TITLE
MM-65074 - channel admin save policy flow

### DIFF
--- a/webapp/channels/src/components/admin_console/access_control/policy_details/__snapshots__/policy_details.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/access_control/policy_details/__snapshots__/policy_details.test.tsx.snap
@@ -98,7 +98,9 @@ exports[`components/admin_console/access_control/policy_details/PolicyDetails sh
             actions={
               Object {
                 "getAccessControlFields": [MockFunction],
+                "getChannelPolicy": [MockFunction],
                 "getVisualAST": [MockFunction],
+                "saveChannelPolicy": [MockFunction],
                 "searchUsers": [MockFunction],
               }
             }
@@ -304,7 +306,9 @@ exports[`components/admin_console/access_control/policy_details/PolicyDetails sh
             actions={
               Object {
                 "getAccessControlFields": [MockFunction],
+                "getChannelPolicy": [MockFunction],
                 "getVisualAST": [MockFunction],
+                "saveChannelPolicy": [MockFunction],
                 "searchUsers": [MockFunction],
               }
             }

--- a/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.test.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.test.tsx
@@ -88,6 +88,8 @@ describe('components/admin_console/access_control/policy_details/PolicyDetails',
             getAccessControlFields: mockGetAccessControlFields,
             getVisualAST: mockGetVisualAST,
             searchUsers: jest.fn(),
+            getChannelPolicy: jest.fn(),
+            saveChannelPolicy: jest.fn(),
         });
 
         mockCreatePolicy.mockReset();

--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_access_rules_tab.test.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_access_rules_tab.test.tsx
@@ -57,6 +57,8 @@ describe('components/channel_settings_modal/ChannelSettingsAccessRulesTab', () =
         getAccessControlFields: jest.fn(),
         getVisualAST: jest.fn(),
         searchUsers: jest.fn(),
+        getChannelPolicy: jest.fn(),
+        saveChannelPolicy: jest.fn(),
     };
 
     const mockUserAttributes: UserPropertyField[] = [
@@ -134,6 +136,12 @@ describe('components/channel_settings_modal/ChannelSettingsAccessRulesTab', () =
         mockActions.getAccessControlFields.mockResolvedValue({
             data: mockUserAttributes,
         });
+
+        // Mock getChannelPolicy to reject (no existing policy)
+        mockActions.getChannelPolicy.mockRejectedValue(new Error('Policy not found'));
+
+        // Mock saveChannelPolicy to resolve successfully
+        mockActions.saveChannelPolicy.mockResolvedValue({data: {success: true}});
 
         // Suppress console methods for tests
         jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -430,15 +438,24 @@ describe('components/channel_settings_modal/ChannelSettingsAccessRulesTab', () =
                 initialState,
             );
 
+            // Wait for initial loading to complete
+            await waitFor(() => {
+                expect(screen.getByTestId('table-editor')).toBeInTheDocument();
+            });
+
             const checkbox = screen.getByRole('checkbox');
             expect(checkbox).not.toBeChecked();
 
             await userEvent.click(checkbox);
-            expect(checkbox).toBeChecked();
+            await waitFor(() => {
+                expect(checkbox).toBeChecked();
+            });
             expect(console.log).toHaveBeenCalledWith('Auto-sync members toggled:', true);
 
             await userEvent.click(checkbox);
-            expect(checkbox).not.toBeChecked();
+            await waitFor(() => {
+                expect(checkbox).not.toBeChecked();
+            });
             expect(console.log).toHaveBeenCalledWith('Auto-sync members toggled:', false);
         });
 
@@ -503,6 +520,11 @@ describe('components/channel_settings_modal/ChannelSettingsAccessRulesTab', () =
                 <ChannelSettingsAccessRulesTab {...baseProps}/>,
                 initialState,
             );
+
+            // Wait for initial loading to complete
+            await waitFor(() => {
+                expect(screen.getByTestId('table-editor')).toBeInTheDocument();
+            });
 
             const checkbox = screen.getByRole('checkbox');
             await userEvent.click(checkbox);
@@ -624,6 +646,11 @@ describe('components/channel_settings_modal/ChannelSettingsAccessRulesTab', () =
                 initialState,
             );
 
+            // Wait for initial loading to complete
+            await waitFor(() => {
+                expect(screen.getByTestId('table-editor')).toBeInTheDocument();
+            });
+
             // Toggle auto-sync to show panel
             const checkbox = screen.getByRole('checkbox');
             await userEvent.click(checkbox);
@@ -640,6 +667,11 @@ describe('components/channel_settings_modal/ChannelSettingsAccessRulesTab', () =
                 <ChannelSettingsAccessRulesTab {...baseProps}/>,
                 initialState,
             );
+
+            // Wait for initial loading to complete
+            await waitFor(() => {
+                expect(screen.getByTestId('table-editor')).toBeInTheDocument();
+            });
 
             // Toggle auto-sync to show panel
             const checkbox = screen.getByRole('checkbox');
@@ -667,6 +699,11 @@ describe('components/channel_settings_modal/ChannelSettingsAccessRulesTab', () =
                 <ChannelSettingsAccessRulesTab {...baseProps}/>,
                 initialState,
             );
+
+            // Wait for initial loading to complete
+            await waitFor(() => {
+                expect(screen.getByTestId('table-editor')).toBeInTheDocument();
+            });
 
             // Toggle auto-sync to show panel
             const checkbox = screen.getByRole('checkbox');

--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_access_rules_tab.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_access_rules_tab.tsx
@@ -128,6 +128,7 @@ function ChannelSettingsAccessRulesTab({
     const handleAutoSyncToggle = useCallback(() => {
         setAutoSyncMembers((prev) => {
             const newValue = !prev;
+
             // Log the toggle state
             // eslint-disable-next-line no-console
             console.log('Auto-sync members toggled:', newValue);
@@ -176,7 +177,7 @@ function ChannelSettingsAccessRulesTab({
             setOriginalAutoSyncMembers(autoSyncMembers);
 
             // Show success alert for testing purposes
-            window.alert(
+            window.alert( // eslint-disable-line no-alert
                 `Access rules saved!\nExpression: ${expression}\nAuto-sync: ${autoSyncMembers ? 'Enabled' : 'Disabled'}`,
             );
 

--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_access_rules_tab.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_access_rules_tab.tsx
@@ -73,18 +73,32 @@ function ChannelSettingsAccessRulesTab({
         loadAttributes();
     }, [actions]);
 
-    // Load existing channel access rules (placeholder for now)
+    // Load existing channel access rules
     useEffect(() => {
-        // TODO: Load existing channel access rules from the backend
-        // For now, we'll just set empty values
-        const existingExpression = ''; // This would come from the channel's existing policy
-        const existingAutoSync = false; // This would come from the channel's existing policy
+        const loadChannelPolicy = async () => {
+            try {
+                const result = await actions.getChannelPolicy(channel.id);
+                if (result.data) {
+                    // Extract expression from the policy rules
+                    const existingExpression = result.data.rules?.[0]?.expression || '';
+                    const existingAutoSync = result.data.active || false;
 
-        setExpression(existingExpression);
-        setOriginalExpression(existingExpression);
-        setAutoSyncMembers(existingAutoSync);
-        setOriginalAutoSyncMembers(existingAutoSync);
-    }, [channel]);
+                    setExpression(existingExpression);
+                    setOriginalExpression(existingExpression);
+                    setAutoSyncMembers(existingAutoSync);
+                    setOriginalAutoSyncMembers(existingAutoSync);
+                }
+            } catch (error) {
+                // If no policy exists (404), that's fine - use defaults
+                setExpression('');
+                setOriginalExpression('');
+                setAutoSyncMembers(false);
+                setOriginalAutoSyncMembers(false);
+            }
+        };
+
+        loadChannelPolicy();
+    }, [channel.id, actions]);
 
     // Update parent component when changes occur
     useEffect(() => {
@@ -112,18 +126,19 @@ function ChannelSettingsAccessRulesTab({
     }, [formatMessage]);
 
     const handleAutoSyncToggle = useCallback(() => {
-        const newValue = !autoSyncMembers;
-        setAutoSyncMembers(newValue);
-
-        // Placeholder: Log the toggle state
-        // eslint-disable-next-line no-console
-        console.log('Auto-sync members toggled:', newValue);
-    }, [autoSyncMembers]);
+        setAutoSyncMembers((prev) => {
+            const newValue = !prev;
+            // Log the toggle state
+            // eslint-disable-next-line no-console
+            console.log('Auto-sync members toggled:', newValue);
+            return newValue;
+        });
+    }, []);
 
     // Handle save action
     const handleSave = useCallback(async (): Promise<boolean> => {
         try {
-            // Placeholder: Log the data that would be saved
+            // Log the save action for testing purposes
             // eslint-disable-next-line no-console
             console.log('Saving channel access rules:', {
                 channelId: channel.id,
@@ -131,16 +146,39 @@ function ChannelSettingsAccessRulesTab({
                 autoSyncMembers,
             });
 
-            // TODO: Implement actual save logic here
-            // This would call the backend API to save the access rules
+            // Build the policy object
+            const policy = {
+                id: channel.id,
+                name: channel.display_name,
+                type: 'channel',
+                version: 'v0.2',
+                active: autoSyncMembers,
+                revision: 1,
+                created_at: Date.now(),
+                rules: expression ? [{
+                    actions: ['*'],
+                    expression,
+                }] : [],
+                imports: systemPolicies.map((p) => p.id), // Include existing parent policies
+                props: {
+                    auto_sync: [autoSyncMembers], // Props expects arrays
+                },
+            };
 
-            // Simulate successful save
+            // Save the policy
+            const result = await actions.saveChannelPolicy(policy);
+            if (result.error) {
+                throw new Error(result.error.message || 'Failed to save policy');
+            }
+
+            // Update original values on successful save
             setOriginalExpression(expression);
             setOriginalAutoSyncMembers(autoSyncMembers);
 
-            // Show alert for demo purposes
-            // eslint-disable-next-line no-alert
-            alert(`Access rules saved!\nExpression: ${expression || '(none)'}\nAuto-sync: ${autoSyncMembers ? 'Enabled' : 'Disabled'}`);
+            // Show success alert for testing purposes
+            window.alert(
+                `Access rules saved!\nExpression: ${expression}\nAuto-sync: ${autoSyncMembers ? 'Enabled' : 'Disabled'}`,
+            );
 
             return true;
         } catch (error) {
@@ -152,7 +190,7 @@ function ChannelSettingsAccessRulesTab({
             }));
             return false;
         }
-    }, [channel.id, expression, autoSyncMembers, formatMessage]);
+    }, [channel.id, channel.display_name, expression, autoSyncMembers, systemPolicies, actions, formatMessage]);
 
     // Handle save changes panel actions
     const handleSaveChanges = useCallback(async () => {

--- a/webapp/channels/src/hooks/useChannelAccessControlActions.ts
+++ b/webapp/channels/src/hooks/useChannelAccessControlActions.ts
@@ -4,13 +4,15 @@
 import {useMemo} from 'react';
 import {useDispatch} from 'react-redux';
 
-import type {AccessControlVisualAST, AccessControlTestResult} from '@mattermost/types/access_control';
+import type {AccessControlVisualAST, AccessControlTestResult, AccessControlPolicy} from '@mattermost/types/access_control';
 import type {UserPropertyField} from '@mattermost/types/properties';
 
 import {
     getAccessControlFields,
     getVisualAST,
     searchUsersForExpression,
+    getAccessControlPolicy,
+    createAccessControlPolicy,
 } from 'mattermost-redux/actions/access_control';
 import type {ActionResult} from 'mattermost-redux/types/actions';
 
@@ -18,6 +20,8 @@ export interface ChannelAccessControlActions {
     getAccessControlFields: (after: string, limit: number) => Promise<ActionResult<UserPropertyField[]>>;
     getVisualAST: (expression: string) => Promise<ActionResult<AccessControlVisualAST>>;
     searchUsers: (expression: string, term: string, after: string, limit: number) => Promise<ActionResult<AccessControlTestResult>>;
+    getChannelPolicy: (channelId: string) => Promise<ActionResult<AccessControlPolicy>>;
+    saveChannelPolicy: (policy: AccessControlPolicy) => Promise<ActionResult<AccessControlPolicy>>;
 }
 
 /**
@@ -58,6 +62,20 @@ export const useChannelAccessControlActions = (): ChannelAccessControlActions =>
          */
         searchUsers: (expression: string, term: string, after: string, limit: number) => {
             return dispatch(searchUsersForExpression(expression, term, after, limit));
+        },
+
+        /**
+         * Get the access control policy for a specific channel
+         */
+        getChannelPolicy: (channelId: string) => {
+            return dispatch(getAccessControlPolicy(channelId));
+        },
+
+        /**
+         * Save or update the access control policy for a channel
+         */
+        saveChannelPolicy: (policy: AccessControlPolicy) => {
+            return dispatch(createAccessControlPolicy(policy));
         },
     }), [dispatch]);
 };


### PR DESCRIPTION
#### Summary
This PR adds the logic to integrate the save changes panel with the save policies in the backend allowing admins to actually store the changes made by them and create/update the policy.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65074

#### Screenshots
<img width="770" height="580" alt="Screenshot 2025-08-18 at 3 24 53 PM" src="https://github.com/user-attachments/assets/3e883f1d-d6df-4c1b-a2e9-c496b1986dac" />


#### Release Note
```release-note
NONE
```
