### PR TITLE
[GH-24944] show preview button when full formatting toolbar is hidden when editing a post

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -805,7 +805,7 @@ const AdvancedTextEditor = ({
                             isInEditMode={isInEditMode}
                         />
                         {attachmentPreview}
-                        {!isDisabled && (showFormattingBar || showPreview) && (
+                        {!isDisabled && showFormattingBar && (
                             <TexteditorActions
                                 placement='top'
                                 isScrollbarRendered={renderScrollbar}
@@ -823,6 +823,7 @@ const AdvancedTextEditor = ({
                                 ref={editorActionsRef}
                                 placement='bottom'
                             >
+                                {!showFormattingBar && showFormatJSX}
                                 <ToggleFormattingBar
                                     onClick={toggleAdvanceTextEditor}
                                     active={showFormattingBar}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This is QOL improvement that enables the preview button when using the inline editor for a post. The button is displayed when the full format toolbar is hidden.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Fixes https://github.com/mattermost/mattermost/issues/24944

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->
| before | after |
|----|----|
| <img width="2040" height="304" alt="Screenshot 2025-08-24 at 23-16-08 Town Square - Art Mattermost" src="https://github.com/user-attachments/assets/61fbeb92-7fb1-4255-87c6-367521d42672" /> | <img width="2040" height="304" alt="Screenshot 2025-08-24 at 23-15-19 Town Square - Art Mattermost" src="https://github.com/user-attachments/assets/aaa71f85-015d-4275-b5ad-bd3b28b5360e" /> |

When preview is clicked during inline editing
<img width="2040" height="400" alt="Screenshot 2025-08-24 at 23-19-28 Town Square - Art Mattermost" src="https://github.com/user-attachments/assets/24dc04c3-11d7-4a3b-b392-f9c8a0da394a" />

Clicking the preview forces a lot of added space although the text only requires 1 line. Should that be addressed in this PR?

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Added preview button to inline post editor.
```
