### PR TITLE
add Node to mattermost-build-server

### DIFF
--- a/.github/workflows/build-server-image.yml
+++ b/.github/workflows/build-server-image.yml
@@ -46,6 +46,8 @@ jobs:
           provenance: false
           file: server/build/Dockerfile.buildenv
           load: true
+          push: false
+          pull: false
           tags: mattermostdevelopment/mattermost-build-server:test
 
       - name: buildenv/test
@@ -58,6 +60,7 @@ jobs:
         with:
           provenance: false
           file: server/build/Dockerfile.buildenv
+          load: false
           push: true
           pull: true
           tags: mattermostdevelopment/mattermost-build-server:${{ steps.go.outputs.GO_VERSION }}
@@ -88,6 +91,8 @@ jobs:
           provenance: false
           file: server/build/Dockerfile.buildenv-fips
           load: true
+          push: false
+          pull: false
           tags: mattermost/mattermost-build-server-fips:test
 
       - name: buildenv/test
@@ -100,6 +105,7 @@ jobs:
         with:
           provenance: false
           file: server/build/Dockerfile.buildenv-fips
+          load: false
           push: true
           pull: true
           tags: mattermost/mattermost-build-server-fips:${{ steps.go.outputs.GO_VERSION }}

--- a/.github/workflows/build-server-image.yml
+++ b/.github/workflows/build-server-image.yml
@@ -8,6 +8,11 @@ on:
       - server/build/Dockerfile.buildenv
       - server/build/Dockerfile.buildenv-fips
       - .github/workflows/build-server-image.yml
+  pull_request:
+    paths:
+      - server/build/Dockerfile.buildenv
+      - server/build/Dockerfile.buildenv-fips
+      - .github/workflows/build-server-image.yml
 
 env:
   CHAINCTL_IDENTITY: ee399b4c72dd4e58e3d617f78fc47b74733c9557/922f2d48307d6f5f
@@ -35,7 +40,20 @@ jobs:
           username: ${{ secrets.DOCKERHUB_DEV_USERNAME }}
           password: ${{ secrets.DOCKERHUB_DEV_TOKEN }}
 
-      - name: buildenv/build-and-push
+      - name: buildenv/build
+        uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
+        with:
+          provenance: false
+          file: server/build/Dockerfile.buildenv
+          load: true
+          tags: mattermostdevelopment/mattermost-build-server:test
+
+      - name: buildenv/test
+        run: |
+          docker run --rm mattermostdevelopment/mattermost-build-server:test /bin/sh -c "go version && node --version"
+
+      - name: buildenv/push
+        if: github.ref == 'refs/heads/master'
         uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
         with:
           provenance: false
@@ -64,7 +82,20 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: buildenv/build-and-push
+      - name: buildenv/build
+        uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
+        with:
+          provenance: false
+          file: server/build/Dockerfile.buildenv-fips
+          load: true
+          tags: mattermost/mattermost-build-server-fips:test
+
+      - name: buildenv/test
+        run: |
+          docker run --rm --entrypoint bash mattermost/mattermost-build-server-fips:test -c "go version && node --version"
+
+      - name: buildenv/push
+        if: github.ref == 'refs/heads/master'
         uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
         with:
           provenance: false

--- a/server/build/Dockerfile.buildenv
+++ b/server/build/Dockerfile.buildenv
@@ -1,5 +1,13 @@
 FROM golang:1.24.5-bullseye@sha256:62ba6b19de03e891f7fa1001326bd48411f2626ff35e7ba5b9d890711ce581d9
+ARG NODE_VERSION=20.11.1
 
 RUN apt-get update && apt-get install -y make git apt-transport-https ca-certificates curl software-properties-common build-essential zip xmlsec1 jq pgloader
+
+# Download and install node via nvm
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+RUN bash -c "source /root/.nvm/nvm.sh && nvm install $NODE_VERSION && nvm use $NODE_VERSION && nvm alias default $NODE_VERSION"
+
+# Make node and npm globally available
+ENV PATH="/root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH"
 
 RUN git config --global --add safe.directory /mattermost

--- a/server/build/Dockerfile.buildenv-fips
+++ b/server/build/Dockerfile.buildenv-fips
@@ -1,5 +1,13 @@
 FROM cgr.dev/mattermost.com/go-msft-fips:1.24.5-dev@sha256:d7b2872c129277c01447903b7fde7a186fe211b59613172a7e40a3cc0dc5f126
+ARG NODE_VERSION=20.11.1
 
 RUN apk add curl ca-certificates mailcap unrtf wv poppler-utils tzdata
+
+# Download and install node via nvm
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+RUN bash -c "source /root/.nvm/nvm.sh && nvm install $NODE_VERSION && nvm use $NODE_VERSION && nvm alias default $NODE_VERSION"
+
+# Make node and npm globally available
+ENV PATH="/root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH"
 
 RUN git config --global --add safe.directory /mattermost


### PR DESCRIPTION
#### Summary
Install Node inside the `mattermost-build-server` Docker containers, used as part of CI/CD.

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-64878

#### Release Note
```release-note
NONE
```
