### PR TITLE
Fix: status dropdown positioning on small screens

### DIFF
--- a/webapp/channels/src/components/custom_status/custom_status.scss
+++ b/webapp/channels/src/components/custom_status/custom_status.scss
@@ -256,3 +256,9 @@ span.emoticon[style]:hover {
         }
     }
 }
+
+.statusExpiry .MenuWrapper .Menu .dropdown-menu {
+    top: 100%;
+    right:auto;
+    left:0;
+}

--- a/webapp/channels/src/sass/responsive/_mobile.scss
+++ b/webapp/channels/src/sass/responsive/_mobile.scss
@@ -1550,8 +1550,8 @@
         .MenuWrapper {
             .Menu {
                 .dropdown-menu {
-                    top: 100%;
-                    right: 5%;
+                    top: 35%;
+                    right: 20%;
                     left: unset;
                 }
             }


### PR DESCRIPTION
#### Summary
Fixes the status dropdown positioning issue on small screens. Previously, at widths <768px, the dropdown options were misaligned or cropped. Updated CSS to ensure the dropdown is fully visible and correctly positioned.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/34839

#### Steps to Reproduce
1. Set a status.  
2. On a small screen with width <768px, open the sidebar.  
3. Click on your status icon to edit it.  
4. Click on "Clear after".  

#### Expected Behavior
The dropdown options should be fully visible and correctly positioned on all screen widths.

#### Observed Behavior
At 768px, the dropdown options were misaligned, and below ~650px they were completely cropped and unusable.

#### Screenshots
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/6e701fe3-dfe1-4794-a360-8fceeb13f76a" width="250"/> | <img src="https://github.com/user-attachments/assets/7fcbcd8d-e526-43f8-bf26-c598b2ca353d" width="250"/> |

#### Release Note
```release-note
Fixed status dropdown misalignment and cropping on small screens (<768px) by updating CSS positioning.
```