### PR TITLE
Set ProdSec as authN/authZ codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,3 +9,5 @@
 /server/channels/db/migrations @mattermost/server-platform
 /server/boards/services/store/sqlstore/migrations @mattermost/server-platform
 /server/playbooks/server/sqlstore/migrations @mattermost/server-platform
+/server/channels/app/authentication.go @mattermost/product-security
+/server/channels/app/authorization.go @mattermost/product-security


### PR DESCRIPTION
#### Summary
Sets product security as codeowners for the `authentication.go` and `authorization.go` files

#### Ticket Link
N/A

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```

