### PR TITLE
[MM-67382] Improve mmctl output by filtering escape sequences

### DIFF
--- a/server/cmd/mmctl/commands/report.go
+++ b/server/cmd/mmctl/commands/report.go
@@ -149,7 +149,7 @@ func printReportPost(post *model.Post) {
 		fmt.Fprintf(os.Stdout, "Channel ID: %s\n", post.ChannelId)
 		fmt.Fprintf(os.Stdout, "Created At: %s\n", createdAt)
 		fmt.Fprintf(os.Stdout, "Updated At: %s\n", updatedAt)
-		fmt.Fprintf(os.Stdout, "Message: %s\n", post.Message)
+		fmt.Fprintf(os.Stdout, "Message: %s\n", printer.SanitizeForTerminal(post.Message))
 		if post.DeleteAt > 0 {
 			deletedAt := time.Unix(post.DeleteAt/1000, 0).Format("2006-01-02 15:04:05")
 			fmt.Fprintf(os.Stdout, "Deleted At: %s\n", deletedAt)

--- a/server/cmd/mmctl/printer/printer.go
+++ b/server/cmd/mmctl/printer/printer.go
@@ -273,7 +273,10 @@ func (p Printer) linesToBytes(opts printOpts) (b []byte, err error) {
 	case FormatPlain:
 		var buf bytes.Buffer
 		for i := range p.Lines {
-			fmt.Fprintf(&buf, "%s%s", p.Lines[i], newline)
+			// Sanitize output to prevent terminal escape injection attacks
+			// when writing user-controlled content to the terminal
+			line := fmt.Sprintf("%s", p.Lines[i])
+			fmt.Fprintf(&buf, "%s%s", SanitizeForTerminal(line), newline)
 		}
 		b = buf.Bytes()
 	case FormatJSON:

--- a/server/cmd/mmctl/printer/printer_helpers.go
+++ b/server/cmd/mmctl/printer/printer_helpers.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package printer
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Precompiled regex for terminal escape sequence sanitization.
+// References:
+// - XTerm Control Sequences: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+var (
+	// csiRegex matches ANSI CSI sequences (colors, cursor movement, etc).
+	csiRegex = regexp.MustCompile(`\x1b\[[0-9;?]*[A-Za-z]`)
+
+	// oscRegex matches OSC sequences (window title, clipboard, etc).
+	oscRegex = regexp.MustCompile(`\x1b\]([^\x07\x1b]|\x1b[^\\])*(\x07|\x1b\\)`)
+
+	// dcsRegex matches DCS sequences (device control).
+	dcsRegex = regexp.MustCompile(`\x1bP([^\x1b]|\x1b[^\\])*\x1b\\`)
+
+	// otherEscRegex matches other escape sequences (APC, PM, single-char).
+	otherEscRegex = regexp.MustCompile(`\x1b[_^X]([^\x1b]|\x1b[^\\])*\x1b\\|\x1b[^\[\]P0-9]`)
+)
+
+// SanitizeForTerminal strips ANSI escape sequences and control characters from
+// user-controlled content to prevent terminal injection attacks.
+// It preserves tabs, newlines, and carriage returns for readability.
+func SanitizeForTerminal(s string) string {
+	// Remove ANSI CSI sequences
+	result := csiRegex.ReplaceAllString(s, "")
+
+	// Remove OSC sequences
+	result = oscRegex.ReplaceAllString(result, "")
+
+	// Remove DCS sequences
+	result = dcsRegex.ReplaceAllString(result, "")
+
+	// Remove other escape sequences
+	result = otherEscRegex.ReplaceAllString(result, "")
+
+	// Remove remaining control characters (0x00-0x1F, 0x7F) except tab, newline, carriage return.
+	var cleaned strings.Builder
+	cleaned.Grow(len(result))
+	for _, r := range result {
+		switch {
+		case r == '\t' || r == '\n' || r == '\r':
+			// Keep whitespace
+			cleaned.WriteRune(r)
+		case r < 0x20 || r == 0x7F:
+			// Skip control characters
+			continue
+		default:
+			cleaned.WriteRune(r)
+		}
+	}
+
+	return cleaned.String()
+}

--- a/server/cmd/mmctl/printer/printer_helpers_test.go
+++ b/server/cmd/mmctl/printer/printer_helpers_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package printer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeForTerminal(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "plain text unchanged",
+			input:    "Hello, World!",
+			expected: "Hello, World!",
+		},
+		{
+			name:     "preserves newlines and tabs",
+			input:    "Line 1\nLine 2\tTabbed",
+			expected: "Line 1\nLine 2\tTabbed",
+		},
+		{
+			name:     "removes ANSI color codes",
+			input:    "\x1b[31mRed Text\x1b[0m",
+			expected: "Red Text",
+		},
+		{
+			name:     "removes cursor movement sequences",
+			input:    "\x1b[2J\x1b[H\x1b[1;1HMalicious content",
+			expected: "Malicious content",
+		},
+		{
+			name:     "removes OSC clipboard hijacking (BEL terminated)",
+			input:    "Normal text\x1b]52;c;SGVsbG8gV29ybGQ=\x07more text",
+			expected: "Normal textmore text",
+		},
+		{
+			name:     "removes OSC clipboard hijacking (ST terminated)",
+			input:    "Normal text\x1b]52;c;SGVsbG8gV29ybGQ=\x1b\\more text",
+			expected: "Normal textmore text",
+		},
+		{
+			name:     "removes OSC window title manipulation",
+			input:    "\x1b]0;Fake Terminal Title\x07Real content",
+			expected: "Real content",
+		},
+		{
+			name:     "removes screen clearing sequences",
+			input:    "\x1b[2J\x1b[3JCleared screen",
+			expected: "Cleared screen",
+		},
+		{
+			name:     "removes bold/underline formatting",
+			input:    "\x1b[1mBold\x1b[0m \x1b[4mUnderline\x1b[0m",
+			expected: "Bold Underline",
+		},
+		{
+			name:     "removes multiple escape sequences",
+			input:    "\x1b[31m\x1b[1m\x1b[4mStyled\x1b[0m",
+			expected: "Styled",
+		},
+		{
+			name:     "removes control characters (NUL, BEL, etc)",
+			input:    "Hello\x00World\x07Test\x08Back",
+			expected: "HelloWorldTestBack",
+		},
+		{
+			name:     "removes DEL character",
+			input:    "Hello\x7fWorld",
+			expected: "HelloWorld",
+		},
+		{
+			name:     "handles complex attack payload",
+			input:    "\x1b[2J\x1b[H\x1b]0;HACKED\x07\x1b[31mFake error!\x1b[0m\nEnter password: ",
+			expected: "Fake error!\nEnter password: ",
+		},
+		{
+			name:     "removes DCS sequences",
+			input:    "Before\x1bPsome DCS content\x1b\\After",
+			expected: "BeforeAfter",
+		},
+		{
+			name:     "handles empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "handles unicode text with escape sequences",
+			input:    "\x1b[31m你好世界\x1b[0m emoji: 🎉",
+			expected: "你好世界 emoji: 🎉",
+		},
+		{
+			name:     "removes CSI with parameters",
+			input:    "\x1b[38;5;196mExtended color\x1b[0m",
+			expected: "Extended color",
+		},
+		{
+			name:     "removes CSI with question mark",
+			input:    "\x1b[?25lHide cursor\x1b[?25h",
+			expected: "Hide cursor",
+		},
+		{
+			name:     "preserves carriage return",
+			input:    "Line with\rcarriage return",
+			expected: "Line with\rcarriage return",
+		},
+		{
+			name:     "removes APC sequences",
+			input:    "Before\x1b_APC content\x1b\\After",
+			expected: "BeforeAfter",
+		},
+		{
+			name:     "removes nested escape attempts",
+			input:    "\x1b[31m\x1b]0;title\x07nested\x1b[0m",
+			expected: "nested",
+		},
+		{
+			name:     "handles realistic malicious message",
+			input:    "Please run: \x1b[2J\x1b[Hsudo rm -rf /\x1b]52;c;cm0gLXJmIC8=\x07",
+			expected: "Please run: sudo rm -rf /",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeForTerminal(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION

#### Summary
This pull request standardizes how user-provided content is rendered in terminal output. It adds a small helper for output normalization, updates existing usages, and includes tests to prevent regressions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67382


#### Release Note

```release-note
NONE
```
