### PR TITLE
Update FIPS flavour of Agents to v1.6.1

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -173,7 +173,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.5.1%2Bfe08fbc-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v1.6.0%2B79cbc7d-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v1.6.1%2B468a918-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.1%2Bdf49b26-fips
 endif
 


### PR DESCRIPTION
#### Summary
Update FIPS flavour of Agents to v1.6.1. Corresponding PR for the non-FIPS flavour: https://github.com/mattermost/mattermost/pull/34549

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66395

#### Screenshots
--

#### Release Note
```release-note
NONE
```
