### PR TITLE
[MM-67626] Update Playbooks plugin to v2.8.0

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -174,7 +174,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # download the package from to work. This will no longer be needed when we unify
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
-	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.7.0%2B1031c5e-fips
+	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.8.0%2Bc4449ac-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v1.7.2%2B866e2dd-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.2%2B4282c63-fips
 endif


### PR DESCRIPTION
#### Summary
Update the bundled Playbooks plugin from v2.7.0 to v2.8.0.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-67626

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```

Playbooks [v2.8.0 release](https://github.com/mattermost/mattermost-plugin-playbooks/releases/tag/v2.8.0)