### PR TITLE
Cherry-pick MM-66789: Restrict log downloads to a root path for support packets

### DIFF
--- a/server/channels/api4/apitestlib.go
+++ b/server/channels/api4/apitestlib.go
@@ -107,7 +107,13 @@ func setupTestHelper(tb testing.TB, dbStore store.Store, sqlSettings *model.SqlS
 		consoleLevel = mlog.LvlStdLog.Name
 	}
 	*memoryConfig.LogSettings.ConsoleLevel = consoleLevel
-	*memoryConfig.LogSettings.FileLocation = filepath.Join(tempWorkspace, "logs", "mattermost.log")
+	// Use a subdirectory within the logging root (from MM_LOG_PATH or default)
+	// to ensure the path is within the allowed logging root for security validation.
+	// Each test gets its own subdirectory based on the tempWorkspace name for isolation.
+	testLogsDir := filepath.Join(config.GetLogRootPath(), filepath.Base(tempWorkspace))
+	err = os.MkdirAll(testLogsDir, 0700)
+	require.NoError(tb, err, "failed to create test logs directory")
+	*memoryConfig.LogSettings.FileLocation = testLogsDir
 	*memoryConfig.AnnouncementSettings.AdminNoticesEnabled = false
 	*memoryConfig.AnnouncementSettings.UserNoticesEnabled = false
 	*memoryConfig.PluginSettings.AutomaticPrepackagedPlugins = false

--- a/server/channels/api4/system.go
+++ b/server/channels/api4/system.go
@@ -87,6 +87,9 @@ func generateSupportPacket(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	auditRec := c.MakeAuditRecord(model.AuditEventGenerateSupportPacket, model.AuditStatusFail)
+	defer c.LogAuditRec(auditRec)
+
 	// We support the existing API hence the logs are always included
 	// if nothing specified.
 	includeLogs := true
@@ -97,6 +100,9 @@ func generateSupportPacket(c *Context, w http.ResponseWriter, r *http.Request) {
 		IncludeLogs:   includeLogs,
 		PluginPackets: r.Form["plugin_packets"],
 	}
+
+	auditRec.AddMeta("include_logs", supportPacketOptions.IncludeLogs)
+	auditRec.AddMeta("plugin_packets", supportPacketOptions.PluginPackets)
 
 	// Checking to see if the server has a e10 or e20 license (this feature is only permitted for servers with licenses)
 	if c.App.Channels().License() == nil {
@@ -116,6 +122,9 @@ func generateSupportPacket(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = model.NewAppError("Api4.generateSupportPacket", "api.unable_to_create_zip_file", nil, "", http.StatusForbidden).Wrap(err)
 		return
 	}
+
+	auditRec.Success()
+	auditRec.AddMeta("filename", outputZipFilename)
 
 	// Prevent caching so support packets are always fresh
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")

--- a/server/channels/app/helper_test.go
+++ b/server/channels/app/helper_test.go
@@ -85,7 +85,13 @@ func setupTestHelper(dbStore store.Store, sqlStore *sqlstore.SqlStore, sqlSettin
 
 	*memoryConfig.AnnouncementSettings.AdminNoticesEnabled = false
 	*memoryConfig.AnnouncementSettings.UserNoticesEnabled = false
-	*memoryConfig.LogSettings.FileLocation = filepath.Join(tempWorkspace, "logs", "mattermost.log")
+	// Use a subdirectory within the logging root (from MM_LOG_PATH or default)
+	// to ensure the path is within the allowed logging root for security validation.
+	// Each test gets its own subdirectory based on the tempWorkspace name for isolation.
+	testLogsDir := filepath.Join(config.GetLogRootPath(), filepath.Base(tempWorkspace))
+	err = os.MkdirAll(testLogsDir, 0700)
+	require.NoError(tb, err, "failed to create test logs directory")
+	*memoryConfig.LogSettings.FileLocation = testLogsDir
 	if updateConfig != nil {
 		updateConfig(memoryConfig)
 	}

--- a/server/channels/app/platform/config.go
+++ b/server/channels/app/platform/config.go
@@ -107,6 +107,9 @@ func (ps *PlatformService) SaveConfig(newCfg *model.Config, sendConfigChangeClus
 		}
 	}
 
+	// Validate log file paths (logs errors for now, will block server startup in future version)
+	config.WarnIfLogPathsOutsideRoot(newCfg)
+
 	oldCfg, newCfg, err := ps.configStore.Set(newCfg)
 	if errors.Is(err, config.ErrReadOnlyConfiguration) {
 		return nil, nil, model.NewAppError("saveConfig", "ent.cluster.save_config.error", nil, "", http.StatusForbidden).Wrap(err)

--- a/server/channels/app/platform/log.go
+++ b/server/channels/app/platform/log.go
@@ -188,12 +188,22 @@ func (ps *PlatformService) GetLogsSkipSend(rctx request.CTX, page, perPage int, 
 	return lines, nil
 }
 
-func (ps *PlatformService) GetLogFile(_ request.CTX) (*model.FileData, error) {
+func (ps *PlatformService) GetLogFile(rctx request.CTX) (*model.FileData, error) {
 	if !*ps.Config().LogSettings.EnableFile {
 		return nil, errors.New("Unable to retrieve mattermost logs because LogSettings.EnableFile is set to false")
 	}
 
 	mattermostLog := config.GetLogFileLocation(*ps.Config().LogSettings.FileLocation)
+
+	// Validate the file path to prevent arbitrary file reads
+	if err := ps.validateLogFilePath(mattermostLog); err != nil {
+		rctx.Logger().Error("Blocked attempt to read log file outside allowed root",
+			mlog.String("path", mattermostLog),
+			mlog.String("config_section", "LogSettings.FileLocation"),
+			mlog.Err(err))
+		return nil, errors.Wrapf(err, "log file path %s is outside allowed logging directory", mattermostLog)
+	}
+
 	mattermostLogFileData, err := os.ReadFile(mattermostLog)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed read mattermost log file at path %s", mattermostLog)
@@ -205,11 +215,25 @@ func (ps *PlatformService) GetLogFile(_ request.CTX) (*model.FileData, error) {
 	}, nil
 }
 
-func (ps *PlatformService) GetAdvancedLogs(_ request.CTX) ([]*model.FileData, error) {
+// validateLogFilePath validates that a log file path is within the logging root directory.
+// This prevents arbitrary file read/write vulnerabilities in logging configuration.
+// The logging root is determined by MM_LOG_PATH environment variable or the default logs directory.
+// Currently used to validate paths when reading logs via GetAdvancedLogs.
+// In future versions, this will also be used to validate paths when saving logging config.
+func (ps *PlatformService) validateLogFilePath(filePath string) error {
+	// Get the logging root path (from env var or default logs directory)
+	loggingRoot := config.GetLogRootPath()
+
+	return config.ValidateLogFilePath(filePath, loggingRoot)
+}
+
+func (ps *PlatformService) GetAdvancedLogs(rctx request.CTX) ([]*model.FileData, error) {
 	var (
 		rErr *multierror.Error
 		ret  []*model.FileData
 	)
+
+	rctx.Logger().Debug("Advanced logs access requested")
 
 	for name, loggingJSON := range map[string]json.RawMessage{
 		"LogSettings.AdvancedLoggingJSON":               ps.Config().LogSettings.AdvancedLoggingJSON,
@@ -237,6 +261,18 @@ func (ps *PlatformService) GetAdvancedLogs(_ request.CTX) ([]*model.FileData, er
 				rErr = multierror.Append(rErr, errors.Wrapf(err, "error decoding file target options in %s", name))
 				continue
 			}
+
+			// Validate the file path to prevent arbitrary file reads
+			if err := ps.validateLogFilePath(fileOption.Filename); err != nil {
+				rctx.Logger().Error("Blocked attempt to read log file outside allowed root",
+					mlog.String("path", fileOption.Filename),
+					mlog.String("config_section", name),
+					mlog.String("user_id", rctx.Session().UserId),
+					mlog.Err(err))
+				rErr = multierror.Append(rErr, errors.Wrapf(err, "log file path %s in %s is outside allowed logging directory", fileOption.Filename, name))
+				continue
+			}
+
 			data, err := os.ReadFile(fileOption.Filename)
 			if err != nil {
 				rErr = multierror.Append(rErr, errors.Wrapf(err, "failed to read advanced log file at path %s in %s", fileOption.Filename, name))
@@ -251,7 +287,7 @@ func (ps *PlatformService) GetAdvancedLogs(_ request.CTX) ([]*model.FileData, er
 		}
 	}
 
-	return ret, nil
+	return ret, rErr.ErrorOrNil()
 }
 
 func isLogFilteredByLevel(logFilter *model.LogFilter, entry *model.LogEntry) bool {

--- a/server/channels/app/platform/log_test.go
+++ b/server/channels/app/platform/log_test.go
@@ -48,6 +48,9 @@ func TestGetMattermostLog(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	// Set MM_LOG_PATH to allow log file reads from our temp directory
+	t.Setenv("MM_LOG_PATH", dir)
+
 	// Enable log file but point to an empty directory to get an error trying to read the file
 	th.Service.UpdateConfig(func(cfg *model.Config) {
 		*cfg.LogSettings.EnableFile = true
@@ -71,6 +74,33 @@ func TestGetMattermostLog(t *testing.T) {
 	require.NotNil(t, fileData)
 	assert.Equal(t, "mattermost.log", fileData.Filename)
 	assert.Positive(t, len(fileData.Body))
+
+	// Test path validation: FileLocation outside MM_LOG_PATH should be blocked
+	t.Run("path validation prevents reading files outside log directory", func(t *testing.T) {
+		// Create a directory outside the allowed log root
+		outsideDir, err := os.MkdirTemp("", "outside")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err = os.RemoveAll(outsideDir)
+			require.NoError(t, err)
+		})
+
+		// Create a file that would be read if validation fails
+		outsideLogLocation := config.GetLogFileLocation(outsideDir)
+		err = os.WriteFile(outsideLogLocation, []byte("secret data"), 0644)
+		require.NoError(t, err)
+
+		// Set FileLocation to the outside directory (MM_LOG_PATH is still set to 'dir')
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			*cfg.LogSettings.FileLocation = outsideDir
+		})
+
+		// Should be blocked by path validation
+		fileData, err = th.Service.GetLogFile(th.Context)
+		assert.Nil(t, fileData)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "outside allowed logging directory")
+	})
 }
 
 func TestGetAdvancedLogs(t *testing.T) {
@@ -86,6 +116,9 @@ func TestGetAdvancedLogs(t *testing.T) {
 			err = os.RemoveAll(dir)
 			require.NoError(t, err)
 		})
+
+		// Set MM_LOG_PATH to allow advanced logging to write to our temp directory
+		t.Setenv("MM_LOG_PATH", dir)
 
 		// Setup log files for each setting
 		optLDAP := map[string]string{
@@ -127,7 +160,7 @@ func TestGetAdvancedLogs(t *testing.T) {
 
 		th.Service.UpdateConfig(func(c *model.Config) {
 			c.LogSettings.AdvancedLoggingJSON = logCfgData
-			// Audit logs are not testiable as they as part of the server, not the platform
+			// Audit logs are not testable as they are part of the server, not the platform
 		})
 
 		// Write some logs and ensure they're flushed
@@ -176,5 +209,120 @@ func TestGetAdvancedLogs(t *testing.T) {
 		fileDatas, err := th.Service.GetAdvancedLogs(th.Context)
 		require.NoError(t, err)
 		require.Len(t, fileDatas, 0)
+	})
+
+	t.Run("path validation prevents reading files outside log directory", func(t *testing.T) {
+		// Create a temporary directory to use as the log root
+		logDir, err := os.MkdirTemp("", "logs")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err = os.RemoveAll(logDir)
+			require.NoError(t, err)
+		})
+
+		// Set MM_LOG_PATH to restrict log file access to logDir
+		t.Setenv("MM_LOG_PATH", logDir)
+
+		// Create a file outside the log directory that should not be accessible
+		outsideDir, err := os.MkdirTemp("", "outside")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err = os.RemoveAll(outsideDir)
+			require.NoError(t, err)
+		})
+
+		secretFile := path.Join(outsideDir, "secret.txt")
+		err = os.WriteFile(secretFile, []byte("secret data"), 0644)
+		require.NoError(t, err)
+
+		// Create a valid log file inside the log directory
+		validLog := path.Join(logDir, "valid.log")
+		err = os.WriteFile(validLog, []byte("valid log data"), 0644)
+		require.NoError(t, err)
+
+		// Test 1: Attempt to read file outside log directory using absolute path
+		optOutside := map[string]string{
+			"filename": secretFile,
+		}
+		dataOutside, err := json.Marshal(optOutside)
+		require.NoError(t, err)
+
+		logCfgOutside := mlog.LoggerConfiguration{
+			"malicious": mlog.TargetCfg{
+				Type:    "file",
+				Format:  "json",
+				Levels:  []mlog.Level{mlog.LvlError},
+				Options: dataOutside,
+			},
+		}
+		logCfgDataOutside, err := json.Marshal(logCfgOutside)
+		require.NoError(t, err)
+
+		th.Service.UpdateConfig(func(c *model.Config) {
+			c.LogSettings.AdvancedLoggingJSON = logCfgDataOutside
+		})
+
+		fileDatas, err := th.Service.GetAdvancedLogs(th.Context)
+		// Should return error indicating path is outside allowed directory
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "outside allowed logging directory")
+		require.Len(t, fileDatas, 0)
+
+		// Test 2: Attempt path traversal attack
+		traversalPath := path.Join(logDir, "..", "..", "etc", "passwd")
+		optTraversal := map[string]string{
+			"filename": traversalPath,
+		}
+		dataTraversal, err := json.Marshal(optTraversal)
+		require.NoError(t, err)
+
+		logCfgTraversal := mlog.LoggerConfiguration{
+			"traversal": mlog.TargetCfg{
+				Type:    "file",
+				Format:  "json",
+				Levels:  []mlog.Level{mlog.LvlError},
+				Options: dataTraversal,
+			},
+		}
+		logCfgDataTraversal, err := json.Marshal(logCfgTraversal)
+		require.NoError(t, err)
+
+		th.Service.UpdateConfig(func(c *model.Config) {
+			c.LogSettings.AdvancedLoggingJSON = logCfgDataTraversal
+		})
+
+		fileDatas, err = th.Service.GetAdvancedLogs(th.Context)
+		// Should return error for path traversal attempt
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "outside")
+		require.Len(t, fileDatas, 0)
+
+		// Test 3: Valid path within log directory should work
+		optValid := map[string]string{
+			"filename": validLog,
+		}
+		dataValid, err := json.Marshal(optValid)
+		require.NoError(t, err)
+
+		logCfgValid := mlog.LoggerConfiguration{
+			"valid": mlog.TargetCfg{
+				Type:    "file",
+				Format:  "json",
+				Levels:  []mlog.Level{mlog.LvlError},
+				Options: dataValid,
+			},
+		}
+		logCfgDataValid, err := json.Marshal(logCfgValid)
+		require.NoError(t, err)
+
+		th.Service.UpdateConfig(func(c *model.Config) {
+			c.LogSettings.AdvancedLoggingJSON = logCfgDataValid
+		})
+
+		fileDatas, err = th.Service.GetAdvancedLogs(th.Context)
+		require.NoError(t, err)
+		require.Len(t, fileDatas, 1)
+		require.Equal(t, "valid.log", fileDatas[0].Filename)
+		require.Equal(t, []byte("valid log data"), fileDatas[0].Body)
 	})
 }

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -38,6 +38,9 @@ func TestGenerateSupportPacket(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	// Set MM_LOG_PATH to allow log file reads from our temp directory
+	t.Setenv("MM_LOG_PATH", dir)
+
 	th.Service.UpdateConfig(func(cfg *model.Config) {
 		*cfg.LogSettings.FileLocation = dir
 	})

--- a/server/channels/app/support_packet_test.go
+++ b/server/channels/app/support_packet_test.go
@@ -36,6 +36,9 @@ func TestGenerateSupportPacket(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	// Set MM_LOG_PATH to allow log file reads from our temp directory
+	t.Setenv("MM_LOG_PATH", dir)
+
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.LogSettings.FileLocation = dir
 	})

--- a/server/channels/testlib/helper.go
+++ b/server/channels/testlib/helper.go
@@ -35,6 +35,7 @@ type MainHelper struct {
 
 	status           int
 	testResourcePath string
+	testLogsPath     string
 	replicas         []string
 	storePool        *sqlstore.TestPool
 }
@@ -86,6 +87,15 @@ func NewMainHelperWithOptions(options *HelperOptions) *MainHelper {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Create a logs directory and set MM_LOG_PATH for tests that validate log file paths.
+	// This is done unconditionally so tests don't need to enable full resources just for logging.
+	logsDir, err := os.MkdirTemp("", "testlogs")
+	if err != nil {
+		log.Fatal("Failed to create test logs directory: " + err.Error())
+	}
+	os.Setenv("MM_LOG_PATH", logsDir)
+	mainHelper.testLogsPath = logsDir
 
 	if options != nil {
 		mainHelper.Options = *options
@@ -287,6 +297,10 @@ func (h *MainHelper) Close() error {
 	}
 	if h.testResourcePath != "" {
 		os.RemoveAll(h.testResourcePath)
+	}
+	if h.testLogsPath != "" {
+		os.RemoveAll(h.testLogsPath)
+		os.Unsetenv("MM_LOG_PATH")
 	}
 
 	if h.storePool != nil {

--- a/server/channels/testlib/resources.go
+++ b/server/channels/testlib/resources.go
@@ -142,6 +142,12 @@ func SetupTestResources() (string, error) {
 		return "", errors.Wrapf(err, "failed to create client directory %s", clientDir)
 	}
 
+	logsDir := path.Join(tempDir, "logs")
+	err = os.Mkdir(logsDir, 0700)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to create logs directory %s", logsDir)
+	}
+
 	err = setupConfig(path.Join(tempDir, "config"))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to setup config")

--- a/server/config/logger.go
+++ b/server/config/logger.go
@@ -6,11 +6,13 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/utils"
 	"github.com/mattermost/mattermost/server/v8/channels/utils/fileutils"
 )
 
@@ -101,6 +103,118 @@ func GetLogFileLocation(fileLocation string) string {
 	}
 
 	return filepath.Join(fileLocation, LogFilename)
+}
+
+// GetLogRootPath returns the root directory for all log files.
+// This is used for security validation to prevent arbitrary file reads via advanced logging.
+// The logging root is determined by:
+// 1. MM_LOG_PATH environment variable (if set and non-empty)
+// 2. The default "logs" directory (found relative to the binary)
+func GetLogRootPath() string {
+	// Check environment variable first
+	if envPath := os.Getenv("MM_LOG_PATH"); envPath != "" {
+		absPath, err := filepath.Abs(envPath)
+		if err == nil {
+			return absPath
+		}
+	}
+
+	// Fall back to default logs directory
+	logsDir, _ := fileutils.FindDir("logs")
+	absPath, err := filepath.Abs(logsDir)
+	if err != nil {
+		return logsDir
+	}
+	return absPath
+}
+
+// ValidateLogFilePath validates that a log file path is within the logging root directory.
+// This prevents arbitrary file read/write vulnerabilities in logging configuration.
+// The logging root is determined by MM_LOG_PATH environment variable or the configured log directory.
+func ValidateLogFilePath(filePath string, loggingRoot string) error {
+	// Resolve file path to absolute
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return fmt.Errorf("cannot resolve path %s: %w", filePath, err)
+	}
+
+	// Resolve symlinks to prevent bypass via symlink attacks
+	realPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		// If file doesn't exist, still validate the intended path
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("cannot resolve symlinks for %s: %w", absPath, err)
+		}
+	} else {
+		absPath = realPath
+	}
+
+	// Resolve logging root to absolute
+	absRoot, err := filepath.Abs(loggingRoot)
+	if err != nil {
+		return fmt.Errorf("cannot resolve logging root %s: %w", loggingRoot, err)
+	}
+
+	// Ensure root has trailing separator for proper prefix matching
+	// This prevents /tmp/log matching /tmp/logger
+	rootWithSep := absRoot
+	if !strings.HasSuffix(rootWithSep, string(filepath.Separator)) {
+		rootWithSep += string(filepath.Separator)
+	}
+
+	// Check if file is within the logging root
+	// Allow exact match (absPath == absRoot) or proper prefix match
+	if absPath != absRoot && !strings.HasPrefix(absPath, rootWithSep) {
+		return fmt.Errorf("path %s is outside logging root %s", filePath, absRoot)
+	}
+
+	return nil
+}
+
+// WarnIfLogPathsOutsideRoot validates log file paths in the config and logs errors for paths outside the logging root.
+// This is called during config save to identify configurations that will cause server startup to fail in a future version.
+// Currently only logs errors; in a future version this will block server startup.
+func WarnIfLogPathsOutsideRoot(cfg *model.Config) {
+	loggingRoot := GetLogRootPath()
+
+	// Check LogSettings.AdvancedLoggingJSON
+	if !utils.IsEmptyJSON(cfg.LogSettings.AdvancedLoggingJSON) {
+		validateAdvancedLoggingConfig(cfg.LogSettings.AdvancedLoggingJSON, "LogSettings.AdvancedLoggingJSON", loggingRoot)
+	}
+
+	// Check ExperimentalAuditSettings.AdvancedLoggingJSON
+	if !utils.IsEmptyJSON(cfg.ExperimentalAuditSettings.AdvancedLoggingJSON) {
+		validateAdvancedLoggingConfig(cfg.ExperimentalAuditSettings.AdvancedLoggingJSON, "ExperimentalAuditSettings.AdvancedLoggingJSON", loggingRoot)
+	}
+}
+
+func validateAdvancedLoggingConfig(loggingJSON json.RawMessage, configName string, loggingRoot string) {
+	logCfg := make(mlog.LoggerConfiguration)
+	if err := json.Unmarshal(loggingJSON, &logCfg); err != nil {
+		return
+	}
+
+	for targetName, target := range logCfg {
+		if target.Type != "file" {
+			continue
+		}
+
+		var fileOption struct {
+			Filename string `json:"filename"`
+		}
+		if err := json.Unmarshal(target.Options, &fileOption); err != nil {
+			continue
+		}
+
+		if err := ValidateLogFilePath(fileOption.Filename, loggingRoot); err != nil {
+			mlog.Error("Log file path in logging config is outside logging root directory. This configuration will cause server startup to fail in a future version. To fix, set MM_LOG_PATH environment variable to a parent directory containing all log paths, or move log files to the configured logging root.",
+				mlog.String("config_section", configName),
+				mlog.String("target", targetName),
+				mlog.String("path", fileOption.Filename),
+				mlog.String("logging_root", loggingRoot),
+				mlog.Err(err))
+		}
+	}
 }
 
 func makeSimpleConsoleTarget(level string, outputJSON bool, color bool) (mlog.TargetCfg, error) {

--- a/server/config/logger_test.go
+++ b/server/config/logger_test.go
@@ -5,6 +5,8 @@ package config
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,5 +50,171 @@ func TestMloggerConfigFromAuditConfig(t *testing.T) {
 		err = json.Unmarshal(targetCfg.FormatOptions, &optionsReceived)
 		require.NoError(t, err, "unmarshal should not fail")
 		assert.Equal(t, optionsExpected, optionsReceived)
+	})
+}
+
+func TestGetLogRootPath(t *testing.T) {
+	t.Run("returns MM_LOG_PATH when set", func(t *testing.T) {
+		// Create a temp directory to use as MM_LOG_PATH
+		dir, err := os.MkdirTemp("", "logroot")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			os.RemoveAll(dir)
+		})
+
+		t.Setenv("MM_LOG_PATH", dir)
+
+		result := GetLogRootPath()
+		absDir, _ := filepath.Abs(dir)
+		assert.Equal(t, absDir, result)
+	})
+
+	t.Run("finds logs directory relative to binary when MM_LOG_PATH not set", func(t *testing.T) {
+		// When MM_LOG_PATH is not set, GetLogRootPath falls back to FindDir("logs"),
+		// which searches for a "logs" directory relative to the working directory
+		// and the binary location. Create a logs directory relative to the test
+		// binary to verify this behavior.
+		t.Setenv("MM_LOG_PATH", "")
+
+		// Get the test binary location
+		exe, err := os.Executable()
+		require.NoError(t, err)
+		exe, err = filepath.EvalSymlinks(exe)
+		require.NoError(t, err)
+		binaryDir := filepath.Dir(exe)
+
+		// Create a "logs" directory next to the binary
+		logsDir := filepath.Join(binaryDir, "logs")
+		err = os.MkdirAll(logsDir, 0755)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			os.RemoveAll(logsDir)
+		})
+
+		result := GetLogRootPath()
+
+		// Result should be an absolute path
+		assert.True(t, filepath.IsAbs(result), "GetLogRootPath should return an absolute path, got: %s", result)
+
+		// FindDir searches working directory first, then binary directory.
+		// The result should be either the logs directory we created or another
+		// logs directory found earlier in the search path. Either way, it should
+		// be a valid directory path ending in "logs".
+		assert.True(t, filepath.Base(result) == "logs" || result == "./",
+			"GetLogRootPath should return a logs directory path, got: %s", result)
+	})
+}
+
+func TestValidateLogFilePath(t *testing.T) {
+	t.Run("valid path within root", func(t *testing.T) {
+		root, err := os.MkdirTemp("", "logroot")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			os.RemoveAll(root)
+		})
+
+		validFile := filepath.Join(root, "app.log")
+		err = os.WriteFile(validFile, []byte("test"), 0644)
+		require.NoError(t, err)
+
+		err = ValidateLogFilePath(validFile, root)
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid path in subdirectory", func(t *testing.T) {
+		root, err := os.MkdirTemp("", "logroot")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			os.RemoveAll(root)
+		})
+
+		subdir := filepath.Join(root, "subdir")
+		err = os.MkdirAll(subdir, 0755)
+		require.NoError(t, err)
+
+		validFile := filepath.Join(subdir, "app.log")
+		err = os.WriteFile(validFile, []byte("test"), 0644)
+		require.NoError(t, err)
+
+		err = ValidateLogFilePath(validFile, root)
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects absolute path outside root", func(t *testing.T) {
+		root, err := os.MkdirTemp("", "logroot")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			os.RemoveAll(root)
+		})
+
+		outsideDir, err := os.MkdirTemp("", "outside")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			os.RemoveAll(outsideDir)
+		})
+
+		outsideFile := filepath.Join(outsideDir, "secret.txt")
+		err = os.WriteFile(outsideFile, []byte("secret"), 0644)
+		require.NoError(t, err)
+
+		err = ValidateLogFilePath(outsideFile, root)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "outside logging root")
+	})
+
+	t.Run("rejects path traversal attack", func(t *testing.T) {
+		root, err := os.MkdirTemp("", "logroot")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			os.RemoveAll(root)
+		})
+
+		traversalPath := filepath.Join(root, "..", "..", "etc", "passwd")
+
+		err = ValidateLogFilePath(traversalPath, root)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "outside logging root")
+	})
+
+	t.Run("rejects symlink pointing outside root", func(t *testing.T) {
+		root, err := os.MkdirTemp("", "logroot")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			os.RemoveAll(root)
+		})
+
+		outsideDir, err := os.MkdirTemp("", "outside")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			os.RemoveAll(outsideDir)
+		})
+
+		// Create a file outside the root
+		outsideFile := filepath.Join(outsideDir, "secret.txt")
+		err = os.WriteFile(outsideFile, []byte("secret"), 0644)
+		require.NoError(t, err)
+
+		// Create a symlink inside root pointing to the outside file
+		symlinkPath := filepath.Join(root, "sneaky.log")
+		err = os.Symlink(outsideFile, symlinkPath)
+		require.NoError(t, err)
+
+		err = ValidateLogFilePath(symlinkPath, root)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "outside logging root")
+	})
+
+	t.Run("allows non-existent file path within root", func(t *testing.T) {
+		root, err := os.MkdirTemp("", "logroot")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			os.RemoveAll(root)
+		})
+
+		// File doesn't exist but path is within root
+		nonExistentFile := filepath.Join(root, "future.log")
+
+		err = ValidateLogFilePath(nonExistentFile, root)
+		assert.NoError(t, err)
 	})
 }

--- a/server/public/model/audit_events.go
+++ b/server/public/model/audit_events.go
@@ -316,6 +316,7 @@ const (
 	AuditEventCompleteOnboarding         = "completeOnboarding"         // complete system onboarding process
 	AuditEventDatabaseRecycle            = "databaseRecycle"            // closes active connections
 	AuditEventDownloadLogs               = "downloadLogs"               // download server log files
+	AuditEventGenerateSupportPacket      = "generateSupportPacket"      // generate support packet with server diagnostics and logs
 	AuditEventGetAppliedSchemaMigrations = "getAppliedSchemaMigrations" // get list of applied database schema migrations
 	AuditEventGetLogs                    = "getLogs"                    // get server log entries
 	AuditEventGetOnboarding              = "getOnboarding"              // get system onboarding status


### PR DESCRIPTION
#### Summary

**Cherry-pick MM-66789 to `release-11.2`**

Improves validation of log file path configurations to ensure files are stored within the designated logging directory.

Changes:
* Add path validation for log file locations
* Support MM_LOG_PATH environment variable for custom logging root directory
* Add configuration validation with appropriate error messaging
* Add comprehensive test coverage for path validation
* Add audit logging for support packet generation

#### Ticket Link
fixes https://mattermost.atlassian.net/browse/MM-66789

#### Release Note
```release-note
Added new MM_LOG_PATH environment variable to restrict log file locations. Log files must now be within a configured root directory.
```
