### PR TITLE
MM-65660 Fix broken calls to save telemetry state

### DIFF
--- a/webapp/channels/src/components/onboarding_tasks/complete_your_profile_tour_tip.tsx
+++ b/webapp/channels/src/components/onboarding_tasks/complete_your_profile_tour_tip.tsx
@@ -49,7 +49,7 @@ export const CompleteYourProfileTour = () => {
     const onDismiss = (e: React.MouseEvent) => {
         e.stopPropagation();
         e.preventDefault();
-        handleTask(taskName, steps.START, true);
+        handleTask(taskName, steps.START);
     };
 
     return (

--- a/webapp/channels/src/components/onboarding_tasks/onboarding_tasks_manager.tsx
+++ b/webapp/channels/src/components/onboarding_tasks/onboarding_tasks_manager.tsx
@@ -170,7 +170,7 @@ export const useHandleOnBoardingTaskData = () => {
     const dispatch = useDispatch();
     const currentUserId = useSelector(getCurrentUserId);
     const storeSavePreferences = useCallback(
-        (taskCategory: string, taskName, step: number) => {
+        (taskCategory: string, taskName: string, step: number) => {
             const preferences = [
                 {
                     user_id: currentUserId,
@@ -187,9 +187,8 @@ export const useHandleOnBoardingTaskData = () => {
     return useCallback((
         taskName: string,
         step: number,
-        taskCategory = OnboardingTaskCategory,
     ) => {
-        storeSavePreferences(taskCategory, taskName, step);
+        storeSavePreferences(OnboardingTaskCategory, taskName, step);
     }, [storeSavePreferences]);
 };
 
@@ -206,7 +205,7 @@ export const useHandleOnBoardingTaskTrigger = () => {
     return (taskName: string) => {
         switch (taskName) {
         case OnboardingTasksName.CHANNELS_TOUR: {
-            handleSaveData(taskName, TaskNameMapToSteps[taskName].STARTED, true);
+            handleSaveData(taskName, TaskNameMapToSteps[taskName].STARTED);
             const tourCategory = TutorialTourName.ONBOARDING_TUTORIAL_STEP;
             const preferences = [
                 {
@@ -233,7 +232,7 @@ export const useHandleOnBoardingTaskTrigger = () => {
         case OnboardingTasksName.COMPLETE_YOUR_PROFILE: {
             openMenu(ELEMENT_ID_FOR_USER_ACCOUNT_MENU_BUTTON);
             dispatch(setShowOnboardingCompleteProfileTour(true));
-            handleSaveData(taskName, TaskNameMapToSteps[taskName].STARTED, true);
+            handleSaveData(taskName, TaskNameMapToSteps[taskName].STARTED);
             if (inAdminConsole) {
                 dispatch(switchToChannels());
             }
@@ -242,7 +241,7 @@ export const useHandleOnBoardingTaskTrigger = () => {
         case OnboardingTasksName.VISIT_SYSTEM_CONSOLE: {
             dispatch(setProductMenuSwitcherOpen(true));
             dispatch(setShowOnboardingVisitConsoleTour(true));
-            handleSaveData(taskName, TaskNameMapToSteps[taskName].STARTED, true);
+            handleSaveData(taskName, TaskNameMapToSteps[taskName].STARTED);
             break;
         }
         case OnboardingTasksName.INVITE_PEOPLE: {
@@ -253,11 +252,11 @@ export const useHandleOnBoardingTaskTrigger = () => {
             } else {
                 dispatch(openInvitationsModal());
             }
-            handleSaveData(taskName, TaskNameMapToSteps[taskName].FINISHED, true);
+            handleSaveData(taskName, TaskNameMapToSteps[taskName].FINISHED);
             break;
         }
         case OnboardingTasksName.DOWNLOAD_APP: {
-            handleSaveData(taskName, TaskNameMapToSteps[taskName].FINISHED, true);
+            handleSaveData(taskName, TaskNameMapToSteps[taskName].FINISHED);
             const preferences = [{
                 user_id: currentUserId,
                 category: OnboardingTaskCategory,
@@ -274,7 +273,7 @@ export const useHandleOnBoardingTaskTrigger = () => {
                 dialogType: LearnMoreTrialModal,
             }));
 
-            handleSaveData(taskName, TaskNameMapToSteps[taskName].FINISHED, true);
+            handleSaveData(taskName, TaskNameMapToSteps[taskName].FINISHED);
             break;
         }
         default:

--- a/webapp/channels/src/components/onboarding_tasks/start_trial_tour_tip.tsx
+++ b/webapp/channels/src/components/onboarding_tasks/start_trial_tour_tip.tsx
@@ -34,7 +34,7 @@ export const StartTrialTour = () => {
     const overlayPunchOut = useMeasurePunchouts([], []);
 
     const onDismiss = useCallback(() => {
-        handleTask(taskName, steps.START, true);
+        handleTask(taskName, steps.START);
     }, [handleTask]);
 
     return (

--- a/webapp/channels/src/components/onboarding_tasks/visit_system_console_tour_tip.tsx
+++ b/webapp/channels/src/components/onboarding_tasks/visit_system_console_tour_tip.tsx
@@ -48,7 +48,7 @@ export const VisitSystemConsoleTour = () => {
     const onDismiss = (e: React.MouseEvent) => {
         e.stopPropagation();
         e.preventDefault();
-        handleTask(taskName, steps.START, true);
+        handleTask(taskName, steps.START);
     };
 
     return (


### PR DESCRIPTION
#### Summary
The current typing for `useCallback` and how the default argument somehow masked that we were now passing arguments wrong as of https://github.com/mattermost/mattermost/commit/8cace746923212ce147e0e9107ed1f81233f1987#diff-0f6c1596ed156b7bd43a5ab6c940fbf2d32560f63d58d88d99ef5834c2d9886f. For whatever reason, the final argument to the callback that's returned by `useHandleOnBoardingTaskList` is treated as `any` which leads to us passing a boolean value as the preference category.

#### Ticket Link
MM-65660

#### Release Note
```release-note
NONE
```
