### PR TITLE
Automated cherry pick of #33965

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/keyboard_shortcuts/shift_up_focuses_on_rhs_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/keyboard_shortcuts/shift_up_focuses_on_rhs_spec.js
@@ -21,7 +21,7 @@ describe('Keyboard Shortcuts', () => {
 
     it('MM-T1277 SHIFT+UP', () => {
         // # Press shift+up to open the latest thread in the channel in the RHS
-        cy.uiGetPostTextBox().type('{shift}{uparrow}');
+        cy.uiGetPostTextBox().type('{shift+uparrow}', {delay: 50});
 
         // * RHS Opens up
         cy.get('.sidebar--right__header').should('be.visible');
@@ -33,7 +33,28 @@ describe('Keyboard Shortcuts', () => {
         cy.uiGetPostTextBox().click();
 
         // # Press shift+up again
-        cy.uiGetPostTextBox().type('{shift}{uparrow}');
+        cy.uiGetPostTextBox().type('{shift+uparrow}', {delay: 50});
+
+        // * RHS textbox should be focused
+        cy.uiGetReplyTextBox().should('be.focused');
+
+        // # Post a reply in the thread
+        cy.uiGetReplyTextBox().type('This is a reply{enter}');
+
+        // # Close the RHS by clicking the X button
+        cy.get('#rhsCloseButton').click();
+
+        // * Verify RHS is closed
+        cy.get('.sidebar--right__header').should('not.exist');
+
+        // # Click into the center channel post textbox
+        cy.uiGetPostTextBox().click();
+
+        // # Press shift+up to open the thread with replies
+        cy.uiGetPostTextBox().type('{shift+uparrow}', {delay: 50});
+
+        // * RHS Opens up
+        cy.get('.sidebar--right__header').should('be.visible');
 
         // * RHS textbox should be focused
         cy.uiGetReplyTextBox().should('be.focused');

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.test.tsx
@@ -236,7 +236,9 @@ describe('components/avanced_text_editor/advanced_text_editor', () => {
             expect(textbox).not.toHaveFocus();
 
             // save is called with a short delayed after pressing escape key
-            jest.advanceTimersByTime(Constants.SAVE_DRAFT_TIMEOUT + 50);
+            act(() => {
+                jest.advanceTimersByTime(Constants.SAVE_DRAFT_TIMEOUT + 50);
+            });
             expect(mockedRemoveDraft).toHaveBeenCalled();
             expect(mockedUpdateDraft).not.toHaveBeenCalled();
         });

--- a/webapp/channels/src/components/advanced_text_editor/use_textbox_focus.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_textbox_focus.tsx
@@ -33,11 +33,20 @@ const useTextboxFocus = (
     const focusTextbox = useCallback((keepFocus = false) => {
         const postTextboxDisabled = !canPost;
         if (textboxRef.current && postTextboxDisabled) {
-            textboxRef.current.blur(); // Fixes Firefox bug which causes keyboard shortcuts to be ignored (MM-22482)
+            // Fixes Firefox bug which causes keyboard shortcuts to be ignored (MM-22482)
+            requestAnimationFrame(() => {
+                textboxRef.current?.blur();
+            });
             return;
         }
         if (textboxRef.current && (keepFocus || !UserAgent.isMobile())) {
-            textboxRef.current.focus();
+            // Focus immediately, so we capture any typed text.
+            textboxRef.current?.focus();
+
+            // Also re-focus after the next animation frame, to work around issues where the RHS is "opening".
+            requestAnimationFrame(() => {
+                textboxRef.current?.focus();
+            });
         }
     }, [canPost, textboxRef]);
 


### PR DESCRIPTION
Cherry pick of #33965 on release-11.0.

/cc  @lieut-data

```release-note
NONE
```