### PR TITLE
[MM-66707] Fix 500 error when agents plugin isn't active or installed

### DIFF
--- a/server/channels/app/agents.go
+++ b/server/channels/app/agents.go
@@ -4,10 +4,17 @@
 package app
 
 import (
+	"github.com/blang/semver/v4"
+
 	agentclient "github.com/mattermost/mattermost-plugin-ai/public/bridgeclient"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/public/shared/request"
+)
+
+const (
+	aiPluginID                  = "mattermost-ai"
+	minAIPluginVersionForBridge = "1.5.0"
 )
 
 // getBridgeClient returns a bridge client for making requests to the plugin bridge API
@@ -15,8 +22,64 @@ func (a *App) getBridgeClient(userID string) *agentclient.Client {
 	return agentclient.NewClientFromApp(a, userID)
 }
 
+// isAIPluginBridgeAvailable checks if the mattermost-ai plugin is active and supports the bridge API (v1.5.0+)
+func (a *App) isAIPluginBridgeAvailable(rctx request.CTX) bool {
+	pluginsEnvironment := a.GetPluginsEnvironment()
+	if pluginsEnvironment == nil {
+		rctx.Logger().Debug("AI plugin bridge not available - plugin environment not initialized")
+		return false
+	}
+
+	// Check if plugin is active
+	if !pluginsEnvironment.IsActive(aiPluginID) {
+		rctx.Logger().Debug("AI plugin bridge not available - plugin is not active or not installed",
+			mlog.String("plugin_id", aiPluginID),
+		)
+		return false
+	}
+
+	// Get the plugin's manifest to check version
+	plugins := pluginsEnvironment.Active()
+	for _, plugin := range plugins {
+		if plugin.Manifest != nil && plugin.Manifest.Id == aiPluginID {
+			pluginVersion, err := semver.Parse(plugin.Manifest.Version)
+			if err != nil {
+				rctx.Logger().Debug("AI plugin bridge not available - failed to parse plugin version",
+					mlog.String("plugin_id", aiPluginID),
+					mlog.String("version", plugin.Manifest.Version),
+					mlog.Err(err),
+				)
+				return false
+			}
+
+			minVersion, err := semver.Parse(minAIPluginVersionForBridge)
+			if err != nil {
+				return false
+			}
+
+			if pluginVersion.LT(minVersion) {
+				rctx.Logger().Debug("AI plugin bridge not available - plugin version is too old",
+					mlog.String("plugin_id", aiPluginID),
+					mlog.String("current_version", plugin.Manifest.Version),
+					mlog.String("minimum_version", minAIPluginVersionForBridge),
+				)
+				return false
+			}
+
+			return true
+		}
+	}
+
+	return false
+}
+
 // GetAgents retrieves all available agents from the bridge API
 func (a *App) GetAgents(rctx request.CTX, userID string) ([]agentclient.BridgeAgentInfo, *model.AppError) {
+	// Check if the AI plugin is active and supports the bridge API (v1.5.0+)
+	if !a.isAIPluginBridgeAvailable(rctx) {
+		return []agentclient.BridgeAgentInfo{}, nil
+	}
+
 	// Create bridge client
 	sessionUserID := ""
 	if session := rctx.Session(); session != nil {
@@ -38,6 +101,11 @@ func (a *App) GetAgents(rctx request.CTX, userID string) ([]agentclient.BridgeAg
 
 // GetLLMServices retrieves all available LLM services from the bridge API
 func (a *App) GetLLMServices(rctx request.CTX, userID string) ([]agentclient.BridgeServiceInfo, *model.AppError) {
+	// Check if the AI plugin is active and supports the bridge API (v1.5.0+)
+	if !a.isAIPluginBridgeAvailable(rctx) {
+		return []agentclient.BridgeServiceInfo{}, nil
+	}
+
 	// Create bridge client
 	sessionUserID := ""
 	if session := rctx.Session(); session != nil {


### PR DESCRIPTION
#### Summary
The Agents Bridge was 500ing instead of gracefully failing when the Agents plugin was not installed, inactive, or the wrong version (ie, the relevant endpoint thru bridgeclient wasn't available in the plugin)

I've added an installation/activity check as well as a semver minimum supported version constant. The app layer will now just respond with an empty agent/service list, which the front-end already handles. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66707

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
None
```
