### PR TITLE
Automated cherry pick of #34864

### DIFF
--- a/server/platform/services/remotecluster/recv.go
+++ b/server/platform/services/remotecluster/recv.go
@@ -71,6 +71,9 @@ func (rcs *Service) ReceiveInviteConfirmation(confirm model.RemoteClusterInvite)
 
 	// If the accepting cluster sent a RefreshedToken (its RemoteToken), set it as our Token
 	if confirm.Version >= 2 && confirm.RefreshedToken != "" {
+		if confirm.RefreshedToken == rc.Token {
+			return nil, fmt.Errorf("cannot accept invite confirmation for remote %s: RefreshedToken must be different from the original invite token", confirm.RemoteId)
+		}
 		rc.Token = confirm.RefreshedToken
 	} else {
 		// For older versions or if no RefreshedToken was provided, generate a new token


### PR DESCRIPTION
Cherry pick of #34864 on release-10.11.

/cc  @enzowritescode

```release-note
NONE
```