### PR TITLE
feat: add slash-command title style

### DIFF
--- a/webapp/channels/src/sass/components/_suggestion-list.scss
+++ b/webapp/channels/src/sass/components/_suggestion-list.scss
@@ -127,6 +127,11 @@
     line-height: 1;
 }
 
+.slash-command__title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .slash-command__desc {
     overflow: hidden;
     margin: 2px 0 0;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

add .slash-command__title style

I noticed that despite the existence of this class, it was not actually described, in certain cases the text went beyond the limits


#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/34542

#### Screenshots

|  before  |  after  |
|<img width="602" height="378" alt="image" src="https://github.com/user-attachments/assets/00e5d7da-af9a-4554-95c6-4ed9bd0f1fa7" />|<img width="602" height="378" alt="image" src="https://github.com/user-attachments/assets/325ed2a8-c2a3-44a8-80be-72efaea40604" />|
| <insert before screenshot here> | <insert after screenshot here> |


#### Release Note
```release-note
fix  slash-command__title text overflow
```
