### PR TITLE
[MM-64797] implement property field seatch within access control policies

### DIFF
--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -635,6 +635,27 @@ func (s *RetryLayerAccessControlPolicyStore) Get(rctx request.CTX, id string) (*
 
 }
 
+func (s *RetryLayerAccessControlPolicyStore) GetPoliciesByFieldID(rctx request.CTX, fieldID string) ([]*model.AccessControlPolicy, error) {
+
+	tries := 0
+	for {
+		result, err := s.AccessControlPolicyStore.GetPoliciesByFieldID(rctx, fieldID)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerAccessControlPolicyStore) Save(rctx request.CTX, policy *model.AccessControlPolicy) (*model.AccessControlPolicy, error) {
 
 	tries := 0

--- a/server/channels/store/sqlstore/access_control_policy_store.go
+++ b/server/channels/store/sqlstore/access_control_policy_store.go
@@ -689,3 +689,36 @@ func (s *SqlAccessControlPolicyStore) SearchPolicies(rctx request.CTX, opts mode
 
 	return policies, total, nil
 }
+
+// GetPoliciesByFieldID finds all policies whose CEL rule expressions reference the
+// given property field ID. It performs a text search on the serialized JSONB Data
+// column for the pattern "id_<fieldID>", which is how property fields are referenced
+// in CEL expressions (e.g., user.attributes.id_<fieldID>).
+//
+// This is a sequential scan over the policies table. At the expected scale (hundreds
+// to low thousands of admin-configured policies) this is well under 1ms.
+// If the table grows beyond ~10K rows or this query lands on a hot path, a GIN
+// trigram index on (Data::text) can accelerate it with no query changes.
+func (s *SqlAccessControlPolicyStore) GetPoliciesByFieldID(_ request.CTX, fieldID string) ([]*model.AccessControlPolicy, error) {
+	if !model.IsValidId(fieldID) {
+		return nil, store.NewErrInvalidInput("AccessControlPolicy", "fieldID", fieldID)
+	}
+
+	p := []storeAccessControlPolicy{}
+	query := s.selectQueryBuilder.Where(sq.Expr("Data::text LIKE ?", fmt.Sprintf("%%id\\_%s%%", fieldID)))
+
+	err := s.GetReplica().SelectBuilder(&p, query)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to find policies referencing field id=%s", fieldID)
+	}
+
+	policies := make([]*model.AccessControlPolicy, len(p))
+	for i := range p {
+		policies[i], err = p[i].toModel()
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse policy with id=%s", p[i].ID)
+		}
+	}
+
+	return policies, nil
+}

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -1150,6 +1150,7 @@ type AccessControlPolicyStore interface {
 	SetActiveStatusMultiple(rctx request.CTX, list []model.AccessControlPolicyActiveUpdate) ([]*model.AccessControlPolicy, error)
 	Get(rctx request.CTX, id string) (*model.AccessControlPolicy, error)
 	SearchPolicies(rctx request.CTX, opts model.AccessControlPolicySearch) ([]*model.AccessControlPolicy, int64, error)
+	GetPoliciesByFieldID(rctx request.CTX, fieldID string) ([]*model.AccessControlPolicy, error)
 }
 
 type AttributesStore interface {

--- a/server/channels/store/storetest/access_control_policy_store.go
+++ b/server/channels/store/storetest/access_control_policy_store.go
@@ -4,6 +4,7 @@
 package storetest
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -19,6 +20,7 @@ func TestAccessControlPolicyStore(t *testing.T, rctx request.CTX, ss store.Store
 	t.Run("SetActiveMultiple", func(t *testing.T) { testAccessControlPolicyStoreSetActiveMultiple(t, rctx, ss) })
 	t.Run("GetAll", func(t *testing.T) { testAccessControlPolicyStoreGetAll(t, rctx, ss) })
 	t.Run("Search", func(t *testing.T) { testAccessControlPolicyStoreSearch(t, rctx, ss) })
+	t.Run("GetPoliciesByFieldID", func(t *testing.T) { testAccessControlPolicyStoreGetPoliciesByFieldID(t, rctx, ss) })
 }
 
 func testAccessControlPolicyStoreSaveAndGet(t *testing.T, rctx request.CTX, ss store.Store) {
@@ -541,5 +543,148 @@ func testAccessControlPolicyStoreSetActiveMultiple(t *testing.T, rctx request.CT
 		require.NoError(t, err)
 		require.NotNil(t, p2)
 		require.True(t, p2.Active)
+	})
+}
+
+func testAccessControlPolicyStoreGetPoliciesByFieldID(t *testing.T, rctx request.CTX, ss store.Store) {
+	fieldA := model.NewId()
+	fieldB := model.NewId()
+
+	makePolicy := func(t *testing.T, expression string) *model.AccessControlPolicy {
+		t.Helper()
+		policy := &model.AccessControlPolicy{
+			ID:       model.NewId(),
+			Name:     "Policy",
+			Type:     model.AccessControlPolicyTypeParent,
+			Active:   true,
+			Revision: 1,
+			Version:  model.AccessControlPolicyVersionV0_2,
+			Imports:  []string{},
+			Rules: []model.AccessControlPolicyRule{
+				{
+					Actions:    []string{"*"},
+					Expression: expression,
+				},
+			},
+		}
+		saved, err := ss.AccessControlPolicy().Save(rctx, policy)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = ss.AccessControlPolicy().Delete(rctx, saved.ID)
+		})
+		return saved
+	}
+
+	t.Run("Single policy matches", func(t *testing.T) {
+		p := makePolicy(t, fmt.Sprintf("user.attributes.id_%s == \"Engineering\"", fieldA))
+
+		policies, err := ss.AccessControlPolicy().GetPoliciesByFieldID(rctx, fieldA)
+		require.NoError(t, err)
+		require.Len(t, policies, 1)
+		require.Equal(t, p.ID, policies[0].ID)
+	})
+
+	t.Run("Multiple policies match same field", func(t *testing.T) {
+		sharedField := model.NewId()
+		p1 := makePolicy(t, fmt.Sprintf("user.attributes.id_%s == \"Engineering\"", sharedField))
+		p2 := makePolicy(t, fmt.Sprintf("user.attributes.id_%s == \"Sales\"", sharedField))
+
+		policies, err := ss.AccessControlPolicy().GetPoliciesByFieldID(rctx, sharedField)
+		require.NoError(t, err)
+		require.Len(t, policies, 2)
+
+		ids := []string{policies[0].ID, policies[1].ID}
+		require.Contains(t, ids, p1.ID)
+		require.Contains(t, ids, p2.ID)
+	})
+
+	t.Run("No policies match", func(t *testing.T) {
+		policies, err := ss.AccessControlPolicy().GetPoliciesByFieldID(rctx, model.NewId())
+		require.NoError(t, err)
+		require.Empty(t, policies)
+	})
+
+	t.Run("Multiple fields in one expression", func(t *testing.T) {
+		expr := fmt.Sprintf("user.attributes.id_%s == \"x\" && user.attributes.id_%s == \"y\"", fieldA, fieldB)
+		makePolicy(t, expr)
+
+		policiesA, err := ss.AccessControlPolicy().GetPoliciesByFieldID(rctx, fieldA)
+		require.NoError(t, err)
+		require.Len(t, policiesA, 1)
+
+		policiesB, err := ss.AccessControlPolicy().GetPoliciesByFieldID(rctx, fieldB)
+		require.NoError(t, err)
+		require.Len(t, policiesB, 1)
+
+		unusedField := model.NewId()
+		policiesC, err := ss.AccessControlPolicy().GetPoliciesByFieldID(rctx, unusedField)
+		require.NoError(t, err)
+		require.Empty(t, policiesC)
+	})
+
+	t.Run("Field removed after policy update", func(t *testing.T) {
+		updatableField := model.NewId()
+		replacementField := model.NewId()
+
+		p := makePolicy(t, fmt.Sprintf("user.attributes.id_%s == \"v1\"", updatableField))
+
+		policies, err := ss.AccessControlPolicy().GetPoliciesByFieldID(rctx, updatableField)
+		require.NoError(t, err)
+		require.Len(t, policies, 1)
+
+		p.Rules = []model.AccessControlPolicyRule{
+			{
+				Actions:    []string{"*"},
+				Expression: fmt.Sprintf("user.attributes.id_%s == \"v2\"", replacementField),
+			},
+		}
+		_, err = ss.AccessControlPolicy().Save(rctx, p)
+		require.NoError(t, err)
+
+		policies, err = ss.AccessControlPolicy().GetPoliciesByFieldID(rctx, updatableField)
+		require.NoError(t, err)
+		require.Empty(t, policies)
+
+		policies, err = ss.AccessControlPolicy().GetPoliciesByFieldID(rctx, replacementField)
+		require.NoError(t, err)
+		require.Len(t, policies, 1)
+	})
+
+	t.Run("Deleted policy no longer matches", func(t *testing.T) {
+		deletableField := model.NewId()
+		policy := &model.AccessControlPolicy{
+			ID:       model.NewId(),
+			Name:     "Policy",
+			Type:     model.AccessControlPolicyTypeParent,
+			Active:   true,
+			Revision: 1,
+			Version:  model.AccessControlPolicyVersionV0_2,
+			Imports:  []string{},
+			Rules: []model.AccessControlPolicyRule{
+				{
+					Actions:    []string{"*"},
+					Expression: fmt.Sprintf("user.attributes.id_%s == \"test\"", deletableField),
+				},
+			},
+		}
+		saved, err := ss.AccessControlPolicy().Save(rctx, policy)
+		require.NoError(t, err)
+
+		policies, err := ss.AccessControlPolicy().GetPoliciesByFieldID(rctx, deletableField)
+		require.NoError(t, err)
+		require.Len(t, policies, 1)
+
+		err = ss.AccessControlPolicy().Delete(rctx, saved.ID)
+		require.NoError(t, err)
+
+		policies, err = ss.AccessControlPolicy().GetPoliciesByFieldID(rctx, deletableField)
+		require.NoError(t, err)
+		require.Empty(t, policies)
+	})
+
+	t.Run("Invalid field ID returns error", func(t *testing.T) {
+		policies, err := ss.AccessControlPolicy().GetPoliciesByFieldID(rctx, "invalid")
+		require.Error(t, err)
+		require.Nil(t, policies)
 	})
 }

--- a/server/channels/store/storetest/mocks/AccessControlPolicyStore.go
+++ b/server/channels/store/storetest/mocks/AccessControlPolicyStore.go
@@ -63,6 +63,36 @@ func (_m *AccessControlPolicyStore) Get(rctx request.CTX, id string) (*model.Acc
 	return r0, r1
 }
 
+// GetPoliciesByFieldID provides a mock function with given fields: rctx, fieldID
+func (_m *AccessControlPolicyStore) GetPoliciesByFieldID(rctx request.CTX, fieldID string) ([]*model.AccessControlPolicy, error) {
+	ret := _m.Called(rctx, fieldID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPoliciesByFieldID")
+	}
+
+	var r0 []*model.AccessControlPolicy
+	var r1 error
+	if rf, ok := ret.Get(0).(func(request.CTX, string) ([]*model.AccessControlPolicy, error)); ok {
+		return rf(rctx, fieldID)
+	}
+	if rf, ok := ret.Get(0).(func(request.CTX, string) []*model.AccessControlPolicy); ok {
+		r0 = rf(rctx, fieldID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.AccessControlPolicy)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(request.CTX, string) error); ok {
+		r1 = rf(rctx, fieldID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Save provides a mock function with given fields: rctx, policy
 func (_m *AccessControlPolicyStore) Save(rctx request.CTX, policy *model.AccessControlPolicy) (*model.AccessControlPolicy, error) {
 	ret := _m.Called(rctx, policy)

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -613,6 +613,22 @@ func (s *TimerLayerAccessControlPolicyStore) Get(rctx request.CTX, id string) (*
 	return result, err
 }
 
+func (s *TimerLayerAccessControlPolicyStore) GetPoliciesByFieldID(rctx request.CTX, fieldID string) ([]*model.AccessControlPolicy, error) {
+	start := time.Now()
+
+	result, err := s.AccessControlPolicyStore.GetPoliciesByFieldID(rctx, fieldID)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("AccessControlPolicyStore.GetPoliciesByFieldID", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerAccessControlPolicyStore) Save(rctx request.CTX, policy *model.AccessControlPolicy) (*model.AccessControlPolicy, error) {
 	start := time.Now()
 

--- a/server/einterfaces/mocks/AccessControlServiceInterface.go
+++ b/server/einterfaces/mocks/AccessControlServiceInterface.go
@@ -161,6 +161,38 @@ func (_m *AccessControlServiceInterface) GetChannelMembersToRemove(rctx request.
 	return r0, r1
 }
 
+// GetPoliciesForFieldIDs provides a mock function with given fields: rctx, fieldIDs
+func (_m *AccessControlServiceInterface) GetPoliciesForFieldIDs(rctx request.CTX, fieldIDs []string) ([]*model.AccessControlPolicy, *model.AppError) {
+	ret := _m.Called(rctx, fieldIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPoliciesForFieldIDs")
+	}
+
+	var r0 []*model.AccessControlPolicy
+	var r1 *model.AppError
+	if rf, ok := ret.Get(0).(func(request.CTX, []string) ([]*model.AccessControlPolicy, *model.AppError)); ok {
+		return rf(rctx, fieldIDs)
+	}
+	if rf, ok := ret.Get(0).(func(request.CTX, []string) []*model.AccessControlPolicy); ok {
+		r0 = rf(rctx, fieldIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.AccessControlPolicy)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(request.CTX, []string) *model.AppError); ok {
+		r1 = rf(rctx, fieldIDs)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // GetPolicy provides a mock function with given fields: rctx, id
 func (_m *AccessControlServiceInterface) GetPolicy(rctx request.CTX, id string) (*model.AccessControlPolicy, *model.AppError) {
 	ret := _m.Called(rctx, id)

--- a/server/einterfaces/mocks/PolicyAdministrationPointInterface.go
+++ b/server/einterfaces/mocks/PolicyAdministrationPointInterface.go
@@ -131,6 +131,38 @@ func (_m *PolicyAdministrationPointInterface) GetChannelMembersToRemove(rctx req
 	return r0, r1
 }
 
+// GetPoliciesForFieldIDs provides a mock function with given fields: rctx, fieldIDs
+func (_m *PolicyAdministrationPointInterface) GetPoliciesForFieldIDs(rctx request.CTX, fieldIDs []string) ([]*model.AccessControlPolicy, *model.AppError) {
+	ret := _m.Called(rctx, fieldIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPoliciesForFieldIDs")
+	}
+
+	var r0 []*model.AccessControlPolicy
+	var r1 *model.AppError
+	if rf, ok := ret.Get(0).(func(request.CTX, []string) ([]*model.AccessControlPolicy, *model.AppError)); ok {
+		return rf(rctx, fieldIDs)
+	}
+	if rf, ok := ret.Get(0).(func(request.CTX, []string) []*model.AccessControlPolicy); ok {
+		r0 = rf(rctx, fieldIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.AccessControlPolicy)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(request.CTX, []string) *model.AppError); ok {
+		r1 = rf(rctx, fieldIDs)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // GetPolicy provides a mock function with given fields: rctx, id
 func (_m *PolicyAdministrationPointInterface) GetPolicy(rctx request.CTX, id string) (*model.AccessControlPolicy, *model.AppError) {
 	ret := _m.Called(rctx, id)

--- a/server/einterfaces/pap.go
+++ b/server/einterfaces/pap.go
@@ -39,4 +39,7 @@ type PolicyAdministrationPointInterface interface {
 	GetPolicy(rctx request.CTX, id string) (*model.AccessControlPolicy, *model.AppError)
 	// DeletePolicy deletes the access control policy with the given ID.
 	DeletePolicy(rctx request.CTX, id string) *model.AppError
+	// GetPoliciesForFieldIDs returns the policies that reference any of the given
+	// property field IDs in their CEL rule expressions.
+	GetPoliciesForFieldIDs(rctx request.CTX, fieldIDs []string) ([]*model.AccessControlPolicy, *model.AppError)
 }

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -6979,6 +6979,10 @@
     "translation": "Could not get channel members to remove."
   },
   {
+    "id": "app.pap.get_policies_for_field_ids.app_error",
+    "translation": "Could not get policies for the given field IDs."
+  },
+  {
     "id": "app.pap.get_policy.app_error",
     "translation": "Unable to retrieve the access control policy."
   },


### PR DESCRIPTION
#### Summary
Add the ability to find access control policies that reference a given property field ID. This enables querying "which policies use this field?" by searching the JSONB `Data` column for `id_<field_id>` patterns in CEL rule expressions.
Changes:
- Add `GetPoliciesByFieldID` to the `AccessControlPolicyStore` interface and implement it using a `Data::text LIKE` query against the existing JSONB column — no new tables or migrations needed.
- Add `GetPoliciesForFieldIDs` to the `PolicyAdministrationPointInterface` for enterprise implementation.
- Store-level tests covering: single match, multiple matches, no match, multi-field expressions, field removed on update, deleted policy, and invalid input.

Companion PR: https://github.com/mattermost/enterprise/pull/2090

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-64797
#### Screenshots
N/A — no UI changes.
#### Release Note
```release-note
NONE
```