### PR TITLE
Fix nil pointer dereference in license validation

### DIFF
--- a/server/channels/utils/license.go
+++ b/server/channels/utils/license.go
@@ -82,6 +82,9 @@ func (l *LicenseValidatorImpl) ValidateLicense(signed []byte) (string, error) {
 		publicKey = testPublicKey
 	}
 	block, _ := pem.Decode(publicKey)
+	if block == nil {
+		return "", fmt.Errorf("failed to decode public key PEM block for environment %q", model.GetServiceEnvironment())
+	}
 
 	public, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {

--- a/server/channels/utils/license_test.go
+++ b/server/channels/utils/license_test.go
@@ -92,6 +92,23 @@ func TestValidateLicense(t *testing.T) {
 		require.Error(t, err)
 		require.Empty(t, str)
 	})
+
+	t.Run("should handle corrupted public key without panicking", func(t *testing.T) {
+		os.Setenv("MM_SERVICEENVIRONMENT", model.ServiceEnvironmentTest)
+		defer os.Unsetenv("MM_SERVICEENVIRONMENT")
+
+		mockValidator := &LicenseValidatorImpl{}
+
+		originalTestKey := testPublicKey
+		defer func() { testPublicKey = originalTestKey }()
+
+		testPublicKey = []byte("not a valid PEM block")
+
+		str, err := mockValidator.ValidateLicense(validTestLicense)
+		require.Error(t, err)
+		require.Empty(t, str)
+		require.Contains(t, err.Error(), "failed to decode public key PEM block")
+	})
 }
 
 func TestGetLicenseFileLocation(t *testing.T) {


### PR DESCRIPTION
#### Summary

This PR fixes a nil pointer dereference crash in the license validation code at `channels/utils/license.go:86`. The crash occurred when `pem.Decode()` returned `nil` due to corrupted or invalid public key PEM data, and the code attempted to access `block.Bytes` without checking if `block` was nil first.

In principle, this should never happen, as the public keys we embed with the product should always validate. Regardless, don't panic here...

#### Release Note

```release-note
NONE
```