### PR TITLE
Automated cherry pick of #34386

### DIFF
--- a/server/public/model/custom_profile_attributes_test.go
+++ b/server/public/model/custom_profile_attributes_test.go
@@ -79,7 +79,7 @@ func TestNewCPAFieldFromPropertyField(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "property field with empty attributes",
+			name: "property field with empty attributes returns empty values",
 			propertyField: &PropertyField{
 				ID:       NewId(),
 				GroupID:  CustomProfileAttributesPropertyGroupName,
@@ -89,7 +89,7 @@ func TestNewCPAFieldFromPropertyField(t *testing.T) {
 				UpdateAt: GetMillis(),
 			},
 			wantAttrs: CPAAttrs{
-				Visibility: "",
+				Visibility: "", // Pure conversion, no defaults (defaults provided by app layer)
 				SortOrder:  0,
 				ValueType:  "",
 				Options:    nil,


### PR DESCRIPTION
Cherry pick of #34386 on release-11.1.

/cc  @calebroseland

```release-note
NONE
```