### PR TITLE
use *_DEV_* and drop unused input

### DIFF
--- a/.github/workflows/build-server-image.yml
+++ b/.github/workflows/build-server-image.yml
@@ -14,10 +14,6 @@ on:
       - server/build/Dockerfile.buildenv-fips
       - .github/workflows/build-server-image.yml
   workflow_dispatch:
-    inputs:
-      branch:
-        description: "Git branch or PR ref to build"
-        required: true
 
 env:
   CHAINCTL_IDENTITY: ee399b4c72dd4e58e3d617f78fc47b74733c9557/922f2d48307d6f5f
@@ -83,8 +79,8 @@ jobs:
       - name: buildenv/docker-login
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_DEV_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_DEV_TOKEN }}
 
       - name: buildenv/build
         uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0


### PR DESCRIPTION
#### Summary
Switch to the `DOCKERHUB_DEV_USERNAME` when accessing `mattermostdevelopment/*`, and also drop an unused input parameter for the workflow dispatch. This enables us to complete the switchover to the `mattermostdevelopment` org for non-production Docker images used for building.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
