### PR TITLE
Add SendToastMessage API and FileWillBeDownloaded hooks

### DIFF
--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -236,11 +236,12 @@ const (
 
 	OutgoingIntegrationRequestsDefaultTimeout = 30
 
-	PluginSettingsDefaultDirectory         = "./plugins"
-	PluginSettingsDefaultClientDirectory   = "./client/plugins"
-	PluginSettingsDefaultEnableMarketplace = true
-	PluginSettingsDefaultMarketplaceURL    = "https://api.integrations.mattermost.com"
-	PluginSettingsOldMarketplaceURL        = "https://marketplace.integrations.mattermost.com"
+	PluginSettingsDefaultDirectory          = "./plugins"
+	PluginSettingsDefaultClientDirectory    = "./client/plugins"
+	PluginSettingsDefaultEnableMarketplace  = true
+	PluginSettingsDefaultMarketplaceURL     = "https://api.integrations.mattermost.com"
+	PluginSettingsOldMarketplaceURL         = "https://marketplace.integrations.mattermost.com"
+	PluginSettingsDefaultHookTimeoutSeconds = 5
 
 	ComplianceExportDirectoryFormat                = "compliance-export-2006-01-02-15h04m"
 	ComplianceExportPath                           = "export"
@@ -3354,6 +3355,7 @@ type PluginSettings struct {
 	MarketplaceURL              *string                   `access:"plugins,write_restrictable,cloud_restrictable"`
 	SignaturePublicKeyFiles     []string                  `access:"plugins,write_restrictable,cloud_restrictable"`
 	ChimeraOAuthProxyURL        *string                   `access:"plugins,write_restrictable,cloud_restrictable"`
+	HookTimeoutSeconds          *int                      `access:"plugins,write_restrictable,cloud_restrictable"`
 }
 
 func (s *PluginSettings) SetDefaults(ls LogSettings) {
@@ -3435,6 +3437,10 @@ func (s *PluginSettings) SetDefaults(ls LogSettings) {
 
 	if s.ChimeraOAuthProxyURL == nil {
 		s.ChimeraOAuthProxyURL = NewPointer("")
+	}
+
+	if s.HookTimeoutSeconds == nil {
+		s.HookTimeoutSeconds = NewPointer(PluginSettingsDefaultHookTimeoutSeconds)
 	}
 }
 

--- a/server/public/model/file_info.go
+++ b/server/public/model/file_info.go
@@ -15,6 +15,20 @@ const (
 	FileinfoSortBySize    = "Size"
 )
 
+// FileDownloadType represents the type of file download or access being performed.
+type FileDownloadType string
+
+const (
+	// FileDownloadTypeFile represents a full file download request.
+	FileDownloadTypeFile FileDownloadType = "file"
+	// FileDownloadTypeThumbnail represents a thumbnail image request.
+	FileDownloadTypeThumbnail FileDownloadType = "thumbnail"
+	// FileDownloadTypePreview represents a preview image request.
+	FileDownloadTypePreview FileDownloadType = "preview"
+	// FileDownloadTypePublic represents a public link access (unauthenticated).
+	FileDownloadTypePublic FileDownloadType = "public"
+)
+
 // GetFileInfosOptions contains options for getting FileInfos
 type GetFileInfosOptions struct {
 	// UserIds optionally limits the FileInfos to those created by the given users.

--- a/server/public/model/plugin_toast.go
+++ b/server/public/model/plugin_toast.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package model
+
+// SendToastMessageOptions contains options for sending a toast message to a user.
+type SendToastMessageOptions struct {
+	// Position is the position where the toast should appear.
+	// Valid values: "top-left", "top-center", "top-right", "bottom-left", "bottom-center", "bottom-right"
+	// If empty or invalid, defaults to "bottom-right" on the frontend.
+	Position string `json:"position,omitempty"`
+}

--- a/server/public/model/websocket_message.go
+++ b/server/public/model/websocket_message.go
@@ -99,6 +99,8 @@ const (
 	WebsocketEventCPAFieldDeleted                     WebsocketEventType = "custom_profile_attributes_field_deleted"
 	WebsocketEventCPAValuesUpdated                    WebsocketEventType = "custom_profile_attributes_values_updated"
 	WebsocketContentFlaggingReportValueUpdated        WebsocketEventType = "content_flagging_report_value_updated"
+	WebsocketEventFileDownloadRejected                WebsocketEventType = "file_download_rejected"
+	WebsocketEventShowToast                           WebsocketEventType = "show_toast"
 
 	WebSocketMsgTypeResponse = "response"
 	WebSocketMsgTypeEvent    = "event"

--- a/server/public/plugin/api.go
+++ b/server/public/plugin/api.go
@@ -860,6 +860,13 @@ type API interface {
 	// Minimum server version: 5.6
 	OpenInteractiveDialog(dialog model.OpenDialogRequest) *model.AppError
 
+	// SendToastMessage sends a toast notification to a specific user.
+	// The options parameter allows customization of the toast appearance.
+	//
+	// @tag Frontend
+	// Minimum server version: 11.3
+	SendToastMessage(userID string, message string, options model.SendToastMessageOptions) *model.AppError
+
 	// Plugin Section
 
 	// GetPlugins will return a list of plugin manifests for currently active plugins.

--- a/server/public/plugin/api_timer_layer_generated.go
+++ b/server/public/plugin/api_timer_layer_generated.go
@@ -930,6 +930,13 @@ func (api *apiTimerLayer) OpenInteractiveDialog(dialog model.OpenDialogRequest) 
 	return _returnsA
 }
 
+func (api *apiTimerLayer) SendToastMessage(userID string, message string, options model.SendToastMessageOptions) *model.AppError {
+	startTime := timePkg.Now()
+	_returnsA := api.apiImpl.SendToastMessage(userID, message, options)
+	api.recordTime(startTime, "SendToastMessage", _returnsA == nil)
+	return _returnsA
+}
+
 func (api *apiTimerLayer) GetPlugins() ([]*model.Manifest, *model.AppError) {
 	startTime := timePkg.Now()
 	_returnsA, _returnsB := api.apiImpl.GetPlugins()

--- a/server/public/plugin/client_rpc.go
+++ b/server/public/plugin/client_rpc.go
@@ -726,6 +726,7 @@ func (s *apiRPCServer) PluginHTTP(args *Z_PluginHTTPArgs, returns *Z_PluginHTTPR
 
 func init() {
 	hookNameToId["FileWillBeUploaded"] = FileWillBeUploadedID
+	hookNameToId["FileWillBeDownloaded"] = FileWillBeDownloadedID
 }
 
 type Z_FileWillBeUploadedArgs struct {

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -500,6 +500,43 @@ func (s *hooksRPCServer) UserHasLeftTeam(args *Z_UserHasLeftTeamArgs, returns *Z
 }
 
 func init() {
+	hookNameToId["FileWillBeDownloaded"] = FileWillBeDownloadedID
+}
+
+type Z_FileWillBeDownloadedArgs struct {
+	A *Context
+	B *model.FileInfo
+	C string
+	D model.FileDownloadType
+}
+
+type Z_FileWillBeDownloadedReturns struct {
+	A string
+}
+
+func (g *hooksRPCClient) FileWillBeDownloaded(c *Context, fileInfo *model.FileInfo, userID string, downloadType model.FileDownloadType) string {
+	_args := &Z_FileWillBeDownloadedArgs{c, fileInfo, userID, downloadType}
+	_returns := &Z_FileWillBeDownloadedReturns{}
+	if g.implemented[FileWillBeDownloadedID] {
+		if err := g.client.Call("Plugin.FileWillBeDownloaded", _args, _returns); err != nil {
+			g.log.Error("RPC call FileWillBeDownloaded to plugin failed.", mlog.Err(err))
+		}
+	}
+	return _returns.A
+}
+
+func (s *hooksRPCServer) FileWillBeDownloaded(args *Z_FileWillBeDownloadedArgs, returns *Z_FileWillBeDownloadedReturns) error {
+	if hook, ok := s.impl.(interface {
+		FileWillBeDownloaded(c *Context, fileInfo *model.FileInfo, userID string, downloadType model.FileDownloadType) string
+	}); ok {
+		returns.A = hook.FileWillBeDownloaded(args.A, args.B, args.C, args.D)
+	} else {
+		return encodableError(fmt.Errorf("Hook FileWillBeDownloaded called but not implemented."))
+	}
+	return nil
+}
+
+func init() {
 	hookNameToId["ReactionHasBeenAdded"] = ReactionHasBeenAddedID
 }
 
@@ -4987,6 +5024,36 @@ func (s *apiRPCServer) OpenInteractiveDialog(args *Z_OpenInteractiveDialogArgs, 
 		returns.A = hook.OpenInteractiveDialog(args.A)
 	} else {
 		return encodableError(fmt.Errorf("API OpenInteractiveDialog called but not implemented."))
+	}
+	return nil
+}
+
+type Z_SendToastMessageArgs struct {
+	A string
+	B string
+	C model.SendToastMessageOptions
+}
+
+type Z_SendToastMessageReturns struct {
+	A *model.AppError
+}
+
+func (g *apiRPCClient) SendToastMessage(userID string, message string, options model.SendToastMessageOptions) *model.AppError {
+	_args := &Z_SendToastMessageArgs{userID, message, options}
+	_returns := &Z_SendToastMessageReturns{}
+	if err := g.client.Call("Plugin.SendToastMessage", _args, _returns); err != nil {
+		log.Printf("RPC call to SendToastMessage API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) SendToastMessage(args *Z_SendToastMessageArgs, returns *Z_SendToastMessageReturns) error {
+	if hook, ok := s.impl.(interface {
+		SendToastMessage(userID string, message string, options model.SendToastMessageOptions) *model.AppError
+	}); ok {
+		returns.A = hook.SendToastMessage(args.A, args.B, args.C)
+	} else {
+		return encodableError(fmt.Errorf("API SendToastMessage called but not implemented."))
 	}
 	return nil
 }

--- a/server/public/plugin/hooks.go
+++ b/server/public/plugin/hooks.go
@@ -64,6 +64,7 @@ const (
 	GenerateSupportDataID                     = 45
 	OnSAMLLoginID                             = 46
 	EmailNotificationWillBeSentID             = 47
+	FileWillBeDownloadedID                    = 48
 	TotalHooksID                              = iota
 )
 
@@ -238,6 +239,22 @@ type Hooks interface {
 	//
 	// Minimum server version: 5.2
 	FileWillBeUploaded(c *Context, info *model.FileInfo, file io.Reader, output io.Writer) (*model.FileInfo, string)
+
+	// FileWillBeDownloaded is invoked when a file is requested for download, but before it is sent to the client.
+	//
+	// To reject a file download, return an non-empty string describing why the file was rejected.
+	// To allow the download, return an empty string.
+	//
+	// The downloadType parameter indicates the type of file access and can be one of:
+	//   - model.FileDownloadTypeFile: Full file download
+	//   - model.FileDownloadTypeThumbnail: Thumbnail request
+	//   - model.FileDownloadTypePreview: Preview image request
+	//   - model.FileDownloadTypePublic: Public link access (userID will be empty string in this case)
+	//
+	// Note that this method will be called for files requested by users with appropriate permissions.
+	//
+	// Minimum server version: 11.3
+	FileWillBeDownloaded(c *Context, fileInfo *model.FileInfo, userID string, downloadType model.FileDownloadType) string
 
 	// ReactionHasBeenAdded is invoked after the reaction has been committed to the database.
 	//

--- a/server/public/plugin/hooks_timer_layer_generated.go
+++ b/server/public/plugin/hooks_timer_layer_generated.go
@@ -164,6 +164,13 @@ func (hooks *hooksTimerLayer) FileWillBeUploaded(c *Context, info *model.FileInf
 	return _returnsA, _returnsB
 }
 
+func (hooks *hooksTimerLayer) FileWillBeDownloaded(c *Context, fileInfo *model.FileInfo, userID string, downloadType model.FileDownloadType) string {
+	startTime := timePkg.Now()
+	_returnsA := hooks.hooksImpl.FileWillBeDownloaded(c, fileInfo, userID, downloadType)
+	hooks.recordTime(startTime, "FileWillBeDownloaded", true)
+	return _returnsA
+}
+
 func (hooks *hooksTimerLayer) ReactionHasBeenAdded(c *Context, reaction *model.Reaction) {
 	startTime := timePkg.Now()
 	hooks.hooksImpl.ReactionHasBeenAdded(c, reaction)

--- a/server/public/plugin/plugintest/api.go
+++ b/server/public/plugin/plugintest/api.go
@@ -5203,6 +5203,26 @@ func (_m *API) SendPushNotification(notification *model.PushNotification, userID
 	return r0
 }
 
+// SendToastMessage provides a mock function with given fields: userID, message, options
+func (_m *API) SendToastMessage(userID string, message string, options model.SendToastMessageOptions) *model.AppError {
+	ret := _m.Called(userID, message, options)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SendToastMessage")
+	}
+
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(string, string, model.SendToastMessageOptions) *model.AppError); ok {
+		r0 = rf(userID, message, options)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.AppError)
+		}
+	}
+
+	return r0
+}
+
 // SetFileSearchableContent provides a mock function with given fields: fileID, content
 func (_m *API) SetFileSearchableContent(fileID string, content string) *model.AppError {
 	ret := _m.Called(fileID, content)

--- a/server/public/plugin/plugintest/hooks.go
+++ b/server/public/plugin/plugintest/hooks.go
@@ -119,6 +119,24 @@ func (_m *Hooks) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 	return r0, r1
 }
 
+// FileWillBeDownloaded provides a mock function with given fields: c, fileInfo, userID, downloadType
+func (_m *Hooks) FileWillBeDownloaded(c *plugin.Context, fileInfo *model.FileInfo, userID string, downloadType model.FileDownloadType) string {
+	ret := _m.Called(c, fileInfo, userID, downloadType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FileWillBeDownloaded")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(*plugin.Context, *model.FileInfo, string, model.FileDownloadType) string); ok {
+		r0 = rf(c, fileInfo, userID, downloadType)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // FileWillBeUploaded provides a mock function with given fields: c, info, file, output
 func (_m *Hooks) FileWillBeUploaded(c *plugin.Context, info *model.FileInfo, file io.Reader, output io.Writer) (*model.FileInfo, string) {
 	ret := _m.Called(c, info, file, output)

--- a/server/public/pluginapi/frontend.go
+++ b/server/public/pluginapi/frontend.go
@@ -28,3 +28,11 @@ func (f *FrontendService) OpenInteractiveDialog(dialog model.OpenDialogRequest) 
 func (f *FrontendService) PublishWebSocketEvent(event string, payload map[string]any, broadcast *model.WebsocketBroadcast) {
 	f.api.PublishWebSocketEvent(event, payload, broadcast)
 }
+
+// SendToastMessage sends a toast notification to a specific user.
+// The options parameter allows customization of the toast appearance.
+//
+// Minimum server version: 11.3
+func (f *FrontendService) SendToastMessage(userID, message string, options model.SendToastMessageOptions) error {
+	return normalizeAppErr(f.api.SendToastMessage(userID, message, options))
+}


### PR DESCRIPTION
#### Summary

This pull request introduces necessary changes to the public package to add two new plugin api calls:

- Introduced SendToastMessage method for sending toast notifications to users with customizable options.
- Added FileWillBeDownloaded hook to handle file download requests, allowing plugins to control access to files.
- Updated related types and constants for file download handling.
- Enhanced PluginSettings to include HookTimeoutSeconds for better timeout management.



#### Release Note
```release-note
Update public package with new filewillbedownloaded and sendusertoast pluginapi calls
```
