### PR TITLE
Adds COALESCE guard for property fields before PSAv2 migrations

### DIFF
--- a/server/channels/store/sqlstore/property_field_store.go
+++ b/server/channels/store/sqlstore/property_field_store.go
@@ -23,7 +23,7 @@ func newPropertyFieldStore(sqlStore *SqlStore) store.PropertyFieldStore {
 	s := SqlPropertyFieldStore{SqlStore: sqlStore}
 
 	s.tableSelectQuery = s.getQueryBuilder().
-		Select("ID", "GroupID", "Name", "Type", "Attrs", "TargetID", "TargetType", "ObjectType", "Protected", "PermissionField", "PermissionValues", "PermissionOptions", "CreateAt", "UpdateAt", "DeleteAt", "CreatedBy", "UpdatedBy").
+		Select("ID", "GroupID", "Name", "Type", "Attrs", "TargetID", "TargetType", "ObjectType", "Protected", "PermissionField", "PermissionValues", "PermissionOptions", "CreateAt", "UpdateAt", "DeleteAt", "COALESCE(CreatedBy, '') as CreatedBy", "COALESCE(UpdatedBy, '') as UpdatedBy").
 		From("PropertyFields")
 
 	return &s

--- a/server/channels/store/storetest/property_field_store.go
+++ b/server/channels/store/storetest/property_field_store.go
@@ -9,15 +9,17 @@ import (
 	"testing"
 	"time"
 
+	sq "github.com/mattermost/squirrel"
+	"github.com/stretchr/testify/require"
+
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
-	"github.com/stretchr/testify/require"
 )
 
 func TestPropertyFieldStore(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
 	t.Run("CreatePropertyField", func(t *testing.T) { testCreatePropertyField(t, rctx, ss) })
-	t.Run("GetPropertyField", func(t *testing.T) { testGetPropertyField(t, rctx, ss) })
+	t.Run("GetPropertyField", func(t *testing.T) { testGetPropertyField(t, rctx, ss, s) })
 	t.Run("GetManyPropertyFields", func(t *testing.T) { testGetManyPropertyFields(t, rctx, ss) })
 	t.Run("GetFieldByName", func(t *testing.T) { testGetFieldByName(t, rctx, ss) })
 	t.Run("UpdatePropertyField", func(t *testing.T) { testUpdatePropertyField(t, rctx, ss) })
@@ -188,7 +190,32 @@ func testCreatePropertyField(t *testing.T, _ request.CTX, ss store.Store) {
 	})
 }
 
-func testGetPropertyField(t *testing.T, _ request.CTX, ss store.Store) {
+// insertPropertyFieldWithNullColumns inserts a property field row that
+// simulates a record created before the migrations that added Protected,
+// Permission*, CreatedBy, and UpdatedBy columns. Those columns are left
+// NULL so that the store's COALESCE and pointer-scanning logic is exercised.
+func insertPropertyFieldWithNullColumns(t *testing.T, ss store.Store, s SqlStore) (string, string) {
+	t.Helper()
+
+	fieldID := model.NewId()
+	groupID := model.NewId()
+	db := ss.GetInternalMasterDB()
+
+	builder := sq.StatementBuilder.PlaceholderFormat(s.GetQueryPlaceholder()).
+		Insert("PropertyFields").
+		Columns("ID", "GroupID", "Name", "Type", "Attrs", "TargetID", "TargetType", "ObjectType", "CreateAt", "UpdateAt", "DeleteAt").
+		Values(fieldID, groupID, "null-columns-field", "text", "{}", "", "", "", model.GetMillis(), model.GetMillis(), 0)
+
+	query, args, err := builder.ToSql()
+	require.NoError(t, err)
+
+	_, err = db.Exec(query, args...)
+	require.NoError(t, err)
+
+	return groupID, fieldID
+}
+
+func testGetPropertyField(t *testing.T, _ request.CTX, ss store.Store, s SqlStore) {
 	t.Run("should fail on nonexisting field", func(t *testing.T) {
 		field, err := ss.PropertyField().Get("", model.NewId())
 		require.Zero(t, field)
@@ -228,6 +255,20 @@ func testGetPropertyField(t *testing.T, _ request.CTX, ss store.Store) {
 		field, err := ss.PropertyField().Get(model.NewId(), newField.ID)
 		require.Zero(t, field)
 		require.ErrorIs(t, err, sql.ErrNoRows)
+	})
+
+	t.Run("null columns, before createdBy, updatedBy, protected and permissions migrations", func(t *testing.T) {
+		groupID, fieldID := insertPropertyFieldWithNullColumns(t, ss, s)
+
+		field, err := ss.PropertyField().Get(groupID, fieldID)
+		require.NoError(t, err)
+		require.Equal(t, fieldID, field.ID)
+		require.Empty(t, field.CreatedBy)
+		require.Empty(t, field.UpdatedBy)
+		require.False(t, field.Protected)
+		require.Nil(t, field.PermissionField)
+		require.Nil(t, field.PermissionValues)
+		require.Nil(t, field.PermissionOptions)
 	})
 }
 


### PR DESCRIPTION
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68113

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The COALESCE modification introduces a behavioral contract change where `CreatedBy` and `UpdatedBy` fields will now return empty strings (`''`) instead of NULL when database columns are absent (legacy data from before the user-tracking migrations). While isolated to the property_field_store's SELECT query, PropertyField objects flow through multiple API handlers (api4/properties.go), service layers (app/properties/), and plugins. Existing code that explicitly type-asserts, nil-checks, or expects pointer-to-pointer semantics on these fields could encounter unexpected behavior. The change is targeted at handling legacy data before PSAv2 migrations, indicating this is prep work for a major system refactoring, which adds migration risk.

**QA Recommendation:** Focused manual QA recommended on property field retrieval APIs and workflows that display/process CreatedBy/UpdatedBy metadata. Verify: (1) legacy property fields with null columns correctly materialize as empty CreatedBy/UpdatedBy in API responses, (2) newly created property fields continue populating user tracking correctly, (3) property field list/search endpoints handle mixed legacy and new data properly, and (4) plugins using PropertyField data via public API gracefully handle empty-string values. Automated test coverage for the null-column scenario is adequate, but integration testing with actual PSAv2 migration workflows is strongly recommended given the migration-prep nature of this change.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->