### PR TITLE
[MM-65573] Fix desktop redirect for pre-auth

### DIFF
--- a/webapp/channels/src/components/login/login.tsx
+++ b/webapp/channels/src/components/login/login.tsx
@@ -835,15 +835,7 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
             );
         }
 
-        if (!enableBaseLogin && !enableExternalSignup) {
-            return (
-                <ColumnLayout
-                    title={formatMessage({id: 'login.noMethods.title', defaultMessage: 'This server doesn’t have any sign-in methods enabled'})}
-                    message={formatMessage({id: 'login.noMethods.subtitle', defaultMessage: 'Please contact your System Administrator to resolve this.'})}
-                />
-            );
-        }
-
+        // Handle redirect before checking configs. This is to support the Pre-Authentication header flow.
         if (desktopLoginLink || query.get('server_token')) {
             return (
                 <Route
@@ -854,6 +846,15 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
                             onLogin={postSubmit}
                         />
                     )}
+                />
+            );
+        }
+
+        if (!enableBaseLogin && !enableExternalSignup) {
+            return (
+                <ColumnLayout
+                    title={formatMessage({id: 'login.noMethods.title', defaultMessage: 'This server doesn’t have any sign-in methods enabled'})}
+                    message={formatMessage({id: 'login.noMethods.subtitle', defaultMessage: 'Please contact your System Administrator to resolve this.'})}
                 />
             );
         }


### PR DESCRIPTION
#### Summary
I repositioned the desktop auth token validation to occur before the configuration checks. This change won't affect existing servers, but it allows servers using the pre-auth header to redirect to the desktop app earlier in the process, before we attempt to validate certain configurations. Those configurations all return false because the request fails in the browser without the pre-auth token.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65573

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
