### PR TITLE
Fix index out of range panic in createProfileImage for empty usernames [MATTERMOST-SERVER-W1]

### DIFF
--- a/server/channels/app/users/profile_picture.go
+++ b/server/channels/app/users/profile_picture.go
@@ -135,7 +135,11 @@ func createProfileImage(username string, userID string, initialFont string) ([]b
 	h.Write([]byte(userID))
 	seed := h.Sum32()
 
-	initial := string(strings.ToUpper(username)[0])
+	trimmedUsername := strings.TrimSpace(username)
+	initial := "?"
+	if len(trimmedUsername) > 0 {
+		initial = string([]rune(strings.ToUpper(trimmedUsername))[0])
+	}
 
 	font, err := getFont(initialFont)
 	if err != nil {

--- a/server/channels/app/users/profile_picture_test.go
+++ b/server/channels/app/users/profile_picture_test.go
@@ -24,3 +24,21 @@ func TestCreateProfileImage(t *testing.T) {
 
 	require.Equal(t, colorful, img.At(1, 1), "Failed to create correct color")
 }
+
+func TestCreateProfileImage_EmptyUsername(t *testing.T) {
+	t.Run("empty username should not panic", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			b, err := createProfileImage("", "eo1zkdr96pdj98pjmq8zy35wba", "nunito-bold.ttf")
+			require.NoError(t, err)
+			require.NotEmpty(t, b)
+		})
+	})
+
+	t.Run("whitespace-only username should not panic", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			b, err := createProfileImage("   ", "eo1zkdr96pdj98pjmq8zy35wba", "nunito-bold.ttf")
+			require.NoError(t, err)
+			require.NotEmpty(t, b)
+		})
+	})
+}


### PR DESCRIPTION
## Summary
Fix [MATTERMOST-SERVER-W1](https://mattermost-mr.sentry.io/issues/7267161420/) — index out of range panic in `createProfileImage` when a user has an empty or whitespace-only username.

## Root Cause
`createProfileImage` accesses `strings.ToUpper(username)[0]` without checking if the string is empty. Users with no displayable name characters trigger a panic:
```
runtime error: index out of range [0] with length 0
```

Call chain: `getProfileImage` → `GetDefaultProfileImage` → `createProfileImage`

## Fix
- Added bounds check on username with fallback to `?` as the initial character
- Used `[]rune` indexing instead of byte indexing to properly handle multi-byte characters (CJK usernames — relevant since affected instances appear to be Chinese deployments)

## Test Added
`TestCreateProfileImage_EmptyUsername` with two sub-tests:
- Empty username (`""`) — should not panic
- Whitespace-only username (`"   "`) — should not panic

## Customer Impact
**1,793 events** across **2 instances:**
- `118.195.136.154` (554 events)
- `175.25.51.228` (1,239 events)

## Suggested Reviewers
Based on git blame for `server/channels/app/users/profile_picture.go`:
- @agnivade (recent changes, 2023)
- @lieut-data (refactoring, 2023)
- @Utsav-Ladani (most recent change, 2024)