### PR TITLE
MM-67795 Fix Recaps sidebar icon alignment

### DIFF
--- a/webapp/channels/src/components/recaps_link/recaps_link.scss
+++ b/webapp/channels/src/components/recaps_link/recaps_link.scss
@@ -44,6 +44,10 @@
             margin-right: 4px;
             font-size: 18px;
             opacity: 0.64;
+
+            svg {
+                vertical-align: middle;
+            }
         }
 
         .SidebarChannelLinkLabel_wrapper {


### PR DESCRIPTION
#### Summary
Fixed the Recaps sidebar icon alignment by vertically centering the SVG icon so it matches neighboring sidebar items like Threads and Drafts.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-67795

#### Screenshots
| before | after |
|--------|-------|
| ![before](https://cursor-plugin-pr-assets.s3.amazonaws.com/cursor/mm-67795-bug-fix-2196/MM-67795-before.png) | ![after](https://cursor-plugin-pr-assets.s3.amazonaws.com/cursor/mm-67795-bug-fix-2196/MM-67795-after.png) |

#### Release Note
```release-note
Fixed a visual issue where the Recaps sidebar icon was vertically misaligned with its label.
```
