### PR TITLE
Adds operation ID to the PatchCPAValuesForUser endpoint

### DIFF
--- a/api/v4/source/custom_profile_attributes.yaml
+++ b/api/v4/source/custom_profile_attributes.yaml
@@ -369,6 +369,7 @@
           required: true
           schema:
             type: string
+      operationId: PatchCPAValuesForUser
       requestBody:
         description: Custom Profile Attribute values that are to be updated
         required: true


### PR DESCRIPTION
#### Summary
Adds the `operationID` to the API docs for the newly added endpoint.

#### Release Note
```release-note
NOTE
```
