### PR TITLE
add xmlsec1 to FIPS docker build image

### DIFF
--- a/server/build/Dockerfile.buildenv-fips
+++ b/server/build/Dockerfile.buildenv-fips
@@ -1,7 +1,7 @@
 FROM cgr.dev/mattermost.com/go-msft-fips:1.24.5-dev@sha256:d7b2872c129277c01447903b7fde7a186fe211b59613172a7e40a3cc0dc5f126
 ARG NODE_VERSION=20.11.1
 
-RUN apk add curl ca-certificates mailcap unrtf wv poppler-utils tzdata gpg
+RUN apk add curl ca-certificates mailcap unrtf wv poppler-utils tzdata gpg xmlsec
 
 # Download and install node via nvm
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash


### PR DESCRIPTION
#### Summary
Add `xmlsec1` to the build image used for FIPS builds.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
