### PR TITLE
Allow permanent deleting of Direct and Group Messages (#27489)

### DIFF
--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -1431,8 +1431,15 @@ func deleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	defer c.LogAuditRec(auditRec)
 
 	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
-		c.Err = model.NewAppError("deleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
-		return
+		if !c.Params.Permanent {
+			c.Err = model.NewAppError("deleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
+			return
+		}
+
+		if ok, _ := c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), channel.Id, model.PermissionDeletePrivateChannel); !ok {
+			c.SetPermissionError(model.PermissionDeletePrivateChannel)
+			return
+		}
 	}
 
 	if channel.Type == model.ChannelTypeOpen {

--- a/server/channels/api4/channel_local.go
+++ b/server/channels/api4/channel_local.go
@@ -422,8 +422,10 @@ func localDeleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	model.AddEventParameterToAuditRec(auditRec, "channel_id", c.Params.ChannelId)
 
 	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
-		c.Err = model.NewAppError("localDeleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
-		return
+		if !c.Params.Permanent {
+			c.Err = model.NewAppError("localDeleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
+			return
+		}
 	}
 
 	if c.Params.Permanent {

--- a/server/channels/api4/channel_test.go
+++ b/server/channels/api4/channel_test.go
@@ -3285,6 +3285,18 @@ func TestDeleteChannel(t *testing.T) {
 		_, err = client.DeleteChannel(context.Background(), publicChannel3.Id)
 		require.NoError(t, err)
 
+		dmChannel, _, err := client.CreateDirectChannel(context.Background(), user.Id, user2.Id)
+		require.NoError(t, err)
+		resp, err = client.DeleteChannel(context.Background(), dmChannel.Id)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+
+		groupChannel, _, err := client.CreateGroupChannel(context.Background(), []string{user.Id, user2.Id})
+		require.NoError(t, err)
+		resp, err = client.DeleteChannel(context.Background(), groupChannel.Id)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+
 		// default channel cannot be deleted.
 		defaultChannel, appErr := th.App.GetChannelByName(th.Context, model.DefaultChannelName, team.Id, false)
 		require.Nil(t, appErr)
@@ -3464,6 +3476,22 @@ func TestPermanentDeleteChannel(t *testing.T) {
 		require.NoError(t, err)
 
 		_, appErr := th.App.GetChannel(th.Context, publicChannel.Id)
+		assert.NotNil(t, appErr)
+
+		// Test permanent delete for DM channel
+		dmChannel, _, err := c.CreateDirectChannel(context.Background(), th.BasicUser.Id, th.BasicUser2.Id)
+		require.NoError(t, err)
+		_, err = c.PermanentDeleteChannel(context.Background(), dmChannel.Id)
+		require.NoError(t, err)
+		_, appErr = th.App.GetChannel(th.Context, dmChannel.Id)
+		assert.NotNil(t, appErr)
+
+		// Test permanent delete for Group channel
+		groupChannel, _, err := c.CreateGroupChannel(context.Background(), []string{th.BasicUser.Id, th.BasicUser2.Id})
+		require.NoError(t, err)
+		_, err = c.PermanentDeleteChannel(context.Background(), groupChannel.Id)
+		require.NoError(t, err)
+		_, appErr = th.App.GetChannel(th.Context, groupChannel.Id)
 		assert.NotNil(t, appErr)
 
 		resp, err := c.PermanentDeleteChannel(context.Background(), "junk")


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This pull request modifies [deleteChannel](cci:1://file:///D:/Mattermost/server/channels/api4/channel.go:1415:0-1482:1) and [localDeleteChannel](cci:1://file:///D:/Mattermost/server/channels/api4/channel_local.go:406:0-446:1) in the `api4` channel controllers to allow the permanent deletion of Direct Message and Group channels. 

Previously, these endpoints unconditionally blocked deletion for these channel types. Now:
- If [Permanent](cci:1://file:///D:/Mattermost/server/channels/api4/channel_test.go:3448:0-3500:1) is true, the deletion is allowed (provided the user has `PermissionDeletePrivateChannel` in the non-local API).
- If [Permanent](cci:1://file:///D:/Mattermost/server/channels/api4/channel_test.go:3448:0-3500:1) is false, it continues to return an error, keeping the restriction that DM and Group channels cannot be soft-deleted or archived.

Unit tests have also been added to verify this behavior for both successful permanent deletion and rejected soft deletion.

#### Ticket Link
<!--

-->
Fixes https://github.com/mattermost/mattermost/issues/27489
Jira https://mattermost.atlassian.net/browse/MM-59260

-->
N/A (Backend API change only)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.

Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.

```release-note
NONE --> Allowed permanent deletion of Direct Message and Group channels via the API for users with appropriate permissions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced channel deletion handling for Direct Message and Group channels. Non-permanent deletion attempts are rejected as expected, while permanent deletion now proceeds with proper permission verification instead of being rejected outright.

* **Tests**
  * Added comprehensive test coverage for channel deletion across all channel types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->