### PR TITLE
Fix: Prevent root.html overwrite errors for unprivileged users

### DIFF
--- a/server/channels/web/static.go
+++ b/server/channels/web/static.go
@@ -90,6 +90,13 @@ func root(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	subpath, _ := utils.GetSubpathFromConfig(c.App.Srv().Config())
+	if updatedContents, err := utils.UpdateRootHTMLContent(string(contents), subpath); err == nil {
+		contents = []byte(updatedContents)
+	} else {
+		c.Logger.Warn("Failed to update root.html content", mlog.Err(err))
+	}
+
 	titleTemplate := "<title>%s</title>"
 	originalHTML := fmt.Sprintf(titleTemplate, html.EscapeString(model.TeamSettingsDefaultSiteName))
 	modifiedHTML := getOpenGraphMetaTags(c)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR fixes a startup failure in Mattermost Server when running as an unprivileged user or on a read-only filesystem. The server currently attempts to rewrite client/root.html at runtime and exits with a fatal error if the file is not writable.

This change removes the hard dependency on filesystem writes by performing the required HTML transformations in memory and serving the corrected content dynamically. As a result, Mattermost can start successfully in hardened environments such as containerized or immutable deployments.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/34962

#### Screenshots
N/A – server-side change with no UI impact.

#### Release Note
Fixed an issue where the server could fail to start if root.html was not writable when a subpath was configured.

