### PR TITLE
chore(i18n): add i18n-verify-translations script

### DIFF
--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -189,6 +189,7 @@
     "stats": "cross-env NODE_ENV=production webpack --profile --json > webpack_stats.json",
     "i18n-extract": "formatjs extract 'src/**/*.{js,jsx,ts,tsx}' --additional-function-names localizeMessage --ignore 'src/**/*.d.ts' --ignore 'src/**/*.test.{js,jsx,ts,tsx}' --out-file src/i18n/en.json --format scripts/formatter.js --id-interpolation-pattern '[sha512:contenthash:base64:6]' --preserve-whitespace",
     "i18n-extract:check": "npm run i18n-extract -- --throws --out-file .i18n-check.tmp.json && diff src/i18n/en.json .i18n-check.tmp.json && rm -f .i18n-check.tmp.json || (rm -f .i18n-check.tmp.json && echo '\nen.json is out of sync with code. \nTo update: npm run i18n-extract' && exit 1)",
+    "i18n-verify-translations": "formatjs verify './src/i18n/*.json' --source-locale 'en' --structural-equality",
     "check-types": "tsc -b",
     "make-emojis": "node --experimental-json-modules build/emoji/make_emojis.mjs"
   }


### PR DESCRIPTION
#### Summary
Add an npm script `i18n-verify-translations` that validates all translation JSON files against the English source using `@formatjs/cli verify`.

This script checks for structural equality between translations and `en.json`, catching:
- Missing or extra ICU variables
- Syntax errors (UNCLOSED_TAG, INVALID_TAG, MALFORMED_ARGUMENT)
- Type mismatches (e.g., plural vs number)
- Missing plural clauses

Usage: `npm run i18n-verify-translations`

#### Ticket Link
N/A - Developer tooling improvement

#### Related Pull Requests
- No server changes
- No mobile changes

#### Screenshots
N/A - No UI changes

#### Release Note
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)