### PR TITLE
Update web app and subpackage versions to 10.12.0 (release-10.12)

### DIFF
--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -3,18 +3,18 @@
   "browser": {
     "./client/web_client.jsx": "./client/browser_web_client.jsx"
   },
-  "version": "10.11.0",
+  "version": "10.12.0",
   "private": true,
   "dependencies": {
     "@floating-ui/react": "0.26.28",
     "@giphy/js-fetch-api": "5.1.0",
     "@giphy/react-components": "8.1.0",
     "@guyplusplus/turndown-plugin-gfm": "1.0.7",
-    "@mattermost/client": "10.11.0",
+    "@mattermost/client": "10.12.0",
     "@mattermost/compass-components": "^0.2.12",
     "@mattermost/desktop-api": "5.10.0-2",
     "@mattermost/dynamic-virtualized-list": "github:mattermost/dynamic-virtualized-list#08dde0c34a12d0384740db27d55e398d139d7a51",
-    "@mattermost/types": "10.11.0",
+    "@mattermost/types": "10.12.0",
     "@mui/base": "5.0.0-alpha.127",
     "@mui/material": "5.11.16",
     "@mui/styled-engine-sc": "5.11.11",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -58,17 +58,17 @@
     },
     "channels": {
       "name": "mattermost-webapp",
-      "version": "10.11.0",
+      "version": "10.12.0",
       "dependencies": {
         "@floating-ui/react": "0.26.28",
         "@giphy/js-fetch-api": "5.1.0",
         "@giphy/react-components": "8.1.0",
         "@guyplusplus/turndown-plugin-gfm": "1.0.7",
-        "@mattermost/client": "10.11.0",
+        "@mattermost/client": "10.12.0",
         "@mattermost/compass-components": "^0.2.12",
         "@mattermost/desktop-api": "5.10.0-2",
         "@mattermost/dynamic-virtualized-list": "github:mattermost/dynamic-virtualized-list#08dde0c34a12d0384740db27d55e398d139d7a51",
-        "@mattermost/types": "10.11.0",
+        "@mattermost/types": "10.12.0",
         "@mui/base": "5.0.0-alpha.127",
         "@mui/material": "5.11.16",
         "@mui/styled-engine-sc": "5.11.11",
@@ -28123,7 +28123,7 @@
     },
     "platform/client": {
       "name": "@mattermost/client",
-      "version": "10.11.0",
+      "version": "10.12.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "28.1.8",
@@ -28131,7 +28131,7 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
-        "@mattermost/types": "10.11.0",
+        "@mattermost/types": "10.12.0",
         "typescript": "^4.3.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
@@ -29587,11 +29587,11 @@
       }
     },
     "platform/mattermost-redux": {
-      "version": "10.11.0",
+      "version": "10.12.0",
       "license": "MIT",
       "dependencies": {
-        "@mattermost/client": "10.11.0",
-        "@mattermost/types": "10.11.0",
+        "@mattermost/client": "10.12.0",
+        "@mattermost/types": "10.12.0",
         "@redux-devtools/extension": "^3.2.3",
         "lodash": "^4.17.21",
         "moment-timezone": "^0.5.38",
@@ -29613,7 +29613,7 @@
     },
     "platform/types": {
       "name": "@mattermost/types",
-      "version": "10.11.0",
+      "version": "10.12.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.0.0"

--- a/webapp/platform/client/package.json
+++ b/webapp/platform/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/client",
-  "version": "10.11.0",
+  "version": "10.12.0",
   "description": "JavaScript/TypeScript client for Mattermost",
   "keywords": [
     "mattermost"
@@ -24,7 +24,7 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "@mattermost/types": "10.11.0",
+    "@mattermost/types": "10.12.0",
     "typescript": "^4.3.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {

--- a/webapp/platform/mattermost-redux/package.json
+++ b/webapp/platform/mattermost-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mattermost-redux",
-  "version": "10.11.0",
+  "version": "10.12.0",
   "description": "Common code (API client, Redux stores, logic, utility functions) for building a Mattermost client",
   "keywords": [
     "mattermost"
@@ -39,8 +39,8 @@
     "directory": "webapp/platform/mattermost-redux"
   },
   "dependencies": {
-    "@mattermost/client": "10.11.0",
-    "@mattermost/types": "10.11.0",
+    "@mattermost/client": "10.12.0",
+    "@mattermost/types": "10.12.0",
     "@redux-devtools/extension": "^3.2.3",
     "lodash": "^4.17.21",
     "moment-timezone": "^0.5.38",

--- a/webapp/platform/types/package.json
+++ b/webapp/platform/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/types",
-  "version": "10.11.0",
+  "version": "10.12.0",
   "description": "Shared type definitions used by the Mattermost web app",
   "keywords": [
     "mattermost"


### PR DESCRIPTION
#### Summary
Normally, this would be done automatically as part of the release pipeline, but similar to https://github.com/mattermost/mattermost/pull/33709, that step isn't done automatically when we make one release branch from another

#### Release Note
```release-note
NONE
```
