### PR TITLE
Feat: MM-65754 Channel Auto-Translate configuration

### DIFF
--- a/server/config/client.go
+++ b/server/config/client.go
@@ -239,7 +239,11 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 		}
 
 		if model.MinimumEnterpriseAdvancedLicense(license) {
+			props["MobileEnableSecureFilePreview"] = strconv.FormatBool(*c.NativeAppSettings.MobileEnableSecureFilePreview)
+			props["MobileAllowPdfLinkNavigation"] = strconv.FormatBool(*c.NativeAppSettings.MobileAllowPdfLinkNavigation)
+
 			props["ContentFlaggingEnabled"] = strconv.FormatBool(c.FeatureFlags.ContentFlagging && *c.ContentFlaggingSettings.EnableContentFlagging)
+			props["EnableAutoTranslation"] = strconv.FormatBool(c.FeatureFlags.AutoTranslate && *c.AutoTranslationSettings.Enable)
 		}
 	}
 
@@ -409,11 +413,6 @@ func GenerateLimitedClientConfig(c *model.Config, telemetryID string, license *m
 			props["MobileEnableBiometrics"] = strconv.FormatBool(*c.NativeAppSettings.MobileEnableBiometrics)
 			props["MobilePreventScreenCapture"] = strconv.FormatBool(*c.NativeAppSettings.MobilePreventScreenCapture)
 			props["MobileJailbreakProtection"] = strconv.FormatBool(*c.NativeAppSettings.MobileJailbreakProtection)
-		}
-
-		if model.MinimumEnterpriseAdvancedLicense(license) {
-			props["MobileEnableSecureFilePreview"] = strconv.FormatBool(*c.NativeAppSettings.MobileEnableSecureFilePreview)
-			props["MobileAllowPdfLinkNavigation"] = strconv.FormatBool(*c.NativeAppSettings.MobileAllowPdfLinkNavigation)
 		}
 	}
 

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9045,6 +9045,30 @@
     "translation": "Invalid RemoteImageProxyURL for atmos/camo. Must be set to your shared key."
   },
   {
+    "id": "model.config.is_valid.autotranslation.libretranslate.url.app_error",
+    "translation": "LibreTranslate URL must be a valid URL and start with http:// or https://."
+  },
+  {
+    "id": "model.config.is_valid.autotranslation.provider.app_error",
+    "translation": "Invalid autotranslation provider, must not be empty."
+  },
+  {
+    "id": "model.config.is_valid.autotranslation.provider.unsupported.app_error",
+    "translation": "Unsupported autotranslation provider."
+  },
+  {
+    "id": "model.config.is_valid.autotranslation.timeouts.fetch.app_error",
+    "translation": "Invalid fetch timeout for autotranslation settings. Must be a positive number."
+  },
+  {
+    "id": "model.config.is_valid.autotranslation.timeouts.new_post.app_error",
+    "translation": "Invalid new post timeout for autotranslation settings. Must be a positive number."
+  },
+  {
+    "id": "model.config.is_valid.autotranslation.timeouts.notification.app_error",
+    "translation": "Invalid notification timeout for autotranslation settings. Must be a positive number."
+  },
+  {
     "id": "model.config.is_valid.cache_type.app_error",
     "translation": "Cache type must be either lru or redis."
   },

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -4701,6 +4701,19 @@ func (s *AutoTranslationSettings) isValid() *AppError {
 		// 		return NewAppError("Config.IsValid", "model.config.is_valid.autotranslation.agents.bot_user_id.app_error", nil, "", http.StatusBadRequest)
 		// 	}
 		// }
+
+		// Validate timeouts if set
+		if s.Timeouts != nil {
+			if s.Timeouts.NewPost != nil && *s.Timeouts.NewPost <= 0 {
+				return NewAppError("Config.IsValid", "model.config.is_valid.autotranslation.timeouts.new_post.app_error", nil, "", http.StatusBadRequest)
+			}
+			if s.Timeouts.Fetch != nil && *s.Timeouts.Fetch <= 0 {
+				return NewAppError("Config.IsValid", "model.config.is_valid.autotranslation.timeouts.fetch.app_error", nil, "", http.StatusBadRequest)
+			}
+			if s.Timeouts.Notification != nil && *s.Timeouts.Notification <= 0 {
+				return NewAppError("Config.IsValid", "model.config.is_valid.autotranslation.timeouts.notification.app_error", nil, "", http.StatusBadRequest)
+			}
+		}
 	}
 
 	return nil

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -2695,7 +2695,8 @@ type AutoTranslationSettings struct {
 	Provider       *string                         `access:"site_localization,cloud_restrictable"`
 	Timeouts       *AutoTranslationTimeouts        `access:"site_localization,cloud_restrictable"`
 	LibreTranslate *LibreTranslateProviderSettings `access:"site_localization,cloud_restrictable"`
-	Agents         *AgentsProviderSettings         `access:"site_localization,cloud_restrictable"`
+	// TODO: Enable Agents provider in future release
+	// Agents         *AgentsProviderSettings         `access:"site_localization,cloud_restrictable"`
 }
 
 type AutoTranslationTimeouts struct {
@@ -2709,9 +2710,10 @@ type LibreTranslateProviderSettings struct {
 	APIKey *string `access:"site_localization,cloud_restrictable"`
 }
 
-type AgentsProviderSettings struct {
-	BotUserId *string `access:"site_localization,cloud_restrictable"`
-}
+// TODO: Enable Agents provider in future release
+// type AgentsProviderSettings struct {
+// 	BotUserId *string `access:"site_localization,cloud_restrictable"`
+// }
 
 func (s *AutoTranslationSettings) SetDefaults() {
 	if s.Enable == nil {
@@ -2719,7 +2721,7 @@ func (s *AutoTranslationSettings) SetDefaults() {
 	}
 
 	if s.Provider == nil {
-		s.Provider = NewPointer("agents")
+		s.Provider = NewPointer("libretranslate")
 	}
 
 	if s.Timeouts == nil {
@@ -2732,10 +2734,11 @@ func (s *AutoTranslationSettings) SetDefaults() {
 	}
 	s.LibreTranslate.SetDefaults()
 
-	if s.Agents == nil {
-		s.Agents = &AgentsProviderSettings{}
-	}
-	s.Agents.SetDefaults()
+	// TODO: Enable Agents provider in future release
+	// if s.Agents == nil {
+	// 	s.Agents = &AgentsProviderSettings{}
+	// }
+	// s.Agents.SetDefaults()
 }
 
 func (s *AutoTranslationTimeouts) SetDefaults() {
@@ -2762,11 +2765,12 @@ func (s *LibreTranslateProviderSettings) SetDefaults() {
 	}
 }
 
-func (s *AgentsProviderSettings) SetDefaults() {
-	if s.BotUserId == nil {
-		s.BotUserId = NewPointer("")
-	}
-}
+// TODO: Enable Agents provider in future release
+// func (s *AgentsProviderSettings) SetDefaults() {
+// 	if s.BotUserId == nil {
+// 		s.BotUserId = NewPointer("")
+// 	}
+// }
 
 type SamlSettings struct {
 	// Basic
@@ -4680,7 +4684,8 @@ func (s *AutoTranslationSettings) isValid() *AppError {
 		if s.Provider == nil {
 			return NewAppError("Config.IsValid", "model.config.is_valid.autotranslation.provider.app_error", nil, "", http.StatusBadRequest)
 		}
-		if *s.Provider != "agents" && *s.Provider != "libretranslate" {
+		// TODO: Enable Agents provider in future release
+		if *s.Provider != "libretranslate" {
 			return NewAppError("Config.IsValid", "model.config.is_valid.autotranslation.provider.unsupported.app_error", nil, "", http.StatusBadRequest)
 		}
 
@@ -4690,11 +4695,12 @@ func (s *AutoTranslationSettings) isValid() *AppError {
 			}
 		}
 
-		if *s.Provider == "agents" {
-			if s.Agents == nil || s.Agents.BotUserId == nil || *s.Agents.BotUserId == "" {
-				return NewAppError("Config.IsValid", "model.config.is_valid.autotranslation.agents.bot_user_id.app_error", nil, "", http.StatusBadRequest)
-			}
-		}
+		// TODO: Enable Agents provider in future release
+		// if *s.Provider == "agents" {
+		// 	if s.Agents == nil || s.Agents.BotUserId == nil || *s.Agents.BotUserId == "" {
+		// 		return NewAppError("Config.IsValid", "model.config.is_valid.autotranslation.agents.bot_user_id.app_error", nil, "", http.StatusBadRequest)
+		// 	}
+		// }
 	}
 
 	return nil

--- a/server/public/model/config_test.go
+++ b/server/public/model/config_test.go
@@ -2474,13 +2474,14 @@ func TestAutoTranslationSettingsDefaults(t *testing.T) {
 		c.SetDefaults()
 
 		require.False(t, *c.AutoTranslationSettings.Enable)
-		require.Equal(t, "agents", *c.AutoTranslationSettings.Provider)
+		require.Equal(t, "libretranslate", *c.AutoTranslationSettings.Provider)
 		require.Equal(t, 800, *c.AutoTranslationSettings.Timeouts.NewPost)
 		require.Equal(t, 2000, *c.AutoTranslationSettings.Timeouts.Fetch)
 		require.Equal(t, 300, *c.AutoTranslationSettings.Timeouts.Notification)
 		require.Equal(t, "", *c.AutoTranslationSettings.LibreTranslate.URL)
 		require.Equal(t, "", *c.AutoTranslationSettings.LibreTranslate.APIKey)
-		require.Equal(t, "", *c.AutoTranslationSettings.Agents.BotUserId)
+		// TODO: Enable Agents provider in future release
+		// require.Equal(t, "", *c.AutoTranslationSettings.Agents.BotUserId)
 	})
 }
 
@@ -2527,18 +2528,19 @@ func TestAutoTranslationSettingsIsValid(t *testing.T) {
 			expectError: true,
 			errorId:     "model.config.is_valid.autotranslation.libretranslate.url.app_error",
 		},
-		{
-			name: "agents without bot user ID should fail",
-			settings: AutoTranslationSettings{
-				Enable:   NewPointer(true),
-				Provider: NewPointer("agents"),
-				Agents: &AgentsProviderSettings{
-					BotUserId: NewPointer(""),
-				},
-			},
-			expectError: true,
-			errorId:     "model.config.is_valid.autotranslation.agents.bot_user_id.app_error",
-		},
+		// TODO: Enable Agents provider in future release
+		// {
+		// 	name: "agents without bot user ID should fail",
+		// 	settings: AutoTranslationSettings{
+		// 		Enable:   NewPointer(true),
+		// 		Provider: NewPointer("agents"),
+		// 		Agents: &AgentsProviderSettings{
+		// 			BotUserId: NewPointer(""),
+		// 		},
+		// 	},
+		// 	expectError: true,
+		// 	errorId:     "model.config.is_valid.autotranslation.agents.bot_user_id.app_error",
+		// },
 		{
 			name: "valid libretranslate settings",
 			settings: AutoTranslationSettings{
@@ -2551,17 +2553,18 @@ func TestAutoTranslationSettingsIsValid(t *testing.T) {
 			},
 			expectError: false,
 		},
-		{
-			name: "valid agents settings",
-			settings: AutoTranslationSettings{
-				Enable:   NewPointer(true),
-				Provider: NewPointer("agents"),
-				Agents: &AgentsProviderSettings{
-					BotUserId: NewPointer("bot123"),
-				},
-			},
-			expectError: false,
-		},
+		// TODO: Enable Agents provider in future release
+		// {
+		// 	name: "valid agents settings",
+		// 	settings: AutoTranslationSettings{
+		// 		Enable:   NewPointer(true),
+		// 		Provider: NewPointer("agents"),
+		// 		Agents: &AgentsProviderSettings{
+		// 			BotUserId: NewPointer("bot123"),
+		// 		},
+		// 	},
+		// 	expectError: false,
+		// },
 	}
 
 	for _, tc := range testCases {

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -78,6 +78,10 @@ type FeatureFlags struct {
 	// FEATURE_FLAG_REMOVAL: ChannelAdminManageABACRules - Remove this field when feature is GA
 	// Enable channel admins to manage ABAC rules for their channels
 	ChannelAdminManageABACRules bool
+
+	// FEATURE_FLAG_REMOVAL: AutoTranslate - Remove this default when MVP is to be released
+	// Enable auto-translation feature for messages in channels
+	AutoTranslate bool
 }
 
 func (f *FeatureFlags) SetDefaults() {
@@ -111,6 +115,9 @@ func (f *FeatureFlags) SetDefaults() {
 	f.EnableMattermostEntry = true
 	// FEATURE_FLAG_REMOVAL: ChannelAdminManageABACRules - Remove this default when feature is GA
 	f.ChannelAdminManageABACRules = false // Default to false for safety
+
+	// FEATURE_FLAG_REMOVAL: AutoTranslate - Remove this default when MVP is to be released
+	f.AutoTranslate = false
 }
 
 // ToMap returns the feature flags as a map[string]string


### PR DESCRIPTION
#### Summary
This PR implements the initial server configuration infrastructure for the Channel Auto-Translation feature. It adds a new AutoTranslation configuration section to the server config structure and exposes the necessary settings to client applications through existing API endpoints.

**Key Changes:**
- Added AutoTranslation configuration section with Enabled, Provider, Timeouts, and LibreTranslate fields
- Implemented configuration validation for provider values and timeout settings
- Exposed AutoTranslation config through client API endpoints with proper license enforcement
- Ensured sensitive fields (API keys) are excluded from client exposure

**Note:**
Let the code related to MM Agents configuration commented out as we decided not to include it in the initial release, but kept it for reference.

**QA Test Steps:**
1. Verify AutoTranslation config appears in server configuration
2. Test that client API returns config only with Enterprise Advanced license
3. Confirm sensitive fields (API keys) are not exposed to clients
4. Validate configuration validation works for invalid provider values and negative timeouts

This is foundational work for the auto-translation feature - translation functionality will be implemented in subsequent PRs.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65754

#### Screenshots
N/A - This PR contains only backend configuration changes with no UI modifications.

#### Release Note
```release-note
NONE
```