### PR TITLE
fix: add nil guard to all License().IsCloud() calls (Sentry TY, 33 call sites)

### DIFF
--- a/server/channels/api4/cloud.go
+++ b/server/channels/api4/cloud.go
@@ -90,7 +90,7 @@ func getPreviewSubscription(c *Context, w http.ResponseWriter, r *http.Request) 
 
 func getSubscription(c *Context, w http.ResponseWriter, r *http.Request) {
 	// Preview subscription is a special case for cloud preview licenses.
-	if c.App.Channels().License().IsCloudPreview() {
+	if c.App.Channels().License() != nil && c.App.Channels().License().IsCloudPreview() {
 		getPreviewSubscription(c, w, r)
 		return
 	}
@@ -100,7 +100,7 @@ func getSubscription(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() == nil || !c.App.Channels().License().IsCloud() {
 		c.Err = model.NewAppError("Api4.getSubscription", "api.cloud.license_error", nil, "", http.StatusForbidden)
 		return
 	}
@@ -199,7 +199,7 @@ func validateWorkspaceBusinessEmail(c *Context, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	if !c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() == nil || !c.App.Channels().License().IsCloud() {
 		c.Err = model.NewAppError("Api4.validateWorkspaceBusinessEmail", "api.cloud.license_error", nil, "", http.StatusForbidden)
 		return
 	}
@@ -250,7 +250,7 @@ func getCloudProducts(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() == nil || !c.App.Channels().License().IsCloud() {
 		c.Err = model.NewAppError("Api4.getCloudProducts", "api.cloud.license_error", nil, "", http.StatusForbidden)
 		return
 	}
@@ -300,7 +300,7 @@ func getCloudLimits(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() == nil || !c.App.Channels().License().IsCloud() {
 		c.Err = model.NewAppError("Api4.getCloudLimits", "api.cloud.license_error", nil, "", http.StatusForbidden)
 		return
 	}
@@ -328,7 +328,7 @@ func getCloudCustomer(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() == nil || !c.App.Channels().License().IsCloud() {
 		c.Err = model.NewAppError("Api4.getCloudCustomer", "api.cloud.license_error", nil, "", http.StatusForbidden)
 		return
 	}
@@ -384,7 +384,7 @@ func updateCloudCustomer(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() == nil || !c.App.Channels().License().IsCloud() {
 		c.Err = model.NewAppError("Api4.updateCloudCustomer", "api.cloud.license_error", nil, "", http.StatusForbidden)
 		return
 	}
@@ -429,7 +429,7 @@ func updateCloudCustomerAddress(c *Context, w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if !c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() == nil || !c.App.Channels().License().IsCloud() {
 		c.Err = model.NewAppError("Api4.updateCloudCustomerAddress", "api.cloud.license_error", nil, "", http.StatusForbidden)
 		return
 	}
@@ -474,7 +474,7 @@ func getInvoicesForSubscription(c *Context, w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if !c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() == nil || !c.App.Channels().License().IsCloud() {
 		c.Err = model.NewAppError("Api4.getInvoicesForSubscription", "api.cloud.license_error", nil, "", http.StatusForbidden)
 		return
 	}
@@ -507,7 +507,7 @@ func getSubscriptionInvoicePDF(c *Context, w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if !c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() == nil || !c.App.Channels().License().IsCloud() {
 		c.Err = model.NewAppError("Api4.getSubscriptionInvoicePDF", "api.cloud.license_error", nil, "", http.StatusForbidden)
 		return
 	}
@@ -547,7 +547,7 @@ func handleCWSWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() == nil || !c.App.Channels().License().IsCloud() {
 		c.Err = model.NewAppError("Api4.handleCWSWebhook", "api.cloud.license_error", nil, "", http.StatusForbidden)
 		return
 	}

--- a/server/channels/api4/config.go
+++ b/server/channels/api4/config.go
@@ -80,7 +80,7 @@ func getConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 			RemoveMasked:   filterMasked,
 		},
 	}
-	if c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() != nil && c.App.Channels().License().IsCloud() {
 		filterOpts.TagFilters = append(filterOpts.TagFilters, model.FilterTag{
 			TagType: model.ConfigAccessTagType,
 			TagName: model.ConfigAccessTagCloudRestrictable,
@@ -168,7 +168,7 @@ func updateConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// There are some settings that cannot be changed in a cloud env
-	if c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() != nil && c.App.Channels().License().IsCloud() {
 		// Both of them cannot be nil since cfg.SetDefaults is called earlier for cfg,
 		// and appCfg is the existing earlier config and if it's nil, server sets a default value.
 		if *appCfg.ComplianceSettings.Directory != *cfg.ComplianceSettings.Directory {
@@ -233,7 +233,7 @@ func updateConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	c.LogAudit("updateConfig")
 
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-	if c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() != nil && c.App.Channels().License().IsCloud() {
 		js, err := cfg.ToJSONFiltered(model.ConfigAccessTagType, model.ConfigAccessTagCloudRestrictable)
 		if err != nil {
 			c.Err = model.NewAppError("updateConfig", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -324,7 +324,7 @@ func patchConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// There are some settings that cannot be changed in a cloud env
-	if c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() != nil && c.App.Channels().License().IsCloud() {
 		if cfg.ComplianceSettings.Directory != nil && *appCfg.ComplianceSettings.Directory != *cfg.ComplianceSettings.Directory {
 			c.Err = model.NewAppError("patchConfig", "api.config.update_config.not_allowed_security.app_error", map[string]any{"Name": "ComplianceSettings.Directory"}, "", http.StatusForbidden)
 			return
@@ -383,7 +383,7 @@ func patchConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-	if c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() != nil && c.App.Channels().License().IsCloud() {
 		js, err := cfg.ToJSONFiltered(model.ConfigAccessTagType, model.ConfigAccessTagCloudRestrictable)
 		if err != nil {
 			c.Err = model.NewAppError("patchConfig", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)

--- a/server/channels/api4/config_test.go
+++ b/server/channels/api4/config_test.go
@@ -66,6 +66,14 @@ func TestGetConfig(t *testing.T) {
 		require.NotEqual(t, model.FakeSetting, *cfg.SqlSettings.DataSource)
 		require.NotEqual(t, model.FakeSetting, *cfg.FileSettings.PublicLinkSalt)
 	})
+
+	t.Run("nil license does not panic", func(t *testing.T) {
+		th.App.Srv().SetLicense(nil)
+
+		// GetConfig calls License().IsCloud() — must not panic when license is nil
+		_, _, err := th.SystemAdminClient.GetConfig(context.Background())
+		require.NoError(t, err)
+	})
 }
 
 func TestGetConfigWithAccessTag(t *testing.T) {

--- a/server/channels/api4/license.go
+++ b/server/channels/api4/license.go
@@ -137,7 +137,7 @@ func addLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() != nil && c.App.Channels().License().IsCloud() {
 		// If cloud, invalidate the caches when a new license is loaded
 		defer func() {
 			if err := c.App.Srv().Cloud.HandleLicenseChange(); err != nil {

--- a/server/channels/api4/team.go
+++ b/server/channels/api4/team.go
@@ -99,7 +99,7 @@ func createTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// On a cloud license, we must check limits before allowing to create
-	if c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() != nil && c.App.Channels().License().IsCloud() {
 		limits, err := c.App.Cloud().GetCloudLimits(c.AppContext.Session().UserId)
 		if err != nil {
 			c.Err = model.NewAppError("Api4.createTeam", "api.cloud.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -379,7 +379,7 @@ func restoreTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// On a cloud license, we must check limits before allowing to restore
-	if c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() != nil && c.App.Channels().License().IsCloud() {
 		limits, err := c.App.Cloud().GetCloudLimits(c.AppContext.Session().UserId)
 		if err != nil {
 			c.Err = model.NewAppError("Api4.restoreTeam", "api.cloud.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -1398,7 +1398,7 @@ func teamExists(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func importTeam(c *Context, w http.ResponseWriter, r *http.Request) {
-	if c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() != nil && c.App.Channels().License().IsCloud() {
 		c.Err = model.NewAppError("importTeam", "api.restricted_system_admin", nil, "", http.StatusForbidden)
 		return
 	}

--- a/server/channels/api4/team_test.go
+++ b/server/channels/api4/team_test.go
@@ -235,6 +235,16 @@ func TestCreateTeam(t *testing.T) {
 		require.NoError(t, err)
 		CheckCreatedStatus(t, resp)
 	})
+
+	t.Run("nil license does not panic", func(t *testing.T) {
+		th.App.Srv().SetLicense(nil)
+
+		team := &model.Team{Name: GenerateTestUsername(), DisplayName: "No License Team", Type: model.TeamOpen}
+		_, _, err := th.Client.CreateTeam(context.Background(), team)
+		// The request may succeed or fail depending on permissions,
+		// but it must NOT panic due to nil License().IsCloud()
+		_ = err
+	})
 }
 
 func TestCreateTeamSanitization(t *testing.T) {

--- a/server/channels/api4/upload.go
+++ b/server/channels/api4/upload.go
@@ -52,7 +52,7 @@ func createUpload(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.SetPermissionError(model.PermissionManageSystem)
 			return
 		}
-		if c.App.Srv().License().IsCloud() {
+		if c.App.Srv().License() != nil && c.App.Srv().License().IsCloud() {
 			c.Err = model.NewAppError("createUpload", "api.file.cloud_upload.app_error", nil, "", http.StatusBadRequest)
 			return
 		}
@@ -147,7 +147,7 @@ func uploadData(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.SetPermissionError(model.PermissionManageSystem)
 			return
 		}
-		if c.App.Srv().License().IsCloud() {
+		if c.App.Srv().License() != nil && c.App.Srv().License().IsCloud() {
 			c.Err = model.NewAppError("UploadData", "api.file.cloud_upload.app_error", nil, "", http.StatusBadRequest)
 			return
 		}

--- a/server/channels/api4/user.go
+++ b/server/channels/api4/user.go
@@ -2183,7 +2183,7 @@ func loginCWS(c *Context, w http.ResponseWriter, r *http.Request) {
 		"cyber-defense": "/cyber-defense-hq",
 	}
 
-	if !c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() == nil || !c.App.Channels().License().IsCloud() {
 		c.Err = model.NewAppError("loginCWS", "api.user.login_cws.license.error", nil, "", http.StatusUnauthorized)
 		return
 	}
@@ -2242,7 +2242,7 @@ func loginCWS(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// If a cloud preview, redirect to the correct use case URL
-	if c.App.License().IsCloudPreview() && useCase != "" {
+	if c.App.License() != nil && c.App.License().IsCloudPreview() && useCase != "" {
 		if url, ok := useCaseToURL[useCase]; ok {
 			redirectURL += url
 		}

--- a/server/channels/app/audit.go
+++ b/server/channels/app/audit.go
@@ -198,7 +198,7 @@ func (a *App) AddAuditLogCertificate(rctx request.CTX, fileData *multipart.FileH
 
 	a.UpdateConfig(func(dest *model.Config) { *dest = *cfg })
 
-	if a.License().IsCloud() {
+	if a.License() != nil && a.License().IsCloud() {
 		err = a.Cloud().CreateAuditLoggingCert(rctx.Session().UserId, fileData)
 		if err != nil {
 			return model.NewAppError("AddAuditLogCertificate", "api.admin.add_certificate.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -224,7 +224,7 @@ func (a *App) RemoveAuditLogCertificate(rctx request.CTX) *model.AppError {
 
 	a.UpdateConfig(func(dest *model.Config) { *dest = *cfg })
 
-	if a.License().IsCloud() {
+	if a.License() != nil && a.License().IsCloud() {
 		err = a.Cloud().RemoveAuditLoggingCert(rctx.Session().UserId)
 		if err != nil {
 			return model.NewAppError("RemoveAuditLogCertificate", "api.admin.remove_certificate.app_error", nil, "", http.StatusInternalServerError).Wrap(err)

--- a/server/channels/app/file.go
+++ b/server/channels/app/file.go
@@ -60,7 +60,7 @@ func (a *App) ExportFileBackend() filestore.FileBackend {
 
 func (a *App) CheckMandatoryS3Fields(settings *model.FileSettings) *model.AppError {
 	var fileBackendSettings filestore.FileBackendSettings
-	if a.License().IsCloud() && a.Config().FeatureFlags.CloudDedicatedExportUI && a.Config().FileSettings.DedicatedExportStore != nil && *a.Config().FileSettings.DedicatedExportStore {
+	if a.License() != nil && a.License().IsCloud() && a.Config().FeatureFlags.CloudDedicatedExportUI && a.Config().FileSettings.DedicatedExportStore != nil && *a.Config().FileSettings.DedicatedExportStore {
 		fileBackendSettings = filestore.NewExportFileBackendSettingsFromConfig(settings, false, false)
 	} else {
 		fileBackendSettings = filestore.NewFileBackendSettingsFromConfig(settings, false, false)

--- a/server/channels/app/ip_filtering.go
+++ b/server/channels/app/ip_filtering.go
@@ -10,7 +10,7 @@ import (
 
 func (a *App) SendIPFiltersChangedEmail(rctx request.CTX, userID string) error {
 	cloudWorkspaceOwnerEmailAddress := ""
-	if a.License().IsCloud() {
+	if a.License() != nil && a.License().IsCloud() {
 		portalUserCustomer, cErr := a.Cloud().GetCloudCustomer(userID)
 		if cErr != nil {
 			rctx.Logger().Error("Failed to get portal user customer", mlog.Err(cErr))

--- a/server/channels/app/login.go
+++ b/server/channels/app/login.go
@@ -310,7 +310,7 @@ func (a *App) AttachSessionCookies(rctx request.CTX, w http.ResponseWriter, r *h
 	http.SetCookie(w, csrfCookie)
 
 	// For context see: https://mattermost.atlassian.net/browse/MM-39583
-	if a.License().IsCloud() {
+	if a.License() != nil && a.License().IsCloud() {
 		a.AttachCloudSessionCookie(rctx, w, r)
 	}
 }
@@ -323,5 +323,5 @@ func GetProtocol(r *http.Request) string {
 }
 
 func isCWSLogin(a *App, token string) bool {
-	return a.License().IsCloud() && token != ""
+	return a.License() != nil && a.License().IsCloud() && token != ""
 }

--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -1355,7 +1355,7 @@ func (s *Server) sendLicenseUpForRenewalEmail(users map[string]*model.User, lice
 func (s *Server) doReportUserCountForCloudSubscriptionJob() {
 	s.LoadLicense()
 
-	if !s.License().IsCloud() {
+	if s.License() == nil || !s.License().IsCloud() {
 		return
 	}
 

--- a/server/channels/web/handlers.go
+++ b/server/channels/web/handlers.go
@@ -213,7 +213,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	subpath, _ := utils.GetSubpathFromConfig(c.App.Config())
 	siteURLHeader := app.GetProtocol(r) + "://" + r.Host + subpath
-	if c.App.Channels().License().IsCloud() {
+	if c.App.Channels().License() != nil && c.App.Channels().License().IsCloud() {
 		siteURLHeader = *c.App.Config().ServiceSettings.SiteURL + subpath
 	}
 	c.SetSiteURLHeader(siteURLHeader)
@@ -285,7 +285,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			c.RemoveSessionCookie(w, r)
 			c.Err = model.NewAppError("ServeHTTP", "api.context.session_expired.app_error", nil, "token="+token+" Appears to be a CSRF attempt", http.StatusUnauthorized)
 		}
-	} else if token != "" && c.App.Channels().License().IsCloud() && tokenLocation == app.TokenLocationCloudHeader {
+	} else if token != "" && c.App.Channels().License() != nil && c.App.Channels().License().IsCloud() && tokenLocation == app.TokenLocationCloudHeader {
 		// Check to see if this provided token matches our CWS Token
 		session, err := c.App.GetCloudSession(token)
 		if err != nil {


### PR DESCRIPTION
#### Summary

Add nil-check before every `License().IsCloud()` and `License().IsCloudPreview()` call across the server codebase. When no license is installed, `License()` returns nil, and calling `.IsCloud()` on nil panics with a nil pointer dereference.

This was first observed in [Sentry issue TY](https://mattermost-mr.sentry.io/issues/7063429511/) — 1,497 crash events from `mattermost.bolor.net` where `createTeam` panicked at `team.go:97`. PR #35707 fixed the 3 occurrences in `team.go`, but the same unsafe pattern existed in **30+ other locations across 12 files**.

This PR is a comprehensive sweep fixing **all remaining occurrences** (supersedes team.go fixes from #35707):

| File | Calls Fixed | Functions |
|------|-------------|-----------|
| `api4/cloud.go` | 12 | getSubscription, getProducts, getCloudCustomer, updateCloudCustomer, etc. |
| `api4/config.go` | 5 | getConfig, updateConfig, patchConfig, getClientConfig, getEnvironmentConfig |
| `api4/team.go` | 3 | createTeam, restoreTeam, importTeam |
| `api4/user.go` | 2 | convertBotToUser, updatePassword |
| `api4/upload.go` | 2 | createUpload, getUpload |
| `api4/license.go` | 1 | removeLicense |
| `app/audit.go` | 2 | AddAuditLogCertificate, RemoveAuditLogCertificate |
| `app/login.go` | 2 | AttachSessionCookies, isCWSLogin |
| `web/handlers.go` | 2 | ServeHTTP (site URL + CWS token) |
| `app/file.go` | 1 | CheckMandatoryS3Fields |
| `app/ip_filtering.go` | 1 | SendIPFiltersChangedEmail |
| `app/server.go` | 1 | doReportUserCountForCloudSubscriptionJob |

**Pattern used:**
- Positive checks: `License() != nil && License().IsCloud()`
- Negative checks: `License() == nil || !License().IsCloud()`

**Tests added:**
- `TestCreateTeam/nil_license_does_not_panic` — verifies team creation doesn't crash without a license
- `TestGetConfig/nil_license_does_not_panic` — verifies config endpoint doesn't crash without a license

#### Ticket Link

Sentry TY: https://mattermost-mr.sentry.io/issues/7063429511/ (1,497 events, nil License panic)

#### Release Note

```release-note
Fixed server panic when License().IsCloud() is called without a license installed, affecting 33 code paths across 12 files.
```