### PR TITLE
Allow degraded opensearch startup

### DIFF
--- a/server/enterprise/elasticsearch/opensearch/opensearch.go
+++ b/server/enterprise/elasticsearch/opensearch/opensearch.go
@@ -129,8 +129,6 @@ func (os *OpensearchInterfaceImpl) Start() *model.AppError {
 	os.version = major
 	os.fullVersion = version
 
-	ctx := context.Background()
-
 	esSettings := os.Platform.Config().ElasticsearchSettings
 	if *esSettings.LiveIndexingBatchSize > 1 {
 		os.bulkProcessor = NewBulk(
@@ -153,59 +151,70 @@ func (os *OpensearchInterfaceImpl) Start() *model.AppError {
 		time.Duration(*esSettings.RequestTimeoutSeconds)*time.Second,
 		os.Platform.Log())
 
+	appErr = os.setupTemplates()
+	if appErr != nil {
+		mlog.Error("Failed to initialize opensearch templates, allowing degraded startup", mlog.Err(appErr))
+	}
+
+	atomic.StoreInt32(&os.ready, 1)
+
+	return nil
+}
+
+func (os *OpensearchInterfaceImpl) setupTemplates() *model.AppError {
+	ctx := context.Background()
+
 	// Set up posts index template.
 	templateBuf, err := json.Marshal(common.GetPostTemplate(os.Platform.Config()))
 	if err != nil {
-		return model.NewAppError("Opensearch.start", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+		return model.NewAppError("Opensearch.setupTemplates", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	_, err = os.client.IndexTemplate.Create(ctx, opensearchapi.IndexTemplateCreateReq{
 		IndexTemplate: *os.Platform.Config().ElasticsearchSettings.IndexPrefix + common.IndexBasePosts,
 		Body:          bytes.NewReader(templateBuf),
 	})
 	if err != nil {
-		return model.NewAppError("Opensearch.start", "ent.elasticsearch.create_template_posts_if_not_exists.template_create_failed", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
+		return model.NewAppError("Opensearch.setupTemplates", "ent.elasticsearch.create_template_posts_if_not_exists.template_create_failed", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	// Set up channels index template.
 	templateBuf, err = json.Marshal(common.GetChannelTemplate(os.Platform.Config()))
 	if err != nil {
-		return model.NewAppError("Opensearch.start", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+		return model.NewAppError("Opensearch.setupTemplates", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	_, err = os.client.IndexTemplate.Create(ctx, opensearchapi.IndexTemplateCreateReq{
 		IndexTemplate: *os.Platform.Config().ElasticsearchSettings.IndexPrefix + common.IndexBaseChannels,
 		Body:          bytes.NewReader(templateBuf),
 	})
 	if err != nil {
-		return model.NewAppError("Opensearch.start", "ent.elasticsearch.create_template_channels_if_not_exists.template_create_failed", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
+		return model.NewAppError("Opensearch.setupTemplates", "ent.elasticsearch.create_template_channels_if_not_exists.template_create_failed", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	// Set up users index template.
 	templateBuf, err = json.Marshal(common.GetUserTemplate(os.Platform.Config()))
 	if err != nil {
-		return model.NewAppError("Opensearch.start", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+		return model.NewAppError("Opensearch.setupTemplates", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	_, err = os.client.IndexTemplate.Create(ctx, opensearchapi.IndexTemplateCreateReq{
 		IndexTemplate: *os.Platform.Config().ElasticsearchSettings.IndexPrefix + common.IndexBaseUsers,
 		Body:          bytes.NewReader(templateBuf),
 	})
 	if err != nil {
-		return model.NewAppError("Opensearch.start", "ent.elasticsearch.create_template_users_if_not_exists.template_create_failed", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
+		return model.NewAppError("Opensearch.setupTemplates", "ent.elasticsearch.create_template_users_if_not_exists.template_create_failed", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	// Set up files index template.
 	templateBuf, err = json.Marshal(common.GetFileInfoTemplate(os.Platform.Config()))
 	if err != nil {
-		return model.NewAppError("Opensearch.start", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+		return model.NewAppError("Opensearch.setupTemplates", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	_, err = os.client.IndexTemplate.Create(ctx, opensearchapi.IndexTemplateCreateReq{
 		IndexTemplate: *os.Platform.Config().ElasticsearchSettings.IndexPrefix + common.IndexBaseFiles,
 		Body:          bytes.NewReader(templateBuf),
 	})
 	if err != nil {
-		return model.NewAppError("Opensearch.start", "ent.elasticsearch.create_template_file_info_if_not_exists.template_create_failed", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
+		return model.NewAppError("Opensearch.setupTemplates", "ent.elasticsearch.create_template_file_info_if_not_exists.template_create_failed", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
 	}
-
-	atomic.StoreInt32(&os.ready, 1)
 
 	return nil
 }


### PR DESCRIPTION
#### Summary
In the event template creation fails for opensearch, allow the search engine to still startup normally, accepting a potentially degraded search state as a consequence.

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-65177

#### Release Note
```release-note
NONE
```
