### PR TITLE
Automated cherry pick of #34653

### DIFF
--- a/server/channels/api4/config.go
+++ b/server/channels/api4/config.go
@@ -159,6 +159,9 @@ func updateConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	// modifications to the slice.
 	cfg.PluginSettings.SignaturePublicKeyFiles = appCfg.PluginSettings.SignaturePublicKeyFiles
 
+	// Do not allow import directory to be changed through the API
+	*cfg.ImportSettings.Directory = *appCfg.ImportSettings.Directory
+
 	// Do not allow marketplace URL to be toggled through the API if EnableUploads are disabled.
 	if cfg.PluginSettings.EnableUploads != nil && !*appCfg.PluginSettings.EnableUploads {
 		*cfg.PluginSettings.MarketplaceURL = *appCfg.PluginSettings.MarketplaceURL
@@ -314,6 +317,12 @@ func patchConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	// Do not allow plugin uploads to be toggled through the API
 	if cfg.PluginSettings.EnableUploads != nil && *cfg.PluginSettings.EnableUploads != *appCfg.PluginSettings.EnableUploads {
 		c.Err = model.NewAppError("patchConfig", "api.config.update_config.not_allowed_security.app_error", map[string]any{"Name": "PluginSettings.EnableUploads"}, "", http.StatusForbidden)
+		return
+	}
+
+	// Do not allow import directory to be changed through the API
+	if cfg.ImportSettings.Directory != nil && *cfg.ImportSettings.Directory != *appCfg.ImportSettings.Directory {
+		c.Err = model.NewAppError("patchConfig", "api.config.update_config.not_allowed_security.app_error", map[string]any{"Name": "ImportSettings.Directory"}, "", http.StatusForbidden)
 		return
 	}
 

--- a/server/channels/api4/config_test.go
+++ b/server/channels/api4/config_test.go
@@ -310,6 +310,43 @@ func TestUpdateConfig(t *testing.T) {
 		CheckForbiddenStatus(t, resp)
 	})
 
+	t.Run("Should not be able to modify ImportSettings.Directory", func(t *testing.T) {
+		t.Run("sysadmin", func(t *testing.T) {
+			oldDirectory := *th.App.Config().ImportSettings.Directory
+			cfg2 := th.App.Config().Clone()
+			*cfg2.ImportSettings.Directory = "./new-import-dir"
+
+			cfg2, _, err = th.SystemAdminClient.UpdateConfig(context.Background(), cfg2)
+			require.NoError(t, err)
+			assert.Equal(t, oldDirectory, *cfg2.ImportSettings.Directory)
+			assert.Equal(t, oldDirectory, *th.App.Config().ImportSettings.Directory)
+
+			cfg2.ImportSettings.Directory = nil
+			cfg2, _, err = th.SystemAdminClient.UpdateConfig(context.Background(), cfg2)
+			require.NoError(t, err)
+			assert.Equal(t, oldDirectory, *cfg2.ImportSettings.Directory)
+			assert.Equal(t, oldDirectory, *th.App.Config().ImportSettings.Directory)
+		})
+
+		t.Run("local mode", func(t *testing.T) {
+			oldDirectory := *th.App.Config().ImportSettings.Directory
+			cfg2 := th.App.Config().Clone()
+			newDirectory := "./new-import-dir"
+			*cfg2.ImportSettings.Directory = newDirectory
+
+			cfg2, _, err = th.LocalClient.UpdateConfig(context.Background(), cfg2)
+			require.NoError(t, err)
+			assert.Equal(t, newDirectory, *cfg2.ImportSettings.Directory)
+			assert.Equal(t, newDirectory, *th.App.Config().ImportSettings.Directory)
+
+			cfg2.ImportSettings.Directory = nil
+			cfg2, _, err = th.LocalClient.UpdateConfig(context.Background(), cfg2)
+			require.NoError(t, err)
+			assert.Equal(t, oldDirectory, *cfg2.ImportSettings.Directory)
+			assert.Equal(t, oldDirectory, *th.App.Config().ImportSettings.Directory)
+		})
+	})
+
 	t.Run("System Admin should not be able to clear Site URL", func(t *testing.T) {
 		siteURL := cfg.ServiceSettings.SiteURL
 		defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.SiteURL = siteURL })
@@ -820,6 +857,30 @@ func TestPatchConfig(t *testing.T) {
 			} else {
 				require.Error(t, err)
 				CheckForbiddenStatus(t, resp)
+			}
+		})
+
+		t.Run("not allowing to change import directory via api, unless local mode", func(t *testing.T) {
+			oldDirectory := *th.App.Config().ImportSettings.Directory
+			config := model.Config{ImportSettings: model.ImportSettings{
+				Directory: model.NewPointer("./new-import-dir"),
+			}}
+
+			updatedConfig, resp, err := client.PatchConfig(context.Background(), &config)
+			if client == th.LocalClient {
+				require.NoError(t, err)
+				CheckOKStatus(t, resp)
+				assert.Equal(t, "./new-import-dir", *updatedConfig.ImportSettings.Directory)
+			} else {
+				require.Error(t, err)
+				CheckForbiddenStatus(t, resp)
+			}
+
+			// Reset for local mode
+			if client == th.LocalClient {
+				th.App.UpdateConfig(func(cfg *model.Config) {
+					*cfg.ImportSettings.Directory = oldDirectory
+				})
 			}
 		})
 	})


### PR DESCRIPTION
Cherry pick of #34653 on release-10.11.

/cc  @lieut-data

```release-note
NONE
```