### PR TITLE
Fix layout shift in search bar by grouping results (Issue #34650)

### DIFF
--- a/webapp/channels/src/components/suggestion/switch_channel_provider.test.tsx
+++ b/webapp/channels/src/components/suggestion/switch_channel_provider.test.tsx
@@ -587,7 +587,9 @@ describe('components/SwitchChannelProvider', () => {
         ];
 
         expect(resultsCallback).toHaveBeenCalledWith(expect.objectContaining({
-            terms: expectedOrder,
+            groups: [expect.objectContaining({
+                terms: expectedOrder,
+            })],
         }));
     });
 
@@ -670,7 +672,9 @@ describe('components/SwitchChannelProvider', () => {
         ];
 
         expect(resultsCallback).toHaveBeenCalledWith(expect.objectContaining({
-            terms: expectedOrder,
+            groups: [expect.objectContaining({
+                terms: expectedOrder,
+            })],
         }));
     });
 
@@ -757,7 +761,9 @@ describe('components/SwitchChannelProvider', () => {
             'channel_other_user1',
         ];
         expect(resultsCallback).toHaveBeenCalledWith(expect.objectContaining({
-            terms: expectedOrder,
+            groups: [expect.objectContaining({
+                terms: expectedOrder,
+            })],
         }));
     });
 
@@ -992,7 +998,9 @@ describe('components/SwitchChannelProvider', () => {
         ];
 
         expect(resultsCallback).toHaveBeenCalledWith(expect.objectContaining({
-            terms: expectedOrder,
+            groups: [expect.objectContaining({
+                terms: expectedOrder,
+            })],
         }));
     });
 

--- a/webapp/channels/src/components/suggestion/switch_channel_provider.tsx
+++ b/webapp/channels/src/components/suggestion/switch_channel_provider.tsx
@@ -574,7 +574,7 @@ export default class SwitchChannelProvider extends Provider {
     private initialFilteredList(channelPrefix: string, {items, terms}: {items: WrappedChannel[]; terms: string[]}): ProviderResults<WrappedChannel> {
         let groups;
 
-        if (items) {
+        if (items && items.length > 0) {
             groups = [{
                 key: 'channels',
                 label: defineMessage({id: 'suggestion.channels', defaultMessage: 'Channels'}),
@@ -585,7 +585,7 @@ export default class SwitchChannelProvider extends Provider {
         } else {
             groups = [{
                 key: 'moreChannels',
-                label: defineMessage({id: 'suggestion.mention.morechannels', defaultMessage: 'Other Channels'}),
+                label: defineMessage({id: 'suggestion.channels', defaultMessage: 'Channels'}),
                 items: [{type: '', loading: true}],
                 terms: [''],
                 component: ConnectedSwitchChannelSuggestion,
@@ -654,9 +654,13 @@ export default class SwitchChannelProvider extends Provider {
 
         resultsCallback({
             matchedPretext: channelPrefix,
-            items: combinedItems,
-            terms: combinedTerms,
-            component: ConnectedSwitchChannelSuggestion,
+            groups: [{
+                key: 'channels',
+                label: defineMessage({id: 'suggestion.channels', defaultMessage: 'Channels'}),
+                items: combinedItems,
+                terms: combinedTerms,
+                component: ConnectedSwitchChannelSuggestion,
+            }],
         });
     }
 


### PR DESCRIPTION
Summary
Fixed a layout shift issue in the "Find Channels" (Ctrl+K) modal. Previously, the "Channels" header would flicker or disappear when switching between local and remote search results, causing the entire list to jump.

This change ensures that 
SwitchChannelProvider
 consistently uses the "Channels" label and returns grouped results for both local and remote searches, maintaining a stable UI layout.

QA Test Steps:

Open the "Find Channels" modal (Cmd+K or Ctrl+K).
Type a search term that fetches remote results (e.g., a public channel name not in your history).
Verify that the "Channels" header appears immediately and remains stable without causing the list to shift up or down as results load.

Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/34650

**Release Note**

```release-note
Fixed a layout shift in the search bar where the 'Channels' header would flicker or disappear when loading remote results.