### PR TITLE
MM-65807: fix focus stability in System Console > User Attributes

### DIFF
--- a/webapp/channels/src/components/admin_console/system_properties/user_properties_table.test.tsx
+++ b/webapp/channels/src/components/admin_console/system_properties/user_properties_table.test.tsx
@@ -165,4 +165,75 @@ describe('UserPropertiesTable', () => {
             expect(screen.getByText('Please enter an attribute name.')).toBeInTheDocument();
         });
     });
+
+    it('autofocuses name input for new text field', () => {
+        const pendingTextField: UserPropertyField = {
+            id: 'pending-text',
+            name: '',
+            type: 'text',
+            group_id: 'custom_profile_attributes',
+            create_at: 0,
+            delete_at: 0,
+            update_at: 0,
+            attrs: {
+                sort_order: 2,
+                visibility: 'when_set',
+                value_type: '',
+            },
+        };
+
+        renderComponent([...baseFields, pendingTextField]);
+
+        // The name input for the new text field should be autofocused
+        const nameInputs = screen.getAllByTestId('property-field-input');
+        expect(document.activeElement).toBe(nameInputs[2]);
+    });
+
+    it('autofocuses values input for new select field', () => {
+        const pendingSelectField: UserPropertyField = {
+            id: 'pending-select',
+            name: 'New Select',
+            type: 'select',
+            group_id: 'custom_profile_attributes',
+            create_at: 0,
+            delete_at: 0,
+            update_at: 0,
+            attrs: {
+                sort_order: 2,
+                visibility: 'when_set',
+                value_type: '',
+                options: [],
+            },
+        };
+
+        renderComponent([...baseFields, pendingSelectField]);
+
+        // The values input (combobox) for the new select field should be autofocused
+        const comboboxes = screen.getAllByRole('combobox');
+        expect(document.activeElement).toBe(comboboxes[comboboxes.length - 1]);
+    });
+
+    it('autofocuses values input for new multiselect field', () => {
+        const pendingMultiselectField: UserPropertyField = {
+            id: 'pending-multiselect',
+            name: 'New Multiselect',
+            type: 'multiselect',
+            group_id: 'custom_profile_attributes',
+            create_at: 0,
+            delete_at: 0,
+            update_at: 0,
+            attrs: {
+                sort_order: 2,
+                visibility: 'when_set',
+                value_type: '',
+                options: [],
+            },
+        };
+
+        renderComponent([...baseFields, pendingMultiselectField]);
+
+        // The values input (combobox) for the new multiselect field should be autofocused
+        const comboboxes = screen.getAllByRole('combobox');
+        expect(document.activeElement).toBe(comboboxes[comboboxes.length - 1]);
+    });
 });

--- a/webapp/channels/src/components/admin_console/system_properties/user_properties_table.tsx
+++ b/webapp/channels/src/components/admin_console/system_properties/user_properties_table.tsx
@@ -8,7 +8,7 @@ import {FormattedMessage, useIntl} from 'react-intl';
 import styled from 'styled-components';
 
 import {PlusIcon} from '@mattermost/compass-icons/components';
-import type {UserPropertyField} from '@mattermost/types/properties';
+import {supportsOptions, type UserPropertyField} from '@mattermost/types/properties';
 import {collectionToArray} from '@mattermost/types/utilities';
 
 import LoadingScreen from 'components/loading_screen';
@@ -158,7 +158,7 @@ export function UserPropertiesTable({
                                 deleted={toDelete}
                                 borderless={!warning}
                                 testid='property-field-input'
-                                autoFocus={isCreatePending(row.original)}
+                                autoFocus={isCreatePending(row.original) && !supportsOptions(row.original)}
                                 setValue={(value: string) => {
                                     updateField({...row.original, name: value.trim()});
                                 }}
@@ -210,6 +210,7 @@ export function UserPropertiesTable({
                         <UserPropertyValues
                             field={row.original}
                             updateField={updateField}
+                            autoFocus={isCreatePending(row.original) && supportsOptions(row.original)}
                         />
                     </>
                 ),

--- a/webapp/channels/src/components/admin_console/system_properties/user_properties_values.test.tsx
+++ b/webapp/channels/src/components/admin_console/system_properties/user_properties_values.test.tsx
@@ -32,11 +32,12 @@ describe('UserPropertyValues', () => {
 
     const updateField = jest.fn();
 
-    const renderComponent = (field: UserPropertyField = baseField) => {
+    const renderComponent = (field: UserPropertyField = baseField, autoFocus = false) => {
         return renderWithContext(
             <UserPropertyValues
                 field={field}
                 updateField={updateField}
+                autoFocus={autoFocus}
             />,
         );
     };
@@ -213,5 +214,19 @@ describe('UserPropertyValues', () => {
 
         const samlLinkElement = screen.getByTestId(`user-property-field-values__saml-${baseField.name}`);
         expect(samlLinkElement).toBeInTheDocument();
+    });
+
+    it('applies autoFocus when prop is true', () => {
+        renderComponent(baseField, true);
+
+        const input = screen.getByRole('combobox');
+        expect(document.activeElement).toBe(input);
+    });
+
+    it('does not autoFocus when prop is false', () => {
+        renderComponent(baseField, false);
+
+        const input = screen.getByRole('combobox');
+        expect(document.activeElement).not.toBe(input);
     });
 });

--- a/webapp/channels/src/components/admin_console/system_properties/user_properties_values.tsx
+++ b/webapp/channels/src/components/admin_console/system_properties/user_properties_values.tsx
@@ -10,7 +10,7 @@ import type {CreatableProps} from 'react-select/creatable';
 import CreatableSelect from 'react-select/creatable';
 
 import {SyncIcon} from '@mattermost/compass-icons/components';
-import type {PropertyFieldOption, UserPropertyField} from '@mattermost/types/properties';
+import {supportsOptions, type PropertyFieldOption, type UserPropertyField} from '@mattermost/types/properties';
 
 import Constants from 'utils/constants';
 import {isKeyPressed} from 'utils/keyboard';
@@ -22,6 +22,7 @@ import {useAttributeLinkModal} from './user_properties_dot_menu';
 type Props = {
     field: UserPropertyField;
     updateField: (field: UserPropertyField) => void;
+    autoFocus?: boolean;
 }
 
 type Option = {label: string; id: string; value: string};
@@ -30,6 +31,7 @@ type SelectProps = CreatableProps<Option, true, GroupBase<Option>>;
 const UserPropertyValues = ({
     field,
     updateField,
+    autoFocus,
 }: Props) => {
     const {formatMessage} = useIntl();
 
@@ -140,7 +142,7 @@ const UserPropertyValues = ({
         );
     }
 
-    if (field.type !== 'multiselect' && field.type !== 'select') {
+    if (!supportsOptions(field)) {
         return (
             <span className='user-property-field-values'>
                 {'-'}
@@ -167,6 +169,7 @@ const UserPropertyValues = ({
                 value={field.attrs.options?.map((option) => ({label: option.name, value: option.name, id: option.id}))}
                 menuPortalTarget={document.body}
                 styles={styles}
+                autoFocus={autoFocus}
             />
             {!isQueryValid && (
                 <FormattedMessage

--- a/webapp/platform/types/src/properties.ts
+++ b/webapp/platform/types/src/properties.ts
@@ -75,4 +75,8 @@ export type SelectPropertyField = PropertyField & {
     };
 }
 
+export const supportsOptions = (field: UserPropertyField) => {
+    return field.type === 'select' || field.type === 'multiselect';
+};
+
 export type UserPropertyFieldPatch = Partial<Pick<UserPropertyField, 'name' | 'attrs' | 'type'>>;


### PR DESCRIPTION
#### Summary

Fixes auto focus stability System Console > User Attributes. The Title/Attribute field would steal focus after entering the first option-value. Fixed by making autofocus conditional, and redirecting it to the option-value column when switching field type to select/multiselect.

#### Ticket Link

- [https://mattermost.atlassian.net/browse/MM-65807](https://mattermost.atlassian.net/browse/MM-65807)

#### Screenshots

| before | after |
| ------ | ----- |
|  https://github.com/user-attachments/assets/33d545ee-19f4-4f2c-8485-cd4436cfd81f  |  https://github.com/user-attachments/assets/1ef521e9-e551-404c-a4bd-7dea37400b5b |


#### Release Note

```release-note
NONE
```
