### PR TITLE
MM-67365 - adjust bor icons and priority labels in compact mode

### DIFF
--- a/webapp/channels/src/components/post_view/burn_on_read_badge/burn_on_read_badge.scss
+++ b/webapp/channels/src/components/post_view/burn_on_read_badge/burn_on_read_badge.scss
@@ -2,17 +2,17 @@
 // See LICENSE.txt for license information.
 
 .BurnOnReadBadge {
-    display: inline-flex;
     position: relative;
     z-index: 25;
+    display: inline-flex;
     align-items: center;
     padding: 0;
     border: none;
     margin-left: 8px;
     background: transparent;
     cursor: pointer;
-    vertical-align: middle;
     pointer-events: auto;
+    vertical-align: middle;
 
     &:disabled {
         cursor: default;

--- a/webapp/channels/src/components/post_view/burn_on_read_timer_chip/burn_on_read_timer_chip.scss
+++ b/webapp/channels/src/components/post_view/burn_on_read_timer_chip/burn_on_read_timer_chip.scss
@@ -2,9 +2,9 @@
 // See LICENSE.txt for license information.
 
 .BurnOnReadTimerChip {
-    display: inline-flex;
     position: relative;
     z-index: 25;
+    display: inline-flex;
     height: 16px;
     align-items: center;
     padding: 0px 4px;
@@ -17,8 +17,8 @@
     font-size: 10px;
     font-weight: 600;
     line-height: 12px;
-    transition: all 0.2s ease;
     pointer-events: auto;
+    transition: all 0.2s ease;
 
     &:hover {
         opacity: 0.9;

--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -851,11 +851,11 @@
         .post__header,
         .post-preview__header {
             display: flex;
+            overflow: visible;
             width: auto;
             max-height: 22px;
             padding: 0;
             margin-bottom: 0;
-            overflow: visible;
         }
 
         .badges-wrapper {


### PR DESCRIPTION
#### Summary
This PR adjust the styles for posts in compact mode so the priority labels and the bor badges and icons work properly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67365

#### Screenshots

Before:
<img width="1371" height="441" alt="Screenshot 2026-01-28 at 12 01 37 PM" src="https://github.com/user-attachments/assets/b4fa0fbb-8ccc-4ef0-8011-8ebc015ef3ac" />


After:

https://github.com/user-attachments/assets/d16b158a-efca-4faa-b6c4-fb7b2aa83b1b


#### Release Note
```release-note
NONE
```
