### PR TITLE
Fix index out of range panic in createProfileImage for empty usernames

### DIFF
--- a/server/channels/app/users/profile_picture.go
+++ b/server/channels/app/users/profile_picture.go
@@ -135,7 +135,14 @@ func createProfileImage(username string, userID string, initialFont string) ([]b
 	h.Write([]byte(userID))
 	seed := h.Sum32()
 
-	initial := string(strings.ToUpper(username)[0])
+	// Guard against empty/whitespace-only usernames which can occur when user records
+	// bypass model validation (e.g. LDAP/SAML sync, direct DB inserts, data migrations).
+	// See: api4.getProfileImage → app.GetProfileImage → GetDefaultProfileImage → createProfileImage
+	trimmedUsername := strings.TrimSpace(username)
+	initial := "?"
+	if trimmedUsername != "" {
+		initial = string([]rune(strings.ToUpper(trimmedUsername))[0])
+	}
 
 	font, err := getFont(initialFont)
 	if err != nil {

--- a/server/channels/app/users/profile_picture_test.go
+++ b/server/channels/app/users/profile_picture_test.go
@@ -24,3 +24,21 @@ func TestCreateProfileImage(t *testing.T) {
 
 	require.Equal(t, colorful, img.At(1, 1), "Failed to create correct color")
 }
+
+func TestCreateProfileImage_EmptyUsername(t *testing.T) {
+	t.Run("empty username should not panic", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			b, err := createProfileImage("", "eo1zkdr96pdj98pjmq8zy35wba", "nunito-bold.ttf")
+			require.NoError(t, err)
+			require.NotEmpty(t, b)
+		})
+	})
+
+	t.Run("whitespace-only username should not panic", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			b, err := createProfileImage("   ", "eo1zkdr96pdj98pjmq8zy35wba", "nunito-bold.ttf")
+			require.NoError(t, err)
+			require.NotEmpty(t, b)
+		})
+	})
+}


### PR DESCRIPTION
#### Summary

Fix runtime panic `index out of range [0] with length 0` in `createProfileImage` when called with an empty or whitespace-only username.

#### Ticket Link

[MATTERMOST-SERVER-W1](https://mattermost-mr.sentry.io/issues/7267161420/) — 1,793 events across 167 customer instances.

#### Release Note

```release-note
Fixed a server panic when generating default profile images for users with empty usernames.
```

---

### Customer Impact

Affects 167 unique instances including: community.mattermost.com, mattermost.bundeswehr.org, mattermost.siemens.cloud, chat.db.de, mm.swisscom.com, and others.

### Call Chain

```
HTTP GET /api/v4/users/{user_id}/image
→ api4.getProfileImage        (user.go:516)
→ app.GetProfileImage          (:971)
→ app.Server.GetProfileImage   (:1716)
→ app.Server.GetDefaultProfileImage (:1733)
→ users.GetDefaultProfileImage (:102)   — passes user.Username directly
→ users.createProfileImage     (:139)   💥 panics on empty string
```

`getProfileImage` fetches the user from the DB via `GetUser` (which succeeds — the user record exists), then passes it to `GetProfileImage` with no username validation. The user record has an empty username, likely from bypassing model validation (e.g. LDAP/SAML sync, direct DB insert, data migration). `model.IsValidUsername` enforces `MinLength=1`, but that validation doesn't run on this read path.

### Changes

- **`server/channels/app/users/profile_picture.go`**: Add bounds checking with `strings.TrimSpace` + length check before indexing into the username string. Falls back to `"?"` for empty/whitespace usernames. Uses `[]rune` conversion for correct Unicode handling. Includes comment documenting the call chain and how empty usernames can occur.
- **`server/channels/app/users/profile_picture_test.go`**: Add `TestCreateProfileImage_EmptyUsername` covering empty and whitespace-only username cases.

### Root Cause

Line 138 directly indexes into the uppercase username string (`strings.ToUpper(username)[0]`) without checking if it's empty. When a user has no username set, this panics with `runtime error: index out of range [0] with length 0`.