### PR TITLE
Fix Copilot mention in recap all-unreads copy

### DIFF
--- a/webapp/channels/src/components/create_recap_modal/recap_configuration.test.tsx
+++ b/webapp/channels/src/components/create_recap_modal/recap_configuration.test.tsx
@@ -239,7 +239,7 @@ describe('RecapConfiguration', () => {
         it('should show description for all unreads option', () => {
             renderWithContext(<RecapConfiguration {...defaultProps}/>);
 
-            expect(screen.getByText('Copilot will create a recap of all unreads across your channels.')).toBeInTheDocument();
+            expect(screen.getByText('Create a recap of all unread messages across your channels.')).toBeInTheDocument();
         });
     });
 });

--- a/webapp/channels/src/components/create_recap_modal/recap_configuration.tsx
+++ b/webapp/channels/src/components/create_recap_modal/recap_configuration.tsx
@@ -43,7 +43,7 @@ const RecapConfiguration = ({recapName, setRecapName, recapType, setRecapType, u
                 <div className='recap-type-card-description'>
                     <FormattedMessage
                         id='recaps.modal.allUnreadsDesc'
-                        defaultMessage='Copilot will create a recap of all unreads across your channels.'
+                        defaultMessage='Create a recap of all unread messages across your channels.'
                     />
                 </div>
             </div>

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -5757,7 +5757,7 @@
   "recaps.messageCount": "Recapped {count} {count, plural, one {message} other {messages}}",
   "recaps.modal.allChannels": "ALL CHANNELS",
   "recaps.modal.allUnreads": "Recap all my unreads",
-  "recaps.modal.allUnreadsDesc": "Copilot will create a recap of all unreads across your channels.",
+  "recaps.modal.allUnreadsDesc": "Create a recap of all unread messages across your channels.",
   "recaps.modal.error.createFailed": "Failed to create recap. Please try again.",
   "recaps.modal.error.noBot": "Please select an AI agent.",
   "recaps.modal.error.noChannels": "Please select at least one channel.",


### PR DESCRIPTION
#### Summary
Removes the hardcoded Copilot mention from the "Recap all my unreads" option and replaces it with generic copy. Updates the matching unit test and English message catalog entry.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-67794

#### Screenshots
| before | after |
|--------|-------|
| ![before](https://cursor-plugin-pr-assets.s3.amazonaws.com/cursor/mm-67794-bug-fix-3833/before.webp) | ![after](https://cursor-plugin-pr-assets.s3.amazonaws.com/cursor/mm-67794-bug-fix-3833/after.webp) |

#### Release Note
```release-note
Fixed incorrect "Copilot" copy shown in the Create Recap modal for the "Recap all my unreads" option.
```
