### PR TITLE
[GH-30108] Preserve user input case in command_provider

### DIFF
--- a/webapp/channels/src/components/suggestion/command_provider/command_provider.tsx
+++ b/webapp/channels/src/components/suggestion/command_provider/command_provider.tsx
@@ -163,7 +163,7 @@ export default class CommandProvider extends Provider {
     handleMobile(pretext: string, resultCallback: ResultsCallback<AutocompleteSuggestion>) {
         const {teamId} = this.props;
 
-        const command = pretext.toLowerCase();
+        const command = pretext;
         Client4.getCommandsList(teamId).then(
             (data) => {
                 let matches: AutocompleteSuggestion[] = [];
@@ -209,7 +209,7 @@ export default class CommandProvider extends Provider {
     }
 
     handleWebapp(pretext: string, resultCallback: ResultsCallback<AutocompleteSuggestion>) {
-        const command = pretext.toLowerCase();
+        const command = pretext;
 
         const {teamId, channelId, rootId} = this.props;
         const args: CommandArgs = {

--- a/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.jsx
+++ b/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.jsx
@@ -236,7 +236,7 @@ export default class SuggestionBox extends React.PureComponent {
 
         if (prevProps.contextId !== this.props.contextId) {
             const textbox = this.getTextbox();
-            const pretext = textbox.value.substring(0, textbox.selectionEnd).toLowerCase();
+            const pretext = textbox.value.substring(0, textbox.selectionEnd);
 
             this.handlePretextChanged(pretext);
         }


### PR DESCRIPTION
#### Summary

Preserve user input case in command_provider to avoid lowercasing commands.  
Added unit tests to ensure pretext is passed to backend unaltered.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/30108
Jira https://mattermost.atlassian.net/browse/MM-62908


#### Related Pull Requests
- Has server changes: N/A
- Has mobile changes: N/A


#### Screenshots
N/A

#### Release Note
```release-note
Fix: Slash command autocomplete now preserves user input case when forwarding pretext to backend.
