### PR TITLE
Automated cherry pick of #34203

### DIFF
--- a/server/channels/app/plugin_requests.go
+++ b/server/channels/app/plugin_requests.go
@@ -161,9 +161,6 @@ func (ch *Channels) servePluginRequest(w http.ResponseWriter, r *http.Request, h
 	// Mattermost-Plugin-ID can only be set by inter-plugin requests
 	r.Header.Del("Mattermost-Plugin-ID")
 
-	// Clean Authorization header. The Mattermost-User-Id header is used to indicate authenticated requests.
-	r.Header.Del(model.HeaderAuth)
-
 	// Clean Mattermost-User-Id header. The server sets this header for authenticated requests
 	r.Header.Del("Mattermost-User-Id")
 
@@ -216,6 +213,11 @@ func (ch *Channels) servePluginRequest(w http.ResponseWriter, r *http.Request, h
 		handler(context, w, r)
 		return
 	}
+
+	// If we get to this point, the token resolved to a valid session, and we don't need to remit
+	// the authorization header to the plugin at all. This also prevents the plugin from incorrectly
+	// using the token if MFA or CSRF fail below.
+	r.Header.Del(model.HeaderAuth)
 
 	rctx = rctx.
 		WithLogger(rctx.Logger().With(

--- a/server/channels/app/plugin_requests_test.go
+++ b/server/channels/app/plugin_requests_test.go
@@ -520,6 +520,22 @@ func TestServePluginRequest(t *testing.T) {
 		th.App.ch.servePluginRequest(rr, req, mockHandler)
 		require.True(t, handlerCalled)
 	})
+
+	t.Run("third-party use of Authorization header preserved", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/plugins/testplugin/endpoint", nil)
+		req.Header.Set(model.HeaderAuth, "Bearer 3rd-party-token")
+		rr := httptest.NewRecorder()
+
+		handlerCalled := false
+		mockHandler := func(ctx *plugin.Context, w http.ResponseWriter, r *http.Request) {
+			handlerCalled = true
+			// Should still have the authorization header
+			assert.Equal(t, "Bearer 3rd-party-token", r.Header.Get(model.HeaderAuth))
+		}
+
+		th.App.ch.servePluginRequest(rr, req, mockHandler)
+		require.True(t, handlerCalled)
+	})
 }
 
 func TestValidateCSRFForPluginRequest(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #34203 on release-11.1.

/cc  @lieut-data

```release-note
NONE
```