### PR TITLE
Automated cherry pick of #35034

### DIFF
--- a/server/channels/app/password/hashers/pbkdf2.go
+++ b/server/channels/app/password/hashers/pbkdf2.go
@@ -195,6 +195,10 @@ func (p PBKDF2) Hash(password string) (string, error) {
 // The provided [phcparser.PHC] is validated to double-check it was generated with
 // this hasher and parameters.
 func (p PBKDF2) CompareHashAndPassword(hash phcparser.PHC, password string) error {
+	if len(password) > PasswordMaxLengthBytes {
+		return ErrPasswordTooLong
+	}
+
 	// Validate parameters
 	if !p.IsPHCValid(hash) {
 		return fmt.Errorf("the stored password does not comply with the PBKDF2 parser's PHC serialization")

--- a/server/channels/app/password/hashers/pbkdf2_test.go
+++ b/server/channels/app/password/hashers/pbkdf2_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/pbkdf2"
 	"crypto/sha256"
 	"encoding/base64"
+	"math/rand"
 	"strings"
 	"testing"
 
@@ -46,6 +47,9 @@ func TestPBKDF2Hash(t *testing.T) {
 }
 
 func TestPBKDF2CompareHashAndPassword(t *testing.T) {
+	passwordTooLong := make([]byte, PasswordMaxLengthBytes+1)
+	rand.Read(passwordTooLong)
+
 	testCases := []struct {
 		testName    string
 		storedPwd   string
@@ -70,6 +74,12 @@ func TestPBKDF2CompareHashAndPassword(t *testing.T) {
 			"one password",
 			"another password",
 			ErrMismatchedHashAndPassword,
+		},
+		{
+			"password too long",
+			"stored password",
+			string(passwordTooLong),
+			ErrPasswordTooLong,
 		},
 	}
 


### PR DESCRIPTION
Cherry pick of #35034 on release-11.2.

/cc  @agarciamontoro

```release-note
NONE
```