### PR TITLE
Add users to the websocket broadcast on property fields

### DIFF
--- a/server/channels/app/property_field.go
+++ b/server/channels/app/property_field.go
@@ -20,7 +20,7 @@ func propertyFieldBroadcastParams(rctx request.CTX, field *model.PropertyField) 
 		return field.TargetID, "", true
 	case "channel":
 		return "", field.TargetID, true
-	case "system":
+	case "user", "system":
 		return "", "", true
 	default:
 		rctx.Logger().Warn(

--- a/server/channels/app/property_field_test.go
+++ b/server/channels/app/property_field_test.go
@@ -415,6 +415,14 @@ func TestPropertyFieldBroadcastParams(t *testing.T) {
 		assert.Equal(t, "chan123", channelID)
 	})
 
+	t.Run("user target type returns empty strings", func(t *testing.T) {
+		field := &model.PropertyField{TargetType: "user", TargetID: "user123"}
+		teamID, channelID, ok := propertyFieldBroadcastParams(rctx, field)
+		assert.True(t, ok)
+		assert.Empty(t, teamID)
+		assert.Empty(t, channelID)
+	})
+
 	t.Run("system target type returns empty strings", func(t *testing.T) {
 		field := &model.PropertyField{TargetType: "system"}
 		teamID, channelID, ok := propertyFieldBroadcastParams(rctx, field)


### PR DESCRIPTION
#### Summary
Contemplates the case to broadcasts user fields to all users in the system.

#### Release Note
```release-note
NONE
```
