### PR TITLE
Fix OnBoardingTaskList appearing during organization setup flow

### DIFF
--- a/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist.tsx
+++ b/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist.tsx
@@ -4,6 +4,7 @@
 import React, {useCallback, useEffect, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
+import {useLocation} from 'react-router-dom';
 import styled, {css} from 'styled-components';
 
 import {CloseIcon, PlaylistCheckIcon} from '@mattermost/compass-icons/components';
@@ -125,6 +126,7 @@ const Button = styled.button<{open: boolean}>(({open}) => {
 
 const OnBoardingTaskList = (): JSX.Element | null => {
     const {formatMessage} = useIntl();
+    const location = useLocation();
     const hasPreferences = useSelector((state: GlobalState) => Object.keys(getMyPreferencesSelector(state)).length !== 0);
     const subscription = useSelector(getCloudSubscription);
     const license = useSelector(getLicense);
@@ -237,7 +239,7 @@ const OnBoardingTaskList = (): JSX.Element | null => {
         dispatch(savePreferences(currentUserId, preferences));
     }, [open, currentUserId]);
 
-    if (!hasPreferences || !showTaskList || !isEnableOnboardingFlow || (isCloud && isCloudPreview)) {
+    if (!hasPreferences || !showTaskList || !isEnableOnboardingFlow || (isCloud && isCloudPreview) || location.pathname === '/preparing-workspace') {
         return null;
     }
 


### PR DESCRIPTION
#### Summary
Hide the "Welcome to Mattermost" onboarding task list when users are on the `/preparing-workspace` route to prevent conflicting UI during the "What's the name of your organization" flow.

This fixes a regression introduced in MM-64380 where the removal of theme-based conditional rendering caused OnBoardingTaskList to appear on all logged-in routes, including the preparing-workspace flow where it conflicts with the organization setup screen.

The fix adds route-based conditional rendering to restore the original intended behavior while maintaining the simplified component structure.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-65817

#### Release Note
```release-note
NONE
```
