### PR TITLE
bumps base image version to build new mattermost-build-server images

### DIFF
--- a/server/build/Dockerfile.buildenv
+++ b/server/build/Dockerfile.buildenv
@@ -1,4 +1,4 @@
-FROM mattermost/golang-bullseye:1.24.11@sha256:648e6d4bd76751787cf8eb2674942f931a01043872ce15ac9501382dabcefbe8
+FROM mattermost/golang-bullseye:1.24.13@sha256:d9d9a35369413840836f677db08beb0aec784a966fe2a1ba1e60dc9baa64e881
 ARG NODE_VERSION=20.11.1
 
 RUN apt-get update && apt-get install -y make git apt-transport-https ca-certificates curl software-properties-common build-essential zip xmlsec1 jq pgloader gnupg

--- a/server/build/Dockerfile.buildenv-fips
+++ b/server/build/Dockerfile.buildenv-fips
@@ -1,4 +1,4 @@
-FROM cgr.dev/mattermost.com/go-msft-fips:1.24.11-dev@sha256:181a7db41bbff8cf0e522bd5f951a44f2a39a5f58ca930930dfbecdc6b690272
+FROM cgr.dev/mattermost.com/go-msft-fips:1.24.13-dev@sha256:46c7f9e469ab1c83a7c1f3d1dfdf9f0aee7ef8a1c93d39a2270af3560b4008b4
 ARG NODE_VERSION=20.11.1
 
 RUN apk add curl ca-certificates mailcap unrtf wv poppler-utils tzdata gpg xmlsec


### PR DESCRIPTION
#### Summary
Updates base images to generate new `mattermost-build-server(-fips)` images based on go 1.24.13

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67569

#### Release Note
```release-note
NONE
```
