### PR TITLE
MM-67040 feat(go+node build image): include go and node versions in the mattermost/mattermost-build-server image

### DIFF
--- a/.github/workflows/build-server-image.yml
+++ b/.github/workflows/build-server-image.yml
@@ -7,13 +7,26 @@ on:
     paths:
       - server/build/Dockerfile.buildenv
       - server/build/Dockerfile.buildenv-fips
+      - server/.go-version
+      - .nvmrc
       - .github/workflows/build-server-image.yml
   pull_request:
     paths:
       - server/build/Dockerfile.buildenv
       - server/build/Dockerfile.buildenv-fips
+      - server/.go-version
+      - .nvmrc
       - .github/workflows/build-server-image.yml
   workflow_dispatch:
+    inputs:
+      GO_VERSION:
+        description: 'Go version (e.g., 1.24.11). Leave empty to read from server/.go-version'
+        required: false
+        type: string
+      NODE_VERSION:
+        description: 'Node version (e.g., 20.11). Leave empty to read from .nvmrc'
+        required: false
+        type: string
 
 env:
   CHAINCTL_IDENTITY: ee399b4c72dd4e58e3d617f78fc47b74733c9557/922f2d48307d6f5f
@@ -30,6 +43,20 @@ jobs:
       - name: buildenv/checkout-repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: buildenv/read-versions-from-files
+        id: versions
+        run: |
+          GO_VERSION="${{ inputs.GO_VERSION }}"
+          NODE_VERSION="${{ inputs.NODE_VERSION }}"
+          if [ -z "$GO_VERSION" ]; then
+            GO_VERSION=$(cat server/.go-version | tr -d '[:space:]')
+          fi
+          if [ -z "$NODE_VERSION" ]; then
+            NODE_VERSION=$(cat .nvmrc | tr -d '[:space:]')
+          fi
+          echo "GO_VERSION=${GO_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "NODE_VERSION=${NODE_VERSION}" >> "${GITHUB_OUTPUT}"
+
       - name: buildenv/docker-login
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
@@ -41,6 +68,9 @@ jobs:
         with:
           provenance: false
           file: server/build/Dockerfile.buildenv
+          build-args: |
+            GO_VERSION=${{ steps.versions.outputs.GO_VERSION }}
+            NODE_VERSION=${{ steps.versions.outputs.NODE_VERSION }}
           load: true
           push: false
           pull: false
@@ -50,22 +80,21 @@ jobs:
         run: |
           docker run --rm mattermost/mattermost-build-server:test /bin/sh -c "go version && node --version"
 
-      - name: buildenv/calculate-golang-version
-        id: go
-        run: |
-          GO_VERSION=$(docker run --rm mattermost/mattermost-build-server:test go version | awk '{print $3}' | sed 's/go//')
-          echo "GO_VERSION=${GO_VERSION}" >> "${GITHUB_OUTPUT}"
-
       - name: buildenv/push
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
         uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
         with:
           provenance: false
           file: server/build/Dockerfile.buildenv
+          build-args: |
+            GO_VERSION=${{ steps.versions.outputs.GO_VERSION }}
+            NODE_VERSION=${{ steps.versions.outputs.NODE_VERSION }}
           load: false
           push: true
           pull: true
-          tags: mattermost/mattermost-build-server:${{ steps.go.outputs.GO_VERSION }}
+          tags: |
+            mattermost/mattermost-build-server:go-${{ steps.versions.outputs.GO_VERSION }}-node-${{ steps.versions.outputs.NODE_VERSION }}
+            mattermost/mattermost-build-server:go-${{ steps.versions.outputs.GO_VERSION }}
 
   build-image-fips:
     runs-on: ubuntu-22.04
@@ -73,8 +102,23 @@ jobs:
       - uses: chainguard-dev/setup-chainctl@f4ed65b781b048c44d4f033ae854c025c5531c19 # v0.3.2
         with:
           identity: ${{ env.CHAINCTL_IDENTITY }}
+
       - name: buildenv/checkout-repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: buildenv/read-versions-from-files
+        id: versions
+        run: |
+          GO_VERSION="${{ inputs.GO_VERSION }}"
+          NODE_VERSION="${{ inputs.NODE_VERSION }}"
+          if [ -z "$GO_VERSION" ]; then
+            GO_VERSION=$(cat server/.go-version | tr -d '[:space:]')
+          fi
+          if [ -z "$NODE_VERSION" ]; then
+            NODE_VERSION=$(cat .nvmrc | tr -d '[:space:]')
+          fi
+          echo "GO_VERSION=${GO_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "NODE_VERSION=${NODE_VERSION}" >> "${GITHUB_OUTPUT}"
 
       - name: buildenv/docker-login
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
@@ -87,6 +131,9 @@ jobs:
         with:
           provenance: false
           file: server/build/Dockerfile.buildenv-fips
+          build-args: |
+            GO_VERSION=${{ steps.versions.outputs.GO_VERSION }}
+            NODE_VERSION=${{ steps.versions.outputs.NODE_VERSION }}
           load: true
           push: false
           pull: false
@@ -96,19 +143,18 @@ jobs:
         run: |
           docker run --rm --entrypoint bash mattermost/mattermost-build-server-fips:test -c "go version && node --version"
 
-      - name: buildenv/calculate-golang-version
-        id: go
-        run: |
-          GO_VERSION=$(docker run --rm --entrypoint bash mattermost/mattermost-build-server-fips:test -c "go version" | awk '{print $3}' | sed 's/go//')
-          echo "GO_VERSION=${GO_VERSION}" >> "${GITHUB_OUTPUT}"
-
       - name: buildenv/push
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
         uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
         with:
           provenance: false
           file: server/build/Dockerfile.buildenv-fips
+          build-args: |
+            GO_VERSION=${{ steps.versions.outputs.GO_VERSION }}
+            NODE_VERSION=${{ steps.versions.outputs.NODE_VERSION }}
           load: false
           push: true
           pull: true
-          tags: mattermost/mattermost-build-server-fips:${{ steps.go.outputs.GO_VERSION }}
+          tags: |
+            mattermost/mattermost-build-server-fips:go-${{ steps.versions.outputs.GO_VERSION }}-node-${{ steps.versions.outputs.NODE_VERSION }}
+            mattermost/mattermost-build-server-fips:go-${{ steps.versions.outputs.GO_VERSION }}

--- a/server/build/Dockerfile.buildenv
+++ b/server/build/Dockerfile.buildenv
@@ -1,5 +1,12 @@
-FROM mattermost/golang-bullseye:1.24.11@sha256:648e6d4bd76751787cf8eb2674942f931a01043872ce15ac9501382dabcefbe8
-ARG NODE_VERSION=20.11.1
+# Build arguments for versioning
+ARG GO_VERSION=1.24.11
+ARG NODE_VERSION=20.11
+
+FROM mattermost/golang-bullseye:${GO_VERSION}
+
+# Re-declare ARGs after FROM to make them available in the build stage
+ARG GO_VERSION
+ARG NODE_VERSION
 
 RUN apt-get update && apt-get install -y make git apt-transport-https ca-certificates curl software-properties-common build-essential zip xmlsec1 jq pgloader gnupg
 
@@ -7,8 +14,10 @@ RUN apt-get update && apt-get install -y make git apt-transport-https ca-certifi
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 RUN bash -c "source /root/.nvm/nvm.sh && nvm install $NODE_VERSION && nvm use $NODE_VERSION && nvm alias default $NODE_VERSION"
 
-# Make node and npm globally available
-ENV PATH="/root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH"
+# Make node and npm globally available by symlinking to /usr/local/bin
+# Note: Can't use ENV PATH with $NODE_VERSION because nvm installs full patch version
+# (e.g., "20.11" in .nvmrc installs to v20.11.1/, not v20.11/)
+RUN bash -c "source /root/.nvm/nvm.sh && ln -sf \$(which node) /usr/local/bin/node && ln -sf \$(which npm) /usr/local/bin/npm && ln -sf \$(which npx) /usr/local/bin/npx"
 
 RUN git config --global --add safe.directory /mattermost
 

--- a/server/build/Dockerfile.buildenv-fips
+++ b/server/build/Dockerfile.buildenv-fips
@@ -1,5 +1,12 @@
-FROM cgr.dev/mattermost.com/go-msft-fips:1.24.11-dev@sha256:181a7db41bbff8cf0e522bd5f951a44f2a39a5f58ca930930dfbecdc6b690272
-ARG NODE_VERSION=20.11.1
+# Build arguments for versioning
+ARG GO_VERSION=1.24.11
+ARG NODE_VERSION=20.11
+
+FROM cgr.dev/mattermost.com/go-msft-fips:${GO_VERSION}-dev
+
+# Re-declare ARGs after FROM to make them available in the build stage
+ARG GO_VERSION
+ARG NODE_VERSION
 
 RUN apk add curl ca-certificates mailcap unrtf wv poppler-utils tzdata gpg xmlsec
 
@@ -7,8 +14,10 @@ RUN apk add curl ca-certificates mailcap unrtf wv poppler-utils tzdata gpg xmlse
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 RUN bash -c "source /root/.nvm/nvm.sh && nvm install $NODE_VERSION && nvm use $NODE_VERSION && nvm alias default $NODE_VERSION"
 
-# Make node and npm globally available
-ENV PATH="/root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH"
+# Make node and npm globally available by symlinking to /usr/local/bin
+# Note: Can't use ENV PATH with $NODE_VERSION because nvm installs full patch version
+# (e.g., "20.11" in .nvmrc installs to v20.11.1/, not v20.11/)
+RUN bash -c "source /root/.nvm/nvm.sh && ln -sf \$(which node) /usr/local/bin/node && ln -sf \$(which npm) /usr/local/bin/npm && ln -sf \$(which npx) /usr/local/bin/npx"
 
 RUN git config --global --add safe.directory /mattermost
 

--- a/server/build/Dockerfile.buildenv-fips
+++ b/server/build/Dockerfile.buildenv-fips
@@ -8,7 +8,11 @@ FROM cgr.dev/mattermost.com/go-msft-fips:${GO_VERSION}-dev
 ARG GO_VERSION
 ARG NODE_VERSION
 
-RUN apk add curl ca-certificates mailcap unrtf wv poppler-utils tzdata gpg xmlsec
+RUN apk add curl ca-certificates mailcap unrtf wv poppler-utils tzdata gpg xmlsec \
+    # coreutils: provides GNU ls (nvm uses 'ls -q' which BusyBox doesn't support)
+    coreutils \
+    # libstdc++: required for Node.js unofficial musl builds used by nvm on Alpine
+    libstdc++
 
 # Download and install node via nvm
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash

--- a/server/build/README.md
+++ b/server/build/README.md
@@ -10,7 +10,81 @@ The `Dockerfile` in this folder (`Dockerfile.buildenv`) is the build environment
 
 We have a docker image to build `mattermost-server` and it is based on Go docker image.
 
-In our Docker Hub Repository we have the following images:
+#### Current Tag Format
+
+Images are published with multiple tags for flexibility:
+
+| Tag Format | Example | Use Case |
+|------------|---------|----------|
+| `go-<GO>-node-<NODE>` | `go-1.24.11-node-20.11` | Full version specification |
+| `go-<GO>` | `go-1.24.11` | When you only care about Go version |
+
+Examples:
+```bash
+# Full specification (includes both Go and Node)
+docker pull mattermost/mattermost-build-server:go-1.24.11-node-20.11
+
+# Go version only (same image, alternative tag)
+docker pull mattermost/mattermost-build-server:go-1.24.11
+```
+
+FIPS images follow the same pattern with `-fips` suffix:
+```bash
+docker pull mattermost/mattermost-build-server-fips:go-1.24.11-node-20.11
+docker pull mattermost/mattermost-build-server-fips:go-1.24.11
+```
+
+The versions are sourced from:
+- Go version: `server/.go-version`
+- Node version: `.nvmrc`
+
+#### Base Image Dependency
+
+The build server image depends on [`mattermost/golang-bullseye`](https://hub.docker.com/r/mattermost/golang-bullseye), which is built from the [mattermost/golang-bullseye](https://github.com/mattermost/golang-bullseye) repository.
+
+**When upgrading Go version**, follow this order:
+1. **First**: Update `mattermost/golang-bullseye` repository
+   - Update the Go version as per README instruction
+   - Merge then wait for the image to be published to Docker Hub
+2. **Then**: Update this repository
+   - Update `server/.go-version` with the new version
+   - Merge to master to trigger the build server image workflow
+
+If you try to build the build server image before the base `golang-bullseye` image exists, the build will fail.
+
+#### When Images Are Published
+
+Images are automatically built and published to Docker Hub via the [BuildEnv Docker Image workflow](/.github/workflows/build-server-image.yml).
+
+**Automatic publishing** occurs on merge to `master` when any of these files change:
+- `server/build/Dockerfile.buildenv`
+- `server/build/Dockerfile.buildenv-fips`
+- `server/.go-version`
+- `.nvmrc`
+- `.github/workflows/build-server-image.yml`
+
+**Manual publishing** can be triggered via GitHub Actions:
+1. Go to Actions > "BuildEnv Docker Image" > "Run workflow"
+2. Optionally specify `GO_VERSION` and/or `NODE_VERSION`
+3. If left empty, versions are read from the source files
+
+Pull requests will build and test the image but will not publish to Docker Hub.
+
+#### Release Branch Images
+
+| Release | Go Version | Node Version | Image Tag |
+|---------|------------|--------------|-----------|
+| 11.4 | 1.24.11 | 20.11 | `go-1.24.11-node-20.11` or `go-1.24.11` |
+| 11.3 | 1.24.6 | 20.11 | `go-1.24.6-node-20.11` or `go-1.24.6` |
+| 11.2 | 1.24.6 | 20.11 | `go-1.24.6-node-20.11` or `go-1.24.6` |
+| 11.1 | 1.24.6 | 20.11 | `go-1.24.6-node-20.11` or `go-1.24.6` |
+| 11.0 | 1.24.6 | 20.11 | `go-1.24.6-node-20.11` or `go-1.24.6` |
+| 10.12 | 1.24.6 | 20.11 | `go-1.24.6-node-20.11` or `go-1.24.6` |
+| 10.11 | 1.24.6 | 20.11 | `go-1.24.6-node-20.11` or `go-1.24.6` |
+
+#### Legacy Images (Historical Reference)
+
+In our Docker Hub Repository we have the following legacy images:
 
 - `mattermost/mattermost-build-server:dec-7-2018` which is based on Go 1.11 you can use for MM versions <= `5.8.0`
 - `mattermost/mattermost-build-server:feb-28-2019` which is based on Go 1.12 you can use for MM versions >= `5.9.0` <= `5.15.0`


### PR DESCRIPTION
#### Summary
This PR introduces new build image, with new tag format: 

Go + Node
- `mattermost/mattermost-build-server:go-<GO_VERSION>-node-<NODE_VERSION> (e.g., go-1.24.11-node-20.11)`
- `mattermost/mattermost-build-server-fips:go-<GO_VERSION>-node-<NODE_VERSION> (e.g., go-1.24.11-node-20.11)`

Go only, for cases where the CI working directory is Go only
- `mattermost/mattermost-build-server:go-<GO_VERSION> (e.g., go-1.24.11)`
- `mattermost/mattermost-build-server-fips:go-<GO_VERSION>- (e.g., go-1.24.11)`

Todo: Follow up PRs to update CI workflow using this new build image, for:
- in this repo: https://github.com/mattermost/mattermost/pull/34914
- enterprise: https://github.com/mattermost/enterprise/pull/2047
- delivery-platform: https://github.com/mattermost/delivery-platform/pull/417

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67040

#### Screenshots
none

#### Release Note
```release-note
NONE
```