### PR TITLE
[GH-34559] Fix: Allow demoting bots from Admin to Member role

### DIFF
--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -1923,17 +1923,21 @@ func (a *App) UpdateUserRolesWithUser(rctx request.CTX, user *model.User, newRol
 	}
 
 	if user.IsSystemAdmin() && !strings.Contains(newRoles, model.SystemAdminRoleId) {
-		// if user being updated is SysAdmin, make sure its not the last one.
-		options := model.UserCountOptions{
-			IncludeBotAccounts: false,
-			Roles:              []string{model.SystemAdminRoleId},
-		}
-		count, err := a.Srv().Store().User().Count(options)
-		if err != nil {
-			return nil, model.NewAppError("UpdateUserRoles", "app.user.update.countAdmins.app_error", nil, "", http.StatusBadRequest).Wrap(err)
-		}
-		if count <= 1 {
-			return nil, model.NewAppError("UpdateUserRoles", "app.user.update.lastAdmin.app_error", nil, "", http.StatusBadRequest)
+		// Bots should never be considered as the "last admin" since a human admin must exist to perform the demotion.
+		// Skip the last admin check for bots.
+		if !user.IsBot {
+			// if user being updated is SysAdmin, make sure its not the last one.
+			options := model.UserCountOptions{
+				IncludeBotAccounts: false,
+				Roles:              []string{model.SystemAdminRoleId},
+			}
+			count, err := a.Srv().Store().User().Count(options)
+			if err != nil {
+				return nil, model.NewAppError("UpdateUserRoles", "app.user.update.countAdmins.app_error", nil, "", http.StatusBadRequest).Wrap(err)
+			}
+			if count <= 1 {
+				return nil, model.NewAppError("UpdateUserRoles", "app.user.update.lastAdmin.app_error", nil, "", http.StatusBadRequest)
+			}
 		}
 	}
 

--- a/server/channels/app/user_test.go
+++ b/server/channels/app/user_test.go
@@ -2222,6 +2222,20 @@ func TestUpdateLastAdminUserRolesWithUser(t *testing.T) {
 		require.Nil(t, appErr)
 		require.NotNil(t, user)
 	})
+
+	t.Run("Can demote bot from admin to member", func(t *testing.T) {
+		bot := th.CreateBot(t)
+		// Promote bot to admin
+		user, appErr := th.App.UpdateUserRoles(th.Context, bot.UserId, model.SystemUserRoleId+" "+model.SystemAdminRoleId, false)
+		require.Nil(t, appErr)
+		require.NotNil(t, user)
+
+		// Attempt to demote bot from admin to member - should succeed
+		user, appErr = th.App.UpdateUserRoles(th.Context, bot.UserId, model.SystemUserRoleId, false)
+		require.Nil(t, appErr)
+		require.NotNil(t, user)
+		require.False(t, user.IsSystemAdmin())
+	})
 }
 
 func TestDeactivateMfa(t *testing.T) {


### PR DESCRIPTION
#### Summary
This PR fixes an issue where bots with System Admin role cannot be demoted to Member role. The system was incorrectly treating bots as the "last System Admin" and blocking their demotion, even though a human admin must exist to perform the demotion operation.

The fix skips the "last admin" validation check when demoting bots, as bots should never be considered as the "last admin" since they cannot perform administrative actions in the same way human admins can.

**QA Test Steps:**
1. Create a bot account
2. Promote the bot to System Admin role
3. Attempt to demote the bot from Admin to Member role
4. Verify the demotion succeeds without the "Cannot demote last System Admin" error
5. Verify the bot's role is correctly updated to Member

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/34559

#### Screenshots
N/A - Backend fix with no UI changes

#### release-note
Fixed an issue where bots with System Admin role could not be demoted to Member role. Bots are now correctly excluded from the "last admin" protection check, allowing them to be demoted while still maintaining protection for human admins.
