### PR TITLE
Add support for pgvector in local dev

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -221,6 +221,13 @@ ifeq ($(ARM_BASED_MAC),true)
   DOCKER_COMPOSE_OVERRIDE := -f docker-compose.makefile.m1.yml $(DOCKER_COMPOSE_OVERRIDE)
 endif
 
+# Support for pgvector postgres image
+MM_USE_PGVECTOR ?= false
+ifeq ($(MM_USE_PGVECTOR),true)
+  $(info Using pgvector/pgvector image for PostgreSQL)
+  DOCKER_COMPOSE_OVERRIDE := -f docker-compose.pgvector.yml $(DOCKER_COMPOSE_OVERRIDE)
+endif
+
 ifneq ($(DOCKER_SERVICES_OVERRIDE),true)
   ifeq (,$(findstring minio,$(ENABLED_DOCKER_SERVICES)))
     TEMP_DOCKER_SERVICES:=$(TEMP_DOCKER_SERVICES) minio
@@ -240,6 +247,9 @@ else ifeq ($(MM_NO_DOCKER),true)
 	@echo No Docker Enabled: skipping docker start
 else
 	@echo Starting docker containers
+ifeq ($(MM_USE_PGVECTOR),true)
+	@echo Using pgvector PostgreSQL image
+endif
 
 	docker compose rm start_dependencies
 	$(GO) run ./build/docker-compose-generator/main.go $(ENABLED_DOCKER_SERVICES) | docker compose -f docker-compose.makefile.yml -f /dev/stdin $(DOCKER_COMPOSE_OVERRIDE) run -T --rm start_dependencies
@@ -577,9 +587,15 @@ build-templates: ## Compile all mjml email templates
 
 run-server: setup-go-work prepackaged-binaries validate-go-version start-docker client ## Starts the server.
 	@echo Running mattermost for development
+ifeq ($(MM_USE_PGVECTOR),true)
+	@echo With pgvector PostgreSQL support enabled
+endif
 
 	mkdir -p $(BUILD_WEBAPP_DIR)/channels/dist/files
 	$(GO) run $(GOFLAGS) -ldflags '$(LDFLAGS)' -tags '$(BUILD_TAGS)' $(PLATFORM_FILES) $(RUN_IN_BACKGROUND)
+
+run-server-pgvector: ## Starts the server with pgvector PostgreSQL image.
+	@MM_USE_PGVECTOR=true $(MAKE) run-server
 
 debug-server: start-docker ## Compile and start server using delve.
 	mkdir -p $(BUILD_WEBAPP_DIR)/channels/dist/files
@@ -635,6 +651,9 @@ run-client-fullmap: client ## Legacy alias to run-client
 
 run: run-server run-client ## Runs the server and webapp.
 
+run-pgvector: ## Runs the server and webapp with pgvector PostgreSQL image.
+	@MM_USE_PGVECTOR=true $(MAKE) run
+
 run-fullmap: run-server run-client ## Legacy alias to run
 
 stop-server: ## Stops the server.
@@ -664,6 +683,9 @@ stop: stop-server stop-client stop-docker ## Stops server, client and the docker
 restart: restart-server restart-client ## Restarts the server and webapp.
 
 restart-server: | stop-server run-server ## Restarts the mattermost server to pick up development change.
+
+restart-server-pgvector: ## Restarts the server with pgvector PostgreSQL image.
+	@MM_USE_PGVECTOR=true $(MAKE) restart-server
 
 restart-haserver:
 	@echo Restarting mattermost in an HA topology

--- a/server/docker-compose.pgvector.yml
+++ b/server/docker-compose.pgvector.yml
@@ -1,0 +1,8 @@
+# Override file to use pgvector/pgvector image instead of standard postgres
+# This file is used when MM_USE_PGVECTOR=true is set
+services:
+  postgres:
+    # Override the postgres image to use pgvector
+    image: "pgvector/pgvector:pg13"
+    # All other settings are inherited from the base service
+


### PR DESCRIPTION
#### Summary
Adds a new command `make run-pgvector` which is a shorthad that wraps the `run` and `run-server` commands to override the base docker-compose database image of postgres/postgres with pgvector/pgvector. This allows for easier local testing of vector search.

#### Ticket Link
N/A

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
None
```
