### PR TITLE
Automated cherry pick of #35384

### DIFF
--- a/webapp/channels/src/actions/websocket_actions.ts
+++ b/webapp/channels/src/actions/websocket_actions.ts
@@ -1755,7 +1755,7 @@ function handleFirstAdminVisitMarketplaceStatusReceivedEvent(msg: WebSocketMessa
 
 function handleThreadReadChanged(msg: WebSocketMessages.ThreadReadChanged): ThunkActionFunc<void> {
     return (doDispatch, doGetState) => {
-        if (msg.data.thread_id && msg.data.channel_id && msg.data.unread_mentions && msg.data.unread_replies) {
+        if ('thread_id' in msg.data && msg.data.thread_id) {
             const state = doGetState();
             const thread = getThreads(state)?.[msg.data.thread_id];
 

--- a/webapp/platform/client/src/websocket_messages.ts
+++ b/webapp/platform/client/src/websocket_messages.ts
@@ -151,15 +151,29 @@ export type ThreadFollowedChanged = BaseWebSocketMessage<WebSocketEvents.ThreadF
     reply_count: number;
 }>;
 
-export type ThreadReadChanged = BaseWebSocketMessage<WebSocketEvents.ThreadReadChanged, {
-    thread_id?: string;
-    timestamp: number;
-    unread_mentions?: number;
-    unread_replies?: number;
-    previous_unread_mentions?: number;
-    previous_unread_replies?: number;
-    channel_id?: string;
-}>;
+export type ThreadReadChanged = BaseWebSocketMessage<WebSocketEvents.ThreadReadChanged, (
+
+    // App.UpdateThreadsReadForUser
+    Record<string, never>
+) | (
+
+    // App.MarkChannelsAsViewed
+    {
+        timestamp: number;
+    }
+) | (
+
+    // App.UpdateThreadReadForUser
+    {
+        thread_id: string;
+        timestamp: number;
+        unread_mentions: number;
+        unread_replies: number;
+        previous_unread_mentions: number;
+        previous_unread_replies: number;
+        channel_id: string;
+    }
+)>;
 
 // Channel and channel member messages
 


### PR DESCRIPTION
Cherry pick of #35384 on release-11.5.

/cc  @hmhealey

```release-note
NONE
```