### PR TITLE
test: replace os.Chdir with t.Chdir for parallel test safety

### DIFF
--- a/server/channels/utils/subpath_test.go
+++ b/server/channels/utils/subpath_test.go
@@ -37,6 +37,8 @@ func TestUpdateAssetsSubpathFromConfig(t *testing.T) {
 	})
 
 	t.Run("no config", func(t *testing.T) {
+		// Explicitly clear IS_CI so UpdateAssetsSubpathFromConfig doesn't return early.
+		// IS_CI is "true" in GitHub Actions runners and persists from the sibling subtest.
 		t.Setenv("IS_CI", "")
 		tempDir := t.TempDir()
 		t.Chdir(tempDir)


### PR DESCRIPTION
## Summary

Replace 5 `os.Chdir` calls across 3 test files with `t.Chdir` (Go 1.24+), which is parallel-safe and auto-restores the working directory on test cleanup.

## PR Chain — Parallel Test Safety (merge in order)

1. **#35746** — `fix/test-setenv-deep-refactor` — Replace t.Setenv with test hooks + production refactors
2. **#35749** — `fix/test-ossetenv-parallel` — Replace os.Setenv calls with parallel-safe alternatives (246→122)
3. **#35750** — `fix/test-oschdir-parallel` — **← this PR** — Replace os.Chdir with t.Chdir (Go 1.24+)
4. **#35751** — `ci/enable-fullyparallel` — Flip fullyparallel: true

Depends on **#35739** (test sharding) being merged first.

## Changes

| File | Calls replaced | Notes |
|------|---------------|-------|
| `utils/subpath_test.go` | 2 | Was using os.Chdir + defer restore |
| `utils/fileutils/fileutils_test.go` | 1 | Same pattern |
| `config/file_test.go` | 1 | Same pattern |
| `config/migrate_test.go` | 1 | Same pattern |
| `config/store_test.go` | 0 | Cleanup of related code |
| `public/utils/fileutils_test.go` | 0 | Cleanup of related code |

`t.Chdir` (added in Go 1.24) is the parallel-safe replacement — it changes the working directory for the current test only and automatically restores it when the test finishes. Unlike `os.Chdir`, it's safe to use with `t.Parallel()`.

#### Release Note
```release-note
NONE
```