### PR TITLE
Initial commit

### DIFF
--- a/webapp/channels/src/components/global_header/left_controls/product_menu/__snapshots__/product_menu.test.tsx.snap
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/__snapshots__/product_menu.test.tsx.snap
@@ -148,6 +148,80 @@ exports[`components/global/product_switcher should match snapshot 1`] = `
 </div>
 `;
 
+exports[`components/global/product_switcher should match snapshot for Entry license 1`] = `
+<div>
+  <MenuWrapper
+    animationComponent={[Function]}
+    className=""
+    open={true}
+  >
+    <ProductMenuContainer
+      onClick={[Function]}
+    >
+      <ProductMenuButton
+        aria-controls="product-switcher-menu"
+        aria-expanded={true}
+        aria-label="Product switch menu"
+        style={
+          Object {
+            "backgroundColor": "rgba(var(--sidebar-text-rgb), 0.16)",
+            "color": "rgba(var(--sidebar-text-rgb), 0.56)",
+          }
+        }
+      >
+        <ProductsIcon
+          color="rgba(var(--sidebar-text-rgb), 0.56)"
+          size={20}
+        />
+        <ProductBrandingFreeEdition />
+      </ProductMenuButton>
+    </ProductMenuContainer>
+    <Menu
+      ariaLabel="switcherOpen"
+      className="product-switcher-menu"
+      id="product-switcher-menu"
+      listId="product-switcher-menu-dropdown"
+    >
+      <ProductMenuItem
+        active={true}
+        destination="/"
+        icon="product-channels"
+        onClick={[Function]}
+        text="Channels"
+      />
+      <ProductMenuItem
+        active={false}
+        destination=""
+        icon="product-boards"
+        id="product-menu-item-Boards"
+        key="Boards"
+        onClick={[Function]}
+        text="Boards"
+      />
+      <ProductMenuItem
+        active={false}
+        destination=""
+        icon="product-playbooks"
+        id="product-menu-item-Playbooks"
+        key="Playbooks"
+        onClick={[Function]}
+        text="Playbooks"
+      />
+      <Connect(ProductMenuList)
+        handleVisitConsoleClick={[Function]}
+        isMessaging={true}
+        onClick={[Function]}
+      />
+      <Memo(MenuGroup)>
+        <MenuStartTrial
+          id="startTrial"
+        />
+      </Memo(MenuGroup)>
+    </Menu>
+  </MenuWrapper>
+</div>
+`;
+
 exports[`components/global/product_switcher should match snapshot with product switcher menu 1`] = `
 <div>
   <MenuWrapper
@@ -247,7 +321,7 @@ exports[`components/global/product_switcher should match snapshot without licens
           color="rgba(var(--sidebar-text-rgb), 0.56)"
           size={20}
         />
-        <ProductBrandingTeamEdition />
+        <ProductBrandingFreeEdition />
       </ProductMenuButton>
     </ProductMenuContainer>
     <Menu

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_team_edition.test.tsx
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_team_edition.test.tsx
@@ -1,0 +1,122 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {renderWithContext, screen} from 'tests/react_testing_utils';
+import {TestHelper} from 'utils/test_helper';
+
+import ProductBrandingFreeEdition from './product_branding_team_edition';
+
+describe('ProductBrandingFreeEdition', () => {
+    const baseProps = {};
+
+    test('should show ENTRY EDITION for Entry license', () => {
+        const state = {
+            entities: {
+                general: {
+                    license: TestHelper.getLicenseMock({
+                        IsLicensed: 'true',
+                        SkuShortName: 'entry',
+                    }),
+                },
+            },
+        };
+
+        const {container} = renderWithContext(
+            <ProductBrandingFreeEdition {...baseProps}/>,
+            state,
+        );
+
+        expect(screen.getByText('ENTRY EDITION')).toBeInTheDocument();
+        const logoElement = container.querySelector('svg');
+        expect(logoElement).toBeInTheDocument();
+    });
+
+    test('should show FREE EDITION for unlicensed', () => {
+        const state = {
+            entities: {
+                general: {
+                    license: TestHelper.getLicenseMock({
+                        IsLicensed: 'false',
+                        SkuShortName: '',
+                    }),
+                },
+            },
+        };
+
+        const {container} = renderWithContext(
+            <ProductBrandingFreeEdition {...baseProps}/>,
+            state,
+        );
+
+        expect(screen.getByText('FREE EDITION')).toBeInTheDocument();
+        const logoElement = container.querySelector('svg');
+        expect(logoElement).toBeInTheDocument();
+    });
+
+    test('should show empty badge for Professional license', () => {
+        const state = {
+            entities: {
+                general: {
+                    license: TestHelper.getLicenseMock({
+                        IsLicensed: 'true',
+                        SkuShortName: 'professional',
+                    }),
+                },
+            },
+        };
+
+        renderWithContext(
+            <ProductBrandingFreeEdition {...baseProps}/>,
+            state,
+        );
+
+        // Should not show any edition badge
+        expect(screen.queryByText('ENTRY EDITION')).not.toBeInTheDocument();
+        expect(screen.queryByText('FREE EDITION')).not.toBeInTheDocument();
+        expect(screen.queryByText('PROFESSIONAL EDITION')).not.toBeInTheDocument();
+    });
+
+    test('should show empty badge for Enterprise license', () => {
+        const state = {
+            entities: {
+                general: {
+                    license: TestHelper.getLicenseMock({
+                        IsLicensed: 'true',
+                        SkuShortName: 'enterprise',
+                    }),
+                },
+            },
+        };
+
+        renderWithContext(
+            <ProductBrandingFreeEdition {...baseProps}/>,
+            state,
+        );
+
+        // Should not show any edition badge
+        expect(screen.queryByText('ENTRY EDITION')).not.toBeInTheDocument();
+        expect(screen.queryByText('FREE EDITION')).not.toBeInTheDocument();
+        expect(screen.queryByText('ENTERPRISE EDITION')).not.toBeInTheDocument();
+    });
+
+    test('should show empty badge when no license object', () => {
+        const state = {
+            entities: {
+                general: {
+                    license: {},
+                },
+            },
+        };
+
+        renderWithContext(
+            <ProductBrandingFreeEdition {...baseProps}/>,
+            state,
+        );
+
+        // Should not show any edition badge when license object is empty
+        expect(screen.queryByText('ENTRY EDITION')).not.toBeInTheDocument();
+        expect(screen.queryByText('FREE EDITION')).not.toBeInTheDocument();
+    });
+});

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_team_edition.tsx
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_team_edition.tsx
@@ -2,11 +2,16 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {useSelector} from 'react-redux';
 import styled from 'styled-components';
+
+import {getLicense} from 'mattermost-redux/selectors/entities/general';
 
 import Logo from 'components/common/svg_images_components/logo_dark_blue_svg';
 
-const ProductBrandingTeamEditionContainer = styled.span`
+import {LicenseSkus} from 'utils/constants';
+
+const ProductBrandingFreeEditionContainer = styled.span`
     display: flex;
     align-items: center;
 
@@ -36,16 +41,25 @@ const Badge = styled.span`
     line-height: 16px;
 `;
 
-const ProductBrandingTeamEdition = (): JSX.Element => {
+const ProductBrandingFreeEdition = (): JSX.Element => {
+    const license = useSelector(getLicense);
+
+    let badgeText = '';
+    if (license?.SkuShortName === LicenseSkus.Entry) {
+        badgeText = 'ENTRY EDITION';
+    } else if (license?.IsLicensed === 'false') {
+        badgeText = 'FREE EDITION';
+    }
+
     return (
-        <ProductBrandingTeamEditionContainer tabIndex={-1}>
+        <ProductBrandingFreeEditionContainer tabIndex={-1}>
             <StyledLogo
                 width={116}
                 height={20}
             />
-            <Badge>{'FREE EDITION'}</Badge>
-        </ProductBrandingTeamEditionContainer>
+            <Badge>{badgeText}</Badge>
+        </ProductBrandingFreeEditionContainer>
     );
 };
 
-export default ProductBrandingTeamEdition;
+export default ProductBrandingFreeEdition;

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu.test.tsx
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu.test.tsx
@@ -10,6 +10,8 @@ import {TopLevelProducts} from 'utils/constants';
 import * as productUtils from 'utils/products';
 import {TestHelper} from 'utils/test_helper';
 
+import ProductBranding from './product_branding';
+import ProductBrandingFreeEdition from './product_branding_team_edition';
 import ProductMenu, {ProductMenuButton, ProductMenuContainer} from './product_menu';
 import ProductMenuItem from './product_menu_item';
 import ProductMenuList from './product_menu_list';
@@ -183,6 +185,120 @@ describe('components/global/product_switcher', () => {
         });
 
         expect(wrapper.find(ProductMenuList)).toHaveLength(1);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should render ProductBrandingFreeEdition for Entry license', () => {
+        const state = {
+            views: {
+                productMenu: {
+                    switcherOpen: false,
+                },
+            },
+        };
+        const store = mockStore(state);
+        const dummyDispatch = jest.fn();
+        useDispatchMock.mockReturnValue(dummyDispatch);
+        useSelectorMock.mockReturnValue(true);
+        useSelectorMock.mockReturnValueOnce(true);
+        useSelectorMock.mockReturnValueOnce({IsLicensed: 'true', SkuShortName: 'entry'});
+        const wrapper = shallow(<ProductMenu/>, {
+            wrappingComponent: reactRedux.Provider,
+            wrappingComponentProps: {store},
+        });
+
+        expect(wrapper.find(ProductBrandingFreeEdition)).toHaveLength(1);
+        expect(wrapper.find(ProductBranding)).toHaveLength(0);
+    });
+
+    it('should render ProductBrandingFreeEdition for unlicensed', () => {
+        const state = {
+            views: {
+                productMenu: {
+                    switcherOpen: false,
+                },
+            },
+        };
+        const store = mockStore(state);
+        const dummyDispatch = jest.fn();
+        useDispatchMock.mockReturnValue(dummyDispatch);
+        useSelectorMock.mockReturnValue(true);
+        useSelectorMock.mockReturnValueOnce(true);
+        useSelectorMock.mockReturnValueOnce({IsLicensed: 'false'});
+        const wrapper = shallow(<ProductMenu/>, {
+            wrappingComponent: reactRedux.Provider,
+            wrappingComponentProps: {store},
+        });
+
+        expect(wrapper.find(ProductBrandingFreeEdition)).toHaveLength(1);
+        expect(wrapper.find(ProductBranding)).toHaveLength(0);
+    });
+
+    it('should render ProductBranding for Professional license', () => {
+        const state = {
+            views: {
+                productMenu: {
+                    switcherOpen: false,
+                },
+            },
+        };
+        const store = mockStore(state);
+        const dummyDispatch = jest.fn();
+        useDispatchMock.mockReturnValue(dummyDispatch);
+        useSelectorMock.mockReturnValue(true);
+        useSelectorMock.mockReturnValueOnce(true);
+        useSelectorMock.mockReturnValueOnce({IsLicensed: 'true', SkuShortName: 'professional'});
+        const wrapper = shallow(<ProductMenu/>, {
+            wrappingComponent: reactRedux.Provider,
+            wrappingComponentProps: {store},
+        });
+
+        expect(wrapper.find(ProductBranding)).toHaveLength(1);
+        expect(wrapper.find(ProductBrandingFreeEdition)).toHaveLength(0);
+    });
+
+    it('should render ProductBranding for Enterprise license', () => {
+        const state = {
+            views: {
+                productMenu: {
+                    switcherOpen: false,
+                },
+            },
+        };
+        const store = mockStore(state);
+        const dummyDispatch = jest.fn();
+        useDispatchMock.mockReturnValue(dummyDispatch);
+        useSelectorMock.mockReturnValue(true);
+        useSelectorMock.mockReturnValueOnce(true);
+        useSelectorMock.mockReturnValueOnce({IsLicensed: 'true', SkuShortName: 'enterprise'});
+        const wrapper = shallow(<ProductMenu/>, {
+            wrappingComponent: reactRedux.Provider,
+            wrappingComponentProps: {store},
+        });
+
+        expect(wrapper.find(ProductBranding)).toHaveLength(1);
+        expect(wrapper.find(ProductBrandingFreeEdition)).toHaveLength(0);
+    });
+
+    it('should match snapshot for Entry license', () => {
+        const state = {
+            views: {
+                productMenu: {
+                    switcherOpen: false,
+                },
+            },
+        };
+        const store = mockStore(state);
+        const dummyDispatch = jest.fn();
+        useDispatchMock.mockReturnValue(dummyDispatch);
+        useSelectorMock.mockReturnValue(true);
+        useSelectorMock.mockReturnValueOnce(true);
+        useSelectorMock.mockReturnValueOnce({IsLicensed: 'true', SkuShortName: 'entry'});
+        const wrapper = shallow(<ProductMenu/>, {
+            wrappingComponent: reactRedux.Provider,
+            wrappingComponentProps: {store},
+        });
+
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu.tsx
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu.tsx
@@ -24,10 +24,11 @@ import {
 import Menu from 'components/widgets/menu/menu';
 import MenuWrapper from 'components/widgets/menu/menu_wrapper';
 
+import {LicenseSkus} from 'utils/constants';
 import {useCurrentProductId, useProducts, isChannels} from 'utils/products';
 
 import ProductBranding from './product_branding';
-import ProductBrandingTeamEdition from './product_branding_team_edition';
+import ProductBrandingFreeEdition from './product_branding_team_edition';
 import ProductMenuItem from './product_menu_item';
 import ProductMenuList from './product_menu_list';
 
@@ -113,6 +114,8 @@ const ProductMenu = (): JSX.Element => {
         );
     });
 
+    const isFreeEdition = license.IsLicensed === 'false' || license.SkuShortName === LicenseSkus.Entry;
+
     return (
         <div ref={menuRef}>
             <MenuWrapper
@@ -132,8 +135,11 @@ const ProductMenu = (): JSX.Element => {
                             size={20}
                             color='rgba(var(--sidebar-text-rgb), 0.56)'
                         />
-                        {license.IsLicensed === 'false' && <ProductBrandingTeamEdition/>}
-                        {license.IsLicensed === 'true' && <ProductBranding/>}
+                        {isFreeEdition ? (
+                            <ProductBrandingFreeEdition/>
+                        ) : (
+                            <ProductBranding/>
+                        )}
                     </ProductMenuButton>
                 </ProductMenuContainer>
                 <Menu

--- a/webapp/channels/src/components/header_footer_route/header.tsx
+++ b/webapp/channels/src/components/header_footer_route/header.tsx
@@ -12,6 +12,7 @@ import BackButton from 'components/common/back_button';
 import Logo from 'components/common/svg_images_components/logo_dark_blue_svg';
 
 import './header.scss';
+import {LicenseSkus} from 'utils/constants';
 
 export type HeaderProps = {
     alternateLink?: React.ReactElement;
@@ -28,6 +29,8 @@ const Header = ({alternateLink, backButtonURL, onBackButtonClick}: HeaderProps) 
     let freeBanner = null;
     if (license.IsLicensed === 'false') {
         freeBanner = <><Logo/><span className='freeBadge'>{'FREE EDITION'}</span></>;
+    } else if (license.SkuShortName === LicenseSkus.Entry) {
+        freeBanner = <><Logo/><span className='freeBadge'>{'ENTRY EDITION'}</span></>;
     }
 
     let title: React.ReactNode = SiteName;

--- a/webapp/channels/src/components/widgets/menu/menu_items/menu_start_trial.test.tsx
+++ b/webapp/channels/src/components/widgets/menu/menu_items/menu_start_trial.test.tsx
@@ -6,6 +6,7 @@ import * as reactRedux from 'react-redux';
 
 import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 import mockStore from 'tests/test_store';
+import {TestHelper} from 'utils/test_helper';
 
 import MenuStartTrial from './menu_start_trial';
 
@@ -16,24 +17,17 @@ describe('components/widgets/menu/menu_items/menu_start_trial', () => {
         useDispatchMock.mockClear();
     });
 
-    test('should render null there is no license currently loaded', () => {
+    test('should render FREE EDITION for unlicensed', () => {
         const state = {
             entities: {
                 users: {
                     currentUserId: 'test_id',
-                    profiles: {
-                        test_id: {
-                            id: 'test_id',
-                            roles: 'system_user',
-                        },
-                    },
                 },
                 general: {
-                    config: {},
-                    license: {
+                    license: TestHelper.getLicenseMock({
                         IsLicensed: 'false',
-                        IsTrial: 'false',
-                    },
+                        SkuShortName: '',
+                    }),
                 },
             },
         };
@@ -41,27 +35,23 @@ describe('components/widgets/menu/menu_items/menu_start_trial', () => {
         const dummyDispatch = jest.fn();
         useDispatchMock.mockReturnValue(dummyDispatch);
         const wrapper = mountWithIntl(<reactRedux.Provider store={store}><MenuStartTrial id='startTrial'/></reactRedux.Provider>);
+
         expect(wrapper.find('.editionText').exists()).toBe(true);
+        expect(wrapper.text()).toContain('FREE EDITION');
+        expect(wrapper.text()).toContain('This is the free');
     });
 
-    test('should render null when there is a license currently loaded', () => {
+    test('should render ENTRY EDITION for Entry license', () => {
         const state = {
             entities: {
                 users: {
                     currentUserId: 'test_id',
-                    profiles: {
-                        test_id: {
-                            id: 'test_id',
-                            roles: 'system_user',
-                        },
-                    },
                 },
                 general: {
-                    config: {},
-                    license: {
+                    license: TestHelper.getLicenseMock({
                         IsLicensed: 'true',
-                        IsTrial: 'false',
-                    },
+                        SkuShortName: 'entry',
+                    }),
                 },
             },
         };
@@ -69,6 +59,53 @@ describe('components/widgets/menu/menu_items/menu_start_trial', () => {
         const dummyDispatch = jest.fn();
         useDispatchMock.mockReturnValue(dummyDispatch);
         const wrapper = mountWithIntl(<reactRedux.Provider store={store}><MenuStartTrial id='startTrial'/></reactRedux.Provider>);
-        expect(wrapper.find('.editionText').exists()).toBe(false);
+
+        expect(wrapper.find('.editionText').exists()).toBe(true);
+        expect(wrapper.text()).toContain('ENTRY EDITION');
+        expect(wrapper.text()).toContain('Entry offers Enterprise Advance capabilities');
+    });
+
+    test('should return null for Professional license', () => {
+        const state = {
+            entities: {
+                users: {
+                    currentUserId: 'test_id',
+                },
+                general: {
+                    license: TestHelper.getLicenseMock({
+                        IsLicensed: 'true',
+                        SkuShortName: 'professional',
+                    }),
+                },
+            },
+        };
+        const store = mockStore(state);
+        const dummyDispatch = jest.fn();
+        useDispatchMock.mockReturnValue(dummyDispatch);
+        const wrapper = mountWithIntl(<reactRedux.Provider store={store}><MenuStartTrial id='startTrial'/></reactRedux.Provider>);
+
+        expect(wrapper.isEmptyRender()).toBe(true);
+    });
+
+    test('should return null for Enterprise license', () => {
+        const state = {
+            entities: {
+                users: {
+                    currentUserId: 'test_id',
+                },
+                general: {
+                    license: TestHelper.getLicenseMock({
+                        IsLicensed: 'true',
+                        SkuShortName: 'enterprise',
+                    }),
+                },
+            },
+        };
+        const store = mockStore(state);
+        const dummyDispatch = jest.fn();
+        useDispatchMock.mockReturnValue(dummyDispatch);
+        const wrapper = mountWithIntl(<reactRedux.Provider store={store}><MenuStartTrial id='startTrial'/></reactRedux.Provider>);
+
+        expect(wrapper.isEmptyRender()).toBe(true);
     });
 });

--- a/webapp/channels/src/components/widgets/menu/menu_items/menu_start_trial.tsx
+++ b/webapp/channels/src/components/widgets/menu/menu_items/menu_start_trial.tsx
@@ -10,7 +10,7 @@ import {getLicense} from 'mattermost-redux/selectors/entities/general';
 
 import ExternalLink from 'components/external_link';
 
-import {LicenseLinks} from 'utils/constants';
+import {LicenseLinks, LicenseSkus} from 'utils/constants';
 
 import './menu_item.scss';
 
@@ -39,10 +39,16 @@ const MenuStartTrial = (props: Props): JSX.Element | null => {
 
     const license = useSelector(getLicense);
     const isCurrentLicensed = license?.IsLicensed;
+    const skuShortName = license?.SkuShortName;
 
-    if (isCurrentLicensed === 'true') {
+    // If licensed and NOT Entry, return null
+    if (isCurrentLicensed === 'true' && skuShortName !== LicenseSkus.Entry) {
         return null;
     }
+
+    // Determine badge text and description based on license type
+    const isEntryLicense = isCurrentLicensed === 'true' && skuShortName === LicenseSkus.Entry;
+    const badgeText = isEntryLicense ? 'ENTRY EDITION' : 'FREE EDITION';
 
     return (
         <li
@@ -50,23 +56,42 @@ const MenuStartTrial = (props: Props): JSX.Element | null => {
             role='menuitem'
             id={props.id}
         >
-            <FreeVersionBadge>{'FREE EDITION'}</FreeVersionBadge>
+            <FreeVersionBadge>{badgeText}</FreeVersionBadge>
             <div className='editionText'>
-                {formatMessage(
-                    {
-                        id: 'navbar_dropdown.versionText',
-                        defaultMessage: 'This is the free <link>unsupported</link> edition of Mattermost.',
+                {isEntryLicense ? (
+                    formatMessage({
+                        id: 'navbar_dropdown.entryVersionText',
+                        defaultMessage: 'Entry offers Enterprise Advance capabilities <link>with limits</link> designed to support evaluation.',
                     },
                     {
                         link: (msg: React.ReactNode) => (
                             <ExternalLink
-                                location='menu_start_trial.unsupported-link'
+                                location='menu_start_trial.entry-link'
+
+                                //TODO: Replace with the correct link
                                 href={LicenseLinks.UNSUPPORTED}
                             >
                                 {msg}
                             </ExternalLink>
                         ),
-                    },
+                    })
+                ) : (
+                    formatMessage(
+                        {
+                            id: 'navbar_dropdown.versionText',
+                            defaultMessage: 'This is the free <link>unsupported</link> edition of Mattermost.',
+                        },
+                        {
+                            link: (msg: React.ReactNode) => (
+                                <ExternalLink
+                                    location='menu_start_trial.unsupported-link'
+                                    href={LicenseLinks.UNSUPPORTED}
+                                >
+                                    {msg}
+                                </ExternalLink>
+                            ),
+                        },
+                    )
                 )}
             </div>
         </li>

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -4919,6 +4919,7 @@
   "navbar_dropdown.userGroups.modal.titleEndUser": "User groups available in paid plans",
   "navbar_dropdown.userGroups.tooltip.cloudFreeTrial": "During your trial you are able to create user groups. These user groups will be archived after your trial.",
   "navbar_dropdown.versionText": "This is the free <link>unsupported</link> edition of Mattermost.",
+  "navbar_dropdown.entryVersionText": "Entry offers Enterprise Advance capabilities <link>with limits</link> designed to support evaluation.",
   "navbar_dropdown.viewMembers": "View Members",
   "navbar.addGroups": "Add Groups",
   "navbar.addMembers": "Add Members",


### PR DESCRIPTION
#### Summary

Extended the `FREE EDITION` label to support new Entry Sku in the Product Header, Product Menu and Header of log in screens. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65066

#### Screenshots

<img width="386" height="516" alt="Screenshot 2025-09-06 at 3 58 29 PM" src="https://github.com/user-attachments/assets/c9174a81-8acf-4f4b-b831-717aec39dba7" />

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
