### PR TITLE
MM-67872 Fixing detection issue in image proxy

### DIFF
--- a/server/platform/services/imageproxy/local.go
+++ b/server/platform/services/imageproxy/local.go
@@ -19,6 +19,9 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 )
 
@@ -272,30 +275,23 @@ func isSVGContent(p *bufio.Reader) bool {
 		return false
 	}
 
-	var text string
-	if len(byt) >= 2 && byt[0] == 0xFF && byt[1] == 0xFE {
-		text = extractASCIIFromUTF16(byt[2:], 0) // UTF-16 LE
-	} else if len(byt) >= 2 && byt[0] == 0xFE && byt[1] == 0xFF {
-		text = extractASCIIFromUTF16(byt[2:], 1) // UTF-16 BE
-	} else {
-		text = string(byt)
-	}
-
-	lower := strings.TrimLeft(strings.ToLower(text), "\x00 \t\n\r")
-	return strings.Contains(lower, "<svg") ||
-		(strings.Contains(lower, "<?xml") && strings.Contains(lower, "<svg"))
-}
-
-// extractASCIIFromUTF16 extracts ASCII characters from a UTF-16 byte slice.
-// charByteOffset is 0 for little-endian (low byte first) and 1 for big-endian.
-func extractASCIIFromUTF16(b []byte, charByteOffset int) string {
-	out := make([]byte, 0, len(b)/2)
-	for i := charByteOffset; i+1 < len(b); i += 2 {
-		if b[i] < 0x80 {
-			out = append(out, b[i])
+	// UseBOM selects endianness from a BOM when present (0xFF 0xFE → LE,
+	// 0xFE 0xFF → BE), defaulting to LE otherwise.
+	enc := unicode.UTF16(unicode.LittleEndian, unicode.UseBOM)
+	if decoded, _, decodeErr := transform.Bytes(enc.NewDecoder(), byt); decodeErr == nil {
+		lower := strings.ToLower(string(decoded))
+		if strings.Contains(lower, "<svg") ||
+			(strings.Contains(lower, "<?xml") && strings.Contains(lower, "<svg")) {
+			return true
 		}
 	}
-	return string(out)
+
+	// Raw-byte scan for UTF-8 / ASCII content; interleaved-NUL patterns cover BOM-less UTF-16 BE.
+	rawLower := strings.ToLower(string(byt))
+	return strings.Contains(rawLower, "<svg") ||
+		(strings.Contains(rawLower, "<?xml") && strings.Contains(rawLower, "<svg")) ||
+		strings.Contains(rawLower, "<\x00s\x00v\x00g\x00") || // BOM-less UTF-16 LE
+		strings.Contains(rawLower, "\x00<\x00s\x00v\x00g") // BOM-less UTF-16 BE
 }
 
 // contentTypeMatches returns whether contentType matches one of the allowed patterns.

--- a/server/platform/services/imageproxy/local_test.go
+++ b/server/platform/services/imageproxy/local_test.go
@@ -237,6 +237,62 @@ func TestLocalBackend_GetImage(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	})
 
+	t.Run("UTF-16 LE BOM SVG with image/png content type", func(t *testing.T) {
+		// Build a UTF-16 LE payload with BOM: 0xFF 0xFE followed by each ASCII
+		// character of the SVG tag as a two-byte little-endian code unit.
+		svgASCII := `<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>`
+		body := []byte{0xFF, 0xFE} // UTF-16 LE BOM
+		for _, c := range svgASCII {
+			body = append(body, byte(c), 0x00)
+		}
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "image/png")
+			w.WriteHeader(http.StatusOK)
+			w.Write(body)
+		})
+
+		mock := httptest.NewServer(handler)
+		defer mock.Close()
+
+		proxy := makeTestLocalProxy()
+
+		recorder := httptest.NewRecorder()
+		request, err := http.NewRequest(http.MethodGet, "", nil)
+		require.NoError(t, err)
+		proxy.GetImage(recorder, request, mock.URL+"/image.png")
+		resp := recorder.Result()
+
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("UTF-16 BE BOM SVG with image/png content type", func(t *testing.T) {
+		// Build a UTF-16 BE payload with BOM: 0xFE 0xFF followed by each ASCII
+		// character as a two-byte big-endian code unit.
+		svgASCII := `<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>`
+		body := []byte{0xFE, 0xFF} // UTF-16 BE BOM
+		for _, c := range svgASCII {
+			body = append(body, 0x00, byte(c))
+		}
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "image/png")
+			w.WriteHeader(http.StatusOK)
+			w.Write(body)
+		})
+
+		mock := httptest.NewServer(handler)
+		defer mock.Close()
+
+		proxy := makeTestLocalProxy()
+
+		recorder := httptest.NewRecorder()
+		request, err := http.NewRequest(http.MethodGet, "", nil)
+		require.NoError(t, err)
+		proxy.GetImage(recorder, request, mock.URL+"/image.png")
+		resp := recorder.Result()
+
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
 	t.Run("SVG body with leading whitespace prefix", func(t *testing.T) {
 		prefix := bytes.Repeat([]byte(" "), 600)
 		body := append(prefix, []byte(`<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>`)...)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Improving content validation in the local image proxy to better detect supported image types

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Fixes https://mattermost.atlassian.net/browse/MM-67872

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Fixed an issue with image proxies not detecting content-types accurately in certain cases
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** The change adds early buffered SVG detection and rejection in the local image proxy (peeking up to 8192 bytes and handling UTF-16 BOMs), which is a localized security-hardening modification to ServeImage with accompanying unit tests.

**Regression Risk:** Medium — behavior for proxied content is altered (SVGs are blocked regardless of Content-Type) and new buffered-peek logic introduces potential false positives/negatives and additional I/O surface; edge cases include chunked/partial responses, compressed bodies, redirects, varied encodings, very small/very large payloads.

** QA Recommendation:** Medium — perform targeted manual QA: validate blocking of a broad set of SVG variants (minified, XML prolog, UTF-16 BE/LE BOMs, whitespace-prefixed), confirm raster/image types (PNG, JPEG, GIF, WebP, etc.) remain proxied correctly, test chunked/partial/compressed responses and redirects, and measure any performance impact from buffering/peeking.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->