### PR TITLE
Replace http with https in .editorconfig comment url

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# http://editorconfig.org/
+# https://editorconfig.org/
 
 root = true
 


### PR DESCRIPTION
#### Summary
This PR fixes a typo in .editorconfig comment url (old url used http instead of https)

#### Ticket Link
NONE

#### Screenshots
NONE

#### Release Note
```release-note
NONE
```
