### PR TITLE
Bump prepackage Github plugin version to 2.5.0

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -153,7 +153,7 @@ TEMPLATES_DIR=templates
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
 PLUGIN_PACKAGES += mattermost-plugin-calls-v1.10.0
-PLUGIN_PACKAGES += mattermost-plugin-github-v2.4.0
+PLUGIN_PACKAGES += mattermost-plugin-github-v2.5.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.11.0
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.4.0
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.4.2


### PR DESCRIPTION
#### Summary
Prepackage Github plugin v2.5.0

#### Release Note
```release-note
Prepackage Github plugin version [v2.5.0](https://github.com/mattermost/mattermost-plugin-github/releases/tag/v2.5.0).
```
Prepackage Github plugin version [v2.5.0](https://github.com/mattermost/mattermost-plugin-github/releases/tag/v2.5.0).