### PR TITLE
Adds ObjectType to the property fields table

### DIFF
--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -295,3 +295,5 @@ channels/db/migrations/postgres/000148_add_burn_on_read_messages.down.sql
 channels/db/migrations/postgres/000148_add_burn_on_read_messages.up.sql
 channels/db/migrations/postgres/000149_add_user_tracking_to_properties.down.sql
 channels/db/migrations/postgres/000149_add_user_tracking_to_properties.up.sql
+channels/db/migrations/postgres/000150_add_object_type_to_property_fields.down.sql
+channels/db/migrations/postgres/000150_add_object_type_to_property_fields.up.sql

--- a/server/channels/db/migrations/postgres/000150_add_object_type_to_property_fields.down.sql
+++ b/server/channels/db/migrations/postgres/000150_add_object_type_to_property_fields.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE PropertyFields DROP COLUMN IF EXISTS ObjectType;

--- a/server/channels/db/migrations/postgres/000150_add_object_type_to_property_fields.up.sql
+++ b/server/channels/db/migrations/postgres/000150_add_object_type_to_property_fields.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE PropertyFields ADD COLUMN IF NOT EXISTS ObjectType varchar(255);

--- a/server/channels/store/sqlstore/property_field_store.go
+++ b/server/channels/store/sqlstore/property_field_store.go
@@ -23,7 +23,7 @@ func newPropertyFieldStore(sqlStore *SqlStore) store.PropertyFieldStore {
 	s := SqlPropertyFieldStore{SqlStore: sqlStore}
 
 	s.tableSelectQuery = s.getQueryBuilder().
-		Select("ID", "GroupID", "Name", "Type", "Attrs", "TargetID", "TargetType", "CreateAt", "UpdateAt", "DeleteAt", "CreatedBy", "UpdatedBy").
+		Select("ID", "GroupID", "Name", "Type", "Attrs", "TargetID", "TargetType", "ObjectType", "CreateAt", "UpdateAt", "DeleteAt", "CreatedBy", "UpdatedBy").
 		From("PropertyFields")
 
 	return &s
@@ -42,8 +42,8 @@ func (s *SqlPropertyFieldStore) Create(field *model.PropertyField) (*model.Prope
 
 	builder := s.getQueryBuilder().
 		Insert("PropertyFields").
-		Columns("ID", "GroupID", "Name", "Type", "Attrs", "TargetID", "TargetType", "CreateAt", "UpdateAt", "DeleteAt", "CreatedBy", "UpdatedBy").
-		Values(field.ID, field.GroupID, field.Name, field.Type, field.Attrs, field.TargetID, field.TargetType, field.CreateAt, field.UpdateAt, field.DeleteAt, field.CreatedBy, field.UpdatedBy)
+		Columns("ID", "GroupID", "Name", "Type", "Attrs", "TargetID", "TargetType", "ObjectType", "CreateAt", "UpdateAt", "DeleteAt", "CreatedBy", "UpdatedBy").
+		Values(field.ID, field.GroupID, field.Name, field.Type, field.Attrs, field.TargetID, field.TargetType, field.ObjectType, field.CreateAt, field.UpdateAt, field.DeleteAt, field.CreatedBy, field.UpdatedBy)
 
 	if _, err := s.GetMaster().ExecBuilder(builder); err != nil {
 		return nil, errors.Wrap(err, "property_field_create_insert")
@@ -166,6 +166,10 @@ func (s *SqlPropertyFieldStore) SearchPropertyFields(opts model.PropertyFieldSea
 
 	if opts.GroupID != "" {
 		builder = builder.Where(sq.Eq{"GroupID": opts.GroupID})
+	}
+
+	if opts.ObjectType != "" {
+		builder = builder.Where(sq.Eq{"ObjectType": opts.ObjectType})
 	}
 
 	if opts.TargetType != "" {

--- a/server/public/model/property_field.go
+++ b/server/public/model/property_field.go
@@ -24,6 +24,7 @@ const (
 	PropertyFieldNameMaxRunes       = 255
 	PropertyFieldTargetIDMaxRunes   = 255
 	PropertyFieldTargetTypeMaxRunes = 255
+	PropertyFieldObjectTypeMaxRunes = 255
 )
 
 type PropertyField struct {
@@ -34,6 +35,7 @@ type PropertyField struct {
 	Attrs      StringInterface   `json:"attrs"`
 	TargetID   string            `json:"target_id"`
 	TargetType string            `json:"target_type"`
+	ObjectType string            `json:"object_type"`
 	CreateAt   int64             `json:"create_at"`
 	UpdateAt   int64             `json:"update_at"`
 	DeleteAt   int64             `json:"delete_at"`
@@ -50,6 +52,7 @@ func (pf *PropertyField) Auditable() map[string]any {
 		"attrs":       pf.Attrs,
 		"target_id":   pf.TargetID,
 		"target_type": pf.TargetType,
+		"object_type": pf.ObjectType,
 		"create_at":   pf.CreateAt,
 		"update_at":   pf.UpdateAt,
 		"delete_at":   pf.DeleteAt,
@@ -93,6 +96,10 @@ func (pf *PropertyField) IsValid() error {
 
 	if utf8.RuneCountInString(pf.TargetID) > PropertyFieldTargetIDMaxRunes {
 		return NewAppError("PropertyField.IsValid", "model.property_field.is_valid.app_error", map[string]any{"FieldName": "target_id", "Reason": "value exceeds maximum length"}, "id="+pf.ID, http.StatusBadRequest)
+	}
+
+	if utf8.RuneCountInString(pf.ObjectType) > PropertyFieldObjectTypeMaxRunes {
+		return NewAppError("PropertyField.IsValid", "model.property_field.is_valid.app_error", map[string]any{"FieldName": "object_type", "Reason": "value exceeds maximum length"}, "id="+pf.ID, http.StatusBadRequest)
 	}
 
 	if pf.Type != PropertyFieldTypeText &&
@@ -211,6 +218,7 @@ func (p PropertyFieldSearchCursor) IsValid() error {
 
 type PropertyFieldSearchOpts struct {
 	GroupID        string
+	ObjectType     string
 	TargetType     string
 	TargetIDs      []string
 	SinceUpdateAt  int64 // UpdatedAt after which to send the items

--- a/server/public/model/property_field_test.go
+++ b/server/public/model/property_field_test.go
@@ -222,6 +222,60 @@ func TestPropertyField_IsValid(t *testing.T) {
 		}
 		require.NoError(t, pf.IsValid())
 	})
+
+	t.Run("empty ObjectType is valid", func(t *testing.T) {
+		pf := &PropertyField{
+			ID:         NewId(),
+			GroupID:    NewId(),
+			Name:       "test field",
+			Type:       PropertyFieldTypeText,
+			ObjectType: "",
+			CreateAt:   GetMillis(),
+			UpdateAt:   GetMillis(),
+		}
+		require.NoError(t, pf.IsValid())
+	})
+
+	t.Run("ObjectType with value is valid", func(t *testing.T) {
+		pf := &PropertyField{
+			ID:         NewId(),
+			GroupID:    NewId(),
+			Name:       "test field",
+			Type:       PropertyFieldTypeText,
+			ObjectType: "post",
+			CreateAt:   GetMillis(),
+			UpdateAt:   GetMillis(),
+		}
+		require.NoError(t, pf.IsValid())
+	})
+
+	t.Run("ObjectType exceeds maximum length", func(t *testing.T) {
+		longObjectType := strings.Repeat("a", PropertyFieldObjectTypeMaxRunes+1)
+		pf := &PropertyField{
+			ID:         NewId(),
+			GroupID:    NewId(),
+			Name:       "test field",
+			Type:       PropertyFieldTypeText,
+			ObjectType: longObjectType,
+			CreateAt:   GetMillis(),
+			UpdateAt:   GetMillis(),
+		}
+		require.Error(t, pf.IsValid())
+	})
+
+	t.Run("ObjectType at maximum length is valid", func(t *testing.T) {
+		maxLengthObjectType := strings.Repeat("a", PropertyFieldObjectTypeMaxRunes)
+		pf := &PropertyField{
+			ID:         NewId(),
+			GroupID:    NewId(),
+			Name:       "test field",
+			Type:       PropertyFieldTypeText,
+			ObjectType: maxLengthObjectType,
+			CreateAt:   GetMillis(),
+			UpdateAt:   GetMillis(),
+		}
+		require.NoError(t, pf.IsValid())
+	})
 }
 
 func TestPropertyFieldPatch_IsValid(t *testing.T) {


### PR DESCRIPTION
#### Summary
Adds the `ObjectType` field to the property fields table as part of the new Property System approach. Changes to the indexes and uniqueness checks will come as part of a follow up PR.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66510

#### Release Note
```release-note
NONE
```
