### PR TITLE
Fix lint error breaking smoke tests

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/channel_settings/more_unreads_position_with_scroll_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/channel_settings/more_unreads_position_with_scroll_spec.ts
@@ -10,8 +10,6 @@
 // Stage: @prod
 // Group: @channels @channel_settings
 
-import * as TIMEOUTS from '../../../fixtures/timeouts';
-
 describe('Channel settings', () => {
     let mainUser: Cypress.UserProfile;
     let otherUser: Cypress.UserProfile;


### PR DESCRIPTION
I think its from this PR https://github.com/mattermost/mattermost/pull/33783, that it was forgotten to remove the unused import.


```release-note
NONE
```
