### PR TITLE
MM-63447/MM-65101 Remaining changes for deprecated registerPostDropdownMenuComponent API

### DIFF
--- a/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss
+++ b/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss
@@ -55,6 +55,7 @@
         span.MenuItem__primary-text {
             display: inline-flex;
             max-width: 100%;
+            align-items: center;
             padding: 5px 0;
             line-height: 22px;
             white-space: nowrap;
@@ -162,8 +163,6 @@
             }
 
             .MenuItem__icon {
-                position: relative;
-                top: 4px;
                 display: inline-flex;
                 width: 20px;
                 height: 20px;

--- a/webapp/channels/src/plugins/registry.ts
+++ b/webapp/channels/src/plugins/registry.ts
@@ -644,9 +644,22 @@ export default class PluginRegistry {
         return {id, rootRegisterMenuItem: registerMenuItem(this.id, id, undefined, text, action, filter)};
     });
 
+    warnedAboutRegisterPostDropdownMenuComponent = false;
+
     // Register a component at the bottom of the post dropdown menu.
     // Accepts a React component. Returns a unique identifier.
     registerPostDropdownMenuComponent = reArg(['component'], ({component}: DPluginComponentProp) => {
+        if (!this.warnedAboutRegisterPostDropdownMenuComponent) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `${this.id}: This plugin is using registerPostDropdownMenuComponent which is deprecated in Mattermost ` +
+                'v11.0. That API will be removed in a future release, and plugins that use it may not work correctly. ' +
+                'Please update the plugin to use registerPostDropdownMenuAction instead. See ' +
+                'https://forum.mattermost.com/t/deprecating-a-post-dropdown-menu-component-plugin-api-v11/25001 for ' +
+                'more information.',
+            );
+            this.warnedAboutRegisterPostDropdownMenuComponent = true;
+        }
         return dispatchPluginComponentAction('PostDropdownMenuItem', this.id, component);
     });
 


### PR DESCRIPTION
#### Summary
These are a bit late, but they're small enough that I'm comfortable squeezing them in before feature complete tomorrow. That's also why I'm comfortable jamming them together into a single PR. 😅

This PR does the following:
1. Adds a one-time console warning for each plugin using `registerPostDropdownMenuComponent`
2. Fixes the vertical alignment of icons when using `registerPostDropdownMenuAction`

Screenshots of those can be seen below

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63447
https://mattermost.atlassian.net/browse/MM-65101

#### Screenshots

<img width="647" height="118" alt="Screenshot 2025-09-18 at 2 20 08 PM" src="https://github.com/user-attachments/assets/2b836253-33e4-49b0-996d-3c4111568805" />

|Current, old version of Playbooks|Current, new version of Playbooks|Branch, new version of Playbooks|
-|-|-
<img width="292" height="197" alt="1 - old api" src="https://github.com/user-attachments/assets/ae2c3aa0-81d0-4957-be95-d903c396ad0d" />|<img width="292" height="197" alt="2- new api, current" src="https://github.com/user-attachments/assets/f47a37a5-2142-4779-b732-c9a505cc474a" />|<img width="292" height="197" alt="3 - new api, pr" src="https://github.com/user-attachments/assets/baf67499-902b-4dad-b03d-63eaa5a03697" />

#### Release Note
```release-note
Added console warning when a plugin uses the now-deprecated registerPostDropdownMenuComponent API
```
