### PR TITLE
[MM-66956] Filter burn on read posts from search results

### DIFF
--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -1100,7 +1100,7 @@ func (a *App) GetPostsPage(rctx request.CTX, options model.GetPostsOptions) (*mo
 	}
 
 	var appErr *model.AppError
-	postList, appErr = a.RevealBurnOnReadPostsForUser(rctx, postList, options.UserId)
+	postList, appErr = a.revealBurnOnReadPostsForUser(rctx, postList, options.UserId)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -1128,7 +1128,7 @@ func (a *App) GetPosts(rctx request.CTX, channelID string, offset int, limit int
 	}
 
 	var appErr *model.AppError
-	postList, appErr = a.RevealBurnOnReadPostsForUser(rctx, postList, rctx.Session().UserId)
+	postList, appErr = a.revealBurnOnReadPostsForUser(rctx, postList, rctx.Session().UserId)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -1157,7 +1157,7 @@ func (a *App) GetPostsSince(rctx request.CTX, options model.GetPostsSinceOptions
 	}
 
 	var appErr *model.AppError
-	postList, appErr = a.RevealBurnOnReadPostsForUser(rctx, postList, options.UserId)
+	postList, appErr = a.revealBurnOnReadPostsForUser(rctx, postList, options.UserId)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -1179,20 +1179,9 @@ func (a *App) GetSinglePost(rctx request.CTX, postID string, includeDeleted bool
 		}
 	}
 
-	if post.Type == model.PostTypeBurnOnRead {
-		tmpPostList := model.NewPostList()
-		tmpPostList.AddPost(post)
-
-		postList, appErr := a.RevealBurnOnReadPostsForUser(rctx, tmpPostList, rctx.Session().UserId)
-		if appErr != nil {
-			return nil, appErr
-		}
-
-		var ok bool
-		post, ok = postList.Posts[post.Id]
-		if !ok {
-			return nil, model.NewAppError("GetSinglePost", "app.post.get.app_error", nil, "", http.StatusNotFound)
-		}
+	post, appErr := a.revealSingleBurnOnReadPost(rctx, post, rctx.Session().UserId)
+	if appErr != nil {
+		return nil, appErr
 	}
 
 	firstInaccessiblePostTime, appErr := a.isInaccessiblePost(post)
@@ -1224,7 +1213,7 @@ func (a *App) GetPostThread(rctx request.CTX, postID string, opts model.GetPosts
 	}
 
 	var appErr *model.AppError
-	posts, appErr = a.RevealBurnOnReadPostsForUser(rctx, posts, userID)
+	posts, appErr = a.revealBurnOnReadPostsForUser(rctx, posts, userID)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -1307,7 +1296,7 @@ func (a *App) GetPermalinkPost(rctx request.CTX, postID string, userID string) (
 	}
 
 	var appErr *model.AppError
-	list, appErr = a.RevealBurnOnReadPostsForUser(rctx, list, userID)
+	list, appErr = a.revealBurnOnReadPostsForUser(rctx, list, userID)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -1348,7 +1337,7 @@ func (a *App) GetPostsBeforePost(rctx request.CTX, options model.GetPostsOptions
 	}
 
 	var appErr *model.AppError
-	postList, appErr = a.RevealBurnOnReadPostsForUser(rctx, postList, options.UserId)
+	postList, appErr = a.revealBurnOnReadPostsForUser(rctx, postList, options.UserId)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -1384,7 +1373,7 @@ func (a *App) GetPostsAfterPost(rctx request.CTX, options model.GetPostsOptions)
 	}
 
 	var appErr *model.AppError
-	postList, appErr = a.RevealBurnOnReadPostsForUser(rctx, postList, options.UserId)
+	postList, appErr = a.revealBurnOnReadPostsForUser(rctx, postList, options.UserId)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -1428,7 +1417,7 @@ func (a *App) GetPostsAroundPost(rctx request.CTX, before bool, options model.Ge
 	}
 
 	var appErr *model.AppError
-	postList, appErr = a.RevealBurnOnReadPostsForUser(rctx, postList, options.UserId)
+	postList, appErr = a.revealBurnOnReadPostsForUser(rctx, postList, options.UserId)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -1757,6 +1746,10 @@ func (a *App) searchPostsInTeam(teamID string, userID string, paramsList []*mode
 		return nil, appErr
 	}
 
+	if appErr := a.filterBurnOnReadPosts(posts); appErr != nil {
+		return nil, appErr
+	}
+
 	return posts, nil
 }
 
@@ -1918,6 +1911,10 @@ func (a *App) SearchPostsForUser(rctx request.CTX, terms string, userID string, 
 	}
 
 	if appErr := a.filterInaccessiblePosts(postSearchResults.PostList, filterPostOptions{assumeSortedCreatedAt: true}); appErr != nil {
+		return nil, appErr
+	}
+
+	if appErr := a.filterBurnOnReadPosts(postSearchResults.PostList); appErr != nil {
 		return nil, appErr
 	}
 
@@ -3366,45 +3363,6 @@ func (a *App) getBurnOnReadPost(rctx request.CTX, post *model.Post) (*model.Post
 	clone.Message = tmpPost.Message
 	clone.FileIds = tmpPost.FileIDs
 	return clone, nil
-}
-
-// RevealBurnOnReadPostsForUser processes burn-on-read posts in a post list for a specific user,
-// revealing posts that the user has access to and handling expired receipts.
-func (a *App) RevealBurnOnReadPostsForUser(rctx request.CTX, postList *model.PostList, userID string) (*model.PostList, *model.AppError) {
-	for _, post := range postList.BurnOnReadPosts {
-		// If user is the author, reveal the post with recipients
-		if post.UserId == userID {
-			if err := a.revealPostForAuthor(rctx, postList, post); err != nil {
-				return nil, err
-			}
-			continue
-		}
-
-		// Get user's read receipt for this post
-		receipt, err := a.getUserReadReceipt(rctx, post.Id, userID)
-		if err != nil {
-			return nil, err
-		}
-
-		// If no receipt exists, show unrevealed message
-		if receipt == nil {
-			a.setUnrevealedPost(postList, post.Id)
-			continue
-		}
-
-		// If receipt expired, remove post from list
-		if a.isReceiptExpired(receipt) {
-			a.removePostFromList(postList, post.Id)
-			continue
-		}
-
-		// Reveal post with expiration metadata
-		if err := a.revealPostForUser(rctx, postList, post, receipt); err != nil {
-			return nil, err
-		}
-	}
-
-	return postList, nil
 }
 
 // revealPostForAuthor reveals a burn-on-read post for its author, including recipient list.

--- a/server/channels/app/post_helpers.go
+++ b/server/channels/app/post_helpers.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 )
 
 type filterPostOptions struct {
@@ -262,4 +263,146 @@ func (a *App) getFilteredAccessiblePosts(posts []*model.Post, options filterPost
 
 	filteredPosts, firstInaccessiblePostTime := linearFilterPostsSlice(posts, lastAccessiblePostTime)
 	return filteredPosts, firstInaccessiblePostTime, nil
+}
+
+// filterBurnOnReadPosts filters out burn-on-read posts from a PostList.
+// This should be used for contexts where burn-on-read posts should not appear (e.g., search results).
+func (a *App) filterBurnOnReadPosts(postList *model.PostList) *model.AppError {
+	if postList == nil || postList.Posts == nil || len(postList.Posts) == 0 {
+		return nil
+	}
+
+	// Check if burn-on-read feature is enabled
+	if !a.Config().FeatureFlags.BurnOnRead || !model.SafeDereference(a.Config().ServiceSettings.EnableBurnOnRead) {
+		// Feature is not enabled, no need to filter
+		return nil
+	}
+
+	// Collect burn-on-read post IDs
+	var burnOnReadPostIDs []string
+	for postID, post := range postList.Posts {
+		if post.Type == model.PostTypeBurnOnRead {
+			burnOnReadPostIDs = append(burnOnReadPostIDs, postID)
+		}
+	}
+
+	// If no burn-on-read posts found, nothing to filter
+	if len(burnOnReadPostIDs) == 0 {
+		return nil
+	}
+
+	// Remove burn-on-read posts from the list
+	for _, postID := range burnOnReadPostIDs {
+		a.removePostFromList(postList, postID)
+	}
+
+	// Filter Order slice directly to ensure all burn-on-read posts are removed
+	filteredOrder := make([]string, 0, len(postList.Order))
+	for _, postID := range postList.Order {
+		if post, exists := postList.Posts[postID]; exists && post.Type != model.PostTypeBurnOnRead {
+			filteredOrder = append(filteredOrder, postID)
+		}
+	}
+	postList.Order = filteredOrder
+
+	// Clear BurnOnReadPosts map as burn-on-read posts should not appear
+	postList.BurnOnReadPosts = make(map[string]*model.Post)
+
+	// Update NextPostId and PrevPostId if they point to removed posts
+	if postList.NextPostId != "" {
+		if _, exists := postList.Posts[postList.NextPostId]; !exists {
+			postList.NextPostId = ""
+		}
+	}
+	if postList.PrevPostId != "" {
+		if _, exists := postList.Posts[postList.PrevPostId]; !exists {
+			postList.PrevPostId = ""
+		}
+	}
+
+	return nil
+}
+
+// revealSingleBurnOnReadPost reveals a single burn-on-read post for a user.
+// If the post is not a burn-on-read post, it returns the post unchanged.
+// If the post is expired or inaccessible, it returns an error.
+func (a *App) revealSingleBurnOnReadPost(rctx request.CTX, post *model.Post, userID string) (*model.Post, *model.AppError) {
+	if post == nil {
+		return nil, model.NewAppError("revealSingleBurnOnReadPost", "app.post.get.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	// If not a burn-on-read post, return as-is
+	if post.Type != model.PostTypeBurnOnRead {
+		return post, nil
+	}
+
+	// Check if burn-on-read feature is enabled
+	if !a.Config().FeatureFlags.BurnOnRead || !model.SafeDereference(a.Config().ServiceSettings.EnableBurnOnRead) {
+		// Feature is not enabled, return post as-is
+		return post, nil
+	}
+
+	tmpPostList := model.NewPostList()
+	tmpPostList.AddPost(post)
+
+	postList, appErr := a.revealBurnOnReadPostsForUser(rctx, tmpPostList, userID)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	revealedPost, ok := postList.Posts[post.Id]
+	if !ok {
+		return nil, model.NewAppError("revealSingleBurnOnReadPost", "app.post.get.app_error", nil, "", http.StatusNotFound)
+	}
+
+	return revealedPost, nil
+}
+
+// revealBurnOnReadPostsForUser processes burn-on-read posts in a post list for a specific user,
+// revealing posts that the user has access to and handling expired receipts.
+func (a *App) revealBurnOnReadPostsForUser(rctx request.CTX, postList *model.PostList, userID string) (*model.PostList, *model.AppError) {
+	if postList == nil || postList.BurnOnReadPosts == nil || len(postList.BurnOnReadPosts) == 0 {
+		return postList, nil
+	}
+
+	// Check if burn-on-read feature is enabled
+	if !a.Config().FeatureFlags.BurnOnRead || !model.SafeDereference(a.Config().ServiceSettings.EnableBurnOnRead) {
+		// Feature is not enabled, return postList as-is
+		return postList, nil
+	}
+
+	for _, post := range postList.BurnOnReadPosts {
+		// If user is the author, reveal the post with recipients
+		if post.UserId == userID {
+			if err := a.revealPostForAuthor(rctx, postList, post); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		// Get user's read receipt for this post
+		receipt, err := a.getUserReadReceipt(rctx, post.Id, userID)
+		if err != nil {
+			return nil, err
+		}
+
+		// If no receipt exists, show unrevealed message
+		if receipt == nil {
+			a.setUnrevealedPost(postList, post.Id)
+			continue
+		}
+
+		// If receipt expired, remove post from list
+		if a.isReceiptExpired(receipt) {
+			a.removePostFromList(postList, post.Id)
+			continue
+		}
+
+		// Reveal post with expiration metadata
+		if err := a.revealPostForUser(rctx, postList, post, receipt); err != nil {
+			return nil, err
+		}
+	}
+
+	return postList, nil
 }

--- a/server/channels/store/sqlstore/file_info_store.go
+++ b/server/channels/store/sqlstore/file_info_store.go
@@ -548,6 +548,7 @@ func (fs SqlFileInfoStore) Search(rctx request.CTX, paramsList []*model.SearchPa
 			sq.Eq{"FileInfo.CreatorId": model.BookmarkFileOwner},
 			sq.NotEq{"FileInfo.PostId": ""},
 		}).
+		Where(sq.Expr("NOT EXISTS (SELECT 1 FROM TemporaryPosts WHERE TemporaryPosts.PostId = FileInfo.PostId)")).
 		OrderBy("FileInfo.CreateAt DESC").
 		Limit(100)
 

--- a/server/channels/store/storetest/file_info_store.go
+++ b/server/channels/store/storetest/file_info_store.go
@@ -41,6 +41,7 @@ func TestFileInfoStore(t *testing.T, rctx request.CTX, ss store.Store, s SqlStor
 	t.Run("FileInfoGetByIds", func(t *testing.T) { testGetByIds(t, rctx, ss) })
 	t.Run("FileInfoDeleteForPostByIds", func(t *testing.T) { testDeleteForPostByIds(t, rctx, ss) })
 	t.Run("FileInfoRestoreForPostByIds", func(t *testing.T) { testRestoreUndeleteForPostByIds(t, rctx, ss) })
+	t.Run("FileInfoSearch", func(t *testing.T) { testFileInfoSearch(t, rctx, ss) })
 }
 
 func testFileInfoSaveGet(t *testing.T, rctx request.CTX, ss store.Store) {
@@ -1537,5 +1538,212 @@ func testRestoreUndeleteForPostByIds(t *testing.T, rctx request.CTX, ss store.St
 		for _, fileInfo := range fileInfos {
 			require.Equal(t, int64(0), fileInfo.DeleteAt)
 		}
+	})
+}
+
+func testFileInfoSearch(t *testing.T, rctx request.CTX, ss store.Store) {
+	t.Run("should exclude FileInfo records with PostIds in TemporaryPosts", func(t *testing.T) {
+		// Create team, channel, and user
+		teamID := model.NewId()
+		userID := model.NewId()
+
+		channel := &model.Channel{
+			TeamId:      teamID,
+			DisplayName: "Test Channel",
+			Name:        "test-channel-" + model.NewId(),
+			Type:        model.ChannelTypeOpen,
+		}
+		channel, err := ss.Channel().Save(rctx, channel, -1)
+		require.NoError(t, err)
+
+		// Create channel member
+		_, err = ss.Channel().SaveMember(rctx, &model.ChannelMember{
+			ChannelId:   channel.Id,
+			UserId:      userID,
+			NotifyProps: model.GetDefaultChannelNotifyProps(),
+		})
+		require.NoError(t, err)
+
+		// Create posts
+		post1 := &model.Post{
+			ChannelId: channel.Id,
+			UserId:    userID,
+			Message:   "post 1",
+		}
+		post1, err = ss.Post().Save(rctx, post1)
+		require.NoError(t, err)
+
+		post2 := &model.Post{
+			ChannelId: channel.Id,
+			UserId:    userID,
+			Message:   "post 2",
+		}
+		post2, err = ss.Post().Save(rctx, post2)
+		require.NoError(t, err)
+
+		post3 := &model.Post{
+			ChannelId: channel.Id,
+			UserId:    userID,
+			Message:   "post 3",
+		}
+		post3, err = ss.Post().Save(rctx, post3)
+		require.NoError(t, err)
+
+		// Create FileInfo records attached to posts
+		fileInfo1, err := ss.FileInfo().Save(rctx, &model.FileInfo{
+			PostId:    post1.Id,
+			ChannelId: channel.Id,
+			CreatorId: userID,
+			Path:      "file1.txt",
+			Name:      "file1.txt",
+		})
+		require.NoError(t, err)
+		defer ss.FileInfo().PermanentDelete(rctx, fileInfo1.Id)
+
+		fileInfo2, err := ss.FileInfo().Save(rctx, &model.FileInfo{
+			PostId:    post2.Id,
+			ChannelId: channel.Id,
+			CreatorId: userID,
+			Path:      "file2.txt",
+			Name:      "file2.txt",
+		})
+		require.NoError(t, err)
+		defer ss.FileInfo().PermanentDelete(rctx, fileInfo2.Id)
+
+		fileInfo3, err := ss.FileInfo().Save(rctx, &model.FileInfo{
+			PostId:    post3.Id,
+			ChannelId: channel.Id,
+			CreatorId: userID,
+			Path:      "file3.txt",
+			Name:      "file3.txt",
+		})
+		require.NoError(t, err)
+		defer ss.FileInfo().PermanentDelete(rctx, fileInfo3.Id)
+
+		// Create TemporaryPost for post2 (fileInfo2 should be excluded)
+		tmpPost := &model.TemporaryPost{
+			ID:       post2.Id,
+			Type:     model.PostTypeBurnOnRead,
+			ExpireAt: model.GetMillis() + 3600000, // 1 hour from now
+			Message:  "temporary message",
+			FileIDs:  []string{fileInfo2.Id},
+		}
+		_, err = ss.TemporaryPost().Save(rctx, tmpPost)
+		require.NoError(t, err)
+		defer ss.TemporaryPost().Delete(rctx, tmpPost.ID)
+
+		// Search for files - should exclude fileInfo2 since its PostId is in TemporaryPosts
+		// Use empty terms to search all files in the channel (works for both PostgreSQL and MySQL)
+		paramsList := []*model.SearchParams{
+			{
+				Terms:               "",
+				InChannels:          []string{channel.Id},
+				SearchWithoutUserId: false,
+			},
+		}
+
+		results, err := ss.FileInfo().Search(rctx, paramsList, userID, teamID, 0, 100)
+		require.NoError(t, err)
+		require.NotNil(t, results)
+
+		// Verify fileInfo2 is excluded (PostId in TemporaryPosts)
+		// fileInfo1 and fileInfo3 should be included
+		foundFileIds := make(map[string]bool)
+		for _, fileInfo := range results.FileInfos {
+			foundFileIds[fileInfo.Id] = true
+		}
+
+		assert.True(t, foundFileIds[fileInfo1.Id], "fileInfo1 should be included in search results")
+		assert.False(t, foundFileIds[fileInfo2.Id], "fileInfo2 should be excluded from search results (PostId in TemporaryPosts)")
+		assert.True(t, foundFileIds[fileInfo3.Id], "fileInfo3 should be included in search results")
+	})
+
+	t.Run("should include FileInfo records when TemporaryPost is deleted", func(t *testing.T) {
+		// Create team, channel, and user
+		teamID := model.NewId()
+		userID := model.NewId()
+
+		channel := &model.Channel{
+			TeamId:      teamID,
+			DisplayName: "Test Channel 2",
+			Name:        "test-channel-" + model.NewId(),
+			Type:        model.ChannelTypeOpen,
+		}
+		channel, err := ss.Channel().Save(rctx, channel, -1)
+		require.NoError(t, err)
+
+		// Create channel member
+		_, err = ss.Channel().SaveMember(rctx, &model.ChannelMember{
+			ChannelId:   channel.Id,
+			UserId:      userID,
+			NotifyProps: model.GetDefaultChannelNotifyProps(),
+		})
+		require.NoError(t, err)
+
+		// Create post
+		post := &model.Post{
+			ChannelId: channel.Id,
+			UserId:    userID,
+			Message:   "post",
+		}
+		post, err = ss.Post().Save(rctx, post)
+		require.NoError(t, err)
+
+		// Create FileInfo attached to post
+		fileInfo, err := ss.FileInfo().Save(rctx, &model.FileInfo{
+			PostId:    post.Id,
+			ChannelId: channel.Id,
+			CreatorId: userID,
+			Path:      "file.txt",
+			Name:      "file.txt",
+		})
+		require.NoError(t, err)
+		defer ss.FileInfo().PermanentDelete(rctx, fileInfo.Id)
+
+		// Create TemporaryPost for the post
+		tmpPost := &model.TemporaryPost{
+			ID:       post.Id,
+			Type:     model.PostTypeBurnOnRead,
+			ExpireAt: model.GetMillis() + 3600000,
+			Message:  "temporary message",
+			FileIDs:  []string{fileInfo.Id},
+		}
+		_, err = ss.TemporaryPost().Save(rctx, tmpPost)
+		require.NoError(t, err)
+
+		// Search - fileInfo should be excluded
+		// Use empty terms to search all files in the channel (works for both PostgreSQL and MySQL)
+		paramsList := []*model.SearchParams{
+			{
+				Terms:               "",
+				InChannels:          []string{channel.Id},
+				SearchWithoutUserId: false,
+			},
+		}
+
+		results, err := ss.FileInfo().Search(rctx, paramsList, userID, teamID, 0, 100)
+		require.NoError(t, err)
+		require.NotNil(t, results)
+
+		foundFileIds := make(map[string]bool)
+		for _, fi := range results.FileInfos {
+			foundFileIds[fi.Id] = true
+		}
+		assert.False(t, foundFileIds[fileInfo.Id], "fileInfo should be excluded when TemporaryPost exists")
+
+		// Delete TemporaryPost
+		err = ss.TemporaryPost().Delete(rctx, tmpPost.ID)
+		require.NoError(t, err)
+
+		// Search again - fileInfo should now be included
+		results, err = ss.FileInfo().Search(rctx, paramsList, userID, teamID, 0, 100)
+		require.NoError(t, err)
+		require.NotNil(t, results)
+
+		foundFileIds = make(map[string]bool)
+		for _, fi := range results.FileInfos {
+			foundFileIds[fi.Id] = true
+		}
+		assert.True(t, foundFileIds[fileInfo.Id], "fileInfo should be included after TemporaryPost is deleted")
 	})
 }


### PR DESCRIPTION


#### Summary

This pull request introduces several improvements and refactorings related to handling burn on read posts and filtering associated file attachments. The main focus is ensuring that temporary posts and their files are properly excluded from search results.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66956


#### Release Note

```release-note
NONE
```
