### PR TITLE
MM-66383: Fix console 

### DIFF
--- a/server/public/model/custom_profile_attributes_test.go
+++ b/server/public/model/custom_profile_attributes_test.go
@@ -79,7 +79,7 @@ func TestNewCPAFieldFromPropertyField(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "property field with empty attributes",
+			name: "property field with empty attributes returns empty values",
 			propertyField: &PropertyField{
 				ID:       NewId(),
 				GroupID:  CustomProfileAttributesPropertyGroupName,
@@ -89,7 +89,7 @@ func TestNewCPAFieldFromPropertyField(t *testing.T) {
 				UpdateAt: GetMillis(),
 			},
 			wantAttrs: CPAAttrs{
-				Visibility: "",
+				Visibility: "", // Pure conversion, no defaults (defaults provided by app layer)
 				SortOrder:  0,
 				ValueType:  "",
 				Options:    nil,


### PR DESCRIPTION
#### Summary
Fixes MM-66383

<details>
<summary>Details</summary>

- Adds backward compatibility for custom profile attributes (CPA) fields that were created before default attrs were enforced
- Ensures that `PropertyField.Attrs` always has default values for `visibility` and `sort_order` when reading CPA fields
- Implements `ensureCPAFieldAttrs` helper function that initializes missing attrs in the read pipeline

#### Changes

- Added `ensureCPAFieldAttrs()` function in `custom_profile_attributes.go` to ensure backward compatibility
- Modified `GetCPAField()` to call `ensureCPAFieldAttrs()` before returning field
- Modified `ListCPAFields()` to call `ensureCPAFieldAttrs()` for all fields before returning
- Added comprehensive tests for fields with nil and empty Attrs
- Updated model test comment to clarify that defaults are provided by app layer, not conversion layer

#### Test Plan

- Added unit tests in `custom_profile_attributes_test.go` that verify:
  - Fields with nil Attrs get initialized with defaults
  - Fields with empty Attrs get initialized with defaults
  - Both `GetCPAField` and `ListCPAFields` properly initialize attrs
- Existing tests continue to pass
</details>

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-66383


🤖 Generated with [Claude Code](https://claude.com/claude-code)


```release-note
NONE
```