### PR TITLE
Add missing 'permalink' embeds item type to API schema

### DIFF
--- a/api/v4/source/definitions.yaml
+++ b/api/v4/source/definitions.yaml
@@ -555,6 +555,7 @@ components:
                   - message_attachment
                   - opengraph
                   - link
+                  - permalink
               url:
                 type: string
                 description: The URL of the embedded content, if one exists.


### PR DESCRIPTION
Fixes https://github.com/mattermost/mattermost/issues/29959

EDIT: I confess the process is a bit heavy to follow for such a small and obvious fix, so I have not followed it properly. That said, if nothing else, this PR can serve as a pointer to what needs to be fixed in the schema.