### PR TITLE
Updated Content Flagging migration version update missed during previous PR

### DIFF
--- a/server/channels/app/migrations.go
+++ b/server/channels/app/migrations.go
@@ -28,7 +28,7 @@ const (
 	remainingSchemaMigrationsKey                   = "RemainingSchemaMigrations"
 	postPriorityConfigDefaultTrueMigrationKey      = "PostPriorityConfigDefaultTrueMigrationComplete"
 	contentFlaggingSetupDoneKey                    = "content_flagging_setup_done"
-	contentFlaggingMigrationVersion                = "v4"
+	contentFlaggingMigrationVersion                = "v5"
 
 	contentFlaggingPropertyNameFlaggedPostId       = "flagged_post_id"
 	contentFlaggingPropertyNameStatus              = "status"
@@ -603,7 +603,7 @@ func (s *Server) doPostPriorityConfigDefaultTrueMigration() error {
 func (s *Server) doSetupContentFlaggingProperties() error {
 	// This migration is designed in a way to allow adding more properties in the future.
 	// When a new property needs to be added, add it to the expectedPropertiesMap map and
-	// update the contentFlaggingMigrationVersion to a new value..
+	// update the contentFlaggingMigrationVersion to a new value.
 
 	// If the migration is already marked as completed, don't do it again.
 	var nfErr *store.ErrNotFound

--- a/server/channels/app/migrations_test.go
+++ b/server/channels/app/migrations_test.go
@@ -14,8 +14,8 @@ func TestDoSetupContentFlaggingProperties(t *testing.T) {
 	t.Run("should register property group and fields", func(t *testing.T) {
 		//we need to call the Setup method and run the full setup instead of
 		//just creating a new server via NewServer() because the Setup method
-		//also care of using the correct database DSN based on environment,
-		//setting up the store and initializing services used in store such as property services.
+		//also takes care of using the correct database DSN based on environment,
+		//settings, setting up the store and initializing services used in store such as property services.
 		th := Setup(t)
 		defer th.TearDown()
 
@@ -27,6 +27,10 @@ func TestDoSetupContentFlaggingProperties(t *testing.T) {
 		propertyFields, err := th.Server.propertyService.SearchPropertyFields(group.ID, model.PropertyFieldSearchOpts{PerPage: 100})
 		require.NoError(t, err)
 		require.Len(t, propertyFields, 11)
+
+		data, err := th.Store.System().GetByName(contentFlaggingSetupDoneKey)
+		require.NoError(t, err)
+		require.Equal(t, "v5", data.Value)
 	})
 
 	t.Run("the migration is idempotent", func(t *testing.T) {
@@ -48,5 +52,9 @@ func TestDoSetupContentFlaggingProperties(t *testing.T) {
 		propertyFields, err := th.Server.propertyService.SearchPropertyFields(group.ID, model.PropertyFieldSearchOpts{PerPage: 100})
 		require.NoError(t, err)
 		require.Len(t, propertyFields, 11)
+
+		data, err := th.Store.System().GetByName(contentFlaggingSetupDoneKey)
+		require.NoError(t, err)
+		require.Equal(t, "v5", data.Value)
 	})
 }


### PR DESCRIPTION
#### Summary
When I added a new properties field in https://github.com/mattermost/mattermost/pull/34162 , I missed updating the data migration version. This caused an issue where an upgraded server didn't get the new field setup in database, causing content flagging to panic.

I have not updated the version and included the expected data migration version key in the tests

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-66499

#### Release Note
```release-note
None
```
