### PR TITLE
feat(api): allow permanent delete of DM/GM channels

### DIFF
--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -1434,7 +1434,7 @@ func deleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.AddEventPriorState(channel)
 	defer c.LogAuditRec(auditRec)
 
-	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
+	if !c.Params.Permanent && (channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup) {
 		c.Err = model.NewAppError("deleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
Closes #27489. This allows permanent deletion of Direct Message (DM) and Group Message (GM) channels when the permanent flag is provided.