### PR TITLE
MM-66880 Fix Components package being included in build twice

### DIFF
--- a/webapp/channels/.eslintrc.json
+++ b/webapp/channels/.eslintrc.json
@@ -53,6 +53,10 @@
               "name": "mattermost-redux/types/actions",
               "importNames": ["DispatchFunc", "GetStateFunc", "ActionFunc", "ActionFuncAsync", "ThunkActionFunc"],
               "message": "Use the web app version of it from types/store"
+            }],
+            "patterns": [{
+              "group": ["@mattermost/client/src/*", "@mattermost/components/src/*", "@mattermost/types/src/*"],
+              "message": "Don't include the src folder when importing from packages in webapp/platform"
             }]
           }
         ]

--- a/webapp/channels/src/components/add_users_to_group_modal/add_users_to_group_modal.tsx
+++ b/webapp/channels/src/components/add_users_to_group_modal/add_users_to_group_modal.tsx
@@ -5,7 +5,7 @@ import React, {useState, useCallback, useMemo, useRef} from 'react';
 import {Modal} from 'react-bootstrap';
 import {defineMessage, FormattedMessage, useIntl} from 'react-intl';
 
-import {useFocusTrap} from '@mattermost/components/src/hooks/useFocusTrap';
+import {useFocusTrap} from '@mattermost/components';
 import type {Group} from '@mattermost/types/groups';
 import type {UserProfile} from '@mattermost/types/users';
 

--- a/webapp/channels/src/components/admin_console/access_control/modals/confirmation/confirmation_modal.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/modals/confirmation/confirmation_modal.tsx
@@ -4,8 +4,9 @@
 import React, {useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 
+import {GenericModal} from '@mattermost/components';
+
 import './confirmation_modal.scss';
-import GenericModal from '@mattermost/components/src/generic_modal/generic_modal';
 
 type Props = {
     active: boolean;

--- a/webapp/channels/src/components/view_user_group_modal/view_user_group_modal.tsx
+++ b/webapp/channels/src/components/view_user_group_modal/view_user_group_modal.tsx
@@ -5,7 +5,7 @@ import React, {useRef, useState, useEffect, useCallback} from 'react';
 import {Modal} from 'react-bootstrap';
 import {defineMessage, FormattedMessage} from 'react-intl';
 
-import {useFocusTrap} from '@mattermost/components/src/hooks/useFocusTrap';
+import {useFocusTrap} from '@mattermost/components';
 import type {Group} from '@mattermost/types/groups';
 import {GroupSource, PluginGroupSourcePrefix} from '@mattermost/types/groups';
 import type {UserProfile} from '@mattermost/types/users';

--- a/webapp/platform/components/src/index.tsx
+++ b/webapp/platform/components/src/index.tsx
@@ -15,6 +15,7 @@ export {TourTipBackdrop} from './tour_tip/tour_tip_backdrop';
 export {PulsatingDot} from './pulsating_dot';
 
 // hooks
-export {useMeasurePunchouts} from './common/hooks/useMeasurePunchouts';
 export {useElementAvailable} from './common/hooks/useElementAvailable';
+export {useFocusTrap} from './hooks/useFocusTrap';
 export {useFollowElementDimensions} from './common/hooks/useFollowElementDimensions';
+export {useMeasurePunchouts} from './common/hooks/useMeasurePunchouts';


### PR DESCRIPTION
#### Summary
Because we were importing from `@mattermost/components/src` directly instead of from the compiled files, we were actually including that package twice if you happened to load one of the places in the code that did that. This usually didn't have any noticeable effect on the app except in one place I found where the `GenericModal` CSS was taking precedence over another rule, but that only happened after visiting the System Console.

#### Ticket Link
MM-66880

#### Release Note
```release-note
Fixed minor UX issue in "Set custom status" modal after visiting the System Console
```
