### PR TITLE
MM-67049: Fix unauthorized access to public channels in private teams

### DIFF
--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -3082,11 +3082,12 @@ func (s SqlChannelStore) Autocomplete(rctx request.CTX, userID, term string, inc
 		OrderBy("c.DisplayName").
 		Limit(model.ChannelSearchDefaultLimit)
 
+	// Always filter out soft-deleted team memberships - users removed from
+	// a team should not see channels from that team regardless of includeDeleted
+	query = query.Where(sq.Eq{"tm.DeleteAt": 0})
+
 	if !includeDeleted {
-		query = query.Where(sq.And{
-			sq.Eq{"c.DeleteAt": 0},
-			sq.Eq{"tm.DeleteAt": 0},
-		})
+		query = query.Where(sq.Eq{"c.DeleteAt": 0})
 	}
 
 	if isGuest {


### PR DESCRIPTION
#### Summary

Fixed a security vulnerability (see original ticket).

**Root Cause:** In the `Autocomplete` store function, the `includeDeleted` parameter was incorrectly controlling both channel deletion filtering (`c.DeleteAt`) and team membership filtering (`tm.DeleteAt`). When `includeDeleted=true` (the default), soft-deleted team memberships were included in results, allowing removed users to see channels.

**Fix:** Separated the team membership check from the channel deletion check. The `tm.DeleteAt = 0` filter is now always applied regardless of the `includeDeleted` parameter, which is meant only for channels.

**QA Test Steps:**
(see next comment for a script)

#### NOTE:
- Incidentally, I dislike how we're using the `a.Srv().Store().Channel().Autocomplete` as a proxy for "search all channels when it's a regular user". That's super confusing.

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-67049

#### Screenshots

N/A - Backend security fix, no UI changes.

#### Release Note
```release-note
Fixed a security issue where users removed from a private team could still enumerate public channels in that team via the channel search API.
```