### PR TITLE
Fix nil License panic in team API endpoints (createTeam, restoreTeam, importTeam)

### DIFF
--- a/server/channels/api4/team.go
+++ b/server/channels/api4/team.go
@@ -99,7 +99,7 @@ func createTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// On a cloud license, we must check limits before allowing to create
-	if c.App.Channels().License().IsCloud() {
+	if license.IsCloud() {
 		limits, err := c.App.Cloud().GetCloudLimits(c.AppContext.Session().UserId)
 		if err != nil {
 			c.Err = model.NewAppError("Api4.createTeam", "api.cloud.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -379,7 +379,7 @@ func restoreTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// On a cloud license, we must check limits before allowing to restore
-	if c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() != nil && c.App.Channels().License().IsCloud() {
 		limits, err := c.App.Cloud().GetCloudLimits(c.AppContext.Session().UserId)
 		if err != nil {
 			c.Err = model.NewAppError("Api4.restoreTeam", "api.cloud.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -1398,7 +1398,7 @@ func teamExists(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func importTeam(c *Context, w http.ResponseWriter, r *http.Request) {
-	if c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() != nil && c.App.Channels().License().IsCloud() {
 		c.Err = model.NewAppError("importTeam", "api.restricted_system_admin", nil, "", http.StatusForbidden)
 		return
 	}

--- a/server/channels/api4/team_test.go
+++ b/server/channels/api4/team_test.go
@@ -235,6 +235,21 @@ func TestCreateTeam(t *testing.T) {
 		require.NoError(t, err)
 		CheckCreatedStatus(t, resp)
 	})
+
+	t.Run("no license does not panic", func(t *testing.T) {
+		// Regression test: createTeam previously called License().IsCloud()
+		// without a nil check, causing a panic on community edition servers
+		// with no license installed.
+		// Sentry: MATTERMOST-SERVER-TY (1,497 events)
+		appErr := th.App.Srv().RemoveLicense()
+		require.Nil(t, appErr)
+		defer th.App.Srv().SetLicense(nil)
+
+		team := &model.Team{Name: GenerateTestUsername(), DisplayName: "No License Team", Type: model.TeamOpen}
+		_, resp, err := th.Client.CreateTeam(context.Background(), team)
+		require.NoError(t, err)
+		CheckCreatedStatus(t, resp)
+	})
 }
 
 func TestCreateTeamSanitization(t *testing.T) {
@@ -1268,6 +1283,20 @@ func TestRestoreTeam(t *testing.T) {
 		}, nil).Twice()
 		team := createTeam(t, true, model.TeamOpen)
 		_, resp, err := client.RestoreTeam(context.Background(), team.Id)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+	})
+
+	t.Run("no license does not panic", func(t *testing.T) {
+		// Regression test: restoreTeam previously called License().IsCloud()
+		// without a nil check, causing a panic with no license installed.
+		// Sentry: MATTERMOST-SERVER-TY
+		team := createTeam(t, true, model.TeamOpen)
+		appErr := th.App.Srv().RemoveLicense()
+		require.Nil(t, appErr)
+		defer th.App.Srv().SetLicense(nil)
+
+		_, resp, err := th.SystemAdminClient.RestoreTeam(context.Background(), team.Id)
 		require.NoError(t, err)
 		CheckOKStatus(t, resp)
 	})
@@ -3879,6 +3908,22 @@ func TestImportTeam(t *testing.T) {
 		_, resp, err := th.Client.ImportTeam(context.Background(), data, binary.Size(data), "slack", "Fake_Team_Import.zip", th.BasicTeam.Id)
 		require.Error(t, err)
 		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("no license does not panic", func(t *testing.T) {
+		// Regression test: importTeam previously called License().IsCloud()
+		// without a nil check, causing a panic with no license installed.
+		// Sentry: MATTERMOST-SERVER-TY
+		appErr := th.App.Srv().RemoveLicense()
+		require.Nil(t, appErr)
+		defer th.App.Srv().SetLicense(nil)
+
+		data, err := testutils.ReadTestFile("Fake_Team_Import.zip")
+		require.False(t, err != nil && len(data) == 0, "Error while reading the test file.")
+
+		fileResp, _, err := th.SystemAdminClient.ImportTeam(context.Background(), data, binary.Size(data), "slack", "Fake_Team_Import.zip", th.BasicTeam.Id)
+		require.NoError(t, err)
+		require.NotNil(t, fileResp)
 	})
 }
 


### PR DESCRIPTION
#### Summary

Guard against nil `License()` in team API endpoints (`createTeam`, `restoreTeam`, `importTeam`). When no license is installed (community edition), `c.App.Channels().License()` returns nil and calling `.IsCloud()` on it causes a nil pointer panic.

#### Ticket Link

[MATTERMOST-SERVER-TY](https://mattermost-mr.sentry.io/issues/7063429511/) — 1,497 events from mattermost.bolor.net (2025-11-25 to 2026-01-14).

#### Release Note

```release-note
Fixed a server crash in team creation, restoration, and import when no license is installed.
```

---

### Root Cause

Three locations in `server/channels/api4/team.go` call `c.App.Channels().License().IsCloud()` without checking if `License()` returns nil:

- **`createTeam` (L102)**: Has `license := c.App.Channels().License()` at L86 but doesn't use it — calls `License()` again directly
- **`restoreTeam` (L382)**: No nil check
- **`importTeam` (L1401)**: No nil check

When a Mattermost server runs without a license (community edition), `License()` returns nil and `.IsCloud()` panics.

### Fix

- `createTeam`: Reuse the `license` variable already saved at L86 (also avoids a redundant `License()` call)
- `restoreTeam` + `importTeam`: Add `c.App.Channels().License() != nil &&` guard

### Broader Pattern ⚠️

The same unsafe `License().IsCloud()` pattern exists in **19 other locations** across:
- `config.go` (5 occurrences)
- `cloud.go` (11 occurrences)
- `license.go` (1 occurrence)
- `user.go` (1 occurrence)
- `upload.go` (2 occurrences)

These should be addressed in a follow-up PR. The `cloud.go` ones may be lower risk since cloud endpoints likely require a license, but `config.go` and `user.go` are general endpoints reachable without a license.

### Customer Impact

**1,497 crash events** from a community-edition deployment (mattermost.bolor.net). Any Mattermost server running without a license that receives a `POST /api/v4/teams`, `POST /api/v4/teams/{id}/restore`, or `POST /api/v4/teams/{id}/import` request will crash.