### PR TITLE
Deactivated users exclusion

### DIFF
--- a/server/channels/app/user_viewmembers_test.go
+++ b/server/channels/app/user_viewmembers_test.go
@@ -539,6 +539,20 @@ func TestRestrictedViewMembers(t *testing.T) {
 				}
 			})
 		}
+
+		t.Run("deactivated users are excluded", func(t *testing.T) {
+			deactivatedUser, appErr := th.App.UpdateActive(th.Context, user2, false)
+			require.Nil(t, appErr)
+			t.Cleanup(func() {
+				_, reactivatedErr := th.App.UpdateActive(th.Context, deactivatedUser, true)
+				require.Nil(t, reactivatedErr)
+			})
+
+			results, appErr := th.App.GetRecentlyActiveUsersForTeamPage(th.Context, team1.Id, 0, 1, false, nil)
+			require.Nil(t, appErr)
+			require.Len(t, results, 1)
+			assert.NotEqual(t, user2.Id, results[0].Id)
+		})
 	})
 
 	t.Run("GetUsers", func(t *testing.T) {

--- a/server/channels/store/sqlstore/user_store.go
+++ b/server/channels/store/sqlstore/user_store.go
@@ -1075,6 +1075,7 @@ func (us SqlUserStore) GetRecentlyActiveUsersForTeam(teamId string, offset, limi
 		Column("s.LastActivityAt").
 		Join("TeamMembers tm ON (tm.UserId = Users.Id AND tm.TeamId = ?)", teamId).
 		Join("Status s ON (s.UserId = Users.Id)").
+		Where("Users.DeleteAt = 0").
 		OrderBy("s.LastActivityAt DESC").
 		OrderBy("Users.Username ASC").
 		Offset(uint64(offset)).Limit(uint64(limit))

--- a/server/channels/store/storetest/user_store.go
+++ b/server/channels/store/storetest/user_store.go
@@ -2673,7 +2673,17 @@ func testUserStoreGetRecentlyActiveUsersForTeam(t *testing.T, rctx request.CTX, 
 	u3.IsBot = true
 	defer func() { require.NoError(t, ss.Bot().PermanentDelete(u3.Id)) }()
 
+	u4, err := ss.User().Save(rctx, &model.User{
+		Email:    MakeEmail(),
+		Username: "u4" + model.NewId(),
+	})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u4.Id)) }()
+	_, nErr = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamID, UserId: u4.Id}, -1)
+	require.NoError(t, nErr)
+
 	millis := model.GetMillis()
+	u4.LastActivityAt = millis + 1
 	u3.LastActivityAt = millis
 	u2.LastActivityAt = millis - 1
 	u1.LastActivityAt = millis - 1
@@ -2681,6 +2691,11 @@ func testUserStoreGetRecentlyActiveUsersForTeam(t *testing.T, rctx request.CTX, 
 	require.NoError(t, ss.Status().SaveOrUpdate(&model.Status{UserId: u1.Id, Status: model.StatusOnline, Manual: false, LastActivityAt: u1.LastActivityAt, ActiveChannel: ""}))
 	require.NoError(t, ss.Status().SaveOrUpdate(&model.Status{UserId: u2.Id, Status: model.StatusOnline, Manual: false, LastActivityAt: u2.LastActivityAt, ActiveChannel: ""}))
 	require.NoError(t, ss.Status().SaveOrUpdate(&model.Status{UserId: u3.Id, Status: model.StatusOnline, Manual: false, LastActivityAt: u3.LastActivityAt, ActiveChannel: ""}))
+	require.NoError(t, ss.Status().SaveOrUpdate(&model.Status{UserId: u4.Id, Status: model.StatusOnline, Manual: false, LastActivityAt: u4.LastActivityAt, ActiveChannel: ""}))
+
+	u4.DeleteAt = model.GetMillis()
+	_, err = ss.User().Update(rctx, u4, true)
+	require.NoError(t, err)
 
 	t.Run("get team 1, offset 0, limit 100", func(t *testing.T) {
 		users, err := ss.User().GetRecentlyActiveUsersForTeam(teamID, 0, 100, nil)
@@ -2706,6 +2721,18 @@ func testUserStoreGetRecentlyActiveUsersForTeam(t *testing.T, rctx request.CTX, 
 		assert.Equal(t, []*model.User{
 			sanitized(u2),
 		}, users)
+	})
+
+	t.Run("deactivated users are excluded", func(t *testing.T) {
+		users, err := ss.User().GetRecentlyActiveUsersForTeam(teamID, 0, 100, nil)
+		require.NoError(t, err)
+
+		ids := []string{}
+		for _, user := range users {
+			ids = append(ids, user.Id)
+		}
+
+		assert.NotContains(t, ids, u4.Id)
 	})
 }
 


### PR DESCRIPTION
#### Summary
Fixes a bug where deactivated users would incorrectly appear in the "Recent Active Users" list on the Team Statistics page. Deactivating a user incorrectly updated their `LastActivityAt`, causing them to be sorted as recently active. This PR updates the `GetRecentlyActiveUsersForTeam` SQL query to filter out users where `Users.DeleteAt != 0`.

**QA Test Steps:**
1.  Open Team Statistics.
2.  Deactivate a user in User Management.
3.  Return to Team Statistics and verify the deactivated user is absent from "Recent Active Users."
4.  (Optional) Verify the deactivated user still appears under "Newly Created Users" (as this is out of scope).

#### Ticket Link
<!-- No ticket link provided in the task -->

#### Screenshots
| before | after |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |
*(Screenshot of Team Statistics "Recent Active Users" section after fix will be provided.)*

#### Release Note
```release-note
Fixed a bug where deactivated users could incorrectly appear in the "Recent Active Users" list on the Team Statistics page.
```

---
<p><a href="https://cursor.com/agents/bc-95e76c80-107a-4a38-8e1c-70d9cfd7d76c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95e76c80-107a-4a38-8e1c-70d9cfd7d76c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

