### PR TITLE
Suppress SiteURL log error when in CI or local_testing mode

### DIFF
--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -384,7 +384,10 @@ func NewServer(options ...Option) (*Server, error) {
 	}
 
 	if _, err = url.ParseRequestURI(*s.platform.Config().ServiceSettings.SiteURL); err != nil {
-		mlog.Error("SiteURL must be set. Some features will operate incorrectly if the SiteURL is not set. See documentation for details: https://mattermost.com/pl/configure-site-url")
+		// Don't spam the logs when in CI or local testing mode
+		if !(os.Getenv("IS_CI") == "true" || os.Getenv("IS_LOCAL_TESTING") == "true") {
+			mlog.Error("SiteURL must be set. Some features will operate incorrectly if the SiteURL is not set. See documentation for details: https://mattermost.com/pl/configure-site-url")
+		}
 	}
 
 	// Start email batching because it's not like the other jobs


### PR DESCRIPTION
#### Summary
- Stop ruining your LLM's context (and your sanity) by suppressing useless log output during tests. 
- To see what I mean, in `server/server`,  run:
```
go test -v -run "TestGetChannel" ./channels/api4/...
```
then run:
```
MM_LOGSETTINGS_CONSOLELEVEL=ERROR IS_LOCAL_TESTING=true go test -v -run "TestGetChannel" ./channels/api4/...
```
Currently, that /mostly/ cleans up the useless logs, but there's one left.
Apply this PR and run it again.
There, clean. Sweet relief.

- I didn't add a test for it. I could have done some like what we do for `TestPanicLog` but I think that's overkill for this (it's for developer / LLM convenience).

#### Ticket Link
- None. This is my personal crusade.
 
#### Release Note

```release-note
NONE
```
