### PR TITLE
Prepackage Calls v1.11.0 (release 10.12)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -142,7 +142,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.10.0
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.0
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.10.0
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.3.0


### PR DESCRIPTION
#### Summary

Manual cherry-pick of [#34399](https://github.com/mattermost/mattermost/pull/34399) into release `10.12`.

#### Release Note

```release-note
Prepackage Calls v1.11.0
```
