### PR TITLE
Automated cherry pick of #34197

### DIFF
--- a/server/channels/app/plugin_api_test.go
+++ b/server/channels/app/plugin_api_test.go
@@ -897,7 +897,7 @@ func TestPluginAPILoadPluginConfiguration(t *testing.T) {
 
 	fullPath := filepath.Join(server.GetPackagePath(), "channels", "app", "plugin_api_tests", "manual.test_load_configuration_plugin", "main.go")
 
-	err = pluginAPIHookTest(t, th, fullPath, "testloadpluginconfig", `{
+	err = pluginAPIHookTest(t, th, fullPath, "testloadpluginconfig", `{"id": "testloadpluginconfig", "server": {"executable": "backend.exe"}, "settings_schema": {
 		"settings": [
 			{
 				"key": "MyStringSetting",
@@ -912,7 +912,7 @@ func TestPluginAPILoadPluginConfiguration(t *testing.T) {
 				"type": "bool"
 			}
 		]
-	}`)
+	}}`)
 	require.NoError(t, err)
 }
 

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -3421,7 +3421,7 @@ func (s *PluginSettings) SetDefaults(ls LogSettings) {
 // Sanitize cleans up the plugin settings by removing any sensitive information.
 // It does so by checking if the setting is marked as secret in the plugin manifest.
 // If it is, the setting is replaced with a fake value.
-// If a plugin is no longer installed or doesn't define any settings, no stored settings for that plugin are returned.
+// If a plugin is no longer installed, all settings of it's are sanitized.
 // If the list of manifests in nil, i.e. plugins are disabled, all settings are sanitized.
 func (s *PluginSettings) Sanitize(pluginManifests []*Manifest) {
 	manifestMap := make(map[string]*Manifest, len(pluginManifests))
@@ -3434,25 +3434,17 @@ func (s *PluginSettings) Sanitize(pluginManifests []*Manifest) {
 		manifest := manifestMap[id]
 
 		for key := range settings {
-			if manifest == nil ||
-				manifest.SettingsSchema == nil {
-				// Don't return any stored plugin settings if
-				//   - The plugin is no longer installed
-				//   - The plugin doesn't define any settings
+			if manifest == nil {
+				// Don't return plugin settings for plugins that are not installed
 				delete(s.Plugins, id)
 				break
 			}
 
-			// notASecret is true when the plugin declared the settings key and it's not declared as secret
-			var notASecret bool
 			for _, definedSetting := range manifest.SettingsSchema.Settings {
-				if strings.EqualFold(definedSetting.Key, key) && !definedSetting.Secret {
-					notASecret = true
+				if definedSetting.Secret && strings.EqualFold(definedSetting.Key, key) {
+					settings[key] = FakeSetting
 					break
 				}
-			}
-			if !notASecret {
-				settings[key] = FakeSetting
 			}
 		}
 	}


### PR DESCRIPTION
Cherry pick of #34197 on release-11.1.

/cc  @lieut-data

```release-note
NONE
```