### PR TITLE
Add guards to avoid cards being created when the integrated boards feature flag is disabled

### DIFF
--- a/server/channels/api4/post.go
+++ b/server/channels/api4/post.go
@@ -85,6 +85,11 @@ func createPostChecks(where string, c *Context, post *model.Post) {
 		return
 	}
 
+	postCardTypeCheckWithContext(where, c, post.Type)
+	if c.Err != nil {
+		return
+	}
+
 	postBurnOnReadCheckWithContext(where, c, post, nil)
 }
 

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -222,19 +222,6 @@ func TestCreatePost(t *testing.T) {
 		assert.Nil(t, rpost)
 	})
 
-	t.Run("with type card", func(t *testing.T) {
-		cardPost, resp, err := client.CreatePost(context.Background(), &model.Post{
-			ChannelId: th.BasicChannel.Id,
-			Message:   "card post",
-			Type:      model.PostTypeCard,
-		})
-		require.NoError(t, err)
-		CheckCreatedStatus(t, resp)
-		require.NotNil(t, cardPost)
-		assert.Equal(t, model.PostTypeCard, cardPost.Type)
-		assert.Equal(t, "card post", cardPost.Message)
-	})
-
 	t.Run("invalid post type", func(t *testing.T) {
 		post := basicPost()
 		post.Type = model.PostTypeSystemGeneric
@@ -6399,5 +6386,59 @@ func TestPatchCardPostByNonOwner(t *testing.T) {
 		_, resp, err := cli.PatchPost(context.Background(), cardPost.Id, patch)
 		require.Error(t, err)
 		CheckForbiddenStatus(t, resp)
+	})
+}
+
+func TestCreateCardPostWithFeatureFlagDisabled(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	t.Run("card post rejected when IntegratedBoards flag is disabled", func(t *testing.T) {
+		th := SetupConfig(t, func(cfg *model.Config) {
+			cfg.FeatureFlags.IntegratedBoards = false
+		}).InitBasic(t)
+		client := th.Client
+
+		post := &model.Post{
+			ChannelId: th.BasicChannel.Id,
+			Message:   "this is a card",
+			Type:      model.PostTypeCard,
+		}
+		_, resp, err := client.CreatePost(context.Background(), post)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+	})
+
+	t.Run("card post allowed when IntegratedBoards flag is enabled", func(t *testing.T) {
+		th := SetupConfig(t, func(cfg *model.Config) {
+			cfg.FeatureFlags.IntegratedBoards = true
+		}).InitBasic(t)
+		client := th.Client
+
+		post := &model.Post{
+			ChannelId: th.BasicChannel.Id,
+			Message:   "card post",
+			Type:      model.PostTypeCard,
+		}
+		rpost, resp, err := client.CreatePost(context.Background(), post)
+		require.NoError(t, err)
+		CheckCreatedStatus(t, resp)
+		require.NotNil(t, rpost)
+		assert.Equal(t, model.PostTypeCard, rpost.Type)
+		assert.Equal(t, "card post", rpost.Message)
+	})
+
+	t.Run("non-card post allowed when IntegratedBoards flag is disabled", func(t *testing.T) {
+		th := SetupConfig(t, func(cfg *model.Config) {
+			cfg.FeatureFlags.IntegratedBoards = false
+		}).InitBasic(t)
+		client := th.Client
+
+		post := &model.Post{
+			ChannelId: th.BasicChannel.Id,
+			Message:   "this is a regular post",
+		}
+		rpost, _, err := client.CreatePost(context.Background(), post)
+		require.NoError(t, err)
+		assert.Equal(t, "", rpost.Type)
 	})
 }

--- a/server/channels/api4/post_utils.go
+++ b/server/channels/api4/post_utils.go
@@ -42,6 +42,13 @@ func postPriorityCheckWithContext(where string, c *Context, priority *model.Post
 	}
 }
 
+func postCardTypeCheckWithContext(where string, c *Context, postType string) {
+	if appErr := app.PostCardTypeCheckWithApp(where, c.App, postType); appErr != nil {
+		appErr.Where = where
+		c.Err = appErr
+	}
+}
+
 func postBurnOnReadCheckWithContext(where string, c *Context, post *model.Post, channel *model.Channel) {
 	appErr := app.PostBurnOnReadCheckWithApp(where, c.App, c.AppContext, post.UserId, post.ChannelId, post.Type, channel)
 	if appErr != nil {

--- a/server/channels/api4/scheduled_post.go
+++ b/server/channels/api4/scheduled_post.go
@@ -44,6 +44,11 @@ func scheduledPostChecks(where string, c *Context, scheduledPost *model.Schedule
 		return
 	}
 
+	postCardTypeCheckWithContext(where, c, scheduledPost.Type)
+	if c.Err != nil {
+		return
+	}
+
 	// Validate burn-on-read restrictions for scheduled post
 	post := &model.Post{
 		ChannelId: scheduledPost.ChannelId,

--- a/server/channels/app/post_permission_utils.go
+++ b/server/channels/app/post_permission_utils.go
@@ -115,6 +115,15 @@ func userCreatePostPermissionCheckWithApp(rctx request.CTX, a *App, userId, chan
 	return nil
 }
 
+// PostCardTypeCheckWithApp validates whether a card post can be created
+// based on the IntegratedBoards feature flag.
+func PostCardTypeCheckWithApp(where string, a *App, postType string) *model.AppError {
+	if postType == model.PostTypeCard && !a.Config().FeatureFlags.IntegratedBoards {
+		return model.NewAppError(where, "api.post.create_post.card_type_disabled.app_error", nil, "", http.StatusBadRequest)
+	}
+	return nil
+}
+
 // PostBurnOnReadCheckWithApp validates whether a burn-on-read post can be created
 // based on channel type and participants. This is called from the API layer before
 // post creation to enforce burn-on-read restrictions.

--- a/server/channels/app/post_permission_utils_test.go
+++ b/server/channels/app/post_permission_utils_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPostCardTypeCheckWithApp(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	t.Run("returns error for card post when IntegratedBoards is disabled", func(t *testing.T) {
+		th := SetupConfig(t, func(cfg *model.Config) {
+			cfg.FeatureFlags.IntegratedBoards = false
+		})
+
+		appErr := PostCardTypeCheckWithApp("test", th.App, model.PostTypeCard)
+		assert.NotNil(t, appErr)
+		assert.Equal(t, "api.post.create_post.card_type_disabled.app_error", appErr.Id)
+	})
+
+	t.Run("returns nil for card post when IntegratedBoards is enabled", func(t *testing.T) {
+		th := SetupConfig(t, func(cfg *model.Config) {
+			cfg.FeatureFlags.IntegratedBoards = true
+		})
+
+		appErr := PostCardTypeCheckWithApp("test", th.App, model.PostTypeCard)
+		assert.Nil(t, appErr)
+	})
+
+	t.Run("returns nil for non-card post when IntegratedBoards is disabled", func(t *testing.T) {
+		th := SetupConfig(t, func(cfg *model.Config) {
+			cfg.FeatureFlags.IntegratedBoards = false
+		})
+
+		appErr := PostCardTypeCheckWithApp("test", th.App, "")
+		assert.Nil(t, appErr)
+	})
+}

--- a/server/channels/app/scheduled_post_job.go
+++ b/server/channels/app/scheduled_post_job.go
@@ -314,6 +314,18 @@ func (a *App) canPostScheduledPost(rctx request.CTX, scheduledPost *model.Schedu
 		return model.ScheduledPostErrorInvalidPost, nil
 	}
 
+	if appErr := PostCardTypeCheckWithApp("ScheduledPostJob.postChecks", a, scheduledPost.Type); appErr != nil {
+		rctx.Logger().Debug(
+			"canPostScheduledPost card type disabled",
+			mlog.String("scheduled_post_id", scheduledPost.Id),
+			mlog.String("user_id", scheduledPost.UserId),
+			mlog.String("channel_id", scheduledPost.ChannelId),
+			mlog.String("error_code", model.ScheduledPostErrorInvalidPost),
+			mlog.Err(appErr),
+		)
+		return model.ScheduledPostErrorInvalidPost, nil
+	}
+
 	// Validate burn-on-read restrictions for scheduled post
 	if appErr := PostBurnOnReadCheckWithApp("ScheduledPostJob.postChecks", a, rctx, scheduledPost.UserId, scheduledPost.ChannelId, scheduledPost.Type, channel); appErr != nil {
 		rctx.Logger().Debug(

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -2781,6 +2781,10 @@
     "translation": "Can not post to deleted channel."
   },
   {
+    "id": "api.post.create_post.card_type_disabled.app_error",
+    "translation": "Card posts are not enabled on this server."
+  },
+  {
     "id": "api.post.create_post.channel_root_id.app_error",
     "translation": "Invalid ChannelId for RootId parameter."
   },


### PR DESCRIPTION
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68112

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes add a new validation guard that follows established patterns in the codebase (similar to existing `postPriorityCheck` and `postBurnOnReadCheck` flows). However, the validation is inserted into critical post creation paths (`createPostChecks` and `scheduledPostChecks`). Since the feature flag defaults to disabled (`IntegratedBoards = false`), all card post creation attempts will be blocked by default until the flag is explicitly enabled. Low risk of breaking non-card post creation since the guard only applies when `postType == model.PostTypeCard`. The main regression concern would be if any integration or internal tool depends on creating card posts through the API without the feature flag enabled, which would now fail with a 400 error.

**QA Recommendation:** While automated test coverage appears comprehensive (covering enabled/disabled flag states and non-card posts), manual QA should focus on: (1) verifying card post creation workflows when the feature flag is enabled to ensure the guard doesn't inadvertently block legitimate use; (2) testing scheduled post creation with card types in both flag states; (3) verifying that non-card posts continue to work unaffected regardless of feature flag state; (4) integration testing with any internal tools or services that may create posts programmatically. Given the medium complexity of the change spanning multiple validation flows, standard manual QA coverage (beyond automated tests) is recommended.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->