### PR TITLE
Use standard session handler for updateUserAuth endpoint

### DIFF
--- a/server/channels/api4/user.go
+++ b/server/channels/api4/user.go
@@ -61,7 +61,7 @@ func (api *API) InitUser() {
 	api.BaseRoutes.User.Handle("/terms_of_service", api.APISessionRequired(getUserTermsOfService)).Methods(http.MethodGet)
 	api.BaseRoutes.User.Handle("/reset_failed_attempts", api.APISessionRequired(resetPasswordFailedAttempts)).Methods(http.MethodPost)
 
-	api.BaseRoutes.User.Handle("/auth", api.APISessionRequiredTrustRequester(updateUserAuth)).Methods(http.MethodPut)
+	api.BaseRoutes.User.Handle("/auth", api.APISessionRequired(updateUserAuth)).Methods(http.MethodPut)
 
 	api.BaseRoutes.User.Handle("/mfa", api.APISessionRequiredMfa(updateUserMfa)).Methods(http.MethodPut)
 	api.BaseRoutes.User.Handle("/mfa/generate", api.APISessionRequiredMfa(generateMfaSecret)).Methods(http.MethodPost)


### PR DESCRIPTION
## Summary

- Update the `PUT /api/v4/users/{user_id}/auth` endpoint to use `APISessionRequired` handler
- This aligns the endpoint with other similar JSON API endpoints

## Details

The `/auth` endpoint was using `APISessionRequiredTrustRequester`, which is intended for resources that may be requested directly by the browser (e.g., images, file downloads). Since this is a standard JSON API endpoint called via XHR/fetch, it should use the standard `APISessionRequired` handler like other user modification endpoints.

Made with [Cursor](https://cursor.com)

#### Release Note
```release-note
Improved security hardening for the user authentication update API endpoint.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication requirements for the user authentication endpoint to use standard session-based access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


