### PR TITLE
Fix PluginHTTPStream request body closing before read

### DIFF
--- a/server/channels/app/plugin_api_test.go
+++ b/server/channels/app/plugin_api_test.go
@@ -1768,7 +1768,6 @@ func TestInterpluginPluginHTTP(t *testing.T) {
 func TestInterpluginPluginHTTPWithBodyAfterWriteHeader(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t)
-	defer th.TearDown()
 
 	setupMultiPluginAPITest(t,
 		[]string{

--- a/server/public/plugin/client_rpc.go
+++ b/server/public/plugin/client_rpc.go
@@ -692,8 +692,11 @@ func (s *apiRPCServer) PluginHTTPStream(args *Z_PluginHTTPStreamArgs, returns *Z
 				}
 				responseConnection.Close()
 			}()
+		} else {
+			r.Body.Close()
 		}
 	} else {
+		r.Body.Close()
 		return encodableError(fmt.Errorf("API PluginHTTP called but not implemented"))
 	}
 


### PR DESCRIPTION
#### Summary
Fixes a regression in PluginHTTPStream where the request body was closed prematurely if WriteHeader was called before reading the body. This affected plugins using POST requests for inter-plugin communication.

The issue occurred because `defer r.Body.Close()` was in the main function scope, causing it to execute immediately after starting the response goroutine. This fix moves it into the goroutine to ensure the request body remains available until after response processing completes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66357
Fixes https://github.com/mattermost/mattermost/pull/34366#issuecomment-2537803488

#### Release Note
```release-note
NONE
```