### PR TITLE
[MM-67797] Send updated title template for popouts when state changes

### DIFF
--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -11,7 +11,7 @@
     "@giphy/react-components": "10.1.0",
     "@guyplusplus/turndown-plugin-gfm": "1.0.7",
     "@mattermost/client": "11.6.0",
-    "@mattermost/desktop-api": "6.0.0-1",
+    "@mattermost/desktop-api": "6.2.0-1",
     "@mattermost/shared": "11.6.0",
     "@mattermost/types": "11.6.0",
     "@mui/base": "5.0.0-alpha.127",

--- a/webapp/channels/src/utils/desktop_api.ts
+++ b/webapp/channels/src/utils/desktop_api.ts
@@ -286,6 +286,7 @@ export class DesktopAppAPI {
 
     sendToParentWindow = (channel: string, ...args: unknown[]) => window.desktopAPI?.sendToParent?.(channel, ...args);
     sendToPopoutWindow = (id: string, channel: string, ...args: unknown[]) => window.desktopAPI?.sendToPopout?.(id, channel, ...args);
+    updatePopoutTitleTemplate = (template: string) => window.desktopAPI?.updatePopoutTitleTemplate?.(template);
 
     /*********************************************************************
      * Helper functions for legacy code

--- a/webapp/channels/src/utils/popouts/use_popout_title.ts
+++ b/webapp/channels/src/utils/popouts/use_popout_title.ts
@@ -9,6 +9,7 @@ import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
+import DesktopApp from 'utils/desktop_api';
 import {isDesktopApp} from 'utils/user_agent';
 
 export default function usePopoutTitle(titleTemplate: MessageDescriptor, params?: Record<string, string>) {
@@ -16,6 +17,18 @@ export default function usePopoutTitle(titleTemplate: MessageDescriptor, params?
     const siteName = useSelector(getConfig).SiteName;
     const currentChannel = useSelector(getCurrentChannel);
     const currentTeam = useSelector(getCurrentTeam);
+
+    useEffect(() => {
+        if (!isDesktopApp()) {
+            return;
+        }
+        DesktopApp.updatePopoutTitleTemplate(intl.formatMessage(titleTemplate, {
+            serverName: '{serverName}',
+            channelName: '{channelName}',
+            teamName: '{teamName}',
+            ...params,
+        }));
+    }, [intl, titleTemplate, params]);
 
     useEffect(() => {
         if (isDesktopApp()) {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -65,7 +65,7 @@
         "@giphy/react-components": "10.1.0",
         "@guyplusplus/turndown-plugin-gfm": "1.0.7",
         "@mattermost/client": "11.6.0",
-        "@mattermost/desktop-api": "6.0.0-1",
+        "@mattermost/desktop-api": "6.2.0-1",
         "@mattermost/shared": "11.6.0",
         "@mattermost/types": "11.6.0",
         "@mui/base": "5.0.0-alpha.127",
@@ -4530,7 +4530,9 @@
       "link": true
     },
     "node_modules/@mattermost/desktop-api": {
-      "version": "6.0.0-1",
+      "version": "6.2.0-1",
+      "resolved": "https://registry.npmjs.org/@mattermost/desktop-api/-/desktop-api-6.2.0-1.tgz",
+      "integrity": "sha512-/C6FXZMskBtCBDqnqwc78IeCtDaf2SsC5FjhDdO6dx57gbYsGjVWi+mBfWqxkZGwjMX4nS4Eh6jb9uFGnOTxag==",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^4.3.0 || ^5.0.0"


### PR DESCRIPTION
#### Summary
Web App companion to https://github.com/mattermost/desktop/pull/3734. This PR consumes the new endpoint and calls it when the title template changes on popouts.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67797

#### Release Note
```release-note
Fixed an issue where popouts changing state do not update the title on Desktop App
```

## Change Impact: 🟢 Low

**Reasoning:** The changes are additive and isolated to desktop popout title synchronization. Existing non-desktop behavior remains completely unchanged, and the new functionality is properly gated by platform detection.

**Regression Risk:** Very low. The modification consists entirely of new code paths with no changes to existing implementations. The non-desktop code path (document.title updates) is untouched. The desktop path uses defensive optional chaining (`window.desktopAPI?.updatePopoutTitleTemplate?.()`) to safely delegate to the desktop API. The two useEffect hooks in `use_popout_title.ts` are explicitly separated by `isDesktopApp()` conditions, ensuring no interaction between desktop and non-desktop flows.

**QA Recommendation:** Minimal manual QA required for desktop environments only. Test focus: verify popout window titles update correctly when popout state changes on the desktop app. Web app title behavior (document.title in browser) requires no regression testing as it is untouched. Skipping manual QA poses negligible risk given the isolated, gated nature of the changes and defensive coding patterns used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->