### PR TITLE
MM-67291: ES health metric

### DIFF
--- a/server/enterprise/metrics/metrics.go
+++ b/server/enterprise/metrics/metrics.go
@@ -154,6 +154,7 @@ type MetricsInterfaceImpl struct {
 	WebSocketBroadcastBufferUsersRegisteredGauge *prometheus.GaugeVec
 	WebSocketReconnectCounter                    *prometheus.CounterVec
 
+	SearchEngineStatusGauge    prometheus.GaugeFunc
 	SearchPostSearchesCounter  prometheus.Counter
 	SearchPostSearchesDuration prometheus.Histogram
 	SearchFileSearchesCounter  prometheus.Counter
@@ -744,6 +745,24 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 	m.Registry.MustRegister(m.WebSocketReconnectCounter)
 
 	// Search Subsystem
+
+	m.SearchEngineStatusGauge = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace:   MetricsNamespace,
+		Subsystem:   MetricsSubsystemSearch,
+		Name:        "engine_status",
+		Help:        "Status of the configured search engine: 1 = healthy or not configured, 0 = configured but unavailable.",
+		ConstLabels: additionalLabels,
+	}, func() float64 {
+		es := m.Platform.SearchEngine.ElasticsearchEngine
+		if es == nil || !es.IsEnabled() {
+			return 1 // no search engine expected; nothing to alert on
+		}
+		if es.IsHealthy() {
+			return 1
+		}
+		return 0
+	})
+	m.Registry.MustRegister(m.SearchEngineStatusGauge)
 
 	m.SearchPostSearchesCounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace:   MetricsNamespace,

--- a/server/enterprise/metrics/metrics_test.go
+++ b/server/enterprise/metrics/metrics_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/v8/channels/api4"
 	"github.com/mattermost/mattermost/server/v8/channels/app"
+	seMocks "github.com/mattermost/mattermost/server/v8/platform/services/searchengine/mocks"
 
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest/mock"
 	"github.com/mattermost/mattermost/server/v8/channels/store/storetest/mocks"
@@ -257,4 +258,56 @@ func TestExtractDBCluster(t *testing.T) {
 			require.Equal(t, tc.expectedClusterName, host)
 		})
 	}
+}
+
+func TestSearchEngineStatusGauge(t *testing.T) {
+	th := api4.SetupEnterprise(t, app.StartMetrics)
+
+	configureMetrics(th)
+	mi := th.App.Metrics()
+
+	miImpl, ok := mi.(*MetricsInterfaceImpl)
+	require.True(t, ok, fmt.Sprintf("App.Metrics is not *MetricsInterfaceImpl, but %T", mi))
+
+	readGauge := func() float64 {
+		m := &prometheusModels.Metric{}
+		require.NoError(t, miImpl.SearchEngineStatusGauge.Write(m))
+		return m.Gauge.GetValue()
+	}
+
+	setEngine := func(t *testing.T, engine *seMocks.SearchEngineInterface) {
+		t.Helper()
+		miImpl.Platform.SearchEngine.ElasticsearchEngine = engine
+		t.Cleanup(func() {
+			miImpl.Platform.SearchEngine.ElasticsearchEngine = nil
+		})
+	}
+
+	t.Run("nil engine returns 1", func(t *testing.T) {
+		miImpl.Platform.SearchEngine.ElasticsearchEngine = nil
+		require.Equal(t, 1.0, readGauge())
+	})
+
+	t.Run("disabled engine returns 1", func(t *testing.T) {
+		esMock := &seMocks.SearchEngineInterface{}
+		esMock.On("IsEnabled").Return(false)
+		setEngine(t, esMock)
+		require.Equal(t, 1.0, readGauge())
+	})
+
+	t.Run("enabled healthy engine returns 1", func(t *testing.T) {
+		esMock := &seMocks.SearchEngineInterface{}
+		esMock.On("IsEnabled").Return(true)
+		esMock.On("IsHealthy").Return(true)
+		setEngine(t, esMock)
+		require.Equal(t, 1.0, readGauge())
+	})
+
+	t.Run("enabled unhealthy engine returns 0", func(t *testing.T) {
+		esMock := &seMocks.SearchEngineInterface{}
+		esMock.On("IsEnabled").Return(true)
+		esMock.On("IsHealthy").Return(false)
+		setEngine(t, esMock)
+		require.Equal(t, 0.0, readGauge())
+	})
 }


### PR DESCRIPTION
#### Summary
This PR builds off of #35747 and #35843 to add a new Prometheus metric that could be used to set up an alert on an unhealthy Elasticsearch cluster.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67291

#### Screenshots
--

#### Release Note
```release-note
Added a new mattermost_search_engine_status metric that reports whether the Elasticsearch/Opensearch cluster is healthy (value = 1) or not (value = 0). If the cluster is not enabled, its value is reported as 1.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change adds a read-only Prometheus GaugeFunc that drives operational alerts and reads search engine state via existing methods; while it doesn't alter runtime behavior, incorrect metric logic or missing coverage could cause false alerts or missed incidents. Some branches were initially untested (reviewer requested four-case coverage), so until tests fully validate all paths there is non-trivial risk to monitoring correctness.

**QA Recommendation:** Run focused QA on monitoring/alerting: verify prometheus exposes mattermost_search_engine_status for nil/disabled/enabled+healthy/enabled+unhealthy cases and confirm alerting rules behave as expected; moderate manual QA recommended until test coverage is confirmed complete.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->