### PR TITLE
Update web app package versions to 11.3.0

### DIFF
--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -3,16 +3,16 @@
   "browser": {
     "./client/web_client.jsx": "./client/browser_web_client.jsx"
   },
-  "version": "11.1.0",
+  "version": "11.3.0",
   "private": true,
   "dependencies": {
     "@floating-ui/react": "0.26.6",
     "@giphy/js-fetch-api": "5.7.0",
     "@giphy/react-components": "10.1.0",
     "@guyplusplus/turndown-plugin-gfm": "1.0.7",
-    "@mattermost/client": "11.1.0",
+    "@mattermost/client": "11.3.0",
     "@mattermost/desktop-api": "6.0.0-1",
-    "@mattermost/types": "11.1.0",
+    "@mattermost/types": "11.3.0",
     "@mui/base": "5.0.0-alpha.127",
     "@mui/material": "5.11.16",
     "@mui/styled-engine-sc": "5.11.11",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -55,15 +55,15 @@
     },
     "channels": {
       "name": "mattermost-webapp",
-      "version": "11.1.0",
+      "version": "11.3.0",
       "dependencies": {
         "@floating-ui/react": "0.26.6",
         "@giphy/js-fetch-api": "5.7.0",
         "@giphy/react-components": "10.1.0",
         "@guyplusplus/turndown-plugin-gfm": "1.0.7",
-        "@mattermost/client": "11.1.0",
+        "@mattermost/client": "11.3.0",
         "@mattermost/desktop-api": "6.0.0-1",
-        "@mattermost/types": "11.1.0",
+        "@mattermost/types": "11.3.0",
         "@mui/base": "5.0.0-alpha.127",
         "@mui/material": "5.11.16",
         "@mui/styled-engine-sc": "5.11.11",
@@ -28693,7 +28693,7 @@
     },
     "platform/client": {
       "name": "@mattermost/client",
-      "version": "11.1.0",
+      "version": "11.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "30.0.0",
@@ -28704,7 +28704,7 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
-        "@mattermost/types": "11.1.0",
+        "@mattermost/types": "11.3.0",
         "typescript": "^4.3.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
@@ -28808,11 +28808,11 @@
       }
     },
     "platform/mattermost-redux": {
-      "version": "11.1.0",
+      "version": "11.3.0",
       "license": "MIT",
       "dependencies": {
-        "@mattermost/client": "11.1.0",
-        "@mattermost/types": "11.1.0",
+        "@mattermost/client": "11.3.0",
+        "@mattermost/types": "11.3.0",
         "@redux-devtools/extension": "3.3.0",
         "lodash": "^4.17.21",
         "moment-timezone": "^0.5.38",
@@ -28834,7 +28834,7 @@
     },
     "platform/types": {
       "name": "@mattermost/types",
-      "version": "11.1.0",
+      "version": "11.3.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.0.0"

--- a/webapp/platform/client/package.json
+++ b/webapp/platform/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/client",
-  "version": "11.1.0",
+  "version": "11.3.0",
   "description": "JavaScript/TypeScript client for Mattermost",
   "keywords": [
     "mattermost"
@@ -27,7 +27,7 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "@mattermost/types": "11.1.0",
+    "@mattermost/types": "11.3.0",
     "typescript": "^4.3.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {

--- a/webapp/platform/mattermost-redux/package.json
+++ b/webapp/platform/mattermost-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mattermost-redux",
-  "version": "11.1.0",
+  "version": "11.3.0",
   "description": "Common code (API client, Redux stores, logic, utility functions) for building a Mattermost client",
   "keywords": [
     "mattermost"
@@ -39,8 +39,8 @@
     "directory": "webapp/platform/mattermost-redux"
   },
   "dependencies": {
-    "@mattermost/client": "11.1.0",
-    "@mattermost/types": "11.1.0",
+    "@mattermost/client": "11.3.0",
+    "@mattermost/types": "11.3.0",
     "@redux-devtools/extension": "3.3.0",
     "lodash": "^4.17.21",
     "moment-timezone": "^0.5.38",

--- a/webapp/platform/types/package.json
+++ b/webapp/platform/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/types",
-  "version": "11.1.0",
+  "version": "11.3.0",
   "description": "Shared type definitions used by the Mattermost web app",
   "keywords": [
     "mattermost"


### PR DESCRIPTION
#### Summary
The script I added to do this automatically isn't working in CI due to a missing dependency, so I have to go back to doing it manually after release branches are cut.

#### Release Note
```release-note
NONE
```
