### PR TITLE
[MM-66709] Avoid magic link login if already logged in

### DIFF
--- a/server/channels/web/magic_link.go
+++ b/server/channels/web/magic_link.go
@@ -25,6 +25,11 @@ func loginWithMagicLinkToken(c *Context, w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	if c.AppContext.Session() != nil && c.AppContext.Session().UserId != "" {
+		http.Redirect(w, r, c.GetSiteURLHeader()+"/error?type=magic_link_already_logged_in", http.StatusFound)
+		return
+	}
+
 	tokenString := r.URL.Query().Get("t")
 	if tokenString == "" {
 		c.Err = model.NewAppError("loginWithMagicLinkToken", "api.user.guest_magic_link.missing_token.app_error", nil, "", http.StatusBadRequest)

--- a/webapp/channels/src/components/error_page/error_message.tsx
+++ b/webapp/channels/src/components/error_page/error_message.tsx
@@ -209,6 +209,16 @@ const ErrorMessage: React.FC<Props> = ({type, message, service, isGuest}: Props)
                 </p>
             );
             break;
+        case ErrorPageTypes.MAGIC_LINK_ALREADY_LOGGED_IN:
+            errorMessage = (
+                <p>
+                    <FormattedMessage
+                        id='error.magic_link_already_logged_in.message'
+                        defaultMessage='You are already logged in. Log out and try again.'
+                    />
+                </p>
+            );
+            break;
         case ErrorPageTypes.PAGE_NOT_FOUND:
         default:
             errorMessage = (

--- a/webapp/channels/src/components/error_page/error_title.tsx
+++ b/webapp/channels/src/components/error_page/error_title.tsx
@@ -88,6 +88,14 @@ const ErrorTitle: React.FC<Props> = ({type, title}: Props) => {
                 />
             );
             break;
+        case ErrorPageTypes.MAGIC_LINK_ALREADY_LOGGED_IN:
+            errorTitle = (
+                <FormattedMessage
+                    id='error.magic_link_already_logged_in.title'
+                    defaultMessage='Cannot log you in with a Magic Link'
+                />
+            );
+            break;
         case ErrorPageTypes.PAGE_NOT_FOUND:
         default:
             errorTitle = (

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -4312,6 +4312,8 @@
   "error.local_storage.help3": "Use a supported browser (IE 11, Chrome 61+, Firefox 60+, Safari 12+, Edge 42+)",
   "error.local_storage.message": "Mattermost was unable to load because a setting in your browser prevents the use of its local storage features. To allow Mattermost to load, try the following actions:",
   "error.local_storage.title": "Cannot Load Mattermost",
+  "error.magic_link_already_logged_in.message": "You are already logged in. Log out and try again.",
+  "error.magic_link_already_logged_in.title": "Cannot log you in with a Magic Link",
   "error.not_found.message": "The page you were trying to reach does not exist",
   "error.not_found.title": "Page Not Found",
   "error.oauth_access_denied": "You must authorize Mattermost to log in with {service}.",

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -907,6 +907,7 @@ export const ErrorPageTypes = {
     CHANNEL_NOT_FOUND: 'channel_not_found',
     POST_NOT_FOUND: 'post_not_found',
     CLOUD_ARCHIVED: 'cloud_archived',
+    MAGIC_LINK_ALREADY_LOGGED_IN: 'magic_link_already_logged_in',
 };
 
 export const JobTypes = {


### PR DESCRIPTION
#### Summary
If a session exist, now we send the user to an error page and we do NOT consume the token.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-66709

#### Release Note
No release note needed since this goes in the same release as the feature.
```release-note
NONE
```
