### PR TITLE
MM-67742 Fixing text color in marketplace banner

### DIFF
--- a/webapp/channels/src/components/plugin_marketplace/__snapshots__/marketplace_modal.test.tsx.snap
+++ b/webapp/channels/src/components/plugin_marketplace/__snapshots__/marketplace_modal.test.tsx.snap
@@ -245,7 +245,7 @@ exports[`components/marketplace/ hides search, shows web marketplace banner in F
                 target="_blank"
               >
                 <div
-                  class="Title-gYlSGh gVisyY"
+                  class="Title-gYlSGh tzosk"
                 >
                   Discover community integrations
                   <svg
@@ -262,7 +262,7 @@ exports[`components/marketplace/ hides search, shows web marketplace banner in F
                   </svg>
                 </div>
                 <p
-                  class="Description-dTdaMR bgBNSS"
+                  class="Description-dTdaMR jbWmtW"
                 >
                   Connect the tools you use most to Mattermost
                 </p>

--- a/webapp/channels/src/components/plugin_marketplace/web_marketplace_banner.tsx
+++ b/webapp/channels/src/components/plugin_marketplace/web_marketplace_banner.tsx
@@ -75,7 +75,7 @@ const Title = styled.div`
     line-height: 24px;
     margin: 4px 0;
     grid-column: 1;
-    color: #FFF;
+    color: var(--neutral-0, #FFF);
 
     svg {
         vertical-align: middle;
@@ -92,7 +92,7 @@ const Description = styled.p`
     line-height: 20px;
     grid-column: 1;
     margin-bottom: 4px;
-    color: #FFF;
+    color: var(--neutral-0, #FFF);
 `;
 
 const PluginIcon = styled.img`


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you have read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR fixes the contrast issues from opening the marketplace modal with a dark theme

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-67742

#### Screenshots

|  before  |  after  |
|----|----|
| <img width="1434" height="152" alt="image" src="https://github.com/user-attachments/assets/30b15f17-36b9-4825-83f0-4e74cefb968d" /> | <img width="1156" height="196" alt="image" src="https://github.com/user-attachments/assets/4007f46c-f06a-4972-a902-a73890c4bc44" /> |

#### Release Note

```release-note
Fix text contrast issues with the marketplace modal when using dark themes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Reasoning:** The PR makes isolated visual-only changes by explicitly setting the banner Title and Description colors to use the neutral foreground CSS variable with a white fallback (color: var(--neutral-0, #FFF)), resolving WCAG contrast issues on dark themes without touching application logic or shared utilities.

**Regression Risk:** Minimal — changes are scoped to a single UI component and a minor layout adjustment; no changes to state, APIs, auth, or data flow.

**QA Recommendation:** Low-effort manual QA: verify marketplace banner text legibility in dark and light themes and confirm the post-image name alignment remains correct. Skipping manual QA is low risk but not recommended for releases requiring strict visual/a11y verification.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
