### PR TITLE
MM-66410 - standardize abac suggestions

### DIFF
--- a/webapp/channels/src/components/admin_console/access_control/editors/cel_editor/editor.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/editors/cel_editor/editor.tsx
@@ -379,7 +379,12 @@ function CELEditor({
                         <HelpText
                             message={intl.formatMessage({
                                 id: 'admin.access_control.cel.help_text',
-                                defaultMessage: 'Write rules like `user.attributes.<attribute> == <value>`. Use `&&` / `||` (and/or) for multiple conditions. Group conditions with `()`.',
+                                defaultMessage: 'Write rules like `user.attributes.{lessThan}attribute{greaterThan} == {lessSign}value{greaterSign}`. Use `&&` / `||` (and/or) for multiple conditions. Group conditions with `()`.',
+                            }, {
+                                lessThan: '<',
+                                greaterThan: '>',
+                                lessSign: '<',
+                                greaterSign: '>',
                             })}
                             onLearnMoreClick={() => setShowHelpModal(true)}
                         />

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -261,7 +261,7 @@
   "admin.access_control.cel_help_modal.important_notes_title": "Important Notes",
   "admin.access_control.cel_help_modal.subheader": "With CEL you can define conditions to filter user attributes and control resource access.",
   "admin.access_control.cel_help_modal.title": "Common Expression Language (CEL)",
-  "admin.access_control.cel.help_text": "Write rules like `user.attributes.<attribute> == <value>`. Use `&&` / `||` (and/or) for multiple conditions. Group conditions with `()`.",
+  "admin.access_control.cel.help_text": "Write rules like `user.attributes.{lessThan}attribute{greaterThan} == {lessSign}value{greaterSign}`. Use `&&` / `||` (and/or) for multiple conditions. Group conditions with `()`.",
   "admin.access_control.cel.incomplete_expression": "Incomplete expression, awaiting input...",
   "admin.access_control.cel.line_and_column_number": "L{lineNumber}:{columnNumber}",
   "admin.access_control.cel.type_expression": "Type an expression...",


### PR DESCRIPTION

#### Summary
in system console > abac > advanced rule editor the text help and the placeholder were different potentially causing confusion. This PR modified the text to make it clear.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66410

#### Screenshots
Before:
<img width="321" height="187" alt="Screenshot 2025-11-10 at 7 55 05 PM" src="https://github.com/user-attachments/assets/500ee168-9801-4735-ba9a-4d8473a2d466" />

after:
<img width="941" height="418" alt="Screenshot 2025-11-10 at 7 13 37 PM" src="https://github.com/user-attachments/assets/f0321894-b07a-4dc2-814f-baff1259bf59" />


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
