### PR TITLE
fix for vscode testing

### DIFF
--- a/e2e-tests/playwright/lib/src/browser_context.ts
+++ b/e2e-tests/playwright/lib/src/browser_context.ts
@@ -2,12 +2,15 @@
 // See LICENSE.txt for license information.
 
 import {writeFile} from 'node:fs/promises';
+import path from 'node:path';
+import fs from 'node:fs';
 
 import {Browser, BrowserContext, request} from '@playwright/test';
 import {UserProfile} from '@mattermost/types/users';
 
 import {testConfig} from './test_config';
 import {pages} from './ui/pages';
+import {resolvePlaywrightPath} from './util';
 
 export class TestBrowser {
     readonly browser: Browser;
@@ -69,9 +72,15 @@ export async function loginByAPI(loginId: string, password: string, token = '', 
     });
 
     // Save signed-in state to a folder
-    const storagePath = `storage_state/${Date.now()}_${loginId}_${password}${token ? '_' + token : ''}${
-        ldapOnly ? '_ldap' : ''
-    }.json`;
+    const storageStateDir = resolvePlaywrightPath('storage_state');
+
+    // Ensure storage_state directory exists
+    if (!fs.existsSync(storageStateDir)) {
+        fs.mkdirSync(storageStateDir, {recursive: true});
+    }
+
+    const filename = `${Date.now()}_${loginId}_${password}${token ? '_' + token : ''}${ldapOnly ? '_ldap' : ''}.json`;
+    const storagePath = path.join(storageStateDir, filename);
     const storageState = await requestContext.storageState({path: storagePath});
     await requestContext.dispose();
 

--- a/e2e-tests/playwright/lib/src/file.ts
+++ b/e2e-tests/playwright/lib/src/file.ts
@@ -6,8 +6,10 @@ import fs from 'node:fs';
 
 import mime from 'mime-types';
 
+import {resolvePlaywrightPath} from './util';
+
 const commonAssetPath = path.resolve(__dirname, 'asset');
-export const assetPath = path.resolve(process.cwd(), 'asset');
+export const assetPath = resolvePlaywrightPath('asset');
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const availableFiles = ['mattermost-icon_128x128.png'] as const;


### PR DESCRIPTION
#### Summary
This PR fixes issue when running test directly via VS Code with:
- Path to asset directory
- Path to storage state

#### Ticket Link
none

#### Screenshots
<img width="527" height="163" alt="Screenshot 2025-10-27 at 3 10 32 PM" src="https://github.com/user-attachments/assets/1702c81b-b119-4d0f-a241-cf10bd0eff9b" />
<img width="582" height="973" alt="Screenshot 2025-10-27 at 3 11 33 PM" src="https://github.com/user-attachments/assets/e5e885ea-deb8-40d6-86fa-1dbbbca65c80" />

#### Release Note
```release-note
NONE
```