### PR TITLE
fix: correct grammar on account creation error

### DIFF
--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -228,7 +228,7 @@ func (a *App) CreateUserWithInviteId(rctx request.CTX, user *model.User, inviteI
 	}
 
 	if !users.CheckUserDomain(user, team.AllowedDomains) {
-		return nil, model.NewAppError("CreateUserWithInviteId", "api.team.invite_members.invalid_email.app_error", map[string]any{"Addresses": team.AllowedDomains}, "", http.StatusForbidden)
+		return nil, model.NewAppError("CreateUserWithInviteId", "api.user.create_user.invalid_invitation_email.app_error", map[string]any{"Addresses": team.AllowedDomains}, "", http.StatusForbidden)
 	}
 
 	user.EmailVerified = false

--- a/server/channels/app/user_test.go
+++ b/server/channels/app/user_test.go
@@ -1047,7 +1047,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 		require.NoError(t, nErr)
 		_, err := th.App.CreateUserWithInviteId(th.Context, &user, th.BasicTeam.InviteId, "")
 		require.NotNil(t, err)
-		require.Equal(t, "api.team.invite_members.invalid_email.app_error", err.Id)
+		require.Equal(t, "api.user.create_user.invalid_invitation_email.app_error", err.Id)
 	})
 }
 

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -4351,6 +4351,10 @@
     "translation": "User creation is disabled."
   },
   {
+    "id": "api.user.create_user.invalid_invitation_email.app_error",
+    "translation": "The email address you entered does not belong to an accepted domain: {{.Addresses}}. Please contact your System Administrator for details."
+  },
+  {
     "id": "api.user.create_user.guest_accounts.disabled.app_error",
     "translation": "Guest accounts are disabled."
   },


### PR DESCRIPTION
## Summary
Fix an issue where the error message for an invalid domain during account creation had incorrect grammar. Added a specific English translation string `api.user.create_user.invalid_invitation_email.app_error` for the user creation flow, replacing the generic `invite_members` error string.

This improves the grammar on the Account Creation Screen and avoids poor UX due to the generic translation string historically used for bulk member invitations.

**Testing**
- Updated and ran the `TestCreateUserWithInviteId` test suite locally.
- Verified test assertions matched the newly implemented translation key name.

## Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/15927

## Screenshots
N/A (text change)

## Release Note
```release-note
Fixed a grammatical error in the user-facing message shown when a new user attempts to sign up with an email address from an unaccepted domain.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This is an isolated fix that changes which translation key is used for a specific validation error in the user account creation flow. The change is limited to error message handling with no modifications to core logic, and test coverage exists for the updated behavior.

**Regression Risk:** Minimal. The change is a direct string replacement in a single error handling path (`CreateUserWithInviteId`). The validation logic remains unchanged—only the translation key identifier is swapped. The corresponding test has been updated to match the new expected key, ensuring the change is exercised and verified.

**QA Recommendation:** Manual QA can be minimal or skipped entirely. The change only affects the error message shown when a user attempts to create an account via invite with an email from a non-accepted domain. Simple verification that the appropriate error message is still displayed (with correct grammar) on this error path would suffice. The risk of skipping manual QA is very low given the isolated nature of the change and existing test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->