### PR TITLE
MM-66975: Prepackage the FIPS flavour of Boards to v9.2.2

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -174,7 +174,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.6.1%2B0e01d28-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v1.7.2%2B866e2dd-fips
-	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.1%2Bdf49b26-fips
+	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.2%2B4282c63-fips
 endif
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)


### PR DESCRIPTION
#### Summary
Update the prepackaged FIPS flavour of Boards to v9.2.2.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66975

#### Screenshots
--

#### Release Note
```release-note
NONE
```
