### PR TITLE
Agent bug fixing workflow

### DIFF
--- a/webapp/channels/src/components/create_recap_modal/recap_configuration.test.tsx
+++ b/webapp/channels/src/components/create_recap_modal/recap_configuration.test.tsx
@@ -239,7 +239,8 @@ describe('RecapConfiguration', () => {
         it('should show description for all unreads option', () => {
             renderWithContext(<RecapConfiguration {...defaultProps}/>);
 
-            expect(screen.getByText('Copilot will create a recap of all unreads across your channels.')).toBeInTheDocument();
+            expect(screen.getByText('Create a recap of all unread messages across your channels.')).toBeInTheDocument();
+            expect(screen.queryByText('Copilot will create a recap of all unreads across your channels.')).not.toBeInTheDocument();
         });
     });
 });

--- a/webapp/channels/src/components/create_recap_modal/recap_configuration.tsx
+++ b/webapp/channels/src/components/create_recap_modal/recap_configuration.tsx
@@ -43,7 +43,7 @@ const RecapConfiguration = ({recapName, setRecapName, recapType, setRecapType, u
                 <div className='recap-type-card-description'>
                     <FormattedMessage
                         id='recaps.modal.allUnreadsDesc'
-                        defaultMessage='Copilot will create a recap of all unreads across your channels.'
+                        defaultMessage='Create a recap of all unread messages across your channels.'
                     />
                 </div>
             </div>

--- a/webapp/channels/src/i18n/en-AU.json
+++ b/webapp/channels/src/i18n/en-AU.json
@@ -5730,7 +5730,7 @@
   "recaps.messageCount": "Recapped {count} {count, plural, one {message} other {messages}}",
   "recaps.modal.allChannels": "ALL CHANNELS",
   "recaps.modal.allUnreads": "Recap all my unreads",
-  "recaps.modal.allUnreadsDesc": "Copilot will create a recap of all unreads across your channels.",
+  "recaps.modal.allUnreadsDesc": "Create a recap of all unread messages across your channels.",
   "recaps.modal.error.createFailed": "Failed to create recap. Please try again.",
   "recaps.modal.error.noBot": "Please select an AI agent.",
   "recaps.modal.error.noChannels": "Please select at least one channel.",

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -5745,7 +5745,7 @@
   "recaps.messageCount": "Recapped {count} {count, plural, one {message} other {messages}}",
   "recaps.modal.allChannels": "ALL CHANNELS",
   "recaps.modal.allUnreads": "Recap all my unreads",
-  "recaps.modal.allUnreadsDesc": "Copilot will create a recap of all unreads across your channels.",
+  "recaps.modal.allUnreadsDesc": "Create a recap of all unread messages across your channels.",
   "recaps.modal.error.createFailed": "Failed to create recap. Please try again.",
   "recaps.modal.error.noBot": "Please select an AI agent.",
   "recaps.modal.error.noChannels": "Please select at least one channel.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Removes the hardcoded "Copilot" mention from the "Recap all my unreads" description in the create recap modal. This updates the UI text, its corresponding unit test, and the English locale files. The fix was verified through both unit tests and a headless Playwright browser session.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-67794

#### Screenshots
This PR includes a UI text change.
| before | after |
|---|---|
| "Copilot will create a recap of all unreads across your channels." | "Create a recap of all unread messages across your channels." |

#### Release Note
```release-note
Removed hardcoded 'Copilot' mention from the 'Recap all my unreads' description in the create recap modal.
```

---
<p><a href="https://cursor.com/agents/bc-c397baa9-0d8d-4c9f-9dbd-ead9dafa0371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c397baa9-0d8d-4c9f-9dbd-ead9dafa0371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->