### PR TITLE
MM-66625 - Drop EnableChannelScopeAccessControl; use permission system only

### DIFF
--- a/e2e-tests/playwright/lib/src/server/default_config.ts
+++ b/e2e-tests/playwright/lib/src/server/default_config.ts
@@ -808,7 +808,6 @@ const defaultServerConfig: AdminConfig = {
     },
     AccessControlSettings: {
         EnableAttributeBasedAccessControl: false,
-        EnableChannelScopeAccessControl: true,
         EnableUserManagedAttributes: false,
     },
     ContentFlaggingSettings: {

--- a/server/config/client.go
+++ b/server/config/client.go
@@ -159,7 +159,6 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 	props["UniqueEmojiReactionLimitPerPost"] = strconv.FormatInt(int64(*c.ServiceSettings.UniqueEmojiReactionLimitPerPost), 10)
 
 	props["EnableAttributeBasedAccessControl"] = strconv.FormatBool(*c.AccessControlSettings.EnableAttributeBasedAccessControl)
-	props["EnableChannelScopeAccessControl"] = strconv.FormatBool(*c.AccessControlSettings.EnableChannelScopeAccessControl)
 	props["EnableUserManagedAttributes"] = strconv.FormatBool(*c.AccessControlSettings.EnableUserManagedAttributes)
 
 	props["WranglerPermittedWranglerRoles"] = strings.Join(c.WranglerSettings.PermittedWranglerRoles, ",")

--- a/server/config/client_test.go
+++ b/server/config/client_test.go
@@ -343,7 +343,6 @@ func TestGetClientConfig(t *testing.T) {
 			&model.Config{
 				AccessControlSettings: model.AccessControlSettings{
 					EnableAttributeBasedAccessControl: model.NewPointer(true),
-					EnableChannelScopeAccessControl:   model.NewPointer(true),
 					EnableUserManagedAttributes:       model.NewPointer(true),
 				},
 			},
@@ -351,7 +350,6 @@ func TestGetClientConfig(t *testing.T) {
 			nil,
 			map[string]string{
 				"EnableAttributeBasedAccessControl": "true",
-				"EnableChannelScopeAccessControl":   "true",
 				"EnableUserManagedAttributes":       "true",
 			},
 		},
@@ -360,7 +358,6 @@ func TestGetClientConfig(t *testing.T) {
 			&model.Config{
 				AccessControlSettings: model.AccessControlSettings{
 					EnableAttributeBasedAccessControl: model.NewPointer(false),
-					EnableChannelScopeAccessControl:   model.NewPointer(false),
 					EnableUserManagedAttributes:       model.NewPointer(false),
 				},
 			},
@@ -368,7 +365,6 @@ func TestGetClientConfig(t *testing.T) {
 			nil,
 			map[string]string{
 				"EnableAttributeBasedAccessControl": "false",
-				"EnableChannelScopeAccessControl":   "false",
 				"EnableUserManagedAttributes":       "false",
 			},
 		},
@@ -379,7 +375,6 @@ func TestGetClientConfig(t *testing.T) {
 			nil,
 			map[string]string{
 				"EnableAttributeBasedAccessControl": "false",
-				"EnableChannelScopeAccessControl":   "true",
 				"EnableUserManagedAttributes":       "false",
 			},
 		},

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -3873,17 +3873,12 @@ func (s *ExportSettings) SetDefaults() {
 
 type AccessControlSettings struct {
 	EnableAttributeBasedAccessControl *bool
-	EnableChannelScopeAccessControl   *bool
 	EnableUserManagedAttributes       *bool `access:"write_restrictable"`
 }
 
 func (s *AccessControlSettings) SetDefaults() {
 	if s.EnableAttributeBasedAccessControl == nil {
 		s.EnableAttributeBasedAccessControl = NewPointer(false)
-	}
-
-	if s.EnableChannelScopeAccessControl == nil {
-		s.EnableChannelScopeAccessControl = NewPointer(true)
 	}
 
 	if s.EnableUserManagedAttributes == nil {

--- a/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.test.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.test.tsx
@@ -48,7 +48,6 @@ describe('components/admin_console/access_control/policy_details/PolicyDetails',
         policyId: 'policy1',
         accessControlSettings: {
             EnableAttributeBasedAccessControl: true,
-            EnableChannelScopeAccessControl: true,
             EnableUserManagedAttributes: false,
         },
         channels: [

--- a/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/channel_level_access_rules.test.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/channel_level_access_rules.test.tsx
@@ -37,7 +37,6 @@ jest.mock('../../../../channel_settings_modal/channel_access_rules_confirm_modal
 // Mock Redux selectors with stable references
 const mockAccessControlSettings = {
     EnableAttributeBasedAccessControl: true,
-    EnableChannelScopeAccessControl: true,
     EnableUserManagedAttributes: true,
 };
 

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/access_control.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/access_control.ts
@@ -25,16 +25,10 @@ export const getAccessControlSettings = createSelector(
         // Otherwise, build from client config (for regular users/channel admins)
         return {
             EnableAttributeBasedAccessControl: config?.EnableAttributeBasedAccessControl === 'true',
-            EnableChannelScopeAccessControl: config?.EnableChannelScopeAccessControl === 'true',
             EnableUserManagedAttributes: config?.EnableUserManagedAttributes === 'true',
         } as AccessControlSettings;
     },
 );
-
-export function isChannelScopeAccessControlEnabled(state: GlobalState): boolean {
-    const settings = getAccessControlSettings(state);
-    return settings?.EnableChannelScopeAccessControl || false;
-}
 
 export function getAccessControlPolicy(state: GlobalState, id: string) {
     return state.entities.admin.accessControlPolicies[id];

--- a/webapp/channels/src/selectors/general.ts
+++ b/webapp/channels/src/selectors/general.ts
@@ -35,7 +35,7 @@ export function isDevModeEnabled(state: GlobalState) {
 export function isChannelAccessControlEnabled(state: GlobalState): boolean {
     const accessControlSettings = getAccessControlSettings(state);
 
-    // Channel-level access control requires both main ABAC and channel scope
-    return accessControlSettings.EnableAttributeBasedAccessControl &&
-           accessControlSettings.EnableChannelScopeAccessControl;
+    // Channel-level access control requires main ABAC toggle
+    // Permission system (MANAGE_CHANNEL_ACCESS_RULES) handles granular access
+    return accessControlSettings.EnableAttributeBasedAccessControl;
 }

--- a/webapp/platform/types/src/config.ts
+++ b/webapp/platform/types/src/config.ts
@@ -236,7 +236,6 @@ export type ClientConfig = {
 
     // Access Control Settings
     EnableAttributeBasedAccessControl: string;
-    EnableChannelScopeAccessControl: string;
     EnableUserManagedAttributes: string;
 
     // Auto Translation Settings
@@ -1015,7 +1014,6 @@ export type ExportSettings = {
 
 export type AccessControlSettings = {
     EnableAttributeBasedAccessControl: boolean;
-    EnableChannelScopeAccessControl: boolean;
     EnableUserManagedAttributes: boolean;
 };
 


### PR DESCRIPTION
#### Summary
Removes the redundant `EnableChannelScopeAccessControl` configuration setting from `AccessControlSettings`. 
Channel level ABAC access is now controlled only by the `EnableAttributeBasedAccessControl` feature config and the `MANAGE_CHANNEL_ACCESS_RULES` permission, eliminating an unnecessary configuration setting..

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66625

#### Screenshots
n/a

#### Release Note
```release-note
Removed redundant `EnableChannelScopeAccessControl` config setting; channel-level ABAC now controlled by main toggle and permissions only.
```
