### PR TITLE
[MM-64541] fix flaky test TestUnassignPoliciesFromChannels

### DIFF
--- a/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.tsx
@@ -176,7 +176,6 @@ function PolicyDetails({
         }).then((result) => {
             if (result.error) {
                 setServerError(result.error.message);
-                setShowConfirmationModal(false);
                 success = false;
                 return;
             }
@@ -187,7 +186,6 @@ function PolicyDetails({
         });
 
         if (!currentPolicyId || !success) {
-            setShowConfirmationModal(false);
             return;
         }
 
@@ -199,7 +197,6 @@ function PolicyDetails({
                 id: 'admin.access_control.policy.edit_policy.error.update_active_status',
                 defaultMessage: 'Error updating policy active status: {error}',
             }, {error: error.message}));
-            setShowConfirmationModal(false);
             success = false;
             return;
         }
@@ -220,7 +217,6 @@ function PolicyDetails({
                     id: 'admin.access_control.policy.edit_policy.error.assign_channels',
                     defaultMessage: 'Error assigning channels: {error}',
                 }, {error: error.message}));
-                setShowConfirmationModal(false);
                 success = false;
                 return;
             }
@@ -237,7 +233,6 @@ function PolicyDetails({
                     id: 'admin.access_control.policy.edit_policy.error.create_job',
                     defaultMessage: 'Error creating job: {error}',
                 }, {error: error.message}));
-                setShowConfirmationModal(false);
                 success = false;
                 return;
             }


### PR DESCRIPTION


#### Summary
Fix a flaky test, now it's much better. Add proper search mock and remove ambiguous `DeletePolicy` assertion on the second child. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64541



#### Release Note

```release-note
NONE
```
