### PR TITLE
Fix failing playwright tests

### DIFF
--- a/e2e-tests/playwright/specs/functional/channels/channel_banner/channel_banner.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/channel_banner/channel_banner.spec.ts
@@ -20,7 +20,7 @@ test('Should show channel banner when configured', async ({pw}) => {
 
     await configurationTab.enableChannelBanner();
     await configurationTab.setChannelBannerText('Example channel banner text');
-    await configurationTab.setChannelBannerTextColor('#77DD88');
+    await configurationTab.setChannelBannerTextColor('77DD88');
 
     await configurationTab.save();
     await channelSettingsModal.close();
@@ -65,7 +65,7 @@ test('Should render markdown', async ({pw}) => {
 
     await configurationTab.enableChannelBanner();
     await configurationTab.setChannelBannerText('**bold** *italic* ~~strikethrough~~');
-    await configurationTab.setChannelBannerTextColor('#77DD88');
+    await configurationTab.setChannelBannerTextColor('77DD88');
 
     await configurationTab.save();
     await channelSettingsModal.close();

--- a/e2e-tests/playwright/specs/functional/system_console/mobile_security.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/mobile_security.spec.ts
@@ -162,7 +162,10 @@ test('should show mobile security upsell when not licensed', async ({pw}) => {
 
     const license = await adminClient.getClientLicenseOld();
 
-    test.skip(license.SkuShortName === 'enterprise', 'Skipping test - server has enterprise license');
+    test.skip(
+        license.SkuShortName !== 'enterprise' || license.short_sku_name !== 'advanced',
+        'Skipping test - server has no enterprise or enterprise advanced license',
+    );
 
     if (!adminUser) {
         throw new Error('Failed to create admin user');


### PR DESCRIPTION
This pull request makes minor updates to the Playwright end-to-end tests for channel banners and mobile security upsell logic. 


```release-note
NONE
```
