### PR TITLE
Fix notification mentions to respect the TeammateNameDisplay setting for the full message text.

### DIFF
--- a/webapp/channels/src/actions/notification_actions.tsx
+++ b/webapp/channels/src/actions/notification_actions.tsx
@@ -215,20 +215,15 @@ const getNotificationUsername = (state: GlobalState, post: Post, msgProps: NewPo
 
 const replaceMentionsWithDisplayNames = (text: string, state: GlobalState): string => {
     const teammateNameDisplay = getTeammateNameDisplaySetting(state);
-    
-    // Replace user mentions with display names
     return text.replace(Constants.MENTIONS_REGEX, (match, username) => {
-        // Skip special mentions (@channel, @all, @here)
         if (['channel', 'all', 'here'].includes(username.toLowerCase())) {
             return match;
         }
-        
         const user = getUserByUsername(state, username);
         if (user) {
             const displayName = displayUsername(user, teammateNameDisplay, false);
             return `@${displayName}`;
         }
-        
         return match;
     });
 };
@@ -250,7 +245,6 @@ const getNotificationBody = (state: GlobalState, post: Post, msgProps: NewPostMe
         image = Boolean(image || (attachment.image_url?.length));
     });
 
-    // Replace mentions with display names before stripping markdown
     notifyText = replaceMentionsWithDisplayNames(notifyText, state);
     const strippedMarkdownNotifyText = stripMarkdown(notifyText);
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Previously, in PC notifications, the displayUsername setting applied only to the sender and did not apply to mentions within the message body (NotifyText).
We have now applied displayUsername to mentions within the message body(NotifyText) as well, ensuring the administrator's teammateNameDisplay setting is reflected.


#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

|  before  |  after  |
|----|----|
| <img width="355" height="105" alt="image" src="https://github.com/user-attachments/assets/01bfa0f5-9698-4a0b-b3fb-2f9a6bc1ff1a" />| <img width="364" height="104" alt="image" src="https://github.com/user-attachments/assets/6787601d-5a33-4673-9927-d76fd251c596" /> |

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
