### PR TITLE
MM-65983: Mirror Postgres 14 docker image

### DIFF
--- a/server/scripts/mirror-docker-images.json
+++ b/server/scripts/mirror-docker-images.json
@@ -2,7 +2,8 @@
   "postgres": {
     "10": "postgres:10@sha256:7a484b11fcabd39596b1bf08780cdb61fa9b0d8bfad0844dbdce3a6922df95d1",
     "12": "postgres:12@sha256:cc7a021d9aff3aa02788d35c27a5cc32d4790ad92d72232a6be75b76ab7d79db",
-    "13": "postgres:13@sha256:1b154a7bbf474aa1a2e67dc7c976835645fe6c3425320e7ad3f5a926d509e8fc"
+    "13": "postgres:13@sha256:1b154a7bbf474aa1a2e67dc7c976835645fe6c3425320e7ad3f5a926d509e8fc",
+    "14": "postgres:14@sha256:1c418702ab77adc7e84c7e726c2ab4f9cb63b8f997341ffcfab56629bab1429d"
   },
   "mysql": {
     "8.0.32": "mysql/mysql-server:8.0.32@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313"


### PR DESCRIPTION
#### Summary
Reading through https://github.com/mattermost/mattermost/pull/30039/files#r1935440302, it seems that we need to first mirror the Postgres image that we want to use, for E2E tests to work when we update the image there.

This pipeline is triggered on merge to `master`, so I don't believe we need to cherry-pick this one to v11.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65983

#### Screenshots
--

#### Release Note
```release-note
NONE
```
