### PR TITLE
fix: flaky flag-messages.spec

### DIFF
--- a/e2e-tests/playwright/lib/src/ui/components/channels/center_view.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/center_view.ts
@@ -25,8 +25,6 @@ export default class ChannelsCenterView {
     readonly editedPostIcon;
     readonly channelBanner;
     readonly flagPostConfirmationDialog;
-    readonly messageDeleted;
-    readonly postText;
 
     constructor(container: Locator, page: Page) {
         this.container = container;
@@ -43,9 +41,6 @@ export default class ChannelsCenterView {
             page.locator('#FlagPostModal div.modal-content'),
             page,
         );
-        this.messageDeleted = (postId: string) =>
-            this.container.locator(`#${postId}_message >> text=(message deleted)`);
-        this.postText = (postID: string) => this.container.locator(`#postMessageText_${postID}`);
     }
 
     async toBeVisible() {
@@ -175,14 +170,5 @@ export default class ChannelsCenterView {
 
         const actualText = await strikethroughText.textContent();
         expect(actualText).toBe(text);
-    }
-
-    async messageDeletedVisible(isVisible: boolean = false, postId: string, message: string) {
-        await expect(this.messageDeleted(postId)).toBeVisible({visible: isVisible});
-        if (!isVisible) {
-            const postMessageText = this.postText(postId);
-            const postMessageTextContent = await postMessageText.textContent();
-            expect(postMessageTextContent).toBe(message);
-        }
     }
 }

--- a/e2e-tests/playwright/specs/functional/channels/content_flagging/flagging/flag-messages.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/content_flagging/flagging/flag-messages.spec.ts
@@ -89,7 +89,8 @@ test('Verify flagged message is hidden by default', async ({pw}) => {
     await flagPostFlow(post, channelsPage, message, FLAG_REASON_INAPPROPRIATE_ALT);
 
     // Verify the message is flagged
-    await channelsPage.centerView.messageDeletedVisible(true, postId, message);
+    const flaggedPost = await channelsPage.centerView.getPostById(postId);
+    await flaggedPost.toContainText('(message deleted)');
     const systemMessage = await channelsPage.getLastPost();
     await expect(systemMessage.body).toContainText(SYSTEM_MESSAGE(user.username));
 });


### PR DESCRIPTION
#### Summary
This failed due to locator not valid when starting in numeric number. Permanent fix should be changing how the ID gets generated `id={isRHS ? undefined : `${post.id}_message`}`. However, it will have significant change due to Cypress usage in several places. Deferring this major change and work around with using better selector (by `.toContainText('(message deleted)')`, more on accessibility selector) 

```
Error: expect(locator).toBeVisible() failed

Locator: getByTestId('channel_view').locator('#69b9w8zx17y6jp3ezr8gt8uzaa_message').locator('text=(message deleted)')
Expected: visible
SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '#69b9w8zx17y6jp3ezr8gt8uzaa_message' is not a valid selector.
```

Other:
- Deleted unnecessary assertion/verification on the lib (`verifyMessageDeleted`)

#### Ticket Link
none

#### Release Note
```release-note
NONE
```