### PR TITLE
MM-67164: bundle loading screen CSS with content hash

### DIFF
--- a/webapp/channels/src/root.html
+++ b/webapp/channels/src/root.html
@@ -30,9 +30,6 @@
         4. The 'href' attribute is empty to prevent unnecessary HTTP requests.
     -->
     <link rel='stylesheet' class='code_theme'>
-
-    <!-- We need this CSS first to show the initial loading screen -->
-    <link id="initialLoadingScreenCSS" rel='stylesheet' href='/static/css/initial_loading_screen.css'>
 </head>
 <body class='font--open_sans enable-animations'>
     <%= require('html-loader!./components/initial_loading_screen/initial_loading_screen_template.html').default %>

--- a/webapp/channels/src/root.tsx
+++ b/webapp/channels/src/root.tsx
@@ -1,6 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+// Import loading screen CSS first to ensure it's in the main CSS bundle (with content hash)
+// and loads before the body renders. This must be before any dynamic imports.
+import './components/initial_loading_screen/initial_loading_screen.css';
+
 // Allow overriding the path used by webpack to dynamically resolve assets. This is driven by
 // an environment variable in development, or by a window variable defined in root.html in
 // production. The window variable is updated by the server after configuring SiteURL and

--- a/webapp/channels/webpack.config.js
+++ b/webapp/channels/webpack.config.js
@@ -198,7 +198,6 @@ var config = {
                 {from: 'src/images/payment_processing.png', to: 'images'},
                 {from: 'src/images/purchase_alert.png', to: 'images'},
                 {from: '../node_modules/pdfjs-dist/cmaps', to: 'cmaps'},
-                {from: 'src/components/initial_loading_screen/initial_loading_screen.css', to: 'css'},
             ],
         }),
 


### PR DESCRIPTION
#### Summary
Move loading screen CSS from a static link to a webpack-bundled import, enabling cache busting via content hash.

Related: #34855

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67164

#### Problem
The `initial_loading_screen.css` was served at a static path (`/static/css/initial_loading_screen.css`) without any versioning. This could cause caching issues with CDNs and browsers when the CSS is updated.

#### Solution
- Import the CSS directly in `root.tsx` so webpack bundles it into `main.[contenthash].css`
- Remove the static `<link>` tag from `root.html`
- Remove the CopyWebpackPlugin entry that copied the CSS file

The CSS is now part of the main bundle and gets a content hash that changes whenever the file is modified.

#### Release Note
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.ai/code)