### PR TITLE
Automated cherry pick of #35680

### DIFF
--- a/webapp/channels/src/components/post_view/post_list_virtualized/post_list_virtualized.test.tsx
+++ b/webapp/channels/src/components/post_view/post_list_virtualized/post_list_virtualized.test.tsx
@@ -335,13 +335,13 @@ describe('PostList', () => {
                 expected: false,
             },
             {
-                name: 'when 11 pixel from the bottom',
-                scrollOffset: 489,
+                name: 'when 101 pixel from the bottom',
+                scrollOffset: 399,
                 expected: false,
             },
             {
-                name: 'when 9 pixel from the bottom also considered to be bottom',
-                scrollOffset: 490,
+                name: 'when 100 pixel from the bottom also considered to be bottom',
+                scrollOffset: 400,
                 expected: true,
             },
             {

--- a/webapp/channels/src/components/post_view/post_list_virtualized/post_list_virtualized.tsx
+++ b/webapp/channels/src/components/post_view/post_list_virtualized/post_list_virtualized.tsx
@@ -28,7 +28,7 @@ import LatestPostReader from './latest_post_reader';
 const OVERSCAN_COUNT_BACKWARD = 80;
 const OVERSCAN_COUNT_FORWARD = 80;
 const HEIGHT_TRIGGER_FOR_MORE_POSTS = 1000;
-const BUFFER_TO_BE_CONSIDERED_BOTTOM = 10;
+const BUFFER_TO_BE_CONSIDERED_BOTTOM = 100;
 
 const MAXIMUM_POSTS_FOR_SLICING = {
     channel: 50,


### PR DESCRIPTION
Cherry pick of #35680 on release-11.6.

/cc  @hmhealey

```release-note
NONE
```