### PR TITLE
Automated cherry pick of #34766

### DIFF
--- a/webapp/channels/src/components/thread_popout/thread_popout.tsx
+++ b/webapp/channels/src/components/thread_popout/thread_popout.tsx
@@ -7,6 +7,7 @@ import {useParams} from 'react-router-dom';
 
 import {fetchChannelsAndMembers, selectChannel} from 'mattermost-redux/actions/channels';
 import {getPostThread} from 'mattermost-redux/actions/posts';
+import {fetchTeamScheduledPosts} from 'mattermost-redux/actions/scheduled_posts';
 import {extractUserIdsAndMentionsFromPosts} from 'mattermost-redux/actions/status_profile_polling';
 import {selectTeam} from 'mattermost-redux/actions/teams';
 import {getThread} from 'mattermost-redux/actions/threads';
@@ -52,6 +53,7 @@ export default function ThreadPopout() {
     useEffect(() => {
         if (teamId) {
             dispatch(fetchChannelsAndMembers(teamId));
+            dispatch(fetchTeamScheduledPosts(teamId, true));
             dispatch(selectTeam(teamId));
         }
     }, [dispatch, teamId]);


### PR DESCRIPTION
Cherry pick of #34766 on release-11.3.

/cc  @devinbinnie

```release-note
NONE
```