### PR TITLE
Update api user endpoint docs to fix useAutomaticTimezone type and document more fields

### DIFF
--- a/api/v4/source/definitions.yaml
+++ b/api/v4/source/definitions.yaml
@@ -2689,11 +2689,33 @@ components:
           type: string
           description: Set to "true" to enable mentions for first name. Defaults to "true"
             if a first name is set, "false" otherwise.
+        auto_responder_message:
+          type: string
+          description: The message sent to users when they are auto-responded to.
+            Defaults to "".
+        push_threads:
+          type: string
+          description: Set to "all" to enable mobile push notifications for followed threads and "none" to disable.
+            Defaults to "all".
+        comments:
+          type: string
+          description: Set to "any" to enable notifications for comments to any post you have
+            replied to, "root" for comments on your posts, and "never" to disable. Only
+            affects users with collapsed reply threads disabled.
+            Defaults to "never".
+        desktop_threads:
+          type: string
+          description: Set to "all" to enable desktop notifications for followed threads and "none" to disable.
+            Defaults to "all".
+        email_threads:
+          type: string
+          description: Set to "all" to enable email notifications for followed threads and "none" to disable.
+            Defaults to "all".
     Timezone:
       type: object
       properties:
         useAutomaticTimezone:
-          type: boolean
+          type: string
           description: Set to "true" to use the browser/system timezone, "false" to set
             manually. Defaults to "true".
         manualTimezone:

--- a/api/v4/source/users.yaml
+++ b/api/v4/source/users.yaml
@@ -183,8 +183,9 @@
         Get a page of a list of users. Based on query string parameters, select
         users from a team, channel, or select users not in a specific channel.
 
-
         Since server version 4.0, some basic sorting is available using the `sort` query parameter. Sorting is currently only supported when selecting users on a team.
+
+        Some fields, like `email_verified` and `notify_props`, are only visible for the authorized user or if the authorized user has the `manage_system` permission.
 
         ##### Permissions
 


### PR DESCRIPTION
#### Summary
This PR makes three updates to the API docs:

1. Updates  the `useAutomaticTimezone` field type to `string` to match implementation
2. Documents more `notify_prop` fields
3. Adds a callout that not all fields will be returned at all times in GET `/api/v4/users`

#### Ticket Link
n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
