### PR TITLE
Automated cherry pick of #35288

### DIFF
--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -125,8 +125,7 @@ func (f *FeatureFlags) SetDefaults() {
 
 	f.MobileSSOCodeExchange = true
 
-	// FEATURE_FLAG_REMOVAL: AutoTranslation - Remove this default when MVP is to be released
-	f.AutoTranslation = false
+	f.AutoTranslation = true
 
 	f.BurnOnRead = true
 


### PR DESCRIPTION
Cherry pick of #35288 on release-11.5.

/cc  @larkox

```release-note
NONE
```