### PR TITLE
MM-68016, MM-68017, MM-68018 Add plugin pre-hooks for membership and channel archive

### DIFF
--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -1604,6 +1604,18 @@ func (a *App) DeleteChannel(rctx request.CTX, channel *model.Channel, userID str
 		return err
 	}
 
+	var archiveRejectionReason string
+	pluginContext := pluginContext(rctx)
+	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
+		archiveRejectionReason = hooks.ChannelWillBeArchived(pluginContext, channel)
+		return archiveRejectionReason == ""
+	}, plugin.ChannelWillBeArchivedID)
+
+	if archiveRejectionReason != "" {
+		return model.NewAppError("DeleteChannel", "app.channel.delete_channel.rejected_by_plugin",
+			map[string]any{"Reason": archiveRejectionReason}, "", http.StatusBadRequest)
+	}
+
 	if user != nil {
 		T := i18n.GetUserTranslations(user.Locale)
 
@@ -1754,6 +1766,25 @@ func (a *App) addUserToChannel(rctx request.CTX, user *model.User, channel *mode
 		} else if appErr != nil {
 			return nil, appErr
 		}
+	}
+
+	var rejectionReason string
+	pluginContext := pluginContext(rctx)
+	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
+		updatedMember, reason := hooks.ChannelMemberWillBeAdded(pluginContext, newMember)
+		if reason != "" {
+			rejectionReason = reason
+			return false
+		}
+		if updatedMember != nil {
+			newMember = updatedMember
+		}
+		return true
+	}, plugin.ChannelMemberWillBeAddedID)
+
+	if rejectionReason != "" {
+		return nil, model.NewAppError("AddUserToChannel", "app.channel.add_user.to.channel.rejected_by_plugin",
+			map[string]any{"Reason": rejectionReason}, "", http.StatusBadRequest)
 	}
 
 	newMember, nErr = a.Srv().Store().Channel().SaveMember(rctx, newMember)

--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -2459,7 +2459,7 @@ func TestHookTeamMemberWillBeAdded(t *testing.T) {
 
 		_, appErr := th.App.JoinUserToTeam(th.Context, team, user, "")
 		require.NotNil(t, appErr)
-		assert.Contains(t, appErr.Error(), "rejected by plugin")
+		assert.Contains(t, appErr.Id, "rejected_by_plugin")
 	})
 
 	t.Run("modified", func(t *testing.T) {
@@ -2534,6 +2534,124 @@ func TestHookTeamMemberWillBeAdded(t *testing.T) {
 		require.Nil(t, appErr)
 		assert.Equal(t, team.Id, member.TeamId)
 		assert.Equal(t, user.Id, member.UserId)
+	})
+
+	t.Run("already active member skips hook", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) TeamMemberWillBeAdded(c *plugin.Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+				return nil, "should not fire for existing member"
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		// BasicUser is already a member of BasicTeam via InitBasic
+		member, appErr := th.App.JoinUserToTeam(th.Context, th.BasicTeam, th.BasicUser, "")
+		require.Nil(t, appErr)
+		assert.Equal(t, th.BasicTeam.Id, member.TeamId)
+	})
+
+	t.Run("re-join after leaving applies hook", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) TeamMemberWillBeAdded(c *plugin.Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+				teamMember.SchemeAdmin = true
+				return teamMember, ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		user := th.CreateUser(t)
+		team := th.CreateTeam(t)
+
+		// First join
+		_, appErr := th.App.JoinUserToTeam(th.Context, team, user, "")
+		require.Nil(t, appErr)
+
+		// Leave
+		err := th.App.LeaveTeam(th.Context, team, user, "")
+		require.Nil(t, err)
+
+		// Re-join — hook should fire on the re-add path
+		member, appErr := th.App.JoinUserToTeam(th.Context, team, user, "")
+		require.Nil(t, appErr)
+		assert.True(t, member.SchemeAdmin)
+	})
+
+	t.Run("CreateTeamWithUser rejected by hook", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) TeamMemberWillBeAdded(c *plugin.Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+				return nil, "team join blocked"
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		team := &model.Team{
+			DisplayName: "Test Team",
+			Name:        "test-team-" + model.NewId()[:8],
+			Type:        model.TeamOpen,
+		}
+		_, appErr := th.App.CreateTeamWithUser(th.Context, team, th.BasicUser.Id)
+		require.NotNil(t, appErr)
+		assert.Contains(t, appErr.Id, "rejected_by_plugin")
 	})
 }
 

--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -2306,3 +2306,311 @@ func TestUserHasJoinedChannel(t *testing.T) {
 		}
 	})
 }
+
+func TestHookChannelMemberWillBeAdded(t *testing.T) {
+	mainHelper.Parallel(t)
+	t.Run("rejected", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) ChannelMemberWillBeAdded(c *plugin.Context, channelMember *model.ChannelMember) (*model.ChannelMember, string) {
+				return nil, "not allowed"
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		user := th.CreateUser(t)
+		_, _, appErr := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, user.Id, "")
+		require.Nil(t, appErr)
+
+		_, appErr = th.App.AddChannelMember(th.Context, user.Id, th.BasicChannel, ChannelMemberOpts{})
+		require.NotNil(t, appErr)
+		assert.Contains(t, appErr.Id, "rejected_by_plugin")
+	})
+
+	t.Run("modified", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) ChannelMemberWillBeAdded(c *plugin.Context, channelMember *model.ChannelMember) (*model.ChannelMember, string) {
+				channelMember.NotifyProps = model.GetDefaultChannelNotifyProps()
+				channelMember.NotifyProps[model.DesktopNotifyProp] = model.ChannelNotifyAll
+				return channelMember, ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		user := th.CreateUser(t)
+		_, _, appErr := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, user.Id, "")
+		require.Nil(t, appErr)
+
+		member, appErr := th.App.AddChannelMember(th.Context, user.Id, th.BasicChannel, ChannelMemberOpts{})
+		require.Nil(t, appErr)
+		assert.Equal(t, model.ChannelNotifyAll, member.NotifyProps[model.DesktopNotifyProp])
+	})
+
+	t.Run("allowed", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) ChannelMemberWillBeAdded(c *plugin.Context, channelMember *model.ChannelMember) (*model.ChannelMember, string) {
+				return nil, ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		user := th.CreateUser(t)
+		_, _, appErr := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, user.Id, "")
+		require.Nil(t, appErr)
+
+		member, appErr := th.App.AddChannelMember(th.Context, user.Id, th.BasicChannel, ChannelMemberOpts{})
+		require.Nil(t, appErr)
+		assert.Equal(t, th.BasicChannel.Id, member.ChannelId)
+		assert.Equal(t, user.Id, member.UserId)
+	})
+}
+
+func TestHookTeamMemberWillBeAdded(t *testing.T) {
+	mainHelper.Parallel(t)
+	t.Run("rejected", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) TeamMemberWillBeAdded(c *plugin.Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+				return nil, "not allowed"
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		user := th.CreateUser(t)
+		team := th.CreateTeam(t)
+
+		_, appErr := th.App.JoinUserToTeam(th.Context, team, user, "")
+		require.NotNil(t, appErr)
+		assert.Contains(t, appErr.Error(), "rejected by plugin")
+	})
+
+	t.Run("modified", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) TeamMemberWillBeAdded(c *plugin.Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+				teamMember.SchemeAdmin = true
+				return teamMember, ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		user := th.CreateUser(t)
+		team := th.CreateTeam(t)
+
+		member, appErr := th.App.JoinUserToTeam(th.Context, team, user, "")
+		require.Nil(t, appErr)
+		assert.True(t, member.SchemeAdmin)
+	})
+
+	t.Run("allowed", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) TeamMemberWillBeAdded(c *plugin.Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+				return nil, ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		user := th.CreateUser(t)
+		team := th.CreateTeam(t)
+
+		member, appErr := th.App.JoinUserToTeam(th.Context, team, user, "")
+		require.Nil(t, appErr)
+		assert.Equal(t, team.Id, member.TeamId)
+		assert.Equal(t, user.Id, member.UserId)
+	})
+}
+
+func TestHookChannelWillBeArchived(t *testing.T) {
+	mainHelper.Parallel(t)
+	t.Run("rejected", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) ChannelWillBeArchived(c *plugin.Context, channel *model.Channel) string {
+				return "archive not permitted"
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		appErr := th.App.DeleteChannel(th.Context, th.BasicChannel, th.BasicUser.Id)
+		require.NotNil(t, appErr)
+		assert.Contains(t, appErr.Id, "rejected_by_plugin")
+
+		// Verify channel was NOT archived
+		ch, err := th.App.GetChannel(th.Context, th.BasicChannel.Id)
+		require.Nil(t, err)
+		assert.Equal(t, int64(0), ch.DeleteAt)
+	})
+
+	t.Run("allowed", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) ChannelWillBeArchived(c *plugin.Context, channel *model.Channel) string {
+				return ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		appErr := th.App.DeleteChannel(th.Context, th.BasicChannel, th.BasicUser.Id)
+		require.Nil(t, appErr)
+
+		// Verify channel was archived
+		ch, err := th.App.GetChannel(th.Context, th.BasicChannel.Id)
+		require.Nil(t, err)
+		assert.NotEqual(t, int64(0), ch.DeleteAt)
+	})
+}

--- a/server/channels/app/team.go
+++ b/server/channels/app/team.go
@@ -786,7 +786,8 @@ func (a *App) JoinUserToTeam(rctx request.CTX, team *model.Team, user *model.Use
 			return true
 		}, plugin.TeamMemberWillBeAddedID)
 		if rejectionReason != "" {
-			return nil, fmt.Errorf("rejected by plugin: %s", rejectionReason)
+			return nil, model.NewAppError("JoinUserToTeam", "app.team.join_user_to_team.rejected_by_plugin",
+				map[string]any{"Reason": rejectionReason}, "", http.StatusBadRequest)
 		}
 		return tm, nil
 	}

--- a/server/channels/app/team.go
+++ b/server/channels/app/team.go
@@ -771,7 +771,27 @@ func (a *App) AddUserToTeamByInviteId(rctx request.CTX, inviteId string, userID 
 }
 
 func (a *App) JoinUserToTeam(rctx request.CTX, team *model.Team, user *model.User, userRequestorId string) (*model.TeamMember, *model.AppError) {
-	teamMember, alreadyAdded, err := a.ch.srv.teamService.JoinUserToTeam(rctx, team, user)
+	preSaveHook := func(tm *model.TeamMember) (*model.TeamMember, error) {
+		var rejectionReason string
+		pluginContext := pluginContext(rctx)
+		a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
+			updatedMember, reason := hooks.TeamMemberWillBeAdded(pluginContext, tm)
+			if reason != "" {
+				rejectionReason = reason
+				return false
+			}
+			if updatedMember != nil {
+				tm = updatedMember
+			}
+			return true
+		}, plugin.TeamMemberWillBeAddedID)
+		if rejectionReason != "" {
+			return nil, fmt.Errorf("rejected by plugin: %s", rejectionReason)
+		}
+		return tm, nil
+	}
+
+	teamMember, alreadyAdded, err := a.ch.srv.teamService.JoinUserToTeam(rctx, team, user, preSaveHook)
 	if err != nil {
 		var appErr *model.AppError
 		var conflictErr *store.ErrConflict

--- a/server/channels/app/teams/teams.go
+++ b/server/channels/app/teams/teams.go
@@ -4,6 +4,8 @@
 package teams
 
 import (
+	"fmt"
+
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/i18n"
 	"github.com/mattermost/mattermost/server/public/shared/request"
@@ -172,6 +174,9 @@ func (ts *TeamService) JoinUserToTeam(rctx request.CTX, team *model.Team, user *
 			if err != nil {
 				return nil, false, err
 			}
+			if tm == nil {
+				return nil, false, fmt.Errorf("preSaveHook returned nil TeamMember without error")
+			}
 		}
 
 		tmr, nErr := ts.store.SaveMember(rctx, tm, *ts.config().TeamSettings.MaxUsersPerTeam)
@@ -200,6 +205,9 @@ func (ts *TeamService) JoinUserToTeam(rctx request.CTX, team *model.Team, user *
 		tm, err = hook(tm)
 		if err != nil {
 			return nil, false, err
+		}
+		if tm == nil {
+			return nil, false, fmt.Errorf("preSaveHook returned nil TeamMember without error")
 		}
 	}
 

--- a/server/channels/app/teams/teams.go
+++ b/server/channels/app/teams/teams.go
@@ -164,17 +164,16 @@ func (ts *TeamService) JoinUserToTeam(rctx request.CTX, team *model.Team, user *
 		tm.SchemeAdmin = true
 	}
 
-	for _, hook := range preSaveHooks {
-		var err error
-		tm, err = hook(tm)
-		if err != nil {
-			return nil, false, err
-		}
-	}
-
 	rtm, err := ts.store.GetMember(rctx, team.Id, user.Id)
 	if err != nil {
 		// Membership appears to be missing. Lets try to add.
+		for _, hook := range preSaveHooks {
+			tm, err = hook(tm)
+			if err != nil {
+				return nil, false, err
+			}
+		}
+
 		tmr, nErr := ts.store.SaveMember(rctx, tm, *ts.config().TeamSettings.MaxUsersPerTeam)
 		if nErr != nil {
 			return nil, false, nErr
@@ -195,6 +194,13 @@ func (ts *TeamService) JoinUserToTeam(rctx request.CTX, team *model.Team, user *
 
 	if membersCount >= int64(*ts.config().TeamSettings.MaxUsersPerTeam) {
 		return nil, false, MaxMemberCountError
+	}
+
+	for _, hook := range preSaveHooks {
+		tm, err = hook(tm)
+		if err != nil {
+			return nil, false, err
+		}
 	}
 
 	member, nErr := ts.store.UpdateMember(rctx, tm)

--- a/server/channels/app/teams/teams.go
+++ b/server/channels/app/teams/teams.go
@@ -136,7 +136,10 @@ func (ts *TeamService) PatchTeam(teamID string, patch *model.TeamPatch) (*model.
 // 1. a pointer to the team member, if successful
 // 2. a boolean: true if the user has a non-deleted team member for that team already, otherwise false.
 // 3. a pointer to an AppError if something went wrong.
-func (ts *TeamService) JoinUserToTeam(rctx request.CTX, team *model.Team, user *model.User) (*model.TeamMember, bool, error) {
+//
+// An optional preSaveHook can be provided to inspect/modify the TeamMember before it is persisted.
+// If the hook returns an error, the addition is rejected.
+func (ts *TeamService) JoinUserToTeam(rctx request.CTX, team *model.Team, user *model.User, preSaveHooks ...func(*model.TeamMember) (*model.TeamMember, error)) (*model.TeamMember, bool, error) {
 	if !ts.IsTeamEmailAllowed(user, team) {
 		return nil, false, AcceptedDomainError
 	}
@@ -159,6 +162,14 @@ func (ts *TeamService) JoinUserToTeam(rctx request.CTX, team *model.Team, user *
 
 	if team.Email == user.Email {
 		tm.SchemeAdmin = true
+	}
+
+	for _, hook := range preSaveHooks {
+		var err error
+		tm, err = hook(tm)
+		if err != nil {
+			return nil, false, err
+		}
 	}
 
 	rtm, err := ts.store.GetMember(rctx, team.Id, user.Id)

--- a/server/channels/app/teams/teams.go
+++ b/server/channels/app/teams/teams.go
@@ -134,6 +134,20 @@ func (ts *TeamService) PatchTeam(teamID string, patch *model.TeamPatch) (*model.
 	return team, nil
 }
 
+func applyPreSaveHooks(hooks []func(*model.TeamMember) (*model.TeamMember, error), tm *model.TeamMember) (*model.TeamMember, error) {
+	for _, hook := range hooks {
+		var err error
+		tm, err = hook(tm)
+		if err != nil {
+			return nil, err
+		}
+		if tm == nil {
+			return nil, fmt.Errorf("preSaveHook returned nil TeamMember without error")
+		}
+	}
+	return tm, nil
+}
+
 // JoinUserToTeam adds a user to the team and it returns three values:
 // 1. a pointer to the team member, if successful
 // 2. a boolean: true if the user has a non-deleted team member for that team already, otherwise false.
@@ -169,14 +183,9 @@ func (ts *TeamService) JoinUserToTeam(rctx request.CTX, team *model.Team, user *
 	rtm, err := ts.store.GetMember(rctx, team.Id, user.Id)
 	if err != nil {
 		// Membership appears to be missing. Lets try to add.
-		for _, hook := range preSaveHooks {
-			tm, err = hook(tm)
-			if err != nil {
-				return nil, false, err
-			}
-			if tm == nil {
-				return nil, false, fmt.Errorf("preSaveHook returned nil TeamMember without error")
-			}
+		tm, err = applyPreSaveHooks(preSaveHooks, tm)
+		if err != nil {
+			return nil, false, err
 		}
 
 		tmr, nErr := ts.store.SaveMember(rctx, tm, *ts.config().TeamSettings.MaxUsersPerTeam)
@@ -201,14 +210,9 @@ func (ts *TeamService) JoinUserToTeam(rctx request.CTX, team *model.Team, user *
 		return nil, false, MaxMemberCountError
 	}
 
-	for _, hook := range preSaveHooks {
-		tm, err = hook(tm)
-		if err != nil {
-			return nil, false, err
-		}
-		if tm == nil {
-			return nil, false, fmt.Errorf("preSaveHook returned nil TeamMember without error")
-		}
+	tm, err = applyPreSaveHooks(preSaveHooks, tm)
+	if err != nil {
+		return nil, false, err
 	}
 
 	member, nErr := ts.store.UpdateMember(rctx, tm)

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -5039,6 +5039,10 @@
     "translation": "Unable to add the user as a member of the channel."
   },
   {
+    "id": "app.channel.add_user.to.channel.rejected_by_plugin",
+    "translation": "Adding channel member rejected by plugin: {{.Reason}}"
+  },
+  {
     "id": "app.channel.analytics_type_count.app_error",
     "translation": "Unable to get channel type counts."
   },
@@ -5109,6 +5113,10 @@
   {
     "id": "app.channel.delete.app_error",
     "translation": "Unable to delete the channel."
+  },
+  {
+    "id": "app.channel.delete_channel.rejected_by_plugin",
+    "translation": "Channel archive rejected by plugin: {{.Reason}}"
   },
   {
     "id": "app.channel.get.app_error",
@@ -8015,6 +8023,10 @@
   {
     "id": "app.team.join_user_to_team.max_accounts.app_error",
     "translation": "This team has reached the maximum number of allowed accounts. Contact your System Administrator to set a higher limit."
+  },
+  {
+    "id": "app.team.join_user_to_team.rejected_by_plugin",
+    "translation": "Adding team member rejected by plugin: {{.Reason}}"
   },
   {
     "id": "app.team.join_user_to_team.save_member.app_error",

--- a/server/public/plugin/client_rpc.go
+++ b/server/public/plugin/client_rpc.go
@@ -1371,3 +1371,79 @@ func (s *hooksRPCServer) ServeMetrics(args *Z_ServeMetricsArgs, returns *struct{
 
 	return nil
 }
+
+// ChannelMemberWillBeAdded is hand-written to preserve the original ChannelMember as the default
+// return value, avoiding unintentional field removal by older plugins.
+func init() {
+	hookNameToId["ChannelMemberWillBeAdded"] = ChannelMemberWillBeAddedID
+}
+
+type Z_ChannelMemberWillBeAddedArgs struct {
+	A *Context
+	B *model.ChannelMember
+}
+
+type Z_ChannelMemberWillBeAddedReturns struct {
+	A *model.ChannelMember
+	B string
+}
+
+func (g *hooksRPCClient) ChannelMemberWillBeAdded(c *Context, channelMember *model.ChannelMember) (*model.ChannelMember, string) {
+	_args := &Z_ChannelMemberWillBeAddedArgs{c, channelMember}
+	_returns := &Z_ChannelMemberWillBeAddedReturns{A: _args.B}
+	if g.implemented[ChannelMemberWillBeAddedID] {
+		if err := g.client.Call("Plugin.ChannelMemberWillBeAdded", _args, _returns); err != nil {
+			g.log.Error("RPC call ChannelMemberWillBeAdded to plugin failed.", mlog.Err(err))
+		}
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *hooksRPCServer) ChannelMemberWillBeAdded(args *Z_ChannelMemberWillBeAddedArgs, returns *Z_ChannelMemberWillBeAddedReturns) error {
+	if hook, ok := s.impl.(interface {
+		ChannelMemberWillBeAdded(c *Context, channelMember *model.ChannelMember) (*model.ChannelMember, string)
+	}); ok {
+		returns.A, returns.B = hook.ChannelMemberWillBeAdded(args.A, args.B)
+	} else {
+		return encodableError(fmt.Errorf("hook ChannelMemberWillBeAdded called but not implemented"))
+	}
+	return nil
+}
+
+// TeamMemberWillBeAdded is hand-written to preserve the original TeamMember as the default
+// return value, avoiding unintentional field removal by older plugins.
+func init() {
+	hookNameToId["TeamMemberWillBeAdded"] = TeamMemberWillBeAddedID
+}
+
+type Z_TeamMemberWillBeAddedArgs struct {
+	A *Context
+	B *model.TeamMember
+}
+
+type Z_TeamMemberWillBeAddedReturns struct {
+	A *model.TeamMember
+	B string
+}
+
+func (g *hooksRPCClient) TeamMemberWillBeAdded(c *Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+	_args := &Z_TeamMemberWillBeAddedArgs{c, teamMember}
+	_returns := &Z_TeamMemberWillBeAddedReturns{A: _args.B}
+	if g.implemented[TeamMemberWillBeAddedID] {
+		if err := g.client.Call("Plugin.TeamMemberWillBeAdded", _args, _returns); err != nil {
+			g.log.Error("RPC call TeamMemberWillBeAdded to plugin failed.", mlog.Err(err))
+		}
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *hooksRPCServer) TeamMemberWillBeAdded(args *Z_TeamMemberWillBeAddedArgs, returns *Z_TeamMemberWillBeAddedReturns) error {
+	if hook, ok := s.impl.(interface {
+		TeamMemberWillBeAdded(c *Context, teamMember *model.TeamMember) (*model.TeamMember, string)
+	}); ok {
+		returns.A, returns.B = hook.TeamMemberWillBeAdded(args.A, args.B)
+	} else {
+		return encodableError(fmt.Errorf("hook TeamMemberWillBeAdded called but not implemented"))
+	}
+	return nil
+}

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -360,6 +360,41 @@ func (s *hooksRPCServer) ChannelHasBeenCreated(args *Z_ChannelHasBeenCreatedArgs
 }
 
 func init() {
+	hookNameToId["ChannelWillBeArchived"] = ChannelWillBeArchivedID
+}
+
+type Z_ChannelWillBeArchivedArgs struct {
+	A *Context
+	B *model.Channel
+}
+
+type Z_ChannelWillBeArchivedReturns struct {
+	A string
+}
+
+func (g *hooksRPCClient) ChannelWillBeArchived(c *Context, channel *model.Channel) string {
+	_args := &Z_ChannelWillBeArchivedArgs{c, channel}
+	_returns := &Z_ChannelWillBeArchivedReturns{}
+	if g.implemented[ChannelWillBeArchivedID] {
+		if err := g.client.Call("Plugin.ChannelWillBeArchived", _args, _returns); err != nil {
+			g.log.Error("RPC call ChannelWillBeArchived to plugin failed.", mlog.Err(err))
+		}
+	}
+	return _returns.A
+}
+
+func (s *hooksRPCServer) ChannelWillBeArchived(args *Z_ChannelWillBeArchivedArgs, returns *Z_ChannelWillBeArchivedReturns) error {
+	if hook, ok := s.impl.(interface {
+		ChannelWillBeArchived(c *Context, channel *model.Channel) string
+	}); ok {
+		returns.A = hook.ChannelWillBeArchived(args.A, args.B)
+	} else {
+		return encodableError(fmt.Errorf("Hook ChannelWillBeArchived called but not implemented."))
+	}
+	return nil
+}
+
+func init() {
 	hookNameToId["UserHasJoinedChannel"] = UserHasJoinedChannelID
 }
 

--- a/server/public/plugin/hooks.go
+++ b/server/public/plugin/hooks.go
@@ -65,6 +65,9 @@ const (
 	OnSAMLLoginID                             = 46
 	EmailNotificationWillBeSentID             = 47
 	FileWillBeDownloadedID                    = 48
+	ChannelMemberWillBeAddedID                = 49
+	TeamMemberWillBeAddedID                   = 50
+	ChannelWillBeArchivedID                   = 51
 	TotalHooksID                              = iota
 )
 
@@ -203,6 +206,25 @@ type Hooks interface {
 	// Minimum server version: 5.2
 	ChannelHasBeenCreated(c *Context, channel *model.Channel)
 
+	// ChannelWillBeArchived is invoked before a channel is archived, allowing plugins to
+	// reject the archive operation.
+	//
+	// To reject the archive, return a non-empty string describing why it was rejected.
+	// To allow the archive, return an empty string.
+	//
+	// Minimum server version: 11.7
+	ChannelWillBeArchived(c *Context, channel *model.Channel) string
+
+	// ChannelMemberWillBeAdded is invoked before a member is added to a channel, allowing
+	// plugins to modify the channel member or reject the addition.
+	//
+	// To reject the addition, return a non-empty string describing why it was rejected.
+	// To modify the member, return the replacement, non-nil *model.ChannelMember and an empty string.
+	// To allow the addition without modification, return a nil *model.ChannelMember and an empty string.
+	//
+	// Minimum server version: 11.7
+	ChannelMemberWillBeAdded(c *Context, channelMember *model.ChannelMember) (*model.ChannelMember, string)
+
 	// UserHasJoinedChannel is invoked after the membership has been committed to the database.
 	// If actor is not nil, the user was invited to the channel by the actor.
 	//
@@ -214,6 +236,16 @@ type Hooks interface {
 	//
 	// Minimum server version: 5.2
 	UserHasLeftChannel(c *Context, channelMember *model.ChannelMember, actor *model.User)
+
+	// TeamMemberWillBeAdded is invoked before a member is added to a team, allowing
+	// plugins to modify the team member or reject the addition.
+	//
+	// To reject the addition, return a non-empty string describing why it was rejected.
+	// To modify the member, return the replacement, non-nil *model.TeamMember and an empty string.
+	// To allow the addition without modification, return a nil *model.TeamMember and an empty string.
+	//
+	// Minimum server version: 11.7
+	TeamMemberWillBeAdded(c *Context, teamMember *model.TeamMember) (*model.TeamMember, string)
 
 	// UserHasJoinedTeam is invoked after the membership has been committed to the database.
 	// If actor is not nil, the user was added to the team by the actor.

--- a/server/public/plugin/hooks_timer_layer_generated.go
+++ b/server/public/plugin/hooks_timer_layer_generated.go
@@ -133,6 +133,20 @@ func (hooks *hooksTimerLayer) ChannelHasBeenCreated(c *Context, channel *model.C
 	hooks.recordTime(startTime, "ChannelHasBeenCreated", true)
 }
 
+func (hooks *hooksTimerLayer) ChannelWillBeArchived(c *Context, channel *model.Channel) string {
+	startTime := timePkg.Now()
+	_returnsA := hooks.hooksImpl.ChannelWillBeArchived(c, channel)
+	hooks.recordTime(startTime, "ChannelWillBeArchived", true)
+	return _returnsA
+}
+
+func (hooks *hooksTimerLayer) ChannelMemberWillBeAdded(c *Context, channelMember *model.ChannelMember) (*model.ChannelMember, string) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := hooks.hooksImpl.ChannelMemberWillBeAdded(c, channelMember)
+	hooks.recordTime(startTime, "ChannelMemberWillBeAdded", true)
+	return _returnsA, _returnsB
+}
+
 func (hooks *hooksTimerLayer) UserHasJoinedChannel(c *Context, channelMember *model.ChannelMember, actor *model.User) {
 	startTime := timePkg.Now()
 	hooks.hooksImpl.UserHasJoinedChannel(c, channelMember, actor)
@@ -143,6 +157,13 @@ func (hooks *hooksTimerLayer) UserHasLeftChannel(c *Context, channelMember *mode
 	startTime := timePkg.Now()
 	hooks.hooksImpl.UserHasLeftChannel(c, channelMember, actor)
 	hooks.recordTime(startTime, "UserHasLeftChannel", true)
+}
+
+func (hooks *hooksTimerLayer) TeamMemberWillBeAdded(c *Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := hooks.hooksImpl.TeamMemberWillBeAdded(c, teamMember)
+	hooks.recordTime(startTime, "TeamMemberWillBeAdded", true)
+	return _returnsA, _returnsB
 }
 
 func (hooks *hooksTimerLayer) UserHasJoinedTeam(c *Context, teamMember *model.TeamMember, actor *model.User) {

--- a/server/public/plugin/interface_generator/main.go
+++ b/server/public/plugin/interface_generator/main.go
@@ -23,7 +23,9 @@ import (
 )
 
 var excludedPluginHooks = []string{
+	"ChannelMemberWillBeAdded",
 	"FileWillBeUploaded",
+	"TeamMemberWillBeAdded",
 	"Implemented",
 	"LoadPluginConfiguration",
 	"InstallPlugin",

--- a/server/public/plugin/plugintest/hooks.go
+++ b/server/public/plugin/plugintest/hooks.go
@@ -27,6 +27,54 @@ func (_m *Hooks) ChannelHasBeenCreated(c *plugin.Context, channel *model.Channel
 	_m.Called(c, channel)
 }
 
+// ChannelMemberWillBeAdded provides a mock function with given fields: c, channelMember
+func (_m *Hooks) ChannelMemberWillBeAdded(c *plugin.Context, channelMember *model.ChannelMember) (*model.ChannelMember, string) {
+	ret := _m.Called(c, channelMember)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChannelMemberWillBeAdded")
+	}
+
+	var r0 *model.ChannelMember
+	var r1 string
+	if rf, ok := ret.Get(0).(func(*plugin.Context, *model.ChannelMember) (*model.ChannelMember, string)); ok {
+		return rf(c, channelMember)
+	}
+	if rf, ok := ret.Get(0).(func(*plugin.Context, *model.ChannelMember) *model.ChannelMember); ok {
+		r0 = rf(c, channelMember)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.ChannelMember)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*plugin.Context, *model.ChannelMember) string); ok {
+		r1 = rf(c, channelMember)
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+
+	return r0, r1
+}
+
+// ChannelWillBeArchived provides a mock function with given fields: c, channel
+func (_m *Hooks) ChannelWillBeArchived(c *plugin.Context, channel *model.Channel) string {
+	ret := _m.Called(c, channel)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChannelWillBeArchived")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(*plugin.Context, *model.Channel) string); ok {
+		r0 = rf(c, channel)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // ConfigurationWillBeSaved provides a mock function with given fields: newCfg
 func (_m *Hooks) ConfigurationWillBeSaved(newCfg *model.Config) (*model.Config, error) {
 	ret := _m.Called(newCfg)
@@ -600,6 +648,36 @@ func (_m *Hooks) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 // ServeMetrics provides a mock function with given fields: c, w, r
 func (_m *Hooks) ServeMetrics(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
 	_m.Called(c, w, r)
+}
+
+// TeamMemberWillBeAdded provides a mock function with given fields: c, teamMember
+func (_m *Hooks) TeamMemberWillBeAdded(c *plugin.Context, teamMember *model.TeamMember) (*model.TeamMember, string) {
+	ret := _m.Called(c, teamMember)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TeamMemberWillBeAdded")
+	}
+
+	var r0 *model.TeamMember
+	var r1 string
+	if rf, ok := ret.Get(0).(func(*plugin.Context, *model.TeamMember) (*model.TeamMember, string)); ok {
+		return rf(c, teamMember)
+	}
+	if rf, ok := ret.Get(0).(func(*plugin.Context, *model.TeamMember) *model.TeamMember); ok {
+		r0 = rf(c, teamMember)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.TeamMember)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*plugin.Context, *model.TeamMember) string); ok {
+		r1 = rf(c, teamMember)
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+
+	return r0, r1
 }
 
 // UserHasBeenCreated provides a mock function with given fields: c, user


### PR DESCRIPTION
#### Summary
- Add `ChannelMemberWillBeAdded` pre-hook: plugins can modify the `ChannelMember` (e.g. roles, notification prefs) or reject the addition before it is persisted

- Add `TeamMemberWillBeAdded` pre-hook: same modify-or-reject pattern for team membership; uses a variadic callback into `TeamService.JoinUserToTeam` to avoid coupling the `teams` package to the plugin system

- Add `ChannelWillBeArchived` pre-hook: reject-only hook that fires after validation but before any side effects (system post, webhook cleanup, DB delete)

All three are the high-priority tickets from epic MM-68003. The two membership hooks use hand-written RPC glue (to preserve the original struct as the default return), while `ChannelWillBeArchived` is auto-generated (string-only return).  See [discussion here](https://hub.mattermost.com/private-core/pl/d9fpywp9j3b5im8fcawmmzphmw) for context.

#### Ticket Link
fixes https://mattermost.atlassian.net/browse/MM-68016
fixes https://mattermost.atlassian.net/browse/MM-68017
fixes https://mattermost.atlassian.net/browse/MM-68018

#### Release Note
```release-note
Plugin API: New pre-hooks for channel membership, team membership, and channel archiving. Plugins can now intercept operations before they are persisted using three new hooks: `ChannelMemberWillBeAdded` (modify or reject a channel member addition), `TeamMemberWillBeAdded` (modify or reject a team member addition), and `ChannelWillBeArchived` (reject a channel archive).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** The PR introduces three high-priority pre-hooks into core membership and channel-archival flows that run before persistence. While additive and scoped to the plugin subsystem, they broaden the surface for plugin-driven behavior changes in critical paths.

**Regression Risk:** Moderate — unit tests were added, but the hooks execute in high-impact code paths (team join, channel member add, channel archive). Mistaken or malicious plugin behavior (rejects, nil returns, or mutated members) could cause unexpected rejections, data mutation before persistence, or client-visible errors.

** QA Recommendation:** Medium — perform targeted manual QA on plugin interactions and edge cases: (1) channel archive rejection (verify DeleteAt remains 0 and callers receive HTTP 400 with rejected_by_plugin), (2) channel/team member add with plugin modifications to fields (roles, NotifyProps), (3) join-path edge cases (re-join, already-active-member, CreateTeamWithUser), and (4) confirm error IDs and payloads surface consistently across API callers. Skipping manual QA is not recommended due to potential user-impacting rejections.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->