### PR TITLE
[MM-67626] Update Playbooks plugin to v2.8.0 (cherry-pick #35549)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -156,7 +156,7 @@ PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.0
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.5.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.12.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.5.0
-PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.6.2
+PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.8.0
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.12.0
 PLUGIN_PACKAGES += mattermost-plugin-agents-v1.7.2
@@ -172,7 +172,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # download the package from to work. This will no longer be needed when we unify
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
-	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.6.2%2Bb8f2bd9-fips
+	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.8.0%2Bc4449ac-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v1.7.2%2B866e2dd-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.2%2B4282c63-fips
 endif


### PR DESCRIPTION
#### Summary
Cherry-pick of #35549 to release-11.3.

Updates the prepackaged Playbooks plugin from v2.6.2 to v2.8.0 (both regular and FIPS builds).

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-67626

#### Screenshots
N/A

#### Release Note
```release-note
Updated prepackaged Playbooks plugin to v2.8.0.
```