### PR TITLE
MM-67754 - Fix ABAC E2E tests flakiness in Enterprise CI environment

### DIFF
--- a/e2e-tests/playwright/specs/functional/system_console/abac/policies/advanced_policies.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/policies/advanced_policies.spec.ts
@@ -81,6 +81,9 @@ test.describe('ABAC Policies - Advanced Policies', () => {
         await adminClient.addToTeam(team.id, satisfyingUserInChannel.id);
         await adminClient.addToTeam(team.id, partialSatisfyingUser.id);
 
+        // Wait for user attributes to be indexed before creating policy
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+
         // Create private channel and add users 2 and 3 (but NOT user 1)
         const privateChannel = await createPrivateChannelForABAC(adminClient, team.id);
         await adminClient.addToChannel(satisfyingUserInChannel.id, privateChannel.id);

--- a/e2e-tests/playwright/specs/functional/system_console/abac/policy_management/edit_policies.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/policy_management/edit_policies.spec.ts
@@ -8,7 +8,6 @@ import {
     navigateToABACPage,
     verifyUserInChannel,
     verifyUserNotInChannel,
-    runSyncJob,
 } from '@mattermost/playwright-lib';
 
 import {
@@ -327,7 +326,7 @@ test.describe('ABAC Policy Management - Edit Policies', () => {
                     // Ignore deletion errors
                 }
             }
-            await new Promise((resolve) => setTimeout(resolve, 1000));
+            await new Promise((resolve) => setTimeout(resolve, 2000));
         } catch {
             // Ignore if no fields exist
         }
@@ -335,12 +334,25 @@ test.describe('ABAC Policy Management - Edit Policies', () => {
         // Enable user-managed attributes FIRST (same pattern as MM-T5783)
         await enableUserManagedAttributes(adminClient);
 
-        // Set up TWO attribute fields: Department AND Office with admin-managed attrs
-        const attributeFields: CustomProfileAttribute[] = [
-            {name: 'Department', type: 'text', value: '', attrs: {managed: 'admin', visibility: 'when_set'} as any},
-            {name: 'Office', type: 'text', value: '', attrs: {managed: 'admin', visibility: 'when_set'} as any},
-        ];
-        const attributeFieldsMap = await setupCustomProfileAttributeFields(adminClient, attributeFields);
+        // create attributes using direct API
+        const attributeFieldsMap: Record<string, any> = {};
+
+        const departmentField = await adminClient.createCustomProfileAttributeField({
+            name: 'Department',
+            type: 'text',
+            attrs: {managed: 'admin', visibility: 'when_set', sort_order: 0},
+        } as any);
+        attributeFieldsMap[departmentField.id] = departmentField;
+
+        const officeField = await adminClient.createCustomProfileAttributeField({
+            name: 'Office',
+            type: 'text',
+            attrs: {managed: 'admin', visibility: 'when_set', sort_order: 1},
+        } as any);
+        attributeFieldsMap[officeField.id] = officeField;
+
+        // Wait for attributes to be indexed
+        await new Promise((resolve) => setTimeout(resolve, 2000));
 
         // Create users:
         // 1. engineerRemoteUser: Dept=Engineering, Office=Remote → satisfies BOTH (after edit)
@@ -497,20 +509,15 @@ test.describe('ABAC Policy Management - Edit Policies', () => {
             await page.waitForTimeout(1000);
         }
 
-        // Navigate to ABAC page
+        // Navigate to ABAC page and wait for auto-triggered sync job
         await navigateToABACPage(page);
-        await page.waitForTimeout(1000);
+        await page.waitForTimeout(2000);
 
-        // Manually trigger a sync job to apply the policy changes
-        await runSyncJob(page, false);
-        await waitForLatestSyncJob(page);
-
-        // Trigger a SECOND sync job - sometimes the first sync only processes additions
-        await runSyncJob(page, false);
+        // Wait for the auto-triggered sync job to complete (policy edit triggers sync automatically)
         await waitForLatestSyncJob(page);
 
         // Additional wait for membership changes to propagate
-        await page.waitForTimeout(3000);
+        await page.waitForTimeout(5000);
 
         // ===========================================
         // STEP 5 & 6: Verify channel membership after edit
@@ -576,7 +583,7 @@ test.describe('ABAC Policy Management - Edit Policies', () => {
                     // Ignore deletion errors
                 }
             }
-            await new Promise((resolve) => setTimeout(resolve, 1000));
+            await new Promise((resolve) => setTimeout(resolve, 2000));
         } catch {
             // Ignore if no fields exist
         }
@@ -584,12 +591,25 @@ test.describe('ABAC Policy Management - Edit Policies', () => {
         // Enable user-managed attributes FIRST (same pattern as MM-T5783)
         await enableUserManagedAttributes(adminClient);
 
-        // Set up TWO attribute fields: Department AND Office with admin-managed attrs
-        const attributeFields: CustomProfileAttribute[] = [
-            {name: 'Department', type: 'text', value: '', attrs: {managed: 'admin', visibility: 'when_set'} as any},
-            {name: 'Office', type: 'text', value: '', attrs: {managed: 'admin', visibility: 'when_set'} as any},
-        ];
-        const attributeFieldsMap = await setupCustomProfileAttributeFields(adminClient, attributeFields);
+        // create attributes using direct API
+        const attributeFieldsMap: Record<string, any> = {};
+
+        const departmentField = await adminClient.createCustomProfileAttributeField({
+            name: 'Department',
+            type: 'text',
+            attrs: {managed: 'admin', visibility: 'when_set', sort_order: 0},
+        } as any);
+        attributeFieldsMap[departmentField.id] = departmentField;
+
+        const officeField = await adminClient.createCustomProfileAttributeField({
+            name: 'Office',
+            type: 'text',
+            attrs: {managed: 'admin', visibility: 'when_set', sort_order: 1},
+        } as any);
+        attributeFieldsMap[officeField.id] = officeField;
+
+        // Wait for attributes to be indexed
+        await new Promise((resolve) => setTimeout(resolve, 2000));
 
         // Create users:
         // 1. engineerRemoteUser: Dept=Engineering, Office=Remote → satisfies ORIGINAL (both rules)


### PR DESCRIPTION
#### Summary
This PR (tries) fixes intermittent ABAC test failures in Enterprise CI by ensuring proper attribute cleanup, using direct API calls for attribute creation instead of helpers that returned existing attributes, and also this PR optimizes sync job waits to handle sequential test execution to prevent potential flakynes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67754

#### Screenshots
<img width="1147" height="953" alt="Screenshot 2026-03-02 at 8 00 07 PM" src="https://github.com/user-attachments/assets/1adfbd34-1dae-49df-925a-f7b705cadbcc" />


#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced e2e test reliability by adding synchronization delays to ensure proper attribute indexing during policy creation.
  * Refactored attribute field creation tests to use API-based approach with improved timeout handling for better test consistency and reduced flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->