### PR TITLE
MM-66952: Disable Generate Test Coverage job in CI

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -227,8 +227,9 @@ jobs:
       fips-enabled: true
   test-coverage:
     name: Generate Test Coverage
-    # Skip coverage generation for cherry-pick PRs into release branches.
-    if: ${{ github.event_name != 'pull_request' || !startsWith(github.event.pull_request.base.ref, 'release-') }}
+    # Disabled: Running out of memory and causing spurious failures.
+    # Old condition: ${{ github.event_name != 'pull_request' || !startsWith(github.event.pull_request.base.ref, 'release-') }}
+    if: false
     needs: go
     uses: ./.github/workflows/server-test-template.yml
     secrets: inherit


### PR DESCRIPTION
#### Summary

Temporarily disable the "Generate Test Coverage" job in CI. This job is running out of memory and causing spurious CI failures.

This is a temporary solution until we can resolve the underlying memory issue.

#### Ticket Link

Relates-to: https://mattermost.atlassian.net/browse/MM-66952

#### Screenshots

N/A

#### Release Note
```release-note
NONE
```