### PR TITLE
Access_problem page banner overlap

### DIFF
--- a/webapp/channels/src/components/header_footer_route/header.scss
+++ b/webapp/channels/src/components/header_footer_route/header.scss
@@ -91,6 +91,14 @@
     }
 }
 
+body.announcement-bar--fixed {
+    .hfroute-header {
+        .header-back-button {
+            top: auto;
+        }
+    }
+}
+
 @media screen and (max-width: 699px) {
     .hfroute-header {
         padding: 0 24px;


### PR DESCRIPTION
#### Summary
This PR fixes a UI overlap issue on the `access_problem` page when a global announcement banner is active. Previously, the Mattermost logo and the "Back" button would overlap due to conflicting CSS positioning rules. The fix introduces a targeted CSS override to ensure the back button maintains its correct `top` positioning, preventing the overlap.

**QA Test Steps:**
1.  Enable a global announcement banner (e.g., via System Console > Site Configuration > Customization > Announcement Banner).
2.  Navigate to the `access_problem` page (e.g., by attempting to access a restricted channel or team).
3.  Observe that the Mattermost logo and the "Back" button at the top of the page do not overlap.
4.  Disable the global banner and confirm the layout on the `access_problem` page remains correct.

#### Ticket Link
N/A

#### Screenshots
Please add screenshots showing the `access_problem` page *before* and *after* this change, both with and without an active global banner.

#### Release Note
```release-note
Fixed an issue where the Mattermost logo and Back button would overlap on the access problem page when a global announcement banner was active.
```

---
<p><a href="https://cursor.com/background-agent?bcId=bc-c43cd7af-2db2-44e5-a9f6-9d2b744d3f86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c43cd7af-2db2-44e5-a9f6-9d2b744d3f86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

