### PR TITLE
Added scheduled task logs

### DIFF
--- a/server/public/model/scheduled_task.go
+++ b/server/public/model/scheduled_task.go
@@ -6,6 +6,8 @@ package model
 import (
 	"fmt"
 	"time"
+
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
 )
 
 type TaskFunc func()
@@ -69,8 +71,10 @@ func createTask(name string, function TaskFunc, interval time.Duration, recurrin
 			select {
 			case <-firstTick:
 				ticker = time.NewTicker(interval)
+				mlog.Debug("Executing scheduled task for first time", mlog.String("task", task.Name), mlog.String("interval", task.Interval.String()))
 				function()
 			case <-ticker.C:
+				mlog.Debug("Executing recurring task", mlog.String("task", task.Name), mlog.String("interval", task.Interval.String()))
 				function()
 			case <-task.cancel:
 				return


### PR DESCRIPTION
#### Summary
Added debug logs to `createTask` function that log the running task's name and interval on each run. This is helpful when debugging issues with a recurring task.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-66556

#### Release Note
```release-note
None
```
