### PR TITLE
Update minimum supported macOS and Safari versions

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -11762,11 +11762,11 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.safari",
-    "translation": "Version 17.4+"
+    "translation": "Version 26.2+"
   },
   {
     "id": "web.error.unsupported_browser.min_os_version.mac",
-    "translation": "macOS 12+"
+    "translation": "macOS 14+"
   },
   {
     "id": "web.error.unsupported_browser.min_os_version.windows",


### PR DESCRIPTION
macOS currently supports 14+ with Safari 26.2+.

```release-note
Updated minimum macOS version to 14+ and minimum Safari version to 26.2+.
```
