### PR TITLE
Removing Alpha Label From Korean Language

### DIFF
--- a/webapp/channels/src/i18n/i18n.jsx
+++ b/webapp/channels/src/i18n/i18n.jsx
@@ -121,7 +121,7 @@ export const languages = {
     },
     ko: {
         value: 'ko',
-        name: '한국어 (Alpha)',
+        name: '한국어',
         order: 18,
         url: langFiles.ko,
     },


### PR DESCRIPTION
#### Summary
Removes the alpha label for the Korean language

#### Ticket Link

#### Screenshots

#### Release Note
```release-note
Upgrading Korean translations from Alpha to Production
```
