### PR TITLE
Allow Cursor bot to trigger docs impact review workflow

### DIFF
--- a/.github/workflows/docs-impact-review.yml
+++ b/.github/workflows/docs-impact-review.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           use_sticky_comment: "true"
+          allowed_bots: "cursor,claude"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- The `claude-code-action` in the docs impact review workflow blocks bot-initiated workflows by default
- PRs opened or synchronized by the Cursor bot were failing with: `Workflow initiated by non-human actor: cursor (type: Bot)`
- Adds `allowed_bots: "cursor, claude"` to the action configuration so Cursor-initiated PRs are properly analyzed

```release-note
NONE
```


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This is an isolated configuration change to a GitHub Actions workflow that adds a single input parameter (`allowed_bots: "cursor"`) to the existing `anthropics/claude-code-action` step. The change permits the Cursor bot to trigger the docs impact review workflow, which previously blocked bot-initiated workflows. No application code, logic, or critical paths are affected.

**Regression Risk:** Negligible. The change only modifies the workflow configuration by enabling an existing action feature for a specific bot. No code paths, business logic, or shared utilities are altered. The action already supports this parameter, and the workflow step structure remains completely unchanged.

**QA Recommendation:** Manual QA can be safely skipped. This is a CI/CD configuration change with zero regression potential. Verification can be limited to: (1) confirming that the Cursor bot can now successfully trigger the workflow without the "non-human actor" error, and (2) verifying that the docs impact review runs to completion with the bot's PR changes. No application-level testing is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->