### PR TITLE
Update plugin-calls to v1.11.4

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -152,7 +152,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.0
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.4
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.5.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.12.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.5.0


### PR DESCRIPTION
Cherry pick of #35561 to release-11.3.

#### Release Note
```release-note
Mattermost Calls was updated to v1.11.4, fixing disconnection issues with Chromium >= 144, and correctly sanitizing configuration
```