### PR TITLE
Fix IntuneSettings config access tags to use correct permission ID

### DIFF
--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -1404,10 +1404,10 @@ func (s *Office365Settings) SSOSettings() *SSOSettings {
 }
 
 type IntuneSettings struct {
-	Enable      *bool   `access:"mobile_intune"`
-	TenantId    *string `access:"mobile_intune"` // telemetry: none
-	ClientId    *string `access:"mobile_intune"` // telemetry: none
-	AuthService *string `access:"mobile_intune"` // "office365" or "saml"
+	Enable      *bool   `access:"environment_mobile_security"`
+	TenantId    *string `access:"environment_mobile_security"` // telemetry: none
+	ClientId    *string `access:"environment_mobile_security"` // telemetry: none
+	AuthService *string `access:"environment_mobile_security"` // "office365" or "saml"
 }
 
 func (s *IntuneSettings) SetDefaults() {


### PR DESCRIPTION
#### Summary

`IntuneSettings` config fields had `access:"mobile_intune"` tags, but no matching permission exists in `AllPermissions`. The correct tag is `"environment_mobile_security"`, which aligns with the permissions already defined in `permission.go` and used by the frontend.

This caused warning logs on every `GET /api/v4/config` call and blocked delegated admins (non-`manage_system` roles) from reading or configuring Intune settings despite having the correct permissions.

Also added `TestConfigAccessTagsMapToValidPermissions` to validate all config `access` tags resolve to real permissions, preventing this class of bug going forward.

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-67693

#### Release Note

```release-note
Fixed an issue where Intune settings had incorrect config access tags, causing warning logs and preventing delegated admins from configuring Intune settings.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Updated access permissions for Intune mobile security settings (enable, tenant, client, and auth service).
* **Tests**
  * Added a validation test to ensure configuration access tags map to known permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->