### PR TITLE
server: ignore tmp mattermost/shared in file

### DIFF
--- a/server/build/notice-file/config.yaml
+++ b/server/build/notice-file/config.yaml
@@ -8,4 +8,5 @@ search:
   - "webapp/channels/package.json"
 ignoreDependencies:
   - "@mattermost/dynamic-virtualized-list"
+  - "@mattermost/shared"
 includeDevDependencies: false


### PR DESCRIPTION
#### Summary
The generation of notice-file is failing with
```
2026/02/16 10:20:39 NPM load failed  @mattermost/shared
2026/02/16 10:20:39 Error occured while generating notice.txt @mattermost/shared:http status code 404 when downloading "https://registry.npmjs.org/@mattermost/shared"
```

This relates with https://github.com/mattermost/mattermost/pull/35065 because the package is still local and isn't yet published in npm

So, temporarily ignoring the shared package while it isn't published.

#### Ticket Link
- https://github.com/mattermost/delivery-platform/actions/runs/22058753354



#### Release Note
```release-note
NONE
```
