### PR TITLE
Add support for make i18n-extract when dep folders are symlinked

### DIFF
--- a/tools/mmgotool/commands/i18n.go
+++ b/tools/mmgotool/commands/i18n.go
@@ -117,6 +117,14 @@ func getBaseFileSrcStrings(mattermostDir string) ([]Translation, error) {
 	return translations, err
 }
 
+// resolveSymlink resolves a path if it's a symlink, otherwise returns the original path
+func resolveSymlink(path string) string {
+	if realPath, err := filepath.EvalSymlinks(path); err == nil {
+		return realPath
+	}
+	return path
+}
+
 func extractSrcStrings(enterpriseDir, mattermostDir, modelDir, pluginDir, portalDir string) map[string]bool {
 	i18nStrings := map[string]bool{}
 	walkFunc := func(p string, info os.FileInfo, err error) error {
@@ -125,13 +133,14 @@ func extractSrcStrings(enterpriseDir, mattermostDir, modelDir, pluginDir, portal
 		}
 		return extractFromPath(p, info, err, i18nStrings)
 	}
+
 	if portalDir != "" {
-		_ = filepath.Walk(portalDir, walkFunc)
+		_ = filepath.Walk(resolveSymlink(portalDir), walkFunc)
 	} else {
-		_ = filepath.Walk(mattermostDir, walkFunc)
-		_ = filepath.Walk(enterpriseDir, walkFunc)
-		_ = filepath.Walk(modelDir, walkFunc)
-		_ = filepath.Walk(pluginDir, walkFunc)
+		_ = filepath.Walk(resolveSymlink(mattermostDir), walkFunc)
+		_ = filepath.Walk(resolveSymlink(enterpriseDir), walkFunc)
+		_ = filepath.Walk(resolveSymlink(modelDir), walkFunc)
+		_ = filepath.Walk(resolveSymlink(pluginDir), walkFunc)
 	}
 	return i18nStrings
 }


### PR DESCRIPTION
#### Summary
When developing in Mattermost repo using git worktrees, it's helpful to symlink the `enterprise` repository into (or near) the worktree. The current implementation of i18n-extract doesn't allow this because filepath.Walk doesn't support symlinks. This PR adds an evaluation of the symlink first before then passing off the dir to filepath.Walk.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
None
```
