### PR TITLE
Add LogWithLevel function to plugin API for custom log levels

### DIFF
--- a/server/channels/app/plugin_api.go
+++ b/server/channels/app/plugin_api.go
@@ -1131,6 +1131,22 @@ func (api *PluginAPI) LogWarn(msg string, keyValuePairs ...any) {
 	api.logger.Warnw(msg, keyValuePairs...)
 }
 
+func (api *PluginAPI) LogWithLevel(level mlog.Level, msg string, keyValuePairs ...any) {
+	// Convert keyValuePairs to mlog.Field slice
+	fields := make([]mlog.Field, 0, len(keyValuePairs)/2+1)
+	fields = append(fields, mlog.String("plugin_id", api.id))
+
+	for i := 0; i < len(keyValuePairs); i += 2 {
+		if i+1 < len(keyValuePairs) {
+			if key, ok := keyValuePairs[i].(string); ok {
+				fields = append(fields, mlog.Any(key, keyValuePairs[i+1]))
+			}
+		}
+	}
+
+	api.app.Log().Log(level, msg, fields...)
+}
+
 func (api *PluginAPI) CreateBot(bot *model.Bot) (*model.Bot, *model.AppError) {
 	// Bots created by a plugin should use the plugin's ID for the creator field, unless
 	// otherwise specified by the plugin.

--- a/server/public/plugin/api.go
+++ b/server/public/plugin/api.go
@@ -1030,6 +1030,15 @@ type API interface {
 	// Minimum server version: 5.2
 	LogWarn(msg string, keyValuePairs ...any)
 
+	// LogWithLevel writes a log message to the Mattermost server log file with a custom log level.
+	// This allows plugins to create logs that can be filtered and routed by the advanced logging system.
+	// Appropriate context such as the plugin name will already be added as fields so plugins
+	// do not need to add that info.
+	//
+	// @tag Logging
+	// Minimum server version: 11.0
+	LogWithLevel(level mlog.Level, msg string, keyValuePairs ...any)
+
 	// SendMail sends an email to a specific address
 	//
 	// Minimum server version: 5.7

--- a/server/public/plugin/api_timer_layer_generated.go
+++ b/server/public/plugin/api_timer_layer_generated.go
@@ -1093,6 +1093,12 @@ func (api *apiTimerLayer) LogWarn(msg string, keyValuePairs ...any) {
 	api.recordTime(startTime, "LogWarn", true)
 }
 
+func (api *apiTimerLayer) LogWithLevel(level mlog.Level, msg string, keyValuePairs ...any) {
+	startTime := timePkg.Now()
+	api.apiImpl.LogWithLevel(level, msg, keyValuePairs...)
+	api.recordTime(startTime, "LogWithLevel", true)
+}
+
 func (api *apiTimerLayer) SendMail(to, subject, htmlBody string) *model.AppError {
 	startTime := timePkg.Now()
 	_returnsA := api.apiImpl.SendMail(to, subject, htmlBody)

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -5544,6 +5544,35 @@ func (s *apiRPCServer) RolesGrantPermission(args *Z_RolesGrantPermissionArgs, re
 	return nil
 }
 
+type Z_LogWithLevelArgs struct {
+	A mlog.Level
+	B string
+	C []any
+}
+
+type Z_LogWithLevelReturns struct {
+}
+
+func (g *apiRPCClient) LogWithLevel(level mlog.Level, msg string, keyValuePairs ...any) {
+	_args := &Z_LogWithLevelArgs{level, msg, keyValuePairs}
+	_returns := &Z_LogWithLevelReturns{}
+	if err := g.client.Call("Plugin.LogWithLevel", _args, _returns); err != nil {
+		log.Printf("RPC call to LogWithLevel API failed: %s", err.Error())
+	}
+
+}
+
+func (s *apiRPCServer) LogWithLevel(args *Z_LogWithLevelArgs, returns *Z_LogWithLevelReturns) error {
+	if hook, ok := s.impl.(interface {
+		LogWithLevel(level mlog.Level, msg string, keyValuePairs ...any)
+	}); ok {
+		hook.LogWithLevel(args.A, args.B, args.C...)
+	} else {
+		return encodableError(fmt.Errorf("API LogWithLevel called but not implemented."))
+	}
+	return nil
+}
+
 type Z_SendMailArgs struct {
 	A string
 	B string


### PR DESCRIPTION
This adds a new LogWithLevel function that allows plugins to log with custom mlog log levels, enabling advanced logging filtering and redirection.

Key features:
- Plugins can specify custom log levels
- Logs can be filtered and routed to specific targets
- Integrates with Mattermost's advanced logging system
- Follows existing logging function patterns

Files modified:
- server/public/plugin/api.go: Added LogWithLevel interface definition
- server/channels/app/plugin_api.go: Implemented core logging function
- Generated files: RPC client/server and timer layer code