### PR TITLE
MM-67953 Changed sorting of channels in some places to prioritize display name matches

### DIFF
--- a/e2e-tests/playwright/lib/src/ui/components/channels/browse_channels_modal.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/browse_channels_modal.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Locator, expect} from '@playwright/test';
+
+export default class BrowseChannelsModal {
+    readonly container: Locator;
+
+    readonly searchInput: Locator;
+
+    readonly results: Locator;
+
+    constructor(container: Locator) {
+        this.container = container;
+
+        this.searchInput = container.getByRole('textbox', {name: 'Search channels'});
+
+        // This role seems incorrect and will likely need to be changed later
+        this.results = this.container.getByRole('search');
+    }
+
+    async toBeVisible() {
+        await expect(this.container).toBeVisible();
+    }
+
+    async toBeDoneLoading() {
+        await expect(this.container.locator('.loading-screen')).toHaveCount(0);
+    }
+
+    async toHaveNResults(count: number) {
+        await expect(this.results.locator('.more-modal__row')).toHaveCount(count);
+    }
+
+    async fillSearchInput(text: string) {
+        await this.searchInput.fill(text);
+    }
+
+    async toHaveChannelAsNthResult(channelName: string, index: number) {
+        const row = this.results.locator('.more-modal__row').nth(index);
+
+        expect(await row.getAttribute('data-testid')).toEqual(`ChannelRow-${channelName}`);
+    }
+}

--- a/e2e-tests/playwright/lib/src/ui/components/channels/browse_channels_modal.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/browse_channels_modal.ts
@@ -6,6 +6,8 @@ import {Locator, expect} from '@playwright/test';
 export default class BrowseChannelsModal {
     readonly container: Locator;
 
+    readonly createNewChannelButton: Locator;
+    readonly hideJoinedCheckbox: Locator;
     readonly searchInput: Locator;
 
     readonly results: Locator;
@@ -13,6 +15,8 @@ export default class BrowseChannelsModal {
     constructor(container: Locator) {
         this.container = container;
 
+        this.createNewChannelButton = container.getByRole('button', {name: 'Create New Channel'});
+        this.hideJoinedCheckbox = container.getByRole('checkbox', {name: 'Hide Joined'});
         this.searchInput = container.getByRole('textbox', {name: 'Search channels'});
 
         // This role seems incorrect and will likely need to be changed later

--- a/e2e-tests/playwright/lib/src/ui/components/index.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/index.ts
@@ -7,6 +7,7 @@ import GlobalHeader from './global_header';
 import MainHeader from './main_header';
 import UserAccountMenu from './user_account_menu';
 // Channels Components
+import BrowseChannelsModal from './channels/browse_channels_modal';
 import ChannelsAppBar from './channels/app_bar';
 import ChannelsCenterView from './channels/center_view';
 import CreateTeamForm from './channels/create_team_form';
@@ -88,6 +89,7 @@ const components = {
     FindChannelsModal,
     FlagPostConfirmationDialog,
     NewChannelModal,
+    BrowseChannelsModal,
     GenericConfirmModal,
     InvitePeopleModal,
     MembersInvitedModal,
@@ -158,6 +160,7 @@ export {
     FindChannelsModal,
     FlagPostConfirmationDialog,
     NewChannelModal,
+    BrowseChannelsModal,
     GenericConfirmModal,
     InvitePeopleModal,
     MembersInvitedModal,

--- a/e2e-tests/playwright/lib/src/ui/pages/channels.ts
+++ b/e2e-tests/playwright/lib/src/ui/pages/channels.ts
@@ -5,6 +5,7 @@ import {expect, Page} from '@playwright/test';
 import {waitUntil} from 'async-wait-until';
 
 import {
+    BrowseChannelsModal,
     ChannelsPost,
     ChannelSettingsModal,
     CreateTeamForm,
@@ -36,6 +37,7 @@ export default class ChannelsPage {
     readonly deletePostModal;
     readonly findChannelsModal;
     readonly newChannelModal;
+    readonly browseChannelsModal;
     public invitePeopleModal: InvitePeopleModal | undefined;
     public membersInvitedModal: MembersInvitedModal | undefined;
     readonly profileModal;
@@ -72,7 +74,8 @@ export default class ChannelsPage {
         this.createTeamForm = new CreateTeamForm(page.locator('.signup-team__container'));
         this.deletePostModal = new components.DeletePostModal(page.locator('#deletePostModal'));
         this.findChannelsModal = new components.FindChannelsModal(page.getByRole('dialog', {name: 'Find Channels'}));
-        this.newChannelModal = new NewChannelModal(page.locator('#new-channel-modal'));
+        this.newChannelModal = new NewChannelModal(page.getByRole('dialog', {name: 'Create a new channel'}));
+        this.browseChannelsModal = new BrowseChannelsModal(page.getByRole('dialog', {name: 'Browse Channels'}));
         this.profileModal = new components.ProfileModal(page.getByRole('dialog', {name: 'Profile'}));
         this.settingsModal = new components.SettingsModal(page.getByRole('dialog', {name: 'Settings'}));
         this.teamSettingsModal = new components.TeamSettingsModal(page.getByRole('dialog', {name: 'Team Settings'}));
@@ -208,10 +211,18 @@ export default class ChannelsPage {
 
     async openNewChannelModal(): Promise<NewChannelModal> {
         await this.sidebarLeft.browseOrCreateChannelButton.click();
-        await this.page.locator('#createNewChannelMenuItem').click();
+        await this.page.getByText('Create new channel').click();
         await this.newChannelModal.toBeVisible();
 
         return this.newChannelModal;
+    }
+
+    async openBrowseChannelsModal(): Promise<BrowseChannelsModal> {
+        await this.sidebarLeft.browseOrCreateChannelButton.click();
+        await this.page.getByText('Browse channels').click();
+        await this.browseChannelsModal.toBeVisible();
+
+        return this.browseChannelsModal;
     }
 
     async openCreateTeamForm(): Promise<CreateTeamForm> {

--- a/e2e-tests/playwright/specs/accessibility/channels/browse_channels_dialog.spec.ts
+++ b/e2e-tests/playwright/specs/accessibility/channels/browse_channels_dialog.spec.ts
@@ -40,32 +40,22 @@ test(
         await channelsPage.goto(team.name, 'town-square');
         await channelsPage.toBeVisible();
 
-        // # Click on Browse or Create Channel button and then Browse Channels
-        await channelsPage.sidebarLeft.browseOrCreateChannelButton.click();
-        const browseChannelsMenuItem = page.locator('#browseChannelsMenuItem');
-        await browseChannelsMenuItem.click();
-
-        // * Verify the Browse Channels dialog is visible
-        const dialog = page.getByRole('dialog', {name: 'Browse Channels'});
-        await expect(dialog).toBeVisible();
-
-        // * Verify the heading
-        await expect(dialog.getByRole('heading', {name: 'Browse Channels'})).toBeVisible();
+        // # Open the Browse Channels modal
+        const dialog = await channelsPage.openBrowseChannelsModal();
 
         // * Verify the search input exists
-        const searchInput = dialog.getByPlaceholder('Search channels');
+        const searchInput = dialog.searchInput;
         await expect(searchInput).toBeVisible();
 
         // # Wait for channel list to load
-        const channelList = dialog.locator('#moreChannelsList');
-        await expect(channelList).toBeVisible();
+        await dialog.toBeDoneLoading();
 
         // # Hide already joined channels
-        const hideJoinedCheckbox = dialog.getByText('Hide Joined');
+        const hideJoinedCheckbox = dialog.hideJoinedCheckbox;
         await hideJoinedCheckbox.click();
 
         // # Focus on Create Channel button and tab through elements
-        const createChannelButton = dialog.locator('#createNewChannelButton');
+        const createChannelButton = dialog.createNewChannelButton;
         await createChannelButton.focus();
         await page.keyboard.press('Tab');
         await page.keyboard.press('Tab');
@@ -74,8 +64,9 @@ test(
         await page.keyboard.press('Tab');
 
         // * Verify channel name is highlighted and has proper aria-label
+        await dialog.toHaveChannelAsNthResult(channel1.name, 0);
         const channel1AriaLabel = `${channel1.display_name.toLowerCase()}, ${channel1.purpose.toLowerCase()}`;
-        const channel1Item = dialog.getByLabel(channel1AriaLabel);
+        const channel1Item = dialog.container.getByLabel(channel1AriaLabel);
         await expect(channel1Item).toBeVisible();
         await expect(channel1Item).toBeFocused();
 
@@ -83,8 +74,9 @@ test(
         await page.keyboard.press('Tab');
 
         // * Verify focus moved to next channel
+        await dialog.toHaveChannelAsNthResult(channel2.name, 1);
         const channel2AriaLabel = `${channel2.display_name.toLowerCase()}, ${channel2.purpose.toLowerCase()}`;
-        const channel2Item = dialog.getByLabel(channel2AriaLabel);
+        const channel2Item = dialog.container.getByLabel(channel2AriaLabel);
         await expect(channel2Item).toBeFocused();
     },
 );
@@ -109,18 +101,11 @@ test(
         await channelsPage.goto(team.name, 'town-square');
         await channelsPage.toBeVisible();
 
-        // # Click on Browse or Create Channel button and then Browse Channels
-        await channelsPage.sidebarLeft.browseOrCreateChannelButton.click();
-        const browseChannelsMenuItem = page.locator('#browseChannelsMenuItem');
-        await browseChannelsMenuItem.click();
-
-        // * Verify the Browse Channels dialog is visible
-        const dialog = page.getByRole('dialog', {name: 'Browse Channels'});
-        await expect(dialog).toBeVisible();
-        await pw.wait(pw.duration.one_sec);
+        // # Open the Browse Channels modal
+        const dialog = await channelsPage.openBrowseChannelsModal();
 
         // * Verify aria snapshot of Browse Channels dialog
-        await expect(dialog).toMatchAriaSnapshot(`
+        await expect(dialog.container).toMatchAriaSnapshot(`
             - dialog "Browse Channels":
               - document:
                 - heading "Browse Channels" [level=1]

--- a/e2e-tests/playwright/specs/accessibility/channels/browse_channels_dialog.spec.ts
+++ b/e2e-tests/playwright/specs/accessibility/channels/browse_channels_dialog.spec.ts
@@ -106,7 +106,7 @@ test(
 
         // * Verify aria snapshot of Browse Channels dialog
         await expect(dialog.container).toMatchAriaSnapshot(`
-            - dialog "Browse Channels":©
+            - dialog "Browse Channels":
               - document:
                 - heading "Browse Channels" [level=1]
                 - button "Create New Channel"

--- a/e2e-tests/playwright/specs/accessibility/channels/browse_channels_dialog.spec.ts
+++ b/e2e-tests/playwright/specs/accessibility/channels/browse_channels_dialog.spec.ts
@@ -106,7 +106,7 @@ test(
 
         // * Verify aria snapshot of Browse Channels dialog
         await expect(dialog.container).toMatchAriaSnapshot(`
-            - dialog "Browse Channels":
+            - dialog "Browse Channels":©
               - document:
                 - heading "Browse Channels" [level=1]
                 - button "Create New Channel"

--- a/e2e-tests/playwright/specs/functional/channels/post_textbox/channel_autocomplete_sorting.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/post_textbox/channel_autocomplete_sorting.spec.ts
@@ -3,7 +3,6 @@
 
 import {expect, test} from '@mattermost/playwright-lib';
 
-
 /**
  * @objective Verify that the "Other Channels" group in the ~channel autocomplete in the message input prioritizes
  * channels whose DisplayName matches the search term.

--- a/e2e-tests/playwright/specs/functional/channels/post_textbox/channel_autocomplete_sorting.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/post_textbox/channel_autocomplete_sorting.spec.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+
+/**
+ * @objective Verify that the "Other Channels" group in the ~channel autocomplete in the message input prioritizes
+ * channels whose DisplayName matches the search term.
+ */
+test(
+    'MM-67953 channel mention autocomplete prioritizes DisplayName matches in Other Channels',
+    {tag: ['@mentions']},
+    async ({pw}) => {
+        // # Initialize setup
+        const {team, user, adminClient} = await pw.initSetup();
+
+        // # Create channels whose DisplayName matches the search term (user is NOT a member)
+        await adminClient.createChannel({
+            team_id: team.id,
+            name: 'ac-gamma-conversation-' + Date.now(),
+            display_name: 'Gamma: Conversation',
+            type: 'O',
+        });
+        await adminClient.createChannel({
+            team_id: team.id,
+            name: 'ac-gamma-logs-' + Date.now(),
+            display_name: 'Gamma: Logs',
+            type: 'O',
+        });
+
+        // # Create channels whose Purpose matches but DisplayName does NOT (user is NOT a member)
+        await adminClient.createChannel({
+            team_id: team.id,
+            name: 'ac-alpha-channel-' + Date.now(),
+            display_name: 'Alpha Channel',
+            type: 'O',
+            purpose: 'alpha release of gamma',
+        });
+        await adminClient.createChannel({
+            team_id: team.id,
+            name: 'ac-beta-channel-' + Date.now(),
+            display_name: 'Beta Channel',
+            type: 'O',
+            purpose: 'beta release of gamma',
+        });
+
+        // # Log in as regular user
+        const {channelsPage} = await pw.testBrowser.login(user);
+
+        // # Visit town-square channel
+        await channelsPage.goto(team.name, 'town-square');
+        await channelsPage.toBeVisible();
+
+        // # Type a channel mention in the message input to trigger autocomplete
+        await channelsPage.centerView.postCreate.writeMessage('~gamma');
+
+        // # Wait for the suggestion list to appear
+        const suggestionList = channelsPage.centerView.postCreate.suggestionList;
+        await expect(suggestionList).toBeVisible();
+
+        // # Get all suggestion items within the "Other Channels" group
+        const otherChannelsGroup = suggestionList.getByRole('group', {name: 'Other Channels'});
+        await expect(otherChannelsGroup).toBeVisible();
+
+        const suggestions = otherChannelsGroup.getByRole('option');
+
+        // * Verify at least 4 suggestions are shown in "Other Channels"
+        await expect(suggestions).toHaveCount(4);
+
+        // * Verify DisplayName-matching channels appear first, sorted alphabetically
+        await expect(suggestions.nth(0)).toContainText('Gamma: Conversation');
+        await expect(suggestions.nth(1)).toContainText('Gamma: Logs');
+
+        // * Verify Purpose-only-matching channels appear after, sorted alphabetically by DisplayName
+        await expect(suggestions.nth(2)).toContainText('Alpha Channel');
+        await expect(suggestions.nth(3)).toContainText('Beta Channel');
+    },
+);

--- a/e2e-tests/playwright/specs/functional/channels/search/browse_channels_sorting.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/search/browse_channels_sorting.spec.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test} from '@mattermost/playwright-lib';
+
+/**
+ * @objective Verify that Browse Channels modal search results prioritize channels whose DisplayName matches the search
+ * term over channels that only match on other fields.
+ */
+test(
+    'MM-67953 Browse Channels modal prioritizes DisplayName matches in search results',
+    {tag: ['@browse_channels']},
+    async ({pw}) => {
+        // # Initialize setup
+        const {team, user, adminClient} = await pw.initSetup();
+
+        // # Create channels whose DisplayName matches the search term
+        const displayMatchA = await adminClient.createChannel({
+            team_id: team.id,
+            name: 'ac-gamma-conversation-' + Date.now(),
+            display_name: 'Gamma: Conversation',
+            type: 'O',
+        });
+        const displayMatchB = await adminClient.createChannel({
+            team_id: team.id,
+            name: 'ac-gamma-logs-' + Date.now(),
+            display_name: 'Gamma: Logs',
+            type: 'O',
+        });
+
+        // # Create channels whose Purpose matches but DisplayName does NOT
+        const purposeMatchA = await adminClient.createChannel({
+            team_id: team.id,
+            name: 'ac-alpha-channel-' + Date.now(),
+            display_name: 'Alpha Channel',
+            type: 'O',
+            purpose: 'alpha release of gamma',
+        });
+        const purposeMatchB = await adminClient.createChannel({
+            team_id: team.id,
+            name: 'ac-beta-channel-' + Date.now(),
+            display_name: 'Beta Channel',
+            type: 'O',
+            purpose: 'beta release of gamma',
+        });
+
+        // # Log in as regular user
+        const {page, channelsPage} = await pw.testBrowser.login(user);
+
+        // # Visit town-square channel
+        await channelsPage.goto(team.name, 'town-square');
+        await channelsPage.toBeVisible();
+
+        // # Open the Browse Channels modal
+        const dialog = await channelsPage.openBrowseChannelsModal();
+        await dialog.toBeVisible();
+
+        // # Search for the term that matches DisplayName on some channels and Purpose on others
+        await dialog.fillSearchInput('gamma');
+        await dialog.toBeDoneLoading();
+        await dialog.toHaveNResults(4);
+
+        // DisplayName matches come first, sorted alphabetically
+        await dialog.toHaveChannelAsNthResult(displayMatchA.name, 0);
+        await dialog.toHaveChannelAsNthResult(displayMatchB.name, 1);
+
+        // Purpose-only matches come after, sorted alphabetically by DisplayName
+        await dialog.toHaveChannelAsNthResult(purposeMatchA.name, 2);
+        await dialog.toHaveChannelAsNthResult(purposeMatchB.name, 3);
+    },
+);

--- a/e2e-tests/playwright/specs/functional/channels/search/browse_channels_sorting.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/search/browse_channels_sorting.spec.ts
@@ -45,7 +45,7 @@ test(
         });
 
         // # Log in as regular user
-        const {page, channelsPage} = await pw.testBrowser.login(user);
+        const {channelsPage} = await pw.testBrowser.login(user);
 
         // # Visit town-square channel
         await channelsPage.goto(team.name, 'town-square');

--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -3096,7 +3096,6 @@ func (s SqlChannelStore) AutocompleteInTeam(rctx request.CTX, teamID, userID, te
 	query := s.getQueryBuilder().Select(channelSliceColumns(true, "c")...).
 		From("Channels c").
 		Where(sq.Eq{"c.TeamId": teamID}).
-		OrderBy("c.DisplayName").
 		Limit(model.ChannelSearchDefaultLimit)
 
 	if !includeDeleted {
@@ -3122,6 +3121,16 @@ func (s SqlChannelStore) AutocompleteInTeam(rctx request.CTX, teamID, userID, te
 	searchClause := s.searchClause(term)
 	if searchClause != nil {
 		query = query.Where(searchClause)
+	}
+
+	// Prioritize channels whose DisplayName matches the search term,
+	// then fall back to alphabetical ordering.
+	sanitizedTerm := sanitizeSearchTerm(term, "*")
+	if sanitizedTerm != "" {
+		likeTerm := wildcardSearchTerm(sanitizedTerm)
+		query = query.OrderByClause("CASE WHEN LOWER(c.DisplayName) LIKE LOWER(?) ESCAPE '*' THEN 0 ELSE 1 END, c.DisplayName", likeTerm)
+	} else {
+		query = query.OrderBy("c.DisplayName")
 	}
 
 	return s.performSearch(query, term)

--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -3036,9 +3036,7 @@ func (s SqlChannelStore) Autocomplete(rctx request.CTX, userID, term string, inc
 			sq.Expr("c.TeamId = t.id"),
 			sq.Expr("t.id = tm.TeamId"),
 			sq.Eq{"tm.UserId": userID},
-		}).
-		OrderBy("c.DisplayName").
-		Limit(model.ChannelSearchDefaultLimit)
+		})
 
 	// Always filter out soft-deleted team memberships - users removed from
 	// a team should not see channels from that team regardless of includeDeleted
@@ -3068,6 +3066,18 @@ func (s SqlChannelStore) Autocomplete(rctx request.CTX, userID, term string, inc
 	if searchClause != nil {
 		query = query.Where(searchClause)
 	}
+
+	// Prioritize channels whose DisplayName matches the search term,
+	// then fall back to alphabetical ordering.
+	sanitizedTerm := sanitizeSearchTerm(term, "*")
+	if sanitizedTerm != "" {
+		likeTerm := wildcardSearchTerm(sanitizedTerm)
+		query = query.OrderByClause("CASE WHEN LOWER(c.DisplayName) LIKE LOWER(?) ESCAPE '*' THEN 0 ELSE 1 END, c.DisplayName", likeTerm)
+	} else {
+		query = query.OrderBy("c.DisplayName")
+	}
+
+	query = query.Limit(model.ChannelSearchDefaultLimit)
 
 	sql, args, err := query.ToSql()
 	if err != nil {

--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -3067,15 +3067,7 @@ func (s SqlChannelStore) Autocomplete(rctx request.CTX, userID, term string, inc
 		query = query.Where(searchClause)
 	}
 
-	// Prioritize channels whose DisplayName matches the search term,
-	// then fall back to alphabetical ordering.
-	sanitizedTerm := sanitizeSearchTerm(term, "*")
-	if sanitizedTerm != "" {
-		likeTerm := wildcardSearchTerm(sanitizedTerm)
-		query = query.OrderByClause("CASE WHEN LOWER(c.DisplayName) LIKE LOWER(?) ESCAPE '*' THEN 0 ELSE 1 END, c.DisplayName", likeTerm)
-	} else {
-		query = query.OrderBy("c.DisplayName")
-	}
+	query = orderByDisplayNameMatch(query, term)
 
 	query = query.Limit(model.ChannelSearchDefaultLimit)
 
@@ -3123,15 +3115,7 @@ func (s SqlChannelStore) AutocompleteInTeam(rctx request.CTX, teamID, userID, te
 		query = query.Where(searchClause)
 	}
 
-	// Prioritize channels whose DisplayName matches the search term,
-	// then fall back to alphabetical ordering.
-	sanitizedTerm := sanitizeSearchTerm(term, "*")
-	if sanitizedTerm != "" {
-		likeTerm := wildcardSearchTerm(sanitizedTerm)
-		query = query.OrderByClause("CASE WHEN LOWER(c.DisplayName) LIKE LOWER(?) ESCAPE '*' THEN 0 ELSE 1 END, c.DisplayName", likeTerm)
-	} else {
-		query = query.OrderBy("c.DisplayName")
-	}
+	query = orderByDisplayNameMatch(query, term)
 
 	return s.performSearch(query, term)
 }
@@ -3600,6 +3584,18 @@ func (s SqlChannelStore) searchClause(term string) sq.Sqlizer {
 		likeClause,
 		s.buildFulltextClause(term, "c.Name", "c.DisplayName", "c.Purpose"),
 	}
+}
+
+// orderByDisplayNameMatch adds an ORDER BY clause that prioritizes channels whose DisplayName matches the search term,
+// then sorts alphabetically by DisplayName.
+func orderByDisplayNameMatch(query sq.SelectBuilder, term string) sq.SelectBuilder {
+	sanitizedTerm := sanitizeSearchTerm(term, "*")
+	if sanitizedTerm == "" {
+		return query.OrderBy("c.DisplayName")
+	}
+
+	likeTerm := wildcardSearchTerm(sanitizedTerm)
+	return query.OrderByClause("CASE WHEN LOWER(c.DisplayName) LIKE LOWER(?) ESCAPE '*' THEN 0 ELSE 1 END, c.DisplayName", likeTerm)
 }
 
 func (s SqlChannelStore) searchGroupChannelsQuery(userId, term string) sq.SelectBuilder {

--- a/server/channels/store/storetest/channel_store.go
+++ b/server/channels/store/storetest/channel_store.go
@@ -6561,33 +6561,33 @@ func testAutocomplete(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore
 			Email:       MakeEmail(),
 			Type:        model.TeamOpen,
 		}
-		sortTeam, err := ss.Team().Save(sortTeam)
-		require.NoError(t, err)
+		sortTeam, err2 := ss.Team().Save(sortTeam)
+		require.NoError(t, err2)
 
 		sortUser := model.NewId()
-		_, err = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: sortTeam.Id, UserId: sortUser}, -1)
-		require.NoError(t, err)
+		_, err2 = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: sortTeam.Id, UserId: sortUser}, -1)
+		require.NoError(t, err2)
 
 		// Channels where DisplayName matches "alpha":
 		chDisplayAlpha2 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Alpha Two", Name: NewTestID(), Type: model.ChannelTypeOpen}
-		_, err = ss.Channel().Save(rctx, &chDisplayAlpha2, -1)
-		require.NoError(t, err)
+		_, err2 = ss.Channel().Save(rctx, &chDisplayAlpha2, -1)
+		require.NoError(t, err2)
 
 		chDisplayAlpha1 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Alpha One", Name: NewTestID(), Type: model.ChannelTypeOpen}
-		_, err = ss.Channel().Save(rctx, &chDisplayAlpha1, -1)
-		require.NoError(t, err)
+		_, err2 = ss.Channel().Save(rctx, &chDisplayAlpha1, -1)
+		require.NoError(t, err2)
 
 		// Channels where only Purpose matches "alpha" (DisplayName does NOT contain "alpha"):
 		chPurposeOnly2 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Zulu Channel", Name: NewTestID(), Purpose: "alpha related work", Type: model.ChannelTypeOpen}
-		_, err = ss.Channel().Save(rctx, &chPurposeOnly2, -1)
-		require.NoError(t, err)
+		_, err2 = ss.Channel().Save(rctx, &chPurposeOnly2, -1)
+		require.NoError(t, err2)
 
 		chPurposeOnly1 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Bravo Channel", Name: NewTestID(), Purpose: "alpha discussions", Type: model.ChannelTypeOpen}
-		_, err = ss.Channel().Save(rctx, &chPurposeOnly1, -1)
-		require.NoError(t, err)
+		_, err2 = ss.Channel().Save(rctx, &chPurposeOnly1, -1)
+		require.NoError(t, err2)
 
-		channels, err := ss.Channel().Autocomplete(rctx, sortUser, "alpha", false, false)
-		require.NoError(t, err)
+		channels, err2 := ss.Channel().Autocomplete(rctx, sortUser, "alpha", false, false)
+		require.NoError(t, err2)
 		require.Len(t, channels, 4)
 
 		// DisplayName matches come first, sorted alphabetically by DisplayName
@@ -6608,24 +6608,24 @@ func testAutocomplete(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore
 			Email:       MakeEmail(),
 			Type:        model.TeamOpen,
 		}
-		sortTeam, err := ss.Team().Save(sortTeam)
-		require.NoError(t, err)
+		sortTeam, err2 := ss.Team().Save(sortTeam)
+		require.NoError(t, err2)
 
 		sortUser := model.NewId()
-		_, err = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: sortTeam.Id, UserId: sortUser}, -1)
-		require.NoError(t, err)
+		_, err2 = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: sortTeam.Id, UserId: sortUser}, -1)
+		require.NoError(t, err2)
 
 		// Create 50 channels that match only on Purpose (not DisplayName).
 		// Give them DisplayNames that sort before the DisplayName-matching channel.
 		for i := range model.ChannelSearchDefaultLimit {
-			_, err = ss.Channel().Save(rctx, &model.Channel{
+			_, err2 = ss.Channel().Save(rctx, &model.Channel{
 				TeamId:      sortTeam.Id,
 				DisplayName: fmt.Sprintf("AAA Channel %03d", i),
 				Name:        NewTestID(),
 				Purpose:     "findme in purpose",
 				Type:        model.ChannelTypeOpen,
 			}, -1)
-			require.NoError(t, err)
+			require.NoError(t, err2)
 		}
 
 		// Create 1 channel whose DisplayName matches the term but sorts last alphabetically.
@@ -6635,11 +6635,11 @@ func testAutocomplete(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore
 			Name:        NewTestID(),
 			Type:        model.ChannelTypeOpen,
 		}
-		_, err = ss.Channel().Save(rctx, &chDisplayMatch, -1)
-		require.NoError(t, err)
+		_, err2 = ss.Channel().Save(rctx, &chDisplayMatch, -1)
+		require.NoError(t, err2)
 
-		channels, err := ss.Channel().Autocomplete(rctx, sortUser, "findme", false, false)
-		require.NoError(t, err)
+		channels, err2 := ss.Channel().Autocomplete(rctx, sortUser, "findme", false, false)
+		require.NoError(t, err2)
 		require.Len(t, channels, model.ChannelSearchDefaultLimit)
 
 		// The DisplayName-matching channel must be first despite sorting last alphabetically.

--- a/server/channels/store/storetest/channel_store.go
+++ b/server/channels/store/storetest/channel_store.go
@@ -6419,6 +6419,101 @@ func testAutocomplete(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore
 		}
 	})
 
+	t.Run("channels with a matching DisplayName are sorted before those matching other fields", func(t *testing.T) {
+		// Clean slate for ordering tests
+		s.GetMaster().Exec("TRUNCATE Channels")
+
+		sortTeam := &model.Team{
+			DisplayName: "sort-team",
+			Name:        NewTestID(),
+			Email:       MakeEmail(),
+			Type:        model.TeamOpen,
+		}
+		sortTeam, err := ss.Team().Save(sortTeam)
+		require.NoError(t, err)
+
+		sortUser := model.NewId()
+		_, err = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: sortTeam.Id, UserId: sortUser}, -1)
+		require.NoError(t, err)
+
+		// Channels where DisplayName matches "alpha":
+		chDisplayAlpha2 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Alpha Two", Name: NewTestID(), Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &chDisplayAlpha2, -1)
+		require.NoError(t, err)
+
+		chDisplayAlpha1 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Alpha One", Name: NewTestID(), Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &chDisplayAlpha1, -1)
+		require.NoError(t, err)
+
+		// Channels where only Purpose matches "alpha" (DisplayName does NOT contain "alpha"):
+		chPurposeOnly2 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Zulu Channel", Name: NewTestID(), Purpose: "alpha related work", Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &chPurposeOnly2, -1)
+		require.NoError(t, err)
+
+		chPurposeOnly1 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Bravo Channel", Name: NewTestID(), Purpose: "alpha discussions", Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &chPurposeOnly1, -1)
+		require.NoError(t, err)
+
+		channels, err := ss.Channel().Autocomplete(rctx, sortUser, "alpha", false, false)
+		require.NoError(t, err)
+		require.Len(t, channels, 4)
+
+		// DisplayName matches come first, sorted alphabetically by DisplayName
+		assert.Equal(t, chDisplayAlpha1.Id, channels[0].Id, "first should be Alpha One (DisplayName match, alphabetically first)")
+		assert.Equal(t, chDisplayAlpha2.Id, channels[1].Id, "second should be Alpha Two (DisplayName match, alphabetically second)")
+
+		// Non-DisplayName matches come second, also sorted alphabetically by DisplayName
+		assert.Equal(t, chPurposeOnly1.Id, channels[2].Id, "third should be Bravo Channel (no DisplayName match, alphabetically first)")
+		assert.Equal(t, chPurposeOnly2.Id, channels[3].Id, "fourth should be Zulu Channel (no DisplayName match, alphabetically second)")
+	})
+
+	t.Run("channels with a matching DisplayName are sorted before those matching other fields, even when the results are cut off", func(t *testing.T) {
+		s.GetMaster().Exec("TRUNCATE Channels")
+
+		sortTeam := &model.Team{
+			DisplayName: "sort-team",
+			Name:        NewTestID(),
+			Email:       MakeEmail(),
+			Type:        model.TeamOpen,
+		}
+		sortTeam, err := ss.Team().Save(sortTeam)
+		require.NoError(t, err)
+
+		sortUser := model.NewId()
+		_, err = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: sortTeam.Id, UserId: sortUser}, -1)
+		require.NoError(t, err)
+
+		// Create 50 channels that match only on Purpose (not DisplayName).
+		// Give them DisplayNames that sort before the DisplayName-matching channel.
+		for i := range model.ChannelSearchDefaultLimit {
+			_, err = ss.Channel().Save(rctx, &model.Channel{
+				TeamId:      sortTeam.Id,
+				DisplayName: fmt.Sprintf("AAA Channel %03d", i),
+				Name:        NewTestID(),
+				Purpose:     "findme in purpose",
+				Type:        model.ChannelTypeOpen,
+			}, -1)
+			require.NoError(t, err)
+		}
+
+		// Create 1 channel whose DisplayName matches the term but sorts last alphabetically.
+		chDisplayMatch := model.Channel{
+			TeamId:      sortTeam.Id,
+			DisplayName: "ZZZ findme channel",
+			Name:        NewTestID(),
+			Type:        model.ChannelTypeOpen,
+		}
+		_, err = ss.Channel().Save(rctx, &chDisplayMatch, -1)
+		require.NoError(t, err)
+
+		channels, err := ss.Channel().Autocomplete(rctx, sortUser, "findme", false, false)
+		require.NoError(t, err)
+		require.Len(t, channels, model.ChannelSearchDefaultLimit)
+
+		// The DisplayName-matching channel must be first despite sorting last alphabetically.
+		assert.Equal(t, chDisplayMatch.Id, channels[0].Id, "DisplayName match should be returned first, not cut off by limit")
+	})
+
 	t.Run("Limit", func(t *testing.T) {
 		for i := range model.ChannelSearchDefaultLimit + 10 {
 			_, err = ss.Channel().Save(rctx, &model.Channel{

--- a/server/channels/store/storetest/channel_store.go
+++ b/server/channels/store/storetest/channel_store.go
@@ -120,7 +120,7 @@ func TestChannelStore(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore
 	t.Run("GetMemberCountsByGroup", func(t *testing.T) { testGetMemberCountsByGroup(t, rctx, ss) })
 	t.Run("GetGuestCount", func(t *testing.T) { testGetGuestCount(t, rctx, ss) })
 	t.Run("SearchMore", func(t *testing.T) { testChannelStoreSearchMore(t, rctx, ss) })
-	t.Run("SearchInTeam", func(t *testing.T) { testChannelStoreSearchInTeam(t, rctx, ss) })
+	t.Run("SearchInTeam", func(t *testing.T) { testChannelStoreSearchInTeam(t, rctx, ss, s) })
 	t.Run("Autocomplete", func(t *testing.T) { testAutocomplete(t, rctx, ss, s) })
 	t.Run("SearchForUserInTeam", func(t *testing.T) { testChannelStoreSearchForUserInTeam(t, rctx, ss) })
 	t.Run("SearchAllChannels", func(t *testing.T) { testChannelStoreSearchAllChannels(t, rctx, ss) })
@@ -5990,7 +5990,7 @@ func testChannelStoreSearchMore(t *testing.T, rctx request.CTX, ss store.Store) 
 	})
 }
 
-func testChannelStoreSearchInTeam(t *testing.T, rctx request.CTX, ss store.Store) {
+func testChannelStoreSearchInTeam(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
 	teamID := model.NewId()
 	otherTeamID := model.NewId()
 
@@ -6206,6 +6206,138 @@ func testChannelStoreSearchInTeam(t *testing.T, rctx request.CTX, ss store.Store
 			require.ElementsMatch(t, testCase.ExpectedResults, channels)
 		})
 	}
+
+	t.Run("AutoCompleteInTeam/DisplayName matches are prioritized in ordering", func(t *testing.T) {
+		s.GetMaster().Exec("TRUNCATE Channels")
+
+		sortTeam := &model.Team{
+			DisplayName: "sort-team",
+			Name:        NewTestID(),
+			Email:       MakeEmail(),
+			Type:        model.TeamOpen,
+		}
+		sortTeam, err := ss.Team().Save(sortTeam)
+		require.NoError(t, err)
+
+		sortUser := model.NewId()
+		_, err = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: sortTeam.Id, UserId: sortUser}, -1)
+		require.NoError(t, err)
+
+		// Channels where DisplayName matches "alpha":
+		chDisplayAlpha2 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Alpha Two", Name: NewTestID(), Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &chDisplayAlpha2, -1)
+		require.NoError(t, err)
+
+		chDisplayAlpha1 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Alpha One", Name: NewTestID(), Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &chDisplayAlpha1, -1)
+		require.NoError(t, err)
+
+		// Channels where only Purpose matches "alpha" (DisplayName does NOT contain "alpha"):
+		chPurposeOnly2 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Zulu Channel", Name: NewTestID(), Purpose: "alpha related work", Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &chPurposeOnly2, -1)
+		require.NoError(t, err)
+
+		chPurposeOnly1 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Bravo Channel", Name: NewTestID(), Purpose: "alpha discussions", Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &chPurposeOnly1, -1)
+		require.NoError(t, err)
+
+		channels, err := ss.Channel().AutocompleteInTeam(rctx, sortTeam.Id, sortUser, "alpha", false, false)
+		require.NoError(t, err)
+		require.Len(t, channels, 4)
+
+		// DisplayName matches come first, sorted alphabetically by DisplayName
+		assert.Equal(t, chDisplayAlpha1.Id, channels[0].Id, "first should be Alpha One (DisplayName match, alphabetically first)")
+		assert.Equal(t, chDisplayAlpha2.Id, channels[1].Id, "second should be Alpha Two (DisplayName match, alphabetically second)")
+
+		// Non-DisplayName matches come second, also sorted alphabetically by DisplayName
+		assert.Equal(t, chPurposeOnly1.Id, channels[2].Id, "third should be Bravo Channel (no DisplayName match, alphabetically first)")
+		assert.Equal(t, chPurposeOnly2.Id, channels[3].Id, "fourth should be Zulu Channel (no DisplayName match, alphabetically second)")
+	})
+
+	t.Run("AutoCompleteInTeam/no DisplayName matches still returns results sorted by DisplayName", func(t *testing.T) {
+		s.GetMaster().Exec("TRUNCATE Channels")
+
+		sortTeam := &model.Team{
+			DisplayName: "sort-team",
+			Name:        NewTestID(),
+			Email:       MakeEmail(),
+			Type:        model.TeamOpen,
+		}
+		sortTeam, err := ss.Team().Save(sortTeam)
+		require.NoError(t, err)
+
+		sortUser := model.NewId()
+		_, err = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: sortTeam.Id, UserId: sortUser}, -1)
+		require.NoError(t, err)
+
+		// All channels match on Purpose only, not DisplayName
+		ch1 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Zulu Display", Name: NewTestID(), Purpose: "searchterm stuff", Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &ch1, -1)
+		require.NoError(t, err)
+
+		ch2 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Alpha Display", Name: NewTestID(), Purpose: "searchterm things", Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &ch2, -1)
+		require.NoError(t, err)
+
+		ch3 := model.Channel{TeamId: sortTeam.Id, DisplayName: "Mike Display", Name: NewTestID(), Purpose: "searchterm items", Type: model.ChannelTypeOpen}
+		_, err = ss.Channel().Save(rctx, &ch3, -1)
+		require.NoError(t, err)
+
+		channels, err := ss.Channel().AutocompleteInTeam(rctx, sortTeam.Id, sortUser, "searchterm", false, false)
+		require.NoError(t, err)
+		require.Len(t, channels, 3)
+
+		// All in the same priority bucket (no DisplayName match), sorted by DisplayName
+		assert.Equal(t, ch2.Id, channels[0].Id, "Alpha Display should be first")
+		assert.Equal(t, ch3.Id, channels[1].Id, "Mike Display should be second")
+		assert.Equal(t, ch1.Id, channels[2].Id, "Zulu Display should be third")
+	})
+
+	t.Run("AutoCompleteInTeam/DisplayName match is not cut off by limit", func(t *testing.T) {
+		s.GetMaster().Exec("TRUNCATE Channels")
+
+		sortTeam := &model.Team{
+			DisplayName: "sort-team",
+			Name:        NewTestID(),
+			Email:       MakeEmail(),
+			Type:        model.TeamOpen,
+		}
+		sortTeam, err := ss.Team().Save(sortTeam)
+		require.NoError(t, err)
+
+		sortUser := model.NewId()
+		_, err = ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: sortTeam.Id, UserId: sortUser}, -1)
+		require.NoError(t, err)
+
+		// Create 50 channels that match only on Purpose (not DisplayName).
+		for i := range model.ChannelSearchDefaultLimit {
+			_, err = ss.Channel().Save(rctx, &model.Channel{
+				TeamId:      sortTeam.Id,
+				DisplayName: fmt.Sprintf("AAA Channel %03d", i),
+				Name:        NewTestID(),
+				Purpose:     "findme in purpose",
+				Type:        model.ChannelTypeOpen,
+			}, -1)
+			require.NoError(t, err)
+		}
+
+		// Create 1 channel whose DisplayName matches the term but sorts last alphabetically.
+		chDisplayMatch := model.Channel{
+			TeamId:      sortTeam.Id,
+			DisplayName: "ZZZ findme channel",
+			Name:        NewTestID(),
+			Type:        model.ChannelTypeOpen,
+		}
+		_, err = ss.Channel().Save(rctx, &chDisplayMatch, -1)
+		require.NoError(t, err)
+
+		channels, err := ss.Channel().AutocompleteInTeam(rctx, sortTeam.Id, sortUser, "findme", false, false)
+		require.NoError(t, err)
+		require.Len(t, channels, model.ChannelSearchDefaultLimit)
+
+		// The DisplayName-matching channel must be first despite sorting last alphabetically.
+		assert.Equal(t, chDisplayMatch.Id, channels[0].Id, "DisplayName match should be returned first, not cut off by limit")
+	})
 }
 
 func testAutocomplete(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {


### PR DESCRIPTION
#### Summary
[Ages ago](https://github.com/mattermost/mattermost/pull/8067), we made it so that searching for a channel included searching its purpose field. When we did that, we never changed how the results were sorted which means that there's some cases where you'd end up not finding the channel you're looking for because there's a lot of channels that just happen to include something in their purpose similar to the channel's name. I think this was reported for an issue on a demo server where the channel name they wanted was in the purpose of another Playbook-created workflow that there were many copies of.

This PR changes it so that the searching of the Browse Channels modal and the "Other Channels" section of the `~channel` autocomplete now prioritize display name matches before sorting by display name as before. There's other places in the app where this may happen or that could also use this change, but this is as wide as I figured we should go with this to avoid conflicting with other sorting logic (such as in the channel switcher modal)

#### Ticket Link
MM-67953

#### Screenshots
before|after
-|-
<img width="980" height="955" alt="Screenshot 2026-03-18 at 5 34 23 PM" src="https://github.com/user-attachments/assets/5cce842d-1db4-4f56-97a9-7177b84bd953" />|<img width="980" height="955" alt="Screenshot 2026-03-18 at 5 35 24 PM" src="https://github.com/user-attachments/assets/56032b04-313b-43d1-a3e1-4d184a9ba1d9" />
<img width="980" height="955" alt="Screenshot 2026-03-18 at 5 34 31 PM" src="https://github.com/user-attachments/assets/cbf96987-1d21-4738-96b3-5a67ab465b84" />|<img width="980" height="955" alt="Screenshot 2026-03-18 at 5 35 19 PM" src="https://github.com/user-attachments/assets/7f6dce55-9dc9-4bce-bf8b-42733186ea0d" />

#### Release Note
```release-note
Changed Browse Channels modal and ~channel autocomplete to prioritize channels with a matching display name
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** The PR adjusts ORDER BY logic for channel autocomplete and adds UI test helpers and E2E tests; changes are localized to search/sorting behavior and test suites but affect multiple user-facing autocomplete flows across server and client layers.

**Regression Risk:** Moderate — altering sort semantics and adding a query limit can change UX across autocomplete, browse modal, and mention completion without modifying filtering or data integrity. The change touches shared server store code used by several endpoints, so unintended ordering or truncation edge cases (special characters, case handling, large result sets) are possible.

**QA Recommendation:** Manual QA recommended across channel autocomplete surfaces (browse channels modal, ~mention autocomplete, channel switcher) with tests for mixed DisplayName vs Purpose matches, case/special-character matching, and large result sets to validate the new limit. Existing E2E tests help, but prioritize exploratory checks around ordering and result counts.  
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->