### PR TITLE
Add files to allow for easily running Mattermost via a subpath locally

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build package run stop run-client run-server run-node run-haserver stop-haserver stop-client stop-server restart restart-server restart-client restart-haserver start-docker update-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-windows package-prep package-linux package-osx package-windows internal-test-web-client vet run-server-for-web-client-tests diff-config prepackaged-plugins prepackaged-binaries test-server test-server-ee test-server-quick test-server-race test-mmctl-unit test-mmctl-e2e test-mmctl test-mmctl-coverage mmctl-build mmctl-docs new-migration migrations-extract test-public mocks-public
+.PHONY: build package run stop run-client run-server run-node run-haserver stop-haserver stop-client stop-server restart restart-server restart-client restart-haserver start-docker update-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-windows package-prep package-linux package-osx package-windows internal-test-web-client vet run-server-for-web-client-tests diff-config prepackaged-plugins prepackaged-binaries test-server test-server-ee test-server-quick test-server-race test-mmctl-unit test-mmctl-e2e test-mmctl test-mmctl-coverage mmctl-build mmctl-docs new-migration migrations-extract test-public mocks-public run-subpath run-subpath-server stop-subpath restart-subpath
 
 ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
@@ -654,6 +654,32 @@ run-pgvector: ## Runs the server and webapp with pgvector PostgreSQL image.
 	@MM_USE_PGVECTOR=true $(MAKE) run
 
 run-fullmap: run-server run-client ## Legacy alias to run
+
+run-subpath-server: export MM_SERVICESETTINGS_SITEURL=http://localhost:8065/mattermost
+run-subpath-server: export MM_SERVICESETTINGS_LISTENADDRESS=:8066
+run-subpath-server: export BUILD_NUMBER=subpath-dev
+run-subpath-server: setup-go-work prepackaged-binaries validate-go-version start-docker client ## Starts the server for subpath setup.
+	@echo Running mattermost for development with subpath support
+	@echo Server will be available at http://localhost:8065/mattermost via nginx reverse proxy
+	@echo Note: Using BUILD_NUMBER=subpath-dev to enable asset subpath rewriting
+
+	mkdir -p $(BUILD_WEBAPP_DIR)/channels/dist/files
+	docker compose -f docker-compose.nginx.subpath.yml up -d
+	$(GO) run $(GOFLAGS) -ldflags '$(LDFLAGS) -X "github.com/mattermost/mattermost/server/public/model.BuildNumber=subpath-dev"' -tags '$(BUILD_TAGS)' $(PLATFORM_FILES) $(RUN_IN_BACKGROUND)
+
+run-subpath: run-subpath-server ## Runs the server with nginx reverse proxy on subpath (serves static webapp files).
+	@echo
+	@echo "========================================"
+	@echo "Note: Subpath mode serves pre-built webapp files, not the live webpack dev server."
+	@echo "If you need to rebuild the webapp, run: cd $(BUILD_WEBAPP_DIR) && make build"
+	@echo "========================================"
+	@echo
+
+stop-subpath: ## Stops the nginx reverse proxy for subpath.
+	@echo Stopping nginx reverse proxy
+	docker compose -f docker-compose.nginx.subpath.yml down
+
+restart-subpath: | stop-subpath stop-server run-subpath ## Restarts the server and nginx proxy for subpath setup.
 
 stop-server: ## Stops the server.
 	@echo Stopping mattermost

--- a/server/build/docker/nginx/subpath.conf
+++ b/server/build/docker/nginx/subpath.conf
@@ -1,0 +1,44 @@
+server {
+  listen 8065;
+
+  # Websocket endpoints need special handling
+  location ~ ^/mattermost/api/v[0-9]+/(users/)?websocket$ {
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_http_version 1.1;
+    client_max_body_size 50M;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Frame-Options SAMEORIGIN;
+    proxy_buffers 256 16k;
+    proxy_buffer_size 16k;
+    proxy_read_timeout 600s;
+
+    # Pass through to Mattermost with full path (don't strip /mattermost)
+    proxy_pass http://host.docker.internal:8066;
+  }
+
+  # Main location block for all other requests under /mattermost
+  location /mattermost/ {
+    client_max_body_size 100M;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_http_version 1.1;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Frame-Options SAMEORIGIN;
+
+    # Pass through to Mattermost with full path (don't strip /mattermost)
+    proxy_pass http://host.docker.internal:8066;
+  }
+
+  # Redirect root to /mattermost for convenience
+  location = / {
+    return 301 /mattermost/;
+  }
+}
+

--- a/server/docker-compose.nginx.subpath.yml
+++ b/server/docker-compose.nginx.subpath.yml
@@ -1,0 +1,19 @@
+# Override file to run nginx as a reverse proxy on a subpath
+# This file is used with the `make run-subpath` target
+services:
+  nginx-subpath:
+    image: nginx:alpine
+    container_name: mattermost-nginx-subpath
+    networks:
+      - mm-test
+    volumes:
+      - ./build/docker/nginx/subpath.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "8065:8065"
+    restart: on-failure
+
+networks:
+  mm-test:
+    external: true
+    name: mattermost-server_mm-test
+


### PR DESCRIPTION
#### Summary
I needed to fix a bug on Agents (see: https://github.com/mattermost/mattermost-plugin-agents/pull/413) related to Mattermost running on a subpath. There wasn't a simple way to do it, so I added some helpers and figured I'd share them here for others to use.

Requires a build of the webapp with `npm run build`
Then, running `make run-subpath` will run the server on port 8066, and bring up an nginx container on 8065 that will proxy requests from the /mattermost endpoint to the backend accordingly.

#### Ticket Link
N/A
#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```
None
```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
