### PR TITLE
MM-67540: Align ES backfill throttle to 10k req/sec

### DIFF
--- a/server/enterprise/elasticsearch/elasticsearch/elasticsearch.go
+++ b/server/enterprise/elasticsearch/elasticsearch/elasticsearch.go
@@ -863,8 +863,9 @@ func (es *ElasticsearchInterfaceImpl) BackfillPostsChannelType(rctx request.CTX,
 		return model.NewAppError("Elasticsearch.BackfillPostsChannelType", "ent.elasticsearch.backfill_posts_channel_type.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError).Wrap(jsonErr)
 	}
 
+	requestsPerSecond := "10000"
 	response, err := es.client.UpdateByQuery(strings.Join(postIndexes, ",")).
-		RequestsPerSecond("1000").
+		RequestsPerSecond(requestsPerSecond).
 		Request(&updatebyquery.Request{
 			Query: query,
 			Script: &types.Script{


### PR DESCRIPTION
## Summary
- Fixes inconsistency in backfill throttle rate between Elasticsearch and OpenSearch implementations
- OpenSearch was set to 10,000 requests/sec but Elasticsearch was set to 1,000
- Aligns both to 10,000 requests/sec

Follow-up fix for #35298.

## Ticket Link
https://mattermost.atlassian.net/browse/MM-67540

#### Release Note

```release-note
NONE
```