### PR TITLE
Unify entrypoint for build Dockerfiles

### DIFF
--- a/server/build/Dockerfile.buildenv
+++ b/server/build/Dockerfile.buildenv
@@ -11,3 +11,5 @@ RUN bash -c "source /root/.nvm/nvm.sh && nvm install $NODE_VERSION && nvm use $N
 ENV PATH="/root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH"
 
 RUN git config --global --add safe.directory /mattermost
+
+ENTRYPOINT ["/bin/bash", "-l", "-c"]

--- a/server/build/Dockerfile.buildenv
+++ b/server/build/Dockerfile.buildenv
@@ -1,7 +1,7 @@
 FROM golang:1.24.5-bullseye@sha256:62ba6b19de03e891f7fa1001326bd48411f2626ff35e7ba5b9d890711ce581d9
 ARG NODE_VERSION=20.11.1
 
-RUN apt-get update && apt-get install -y make git apt-transport-https ca-certificates curl software-properties-common build-essential zip xmlsec1 jq pgloader
+RUN apt-get update && apt-get install -y make git apt-transport-https ca-certificates curl software-properties-common build-essential zip xmlsec1 jq pgloader gnupg
 
 # Download and install node via nvm
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash

--- a/server/build/Dockerfile.buildenv
+++ b/server/build/Dockerfile.buildenv
@@ -12,4 +12,6 @@ ENV PATH="/root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH"
 
 RUN git config --global --add safe.directory /mattermost
 
-ENTRYPOINT ["/bin/bash", "-l", "-c"]
+# Remove any existing entrypoint, and use bash as the default command
+ENTRYPOINT []
+CMD ["bash"]

--- a/server/build/Dockerfile.buildenv-fips
+++ b/server/build/Dockerfile.buildenv-fips
@@ -11,3 +11,5 @@ RUN bash -c "source /root/.nvm/nvm.sh && nvm install $NODE_VERSION && nvm use $N
 ENV PATH="/root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH"
 
 RUN git config --global --add safe.directory /mattermost
+
+ENTRYPOINT ["/bin/bash", "-l", "-c"]

--- a/server/build/Dockerfile.buildenv-fips
+++ b/server/build/Dockerfile.buildenv-fips
@@ -12,4 +12,6 @@ ENV PATH="/root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH"
 
 RUN git config --global --add safe.directory /mattermost
 
-ENTRYPOINT ["/bin/bash", "-l", "-c"]
+# Remove any existing entrypoint, and use bash as the default command
+ENTRYPOINT []
+CMD ["bash"]

--- a/server/build/Dockerfile.buildenv-fips
+++ b/server/build/Dockerfile.buildenv-fips
@@ -1,7 +1,7 @@
 FROM cgr.dev/mattermost.com/go-msft-fips:1.24.5-dev@sha256:d7b2872c129277c01447903b7fde7a186fe211b59613172a7e40a3cc0dc5f126
 ARG NODE_VERSION=20.11.1
 
-RUN apk add curl ca-certificates mailcap unrtf wv poppler-utils tzdata
+RUN apk add curl ca-certificates mailcap unrtf wv poppler-utils tzdata gpg
 
 # Download and install node via nvm
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash


### PR DESCRIPTION
#### Summary

This PR resets the entrypoint to both build environment Dockerfiles (`Dockerfile.buildenv` and `Dockerfile.buildenv-fips`) to unify invoking either a shell or running a command without jumping through hoops.

#### Release Note
```release-note
NONE
```