### PR TITLE
Avoid triggering unnecessary rerenders on the shared channels tooltip for users

### DIFF
--- a/webapp/channels/src/components/user_profile/user_profile.tsx
+++ b/webapp/channels/src/components/user_profile/user_profile.tsx
@@ -36,10 +36,10 @@ export default function UserProfile({
 }: Props) {
     // Fetch remote info when component mounts for remote users
     useEffect(() => {
-        if (user?.remote_id && (!remoteNames || remoteNames.length === 0)) {
+        if (user?.remote_id) {
             actions.fetchRemoteClusterInfo(user.remote_id);
         }
-    }, [user?.remote_id, remoteNames, actions]);
+    }, [user?.remote_id]);
     let name: ReactNode;
     if (user && displayUsername) {
         name = `@${(getUsername(user))}`;


### PR DESCRIPTION
#### Summary
Cherry pick for https://github.com/mattermost/mattermost/pull/34336

#### Release Note
```release-note
* Infinite loop on shared channels tooltip for users when the remote cluster is not available has been fixed
```