### PR TITLE
Fix TXT file preview in FilePreviewModal

### DIFF
--- a/webapp/channels/src/components/file_preview/file_preview.tsx
+++ b/webapp/channels/src/components/file_preview/file_preview.tsx
@@ -80,6 +80,18 @@ export default class FilePreview extends React.PureComponent<Props> {
                         }}
                     />
                 );
+            } else if (type === FileTypes.TEXT) {
+                previewImage = (
+                    <iframe
+                        src={getFileUrl(info.id)}
+                        className='post-image normal txt-preview'
+                        title='Text file Preview'
+                        style={{
+                            width: '100%',
+                            backgroundColor: '#f9f9f9',
+                        }}
+                    />
+                );
             } else {
                 className += ' custom-file';
                 previewImage = <div className={'file-icon ' + Utils.getIconClassName(type)}/>;

--- a/webapp/channels/src/components/file_preview_modal/file_preview_modal.test.tsx
+++ b/webapp/channels/src/components/file_preview_modal/file_preview_modal.test.tsx
@@ -13,7 +13,9 @@ import {generateId} from 'utils/utils';
 
 describe('components/FilePreviewModal', () => {
     const baseProps = {
-        fileInfos: [TestHelper.getFileInfoMock({id: 'file_id', extension: 'jpg'})],
+        fileInfos: [
+            TestHelper.getFileInfoMock({id: 'file_id', extension: 'jpg'}),
+        ],
         startIndex: 0,
         canDownloadFiles: true,
         enablePublicLink: true,
@@ -36,7 +38,9 @@ describe('components/FilePreviewModal', () => {
     });
 
     test('should match snapshot, loaded with .mov file', () => {
-        const fileInfos = [TestHelper.getFileInfoMock({id: 'file_id', extension: 'mov'})];
+        const fileInfos = [
+            TestHelper.getFileInfoMock({id: 'file_id', extension: 'mov'}),
+        ];
         const props = {...baseProps, fileInfos};
         const wrapper = shallow(<FilePreviewModal {...props}/>);
 
@@ -45,7 +49,9 @@ describe('components/FilePreviewModal', () => {
     });
 
     test('should match snapshot, loaded with .m4a file', () => {
-        const fileInfos = [TestHelper.getFileInfoMock({id: 'file_id', extension: 'm4a'})];
+        const fileInfos = [
+            TestHelper.getFileInfoMock({id: 'file_id', extension: 'm4a'}),
+        ];
         const props = {...baseProps, fileInfos};
         const wrapper = shallow(<FilePreviewModal {...props}/>);
 
@@ -54,7 +60,9 @@ describe('components/FilePreviewModal', () => {
     });
 
     test('should match snapshot, loaded with .js file', () => {
-        const fileInfos = [TestHelper.getFileInfoMock({id: 'file_id', extension: 'js'})];
+        const fileInfos = [
+            TestHelper.getFileInfoMock({id: 'file_id', extension: 'js'}),
+        ];
         const props = {...baseProps, fileInfos};
         const wrapper = shallow(<FilePreviewModal {...props}/>);
 
@@ -63,7 +71,9 @@ describe('components/FilePreviewModal', () => {
     });
 
     test('should match snapshot, loaded with other file', () => {
-        const fileInfos = [TestHelper.getFileInfoMock({id: 'file_id', extension: 'other'})];
+        const fileInfos = [
+            TestHelper.getFileInfoMock({id: 'file_id', extension: 'other'}),
+        ];
         const props = {...baseProps, fileInfos};
         const wrapper = shallow(<FilePreviewModal {...props}/>);
 
@@ -105,7 +115,9 @@ describe('components/FilePreviewModal', () => {
             TestHelper.getFileInfoMock({id: 'file_id_3', extension: 'mp4'}),
         ];
         const props = {...baseProps, fileInfos};
-        const wrapper = shallow<FilePreviewModal>(<FilePreviewModal {...props}/>);
+        const wrapper = shallow<FilePreviewModal>(
+            <FilePreviewModal {...props}/>,
+        );
 
         wrapper.setState({loaded: [true, true, true]});
 
@@ -124,7 +136,9 @@ describe('components/FilePreviewModal', () => {
     });
 
     test('should handle onMouseEnter and onMouseLeave', () => {
-        const wrapper = shallow<FilePreviewModal>(<FilePreviewModal {...baseProps}/>);
+        const wrapper = shallow<FilePreviewModal>(
+            <FilePreviewModal {...baseProps}/>,
+        );
         wrapper.setState({loaded: [true]});
 
         wrapper.instance().onMouseEnterImage();
@@ -135,7 +149,9 @@ describe('components/FilePreviewModal', () => {
     });
 
     test('should handle on modal close', () => {
-        const wrapper = shallow<FilePreviewModal>(<FilePreviewModal {...baseProps}/>);
+        const wrapper = shallow<FilePreviewModal>(
+            <FilePreviewModal {...baseProps}/>,
+        );
         wrapper.setState({
             loaded: [true],
         });
@@ -145,56 +161,82 @@ describe('components/FilePreviewModal', () => {
     });
 
     test('should match snapshot for external file', () => {
-        const fileInfos = [
-            TestHelper.getFileInfoMock({extension: 'png'}),
-        ];
+        const fileInfos = [TestHelper.getFileInfoMock({extension: 'png'})];
         const props = {...baseProps, fileInfos};
         const wrapper = shallow(<FilePreviewModal {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should correctly identify image URLs with isImageUrl method', () => {
-        const wrapper = shallow<FilePreviewModal>(<FilePreviewModal {...baseProps}/>);
+        const wrapper = shallow<FilePreviewModal>(
+            <FilePreviewModal {...baseProps}/>,
+        );
 
         // Test proxied image URLs
-        expect(wrapper.instance().isImageUrl('http://localhost:8065/api/v4/image?url=https%3A%2F%2Fexample.com%2Fimage.jpg')).toBe(true);
+        expect(
+            wrapper.
+                instance().
+                isImageUrl(
+                    'http://localhost:8065/api/v4/image?url=https%3A%2F%2Fexample.com%2Fimage.jpg',
+                ),
+        ).toBe(true);
 
         // Test URLs with image extensions
-        expect(wrapper.instance().isImageUrl('https://example.com/image.jpg')).toBe(true);
-        expect(wrapper.instance().isImageUrl('https://example.com/image.png')).toBe(true);
-        expect(wrapper.instance().isImageUrl('https://example.com/image.gif')).toBe(true);
+        expect(
+            wrapper.instance().isImageUrl('https://example.com/image.jpg'),
+        ).toBe(true);
+        expect(
+            wrapper.instance().isImageUrl('https://example.com/image.png'),
+        ).toBe(true);
+        expect(
+            wrapper.instance().isImageUrl('https://example.com/image.gif'),
+        ).toBe(true);
 
         // Test non-image URLs
-        expect(wrapper.instance().isImageUrl('https://example.com/document.pdf')).toBe(false);
-        expect(wrapper.instance().isImageUrl('https://example.com/file.txt')).toBe(false);
+        expect(
+            wrapper.instance().isImageUrl('https://example.com/document.pdf'),
+        ).toBe(false);
+        expect(
+            wrapper.instance().isImageUrl('https://example.com/file.txt'),
+        ).toBe(false);
     });
 
     test('should handle external image URLs correctly', () => {
         // Create a mock for Utils.loadImage
-        const loadImageSpy = jest.spyOn(Utils, 'loadImage').mockImplementation((url, onLoad) => {
-            // Create a mock ProgressEvent
-            const mockProgressEvent = new ProgressEvent('progress');
+        const loadImageSpy = jest.
+            spyOn(Utils, 'loadImage').
+            mockImplementation((url, onLoad) => {
+                // Create a mock ProgressEvent
+                const mockProgressEvent = new ProgressEvent('progress');
 
-            // Call onLoad with the mock event if it exists
-            if (onLoad) {
-                onLoad.call({} as XMLHttpRequest, mockProgressEvent);
-            }
-        });
+                // Call onLoad with the mock event if it exists
+                if (onLoad) {
+                    onLoad.call({} as XMLHttpRequest, mockProgressEvent);
+                }
+            });
 
         // Create a LinkInfo object for an external image URL
-        const externalImageUrl = 'http://localhost:8065/api/v4/image?url=https%3A%2F%2Fexample.com%2Fimage.jpg';
-        const fileInfos = [{
-            has_preview_image: false,
-            link: externalImageUrl,
-            extension: '',
-            name: 'External Image',
-        }];
+        const externalImageUrl =
+            'http://localhost:8065/api/v4/image?url=https%3A%2F%2Fexample.com%2Fimage.jpg';
+        const fileInfos = [
+            {
+                has_preview_image: false,
+                link: externalImageUrl,
+                extension: '',
+                name: 'External Image',
+            },
+        ];
 
         const props = {...baseProps, fileInfos};
-        const wrapper = shallow<FilePreviewModal>(<FilePreviewModal {...props}/>);
+        const wrapper = shallow<FilePreviewModal>(
+            <FilePreviewModal {...props}/>,
+        );
 
         // Spy on handleImageLoaded
-        const handleImageLoadedSpy = jest.spyOn(wrapper.instance(), 'handleImageLoaded');
+        const handleImageLoadedSpy = jest.spyOn(
+            wrapper.instance(),
+            'handleImageLoaded',
+        );
 
         // Call loadImage with the external image URL
         wrapper.instance().loadImage(0);
@@ -220,7 +262,9 @@ describe('components/FilePreviewModal', () => {
             TestHelper.getFileInfoMock({id: 'file_id_3', extension: 'mp4'}),
         ];
         const props = {...baseProps, fileInfos};
-        const wrapper = shallow<FilePreviewModal>(<FilePreviewModal {...props}/>);
+        const wrapper = shallow<FilePreviewModal>(
+            <FilePreviewModal {...props}/>,
+        );
 
         let index = 1;
         wrapper.setState({loaded: [true, false, false]});
@@ -240,7 +284,9 @@ describe('components/FilePreviewModal', () => {
             TestHelper.getFileInfoMock({id: 'file_id_3', extension: 'mp4'}),
         ];
         const props = {...baseProps, fileInfos};
-        const wrapper = shallow<FilePreviewModal>(<FilePreviewModal {...props}/>);
+        const wrapper = shallow<FilePreviewModal>(
+            <FilePreviewModal {...props}/>,
+        );
 
         let index = 1;
         wrapper.setState({loaded: [true, false, false]});
@@ -260,7 +306,9 @@ describe('components/FilePreviewModal', () => {
             TestHelper.getFileInfoMock({id: 'file_id_3', extension: 'mp4'}),
         ];
         const props = {...baseProps, fileInfos};
-        const wrapper = shallow<FilePreviewModal>(<FilePreviewModal {...props}/>);
+        const wrapper = shallow<FilePreviewModal>(
+            <FilePreviewModal {...props}/>,
+        );
 
         const index = 1;
         let completedPercentage = 30;
@@ -276,16 +324,27 @@ describe('components/FilePreviewModal', () => {
     });
 
     test('should pass componentWillReceiveProps', () => {
-        const wrapper = shallow<FilePreviewModal>(<FilePreviewModal {...baseProps}/>);
+        const wrapper = shallow<FilePreviewModal>(
+            <FilePreviewModal {...baseProps}/>,
+        );
 
         expect(Object.keys(wrapper.state('loaded')).length).toBe(1);
         expect(Object.keys(wrapper.state('progress')).length).toBe(1);
 
         wrapper.setProps({
             fileInfos: [
-                TestHelper.getFileInfoMock({id: 'file_id_1', extension: 'gif'}),
-                TestHelper.getFileInfoMock({id: 'file_id_2', extension: 'wma'}),
-                TestHelper.getFileInfoMock({id: 'file_id_3', extension: 'mp4'}),
+                TestHelper.getFileInfoMock({
+                    id: 'file_id_1',
+                    extension: 'gif',
+                }),
+                TestHelper.getFileInfoMock({
+                    id: 'file_id_2',
+                    extension: 'wma',
+                }),
+                TestHelper.getFileInfoMock({
+                    id: 'file_id_3',
+                    extension: 'mp4',
+                }),
             ],
         });
         expect(Object.keys(wrapper.state('loaded')).length).toBe(3);
@@ -293,12 +352,14 @@ describe('components/FilePreviewModal', () => {
     });
 
     test('should match snapshot when plugin overrides the preview component', () => {
-        const pluginFilePreviewComponents = [{
-            id: generateId(),
-            pluginId: 'file-preview',
-            override: () => true,
-            component: () => <div>{'Preview'}</div>,
-        }];
+        const pluginFilePreviewComponents = [
+            {
+                id: generateId(),
+                pluginId: 'file-preview',
+                override: () => true,
+                component: () => <div>{'Preview'}</div>,
+            },
+        ];
         const props = {...baseProps, pluginFilePreviewComponents};
         const wrapper = shallow(<FilePreviewModal {...props}/>);
 
@@ -306,15 +367,38 @@ describe('components/FilePreviewModal', () => {
     });
 
     test('should fall back to default preview if plugin does not need to override preview component', () => {
-        const pluginFilePreviewComponents = [{
-            id: generateId(),
-            pluginId: 'file-preview',
-            override: () => false,
-            component: () => <div>{'Preview'}</div>,
-        }];
+        const pluginFilePreviewComponents = [
+            {
+                id: generateId(),
+                pluginId: 'file-preview',
+                override: () => false,
+                component: () => <div>{'Preview'}</div>,
+            },
+        ];
         const props = {...baseProps, pluginFilePreviewComponents};
         const wrapper = shallow(<FilePreviewModal {...props}/>);
 
         expect(wrapper).toMatchSnapshot();
+    });
+
+    // tested the rendering of txt file preview
+    test('should render TXT file in preview modal', () => {
+        const txtFile = TestHelper.getFileInfoMock({
+            id: 'file_id_txt',
+            extension: 'txt',
+            mime_type: 'text/plain',
+            name: 'sample.txt',
+        });
+
+        const props = {...baseProps, fileInfos: [txtFile]};
+        const wrapper = shallow<FilePreviewModal>(
+            <FilePreviewModal {...props}/>,
+        );
+
+        wrapper.setState({loaded: [true]});
+
+        // Expect the modal to render an iframe or pre block for TXT
+        expect(wrapper.find('.txt-preview').exists()).toBe(true);
+        console.log(wrapper.debug());
     });
 });

--- a/webapp/channels/src/components/file_preview_modal/file_preview_modal.tsx
+++ b/webapp/channels/src/components/file_preview_modal/file_preview_modal.tsx
@@ -9,7 +9,11 @@ import {FormattedMessage} from 'react-intl';
 import type {FileInfo} from '@mattermost/types/files';
 import type {Post} from '@mattermost/types/posts';
 
-import {getFileDownloadUrl, getFilePreviewUrl, getFileUrl} from 'mattermost-redux/utils/file_utils';
+import {
+    getFileDownloadUrl,
+    getFilePreviewUrl,
+    getFileUrl,
+} from 'mattermost-redux/utils/file_utils';
 
 import ArchivedPreview from 'components/archived_preview';
 import AudioVideoPreview from 'components/audio_video_preview';
@@ -33,7 +37,9 @@ import type {LinkInfo} from './types';
 
 import './file_preview_modal.scss';
 
-const PDFPreview = React.lazy<React.ComponentType<PDFPreviewComponentProps>>(() => import('components/pdf_preview'));
+const PDFPreview = React.lazy<React.ComponentType<PDFPreviewComponentProps>>(
+    () => import('components/pdf_preview'),
+);
 
 const KeyCodes = Constants.KeyCodes;
 
@@ -65,7 +71,7 @@ export type Props = {
      * The index number of starting image
      **/
     startIndex: number;
-}
+};
 
 type State = {
     show: boolean;
@@ -78,9 +84,12 @@ type State = {
     showZoomControls: boolean;
     scale: Record<number, number>;
     content: string;
-}
+};
 
-export default class FilePreviewModal extends React.PureComponent<Props, State> {
+export default class FilePreviewModal extends React.PureComponent<
+Props,
+State
+> {
     static defaultProps = {
         fileInfos: [],
         startIndex: 0,
@@ -99,7 +108,10 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
             progress: Utils.fillRecord(0, this.props.fileInfos.length),
             showCloseBtn: false,
             showZoomControls: false,
-            scale: Utils.fillRecord(ZoomSettings.DEFAULT_SCALE, this.props.fileInfos.length),
+            scale: Utils.fillRecord(
+                ZoomSettings.DEFAULT_SCALE,
+                this.props.fileInfos.length,
+            ),
             content: '',
         };
     }
@@ -140,13 +152,19 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
 
     static getDerivedStateFromProps(props: Props, state: State) {
         const updatedState: Partial<State> = {};
-        if (props.fileInfos[state.imageIndex] && props.fileInfos[state.imageIndex].extension === FileTypes.PDF) {
+        if (
+            props.fileInfos[state.imageIndex] &&
+            props.fileInfos[state.imageIndex].extension === FileTypes.PDF
+        ) {
             updatedState.showZoomControls = true;
         } else {
             updatedState.showZoomControls = false;
         }
         if (props.fileInfos.length !== state.prevFileInfosCount) {
-            updatedState.loaded = Utils.fillRecord(false, props.fileInfos.length);
+            updatedState.loaded = Utils.fillRecord(
+                false,
+                props.fileInfos.length,
+            );
             updatedState.progress = Utils.fillRecord(0, props.fileInfos.length);
             updatedState.prevFileInfosCount = props.fileInfos.length;
         }
@@ -169,7 +187,9 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
         return fileType === FileTypes.IMAGE || fileType === FileTypes.SVG;
     };
 
-    private getFileTypeFromFileInfo = (fileInfo: FileInfo | LinkInfo): typeof FileTypes[keyof typeof FileTypes] => {
+    private getFileTypeFromFileInfo = (
+        fileInfo: FileInfo | LinkInfo,
+    ): typeof FileTypes[keyof typeof FileTypes] => {
         if (isFileInfo(fileInfo)) {
             return Utils.getFileType(fileInfo.extension);
         }
@@ -177,7 +197,9 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
         if (isLinkInfo(fileInfo)) {
             // if extension is not available or is longer than 5 characters, use the link to determine the file type
             const maxLenghtExtension = 11; // applescript is the longest extension
-            const extensionOrLink = fileInfo.extension && fileInfo.extension.length <= maxLenghtExtension ? fileInfo.extension : fileInfo.link;
+            const extensionOrLink =
+                fileInfo.extension &&
+                    fileInfo.extension.length <= maxLenghtExtension ? fileInfo.extension : fileInfo.link;
             return Utils.getFileType(extensionOrLink);
         }
 
@@ -214,8 +236,12 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
             Utils.loadImage(
                 previewUrl,
                 () => this.handleImageLoaded(index),
-                (completedPercentage) => this.handleImageProgress(index, completedPercentage),
+                (completedPercentage) =>
+                    this.handleImageProgress(index, completedPercentage),
             );
+        } else if (fileType === FileTypes.TEXT) {
+            // for text file nothing to preload but mark as loaded
+            this.handleImageLoaded(index);
         } else {
             // there's nothing to load for non-image files
             this.handleImageLoaded(index);
@@ -265,13 +291,19 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
 
     handleZoomIn = () => {
         let newScale = this.state.scale[this.state.imageIndex];
-        newScale = Math.min(newScale + ZoomSettings.SCALE_DELTA, ZoomSettings.MAX_SCALE);
+        newScale = Math.min(
+            newScale + ZoomSettings.SCALE_DELTA,
+            ZoomSettings.MAX_SCALE,
+        );
         this.setScale(this.state.imageIndex, newScale);
     };
 
     handleZoomOut = () => {
         let newScale = this.state.scale[this.state.imageIndex];
-        newScale = Math.max(newScale - ZoomSettings.SCALE_DELTA, ZoomSettings.MIN_SCALE);
+        newScale = Math.max(
+            newScale - ZoomSettings.SCALE_DELTA,
+            ZoomSettings.MIN_SCALE,
+        );
         this.setScale(this.state.imageIndex, newScale);
     };
 
@@ -294,7 +326,10 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
     };
 
     render() {
-        if (this.props.fileInfos.length < 1 || this.props.fileInfos.length - 1 < this.state.imageIndex) {
+        if (
+            this.props.fileInfos.length < 1 ||
+            this.props.fileInfos.length - 1 < this.state.imageIndex
+        ) {
             return null;
         }
 
@@ -329,23 +364,25 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
         let zoomBar;
 
         if (isFileInfo(fileInfo) && fileInfo.archived) {
-            content = (
-                <ArchivedPreview
-                    fileInfo={fileInfo}
-                />
-            );
+            content = <ArchivedPreview fileInfo={fileInfo}/>;
         }
 
         if (!isFileInfo(fileInfo) || !fileInfo.archived) {
             if (this.state.loaded[this.state.imageIndex]) {
-                if (fileType === FileTypes.IMAGE || fileType === FileTypes.SVG) {
+                if (
+                    fileType === FileTypes.IMAGE ||
+                    fileType === FileTypes.SVG
+                ) {
                     content = (
                         <ImagePreview
                             fileInfo={fileInfo as FileInfo}
                             canDownloadFiles={this.props.canDownloadFiles}
                         />
                     );
-                } else if (fileType === FileTypes.VIDEO || fileType === FileTypes.AUDIO) {
+                } else if (
+                    fileType === FileTypes.VIDEO ||
+                    fileType === FileTypes.AUDIO
+                ) {
                     content = (
                         <AudioVideoPreview
                             fileInfo={fileInfo as FileInfo}
@@ -362,7 +399,9 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
                                 <PDFPreview
                                     fileInfo={fileInfo as FileInfo}
                                     fileUrl={fileUrl}
-                                    scale={this.state.scale[this.state.imageIndex]}
+                                    scale={
+                                        this.state.scale[this.state.imageIndex]
+                                    }
                                     handleBgClose={this.handleBgClose}
                                 />
                             </React.Suspense>
@@ -376,6 +415,16 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
                             handleZoomOut={this.handleZoomOut}
                             handleZoomReset={this.handleZoomReset}
                         />
+                    );
+                } else if (fileType === FileTypes.TEXT) {
+                    content = (
+                        <div className='file-preview-modal__scrollable'>
+                            <iframe
+                                src={fileUrl}
+                                title='Text file Preview'
+                                className='file-preview-modal__code-preview normal txt-preview'
+                            />
+                        </div>
                     );
                 } else if (hasSupportedLanguage(fileInfo)) {
                     dialogClassName += ' modal-code';
@@ -398,7 +447,9 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
                 }
             } else {
                 // display a progress indicator when the preview for an image is still loading
-                const progress = Math.floor(this.state.progress[this.state.imageIndex]);
+                const progress = Math.floor(
+                    this.state.progress[this.state.imageIndex],
+                );
 
                 content = (
                     <LoadingImagePreview
@@ -467,8 +518,12 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
                                     filename={fileName}
                                     fileURL={fileDownloadUrl}
                                     fileInfo={fileInfo}
-                                    enablePublicLink={this.props.enablePublicLink}
-                                    canDownloadFiles={this.props.canDownloadFiles}
+                                    enablePublicLink={
+                                        this.props.enablePublicLink
+                                    }
+                                    canDownloadFiles={
+                                        this.props.canDownloadFiles
+                                    }
                                     canCopyContent={canCopyContent}
                                     isExternalFile={isExternalFile}
                                     handlePrev={this.handlePrev}
@@ -482,28 +537,38 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
                                 className={classNames(
                                     'file-preview-modal__content',
                                     {
-                                        'file-preview-modal__content-scrollable': (!isFileInfo(fileInfo) || !fileInfo.archived) && this.state.loaded[this.state.imageIndex] && (fileType === FileTypes.PDF),
+                                        'file-preview-modal__content-scrollable':
+                                            (!isFileInfo(fileInfo) ||
+                                                !fileInfo.archived) &&
+                                            this.state.loaded[
+                                                this.state.imageIndex
+                                            ] &&
+                                            fileType === FileTypes.PDF,
                                     },
                                 )}
                                 onClick={this.handleBgClose}
                             >
                                 {content}
                             </div>
-                            { this.props.isMobileView &&
+                            {this.props.isMobileView && (
                                 <FilePreviewModalFooter
                                     post={this.props.post}
                                     showPublicLink={showPublicLink}
                                     filename={fileName}
                                     fileURL={fileDownloadUrl}
                                     fileInfo={fileInfo}
-                                    enablePublicLink={this.props.enablePublicLink}
-                                    canDownloadFiles={this.props.canDownloadFiles}
+                                    enablePublicLink={
+                                        this.props.enablePublicLink
+                                    }
+                                    canDownloadFiles={
+                                        this.props.canDownloadFiles
+                                    }
                                     canCopyContent={canCopyContent}
                                     isExternalFile={isExternalFile}
                                     handleModalClose={this.handleModalClose}
                                     content={this.state.content}
                                 />
-                            }
+                            )}
                         </div>
                     </div>
                 </Modal.Body>

--- a/webapp/channels/src/sass/components/_files.scss
+++ b/webapp/channels/src/sass/components/_files.scss
@@ -450,6 +450,13 @@
     }
 }
 
+.txt-preview{
+    font-family: monospace;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+
 .post-image__thumbnail {
     @include mixins.cursor(zoom-in);
 

--- a/webapp/channels/src/utils/file_utils.tsx
+++ b/webapp/channels/src/utils/file_utils.tsx
@@ -71,6 +71,9 @@ export function getFileTypeFromMime(mimetype: string) {
         return 'audio';
     } else if (mimeTypePrefix === 'image') {
         return 'image';
+    } else if (mimeTypePrefix === 'text' && mimeTypeSuffix === 'plain') {
+        // added this branch for text/plain mimetype since it is not covered below under 'other' category
+        return 'text';
     }
 
     if (mimeTypeSuffix) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

This PR fixes the File Preview Modal behavior for `.txt` files. Previously, uploading and opening a `.txt` file  resulted in an endless loading spinner . With this change, `.txt` files are now rendered inside an iframe (`.txt-preview`) so their contents display correctly in the modal.

**QA Stepss:**
1. Upload a `.txt` file to a channel.
2. Click the file to open the File Preview Modal
3. Verify that the file contents are displayed the modal instead of a perpetual spinner.


#### Ticket Link
<!--
If applicable, please include both or either of the following links:


Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Fixes https://github.com/mattermost/mattermost/issues/34251#event-20517779945

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|couldn't get it on my local machine|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
```release-note
Fixed an issue where `.txt` files in the File Preview Modal would show an endless spinner. They now render properly inside the modal.
```