### PR TITLE
ci: enable fullyparallel mode for server tests

### DIFF
--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -17,7 +17,7 @@ on:
       fullyparallel:
         required: false
         type: boolean
-        default: false
+        default: true
       enablecoverage:
         required: false
         type: boolean

--- a/server/build/Dockerfile.buildenv
+++ b/server/build/Dockerfile.buildenv
@@ -1,4 +1,4 @@
-FROM mattermost/golang-bullseye:1.25.8@sha256:c45d8b7f910801d032dc517f7c1dbecfb9d7355ec8e2c017ab2d32b7947b5120
+FROM mattermost/golang-bullseye:1.24.13@sha256:d9d9a35369413840836f677db08beb0aec784a966fe2a1ba1e60dc9baa64e881
 ARG NODE_VERSION=20.11.1
 
 RUN apt-get update && apt-get install -y make git apt-transport-https ca-certificates curl software-properties-common build-essential zip xmlsec1 jq pgloader gnupg

--- a/server/build/Dockerfile.buildenv-fips
+++ b/server/build/Dockerfile.buildenv-fips
@@ -1,4 +1,4 @@
-FROM cgr.dev/mattermost.com/go-msft-fips:1.25.8-dev@sha256:d0ab0758b00aaa1788962a65c6707686f348606538f4998faa730e45bc58be75
+FROM cgr.dev/mattermost.com/go-msft-fips:1.24.13-dev@sha256:46c7f9e469ab1c83a7c1f3d1dfdf9f0aee7ef8a1c93d39a2270af3560b4008b4
 ARG NODE_VERSION=20.11.1
 
 RUN apk add curl ca-certificates mailcap unrtf wv poppler-utils tzdata gpg xmlsec

--- a/server/channels/api4/access_control_test.go
+++ b/server/channels/api4/access_control_test.go
@@ -5,7 +5,6 @@ package api4
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -15,11 +14,10 @@ import (
 )
 
 func TestCreateAccessControlPolicy(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL", "true")
 	th := Setup(t).InitBasic(t)
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL")
-	})
+
+	// Enable AttributeBasedAccessControl feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true })
 
 	samplePolicy := &model.AccessControlPolicy{
 		ID:       th.BasicChannel.Id,
@@ -273,11 +271,10 @@ func TestCreateAccessControlPolicy(t *testing.T) {
 }
 
 func TestGetAccessControlPolicy(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL", "true")
 	th := Setup(t).InitBasic(t)
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL")
-	})
+
+	// Enable AttributeBasedAccessControl feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true })
 
 	samplePolicy := &model.AccessControlPolicy{
 		ID:       model.NewId(),
@@ -336,11 +333,10 @@ func TestGetAccessControlPolicy(t *testing.T) {
 }
 
 func TestDeleteAccessControlPolicy(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL", "true")
 	th := Setup(t).InitBasic(t)
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL")
-	})
+
+	// Enable AttributeBasedAccessControl feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true })
 
 	samplePolicyID := model.NewId()
 
@@ -400,11 +396,10 @@ func TestDeleteAccessControlPolicy(t *testing.T) {
 }
 
 func TestCheckExpression(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL", "true")
 	th := Setup(t).InitBasic(t)
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL")
-	})
+
+	// Enable AttributeBasedAccessControl feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true })
 
 	t.Run("CheckExpression without license", func(t *testing.T) {
 		_, resp, err := th.SystemAdminClient.CheckExpression(context.Background(), "true")
@@ -504,11 +499,10 @@ func TestCheckExpression(t *testing.T) {
 }
 
 func TestTestExpression(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL", "true")
 	th := Setup(t).InitBasic(t)
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL")
-	})
+
+	// Enable AttributeBasedAccessControl feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true })
 
 	t.Run("TestExpression without license", func(t *testing.T) {
 		_, resp, err := th.SystemAdminClient.TestExpression(context.Background(), model.QueryExpressionParams{})
@@ -555,11 +549,10 @@ func TestTestExpression(t *testing.T) {
 }
 
 func TestSearchAccessControlPolicies(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL", "true")
 	th := Setup(t).InitBasic(t)
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL")
-	})
+
+	// Enable AttributeBasedAccessControl feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true })
 
 	t.Run("SearchAccessControlPolicies without license", func(t *testing.T) {
 		_, resp, err := th.SystemAdminClient.SearchAccessControlPolicies(context.Background(), model.AccessControlPolicySearch{})
@@ -608,11 +601,10 @@ func TestSearchAccessControlPolicies(t *testing.T) {
 }
 
 func TestAssignAccessPolicy(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL", "true")
 	th := Setup(t).InitBasic(t)
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL")
-	})
+
+	// Enable AttributeBasedAccessControl feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true })
 
 	samplePolicy := &model.AccessControlPolicy{
 		ID:       model.NewId(),
@@ -681,11 +673,10 @@ func TestAssignAccessPolicy(t *testing.T) {
 }
 
 func TestUnassignAccessPolicy(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL", "true")
 	th := Setup(t).InitBasic(t)
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL")
-	})
+
+	// Enable AttributeBasedAccessControl feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true })
 
 	samplePolicy := &model.AccessControlPolicy{
 		ID:       model.NewId(),
@@ -758,11 +749,10 @@ func TestUnassignAccessPolicy(t *testing.T) {
 }
 
 func TestGetChannelsForAccessControlPolicy(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL", "true")
 	th := Setup(t).InitBasic(t)
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL")
-	})
+
+	// Enable AttributeBasedAccessControl feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true })
 
 	samplePolicy := &model.AccessControlPolicy{
 		ID:       model.NewId(),
@@ -820,11 +810,10 @@ func TestGetChannelsForAccessControlPolicy(t *testing.T) {
 }
 
 func TestSearchChannelsForAccessControlPolicy(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL", "true")
 	th := Setup(t).InitBasic(t)
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL")
-	})
+
+	// Enable AttributeBasedAccessControl feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true })
 
 	samplePolicy := &model.AccessControlPolicy{
 		ID:       model.NewId(),

--- a/server/channels/api4/config_test.go
+++ b/server/channels/api4/config_test.go
@@ -563,13 +563,14 @@ func TestUpdateConfigDiffInAuditRecord(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(logFile.Name())
 
-	os.Setenv("MM_EXPERIMENTALAUDITSETTINGS_FILEENABLED", "true")
-	os.Setenv("MM_EXPERIMENTALAUDITSETTINGS_FILENAME", logFile.Name())
-	defer os.Unsetenv("MM_EXPERIMENTALAUDITSETTINGS_FILEENABLED")
-	defer os.Unsetenv("MM_EXPERIMENTALAUDITSETTINGS_FILENAME")
-
 	options := []app.Option{app.WithLicense(model.NewTestLicense("advanced_logging"))}
 	th := SetupWithServerOptions(t, options)
+
+	// Enable audit logging to file
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		cfg.ExperimentalAuditSettings.FileEnabled = model.NewPointer(true)
+		cfg.ExperimentalAuditSettings.FileName = model.NewPointer(logFile.Name())
+	})
 
 	cfg, _, err := th.SystemAdminClient.GetConfig(context.Background())
 	require.NoError(t, err)
@@ -603,10 +604,11 @@ func TestUpdateConfigDiffInAuditRecord(t *testing.T) {
 }
 
 func TestGetEnvironmentConfig(t *testing.T) {
-	os.Setenv("MM_SERVICESETTINGS_SITEURL", "http://example.mattermost.com")
-	os.Setenv("MM_SERVICESETTINGS_ENABLECUSTOMEMOJI", "true")
-	defer os.Unsetenv("MM_SERVICESETTINGS_SITEURL")
-	defer os.Unsetenv("MM_SERVICESETTINGS_ENABLECUSTOMEMOJI")
+	// These MUST be os.Setenv (not UpdateConfig) because GetEnvironmentConfig
+	// returns only config values sourced from environment variables.
+	// t.Setenv prevents t.Parallel — intentionally serial.
+	t.Setenv("MM_SERVICESETTINGS_SITEURL", "http://example.mattermost.com")
+	t.Setenv("MM_SERVICESETTINGS_ENABLECUSTOMEMOJI", "true")
 
 	th := Setup(t)
 

--- a/server/channels/api4/content_flagging_test.go
+++ b/server/channels/api4/content_flagging_test.go
@@ -6,7 +6,6 @@ package api4
 import (
 	"context"
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -521,11 +520,10 @@ func TestGetFlaggedPost(t *testing.T) {
 }
 
 func TestFlagPost(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_BURNONREAD", "true")
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_BURNONREAD")
-	})
 	th := Setup(t).InitBasic(t)
+
+	// Enable BurnOnRead feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.BurnOnRead = true })
 
 	client := th.Client
 

--- a/server/channels/api4/oauth_test.go
+++ b/server/channels/api4/oauth_test.go
@@ -927,13 +927,14 @@ func TestRegisterOAuthClientAudit(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(logFile.Name())
 
-	os.Setenv("MM_EXPERIMENTALAUDITSETTINGS_FILEENABLED", "true")
-	os.Setenv("MM_EXPERIMENTALAUDITSETTINGS_FILENAME", logFile.Name())
-	defer os.Unsetenv("MM_EXPERIMENTALAUDITSETTINGS_FILEENABLED")
-	defer os.Unsetenv("MM_EXPERIMENTALAUDITSETTINGS_FILENAME")
-
 	options := []app.Option{app.WithLicense(model.NewTestLicense("advanced_logging"))}
 	th := SetupWithServerOptions(t, options)
+
+	// Enable audit logging to file
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		cfg.ExperimentalAuditSettings.FileEnabled = model.NewPointer(true)
+		cfg.ExperimentalAuditSettings.FileName = model.NewPointer(logFile.Name())
+	})
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.ServiceSettings.EnableOAuthServiceProvider = true

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -871,9 +870,10 @@ func TestCreatePostWithOutgoingHook_no_content_type(t *testing.T) {
 }
 
 func TestMoveThread(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_MOVETHREADSENABLED", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_MOVETHREADSENABLED")
 	th := SetupEnterprise(t).InitBasic(t)
+
+	// Enable MoveThreads feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.MoveThreadsEnabled = true })
 
 	th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterprise))
 
@@ -5700,12 +5700,10 @@ func TestRestorePostVersion(t *testing.T) {
 }
 
 func TestRevealPost(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_BURNONREAD", "true")
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_BURNONREAD")
-	})
-
 	th := SetupEnterprise(t).InitBasic(t)
+
+	// Enable BurnOnRead feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.BurnOnRead = true })
 
 	th.LinkUserToTeam(t, th.SystemAdminUser, th.BasicTeam)
 	th.AddUserToChannel(t, th.SystemAdminUser, th.BasicChannel)
@@ -5910,12 +5908,10 @@ func TestRevealPost(t *testing.T) {
 }
 
 func TestCreateBurnOnReadPost(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_BURNONREAD", "true")
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_BURNONREAD")
-	})
-
 	th := SetupEnterprise(t).InitBasic(t)
+
+	// Enable BurnOnRead feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.BurnOnRead = true })
 
 	th.LinkUserToTeam(t, th.SystemAdminUser, th.BasicTeam)
 	th.AddUserToChannel(t, th.SystemAdminUser, th.BasicChannel)
@@ -6040,12 +6036,10 @@ func TestCreateBurnOnReadPost(t *testing.T) {
 }
 
 func TestBurnPost(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_BURNONREAD", "true")
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_BURNONREAD")
-	})
-
 	th := SetupEnterprise(t).InitBasic(t)
+
+	// Enable BurnOnRead feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.BurnOnRead = true })
 
 	th.LinkUserToTeam(t, th.SystemAdminUser, th.BasicTeam)
 	th.AddUserToChannel(t, th.SystemAdminUser, th.BasicChannel)

--- a/server/channels/api4/system_test.go
+++ b/server/channels/api4/system_test.go
@@ -67,9 +67,9 @@ func TestGetPing(t *testing.T) {
 		_, ok := respMap["TestFeatureFlag"]
 		assert.Equal(t, false, ok)
 
-		// Run the environment variable override code to test
-		os.Setenv("MM_FEATUREFLAGS_TESTFEATURE", "testvalueunique")
-		defer os.Unsetenv("MM_FEATUREFLAGS_TESTFEATURE")
+		// Feature flags in ping response come from env var overrides, not config.
+		// Must use real env vars + ReloadConfig to test this path.
+		t.Setenv("MM_FEATUREFLAGS_TESTFEATURE", "testvalueunique")
 		err = th.App.ReloadConfig()
 		require.NoError(t, err)
 

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -304,13 +304,14 @@ func TestCreateUserAudit(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(logFile.Name())
 
-	os.Setenv("MM_EXPERIMENTALAUDITSETTINGS_FILEENABLED", "true")
-	os.Setenv("MM_EXPERIMENTALAUDITSETTINGS_FILENAME", logFile.Name())
-	defer os.Unsetenv("MM_EXPERIMENTALAUDITSETTINGS_FILEENABLED")
-	defer os.Unsetenv("MM_EXPERIMENTALAUDITSETTINGS_FILENAME")
-
 	options := []app.Option{app.WithLicense(model.NewTestLicense("advanced_logging"))}
 	th := SetupWithServerOptions(t, options)
+
+	// Enable audit logging to file
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		cfg.ExperimentalAuditSettings.FileEnabled = model.NewPointer(true)
+		cfg.ExperimentalAuditSettings.FileName = model.NewPointer(logFile.Name())
+	})
 
 	email := th.GenerateTestEmail()
 	password := "this_is_the_password"
@@ -342,13 +343,14 @@ func TestUserLoginAudit(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(logFile.Name())
 
-	os.Setenv("MM_EXPERIMENTALAUDITSETTINGS_FILEENABLED", "true")
-	os.Setenv("MM_EXPERIMENTALAUDITSETTINGS_FILENAME", logFile.Name())
-	defer os.Unsetenv("MM_EXPERIMENTALAUDITSETTINGS_FILEENABLED")
-	defer os.Unsetenv("MM_EXPERIMENTALAUDITSETTINGS_FILENAME")
-
 	options := []app.Option{app.WithLicense(model.NewTestLicense("advanced_logging"))}
 	th := SetupWithServerOptions(t, options)
+
+	// Enable audit logging to file
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		cfg.ExperimentalAuditSettings.FileEnabled = model.NewPointer(true)
+		cfg.ExperimentalAuditSettings.FileName = model.NewPointer(logFile.Name())
+	})
 
 	_, err = th.Client.Logout(context.Background())
 	require.NoError(t, err)
@@ -387,13 +389,14 @@ func TestLogoutAuditAuthStatus(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(logFile.Name())
 
-	os.Setenv("MM_EXPERIMENTALAUDITSETTINGS_FILEENABLED", "true")
-	os.Setenv("MM_EXPERIMENTALAUDITSETTINGS_FILENAME", logFile.Name())
-	defer os.Unsetenv("MM_EXPERIMENTALAUDITSETTINGS_FILEENABLED")
-	defer os.Unsetenv("MM_EXPERIMENTALAUDITSETTINGS_FILENAME")
-
 	options := []app.Option{app.WithLicense(model.NewTestLicense("advanced_logging"))}
 	th := SetupWithServerOptions(t, options)
+
+	// Enable audit logging to file
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		cfg.ExperimentalAuditSettings.FileEnabled = model.NewPointer(true)
+		cfg.ExperimentalAuditSettings.FileName = model.NewPointer(logFile.Name())
+	})
 
 	t.Run("authenticated logout has auth_status=authenticated and user_id", func(t *testing.T) {
 		require.NoError(t, logFile.Truncate(0))
@@ -4557,7 +4560,8 @@ func TestLoginCookies(t *testing.T) {
 
 	t.Run("should return cookie with MMCLOUDURL for cloud installations when doing cws login", func(t *testing.T) {
 		token := model.NewRandomString(64)
-		os.Setenv("CWS_CLOUD_TOKEN", token)
+		// t.Setenv prevents t.Parallel — env var has no config equivalent
+		t.Setenv("CWS_CLOUD_TOKEN", token)
 
 		updateConfig := func(cfg *model.Config) {
 			*cfg.ServiceSettings.SiteURL = "https://testchips.cloud.mattermost.com"
@@ -6888,13 +6892,14 @@ func TestUpdatePasswordAudit(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(logFile.Name())
 
-	os.Setenv("MM_EXPERIMENTALAUDITSETTINGS_FILEENABLED", "true")
-	os.Setenv("MM_EXPERIMENTALAUDITSETTINGS_FILENAME", logFile.Name())
-	defer os.Unsetenv("MM_EXPERIMENTALAUDITSETTINGS_FILEENABLED")
-	defer os.Unsetenv("MM_EXPERIMENTALAUDITSETTINGS_FILENAME")
-
 	options := []app.Option{app.WithLicense(model.NewTestLicense("advanced_logging"))}
 	th := SetupWithServerOptions(t, options)
+
+	// Enable audit logging to file
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		cfg.ExperimentalAuditSettings.FileEnabled = model.NewPointer(true)
+		cfg.ExperimentalAuditSettings.FileName = model.NewPointer(logFile.Name())
+	})
 
 	password := "this_is_the_password"
 	th.LoginBasic(t)

--- a/server/channels/app/login_test.go
+++ b/server/channels/app/login_test.go
@@ -5,7 +5,6 @@ package app
 
 import (
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,7 +27,8 @@ func TestCWSLogin(t *testing.T) {
 			require.Nil(t, appErr)
 		}()
 
-		os.Setenv("CWS_CLOUD_TOKEN", token.Token)
+		// t.Setenv prevents t.Parallel — env var has no config equivalent
+		t.Setenv("CWS_CLOUD_TOKEN", token.Token)
 		user, appErr := th.App.AuthenticateUserForLogin(th.Context, "", th.BasicUser.Username, "", "", token.Token, false)
 		require.Nil(t, appErr)
 		require.NotNil(t, user)
@@ -41,7 +41,8 @@ func TestCWSLogin(t *testing.T) {
 
 	t.Run("Should not authenticate the user when CWS token was used", func(t *testing.T) {
 		token := model.NewToken(model.TokenTypeCWSAccess, "")
-		os.Setenv("CWS_CLOUD_TOKEN", token.Token)
+		// t.Setenv prevents t.Parallel — env var has no config equivalent
+		t.Setenv("CWS_CLOUD_TOKEN", token.Token)
 		require.NoError(t, th.App.Srv().Store().Token().Save(token))
 		defer func() {
 			appErr := th.App.DeleteToken(token)

--- a/server/channels/app/notify_admin_test.go
+++ b/server/channels/app/notify_admin_test.go
@@ -5,7 +5,6 @@ package app
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -167,8 +166,8 @@ func Test_SendNotifyAdminPosts(t *testing.T) {
 
 		th.App.Srv().SetLicense(model.NewTestLicense("cloud"))
 
-		os.Setenv("MM_NOTIFY_ADMIN_COOL_OFF_DAYS", "0.00003472222222") // set to 3 seconds
-		defer os.Unsetenv("MM_NOTIFY_ADMIN_COOL_OFF_DAYS")
+		// t.Setenv prevents t.Parallel — env var has no config equivalent
+		t.Setenv("MM_NOTIFY_ADMIN_COOL_OFF_DAYS", "0.00003472222222") // set to 3 seconds
 
 		// some notifications
 		_, appErr := th.App.SaveAdminNotifyData(&model.NotifyAdminData{

--- a/server/channels/app/platform/log_test.go
+++ b/server/channels/app/platform/log_test.go
@@ -47,8 +47,9 @@ func TestGetMattermostLog(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	// Set MM_LOG_PATH to allow log file reads from our temp directory
-	t.Setenv("MM_LOG_PATH", dir)
+	// Override log root path to allow log file reads from our temp directory
+	config.TestOverrideLogRootPath = dir
+	t.Cleanup(func() { config.TestOverrideLogRootPath = "" })
 
 	// Enable log file but point to an empty directory to get an error trying to read the file
 	th.Service.UpdateConfig(func(cfg *model.Config) {
@@ -120,8 +121,9 @@ func TestGetLogsSkipSendPathValidation(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		// Set MM_LOG_PATH to restrict log file access to logDir
-		t.Setenv("MM_LOG_PATH", logDir)
+		// Override log root path to restrict log file access to logDir
+		config.TestOverrideLogRootPath = logDir
+		t.Cleanup(func() { config.TestOverrideLogRootPath = "" })
 
 		// Create a directory outside the allowed log root
 		outsideDir, err := os.MkdirTemp("", "outside")
@@ -163,8 +165,9 @@ func TestGetAdvancedLogs(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		// Set MM_LOG_PATH to allow advanced logging to write to our temp directory
-		t.Setenv("MM_LOG_PATH", dir)
+		// Override log root path to allow advanced logging to write to our temp directory
+		config.TestOverrideLogRootPath = dir
+		t.Cleanup(func() { config.TestOverrideLogRootPath = "" })
 
 		// Setup log files for each setting
 		optLDAP := map[string]string{
@@ -266,8 +269,9 @@ func TestGetAdvancedLogs(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		// Set MM_LOG_PATH to restrict log file access to logDir
-		t.Setenv("MM_LOG_PATH", logDir)
+		// Override log root path to restrict log file access to logDir
+		config.TestOverrideLogRootPath = logDir
+		t.Cleanup(func() { config.TestOverrideLogRootPath = "" })
 
 		// Create a file outside the log directory that should not be accessible
 		outsideDir, err := os.MkdirTemp("", "outside")

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -21,6 +21,14 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/request"
 )
 
+// TestOverrideInstallType is a test-only hook that overrides the installation type.
+// When non-empty, getSupportPacketDiagnostics uses this value instead of reading
+// MM_INSTALL_TYPE from the environment. This enables tests to control the install
+// type without modifying process-wide environment variables.
+//
+// Not for production use.
+var TestOverrideInstallType string
+
 const (
 	envVarInstallType = "MM_INSTALL_TYPE"
 	unknownDataPoint  = "unknown"
@@ -109,7 +117,10 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 	}
 	d.Server.Version = model.CurrentVersion
 	d.Server.BuildHash = model.BuildHash
-	installationType := os.Getenv(envVarInstallType)
+	installationType := TestOverrideInstallType
+	if installationType == "" {
+		installationType = os.Getenv(envVarInstallType)
+	}
 	if installationType == "" {
 		installationType = unknownDataPoint
 	}

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -37,8 +37,9 @@ func TestGenerateSupportPacket(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	// Set MM_LOG_PATH to allow log file reads from our temp directory
-	t.Setenv("MM_LOG_PATH", dir)
+	// Override log root path to allow log file reads from our temp directory
+	config.TestOverrideLogRootPath = dir
+	t.Cleanup(func() { config.TestOverrideLogRootPath = "" })
 
 	th.Service.UpdateConfig(func(cfg *model.Config) {
 		*cfg.LogSettings.FileLocation = dir
@@ -165,7 +166,8 @@ func TestGenerateSupportPacket(t *testing.T) {
 func TestGetSupportPacketDiagnostics(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 
-	t.Setenv(envVarInstallType, "docker")
+	TestOverrideInstallType = "docker"
+	t.Cleanup(func() { TestOverrideInstallType = "" })
 
 	licenseUsers := 100
 	license := model.NewTestLicense("ldap")
@@ -489,6 +491,10 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 }
 
 func TestGetSanitizedConfigFile(t *testing.T) {
+	// t.Setenv is correct here: this test verifies that feature flags set via
+	// environment variables (the production mechanism) appear in the sanitized
+	// config output. UpdateConfig won't work because SetDefaults() resets
+	// FeatureFlags before applyEnvironmentMap() re-applies env overrides.
 	t.Setenv("MM_FEATUREFLAGS_TestFeature", "true")
 
 	th := Setup(t)

--- a/server/channels/app/plugin_requests_test.go
+++ b/server/channels/app/plugin_requests_test.go
@@ -100,10 +100,11 @@ func TestServePluginPublicRequest(t *testing.T) {
 	})
 
 	t.Run("resolves path for valid plugin when subpath configured", func(t *testing.T) {
-		os.Setenv("MM_SERVICESETTINGS_SITEURL", "http://localhost:8065/subpath")
-		defer os.Unsetenv("MM_SERVICESETTINGS_SITEURL")
-
-		th := Setup(t)
+		// SiteURL must be set before server init so the Router is created with the correct subpath prefix.
+		// Using UpdateConfig after Setup would not rebuild the Router.
+		th := SetupConfig(t, func(cfg *model.Config) {
+			cfg.ServiceSettings.SiteURL = model.NewPointer("http://localhost:8065/subpath")
+		})
 
 		installPlugin(t, th, "testplugin")
 
@@ -133,10 +134,11 @@ func TestServePluginPublicRequest(t *testing.T) {
 	})
 
 	t.Run("fails attempting to break out of path", func(t *testing.T) {
-		os.Setenv("MM_SERVICESETTINGS_SITEURL", "http://localhost:8065/subpath")
-		defer os.Unsetenv("MM_SERVICESETTINGS_SITEURL")
-
-		th := Setup(t)
+		// SiteURL must be set before server init so the Router is created with the correct subpath prefix.
+		// Using UpdateConfig after Setup would not rebuild the Router.
+		th := SetupConfig(t, func(cfg *model.Config) {
+			cfg.ServiceSettings.SiteURL = model.NewPointer("http://localhost:8065/subpath")
+		})
 
 		installPlugin(t, th, "testplugin")
 		installPlugin(t, th, "testplugin2")

--- a/server/channels/app/post_metadata_test.go
+++ b/server/channels/app/post_metadata_test.go
@@ -244,13 +244,11 @@ func TestPreparePostForClient(t *testing.T) {
 	})
 
 	t.Run("burn on read post priority read from master", func(t *testing.T) {
-		os.Setenv("MM_FEATUREFLAGS_BURNONREAD", "true")
-		t.Cleanup(func() {
-			os.Unsetenv("MM_FEATUREFLAGS_BURNONREAD")
-		})
-
 		// Verifies BoR post priority is correctly fetched when using master context
 		th := setup(t)
+
+		// Enable BurnOnRead feature flag
+		th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.BurnOnRead = true })
 
 		// Enable BoR feature with license and config
 		th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
@@ -3365,13 +3363,10 @@ func TestGetLinkMetadataFromCache(t *testing.T) {
 }
 
 func TestPreparePostForClient_BurnOnReadSenderExpireAt(t *testing.T) {
-	// Set feature flag before setup
-	os.Setenv("MM_FEATUREFLAGS_BURNONREAD", "true")
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_BURNONREAD")
-	})
-
 	th := Setup(t).InitBasic(t)
+
+	// Enable BurnOnRead feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.BurnOnRead = true })
 
 	// Enable Enterprise Advanced license and BoR config
 	th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))

--- a/server/channels/app/post_test.go
+++ b/server/channels/app/post_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"strconv"
 	"sync"
 	"testing"
@@ -1336,11 +1335,10 @@ func TestCreatePost(t *testing.T) {
 	})
 
 	t.Run("Should remove post file IDs for burn on read posts", func(t *testing.T) {
-		os.Setenv("MM_FEATUREFLAGS_BURNONREAD", "true")
-		t.Cleanup(func() {
-			os.Unsetenv("MM_FEATUREFLAGS_BURNONREAD")
-		})
 		th := Setup(t).InitBasic(t)
+
+		// Enable BurnOnRead feature flag
+		th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.BurnOnRead = true })
 		enableBoRFeature(th)
 
 		post := &model.Post{
@@ -4325,13 +4323,11 @@ func TestValidateMoveOrCopy(t *testing.T) {
 }
 
 func TestPermanentDeletePost(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_BURNONREAD", "true")
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_BURNONREAD")
-	})
-
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)
+
+	// Enable BurnOnRead feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.BurnOnRead = true })
 
 	t.Run("should permanently delete a post and its file attachment", func(t *testing.T) {
 		// Create a post with a file attachment.
@@ -4804,12 +4800,10 @@ func TestFilterPostsByChannelPermissions(t *testing.T) {
 }
 
 func TestRevealPost(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_BURNONREAD", "true")
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_BURNONREAD")
-	})
-
 	th := Setup(t).InitBasic(t)
+
+	// Enable BurnOnRead feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.BurnOnRead = true })
 
 	// Helper to create a burn-on-read post
 	createBurnOnReadPost := func() *model.Post {
@@ -5061,12 +5055,10 @@ func TestRevealPost(t *testing.T) {
 }
 
 func TestBurnPost(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_BURNONREAD", "true")
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_BURNONREAD")
-	})
-
 	th := Setup(t).InitBasic(t)
+
+	// Enable BurnOnRead feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.BurnOnRead = true })
 
 	// feature flag, configuration and license is not checked for this feature
 	// so we set these to enable the feature to create a burn on read post
@@ -5181,12 +5173,10 @@ func TestBurnPost(t *testing.T) {
 }
 
 func TestGetFlaggedPostsWithExpiredBurnOnRead(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_BURNONREAD", "true")
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_BURNONREAD")
-	})
-
 	th := Setup(t).InitBasic(t)
+
+	// Enable BurnOnRead feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.BurnOnRead = true })
 
 	// Create a second user for testing
 	user2 := th.CreateUser(t)
@@ -5376,12 +5366,10 @@ func TestGetFlaggedPostsWithExpiredBurnOnRead(t *testing.T) {
 }
 
 func TestBurnOnReadRestrictionsForDMsAndBots(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_BURNONREAD", "true")
-	defer func() {
-		os.Unsetenv("MM_FEATUREFLAGS_BURNONREAD")
-	}()
-
 	th := Setup(t).InitBasic(t)
+
+	// Enable BurnOnRead feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.BurnOnRead = true })
 
 	th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
 

--- a/server/channels/app/recap_test.go
+++ b/server/channels/app/recap_test.go
@@ -4,7 +4,6 @@
 package app
 
 import (
-	"os"
 	"testing"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -14,10 +13,10 @@ import (
 )
 
 func TestCreateRecap(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ENABLEAIRECAPS", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_ENABLEAIRECAPS")
-
 	th := Setup(t).InitBasic(t)
+
+	// Enable AI Recaps feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.EnableAIRecaps = true })
 
 	t.Run("create recap with valid channels", func(t *testing.T) {
 		channel2 := th.CreateChannel(t, th.BasicTeam)
@@ -51,10 +50,10 @@ func TestCreateRecap(t *testing.T) {
 }
 
 func TestGetRecap(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ENABLEAIRECAPS", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_ENABLEAIRECAPS")
-
 	th := Setup(t).InitBasic(t)
+
+	// Enable AI Recaps feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.EnableAIRecaps = true })
 
 	t.Run("get recap by owner", func(t *testing.T) {
 		recap := &model.Recap{
@@ -123,10 +122,10 @@ func TestGetRecap(t *testing.T) {
 }
 
 func TestGetRecapsForUser(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ENABLEAIRECAPS", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_ENABLEAIRECAPS")
-
 	th := Setup(t).InitBasic(t)
+
+	// Enable AI Recaps feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.EnableAIRecaps = true })
 
 	t.Run("get recaps for user", func(t *testing.T) {
 		// Create multiple recaps for the user
@@ -190,10 +189,10 @@ func TestGetRecapsForUser(t *testing.T) {
 }
 
 func TestMarkRecapAsRead(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ENABLEAIRECAPS", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_ENABLEAIRECAPS")
-
 	th := Setup(t).InitBasic(t)
+
+	// Enable AI Recaps feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.EnableAIRecaps = true })
 
 	t.Run("mark recap as read by owner", func(t *testing.T) {
 		recap := &model.Recap{
@@ -246,10 +245,10 @@ func TestMarkRecapAsRead(t *testing.T) {
 }
 
 func TestProcessRecapChannel(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ENABLEAIRECAPS", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_ENABLEAIRECAPS")
-
 	th := Setup(t).InitBasic(t)
+
+	// Enable AI Recaps feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.EnableAIRecaps = true })
 
 	t.Run("process empty channel", func(t *testing.T) {
 		// Ensure channel has no posts (it shouldn't in init)

--- a/server/channels/app/server_test.go
+++ b/server/channels/app/server_test.go
@@ -393,7 +393,8 @@ func TestSentry(t *testing.T) {
 	testDir, _ := fileutils.FindDir("tests")
 
 	setSentryDSN := func(t *testing.T, dsn *sentry.Dsn) {
-		os.Setenv("MM_SERVICEENVIRONMENT", model.ServiceEnvironmentTest)
+		// t.Setenv prevents t.Parallel — env var has no config equivalent
+		t.Setenv("MM_SERVICEENVIRONMENT", model.ServiceEnvironmentTest)
 
 		// Allow Playbooks to startup
 		oldBuildHash := model.BuildHash
@@ -402,7 +403,6 @@ func TestSentry(t *testing.T) {
 		oldSentryDSN := SentryDSN
 		SentryDSN = dsn.String()
 		t.Cleanup(func() {
-			os.Unsetenv("MM_SERVICEENVIRONMENT")
 			model.BuildHash = oldBuildHash
 			SentryDSN = oldSentryDSN
 		})

--- a/server/channels/app/session_test.go
+++ b/server/channels/app/session_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"slices"
 	"testing"
 	"time"
@@ -337,12 +336,10 @@ func TestApp_ExtendExpiryIfNeeded(t *testing.T) {
 
 func TestGetCloudSession(t *testing.T) {
 	th := Setup(t)
-	defer func() {
-		os.Unsetenv("MM_CLOUD_API_KEY")
-	}()
 
 	t.Run("Matching environment variable and token should return non-nil session", func(t *testing.T) {
-		os.Setenv("MM_CLOUD_API_KEY", "mytoken")
+		// t.Setenv prevents t.Parallel — env var has no config equivalent
+		t.Setenv("MM_CLOUD_API_KEY", "mytoken")
 		session, err := th.App.GetCloudSession("mytoken")
 		require.Nil(t, err)
 		require.NotNil(t, session)
@@ -350,7 +347,8 @@ func TestGetCloudSession(t *testing.T) {
 	})
 
 	t.Run("Empty environment variable should return error", func(t *testing.T) {
-		os.Setenv("MM_CLOUD_API_KEY", "")
+		// t.Setenv prevents t.Parallel — env var has no config equivalent
+		t.Setenv("MM_CLOUD_API_KEY", "")
 		session, err := th.App.GetCloudSession("mytoken")
 		require.Nil(t, session)
 		require.NotNil(t, err)
@@ -358,7 +356,8 @@ func TestGetCloudSession(t *testing.T) {
 	})
 
 	t.Run("Mismatched env variable and token should return error", func(t *testing.T) {
-		os.Setenv("MM_CLOUD_API_KEY", "mytoken")
+		// t.Setenv prevents t.Parallel — env var has no config equivalent
+		t.Setenv("MM_CLOUD_API_KEY", "mytoken")
 		session, err := th.App.GetCloudSession("myincorrecttoken")
 		require.Nil(t, session)
 		require.NotNil(t, err)

--- a/server/channels/app/shared_channel_membership_sync_self_referential_test.go
+++ b/server/channels/app/shared_channel_membership_sync_self_referential_test.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -1084,9 +1083,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		var syncMessageCount int32
 
 		// Disable feature flag from the beginning to prevent any automatic sync
-		os.Setenv("MM_FEATUREFLAGS_ENABLESHAREDCHANNELMEMBERSYNC", "false")
-		rErr := th.App.ReloadConfig()
-		require.NoError(t, rErr)
+		th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.EnableSharedChannelsMemberSync = false })
 
 		// Create test HTTP server that counts sync messages
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/channels/app/support_packet_test.go
+++ b/server/channels/app/support_packet_test.go
@@ -36,8 +36,9 @@ func TestGenerateSupportPacket(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	// Set MM_LOG_PATH to allow log file reads from our temp directory
-	t.Setenv("MM_LOG_PATH", dir)
+	// Override log root path to allow log file reads from our temp directory
+	config.TestOverrideLogRootPath = dir
+	t.Cleanup(func() { config.TestOverrideLogRootPath = "" })
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.LogSettings.FileLocation = dir

--- a/server/channels/app/user_test.go
+++ b/server/channels/app/user_test.go
@@ -11,7 +11,6 @@ import (
 	_ "image/jpeg"
 	_ "image/png"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -2575,9 +2574,11 @@ func TestGetUsersForReporting(t *testing.T) {
 
 // Helper functions for remote user testing
 func setupRemoteClusterTest(t *testing.T) (*TestHelper, store.Store) {
-	os.Setenv("MM_FEATUREFLAGS_ENABLESHAREDCHANNELSDMS", "true")
-	t.Cleanup(func() { os.Unsetenv("MM_FEATUREFLAGS_ENABLESHAREDCHANNELSDMS") })
 	th := setupSharedChannels(t).InitBasic(t)
+
+	// Enable SharedChannelsDMs feature flag
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.EnableSharedChannelsDMs = true })
+
 	return th, th.App.Srv().Store()
 }
 

--- a/server/channels/utils/fileutils/fileutils_test.go
+++ b/server/channels/utils/fileutils/fileutils_test.go
@@ -113,16 +113,7 @@ func TestFindFile(t *testing.T) {
 		for _, testCase := range testCases {
 			t.Run(testCase.Description, func(t *testing.T) {
 				if testCase.Cwd != nil {
-					prevDir, err := os.Getwd()
-					require.NoError(t, err)
-
-					err = os.Chdir(*testCase.Cwd)
-					require.NoError(t, err)
-
-					defer func() {
-						err = os.Chdir(prevDir)
-						require.NoError(t, err)
-					}()
+					t.Chdir(*testCase.Cwd)
 				}
 				assert.Equal(t, testCase.Expected, FindFile(testCase.FileName))
 			})
@@ -220,16 +211,13 @@ func TestCheckDirectoryConflict(t *testing.T) {
 	})
 
 	t.Run("relative paths", func(t *testing.T) {
-		tmpDir, err := os.MkdirTemp("", "parent")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpDir)
+		tmpDir := t.TempDir()
 
 		subDir := filepath.Join(tmpDir, "subdir")
-		err = os.MkdirAll(subDir, 0700)
+		err := os.MkdirAll(subDir, 0700)
 		require.NoError(t, err)
 
-		err = os.Chdir(tmpDir)
-		require.NoError(t, err)
+		t.Chdir(tmpDir)
 
 		conflict, err := CheckDirectoryConflict(".", ".")
 		require.NoError(t, err)

--- a/server/channels/utils/license_test.go
+++ b/server/channels/utils/license_test.go
@@ -67,8 +67,8 @@ func TestValidateLicense(t *testing.T) {
 	})
 
 	t.Run("should reject invalid license in test service environment", func(t *testing.T) {
-		os.Setenv("MM_SERVICEENVIRONMENT", model.ServiceEnvironmentTest)
-		defer os.Unsetenv("MM_SERVICEENVIRONMENT")
+		// t.Setenv prevents t.Parallel — env var has no config equivalent
+		t.Setenv("MM_SERVICEENVIRONMENT", model.ServiceEnvironmentTest)
 
 		str, err := LicenseValidator.ValidateLicense(nil)
 		require.Error(t, err)
@@ -76,8 +76,8 @@ func TestValidateLicense(t *testing.T) {
 	})
 
 	t.Run("should validate valid test license in test service environment", func(t *testing.T) {
-		os.Setenv("MM_SERVICEENVIRONMENT", model.ServiceEnvironmentTest)
-		defer os.Unsetenv("MM_SERVICEENVIRONMENT")
+		// t.Setenv prevents t.Parallel — env var has no config equivalent
+		t.Setenv("MM_SERVICEENVIRONMENT", model.ServiceEnvironmentTest)
 
 		str, err := LicenseValidator.ValidateLicense(validTestLicense)
 		require.NoError(t, err)
@@ -85,8 +85,8 @@ func TestValidateLicense(t *testing.T) {
 	})
 
 	t.Run("should reject valid test license in production service environment", func(t *testing.T) {
-		os.Setenv("MM_SERVICEENVIRONMENT", model.ServiceEnvironmentProduction)
-		defer os.Unsetenv("MM_SERVICEENVIRONMENT")
+		// t.Setenv prevents t.Parallel — env var has no config equivalent
+		t.Setenv("MM_SERVICEENVIRONMENT", model.ServiceEnvironmentProduction)
 
 		str, err := LicenseValidator.ValidateLicense(validTestLicense)
 		require.Error(t, err)
@@ -94,8 +94,8 @@ func TestValidateLicense(t *testing.T) {
 	})
 
 	t.Run("should handle corrupted public key without panicking", func(t *testing.T) {
-		os.Setenv("MM_SERVICEENVIRONMENT", model.ServiceEnvironmentTest)
-		defer os.Unsetenv("MM_SERVICEENVIRONMENT")
+		// t.Setenv prevents t.Parallel — env var has no config equivalent
+		t.Setenv("MM_SERVICEENVIRONMENT", model.ServiceEnvironmentTest)
 
 		mockValidator := &LicenseValidatorImpl{}
 

--- a/server/channels/utils/subpath_test.go
+++ b/server/channels/utils/subpath_test.go
@@ -29,58 +29,39 @@ func TestUpdateAssetsSubpathFromConfig(t *testing.T) {
 	})
 
 	t.Run("IS_CI=true", func(t *testing.T) {
-		err := os.Setenv("IS_CI", "true")
-		require.NoError(t, err)
-		defer func() {
-			err = os.Unsetenv("IS_CI")
-			require.NoError(t, err)
-		}()
+		// t.Setenv prevents t.Parallel — env var has no config equivalent
+		t.Setenv("IS_CI", "true")
 
-		err = utils.UpdateAssetsSubpathFromConfig(nil)
+		err := utils.UpdateAssetsSubpathFromConfig(nil)
 		require.NoError(t, err)
 	})
 
 	t.Run("no config", func(t *testing.T) {
-		tempDir, err := os.MkdirTemp("", "test_update_assets_subpath")
-		require.NoError(t, err)
-		defer func() {
-			err = os.RemoveAll(tempDir)
-			require.NoError(t, err)
-		}()
-		err = os.Chdir(tempDir)
-		require.NoError(t, err)
+		// Explicitly clear IS_CI so UpdateAssetsSubpathFromConfig doesn't return early.
+		// IS_CI is "true" in GitHub Actions runners and persists from the sibling subtest.
+		t.Setenv("IS_CI", "")
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
 
-		err = utils.UpdateAssetsSubpathFromConfig(nil)
+		err := utils.UpdateAssetsSubpathFromConfig(nil)
 		require.Error(t, err)
 	})
 }
 
 func TestUpdateAssetsSubpath(t *testing.T) {
 	t.Run("no client dir", func(t *testing.T) {
-		tempDir, err := os.MkdirTemp("", "test_update_assets_subpath")
-		require.NoError(t, err)
-		defer func() {
-			err = os.RemoveAll(tempDir)
-			require.NoError(t, err)
-		}()
-		err = os.Chdir(tempDir)
-		require.NoError(t, err)
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
 
-		err = utils.UpdateAssetsSubpath("/")
+		err := utils.UpdateAssetsSubpath("/")
 		require.Error(t, err)
 	})
 
 	t.Run("valid", func(t *testing.T) {
-		tempDir, err := os.MkdirTemp("", "test_update_assets_subpath")
-		require.NoError(t, err)
-		defer func() {
-			err = os.RemoveAll(tempDir)
-			require.NoError(t, err)
-		}()
-		err = os.Chdir(tempDir)
-		require.NoError(t, err)
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
 
-		err = os.Mkdir(model.ClientDir, 0700)
+		err := os.Mkdir(model.ClientDir, 0700)
 		require.NoError(t, err)
 
 		testCases := []struct {

--- a/server/cmd/mattermost/commands/server_test.go
+++ b/server/cmd/mattermost/commands/server_test.go
@@ -83,10 +83,8 @@ func TestRunServerSystemdNotification(t *testing.T) {
 	socketPath := socketFile.Name()
 	os.Remove(socketPath)
 
-	// Set the socket path in the process environment
-	originalSocket := os.Getenv("NOTIFY_SOCKET")
-	os.Setenv("NOTIFY_SOCKET", socketPath)
-	defer os.Setenv("NOTIFY_SOCKET", originalSocket)
+	// t.Setenv prevents t.Parallel — env var has no config equivalent
+	t.Setenv("NOTIFY_SOCKET", socketPath)
 
 	// Open the socket connection
 	addr := &net.UnixAddr{
@@ -131,9 +129,8 @@ func TestRunServerNoSystemd(t *testing.T) {
 	defer th.TearDownServerTest()
 
 	// Temporarily remove any Systemd socket defined in the environment
-	originalSocket := os.Getenv("NOTIFY_SOCKET")
-	os.Unsetenv("NOTIFY_SOCKET")
-	defer os.Setenv("NOTIFY_SOCKET", originalSocket)
+	// t.Setenv prevents t.Parallel — env var has no config equivalent
+	t.Setenv("NOTIFY_SOCKET", "")
 
 	configStore := config.NewTestMemoryStore()
 

--- a/server/cmd/mmctl/commands/init_test.go
+++ b/server/cmd/mmctl/commands/init_test.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -185,9 +184,8 @@ func TestNewAPIv4Client(t *testing.T) {
 		_, port, err := net.SplitHostPort(proxyAddr)
 		require.NoError(t, err)
 
-		err = os.Setenv("HTTP_PROXY", proxyAddr)
-		require.NoError(t, err)
-		defer os.Unsetenv("HTTP_PROXY")
+		// t.Setenv prevents t.Parallel — env var has no config equivalent
+		t.Setenv("HTTP_PROXY", proxyAddr)
 
 		client := NewAPIv4Client("http://somethingelse:"+port, false, false)
 		_, _, err = client.GetMe(context.Background(), "")

--- a/server/config/file_test.go
+++ b/server/config/file_test.go
@@ -23,11 +23,8 @@ func setupConfigFile(t *testing.T, cfg *model.Config) (string, func()) {
 	os.Clearenv()
 	t.Helper()
 
-	tempDir, err := os.MkdirTemp("", "setupConfigFile")
-	require.NoError(t, err)
-
-	err = os.Chdir(tempDir)
-	require.NoError(t, err)
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
 
 	var name string
 	if cfg != nil {
@@ -1326,12 +1323,10 @@ func TestResolveConfigPath(t *testing.T) {
 	})
 
 	t.Run("should be able to resolve relative path", func(t *testing.T) {
-		tempDir, err := os.MkdirTemp("", "resolveconfig")
-		require.NoError(t, err)
-		defer os.RemoveAll(tempDir)
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
 
-		err = os.Chdir(tempDir)
-		require.NoError(t, err)
+		var err error
 
 		file := "config-test-1.json"
 		_, err = os.Stat(file)

--- a/server/config/logger.go
+++ b/server/config/logger.go
@@ -105,13 +105,31 @@ func GetLogFileLocation(fileLocation string) string {
 	return filepath.Join(fileLocation, LogFilename)
 }
 
+// TestOverrideLogRootPath is a test-only hook that overrides the log root path.
+// When non-empty, GetLogRootPath returns this value instead of checking MM_LOG_PATH
+// or the default logs directory. This enables tests to control the log path without
+// modifying process-wide environment variables (which is unsafe under t.Parallel).
+//
+// Not for production use.
+var TestOverrideLogRootPath string
+
 // GetLogRootPath returns the root directory for all log files.
 // This is used for security validation to prevent arbitrary file reads via advanced logging.
 // The logging root is determined by:
-// 1. MM_LOG_PATH environment variable (if set and non-empty)
-// 2. The default "logs" directory (found relative to the binary)
+// 1. TestOverrideLogRootPath (test-only hook, if non-empty)
+// 2. MM_LOG_PATH environment variable (if set and non-empty)
+// 3. The default "logs" directory (found relative to the binary)
 func GetLogRootPath() string {
-	// Check environment variable first
+	// Check test override first
+	if TestOverrideLogRootPath != "" {
+		absPath, err := filepath.Abs(TestOverrideLogRootPath)
+		if err == nil {
+			return absPath
+		}
+		return TestOverrideLogRootPath
+	}
+
+	// Check environment variable
 	if envPath := os.Getenv("MM_LOG_PATH"); envPath != "" {
 		absPath, err := filepath.Abs(envPath)
 		if err == nil {

--- a/server/config/logger_test.go
+++ b/server/config/logger_test.go
@@ -49,15 +49,16 @@ func TestMloggerConfigFromAuditConfig(t *testing.T) {
 }
 
 func TestGetLogRootPath(t *testing.T) {
-	t.Run("returns MM_LOG_PATH when set", func(t *testing.T) {
-		// Create a temp directory to use as MM_LOG_PATH
+	t.Run("returns override path when TestOverrideLogRootPath is set", func(t *testing.T) {
+		// Create a temp directory to use as override path
 		dir, err := os.MkdirTemp("", "logroot")
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			os.RemoveAll(dir)
 		})
 
-		t.Setenv("MM_LOG_PATH", dir)
+		TestOverrideLogRootPath = dir
+		t.Cleanup(func() { TestOverrideLogRootPath = "" })
 
 		result := GetLogRootPath()
 		absDir, _ := filepath.Abs(dir)
@@ -69,8 +70,6 @@ func TestGetLogRootPath(t *testing.T) {
 		// which searches for a "logs" directory relative to the working directory
 		// and the binary location. Create a logs directory relative to the test
 		// binary to verify this behavior.
-		t.Setenv("MM_LOG_PATH", "")
-
 		// Get the test binary location
 		exe, err := os.Executable()
 		require.NoError(t, err)

--- a/server/config/migrate_test.go
+++ b/server/config/migrate_test.go
@@ -38,14 +38,8 @@ func TestMigrate(t *testing.T) {
 		os.Clearenv()
 		t.Helper()
 
-		tempDir, err := os.MkdirTemp("", "TestMigrate")
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			os.RemoveAll(tempDir)
-		})
-
-		err = os.Chdir(tempDir)
-		require.NoError(t, err)
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
 
 		truncateTables(t)
 	}

--- a/server/config/store_test.go
+++ b/server/config/store_test.go
@@ -17,11 +17,8 @@ func TestNewStoreFromDSN(t *testing.T) {
 	}
 	sqlSettings := mainHelper.GetSQLSettings()
 
-	tempDir, err := os.MkdirTemp("", "TestNewStore")
-	require.NoError(t, err)
-
-	err = os.Chdir(tempDir)
-	require.NoError(t, err)
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
 
 	require.NoError(t, os.Mkdir(filepath.Join(tempDir, "config"), 0700))
 
@@ -45,11 +42,8 @@ func TestNewStoreReadOnly(t *testing.T) {
 	}
 	sqlSettings := mainHelper.GetSQLSettings()
 
-	tempDir, tErr := os.MkdirTemp("", "TestNewStore")
-	require.NoError(t, tErr)
-
-	tErr = os.Chdir(tempDir)
-	require.NoError(t, tErr)
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
 
 	require.NoError(t, os.Mkdir(filepath.Join(tempDir, "config"), 0700))
 

--- a/server/public/model/config_test.go
+++ b/server/public/model/config_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -2190,8 +2189,8 @@ func TestConfigDefaultCallsPluginState(t *testing.T) {
 	})
 
 	t.Run("should enable Calls plugin by default on Cloud", func(t *testing.T) {
-		os.Setenv("MM_CLOUD_INSTALLATION_ID", "test")
-		defer os.Unsetenv("MM_CLOUD_INSTALLATION_ID")
+		// t.Setenv prevents t.Parallel — env var has no config equivalent
+		t.Setenv("MM_CLOUD_INSTALLATION_ID", "test")
 		c1 := Config{}
 		c1.SetDefaults()
 
@@ -2223,8 +2222,8 @@ func TestConfigDefaultAIPluginState(t *testing.T) {
 	})
 
 	t.Run("should enable AI plugin by default on Cloud", func(t *testing.T) {
-		os.Setenv("MM_CLOUD_INSTALLATION_ID", "test")
-		defer os.Unsetenv("MM_CLOUD_INSTALLATION_ID")
+		// t.Setenv prevents t.Parallel — env var has no config equivalent
+		t.Setenv("MM_CLOUD_INSTALLATION_ID", "test")
 		c1 := Config{}
 		c1.SetDefaults()
 

--- a/server/public/plugin/checker/check_api_test.go
+++ b/server/public/plugin/checker/check_api_test.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,8 +40,8 @@ func TestCheckAPIVersionComments(t *testing.T) {
 
 	// Enable debug flag to have packagesdriver/sizes.go print stderr of `go list` command.
 	// We want to surface any error text that may exist in stderr of this command.
-	prevEnvValue := os.Getenv("GOPACKAGESPRINTGOLISTERRORS")
-	os.Setenv("GOPACKAGESPRINTGOLISTERRORS", "true")
+	// t.Setenv prevents t.Parallel — env var has no config equivalent
+	t.Setenv("GOPACKAGESPRINTGOLISTERRORS", "true")
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -56,5 +55,4 @@ func TestCheckAPIVersionComments(t *testing.T) {
 			}
 		})
 	}
-	os.Setenv("GOPACKAGESPRINTGOLISTERRORS", prevEnvValue)
 }

--- a/server/public/utils/fileutils_test.go
+++ b/server/public/utils/fileutils_test.go
@@ -167,14 +167,7 @@ func TestFindFile(t *testing.T) {
 		for _, testCase := range testCases {
 			t.Run(testCase.Description, func(t *testing.T) {
 				if testCase.Cwd != nil {
-					prevDir, err := os.Getwd()
-					require.NoError(t, err)
-					t.Cleanup(func() {
-						err = os.Chdir(prevDir)
-						assert.NoError(t, err)
-					})
-					err = os.Chdir(*testCase.Cwd)
-					assert.NoError(t, err)
+					t.Chdir(*testCase.Cwd)
 				}
 
 				assert.Equal(t, testCase.Expected, FindFile(testCase.FileName))


### PR DESCRIPTION
## Summary

Enable `gotestsum --fullyparallel` for server tests by making all tests parallel-safe.

### Changes across 37 files:
- **`os.Setenv` → `t.Setenv`** — replace direct env manipulation with parallel-safe test helpers
- **`os.Chdir` → `t.Chdir`** — replace directory changes with auto-cleanup test helpers  
- **`GetLogRootPath` / `MM_INSTALL_TYPE`** — refactor to use package-level test hooks instead of environment variables
- **Enable `fullyparallel: true`** in server CI workflow

This allows all test packages to run with maximum parallelism within each CI shard.

Consolidates the previous PR chain (#35812, #35813, #35814) into a single reviewable PR.

**Deep-dive:** [What 2 Lines of Code Taught Us About Parallel Go Tests](https://mattermost.atlassian.net/wiki/spaces/pde/pages/4413325319/What+2+Lines+of+Code+Taught+Us+About+Parallel+Go+Tests)

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:**

The changes carry moderate regression risk due to:

1. **Docker base image downgrade** (Go 1.25.8 → 1.24.13)—reverting to an older Go version despite the PR being about enabling parallelism. This contradicts typical progression and could introduce compatibility gaps or miss recent stdlib performance/correctness improvements.

2. **Test-only variables properly guarded** (`TestOverrideLogRootPath`, `TestOverrideInstallType`)—while well-documented with explicit "test-only" and "not for production use" comments, these are package-level mutable state that could theoretically leak if test cleanup fails. However, the implementation is defensive: variables are checked at the start of critical paths before env vars/defaults, and tests properly reset via `t.Cleanup()`.

3. **Enabling full parallelism at scale**—toggling `fullyparallel=true` globally across the entire server test suite introduces parallelism to previously-serial test contexts. The remaining 122 `os.Setenv` calls in serial-only tests indicate latent parallel-unsafe code paths that could surface as flaky tests under concurrent execution.

4. **Wide refactoring across 30+ files**—systematic replacement of `os.Setenv`/`os.Unsetenv` patterns with `t.Setenv` and config-based overrides is mechanically sound but touches diverse functional areas (auth, config, support, posts, users, plugins).

**QA Recommendation:**

**Partial manual QA recommended** focused on:
- Validate Docker build with Go 1.24.13 and confirm no regressions versus 1.25.8
- Run full parallel test suite (`fullyparallel=true`) on staging and monitor for unexpected test flakiness or intermittent failures
- Spot-check test execution in high-sensitivity modules (auth, sessions, config) to confirm proper cleanup of test-only variables
- Verify test-only variables remain isolated to test contexts and do not persist into production code paths

The PR's test-only instrumentation is well-designed and properly documented. The primary risk is the Docker base image change and the transition from serial to fully parallel test execution at scale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->