### PR TITLE
Interactive button fix

### DIFF
--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -921,7 +921,12 @@ func (a *App) UpdatePost(rctx request.CTX, receivedUpdatedPost *model.Post, upda
 	if !updatePostOptions.SafeUpdate {
 		newPost.IsPinned = receivedUpdatedPost.IsPinned
 		newPost.HasReactions = receivedUpdatedPost.HasReactions
-		newPost.SetProps(receivedUpdatedPost.GetProps())
+
+		if receivedUpdatedPost.GetProps() != nil {
+			newPost.SetProps(receivedUpdatedPost.GetProps())
+		} else {
+			newPost.SetProps(oldPost.GetProps())
+		}
 		newPost.PreserveIdentityPropsFrom(oldPost)
 
 		// mm_blocks_actions can only be modified by trusted paths that have
@@ -939,12 +944,26 @@ func (a *App) UpdatePost(rctx request.CTX, receivedUpdatedPost *model.Post, upda
 			}
 		}
 
-		var fileIds []string
-		fileIds, appErr = a.processPostFileChanges(rctx, receivedUpdatedPost, oldPost, updatePostOptions)
-		if appErr != nil {
-			return nil, false, appErr
+		if newPost.GetProp(model.PostPropsAttachments) == nil {
+			if oldAttachments := oldPost.GetProp(model.PostPropsAttachments); oldAttachments != nil {
+				newPost.AddProp(model.PostPropsAttachments, oldAttachments)
+			}
+		} else {
+			// Clients only ever see attachments with action Integration stripped
+			// (see Post.StripActionIntegrations), so an edit that echoes those
+			// attachments back needs the integration data restored or interactive
+			// buttons stop working after the post is edited.
+			newPost.RestoreActionIntegrations(oldPost)
 		}
-		newPost.FileIds = fileIds
+
+		if receivedUpdatedPost.FileIds != nil {
+			var fileIds []string
+			fileIds, appErr = a.processPostFileChanges(rctx, receivedUpdatedPost, oldPost, updatePostOptions)
+			if appErr != nil {
+				return nil, false, appErr
+			}
+			newPost.FileIds = fileIds
+		}
 	}
 
 	// Avoid deep-equal checks if EditAt was already modified through message change

--- a/server/channels/app/post_test.go
+++ b/server/channels/app/post_test.go
@@ -2731,6 +2731,176 @@ func TestUpdatePost(t *testing.T) {
 			*cfg.TeamSettings.RestrictDirectMessage = model.DirectMessageAny
 		})
 	})
+
+	t.Run("preserves existing props when update has nil props", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		attachments := []any{map[string]any{
+			"text": "Click me",
+			"actions": []any{map[string]any{
+				"id":   "action1",
+				"name": "Button",
+				"integration": map[string]any{
+					"url": "http://example.com/action",
+				},
+			}},
+		}}
+
+		post := &model.Post{
+			ChannelId: th.BasicChannel.Id,
+			Message:   "original message",
+			UserId:    th.BasicUser.Id,
+			Props: model.StringInterface{
+				model.PostPropsAttachments: attachments,
+			},
+		}
+
+		createdPost, _, err := th.App.CreatePost(th.Context, post, th.BasicChannel, model.CreatePostFlags{SetOnline: true})
+		require.Nil(t, err)
+
+		// Update with nil props — attachments should be preserved
+		updatePost := createdPost.Clone()
+		updatePost.Message = "edited message"
+		updatePost.Props = nil
+
+		updatedPost, _, err := th.App.UpdatePost(th.Context, updatePost, nil)
+		require.Nil(t, err)
+		assert.Equal(t, "edited message", updatedPost.Message)
+		assert.NotNil(t, updatedPost.GetProps()[model.PostPropsAttachments], "attachments should be preserved when props is nil in the update")
+	})
+
+	t.Run("merges new props with existing props on update", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		attachments := []any{map[string]any{
+			"text": "Click me",
+			"actions": []any{map[string]any{
+				"id":   "action1",
+				"name": "Button",
+				"integration": map[string]any{
+					"url": "http://example.com/action",
+				},
+			}},
+		}}
+
+		post := &model.Post{
+			ChannelId: th.BasicChannel.Id,
+			Message:   "original message",
+			UserId:    th.BasicUser.Id,
+			Props: model.StringInterface{
+				model.PostPropsAttachments: attachments,
+				"custom_key":               "original_value",
+			},
+		}
+
+		createdPost, _, err := th.App.CreatePost(th.Context, post, th.BasicChannel, model.CreatePostFlags{SetOnline: true})
+		require.Nil(t, err)
+
+		// Update with new props — existing props should be merged, not replaced
+		updatePost := createdPost.Clone()
+		updatePost.Message = "edited message"
+		updatePost.Props = model.StringInterface{
+			"new_key": "new_value",
+		}
+
+		updatedPost, _, err := th.App.UpdatePost(th.Context, updatePost, nil)
+		require.Nil(t, err)
+		assert.Equal(t, "new_value", updatedPost.GetProps()["new_key"], "new prop should be present")
+		assert.NotNil(t, updatedPost.GetProps()[model.PostPropsAttachments], "attachments should be preserved after merge")
+	})
+
+	t.Run("SafeUpdate skips prop merging", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		post := &model.Post{
+			ChannelId: th.BasicChannel.Id,
+			Message:   "original message",
+			UserId:    th.BasicUser.Id,
+			Props: model.StringInterface{
+				"original_key": "original_value",
+			},
+		}
+
+		createdPost, _, err := th.App.CreatePost(th.Context, post, th.BasicChannel, model.CreatePostFlags{SetOnline: true})
+		require.Nil(t, err)
+
+		// With SafeUpdate=true, props on the update are ignored
+		updatePost := createdPost.Clone()
+		updatePost.Message = "safely updated message"
+		updatePost.Props = model.StringInterface{
+			"new_key": "new_value",
+		}
+
+		safeUpdateOptions := &model.UpdatePostOptions{SafeUpdate: true}
+		updatedPost, _, err := th.App.UpdatePost(th.Context, updatePost, safeUpdateOptions)
+		require.Nil(t, err)
+		assert.Equal(t, "safely updated message", updatedPost.Message)
+		// SafeUpdate should not apply prop changes
+		assert.Nil(t, updatedPost.GetProps()["new_key"], "SafeUpdate should not apply prop updates")
+		assert.Equal(t, "original_value", updatedPost.GetProps()["original_key"], "original props should remain unchanged with SafeUpdate")
+	})
+
+	t.Run("restores stripped integration urls when attachments are echoed back on edit", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		attachments := []any{map[string]any{
+			"text": "Click me",
+			"actions": []any{map[string]any{
+				"id":   "action1",
+				"name": "Button",
+				"integration": map[string]any{
+					"url": "http://example.com/action",
+				},
+			}},
+		}}
+
+		post := &model.Post{
+			ChannelId: th.BasicChannel.Id,
+			Message:   "original message",
+			UserId:    th.BasicUser.Id,
+			Props: model.StringInterface{
+				model.PostPropsAttachments: attachments,
+			},
+		}
+
+		createdPost, _, err := th.App.CreatePost(th.Context, post, th.BasicChannel, model.CreatePostFlags{SetOnline: true})
+		require.Nil(t, err)
+
+		// Mirrors the webapp: it only ever receives attachments with Integration
+		// stripped (see model.Post.StripActionIntegrations), and echoes that
+		// stripped version back on edit.
+		strippedAttachments := []any{map[string]any{
+			"text": "Click me",
+			"actions": []any{map[string]any{
+				"id":   "action1",
+				"name": "Button",
+			}},
+		}}
+
+		updatePost := createdPost.Clone()
+		updatePost.Message = "edited message"
+		updatePost.Props = model.StringInterface{
+			model.PostPropsAttachments: strippedAttachments,
+		}
+
+		_, _, err = th.App.UpdatePost(th.Context, updatePost, nil)
+		require.Nil(t, err)
+
+		// UpdatePost strips Integration off its returned post for client
+		// consumption (see Post.StripActionIntegrations), same as every other
+		// post read path, so verify against what was actually persisted.
+		storedPost, sErr := th.App.Srv().Store().Post().GetSingle(th.Context, createdPost.Id, false)
+		require.NoError(t, sErr)
+
+		action := storedPost.GetAction("action1")
+		require.NotNil(t, action)
+		require.NotNil(t, action.Integration, "integration should be restored from the old post's matching action")
+		assert.Equal(t, "http://example.com/action", action.Integration.URL)
+	})
 }
 
 func TestSearchPostsForUser(t *testing.T) {

--- a/server/public/model/integration_action.go
+++ b/server/public/model/integration_action.go
@@ -1243,6 +1243,31 @@ func pathHasTraversalSegment(path string) bool {
 		path == "/.." || strings.HasPrefix(path, "/..")
 }
 
+// RestoreActionIntegrations re-attaches the Integration field of actions that are
+// missing it, using the matching action (by id) from oldPost. Clients only ever
+// receive attachments with Integration stripped (see StripActionIntegrations), so
+// when they echo those attachments back on a post edit, the integration data must
+// be restored from the previous version of the post or button callbacks break.
+func (o *Post) RestoreActionIntegrations(oldPost *Post) {
+	if o.GetProp(PostPropsAttachments) != nil {
+		o.AddProp(PostPropsAttachments, o.Attachments())
+	}
+	attachments, ok := o.GetProp(PostPropsAttachments).([]*MessageAttachment)
+	if !ok {
+		return
+	}
+	for _, attachment := range attachments {
+		for _, action := range attachment.Actions {
+			if action == nil || action.Integration != nil {
+				continue
+			}
+			if oldAction := oldPost.GetAction(action.Id); oldAction != nil {
+				action.Integration = oldAction.Integration
+			}
+		}
+	}
+}
+
 func (o *Post) GenerateActionIds() {
 	if o.GetProp(PostPropsAttachments) != nil {
 		o.AddProp(PostPropsAttachments, o.Attachments())

--- a/server/public/model/integration_action_test.go
+++ b/server/public/model/integration_action_test.go
@@ -2769,3 +2769,77 @@ func TestDialogElementIsValid_ActionButton(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid action_button URL")
 	})
 }
+
+func TestPostRestoreActionIntegrations(t *testing.T) {
+	newAttachmentPost := func(actions []*PostAction) *Post {
+		return &Post{
+			Props: StringInterface{
+				PostPropsAttachments: []*MessageAttachment{
+					{Text: "Click me", Actions: actions},
+				},
+			},
+		}
+	}
+
+	t.Run("restores integration missing on the matching action id", func(t *testing.T) {
+		oldPost := newAttachmentPost([]*PostAction{
+			{Id: "action1", Name: "Button", Integration: &PostActionIntegration{URL: "http://example.com/action"}},
+		})
+
+		// Mirrors what the webapp echoes back on edit: attachments are present,
+		// but Integration was stripped before the client ever saw them.
+		newPost := newAttachmentPost([]*PostAction{
+			{Id: "action1", Name: "Button"},
+		})
+
+		newPost.RestoreActionIntegrations(oldPost)
+
+		action := newPost.GetAction("action1")
+		require.NotNil(t, action)
+		require.NotNil(t, action.Integration)
+		assert.Equal(t, "http://example.com/action", action.Integration.URL)
+	})
+
+	t.Run("does not override an integration the client did provide", func(t *testing.T) {
+		oldPost := newAttachmentPost([]*PostAction{
+			{Id: "action1", Name: "Button", Integration: &PostActionIntegration{URL: "http://example.com/old"}},
+		})
+		newPost := newAttachmentPost([]*PostAction{
+			{Id: "action1", Name: "Button", Integration: &PostActionIntegration{URL: "http://example.com/new"}},
+		})
+
+		newPost.RestoreActionIntegrations(oldPost)
+
+		action := newPost.GetAction("action1")
+		require.NotNil(t, action)
+		require.NotNil(t, action.Integration)
+		assert.Equal(t, "http://example.com/new", action.Integration.URL)
+	})
+
+	t.Run("no-op when there are no attachments", func(t *testing.T) {
+		oldPost := newAttachmentPost([]*PostAction{
+			{Id: "action1", Integration: &PostActionIntegration{URL: "http://example.com/action"}},
+		})
+		newPost := &Post{}
+
+		require.NotPanics(t, func() {
+			newPost.RestoreActionIntegrations(oldPost)
+		})
+		assert.Nil(t, newPost.GetProp(PostPropsAttachments))
+	})
+
+	t.Run("leaves action without a matching old action untouched", func(t *testing.T) {
+		oldPost := newAttachmentPost([]*PostAction{
+			{Id: "action1", Integration: &PostActionIntegration{URL: "http://example.com/action"}},
+		})
+		newPost := newAttachmentPost([]*PostAction{
+			{Id: "action2", Name: "Other button"},
+		})
+
+		newPost.RestoreActionIntegrations(oldPost)
+
+		action := newPost.GetAction("action2")
+		require.NotNil(t, action)
+		assert.Nil(t, action.Integration)
+	})
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

When a post with interactive buttons (attachments stored in post.Props[PostPropsAttachments]) is edited, the client sends an updated Post containing only the edited fields (id, message, etc.) and typically omits props/attachments.
The server's UpdatePost code was replacing the post props with the incoming props (newPost.SetProps(receivedUpdatedPost.GetProps())), which means attachments (and therefore action integration URLs / cookies) were cleared when the edit payload did not include them.
Clearing attachments removes the integration configuration for the action buttons, so subsequent clicks do nothing (no callback is sent).
So I changed UpdatePost so we merge props rather than naively replacing them. If the incoming update does not include props, preserve the existing props (most importantly PostPropsAttachments). If the incoming props explicitly include keys, use those values (so a deliberate removal still works).

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Fixes #34438 
#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** UpdatePost now treats omitted `Props`/`FileIds` differently by preserving existing state and restoring action integration data, which is a behavioral contract change for edits. While covered by new unit tests, subtle client/integration differences between “omitting” vs “explicitly setting” props could still lead to edge-case regressions.

**QA Recommendation:** Minimal manual QA—focus on editing messages that contain interactive buttons from integrations across multiple clients; verify button callbacks still reach the integration endpoint after edits, including scenarios with file attachments and any explicit prop-removal behavior.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->