### PR TITLE
[MM-67033] invite input padding

### DIFF
--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.scss
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.scss
@@ -83,24 +83,24 @@
     }
 
     .users-emails-input__value-container {
-        margin-left: 2px;
         padding-left: 0;
+        margin-left: 2px;
     }
 
     .users-emails-input__input-container {
-        margin-left: 2px;
         padding-left: 8px;
+        margin-left: 2px;
     }
 
     .users-emails-input__placeholder {
-        color: rgba(var(--center-channel-color-rgb), 0.75);
-        margin-left: 2px;
         padding-left: 8px;
+        margin-left: 2px;
+        color: rgba(var(--center-channel-color-rgb), 0.75);
     }
 
     .users-emails-input__input {
-        color: var(--center-channel-color);
         margin-left: 8px;
+        color: var(--center-channel-color);
 
         .a11y--focused {
             box-shadow: none;


### PR DESCRIPTION
### Summary
This PR fixes padding and spacing issues in the users/emails input component used in the invite modal. The changes ensure consistent alignment and spacing for:
- Input placeholder text
- Selected user/email chips
- Input field cursor position

**QA Test Steps:**
1. Open the invite modal (from team menu, or when inviting guest to a channel)
2. Verify the input field has correct padding on the left (see screenshot below) and the typed in text does not sit too close to the left edge.
3. Add multiple users or email addresses
4. Verify that selected chips have consistent spacing and alignment
5. Verify the input cursor position is properly aligned with the placeholder and chips

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-67033

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="621" height="398" alt="image" src="https://github.com/user-attachments/assets/3ba03012-bb44-4d67-8872-78f90925f54f" /> | <img width="622" height="407" alt="image" src="https://github.com/user-attachments/assets/52300fc6-b49d-43c4-a38d-44877fed7550" /> |
| <img width="619" height="533" alt="image" src="https://github.com/user-attachments/assets/9e88fb7d-570c-48cd-8dfa-38204013f136" /> | <img width="642" height="545" alt="image" src="https://github.com/user-attachments/assets/8a9d4c33-07b2-4850-be0b-da62367b2ae8" /> |
| <img width="621" height="535" alt="image" src="https://github.com/user-attachments/assets/f4d95d67-2c80-4c68-88ce-e738d576c7f7" /> | <img width="620" height="520" alt="image" src="https://github.com/user-attachments/assets/08c90e17-91e0-4f09-9d5f-4cc71f956527" /> |

#### Release Note
```release-note
NONE
```