### PR TITLE
[MM-66889] Load scheduled posts for team in thread popout

### DIFF
--- a/webapp/channels/src/components/thread_popout/thread_popout.tsx
+++ b/webapp/channels/src/components/thread_popout/thread_popout.tsx
@@ -7,6 +7,7 @@ import {useParams} from 'react-router-dom';
 
 import {fetchChannelsAndMembers, selectChannel} from 'mattermost-redux/actions/channels';
 import {getPostThread} from 'mattermost-redux/actions/posts';
+import {fetchTeamScheduledPosts} from 'mattermost-redux/actions/scheduled_posts';
 import {extractUserIdsAndMentionsFromPosts} from 'mattermost-redux/actions/status_profile_polling';
 import {selectTeam} from 'mattermost-redux/actions/teams';
 import {getThread} from 'mattermost-redux/actions/threads';
@@ -52,6 +53,7 @@ export default function ThreadPopout() {
     useEffect(() => {
         if (teamId) {
             dispatch(fetchChannelsAndMembers(teamId));
+            dispatch(fetchTeamScheduledPosts(teamId, true));
             dispatch(selectTeam(teamId));
         }
     }, [dispatch, teamId]);


### PR DESCRIPTION
#### Summary
Scheduled posts were not working/loading in thread popouts, because we didn't load them using the pop-out component.

This PR ensures we load the scheduled posts for the given team so that the thread and the scheduled posts can behave normally.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66889

```release-note
Fixed an issue where scheduling a post in the thread popout did not work
```
