### PR TITLE
MM-66286 Copy Redux type extensions to mattermost-redux

### DIFF
--- a/webapp/platform/mattermost-redux/package.json
+++ b/webapp/platform/mattermost-redux/package.json
@@ -61,7 +61,7 @@
   },
   "scripts": {
     "build": "tsc --build --verbose",
-    "postbuild": "cp ../../channels/src/packages/mattermost-redux/src/selectors/create_selector/index.d.ts lib/selectors/create_selector/index.d.ts",
+    "postbuild": "sh postbuild.sh",
     "clean": "rm -rf lib node_modules *.tsbuildinfo"
   }
 }

--- a/webapp/platform/mattermost-redux/postbuild.sh
+++ b/webapp/platform/mattermost-redux/postbuild.sh
@@ -1,0 +1,3 @@
+cp ../../channels/src/packages/mattermost-redux/src/selectors/create_selector/index.d.ts lib/selectors/create_selector/index.d.ts
+cp ../../channels/src/packages/mattermost-redux/src/types/extend_redux.d.ts lib/types/extend_redux.d.ts
+cp ../../channels/src/packages/mattermost-redux/src/types/extend_react_redux.d.ts lib/types/extend_react_redux.d.ts


### PR DESCRIPTION
#### Summary
The newer version of Redux Thunk added with React 18 changed how the global Redux types like `Dispatch` were extended to allow for dispatching Thunk actions. It was changed to be cleaner by not modifying the global types, but it would've required a ton of changes on our end, so I worked around it be reintroducing the old way it used to work.

Unfortunately, I forgot that we need to copy `.d.ts` files manually while build `mattermost-redux`, and I forgot to do that sooner.

This should also be cherry-picked onto the 11.1 branch

#### Ticket Link
MM-66286

#### Release Note
```release-note
NONE
```
