### PR TITLE
Automated cherry pick of #34073

### DIFF
--- a/webapp/channels/src/components/error_page/error_page.tsx
+++ b/webapp/channels/src/components/error_page/error_page.tsx
@@ -98,7 +98,7 @@ export default class ErrorPage extends React.PureComponent<Props> {
             );
         } else if (type === ErrorPageTypes.CHANNEL_NOT_FOUND) {
             backButton = (
-                <Link to={params.get('returnTo') as string}>
+                <Link to={returnTo}>
                     <FormattedMessage
                         id='error.channelNotFound.link'
                         defaultMessage='Back to {defaultChannelName}'


### PR DESCRIPTION
Cherry pick of #34073 on release-11.0.

/cc  @esarafianou

```release-note
NONE
```