### PR TITLE
MM-6569 - disable test button when not matching attributes for channe…

### DIFF
--- a/webapp/channels/src/components/admin_console/access_control/editors/shared.test.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/editors/shared.test.tsx
@@ -1,0 +1,168 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {renderWithContext, screen} from 'tests/react_testing_utils';
+
+import {TestButton} from './shared';
+
+describe('TestButton', () => {
+    const baseProps = {
+        onClick: jest.fn(),
+        disabled: false,
+    };
+
+    beforeEach(() => {
+        baseProps.onClick.mockClear();
+    });
+
+    test('should render test button with correct text and icon', () => {
+        renderWithContext(<TestButton {...baseProps}/>, {});
+
+        const button = screen.getByRole('button', {name: /test access rule/i});
+        expect(button).toBeInTheDocument();
+        expect(button).toHaveClass('btn', 'btn-sm', 'btn-tertiary');
+
+        // Check for icon
+        const icon = button.querySelector('i.icon.icon-lock-outline');
+        expect(icon).toBeInTheDocument();
+    });
+
+    test('should be enabled and clickable when disabled is false', () => {
+        renderWithContext(<TestButton {...baseProps}/>, {});
+
+        const button = screen.getByRole('button', {name: /test access rule/i});
+        expect(button).not.toBeDisabled();
+        expect(button).toBeEnabled();
+    });
+
+    test('should be disabled when disabled is true', () => {
+        const props = {
+            ...baseProps,
+            disabled: true,
+        };
+
+        renderWithContext(<TestButton {...props}/>, {});
+
+        const button = screen.getByRole('button', {name: /test access rule/i});
+        expect(button).toBeDisabled();
+    });
+
+    test('should call onClick when clicked and not disabled', () => {
+        renderWithContext(<TestButton {...baseProps}/>, {});
+
+        const button = screen.getByRole('button', {name: /test access rule/i});
+        button.click();
+
+        expect(baseProps.onClick).toHaveBeenCalledTimes(1);
+    });
+
+    test('should not call onClick when clicked and disabled', () => {
+        const props = {
+            ...baseProps,
+            disabled: true,
+        };
+
+        renderWithContext(<TestButton {...props}/>, {});
+
+        const button = screen.getByRole('button', {name: /test access rule/i});
+        button.click();
+
+        expect(baseProps.onClick).not.toHaveBeenCalled();
+    });
+
+    test('should not show tooltip when not disabled', () => {
+        renderWithContext(<TestButton {...baseProps}/>, {});
+
+        const button = screen.getByRole('button', {name: /test access rule/i});
+
+        // Should not be wrapped with WithTooltip when enabled
+        expect(button.parentElement).not.toHaveAttribute('data-testid', 'tooltip-wrapper');
+        expect(button).not.toHaveAttribute('title');
+    });
+
+    test('should not show tooltip when disabled but no disabledTooltip provided', () => {
+        const props = {
+            ...baseProps,
+            disabled: true,
+        };
+
+        renderWithContext(<TestButton {...props}/>, {});
+
+        const button = screen.getByRole('button', {name: /test access rule/i});
+
+        // Should not be wrapped with WithTooltip when no tooltip text provided
+        expect(button.parentElement).not.toHaveAttribute('data-testid', 'tooltip-wrapper');
+        expect(button).not.toHaveAttribute('title');
+    });
+
+    test('should show tooltip when disabled and disabledTooltip is provided', () => {
+        const tooltipMessage = 'You cannot test access rules that would exclude you from the channel';
+        const props = {
+            ...baseProps,
+            disabled: true,
+            disabledTooltip: tooltipMessage,
+        };
+
+        renderWithContext(<TestButton {...props}/>, {});
+
+        const button = screen.getByRole('button', {name: /test access rule/i});
+        expect(button).toBeDisabled();
+
+        // The main test is that the button is disabled when it should be
+        // The tooltip implementation is complex with floating-ui, so we focus on the behavior
+        // In actual usage, hovering over the button would show the tooltip
+    });
+
+    test('should show correct tooltip message when disabled and disabledTooltip is provided', () => {
+        const tooltipMessage = 'Custom tooltip message';
+        const props = {
+            ...baseProps,
+            disabled: true,
+            disabledTooltip: tooltipMessage,
+        };
+
+        renderWithContext(<TestButton {...props}/>, {});
+
+        // Since WithTooltip is complex and uses floating-ui, we mainly test that
+        // the tooltip wrapper is present when needed
+        const button = screen.getByRole('button', {name: /test access rule/i});
+        expect(button).toBeDisabled();
+
+        // The presence of tooltip is implied by the wrapper structure change
+        // In a real test environment, you could hover over the button and check for tooltip
+    });
+
+    test('should handle empty string tooltip', () => {
+        const props = {
+            ...baseProps,
+            disabled: true,
+            disabledTooltip: '',
+        };
+
+        renderWithContext(<TestButton {...props}/>, {});
+
+        const button = screen.getByRole('button', {name: /test access rule/i});
+        expect(button).toBeDisabled();
+
+        // Empty string tooltip should still not show tooltip
+        expect(button.parentElement).not.toHaveAttribute('data-testid', 'tooltip-wrapper');
+    });
+
+    test('should handle undefined disabledTooltip same as no tooltip', () => {
+        const props = {
+            ...baseProps,
+            disabled: true,
+            disabledTooltip: undefined,
+        };
+
+        renderWithContext(<TestButton {...props}/>, {});
+
+        const button = screen.getByRole('button', {name: /test access rule/i});
+        expect(button).toBeDisabled();
+
+        // Undefined tooltip should not show tooltip
+        expect(button.parentElement).not.toHaveAttribute('data-testid', 'tooltip-wrapper');
+    });
+});

--- a/webapp/channels/src/components/admin_console/access_control/editors/shared.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/editors/shared.tsx
@@ -4,8 +4,10 @@
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import './shared.scss';
 import Markdown from 'components/markdown';
+import WithTooltip from 'components/with_tooltip';
+
+import './shared.scss';
 
 // CEL operator constants
 export enum CELOperator {
@@ -52,6 +54,7 @@ export const OPERATOR_CONFIG: Record<string, {type: OperatorType; celOp: CELOper
 interface TestButtonProps {
     onClick: () => void;
     disabled: boolean;
+    disabledTooltip?: string;
 }
 
 interface AddAttributeButtonProps {
@@ -64,8 +67,8 @@ interface HelpTextProps {
     onLearnMoreClick?: () => void;
 }
 
-export function TestButton({onClick, disabled}: TestButtonProps): JSX.Element {
-    return (
+export function TestButton({onClick, disabled, disabledTooltip}: TestButtonProps): JSX.Element {
+    const button = (
         <button
             className='btn btn-sm btn-tertiary'
             onClick={onClick}
@@ -78,6 +81,16 @@ export function TestButton({onClick, disabled}: TestButtonProps): JSX.Element {
             />
         </button>
     );
+
+    if (disabled && disabledTooltip) {
+        return (
+            <WithTooltip title={disabledTooltip}>
+                {button}
+            </WithTooltip>
+        );
+    }
+
+    return button;
 }
 
 export function AddAttributeButton({onClick, disabled}: AddAttributeButtonProps): JSX.Element {

--- a/webapp/channels/src/components/admin_console/access_control/editors/table_editor/table_editor_channel_admin.test.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/editors/table_editor/table_editor_channel_admin.test.tsx
@@ -1,0 +1,271 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import type {UserPropertyField} from '@mattermost/types/properties';
+
+import {renderWithContext, screen, waitFor} from 'tests/react_testing_utils';
+
+import TableEditor from './table_editor';
+
+describe('TableEditor - User Self-Exclusion', () => {
+    const mockUserAttributes: UserPropertyField[] = [
+        {
+            id: 'attr1',
+            name: 'department',
+            type: 'select',
+            group_id: 'custom_profile_attributes',
+            create_at: 1736541716295,
+            update_at: 1736541716295,
+            delete_at: 0,
+            attrs: {
+                sort_order: 0,
+                visibility: 'when_set',
+                value_type: '',
+                options: [
+                    {id: 'eng', name: 'Engineering'},
+                    {id: 'sales', name: 'Sales'},
+                ],
+            },
+        },
+    ];
+
+    const mockActions = {
+        getVisualAST: jest.fn(),
+    };
+
+    const baseProps = {
+        value: 'user.attributes.department == "Engineering"',
+        onChange: jest.fn(),
+        userAttributes: mockUserAttributes,
+        enableUserManagedAttributes: true,
+        onParseError: jest.fn(),
+        actions: mockActions,
+    };
+
+    beforeEach(() => {
+        mockActions.getVisualAST.mockClear();
+        mockActions.getVisualAST.mockResolvedValue({
+            data: {
+                conditions: [
+                    {
+                        attribute: 'user.attributes.department',
+                        operator: '==',
+                        value: 'Engineering',
+                        value_type: 0,
+                        attribute_type: 'text',
+                    },
+                ],
+            },
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('should disable Test Access Rules button when user would be excluded', async () => {
+        const mockValidateExpression = jest.fn().mockResolvedValue({
+            data: {requester_matches: false}, // User would be excluded
+        });
+
+        const props = {
+            ...baseProps,
+            isSystemAdmin: false,
+            validateExpressionAgainstRequester: mockValidateExpression,
+        };
+
+        renderWithContext(<TableEditor {...props}/>, {});
+
+        // Wait for component to load and validate
+        await waitFor(() => {
+            expect(mockValidateExpression).toHaveBeenCalledWith('user.attributes.department == "Engineering"');
+        });
+
+        // Check that the Test Access Rules button is disabled
+        const testButton = screen.getByRole('button', {name: /test access rule/i});
+        expect(testButton).toBeDisabled();
+    });
+
+    test('should show tooltip when user would be excluded', async () => {
+        const mockValidateExpression = jest.fn().mockResolvedValue({
+            data: {requester_matches: false}, // User would be excluded
+        });
+
+        const props = {
+            ...baseProps,
+            isSystemAdmin: false,
+            validateExpressionAgainstRequester: mockValidateExpression,
+        };
+
+        renderWithContext(<TableEditor {...props}/>, {});
+
+        // Wait for validation to complete
+        await waitFor(() => {
+            expect(mockValidateExpression).toHaveBeenCalledWith('user.attributes.department == "Engineering"');
+        });
+
+        // Check that the button is disabled - this is the main behavior we're testing
+        const testButton = screen.getByRole('button', {name: /test access rule/i});
+        expect(testButton).toBeDisabled();
+
+        // The tooltip functionality is complex with floating-ui and is already tested in the TestButton unit tests
+        // The main functionality we care about is that the button is disabled when the user would be excluded
+    });
+
+    test('should not disable Test Access Rules button for system admins even if they would be excluded', async () => {
+        const mockValidateExpression = jest.fn().mockResolvedValue({
+            data: {requester_matches: false}, // System admin would be excluded but shouldn't matter
+        });
+
+        const props = {
+            ...baseProps,
+            isSystemAdmin: true,
+            validateExpressionAgainstRequester: mockValidateExpression,
+        };
+
+        renderWithContext(<TableEditor {...props}/>, {});
+
+        // Wait for component to load
+        await waitFor(() => {
+            expect(screen.getByRole('button', {name: /test access rule/i})).toBeInTheDocument();
+        });
+
+        // Validation should not be called for system admins (they are never restricted)
+        expect(mockValidateExpression).not.toHaveBeenCalled();
+
+        // Test button should not be disabled
+        const testButton = screen.getByRole('button', {name: /test access rule/i});
+        expect(testButton).not.toBeDisabled();
+    });
+
+    test('should not disable Test Access Rules button when user would not be excluded', async () => {
+        const mockValidateExpression = jest.fn().mockResolvedValue({
+            data: {requester_matches: true}, // User would NOT be excluded
+        });
+
+        const props = {
+            ...baseProps,
+            isSystemAdmin: false,
+            validateExpressionAgainstRequester: mockValidateExpression,
+        };
+
+        renderWithContext(<TableEditor {...props}/>, {});
+
+        // Wait for validation to complete
+        await waitFor(() => {
+            expect(mockValidateExpression).toHaveBeenCalledWith('user.attributes.department == "Engineering"');
+        });
+
+        // Test button should not be disabled
+        const testButton = screen.getByRole('button', {name: /test access rule/i});
+        expect(testButton).not.toBeDisabled();
+    });
+
+    test('should handle validation errors gracefully', async () => {
+        const mockValidateExpression = jest.fn().mockRejectedValue(new Error('Validation failed'));
+
+        const props = {
+            ...baseProps,
+            isSystemAdmin: false,
+            validateExpressionAgainstRequester: mockValidateExpression,
+        };
+
+        renderWithContext(<TableEditor {...props}/>, {});
+
+        // Wait for validation attempt
+        await waitFor(() => {
+            expect(mockValidateExpression).toHaveBeenCalledWith('user.attributes.department == "Engineering"');
+        });
+
+        // Test button should not be disabled when validation fails (fail-safe approach)
+        const testButton = screen.getByRole('button', {name: /test access rule/i});
+        expect(testButton).not.toBeDisabled();
+    });
+
+    test('should not validate when expression is empty', async () => {
+        const mockValidateExpression = jest.fn();
+
+        const props = {
+            ...baseProps,
+            value: '', // Empty expression
+            isSystemAdmin: false,
+            validateExpressionAgainstRequester: mockValidateExpression,
+        };
+
+        renderWithContext(<TableEditor {...props}/>, {});
+
+        // Wait for component to render
+        await waitFor(() => {
+            expect(screen.getByRole('button', {name: /test access rule/i})).toBeInTheDocument();
+        });
+
+        // Validation should not be called for empty expressions
+        expect(mockValidateExpression).not.toHaveBeenCalled();
+
+        // Test button should be disabled due to empty expression (existing behavior)
+        const testButton = screen.getByRole('button', {name: /test access rule/i});
+        expect(testButton).toBeDisabled();
+    });
+
+    test('should not validate when validateExpressionAgainstRequester is not provided', async () => {
+        const props = {
+            ...baseProps,
+            isSystemAdmin: false,
+
+            // validateExpressionAgainstRequester not provided
+        };
+
+        renderWithContext(<TableEditor {...props}/>, {});
+
+        // Wait for component to render
+        await waitFor(() => {
+            expect(screen.getByRole('button', {name: /test access rule/i})).toBeInTheDocument();
+        });
+
+        // Test button should not be disabled when validation function is not provided
+        const testButton = screen.getByRole('button', {name: /test access rule/i});
+        expect(testButton).not.toBeDisabled();
+    });
+
+    test('should re-validate when expression changes', async () => {
+        const mockValidateExpression = jest.fn().
+            mockResolvedValueOnce({data: {requester_matches: true}}). // First call
+            mockResolvedValueOnce({data: {requester_matches: false}}); // Second call after change
+
+        const props = {
+            ...baseProps,
+            isSystemAdmin: false,
+            validateExpressionAgainstRequester: mockValidateExpression,
+        };
+
+        const {rerender} = renderWithContext(<TableEditor {...props}/>, {});
+
+        // Wait for initial validation
+        await waitFor(() => {
+            expect(mockValidateExpression).toHaveBeenCalledWith('user.attributes.department == "Engineering"');
+        });
+
+        // Initially button should not be disabled
+        let testButton = screen.getByRole('button', {name: /test access rule/i});
+        expect(testButton).not.toBeDisabled();
+
+        // Change expression
+        const newProps = {
+            ...props,
+            value: 'user.attributes.department == "Sales"',
+        };
+
+        rerender(<TableEditor {...newProps}/>);
+
+        // Wait for re-validation with new expression
+        await waitFor(() => {
+            expect(mockValidateExpression).toHaveBeenCalledWith('user.attributes.department == "Sales"');
+        });
+
+        // Now button should be disabled since second validation returns false
+        testButton = screen.getByRole('button', {name: /test access rule/i});
+        expect(testButton).toBeDisabled();
+    });
+});

--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_access_rules_tab.test.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_access_rules_tab.test.tsx
@@ -131,8 +131,40 @@ describe('components/channel_settings_modal/ChannelSettingsAccessRulesTab', () =
                         first_name: 'Test',
                         last_name: 'User',
                         email: 'test@example.com',
+                        roles: 'channel_user', // Not system_admin
                     },
                 },
+            },
+            roles: {
+                roles: {
+                    channel_user: {
+                        id: 'channel_user',
+                        name: 'channel_user',
+                        permissions: [],
+                    },
+                    channel_admin: {
+                        id: 'channel_admin',
+                        name: 'channel_admin',
+                        permissions: ['manage_channel_access_rules'],
+                    },
+                },
+                myRoles: {
+                    channel_id: new Set(['channel_admin']),
+                },
+            },
+            channels: {
+                myMembers: {
+                    channel_id: {
+                        channel_id: 'channel_id',
+                        user_id: 'current_user_id',
+                        roles: 'channel_admin',
+                        mention_count: 0,
+                        msg_count: 0,
+                    },
+                },
+            },
+            teams: {
+                currentTeamId: 'team_id',
             },
         },
         plugins: {
@@ -338,9 +370,29 @@ describe('components/channel_settings_modal/ChannelSettingsAccessRulesTab', () =
                 onChange: expect.any(Function),
                 onValidate: expect.any(Function),
                 onParseError: expect.any(Function),
+                isSystemAdmin: expect.any(Boolean),
+                validateExpressionAgainstRequester: mockActions.validateExpressionAgainstRequester,
             }),
             expect.anything(),
         );
+    });
+
+    test('should pass user self-exclusion props to TableEditor', async () => {
+        renderWithContext(
+            <ChannelSettingsAccessRulesTab {...baseProps}/>,
+            initialState,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('table-editor')).toBeInTheDocument();
+        });
+
+        // Verify the new props for user self-exclusion are passed
+        const call = MockedTableEditor.mock.calls[0][0];
+        expect(call).toHaveProperty('isSystemAdmin');
+        expect(call).toHaveProperty('validateExpressionAgainstRequester');
+        expect(typeof call.isSystemAdmin).toBe('boolean');
+        expect(typeof call.validateExpressionAgainstRequester).toBe('function');
     });
 
     test('should call setAreThereUnsavedChanges when expression changes', async () => {
@@ -1392,6 +1444,9 @@ describe('components/channel_settings_modal/ChannelSettingsAccessRulesTab', () =
                                 id: 'current_user_id',
                                 username: 'current_user',
                                 email: 'current@test.com',
+                                roles: 'channel_user', // Add missing roles property
+                                first_name: 'Current',
+                                last_name: 'User',
                             },
                         },
                     },

--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_access_rules_tab.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_access_rules_tab.tsx
@@ -9,7 +9,7 @@ import type {Channel} from '@mattermost/types/channels';
 import type {UserPropertyField} from '@mattermost/types/properties';
 
 import {getAccessControlSettings} from 'mattermost-redux/selectors/entities/access_control';
-import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUser, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 
 import TableEditor from 'components/admin_console/access_control/editors/table_editor/table_editor';
 import ConfirmModal from 'components/confirm_modal';
@@ -41,6 +41,9 @@ function ChannelSettingsAccessRulesTab({
     // Get access control settings and current user from Redux state
     const accessControlSettings = useSelector((state: GlobalState) => getAccessControlSettings(state));
     const currentUser = useSelector(getCurrentUser);
+
+    // Check if current user is system admin (system admins should never be restricted)
+    const isSystemAdmin = useSelector(isCurrentUserSystemAdmin);
 
     // State for the access control expression and user attributes
     const [expression, setExpression] = useState('');
@@ -584,6 +587,8 @@ function ChannelSettingsAccessRulesTab({
                         channelId={channel.id}
                         actions={actions}
                         enableUserManagedAttributes={accessControlSettings?.EnableUserManagedAttributes || false}
+                        isSystemAdmin={isSystemAdmin}
+                        validateExpressionAgainstRequester={actions.validateExpressionAgainstRequester}
                     />
                 </div>
             )}

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -342,6 +342,7 @@
   "admin.access_control.table_editor.selector.filter_or_create": "Search or create value...",
   "admin.access_control.table_editor.selector.select_attribute": "Select attribute",
   "admin.access_control.table_editor.test_access_rule": "Test access rule",
+  "admin.access_control.table_editor.user_excluded_tooltip": "You cannot test access rules that would exclude you from the channel",
   "admin.access_control.table_editor.value.placeholder": "Add value...",
   "admin.access_control.table_editor.value.select_value": "Select value",
   "admin.access_control.table_editor.values": "Values",


### PR DESCRIPTION
#### Summary
disable test button when not matching attributes for channel admin

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65699

#### Screenshots

https://github.com/user-attachments/assets/885236b7-2b73-4064-8972-9ba9dde4adef



#### Release Note
```release-note
NONE
```
