### PR TITLE
Fix nil pointer dereference in UpdateUser (MATTERMOST-SERVER-VF)

### DIFF
--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -1504,8 +1504,11 @@ func (a *App) UpdateUser(rctx request.CTX, user *model.User, sendNotifications b
 		}
 	}
 
-	if userUpdate == nil || userUpdate.New == nil {
-		return nil, model.NewAppError("UpdateUser", "app.user.update.find.app_error", nil, "received nil result from store update for userId="+user.Id, http.StatusInternalServerError)
+	if userUpdate == nil {
+		return nil, model.NewAppError("UpdateUser", "app.user.update.find.app_error", nil, "received nil update result from store for userId="+user.Id, http.StatusInternalServerError)
+	}
+	if userUpdate.New == nil {
+		return nil, model.NewAppError("UpdateUser", "app.user.update.find.app_error", nil, "received update result with nil New user from store for userId="+user.Id, http.StatusInternalServerError)
 	}
 
 	newUser := userUpdate.New

--- a/server/channels/app/user_test.go
+++ b/server/channels/app/user_test.go
@@ -271,6 +271,7 @@ func TestUpdateUser(t *testing.T) {
 }
 
 func TestUpdateUserNilUpdateResult(t *testing.T) {
+	mainHelper.Parallel(t)
 	th := SetupWithStoreMock(t)
 
 	fakeUserID := model.NewId()


### PR DESCRIPTION
## Sentry Impact
**Issue:** [MATTERMOST-SERVER-VF](https://us.sentry.io/issues/7132378868/) — 14 events since Dec 22, 2025
**Error:** `runtime error: invalid memory address or nil pointer dereference` in `(*App).UpdateUser`
**Impact:** Server panic on user patch/update operations

---

## Summary
Adds a nil check on the `userUpdate` result from `userService.UpdateUser()` in `(*App).UpdateUser`. The nil pointer dereference occurs when accessing `userUpdate.New` after the store update returns an unexpected nil result without an error.

The defensive check prevents a server panic by returning a proper error instead of crashing.

## Ticket Link
https://us.sentry.io/issues/7132378868/

## Release Note
- Fixed a server crash (nil pointer dereference) that could occur during user patch/update operations.

---
_Migrated from #35710 (fork → org branch)_
```release-note
Fixed a nil pointer dereference in UpdateUser when the user update operation returned an unexpected nil result (Sentry VF, 14 events).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Reasoning:** This is a defensive nil-check added to an error-handling path that previously caused runtime panics. The change is tightly scoped to a single method's error case, includes explicit test coverage for the new scenario, and does not alter any normal execution flows or public APIs.

**Regression Risk:** Very low. The nil-check only adds an early return when `userUpdate` is nil—a previously unhandled error condition that caused server panics. The normal success path (when `userUpdate` is non-nil) remains completely unchanged. This change cannot break existing working scenarios; it can only convert potential runtime panics into graceful error returns.

**QA Recommendation:** Minimal manual QA required. The fix is well-isolated and includes explicit test coverage (`TestUpdateUserNilUpdateResult`) that verifies the nil-check behavior. Standard smoke testing of user update operations in typical workflows is sufficient. The risk of regression is negligible, allowing this to proceed confidently with automated test validation and basic spot-check QA.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->