### PR TITLE
fix(audit): correct IncomingWebhook icon_url key in Auditable()

### DIFF
--- a/server/public/model/incoming_webhook.go
+++ b/server/public/model/incoming_webhook.go
@@ -42,7 +42,7 @@ func (o *IncomingWebhook) Auditable() map[string]any {
 		"display_name":   o.DisplayName,
 		"description":    o.Description,
 		"username":       o.Username,
-		"icon_url:":      o.IconURL,
+		"icon_url":      o.IconURL,
 		"channel_locked": o.ChannelLocked,
 	}
 }


### PR DESCRIPTION
```release-note
Fixed an audit logging typo where incoming webhook icon_url was recorded under the wrong key, improving audit state consistency.
```