### PR TITLE
page up down while text input scrollable

### DIFF
--- a/e2e-tests/playwright/specs/functional/channels/center_view/page_up_down_scroll.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/center_view/page_up_down_scroll.spec.ts
@@ -62,34 +62,37 @@ test('should be able to scroll textinput with pageup/pagedown when overflow', as
     await channelsPage.goto();
     await channelsPage.toBeVisible();
 
-    // Fill the input with multiple long lines
+    // # Fill the input with multiple long lines
     const multiLineMessage = Array.from({length: 30}, () => 'This is a long line for scroll testing.').join('\n');
     await channelsPage.centerView.postCreate.input.fill(multiLineMessage);
 
-    // Focus the input and scroll to the bottom
-    const inputSelector = await channelsPage.centerView.postCreate.input.selector;
-    await page.focus(inputSelector);
-    await page.$eval(inputSelector, el => el.scrollTop = el.scrollHeight);
+    // # Focus the input and scroll to the bottom
+    const input = channelsPage.centerView.postCreate.input;
+    await input.focus();
+    await input.evaluate((el: HTMLTextAreaElement) => {
+        el.scrollTop = el.scrollHeight;
+    });
 
-    // Save initial scroll positions
-    const inputScrollBefore = await page.$eval(inputSelector, el => el.scrollTop);
+    // # Save initial scroll positions
+    const inputScrollBefore = await input.evaluate((el: HTMLTextAreaElement) => el.scrollTop);
 
-    // Press PageUp in the input
+    // # Press PageUp in the input
     await page.keyboard.press('PageUp');
     await page.waitForTimeout(200);
 
     // * Expect input to scroll up
-    const inputScrollAfterUp = await page.$eval(inputSelector, el => el.scrollTop);
+    const inputScrollAfterUp = await input.evaluate((el: HTMLTextAreaElement) => el.scrollTop);
     expect(inputScrollAfterUp).toBeLessThan(inputScrollBefore);
 
-    // Press PageDown in the input
+    // # Press PageDown in the input
     await page.keyboard.press('PageDown');
     await page.waitForTimeout(200);
 
     // * Expect input to scroll back down
-    const inputScrollAfterDown = await page.$eval(inputSelector, el => el.scrollTop);
+    const inputScrollAfterDown = await input.evaluate((el: HTMLTextAreaElement) => el.scrollTop);
     expect(inputScrollAfterDown).toBeGreaterThan(inputScrollAfterUp);
 });
+
 
 async function getScrollTop(page: Page, selector: string): Promise<number> {
     const locator = await page.locator(selector);

--- a/e2e-tests/playwright/specs/functional/channels/center_view/page_up_down_scroll.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/center_view/page_up_down_scroll.spec.ts
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import {Page} from '@playwright/test';
-
 import {expect, test} from '@mattermost/playwright-lib';
 
 test('should be able to scroll the post list with page up and down', async ({pw}) => {
@@ -54,6 +53,42 @@ test('should be able to scroll the post list with page up and down', async ({pw}
     // * Verify that the post list scrolled back to the bottom
     currentScrollTop = await getScrollTop(page, '#postListScrollContainer');
     expect(currentScrollTop).toBeGreaterThan(lastScrollTop);
+});
+
+test('should be able to scroll textinput with pageup/pagedown when overflow', async ({pw}) => {
+    const {user} = await pw.initSetup();
+    const {channelsPage, page} = await pw.testBrowser.login(user);
+
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    // Fill the input with multiple long lines
+    const multiLineMessage = Array.from({length: 30}, () => 'This is a long line for scroll testing.').join('\n');
+    await channelsPage.centerView.postCreate.input.fill(multiLineMessage);
+
+    // Focus the input and scroll to the bottom
+    const inputSelector = await channelsPage.centerView.postCreate.input.selector;
+    await page.focus(inputSelector);
+    await page.$eval(inputSelector, el => el.scrollTop = el.scrollHeight);
+
+    // Save initial scroll positions
+    const inputScrollBefore = await page.$eval(inputSelector, el => el.scrollTop);
+
+    // Press PageUp in the input
+    await page.keyboard.press('PageUp');
+    await page.waitForTimeout(200);
+
+    // * Expect input to scroll up
+    const inputScrollAfterUp = await page.$eval(inputSelector, el => el.scrollTop);
+    expect(inputScrollAfterUp).toBeLessThan(inputScrollBefore);
+
+    // Press PageDown in the input
+    await page.keyboard.press('PageDown');
+    await page.waitForTimeout(200);
+
+    // * Expect input to scroll back down
+    const inputScrollAfterDown = await page.$eval(inputSelector, el => el.scrollTop);
+    expect(inputScrollAfterDown).toBeGreaterThan(inputScrollAfterUp);
 });
 
 async function getScrollTop(page: Page, selector: string): Promise<number> {

--- a/webapp/channels/src/components/advanced_text_editor/use_key_handler.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_key_handler.tsx
@@ -164,7 +164,15 @@ const useKeyHandler = (
             const hasScrollableContent = textbox && textbox.scrollHeight > textbox.clientHeight;
 
             if (hasScrollableContent) {
-                return;
+                const isPageUp = Keyboard.isKeyPressed(e, KeyCodes.PAGE_UP);
+                const isPageDown = Keyboard.isKeyPressed(e, KeyCodes.PAGE_DOWN);
+
+                const canScrollUp = textbox.scrollTop > 0;
+                const canScrollDown = textbox.scrollTop + textbox.clientHeight < textbox.scrollHeight;
+
+                if ((isPageUp && canScrollUp) || (isPageDown && canScrollDown)) {
+                    return;
+                }
             }
 
             // Moving the focus to the post list will cause the post list to scroll as if it already had focus

--- a/webapp/channels/src/components/advanced_text_editor/use_key_handler.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_key_handler.tsx
@@ -160,9 +160,10 @@ const useKeyHandler = (
 
         if ((Keyboard.isKeyPressed(e, KeyCodes.PAGE_UP) || Keyboard.isKeyPressed(e, KeyCodes.PAGE_DOWN))) {
             const textbox = textboxRef.current?.getInputBox();
-            const hasScrollableContent = textbox.scrollHeight > textbox.clientHeight;
 
-            if (textbox && textbox === document.activeElement && hasScrollableContent) {
+            const hasScrollableContent = textbox && textbox.scrollHeight > textbox.clientHeight;
+
+            if (hasScrollableContent) {
                 return;
             }
 

--- a/webapp/channels/src/components/advanced_text_editor/use_key_handler.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_key_handler.tsx
@@ -159,6 +159,13 @@ const useKeyHandler = (
         }
 
         if ((Keyboard.isKeyPressed(e, KeyCodes.PAGE_UP) || Keyboard.isKeyPressed(e, KeyCodes.PAGE_DOWN))) {
+            const textbox = textboxRef.current?.getInputBox();
+            const hasScrollableContent = textbox.scrollHeight > textbox.clientHeight;
+
+            if (textbox && textbox === document.activeElement && hasScrollableContent) {
+                return;
+            }
+
             // Moving the focus to the post list will cause the post list to scroll as if it already had focus
             // before the key was pressed
             if (location === Locations.CENTER) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
When the text input is scrollable when pressed PageUp or PageDown it should scroll the text input instead of post list

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Fixes #33904 

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
