### PR TITLE
[MM-66884] Implement Post Edit History popout

### DIFF
--- a/webapp/channels/src/components/post_edit_history/__snapshots__/post_edit_history.test.tsx.snap
+++ b/webapp/channels/src/components/post_edit_history/__snapshots__/post_edit_history.test.tsx.snap
@@ -73,6 +73,12 @@ exports[`components/post_edit_history should display error screen if errors are 
                       />
                     </button>
                     <button
+                      aria-label="Open in new window"
+                      data-testid="popout-button"
+                    >
+                      PopoutButton
+                    </button>
+                    <button
                       aria-label="Close"
                       class="sidebar--right__close btn btn-icon btn-sm"
                       id="searchResultsCloseButton"
@@ -275,6 +281,12 @@ exports[`components/post_edit_history should match snapshot 1`] = `
                       />
                     </button>
                     <button
+                      aria-label="Open in new window"
+                      data-testid="popout-button"
+                    >
+                      PopoutButton
+                    </button>
+                    <button
                       aria-label="Close"
                       class="sidebar--right__close btn btn-icon btn-sm"
                       id="searchResultsCloseButton"
@@ -291,7 +303,6 @@ exports[`components/post_edit_history should match snapshot 1`] = `
                   class="edit-post-history__container edit-post-history__container__background"
                 >
                   <div
-                    aria-label="At 12:00 AM Thursday, January 1, Someone wrote, post message"
                     class="a11y__section post"
                     id="searchResult_post_id"
                   >
@@ -384,7 +395,6 @@ exports[`components/post_edit_history should match snapshot 1`] = `
                   class="edit-post-history__container"
                 >
                   <div
-                    aria-label="At 12:00 AM Thursday, January 1, Someone wrote, post message version 1"
                     class="a11y__section post"
                     id="searchResult_post_id_1"
                   >
@@ -427,7 +437,6 @@ exports[`components/post_edit_history should match snapshot 1`] = `
                   class="edit-post-history__container"
                 >
                   <div
-                    aria-label="At 12:00 AM Thursday, January 1, Someone wrote, post message version 2"
                     class="a11y__section post"
                     id="searchResult_post_id_2"
                   >

--- a/webapp/channels/src/components/post_edit_history/post_edit_history.test.tsx
+++ b/webapp/channels/src/components/post_edit_history/post_edit_history.test.tsx
@@ -3,16 +3,48 @@
 
 import React from 'react';
 import type {ComponentProps} from 'react';
+import * as ReactRedux from 'react-redux';
 
 import {Client4} from 'mattermost-redux/client';
+import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import {renderWithContext, screen, waitForElementToBeRemoved} from 'tests/react_testing_utils';
+import {isPopoutWindow, popoutPostEditHistory} from 'utils/popouts/popout_windows';
 import {TestHelper} from 'utils/test_helper';
 
 import PostEditHistory from './post_edit_history';
 
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux'),
+    useSelector: jest.fn(),
+}));
+
+jest.mock('utils/popouts/popout_windows', () => ({
+    isPopoutWindow: jest.fn(),
+    popoutPostEditHistory: jest.fn(),
+    canPopout: jest.fn(() => true),
+}));
+
+jest.mock('components/popout_button', () => ({
+    __esModule: true,
+    default: ({onClick}: {onClick: () => void}) => (
+        <button
+            data-testid='popout-button'
+            onClick={onClick}
+            aria-label='Open in new window'
+        >
+            {'PopoutButton'}
+        </button>
+    ),
+}));
+
 // jsdom doesn't implement scrolling, so we need to manually define this
 window.HTMLElement.prototype.scrollTo = jest.fn();
+
+const mockIsPopoutWindow = isPopoutWindow as jest.MockedFunction<typeof isPopoutWindow>;
+const mockPopoutPostEditHistory = popoutPostEditHistory as jest.MockedFunction<typeof popoutPostEditHistory>;
+const mockUseSelector = ReactRedux.useSelector as jest.MockedFunction<typeof ReactRedux.useSelector>;
 
 describe('components/post_edit_history', () => {
     const baseProps: ComponentProps<typeof PostEditHistory> = {
@@ -24,6 +56,23 @@ describe('components/post_edit_history', () => {
         dispatch: jest.fn(),
     };
     const mock = jest.spyOn(Client4, 'getPostEditHistory');
+
+    const mockTeam = TestHelper.getTeamMock({id: 'team_id', name: 'team_name'});
+    const mockChannel = TestHelper.getChannelMock({id: 'channel_id', name: 'channel_name'});
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockIsPopoutWindow.mockReturnValue(false);
+        mockUseSelector.mockImplementation((selector) => {
+            if (selector === getCurrentTeam) {
+                return mockTeam;
+            }
+            if (selector === getCurrentChannel) {
+                return mockChannel;
+            }
+            return undefined;
+        });
+    });
 
     test('should match snapshot', async () => {
         const data = [
@@ -56,5 +105,59 @@ describe('components/post_edit_history', () => {
 
         expect(wrapper.container).toMatchSnapshot();
         expect(mock).toHaveBeenCalledWith(baseProps.originalPost.id);
+    });
+
+    test('should not show popout button when in popout window', async () => {
+        mockIsPopoutWindow.mockReturnValue(true);
+        const data = [
+            TestHelper.getPostMock({
+                id: 'post_id_1',
+                message: 'post message version 1',
+            }),
+        ];
+        mock.mockResolvedValue(data);
+
+        renderWithContext(<PostEditHistory {...baseProps}/>);
+
+        await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+
+        expect(screen.queryByTestId('popout-button')).not.toBeInTheDocument();
+    });
+
+    test('should call popoutPostEditHistory when popout button is clicked', async () => {
+        mockIsPopoutWindow.mockReturnValue(false);
+        mockUseSelector.mockImplementation((selector) => {
+            if (selector === getCurrentTeam) {
+                return mockTeam;
+            }
+            if (selector === getCurrentChannel) {
+                return mockChannel;
+            }
+            return undefined;
+        });
+        const data = [
+            TestHelper.getPostMock({
+                id: 'post_id_1',
+                message: 'post message version 1',
+            }),
+        ];
+        mock.mockResolvedValue(data);
+
+        renderWithContext(<PostEditHistory {...baseProps}/>);
+
+        await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+
+        const popoutButton = screen.getByTestId('popout-button');
+        popoutButton.click();
+
+        expect(mockPopoutPostEditHistory).toHaveBeenCalledTimes(1);
+        expect(mockPopoutPostEditHistory).toHaveBeenCalledWith(
+            expect.objectContaining({
+                formatMessage: expect.any(Function),
+            }),
+            baseProps.originalPost.id,
+            mockTeam.name,
+            mockChannel.name,
+        );
     });
 });

--- a/webapp/channels/src/components/post_edit_history_popout/index.ts
+++ b/webapp/channels/src/components/post_edit_history_popout/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export {default} from './post_edit_history_popout';

--- a/webapp/channels/src/components/post_edit_history_popout/post_edit_history_popout.tsx
+++ b/webapp/channels/src/components/post_edit_history_popout/post_edit_history_popout.tsx
@@ -1,0 +1,34 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useEffect} from 'react';
+import {useDispatch, useSelector} from 'react-redux';
+import {useParams} from 'react-router-dom';
+
+import {selectPost} from 'actions/views/rhs';
+import {getSelectedPostId} from 'selectors/rhs';
+
+import {usePost} from 'components/common/hooks/usePost';
+import LoadingScreen from 'components/loading_screen';
+import PostEditHistory from 'components/post_edit_history/';
+
+export default function PostEditHistoryPopout() {
+    const dispatch = useDispatch();
+    const {postId} = useParams<{postId: string}>();
+    const post = usePost(postId || '');
+    const selectedPostId = useSelector(getSelectedPostId);
+
+    useEffect(() => {
+        if (post) {
+            dispatch(selectPost(post));
+        }
+    }, [post, dispatch]);
+
+    if (!selectedPostId) {
+        return <LoadingScreen/>;
+    }
+
+    return (
+        <PostEditHistory/>
+    );
+}

--- a/webapp/channels/src/components/rhs_popout/rhs_popout.test.tsx
+++ b/webapp/channels/src/components/rhs_popout/rhs_popout.test.tsx
@@ -53,6 +53,11 @@ jest.mock('components/rhs_plugin_popout', () => ({
     default: () => <div data-testid='rhs-plugin-popout'>{'RHS Plugin Popout'}</div>,
 }));
 
+jest.mock('components/post_edit_history_popout', () => ({
+    __esModule: true,
+    default: () => <div data-testid='post-edit-history-popout'>{'Post Edit History Popout'}</div>,
+}));
+
 const mockDispatch = jest.fn();
 const mockUseDispatch = ReactRedux.useDispatch as jest.MockedFunction<typeof ReactRedux.useDispatch>;
 const mockUseSelector = ReactRedux.useSelector as jest.MockedFunction<typeof ReactRedux.useSelector>;
@@ -135,6 +140,20 @@ describe('RhsPopout', () => {
         );
 
         expect(screen.getByTestId('rhs-plugin-popout')).toBeInTheDocument();
+    });
+
+    it('should render PostEditHistoryPopout for post-edit-history route', () => {
+        const postId = 'a'.repeat(26);
+        renderWithContext(
+            <MemoryRouter initialEntries={[`/_popout/rhs/team1/channel1/post-edit-history/${postId}`]}>
+                <Route
+                    path='/_popout/rhs/:team/:identifier'
+                    component={RhsPopout}
+                />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId('post-edit-history-popout')).toBeInTheDocument();
     });
 });
 

--- a/webapp/channels/src/components/rhs_popout/rhs_popout.tsx
+++ b/webapp/channels/src/components/rhs_popout/rhs_popout.tsx
@@ -10,8 +10,11 @@ import {selectTeam} from 'mattermost-redux/actions/teams';
 import {getChannelByName} from 'mattermost-redux/selectors/entities/channels';
 
 import {useTeamByName} from 'components/common/hooks/use_team';
+import PostEditHistoryPopout from 'components/post_edit_history_popout';
 import RhsPluginPopout from 'components/rhs_plugin_popout';
 import UnreadsStatusHandler from 'components/unreads_status_handler';
+
+import {ID_PATH_PATTERN} from 'utils/path';
 
 import type {GlobalState} from 'types/store';
 
@@ -53,6 +56,10 @@ export default function RhsPopout() {
                             <Route
                                 path={`${match.path}/plugin/:pluginId`}
                                 component={RhsPluginPopout}
+                            />
+                            <Route
+                                path={`${match.path}/post-edit-history/:postId(${ID_PATH_PATTERN})`}
+                                component={PostEditHistoryPopout}
                             />
                         </Switch>
                     </div>

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -5307,6 +5307,7 @@
   "post_delete.notPosted": "Comment could not be posted",
   "post_delete.okay": "Okay",
   "post_delete.someone": "Someone deleted the message on which you tried to post a comment.",
+  "post_edit_history_popout.title": "Post Edit History - {channelName} - {teamName}",
   "post_header.update_status": "Update your status",
   "post_info.actions.noActions.first_line": "No Actions currently",
   "post_info.actions.noActions.second_line": "configured for this server",

--- a/webapp/channels/src/utils/popouts/popout_windows.ts
+++ b/webapp/channels/src/utils/popouts/popout_windows.ts
@@ -75,6 +75,24 @@ export async function popoutRhsPlugin(
     return listeners;
 }
 
+export async function popoutPostEditHistory(
+    intl: IntlShape,
+    postId: string,
+    teamName: string,
+    channelName: string,
+) {
+    return popout(
+        `/_popout/rhs/${teamName}/${channelName}/post-edit-history/${postId}`,
+        {
+            isRHS: true,
+            titleTemplate: intl.formatMessage({
+                id: 'post_edit_history_popout.title',
+                defaultMessage: 'Post Edit History - {channelName} - {teamName}',
+            }, {channelName: '{channelName}', teamName: '{teamName}'}),
+        },
+    );
+}
+
 /**
  * Below this is generic popout code
  * You likely do not need to add anything below this.


### PR DESCRIPTION
#### Summary
This PR enables the Post Edit History to be popped out, using a new route that takes in the `postId` as a parameter. Unlike the main RHS view, this one will not currently auto-close.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66884

#### Screenshots
<img width="912" height="865" alt="Screenshot 2025-12-15 at 11 56 29 AM" src="https://github.com/user-attachments/assets/f555b1ab-0fdb-4006-b001-e3c27d3cf695" />
<img width="912" height="865" alt="Screenshot 2025-12-15 at 11 56 23 AM" src="https://github.com/user-attachments/assets/a210833b-8503-459b-91db-28cef34673a0" />

```release-note
Add Post Edit History RHS popout
```