### PR TITLE
Downgrade French language

### DIFF
--- a/webapp/channels/src/components/admin_console/__snapshots__/schema_admin_settings.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/__snapshots__/schema_admin_settings.test.tsx.snap
@@ -322,7 +322,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 4,
-                  "text": "Français (Beta)",
+                  "text": "Français (Alpha)",
                   "value": "fr",
                 },
                 Object {
@@ -451,7 +451,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 4,
-                  "text": "Français (Beta)",
+                  "text": "Français (Alpha)",
                   "value": "fr",
                 },
                 Object {

--- a/webapp/channels/src/i18n/i18n.jsx
+++ b/webapp/channels/src/i18n/i18n.jsx
@@ -37,7 +37,7 @@ export const languages = {
     },
     fr: {
         value: 'fr',
-        name: 'Français (Beta)',
+        name: 'Français (Alpha)',
         order: 4,
         url: langFiles.fr,
     },


### PR DESCRIPTION
French language has been consistently below the 79% quality threshold for more than three months. Downgrading it from Beta to Alpha.

```release-note
Downgraded French language support from Beta to Alpha.
```
