### PR TITLE
MM-66128 Remove nock.disableNetConnect

### DIFF
--- a/webapp/channels/src/tests/setup_jest.ts
+++ b/webapp/channels/src/tests/setup_jest.ts
@@ -7,7 +7,6 @@ import * as util from 'node:util';
 
 import Adapter from '@cfaester/enzyme-adapter-react-18';
 import {configure} from 'enzyme';
-import nock from 'nock';
 
 import '@testing-library/jest-dom';
 import 'isomorphic-fetch';
@@ -165,6 +164,3 @@ jest.mock('react-redux', () => ({
     __esModule: true,
     ...jest.requireActual('react-redux'),
 }));
-
-// Prevent any connections from being made to the internet outside of Nock
-nock.disableNetConnect();


### PR DESCRIPTION
#### Summary
This seems to fix the issue where unit tests are leaking massive amounts of memory since https://github.com/mattermost/mattermost/pull/33858.

I thought I needed this as part of https://github.com/mattermost/mattermost/pull/33858 because I saw some of the tests connecting to my local dev instance, but I reproed that on a previous commit, so that's just the existing behaviour apparently. It seemed like a worse problem when I was working on React 18, so I don't know why it's not a problem now.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66128

#### Release Note
```release-note
NONE
```
