### PR TITLE
Fix warnings from NPM about package URLs

### DIFF
--- a/webapp/platform/client/package.json
+++ b/webapp/platform/client/package.json
@@ -15,7 +15,7 @@
   "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "github:mattermost/mattermost",
+    "url": "git+https://github.com/mattermost/mattermost.git",
     "directory": "webapp/platform/client"
   },
   "devDependencies": {

--- a/webapp/platform/types/package.json
+++ b/webapp/platform/types/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "github:mattermost/mattermost",
+    "url": "git+https://github.com/mattermost/mattermost.git",
     "directory": "webapp/platform/types"
   },
   "devDependencies": {


### PR DESCRIPTION
#### Summary
The previous URLs are getting normalized to these new ones, and NPM likes complaining about it, so I changed them to make NPM happy.

#### Release Note
```release-note
NONE
```