### PR TITLE
fix(avatar): export helper to reuse logic for updating cache

### DIFF
--- a/webapp/channels/src/components/post_profile_picture/post_profile_picture.tsx
+++ b/webapp/channels/src/components/post_profile_picture/post_profile_picture.tsx
@@ -13,7 +13,7 @@ import MattermostLogo from 'components/widgets/icons/mattermost_logo';
 
 import Constants, {UserStatuses} from 'utils/constants';
 import * as PostUtils from 'utils/post_utils';
-import * as Utils from 'utils/utils';
+import {getProfilePictureURL} from 'utils/post_utils';
 
 type Props = {
     availabilityStatusOnPosts: string;
@@ -30,18 +30,6 @@ type Props = {
 export default class PostProfilePicture extends React.PureComponent<Props> {
     static defaultProps = {
         status: UserStatuses.OFFLINE,
-    };
-
-    getProfilePictureURL = (): string => {
-        const {post, user} = this.props;
-
-        if (user && user.id === post.user_id) {
-            return Utils.imageURLForUser(user.id, user.last_picture_update);
-        } else if (post.user_id) {
-            return Utils.imageURLForUser(post.user_id);
-        }
-
-        return '';
     };
 
     getStatus = (fromAutoResponder: boolean, fromWebhook: boolean, user: UserProfile): string | undefined => {
@@ -90,7 +78,7 @@ export default class PostProfilePicture extends React.PureComponent<Props> {
         }
         const fromAutoResponder = PostUtils.fromAutoResponder(post);
 
-        const profileSrc = this.getProfilePictureURL();
+        const profileSrc = getProfilePictureURL(post, user);
         const src = this.getPostIconURL(profileSrc, fromAutoResponder, fromWebhook);
 
         const overrideIconEmoji = ensureString(post.props.override_icon_emoji);

--- a/webapp/channels/src/components/post_view/post_message_preview/avatar/avatar.tsx
+++ b/webapp/channels/src/components/post_view/post_message_preview/avatar/avatar.tsx
@@ -13,7 +13,7 @@ import Avatar from 'components/widgets/users/avatar';
 
 import {Constants} from 'utils/constants';
 import * as PostUtils from 'utils/post_utils';
-import {imageURLForUser} from 'utils/utils';
+import {getProfilePictureURL} from 'utils/post_utils';
 
 type Props = {
     post?: Post;
@@ -40,8 +40,8 @@ export default function PreviewPostAvatar({post, user, enablePostIconOverride, h
             return Constants.DEFAULT_WEBHOOK_LOGO;
         }
 
-        return imageURLForUser(user?.id ?? '');
-    }, [enablePostIconOverride, fromAutoResponder, fromWebhook, hasImageProxy, post?.props, user?.id]);
+        return getProfilePictureURL(post, user);
+    }, [enablePostIconOverride, fromAutoResponder, fromWebhook, hasImageProxy, post, user]);
 
     let avatar = (
         <Avatar

--- a/webapp/channels/src/utils/post_utils.ts
+++ b/webapp/channels/src/utils/post_utils.ts
@@ -43,6 +43,7 @@ import {formatWithRenderer} from 'utils/markdown';
 import MentionableRenderer from 'utils/markdown/mentionable_renderer';
 import {allAtMentions} from 'utils/text_formatting';
 import {isMobile} from 'utils/user_agent';
+import * as Utils from 'utils/utils';
 
 import type {GlobalState} from 'types/store';
 
@@ -854,4 +855,14 @@ export function hasRequestedPersistentNotifications(priority?: PostPriorityMetad
         priority?.priority === PostPriority.URGENT &&
         priority?.persistent_notifications
     );
+}
+
+export function getProfilePictureURL(post?: Post, user?: UserProfile | null): string {
+    if (user && user.id === post?.user_id) {
+        return Utils.imageURLForUser(user.id, user.last_picture_update);
+    } else if (post?.user_id) {
+        return Utils.imageURLForUser(post.user_id);
+    }
+
+    return '';
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
When you change your profile picture, the old one still appears because the cache update logic wasn’t applied in the profile preview avatar.
I extracted the helper in `PostProfilePicture` to reuse the cache update logic. There might be a better long-term solution, such as creating a generic component for handling this.
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
No ticket found, but you may be interested in this fix.
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="861" height="190" alt="image" src="https://github.com/user-attachments/assets/6951d361-7428-4b4f-8fc9-a7e86018002f" /> | <img width="824" height="187" alt="image" src="https://github.com/user-attachments/assets/1f4156da-cef3-466f-a360-528ccfa5c3a4" />|
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
