### PR TITLE
Access problem banner header

### DIFF
--- a/webapp/channels/src/components/header_footer_route/header.scss
+++ b/webapp/channels/src/components/header_footer_route/header.scss
@@ -91,6 +91,14 @@
     }
 }
 
+body.announcement-bar--fixed {
+    .hfroute-header {
+        .header-back-button {
+            top: unset;
+        }
+    }
+}
+
 @media screen and (max-width: 699px) {
     .hfroute-header {
         padding: 0 24px;


### PR DESCRIPTION
#### Summary
Fixes an issue on the `access_problem` page where the Mattermost logo and the "Back" button would overlap when a global announcement banner was displayed. This occurred because the `BackButton` (which uses the `signup-header` class) incorrectly inherited a `top` offset from `_signup.scss` when `body.announcement-bar--fixed` was active, conflicting with its intended positioning in `header.scss`.

The fix adds a targeted CSS override in `webapp/channels/src/components/header_footer_route/header.scss` to unset the `top` property for `.hfroute-header .header-back-button` when `body.announcement-bar--fixed` is present, ensuring correct layout.

**QA Test Steps:**
1.  Enable a global announcement banner in System Console (e.g., `System Console > Site Configuration > Customization > Announcement Banner`).
2.  Navigate to the `/access_problem` page (e.g., by trying to access a restricted channel or team you don't have permission for).
3.  Observe the header area: the Mattermost logo and the "Back" button should no longer overlap.
4.  Optionally, disable the global banner and verify the layout remains correct.

#### Ticket Link
N/A

#### Screenshots
Screenshots were provided in the original task description. Please refer to the task for visual context.

#### Release Note
```release-note
Fixed an issue where the Mattermost logo and Back button overlapped on the access problem page when a global announcement banner was active.
```

---
<p><a href="https://cursor.com/background-agent?bcId=bc-c0319216-6487-441b-91d5-7e8e35980124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c0319216-6487-441b-91d5-7e8e35980124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

