### PR TITLE
Updated minimum supported Edge and Chrome versions

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -11706,11 +11706,11 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "Version 142+"
+    "translation": "Version 144+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "Version 142+"
+    "translation": "Version 144+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",


### PR DESCRIPTION
Desktop app v6.1 will include Electron 40.1.0+ which supports Chrome 144+.

```release-note
Updated minimum Edge and Chrome versions to 144+.
```
