### PR TITLE
Update web app package versions to 11.0.4

### DIFF
--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -3,17 +3,17 @@
   "browser": {
     "./client/web_client.jsx": "./client/browser_web_client.jsx"
   },
-  "version": "10.12.0",
+  "version": "11.0.4",
   "private": true,
   "dependencies": {
     "@floating-ui/react": "0.26.28",
     "@giphy/js-fetch-api": "5.1.0",
     "@giphy/react-components": "8.1.0",
     "@guyplusplus/turndown-plugin-gfm": "1.0.7",
-    "@mattermost/client": "10.12.0",
+    "@mattermost/client": "11.0.4",
     "@mattermost/desktop-api": "5.10.0-2",
     "@mattermost/dynamic-virtualized-list": "github:mattermost/dynamic-virtualized-list#08dde0c34a12d0384740db27d55e398d139d7a51",
-    "@mattermost/types": "10.12.0",
+    "@mattermost/types": "11.0.4",
     "@mui/base": "5.0.0-alpha.127",
     "@mui/material": "5.11.16",
     "@mui/styled-engine-sc": "5.11.11",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -58,16 +58,16 @@
     },
     "channels": {
       "name": "mattermost-webapp",
-      "version": "10.12.0",
+      "version": "11.0.4",
       "dependencies": {
         "@floating-ui/react": "0.26.28",
         "@giphy/js-fetch-api": "5.1.0",
         "@giphy/react-components": "8.1.0",
         "@guyplusplus/turndown-plugin-gfm": "1.0.7",
-        "@mattermost/client": "10.12.0",
+        "@mattermost/client": "11.0.4",
         "@mattermost/desktop-api": "5.10.0-2",
         "@mattermost/dynamic-virtualized-list": "github:mattermost/dynamic-virtualized-list#08dde0c34a12d0384740db27d55e398d139d7a51",
-        "@mattermost/types": "10.12.0",
+        "@mattermost/types": "11.0.4",
         "@mui/base": "5.0.0-alpha.127",
         "@mui/material": "5.11.16",
         "@mui/styled-engine-sc": "5.11.11",
@@ -28054,7 +28054,7 @@
     },
     "platform/client": {
       "name": "@mattermost/client",
-      "version": "10.12.0",
+      "version": "11.0.4",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "28.1.8",
@@ -28062,7 +28062,7 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
-        "@mattermost/types": "10.12.0",
+        "@mattermost/types": "11.0.4",
         "typescript": "^4.3.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
@@ -29520,11 +29520,11 @@
       }
     },
     "platform/mattermost-redux": {
-      "version": "10.12.0",
+      "version": "11.0.4",
       "license": "MIT",
       "dependencies": {
-        "@mattermost/client": "10.12.0",
-        "@mattermost/types": "10.12.0",
+        "@mattermost/client": "11.0.4",
+        "@mattermost/types": "11.0.4",
         "@redux-devtools/extension": "^3.2.3",
         "lodash": "^4.17.21",
         "moment-timezone": "^0.5.38",
@@ -29546,7 +29546,7 @@
     },
     "platform/types": {
       "name": "@mattermost/types",
-      "version": "10.12.0",
+      "version": "11.0.4",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.0.0"

--- a/webapp/platform/client/package.json
+++ b/webapp/platform/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/client",
-  "version": "10.12.0",
+  "version": "11.0.4",
   "description": "JavaScript/TypeScript client for Mattermost",
   "keywords": [
     "mattermost"
@@ -24,7 +24,7 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "@mattermost/types": "10.12.0",
+    "@mattermost/types": "11.0.4",
     "typescript": "^4.3.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {

--- a/webapp/platform/mattermost-redux/package.json
+++ b/webapp/platform/mattermost-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mattermost-redux",
-  "version": "10.12.0",
+  "version": "11.0.4",
   "description": "Common code (API client, Redux stores, logic, utility functions) for building a Mattermost client",
   "keywords": [
     "mattermost"
@@ -39,8 +39,8 @@
     "directory": "webapp/platform/mattermost-redux"
   },
   "dependencies": {
-    "@mattermost/client": "10.12.0",
-    "@mattermost/types": "10.12.0",
+    "@mattermost/client": "11.0.4",
+    "@mattermost/types": "11.0.4",
     "@redux-devtools/extension": "^3.2.3",
     "lodash": "^4.17.21",
     "moment-timezone": "^0.5.38",

--- a/webapp/platform/types/package.json
+++ b/webapp/platform/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/types",
-  "version": "10.12.0",
+  "version": "11.0.4",
   "description": "Shared type definitions used by the Mattermost web app",
   "keywords": [
     "mattermost"


### PR DESCRIPTION
#### Summary
This wasn't included in https://github.com/mattermost/mattermost/pull/33833 for whatever reason even though the build pipeline should still handle it. I assume the issue is something to do with those pipelines perhaps not supporting incrementing major versions for some reason.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65791

#### Release Note
```release-note
NONE
```
