### PR TITLE
MM-66907 - hide bor ui elements with prof or ent licenses

### DIFF
--- a/webapp/channels/src/selectors/burn_on_read.test.ts
+++ b/webapp/channels/src/selectors/burn_on_read.test.ts
@@ -4,6 +4,8 @@
 import {getPreferenceKey} from 'mattermost-redux/utils/preference_utils';
 
 import TestHelper from 'packages/mattermost-redux/test/test_helper';
+import {LicenseSkus} from 'utils/constants';
+import {TestHelper as WebappTestHelper} from 'utils/test_helper';
 
 import type {GlobalState} from 'types/store';
 
@@ -26,6 +28,10 @@ describe('selectors/burn_on_read', () => {
             entities: {
                 general: {
                     config: {},
+                    license: WebappTestHelper.getLicenseMock({
+                        IsLicensed: 'true',
+                        SkuShortName: LicenseSkus.EnterpriseAdvanced,
+                    }),
                 },
                 preferences: {
                     myPreferences: {},
@@ -41,19 +47,64 @@ describe('selectors/burn_on_read', () => {
     });
 
     describe('isBurnOnReadEnabled', () => {
-        it('should return true when config.EnableBurnOnRead is true', () => {
+        it('should return true when config is enabled AND license is Enterprise Advanced', () => {
             state.entities.general.config.EnableBurnOnRead = 'true';
+            state.entities.general.license = WebappTestHelper.getLicenseMock({
+                IsLicensed: 'true',
+                SkuShortName: LicenseSkus.EnterpriseAdvanced,
+            });
             const result = isBurnOnReadEnabled(state);
             expect(result).toBe(true);
         });
 
-        it('should return false when config.EnableBurnOnRead is false', () => {
+        it('should return true when config is enabled AND license is Entry (legacy tier)', () => {
+            state.entities.general.config.EnableBurnOnRead = 'true';
+            state.entities.general.license = WebappTestHelper.getLicenseMock({
+                IsLicensed: 'true',
+                SkuShortName: LicenseSkus.Entry,
+            });
+            const result = isBurnOnReadEnabled(state);
+            expect(result).toBe(true);
+        });
+
+        it('should return false when config is enabled but license is Enterprise (not Advanced)', () => {
+            state.entities.general.config.EnableBurnOnRead = 'true';
+            state.entities.general.license = WebappTestHelper.getLicenseMock({
+                IsLicensed: 'true',
+                SkuShortName: LicenseSkus.Enterprise,
+            });
+            const result = isBurnOnReadEnabled(state);
+            expect(result).toBe(false);
+        });
+
+        it('should return false when config is enabled but license is Professional', () => {
+            state.entities.general.config.EnableBurnOnRead = 'true';
+            state.entities.general.license = WebappTestHelper.getLicenseMock({
+                IsLicensed: 'true',
+                SkuShortName: LicenseSkus.Professional,
+            });
+            const result = isBurnOnReadEnabled(state);
+            expect(result).toBe(false);
+        });
+
+        it('should return false when license is Enterprise Advanced but config is disabled', () => {
             state.entities.general.config.EnableBurnOnRead = 'false';
+            state.entities.general.license = WebappTestHelper.getLicenseMock({
+                IsLicensed: 'true',
+                SkuShortName: LicenseSkus.EnterpriseAdvanced,
+            });
             const result = isBurnOnReadEnabled(state);
             expect(result).toBe(false);
         });
 
         it('should return false when config.EnableBurnOnRead is not set', () => {
+            const result = isBurnOnReadEnabled(state);
+            expect(result).toBe(false);
+        });
+
+        it('should return false when no license exists', () => {
+            state.entities.general.config.EnableBurnOnRead = 'true';
+            state.entities.general.license = {} as any;
             const result = isBurnOnReadEnabled(state);
             expect(result).toBe(false);
         });
@@ -91,10 +142,24 @@ describe('selectors/burn_on_read', () => {
     });
 
     describe('canUserSendBurnOnRead', () => {
-        it('should return true when feature is enabled', () => {
+        it('should return true when feature is enabled and license is Enterprise Advanced', () => {
             state.entities.general.config.EnableBurnOnRead = 'true';
+            state.entities.general.license = WebappTestHelper.getLicenseMock({
+                IsLicensed: 'true',
+                SkuShortName: LicenseSkus.EnterpriseAdvanced,
+            });
             const result = canUserSendBurnOnRead(state);
             expect(result).toBe(true);
+        });
+
+        it('should return false when feature is enabled but license is insufficient', () => {
+            state.entities.general.config.EnableBurnOnRead = 'true';
+            state.entities.general.license = WebappTestHelper.getLicenseMock({
+                IsLicensed: 'true',
+                SkuShortName: LicenseSkus.Professional,
+            });
+            const result = canUserSendBurnOnRead(state);
+            expect(result).toBe(false);
         });
 
         it('should return false when feature is disabled', () => {


### PR DESCRIPTION
#### Summary
This PR adds the logic to hide/display the BoR messaging elements based on the license (only show for ent adv or Entry)

License | Config | BoR UI Messages | Feature Works
-- | -- | -- | --
Enterprise Advanced | Enabled | ✅ Visible | ✅ Yes
Entry (legacy) | Enabled | ✅ Visible | ✅ Yes
Enterprise | Enabled | ❌ Hidden | ❌ No
Professional | Enabled | ❌ Hidden | ❌ No

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66907

#### Screenshots

https://github.com/user-attachments/assets/2a4a232e-9d48-4502-afbd-b7f699249c5b



#### Release Note
```release-note
NONE
```
