### PR TITLE
Automated cherry pick of #35355

### DIFF
--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -204,6 +204,8 @@ const (
 	AnnouncementSettingsDefaultNoticesJsonURL               = "https://notices.mattermost.com/"
 	AnnouncementSettingsDefaultNoticesFetchFrequencySeconds = 3600
 
+	AutoTranslationDefaultWorkers = 6
+
 	TeamSettingsDefaultTeamText = "default"
 
 	ElasticsearchSettingsDefaultConnectionURL               = "http://localhost:9200"
@@ -2823,7 +2825,7 @@ func (s *AutoTranslationSettings) SetDefaults() {
 	}
 
 	if s.Workers == nil {
-		s.Workers = NewPointer(4)
+		s.Workers = NewPointer(AutoTranslationDefaultWorkers)
 	}
 
 	if s.TimeoutMs == nil {


### PR DESCRIPTION
Cherry pick of #35355 on release-11.5.

/cc  @BenCookie95

```release-note
NONE
```