### PR TITLE
Automated cherry pick of #35558

### DIFF
--- a/server/channels/api4/post.go
+++ b/server/channels/api4/post.go
@@ -1055,7 +1055,7 @@ func postPatchChecks(c *Context, auditRec *model.AuditRecord, message *string) {
 	// Users who can't create posts in a channel shouldn't be able to edit them either.
 	userCreatePostPermissionCheckWithContext(c, originalPost.ChannelId)
 	if c.Err != nil {
-		return false
+		return
 	}
 
 	if *c.App.Config().ServiceSettings.PostEditTimeLimit != -1 && model.GetMillis() > originalPost.CreateAt+int64(*c.App.Config().ServiceSettings.PostEditTimeLimit*1000) && message != nil {

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -1691,7 +1691,7 @@ func TestUpdatePost(t *testing.T) {
 	t.Run("should prevent editing when create_post permission is revoked", func(t *testing.T) {
 		th.LoginBasic(t)
 
-		postToEdit, _, appErr := th.App.CreatePost(th.Context, &model.Post{
+		postToEdit, appErr := th.App.CreatePost(th.Context, &model.Post{
 			UserId:    th.BasicUser.Id,
 			ChannelId: channel.Id,
 			Message:   "original message",


### PR DESCRIPTION
Cherry pick of #35558 on release-11.4.

/cc  @davidkrauser

```release-note
NONE
```