### PR TITLE
[MM-64637] make sure confirmation modal is closed once there is an error at save

### DIFF
--- a/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.tsx
@@ -176,6 +176,7 @@ function PolicyDetails({
         }).then((result) => {
             if (result.error) {
                 setServerError(result.error.message);
+                setShowConfirmationModal(false);
                 success = false;
                 return;
             }
@@ -186,6 +187,7 @@ function PolicyDetails({
         });
 
         if (!currentPolicyId || !success) {
+            setShowConfirmationModal(false);
             return;
         }
 
@@ -197,6 +199,7 @@ function PolicyDetails({
                 id: 'admin.access_control.policy.edit_policy.error.update_active_status',
                 defaultMessage: 'Error updating policy active status: {error}',
             }, {error: error.message}));
+            setShowConfirmationModal(false);
             success = false;
             return;
         }
@@ -217,6 +220,7 @@ function PolicyDetails({
                     id: 'admin.access_control.policy.edit_policy.error.assign_channels',
                     defaultMessage: 'Error assigning channels: {error}',
                 }, {error: error.message}));
+                setShowConfirmationModal(false);
                 success = false;
                 return;
             }
@@ -233,6 +237,7 @@ function PolicyDetails({
                     id: 'admin.access_control.policy.edit_policy.error.create_job',
                     defaultMessage: 'Error creating job: {error}',
                 }, {error: error.message}));
+                setShowConfirmationModal(false);
                 success = false;
                 return;
             }


### PR DESCRIPTION


#### Summary
We should close the confirmation modal in case of an error.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64637



#### Release Note

```release-note
NONE
```
