### PR TITLE
Update latest minor version to 11.1.0

### DIFF
--- a/server/public/model/version.go
+++ b/server/public/model/version.go
@@ -13,7 +13,7 @@ import (
 // It should be maintained in chronological order with most current
 // release at the front of the list.
 var versions = []string{
-    "11.1.0",
+	"11.1.0",
 	"11.0.0",
 	"10.12.0",
 	"10.11.0",


### PR DESCRIPTION
The next latest minor version normally gets updated automatically upon cutting the final release for the latest version (example PR https://github.com/mattermost/mattermost/pull/31304), but this time I had to do it manually. Maybe the pipeline is broken?

```release-note
NONE
```
