### PR TITLE
MM-68071 Revert "Replace TextFormatting.escapeRegex with built-in RegExp.escape" (11.6)

### DIFF
--- a/webapp/channels/src/actions/notification_actions.tsx
+++ b/webapp/channels/src/actions/notification_actions.tsx
@@ -31,7 +31,7 @@ import {stripMarkdown, formatWithRenderer} from 'utils/markdown';
 import MentionableRenderer from 'utils/markdown/mentionable_renderer';
 import {DesktopNotificationSounds, ding} from 'utils/notification_sounds';
 import {showNotification} from 'utils/notifications';
-import {cjkrPattern} from 'utils/text_formatting';
+import {cjkrPattern, escapeRegex} from 'utils/text_formatting';
 import {isDesktopApp, isMobileApp} from 'utils/user_agent';
 import * as Utils from 'utils/utils';
 
@@ -369,10 +369,10 @@ function shouldSkipNotification(
             let pattern;
             if (cjkrPattern.test(mention.key)) {
                 // In the case of CJK mention key, even if there's no delimiters (such as spaces) at both ends of a word, it is recognized as a mention key
-                pattern = new RegExp(`()(${RegExp.escape(mention.key)})()`, flags);
+                pattern = new RegExp(`()(${escapeRegex(mention.key)})()`, flags);
             } else {
                 pattern = new RegExp(
-                    `(^|\\W)(${RegExp.escape(mention.key)})(\\b|_+\\b)`,
+                    `(^|\\W)(${escapeRegex(mention.key)})(\\b|_+\\b)`,
                     flags,
                 );
             }

--- a/webapp/channels/src/components/new_search/search_box.tsx
+++ b/webapp/channels/src/components/new_search/search_box.tsx
@@ -11,6 +11,7 @@ import {hasResults} from 'components/suggestion/suggestion_results';
 
 import Constants from 'utils/constants';
 import * as Keyboard from 'utils/keyboard';
+import {escapeRegex} from 'utils/text_formatting';
 
 import {useSearchSuggestions, useSearchSuggestionSelection} from './hooks';
 import SearchBoxHints from './search_box_hints';
@@ -167,7 +168,7 @@ const SearchBox = forwardRef(
 
         const updateSearchValue = useCallback(
             (value: string, matchedPretext: string) => {
-                const escapedMatchedPretext = RegExp.escape(matchedPretext);
+                const escapedMatchedPretext = escapeRegex(matchedPretext);
                 const caretPosition = getCaretPosition();
                 const extraSpace = caretPosition === searchTerms.length ? ' ' : '';
                 const existing = searchTerms.slice(0, caretPosition).replace(new RegExp(escapedMatchedPretext + '$', 'i'), '');

--- a/webapp/channels/src/types/global.d.ts
+++ b/webapp/channels/src/types/global.d.ts
@@ -1,9 +1,5 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-// RegExp.escape is a new function in ES2025 which isn't defined in TypeScript yet. This should be removed when
-// we upgrade to TS 6.0.
-interface RegExpConstructor {
-    escape(str: string): string;
-}
+declare const COMMIT_HASH: string;
 

--- a/webapp/channels/src/utils/markdown/remove_markdown.ts
+++ b/webapp/channels/src/utils/markdown/remove_markdown.ts
@@ -49,7 +49,7 @@ const HTML_ENTITY_DECODE_MAP: Record<string, string> = {
 };
 
 const HTML_ENTITY_PATTERN = new RegExp(
-    Object.keys(HTML_ENTITY_DECODE_MAP).map((key) => RegExp.escape(key)).join('|'),
+    Object.keys(HTML_ENTITY_DECODE_MAP).map((key) => TextFormatting.escapeRegex(key)).join('|'),
     'g',
 );
 

--- a/webapp/channels/src/utils/text_formatting.tsx
+++ b/webapp/channels/src/utils/text_formatting.tsx
@@ -663,6 +663,10 @@ export function autolinkChannelMentions(
     return output;
 }
 
+export function escapeRegex(text?: string): string {
+    return text?.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&') || '';
+}
+
 export function escapeReplaceSpecialPatterns(text?: string): string {
     return text?.replace(/[$]/g, '$$$$') || '';
 }
@@ -751,10 +755,10 @@ export function highlightCurrentMentions(
         let pattern;
         if (cjkrPattern.test(mention.key)) {
             // In the case of CJK mention key, even if there's no delimiters (such as spaces) at both ends of a word, it is recognized as a mention key
-            pattern = new RegExp(`()(${RegExp.escape(mention.key)})()`, flags);
+            pattern = new RegExp(`()(${escapeRegex(mention.key)})()`, flags);
         } else {
             pattern = new RegExp(
-                `(^|\\W)(${RegExp.escape(mention.key)})(\\b|_+\\b)`,
+                `(^|\\W)(${escapeRegex(mention.key)})(\\b|_+\\b)`,
                 flags,
             );
         }
@@ -824,10 +828,10 @@ export function highlightWithoutNotificationKeywords(
             let pattern;
             if (cjkrPattern.test(key)) {
             // If the key contains Chinese, Japanese, Korean or Russian characters, don't mark word boundaries
-                pattern = new RegExp(`()(${RegExp.escape(key)})()`, 'gi');
+                pattern = new RegExp(`()(${escapeRegex(key)})()`, 'gi');
             } else {
             // If the key contains only English characters, mark word boundaries
-                pattern = new RegExp(`(^|\\W)(${RegExp.escape(key)})(\\b|_+\\b)`, 'gi');
+                pattern = new RegExp(`(^|\\W)(${escapeRegex(key)})(\\b|_+\\b)`, 'gi');
             }
 
             // Replace the key with the token for each occurrence of the key
@@ -969,14 +973,14 @@ function convertSearchTermToRegex(term: string): SearchPattern {
 
     if (cjkrPattern.test(term)) {
         // term contains Chinese, Japanese, or Korean characters so don't mark word boundaries
-        pattern = '()(' + RegExp.escape(term.replace(/\*/g, '')) + ')';
+        pattern = '()(' + escapeRegex(term.replace(/\*/g, '')) + ')';
     } else if ((/[^\s][*]$/).test(term)) {
-        pattern = '\\b()(' + RegExp.escape(term.substring(0, term.length - 1)) + ')';
+        pattern = '\\b()(' + escapeRegex(term.substring(0, term.length - 1)) + ')';
     } else if (term.startsWith('@') || term.startsWith('#')) {
         // needs special handling of the first boundary because a word boundary doesn't work before a symbol
-        pattern = '(\\W|^)(' + RegExp.escape(term) + ')\\b';
+        pattern = '(\\W|^)(' + escapeRegex(term) + ')\\b';
     } else {
-        pattern = '\\b()(' + RegExp.escape(term) + ')\\b';
+        pattern = '\\b()(' + escapeRegex(term) + ')\\b';
     }
 
     return {

--- a/webapp/channels/src/utils/url.tsx
+++ b/webapp/channels/src/utils/url.tsx
@@ -8,6 +8,7 @@ import type {IntlShape, MessageDescriptor} from 'react-intl';
 import {getModule} from 'module_registry';
 import Constants from 'utils/constants';
 import {latinise} from 'utils/latinise';
+import * as TextFormatting from 'utils/text_formatting';
 
 import {unescapeHtmlEntities} from './markdown/renderer';
 
@@ -263,7 +264,7 @@ export function shouldOpenInNewTab(url: string, siteURL?: string, managedResourc
     // Paths managed by another service shouldn't be handled by the web app either
     if (managedResourcePaths) {
         for (const managedPath of managedResourcePaths) {
-            unhandledPaths.push(RegExp.escape(managedPath));
+            unhandledPaths.push(TextFormatting.escapeRegex(managedPath));
         }
     }
 


### PR DESCRIPTION
#### Summary
Rainforest tests are currently failing because the version of Safari they use doesn't support this function. I'll look at polyfilling it on master, but this is an easier fix to unblock release testing

#### Ticket Link
MM-68071

#### Release Note
```release-note
NONE
```
