### PR TITLE
Revert "[MM-64517] Fix NPE in PluginSettings.Sanitize (#31361)"

### DIFF
--- a/server/channels/app/plugin_api_test.go
+++ b/server/channels/app/plugin_api_test.go
@@ -897,7 +897,7 @@ func TestPluginAPILoadPluginConfiguration(t *testing.T) {
 
 	fullPath := filepath.Join(server.GetPackagePath(), "channels", "app", "plugin_api_tests", "manual.test_load_configuration_plugin", "main.go")
 
-	err = pluginAPIHookTest(t, th, fullPath, "testloadpluginconfig", `{
+	err = pluginAPIHookTest(t, th, fullPath, "testloadpluginconfig", `{"id": "testloadpluginconfig", "server": {"executable": "backend.exe"}, "settings_schema": {
 		"settings": [
 			{
 				"key": "MyStringSetting",
@@ -912,7 +912,7 @@ func TestPluginAPILoadPluginConfiguration(t *testing.T) {
 				"type": "bool"
 			}
 		]
-	}`)
+	}}`)
 	require.NoError(t, err)
 }
 

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -3421,7 +3421,7 @@ func (s *PluginSettings) SetDefaults(ls LogSettings) {
 // Sanitize cleans up the plugin settings by removing any sensitive information.
 // It does so by checking if the setting is marked as secret in the plugin manifest.
 // If it is, the setting is replaced with a fake value.
-// If a plugin is no longer installed or doesn't define any settings, no stored settings for that plugin are returned.
+// If a plugin is no longer installed, all settings of it's are sanitized.
 // If the list of manifests in nil, i.e. plugins are disabled, all settings are sanitized.
 func (s *PluginSettings) Sanitize(pluginManifests []*Manifest) {
 	manifestMap := make(map[string]*Manifest, len(pluginManifests))
@@ -3434,25 +3434,17 @@ func (s *PluginSettings) Sanitize(pluginManifests []*Manifest) {
 		manifest := manifestMap[id]
 
 		for key := range settings {
-			if manifest == nil ||
-				manifest.SettingsSchema == nil {
-				// Don't return any stored plugin settings if
-				//   - The plugin is no longer installed
-				//   - The plugin doesn't define any settings
+			if manifest == nil {
+				// Don't return plugin settings for plugins that are not installed
 				delete(s.Plugins, id)
 				break
 			}
 
-			// notASecret is true when the plugin declared the settings key and it's not declared as secret
-			var notASecret bool
 			for _, definedSetting := range manifest.SettingsSchema.Settings {
-				if strings.EqualFold(definedSetting.Key, key) && !definedSetting.Secret {
-					notASecret = true
+				if definedSetting.Secret && strings.EqualFold(definedSetting.Key, key) {
+					settings[key] = FakeSetting
 					break
 				}
-			}
-			if !notASecret {
-				settings[key] = FakeSetting
 			}
 		}
 	}


### PR DESCRIPTION
#### Summary

This reverts commit 832d0337857b03c35a3d43db58a5fccd71f694b7 which introduced a bug in plugin configuration sanitization.

**The Issue:**
After the original commit, plugin configurations returned by the API and to plugins show sanitized values like `"allowenablecalls": "********************************"` instead of the actual values like `"allowenablecalls": true`.

**Root Cause:**
The commit inverted the sanitization logic. The new code sanitized ALL settings by default unless they were explicitly defined in the plugin's `SettingsSchema` AND marked as not secret. This meant that any setting not explicitly declared in the manifest would be sanitized, which is the opposite of the intended behavior.

**The Fix:**
This revert restores the original logic which only sanitizes settings that are explicitly marked as `Secret` in the plugin manifest. Non-secret settings and settings not defined in the schema are left unchanged.

**Testing:**
- Verify that plugin configurations return actual values for non-secret settings
- Verify that the `/api/v4/config` endpoint returns proper plugin settings
- Verify that secret settings marked in plugin manifests are still properly sanitized

#### Release Note

```release-note
Fixed a bug where plugin configuration settings were incorrectly sanitized, causing API endpoints and plugins to receive masked values instead of actual configuration values.
```