### PR TITLE
Limit test parallelism when coverage is enabled to prevent OOM

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -48,7 +48,7 @@ GOTESTSUM_JSONFILE ?= gotestsum.json
 # GOGC=50 triggers GC more frequently to keep memory usage lower.
 ENABLE_COVERAGE ?= false
 ifeq ($(ENABLE_COVERAGE),true)
-COVERAGE_FLAG = -p 1 -parallel 0 -coverprofile=cover.out -covermode=atomic
+COVERAGE_FLAG = -p 1 -parallel 1 -coverprofile=cover.out -covermode=atomic
 COVERAGE_ENV = GOGC=50
 endif
 


### PR DESCRIPTION
#### Summary

The "Generate Test Coverage" CI job has been experiencing OOM (Out of Memory) kills, causing ~174 test failures with `signal: killed` (SIGKILL) terminations.

**Root cause:** Coverage instrumentation significantly increases memory usage per test. When combined with `ENABLE_FULLY_PARALLEL_TESTS=true`, the CI runner exhausts available memory and the OS kills test processes.

**Fix:** When `ENABLE_COVERAGE=true`:
- `-p 1`: Run one package at a time (no concurrent package testing)
- `-parallel 1`: Run one test at a time within each package (no parallel test execution)
- `GOGC=50`: Trigger garbage collection more frequently to keep memory usage lower

In short, should fix this:

<img width="1767" height="942" alt="CleanShot 2025-12-11 at 12 23 28@2x" src="https://github.com/user-attachments/assets/e09b962b-0d1f-4c54-8733-c4d1f9241885" />

#### Ticket Link

None

#### Release Note

```release-note
NONE
```