### PR TITLE
[MM-65830] Fix mmctl system status exit code for health check failures

### DIFF
--- a/server/cmd/mmctl/commands/init.go
+++ b/server/cmd/mmctl/commands/init.go
@@ -141,6 +141,8 @@ func withClientAndExitCode(fn func(c client.Client, cmd *cobra.Command, args []s
 			return err
 		}
 		if shouldExit {
+			// Flush the printer as the program will exit soon
+			printer.Flush()
 			os.Exit(1)
 		}
 		return nil

--- a/server/cmd/mmctl/commands/init.go
+++ b/server/cmd/mmctl/commands/init.go
@@ -134,33 +134,6 @@ func withClient(fn func(c client.Client, cmd *cobra.Command, args []string) erro
 	}
 }
 
-// withClientAndExitCode wraps command functions that return (bool, error) to work with cobra.
-// The boolean indicates whether the command should exit with code 1 (true) or 0 (false).
-// This is useful for health check commands where you want to print output and then exit
-// with a specific exit code without displaying error messages.
-//
-// Usage:
-//
-//	RunE: withClientAndExitCode(myCommandFunc)
-//
-// where myCommandFunc has signature:
-//
-//	func(c client.Client, cmd *cobra.Command, args []string) (bool, error)
-func withClientAndExitCode(fn func(c client.Client, cmd *cobra.Command, args []string) (bool, error)) func(cmd *cobra.Command, args []string) error {
-	return withClient(func(c client.Client, cmd *cobra.Command, args []string) error {
-		shouldExit, err := fn(c, cmd, args)
-		if err != nil {
-			return err
-		}
-		if shouldExit {
-			// Flush the printer as the program will exit soon
-			printer.Flush()
-			os.Exit(1)
-		}
-		return nil
-	})
-}
-
 func localOnlyPrecheck(cmd *cobra.Command, args []string) {
 	local := viper.GetBool("local")
 	if !local {

--- a/server/cmd/mmctl/commands/init.go
+++ b/server/cmd/mmctl/commands/init.go
@@ -134,6 +134,19 @@ func withClient(fn func(c client.Client, cmd *cobra.Command, args []string) erro
 	}
 }
 
+func withClientAndExitCode(fn func(c client.Client, cmd *cobra.Command, args []string) (bool, error)) func(cmd *cobra.Command, args []string) error {
+	return withClient(func(c client.Client, cmd *cobra.Command, args []string) error {
+		shouldExit, err := fn(c, cmd, args)
+		if err != nil {
+			return err
+		}
+		if shouldExit {
+			os.Exit(1)
+		}
+		return nil
+	})
+}
+
 func localOnlyPrecheck(cmd *cobra.Command, args []string) {
 	local := viper.GetBool("local")
 	if !local {

--- a/server/cmd/mmctl/commands/init.go
+++ b/server/cmd/mmctl/commands/init.go
@@ -134,6 +134,18 @@ func withClient(fn func(c client.Client, cmd *cobra.Command, args []string) erro
 	}
 }
 
+// withClientAndExitCode wraps command functions that return (bool, error) to work with cobra.
+// The boolean indicates whether the command should exit with code 1 (true) or 0 (false).
+// This is useful for health check commands where you want to print output and then exit
+// with a specific exit code without displaying error messages.
+//
+// Usage:
+//
+//	RunE: withClientAndExitCode(myCommandFunc)
+//
+// where myCommandFunc has signature:
+//
+//	func(c client.Client, cmd *cobra.Command, args []string) (bool, error)
 func withClientAndExitCode(fn func(c client.Client, cmd *cobra.Command, args []string) (bool, error)) func(cmd *cobra.Command, args []string) error {
 	return withClient(func(c client.Client, cmd *cobra.Command, args []string) error {
 		shouldExit, err := fn(c, cmd, args)

--- a/server/cmd/mmctl/commands/root.go
+++ b/server/cmd/mmctl/commands/root.go
@@ -62,7 +62,14 @@ func Run(args []string) error {
 		}
 	}()
 
-	return RootCmd.Execute()
+	err := RootCmd.Execute()
+	// Flush the printer first before printing any error
+	_ = printer.Flush()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+	}
+
+	return err
 }
 
 func printPanic(x any) {
@@ -111,8 +118,6 @@ var RootCmd = &cobra.Command{
 			printer.PrintError(fmt.Sprintf("Per page value is greater than the maximum allowed. Mattermost might only return %d items.", MaxPageSize))
 		}
 	},
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		_ = printer.Flush()
-	},
-	SilenceUsage: true,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }

--- a/server/cmd/mmctl/commands/system.go
+++ b/server/cmd/mmctl/commands/system.go
@@ -169,6 +169,17 @@ Ios Minimum Version: {{.IosMinVersion}}
 Database Status: {{.database_status}}
 Filestore Status: {{.filestore_status}}`, status)
 
+	// Check health status and return non-zero exit code if any component is unhealthy
+	if status["status"] != model.StatusOk {
+		return fmt.Errorf("server status is unhealthy: %s", status["status"])
+	}
+	if dbStatus := status["database_status"]; dbStatus != "" && dbStatus != model.StatusOk {
+		return fmt.Errorf("database status is unhealthy: %s", dbStatus)
+	}
+	if filestoreStatus := status["filestore_status"]; filestoreStatus != "" && filestoreStatus != model.StatusOk {
+		return fmt.Errorf("filestore status is unhealthy: %s", filestoreStatus)
+	}
+
 	return nil
 }
 

--- a/server/cmd/mmctl/commands/system_test.go
+++ b/server/cmd/mmctl/commands/system_test.go
@@ -197,8 +197,7 @@ func (s *MmctlUnitTestSuite) TestServerStatusCmd() {
 			Return(expectedStatus, &model.Response{}, nil).
 			Times(1)
 
-		shouldExit, err := systemStatusCmdF(s.client, &cobra.Command{}, []string{})
-		s.Require().False(shouldExit)
+		err := systemStatusCmdF(s.client, &cobra.Command{}, []string{})
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetErrorLines(), 0)
 		s.Require().Len(printer.GetLines(), 1)
@@ -218,8 +217,7 @@ func (s *MmctlUnitTestSuite) TestServerStatusCmd() {
 			Return(expectedStatus, &model.Response{}, nil).
 			Times(1)
 
-		shouldExit, err := systemStatusCmdF(s.client, &cobra.Command{}, []string{})
-		s.Require().False(shouldExit)
+		err := systemStatusCmdF(s.client, &cobra.Command{}, []string{})
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetErrorLines(), 0)
 		s.Require().Len(printer.GetLines(), 1)
@@ -238,8 +236,7 @@ func (s *MmctlUnitTestSuite) TestServerStatusCmd() {
 			Return(nil, &model.Response{}, errors.New("mock error")).
 			Times(1)
 
-		shouldExit, err := systemStatusCmdF(s.client, &cobra.Command{}, []string{})
-		s.Require().False(shouldExit)
+		err := systemStatusCmdF(s.client, &cobra.Command{}, []string{})
 		s.Require().Error(err)
 		s.Require().Len(printer.GetErrorLines(), 0)
 		s.Require().Len(printer.GetLines(), 0)
@@ -262,8 +259,7 @@ func (s *MmctlUnitTestSuite) TestServerStatusCmd() {
 			Return(emptyDbStatus, &model.Response{}, nil).
 			Times(1)
 
-		shouldExit, err := systemStatusCmdF(s.client, &cobra.Command{}, []string{})
-		s.Require().False(shouldExit)
+		err := systemStatusCmdF(s.client, &cobra.Command{}, []string{})
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetErrorLines(), 0)
 		s.Require().Len(printer.GetLines(), 1)
@@ -286,9 +282,9 @@ func (s *MmctlUnitTestSuite) TestServerStatusCmd() {
 			Return(unhealthyStatus, &model.Response{}, nil).
 			Times(1)
 
-		shouldExit, err := systemStatusCmdF(s.client, &cobra.Command{}, []string{})
-		s.Require().True(shouldExit)
-		s.Require().Nil(err)
+		err := systemStatusCmdF(s.client, &cobra.Command{}, []string{})
+		s.Require().Error(err)
+		s.Require().Contains(err.Error(), "server status is unhealthy")
 		s.Require().Len(printer.GetErrorLines(), 0)
 		s.Require().Len(printer.GetLines(), 1)
 		s.Require().Equal(printer.GetLines()[0], unhealthyStatus)
@@ -311,9 +307,9 @@ func (s *MmctlUnitTestSuite) TestServerStatusCmd() {
 			Return(unhealthyStatus, &model.Response{}, nil).
 			Times(1)
 
-		shouldExit, err := systemStatusCmdF(s.client, &cobra.Command{}, []string{})
-		s.Require().True(shouldExit)
-		s.Require().Nil(err)
+		err := systemStatusCmdF(s.client, &cobra.Command{}, []string{})
+		s.Require().Error(err)
+		s.Require().Contains(err.Error(), "database status is unhealthy")
 		s.Require().Len(printer.GetErrorLines(), 0)
 		s.Require().Len(printer.GetLines(), 1)
 		s.Require().Equal(printer.GetLines()[0], unhealthyStatus)
@@ -336,9 +332,9 @@ func (s *MmctlUnitTestSuite) TestServerStatusCmd() {
 			Return(unhealthyStatus, &model.Response{}, nil).
 			Times(1)
 
-		shouldExit, err := systemStatusCmdF(s.client, &cobra.Command{}, []string{})
-		s.Require().True(shouldExit)
-		s.Require().Nil(err)
+		err := systemStatusCmdF(s.client, &cobra.Command{}, []string{})
+		s.Require().Error(err)
+		s.Require().Contains(err.Error(), "filestore status is unhealthy")
 		s.Require().Len(printer.GetErrorLines(), 0)
 		s.Require().Len(printer.GetLines(), 1)
 		s.Require().Equal(printer.GetLines()[0], unhealthyStatus)


### PR DESCRIPTION
#### Summary

Fix `mmctl system status` to return non-zero exit codes when health checks fail. This addresses a customer blocker where AWS ECS health checks were broken after the distroless Docker image change, as they rely on exit codes to determine service health.

See https://hub.mattermost.com/private-core/pl/5hwu8foz8pgmfk7m9uhxkh881a for more details.

**Changes:**
- Return error (non-zero exit) when server status != "OK"
- Return error when database_status != "OK"  
- Return error when filestore_status != "OK"
- Return success (exit code 0) only when all components are healthy


#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-65830

#### Release Note

```release-note
Fixed mmctl system status to return non-zero exit codes when health checks fail, ensuring proper integration with container orchestration health check systems.
```