### PR TITLE
fix: correct audit CommandArgs team_id/trigger_id mapping

### DIFF
--- a/server/public/model/auditconv.go
+++ b/server/public/model/auditconv.go
@@ -280,8 +280,8 @@ func newAuditCommandArgs(ca *CommandArgs) auditCommandArgs {
 
 func (ca auditCommandArgs) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.StringKey("channel_id", ca.ChannelID)
-	enc.StringKey("team_id", ca.TriggerID)
-	enc.StringKey("trigger_id", ca.TeamID)
+	enc.StringKey("team_id", ca.TeamID)
+	enc.StringKey("trigger_id", ca.TriggerID)
 	enc.StringKey("command", ca.Command)
 }
 


### PR DESCRIPTION
```release-note
Fixed an issue where audit logs serialized team_id and trigger_id for command arguments with swapped values.
```