### PR TITLE
Bump prepackage MsTeams plugin version to 2.3.0

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -163,7 +163,7 @@ PLUGIN_PACKAGES += mattermost-plugin-agents-v1.4.0
 PLUGIN_PACKAGES += mattermost-plugin-boards-v9.1.7
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.3.4
-PLUGIN_PACKAGES += mattermost-plugin-msteams-meetings-v2.2.0
+PLUGIN_PACKAGES += mattermost-plugin-msteams-meetings-v2.3.0
 PLUGIN_PACKAGES += mattermost-plugin-metrics-v0.7.0
 PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.2.1
 


### PR DESCRIPTION
#### Summary
Prepackage MsTeams plugin v2.3.0

#### Release Note
```release-note
Prepackage MsTeams plugin version [v2.3.0](https://github.com/mattermost/mattermost-plugin-msteams/releases/tag/v2.3.0).
```
Prepackage MsTeams Meeting plugin version [v2.3.0](https://github.com/mattermost/mattermost-plugin-msteams-meetings/releases).