### PR TITLE
Update Calls to v1.11.1

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -154,7 +154,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.0
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.1
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.6.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.12.0
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.5.1


### PR DESCRIPTION
#### Summary
- Update prepackaged Calls to v1.11.1

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-67197


#### Release Note
```release-note
Mattermost Calls was updated to v1.11.1, fixing call disconnection issue with Chrome/Edge >= 144
```

Calls v1.11.1 https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v1.11.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Mattermost plugin-calls dependency to v1.11.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->