### PR TITLE
Fix ActiveUserCount check to ignore when MaxUsersLimit == 0

### DIFF
--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -1131,7 +1131,7 @@ func (a *App) UpdateActive(rctx request.CTX, user *model.User, active bool) (*mo
 		if appErr != nil {
 			rctx.Logger().Error("Error fetching user limits in UpdateActive", mlog.Err(appErr))
 		} else {
-			if userLimits.ActiveUserCount > userLimits.MaxUsersLimit {
+			if userLimits.MaxUsersLimit > 0 && userLimits.ActiveUserCount > userLimits.MaxUsersLimit {
 				// Use different warning messages based on whether server is licensed
 				if a.License() != nil {
 					rctx.Logger().Warn("ERROR_LICENSED_USERS_LIMIT_EXCEEDED: Activated user exceeds the maximum licensed users.", mlog.Int("user_limit", userLimits.MaxUsersLimit))


### PR DESCRIPTION
#### Summary

Fixed a bug in `channels/app/user.go` where the `ActiveUserCount` check in the `UpdateActive` function was missing a condition to ignore when `MaxUsersLimit == 0`. This makes it consistent with the similar check in the `createUserOrGuest` function.

The issue was at line 1134 where it only checked:
```go
if userLimits.ActiveUserCount > userLimits.MaxUsersLimit {
```

Changed to:
```go
if userLimits.MaxUsersLimit > 0 && userLimits.ActiveUserCount > userLimits.MaxUsersLimit {
```

This prevents false warnings when user limits are disabled (MaxUsersLimit == 0).

#### Ticket Link

NONE

#### Screenshots

N/A

#### Release Note

```release-note
NONE
```