### PR TITLE
Agent environment setup verification

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -33,6 +33,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxss1 libglib2.0-0 libx11-6 libxcb1 libxext6 \
     # Fonts (needed for Chromium to render pages correctly)
     fonts-liberation fonts-noto-color-emoji \
+    # Terminal multiplexer (for managing server/webapp terminals)
+    tmux \
     && rm -rf /var/lib/apt/lists/*
 
 # ============================================

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -126,7 +126,19 @@ echo ">>> Installing agent-browser skills..."
 cd "${WORKSPACE_ROOT}"
 npx -y skills add vercel-labs/agent-browser -a cursor -y --all
 
+# ============================================
+# Playwright browsers for agent-browser
+# agent-browser uses Playwright under the hood.
+# Pre-install Chromium so `agent-browser open`
+# works without needing `agent-browser install
+# --with-deps` first.
+# ============================================
+echo ">>> Installing Playwright browsers (Chromium)..."
+cd "${WORKSPACE_ROOT}"
+npx -y playwright install chromium
+
 echo ""
 echo ">>> Install complete!"
 echo ">>> Go modules cached, webapp built, mmctl compiled."
+echo ">>> Playwright Chromium installed for agent-browser."
 echo ">>> Config generated at server/config/config-cursor-cloud.json"

--- a/.cursor/setup-admin.sh
+++ b/.cursor/setup-admin.sh
@@ -22,8 +22,8 @@ SOCKET="/var/tmp/mattermost_cursor_cloud.sock"
 ADMIN_EMAIL="admin@localhost"
 ADMIN_USERNAME="admin"
 ADMIN_PASSWORD="Passw0rd!"
-TEAM_NAME="default"
-TEAM_DISPLAY="Default"
+TEAM_NAME="dev"
+TEAM_DISPLAY="Development"
 
 echo ">>> Mattermost Admin Setup"
 

--- a/.cursor/skills/browser-qa.md
+++ b/.cursor/skills/browser-qa.md
@@ -31,9 +31,9 @@ agent-browser snapshot -i
 
 ## Admin Login
 
-Default dev admin credentials (created via `make cursor-cloud-setup-admin`):
+Default dev admin credentials (created via `make cursor-cloud-setup-admin` or `bash .cursor/setup-admin.sh`):
 - **Username**: `admin`
-- **Password**: `Admin@1234`
+- **Password**: `Passw0rd!`
 
 If sample data was injected (`make inject-test-data`):
 - **Username**: `sysadmin`
@@ -50,7 +50,7 @@ agent-browser snapshot -i
 # Find the submit button (look for button with text "Log in")
 
 agent-browser fill @eLoginInput "admin"
-agent-browser fill @ePasswordInput "Admin@1234"
+agent-browser fill @ePasswordInput "Passw0rd!"
 agent-browser click @eLoginButton
 agent-browser wait --load networkidle
 agent-browser snapshot -i
@@ -58,7 +58,7 @@ agent-browser snapshot -i
 
 After login, you may be redirected to:
 - `/preparing-workspace` (first-time onboarding wizard) - complete or skip it
-- `/dev-team/channels/town-square` (default channel) - you are ready
+- `/dev/channels/town-square` (default channel) - you are ready
 
 ### Save Login State (Optional)
 
@@ -76,9 +76,9 @@ On a fresh Mattermost install with no users, the preferred setup is via mmctl:
 ```bash
 cd server
 ./scripts/wait-for-system-start.sh
-bin/mmctl user create --email admin@example.com --username admin --password 'Admin@1234' --system-admin --email-verified --local
-bin/mmctl team create --name dev-team --display-name "Dev Team" --local
-bin/mmctl team users add dev-team admin --local
+bin/mmctl user create --email admin@localhost --username admin --password 'Passw0rd!' --system-admin --email-verified --local
+bin/mmctl team create --name dev --display-name "Development" --local
+bin/mmctl team users add dev admin --local
 ```
 
 Or use the make target:
@@ -110,7 +110,7 @@ If you need to set up via browser instead (e.g., testing the signup flow):
 
 ```bash
 # Navigate to a channel (e.g., Town Square)
-agent-browser open http://localhost:8065/dev-team/channels/town-square
+agent-browser open http://localhost:8065/dev/channels/town-square
 agent-browser wait --load networkidle
 agent-browser snapshot -i
 
@@ -141,7 +141,7 @@ agent-browser snapshot -i
 
 ```bash
 # Option 1: Direct URL navigation
-agent-browser open http://localhost:8065/dev-team/channels/off-topic
+agent-browser open http://localhost:8065/dev/channels/off-topic
 
 # Option 2: Click channel in sidebar
 agent-browser snapshot -i

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -78,6 +78,16 @@ done
 # the agent doesn't need browser access.
 # ============================================
 
+# ============================================
+# mmctl socket symlink
+# The config uses a custom socket path
+# (/var/tmp/mattermost_cursor_cloud.sock) but
+# mmctl --local expects the default path.
+# Create a symlink so mmctl works out of the box.
+# ============================================
+echo ">>> Creating mmctl socket symlink..."
+ln -sf /var/tmp/mattermost_cursor_cloud.sock /var/tmp/mattermost_local.socket
+
 echo ""
 echo ">>> All services started!"
 echo ">>> PostgreSQL: localhost:5432 (mmuser:mostest / mattermost_test)"

--- a/server/cursor-cloud.mk
+++ b/server/cursor-cloud.mk
@@ -84,8 +84,8 @@ cursor-cloud-setup-admin:
 	@echo "Waiting for server to start..."
 	@./scripts/wait-for-system-start.sh
 	@echo "Creating admin user..."
-	@bin/mmctl user create --email admin@example.com --username admin --password 'Admin@1234' --system-admin --email-verified --local 2>/dev/null || echo "Admin user already exists"
-	@echo "Creating default team..."
-	@bin/mmctl team create --name dev-team --display-name "Dev Team" --local 2>/dev/null || echo "Team already exists"
-	@bin/mmctl team users add dev-team admin --local 2>/dev/null || echo "User already in team"
-	@echo "Admin setup complete: username=admin password=Admin@1234"
+	@bin/mmctl user create --email admin@localhost --username admin --password 'Passw0rd!' --system-admin --email-verified --local 2>/dev/null || echo "Admin user already exists"
+	@echo "Creating dev team..."
+	@bin/mmctl team create --name dev --display-name "Development" --local 2>/dev/null || echo "Team already exists"
+	@bin/mmctl team users add dev admin --local 2>/dev/null || echo "User already in team"
+	@echo "Admin setup complete: username=admin password=Passw0rd!"


### PR DESCRIPTION
#### Summary
This PR addresses several issues found during an environment verification test plan, improving the out-of-the-box setup for the Mattermost development environment. Key fixes include:
*   Ensuring the Mattermost server starts automatically and the webapp is built on environment initialization.
*   Correcting admin user and "dev" team creation, including credential and team name consistency.
*   Setting up the `mmctl` socket symlink for proper local command-line interaction.
*   Installing necessary browser automation dependencies (Playwright Chromium) and `tmux`.
*   Updating internal skill documentation (`browser-qa.md`) with correct credentials and paths.

#### Ticket Link
NONE

#### Screenshots
NONE

#### Release Note
```release-note
Improved Mattermost development environment setup scripts to ensure automatic server startup, webapp build, correct admin user/team creation, and installation of browser automation dependencies and tmux. Updated internal skill documentation.
```

---
<p><a href="https://cursor.com/background-agent?bcId=bc-696682cc-0653-444f-b653-3375c22044f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-696682cc-0653-444f-b653-3375c22044f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

