### PR TITLE
Encode cloud support contact query params to avoid broken URLs

### DIFF
--- a/webapp/channels/src/components/commercial_support_modal/commercial_support_modal.tsx
+++ b/webapp/channels/src/components/commercial_support_modal/commercial_support_modal.tsx
@@ -135,7 +135,7 @@ export default class CommercialSupportModal extends React.PureComponent<Props, S
         const {showBannerWarning} = this.state;
         const {isCloud, currentUser} = this.props;
 
-        const supportLink = isCloud ? `https://customers.mattermost.com/cloud/contact-us?name=${currentUser.first_name} ${currentUser.last_name}&email=${currentUser.email}&inquiry=technical` : 'https://support.mattermost.com/hc/en-us/requests/new';
+        const supportLink = isCloud ? `https://customers.mattermost.com/cloud/contact-us?name=${encodeURIComponent(currentUser.first_name + ' ' + currentUser.last_name)}&email=${encodeURIComponent(currentUser.email)}&inquiry=technical` : 'https://support.mattermost.com/hc/en-us/requests/new';
         return (
             <Modal
                 id='commercialSupportModal'


### PR DESCRIPTION
Encode user name and email when building the cloud support contact URL to ensure spaces and special characters do not break the link or lose data (uses encodeURIComponent for name and email).

```release-note
Fixed an issue where cloud support contact URLs were broken due to unencoded query parameters.
```
