### PR TITLE
Fix flaky test for makeGetProfilesInChannel

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/users.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/users.test.ts
@@ -28,21 +28,29 @@ describe('Selectors.Users', () => {
     const group2 = TestHelper.fakeGroupWithId('');
 
     const user1 = TestHelper.fakeUserWithId('');
+    user1.username = 'user1';
     user1.position = 'Software Engineer at Mattermost';
     user1.notify_props = {mention_keys: 'testkey1,testkey2'} as UserProfile['notify_props'];
     user1.roles = 'system_admin system_user';
     const user2 = TestHelper.fakeUserWithId();
+    user2.username = 'user2';
     user2.delete_at = 1;
     const user3 = TestHelper.fakeUserWithId();
+    user3.username = 'user3';
     const user4 = TestHelper.fakeUserWithId();
+    user4.username = 'user4';
     const user5 = TestHelper.fakeUserWithId();
+    user5.username = 'user5';
     const user6 = TestHelper.fakeUserWithId();
+    user6.username = 'user6';
     user6.roles = 'system_admin system_user';
     const user7 = TestHelper.fakeUserWithId();
+    user7.username = 'user7';
     user7.delete_at = 1;
     user7.roles = 'system_admin system_user';
     const user8 = TestHelper.fakeUserWithId();
-    user8.nickname = 'vertex_to_edge';
+    user8.username = 'user8';
+    user8.nickname = 'some.body';
     const profiles: Record<string, UserProfile> = {};
     profiles[user1.id] = user1;
     profiles[user2.id] = user2;
@@ -472,7 +480,7 @@ describe('Selectors.Users', () => {
         expect(Selectors.searchProfilesInCurrentChannel(testState, user1.username)).toEqual([user1]);
         expect(Selectors.searchProfilesInCurrentChannel(testState, 'engineer at mattermost')).toEqual([user1]);
         expect(Selectors.searchProfilesInCurrentChannel(testState, user1.username, true)).toEqual([]);
-        expect(Selectors.searchProfilesInCurrentChannel(testState, 'to_edge', true)).toEqual([user8]);
+        expect(Selectors.searchProfilesInCurrentChannel(testState, 'body', true)).toEqual([user8]);
     });
 
     it('searchProfilesNotInCurrentChannel', () => {


### PR DESCRIPTION
#### Summary
`TestHelper.fakeUserWithId` returns a user with a random username, and the tests in this file which were updated in https://github.com/mattermost/mattermost/pull/35017 to return multiple users would now return those users in an inconsistent order. Those fake users now have a consistent username, so they'll return in the same order.

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This PR contains exclusively test-scoped changes affecting only the test fixtures in `users.test.ts`. The modifications ensure deterministic test behavior by explicitly assigning consistent usernames to fake user objects, eliminating the flakiness caused by randomized usernames from `TestHelper.fakeUserWithId()`. There are no production code changes, no public API modifications, and no impact on other modules or systems.

**Regression Risk:** Minimal. The changes are isolated to test fixture setup and improve test reliability by reducing non-deterministic behavior. No production code paths are affected, and the changes maintain backward compatibility with existing assertions.

**QA Recommendation:** Manual QA is not required for this change since it only affects test infrastructure and improves test stability. Automated test execution should confirm that the `makeGetProfilesInChannel` and related selector tests no longer exhibit flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->