### PR TITLE
[MM-67184] New column to handle autotranslation for channel members

### DIFF
--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -1828,7 +1828,7 @@ func updateChannelMemberNotifyProps(c *Context, w http.ResponseWriter, r *http.R
 }
 
 type UpdateChannelMemberAutotranslationProps struct {
-	AutotranslationEnabled bool `json:"autotranslation_enabled"`
+	AutotranslationDisabled bool `json:"autotranslation_disabled"`
 }
 
 func updateChannelMemberAutotranslation(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -1839,21 +1839,21 @@ func updateChannelMemberAutotranslation(c *Context, w http.ResponseWriter, r *ht
 
 	props := UpdateChannelMemberAutotranslationProps{}
 	if err := json.NewDecoder(r.Body).Decode(&props); err != nil {
-		c.SetInvalidParamWithErr("autotranslation_enabled", err)
+		c.SetInvalidParamWithErr("autotranslation_disabled", err)
 		return
 	}
 
 	auditRec := c.MakeAuditRecord(model.AuditEventUpdateChannelMemberAutotranslation, model.AuditStatusFail)
 	defer c.LogAuditRec(auditRec)
 	model.AddEventParameterToAuditRec(auditRec, "channel_id", c.Params.ChannelId)
-	model.AddEventParameterToAuditRec(auditRec, "autotranslation_enabled", props.AutotranslationEnabled)
+	model.AddEventParameterToAuditRec(auditRec, "autotranslation_disabled", props.AutotranslationDisabled)
 
 	if !c.App.SessionHasPermissionToUser(*c.AppContext.Session(), c.Params.UserId) {
 		c.SetPermissionError(model.PermissionEditOtherUsers)
 		return
 	}
 
-	_, appErr := c.App.UpdateChannelMemberAutotranslation(c.AppContext, c.Params.ChannelId, c.Params.UserId, props.AutotranslationEnabled)
+	_, appErr := c.App.UpdateChannelMemberAutotranslationDisabled(c.AppContext, c.Params.ChannelId, c.Params.UserId, props.AutotranslationDisabled)
 	if appErr != nil {
 		c.Err = appErr
 		return

--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -1453,13 +1453,13 @@ func (a *App) UpdateChannelMemberNotifyProps(rctx request.CTX, data map[string]s
 	return member, nil
 }
 
-func (a *App) UpdateChannelMemberAutotranslation(rctx request.CTX, channelID string, userID string, autotranslation bool) (*model.ChannelMember, *model.AppError) {
+func (a *App) UpdateChannelMemberAutotranslationDisabled(rctx request.CTX, channelID string, userID string, disabled bool) (*model.ChannelMember, *model.AppError) {
 	member, err := a.GetChannelMember(rctx, channelID, userID)
 	if err != nil {
 		return nil, err
 	}
 
-	member.AutoTranslationEnabled = autotranslation
+	member.AutoTranslationDisabled = disabled
 	return a.updateChannelMember(rctx, member)
 }
 

--- a/server/channels/app/post_metadata.go
+++ b/server/channels/app/post_metadata.go
@@ -119,6 +119,9 @@ func (a *App) populatePostListTranslations(rctx request.CTX, list *model.PostLis
 	for channelID, postIDs := range postsNeedingTranslations {
 		userLang, err := a.AutoTranslation().GetUserLanguage(userID, channelID)
 		if err != nil {
+			if err.StatusCode == http.StatusNotFound {
+				continue // User not eligible for translation - skip silently
+			}
 			var notAvailErr *model.ErrAutoTranslationNotAvailable
 			if !errors.As(err, &notAvailErr) {
 				// Log non-availability errors

--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -297,5 +297,5 @@ channels/db/migrations/postgres/000149_create_recaps.down.sql
 channels/db/migrations/postgres/000149_create_recaps.up.sql
 channels/db/migrations/postgres/000150_add_translation_state.down.sql
 channels/db/migrations/postgres/000150_add_translation_state.up.sql
-channels/db/migrations/postgres/000151_add_autotranslationenabled_channelmembers.down.sql
-channels/db/migrations/postgres/000151_add_autotranslationenabled_channelmembers.up.sql
+channels/db/migrations/postgres/000151_add_autotranslationdisabled_channelmembers.down.sql
+channels/db/migrations/postgres/000151_add_autotranslationdisabled_channelmembers.up.sql

--- a/server/channels/db/migrations/postgres/000151_add_autotranslationdisabled_channelmembers.down.sql
+++ b/server/channels/db/migrations/postgres/000151_add_autotranslationdisabled_channelmembers.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE channelmembers
+    DROP COLUMN IF EXISTS autotranslationdisabled;

--- a/server/channels/db/migrations/postgres/000151_add_autotranslationdisabled_channelmembers.up.sql
+++ b/server/channels/db/migrations/postgres/000151_add_autotranslationdisabled_channelmembers.up.sql
@@ -1,0 +1,3 @@
+-- Add autotranslationdisabled column with default false (users have autotranslation enabled by default)
+ALTER TABLE channelmembers
+    ADD COLUMN IF NOT EXISTS autotranslationdisabled boolean NOT NULL DEFAULT false;

--- a/server/channels/db/migrations/postgres/000151_add_autotranslationenabled_channelmembers.down.sql
+++ b/server/channels/db/migrations/postgres/000151_add_autotranslationenabled_channelmembers.down.sql
@@ -1,2 +1,0 @@
-ALTER TABLE channelmembers
-    DROP COLUMN IF EXISTS autotranslationenabled;

--- a/server/channels/db/migrations/postgres/000151_add_autotranslationenabled_channelmembers.up.sql
+++ b/server/channels/db/migrations/postgres/000151_add_autotranslationenabled_channelmembers.up.sql
@@ -1,3 +1,0 @@
--- Add autotranslationenabled column with default true (opt-out instead of opt-in)
-ALTER TABLE channelmembers
-    ADD COLUMN IF NOT EXISTS autotranslationenabled boolean NOT NULL DEFAULT true;

--- a/server/channels/store/localcachelayer/autotranslation_layer.go
+++ b/server/channels/store/localcachelayer/autotranslation_layer.go
@@ -69,27 +69,27 @@ func (s LocalCacheAutoTranslationStore) SetChannelEnabled(channelID string, enab
 	return nil
 }
 
-// IsUserEnabled checks if auto-translation is enabled for a user in a channel (with caching)
-func (s LocalCacheAutoTranslationStore) IsUserEnabled(userID, channelID string) (bool, *model.AppError) {
+// IsUserDisabled checks if auto-translation is disabled for a user in a channel (with caching)
+func (s LocalCacheAutoTranslationStore) IsUserDisabled(userID, channelID string) (bool, *model.AppError) {
 	key := userAutoTranslationKey(userID, channelID)
 
-	var enabled bool
-	if err := s.rootStore.doStandardReadCache(s.rootStore.userAutoTranslationCache, key, &enabled); err == nil {
-		return enabled, nil
+	var disabled bool
+	if err := s.rootStore.doStandardReadCache(s.rootStore.userAutoTranslationCache, key, &disabled); err == nil {
+		return disabled, nil
 	}
 
-	enabled, appErr := s.AutoTranslationStore.IsUserEnabled(userID, channelID)
+	disabled, appErr := s.AutoTranslationStore.IsUserDisabled(userID, channelID)
 	if appErr != nil {
-		return false, appErr
+		return true, appErr
 	}
 
-	s.rootStore.doStandardAddToCache(s.rootStore.userAutoTranslationCache, key, enabled)
-	return enabled, nil
+	s.rootStore.doStandardAddToCache(s.rootStore.userAutoTranslationCache, key, disabled)
+	return disabled, nil
 }
 
-// SetUserEnabled sets auto-translation status for a user in a channel and invalidates cache
-func (s LocalCacheAutoTranslationStore) SetUserEnabled(userID, channelID string, enabled bool) *model.AppError {
-	appErr := s.AutoTranslationStore.SetUserEnabled(userID, channelID, enabled)
+// SetUserDisabled sets auto-translation disabled status for a user in a channel and invalidates cache
+func (s LocalCacheAutoTranslationStore) SetUserDisabled(userID, channelID string, disabled bool) *model.AppError {
+	appErr := s.AutoTranslationStore.SetUserDisabled(userID, channelID, disabled)
 	if appErr != nil {
 		return appErr
 	}

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -926,9 +926,9 @@ func (s *RetryLayerAutoTranslationStore) IsChannelEnabled(channelID string) (boo
 
 }
 
-func (s *RetryLayerAutoTranslationStore) IsUserEnabled(userID string, channelID string) (bool, *model.AppError) {
+func (s *RetryLayerAutoTranslationStore) IsUserDisabled(userID string, channelID string) (bool, *model.AppError) {
 
-	return s.AutoTranslationStore.IsUserEnabled(userID, channelID)
+	return s.AutoTranslationStore.IsUserDisabled(userID, channelID)
 
 }
 
@@ -944,9 +944,9 @@ func (s *RetryLayerAutoTranslationStore) SetChannelEnabled(channelID string, ena
 
 }
 
-func (s *RetryLayerAutoTranslationStore) SetUserEnabled(userID string, channelID string, enabled bool) *model.AppError {
+func (s *RetryLayerAutoTranslationStore) SetUserDisabled(userID string, channelID string, disabled bool) *model.AppError {
 
-	return s.AutoTranslationStore.SetUserEnabled(userID, channelID, enabled)
+	return s.AutoTranslationStore.SetUserDisabled(userID, channelID, disabled)
 
 }
 

--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -52,21 +52,21 @@ type channelMember struct {
 
 func NewMapFromChannelMemberModel(cm *model.ChannelMember) map[string]any {
 	return map[string]any{
-		"ChannelId":              cm.ChannelId,
-		"UserId":                 cm.UserId,
-		"Roles":                  cm.ExplicitRoles,
-		"LastViewedAt":           cm.LastViewedAt,
-		"MsgCount":               cm.MsgCount,
-		"MentionCount":           cm.MentionCount,
-		"MentionCountRoot":       cm.MentionCountRoot,
-		"UrgentMentionCount":     cm.UrgentMentionCount,
-		"MsgCountRoot":           cm.MsgCountRoot,
-		"NotifyProps":            cm.NotifyProps,
-		"LastUpdateAt":           cm.LastUpdateAt,
-		"SchemeGuest":            sql.NullBool{Valid: true, Bool: cm.SchemeGuest},
-		"SchemeUser":             sql.NullBool{Valid: true, Bool: cm.SchemeUser},
-		"SchemeAdmin":            sql.NullBool{Valid: true, Bool: cm.SchemeAdmin},
-		"AutoTranslationEnabled": cm.AutoTranslationEnabled,
+		"ChannelId":               cm.ChannelId,
+		"UserId":                  cm.UserId,
+		"Roles":                   cm.ExplicitRoles,
+		"LastViewedAt":            cm.LastViewedAt,
+		"MsgCount":                cm.MsgCount,
+		"MentionCount":            cm.MentionCount,
+		"MentionCountRoot":        cm.MentionCountRoot,
+		"UrgentMentionCount":      cm.UrgentMentionCount,
+		"MsgCountRoot":            cm.MsgCountRoot,
+		"NotifyProps":             cm.NotifyProps,
+		"LastUpdateAt":            cm.LastUpdateAt,
+		"SchemeGuest":             sql.NullBool{Valid: true, Bool: cm.SchemeGuest},
+		"SchemeUser":              sql.NullBool{Valid: true, Bool: cm.SchemeUser},
+		"SchemeAdmin":             sql.NullBool{Valid: true, Bool: cm.SchemeAdmin},
+		"AutoTranslationDisabled": cm.AutoTranslationDisabled,
 	}
 }
 
@@ -91,7 +91,7 @@ type channelMemberWithSchemeRoles struct {
 	ChannelSchemeDefaultUserRole  sql.NullString
 	ChannelSchemeDefaultAdminRole sql.NullString
 	MsgCountRoot                  int64
-	AutoTranslationEnabled        bool
+	AutoTranslationDisabled       bool
 }
 
 type channelMemberWithTeamWithSchemeRoles struct {
@@ -104,7 +104,7 @@ type channelMemberWithTeamWithSchemeRoles struct {
 type channelMemberWithTeamWithSchemeRolesList []channelMemberWithTeamWithSchemeRoles
 
 func channelMemberSliceColumns() []string {
-	return []string{"ChannelId", "UserId", "Roles", "LastViewedAt", "MsgCount", "MsgCountRoot", "MentionCount", "MentionCountRoot", "UrgentMentionCount", "NotifyProps", "LastUpdateAt", "SchemeUser", "SchemeAdmin", "SchemeGuest", "AutoTranslationEnabled"}
+	return []string{"ChannelId", "UserId", "Roles", "LastViewedAt", "MsgCount", "MsgCountRoot", "MentionCount", "MentionCountRoot", "UrgentMentionCount", "NotifyProps", "LastUpdateAt", "SchemeUser", "SchemeAdmin", "SchemeGuest", "AutoTranslationDisabled"}
 }
 
 // channelSliceColumns returns fields of the channel as a string slice.
@@ -197,7 +197,7 @@ func channelMemberToSlice(member *model.ChannelMember) []any {
 	resultSlice = append(resultSlice, member.SchemeUser)
 	resultSlice = append(resultSlice, member.SchemeAdmin)
 	resultSlice = append(resultSlice, member.SchemeGuest)
-	resultSlice = append(resultSlice, member.AutoTranslationEnabled)
+	resultSlice = append(resultSlice, member.AutoTranslationDisabled)
 	return resultSlice
 }
 
@@ -313,22 +313,22 @@ func (db channelMemberWithSchemeRoles) ToModel() *model.ChannelMember {
 		strings.Fields(db.Roles),
 	)
 	return &model.ChannelMember{
-		ChannelId:              db.ChannelId,
-		UserId:                 db.UserId,
-		Roles:                  strings.Join(rolesResult.roles, " "),
-		LastViewedAt:           db.LastViewedAt,
-		MsgCount:               db.MsgCount,
-		MsgCountRoot:           db.MsgCountRoot,
-		MentionCount:           db.MentionCount,
-		MentionCountRoot:       db.MentionCountRoot,
-		UrgentMentionCount:     db.UrgentMentionCount,
-		NotifyProps:            db.NotifyProps,
-		LastUpdateAt:           db.LastUpdateAt,
-		SchemeAdmin:            rolesResult.schemeAdmin,
-		SchemeUser:             rolesResult.schemeUser,
-		SchemeGuest:            rolesResult.schemeGuest,
-		ExplicitRoles:          strings.Join(rolesResult.explicitRoles, " "),
-		AutoTranslationEnabled: db.AutoTranslationEnabled,
+		ChannelId:               db.ChannelId,
+		UserId:                  db.UserId,
+		Roles:                   strings.Join(rolesResult.roles, " "),
+		LastViewedAt:            db.LastViewedAt,
+		MsgCount:                db.MsgCount,
+		MsgCountRoot:            db.MsgCountRoot,
+		MentionCount:            db.MentionCount,
+		MentionCountRoot:        db.MentionCountRoot,
+		UrgentMentionCount:      db.UrgentMentionCount,
+		NotifyProps:             db.NotifyProps,
+		LastUpdateAt:            db.LastUpdateAt,
+		SchemeAdmin:             rolesResult.schemeAdmin,
+		SchemeUser:              rolesResult.schemeUser,
+		SchemeGuest:             rolesResult.schemeGuest,
+		ExplicitRoles:           strings.Join(rolesResult.explicitRoles, " "),
+		AutoTranslationDisabled: db.AutoTranslationDisabled,
 	}
 }
 
@@ -378,22 +378,22 @@ func (db channelMemberWithTeamWithSchemeRoles) ToModel() *model.ChannelMemberWit
 	)
 	return &model.ChannelMemberWithTeamData{
 		ChannelMember: model.ChannelMember{
-			ChannelId:              db.ChannelId,
-			UserId:                 db.UserId,
-			Roles:                  strings.Join(rolesResult.roles, " "),
-			LastViewedAt:           db.LastViewedAt,
-			MsgCount:               db.MsgCount,
-			MsgCountRoot:           db.MsgCountRoot,
-			MentionCount:           db.MentionCount,
-			MentionCountRoot:       db.MentionCountRoot,
-			UrgentMentionCount:     db.UrgentMentionCount,
-			NotifyProps:            db.NotifyProps,
-			LastUpdateAt:           db.LastUpdateAt,
-			SchemeAdmin:            rolesResult.schemeAdmin,
-			SchemeUser:             rolesResult.schemeUser,
-			SchemeGuest:            rolesResult.schemeGuest,
-			ExplicitRoles:          strings.Join(rolesResult.explicitRoles, " "),
-			AutoTranslationEnabled: db.AutoTranslationEnabled,
+			ChannelId:               db.ChannelId,
+			UserId:                  db.UserId,
+			Roles:                   strings.Join(rolesResult.roles, " "),
+			LastViewedAt:            db.LastViewedAt,
+			MsgCount:                db.MsgCount,
+			MsgCountRoot:            db.MsgCountRoot,
+			MentionCount:            db.MentionCount,
+			MentionCountRoot:        db.MentionCountRoot,
+			UrgentMentionCount:      db.UrgentMentionCount,
+			NotifyProps:             db.NotifyProps,
+			LastUpdateAt:            db.LastUpdateAt,
+			SchemeAdmin:             rolesResult.schemeAdmin,
+			SchemeUser:              rolesResult.schemeUser,
+			SchemeGuest:             rolesResult.schemeGuest,
+			ExplicitRoles:           strings.Join(rolesResult.explicitRoles, " "),
+			AutoTranslationDisabled: db.AutoTranslationDisabled,
 		},
 		TeamName:        db.TeamName,
 		TeamDisplayName: db.TeamDisplayName,
@@ -535,7 +535,7 @@ func (s *SqlChannelStore) initializeQueries() {
 			"ChannelScheme.DefaultChannelGuestRole ChannelSchemeDefaultGuestRole",
 			"ChannelScheme.DefaultChannelUserRole ChannelSchemeDefaultUserRole",
 			"ChannelScheme.DefaultChannelAdminRole ChannelSchemeDefaultAdminRole",
-			"ChannelMembers.AutoTranslationEnabled",
+			"ChannelMembers.AutoTranslationDisabled",
 		).
 		From("ChannelMembers").
 		InnerJoin("Channels ON ChannelMembers.ChannelId = Channels.Id").
@@ -1635,7 +1635,7 @@ var channelMembersWithSchemeSelectQuery = `
 		ChannelMembers.SchemeUser,
 		ChannelMembers.SchemeAdmin,
 		ChannelMembers.SchemeGuest,
-		ChannelMembers.AutoTranslationEnabled,
+		ChannelMembers.AutoTranslationDisabled,
 		COALESCE(Teams.DisplayName, '') TeamDisplayName,
 		COALESCE(Teams.Name, '') TeamName,
 		COALESCE(Teams.UpdateAt, 0) TeamUpdateAt,
@@ -2197,7 +2197,7 @@ func (s SqlChannelStore) GetMemberForPost(postId string, userId string) (*model.
 			ChannelMembers.SchemeUser,
 			ChannelMembers.SchemeAdmin,
 			ChannelMembers.SchemeGuest,
-			ChannelMembers.AutoTranslationEnabled,
+			ChannelMembers.AutoTranslationDisabled,
 			TeamScheme.DefaultChannelGuestRole TeamSchemeDefaultGuestRole,
 			TeamScheme.DefaultChannelUserRole TeamSchemeDefaultUserRole,
 			TeamScheme.DefaultChannelAdminRole TeamSchemeDefaultAdminRole,
@@ -4125,7 +4125,7 @@ func (s SqlChannelStore) GetChannelMembersForExport(userId string, teamId string
 		ChannelMembers.SchemeAdmin,
 		(ChannelMembers.SchemeGuest IS NOT NULL AND ChannelMembers.SchemeGuest) as SchemeGuest,
 		Channels.Name as ChannelName,
-		ChannelMembers.AutoTranslationEnabled
+		ChannelMembers.AutoTranslationDisabled
 	FROM
 		ChannelMembers
 	INNER JOIN
@@ -4176,7 +4176,7 @@ func (s SqlChannelStore) GetAllDirectChannelsForExportAfter(limit int, afterId s
 		channelIds = append(channelIds, channel.Id)
 	}
 	query = s.getQueryBuilder().
-		Select("u.Username as Username, ChannelId, UserId, cm.Roles as Roles, LastViewedAt, MsgCount, MsgCountRoot, MentionCount, MentionCountRoot, COALESCE(UrgentMentionCount, 0) UrgentMentionCount, cm.NotifyProps as NotifyProps, LastUpdateAt, SchemeUser, SchemeAdmin, (SchemeGuest IS NOT NULL AND SchemeGuest) as SchemeGuest, cm.AutoTranslationEnabled as AutoTranslationEnabled").
+		Select("u.Username as Username, ChannelId, UserId, cm.Roles as Roles, LastViewedAt, MsgCount, MsgCountRoot, MentionCount, MentionCountRoot, COALESCE(UrgentMentionCount, 0) UrgentMentionCount, cm.NotifyProps as NotifyProps, LastUpdateAt, SchemeUser, SchemeAdmin, (SchemeGuest IS NOT NULL AND SchemeGuest) as SchemeGuest, cm.AutoTranslationDisabled as AutoTranslationDisabled").
 		From("ChannelMembers cm").
 		Join("Users u ON ( u.Id = cm.UserId )").
 		Where(sq.Eq{"cm.ChannelId": channelIds})

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -1160,8 +1160,8 @@ type AttributesStore interface {
 type AutoTranslationStore interface {
 	IsChannelEnabled(channelID string) (bool, *model.AppError)
 	SetChannelEnabled(channelID string, enabled bool) *model.AppError
-	IsUserEnabled(userID, channelID string) (bool, *model.AppError)
-	SetUserEnabled(userID, channelID string, enabled bool) *model.AppError
+	IsUserDisabled(userID, channelID string) (bool, *model.AppError)
+	SetUserDisabled(userID, channelID string, disabled bool) *model.AppError
 	GetUserLanguage(userID, channelID string) (string, *model.AppError)
 	Get(objectID, dstLang string) (*model.Translation, *model.AppError)
 	GetBatch(objectIDs []string, dstLang string) (map[string]*model.Translation, *model.AppError)

--- a/server/channels/store/storetest/mocks/AutoTranslationStore.go
+++ b/server/channels/store/storetest/mocks/AutoTranslationStore.go
@@ -249,12 +249,12 @@ func (_m *AutoTranslationStore) IsChannelEnabled(channelID string) (bool, *model
 	return r0, r1
 }
 
-// IsUserEnabled provides a mock function with given fields: userID, channelID
-func (_m *AutoTranslationStore) IsUserEnabled(userID string, channelID string) (bool, *model.AppError) {
+// IsUserDisabled provides a mock function with given fields: userID, channelID
+func (_m *AutoTranslationStore) IsUserDisabled(userID string, channelID string) (bool, *model.AppError) {
 	ret := _m.Called(userID, channelID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for IsUserEnabled")
+		panic("no return value specified for IsUserDisabled")
 	}
 
 	var r0 bool
@@ -319,17 +319,17 @@ func (_m *AutoTranslationStore) SetChannelEnabled(channelID string, enabled bool
 	return r0
 }
 
-// SetUserEnabled provides a mock function with given fields: userID, channelID, enabled
-func (_m *AutoTranslationStore) SetUserEnabled(userID string, channelID string, enabled bool) *model.AppError {
-	ret := _m.Called(userID, channelID, enabled)
+// SetUserDisabled provides a mock function with given fields: userID, channelID, disabled
+func (_m *AutoTranslationStore) SetUserDisabled(userID string, channelID string, disabled bool) *model.AppError {
+	ret := _m.Called(userID, channelID, disabled)
 
 	if len(ret) == 0 {
-		panic("no return value specified for SetUserEnabled")
+		panic("no return value specified for SetUserDisabled")
 	}
 
 	var r0 *model.AppError
 	if rf, ok := ret.Get(0).(func(string, string, bool) *model.AppError); ok {
-		r0 = rf(userID, channelID, enabled)
+		r0 = rf(userID, channelID, disabled)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.AppError)

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -946,10 +946,10 @@ func (s *TimerLayerAutoTranslationStore) IsChannelEnabled(channelID string) (boo
 	return result, resultVar1
 }
 
-func (s *TimerLayerAutoTranslationStore) IsUserEnabled(userID string, channelID string) (bool, *model.AppError) {
+func (s *TimerLayerAutoTranslationStore) IsUserDisabled(userID string, channelID string) (bool, *model.AppError) {
 	start := time.Now()
 
-	result, resultVar1 := s.AutoTranslationStore.IsUserEnabled(userID, channelID)
+	result, resultVar1 := s.AutoTranslationStore.IsUserDisabled(userID, channelID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -957,7 +957,7 @@ func (s *TimerLayerAutoTranslationStore) IsUserEnabled(userID string, channelID 
 		if true {
 			success = "true"
 		}
-		s.Root.Metrics.ObserveStoreMethodDuration("AutoTranslationStore.IsUserEnabled", success, elapsed)
+		s.Root.Metrics.ObserveStoreMethodDuration("AutoTranslationStore.IsUserDisabled", success, elapsed)
 	}
 	return result, resultVar1
 }
@@ -994,10 +994,10 @@ func (s *TimerLayerAutoTranslationStore) SetChannelEnabled(channelID string, ena
 	return result
 }
 
-func (s *TimerLayerAutoTranslationStore) SetUserEnabled(userID string, channelID string, enabled bool) *model.AppError {
+func (s *TimerLayerAutoTranslationStore) SetUserDisabled(userID string, channelID string, disabled bool) *model.AppError {
 	start := time.Now()
 
-	result := s.AutoTranslationStore.SetUserEnabled(userID, channelID, enabled)
+	result := s.AutoTranslationStore.SetUserDisabled(userID, channelID, disabled)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {
@@ -1005,7 +1005,7 @@ func (s *TimerLayerAutoTranslationStore) SetUserEnabled(userID string, channelID
 		if true {
 			success = "true"
 		}
-		s.Root.Metrics.ObserveStoreMethodDuration("AutoTranslationStore.SetUserEnabled", success, elapsed)
+		s.Root.Metrics.ObserveStoreMethodDuration("AutoTranslationStore.SetUserDisabled", success, elapsed)
 	}
 	return result
 }

--- a/server/public/model/channel_member.go
+++ b/server/public/model/channel_member.go
@@ -52,22 +52,22 @@ type ChannelUnreadAt struct {
 }
 
 type ChannelMember struct {
-	ChannelId          string    `json:"channel_id"`
-	UserId             string    `json:"user_id"`
-	Roles              string    `json:"roles"`
-	LastViewedAt       int64     `json:"last_viewed_at"`
-	MsgCount           int64     `json:"msg_count"`
-	MentionCount       int64     `json:"mention_count"`
-	MentionCountRoot   int64     `json:"mention_count_root"`
-	UrgentMentionCount int64     `json:"urgent_mention_count"`
-	MsgCountRoot       int64     `json:"msg_count_root"`
-	NotifyProps        StringMap `json:"notify_props"`
-	LastUpdateAt       int64     `json:"last_update_at"`
-	SchemeGuest        bool      `json:"scheme_guest"`
-	SchemeUser         bool      `json:"scheme_user"`
-	SchemeAdmin        bool      `json:"scheme_admin"`
-	ExplicitRoles          string `json:"explicit_roles"`
-	AutoTranslationEnabled bool   `json:"autotranslation_enabled"`
+	ChannelId               string    `json:"channel_id"`
+	UserId                  string    `json:"user_id"`
+	Roles                   string    `json:"roles"`
+	LastViewedAt            int64     `json:"last_viewed_at"`
+	MsgCount                int64     `json:"msg_count"`
+	MentionCount            int64     `json:"mention_count"`
+	MentionCountRoot        int64     `json:"mention_count_root"`
+	UrgentMentionCount      int64     `json:"urgent_mention_count"`
+	MsgCountRoot            int64     `json:"msg_count_root"`
+	NotifyProps             StringMap `json:"notify_props"`
+	LastUpdateAt            int64     `json:"last_update_at"`
+	SchemeGuest             bool      `json:"scheme_guest"`
+	SchemeUser              bool      `json:"scheme_user"`
+	SchemeAdmin             bool      `json:"scheme_admin"`
+	ExplicitRoles           string    `json:"explicit_roles"`
+	AutoTranslationDisabled bool      `json:"autotranslation_disabled"`
 }
 
 func (o *ChannelMember) Auditable() map[string]any {
@@ -87,7 +87,7 @@ func (o *ChannelMember) Auditable() map[string]any {
 		"scheme_user":              o.SchemeUser,
 		"scheme_admin":             o.SchemeAdmin,
 		"explicit_roles":           o.ExplicitRoles,
-		"autotranslation_enabled":  o.AutoTranslationEnabled,
+		"autotranslation_disabled": o.AutoTranslationDisabled,
 	}
 }
 

--- a/webapp/channels/src/actions/websocket_actions.jsx
+++ b/webapp/channels/src/actions/websocket_actions.jsx
@@ -745,7 +745,7 @@ function handleChannelMemberUpdatedEvent(msg) {
         const existingMember = getMyChannelMemberInternal(state, channelMember.channel_id);
 
         // If user autotranslation changed, delete posts for this channel
-        if (existingMember && existingMember.autotranslation_enabled !== channelMember.autotranslation_enabled) {
+        if (existingMember && existingMember.autotranslation_disabled !== channelMember.autotranslation_disabled) {
             doDispatch(resetReloadPostsInChannel(channelMember.channel_id));
         }
 

--- a/webapp/channels/src/components/channel_header_menu/menu_items/autotranslation.tsx
+++ b/webapp/channels/src/components/channel_header_menu/menu_items/autotranslation.tsx
@@ -8,7 +8,7 @@ import {useDispatch, useSelector} from 'react-redux';
 import {TranslateIcon} from '@mattermost/compass-icons/components';
 import type {Channel} from '@mattermost/types/channels';
 
-import {setMyChannelAutotranslation} from 'mattermost-redux/actions/channels';
+import {setMyChannelAutotranslationDisabled} from 'mattermost-redux/actions/channels';
 import {isChannelAutotranslated} from 'mattermost-redux/selectors/entities/channels';
 
 import {openModal} from 'actions/views/modals';
@@ -42,8 +42,8 @@ const Autotranslation = ({channel, ...rest}: Props): JSX.Element => {
                 }),
             );
         } else {
-            // Enable directly without confirmation
-            dispatch(setMyChannelAutotranslation(channel.id, true));
+            // Enable directly without confirmation (set disabled = false)
+            dispatch(setMyChannelAutotranslationDisabled(channel.id, false));
         }
     }, [channel, config, dispatch]);
 

--- a/webapp/channels/src/components/disable_autotranslation_modal.tsx
+++ b/webapp/channels/src/components/disable_autotranslation_modal.tsx
@@ -7,7 +7,7 @@ import {useDispatch} from 'react-redux';
 
 import type {Channel} from '@mattermost/types/channels';
 
-import {setMyChannelAutotranslation} from 'mattermost-redux/actions/channels';
+import {setMyChannelAutotranslationDisabled} from 'mattermost-redux/actions/channels';
 
 import {sendEphemeralPost} from 'actions/global_actions';
 import {closeModal} from 'actions/views/modals';
@@ -31,7 +31,7 @@ const DisableAutotranslationModal = ({channel}: Props) => {
 
     const handleConfirm = useCallback(async () => {
         handleHide();
-        await dispatch(setMyChannelAutotranslation(channel.id, false));
+        await dispatch(setMyChannelAutotranslationDisabled(channel.id, true));
 
         // Disabling autotranslations removes all the posts in a channel,
         // so we need to wait for the posts to be removed before sending the ephemeral post.

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/channels.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/channels.ts
@@ -263,14 +263,14 @@ export function patchChannel(channelId: string, patch: Partial<Channel>): Action
     });
 }
 
-export function setMyChannelAutotranslation(channelId: string, enabled: boolean): ActionFuncAsync<boolean> {
+export function setMyChannelAutotranslationDisabled(channelId: string, disabled: boolean): ActionFuncAsync<boolean> {
     return async (dispatch, getState) => {
         const state = getState();
         const myChannelMember = getMyChannelMemberSelector(state, channelId);
-        const wasEnabled = myChannelMember?.autotranslation_enabled;
+        const wasDisabled = myChannelMember?.autotranslation_disabled ?? true;
 
         try {
-            await Client4.setMyChannelAutotranslation(channelId, enabled);
+            await Client4.setMyChannelAutotranslationDisabled(channelId, disabled);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));
@@ -281,12 +281,12 @@ export function setMyChannelAutotranslation(channelId: string, enabled: boolean)
             type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER,
             data: {
                 ...myChannelMember,
-                autotranslation_enabled: enabled,
+                autotranslation_disabled: disabled,
             },
         });
 
-        // If autotranslation changed, delete posts for this channel
-        if (wasEnabled !== enabled) {
+        // If autotranslation disabled state changed, delete posts for this channel
+        if (wasDisabled !== disabled) {
             await dispatch(resetReloadPostsInChannel(channelId));
         }
 

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channels.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/channels.ts
@@ -1471,7 +1471,7 @@ export function getMyChannelAutotranslation(state: GlobalState, channelId: strin
     return Boolean(
         config?.EnableAutoTranslation === 'true' &&
         channel?.autotranslation &&
-        myChannelMember?.autotranslation_enabled,
+        !myChannelMember?.autotranslation_disabled,
     );
 }
 

--- a/webapp/platform/client/src/client4.ts
+++ b/webapp/platform/client/src/client4.ts
@@ -1755,10 +1755,10 @@ export default class Client4 {
         );
     };
 
-    setMyChannelAutotranslation = (channelId: string, enabled: boolean) => {
+    setMyChannelAutotranslationDisabled = (channelId: string, disabled: boolean) => {
         return this.doFetch<ChannelMembership>(
             `${this.getChannelMemberRoute(channelId, 'me')}/autotranslation`,
-            {method: 'put', body: JSON.stringify({autotranslation_enabled: enabled})},
+            {method: 'put', body: JSON.stringify({autotranslation_disabled: disabled})},
         );
     };
 

--- a/webapp/platform/types/src/channels.ts
+++ b/webapp/platform/types/src/channels.ts
@@ -137,7 +137,7 @@ export type ChannelMembership = {
     scheme_user: boolean;
     scheme_admin: boolean;
     post_root_id?: string;
-    autotranslation_enabled?: boolean;
+    autotranslation_disabled?: boolean;
 };
 
 export type ChannelUnread = {


### PR DESCRIPTION
#### Summary
We need to flip the logic for how autotranslation works in the channel member table. It needs to be default enabled for all channel members when autotranslations is enabled in a channel. The name of the old column `autotranslation` with a default of `false` doesn't make sense. I decided to add a new column called `autotranslationenabled` with a default of `true`. 

I also decided this doesn't need an index like the old column had. There are already indexes that handle the initial filtering by `channel_id` and `user_id`. It made sense in the old logic because we were partial indexing based off the non-default value but there's not much point in indexing on the default value? Let me know what you think.

I also removed the `GetActiveDestinationLanguages` function because it's unused.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67184

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Add new column to the ChannelMembers table for auto-translations 
```
