### PR TITLE
Automated cherry pick of #34283

### DIFF
--- a/webapp/channels/src/components/admin_console/content_flagging/content_flagging_settings.tsx
+++ b/webapp/channels/src/components/admin_console/content_flagging/content_flagging_settings.tsx
@@ -13,7 +13,6 @@ import type {ServerError} from '@mattermost/types/errors';
 
 import {Client4} from 'mattermost-redux/client';
 
-import BlockableLink from 'components/admin_console/blockable_link';
 import BooleanSetting from 'components/admin_console/boolean_setting';
 import ContentFlaggingAdditionalSettingsSection
     from 'components/admin_console/content_flagging/additional_settings/additional_settings';
@@ -99,12 +98,8 @@ export default function ContentFlaggingSettings() {
 
     return (
         <div className='wrapper--fixed ContentFlaggingSettings'>
-            <AdminHeader withBackButton={true}>
+            <AdminHeader>
                 <div>
-                    <BlockableLink
-                        to='/admin_console/system_attributes/attribute_based_access_control'
-                        className='fa fa-angle-left back'
-                    />
                     <FormattedMessage
                         id='admin.contentFlagging.title'
                         defaultMessage='Content Flagging'


### PR DESCRIPTION
Cherry pick of #34283 on release-11.1.

/cc  @harshilsharma63

```release-note
NONE
```