### PR TITLE
Add UTM tracking to message limit banner

### DIFF
--- a/webapp/channels/src/components/announcement_bar/post_history_limit_banner/index.tsx
+++ b/webapp/channels/src/components/announcement_bar/post_history_limit_banner/index.tsx
@@ -21,7 +21,7 @@ import './post_history_limit_banner.scss';
 const ONE_DAY_MS = 1000 * 60 * 60 * 24;
 
 const PostHistoryLimitBanner = () => {
-    const {openPricingModal} = useOpenPricingModal();
+    const {openPricingModal} = useOpenPricingModal('history_limit');
     const dispatch = useDispatch();
 
     const currentUser = useSelector(getCurrentUser);

--- a/webapp/channels/src/components/common/hooks/useOpenPricingModal.ts
+++ b/webapp/channels/src/components/common/hooks/useOpenPricingModal.ts
@@ -11,9 +11,9 @@ export type UseOpenPricingModalReturn = {
     isAirGapped: boolean;
 }
 
-export default function useOpenPricingModal(): UseOpenPricingModalReturn {
+export default function useOpenPricingModal(location?: string): UseOpenPricingModalReturn {
     const cwsAvailability = useCWSAvailabilityCheck();
-    const [externalLink] = useExternalLink('https://mattermost.com/pricing');
+    const [externalLink] = useExternalLink('https://mattermost.com/pl/pricing', location || '');
 
     const isAirGapped = cwsAvailability === CSWAvailabilityCheckTypes.Unavailable;
 


### PR DESCRIPTION
- Updated useOpenPricingModal hook to accept optional location parameter
- Updated external URL to /pl/pricing with UTM parameters (source, medium, content)
- Added 'history_limit' as location for post history limit banner
- Maintains backwards compatibility for existing hook usages

Generated with Cursor + Claude

#### Release Note

```release-note
Added UTM parameters to announcement banner external URLs
```