### PR TITLE
Update Agents plugin to v1.6.2

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -173,7 +173,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.6.1%2B0e01d28-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v1.6.1%2B468a918-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v1.6.2%2B66117c7-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.1%2Bdf49b26-fips
 endif
 


### PR DESCRIPTION
#### Summary
Update Agents plugin to v1.6.2


#### Release Note
```release-note
Update Agents plugin to v1.6.2
```

[Agents v1.6.2 release](https://github.com/mattermost/mattermost-plugin-agents/releases/tag/v1.6.2).