### PR TITLE
Fix flaky test in accessibility_modals_dialogs_spec.ts

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/enterprise/accessibility/accessibility_modals_dialogs_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/enterprise/accessibility/accessibility_modals_dialogs_spec.ts
@@ -186,7 +186,9 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
                 should('have.attr', 'aria-live', 'polite').
                 and('have.attr', 'aria-atomic', 'true').
                 invoke('text').then((text) => {
-                    expect(text).equal(selectedRowText);
+                    // Check that the readout starts with the selected user since it may be followed by
+                    // "Already in Channel" depending on which user was selected
+                    expect(text).to.match(new RegExp(`^${selectedRowText}\\b`));
                 });
 
             // # Search for an invalid text and check if reader can read no results


### PR DESCRIPTION
#### Summary
I've seen this fail a few times recently, and looking at the recording, it seems like the issue is that the users in that dialog are in a semi-random order, and sometimes one of the users that's already in the channel is selected, so it includes extra information in the readout.

Failure on PR: https://github.com/mattermost/mattermost/pull/34643#issuecomment-3629479568 / https://automation-dashboard.vercel.app/cycle/20045369102_1-1c2b8c9-pr-onprem-ent
Failure on master: https://github.com/mattermost/mattermost/actions/runs/20048162573 / https://automation-dashboard.vercel.app/cycles/cbc33937-d8b0-4637-9bf8-6ca97e4fc844

#### Release Note
```release-note
NONE
```
