### PR TITLE
Fix Code Checkout for Doc Impact Review Action

### DIFF
--- a/.github/workflows/docs-impact-review.yml
+++ b/.github/workflows/docs-impact-review.yml
@@ -22,6 +22,11 @@ jobs:
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-24.04
     steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+
       - name: Checkout documentation repo
         uses: actions/checkout@v4
         with:
@@ -119,7 +124,7 @@ jobs:
 
             Follow these steps in order. Complete each step before moving to the next.
 
-            1. **Read the PR diff** using `git diff` against the base branch to understand what changed.
+            1. **Read the PR diff** using `gh pr diff ${{ github.event.issue.number }}` to understand what changed.
             2. **Categorize each changed file** by documentation relevance using one or more of these labels:
               - API changes (new endpoints, changed parameters, changed responses)
               - Configuration changes (new or modified settings in `config.go` or `feature_flags.go`)


### PR DESCRIPTION

#### Summary
The docs-impact-review workflow was failing because the Claude agent couldn't find the Mattermost codebase — only the mattermost/docs repo was being checked out into the workspace.

This PR fixes the workflow by:

Adding a checkout step for the PR code at the workspace root using refs/pull/<number>/head, so the agent has access to the full monorepo (server/, webapp/, api/, etc.) for context
Switching from git diff to gh pr diff in the agent prompt, since the shallow checkout doesn't include base branch history — gh pr diff fetches the diff via GitHub API instead


#### Release Note
```release-note
NONE
```
