### PR TITLE
chore(server): bump prepackaged playbooks to v2.5.1

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -172,7 +172,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.2.1
 # download the package from to work. This will no longer be needed when we unify
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
-	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.5.0%2Bc140653-fips
+	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.5.1%2Bfe08fbc-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v1.4.0%2B2f27b68-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.1.7%2Ba980cd2-fips
 endif


### PR DESCRIPTION
#### Summary
Updated the prepackaged playbooks plugin version from v2.5.0 to v2.5.1 in the server Makefile for both standard and FIPS builds.

**Changes:**
- Standard playbooks: v2.5.0 → v2.5.1
- FIPS playbooks: v2.5.0+c140653 → v2.5.1+fe08fbc

**QA Test Steps:**
1. Run `make prepackaged-plugins` to download the plugins
2. Verify that mattermost-plugin-playbooks-v2.5.1.tar.gz is downloaded successfully
3. Build and run the server
4. Verify the playbooks plugin version v2.5.1 is available and loads properly
5. For FIPS builds, verify the FIPS version downloads correctly

#### Ticket Link
N/A

#### Screenshots
N/A

#### Release Note
```release-note
Updated prepackaged Playbooks plugin to version 2.5.1.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)