### PR TITLE
Prevent easy login accounts to reset their password

### DIFF
--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -1714,6 +1714,10 @@ func (a *App) resetPasswordFromToken(rctx request.CTX, userSuppliedTokenString, 
 		return model.NewAppError("ResetPasswordFromCode", "api.user.reset_password.sso.app_error", nil, "userId="+user.Id, http.StatusBadRequest)
 	}
 
+	if user.IsGuest() && user.IsEasyLoginEnabled() {
+		return model.NewAppError("ResetPasswordFromCode", "api.user.send_password_reset.easy_login.app_error", nil, "userId="+user.Id, http.StatusBadRequest)
+	}
+
 	// don't allow password reset for remote/synthetic users
 	if user.IsRemote() {
 		return model.NewAppError("resetPassword", "api.user.reset_password.broken_token.app_error", nil, "", http.StatusBadRequest)
@@ -1745,6 +1749,10 @@ func (a *App) SendPasswordReset(rctx request.CTX, email string, siteURL string) 
 
 	if user.AuthData != nil && *user.AuthData != "" {
 		return false, model.NewAppError("SendPasswordReset", "api.user.send_password_reset.sso.app_error", nil, "userId="+user.Id, http.StatusBadRequest)
+	}
+
+	if user.IsGuest() && user.IsEasyLoginEnabled() {
+		return false, model.NewAppError("SendPasswordReset", "api.user.send_password_reset.easy_login.app_error", nil, "userId="+user.Id, http.StatusBadRequest)
 	}
 
 	token, err := a.CreatePasswordRecoveryToken(rctx, user.Id, user.Email)

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -4435,6 +4435,10 @@
     "translation": "Failed to send email change verification email successfully"
   },
   {
+    "id": "api.user.send_password_reset.easy_login.app_error",
+    "translation": "Unable to reset password for easy login accounts."
+  },
+  {
     "id": "api.user.send_password_reset.send.app_error",
     "translation": "Failed to send password reset email successfully."
   },


### PR DESCRIPTION


#### Summary
Easy login account neither can reset their password nor in case they got a link, they can't use that token to actually reset.



#### Screenshots
<img width="505" height="321" alt="image" src="https://github.com/user-attachments/assets/74cb1ec4-8c36-4d64-a113-9b61d18f88af" />


#### Release Note

```release-note
NONE
```
