### PR TITLE
MM-66460: Add migration to apply default attrs to CPA fields

### DIFF
--- a/server/channels/app/custom_profile_attributes.go
+++ b/server/channels/app/custom_profile_attributes.go
@@ -19,28 +19,6 @@ const (
 	CustomProfileAttributesFieldLimit = 20
 )
 
-// ensureCPAFieldAttrs ensures that PropertyField.Attrs has default values for CPA fields
-// that were created before default attrs were enforced. This provides backward compatibility.
-func ensureCPAFieldAttrs(field *model.PropertyField) {
-	if field == nil {
-		return
-	}
-
-	if field.Attrs == nil {
-		field.Attrs = model.StringInterface{}
-	}
-
-	// Ensure visibility has a default value (this is the most critical attr)
-	if visibility, ok := field.Attrs[model.CustomProfileAttributesPropertyAttrsVisibility]; !ok || visibility == "" {
-		field.Attrs[model.CustomProfileAttributesPropertyAttrsVisibility] = model.CustomProfileAttributesVisibilityDefault
-	}
-
-	// Ensure sort_order exists (defaults to 0 if missing, which is fine)
-	if _, ok := field.Attrs[model.CustomProfileAttributesPropertyAttrsSortOrder]; !ok {
-		field.Attrs[model.CustomProfileAttributesPropertyAttrsSortOrder] = float64(0)
-	}
-}
-
 var cpaGroupID string
 
 // ToDo: we should explore moving this to the database cache layer
@@ -75,8 +53,6 @@ func (a *App) GetCPAField(fieldID string) (*model.PropertyField, *model.AppError
 		}
 	}
 
-	ensureCPAFieldAttrs(field)
-
 	return field, nil
 }
 
@@ -94,10 +70,6 @@ func (a *App) ListCPAFields() ([]*model.PropertyField, *model.AppError) {
 	fields, err := a.Srv().propertyService.SearchPropertyFields(groupID, opts)
 	if err != nil {
 		return nil, model.NewAppError("GetCPAFields", "app.custom_profile_attributes.search_property_fields.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
-	}
-
-	for _, field := range fields {
-		ensureCPAFieldAttrs(field)
 	}
 
 	sort.Slice(fields, func(i, j int) bool {

--- a/server/channels/app/custom_profile_attributes_test.go
+++ b/server/channels/app/custom_profile_attributes_test.go
@@ -64,44 +64,6 @@ func TestGetCPAField(t *testing.T) {
 		require.Equal(t, model.CustomProfileAttributesVisibilityHidden, fetchedField.Attrs["visibility"])
 	})
 
-	t.Run("should initialize default attrs when field has nil Attrs", func(t *testing.T) {
-		// Create a field with nil Attrs directly via property service (bypassing CPA validation)
-		field := &model.PropertyField{
-			GroupID: cpaGroupID,
-			Name:    "Field with nil attrs",
-			Type:    model.PropertyFieldTypeText,
-			Attrs:   nil,
-		}
-		createdField, err := th.App.Srv().propertyService.CreatePropertyField(field)
-		require.NoError(t, err)
-
-		// GetCPAField should initialize Attrs with defaults
-		fetchedField, appErr := th.App.GetCPAField(createdField.ID)
-		require.Nil(t, appErr)
-		require.NotNil(t, fetchedField.Attrs)
-		require.Equal(t, model.CustomProfileAttributesVisibilityDefault, fetchedField.Attrs[model.CustomProfileAttributesPropertyAttrsVisibility])
-		require.Equal(t, float64(0), fetchedField.Attrs[model.CustomProfileAttributesPropertyAttrsSortOrder])
-	})
-
-	t.Run("should initialize default attrs when field has empty Attrs", func(t *testing.T) {
-		// Create a field with empty Attrs directly via property service
-		field := &model.PropertyField{
-			GroupID: cpaGroupID,
-			Name:    "Field with empty attrs",
-			Type:    model.PropertyFieldTypeText,
-			Attrs:   model.StringInterface{},
-		}
-		createdField, err := th.App.Srv().propertyService.CreatePropertyField(field)
-		require.NoError(t, err)
-
-		// GetCPAField should add missing default attrs
-		fetchedField, appErr := th.App.GetCPAField(createdField.ID)
-		require.Nil(t, appErr)
-		require.NotNil(t, fetchedField.Attrs)
-		require.Equal(t, model.CustomProfileAttributesVisibilityDefault, fetchedField.Attrs[model.CustomProfileAttributesPropertyAttrsVisibility])
-		require.Equal(t, float64(0), fetchedField.Attrs[model.CustomProfileAttributesPropertyAttrsSortOrder])
-	})
-
 	t.Run("should validate LDAP/SAML synced fields", func(t *testing.T) {
 		// Create LDAP synced field
 		ldapField, err := model.NewCPAFieldFromPropertyField(&model.PropertyField{
@@ -198,42 +160,6 @@ func TestListCPAFields(t *testing.T) {
 		require.Len(t, fields, 2)
 		require.Equal(t, "Field 3", fields[0].Name)
 		require.Equal(t, "Field 1", fields[1].Name)
-	})
-
-	t.Run("should initialize default attrs for fields with nil or empty Attrs", func(t *testing.T) {
-		// Create a field with nil Attrs
-		fieldWithNilAttrs := &model.PropertyField{
-			GroupID: cpaGroupID,
-			Name:    "Field with nil attrs",
-			Type:    model.PropertyFieldTypeText,
-			Attrs:   nil,
-		}
-		_, err := th.App.Srv().propertyService.CreatePropertyField(fieldWithNilAttrs)
-		require.NoError(t, err)
-
-		// Create a field with empty Attrs
-		fieldWithEmptyAttrs := &model.PropertyField{
-			GroupID: cpaGroupID,
-			Name:    "Field with empty attrs",
-			Type:    model.PropertyFieldTypeText,
-			Attrs:   model.StringInterface{},
-		}
-		_, err = th.App.Srv().propertyService.CreatePropertyField(fieldWithEmptyAttrs)
-		require.NoError(t, err)
-
-		// ListCPAFields should initialize Attrs with defaults
-		fields, appErr := th.App.ListCPAFields()
-		require.Nil(t, appErr)
-		require.NotEmpty(t, fields)
-
-		// Find our test fields and verify default attrs are set
-		for _, field := range fields {
-			if field.Name == "Field with nil attrs" || field.Name == "Field with empty attrs" {
-				require.NotNil(t, field.Attrs)
-				require.Equal(t, model.CustomProfileAttributesVisibilityDefault, field.Attrs[model.CustomProfileAttributesPropertyAttrsVisibility])
-				require.Equal(t, float64(0), field.Attrs[model.CustomProfileAttributesPropertyAttrsSortOrder])
-			}
-		}
 	})
 }
 

--- a/server/channels/app/migrations_test.go
+++ b/server/channels/app/migrations_test.go
@@ -50,3 +50,117 @@ func TestDoSetupContentFlaggingProperties(t *testing.T) {
 		require.Len(t, propertyFields, 10)
 	})
 }
+
+func TestDoCPAFieldApplyDefaultAttrs(t *testing.T) {
+	t.Run("should apply default attrs to existing CPA fields", func(t *testing.T) {
+		th := Setup(t)
+		defer th.TearDown()
+
+		// Register CPA property group
+		group, err := th.Server.propertyService.RegisterPropertyGroup(model.CustomProfileAttributesPropertyGroupName)
+		require.NoError(t, err)
+
+		// Create fields with missing attrs to simulate old data
+		fieldWithNilAttrs := &model.PropertyField{
+			GroupID: group.ID,
+			Name:    "Field with nil attrs",
+			Type:    model.PropertyFieldTypeText,
+			Attrs:   nil,
+		}
+		createdField1, err := th.Server.propertyService.CreatePropertyField(fieldWithNilAttrs)
+		require.NoError(t, err)
+
+		fieldWithEmptyAttrs := &model.PropertyField{
+			GroupID: group.ID,
+			Name:    "Field with empty attrs",
+			Type:    model.PropertyFieldTypeText,
+			Attrs:   model.StringInterface{},
+		}
+		createdField2, err := th.Server.propertyService.CreatePropertyField(fieldWithEmptyAttrs)
+		require.NoError(t, err)
+
+		// Remove the migration done key to allow migration to run
+		_, err = th.Store.System().PermanentDeleteByName(cpaFieldDefaultAttrsMigrationKey)
+		require.NoError(t, err)
+
+		// Run the migration
+		err = th.Server.doCPAFieldApplyDefaultAttrs()
+		require.NoError(t, err)
+
+		// Verify fields now have default attrs
+		updatedField1, err := th.Server.propertyService.GetPropertyField(group.ID, createdField1.ID)
+		require.NoError(t, err)
+		require.NotNil(t, updatedField1.Attrs)
+		require.Equal(t, model.CustomProfileAttributesVisibilityDefault, updatedField1.Attrs[model.CustomProfileAttributesPropertyAttrsVisibility])
+		require.Equal(t, float64(0), updatedField1.Attrs[model.CustomProfileAttributesPropertyAttrsSortOrder])
+
+		updatedField2, err := th.Server.propertyService.GetPropertyField(group.ID, createdField2.ID)
+		require.NoError(t, err)
+		require.NotNil(t, updatedField2.Attrs)
+		require.Equal(t, model.CustomProfileAttributesVisibilityDefault, updatedField2.Attrs[model.CustomProfileAttributesPropertyAttrsVisibility])
+		require.Equal(t, float64(0), updatedField2.Attrs[model.CustomProfileAttributesPropertyAttrsSortOrder])
+
+		// Verify migration key was set
+		_, err = th.Store.System().GetByName(cpaFieldDefaultAttrsMigrationKey)
+		require.NoError(t, err)
+	})
+
+	t.Run("the migration is idempotent", func(t *testing.T) {
+		th := Setup(t)
+		defer th.TearDown()
+
+		// Register CPA property group
+		group, err := th.Server.propertyService.RegisterPropertyGroup(model.CustomProfileAttributesPropertyGroupName)
+		require.NoError(t, err)
+
+		// Create a field with proper attrs
+		field := &model.PropertyField{
+			GroupID: group.ID,
+			Name:    "Field with proper attrs",
+			Type:    model.PropertyFieldTypeText,
+			Attrs: model.StringInterface{
+				model.CustomProfileAttributesPropertyAttrsVisibility: model.CustomProfileAttributesVisibilityDefault,
+				model.CustomProfileAttributesPropertyAttrsSortOrder:  float64(5),
+			},
+		}
+		createdField, err := th.Server.propertyService.CreatePropertyField(field)
+		require.NoError(t, err)
+
+		// Remove the migration done key
+		_, err = th.Store.System().PermanentDeleteByName(cpaFieldDefaultAttrsMigrationKey)
+		require.NoError(t, err)
+
+		// Run the migration first time
+		err = th.Server.doCPAFieldApplyDefaultAttrs()
+		require.NoError(t, err)
+
+		// Remove the key again and run migration second time
+		_, err = th.Store.System().PermanentDeleteByName(cpaFieldDefaultAttrsMigrationKey)
+		require.NoError(t, err)
+		err = th.Server.doCPAFieldApplyDefaultAttrs()
+		require.NoError(t, err)
+
+		// Verify field attrs are still correct and not overwritten
+		updatedField, err := th.Server.propertyService.GetPropertyField(group.ID, createdField.ID)
+		require.NoError(t, err)
+		require.Equal(t, model.CustomProfileAttributesVisibilityDefault, updatedField.Attrs[model.CustomProfileAttributesPropertyAttrsVisibility])
+		require.Equal(t, float64(5), updatedField.Attrs[model.CustomProfileAttributesPropertyAttrsSortOrder])
+	})
+
+	t.Run("should handle case where no CPA fields exist", func(t *testing.T) {
+		th := Setup(t)
+		defer th.TearDown()
+
+		// Remove the migration done key
+		_, err := th.Store.System().PermanentDeleteByName(cpaFieldDefaultAttrsMigrationKey)
+		require.NoError(t, err)
+
+		// Run the migration with no CPA fields
+		err = th.Server.doCPAFieldApplyDefaultAttrs()
+		require.NoError(t, err)
+
+		// Verify migration key was still set
+		_, err = th.Store.System().GetByName(cpaFieldDefaultAttrsMigrationKey)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
#### Summary

Adds database migration to apply default `visibility` and `sort_order` attrs to existing Custom Profile Attributes fields that are missing them. The migration uses cursor-based pagination to process all fields and is idempotent.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-66460

#### Screenshots

N/A - Backend only

#### Release Note

```release-note
Added database migration to apply default attrs to Custom Profile Attributes fields created before defaults were enforced.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>