### PR TITLE
preserve Authorization headers if not used to resolve a session

### DIFF
--- a/server/channels/app/plugin_requests.go
+++ b/server/channels/app/plugin_requests.go
@@ -161,9 +161,6 @@ func (ch *Channels) servePluginRequest(w http.ResponseWriter, r *http.Request, h
 	// Mattermost-Plugin-ID can only be set by inter-plugin requests
 	r.Header.Del("Mattermost-Plugin-ID")
 
-	// Clean Authorization header. The Mattermost-User-Id header is used to indicate authenticated requests.
-	r.Header.Del(model.HeaderAuth)
-
 	// Clean Mattermost-User-Id header. The server sets this header for authenticated requests
 	r.Header.Del("Mattermost-User-Id")
 
@@ -216,6 +213,11 @@ func (ch *Channels) servePluginRequest(w http.ResponseWriter, r *http.Request, h
 		handler(context, w, r)
 		return
 	}
+
+	// If we get to this point, the token resolved to a valid session, and we don't need to remit
+	// the authorization header to the plugin at all. This also prevents the plugin from incorrectly
+	// using the token if MFA or CSRF fail below.
+	r.Header.Del(model.HeaderAuth)
 
 	rctx = rctx.
 		WithLogger(rctx.Logger().With(

--- a/server/channels/app/plugin_requests_test.go
+++ b/server/channels/app/plugin_requests_test.go
@@ -520,6 +520,22 @@ func TestServePluginRequest(t *testing.T) {
 		th.App.ch.servePluginRequest(rr, req, mockHandler)
 		require.True(t, handlerCalled)
 	})
+
+	t.Run("third-party use of Authorization header preserved", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/plugins/testplugin/endpoint", nil)
+		req.Header.Set(model.HeaderAuth, "Bearer 3rd-party-token")
+		rr := httptest.NewRecorder()
+
+		handlerCalled := false
+		mockHandler := func(ctx *plugin.Context, w http.ResponseWriter, r *http.Request) {
+			handlerCalled = true
+			// Should still have the authorization header
+			assert.Equal(t, "Bearer 3rd-party-token", r.Header.Get(model.HeaderAuth))
+		}
+
+		th.App.ch.servePluginRequest(rr, req, mockHandler)
+		require.True(t, handlerCalled)
+	})
 }
 
 func TestValidateCSRFForPluginRequest(t *testing.T) {


### PR DESCRIPTION
#### Summary
In https://github.com/mattermost/mattermost/pull/30795, I incorrectly recommended we unconditionally delete the `Authorization` header, forgetting that we explicitly allow plugins to receive this header when used with 3rd-party tokens.

Add test coverage to preserve these semantics going forward, and only delete the header if we resolve it to a session.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/34200
Fixes: https://mattermost.atlassian.net/browse/MM-66335

#### Release Note
```release-note
Restore ability for plugins to receive 3rd-party authorization headers
```
