### PR TITLE
Automated cherry pick of #35099

### DIFF
--- a/server/channels/app/slashcommands/command_mute.go
+++ b/server/channels/app/slashcommands/command_mute.go
@@ -64,7 +64,7 @@ func (*MuteProvider) DoCommand(a *app.App, rctx request.CTX, args *model.Command
 
 	channelMember, err := a.ToggleMuteChannel(rctx, channel.Id, args.UserId)
 	if err != nil {
-		return &model.CommandResponse{Text: args.T("api.command_mute.not_member.error", map[string]any{"Channel": channelName}), ResponseType: model.CommandResponseTypeEphemeral}
+		return &model.CommandResponse{Text: args.T("api.command_mute.error", map[string]any{"Channel": channelName}), ResponseType: model.CommandResponseTypeEphemeral}
 	}
 
 	// Direct and Group messages won't have a nice channel title, omit it

--- a/server/channels/app/slashcommands/command_mute_test.go
+++ b/server/channels/app/slashcommands/command_mute_test.go
@@ -130,13 +130,14 @@ func TestMuteCommandNotMember(t *testing.T) {
 
 	cmd := &MuteProvider{}
 
-	// First mute the channel
+	// Muting a channel that the user is not a member of should return
+	// the same error as a non-existent channel to prevent channel enumeration
 	resp := cmd.DoCommand(th.App, th.Context, &model.CommandArgs{
 		T:         i18n.IdentityTfunc(),
 		ChannelId: channel1.Id,
 		UserId:    th.BasicUser.Id,
 	}, channel2.Name)
-	assert.Equal(t, "api.command_mute.not_member.error", resp.Text)
+	assert.Equal(t, "api.command_mute.error", resp.Text)
 }
 
 func TestMuteCommandNotChannel(t *testing.T) {

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -1262,10 +1262,6 @@
     "translation": "Could not find the specified channel. Please use the [channel handle](https://docs.mattermost.com/messaging/managing-channels.html#naming-a-channel) to identify channels."
   },
   {
-    "id": "api.command_mute.not_member.error",
-    "translation": "Could not mute channel {{.Channel}} as you are not a member."
-  },
-  {
     "id": "api.command_mute.success_mute",
     "translation": "You will not receive notifications for {{.Channel}} until channel mute is turned off."
   },


### PR DESCRIPTION
Cherry pick of #35099 on release-11.3.

/cc  @lieut-data

```release-note
NONE
```