### PR TITLE
Fix: Split CI cache for platform builds to use source-based key

### DIFF
--- a/.github/actions/webapp-setup/action.yml
+++ b/.github/actions/webapp-setup/action.yml
@@ -15,13 +15,25 @@ runs:
         path: |
           webapp/node_modules
           webapp/channels/node_modules
+        key: node-modules-${{ runner.os }}-${{ hashFiles('webapp/package-lock.json') }}
+    - name: ci/cache-platform-builds
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      id: cache-platform-builds
+      with:
+        path: |
           webapp/platform/types/lib
           webapp/platform/client/lib
           webapp/platform/components/dist
-        key: node-modules-${{ runner.os }}-${{ hashFiles('webapp/package-lock.json') }}
+        key: platform-builds-${{ runner.os }}-${{ hashFiles('webapp/platform/types/src/**', 'webapp/platform/client/src/**', 'webapp/platform/components/src/**') }}
     - name: ci/get-node-modules
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
       shell: bash
       working-directory: webapp
       run: |
         make node_modules
+    - name: ci/build-platform-packages
+      if: steps.cache-platform-builds.outputs.cache-hit != 'true'
+      shell: bash
+      working-directory: webapp
+      run: |
+        npm run build --workspace=platform/types --workspace=platform/client --workspace=platform/components


### PR DESCRIPTION

#### Summary
This PR solves a cache issue with CI, since CI was caching built platform packages (types, client, components https://github.com/mattermost/mattermost/pull/34656/files#diff-daa8776408ed3bcbd86245fea129f8b09e3de8af9b212f685abddb835f2bd799R18) but only invalidating the cache when package-lock.json changed. This meant source code changes didn't trigger rebuilds, causing TypeScript and test failures. To solve this, this PR splits the cache so platform builds invalidate when their source files change, and added a step to rebuild them when needed

#### Ticket Link
n/a

#### Screenshots
n/a

#### Release Note
```release-note
NONE
```
