### PR TITLE
build 1.24.6, ignore Docker.buildenv for server-ci

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -11,6 +11,8 @@ on:
       - ".github/workflows/server-ci.yml"
       - ".github/workflows/server-test-template.yml"
       - ".github/workflows/mmctl-test-template.yml"
+      - "!server/build/Dockerfile.buildenv"
+      - "!server/build/Dockerfile.buildenv-fips"
 
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || github.run_id }}

--- a/server/build/Dockerfile.buildenv
+++ b/server/build/Dockerfile.buildenv
@@ -1,4 +1,4 @@
-FROM golang:1.24.5-bullseye@sha256:62ba6b19de03e891f7fa1001326bd48411f2626ff35e7ba5b9d890711ce581d9
+FROM golang:1.24.6-bullseye@sha256:cf78ce8205287fdb2ca403aac77d68965c75734749e560c577c00e20ecb11954
 ARG NODE_VERSION=20.11.1
 
 RUN apt-get update && apt-get install -y make git apt-transport-https ca-certificates curl software-properties-common build-essential zip xmlsec1 jq pgloader gnupg

--- a/server/build/Dockerfile.buildenv-fips
+++ b/server/build/Dockerfile.buildenv-fips
@@ -1,4 +1,4 @@
-FROM cgr.dev/mattermost.com/go-msft-fips:1.24.5-dev@sha256:d7b2872c129277c01447903b7fde7a186fe211b59613172a7e40a3cc0dc5f126
+FROM cgr.dev/mattermost.com/go-msft-fips:1.24.6-dev@sha256:53d076b1cfa53f8189c4723d813d711d92107c2e8b140805c71e39f4a06dc9cc
 ARG NODE_VERSION=20.11.1
 
 RUN apk add curl ca-certificates mailcap unrtf wv poppler-utils tzdata gpg xmlsec


### PR DESCRIPTION
#### Summary
Build [mattermost-build-server](https://hub.docker.com/repository/docker/mattermost/mattermost-build-server/general) for go 1.24.6. Similar changes for FIPS. Note that this doesn't actually use the image to be built, that will come when we bump `.go-version` in a separate pull request.

As an aside, to expedite this step in the future, I've marked these Docker files to be ignored for server-ci.yml, which doesn't use them anyway.

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-65826

#### Release Note
```release-note
NONE
```
