### PR TITLE
[MM-67651] Use master instead of replica for GetAllForObject in auto-translations

### DIFF
--- a/server/channels/store/sqlstore/autotranslation_store.go
+++ b/server/channels/store/sqlstore/autotranslation_store.go
@@ -233,7 +233,8 @@ func (s *SqlAutoTranslationStore) GetAllForObject(objectType, objectID string) (
 		Where(sq.Eq{"ObjectType": objectType, "ObjectId": objectID})
 
 	var translations []Translation
-	if err := s.GetReplica().SelectBuilder(&translations, query); err != nil {
+	// Use GetMaster to avoid replica lag issues when workers fetch queued items
+	if err := s.GetMaster().SelectBuilder(&translations, query); err != nil {
 		return nil, errors.Wrapf(err, "failed to get all translations for object_id=%s", objectID)
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Workers can sometimes grab items before they are available on the replica node. This store function is only used by workers to get queued items for a certain objectID

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67651

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Use master instead of replica for GetAllForObject in auto-translations
```
