### PR TITLE
Not allowing empty roles

### DIFF
--- a/server/channels/api4/team.go
+++ b/server/channels/api4/team.go
@@ -1145,7 +1145,7 @@ func updateTeamMemberRoles(c *Context, w http.ResponseWriter, r *http.Request) {
 	props := model.MapFromJSON(r.Body)
 
 	newRoles := props["roles"]
-	if !model.IsValidUserRoles(newRoles) {
+	if !model.IsValidUserRoles(newRoles) || len(strings.TrimSpace(newRoles)) == 0 {
 		c.SetInvalidParam("team_member_roles")
 		return
 	}

--- a/server/channels/api4/team_test.go
+++ b/server/channels/api4/team_test.go
@@ -3345,6 +3345,11 @@ func TestUpdateTeamMemberRoles(t *testing.T) {
 	require.Error(t, err)
 	CheckForbiddenStatus(t, resp)
 
+	// user 1 tries to demote someone by setting empty role
+	resp, err = client.UpdateTeamMemberRoles(context.Background(), th.BasicTeam.Id, th.SystemAdminUser.Id, "")
+	require.Error(t, err)
+	CheckBadRequestStatus(t, resp)
+
 	// system admin promotes user 1
 	_, err = SystemAdminClient.UpdateTeamMemberRoles(context.Background(), th.BasicTeam.Id, th.BasicUser.Id, TeamAdmin)
 	require.NoError(t, err)

--- a/server/public/model/user.go
+++ b/server/public/model/user.go
@@ -852,10 +852,6 @@ func (u *User) GetRawRoles() string {
 func IsValidUserRoles(userRoles string) bool {
 	roles := strings.Fields(userRoles)
 
-	if len(roles) == 0 {
-		return false
-	}
-
 	for _, r := range roles {
 		if !IsValidRoleName(r) {
 			return false

--- a/server/public/model/user_test.go
+++ b/server/public/model/user_test.go
@@ -507,7 +507,6 @@ func TestRoles(t *testing.T) {
 	require.True(t, IsValidUserRoles("team_user"))
 	require.False(t, IsValidUserRoles("system_admin"))
 	require.True(t, IsValidUserRoles("system_user system_admin"))
-	require.False(t, IsValidUserRoles(""))
 
 	require.False(t, IsInRole("system_admin junk", "admin"))
 	require.True(t, IsInRole("system_admin junk", "system_admin"))


### PR DESCRIPTION
#### Summary
Not allowing empty roles. The validation is being performed exclusively in the API layer instead in the shared `IsValidUserRoles` function as empty roles are valid in some scenarios and changing the logic of that function breaks those valid cases. 

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-66092

#### Release Note
```release-note
None
```
