### PR TITLE
Fix bool values sent as JSON booleans instead of strings in dialog submissions

### DIFF
--- a/webapp/channels/src/components/dialog_router/interactive_dialog_adapter.tsx
+++ b/webapp/channels/src/components/dialog_router/interactive_dialog_adapter.tsx
@@ -270,11 +270,23 @@ class InteractiveDialogAdapter extends React.PureComponent<Props> {
                 }
             }
 
+            // Convert boolean values to string ("true"/"false") before submission
+            // to ensure consistent typing for plugins expecting map[string]string
+            const stringifiedSubmission: {[x: string]: string} = {};
+            for (const key of Object.keys(finalSubmission)) {
+                const val = finalSubmission[key];
+                if (typeof val === 'boolean') {
+                    stringifiedSubmission[key] = String(val);
+                } else {
+                    stringifiedSubmission[key] = val as string;
+                }
+            }
+
             const legacySubmission: DialogSubmission = {
                 url: this.props.url || '',
                 callback_id: this.props.callbackId || '',
                 state: dialogState, // Dialog state for multiform step tracking
-                submission: finalSubmission as {[x: string]: string},
+                submission: stringifiedSubmission,
                 user_id: '', // Populated by submitInteractiveDialog action
                 channel_id: '', // Populated by submitInteractiveDialog action
                 team_id: '', // Populated by submitInteractiveDialog action

--- a/webapp/channels/src/components/interactive_dialog/interactive_dialog.test.tsx
+++ b/webapp/channels/src/components/interactive_dialog/interactive_dialog.test.tsx
@@ -105,6 +105,78 @@ describe('components/interactive_dialog/InteractiveDialog', () => {
         });
     });
 
+    describe('bool element submission values', () => {
+        test('should submit boolean values as strings', async () => {
+            const boolElement: TDialogElement = {
+                data_source: '',
+                display_name: 'Boolean Selector',
+                name: 'somebool',
+                optional: false,
+                type: 'bool',
+                placeholder: 'Subscribe?',
+                subtype: '',
+                default: 'true',
+                help_text: '',
+                min_length: 0,
+                max_length: 0,
+                options: [],
+            };
+
+            const submitMock = jest.fn().mockResolvedValue({data: {}});
+            const props = {
+                ...baseProps,
+                elements: [boolElement],
+                actions: {
+                    submitInteractiveDialog: submitMock,
+                    lookupInteractiveDialog: jest.fn(),
+                },
+            };
+
+            const wrapper = shallow<InteractiveDialog>(<InteractiveDialog {...props}/>);
+            await wrapper.instance().handleSubmit(submitEvent);
+
+            expect(submitMock).toHaveBeenCalledTimes(1);
+            const submittedDialog = submitMock.mock.calls[0][0];
+            expect(submittedDialog.submission.somebool).toBe('true');
+            expect(typeof submittedDialog.submission.somebool).toBe('string');
+        });
+
+        test('should submit false boolean values as string "false"', async () => {
+            const boolElement: TDialogElement = {
+                data_source: '',
+                display_name: 'Boolean Selector',
+                name: 'somebool',
+                optional: false,
+                type: 'bool',
+                placeholder: 'Subscribe?',
+                subtype: '',
+                default: 'false',
+                help_text: '',
+                min_length: 0,
+                max_length: 0,
+                options: [],
+            };
+
+            const submitMock = jest.fn().mockResolvedValue({data: {}});
+            const props = {
+                ...baseProps,
+                elements: [boolElement],
+                actions: {
+                    submitInteractiveDialog: submitMock,
+                    lookupInteractiveDialog: jest.fn(),
+                },
+            };
+
+            const wrapper = shallow<InteractiveDialog>(<InteractiveDialog {...props}/>);
+            await wrapper.instance().handleSubmit(submitEvent);
+
+            expect(submitMock).toHaveBeenCalledTimes(1);
+            const submittedDialog = submitMock.mock.calls[0][0];
+            expect(submittedDialog.submission.somebool).toBe('false');
+            expect(typeof submittedDialog.submission.somebool).toBe('string');
+        });
+    });
+
     describe('bool element in Interactive Dialog', () => {
         const element: TDialogElement = {
             data_source: '',

--- a/webapp/channels/src/components/interactive_dialog/interactive_dialog.tsx
+++ b/webapp/channels/src/components/interactive_dialog/interactive_dialog.tsx
@@ -90,11 +90,23 @@ export default class InteractiveDialog extends React.PureComponent<Props, State>
 
         const {url, callbackId, state} = this.props;
 
+        // Convert boolean values to string ("true"/"false") before submission
+        // to ensure consistent typing for plugins expecting map[string]string
+        const submission: { [x: string]: string } = {};
+        for (const key of Object.keys(values)) {
+            const val = values[key];
+            if (typeof val === 'boolean') {
+                submission[key] = String(val);
+            } else {
+                submission[key] = val as string;
+            }
+        }
+
         const dialog: DialogSubmission = {
             url,
             callback_id: callbackId ?? '',
             state: state ?? '',
-            submission: values as { [x: string]: string },
+            submission,
             user_id: '',
             channel_id: '',
             team_id: '',


### PR DESCRIPTION
#### Summary

Boolean fields in interactive dialogs were sending actual JSON boolean values (`true`/`false`) instead of string values (`"true"`/`"false"`) in the submission payload. This caused a type mismatch for plugins expecting `map[string]string` on the server side, as `DialogSubmission.Submission` is typed as `map[string]string` but received JSON booleans from the frontend `BoolSetting` component.

The fix converts boolean values to their string representation at submission time in both `InteractiveDialog` and `InteractiveDialogAdapter` components, ensuring consistent string typing in the submission payload.

Fixes https://github.com/mattermost/mattermost/issues/35631

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/35631

#### Screenshots

N/A - logic-only change

#### Release Note

```
Fixed an issue where boolean field values in interactive dialogs were sent as JSON booleans instead of strings, causing type mismatches for plugins.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This PR fixes a type mismatch bug by converting boolean values to string representations in dialog submissions. The changes are isolated to two dialog components with comprehensive test coverage, and the fix ensures frontend behavior aligns with server-side type expectations (`map[string]string`). No shared utilities, validation logic, or critical paths are affected.

**Regression Risk:** Very low. The changes only affect the conversion of boolean field values to strings before submission payload construction. Other field types pass through unchanged. The modification addresses a bug where JSON boolean values were violating the `DialogSubmission.submission` type contract (`{[x: string]: string | string[]}`). Both the legacy `InteractiveDialog` and newer `InteractiveDialogAdapter` components are updated consistently. No validation, error handling, or control flow logic is altered—only the submission payload format is corrected.

**QA Recommendation:** Minimal manual QA is required. The fix is straightforward and well-tested: verify that interactive dialogs with boolean elements now submit string values ("true"/"false") instead of JSON booleans, both for new submissions and dialog refresh operations. Test both `InteractiveDialog` (legacy) and `InteractiveDialogAdapter` (newer form) paths. Server-side plugin handlers expecting `map[string]string` should now receive properly typed submissions without type assertion errors. Skipping manual QA is acceptable given the limited scope and new test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->