### PR TITLE
Update supported software versions

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10958,15 +10958,15 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "Version 138+"
+    "translation": "Version 140+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "Version 138+"
+    "translation": "Version 140+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",
-    "translation": "Version 128+"
+    "translation": "Version 140+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.safari",


### PR DESCRIPTION
 - Desktop v6.0 includes Electron v38, which supports Chrome v140+. Supported Edge version follows the supported Chrome version. 
 - Current Firefox minimum supported versions include v140+.

```release-note
Updated minimum required Edge, Chrome and Firefox versions to v140+.
```
