### PR TITLE
Fix /api/v4/posts/ids/reactions description

### DIFF
--- a/api/v4/source/reactions.yaml
+++ b/api/v4/source/reactions.yaml
@@ -107,7 +107,7 @@
         - reactions
       summary: Bulk get the reaction for posts
       description: |
-        Get a list of reactions made by all users to a given post.
+        Get a list of reactions made by all users to the given posts.
         ##### Permissions
         Must have `read_channel` permission for the channel the post is in.
 


### PR DESCRIPTION
#### Summary
This is a documentation only change. 
[GetBulkReactions](https://developers.mattermost.com/api-documentation/#/operations/GetBulkReactions) documentation says `Get a list of reactions made by all users to a given post.` while the given parameter is a list of posts.

#### Ticket Link
No ticket, minor change.

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```
