### PR TITLE
Stop desktop token infinite redirect

### DIFF
--- a/webapp/channels/src/components/desktop_auth_token.tsx
+++ b/webapp/channels/src/components/desktop_auth_token.tsx
@@ -11,6 +11,7 @@ import {useHistory, useLocation} from 'react-router-dom';
 import {loginWithDesktopToken} from 'actions/views/login';
 
 import DesktopApp from 'utils/desktop_api';
+import {isDesktopApp} from 'utils/user_agent';
 
 import './desktop_auth_token.scss';
 
@@ -98,7 +99,7 @@ const DesktopAuthToken: React.FC<Props> = ({href, onLogin}: Props) => {
         if (serverToken) {
             if (storedClientToken) {
                 tryDesktopLogin();
-            } else {
+            } else if (!isDesktopApp()) {
                 forwardToDesktopApp();
             }
             return;


### PR DESCRIPTION
#### Summary
There is an edge case with the Desktop App login flow in which it is possible for the user to open the returning deep link (with the server token) in the wrong Desktop App (when a user may have more than one app installed). This leads to an issue in which the login flow, without a client token will repeatedly try to forward to the Desktop App (which is itself) due to having a server token (but missing a client one).

This PR stops the app from trying to forward to the Desktop App when we are already in the Desktop App to avoid the possible infinite redirect.

```release-note
Stop desktop token infinite redirect when the wrong app is opened
```
