### PR TITLE
Fix Permission Request for Docs Agent

### DIFF
--- a/.github/workflows/docs-impact-review.yml
+++ b/.github/workflows/docs-impact-review.yml
@@ -12,6 +12,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: read
+  id-token: write
 
 jobs:
   docs-impact-review:


### PR DESCRIPTION
## Summary
Add missing `id-token: write` permission to the `docs-impact-review` workflow, fixing OIDC token authentication failures in `claude-code-action`

## Details
The `docs-impact-review` workflow was failing with:
> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

The `claude-code-action@v1` requires the `id-token: write` permission to request a short-lived OIDC token during execution. This permission is scoped to the workflow run and does not expand the existing security surface — merging is still blocked by `contents: read`.

## Test plan
- [ ] Trigger `/docs-review` on a PR and verify the workflow completes successfully

#### Release Note
```release-note
NONE
```
