### PR TITLE
fix(scheduled): enhance timezone formatting by incorporating user loc…

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/core_menu_options.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/core_menu_options.test.tsx
@@ -179,4 +179,36 @@ describe('CoreMenuOptions Component', () => {
         // Check the trailing element is NOT rendered in the component as this is a bot
         expect(screen.queryByText(/John Doe/)).toBeNull();
     });
+
+    it('should format teammate time according to user locale', () => {
+        setMockDate(2); // Tuesday
+
+        const stateWithFrenchLocale = {
+            ...initialState,
+            entities: {
+                ...initialState.entities,
+                users: {
+                    ...initialState.entities.users,
+                    profiles: {
+                        currentUserId: {
+                            locale: 'fr',
+                        },
+                    },
+                },
+            },
+        };
+
+        mockedUseTimePostBoxIndicator.mockReturnValue({
+            ...defaultUseTimePostBoxIndicatorReturnValue,
+            isDM: true,
+            isSelfDM: false,
+            isBot: false,
+        });
+
+        renderComponent(stateWithFrenchLocale);
+
+        // Verify French format (no AM/PM)
+        const timeTexts = screen.getAllByText(/\d{2}:\d{2}(?!\s*[AP]M)/);
+        expect(timeTexts.length).toBeGreaterThan(0);
+    });
 });

--- a/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/core_menu_options.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/send_button/send_post_options/core_menu_options.tsx
@@ -20,6 +20,17 @@ type Props = {
     channelId: string;
 }
 
+/**
+ * Formats a timestamp in the teammate's timezone using the current user's locale.
+ * @param userCurrentTimestamp - Timestamp in milliseconds (UTC)
+ * @param teammateTimezoneString - IANA timezone string (e.g., "America/New_York")
+ * @param userLocale - User's locale code (e.g., "fr", "en", "de")
+ * @returns Formatted time string respecting the user's locale
+ * @example
+ * // US locale: "8:00 AM"
+ * // French locale: "08:00"
+ * getScheduledTimeInTeammateTimezone(1635768000000, 'Europe/Paris', 'fr')
+ */
 function getScheduledTimeInTeammateTimezone(userCurrentTimestamp: number, teammateTimezoneString: string, userLocale: string): string {
     const scheduledTimeUTC = DateTime.fromMillis(userCurrentTimestamp, {zone: 'utc'});
     const teammateScheduledTime = scheduledTimeUTC.setZone(teammateTimezoneString);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
When sending a scheduled message, the time of the other user was always displayed in US format (AM/PM), regardless of the locale of the current user.
This fix ensures that the current user's locale is applied when formatting the time. For example, in French, the time will be shown as 8:00 instead of 8:00 AM.

```tsx
const formattedTime = teammateScheduledTime
    .setLocale(userLocale)       // sets the locale for formatting (e.g., "fr" for French)
    .toLocaleString(DateTime.TIME_SIMPLE); // formats the time using the standard format of the locale
```

#### Ticket Link
No specific ticket was found for this bug, but this fix may be of interest.

#### Screenshots
|  before  |  after  |
|----|----|
| <insert before screenshot here> | https://github.com/user-attachments/assets/2e050799-bff2-4d29-84d1-fc4fbb442a94  |
| <insert before screenshot here> | (It seems some French translations were missing too) |
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
