### PR TITLE
Introduce model.AssertNotSameMap

### DIFF
--- a/server/channels/app/platform/web_broadcast_hook_test.go
+++ b/server/channels/app/platform/web_broadcast_hook_test.go
@@ -73,7 +73,7 @@ func TestRunBroadcastHooks(t *testing.T) {
 		result := hub.runBroadcastHooks(event, webConn, hookIDs, hookArgs)
 
 		assert.NotSame(t, event, result)
-		assert.NotSame(t, model.NewPointer(event.GetData()), model.NewPointer(result.GetData()))
+		model.AssertNotSameMap(t, event.GetData(), result.GetData())
 		assert.Equal(t, map[string]any{}, event.GetData())
 		assert.Equal(t, result.GetData(), map[string]any{
 			"changes_made": 1,
@@ -120,7 +120,7 @@ func TestRunBroadcastHooks(t *testing.T) {
 		result := hub.runBroadcastHooks(event, webConn, hookIDs, hookArgs)
 
 		assert.NotSame(t, event, result)
-		assert.NotSame(t, model.NewPointer(event.GetData()), model.NewPointer(result.GetData()))
+		model.AssertNotSameMap(t, event.GetData(), result.GetData())
 		assert.Equal(t, event.GetData(), map[string]any{})
 		assert.Equal(t, result.GetData(), map[string]any{
 			"changes_made": 1,
@@ -142,7 +142,7 @@ func TestRunBroadcastHooks(t *testing.T) {
 		result := hub.runBroadcastHooks(event, webConn, hookIDs, hookArgs)
 
 		assert.NotSame(t, event, result)
-		assert.NotSame(t, model.NewPointer(event.GetData()), model.NewPointer(result.GetData()))
+		model.AssertNotSameMap(t, event.GetData(), result.GetData())
 		assert.Equal(t, event.GetData(), map[string]any{})
 		assert.Equal(t, result.GetData(), map[string]any{
 			"changes_made": 10,

--- a/server/public/model/map.go
+++ b/server/public/model/map.go
@@ -1,0 +1,12 @@
+package model
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func AssertNotSameMap[K comparable, V any](t *testing.T, a, b map[K]V) {
+	assert.False(t, reflect.ValueOf(a).UnsafePointer() == reflect.ValueOf(b).UnsafePointer())
+}

--- a/server/public/model/map_test.go
+++ b/server/public/model/map_test.go
@@ -1,0 +1,54 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssertNotSameMap(t *testing.T) {
+	t.Run("both nil maps are the same", func(t *testing.T) {
+		mockT := &testing.T{}
+		var a, b map[string]int
+
+		AssertNotSameMap(mockT, a, b)
+		require.True(t, mockT.Failed())
+	})
+
+	t.Run("one nil map is not the same", func(t *testing.T) {
+		mockT := &testing.T{}
+		var a map[string]int
+		b := map[string]int{"key1": 1}
+
+		AssertNotSameMap(mockT, a, b)
+		require.False(t, mockT.Failed())
+	})
+
+	t.Run("different maps should not be the same", func(t *testing.T) {
+		mockT := &testing.T{}
+		a := map[string]int{"key1": 1}
+		b := map[string]int{"key1": 1}
+
+		AssertNotSameMap(mockT, a, b)
+		require.False(t, mockT.Failed())
+	})
+
+	t.Run("same map should be the same", func(t *testing.T) {
+		mockT := &testing.T{}
+		a := map[string]int{"key1": 1}
+		b := a
+
+		AssertNotSameMap(mockT, a, b)
+		require.True(t, mockT.Failed())
+	})
+
+	t.Run("same map should be the same after modification", func(t *testing.T) {
+		mockT := &testing.T{}
+		a := map[string]int{"key1": 1}
+		b := a
+		b["key2"] = 2
+
+		AssertNotSameMap(mockT, a, b)
+		require.True(t, mockT.Failed())
+	})
+}

--- a/server/public/model/websocket_message_test.go
+++ b/server/public/model/websocket_message_test.go
@@ -228,7 +228,7 @@ func TestWebSocketEventDeepCopy(t *testing.T) {
 
 	evCopy := ev.DeepCopy()
 	require.Equal(t, ev, evCopy)
-	require.NotSame(t, &ev.data, &evCopy.data)
+	AssertNotSameMap(t, ev.data, evCopy.data)
 	require.NotSame(t, ev.broadcast, evCopy.broadcast)
 	require.NotSame(t, ev.precomputedJSON, evCopy.precomputedJSON)
 


### PR DESCRIPTION
#### Summary
When we last bumped dependencies in https://github.com/mattermost/mattermost/pull/30005, `assert.NotSame` for maps started failing because of the change in https://github.com/stretchr/testify/issues/1661. The reality was that the previous assertion was silently skipped, and just now reporting as much.

Here's an illustrative example:
```go
package main

import (
	"maps"
	"testing"

	"github.com/stretchr/testify/assert"
)

func TestClonedMapsAreNotSame(t *testing.T) {
	original := map[string]int{
		"a": 1,
		"b": 2,
		"c": 3,
	}

	cloned := maps.Clone(original)

	assert.NotSame(t, original, cloned)
}

func TestSameMaps(t *testing.T) {
	original := map[string]int{
		"a": 1,
		"b": 2,
		"c": 3,
	}

	cloned := original
	assert.Same(t, original, cloned)

	cloned["d"] = 4
	assert.Same(t, original, cloned)
}
```

which fails with the following after the original dependency update:
```
--- FAIL: TestClonedMapsAreNotSame (0.00s)
    main_test.go:19:
                Error Trace:    /Users/jesse/tmp/testify/main_test.go:19
                Error:          Both arguments must be pointers
                Test:           TestClonedMapsAreNotSame
--- FAIL: TestSameMaps (0.00s)
    main_test.go:30:
                Error Trace:    /Users/jesse/tmp/testify/main_test.go:30
                Error:          Both arguments must be pointers
                Test:           TestSameMaps
    main_test.go:33:
                Error Trace:    /Users/jesse/tmp/testify/main_test.go:33
                Error:          Both arguments must be pointers
                Test:           TestSameMaps
FAIL
FAIL    testassertequal 0.149s
FAIL
```

However, instead of fixing the underlying issue, we took the address of those variables and kept using `assert.Same`. This isn't meaningful, since it doesn't directly compare the underlying pointers of the map objects in question, just the address of the pointers to those maps. Here's the output after taking the address (e.g. `&original` and `&cloned`):

```
--- FAIL: TestSameMaps (0.00s)
    main_test.go:30:
                Error Trace:    /Users/jesse/tmp/testify/main_test.go:30
                Error:          Not same:
                                expected: 0x14000070170 &map[string]int{"a":1, "b":2, "c":3}
                                actual  : 0x14000070178 &map[string]int{"a":1, "b":2, "c":3}
                Test:           TestSameMaps
    main_test.go:33:
                Error Trace:    /Users/jesse/tmp/testify/main_test.go:33
                Error:          Not same:
                                expected: 0x14000070170 &map[string]int{"a":1, "b":2, "c":3, "d":4}
                                actual  : 0x14000070178 &map[string]int{"a":1, "b":2, "c":3, "d":4}
                Test:           TestSameMaps
FAIL
FAIL    testassertequal 0.157s
FAIL
```

They are obviously the same map, since modifying `cloned` modified the original, yet `assert.Same` thinks they are different (because the pointer values are indeed different). (`assert.NotSame` "passes", but for the wrong reasons.)

To fix this, introduce `model.AssertNotSameMap` to check this correctly. Note that there's an open request to make `assert.NotSame` just do this natively in testify, but not resolved: https://github.com/stretchr/testify/pull/1777.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
