### PR TITLE
MM-68076 Chunk bulk INSERTs to respect PostgreSQL 65,535 parameter limit

### DIFF
--- a/server/channels/store/sqlstore/bulk_insert_test.go
+++ b/server/channels/store/sqlstore/bulk_insert_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package sqlstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+	"github.com/mattermost/mattermost/server/v8/channels/store"
+	"github.com/mattermost/mattermost/server/v8/channels/store/storetest"
+)
+
+func TestBulkInsertChunking(t *testing.T) {
+	StoreTest(t, testBulkInsertChunking)
+}
+
+func testBulkInsertChunking(t *testing.T, rctx request.CTX, ss store.Store) {
+	t.Run("ChannelMembers across multiple chunks", func(t *testing.T) {
+		// 15 columns/row. With maxInsertParams=30, chunkSize=2,
+		// so 5 members split into 3 chunks (2+2+1).
+		orig := maxInsertParams
+		maxInsertParams = 30
+		defer func() { maxInsertParams = orig }()
+
+		team := &model.Team{
+			DisplayName: "ChunkTest",
+			Name:        storetest.NewTestID(),
+			Email:       storetest.MakeEmail(),
+			Type:        model.TeamOpen,
+		}
+		team, err := ss.Team().Save(team)
+		require.NoError(t, err)
+
+		channel := &model.Channel{
+			DisplayName: "ChunkTest",
+			Name:        "z-z-z" + model.NewId(),
+			Type:        model.ChannelTypeOpen,
+			TeamId:      team.Id,
+		}
+		channel, err = ss.Channel().Save(rctx, channel, -1)
+		require.NoError(t, err)
+
+		const n = 5
+		members := make([]*model.ChannelMember, n)
+		defaultNotifyProps := model.GetDefaultChannelNotifyProps()
+		for i := range members {
+			u, uErr := ss.User().Save(rctx, &model.User{Username: model.NewUsername(), Email: storetest.MakeEmail()})
+			require.NoError(t, uErr)
+			members[i] = &model.ChannelMember{
+				ChannelId:   channel.Id,
+				UserId:      u.Id,
+				NotifyProps: defaultNotifyProps,
+			}
+		}
+
+		saved, err := ss.Channel().SaveMultipleMembers(members)
+		require.NoError(t, err)
+		require.Len(t, saved, n)
+
+		for _, m := range saved {
+			got, gErr := ss.Channel().GetMember(rctx, channel.Id, m.UserId)
+			require.NoError(t, gErr)
+			require.Equal(t, channel.Id, got.ChannelId)
+		}
+	})
+
+	t.Run("TeamMembers across multiple chunks", func(t *testing.T) {
+		// 8 columns/row. With maxInsertParams=16, chunkSize=2,
+		// so 5 members split into 3 chunks (2+2+1).
+		orig := maxInsertParams
+		maxInsertParams = 16
+		defer func() { maxInsertParams = orig }()
+
+		teamID := model.NewId()
+		const n = 5
+		members := make([]*model.TeamMember, n)
+		for i := range members {
+			u, uErr := ss.User().Save(rctx, &model.User{Username: model.NewUsername(), Email: storetest.MakeEmail()})
+			require.NoError(t, uErr)
+			members[i] = &model.TeamMember{TeamId: teamID, UserId: u.Id}
+		}
+
+		saved, err := ss.Team().SaveMultipleMembers(members, -1)
+		require.NoError(t, err)
+		require.Len(t, saved, n)
+
+		for _, m := range saved {
+			got, gErr := ss.Team().GetMember(rctx, teamID, m.UserId)
+			require.NoError(t, gErr)
+			require.Equal(t, teamID, got.TeamId)
+		}
+	})
+
+	t.Run("ThreadMemberships across multiple chunks", func(t *testing.T) {
+		// 6 columns/row. With maxInsertParams=12, chunkSize=2,
+		// so 5 memberships split into 3 chunks (2+2+1).
+		orig := maxInsertParams
+		maxInsertParams = 12
+		defer func() { maxInsertParams = orig }()
+
+		const n = 5
+		memberships := make([]*model.ThreadMembership, n)
+		for i := range memberships {
+			memberships[i] = &model.ThreadMembership{
+				PostId:    model.NewId(),
+				UserId:    model.NewId(),
+				Following: true,
+			}
+		}
+
+		saved, err := ss.Thread().SaveMultipleMemberships(memberships)
+		require.NoError(t, err)
+		require.Len(t, saved, n)
+
+		for _, m := range saved {
+			got, gErr := ss.Thread().GetMembershipForUser(m.UserId, m.PostId)
+			require.NoError(t, gErr)
+			require.Equal(t, m.PostId, got.PostId)
+			require.Equal(t, m.UserId, got.UserId)
+		}
+	})
+}

--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -1777,21 +1777,22 @@ func (s SqlChannelStore) saveMultipleMembers(members []*model.ChannelMember) ([]
 		defaultTeamRolesByChannel[defaultRoles.Id] = defaultRoles
 	}
 
-	query := s.getQueryBuilder().Insert("ChannelMembers").Columns(channelMemberSliceColumns()...)
-	for _, member := range members {
-		query = query.Values(channelMemberToSlice(member)...)
-	}
-
-	sql, args, err := query.ToSql()
-	if err != nil {
-		return nil, errors.Wrap(err, "channel_members_tosql")
-	}
-
-	if _, err := s.GetMaster().Exec(sql, args...); err != nil {
-		if IsUniqueConstraintError(err, []string{"ChannelId", "channelmembers_pkey", "PRIMARY"}) {
-			return nil, store.NewErrConflict("ChannelMembers", err, "")
+	chunks := chunkSlice(members, len(channelMemberSliceColumns()))
+	for _, chunk := range chunks {
+		query := s.getQueryBuilder().Insert("ChannelMembers").Columns(channelMemberSliceColumns()...)
+		for _, member := range chunk {
+			query = query.Values(channelMemberToSlice(member)...)
 		}
-		return nil, errors.Wrap(err, "channel_members_save")
+		sql, args, err := query.ToSql()
+		if err != nil {
+			return nil, errors.Wrap(err, "channel_members_tosql")
+		}
+		if _, err := s.GetMaster().Exec(sql, args...); err != nil {
+			if IsUniqueConstraintError(err, []string{"ChannelId", "channelmembers_pkey", "PRIMARY"}) {
+				return nil, store.NewErrConflict("ChannelMembers", err, "")
+			}
+			return nil, errors.Wrap(err, "channel_members_save")
+		}
 	}
 
 	newMembers := []*model.ChannelMember{}

--- a/server/channels/store/sqlstore/team_store.go
+++ b/server/channels/store/sqlstore/team_store.go
@@ -835,21 +835,22 @@ func (s SqlTeamStore) SaveMultipleMembers(members []*model.TeamMember, maxUsersP
 		}
 	}
 
-	query := s.getQueryBuilder().Insert("TeamMembers").Columns(teamMemberSliceColumns()...)
-	for _, member := range members {
-		query = query.Values(teamMemberToSlice(member)...)
-	}
-
-	sql, args, err := query.ToSql()
-	if err != nil {
-		return nil, errors.Wrap(err, "insert_members_to_sql")
-	}
-
-	if _, err = s.GetMaster().Exec(sql, args...); err != nil {
-		if IsUniqueConstraintError(err, []string{"TeamId", "teammembers_pkey", "PRIMARY"}) {
-			return nil, store.NewErrConflict("TeamMember", err, "")
+	chunks := chunkSlice(members, len(teamMemberSliceColumns()))
+	for _, chunk := range chunks {
+		query := s.getQueryBuilder().Insert("TeamMembers").Columns(teamMemberSliceColumns()...)
+		for _, member := range chunk {
+			query = query.Values(teamMemberToSlice(member)...)
 		}
-		return nil, errors.Wrap(err, "unable_to_save_team_member")
+		sql, args, err := query.ToSql()
+		if err != nil {
+			return nil, errors.Wrap(err, "insert_members_to_sql")
+		}
+		if _, err = s.GetMaster().Exec(sql, args...); err != nil {
+			if IsUniqueConstraintError(err, []string{"TeamId", "teammembers_pkey", "PRIMARY"}) {
+				return nil, store.NewErrConflict("TeamMember", err, "")
+			}
+			return nil, errors.Wrap(err, "unable_to_save_team_member")
+		}
 	}
 
 	newMembers := []*model.TeamMember{}

--- a/server/channels/store/sqlstore/thread_store.go
+++ b/server/channels/store/sqlstore/thread_store.go
@@ -1066,16 +1066,11 @@ func (s *SqlThreadStore) SaveMultipleMemberships(memberships []*model.ThreadMemb
 		return memberships, nil
 	}
 
-	query := s.getQueryBuilder().
-		Insert("ThreadMemberships").
-		Columns("PostId", "UserId", "Following", "LastViewed", "LastUpdated", "UnreadMentions")
-
 	for _, member := range memberships {
 		if err := member.IsValid(); err != nil {
 			return memberships, err
 		}
 		member.LastUpdated = model.GetMillis()
-		query = query.Values(member.PostId, member.UserId, member.Following, member.LastViewed, member.LastUpdated, member.UnreadMentions)
 	}
 
 	tx, err := s.GetMaster().Beginx()
@@ -1084,10 +1079,21 @@ func (s *SqlThreadStore) SaveMultipleMemberships(memberships []*model.ThreadMemb
 	}
 	defer finalizeTransactionX(tx, &err)
 
-	_, err = tx.ExecBuilder(query)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to save thread memberships")
+	// 6 columns: PostId, UserId, Following, LastViewed, LastUpdated, UnreadMentions
+	chunks := chunkSlice(memberships, 6)
+	for _, chunk := range chunks {
+		query := s.getQueryBuilder().
+			Insert("ThreadMemberships").
+			Columns("PostId", "UserId", "Following", "LastViewed", "LastUpdated", "UnreadMentions")
+		for _, member := range chunk {
+			query = query.Values(member.PostId, member.UserId, member.Following, member.LastViewed, member.LastUpdated, member.UnreadMentions)
+		}
+		_, err = tx.ExecBuilder(query)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to save thread memberships")
+		}
 	}
+
 	err = tx.Commit()
 	if err != nil {
 		return nil, errors.Wrap(err, "commit_transaction")

--- a/server/channels/store/sqlstore/utils.go
+++ b/server/channels/store/sqlstore/utils.go
@@ -20,6 +20,34 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 )
 
+// maxInsertParams is a conservative threshold (76% of PostgreSQL's 65,535
+// parameter limit) used to chunk bulk INSERT statements so they never overflow
+// the wire-protocol's 16-bit parameter counter.
+var maxInsertParams = 50_000
+
+// chunkSlice splits items into sub-slices sized so that each chunk uses at most
+// maxInsertParams query parameters (columnsPerRow params per item). When the
+// input already fits in one chunk the original slice is returned with zero
+// allocation overhead.
+func chunkSlice[T any](items []T, columnsPerRow int) [][]T {
+	if len(items) == 0 {
+		return nil
+	}
+	chunkSize := maxInsertParams / columnsPerRow
+	if chunkSize == 0 {
+		chunkSize = 1
+	}
+	if len(items) <= chunkSize {
+		return [][]T{items}
+	}
+	var chunks [][]T
+	for i := 0; i < len(items); i += chunkSize {
+		end := min(i+chunkSize, len(items))
+		chunks = append(chunks, items[i:end])
+	}
+	return chunks
+}
+
 var escapeLikeSearchChar = []string{
 	"%",
 	"_",

--- a/server/channels/store/sqlstore/utils_test.go
+++ b/server/channels/store/sqlstore/utils_test.go
@@ -12,6 +12,62 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestChunkSlice(t *testing.T) {
+	if enableFullyParallelTests {
+		t.Parallel()
+	}
+
+	t.Run("empty slice returns nil", func(t *testing.T) {
+		result := chunkSlice([]int{}, 5)
+		require.Nil(t, result)
+	})
+
+	t.Run("under limit returns single chunk", func(t *testing.T) {
+		items := []int{1, 2, 3}
+		result := chunkSlice(items, 15) // 3*15=45 params, well under 50k
+		require.Len(t, result, 1)
+		require.Equal(t, items, result[0])
+	})
+
+	t.Run("exact boundary returns single chunk", func(t *testing.T) {
+		n := maxInsertParams / 10 // exactly at limit with 10 cols
+		items := make([]int, n)
+		result := chunkSlice(items, 10)
+		require.Len(t, result, 1)
+		require.Len(t, result[0], n)
+	})
+
+	t.Run("over limit splits into chunks", func(t *testing.T) {
+		n := maxInsertParams/10 + 1 // one over
+		items := make([]int, n)
+		result := chunkSlice(items, 10)
+		require.Len(t, result, 2)
+		require.Len(t, result[0], maxInsertParams/10)
+		require.Len(t, result[1], 1)
+	})
+
+	t.Run("remainder is handled correctly", func(t *testing.T) {
+		chunkSize := maxInsertParams / 15 // 3333
+		n := chunkSize*2 + 100            // two full chunks + 100 remainder
+		items := make([]int, n)
+		result := chunkSlice(items, 15)
+		require.Len(t, result, 3)
+		require.Len(t, result[0], chunkSize)
+		require.Len(t, result[1], chunkSize)
+		require.Len(t, result[2], 100)
+	})
+
+	t.Run("very high columns per row", func(t *testing.T) {
+		// columnsPerRow > maxInsertParams → chunkSize would be 0, forced to 1
+		items := []int{1, 2, 3}
+		result := chunkSlice(items, maxInsertParams+1)
+		require.Len(t, result, 3)
+		for _, chunk := range result {
+			require.Len(t, chunk, 1)
+		}
+	})
+}
+
 func TestMapStringsToQueryParams(t *testing.T) {
 	if enableFullyParallelTests {
 		t.Parallel()


### PR DESCRIPTION
#### Summary
PostgreSQL's wire protocol uses a 16-bit integer for parameter count, limiting queries to 65,535 parameters. Bulk import of channel members, team members, or thread memberships can exceed this limit, crashing the import.

This PR adds a generic `chunkSlice` helper that splits rows into sub-batches capped at 50,000 parameters, and wraps the INSERT loops in `saveMultipleMembers` (channel, 15 cols), `SaveMultipleMembers` (team, 8 cols), and `SaveMultipleMemberships` (thread, 6 cols).

Normal operations (< 3,333 rows) remain a single INSERT with one bounds-check of overhead. No store interface or caller changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68076

#### Release Note
```release-note
Fixed bulk imports failing on PostgreSQL when channel, team, or thread membership batches exceeded the 65,535 query parameter limit by automatically chunking large INSERT statements.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Reasoning:** Changes modify critical data persistence logic for bulk membership operations (channels, teams, threads) but are well-isolated to specific store methods with comprehensive test coverage. The chunking logic is straightforward and backward-compatible, though the scope spans multiple core business entities.

**Regression Risk:** Moderate. The modifications touch bulk INSERT execution paths and introduce a new shared utility (`chunkSlice`). However, the chunking logic preserves the original insert semantics—data integrity is not altered, only execution is split. Existing test coverage has been expanded to cover edge cases. The primary risk is incomplete testing of large-scale batch operations or edge cases in the chunking calculation.

**QA Recommendation:** Medium manual QA is recommended. Focus on:
- Large bulk operations (>3,333 rows) to verify chunking behavior
- PostgreSQL-specific testing (the fix targets PostgreSQL parameter limits)
- Concurrent membership operations to ensure no race conditions in chunked inserts
- Data consistency verification after bulk operations
Manual QA can be reduced if continuous integration covers large-scale batch import scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->