### PR TITLE
fix(pr-analysis): on large diff and reduce gh pr calls

### DIFF
--- a/.github/workflows/pr-test-analysis.yml
+++ b/.github/workflows/pr-test-analysis.yml
@@ -82,7 +82,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
           # Write PR body to a temp path that survives checkout
-          echo "$PR_BODY" > "$RUNNER_TEMP/pr_body.txt"
+          printf '%s\n' "$PR_BODY" > "$RUNNER_TEMP/pr_body.txt"
 
       # Required: claude-code-action needs a git directory to initialize.
       - name: ci/checkout
@@ -101,7 +101,11 @@ jobs:
 
           # Fetch the PR head and base branch, then diff locally (no API size limits)
           git fetch origin "$BASE_BRANCH" "pull/$PR_NUM/head:pr-$PR_NUM" --depth=50
-          MERGE_BASE=$(git merge-base "origin/$BASE_BRANCH" "pr-$PR_NUM")
+          if ! MERGE_BASE=$(git merge-base "origin/$BASE_BRANCH" "pr-$PR_NUM" 2>/dev/null); then
+            echo "Merge base not found in shallow history — fetching full history"
+            git fetch --unshallow origin "$BASE_BRANCH" "pull/$PR_NUM/head:pr-$PR_NUM"
+            MERGE_BASE=$(git merge-base "origin/$BASE_BRANCH" "pr-$PR_NUM")
+          fi
           git diff "$MERGE_BASE" "pr-$PR_NUM" > full_diff.diff
 
           # Derive file list from the diff (avoids a second API call)


### PR DESCRIPTION
#### Summary
Fix for PR analysis:
- on large diff to use `git diff` instead of via `gh pr diff`
- reduce calls to `gh pr`

#### Ticket Link
none

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Reasoning:** Changes are confined to CI workflow scripts and replace GitHub CLI calls with local git operations; they do not modify production code, shared libraries, or application logic.

**Regression Risk:** Minimal — only the PR analysis workflow is affected. Using git diff locally reduces dependence on GitHub API/diff size limits; the scripts use standard git and Unix utilities with limited surface area and no changes to runtime behavior of the application.

** QA Recommendation:** Light manual QA recommended — run the updated workflow on 1–2 test PRs (including both pull_request and workflow_dispatch scenarios) to confirm merge-base resolution, shallow-fetch fallback, and file/diff filtering produce expected outputs. Skipping extensive manual QA is acceptable given the low-risk nature, but basic verification is advised.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->