### PR TITLE
refactor: remove uuid package

### DIFF
--- a/e2e-tests/cypress/package-lock.json
+++ b/e2e-tests/cypress/package-lock.json
@@ -28,7 +28,6 @@
         "@types/pdf-parse": "1.1.5",
         "@types/recursive-readdir": "2.2.4",
         "@types/shelljs": "0.8.17",
-        "@types/uuid": "10.0.0",
         "@typescript-eslint/eslint-plugin": "8.39.1",
         "@typescript-eslint/parser": "8.39.1",
         "async": "3.2.6",
@@ -83,7 +82,6 @@
         "timezones.json": "1.7.2",
         "typescript": "5.9.2",
         "typescript-eslint": "8.41.0",
-        "uuid": "11.1.0",
         "yargs": "17.7.2"
       }
     },
@@ -3122,13 +3120,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -12450,20 +12441,6 @@
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
     },
     "node_modules/validator": {
       "version": "13.15.15",

--- a/e2e-tests/cypress/package.json
+++ b/e2e-tests/cypress/package.json
@@ -23,7 +23,6 @@
     "@types/pdf-parse": "1.1.5",
     "@types/recursive-readdir": "2.2.4",
     "@types/shelljs": "0.8.17",
-    "@types/uuid": "10.0.0",
     "@typescript-eslint/eslint-plugin": "8.39.1",
     "@typescript-eslint/parser": "8.39.1",
     "async": "3.2.6",
@@ -78,7 +77,6 @@
     "timezones.json": "1.7.2",
     "typescript": "5.9.2",
     "typescript-eslint": "8.41.0",
-    "uuid": "11.1.0",
     "yargs": "17.7.2"
   },
   "overrides": {

--- a/e2e-tests/cypress/tests/integration/channels/enterprise/teams/search_teams_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/enterprise/teams/search_teams_spec.js
@@ -10,7 +10,7 @@
 // Stage: @prod
 // Group: @channels @enterprise @system_console
 
-import {v4 as uuidv4} from 'uuid';
+import {randomUUID} from 'crypto';
 const PAGE_SIZE = 10;
 
 describe('Search teams', () => {
@@ -30,7 +30,7 @@ describe('Search teams', () => {
     });
 
     it('returns results', () => {
-        const displayName = uuidv4();
+        const displayName = randomUUID();
 
         // # Create a new team.
         cy.apiCreateTeam('team-search', displayName);
@@ -43,7 +43,7 @@ describe('Search teams', () => {
     });
 
     it('results are paginated', () => {
-        const displayName = uuidv4();
+        const displayName = randomUUID();
 
         // # Create enough new teams with common name prefixes to get multiple pages of search results.
         Cypress._.times(PAGE_SIZE + 2, (i) => {
@@ -64,7 +64,7 @@ describe('Search teams', () => {
     });
 
     it('clears the results when "x" is clicked', () => {
-        const displayName = uuidv4();
+        const displayName = randomUUID();
 
         // # Create a new team.
         cy.apiCreateTeam('team-search', displayName);
@@ -86,7 +86,7 @@ describe('Search teams', () => {
     });
 
     it('clears the results when the search term is deleted with backspace', () => {
-        const displayName = uuidv4();
+        const displayName = randomUUID();
 
         // # Create a team.
         cy.apiCreateTeam('team-search', displayName);

--- a/e2e-tests/cypress/tests/utils/index.js
+++ b/e2e-tests/cypress/tests/utils/index.js
@@ -3,7 +3,7 @@
 
 
 
-import {v4 as uuidv4} from 'uuid';
+import {randomUUID} from 'crypto';
 
 import messageMenusData from '../fixtures/hooks/message_menus.json';
 import messageMenusWithDatasourceData from '../fixtures/hooks/message_menus_with_datasource.json';
@@ -20,7 +20,7 @@ export * from './plugins';
 export function getRandomId(length = 7) {
     const MAX_SUBSTRING_INDEX = 27;
 
-    return uuidv4().replace(/-/g, '').substring(MAX_SUBSTRING_INDEX - length, MAX_SUBSTRING_INDEX);
+    return randomUUID().replace(/-/g, '').substring(MAX_SUBSTRING_INDEX - length, MAX_SUBSTRING_INDEX);
 }
 
 export function getRandomLetter(length) {

--- a/e2e-tests/playwright/lib/package.json
+++ b/e2e-tests/playwright/lib/package.json
@@ -51,8 +51,7 @@
     "axe-core": "4.10.3",
     "deepmerge": "4.3.1",
     "dotenv": "17.2.1",
-    "mime-types": "3.0.1",
-    "uuid": "11.1.0"
+    "mime-types": "3.0.1"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "12.1.4",

--- a/e2e-tests/playwright/lib/src/util.ts
+++ b/e2e-tests/playwright/lib/src/util.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {v4 as uuidv4} from 'uuid';
+import {randomUUID} from 'crypto';
 
 const second = 1000;
 const minute = 60 * 1000;
@@ -34,7 +34,7 @@ export const wait = async (ms = 0) => {
 export function getRandomId(length = 7): string {
     const MAX_SUBSTRING_INDEX = 27;
 
-    return uuidv4()
+    return randomUUID()
         .replace(/-/g, '')
         .substring(MAX_SUBSTRING_INDEX - length, MAX_SUBSTRING_INDEX);
 }

--- a/e2e-tests/playwright/package-lock.json
+++ b/e2e-tests/playwright/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "name": "mattermost-playwright",
-      "hasInstallScript": true,
       "workspaces": [
         "lib"
       ],
@@ -80,8 +79,7 @@
         "axe-core": "4.10.3",
         "deepmerge": "4.3.1",
         "dotenv": "17.2.1",
-        "mime-types": "3.0.1",
-        "uuid": "11.1.0"
+        "mime-types": "3.0.1"
       },
       "devDependencies": {
         "@rollup/plugin-typescript": "12.1.4",
@@ -6190,19 +6188,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/e2e-tests/playwright/utils/utils.ts
+++ b/e2e-tests/playwright/utils/utils.ts
@@ -1,12 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {v4 as uuidv4} from 'uuid';
+import {randomUUID} from 'crypto';
 
 export function getRandomId(length = 7): string {
     const MAX_SUBSTRING_INDEX = 27;
 
-    return uuidv4()
+    return randomUUID()
         .replace(/-/g, '')
         .substring(MAX_SUBSTRING_INDEX - length, MAX_SUBSTRING_INDEX);
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR drops the uuid package from node modules and replaces it with standard randomUUID usage.

[Node.js crypto](https://nodejs.org/api/crypto.html#cryptorandomuuidoptions)

#### Release Note
```
1. Removed `uuid` and `@types/uuid` package from package.json.
2. Replaced `uuid` package with `crypto` module in code.
```
