### PR TITLE
Automated cherry pick of #34604

### DIFF
--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -3251,6 +3251,7 @@ const AdminDefinition: AdminDefinitionType = {
                                     },
                                 },
                             ],
+                            isHidden: it.configIsFalse('FeatureFlags', 'BurnOnRead'),
                         },
                         {
                             key: 'PostSettings.Previews',


### PR DESCRIPTION
Cherry pick of #34604 on release-11.2.

/cc  @pvev

```release-note
NONE
```