### PR TITLE
MM-65183 - rename access rules tab to access control

### DIFF
--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_modal.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_modal.tsx
@@ -20,7 +20,7 @@ import {
     setShowPreviewOnChannelSettingsHeaderModal,
     setShowPreviewOnChannelSettingsPurposeModal,
 } from 'actions/views/textbox';
-import {isChannelAdminManageABACRulesEnabled} from 'selectors/general';
+import {isChannelAdminManageABACControlEnabled} from 'selectors/general';
 
 import {focusElement} from 'utils/a11y_utils';
 import Constants from 'utils/constants';
@@ -81,10 +81,10 @@ function ChannelSettingsModal({channelId, isOpen, onExited, focusOriginElement}:
         haveIChannelPermission(state, channel.team_id, channel.id, Permissions.MANAGE_CHANNEL_ACCESS_RULES),
     );
 
-    // FEATURE_FLAG_REMOVAL: ChannelAdminManageABACRules - Remove the feature flag check when feature is GA
-    const channelAdminABACRulesEnabled = useSelector(isChannelAdminManageABACRulesEnabled);
+    // FEATURE_FLAG_REMOVAL: ChannelAdminManageABACControl - Remove the feature flag check when feature is GA
+    const channelAdminABACControlEnabled = useSelector(isChannelAdminManageABACControlEnabled);
 
-    const shouldShowAccessRulesTab = channelAdminABACRulesEnabled && canManageChannelAccessRules && channel.type === Constants.PRIVATE_CHANNEL;
+    const shouldShowAccessRulesTab = channelAdminABACControlEnabled && canManageChannelAccessRules && channel.type === Constants.PRIVATE_CHANNEL;
 
     const [show, setShow] = useState(isOpen);
 
@@ -209,7 +209,7 @@ function ChannelSettingsModal({channelId, isOpen, onExited, focusOriginElement}:
         },
         {
             name: ChannelSettingsTabs.ACCESS_RULES,
-            uiName: formatMessage({id: 'channel_settings.tab.access_rules', defaultMessage: 'Access Rules'}),
+            uiName: formatMessage({id: 'channel_settings.tab.access_control', defaultMessage: 'Access Control'}),
             icon: 'icon icon-account-multiple-outline',
             iconTitle: formatMessage({id: 'generic_icons.access_rules', defaultMessage: 'Access Rules Icon'}),
             display: shouldShowAccessRulesTab,

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -3718,7 +3718,7 @@
   "channel_settings.save_changes_panel.banner_text.required_error": "Channel banner text cannot be empty when enabled",
   "channel_settings.save_changes_panel.reset": "Reset",
   "channel_settings.save_changes_panel.standard_error": "There are errors in the form above",
-  "channel_settings.tab.access_rules": "Access Rules",
+  "channel_settings.tab.access_control": "Access Control",
   "channel_settings.tab.archive": "Archive Channel",
   "channel_settings.tab.configuration": "Configuration",
   "channel_settings.tab.info": "Info",

--- a/webapp/channels/src/selectors/general.ts
+++ b/webapp/channels/src/selectors/general.ts
@@ -32,7 +32,7 @@ export function isDevModeEnabled(state: GlobalState) {
 }
 
 // FEATURE_FLAG_REMOVAL: ChannelAdminManageABACRules - Remove this function when feature is GA
-export function isChannelAdminManageABACRulesEnabled(state: GlobalState): boolean {
+export function isChannelAdminManageABACControlEnabled(state: GlobalState): boolean {
     const config = getConfig(state);
 
     // Check both the feature flag and the EnableChannelScopeAccessControl setting


### PR DESCRIPTION
#### Summary
This PR adds the changes to rename the Access Rules tab in the channel settings modal to be "Access Control" given that the section where the attributes are defined was already called Access Rules that could cause some sort of confusion. This PR also adds the required unit tests to the channel settings modal so we cover the scenarios via unit test of when the tab must be shown/hidden.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65183


#### Screenshots
Before:
<img width="845" height="691" alt="Screenshot 2025-08-30 at 7 49 45 PM" src="https://github.com/user-attachments/assets/1d4e5e45-a55b-4ef1-97f3-e927c4b7c0a0" />

After:
<img width="867" height="739" alt="Screenshot 2025-08-30 at 7 50 34 PM" src="https://github.com/user-attachments/assets/1fe2fe94-2c95-4d3f-9bf0-b5a5ac669e43" />


#### Release Note
```release-note
NONE
```
