### PR TITLE
  MM-66830: Fix RHS panel snapping to minimum width on resize

### DIFF
--- a/webapp/channels/src/components/resizable_sidebar/resizable_divider.tsx
+++ b/webapp/channels/src/components/resizable_sidebar/resizable_divider.tsx
@@ -132,7 +132,7 @@ function ResizableDivider({
 
         const currentWidth = containerRef.current.getBoundingClientRect().width;
         startWidth.current = currentWidth;
-        lastWidth.current = currentWidth; // FIX: Initialize immediately to prevent race condition
+        lastWidth.current = currentWidth;
 
         setIsActive(true);
 
@@ -163,7 +163,7 @@ function ResizableDivider({
 
             e.preventDefault();
 
-            // FIX: Prevent race condition - if lastWidth is null, recover from container
+            // Prevent race condition - if lastWidth is null, recover from container
             // This can occur when a mousemove event fires after reset() but before cleanup
             let previousWidth = lastWidth.current;
             if (previousWidth === null || previousWidth === 0) {


### PR DESCRIPTION
#### Summary
Fixes MM-66830 where RHS would unexpectedly snap to 304px on Windows.

Race condition caused mousemove events to fire after reset() but before cleanup, resulting in negative width calculations that CSS clamped to min-width.

Fix: Initialize lastWidth on mouse down and add defensive recovery in mousemove to prevent negative width calculations.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-66830

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Fix RHS panel snapping to minimum width on resize
```
