### PR TITLE
MM-59260: Allow permanent deleting a Direct and Group Message

### DIFF
--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -1435,8 +1435,14 @@ func deleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	defer c.LogAuditRec(auditRec)
 
 	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
-		c.Err = model.NewAppError("deleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
-		return
+		if !c.Params.Permanent {
+			c.Err = model.NewAppError("deleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
+			return
+		}
+		if ok, _ := c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), channel.Id, model.PermissionDeletePrivateChannel); !ok {
+			c.SetPermissionError(model.PermissionDeletePrivateChannel)
+			return
+		}
 	}
 
 	if channel.Type == model.ChannelTypeOpen {

--- a/server/channels/api4/channel_local.go
+++ b/server/channels/api4/channel_local.go
@@ -422,8 +422,10 @@ func localDeleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	model.AddEventParameterToAuditRec(auditRec, "channel_id", c.Params.ChannelId)
 
 	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
-		c.Err = model.NewAppError("localDeleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
-		return
+		if !c.Params.Permanent {
+			c.Err = model.NewAppError("localDeleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
+			return
+		}
 	}
 
 	if c.Params.Permanent {


### PR DESCRIPTION
Fixes https://github.com/mattermost/mattermost/issues/27489

Currently `deleteChannel` function in `api4/channel.go` and `api4/channel_local.go` doesn’t allow deleting a Direct Message Channel and Group Type Channel.

This PR allows permanently deleting both channel types.
User must have permission `PermissionDeletePrivateChannel` for deletions.

NOTE: These channels are only allowed to be permanently deleted and not soft-deleted/archived.

```release-note
Allowed permanent deletion of Direct Message and Group channels via the API for users with the appropriate permissions.
```
