### PR TITLE
MM-66943: Fix SavePluginConfig wiping other plugins' configs

### DIFF
--- a/server/channels/app/plugin_api.go
+++ b/server/channels/app/plugin_api.go
@@ -120,7 +120,7 @@ func (api *PluginAPI) GetPluginConfig() map[string]any {
 }
 
 func (api *PluginAPI) SavePluginConfig(pluginConfig map[string]any) *model.AppError {
-	cfg := api.app.GetSanitizedConfig()
+	cfg := api.app.Config().Clone()
 	cfg.PluginSettings.Plugins[api.manifest.Id] = pluginConfig
 	_, _, err := api.app.SaveConfig(cfg, true)
 	return err


### PR DESCRIPTION
#### Summary

Fixed `PluginAPI.SavePluginConfig` to use the unsanitized config as the base when saving, preventing it from deleting configurations for plugins whose manifests aren't currently loaded.

When a plugin's manifest is temporarily unavailable (e.g., during signature verification failure, sync operations, or upgrades) and another plugin calls `SavePluginConfig()`, the unavailable plugin's configuration was being permanently deleted. This happened because `SavePluginConfig` used `GetSanitizedConfig()` which removes configs for plugins without loaded manifests.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-66943

#### Screenshots

N/A - no UI changes

```release-note
Fixed an issue where some plugin configurations were deleted when another plugin saved its configuration.
```