### PR TITLE
MM-66939 -Hide plugin actions menu for burn-on-read posts

### DIFF
--- a/webapp/channels/src/components/post/post_options.tsx
+++ b/webapp/channels/src/components/post/post_options.tsx
@@ -210,7 +210,7 @@ const PostOptions = (props: Props): JSX.Element => {
     let pluginItems: ReactNode = null;
     const pluginItemsVisible = usePluginVisibilityInSharedChannel(post.channel_id);
 
-    if ((!isEphemeral && !post.failed && !systemMessage) && hoverLocal && pluginItemsVisible) {
+    if ((!isEphemeral && !post.failed && !systemMessage && !isBurnOnReadPost) && hoverLocal && pluginItemsVisible) {
         pluginItems = props.pluginActions?.
             map((item) => {
                 if (item.component) {

--- a/webapp/channels/src/utils/post_utils.test.tsx
+++ b/webapp/channels/src/utils/post_utils.test.tsx
@@ -3,6 +3,8 @@
 
 import {createIntl} from 'react-intl';
 
+import type {Post} from '@mattermost/types/posts';
+
 import {Preferences} from 'mattermost-redux/constants';
 
 import enMessages from 'i18n/en.json';
@@ -1435,5 +1437,26 @@ describe('makeGetUniqueEmojiNameReactionsForPost', () => {
         const getUniqueEmojiNameReactionsForPost = PostUtils.makeGetUniqueEmojiNameReactionsForPost();
 
         expect(getUniqueEmojiNameReactionsForPost(baseState, 'post_id_1')).toEqual(['smile', 'cry']);
+    });
+});
+
+describe('shouldShowActionsMenu', () => {
+    const baseState = {
+        entities: {
+            general: {
+                config: {
+                    PluginsEnabled: 'true',
+                },
+            },
+        },
+    } as unknown as GlobalState;
+
+    test('should return false for burn-on-read posts', () => {
+        const borPost = TestHelper.getPostMock({
+            id: 'post_id_1',
+            type: Constants.PostTypes.BURN_ON_READ as Post['type'],
+        });
+
+        expect(PostUtils.shouldShowActionsMenu(baseState, borPost)).toBe(false);
     });
 });

--- a/webapp/channels/src/utils/post_utils.ts
+++ b/webapp/channels/src/utils/post_utils.ts
@@ -157,6 +157,11 @@ export function shouldShowActionsMenu(state: GlobalState, post: Post): boolean {
         return false;
     }
 
+    // Hide plugin/app actions for burn-on-read posts
+    if (post.type === Constants.PostTypes.BURN_ON_READ) {
+        return false;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
#### Summary
This Pr hides the ActionsMenu (plugin integrations like Jira, playbooks, etc.) and individual plugin action buttons for burn-on-read messages. The backend already prevents hooks calls for BoR posts; this change ensures the frontend no longer exposes those actions to users.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66939

#### Screenshots

Before:

<img width="1075" height="96" alt="Screenshot 2025-12-12 at 1 01 41 AM" src="https://github.com/user-attachments/assets/c75b9b7e-c67b-421a-bc58-fbf75627f916" />

After:
<img width="1186" height="113" alt="Screenshot 2025-12-12 at 1 03 48 AM" src="https://github.com/user-attachments/assets/08cfc956-b43d-41e6-b1df-a79e79c1d65e" />


#### Release Note
```release-note
NONE
```
