### PR TITLE
MM-65962: remove plugin-msteams (aka msteams-sync) from prepackaged plugins

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -161,7 +161,6 @@ PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.3.4
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.8.0
 PLUGIN_PACKAGES += mattermost-plugin-agents-v1.3.1
 PLUGIN_PACKAGES += mattermost-plugin-boards-v9.1.6
-PLUGIN_PACKAGES += mattermost-plugin-msteams-v2.2.2
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.3.4
 PLUGIN_PACKAGES += mattermost-plugin-msteams-meetings-v2.2.0


### PR DESCRIPTION
#### Summary
Remove mattermost-plugin-msteams` from the list of prepackaged plugins for MM server.  This may be temporary.  

This will prevent nightly builds from deploying the plugin to Community, which over-writes the custom build deployed there.

A discussion is underway to determine if this plug should be prepackaged ongoing.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65962

#### Release Note
```release-note
Remove `mattermost-plugin-msteams-sync` plugin from prepackaged plugins.
```
