### PR TITLE
Update system health API docs to clarify authentication requirements

### DIFF
--- a/api/v4/source/system.yaml
+++ b/api/v4/source/system.yaml
@@ -54,12 +54,30 @@
 
         ##### Permissions
 
-        None.
+        None. Authentication is not required for this endpoint.
+
+        ##### Response Details
+
+        The response varies based on query parameters and authentication:
+
+        - **Basic response** (no parameters): Returns basic server information including
+          `status`, mobile app versions, and active search backend.
+
+        - **Enhanced response** (`get_server_status=true`): Additionally returns
+          `database_status` and `filestore_status` to verify backend connectivity.
+          Authentication is not required.
+
+        - **Admin response** (`get_server_status=true` with `manage_system` permission):
+          Additionally returns `root_status` indicating whether the server is running as root.
+          Requires authentication with `manage_system` permission.
       operationId: GetPing
       parameters:
         - name: get_server_status
           in: query
-          description: Check the status of the database and file storage as well
+          description: >
+            Check the status of the database and file storage as well.
+            When true, adds `database_status` and `filestore_status` to the response.
+            If authenticated with `manage_system` permission, also adds `root_status`.
           required: false
           schema:
             type: boolean


### PR DESCRIPTION
#### Summary

Clarified the authentication requirements for the `/api/v4/system/ping` endpoint in the OpenAPI documentation. The endpoint does not require authentication, but returns different levels of information based on query parameters and user permissions.

Documented three response scenarios:
- **Basic response** (no auth, no parameters): Returns status, mobile app versions, and active search backend
- **Enhanced response** (`get_server_status=true`, no auth required): Additionally returns `database_status` and `filestore_status`
- **Admin response** (`get_server_status=true` with `manage_system` permission): Additionally returns `root_status` indicating if server is running as root

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-66073

#### Screenshots

N/A - Documentation only change

#### Release Note

```release-note
NONE
```