### PR TITLE
Increase minimum version of Node to 24 and NPM to 11

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -2,7 +2,7 @@
   "name": "@mattermost/webapp",
   "private": true,
   "engines": {
-    "node": "^20 || ^22 || ^24",
+    "node": "^24",
     "npm": "^11"
   },
   "scripts": {


### PR DESCRIPTION
#### Summary
When we updated the Node.js version, I asked Saturn to make the Node/NPM version checks looser because I didn't know about anything that would cause the package-lock.json or package.json formats to change. It seems like NPM 10 is causing a few fields to be removed now, so we should require 11 to avoid thrashing on that.

#### Release Note
```release-note
NONE
```