### PR TITLE
Add explicit types for burn on read

### DIFF
--- a/webapp/platform/mattermost-redux/tsconfig.json
+++ b/webapp/platform/mattermost-redux/tsconfig.json
@@ -29,5 +29,9 @@
     ],
     "exclude": [
         "../../**/*.test.*"
+    ],
+    "references": [
+        {"path": "../types"},
+        {"path": "../client"}
     ]
 }


### PR DESCRIPTION
#### Summary
Seems like an issue in the webapp build CI, I don't know why it didn't show up in the feature branch PR.

See: https://github.com/mattermost/mattermost/actions/runs/20124746632/job/57752088141

#### Release Note

```release-note
NONE
```
