### PR TITLE
[MM-67379] Improve archive content extraction handling

### DIFF
--- a/server/channels/app/file.go
+++ b/server/channels/app/file.go
@@ -1567,6 +1567,7 @@ func (a *App) ExtractContentFromFileInfo(rctx request.CTX, fileInfo *model.FileI
 	defer file.Close()
 	text, err := docextractor.Extract(rctx.Logger(), fileInfo.Name, file, docextractor.ExtractSettings{
 		ArchiveRecursion: *a.Config().FileSettings.ArchiveRecursion,
+		MaxFileSize:      *a.Config().FileSettings.MaxFileSize,
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to extract file content")

--- a/server/platform/services/docextractor/combine.go
+++ b/server/platform/services/docextractor/combine.go
@@ -31,11 +31,11 @@ func (ce *combineExtractor) Match(filename string) bool {
 	return false
 }
 
-func (ce *combineExtractor) Extract(filename string, r io.ReadSeeker) (string, error) {
+func (ce *combineExtractor) Extract(filename string, r io.ReadSeeker, maxFileSize int64) (string, error) {
 	for _, extractor := range ce.SubExtractors {
 		if extractor.Match(filename) {
 			r.Seek(0, io.SeekStart)
-			text, err := extractor.Extract(filename, r)
+			text, err := extractor.Extract(filename, r, maxFileSize)
 			if err != nil {
 				ce.logger.Warn("Unable to extract file content", mlog.String("file_name", filename), mlog.String("extractor", extractor.Name()), mlog.Err(err))
 				continue

--- a/server/platform/services/docextractor/docextractor.go
+++ b/server/platform/services/docextractor/docextractor.go
@@ -12,6 +12,7 @@ import (
 // ExtractSettings defines the features enabled/disable during the document text extraction.
 type ExtractSettings struct {
 	ArchiveRecursion bool
+	MaxFileSize      int64
 	MMPreviewURL     string
 	MMPreviewSecret  string
 }
@@ -44,7 +45,7 @@ func ExtractWithExtraExtractors(logger mlog.LoggerIFace, filename string, r io.R
 	enabledExtractors.Add(&plainExtractor{})
 
 	if enabledExtractors.Match(filename) {
-		return enabledExtractors.Extract(filename, r)
+		return enabledExtractors.Extract(filename, r, settings.MaxFileSize)
 	}
 	return "", nil
 }

--- a/server/platform/services/docextractor/documents.go
+++ b/server/platform/services/docextractor/documents.go
@@ -36,7 +36,7 @@ func (de *documentExtractor) Match(filename string) bool {
 	return ok
 }
 
-func (de *documentExtractor) Extract(filename string, r io.ReadSeeker) (out string, outErr error) {
+func (de *documentExtractor) Extract(filename string, r io.ReadSeeker, _ int64) (out string, outErr error) {
 	defer func() {
 		if r := recover(); r != nil {
 			out = ""

--- a/server/platform/services/docextractor/interface.go
+++ b/server/platform/services/docextractor/interface.go
@@ -10,6 +10,6 @@ import (
 // Extractors define the interface needed to extract file content
 type Extractor interface {
 	Match(filename string) bool
-	Extract(filename string, file io.ReadSeeker) (string, error)
+	Extract(filename string, file io.ReadSeeker, maxFileSize int64) (string, error)
 	Name() string
 }

--- a/server/platform/services/docextractor/mmpreview.go
+++ b/server/platform/services/docextractor/mmpreview.go
@@ -45,7 +45,7 @@ func (mpe *mmPreviewExtractor) Match(filename string) bool {
 	return mmpreviewSupportedExtensions[extension]
 }
 
-func (mpe *mmPreviewExtractor) Extract(filename string, file io.ReadSeeker) (string, error) {
+func (mpe *mmPreviewExtractor) Extract(filename string, file io.ReadSeeker, maxFileSize int64) (string, error) {
 	b, w, err := createMultipartFormData("file", filename, file)
 	if err != nil {
 		return "", errors.Wrap(err, "Unable to generate file preview using mmpreview.")
@@ -70,7 +70,7 @@ func (mpe *mmPreviewExtractor) Extract(filename string, file io.ReadSeeker) (str
 	if err != nil {
 		return "", errors.Wrap(err, "unable to read the response from mmpreview")
 	}
-	return mpe.pdfExtractor.Extract(filename, bytes.NewReader(data))
+	return mpe.pdfExtractor.Extract(filename, bytes.NewReader(data), maxFileSize)
 }
 
 func createMultipartFormData(fieldName, fileName string, fileData io.ReadSeeker) (bytes.Buffer, *multipart.Writer, error) {

--- a/server/platform/services/docextractor/pdf.go
+++ b/server/platform/services/docextractor/pdf.go
@@ -29,7 +29,7 @@ func (pe *pdfExtractor) Match(filename string) bool {
 	return supportedExtensions[extension]
 }
 
-func (pe *pdfExtractor) Extract(filename string, r io.ReadSeeker) (out string, outErr error) {
+func (pe *pdfExtractor) Extract(filename string, r io.ReadSeeker, _ int64) (out string, outErr error) {
 	defer func() {
 		if r := recover(); r != nil {
 			out = ""

--- a/server/platform/services/docextractor/pdf_test.go
+++ b/server/platform/services/docextractor/pdf_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestPdfEmptyFile(t *testing.T) {
 	extractor := pdfExtractor{}
-	_, err := extractor.Extract("test.pdf", bytes.NewReader([]byte{}))
+	_, err := extractor.Extract("test.pdf", bytes.NewReader([]byte{}), 0)
 	require.Error(t, err)
 }
 
@@ -23,7 +23,7 @@ func TestPdfFile(t *testing.T) {
 	contentText := "\nThis is a simple document that contains some text."
 	content, err := testutils.ReadTestFile("sample-doc.pdf")
 	require.NoError(t, err)
-	extractedText, err := extractor.Extract("sample-doc.pdf", bytes.NewReader(content))
+	extractedText, err := extractor.Extract("sample-doc.pdf", bytes.NewReader(content), 0)
 	require.NoError(t, err)
 	require.Equal(t, contentText, extractedText)
 }
@@ -32,6 +32,6 @@ func TestWrongPdfFile(t *testing.T) {
 	extractor := pdfExtractor{}
 	content, err := testutils.ReadTestFile("sample-doc.docx")
 	require.NoError(t, err)
-	_, err = extractor.Extract("sample-doc.pdf", bytes.NewReader(content))
+	_, err = extractor.Extract("sample-doc.pdf", bytes.NewReader(content), 0)
 	require.Error(t, err)
 }

--- a/server/platform/services/docextractor/plain.go
+++ b/server/platform/services/docextractor/plain.go
@@ -19,7 +19,7 @@ func (pe *plainExtractor) Match(filename string) bool {
 	return true
 }
 
-func (pe *plainExtractor) Extract(filename string, r io.ReadSeeker) (string, error) {
+func (pe *plainExtractor) Extract(filename string, r io.ReadSeeker, _ int64) (string, error) {
 	// This detects any visible character plus any whitespace
 	validRanges := append(unicode.GraphicRanges, unicode.White_Space)
 

--- a/server/platform/services/docextractor/plain_test.go
+++ b/server/platform/services/docextractor/plain_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestPlainEmptyFile(t *testing.T) {
 	extractor := plainExtractor{}
-	extractedText, err := extractor.Extract("test.txt", bytes.NewReader([]byte{}))
+	extractedText, err := extractor.Extract("test.txt", bytes.NewReader([]byte{}), 0)
 	require.NoError(t, err)
 	require.Equal(t, "", extractedText)
 }
@@ -21,7 +21,7 @@ func TestPlainEmptyFile(t *testing.T) {
 func TestPlainTextSmallFile(t *testing.T) {
 	extractor := plainExtractor{}
 	content := strings.Repeat("test \n", 5)
-	extractedText, err := extractor.Extract("test.txt", bytes.NewReader([]byte(content)))
+	extractedText, err := extractor.Extract("test.txt", bytes.NewReader([]byte(content)), 0)
 	require.NoError(t, err)
 	require.Equal(t, content, extractedText)
 }
@@ -29,7 +29,7 @@ func TestPlainTextSmallFile(t *testing.T) {
 func TestPlainBigFile(t *testing.T) {
 	extractor := plainExtractor{}
 	content := strings.Repeat("test \n", 1000)
-	extractedText, err := extractor.Extract("test.txt", bytes.NewReader([]byte(content)))
+	extractedText, err := extractor.Extract("test.txt", bytes.NewReader([]byte(content)), 0)
 	require.NoError(t, err)
 	require.Equal(t, content, extractedText)
 }
@@ -38,7 +38,7 @@ func TestSmallBinaryFile(t *testing.T) {
 	extractor := plainExtractor{}
 	notUTF8Char := byte(0x7)
 	content := bytes.Repeat([]byte{notUTF8Char}, 1000)
-	extractedText, err := extractor.Extract("test.bin", bytes.NewReader(content))
+	extractedText, err := extractor.Extract("test.bin", bytes.NewReader(content), 0)
 	require.NoError(t, err)
 	require.Equal(t, "", extractedText)
 }
@@ -47,7 +47,7 @@ func TestBigBinaryFile(t *testing.T) {
 	extractor := plainExtractor{}
 	notUTF8Char := byte(0x7)
 	content := bytes.Repeat([]byte{notUTF8Char}, 10000)
-	extractedText, err := extractor.Extract("test.bin", bytes.NewReader(content))
+	extractedText, err := extractor.Extract("test.bin", bytes.NewReader(content), 0)
 	require.NoError(t, err)
 	require.Equal(t, "", extractedText)
 }


### PR DESCRIPTION


#### Summary
 - Add size-aware reading for archive entries during document content extraction
 - Pass file size configuration through the extractor interface to enforce limits consistently
 - Update ExtractSettings to carry the relevant configuration from FileSetting
 
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67379


#### Release Note

```release-note
NONE
```
