### PR TITLE
Increase timeout in test-server-race to two hours

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -433,9 +433,9 @@ test-server-race: export GOTESTSUM_JUNITFILE := $(GOTESTSUM_JUNITFILE)
 test-server-race: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
 test-server-race: test-server-pre
 ifeq ($(IS_CI),true)
-	GOMAXPROCS=4 $(GOBIN)/gotestsum --rerun-fails=3 --packages="$(TE_PACKAGES) $(EE_PACKAGES)" -- -race $(GOFLAGS) -timeout=90m
+	GOMAXPROCS=4 $(GOBIN)/gotestsum --rerun-fails=3 --packages="$(TE_PACKAGES) $(EE_PACKAGES)" -- -race $(GOFLAGS) -timeout=2h
 else
-	$(GOBIN)/gotestsum --rerun-fails=3 --packages="$(TE_PACKAGES) $(EE_PACKAGES)" -- -race $(GOFLAGS) -timeout=90m
+	$(GOBIN)/gotestsum --rerun-fails=3 --packages="$(TE_PACKAGES) $(EE_PACKAGES)" -- -race $(GOFLAGS) -timeout=2h
 endif
 ifneq ($(IS_CI),true)
   ifneq ($(MM_NO_DOCKER),true)


### PR DESCRIPTION
#### Summary
Since #33749 was merged, we are seeing tests take more time, eventually reaching the `timeout=90m`. To fix this, we're increasing this timeout to 2 hours.

For more information, see [this thread](https://community.mattermost.com/core/pl/69t3w7mxe3dtie4g7phfp4nndr).

#### Ticket Link
--

#### Screenshots


#### Release Note
```release-note
NONE
```
