### PR TITLE
Simplify useOpenPricingModal to always open external pricing link

### DIFF
--- a/webapp/channels/src/components/common/hooks/useOpenPricingModal.ts
+++ b/webapp/channels/src/components/common/hooks/useOpenPricingModal.ts
@@ -16,17 +16,10 @@ export default function useOpenPricingModal(): UseOpenPricingModalReturn {
     const [externalLink] = useExternalLink('https://mattermost.com/pricing');
 
     const isAirGapped = cwsAvailability === CSWAvailabilityCheckTypes.Unavailable;
-    const canAccessExternalPricing = cwsAvailability === CSWAvailabilityCheckTypes.Available ||
-                                     cwsAvailability === CSWAvailabilityCheckTypes.NotApplicable;
 
     const openPricingModal = useCallback(() => {
-        if (canAccessExternalPricing) {
-            // Redirect to external pricing page
-            window.open(externalLink, '_blank', 'noopener,noreferrer');
-        }
-
-        // For air-gapped instances, we don't open anything since the pricing modal has been removed
-    }, [canAccessExternalPricing]);
+        window.open(externalLink, '_blank', 'noopener,noreferrer');
+    }, [externalLink]);
 
     return {
         openPricingModal,


### PR DESCRIPTION
## Summary
- Removes CWS availability check that prevented pricing link from opening on air-gapped instances
- Always opens external pricing page when `openPricingModal` is called

https://mattermost.atlassian.net/browse/MM-66669

🤖 Generated with [Claude Code](https://claude.com/claude-code)