### PR TITLE
Update version.go

### DIFF
--- a/server/public/model/version.go
+++ b/server/public/model/version.go
@@ -13,6 +13,7 @@ import (
 // It should be maintained in chronological order with most current
 // release at the front of the list.
 var versions = []string{
+	"11.0.1",
 	"11.0.0",
 	"10.12.0",
 	"10.11.0",


### PR DESCRIPTION
The patch versions usually get updated automatically but in this case I need to update this manually since v11.0.0 got skipped.

```release-note
NONE
```
