### PR TITLE
[MM-65786] Resolve websocket issues

### DIFF
--- a/webapp/channels/src/components/file_info_preview/__snapshots__/file_info_preview.test.tsx.snap
+++ b/webapp/channels/src/components/file_info_preview/__snapshots__/file_info_preview.test.tsx.snap
@@ -4,9 +4,9 @@ exports[`components/FileInfoPreview should match snapshot, can download files 1`
 <div
   className="file-details__container"
 >
-  <a
-    className="file-details__preview"
-    href="https://pre-release.mattermost.com/api/v4/files/rqir81f7a7ft8m6j6ej7g1txuo"
+  <div
+    className="file-details__preview--clickable"
+    onClick={[Function]}
   >
     <span
       className="file-details__preview-helper"
@@ -15,7 +15,7 @@ exports[`components/FileInfoPreview should match snapshot, can download files 1`
       alt="file preview"
       src=""
     />
-  </a>
+  </div>
   <div
     className="file-details"
   >

--- a/webapp/channels/src/components/file_info_preview/file_info_preview.tsx
+++ b/webapp/channels/src/components/file_info_preview/file_info_preview.tsx
@@ -40,19 +40,45 @@ const FileInfoPreview = ({
 
     const infoString = infoParts.join(', ');
 
+    // Using <a href> for file downloads triggers a full-page navigation, which closes the WebSocket connection.
+    // To avoid this, the file is fetched and downloaded in memory instead.
+    const handleDownload = async () => {
+        try{
+            const res = await fetch(fileUrl);
+            if(!res.ok) {
+                throw new Error(`Failed to download file: HTTP ${res.status}`);
+            }
+
+            const blob = await res.blob();
+            const url = URL.createObjectURL(blob);
+            
+            const aTag = document.createElement("a");
+            aTag.href = url;
+            aTag.download = fileInfo.name || "download";
+            
+            document.body.appendChild(aTag);
+            aTag.click();
+            aTag.remove();
+
+            URL.revokeObjectURL(url);
+        } catch(err) {
+            console.error(err);
+        }
+    };
+
     let preview = null;
     if (canDownloadFiles) {
         preview = (
-            <a
-                className='file-details__preview'
-                href={fileUrl}
+            <div
+                className='file-details__preview--clickable'
+                onClick={handleDownload}
             >
                 <span className='file-details__preview-helper'/>
                 <img
                     alt={'file preview'}
                     src={Utils.getFileIconPath(fileInfo)}
                 />
-            </a>
+            </div>
         );
     } else {
         preview = (

--- a/webapp/channels/src/sass/components/_files.scss
+++ b/webapp/channels/src/sass/components/_files.scss
@@ -680,6 +680,11 @@
             justify-content: center;
         }
 
+        &--clickable {
+            @extend .file-details__preview;
+            cursor: pointer;
+        }
+
         // helper to center the image icon in the preview window
         .file-details__preview-helper {
             display: inline-block;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Previously, file downloads were triggered via the href attribute, which caused a full page reload. 
This unintentionally closed the active WebSocket connection during the download process. 
To fix this, I changed the download process to occur entirely in memory using fetch() and a generated Blob URL.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Fixes #33755
Jira MM-65786

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
