### PR TITLE
Fix SearchAllChannels unmarshal failure

### DIFF
--- a/server/public/model/client4.go
+++ b/server/public/model/client4.go
@@ -3552,12 +3552,13 @@ func (c *Client4) SearchAllChannels(ctx context.Context, search *ChannelSearch) 
 	}
 	defer closeBody(r)
 
-	var ch ChannelListWithTeamData
-	err = json.NewDecoder(r.Body).Decode(&ch)
+	// The API returns a paginated response with channels and total_count
+	var cwc *ChannelsWithCount
+	err = json.NewDecoder(r.Body).Decode(&cwc)
 	if err != nil {
 		return nil, BuildResponse(r), NewAppError("SearchAllChannels", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
-	return ch, BuildResponse(r), nil
+	return cwc.Channels, BuildResponse(r), nil
 }
 
 // SearchAllChannelsForUser search in all the channels for a regular user.
@@ -3575,12 +3576,13 @@ func (c *Client4) SearchAllChannelsForUser(ctx context.Context, term string) (Ch
 	}
 	defer closeBody(r)
 
-	var ch ChannelListWithTeamData
-	err = json.NewDecoder(r.Body).Decode(&ch)
+	// The API returns a paginated response with channels and total_count
+	var cwc *ChannelsWithCount
+	err = json.NewDecoder(r.Body).Decode(&cwc)
 	if err != nil {
 		return nil, BuildResponse(r), NewAppError("SearchAllChannelsForUser", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
-	return ch, BuildResponse(r), nil
+	return cwc.Channels, BuildResponse(r), nil
 }
 
 // SearchAllChannelsPaged searches all the channels and returns the results paged with the total count.


### PR DESCRIPTION
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

This PR fixes an unmarshal failure in the `SearchAllChannels` and `SearchAllChannelsForUser` methods in the Go client library. The methods were failing to unmarshal API responses due to a mismatch between the expected response format and the actual API response format.

**Root Cause**: The `/api/v4/channels/search` endpoint returns a paginated response with structure `{"channels": [...], "total_count": number}`, but the methods were trying to unmarshal directly into `ChannelListWithTeamData` (array).

**Solution**: Modified both methods to unmarshal into `ChannelsWithCount` structure and extract the channels array, matching the actual API response format.

**QA Test Steps**:
1. Use the Go client library to call `SearchAllChannels` or `SearchAllChannelsForUser` methods
2. Verify no unmarshal errors occur
3. Confirm the methods return the expected channel data

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/33807

#### Screenshots

N/A - This is a backend API client library fix with no UI changes.

#### Release Note

```release-note
Fixed unmarshal failure in SearchAllChannels and SearchAllChannelsForUser methods in the Go client library when calling the channels search API endpoint.
```
```

