### PR TITLE
[MM-65127] Add Elasticsearch test to support packet diagnostics

### DIFF
--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -180,6 +180,12 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 	if se := ps.SearchEngine.ElasticsearchEngine; se != nil {
 		d.ElasticSearch.ServerVersion = se.GetFullVersion()
 		d.ElasticSearch.ServerPlugins = se.GetPlugins()
+		if *ps.Config().ElasticsearchSettings.EnableIndexing {
+			appErr := se.TestConfig(rctx, ps.Config())
+			if appErr != nil {
+				d.ElasticSearch.Error = appErr.Error()
+			}
+		}
 	}
 
 	b, err := yaml.Marshal(&d)

--- a/server/public/model/support_packet.go
+++ b/server/public/model/support_packet.go
@@ -63,7 +63,7 @@ type SupportPacketDiagnostics struct {
 
 	LDAP struct {
 		Status        string `yaml:"status,omitempty"`
-		Error         string `yaml:"erorr,omitempty"`
+		Error         string `yaml:"error,omitempty"`
 		ServerName    string `yaml:"server_name,omitempty"`
 		ServerVersion string `yaml:"server_version,omitempty"`
 	} `yaml:"ldap"`
@@ -71,6 +71,7 @@ type SupportPacketDiagnostics struct {
 	ElasticSearch struct {
 		ServerVersion string   `yaml:"server_version,omitempty"`
 		ServerPlugins []string `yaml:"server_plugins,omitempty"`
+		Error         string   `yaml:"error,omitempty"`
 	} `yaml:"elastic"`
 }
 


### PR DESCRIPTION
#### Summary
Test the ES/OS connection when generating a Support Packet and add any errors to the Support Packet.

The output in the error case looks like this:
```yaml
elastic:
    server_version: 8.9.0
    server_plugins:
        - analysis-icu
    error 'Elasticsearch.checkMaxVersion: Failed to get elasticsearch server version., an error happened during the Info query execution: dial tcp 127.0.0.1:9200: connect: connection refused'
```

🤖 Generated with [Claude Code](https://claude.ai/code)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65127

#### Release Note
```release-note
Add Elasticsearch test to support packet diagnostics
```
