### PR TITLE
Skip Webpack image optimizations during dev

### DIFF
--- a/webapp/channels/webpack.config.js
+++ b/webapp/channels/webpack.config.js
@@ -107,7 +107,9 @@ var config = {
                 test: /\.(png|eot|tiff|svg|woff2|woff|ttf|gif|mp3|jpg)$/,
                 type: 'asset/resource',
                 use: [
-                    {
+
+                    // Skip image optimizations during development to speed up build time
+                    !DEV && {
                         loader: 'image-webpack-loader',
                         options: {},
                     },


### PR DESCRIPTION
#### Summary
We don't care about bandwidth usage when running a development build locally, so we don't need to worry about optimizing images then. On my laptop (with an M4 Max), this reduces the first build time when running `make run` from 35 seconds to about 22 seconds.

#### Release Note
```release-note
NONE
```
