### PR TITLE
Update web app package versions to 11.1.0

### DIFF
--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -3,16 +3,16 @@
   "browser": {
     "./client/web_client.jsx": "./client/browser_web_client.jsx"
   },
-  "version": "10.12.0",
+  "version": "11.1.0",
   "private": true,
   "dependencies": {
     "@floating-ui/react": "0.26.6",
     "@giphy/js-fetch-api": "5.1.0",
     "@giphy/react-components": "8.1.0",
     "@guyplusplus/turndown-plugin-gfm": "1.0.7",
-    "@mattermost/client": "10.12.0",
+    "@mattermost/client": "11.1.0",
     "@mattermost/desktop-api": "6.0.0-1",
-    "@mattermost/types": "10.12.0",
+    "@mattermost/types": "11.1.0",
     "@mui/base": "5.0.0-alpha.127",
     "@mui/material": "5.11.16",
     "@mui/styled-engine-sc": "5.11.11",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -56,15 +56,15 @@
     },
     "channels": {
       "name": "mattermost-webapp",
-      "version": "10.12.0",
+      "version": "11.1.0",
       "dependencies": {
         "@floating-ui/react": "0.26.6",
         "@giphy/js-fetch-api": "5.1.0",
         "@giphy/react-components": "8.1.0",
         "@guyplusplus/turndown-plugin-gfm": "1.0.7",
-        "@mattermost/client": "10.12.0",
+        "@mattermost/client": "11.1.0",
         "@mattermost/desktop-api": "6.0.0-1",
-        "@mattermost/types": "10.12.0",
+        "@mattermost/types": "11.1.0",
         "@mui/base": "5.0.0-alpha.127",
         "@mui/material": "5.11.16",
         "@mui/styled-engine-sc": "5.11.11",
@@ -27561,7 +27561,7 @@
     },
     "platform/client": {
       "name": "@mattermost/client",
-      "version": "10.12.0",
+      "version": "11.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "28.1.8",
@@ -27569,7 +27569,7 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
-        "@mattermost/types": "10.12.0",
+        "@mattermost/types": "11.1.0",
         "typescript": "^4.3.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
@@ -29027,11 +29027,11 @@
       }
     },
     "platform/mattermost-redux": {
-      "version": "10.12.0",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
-        "@mattermost/client": "10.12.0",
-        "@mattermost/types": "10.12.0",
+        "@mattermost/client": "11.1.0",
+        "@mattermost/types": "11.1.0",
         "@redux-devtools/extension": "3.3.0",
         "lodash": "^4.17.21",
         "moment-timezone": "^0.5.38",
@@ -29053,7 +29053,7 @@
     },
     "platform/types": {
       "name": "@mattermost/types",
-      "version": "10.12.0",
+      "version": "11.1.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.0.0"

--- a/webapp/platform/client/package.json
+++ b/webapp/platform/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/client",
-  "version": "10.12.0",
+  "version": "11.1.0",
   "description": "JavaScript/TypeScript client for Mattermost",
   "keywords": [
     "mattermost"
@@ -24,7 +24,7 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "@mattermost/types": "10.12.0",
+    "@mattermost/types": "11.1.0",
     "typescript": "^4.3.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {

--- a/webapp/platform/mattermost-redux/package.json
+++ b/webapp/platform/mattermost-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mattermost-redux",
-  "version": "10.12.0",
+  "version": "11.1.0",
   "description": "Common code (API client, Redux stores, logic, utility functions) for building a Mattermost client",
   "keywords": [
     "mattermost"
@@ -39,8 +39,8 @@
     "directory": "webapp/platform/mattermost-redux"
   },
   "dependencies": {
-    "@mattermost/client": "10.12.0",
-    "@mattermost/types": "10.12.0",
+    "@mattermost/client": "11.1.0",
+    "@mattermost/types": "11.1.0",
     "@redux-devtools/extension": "3.3.0",
     "lodash": "^4.17.21",
     "moment-timezone": "^0.5.38",

--- a/webapp/platform/types/package.json
+++ b/webapp/platform/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/types",
-  "version": "10.12.0",
+  "version": "11.1.0",
   "description": "Shared type definitions used by the Mattermost web app",
   "keywords": [
     "mattermost"


### PR DESCRIPTION
#### Summary
For whatever reason, we have to update the version manually for this release. https://github.com/mattermost/mattermost/pull/34090 did it for the server, and this will do it for the web app.

This needs to be merged by the time that the 11.2.0 branch is cut so that the automation at that point will update this to 11.2.0 automatically

#### Release Note
```release-note
NONE
```
