### PR TITLE
Current issue

### DIFF
--- a/server/public/model/metrics.go
+++ b/server/public/model/metrics.go
@@ -148,13 +148,13 @@ func processLabel(labels map[string]string, name string, acceptedValues map[stri
 	if !ok {
 		return defaultValue
 	}
-	value = strings.ToLower(value)
 
-	// check if the value is one that we accept
-	_, ok = acceptedValues[value]
-	if !ok {
-		return defaultValue
+	// Match case-insensitively while preserving the canonical accepted value.
+	for acceptedValue := range acceptedValues {
+		if strings.EqualFold(value, acceptedValue) {
+			return acceptedValue
+		}
 	}
 
-	return value
+	return defaultValue
 }

--- a/server/public/model/metrics_test.go
+++ b/server/public/model/metrics_test.go
@@ -75,3 +75,61 @@ func TestPerformanceReport_IsValid(t *testing.T) {
 		})
 	}
 }
+
+func TestPerformanceReport_ProcessLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		expected map[string]string
+	}{
+		{
+			name: "normalizes known values case-insensitively",
+			labels: map[string]string{
+				"platform":              "IOS",
+				"agent":                 "SafARi",
+				"desktop_app_version":   "6.2.0",
+				"network_request_group": "websocket reconnect deferred",
+			},
+			expected: map[string]string{
+				"platform":              "ios",
+				"agent":                 "safari",
+				"desktop_app_version":   "6.2.0",
+				"network_request_group": "WebSocket Reconnect Deferred",
+			},
+		},
+		{
+			name: "defaults unknown values",
+			labels: map[string]string{
+				"platform":              "plan9",
+				"agent":                 "netscape",
+				"network_request_group": "mystery",
+			},
+			expected: map[string]string{
+				"platform":              "other",
+				"agent":                 "other",
+				"desktop_app_version":   "",
+				"network_request_group": "Login",
+			},
+		},
+		{
+			name:   "handles missing labels",
+			labels: nil,
+			expected: map[string]string{
+				"platform":              "other",
+				"agent":                 "other",
+				"desktop_app_version":   "",
+				"network_request_group": "Login",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := &PerformanceReport{
+				Labels: tt.labels,
+			}
+
+			require.Equal(t, tt.expected, report.ProcessLabels())
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
Fixed a bug in `server/public/model/metrics.go` where `processLabel` was lowercasing incoming label values before map lookup. This caused valid mixed-case labels (e.g., `network_request_group`) to be incorrectly rejected, leading to fallback default values being used.

The fix makes label matching case-insensitive while ensuring the canonical accepted value is returned.

**QA Test Steps:**
Added new unit tests in `server/public/model/metrics_test.go` to verify:
- Case-insensitive normalization for known values.
- Correct fallback behavior for unknown values.
- Handling of missing labels.

#### Ticket Link
NONE

#### Screenshots
NONE

#### Release Note
```release-note
Fixed a bug in performance report label handling where mixed-case labels were incorrectly rejected, causing fallback to default values. Label matching is now case-insensitive.
```

---
<p><a href="https://cursor.com/background-agent?bcId=bc-513e7f53-b62b-4f28-beee-3b12b9d7a353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-513e7f53-b62b-4f28-beee-3b12b9d7a353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

