### PR TITLE
[MM-66804] Mimic redirect logic for login page in desktop auth page

### DIFF
--- a/webapp/channels/src/components/desktop_auth_token.tsx
+++ b/webapp/channels/src/components/desktop_auth_token.tsx
@@ -5,9 +5,12 @@ import classNames from 'classnames';
 import crypto from 'crypto';
 import React, {useEffect, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
-import {useDispatch} from 'react-redux';
+import {useDispatch, useSelector} from 'react-redux';
 import {useHistory, useLocation} from 'react-router-dom';
 
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+
+import {redirectUserToDefaultTeam} from 'actions/global_actions';
 import {loginWithDesktopToken} from 'actions/views/login';
 
 import DesktopApp from 'utils/desktop_api';
@@ -39,6 +42,8 @@ const DesktopAuthToken: React.FC<Props> = ({href, onLogin}: Props) => {
 
     const serverToken = query.get('server_token');
     const receivedClientToken = query.get('client_token');
+    const redirectTo = query.get('redirect_to');
+    const currentUser = useSelector(getCurrentUser);
     const storedClientToken = sessionStorage.getItem(DESKTOP_AUTH_PREFIX);
     const [status, setStatus] = useState(serverToken ? DesktopAuthStatus.LoggedIn : DesktopAuthStatus.None);
     const [showBottomMessage, setShowBottomMessage] = useState<boolean>();
@@ -82,6 +87,16 @@ const DesktopAuthToken: React.FC<Props> = ({href, onLogin}: Props) => {
 
         window.location.href = url.toString().replace(url.protocol, `${protocol}:`);
     };
+
+    useEffect(() => {
+        if (currentUser) {
+            if (redirectTo && redirectTo.match(/^\/([^/]|$)/)) {
+                history.push(redirectTo);
+                return;
+            }
+            redirectUserToDefaultTeam();
+        }
+    }, []);
 
     useEffect(() => {
         setShowBottomMessage(false);


### PR DESCRIPTION
#### Summary
Pressing the back button after logging into the Desktop App via an external provider (ie. OIDC, SAML) would cause the app to navigate back to the token acceptance screen, putting the app into a logged in state on a logged out page. This can cause strange behaviour.

This PR adds the same redirect logic that the `Login` component users to force the user back into the app if they're still logged in.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66804

```release-note
Fixed an issue where pressing Back in the Desktop App after an external login would causing a weird state
```
