### PR TITLE
Accessibility: Enter key press on a message as shortcut to reply button

### DIFF
--- a/webapp/channels/src/components/common/comment_icon.tsx
+++ b/webapp/channels/src/components/common/comment_icon.tsx
@@ -46,6 +46,14 @@ const CommentIcon = ({
         defaultMessage: 'Reply',
     });
 
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' && handleCommentClick) {
+            handleCommentClick(e as unknown as React.MouseEvent);
+            e.stopPropagation();
+            e.preventDefault();
+        }
+    };
+
     return (
         <WithTooltip
             title={replyTitle}
@@ -55,6 +63,7 @@ const CommentIcon = ({
                 aria-label={replyTitle.toLowerCase()}
                 className={`${iconStyle} ${extraClass}`}
                 onClick={handleCommentClick}
+                onKeyDown={handleKeyDown}
             >
                 <span className='d-flex align-items-center'>
                     <ReplyIcon className='icon icon--small'/>

--- a/webapp/channels/src/components/post/post_component.tsx
+++ b/webapp/channels/src/components/post/post_component.tsx
@@ -480,7 +480,7 @@ function PostComponent(props: Props) {
     const channelDisplayName = getChannelName();
     const showReactions = props.location !== Locations.SEARCH || props.isPinnedPosts || props.isFlaggedPosts;
 
-    const getTestId = () => {
+    const getId = () => {
         let idPrefix: string;
         switch (props.location) {
         case 'CENTER':
@@ -500,6 +500,21 @@ function PostComponent(props: Props) {
 
         return idPrefix + `_${post.id}`;
     };
+    const id = getId();
+
+    const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+        if (isKeyPressed(e, Constants.KeyCodes.ENTER)) {
+            // ENTER to focus comment button if available
+            const isTargetSelf = (e.target as HTMLElement | null)?.id === id;
+            const commentId = `CENTER_commentIcon_${props.post.id}`;
+            const commentButton = document.getElementById(commentId);
+            if (commentButton && isTargetSelf) {
+                e.stopPropagation();
+                e.preventDefault();
+                commentButton.focus();
+            }
+        }
+    }, [props.post.id, id]);
 
     let priority;
     if (post.metadata?.priority && props.isPostPriorityEnabled && post.state !== Posts.POST_DELETED) {
@@ -519,13 +534,14 @@ function PostComponent(props: Props) {
         <>
             <PostAriaLabelDiv
                 ref={postRef}
-                id={getTestId()}
+                id={id}
                 data-testid={postAriaLabelDivTestId}
                 post={post}
                 className={getClassName()}
                 onClick={handlePostClick}
                 onMouseOver={handleMouseOver}
                 onMouseLeave={handleMouseLeave}
+                onKeyDown={handleKeyDown}
             >
                 {(Boolean(isSearchResultItem) || (props.location !== Locations.CENTER && props.isFlagged)) &&
                     <div


### PR DESCRIPTION
#### Summary
* Enter key press on a message jumps right to the reply button for easier navigation when using screen readers

#### Ticket Link
#26961 

#### Release Note

```release-note
NONE
```

#### Screenshots

Pressing `ENTER` after the message is selected in the screencast below. This is much easier than pressing `TAB` 10 times when the message has focus to reach the comment button as it was before.

https://github.com/user-attachments/assets/902535d6-8c96-4358-9d1e-c495a3b3319f

