### PR TITLE
Allows ABAC to use admin managed attributes

### DIFF
--- a/webapp/channels/src/components/admin_console/access_control/editors/table_editor/attribute_selector_menu.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/editors/table_editor/attribute_selector_menu.tsx
@@ -136,7 +136,8 @@ const AttributeSelectorMenu = ({currentAttribute, availableAttributes, disabled,
                 const {name} = option;
                 const hasSpaces = name.includes(' ');
                 const isSynced = option.attrs?.ldap || option.attrs?.saml;
-                const allowed = isSynced || enableUserManagedAttributes;
+                const isAdminManaged = option.attrs?.managed === 'admin';
+                const allowed = isSynced || isAdminManaged || enableUserManagedAttributes;
 
                 const menuItem = (
                     <Menu.Item

--- a/webapp/channels/src/components/admin_console/access_control/editors/table_editor/table_editor.test.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/editors/table_editor/table_editor.test.tsx
@@ -213,6 +213,17 @@ describe('findFirstAvailableAttributeFromList', () => {
         expect(result?.name).toBe('user_managed_attribute');
     });
 
+    test('returns first attribute that is admin-managed', () => {
+        const attributes = [
+            createMockAttribute('invalid attribute'), // Has spaces
+            createMockAttribute('unsafe_attribute'), // Not synced or admin-managed
+            createMockAttribute('admin_managed_attribute', {managed: 'admin'}), // Admin-managed
+        ];
+
+        const result = findFirstAvailableAttributeFromList(attributes, false);
+        expect(result?.name).toBe('admin_managed_attribute');
+    });
+
     test('skips attributes with spaces even when synced', () => {
         const attributes = [
             createMockAttribute('synced attribute', {ldap: 'ldap_field'}), // Has spaces but synced

--- a/webapp/channels/src/components/admin_console/access_control/editors/table_editor/table_editor.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/editors/table_editor/table_editor.tsx
@@ -36,7 +36,7 @@ interface TableEditorProps {
 
 // Finds the first available (non-disabled) attribute from a list of user attributes.
 // An attribute is considered available if it doesn't have spaces in its name (CEL incompatible)
-// and is considered "safe" (synced from LDAP/SAML OR enableUserManagedAttributes is true).
+// and is considered "safe" (synced from LDAP/SAML, admin-managed, OR enableUserManagedAttributes is true).
 export const findFirstAvailableAttributeFromList = (
     userAttributes: UserPropertyField[],
     enableUserManagedAttributes: boolean,
@@ -44,7 +44,8 @@ export const findFirstAvailableAttributeFromList = (
     return userAttributes.find((attr) => {
         const hasSpaces = attr.name.includes(' ');
         const isSynced = attr.attrs?.ldap || attr.attrs?.saml;
-        const allowed = isSynced || enableUserManagedAttributes;
+        const isAdminManaged = attr.attrs?.managed === 'admin';
+        const allowed = isSynced || isAdminManaged || enableUserManagedAttributes;
         return !hasSpaces && allowed;
     });
 };


### PR DESCRIPTION
#### Summary
Updates the webapp to allow ABAC to select and use admin-managed CPA fields as part of rules and policies.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65124

#### Release Note
```release-note
* Admin managed CPA fields can now be used as part of ABAC policies.
```
