### PR TITLE
fix(add_emoji): disable file input while saving and add tests

### DIFF
--- a/webapp/channels/src/components/emoji/add_emoji/__snapshots__/add_emoji.test.tsx.snap
+++ b/webapp/channels/src/components/emoji/add_emoji/__snapshots__/add_emoji.test.tsx.snap
@@ -87,6 +87,7 @@ exports[`components/emoji/components/AddEmoji should match snapshot 1`] = `
               </button>
               <input
                 accept=".jpeg,.jpg,.png,.gif"
+                disabled={false}
                 id="select-emoji"
                 multiple={false}
                 onChange={[Function]}
@@ -231,6 +232,7 @@ exports[`components/emoji/components/AddEmoji should select a file and match sna
               </button>
               <input
                 accept=".jpeg,.jpg,.png,.gif"
+                disabled={false}
                 id="select-emoji"
                 multiple={false}
                 onChange={[Function]}
@@ -411,6 +413,7 @@ exports[`components/emoji/components/AddEmoji should update emoji name and match
               </button>
               <input
                 accept=".jpeg,.jpg,.png,.gif"
+                disabled={false}
                 id="select-emoji"
                 multiple={false}
                 onChange={[Function]}

--- a/webapp/channels/src/components/emoji/add_emoji/add_emoji.test.tsx
+++ b/webapp/channels/src/components/emoji/add_emoji/add_emoji.test.tsx
@@ -138,6 +138,26 @@ describe('components/emoji/components/AddEmoji', () => {
         expect(wrapper.state().error).toBeNull();
     });
 
+    test('should disable file input when already saving', () => {
+        const wrapper = shallow<AddEmoji>(
+            <AddEmoji {...baseProps}/>,
+            {context},
+        );
+
+        let fileInput = wrapper.find('#select-emoji');
+        expect(fileInput.prop('disabled')).toBe(false);
+
+        wrapper.setState({saving: true});
+        fileInput = wrapper.find('#select-emoji');
+        expect(fileInput.prop('disabled')).toBe(true);
+
+        wrapper.setState({saving: false});
+        wrapper.update();
+
+        fileInput = wrapper.find('#select-emoji');
+        expect(fileInput.prop('disabled')).toBe(false);
+    });
+
     test('should not submit when already saving', () => {
         const wrapper = shallow<AddEmoji>(
             <AddEmoji {...baseProps}/>,

--- a/webapp/channels/src/components/emoji/add_emoji/add_emoji.tsx
+++ b/webapp/channels/src/components/emoji/add_emoji/add_emoji.tsx
@@ -356,6 +356,7 @@ export default class AddEmoji extends React.PureComponent<AddEmojiProps, AddEmoj
                                             accept={Constants.ACCEPT_EMOJI_IMAGE}
                                             multiple={false}
                                             onChange={this.updateImage}
+                                            disabled={this.state.saving}
                                         />
                                     </div>
                                     {filename}


### PR DESCRIPTION
#### Summary

- This PR prevents users from re-selecting or removing an emoji file while the Add Emoji form is saving.
- Adds `disabled={this.state.saving}` to the file input so the native file picker cannot be triggered mid-submit on slower networks. 
- Adds a unit test `should disable file input when already saving` to verify the disabled prop toggles with saving.
- Updates snapshots where the file input now renders `disabled={false}` in the default state.

#### QA Steps

1. Click on emoji
2. Select `Custom Emoji`.
3. Click `Add Custom Emoji`.
4. In the DevTools, set Network to a slower profile to simulate latency. 
5. Enter a valid emoji Name.
6. Click `Select` and choose an Image.
7. Click `Save`.
8. While the form is saving, try clicking `Select` again and confirm that no file picker opens.

#### Ticket Link

Fixes #34153 

#### Screenshots

##### Before

https://github.com/user-attachments/assets/0eaabbe7-b82f-4de6-92b1-582fe726d59d

##### After

https://github.com/user-attachments/assets/26aef581-1c46-40dc-a8bc-d2c7e2775abc

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
