### PR TITLE
ci: skip server CI for docs-only changes

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -17,6 +17,9 @@ on:
       - ".github/workflows/mmctl-test-template.yml"
       - "!server/build/Dockerfile.buildenv"
       - "!server/build/Dockerfile.buildenv-fips"
+      - "!server/**/*.md"
+      - "!server/NOTICE.txt"
+      - "!server/CHANGELOG.md"
 
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || github.run_id }}


### PR DESCRIPTION
#### Summary

Skip the full Server CI suite for documentation-only pull requests by adding path exclusions to the `pull_request` trigger.

Currently, editing a markdown file under `server/` triggers the full 60-minute CI pipeline (Postgres tests, linting, build, etc.) even though no code changed.

**Exclusions added:**
- `server/**/*.md`
- `server/NOTICE.txt`
- `server/CHANGELOG.md`

**How GitHub path filters work:** When a PR contains *only* files matching the exclusion patterns, CI is skipped. If even one file outside the exclusions is changed, CI runs normally. This is safe — mixed PRs (docs + code) still get full CI.

**Expected savings:** Full CI run (~60 min) avoided for docs-only PRs.

**Risk:** Very low. Only affects PR trigger, not push to master. If a `.md` file somehow contains code that matters, it would need to be paired with a non-`.md` change anyway.

#### Ticket Link

N/A — CI improvement. Analysis: https://mmworkbrain.pages.dev/docs/status/ci-analysis-mattermost-server/

#### Release Note

```release-note
NONE
```

---
_Migrated from #35705 (fork → org branch)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This change is isolated to GitHub Actions workflow configuration and only modifies when CI is triggered for PRs, not the CI execution itself. It has no impact on production code, shared dependencies, or critical paths.

**Regression Risk:** Minimal. The change only adds path exclusions to prevent unnecessary CI runs on documentation-only changes. The trigger logic remains safe—any non-documentation file change will still trigger full CI, ensuring no legitimate code changes bypass testing.

**QA Recommendation:** Manual QA is not required. This is a CI configuration change that can be validated by testing a documentation-only PR to verify CI is skipped, and a mixed docs+code PR to verify CI still runs. Automated workflow testing is sufficient; no manual QA on production code is needed.

Generated by CodeRabbitAI

<!-- end of auto-generated comment: release notes by coderabbit.ai -->