### PR TITLE
Handled null column for scheduled post type in database

### DIFF
--- a/server/channels/store/sqlstore/scheduled_post_store.go
+++ b/server/channels/store/sqlstore/scheduled_post_store.go
@@ -26,14 +26,14 @@ func newScheduledPostStore(sqlStore *SqlStore) *SqlScheduledPostStore {
 	}
 }
 
-func (s *SqlScheduledPostStore) normalizePrefix(prefix string) string {
+func normalizePrefix(prefix string) string {
 	if prefix != "" && !strings.HasSuffix(prefix, ".") {
 		return prefix + "."
 	}
 	return prefix
 }
 
-func (s *SqlScheduledPostStore) baseColumns(prefix string) []string {
+func baseColumns(prefix string) []string {
 	return []string{
 		prefix + "Id",
 		prefix + "CreateAt",
@@ -52,14 +52,14 @@ func (s *SqlScheduledPostStore) baseColumns(prefix string) []string {
 }
 
 func (s *SqlScheduledPostStore) columnsForWrite(prefix string) []string {
-	prefix = s.normalizePrefix(prefix)
-	columns := s.baseColumns(prefix)
+	prefix = normalizePrefix(prefix)
+	columns := baseColumns(prefix)
 	return append(columns, prefix+"Type")
 }
 
 func (s *SqlScheduledPostStore) columnsForRead(prefix string) []string {
-	prefix = s.normalizePrefix(prefix)
-	columns := s.baseColumns(prefix)
+	prefix = normalizePrefix(prefix)
+	columns := baseColumns(prefix)
 	return append(columns, "COALESCE("+prefix+"Type, '') AS Type")
 }
 


### PR DESCRIPTION
#### Summary
Handled `NULL` in `ScheduledPost.Type` column.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-67373?actionerId=5d07d1654e8b120bc5cf6fa9&sourceType=assign

#### Release Note
```release-note
Fixed a bug where old scheduled posts with `NULL` value in `Type` column caused  a SQL error when fetching team's scheduled posts.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of scheduled-post storage to standardize read vs. write column sets and ensure the post "Type" is consistently persisted and read.
  * Internal normalization of column prefixes and safer read output handling.
  * No changes to public APIs or user-visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->