### PR TITLE
Access problem banner overlap

### DIFF
--- a/webapp/channels/src/components/header_footer_route/header.scss
+++ b/webapp/channels/src/components/header_footer_route/header.scss
@@ -65,7 +65,7 @@
         }
     }
 
-    .header-back-button {
+    .header-back-button.signup-header {
         position: absolute;
         top: unset;
         bottom: -8px;


### PR DESCRIPTION
#### Summary
Fixes an issue where the Mattermost logo and Back button overlapped on the `access_problem` page when a global banner was displayed. This was caused by a CSS specificity conflict where a global banner rule (`body.announcement-bar--fixed .signup-header`) was overriding the intended positioning of the Back button.

The fix involves making the `.header-back-button` selector more specific by changing it to `.header-back-button.signup-header` in `webapp/channels/src/components/header_footer_route/header.scss`. This ensures the `top: unset` property for the back button maintains its correct position, preventing the overlap.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/XXX

#### Screenshots
| before | after |
|---|---|
| <insert before screenshot with banner here> | <insert after screenshot with banner here> |

#### Release Note
```release-note
Fixed an issue where the Mattermost logo and Back button overlapped on the access problem page when a global banner was displayed.
```

---
<p><a href="https://cursor.com/background-agent?bcId=bc-79cabc9c-578d-4a32-92be-f6a236149786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-79cabc9c-578d-4a32-92be-f6a236149786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

