### PR TITLE
ci: enable fullyparallel mode for server tests

### DIFF
--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -17,7 +17,7 @@ on:
       fullyparallel:
         required: false
         type: boolean
-        default: false
+        default: true
       enablecoverage:
         required: false
         type: boolean


### PR DESCRIPTION
## Summary

Flip `fullyparallel: true` in the server test template, enabling `t.Parallel()` on all tests. This is the final step after fixing all blockers in the preceding PRs.

## PR Chain — Parallel Test Safety (merge in order)

1. **#35746** — `fix/test-setenv-deep-refactor` — Replace t.Setenv with test hooks + production refactors
2. **#35749** — `fix/test-ossetenv-parallel` — Replace os.Setenv calls with parallel-safe alternatives (246→122)
3. **#35750** — `fix/test-oschdir-parallel` — Replace os.Chdir with t.Chdir (Go 1.24+)
4. **#35751** — `ci/enable-fullyparallel` — **← this PR** — Flip fullyparallel: true

Depends on **#35739** (test sharding) being merged first.

## Changes

One-line change in `server-test-template.yml`:
```yaml
fullyparallel: true  # was: false
```

## What this enables

With `fullyparallel: true`, gotestsum adds `t.Parallel()` to every test that doesn't already call it. Combined with the 4-shard sharding from #35739, this means:

- **Cross-runner parallelism** (sharding): 4 runners executing different packages/tests
- **Intra-package parallelism** (fullyparallel): tests within each package run concurrently

The preceding PRs (#35746, #35749, #35750) fixed the blockers:
- 9 `t.Setenv` calls replaced with config hooks (would panic under `t.Parallel()`)
- 124 `os.Setenv` calls replaced with parallel-safe alternatives (would race)
- 5 `os.Chdir` calls replaced with `t.Chdir` (would race)

The remaining 122 `os.Setenv` calls are in tests that legitimately need env var manipulation — those tests will run serially (gotestsum respects existing `t.Setenv`/`os.Setenv` patterns).

#### Release Note
```release-note
NONE
```