### PR TITLE
Fix flaky smoke test for channel switcher

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/channel/channel_switcher_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/channel/channel_switcher_spec.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {Channel} from '@mattermost/types/channels';
 import {Team} from '@mattermost/types/teams';
 
 // ***************************************************************
@@ -14,20 +15,25 @@ import {Team} from '@mattermost/types/teams';
 
 describe('Channel Switcher', () => {
     let testTeam: Team;
-    let testChannelName: string;
     let offTopicUrl: string;
     const channelNamePrefix = 'aswitchchannel';
     const channelDisplayNamePrefix = 'ASwitchChannel';
 
+    let channelB: Channel;
+    let channelC: Channel;
+
     before(() => {
         cy.apiInitSetup({channelPrefix: {name: `${channelNamePrefix}-a`, displayName: `${channelDisplayNamePrefix} A`}}).then(({team, channel, user, offTopicUrl: url}) => {
             testTeam = team;
-            testChannelName = channel.display_name;
             offTopicUrl = url;
 
             // # Add some channels
-            cy.apiCreateChannel(testTeam.id, `${channelNamePrefix}-b`, `${channelDisplayNamePrefix} B`, 'O');
-            cy.apiCreateChannel(testTeam.id, `${channelNamePrefix}-c`, `${channelDisplayNamePrefix} C`, 'O');
+            cy.apiCreateChannel(testTeam.id, `${channelNamePrefix}-b`, `${channelDisplayNamePrefix} B`, 'O').then(({channel}) => {
+                channelB = channel;
+            });
+            cy.apiCreateChannel(testTeam.id, `${channelNamePrefix}-c`, `${channelDisplayNamePrefix} C`, 'O').then(({channel}) => {
+                channelC = channel;
+            });
 
             // # Login as test user and go to off-topic
             cy.apiLogin(user);
@@ -42,17 +48,17 @@ describe('Channel Switcher', () => {
         // # Start typing channel name in the "Switch Channels" modal message box
         // # Use up/down arrow keys to highlight second channel
         // # Press ENTER
-        cy.findByRole('combobox', {name: 'quick switch input'}).
-            type(`${channelDisplayNamePrefix} `).
-            type('{downarrow}{downarrow}{enter}');
+        cy.findByRole('combobox', {name: 'quick switch input'}).type(`${channelDisplayNamePrefix}`);
+        cy.findByRole('option', {name: channelB.display_name}).should('be.visible');
+        cy.findByRole('combobox', {name: 'quick switch input'}).type('{downarrow}{downarrow}{enter}');
 
         // * Expect channel title to match title
         cy.get('#channelHeaderTitle').
             should('be.visible').
-            and('contain.text', testChannelName);
+            and('contain.text', channelB.display_name);
 
         // * Expect url to match url
-        cy.url().should('contain', `${testChannelName.replace(/ /g, '-').toLowerCase()}`);
+        cy.url().should('contain', `${channelB.name}`);
     });
 
     it('MM-T2031_2 - should switch channels by mouse', () => {
@@ -62,15 +68,15 @@ describe('Channel Switcher', () => {
         // # Start typing channel name in the "Switch Channels" modal message box
         cy.findByRole('combobox', {name: 'quick switch input'}).type(`${channelDisplayNamePrefix} `);
 
-        cy.get(`[data-testid^=${channelNamePrefix}-c] > span`).click();
+        cy.get(`[data-testid^=${channelC.name}] > span`).click();
 
         // * Expect channel title to match title
         cy.get('#channelHeaderTitle').
             should('be.visible').
-            and('contain.text', `${channelDisplayNamePrefix} C`);
+            and('contain.text', channelC.display_name);
 
         // * Expect url to match url
-        cy.url().should('contain', `${channelNamePrefix}-c`);
+        cy.url().should('contain', `${channelC.name}`);
     });
 
     it('MM-T2031_3 - should show empty result', () => {


### PR DESCRIPTION
#### Summary
These seem like they've been flakier lately than they used to be, and since there's seemingly no easy way to rerun them, I got annoyed enough to fix them.

I could also repro this failure locally, so it was failing pretty reliably.

#### Release Note
```release-note
NONE
```
