### PR TITLE
feat: add show-roles and role params to mmctl

### DIFF
--- a/server/cmd/mmctl/commands/user.go
+++ b/server/cmd/mmctl/commands/user.go
@@ -385,6 +385,8 @@ func init() {
 	ListUsersCmd.Flags().Bool("all", false, "Fetch all users. --page flag will be ignore if provided")
 	ListUsersCmd.Flags().String("team", "", "If supplied, only users belonging to this team will be listed")
 	ListUsersCmd.Flags().Bool("inactive", false, "If supplied, only users which are inactive will be fetch")
+	ListUsersCmd.Flags().Bool("show-roles", false, "If supplied, the roles of the users will be shown")
+	ListUsersCmd.Flags().String("role", "", "Filter users by role.")
 
 	UserConvertCmd.Flags().Bool("bot", false, "If supplied, convert users to bots")
 	UserConvertCmd.Flags().Bool("user", false, "If supplied, convert a bot to a user")
@@ -868,6 +870,8 @@ func ResetListUsersCmd(t *testing.T) *cobra.Command {
 	require.NoError(t, ListUsersCmd.Flags().Set("all", "false"))
 	require.NoError(t, ListUsersCmd.Flags().Set("team", ""))
 	require.NoError(t, ListUsersCmd.Flags().Set("inactive", "false"))
+	require.NoError(t, ListUsersCmd.Flags().Set("show-roles", "false"))
+	require.NoError(t, ListUsersCmd.Flags().Set("role", ""))
 
 	return ListUsersCmd
 }
@@ -895,6 +899,16 @@ func listUsersCmdF(c client.Client, command *cobra.Command, args []string) error
 		return err
 	}
 
+	showRoles, err := command.Flags().GetBool("show-roles")
+	if err != nil {
+		return err
+	}
+
+	role, err := command.Flags().GetString("role")
+	if err != nil {
+		return err
+	}
+
 	if showAll {
 		page = 0
 	}
@@ -916,7 +930,17 @@ func listUsersCmdF(c client.Client, command *cobra.Command, args []string) error
 		params.Add("in_team", team.Id)
 	}
 
-	tpl := `{{.Id}}: {{.Username}} ({{.Email}})`
+	if role != "" {
+		params.Add("role", role)
+	}
+
+	var tpl string
+
+	if showRoles {
+		tpl = `{{.Id}}: {{.Username}} ({{.Email}}) roles: {{.Roles}}`
+	} else {
+		tpl = `{{.Id}}: {{.Username}} ({{.Email}})`
+	}
 	for {
 		users, _, err := c.GetUsersWithCustomQueryParameters(context.TODO(), page, perPage, params.Encode(), "")
 		if err != nil {

--- a/server/cmd/mmctl/commands/user_test.go
+++ b/server/cmd/mmctl/commands/user_test.go
@@ -2180,6 +2180,54 @@ func (s *MmctlUnitTestSuite) TestListUserCmdF() {
 		s.Require().Equal(&mockUser1, printer.GetLines()[0])
 		s.Require().Equal(&mockUser2, printer.GetLines()[1])
 	})
+
+	s.Run("Listing users for given role", func() {
+		printer.Clean()
+
+		email := "example@example.com"
+		mockUser := model.User{Username: "ExampleUser", Email: email, Roles: "system_user system_admin"}
+
+		selectedRole := "system_user"
+
+		cmd := ResetListUsersCmd(s.T())
+		s.Require().NoError(cmd.Flags().Set("page", "0"))
+		s.Require().NoError(cmd.Flags().Set("per-page", "1"))
+		s.Require().NoError(cmd.Flags().Set("role", selectedRole))
+
+		s.client.
+			EXPECT().
+			GetUsersWithCustomQueryParameters(context.TODO(), 0, 1, "role="+selectedRole, "").
+			Return([]*model.User{&mockUser}, &model.Response{}, nil).
+			Times(1)
+
+		err := listUsersCmdF(s.client, cmd, []string{})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(&mockUser, printer.GetLines()[0])
+	})
+
+	s.Run("Listing users with their roles", func() {
+		printer.Clean()
+
+		email := "example@example.com"
+		mockUser := model.User{Username: "ExampleUser", Email: email, Roles: "system_user system_admin"}
+
+		cmd := ResetListUsersCmd(s.T())
+		s.Require().NoError(cmd.Flags().Set("page", "0"))
+		s.Require().NoError(cmd.Flags().Set("per-page", "1"))
+		s.Require().NoError(cmd.Flags().Set("show-roles", "true"))
+
+		s.client.
+			EXPECT().
+			GetUsersWithCustomQueryParameters(context.TODO(), 0, 1, "", "").
+			Return([]*model.User{&mockUser}, &model.Response{}, nil).
+			Times(1)
+
+		err := listUsersCmdF(s.client, cmd, []string{})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(&mockUser, printer.GetLines()[0])
+	})
 }
 
 func (s *MmctlUnitTestSuite) TestUserDeactivateCmd() {


### PR DESCRIPTION
#### Summary
Add Flags to MMCTL to allow users to display the roles of the users on the list and to filter users of a specific role.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/21197
JIRA https://mattermost.atlassian.net/browse/MM-65745 (??)



#### Release Note

```release-note
Added the --role and --show-roles flags to MMCTL, to allow filtering users by a specific role and display the roles of the users on the list, respectively.
```
