### PR TITLE
MM-65753 - hide access control tab to ldap/ad synced channels

### DIFF
--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_modal.test.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_modal.test.tsx
@@ -18,6 +18,9 @@ let mockPrivateChannelPermission = true;
 let mockPublicChannelPermission = true;
 let mockManageChannelAccessRulesPermission = false;
 
+// Variable to control group-constrained status in tests
+let mockGroupConstrained = false;
+
 // Mock the redux selectors
 jest.mock('mattermost-redux/selectors/entities/channels', () => ({
     getChannel: jest.fn().mockImplementation((state, channelId) => {
@@ -39,7 +42,7 @@ jest.mock('mattermost-redux/selectors/entities/channels', () => ({
             creator_id: 'creator1',
             last_root_post_at: 0,
             scheme_id: '',
-            group_constrained: false,
+            group_constrained: mockGroupConstrained,
         };
     }),
 }));
@@ -145,6 +148,7 @@ describe('ChannelSettingsModal', () => {
         mockPrivateChannelPermission = true;
         mockPublicChannelPermission = true;
         mockManageChannelAccessRulesPermission = false; // Default to no access rules permission
+        mockGroupConstrained = false; // Default to not group-constrained
     });
 
     it('should render the modal with correct header text', async () => {
@@ -436,6 +440,57 @@ describe('ChannelSettingsModal', () => {
 
             // Access Control tab visibility is not restricted for default channel - only depends on channel type and permission
             expect(screen.getByRole('tab', {name: 'access_rules'})).toBeInTheDocument();
+        });
+
+        it('should not show Access Control tab for group-constrained private channel even with permission', async () => {
+            mockChannelType = 'P';
+            mockManageChannelAccessRulesPermission = true;
+            mockGroupConstrained = true;
+
+            renderWithContext(<ChannelSettingsModal {...baseProps}/>);
+
+            // Wait for the sidebar to load
+            await waitFor(() => {
+                expect(screen.getByTestId('settings-sidebar')).toBeInTheDocument();
+            });
+
+            // The Access Control tab should not be visible for group-constrained channels
+            expect(screen.queryByRole('tab', {name: 'access_rules'})).not.toBeInTheDocument();
+            expect(screen.queryByText('Access Control')).not.toBeInTheDocument();
+        });
+
+        it('should not show Access Control tab for group-constrained private channel without permission', async () => {
+            mockChannelType = 'P';
+            mockManageChannelAccessRulesPermission = false;
+            mockGroupConstrained = true;
+
+            renderWithContext(<ChannelSettingsModal {...baseProps}/>);
+
+            // Wait for the sidebar to load
+            await waitFor(() => {
+                expect(screen.getByTestId('settings-sidebar')).toBeInTheDocument();
+            });
+
+            // The Access Control tab should not be visible (for multiple reasons)
+            expect(screen.queryByRole('tab', {name: 'access_rules'})).not.toBeInTheDocument();
+            expect(screen.queryByText('Access Control')).not.toBeInTheDocument();
+        });
+
+        it('should not show Access Control tab for group-constrained public channel', async () => {
+            mockChannelType = 'O';
+            mockManageChannelAccessRulesPermission = true;
+            mockGroupConstrained = true;
+
+            renderWithContext(<ChannelSettingsModal {...baseProps}/>);
+
+            // Wait for the sidebar to load
+            await waitFor(() => {
+                expect(screen.getByTestId('settings-sidebar')).toBeInTheDocument();
+            });
+
+            // The Access Control tab should not be visible (for multiple reasons: public + group-constrained)
+            expect(screen.queryByRole('tab', {name: 'access_rules'})).not.toBeInTheDocument();
+            expect(screen.queryByText('Access Control')).not.toBeInTheDocument();
         });
     });
 });

--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_modal.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_modal.tsx
@@ -84,7 +84,7 @@ function ChannelSettingsModal({channelId, isOpen, onExited, focusOriginElement}:
     // FEATURE_FLAG_REMOVAL: ChannelAdminManageABACControl - Remove the feature flag check when feature is GA
     const channelAdminABACControlEnabled = useSelector(isChannelAdminManageABACControlEnabled);
 
-    const shouldShowAccessRulesTab = channelAdminABACControlEnabled && canManageChannelAccessRules && channel.type === Constants.PRIVATE_CHANNEL;
+    const shouldShowAccessRulesTab = channelAdminABACControlEnabled && canManageChannelAccessRules && channel.type === Constants.PRIVATE_CHANNEL && !channel.group_constrained;
 
     const [show, setShow] = useState(isOpen);
 


### PR DESCRIPTION
#### Summary
This PR adds the restriction to not display the Access Control tab for group-constrained (LDAP/AD synced) channels since group synchronization and ABAC are mutually exclusive features.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65753

#### Screenshots
<img width="1087" height="809" alt="Screenshot 2025-09-17 at 10 59 40 AM" src="https://github.com/user-attachments/assets/4616b390-8ac9-4712-a535-0e4965d7622e" />


#### Release Note
```release-note
NONE
```
