### PR TITLE
[MM-66444] Remove onboarding task list and cloud preview modal from popouts

### DIFF
--- a/webapp/channels/src/components/popout_controller/popout_controller.test.tsx
+++ b/webapp/channels/src/components/popout_controller/popout_controller.test.tsx
@@ -27,6 +27,11 @@ jest.mock('components/thread_popout', () => ({
     default: () => <div data-testid='thread-popout'>{'Thread Popout'}</div>,
 }));
 
+jest.mock('components/logged_in', () => ({
+    __esModule: true,
+    default: ({children}: {children: React.ReactNode}) => <div data-testid='logged-in'>{children}</div>,
+}));
+
 const mockGetProfiles = getProfiles as jest.MockedFunction<typeof getProfiles>;
 
 // Base mock route props with meaningful route data

--- a/webapp/channels/src/components/popout_controller/popout_controller.tsx
+++ b/webapp/channels/src/components/popout_controller/popout_controller.tsx
@@ -8,6 +8,7 @@ import type {RouteComponentProps} from 'react-router-dom';
 
 import {getProfiles} from 'mattermost-redux/actions/users';
 
+import LoggedIn from 'components/logged_in';
 import ModalController from 'components/modal_controller';
 import ThreadPopout from 'components/thread_popout';
 
@@ -15,7 +16,7 @@ import {TEAM_NAME_PATH_PATTERN, ID_PATH_PATTERN} from 'utils/path';
 
 import './popout_controller.scss';
 
-const PopoutController: React.FC<RouteComponentProps> = () => {
+const PopoutController: React.FC<RouteComponentProps> = (routeProps) => {
     const dispatch = useDispatch();
     useEffect(() => {
         document.body.classList.add('app__body', 'popout');
@@ -23,7 +24,7 @@ const PopoutController: React.FC<RouteComponentProps> = () => {
     }, []);
 
     return (
-        <>
+        <LoggedIn {...routeProps}>
             <ModalController/>
             <Switch>
                 <Route
@@ -31,7 +32,7 @@ const PopoutController: React.FC<RouteComponentProps> = () => {
                     component={ThreadPopout}
                 />
             </Switch>
-        </>
+        </LoggedIn>
     );
 };
 

--- a/webapp/channels/src/components/root/root.tsx
+++ b/webapp/channels/src/components/root/root.tsx
@@ -409,7 +409,7 @@ export default class Root extends React.PureComponent<Props, State> {
                         from={'/_redirect/pl/:postid'}
                         to={`/${this.props.permalinkRedirectTeamName}/pl/:postid`}
                     />
-                    <LoggedInRoute
+                    <Route
                         path={'/_popout'}
                         component={PopoutController}
                     />


### PR DESCRIPTION
#### Summary
For some reason, the `OnboardingTaskList` and the `CloudPreviewModal` are inside the `LoggedInRoute` component rather than attached to the root or the team_controller. This caused some strange style issues with the thread popout as they were being rendered side-by-side in a `grid` which causes the `thread-pane-container` to be much too small.

Since neither are needed to be shown in a pop-out window, this PR forgoes using `LoggedInRoute` and just adds the `LoggedIn` component at the `PopoutController` level.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66444

```release-note
NONE
```
