### PR TITLE
Fix CI concurrency group evaluation error for master builds

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/mmctl-test-template.yml"
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || '' }}
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/webapp-ci.yml
+++ b/.github/workflows/webapp-ci.yml
@@ -12,7 +12,7 @@ on:
       - ".github/actions/webapp-setup/**"
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || '' }}
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
#### Summary

Fixes CI workflow evaluation error that was preventing the full test suite from running on master branch pushes since commit 95a9bcec289bb4403fdd0ad415cbb0be6113edc9:

<img width="1998" height="370" alt="CleanShot 2025-08-20 at 11 03 03@2x" src="https://github.com/user-attachments/assets/3c159f96-d56a-4cfd-a395-3e1d32821967" />

Replace the empty string fallback with `github.run_id`, ensuring each master build gets a unique concurrency group while maintaining the intended behavior:
- **Pull requests**: Proper concurrency control with `cancel-in-progress: true`
- **Master builds**: Each gets unique concurrency group, allowing simultaneous execution

#### Release Note
```release-note
NONE
```