### PR TITLE
[MM-66547] Restore expanded view button alongside popout button

### DIFF
--- a/webapp/channels/src/sass/layout/_sidebar-right.scss
+++ b/webapp/channels/src/sass/layout/_sidebar-right.scss
@@ -120,10 +120,6 @@
         }
     }
 
-    .PopoutButton + .sidebar--right__expand {
-        display: none;
-    }
-
     .sidebar--right__title {
         display: flex;
         height: auto;


### PR DESCRIPTION
#### Summary
We've decided to restore the expanded view button with the popouts changes, we will look into a way to clean up the RHS header for threads in a future release.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66547

#### Screenshots
<img width="524" height="90" alt="image" src="https://github.com/user-attachments/assets/093ad882-baa6-4eae-96d7-369df68e6119" />

```release-note
NONE
```
