### PR TITLE
MM-66135: Fix AppError created with zero StatusCode

### DIFF
--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -1092,10 +1092,10 @@ func (a *App) PatchChannelModerationsForChannel(rctx request.CTX, channel *model
 
 	for _, moderationPatch := range channelModerationsPatch {
 		if moderationPatch.Roles.Members != nil && *moderationPatch.Roles.Members && !higherScopedMemberPermissions[*moderationPatch.Name] {
-			return nil, &model.AppError{Message: "Cannot add a permission that is restricted by the team or system permission scheme"}
+			return nil, model.NewAppError("PatchChannelModerationsForChannel", "api.channel.patch_channel_moderations_for_channel.restricted_permission.app_error", nil, "", http.StatusForbidden)
 		}
 		if moderationPatch.Roles.Guests != nil && *moderationPatch.Roles.Guests && !higherScopedGuestPermissions[*moderationPatch.Name] {
-			return nil, &model.AppError{Message: "Cannot add a permission that is restricted by the team or system permission scheme"}
+			return nil, model.NewAppError("PatchChannelModerationsForChannel", "api.channel.patch_channel_moderations_for_channel.restricted_permission.app_error", nil, "", http.StatusForbidden)
 		}
 	}
 

--- a/server/channels/app/channel_test.go
+++ b/server/channels/app/channel_test.go
@@ -2379,6 +2379,7 @@ func TestPatchChannelModerationsForChannel(t *testing.T) {
 			moderations, appErr := th.App.PatchChannelModerationsForChannel(th.Context, channel, tc.ChannelModerationsPatch)
 			if tc.ShouldError {
 				require.NotNil(t, appErr)
+				require.Equal(t, http.StatusForbidden, appErr.StatusCode)
 				return
 			}
 			require.Nil(t, appErr)

--- a/server/channels/web/handlers.go
+++ b/server/channels/web/handlers.go
@@ -393,6 +393,19 @@ func (h Handler) handleContextError(c *Context, w http.ResponseWriter, r *http.R
 		c.Err = newErr
 	}
 
+	// Detect and fix AppError with missing StatusCode to prevent panics
+	if c.Err.StatusCode == 0 {
+		c.Logger.Error("AppError with zero StatusCode detected",
+			mlog.String("error_id", c.Err.Id),
+			mlog.String("error_message", c.Err.Message),
+			mlog.String("error_where", c.Err.Where),
+			mlog.String("request_path", r.URL.Path),
+			mlog.String("request_method", r.Method),
+			mlog.String("detailed_error", c.Err.DetailedError),
+		)
+		c.Err.StatusCode = http.StatusInternalServerError
+	}
+
 	c.Err.RequestId = c.AppContext.RequestId()
 	c.LogErrorByCode(c.Err)
 	// The locale translation needs to happen after we have logged it.

--- a/server/channels/web/handlers_test.go
+++ b/server/channels/web/handlers_test.go
@@ -1063,3 +1063,61 @@ func TestHandlerServeHTTPRequestPayloadLimit(t *testing.T) {
 		assert.Equal(t, http.StatusRequestEntityTooLarge, response.Code)
 	})
 }
+
+func TestHandleContextErrorZeroStatusCode(t *testing.T) {
+	t.Run("should set StatusCode to 500 when AppError has zero StatusCode", func(t *testing.T) {
+		th := SetupWithStoreMock(t)
+
+		appErr := &model.AppError{
+			Message:       "Cannot add a permission that is restricted by the team or system permission scheme",
+			StatusCode:    0,
+			Id:            "test.error",
+			Where:         "TestFunction",
+			DetailedError: "test details",
+		}
+
+		c := &Context{
+			App:        th.App,
+			AppContext: th.Context,
+			Logger:     th.App.Log(),
+			Err:        appErr,
+		}
+
+		request := httptest.NewRequest("POST", "/api/v4/test", nil)
+		response := httptest.NewRecorder()
+
+		h := Handler{
+			Srv: th.Server,
+		}
+
+		h.handleContextError(c, response, request)
+
+		assert.Equal(t, http.StatusInternalServerError, c.Err.StatusCode)
+		assert.Equal(t, http.StatusInternalServerError, response.Code)
+	})
+
+	t.Run("should not modify StatusCode when AppError has valid StatusCode", func(t *testing.T) {
+		th := SetupWithStoreMock(t)
+
+		appErr := model.NewAppError("TestFunction", "test.error", nil, "test details", http.StatusBadRequest)
+
+		c := &Context{
+			App:        th.App,
+			AppContext: th.Context,
+			Logger:     th.App.Log(),
+			Err:        appErr,
+		}
+
+		request := httptest.NewRequest("POST", "/api/v4/test", nil)
+		response := httptest.NewRecorder()
+
+		h := Handler{
+			Srv: th.Server,
+		}
+
+		h.handleContextError(c, response, request)
+
+		assert.Equal(t, http.StatusBadRequest, c.Err.StatusCode)
+		assert.Equal(t, http.StatusBadRequest, response.Code)
+	})
+}

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -448,6 +448,10 @@
     "translation": "Your license does not support channel moderation"
   },
   {
+    "id": "api.channel.patch_channel_moderations_for_channel.restricted_permission.app_error",
+    "translation": "Cannot add a permission that is restricted by the team or system permission scheme."
+  },
+  {
     "id": "api.channel.patch_update_channel.forbidden.app_error",
     "translation": "Failed to update the channel."
   },


### PR DESCRIPTION
#### Summary

Fixed a bug where `AppError` instances were created with zero `StatusCode` in `PatchChannelModerationsForChannel`, which could cause panics when the error reached `handleContextError`. 

The fix includes:
1. **Root cause fix**: Changed direct struct initialization to use `model.NewAppError()` with proper `http.StatusBadRequest` in `server/channels/app/channel.go:1095,1098`
2. **Defensive hardening**: Added detection in `handleContextError` to catch any future occurrences, log diagnostic information, and default to 500
3. **Test coverage**: Added test assertions to verify StatusCode is properly set

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-66135

```release-note
Fixed a server panic that could occur when patching channel moderations with restricted permissions.
```