### PR TITLE
[MM-65769] add updatedSince to field search

### DIFF
--- a/server/channels/store/sqlstore/property_field_store.go
+++ b/server/channels/store/sqlstore/property_field_store.go
@@ -176,6 +176,10 @@ func (s *SqlPropertyFieldStore) SearchPropertyFields(opts model.PropertyFieldSea
 		builder = builder.Where(sq.Eq{"TargetID": opts.TargetIDs})
 	}
 
+	if opts.SinceUpdateAt > 0 {
+		builder = builder.Where(sq.Gt{"UpdateAt": opts.SinceUpdateAt})
+	}
+
 	fields := []*model.PropertyField{}
 	if err := s.GetReplica().SelectBuilder(&fields, builder); err != nil {
 		return nil, errors.Wrap(err, "property_field_search_query")

--- a/server/channels/store/storetest/property_field_store.go
+++ b/server/channels/store/storetest/property_field_store.go
@@ -1021,8 +1021,8 @@ func testSearchPropertyFieldsSince(t *testing.T, _ request.CTX, ss store.Store) 
 	})
 
 	t.Run("SinceUpdateAt with boundary condition", func(t *testing.T) {
-		// Get fields updated after field3's timestamp
-		// Should get both field2 (updated) and field3, so expect 2 results
+		// Get fields updated after just before field3's timestamp
+		// Should get both field3 and field2 (which was updated last and now has the most recent UpdateAt), so expect 2 results
 		results, err := ss.PropertyField().SearchPropertyFields(model.PropertyFieldSearchOpts{
 			GroupID:       groupID,
 			SinceUpdateAt: field3.UpdateAt - 1, // Slightly before field3's timestamp

--- a/server/channels/store/storetest/property_field_store.go
+++ b/server/channels/store/storetest/property_field_store.go
@@ -23,6 +23,7 @@ func TestPropertyFieldStore(t *testing.T, rctx request.CTX, ss store.Store, s Sq
 	t.Run("UpdatePropertyField", func(t *testing.T) { testUpdatePropertyField(t, rctx, ss) })
 	t.Run("DeletePropertyField", func(t *testing.T) { testDeletePropertyField(t, rctx, ss) })
 	t.Run("SearchPropertyFields", func(t *testing.T) { testSearchPropertyFields(t, rctx, ss) })
+	t.Run("SearchPropertyFieldsSince", func(t *testing.T) { testSearchPropertyFieldsSince(t, rctx, ss) })
 	t.Run("CountForGroup", func(t *testing.T) { testCountForGroup(t, rctx, ss) })
 }
 
@@ -902,6 +903,40 @@ func testSearchPropertyFields(t *testing.T, _ request.CTX, ss store.Store) {
 			},
 			expectedIDs: []string{field1.ID, field2.ID},
 		},
+		{
+			name: "filter by SinceUpdateAt timestamp - no results before",
+			opts: model.PropertyFieldSearchOpts{
+				SinceUpdateAt: field3.UpdateAt, // After all existing fields
+				PerPage:       10,
+			},
+			expectedIDs: []string{},
+		},
+		{
+			name: "filter by SinceUpdateAt timestamp - get fields after specific time",
+			opts: model.PropertyFieldSearchOpts{
+				SinceUpdateAt: field1.UpdateAt, // After field1, should get field2 and field3
+				PerPage:       10,
+			},
+			expectedIDs: []string{field2.ID, field3.ID},
+		},
+		{
+			name: "filter by SinceUpdateAt timestamp with group filter",
+			opts: model.PropertyFieldSearchOpts{
+				GroupID:       groupID,
+				SinceUpdateAt: field1.UpdateAt, // After field1, should only get field2 from same group
+				PerPage:       10,
+			},
+			expectedIDs: []string{field2.ID},
+		},
+		{
+			name: "filter by SinceUpdateAt timestamp including deleted",
+			opts: model.PropertyFieldSearchOpts{
+				SinceUpdateAt:  field3.UpdateAt, // After field3, should get field4 (deleted)
+				IncludeDeleted: true,
+				PerPage:        10,
+			},
+			expectedIDs: []string{field4.ID},
+		},
 	}
 
 	for _, tc := range tests {
@@ -920,4 +955,109 @@ func testSearchPropertyFields(t *testing.T, _ request.CTX, ss store.Store) {
 			require.ElementsMatch(t, tc.expectedIDs, ids)
 		})
 	}
+}
+
+func testSearchPropertyFieldsSince(t *testing.T, _ request.CTX, ss store.Store) {
+	// Create fields with controlled timestamps for precise testing
+	groupID := model.NewId()
+
+	// Create field 1 (will remain unchanged)
+	field1, err := ss.PropertyField().Create(&model.PropertyField{
+		GroupID:    groupID,
+		Name:       "Field 1",
+		Type:       model.PropertyFieldTypeText,
+		TargetID:   model.NewId(),
+		TargetType: "test_type",
+	})
+	require.NoError(t, err)
+
+	time.Sleep(10 * time.Millisecond) // Ensure different timestamps
+
+	// Create field 2 (will be updated later)
+	field2, err := ss.PropertyField().Create(&model.PropertyField{
+		GroupID:    groupID,
+		Name:       "Field 2",
+		Type:       model.PropertyFieldTypeText,
+		TargetID:   model.NewId(),
+		TargetType: "test_type",
+	})
+	require.NoError(t, err)
+
+	time.Sleep(10 * time.Millisecond)
+
+	// Create field 3 (will remain unchanged)
+	field3, err := ss.PropertyField().Create(&model.PropertyField{
+		GroupID:    groupID,
+		Name:       "Field 3",
+		Type:       model.PropertyFieldTypeText,
+		TargetID:   model.NewId(),
+		TargetType: "test_type",
+	})
+	require.NoError(t, err)
+
+	// Update field2 to change its UpdateAt timestamp
+	time.Sleep(10 * time.Millisecond)
+	field2.Name = "Field 2 Updated"
+	updatedFields, err := ss.PropertyField().Update("", []*model.PropertyField{field2})
+	require.NoError(t, err)
+	require.Len(t, updatedFields, 1)
+	updatedField2 := updatedFields[0]
+
+	t.Run("SinceUpdateAt filters correctly by UpdateAt", func(t *testing.T) {
+		// Get fields updated after field1 (should get field2 and field3)
+		results, err := ss.PropertyField().SearchPropertyFields(model.PropertyFieldSearchOpts{
+			GroupID:       groupID,
+			SinceUpdateAt: field1.UpdateAt,
+			PerPage:       10,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+
+		resultIDs := make([]string, len(results))
+		for i, result := range results {
+			resultIDs[i] = result.ID
+		}
+		require.ElementsMatch(t, []string{field2.ID, field3.ID}, resultIDs)
+	})
+
+	t.Run("SinceUpdateAt with boundary condition", func(t *testing.T) {
+		// Get fields updated after field3's timestamp
+		// Should get both field2 (updated) and field3, so expect 2 results
+		results, err := ss.PropertyField().SearchPropertyFields(model.PropertyFieldSearchOpts{
+			GroupID:       groupID,
+			SinceUpdateAt: field3.UpdateAt - 1, // Slightly before field3's timestamp
+			PerPage:       10,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+
+		resultIDs := make([]string, len(results))
+		for i, result := range results {
+			resultIDs[i] = result.ID
+		}
+		// Should get both field2 (updated with new timestamp) and field3
+		require.ElementsMatch(t, []string{field2.ID, field3.ID}, resultIDs)
+	})
+
+	t.Run("SinceUpdateAt after all updates", func(t *testing.T) {
+		// Get fields updated after the most recent update
+		results, err := ss.PropertyField().SearchPropertyFields(model.PropertyFieldSearchOpts{
+			GroupID:       groupID,
+			SinceUpdateAt: updatedField2.UpdateAt, // After the update
+			PerPage:       10,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 0) // Should be empty
+	})
+
+	t.Run("SinceUpdateAt with very recent timestamp", func(t *testing.T) {
+		// Get fields updated since current time
+		results, err := ss.PropertyField().SearchPropertyFields(model.PropertyFieldSearchOpts{
+			GroupID:       groupID,
+			SinceUpdateAt: model.GetMillis(),
+			PerPage:       10,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 0)
+	})
 }

--- a/server/public/model/property_field.go
+++ b/server/public/model/property_field.go
@@ -209,7 +209,7 @@ type PropertyFieldSearchOpts struct {
 	GroupID        string
 	TargetType     string
 	TargetIDs      []string
-	SinceUpdateAt  int64 // UpdateAt after which to send the items
+	SinceUpdateAt  int64 // UpdatedAt after which to send the items
 	IncludeDeleted bool
 	Cursor         PropertyFieldSearchCursor
 	PerPage        int

--- a/server/public/model/property_field.go
+++ b/server/public/model/property_field.go
@@ -209,6 +209,7 @@ type PropertyFieldSearchOpts struct {
 	GroupID        string
 	TargetType     string
 	TargetIDs      []string
+	SinceUpdateAt  int64 // UpdateAt after which to send the items
 	IncludeDeleted bool
 	Cursor         PropertyFieldSearchCursor
 	PerPage        int


### PR DESCRIPTION
#### Summary
Follow up to https://github.com/mattermost/mattermost/pull/33959

Add updatedSince to property field search

While this isn't strictly needed right now for displaying playbook run attributes, we might need this in the near future when we allow to add/remove attributes

#### Ticket Link
[MM-65769](Jira https://mattermost.atlassian.net/browse/MM-65769)


#### Release Note
This goes along with the previous PR and doesn't need a separete release note
```release-note
NONE
```


[MM-65769]: https://mattermost.atlassian.net/browse/MM-65769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ