### PR TITLE
Automated cherry pick of #34010

### DIFF
--- a/e2e-tests/.ci/server.generate.sh
+++ b/e2e-tests/.ci/server.generate.sh
@@ -81,7 +81,7 @@ $(for service in $ENABLED_DOCKER_SERVICES; do
 $(if mme2e_is_token_in_list "postgres" "$ENABLED_DOCKER_SERVICES"; then
     echo '
   postgres:
-    image: mattermostdevelopment/mirrored-postgres:13
+    image: mattermostdevelopment/mirrored-postgres:14
     restart: "no"
     network_mode: host
     networks: !reset []

--- a/server/build/docker-compose.common.yml
+++ b/server/build/docker-compose.common.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: "postgres:13"
+    image: "postgres:14"
     restart: always
     networks:
       - mm-test

--- a/server/build/docker-preview/Dockerfile
+++ b/server/build/docker-preview/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 # See License.txt for license information.
-FROM postgres:13
+FROM postgres:14
 
 RUN apt-get update && apt-get install -y ca-certificates
 

--- a/server/channels/store/sqlstore/store.go
+++ b/server/channels/store/sqlstore/store.go
@@ -49,7 +49,7 @@ const (
 	// After 10, it's major and minor only.
 	// 10.1 would be 100001.
 	// 9.6.3 would be 90603.
-	minimumRequiredPostgresVersion = 130000
+	minimumRequiredPostgresVersion = 140000
 
 	migrationsDirectionUp   migrationDirection = "up"
 	migrationsDirectionDown migrationDirection = "down"

--- a/server/channels/store/sqlstore/store_test.go
+++ b/server/channels/store/sqlstore/store_test.go
@@ -543,6 +543,24 @@ func TestEnsureMinimumDBVersion(t *testing.T) {
 		{
 			driver: model.DatabaseDriverPostgres,
 			ver:    "130001",
+			ok:     false,
+			err:    "",
+		},
+		{
+			driver: model.DatabaseDriverPostgres,
+			ver:    "140000",
+			ok:     true,
+			err:    "",
+		},
+		{
+			driver: model.DatabaseDriverPostgres,
+			ver:    "141900",
+			ok:     true,
+			err:    "",
+		},
+		{
+			driver: model.DatabaseDriverPostgres,
+			ver:    "150000",
 			ok:     true,
 			err:    "",
 		},


### PR DESCRIPTION
Cherry pick of #34010 on release-11.0.

/cc  @agarciamontoro

```release-note
NONE
```