### PR TITLE
[MM-67488] Set autotranslation feature flag default to true

### DIFF
--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -125,8 +125,7 @@ func (f *FeatureFlags) SetDefaults() {
 
 	f.MobileSSOCodeExchange = true
 
-	// FEATURE_FLAG_REMOVAL: AutoTranslation - Remove this default when MVP is to be released
-	f.AutoTranslation = false
+	f.AutoTranslation = true
 
 	f.BurnOnRead = true
 


### PR DESCRIPTION
#### Summary
Set Autotranslations feature flag to default to true

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-67488

#### Release Note
Part of autotranslations feature
```release-note
NONE
```
