### PR TITLE
[MM-65769] Add UpdatedSince to properties search in pluginapi

### DIFF
--- a/server/channels/store/sqlstore/property_value_store.go
+++ b/server/channels/store/sqlstore/property_value_store.go
@@ -133,8 +133,8 @@ func (s *SqlPropertyValueStore) SearchPropertyValues(opts model.PropertyValueSea
 		builder = builder.Where(sq.Eq{"FieldID": opts.FieldID})
 	}
 
-	if opts.Since > 0 {
-		builder = builder.Where(sq.Gt{"UpdateAt": opts.Since})
+	if opts.UpdatedSince > 0 {
+		builder = builder.Where(sq.Gt{"UpdateAt": opts.UpdatedSince})
 	}
 
 	var values []*model.PropertyValue

--- a/server/channels/store/sqlstore/property_value_store.go
+++ b/server/channels/store/sqlstore/property_value_store.go
@@ -133,8 +133,8 @@ func (s *SqlPropertyValueStore) SearchPropertyValues(opts model.PropertyValueSea
 		builder = builder.Where(sq.Eq{"FieldID": opts.FieldID})
 	}
 
-	if opts.UpdatedSince > 0 {
-		builder = builder.Where(sq.Gt{"UpdateAt": opts.UpdatedSince})
+	if opts.SinceUpdateAt > 0 {
+		builder = builder.Where(sq.Gt{"UpdateAt": opts.SinceUpdateAt})
 	}
 
 	var values []*model.PropertyValue

--- a/server/channels/store/sqlstore/property_value_store.go
+++ b/server/channels/store/sqlstore/property_value_store.go
@@ -133,6 +133,10 @@ func (s *SqlPropertyValueStore) SearchPropertyValues(opts model.PropertyValueSea
 		builder = builder.Where(sq.Eq{"FieldID": opts.FieldID})
 	}
 
+	if opts.Since > 0 {
+		builder = builder.Where(sq.Gt{"UpdateAt": opts.Since})
+	}
+
 	var values []*model.PropertyValue
 	if err := s.GetReplica().SelectBuilder(&values, builder); err != nil {
 		return nil, errors.Wrap(err, "property_value_search_query")

--- a/server/channels/store/storetest/property_value_store.go
+++ b/server/channels/store/storetest/property_value_store.go
@@ -883,7 +883,7 @@ func testSearchPropertyValues(t *testing.T, _ request.CTX, ss store.Store) {
 		{
 			name: "filter by since timestamp - no results before",
 			opts: model.PropertyValueSearchOpts{
-				Since:   value3.UpdateAt, // After all existing values
+				UpdatedSince:   value3.UpdateAt, // After all existing values
 				PerPage: 10,
 			},
 			expectedIDs: []string{},
@@ -891,7 +891,7 @@ func testSearchPropertyValues(t *testing.T, _ request.CTX, ss store.Store) {
 		{
 			name: "filter by since timestamp - get values after specific time",
 			opts: model.PropertyValueSearchOpts{
-				Since:   value1.UpdateAt, // After value1, should get value2 and value3
+				UpdatedSince:   value1.UpdateAt, // After value1, should get value2 and value3
 				PerPage: 10,
 			},
 			expectedIDs: []string{value2.ID, value3.ID},
@@ -900,7 +900,7 @@ func testSearchPropertyValues(t *testing.T, _ request.CTX, ss store.Store) {
 			name: "filter by since timestamp with group filter",
 			opts: model.PropertyValueSearchOpts{
 				GroupID: groupID,
-				Since:   value1.UpdateAt, // After value1, should only get value2 from same group
+				UpdatedSince:   value1.UpdateAt, // After value1, should only get value2 from same group
 				PerPage: 10,
 			},
 			expectedIDs: []string{value2.ID},
@@ -908,7 +908,7 @@ func testSearchPropertyValues(t *testing.T, _ request.CTX, ss store.Store) {
 		{
 			name: "filter by since timestamp including deleted",
 			opts: model.PropertyValueSearchOpts{
-				Since:          value3.UpdateAt, // After value3, should get value4 (deleted)
+				UpdatedSince:          value3.UpdateAt, // After value3, should get value4 (deleted)
 				IncludeDeleted: true,
 				PerPage:        10,
 			},
@@ -984,7 +984,7 @@ func testSearchPropertyValuesSince(t *testing.T, _ request.CTX, ss store.Store) 
 		// Get values updated after value1 (should get value2 and value3)
 		results, err := ss.PropertyValue().SearchPropertyValues(model.PropertyValueSearchOpts{
 			GroupID: groupID,
-			Since:   value1.UpdateAt,
+			UpdatedSince:   value1.UpdateAt,
 			PerPage: 10,
 		})
 		require.NoError(t, err)
@@ -1002,7 +1002,7 @@ func testSearchPropertyValuesSince(t *testing.T, _ request.CTX, ss store.Store) 
 		// Should get both value2 (updated) and value3, so expect 2 results
 		results, err := ss.PropertyValue().SearchPropertyValues(model.PropertyValueSearchOpts{
 			GroupID: groupID,
-			Since:   value3.UpdateAt - 1, // Slightly before value3's timestamp
+			UpdatedSince:   value3.UpdateAt - 1, // Slightly before value3's timestamp
 			PerPage: 10,
 		})
 		require.NoError(t, err)
@@ -1020,7 +1020,7 @@ func testSearchPropertyValuesSince(t *testing.T, _ request.CTX, ss store.Store) 
 		// Get values updated after the most recent update
 		results, err := ss.PropertyValue().SearchPropertyValues(model.PropertyValueSearchOpts{
 			GroupID: groupID,
-			Since:   updatedValue2.UpdateAt, // After the update
+			UpdatedSince:   updatedValue2.UpdateAt, // After the update
 			PerPage: 10,
 		})
 		require.NoError(t, err)
@@ -1031,7 +1031,7 @@ func testSearchPropertyValuesSince(t *testing.T, _ request.CTX, ss store.Store) 
 		// Get values updated since current time
 		results, err := ss.PropertyValue().SearchPropertyValues(model.PropertyValueSearchOpts{
 			GroupID: groupID,
-			Since:   model.GetMillis(),
+			UpdatedSince:   model.GetMillis(),
 			PerPage: 10,
 		})
 		require.NoError(t, err)

--- a/server/channels/store/storetest/property_value_store.go
+++ b/server/channels/store/storetest/property_value_store.go
@@ -881,34 +881,34 @@ func testSearchPropertyValues(t *testing.T, _ request.CTX, ss store.Store) {
 			expectedIDs: []string{value1.ID, value2.ID},
 		},
 		{
-			name: "filter by UpdatedSince timestamp - no results before",
+			name: "filter by SinceUpdateAt timestamp - no results before",
 			opts: model.PropertyValueSearchOpts{
-				UpdatedSince: value3.UpdateAt, // After all existing values
-				PerPage:      10,
+				SinceUpdateAt: value3.UpdateAt, // After all existing values
+				PerPage:       10,
 			},
 			expectedIDs: []string{},
 		},
 		{
-			name: "filter by UpdatedSince timestamp - get values after specific time",
+			name: "filter by SinceUpdateAt timestamp - get values after specific time",
 			opts: model.PropertyValueSearchOpts{
-				UpdatedSince: value1.UpdateAt, // After value1, should get value2 and value3
-				PerPage:      10,
+				SinceUpdateAt: value1.UpdateAt, // After value1, should get value2 and value3
+				PerPage:       10,
 			},
 			expectedIDs: []string{value2.ID, value3.ID},
 		},
 		{
-			name: "filter by UpdatedSince timestamp with group filter",
+			name: "filter by SinceUpdateAt timestamp with group filter",
 			opts: model.PropertyValueSearchOpts{
-				GroupID:      groupID,
-				UpdatedSince: value1.UpdateAt, // After value1, should only get value2 from same group
-				PerPage:      10,
+				GroupID:       groupID,
+				SinceUpdateAt: value1.UpdateAt, // After value1, should only get value2 from same group
+				PerPage:       10,
 			},
 			expectedIDs: []string{value2.ID},
 		},
 		{
-			name: "filter by UpdatedSince timestamp including deleted",
+			name: "filter by SinceUpdateAt timestamp including deleted",
 			opts: model.PropertyValueSearchOpts{
-				UpdatedSince:   value3.UpdateAt, // After value3, should get value4 (deleted)
+				SinceUpdateAt:  value3.UpdateAt, // After value3, should get value4 (deleted)
 				IncludeDeleted: true,
 				PerPage:        10,
 			},
@@ -980,12 +980,12 @@ func testSearchPropertyValuesSince(t *testing.T, _ request.CTX, ss store.Store) 
 	require.Len(t, updatedValues, 1)
 	updatedValue2 := updatedValues[0]
 
-	t.Run("UpdatedSince filters correctly by UpdateAt", func(t *testing.T) {
+	t.Run("SinceUpdateAt filters correctly by UpdateAt", func(t *testing.T) {
 		// Get values updated after value1 (should get value2 and value3)
 		results, err := ss.PropertyValue().SearchPropertyValues(model.PropertyValueSearchOpts{
-			GroupID:      groupID,
-			UpdatedSince: value1.UpdateAt,
-			PerPage:      10,
+			GroupID:       groupID,
+			SinceUpdateAt: value1.UpdateAt,
+			PerPage:       10,
 		})
 		require.NoError(t, err)
 		require.Len(t, results, 2)
@@ -997,13 +997,13 @@ func testSearchPropertyValuesSince(t *testing.T, _ request.CTX, ss store.Store) 
 		require.ElementsMatch(t, []string{value2.ID, value3.ID}, resultIDs)
 	})
 
-	t.Run("UpdatedSince with boundary condition", func(t *testing.T) {
+	t.Run("SinceUpdateAt with boundary condition", func(t *testing.T) {
 		// Get values updated after value3's timestamp
 		// Should get both value2 (updated) and value3, so expect 2 results
 		results, err := ss.PropertyValue().SearchPropertyValues(model.PropertyValueSearchOpts{
-			GroupID:      groupID,
-			UpdatedSince: value3.UpdateAt - 1, // Slightly before value3's timestamp
-			PerPage:      10,
+			GroupID:       groupID,
+			SinceUpdateAt: value3.UpdateAt - 1, // Slightly before value3's timestamp
+			PerPage:       10,
 		})
 		require.NoError(t, err)
 		require.Len(t, results, 2)
@@ -1016,23 +1016,23 @@ func testSearchPropertyValuesSince(t *testing.T, _ request.CTX, ss store.Store) 
 		require.ElementsMatch(t, []string{value2.ID, value3.ID}, resultIDs)
 	})
 
-	t.Run("UpdatedSince after all updates", func(t *testing.T) {
+	t.Run("SinceUpdateAt after all updates", func(t *testing.T) {
 		// Get values updated after the most recent update
 		results, err := ss.PropertyValue().SearchPropertyValues(model.PropertyValueSearchOpts{
-			GroupID:      groupID,
-			UpdatedSince: updatedValue2.UpdateAt, // After the update
-			PerPage:      10,
+			GroupID:       groupID,
+			SinceUpdateAt: updatedValue2.UpdateAt, // After the update
+			PerPage:       10,
 		})
 		require.NoError(t, err)
 		require.Len(t, results, 0) // Should be empty
 	})
 
-	t.Run("UpdatedSince with very recent timestamp", func(t *testing.T) {
+	t.Run("SinceUpdateAt with very recent timestamp", func(t *testing.T) {
 		// Get values updated since current time
 		results, err := ss.PropertyValue().SearchPropertyValues(model.PropertyValueSearchOpts{
-			GroupID:      groupID,
-			UpdatedSince: model.GetMillis(),
-			PerPage:      10,
+			GroupID:       groupID,
+			SinceUpdateAt: model.GetMillis(),
+			PerPage:       10,
 		})
 		require.NoError(t, err)
 		require.Len(t, results, 0)

--- a/server/channels/store/storetest/property_value_store.go
+++ b/server/channels/store/storetest/property_value_store.go
@@ -883,32 +883,32 @@ func testSearchPropertyValues(t *testing.T, _ request.CTX, ss store.Store) {
 		{
 			name: "filter by UpdatedSince timestamp - no results before",
 			opts: model.PropertyValueSearchOpts{
-				UpdatedSince:   value3.UpdateAt, // After all existing values
-				PerPage: 10,
+				UpdatedSince: value3.UpdateAt, // After all existing values
+				PerPage:      10,
 			},
 			expectedIDs: []string{},
 		},
 		{
 			name: "filter by UpdatedSince timestamp - get values after specific time",
 			opts: model.PropertyValueSearchOpts{
-				UpdatedSince:   value1.UpdateAt, // After value1, should get value2 and value3
-				PerPage: 10,
+				UpdatedSince: value1.UpdateAt, // After value1, should get value2 and value3
+				PerPage:      10,
 			},
 			expectedIDs: []string{value2.ID, value3.ID},
 		},
 		{
 			name: "filter by UpdatedSince timestamp with group filter",
 			opts: model.PropertyValueSearchOpts{
-				GroupID: groupID,
-				UpdatedSince:   value1.UpdateAt, // After value1, should only get value2 from same group
-				PerPage: 10,
+				GroupID:      groupID,
+				UpdatedSince: value1.UpdateAt, // After value1, should only get value2 from same group
+				PerPage:      10,
 			},
 			expectedIDs: []string{value2.ID},
 		},
 		{
 			name: "filter by UpdatedSince timestamp including deleted",
 			opts: model.PropertyValueSearchOpts{
-				UpdatedSince:          value3.UpdateAt, // After value3, should get value4 (deleted)
+				UpdatedSince:   value3.UpdateAt, // After value3, should get value4 (deleted)
 				IncludeDeleted: true,
 				PerPage:        10,
 			},
@@ -983,9 +983,9 @@ func testSearchPropertyValuesSince(t *testing.T, _ request.CTX, ss store.Store) 
 	t.Run("UpdatedSince filters correctly by UpdateAt", func(t *testing.T) {
 		// Get values updated after value1 (should get value2 and value3)
 		results, err := ss.PropertyValue().SearchPropertyValues(model.PropertyValueSearchOpts{
-			GroupID: groupID,
-			UpdatedSince:   value1.UpdateAt,
-			PerPage: 10,
+			GroupID:      groupID,
+			UpdatedSince: value1.UpdateAt,
+			PerPage:      10,
 		})
 		require.NoError(t, err)
 		require.Len(t, results, 2)
@@ -1001,9 +1001,9 @@ func testSearchPropertyValuesSince(t *testing.T, _ request.CTX, ss store.Store) 
 		// Get values updated after value3's timestamp
 		// Should get both value2 (updated) and value3, so expect 2 results
 		results, err := ss.PropertyValue().SearchPropertyValues(model.PropertyValueSearchOpts{
-			GroupID: groupID,
-			UpdatedSince:   value3.UpdateAt - 1, // Slightly before value3's timestamp
-			PerPage: 10,
+			GroupID:      groupID,
+			UpdatedSince: value3.UpdateAt - 1, // Slightly before value3's timestamp
+			PerPage:      10,
 		})
 		require.NoError(t, err)
 		require.Len(t, results, 2)
@@ -1019,9 +1019,9 @@ func testSearchPropertyValuesSince(t *testing.T, _ request.CTX, ss store.Store) 
 	t.Run("UpdatedSince after all updates", func(t *testing.T) {
 		// Get values updated after the most recent update
 		results, err := ss.PropertyValue().SearchPropertyValues(model.PropertyValueSearchOpts{
-			GroupID: groupID,
-			UpdatedSince:   updatedValue2.UpdateAt, // After the update
-			PerPage: 10,
+			GroupID:      groupID,
+			UpdatedSince: updatedValue2.UpdateAt, // After the update
+			PerPage:      10,
 		})
 		require.NoError(t, err)
 		require.Len(t, results, 0) // Should be empty
@@ -1030,9 +1030,9 @@ func testSearchPropertyValuesSince(t *testing.T, _ request.CTX, ss store.Store) 
 	t.Run("UpdatedSince with very recent timestamp", func(t *testing.T) {
 		// Get values updated since current time
 		results, err := ss.PropertyValue().SearchPropertyValues(model.PropertyValueSearchOpts{
-			GroupID: groupID,
-			UpdatedSince:   model.GetMillis(),
-			PerPage: 10,
+			GroupID:      groupID,
+			UpdatedSince: model.GetMillis(),
+			PerPage:      10,
 		})
 		require.NoError(t, err)
 		require.Len(t, results, 0)

--- a/server/channels/store/storetest/property_value_store.go
+++ b/server/channels/store/storetest/property_value_store.go
@@ -881,7 +881,7 @@ func testSearchPropertyValues(t *testing.T, _ request.CTX, ss store.Store) {
 			expectedIDs: []string{value1.ID, value2.ID},
 		},
 		{
-			name: "filter by since timestamp - no results before",
+			name: "filter by UpdatedSince timestamp - no results before",
 			opts: model.PropertyValueSearchOpts{
 				UpdatedSince:   value3.UpdateAt, // After all existing values
 				PerPage: 10,
@@ -889,7 +889,7 @@ func testSearchPropertyValues(t *testing.T, _ request.CTX, ss store.Store) {
 			expectedIDs: []string{},
 		},
 		{
-			name: "filter by since timestamp - get values after specific time",
+			name: "filter by UpdatedSince timestamp - get values after specific time",
 			opts: model.PropertyValueSearchOpts{
 				UpdatedSince:   value1.UpdateAt, // After value1, should get value2 and value3
 				PerPage: 10,
@@ -897,7 +897,7 @@ func testSearchPropertyValues(t *testing.T, _ request.CTX, ss store.Store) {
 			expectedIDs: []string{value2.ID, value3.ID},
 		},
 		{
-			name: "filter by since timestamp with group filter",
+			name: "filter by UpdatedSince timestamp with group filter",
 			opts: model.PropertyValueSearchOpts{
 				GroupID: groupID,
 				UpdatedSince:   value1.UpdateAt, // After value1, should only get value2 from same group
@@ -906,7 +906,7 @@ func testSearchPropertyValues(t *testing.T, _ request.CTX, ss store.Store) {
 			expectedIDs: []string{value2.ID},
 		},
 		{
-			name: "filter by since timestamp including deleted",
+			name: "filter by UpdatedSince timestamp including deleted",
 			opts: model.PropertyValueSearchOpts{
 				UpdatedSince:          value3.UpdateAt, // After value3, should get value4 (deleted)
 				IncludeDeleted: true,
@@ -980,7 +980,7 @@ func testSearchPropertyValuesSince(t *testing.T, _ request.CTX, ss store.Store) 
 	require.Len(t, updatedValues, 1)
 	updatedValue2 := updatedValues[0]
 
-	t.Run("Since filters correctly by UpdateAt", func(t *testing.T) {
+	t.Run("UpdatedSince filters correctly by UpdateAt", func(t *testing.T) {
 		// Get values updated after value1 (should get value2 and value3)
 		results, err := ss.PropertyValue().SearchPropertyValues(model.PropertyValueSearchOpts{
 			GroupID: groupID,
@@ -997,7 +997,7 @@ func testSearchPropertyValuesSince(t *testing.T, _ request.CTX, ss store.Store) 
 		require.ElementsMatch(t, []string{value2.ID, value3.ID}, resultIDs)
 	})
 
-	t.Run("Since with boundary condition", func(t *testing.T) {
+	t.Run("UpdatedSince with boundary condition", func(t *testing.T) {
 		// Get values updated after value3's timestamp
 		// Should get both value2 (updated) and value3, so expect 2 results
 		results, err := ss.PropertyValue().SearchPropertyValues(model.PropertyValueSearchOpts{
@@ -1016,7 +1016,7 @@ func testSearchPropertyValuesSince(t *testing.T, _ request.CTX, ss store.Store) 
 		require.ElementsMatch(t, []string{value2.ID, value3.ID}, resultIDs)
 	})
 
-	t.Run("Since after all updates", func(t *testing.T) {
+	t.Run("UpdatedSince after all updates", func(t *testing.T) {
 		// Get values updated after the most recent update
 		results, err := ss.PropertyValue().SearchPropertyValues(model.PropertyValueSearchOpts{
 			GroupID: groupID,
@@ -1027,7 +1027,7 @@ func testSearchPropertyValuesSince(t *testing.T, _ request.CTX, ss store.Store) 
 		require.Len(t, results, 0) // Should be empty
 	})
 
-	t.Run("Since with very recent timestamp", func(t *testing.T) {
+	t.Run("UpdatedSince with very recent timestamp", func(t *testing.T) {
 		// Get values updated since current time
 		results, err := ss.PropertyValue().SearchPropertyValues(model.PropertyValueSearchOpts{
 			GroupID: groupID,

--- a/server/public/model/property_value.go
+++ b/server/public/model/property_value.go
@@ -94,7 +94,7 @@ type PropertyValueSearchOpts struct {
 	TargetType     string
 	TargetIDs      []string
 	FieldID        string
-	Since          int64 // UpdateAt after which to send the items
+	UpdatedSince    int64 // UpdateAt after which to send the items
 	IncludeDeleted bool
 	Cursor         PropertyValueSearchCursor
 	PerPage        int

--- a/server/public/model/property_value.go
+++ b/server/public/model/property_value.go
@@ -94,7 +94,7 @@ type PropertyValueSearchOpts struct {
 	TargetType     string
 	TargetIDs      []string
 	FieldID        string
-	UpdatedSince    int64 // UpdateAt after which to send the items
+	UpdatedSince   int64 // UpdateAt after which to send the items
 	IncludeDeleted bool
 	Cursor         PropertyValueSearchCursor
 	PerPage        int

--- a/server/public/model/property_value.go
+++ b/server/public/model/property_value.go
@@ -94,7 +94,7 @@ type PropertyValueSearchOpts struct {
 	TargetType     string
 	TargetIDs      []string
 	FieldID        string
-	UpdatedSince   int64 // UpdateAt after which to send the items
+	SinceUpdateAt  int64 // UpdateAt after which to send the items
 	IncludeDeleted bool
 	Cursor         PropertyValueSearchCursor
 	PerPage        int

--- a/server/public/model/property_value.go
+++ b/server/public/model/property_value.go
@@ -94,6 +94,7 @@ type PropertyValueSearchOpts struct {
 	TargetType     string
 	TargetIDs      []string
 	FieldID        string
+	Since          int64 // UpdateAt after which to send the items
 	IncludeDeleted bool
 	Cursor         PropertyValueSearchCursor
 	PerPage        int


### PR DESCRIPTION
#### Summary
add a since parameter to the plugin api search for properties, which will help plugins do a scoped search in behalf of mobile clients

#### Ticket Link
[MM-65769](https://mattermost.atlassian.net/browse/MM-65769)

#### Release Note
```release-note
Added `since` parameter to the property value search method of the PluginApi
```


[MM-65769]: https://mattermost.atlassian.net/browse/MM-65769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ