### PR TITLE
Fix quick reaction emoji display in "Followed Threads" view

### DIFF
--- a/webapp/channels/src/components/post/index.tsx
+++ b/webapp/channels/src/components/post/index.tsx
@@ -193,7 +193,6 @@ function makeMapStateToProps() {
             recentEmojis: emojis,
             center: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT) === Preferences.CHANNEL_DISPLAY_MODE_CENTERED,
             isCollapsedThreadsEnabled: isCollapsedThreadsEnabled(state),
-            isExpanded: state.views.rhs.isSidebarExpanded,
             isPostBeingEdited: ownProps.location === Locations.CENTER ? !getIsPostBeingEditedInRHS(state, post.id) && getIsPostBeingEdited(state, post.id) : getIsPostBeingEditedInRHS(state, post.id),
             isMobileView: getIsMobileView(state),
             previewCollapsed,

--- a/webapp/channels/src/components/post/post_options.test.tsx
+++ b/webapp/channels/src/components/post/post_options.test.tsx
@@ -1,0 +1,142 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {renderWithContext} from 'tests/react_testing_utils';
+import {Locations} from 'utils/constants';
+import {TestHelper} from 'utils/test_helper';
+
+import PostOptions from './post_options';
+
+// Mock PostRecentReactions to capture the size prop
+jest.mock('components/post_view/post_recent_reactions', () => {
+    return jest.fn((props: {size: number}) => (
+        <div
+            data-testid='post-recent-reactions'
+            data-size={props.size}
+        />
+    ));
+});
+
+describe('PostOptions - Emoji count based on container width', () => {
+    const baseProps = {
+        post: TestHelper.getPostMock({type: '', state: undefined}),
+        teamId: 'team-id',
+        isFlagged: false,
+        removePost: jest.fn(),
+        enableEmojiPicker: true,
+        isReadOnly: false,
+        channelIsArchived: false,
+        handleDropdownOpened: jest.fn(),
+        collapsedThreadsEnabled: false,
+        shouldShowActionsMenu: false,
+        oneClickReactionsEnabled: false,
+        recentEmojis: [],
+        hover: true,
+        isMobileView: false,
+        location: Locations.CENTER,
+        pluginActions: [],
+        isPostBeingEdited: false,
+        actions: {
+            emitShortcutReactToLastPostFrom: jest.fn(),
+        },
+    };
+
+    const propsWithReactions = {
+        ...baseProps,
+        oneClickReactionsEnabled: true,
+        recentEmojis: [
+            TestHelper.getSystemEmojiMock({name: 'thumbsup', short_name: 'thumbsup'}),
+            TestHelper.getSystemEmojiMock({name: 'fire', short_name: 'fire'}),
+            TestHelper.getSystemEmojiMock({name: 'heart', short_name: 'heart'}),
+        ],
+    };
+
+    test('should show 3 emojis when container width > SIDEBAR_MINIMUM_WIDTH (640px)', () => {
+        const mockGetBoundingClientRect = jest.fn(() => ({
+            width: 800,
+            height: 0,
+            top: 0,
+            left: 0,
+            bottom: 0,
+            right: 0,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+        }));
+
+        const WrapperComponent = () => {
+            const postRef = React.useRef<HTMLDivElement>(null);
+
+            React.useEffect(() => {
+                if (postRef.current) {
+                    postRef.current.getBoundingClientRect = mockGetBoundingClientRect;
+                }
+            }, []);
+
+            return (
+                <div
+                    ref={postRef}
+                    className='post'
+                >
+                    <PostOptions {...propsWithReactions}/>
+                </div>
+            );
+        };
+
+        const {container, rerender} = renderWithContext(<WrapperComponent/>);
+        rerender(<WrapperComponent/>);
+
+        const reactionsComponent = container.querySelector('[data-testid="post-recent-reactions"]');
+        expect(reactionsComponent).toBeInTheDocument();
+        expect(reactionsComponent?.getAttribute('data-size')).toBe('3');
+    });
+
+    test('should show 1 emoji when container width <= SIDEBAR_MINIMUM_WIDTH (640px)', () => {
+        const mockGetBoundingClientRect = jest.fn(() => ({
+            width: 500,
+            height: 0,
+            top: 0,
+            left: 0,
+            bottom: 0,
+            right: 0,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+        }));
+
+        const WrapperComponent = () => {
+            const postRef = React.useRef<HTMLDivElement>(null);
+
+            React.useEffect(() => {
+                if (postRef.current) {
+                    postRef.current.getBoundingClientRect = mockGetBoundingClientRect;
+                }
+            }, []);
+
+            return (
+                <div
+                    ref={postRef}
+                    className='post'
+                >
+                    <PostOptions {...propsWithReactions}/>
+                </div>
+            );
+        };
+
+        const {container, rerender} = renderWithContext(<WrapperComponent/>);
+        rerender(<WrapperComponent/>);
+
+        const reactionsComponent = container.querySelector('[data-testid="post-recent-reactions"]');
+        expect(reactionsComponent).toBeInTheDocument();
+        expect(reactionsComponent?.getAttribute('data-size')).toBe('1');
+    });
+
+    test('should show 1 emoji when no .post parent is found (default case)', () => {
+        const {container} = renderWithContext(<PostOptions {...propsWithReactions}/>);
+        const reactionsComponent = container.querySelector('[data-testid="post-recent-reactions"]');
+        expect(reactionsComponent).toBeInTheDocument();
+        expect(reactionsComponent?.getAttribute('data-size')).toBe('1');
+    });
+});

--- a/webapp/channels/src/components/post/post_options.tsx
+++ b/webapp/channels/src/components/post/post_options.tsx
@@ -41,7 +41,6 @@ type Props = {
     shouldShowActionsMenu?: boolean;
     oneClickReactionsEnabled?: boolean;
     recentEmojis: Emoji[];
-    isExpanded?: boolean;
     hover?: boolean;
     isMobileView: boolean;
     hasReplies?: boolean;
@@ -64,6 +63,7 @@ const PostOptions = (props: Props): JSX.Element => {
     const [showEmojiPicker, setShowEmojiPicker] = useState(false);
     const [showDotMenu, setShowDotMenu] = useState(false);
     const [showActionsMenu, setShowActionsMenu] = useState(false);
+    const postOptionsRef = useRef<HTMLUListElement>(null);
 
     const toggleEmojiPicker = useCallback((show: boolean) => {
         setShowEmojiPicker(show);
@@ -143,13 +143,11 @@ const PostOptions = (props: Props): JSX.Element => {
 
     let showRecentReactions: ReactNode;
     if (showRecentlyUsedReactions) {
-        const threadViewContainer = document.getElementById('sidebar-right');
-        const followingThreadContainer = document.getElementById('thread-pane-container');
-        const containerWidth = (threadViewContainer ?? followingThreadContainer)?.getBoundingClientRect().width ?? 0;
+        // Find the nearest .post parent to determine available width
+        const postContainer = postOptionsRef.current?.closest('.post');
+        const containerWidth = postContainer?.getBoundingClientRect().width ?? 0;
 
-        const showMoreReactions = props.isExpanded ||
-            props.location === 'CENTER' ||
-            containerWidth > Constants.SIDEBAR_MINIMUM_WIDTH;
+        const showMoreReactions = containerWidth > Constants.SIDEBAR_MINIMUM_WIDTH;
 
         showRecentReactions = (
             <PostRecentReactions
@@ -291,6 +289,7 @@ const PostOptions = (props: Props): JSX.Element => {
     } else if (!props.isPostBeingEdited) {
         options = (
             <ul
+                ref={postOptionsRef}
                 data-testid={`post-menu-${props.post.id}`}
                 className={classnames('col post-menu', {'post-menu--position': !hoverLocal && showCommentIcon})}
             >

--- a/webapp/channels/src/components/post/post_options.tsx
+++ b/webapp/channels/src/components/post/post_options.tsx
@@ -143,9 +143,13 @@ const PostOptions = (props: Props): JSX.Element => {
 
     let showRecentReactions: ReactNode;
     if (showRecentlyUsedReactions) {
+        const threadViewContainer = document.getElementById('sidebar-right');
+        const followingThreadContainer = document.getElementById('thread-pane-container');
+        const containerWidth = (threadViewContainer ?? followingThreadContainer)?.getBoundingClientRect().width ?? 0;
+
         const showMoreReactions = props.isExpanded ||
             props.location === 'CENTER' ||
-            (document.getElementById('sidebar-right')?.getBoundingClientRect().width ?? 0) > Constants.SIDEBAR_MINIMUM_WIDTH;
+            containerWidth > Constants.SIDEBAR_MINIMUM_WIDTH;
 
         showRecentReactions = (
             <PostRecentReactions


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->


#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

Previously, the quick reaction menu in the "Followed Threads" view only showed a single emoji. The root cause was that the component was still using the default container, which was undefined in this context.

This PR updates the logic to use whichever container is defined, ensuring the quick reaction menu displays correctly based on available space.

Changes:

Use the first defined container for quick reactions instead of defaulting to undefined.

Ensures consistent emoji menu behavior across standard threads and "Followed Threads" view.

Testing:

Hover over messages in both standard threads and "Followed Threads" view.

Verify multiple emojis appear when thread width allows.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

https://github.com/mattermost/mattermost/issues/34545

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->
|  before  |  after  |
|----|----|
| <img width="1074" height="1071" alt="image" src="https://github.com/user-attachments/assets/4a0ce00b-481a-4442-9f14-b85e78d0b217" /> | <img width="1071" height="1074" alt="image" src="https://github.com/user-attachments/assets/23bf5fc5-ed2f-4804-864d-0ccdcb8b75c9" /> |



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Quick reaction menu now correctly shows multiple emojis in "Followed Threads" view
```
