### PR TITLE
Fix docs-impact-review CI hitting max turns limit

### DIFF
--- a/.github/workflows/docs-impact-review.yml
+++ b/.github/workflows/docs-impact-review.yml
@@ -203,7 +203,7 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-20250514
             --max-turns 30
-            --allowedTools "Bash(gh pr diff*),Bash(gh pr view*),Bash(ls ./docs/source*),Bash(cat ./docs/source*),Bash(grep * ./docs/source*),mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "Bash(gh pr diff*),Bash(gh pr view*),Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment"
 
       - name: Manage docs/needed label
         if: ${{ steps.docs-analysis.outcome == 'success' }}


### PR DESCRIPTION
## Summary
- The `docs-impact-review` workflow's `--allowedTools` only grants `gh pr diff`, `gh pr view`, and the inline comment MCP tool, but the prompt instructs Claude to search `./docs/source/` for existing documentation.
- Claude repeatedly attempts filesystem access (`find`, `grep`, `cat`, `ls`), gets denied each time, and exhausts the 30-turn limit — causing the job to fail with `error_max_turns`.
- Adds `find`, `grep`, `cat`, and `ls` to `--allowedTools` so Claude can actually search the checked-out docs repo.

## Test plan
- [ ] Trigger the `docs-impact-review` workflow on a PR and verify it completes within the turn limit
- [ ] Verify the analysis output correctly references RST files from `./docs/source/`

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Reasoning:** The change is limited to a CI workflow (docs-impact-review) and replaces scoped Bash wrappers with built-in Read/Glob/Grep tools while also setting persist-credentials: false; this keeps impact localized but expands the AI action's filesystem-access capabilities, raising operational and safety considerations.

**Regression Risk:** Low-to-moderate. No production code or shared libraries are changed, so functional regressions are unlikely; however, misconfiguration of the workflow or the AI tooling could cause CI failures or unexpected analysis behavior.

** QA Recommendation:** Run the docs-impact-review workflow on a representative PR containing doc-relevant changes and verify it completes within the Claude turn limit and references exact RST files in ./docs/source/. At least one manual verification run is recommended before wide rollout.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->