### PR TITLE
Use validated redirectTo when channel is not found

### DIFF
--- a/webapp/channels/src/components/error_page/error_page.tsx
+++ b/webapp/channels/src/components/error_page/error_page.tsx
@@ -98,7 +98,7 @@ export default class ErrorPage extends React.PureComponent<Props> {
             );
         } else if (type === ErrorPageTypes.CHANNEL_NOT_FOUND) {
             backButton = (
-                <Link to={params.get('returnTo') as string}>
+                <Link to={returnTo}>
                     <FormattedMessage
                         id='error.channelNotFound.link'
                         defaultMessage='Back to {defaultChannelName}'


### PR DESCRIPTION
#### Summary
Use validated redirectTo when channel is not found

#### Ticket Link
N/A

#### Screenshots

Before:
<img width="953" height="638" alt="Screenshot 2025-10-06 at 23 06 10" src="https://github.com/user-attachments/assets/01b83dc3-dc4a-46a0-8d73-e9b1b3417fee" /> 

After:
<img width="1037" height="551" alt="Screenshot 2025-10-06 at 23 03 50" src="https://github.com/user-attachments/assets/541c5800-ea9f-4edb-85d1-395a67570619" /> 


#### Release Note
```release-note
FixedFixed an issue where the link on error pages could redirect to unintended locations when opened in a new tab
```

