### PR TITLE
Fix inconsistent terminology for revoking user sessions (#MM-66613)

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/enterprise/guest_accounts/system_console_manage_guest_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/enterprise/guest_accounts/system_console_manage_guest_spec.ts
@@ -66,7 +66,7 @@ describe('Guest Account - Verify Manage Guest Users', () => {
         cy.get('#systemUsersTable-cell-0_actionsColumn').should('have.text', 'Guest').click();
 
         // * Verify the manage options which should be displayed for Guest User
-        const includeOptions = ['Deactivate', 'Manage roles', 'Manage teams', 'Reset password', 'Update email', 'Promote to member', 'Remove sessions'];
+        const includeOptions = ['Deactivate', 'Manage roles', 'Manage teams', 'Reset password', 'Update email', 'Promote to member', 'Revoke sessions'];
         includeOptions.forEach((includeOption) => {
             cy.findByText(includeOption).should('be.visible');
         });
@@ -102,7 +102,7 @@ describe('Guest Account - Verify Manage Guest Users', () => {
     it('MM-18048 Revoke Session of a Guest User and Verify', () => {
         // # Click on the Revoke Session option
         cy.get('#systemUsersTable-cell-0_actionsColumn').should('have.text', 'Guest').click();
-        cy.findByText('Remove sessions').click();
+        cy.findByText('Revoke sessions').click();
 
         // * Verify the confirmation message displayed
         cy.get('#confirmModal').should('be.visible').within(() => {

--- a/e2e-tests/playwright/specs/functional/system_console/system_users/actions.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/system_users/actions.spec.ts
@@ -191,7 +191,7 @@ test('MM-T5520-6 should revoke sessions', async ({pw}) => {
 
     // # Open menu and revoke sessions
     await systemConsolePage.systemUsers.actionMenuButtons[0].click();
-    const removeSessions = await systemConsolePage.systemUsersActionMenus[0].getMenuItem('Remove sessions');
+    const removeSessions = await systemConsolePage.systemUsersActionMenus[0].getMenuItem('Revoke sessions');
     await removeSessions.click();
 
     // # Press confirm on the modal

--- a/webapp/channels/src/components/widgets/inputs/dropdown_input_hybrid.tsx
+++ b/webapp/channels/src/components/widgets/inputs/dropdown_input_hybrid.tsx
@@ -233,7 +233,7 @@ const DropdownInputHybrid = <T extends OptionType = OptionType>(props: Props<T>)
                         placeholder={focused ? '' : formatAsString(intl.formatMessage, placeholder)}
                         components={{
                             IndicatorsContainer,
-                            Option,
+                            Option: Option as React.ComponentType<OptionProps<T, false, GroupBase<T>>>,
                             Control,
                         }}
                         className={classNames('Input', className, {Input__focus: showLegend})}

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -2960,7 +2960,7 @@
   "admin.system_users.list.actions.menu.manageTokens": "Manage tokens",
   "admin.system_users.list.actions.menu.promoteToMember": "Promote to member",
   "admin.system_users.list.actions.menu.removeMFA": "Remove MFA",
-  "admin.system_users.list.actions.menu.removeSessions": "Remove sessions",
+  "admin.system_users.list.actions.menu.removeSessions": "Revoke sessions",
   "admin.system_users.list.actions.menu.resetAttempts": "Reset login attempts",
   "admin.system_users.list.actions.menu.resetPassword": "Reset password",
   "admin.system_users.list.actions.menu.resyncUserViaLdapGroups": "Re-sync user via LDAP groups",


### PR DESCRIPTION
#### Summary
Changed "Remove sessions" to "Revoke sessions" in System Console menu to match modal and API terminology.

<img width="456" height="806" alt="CleanShot 2025-11-12 at 10 59 22@2x" src="https://github.com/user-attachments/assets/5ed40a6b-85a1-4a67-ab18-dbc2e4851039" />

Also fixed pre-existing TypeScript error in `dropdown_input_hybrid` component.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-66613

#### Release Note
```release-note
NONE
```

~ Claude