### PR TITLE
MM-65707 Fix justification of sidebar icons

### DIFF
--- a/webapp/channels/src/sass/layout/_team-sidebar.scss
+++ b/webapp/channels/src/sass/layout/_team-sidebar.scss
@@ -4,6 +4,7 @@
     overflow: hidden;
     width: 65px;
     flex-direction: column;
+    justify-content: space-between;
     background-color: var(--sidebar-header-bg);
     text-align: center;
 


### PR DESCRIPTION
#### Summary
See the screenshots below

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65707

#### Screenshots
|  before  |  after  |
|----|----|
<img width="1392" height="819" alt="Screenshot 2025-10-07 at 11 28 04 AM" src="https://github.com/user-attachments/assets/ec84625a-f176-4d45-a9dd-8898574ab17d" />|<img width="1392" height="819" alt="Screenshot 2025-10-07 at 11 28 18 AM" src="https://github.com/user-attachments/assets/4b6db157-1556-4d18-850e-5509320d8093" />

#### Release Note
```release-note
Fixed justification of sidebar icons for plugins
```
