### PR TITLE
Remove context.Context from Store

### DIFF
--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -17051,10 +17051,6 @@ func (s *RetryLayer) MarkSystemRanUnitTests() {
 	s.Store.MarkSystemRanUnitTests()
 }
 
-func (s *RetryLayer) SetContext(context context.Context) {
-	s.Store.SetContext(context)
-}
-
 func (s *RetryLayer) TotalMasterDbConnections() int {
 	return s.Store.TotalMasterDbConnections()
 }

--- a/server/channels/store/sqlstore/store.go
+++ b/server/channels/store/sqlstore/store.go
@@ -4,7 +4,6 @@
 package sqlstore
 
 import (
-	"context"
 	"database/sql"
 	"fmt"
 	"path"
@@ -130,7 +129,6 @@ type SqlStore struct {
 	stores            SqlStoreStores
 	settings          *model.SqlSettings
 	lockedToMaster    bool
-	context           context.Context
 	license           *model.License
 	licenseMutex      sync.RWMutex
 	logger            mlog.LoggerIFace
@@ -267,14 +265,6 @@ func New(settings model.SqlSettings, logger mlog.LoggerIFace, metrics einterface
 	store.stores.preference.(*SqlPreferenceStore).deleteUnusedFeatures()
 
 	return store, nil
-}
-
-func (ss *SqlStore) SetContext(context context.Context) {
-	ss.context = context
-}
-
-func (ss *SqlStore) Context() context.Context {
-	return ss.context
 }
 
 func (ss *SqlStore) Logger() mlog.LoggerIFace {

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -82,8 +82,6 @@ type Store interface {
 	ReplicaLagTime() error
 	ReplicaLagAbs() error
 	CheckIntegrity() <-chan model.IntegrityCheckResult
-	SetContext(context context.Context)
-	Context() context.Context
 	Logger() mlog.LoggerIFace
 	NotifyAdmin() NotifyAdminStore
 	PostPriority() PostPriorityStore

--- a/server/channels/store/storetest/mocks/PostStore.go
+++ b/server/channels/store/storetest/mocks/PostStore.go
@@ -1224,9 +1224,9 @@ func (_m *PostStore) RefreshPostStats() error {
 	return r0
 }
 
-// Restore provides a mock function with given fields: post, deletedBy, statusFieldId
-func (_m *PostStore) RestoreContentFlaggedPost(post *model.Post, deletedBy string, statusFieldId string) error {
-	ret := _m.Called(post, deletedBy, statusFieldId)
+// RestoreContentFlaggedPost provides a mock function with given fields: post, statusFieldId, contentFlaggingManagedFieldId
+func (_m *PostStore) RestoreContentFlaggedPost(post *model.Post, statusFieldId string, contentFlaggingManagedFieldId string) error {
+	ret := _m.Called(post, statusFieldId, contentFlaggingManagedFieldId)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RestoreContentFlaggedPost")
@@ -1234,7 +1234,7 @@ func (_m *PostStore) RestoreContentFlaggedPost(post *model.Post, deletedBy strin
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(*model.Post, string, string) error); ok {
-		r0 = rf(post, deletedBy, statusFieldId)
+		r0 = rf(post, statusFieldId, contentFlaggingManagedFieldId)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/server/channels/store/storetest/mocks/Store.go
+++ b/server/channels/store/storetest/mocks/Store.go
@@ -5,8 +5,6 @@
 package mocks
 
 import (
-	context "context"
-
 	mlog "github.com/mattermost/mattermost/server/public/shared/mlog"
 	mock "github.com/stretchr/testify/mock"
 
@@ -283,26 +281,6 @@ func (_m *Store) ContentFlagging() store.ContentFlaggingStore {
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.ContentFlaggingStore)
-		}
-	}
-
-	return r0
-}
-
-// Context provides a mock function with no fields
-func (_m *Store) Context() context.Context {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for Context")
-	}
-
-	var r0 context.Context
-	if rf, ok := ret.Get(0).(func() context.Context); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(context.Context)
 		}
 	}
 
@@ -1127,11 +1105,6 @@ func (_m *Store) Session() store.SessionStore {
 	}
 
 	return r0
-}
-
-// SetContext provides a mock function with given fields: _a0
-func (_m *Store) SetContext(_a0 context.Context) {
-	_m.Called(_a0)
 }
 
 // SharedChannel provides a mock function with no fields

--- a/server/channels/store/storetest/store.go
+++ b/server/channels/store/storetest/store.go
@@ -4,7 +4,6 @@
 package storetest
 
 import (
-	"context"
 	"database/sql"
 	"time"
 
@@ -58,7 +57,6 @@ type Store struct {
 	ProductNoticesStore             mocks.ProductNoticesStore
 	DraftStore                      mocks.DraftStore
 	logger                          mlog.LoggerIFace
-	context                         context.Context
 	NotifyAdminStore                mocks.NotifyAdminStore
 	PostPriorityStore               mocks.PostPriorityStore
 	PostAcknowledgementStore        mocks.PostAcknowledgementStore
@@ -74,8 +72,6 @@ type Store struct {
 	ContentFlaggingStore            mocks.ContentFlaggingStore
 }
 
-func (s *Store) SetContext(context context.Context)            { s.context = context }
-func (s *Store) Context() context.Context                      { return s.context }
 func (s *Store) Logger() mlog.LoggerIFace                      { return s.logger }
 func (s *Store) Team() store.TeamStore                         { return &s.TeamStore }
 func (s *Store) Channel() store.ChannelStore                   { return &s.ChannelStore }

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -13445,10 +13445,6 @@ func (s *TimerLayer) MarkSystemRanUnitTests() {
 	s.Store.MarkSystemRanUnitTests()
 }
 
-func (s *TimerLayer) SetContext(context context.Context) {
-	s.Store.SetContext(context)
-}
-
 func (s *TimerLayer) TotalMasterDbConnections() int {
 	return s.Store.TotalMasterDbConnections()
 }


### PR DESCRIPTION
#### Summary
This PR removes the `context.Context` from the Store struct. It was used for request tracing, which we removed a few releases ago.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
