### PR TITLE
MM-66373: Update FIPS flavor of Playbooks, Agents and Boards

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -172,9 +172,9 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.2.1
 # download the package from to work. This will no longer be needed when we unify
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
-	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.4.2%2B4a22550-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v1.3.1%2B6e1b6eb-fips
-	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.1.6%2B2b0e66a-fips
+	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.5.0%2Bc140653-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v1.4.0%2B2f27b68-fips
+	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.1.7%2Ba980cd2-fips
 endif
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)


### PR DESCRIPTION
#### Summary
Match the prepackaged FIPS flavour of Playbooks, Agents and Boards to their non-FIPS counterparts.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66373

#### Screenshots
--

#### Release Note
```release-note
NONE
```
