### PR TITLE
Patch MM-67126 issue for release-10.11

### DIFF
--- a/api/v4/source/access_control.yaml
+++ b/api/v4/source/access_control.yaml
@@ -239,6 +239,16 @@
       tags:
         - access control
       summary: Activate or deactivate an access control policy
+      deprecated: true
+      description: |
+        This endpoint is deprecated. Use the POST /api/v4/access_control_policies/{policy_id}/activate instead.
+      responses:
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+    post:
+      tags:
+        - access control
+      summary: Activate or deactivate an access control policy
       description: |
         Updates the active status of an access control policy.
         ##### Permissions

--- a/api/v4/source/definitions.yaml
+++ b/api/v4/source/definitions.yaml
@@ -28,6 +28,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/AppError"
+    MethodNotAllowed:
+      description: Method not allowed
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/AppError"
     TooLarge:
       description: Content too large
       content:

--- a/server/channels/api4/access_control.go
+++ b/server/channels/api4/access_control.go
@@ -27,7 +27,8 @@ func (api *API) InitAccessControlPolicy() {
 
 	api.BaseRoutes.AccessControlPolicy.Handle("", api.APISessionRequired(getAccessControlPolicy)).Methods(http.MethodGet)
 	api.BaseRoutes.AccessControlPolicy.Handle("", api.APISessionRequired(deleteAccessControlPolicy)).Methods(http.MethodDelete)
-	api.BaseRoutes.AccessControlPolicy.Handle("/activate", api.APISessionRequired(updateActiveStatus)).Methods(http.MethodGet)
+	api.BaseRoutes.AccessControlPolicy.Handle("/activate", api.APISessionRequired(updateActiveStatusDeprecated)).Methods(http.MethodGet)
+	api.BaseRoutes.AccessControlPolicy.Handle("/activate", api.APISessionRequired(updateActiveStatus)).Methods(http.MethodPost)
 	api.BaseRoutes.AccessControlPolicy.Handle("/assign", api.APISessionRequired(assignAccessPolicy)).Methods(http.MethodPost)
 	api.BaseRoutes.AccessControlPolicy.Handle("/unassign", api.APISessionRequired(unassignAccessPolicy)).Methods(http.MethodDelete)
 	api.BaseRoutes.AccessControlPolicy.Handle("/resources/channels", api.APISessionRequired(getChannelsForAccessControlPolicy)).Methods(http.MethodGet)
@@ -230,6 +231,12 @@ func searchAccessControlPolicies(c *Context, w http.ResponseWriter, r *http.Requ
 	if _, err := w.Write(js); err != nil {
 		c.Logger.Warn("Error while writing response", mlog.Err(err))
 	}
+}
+
+func updateActiveStatusDeprecated(c *Context, w http.ResponseWriter, r *http.Request) {
+	// Set deprecation header to inform clients
+	w.Header().Set("Deprecation", "true")
+	c.Err = model.NewAppError("updateActiveStatusDeprecated", "api.access_control_policy.update_active_status.deprecated", nil, "", http.StatusMethodNotAllowed)
 }
 
 func updateActiveStatus(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -56,6 +56,10 @@
     "translation": "Get fields limit is not valid."
   },
   {
+    "id": "api.access_control_policy.update_active_status.deprecated",
+    "translation": "This method is deprecated. Please use the POST method instead."
+  },
+  {
     "id": "api.acknowledgement.delete.archived_channel.app_error",
     "translation": "You cannot remove an acknowledgment in an archived channel."
   },

--- a/webapp/platform/client/src/client4.ts
+++ b/webapp/platform/client/src/client4.ts
@@ -4527,7 +4527,7 @@ export default class Client4 {
     updateAccessControlPolicyActive = (policyId: string, active: boolean) => {
         return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/access_control_policies/${policyId}/activate?active=${active}`,
-            {method: 'get'},
+            {method: 'post'},
         );
     };
 


### PR DESCRIPTION
#### Summary
Since the fix in #34940 based on features released on `v11.3`, we are taking a slightly different approach for the previous releases. Basically we are deprecating the `GET` method immediately with a deprecation header, and using `POST` method.

#### Release Note

```release-note
Deprecates GET method for api/v4/access_control_policies/activate API
```
