### PR TITLE
Help for AI: Implement ConsoleLevel changes for all test memory stores

### DIFF
--- a/server/channels/app/helper_test.go
+++ b/server/channels/app/helper_test.go
@@ -75,7 +75,14 @@ func setupTestHelper(dbStore store.Store, sqlStore *sqlstore.SqlStore, sqlSettin
 	*memoryConfig.PluginSettings.ClientDirectory = filepath.Join(tempWorkspace, "webapp")
 	*memoryConfig.PluginSettings.AutomaticPrepackagedPlugins = false
 	*memoryConfig.LogSettings.EnableSentry = false // disable error reporting during tests
-	*memoryConfig.LogSettings.ConsoleLevel = mlog.LvlStdLog.Name
+
+	// Check for environment variable override for console log level (useful for debugging tests)
+	consoleLevel := os.Getenv("MM_LOGSETTINGS_CONSOLELEVEL")
+	if consoleLevel == "" {
+		consoleLevel = mlog.LvlStdLog.Name
+	}
+	*memoryConfig.LogSettings.ConsoleLevel = consoleLevel
+
 	*memoryConfig.AnnouncementSettings.AdminNoticesEnabled = false
 	*memoryConfig.AnnouncementSettings.UserNoticesEnabled = false
 	*memoryConfig.LogSettings.FileLocation = filepath.Join(tempWorkspace, "logs", "mattermost.log")

--- a/server/channels/app/slashcommands/helper_test.go
+++ b/server/channels/app/slashcommands/helper_test.go
@@ -54,7 +54,14 @@ func setupTestHelper(dbStore store.Store, enterprise bool, includeCacheLayer boo
 	*memoryConfig.PluginSettings.ClientDirectory = filepath.Join(tempWorkspace, "webapp")
 	*memoryConfig.PluginSettings.AutomaticPrepackagedPlugins = false
 	*memoryConfig.LogSettings.EnableSentry = false // disable error reporting during tests
-	*memoryConfig.LogSettings.ConsoleLevel = mlog.LvlStdLog.Name
+
+	// Check for environment variable override for console log level (useful for debugging tests)
+	consoleLevel := os.Getenv("MM_LOGSETTINGS_CONSOLELEVEL")
+	if consoleLevel == "" {
+		consoleLevel = mlog.LvlStdLog.Name
+	}
+	*memoryConfig.LogSettings.ConsoleLevel = consoleLevel
+
 	_, _, err = memoryStore.Set(memoryConfig)
 	require.NoError(tb, err)
 

--- a/server/channels/jobs/helper_test.go
+++ b/server/channels/jobs/helper_test.go
@@ -53,7 +53,14 @@ func setupTestHelper(tb testing.TB, dbStore store.Store, sqlSettings *model.SqlS
 	*memoryConfig.PluginSettings.ClientDirectory = filepath.Join(tempWorkspace, "webapp")
 	*memoryConfig.PluginSettings.AutomaticPrepackagedPlugins = false
 	*memoryConfig.LogSettings.EnableSentry = false // disable error reporting during tests
-	*memoryConfig.LogSettings.ConsoleLevel = mlog.LvlStdLog.Name
+
+	// Check for environment variable override for console log level (useful for debugging tests)
+	consoleLevel := os.Getenv("MM_LOGSETTINGS_CONSOLELEVEL")
+	if consoleLevel == "" {
+		consoleLevel = mlog.LvlStdLog.Name
+	}
+	*memoryConfig.LogSettings.ConsoleLevel = consoleLevel
+
 	*memoryConfig.AnnouncementSettings.AdminNoticesEnabled = false
 	*memoryConfig.AnnouncementSettings.UserNoticesEnabled = false
 

--- a/server/channels/web/web_test.go
+++ b/server/channels/web/web_test.go
@@ -77,7 +77,14 @@ func setupTestHelper(tb testing.TB, includeCacheLayer bool, options []app.Option
 	*newConfig.PluginSettings.AutomaticPrepackagedPlugins = false
 	*newConfig.LogSettings.EnableSentry = false // disable error reporting during tests
 	*newConfig.LogSettings.ConsoleJson = false
-	*newConfig.LogSettings.ConsoleLevel = mlog.LvlStdLog.Name
+
+	// Check for environment variable override for console log level (useful for debugging tests)
+	consoleLevel := os.Getenv("MM_LOGSETTINGS_CONSOLELEVEL")
+	if consoleLevel == "" {
+		consoleLevel = mlog.LvlStdLog.Name
+	}
+	*newConfig.LogSettings.ConsoleLevel = consoleLevel
+
 	_, _, err := memoryStore.Set(newConfig)
 	require.NoError(tb, err)
 	options = append(options, app.ConfigStore(memoryStore))


### PR DESCRIPTION
#### Summary
- We made changes in https://github.com/mattermost/mattermost/pull/31278 that affected tests using the `apitestlib` test helper, but we (I) forgot to add those changes to all the other test helpers. 
- This lets us call tests using: `MM_LOGSETTINGS_CONSOLELEVEL="ERROR" IS_LOCAL_TESTING="true" go test -v -run '^TestUserHasJoinedChannel$'` and it will only show errors -- super helpful for seeing real problems while running tests, or reducing noise that eats up an AI's context

#### Ticket Link
- None

#### Release Note

```release-note
NONE
```
