### PR TITLE
[MM-67502] Sanitize secret plugin settings inside sections

### DIFF
--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -3539,6 +3539,15 @@ func (s *PluginSettings) Sanitize(pluginManifests []*Manifest) {
 					break
 				}
 			}
+
+			for _, section := range manifest.SettingsSchema.Sections {
+				for _, definedSetting := range section.Settings {
+					if definedSetting.Secret && strings.EqualFold(definedSetting.Key, key) {
+						settings[key] = FakeSetting
+						break
+					}
+				}
+			}
 		}
 	}
 }

--- a/server/public/model/config_test.go
+++ b/server/public/model/config_test.go
@@ -1790,6 +1790,91 @@ func TestPluginSettingsSanitize(t *testing.T) {
 				},
 			},
 		},
+		"secret settings in sections are sanitized": {
+			manifests: []*Manifest{
+				{
+					Id: pluginID1,
+					SettingsSchema: &PluginSettingsSchema{
+						Settings: []*PluginSetting{
+							{
+								Key:    "somesetting",
+								Type:   "text",
+								Secret: false,
+							},
+						},
+						Sections: []*PluginSettingsSection{
+							{
+								Key: "section1",
+								Settings: []*PluginSetting{
+									{
+										Key:    "secrettext",
+										Type:   "text",
+										Secret: true,
+									},
+									{
+										Key:    "secretnumber",
+										Type:   "number",
+										Secret: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]map[string]any{
+				pluginID1: {
+					"someoldsettings": "some old value",
+					"somesetting":     "some value",
+					"secrettext":      FakeSetting,
+					"secretnumber":    FakeSetting,
+				},
+			},
+		},
+		"secret settings across multiple sections": {
+			manifests: []*Manifest{
+				{
+					Id: pluginID1,
+					SettingsSchema: &PluginSettingsSchema{
+						Sections: []*PluginSettingsSection{
+							{
+								Key: "section1",
+								Settings: []*PluginSetting{
+									{
+										Key:    "somesetting",
+										Type:   "text",
+										Secret: false,
+									},
+									{
+										Key:    "secrettext",
+										Type:   "text",
+										Secret: true,
+									},
+								},
+							},
+							{
+								Key: "section2",
+								Settings: []*PluginSetting{
+									{
+										Key:    "secretnumber",
+										Type:   "number",
+										Secret: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]map[string]any{
+				pluginID1: {
+					"someoldsettings": "some old value",
+					"somesetting":     "some value",
+					"secrettext":      FakeSetting,
+					"secretnumber":    FakeSetting,
+				},
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			c := PluginSettings{}


### PR DESCRIPTION
#### Summary

The `PluginSettings.Sanitize()` method only iterated over top-level `SettingsSchema.Settings` when redacting secret values. Settings defined inside `SettingsSchema.Sections[].Settings` with `secret: true` were not sanitized, causing their plaintext values to be returned through the API.

This fix adds iteration over section settings in the `Sanitize()` method so that secrets defined in sections are properly redacted with `FakeSetting`, consistent with top-level secret settings.



Demo plugin PR: https://github.com/mattermost/mattermost-plugin-demo/pull/200

#### Ticket Link

 https://mattermost.atlassian.net/browse/MM-67502

#### Release Note
```release-note
Fixed an issue where plugin settings marked as `secret: true` inside `settings_schema.sections[]` were not sanitized, potentially exposing secret values through the API.
```