### PR TITLE
sqlstore: fix TeamId filter in AnalyticsOutgoingCount

### DIFF
--- a/server/channels/store/sqlstore/webhook_store.go
+++ b/server/channels/store/sqlstore/webhook_store.go
@@ -417,7 +417,7 @@ func (s SqlWebhookStore) AnalyticsOutgoingCount(teamId string) (int64, error) {
 			Where("DeleteAt = 0")
 
 	if teamId != "" {
-		queryBuilder = queryBuilder.Where("TeamId", teamId)
+		queryBuilder = queryBuilder.Where("TeamId = ?", teamId)
 	}
 
 	var count int64


### PR DESCRIPTION
```release-note
Fixed an issue where outgoing webhook analytics could error when filtering by team, due to an invalid SQL WHERE clause.
```