### PR TITLE
Enabling Prometheus, Grafana, Loki and Promtail running as containers…

### DIFF
--- a/server/config.mk
+++ b/server/config.mk
@@ -11,7 +11,7 @@
 # Must be space separated names.
 #
 # Example: postgres elasticsearch
-ENABLED_DOCKER_SERVICES ?= postgres inbucket redis
+ENABLED_DOCKER_SERVICES ?= postgres inbucket redis prometheus grafana loki promtail
 
 # Disable entirely the use of docker
 MM_NO_DOCKER ?= false


### PR DESCRIPTION
All Mattermost engineers should be able to easily use Grafana and Loki for metric dashboard and log management. 

* Prometheus - http://localhost:9090/
* Grafana - http://localhost:3000/
* Loki - http://localhost:3100/
* Promtail - http://localhost:3180/

Note - a lot of this was enabled by @lieut-data in May 2014 in [https://github.com/mattermost/mattermost/pull/26997](https://github.com/mattermost/mattermost/pull/26997), but perhaps it wasn't on by default, it didn't quite get the adoption we'd like to see.

These are the same tools we use in incident management and customer escalations, so we'd like to train and build out the skillset and have as many engineers as possible be fluent with these tools. 

### Release Note
```release-note
NONE
```
