### PR TITLE
[MM-65684] Sanitize teams for /api/v4/channels/{channel_id}/common_teams endpoint

### DIFF
--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -3713,12 +3713,6 @@ func (a *App) GetDirectOrGroupMessageMembersCommonTeams(rctx request.CTX, channe
 		teams, appErr = a.GetTeams(commonTeamIDs)
 	}
 
-	if !model.SafeDereference(a.Config().PrivacySettings.ShowEmailAddress) {
-		for _, team := range teams {
-			team.Email = ""
-		}
-	}
-
 	return teams, appErr
 }
 

--- a/server/channels/app/channel_test.go
+++ b/server/channels/app/channel_test.go
@@ -2917,34 +2917,6 @@ func TestGetDirectOrGroupMessageMembersCommonTeams(t *testing.T) {
 		require.Nil(t, appErr)
 		require.Equal(t, 0, len(commonTeams))
 	})
-
-	t.Run("Privacy mode enabled, should redact email address", func(t *testing.T) {
-		currentPrivacySetting := *th.App.Config().PrivacySettings.ShowEmailAddress
-		th.App.UpdateConfig(func(cfg *model.Config) {
-			cfg.PrivacySettings.ShowEmailAddress = model.NewPointer(true)
-		})
-
-		commonTeams, appErr := th.App.GetDirectOrGroupMessageMembersCommonTeams(th.Context, gmChannel.Id)
-		require.Nil(t, appErr)
-		require.Equal(t, 2, len(commonTeams))
-		for _, team := range commonTeams {
-			require.NotEmpty(t, team.Email)
-		}
-
-		th.App.UpdateConfig(func(cfg *model.Config) {
-			cfg.PrivacySettings.ShowEmailAddress = model.NewPointer(false)
-		})
-		defer th.App.UpdateConfig(func(cfg *model.Config) {
-			*cfg.PrivacySettings.ShowEmailAddress = currentPrivacySetting
-		})
-
-		commonTeams, appErr = th.App.GetDirectOrGroupMessageMembersCommonTeams(th.Context, gmChannel.Id)
-		require.Nil(t, appErr)
-		require.Equal(t, 2, len(commonTeams))
-		for _, team := range commonTeams {
-			require.Empty(t, team.Email)
-		}
-	})
 }
 
 func TestConvertGroupMessageToChannel(t *testing.T) {


### PR DESCRIPTION

#### Summary
~~Remove email address from teams if the privacy settings says emails shouldn't be displayed. Maybe we could prevent redacting email if the requester is actually the owner of the team but setting wording is not something like "HideOtherUserEmails" etc. Hence it's handled this way.~~

Update: added sanitization logic to the `/api/v4/channels/{channel_id}/common_teams` endpoint, and since I already added test cases keeping them as is. (it's safer to use actual store)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65684


#### Release Note

```release-note
NONE
```
