### PR TITLE
Mm 65023 action buttons tooltip

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/interactive_menu/action_button_error_handling_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/interactive_menu/action_button_error_handling_spec.js
@@ -1,0 +1,170 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @channels @interactive_menu
+
+/**
+* Note: This test requires webhook server running. Initiate `npm run start:webhook` to start.
+*/
+
+import * as TIMEOUTS from '../../../fixtures/timeouts';
+
+describe('Interactive Menu - Action Button Error Handling', () => {
+    let incomingWebhook;
+
+    before(() => {
+        cy.requireWebhookServer();
+
+        // # Create and visit new channel and create incoming webhook
+        cy.apiInitSetup().then(({team, channel}) => {
+            const newIncomingHook = {
+                channel_id: channel.id,
+                channel_locked: true,
+                description: 'Incoming webhook for action button error testing',
+                display_name: 'actionErrorTest' + Date.now(),
+            };
+
+            cy.apiCreateWebhook(newIncomingHook).then((hook) => {
+                incomingWebhook = hook;
+            });
+
+            cy.visit(`/${team.name}/channels/${channel.name}`);
+        });
+    });
+
+    it('MM-65023 should display error message when action button fails', () => {
+        const payload = getPayloadWithErrorAction();
+
+        // # Post an incoming webhook with action button that will trigger an error
+        cy.postIncomingWebhook({url: incomingWebhook.url, data: payload, waitFor: 'attachment-pretext'});
+        
+        // * Wait for the button to be available
+        cy.findByText('Error Button 1').should('be.visible');
+
+        // # Click on "Error Button 1" (invalid URL will cause error)
+        cy.findByText('Error Button 1').should('be.visible').click({force: true});
+        cy.wait(TIMEOUTS.HALF_SEC);
+
+        // * Verify that error message is displayed
+        cy.get('.has-error').should('be.visible');
+        cy.get('.has-error .control-label').should('contain.text', 'Action integration error.');
+    });
+
+    it('MM-65023 should clear error message when successful action is triggered', () => {
+        const payload = getPayloadWithErrorAndSuccess(Cypress.env().webhookBaseUrl);
+
+        // # Post an incoming webhook with error and success buttons
+        cy.postIncomingWebhook({url: incomingWebhook.url, data: payload, waitFor: 'attachment-pretext'});
+        
+        // * Wait for the buttons to be available
+        cy.findByText('Error Button').should('be.visible');
+        cy.findByText('Success Button').should('be.visible');
+
+        // # Click on "Error Button" first
+        cy.findByText('Error Button').should('be.visible').click({force: true});
+        cy.wait(TIMEOUTS.HALF_SEC);
+
+        // * Verify that error message is displayed for test2
+        cy.get('.has-error').should('be.visible');
+        cy.get('.has-error .control-label').should('contain.text', 'Action integration error.');
+
+        // # Click on "Success Button" to trigger successful action
+        cy.findByText('Success Button').should('be.visible').click({force: true});
+        
+        // * Wait for successful response and verify the specific error from this test is cleared
+        cy.uiWaitUntilMessagePostedIncludes('a < a | b > a');
+        
+        // * Find the specific attachment container for this test and verify its error is cleared
+        cy.contains('.attachment', 'Action Button Error Clear Test - Error and Success')
+            .find('.has-error').should('not.exist');
+    });
+
+    it('MM-65023 should display tooltip on action button hover', () => {
+        const payload = getPayloadWithTooltip();
+
+        // # Post an incoming webhook with action button that has tooltip
+        cy.postIncomingWebhook({url: incomingWebhook.url, data: payload, waitFor: 'attachment-pretext'});
+        
+        // * Wait for the tooltip button to be available
+        cy.findByText('Button with Tooltip').should('be.visible');
+
+        // # Hover over the action button
+        cy.findByText('Button with Tooltip').should('be.visible').trigger('mouseover');
+
+        // * Verify that tooltip is displayed with correct text
+        cy.findByText('Button with Tooltip')
+            .should('have.attr', 'title', 'This is a helpful tooltip');
+    });
+});
+
+function getPayloadWithErrorAction() {
+    return {
+        attachments: [{
+            pretext: 'Action Button Error Test - Single Button',
+            actions: [{
+                name: 'Error Button 1',
+                tooltip: 'This button will trigger an error',
+                integration: {
+                    url: 'http://invalid-url-test1.example.com/fail',
+                    context: {
+                        action: 'trigger_error_test1',
+                    },
+                },
+            }],
+        }],
+    };
+}
+
+function getPayloadWithErrorAndSuccess(webhookBaseUrl) {
+    return {
+        attachments: [{
+            pretext: 'Action Button Error Clear Test - Error and Success',
+            actions: [{
+                name: 'Error Button',
+                tooltip: 'This button will trigger an error',
+                integration: {
+                    url: 'http://invalid-url-test2.example.com/fail',
+                    context: {
+                        action: 'trigger_error_test2',
+                    },
+                },
+            }, {
+                name: 'Success Button',
+                tooltip: 'This button will work',
+                integration: {
+                    url: `${webhookBaseUrl}/slack_compatible_message_response`,
+                    context: {
+                        action: 'show_spoiler',
+                        spoiler: 'a < a | b > a',
+                        skipSlackParsing: true,
+                    },
+                },
+            }],
+        }],
+    };
+}
+
+function getPayloadWithTooltip() {
+    return {
+        attachments: [{
+            pretext: 'Action Button Tooltip Test',
+            actions: [{
+                name: 'Button with Tooltip',
+                tooltip: 'This is a helpful tooltip',
+                integration: {
+                    url: 'http://localhost:3000/success',
+                    context: {
+                        action: 'tooltip_test',
+                    },
+                },
+            }],
+        }],
+    };
+}

--- a/server/public/model/integration_action.go
+++ b/server/public/model/integration_action.go
@@ -62,6 +62,9 @@ type PostAction struct {
 	// The text on the button, or in the select placeholder.
 	Name string `json:"name,omitempty"`
 
+	// Tooltip text displayed on hover.
+	Tooltip string `json:"tooltip,omitempty"`
+
 	// If the action is disabled.
 	Disabled bool `json:"disabled,omitempty"`
 

--- a/webapp/channels/src/components/post_view/message_attachments/action_button/action_button.tsx
+++ b/webapp/channels/src/components/post_view/message_attachments/action_button/action_button.tsx
@@ -67,6 +67,7 @@ const ActionButton = ({
             onClick={handleActionClick}
             className='btn btn-sm'
             hexColor={hexColor}
+            title={action.tooltip}
         >
             <LoadingWrapper
                 loading={actionExecuting}

--- a/webapp/channels/src/components/post_view/message_attachments/message_attachment/message_attachment.test.tsx
+++ b/webapp/channels/src/components/post_view/message_attachments/message_attachment/message_attachment.test.tsx
@@ -256,4 +256,114 @@ describe('components/post_view/MessageAttachment', () => {
         const wrapper = shallow(<MessageAttachment {...props}/>);
         expect(wrapper.find('.attachment')).toMatchSnapshot();
     });
+
+    test('should handle action errors and display error message', async () => {
+        const errorMessage = 'Action failed to execute';
+        const doPostActionWithCookie = jest.fn().mockResolvedValue({
+            error: {message: errorMessage},
+        });
+        const actionId = 'action_id_1';
+        const newAttachment = {
+            ...attachment,
+            actions: [{id: actionId, name: 'action_name_1', cookie: 'cookie-contents'}] as PostAction[],
+        };
+        const props = {...baseProps, actions: {doPostActionWithCookie, openModal: jest.fn()}, attachment: newAttachment};
+        const wrapper = shallow<MessageAttachment>(<MessageAttachment {...props}/>);
+
+        // Initially no error should be shown
+        expect(wrapper.find('.has-error')).toHaveLength(0);
+
+        // Trigger action
+        await wrapper.instance().handleAction({
+            preventDefault: jest.fn(),
+            currentTarget: {getAttribute: jest.fn().mockReturnValue('attr_value')} as any,
+        } as React.MouseEvent, []);
+
+        // Update wrapper to get latest state
+        wrapper.update();
+
+        // Error should now be displayed
+        expect(wrapper.state('actionError')).toBe(errorMessage);
+        expect(wrapper.find('.has-error')).toHaveLength(1);
+        expect(wrapper.find('.control-label').text()).toBe(errorMessage);
+    });
+
+    test('should handle promise rejection errors', async () => {
+        const errorMessage = 'Network error occurred';
+        const doPostActionWithCookie = jest.fn().mockRejectedValue(new Error(errorMessage));
+        const actionId = 'action_id_1';
+        const newAttachment = {
+            ...attachment,
+            actions: [{id: actionId, name: 'action_name_1', cookie: 'cookie-contents'}] as PostAction[],
+        };
+        const props = {...baseProps, actions: {doPostActionWithCookie, openModal: jest.fn()}, attachment: newAttachment};
+        const wrapper = shallow<MessageAttachment>(<MessageAttachment {...props}/>);
+
+        // Initially no error should be shown
+        expect(wrapper.find('.has-error')).toHaveLength(0);
+
+        // Trigger action
+        await wrapper.instance().handleAction({
+            preventDefault: jest.fn(),
+            currentTarget: {getAttribute: jest.fn().mockReturnValue('attr_value')} as any,
+        } as React.MouseEvent, []);
+
+        // Update wrapper to get latest state
+        wrapper.update();
+
+        // Error should now be displayed
+        expect(wrapper.state('actionError')).toBe(errorMessage);
+        expect(wrapper.find('.has-error')).toHaveLength(1);
+        expect(wrapper.find('.control-label').text()).toBe(errorMessage);
+    });
+
+    test('should clear previous errors when new action is triggered', async () => {
+        const doPostActionWithCookie = jest.fn().mockResolvedValue({data: 'success'});
+        const actionId = 'action_id_1';
+        const newAttachment = {
+            ...attachment,
+            actions: [{id: actionId, name: 'action_name_1', cookie: 'cookie-contents'}] as PostAction[],
+        };
+        const props = {...baseProps, actions: {doPostActionWithCookie, openModal: jest.fn()}, attachment: newAttachment};
+        const wrapper = shallow<MessageAttachment>(<MessageAttachment {...props}/>);
+
+        // Set initial error state
+        wrapper.setState({actionError: 'Previous error'});
+        expect(wrapper.state('actionError')).toBe('Previous error');
+
+        // Trigger new action
+        await wrapper.instance().handleAction({
+            preventDefault: jest.fn(),
+            currentTarget: {getAttribute: jest.fn().mockReturnValue('attr_value')} as any,
+        } as React.MouseEvent, []);
+
+        // Error should be cleared on successful action
+        expect(wrapper.state('actionError')).toBeNull();
+    });
+
+    test('should render error message with default text when no error message provided', async () => {
+        const doPostActionWithCookie = jest.fn().mockResolvedValue({
+            error: {}, // Error object without message
+        });
+        const actionId = 'action_id_1';
+        const newAttachment = {
+            ...attachment,
+            actions: [{id: actionId, name: 'action_name_1', cookie: 'cookie-contents'}] as PostAction[],
+        };
+        const props = {...baseProps, actions: {doPostActionWithCookie, openModal: jest.fn()}, attachment: newAttachment};
+        const wrapper = shallow<MessageAttachment>(<MessageAttachment {...props}/>);
+
+        // Trigger action
+        await wrapper.instance().handleAction({
+            preventDefault: jest.fn(),
+            currentTarget: {getAttribute: jest.fn().mockReturnValue('attr_value')} as any,
+        } as React.MouseEvent, []);
+
+        // Update wrapper to get latest state
+        wrapper.update();
+
+        // Should show default error message
+        expect(wrapper.state('actionError')).toBe('Action failed to execute');
+        expect(wrapper.find('.control-label').text()).toBe('Action failed to execute');
+    });
 });

--- a/webapp/platform/types/src/integration_actions.ts
+++ b/webapp/platform/types/src/integration_actions.ts
@@ -6,7 +6,8 @@ import {isArrayOf} from './utilities';
 export type PostAction = {
     id?: string;
     type?: string;
-    name?: string;
+    name: string;
+    tooltip?: string;
     disabled?: boolean;
     style?: string;
     data_source?: string;
@@ -33,6 +34,10 @@ export function isPostAction(v: unknown): v is PostAction {
     }
 
     if ('disabled' in v && typeof v.disabled !== 'boolean') {
+        return false;
+    }
+
+    if ('tooltip' in v && typeof v.tooltip !== 'string') {
         return false;
     }
 


### PR DESCRIPTION

#### Summary
 Add tooltip support and comprehensive error handling for action buttons

  Changes Made

  🎯 New Features:
  - Tooltip Support: Action buttons now display helpful tooltips on hover via new tooltip field
  - Enhanced Error Handling: Comprehensive error display and management for failed button actions
  - Error Clearing: Previous errors are automatically cleared when new actions are triggered

  🔧 Implementation:
  - Added tooltip field to PostAction type (server model and TypeScript types)
  - Enhanced action button component to display tooltips using HTML title attribute
  - Improved error state management in message attachments with proper clearing logic
  - Added comprehensive test coverage for error scenarios

  🧪 Testing:
  - Unit Tests: Added comprehensive test coverage for error handling functionality
  - E2E Tests: Created 3 test scenarios covering error display, error clearing, and tooltip functionality
  - Error Scenarios: Tests both network failures and successful webhook responses

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-65023

#### Screenshots
<img width="1087" height="206" alt="Screenshot 2025-08-21 at 5 34 18 PM" src="https://github.com/user-attachments/assets/a7160f53-16fc-4293-b3de-90f8ebeba9ec" />

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Added tooltips to action buttons, display action errors back on form.
```
