### PR TITLE
MM-66372: Improve OAuth state token validation

### DIFF
--- a/server/channels/app/oauth.go
+++ b/server/channels/app/oauth.go
@@ -1041,9 +1041,8 @@ func generateOAuthStateTokenExtra(email, action, cookie string) string {
 	return email + ":" + action + ":" + cookie
 }
 
-// parseOAuthStateTokenExtra parses the token extra string into its constituent parts.
-// The token extra format is "email:action:cookie".
-// Returns an error if the format is invalid or any field is empty.
+// parseOAuthStateTokenExtra parses a token extra string in the format "email:action:cookie".
+// Returns an error if the token does not contain exactly 3 colon-separated parts.
 func parseOAuthStateTokenExtra(tokenExtra string) (email, action, cookie string, err error) {
 	parts := strings.Split(tokenExtra, ":")
 	if len(parts) != 3 {
@@ -1053,18 +1052,6 @@ func parseOAuthStateTokenExtra(tokenExtra string) (email, action, cookie string,
 	email = parts[0]
 	action = parts[1]
 	cookie = parts[2]
-
-	if email == "" {
-		return "", "", "", fmt.Errorf("email cannot be empty")
-	}
-
-	if action == "" {
-		return "", "", "", fmt.Errorf("action cannot be empty")
-	}
-
-	if cookie == "" {
-		return "", "", "", fmt.Errorf("cookie cannot be empty")
-	}
 
 	return email, action, cookie, nil
 }

--- a/server/channels/app/oauth_test.go
+++ b/server/channels/app/oauth_test.go
@@ -534,6 +534,7 @@ func TestAuthorizeOAuthUser(t *testing.T) {
 				recorder := httptest.ResponseRecorder{}
 				body, receivedStateProps, _, err := th.App.AuthorizeOAuthUser(th.Context, &recorder, request, model.ServiceGitlab, "", state, "")
 
+				require.Nil(t, err)
 				require.NotNil(t, body)
 				bodyBytes, bodyErr := io.ReadAll(body)
 				require.NoError(t, bodyErr)
@@ -705,22 +706,12 @@ func TestParseOAuthStateTokenExtra(t *testing.T) {
 		assert.Equal(t, "randomcookie123", cookie)
 	})
 
-	t.Run("valid token with empty email should fail", func(t *testing.T) {
-		_, _, _, err := parseOAuthStateTokenExtra(":email_to_sso:randomcookie123")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "email cannot be empty")
-	})
-
-	t.Run("valid token with empty action should fail", func(t *testing.T) {
-		_, _, _, err := parseOAuthStateTokenExtra("user@example.com::randomcookie123")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "action cannot be empty")
-	})
-
-	t.Run("valid token with empty cookie should fail", func(t *testing.T) {
-		_, _, _, err := parseOAuthStateTokenExtra("user@example.com:email_to_sso:")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "cookie cannot be empty")
+	t.Run("valid token with empty email and action", func(t *testing.T) {
+		email, action, cookie, err := parseOAuthStateTokenExtra("::randomcookie123")
+		require.NoError(t, err)
+		assert.Equal(t, "", email)
+		assert.Equal(t, "", action)
+		assert.Equal(t, "randomcookie123", cookie)
 	})
 
 	t.Run("token with too many colons", func(t *testing.T) {


### PR DESCRIPTION
#### Summary
Add structured parsing to validate OAuth state token format and ensure all required fields are present and properly delimited.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-66372

#### Release Note
```release-note
NONE
```