### PR TITLE
Update ObjectType migration setting an empty value and marking the co…

### DIFF
--- a/server/channels/db/migrations/postgres/000150_add_object_type_to_property_fields.up.sql
+++ b/server/channels/db/migrations/postgres/000150_add_object_type_to_property_fields.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE PropertyFields ADD COLUMN IF NOT EXISTS ObjectType varchar(255);
+ALTER TABLE PropertyFields ADD COLUMN IF NOT EXISTS ObjectType varchar(255) NOT NULL DEFAULT '';


### PR DESCRIPTION
#### Summary
This change sets an empty value on the column and marks it as `NOT NULL`. Normally we would do this through another migration, but we're working on a feature branch in this case.

#### Release Note
```release-note
NONE
```
