### PR TITLE
Bumping prepackaged MS Teams Meetings plugin version to 2.4.1 (#35564)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -165,7 +165,7 @@ PLUGIN_PACKAGES += mattermost-plugin-agents-v1.7.2
 PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.2
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.5.0
-PLUGIN_PACKAGES += mattermost-plugin-msteams-meetings-v2.4.0
+PLUGIN_PACKAGES += mattermost-plugin-msteams-meetings-v2.4.1
 PLUGIN_PACKAGES += mattermost-plugin-metrics-v0.7.0
 PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 


### PR DESCRIPTION
Cherry pick of #35564 on release-11.5.

```release-note
NONE
```