### PR TITLE
MM-65815: Fix search results causing blank page when leaving channel

### DIFF
--- a/webapp/channels/src/components/search_results/index.tsx
+++ b/webapp/channels/src/components/search_results/index.tsx
@@ -30,24 +30,14 @@ function makeMapStateToProps() {
     let results: Post[];
     let fileResults: FileSearchResultItem[];
     let files: FileSearchResultItem[] = [];
-    let posts: Post[];
     const addDateSeparatorsForSearchResults = makeAddDateSeparatorsForSearchResults();
 
     return function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
         const newResults = getSearchResults(state);
 
-        // Cache posts and channels
+        // Cache results
         if (newResults && newResults !== results) {
             results = newResults;
-
-            posts = [];
-            results.forEach((post) => {
-                if (!post) {
-                    return;
-                }
-
-                posts.push(post);
-            });
 
             if (ownProps.isPinnedPosts) {
                 results = results.sort((postA: Post | FileSearchResultItem, postB: Post | FileSearchResultItem) => postB.create_at - postA.create_at);

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/posts.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/posts.test.ts
@@ -1438,3 +1438,80 @@ describe('makeGetProfilesForThread', () => {
         expect(getProfilesForThread(state, '1001')).toEqual([]);
     });
 });
+
+describe('getSearchResults', () => {
+    it('should return empty array when no search results', () => {
+        const state = {
+            entities: {
+                posts: {
+                    posts: {},
+                },
+                search: {
+                    results: [],
+                },
+            },
+        } as unknown as GlobalState;
+
+        const results = Selectors.getSearchResults(state);
+        expect(results).toEqual([]);
+    });
+
+    it('should return posts for valid search result IDs', () => {
+        const post1 = p({id: 'post1', message: 'Hello'});
+        const post2 = p({id: 'post2', message: 'World'});
+
+        const state = {
+            entities: {
+                posts: {
+                    posts: {
+                        post1,
+                        post2,
+                    },
+                },
+                search: {
+                    results: ['post1', 'post2'],
+                },
+            },
+        } as unknown as GlobalState;
+
+        const results = Selectors.getSearchResults(state);
+        expect(results).toEqual([post1, post2]);
+    });
+
+    it('should filter out non-existent posts from search results', () => {
+        const post1 = p({id: 'post1', message: 'Hello'});
+
+        const state = {
+            entities: {
+                posts: {
+                    posts: {
+                        post1,
+                    },
+                },
+                search: {
+                    results: ['post1', 'non_existent_post', 'another_missing_post'],
+                },
+            },
+        } as unknown as GlobalState;
+
+        const results = Selectors.getSearchResults(state);
+        expect(results).toEqual([post1]);
+        expect(results).toHaveLength(1);
+    });
+
+    it('should return empty array when all search result posts are non-existent', () => {
+        const state = {
+            entities: {
+                posts: {
+                    posts: {},
+                },
+                search: {
+                    results: ['non_existent_post1', 'non_existent_post2'],
+                },
+            },
+        } as unknown as GlobalState;
+
+        const results = Selectors.getSearchResults(state);
+        expect(results).toEqual([]);
+    });
+});

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/posts.ts
@@ -336,7 +336,8 @@ export const getSearchResults: (state: GlobalState) => Post[] = createSelector(
             return [];
         }
 
-        return postIds.map((id) => posts[id]);
+        // Filter out posts that may no longer exist
+        return postIds.map((id) => posts[id]).filter((post) => post);
     },
 );
 


### PR DESCRIPTION
#### Summary

Fixed an issue where leaving a channel after jumping to a post from search results would cause a blank page with JavaScript console errors. The root cause was that search results could reference posts that no longer existed in the Redux store, leading to undefined values being processed by UI components.

**QA Test Steps:**
1. Create a channel and post a message
2. Search for words from that message
3. Click "Jump" from search results to navigate to the post
4. Select the channel dropdown and choose "Leave channel"
5. Verify you're redirected to Town Square without errors

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-65815

#### Release Note
```release-note
NONE
```