### PR TITLE
ci: add Go module and build cache for server and mmctl tests

### DIFF
--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -54,6 +54,22 @@ jobs:
         run: |
           echo "${{ inputs.name }}" > server/test-name
           echo "${{ github.event.pull_request.number }}" > server/pr-number
+
+      # Cache Go modules and build artifacts on the host, then bind-mount them
+      # into the Docker test container. Without this, every CI run downloads all
+      # Go dependencies (~500MB) and recompiles all packages from scratch.
+      # Expected savings: 5-10 minutes per test job on cache hits.
+      # Key invalidates when Go version or go.sum changes.
+      - name: Restore Go module and build cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            /home/runner/go-cache/mod
+            /home/runner/go-cache/build
+          key: go-mmctl-cache-${{ inputs.go-version }}-${{ hashFiles('server/go.sum') }}
+          restore-keys: |
+            go-mmctl-cache-${{ inputs.go-version }}-
+
       - name: Setup needed prepackaged plugins
         run: |
           cd server
@@ -78,12 +94,20 @@ jobs:
           else
             export TESTFLAGS="-timeout 30m"
           fi
+          # Mount cached Go modules and build cache into the container.
+          # GOMODCACHE: avoids re-downloading dependencies (~500MB).
+          # GOCACHE: avoids recompiling unchanged packages.
+          mkdir -p /home/runner/go-cache/mod /home/runner/go-cache/build
           docker run --net ghactions_mm-test \
             --ulimit nofile=8096:8096 \
             --env-file=server/build/dotenv/test.env \
             --env MM_SQLSETTINGS_DATASOURCE="${{ inputs.datasource }}" \
             --env MMCTL_TESTFLAGS="$TESTFLAGS" \
             --env FIPS_ENABLED="${{ inputs.fips-enabled }}" \
+            --env GOMODCACHE=/go-cache/mod \
+            --env GOCACHE=/go-cache/build \
+            -v /home/runner/go-cache/mod:/go-cache/mod \
+            -v /home/runner/go-cache/build:/go-cache/build \
             -v $PWD:/mattermost \
             -w /mattermost/server \
             $BUILD_IMAGE \

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -68,6 +68,21 @@ jobs:
           echo "${{ inputs.name }}" > server/test-name
           echo "${{ github.event.pull_request.number }}" > server/pr-number
 
+      # Cache Go modules and build artifacts on the host, then bind-mount them
+      # into the Docker test container. Without this, every CI run downloads all
+      # Go dependencies (~500MB) and recompiles all packages from scratch.
+      # Expected savings: 5-10 minutes per test job on cache hits.
+      # Key invalidates when Go version or go.sum changes.
+      - name: Restore Go module and build cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            /home/runner/go-cache/mod
+            /home/runner/go-cache/build
+          key: go-test-cache-${{ inputs.go-version }}-${{ hashFiles('server/go.sum') }}
+          restore-keys: |
+            go-test-cache-${{ inputs.go-version }}-
+
       - name: Run docker compose
         run: |
           cd server/build
@@ -85,6 +100,10 @@ jobs:
           if [[ ${{ github.ref_name }} == 'master' && ${{ inputs.fullyparallel }} != true ]]; then
             export RACE_MODE="-race"
           fi
+          # Mount cached Go modules and build cache into the container.
+          # GOMODCACHE: avoids re-downloading dependencies (~500MB).
+          # GOCACHE: avoids recompiling unchanged packages.
+          mkdir -p /home/runner/go-cache/mod /home/runner/go-cache/build
           docker run --net ghactions_mm-test \
             --ulimit nofile=8096:8096 \
             --env-file=server/build/dotenv/test.env \
@@ -94,6 +113,10 @@ jobs:
             --env ENABLE_FULLY_PARALLEL_TESTS="${{ inputs.fullyparallel }}" \
             --env ENABLE_COVERAGE="${{ inputs.enablecoverage }}" \
             --env FIPS_ENABLED="${{ inputs.fips-enabled }}" \
+            --env GOMODCACHE=/go-cache/mod \
+            --env GOCACHE=/go-cache/build \
+            -v /home/runner/go-cache/mod:/go-cache/mod \
+            -v /home/runner/go-cache/build:/go-cache/build \
             -v $PWD:/mattermost \
             -w /mattermost/server \
             $BUILD_IMAGE \


### PR DESCRIPTION
#### Summary

Add Go module and build cache for server and mmctl Docker-based test jobs. Currently every CI run downloads all Go dependencies and recompiles all packages from scratch because tests run inside Docker containers that do not benefit from GitHub Actions cache.

This PR mounts host-side cache directories into the Docker containers via bind mounts, persisted between runs using `actions/cache` keyed on Go version + `go.sum` hash.

**Changes:**
- `server-test-template.yml`: Add `actions/cache` step + mount `GOMODCACHE`/`GOCACHE` into Docker container
- `mmctl-test-template.yml`: Same

**Measured results (run #23325914142):**
- **mmctl: 6m 00s** with warm cache vs ~8min baseline → **25% faster (~2min saved per run)**
- **Postgres: 59m 54s** (cold cache miss — cache saved for next run; warm-cache measurement pending)

**Risk:** If the build container runs as a different UID, cache dirs may have permission issues. The `mkdir -p` step ensures dirs exist on the host. Worst case on failure: tests recompile from scratch (no worse than today).

#### Ticket Link

N/A — CI improvement. Analysis: https://mmworkbrain.pages.dev/docs/status/ci-analysis-mattermost-server/

#### Release Note

```release-note
NONE
```