### PR TITLE
Delete Postgres volume when cleaning up dev Docker environment

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -292,6 +292,8 @@ else
 
 	docker compose down -v
 	docker compose rm -v
+
+	docker volume rm mattermost-server_postgres-14-data || true
 endif
 
 plugin-checker:


### PR DESCRIPTION
#### Summary
`make clean-docker` and `make nuke` don't actually remove the volumes for any Docker containers when they're run. We just remove the Docker containers, and if those containers are recreated in the future, new volumes are created for them.

https://github.com/mattermost/mattermost/pull/33954 made it so that the Postgres container uses a consistently named volume, so after a `make clean-docker`, the previous data volume would still continue to be used. This fixes that by explicitly deleting the volume.

#### Release Note
```release-note
NONE
```
