### PR TITLE
Expose popoutRhsPlugin via WebappUtils.popouts for plugin access

### DIFF
--- a/webapp/channels/src/plugins/export.ts
+++ b/webapp/channels/src/plugins/export.ts
@@ -24,7 +24,7 @@ import {ModalIdentifiers} from 'utils/constants';
 import DesktopApp from 'utils/desktop_api';
 import messageHtmlToComponent from 'utils/message_html_to_component';
 import * as NotificationSounds from 'utils/notification_sounds';
-import {sendToParent, onMessageFromParent, isPopoutWindow, canPopout} from 'utils/popouts/popout_windows';
+import {sendToParent, onMessageFromParent, isPopoutWindow, canPopout, popoutRhsPlugin} from 'utils/popouts/popout_windows';
 import {formatText} from 'utils/text_formatting';
 import {useWebSocket, useWebSocketClient, WebSocketContext} from 'utils/use_websocket';
 import {imageURLForUser} from 'utils/utils';
@@ -72,6 +72,7 @@ interface WindowWithLibraries {
             onMessageFromParent: typeof onMessageFromParent;
             isPopoutWindow: typeof isPopoutWindow;
             canPopout: typeof canPopout;
+            popoutRhsPlugin: typeof popoutRhsPlugin;
         };
     };
     loadSharedDependency(request: string): unknown;
@@ -150,6 +151,7 @@ window.WebappUtils = {
         onMessageFromParent,
         isPopoutWindow,
         canPopout,
+        popoutRhsPlugin,
     },
 };
 window.loadSharedDependency = loadSharedDependency;


### PR DESCRIPTION

#### Summary
Allows plugins to programmatically trigger their RHS panel to pop out into a separate window by calling window.WebappUtils.popouts.popoutRhsPlugin().

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-67787

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Added the ability for plugins to programmatically open their RHS panel in a pop-out window
```
