### PR TITLE
Fix duplicate LHS selection on Recaps

### DIFF
--- a/webapp/channels/src/components/recaps/recaps.test.tsx
+++ b/webapp/channels/src/components/recaps/recaps.test.tsx
@@ -1,0 +1,74 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {MemoryRouter} from 'react-router-dom';
+
+import {renderWithContext} from 'tests/react_testing_utils';
+
+import {LhsItemType, LhsPage} from 'types/store/lhs';
+
+import Recaps from './recaps';
+
+const mockDispatch = jest.fn();
+const mockGetAgents = jest.fn(() => ({type: 'GET_AGENTS'}));
+const mockGetRecaps = jest.fn((page: number, perPage: number) => ({type: 'GET_RECAPS', meta: {page, perPage}}));
+const mockSelectLhsItem = jest.fn((type: string, id?: string) => {
+    return {type: 'SELECT_LHS_ITEM', meta: {lhsType: type, id}};
+});
+
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux') as typeof import('react-redux'),
+    useDispatch: () => mockDispatch,
+    useSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
+jest.mock('mattermost-redux/actions/agents', () => ({
+    getAgents: () => mockGetAgents(),
+}));
+
+jest.mock('mattermost-redux/actions/recaps', () => ({
+    getRecaps: (page: number, perPage: number) => mockGetRecaps(page, perPage),
+}));
+
+jest.mock('mattermost-redux/selectors/entities/recaps', () => ({
+    getUnreadRecaps: jest.fn(() => []),
+    getReadRecaps: jest.fn(() => []),
+}));
+
+jest.mock('actions/views/lhs', () => ({
+    selectLhsItem: (type: string, id?: string) => mockSelectLhsItem(type, id),
+}));
+
+jest.mock('actions/views/modals', () => ({
+    openModal: jest.fn(() => ({type: 'OPEN_MODAL'})),
+}));
+
+jest.mock('components/common/hooks/useGetAgentsBridgeEnabled', () => jest.fn(() => ({available: true})));
+jest.mock('components/common/hooks/useGetFeatureFlagValue', () => jest.fn(() => 'true'));
+jest.mock('components/create_recap_modal', () => () => <div data-testid='create-recap-modal'/>);
+jest.mock('./recaps_list', () => ({__esModule: true, default: () => <div data-testid='recaps-list'/>}));
+
+describe('components/recaps/Recaps', () => {
+    beforeEach(() => {
+        mockDispatch.mockClear();
+        mockGetAgents.mockClear();
+        mockGetRecaps.mockClear();
+        mockSelectLhsItem.mockClear();
+    });
+
+    test('selects Recaps in the LHS on mount', () => {
+        renderWithContext(
+            <MemoryRouter>
+                <Recaps/>
+            </MemoryRouter>,
+        );
+
+        expect(mockSelectLhsItem).toHaveBeenCalledWith(LhsItemType.Page, LhsPage.Recaps);
+        expect(mockGetRecaps).toHaveBeenCalledWith(0, 60);
+        expect(mockGetAgents).toHaveBeenCalled();
+        expect(mockDispatch).toHaveBeenCalledWith(expect.objectContaining({type: 'SELECT_LHS_ITEM'}));
+        expect(mockDispatch).toHaveBeenCalledWith(expect.objectContaining({type: 'GET_RECAPS'}));
+        expect(mockDispatch).toHaveBeenCalledWith({type: 'GET_AGENTS'});
+    });
+});

--- a/webapp/channels/src/components/recaps/recaps.tsx
+++ b/webapp/channels/src/components/recaps/recaps.tsx
@@ -12,6 +12,7 @@ import {getAgents} from 'mattermost-redux/actions/agents';
 import {getRecaps} from 'mattermost-redux/actions/recaps';
 import {getUnreadRecaps, getReadRecaps} from 'mattermost-redux/selectors/entities/recaps';
 
+import {selectLhsItem} from 'actions/views/lhs';
 import {openModal} from 'actions/views/modals';
 
 import useGetAgentsBridgeEnabled from 'components/common/hooks/useGetAgentsBridgeEnabled';
@@ -19,6 +20,8 @@ import useGetFeatureFlagValue from 'components/common/hooks/useGetFeatureFlagVal
 import CreateRecapModal from 'components/create_recap_modal';
 
 import {ModalIdentifiers} from 'utils/constants';
+
+import {LhsItemType, LhsPage} from 'types/store/lhs';
 
 import RecapsList from './recaps_list';
 
@@ -35,6 +38,7 @@ const Recaps = () => {
     const readRecaps = useSelector(getReadRecaps);
 
     useEffect(() => {
+        dispatch(selectLhsItem(LhsItemType.Page, LhsPage.Recaps));
         dispatch(getRecaps(0, 60));
         dispatch(getAgents());
     }, [dispatch]);

--- a/webapp/channels/src/types/store/lhs.ts
+++ b/webapp/channels/src/types/store/lhs.ts
@@ -20,6 +20,7 @@ export enum LhsItemType {
 
 export enum LhsPage {
     Drafts = 'drafts',
+    Recaps = 'recaps',
     Threads = 'threads',
 }
 


### PR DESCRIPTION
#### Summary
- Clear the previously selected channel when the Recaps page mounts so the left-hand sidebar only highlights Recaps.
- Add unit coverage for the Recaps mount behavior.
- Verify in the browser that navigating from a selected channel into Recaps no longer leaves a duplicate active section in the LHS.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-67811

#### Screenshots
| before | after |
|--------|-------|
| ![before](https://cursor-plugin-pr-assets.s3.amazonaws.com/cursor/agent-bug-fixing-df0d/before.webp) | ![after](https://cursor-plugin-pr-assets.s3.amazonaws.com/cursor/agent-bug-fixing-df0d/after.webp) |

#### Release Note
```release-note
Fixed an issue where opening Recaps could leave the previously selected channel highlighted in the left-hand sidebar.
```
