### PR TITLE
updates buildserver go base image versions to 1.25.8

### DIFF
--- a/server/build/Dockerfile.buildenv
+++ b/server/build/Dockerfile.buildenv
@@ -1,4 +1,4 @@
-FROM mattermost/golang-bullseye:1.24.13@sha256:d9d9a35369413840836f677db08beb0aec784a966fe2a1ba1e60dc9baa64e881
+FROM mattermost/golang-bullseye:1.25.8@sha256:c45d8b7f910801d032dc517f7c1dbecfb9d7355ec8e2c017ab2d32b7947b5120
 ARG NODE_VERSION=20.11.1
 
 RUN apt-get update && apt-get install -y make git apt-transport-https ca-certificates curl software-properties-common build-essential zip xmlsec1 jq pgloader gnupg

--- a/server/build/Dockerfile.buildenv-fips
+++ b/server/build/Dockerfile.buildenv-fips
@@ -1,4 +1,4 @@
-FROM cgr.dev/mattermost.com/go-msft-fips:1.24.13-dev@sha256:46c7f9e469ab1c83a7c1f3d1dfdf9f0aee7ef8a1c93d39a2270af3560b4008b4
+FROM cgr.dev/mattermost.com/go-msft-fips:1.25.8-dev@sha256:d0ab0758b00aaa1788962a65c6707686f348606538f4998faa730e45bc58be75
 ARG NODE_VERSION=20.11.1
 
 RUN apk add curl ca-certificates mailcap unrtf wv poppler-utils tzdata gpg xmlsec


### PR DESCRIPTION
#### Summary
Updates base image for buildimage docker definitions to 1.25.8

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67154

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** 
Minimal. These changes are isolated to build-time infrastructure (base Docker images) and do not modify any production code, shared utilities, or critical paths. The Go version update from 1.24.13 to 1.25.8 follows a established upgrade path. Build step sequences and application logic remain unchanged. Any incompatibilities would be detected immediately during the build phase and are easily reversible.

**QA Recommendation:** 
No additional manual QA beyond standard build verification is required. Automated CI/CD pipeline execution will validate that builds succeed with the new Go versions. Given the isolated nature of this change (infrastructure-only), full automated testing of the build pipeline is sufficient. If builds pass and application functionality tests pass under the new Go version, the change is safe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->