### PR TITLE
Fix: correct force_notification prop type to boolean

### DIFF
--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -232,7 +232,7 @@ func (a *App) CreatePost(rctx request.CTX, post *model.Post, channel *model.Chan
 	}
 
 	if flags.ForceNotification {
-		post.AddProp(model.PostPropsForceNotification, model.NewId())
+		post.AddProp(model.PostPropsForceNotification, true)
 	}
 
 	if rctx.Session().IsOAuth {


### PR DESCRIPTION
#### Summary
This PR fixes a type mismatch warning appearing in the server logs.

The Issue: The logs showed force_notification prop must be a boolean, but the code was passing model.NewId() (which generates a  String).

The Fix: I updated server/channels/app/post.go to pass true instead of a string ID when flags.ForceNotification is enabled, which satisfies the expected boolean type.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/34379

#### Screenshots
 N/A (Backend fix only)

#### Release Note

```release-note
Fixed a type mismatch warning in server logs where `force_notification` was incorrectly set to a string ID instead of a boolean.
```
