### PR TITLE
E2E/Test: Fix E2E-only PR image tag for release branches

### DIFF
--- a/.github/workflows/e2e-tests-check.yml
+++ b/.github/workflows/e2e-tests-check.yml
@@ -57,9 +57,12 @@ jobs:
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           head_sha: ${{ github.event.pull_request.head.sha }}
+          pr_number: ${{ github.event.pull_request.number }}
 
-      - name: ci/trigger-e2e-with-master-image
-        if: steps.check.outputs.e2e_test_only == 'true'
+      - name: ci/trigger-e2e-with-branch-image
+        if: >-
+          steps.check.outputs.e2e_test_only == 'true' &&
+          (github.event.pull_request.base.ref == 'master' || startsWith(github.event.pull_request.base.ref, 'release-'))
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
#### Summary
- Fix E2E-test-only image tag resolution to use the target branch name (e.g. `release-11.5`) instead of always defaulting to `master`
- For E2E-test-only change, trigger only when PR targets `master` or `release-*` branches

Ref: https://community.mattermost.com/core/pl/fqu7akyx6tn9bc555rfd18fkdo

__Details__
When a PR with E2E-only changes targets a release branch, the `check-e2e-test-only` action was not resolving the base branch because `pr_number` was not passed alongside `base_sha`/`head_sha`. This caused `BASE_REF` to default to `master`, so the docker image tag was always `master` even for release branch PRs.

**Changes:**
1. Pass `pr_number` to the `check-e2e-test-only` action so it can resolve the PR's actual base branch and use the correct image tag (e.g. `release-11.5`)
2. Add a branch guard so E2E-only triggers only fire for PRs targeting `master` or `release-*` branches

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to improve E2E test triggering logic. Enhanced conditions for test execution to require specific branch criteria, ensuring tests run appropriately based on PR base branch configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->