### PR TITLE
Upgrade golangci-lint to v2.11.4

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -332,7 +332,7 @@ golang-versions: ## Install Golang versions used for compatibility testing (e.g.
 	export GO_COMPATIBILITY_TEST_VERSIONS="${GO_COMPATIBILITY_TEST_VERSIONS}"
 
 golangci-lint: setup-go-work ## Run golangci-lint on codebase
-	$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.0
+	$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
 ifeq ($(BUILD_ENTERPRISE_READY),true)
 	$(GOBIN)/golangci-lint run ./... ./public/... $(BUILD_ENTERPRISE_DIR)/...
 else

--- a/server/channels/app/app_test.go
+++ b/server/channels/app/app_test.go
@@ -62,9 +62,9 @@ func TestUnitUpdateConfig(t *testing.T) {
 
 	require.False(t, th.App.IsConfigReadOnly())
 
-	var called int32
+	var called atomic.Int32
 	th.App.AddConfigListener(func(old, current *model.Config) {
-		atomic.AddInt32(&called, 1)
+		called.Add(1)
 		assert.Equal(t, prev, *old.ServiceSettings.SiteURL)
 		assert.Equal(t, "http://foo.com", *current.ServiceSettings.SiteURL)
 	})
@@ -74,7 +74,7 @@ func TestUnitUpdateConfig(t *testing.T) {
 	})
 
 	// callback should be called once
-	assert.Equal(t, int32(1), atomic.LoadInt32(&called))
+	assert.Equal(t, int32(1), called.Load())
 }
 
 func TestDoAdvancedPermissionsMigration(t *testing.T) {

--- a/server/channels/app/email/email_batching_test.go
+++ b/server/channels/app/email/email_batching_test.go
@@ -126,9 +126,9 @@ func TestCheckPendingNotifications(t *testing.T) {
 	}})
 	require.NoError(t, nErr)
 
-	var wasCalled int32
+	var wasCalled atomic.Int32
 	job.checkPendingNotifications(time.Unix(10050, 0), func(string, []*batchedNotification) {
-		atomic.StoreInt32(&wasCalled, int32(1))
+		wasCalled.Store(int32(1))
 	})
 
 	// A hack to check whether the handler was called.
@@ -138,7 +138,7 @@ func TestCheckPendingNotifications(t *testing.T) {
 	// We do a check outside the email handler, because otherwise, failing from
 	// inside the handler doesn't let the .Go() function exit cleanly, and it gets
 	// stuck during server shutdown, trying to wait for the goroutine to exit
-	require.Equal(t, int32(0), atomic.LoadInt32(&wasCalled), "email handler should not have been called")
+	require.Equal(t, int32(0), wasCalled.Load(), "email handler should not have been called")
 
 	require.Nil(t, job.pendingNotifications[th.BasicUser.Id])
 	require.Empty(t, job.pendingNotifications[th.BasicUser.Id], "should've remove queued post since user acted")

--- a/server/channels/app/shared_channel_global_user_sync_self_referential_test.go
+++ b/server/channels/app/shared_channel_global_user_sync_self_referential_test.go
@@ -453,7 +453,7 @@ func TestSharedChannelGlobalUserSyncSelfReferential(t *testing.T) {
 		// - Cursor updates only when sync is successful
 		EnsureCleanState(t, th, ss)
 
-		var syncAttempts int32
+		var syncAttempts atomic.Int32
 		var failureMode atomic.Bool
 		failureMode.Store(false)
 		var syncHandler *SelfReferentialSyncHandler
@@ -462,7 +462,7 @@ func TestSharedChannelGlobalUserSyncSelfReferential(t *testing.T) {
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
 			case "/api/v4/remotecluster/msg":
-				atomic.AddInt32(&syncAttempts, 1)
+				syncAttempts.Add(1)
 
 				if failureMode.Load() {
 					w.WriteHeader(http.StatusInternalServerError)
@@ -520,7 +520,7 @@ func TestSharedChannelGlobalUserSyncSelfReferential(t *testing.T) {
 
 		// Wait for first sync
 		require.Eventually(t, func() bool {
-			return atomic.LoadInt32(&syncAttempts) > 0
+			return syncAttempts.Load() > 0
 		}, 5*time.Second, 100*time.Millisecond, "Should have attempted sync")
 
 		// Verify cursor was updated
@@ -539,13 +539,13 @@ func TestSharedChannelGlobalUserSyncSelfReferential(t *testing.T) {
 		require.NoError(t, err)
 
 		// Second sync - should fail
-		initialAttempts := atomic.LoadInt32(&syncAttempts)
+		initialAttempts := syncAttempts.Load()
 		err = service.HandleSyncAllUsersForTesting(selfCluster)
 		require.NoError(t, err) // The method itself shouldn't error, just the remote call
 
 		// Wait for failed sync attempt
 		require.Eventually(t, func() bool {
-			return atomic.LoadInt32(&syncAttempts) > initialAttempts
+			return syncAttempts.Load() > initialAttempts
 		}, 5*time.Second, 100*time.Millisecond, "Should have attempted sync")
 
 		// Verify cursor was NOT updated on failure
@@ -557,13 +557,13 @@ func TestSharedChannelGlobalUserSyncSelfReferential(t *testing.T) {
 		failureMode.Store(false)
 
 		// Third sync - should succeed and update cursor
-		preSuccessAttempts := atomic.LoadInt32(&syncAttempts)
+		preSuccessAttempts := syncAttempts.Load()
 		err = service.HandleSyncAllUsersForTesting(selfCluster)
 		require.NoError(t, err)
 
 		// Wait for successful sync
 		require.Eventually(t, func() bool {
-			return atomic.LoadInt32(&syncAttempts) > preSuccessAttempts
+			return syncAttempts.Load() > preSuccessAttempts
 		}, 5*time.Second, 100*time.Millisecond, "Should have attempted sync")
 
 		// Verify cursor was updated after successful sync
@@ -579,12 +579,12 @@ func TestSharedChannelGlobalUserSyncSelfReferential(t *testing.T) {
 		// - Ensures cursor is only updated when flag is enabled
 		EnsureCleanState(t, th, ss)
 
-		var syncMessageCount int32
+		var syncMessageCount atomic.Int32
 
 		// Create test HTTP server
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/api/v4/remotecluster/msg" {
-				atomic.AddInt32(&syncMessageCount, 1)
+				syncMessageCount.Add(1)
 			}
 			writeOKResponse(w)
 		}))
@@ -622,13 +622,13 @@ func TestSharedChannelGlobalUserSyncSelfReferential(t *testing.T) {
 		err = th.App.ReloadConfig()
 		require.NoError(t, err)
 
-		atomic.StoreInt32(&syncMessageCount, 0)
+		syncMessageCount.Store(0)
 		err = service.HandleSyncAllUsersForTesting(selfCluster)
 		require.NoError(t, err)
 
 		// Verify no sync messages were sent
 		require.Never(t, func() bool {
-			return atomic.LoadInt32(&syncMessageCount) > 0
+			return syncMessageCount.Load() > 0
 		}, 2*time.Second, 100*time.Millisecond, "No sync should occur with feature flag disabled")
 
 		// Verify cursor was not updated
@@ -645,13 +645,13 @@ func TestSharedChannelGlobalUserSyncSelfReferential(t *testing.T) {
 		err = th.App.ReloadConfig()
 		require.NoError(t, err)
 
-		atomic.StoreInt32(&syncMessageCount, 0)
+		syncMessageCount.Store(0)
 		err = service.HandleSyncAllUsersForTesting(selfCluster)
 		require.NoError(t, err)
 
 		// Verify sync messages were sent
 		require.Eventually(t, func() bool {
-			return atomic.LoadInt32(&syncMessageCount) > 0
+			return syncMessageCount.Load() > 0
 		}, 5*time.Second, 100*time.Millisecond, "Sync should occur with feature flag enabled")
 
 		// Verify cursor was updated
@@ -667,13 +667,13 @@ func TestSharedChannelGlobalUserSyncSelfReferential(t *testing.T) {
 		// - Tests cursor updates in both scenarios
 		EnsureCleanState(t, th, ss)
 
-		var syncMessageCount int32
+		var syncMessageCount atomic.Int32
 		var connectionOpenSyncOccurred atomic.Bool
 
 		// Create test HTTP server
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/api/v4/remotecluster/msg" {
-				atomic.AddInt32(&syncMessageCount, 1)
+				syncMessageCount.Add(1)
 
 				// Parse message to check if it's a user sync
 				bodyBytes, _ := io.ReadAll(r.Body)
@@ -724,12 +724,12 @@ func TestSharedChannelGlobalUserSyncSelfReferential(t *testing.T) {
 
 		// Verify no automatic sync occurs within a reasonable time
 		require.Never(t, func() bool {
-			return connectionOpenSyncOccurred.Load() || atomic.LoadInt32(&syncMessageCount) > 0
+			return connectionOpenSyncOccurred.Load() || syncMessageCount.Load() > 0
 		}, 2*time.Second, 100*time.Millisecond, "No automatic sync should occur when config is disabled")
 
 		// Test 2: Connection open with sync enabled
 		// Reset counters
-		atomic.StoreInt32(&syncMessageCount, 0)
+		syncMessageCount.Store(0)
 		connectionOpenSyncOccurred.Store(false)
 
 		// Enable config option
@@ -767,7 +767,7 @@ func TestSharedChannelGlobalUserSyncSelfReferential(t *testing.T) {
 		}, 5*time.Second, 100*time.Millisecond, "Automatic sync should occur when config is enabled")
 
 		// Verify sync occurred
-		assert.Greater(t, atomic.LoadInt32(&syncMessageCount), int32(0), "Should have sync messages when config enabled")
+		assert.Greater(t, syncMessageCount.Load(), int32(0), "Should have sync messages when config enabled")
 
 		// Verify cursor was updated
 		updatedCluster, err2 := ss.RemoteCluster().Get(selfCluster2.RemoteId, true)
@@ -849,7 +849,7 @@ func TestSharedChannelGlobalUserSyncSelfReferential(t *testing.T) {
 		// - No partial data should be persisted
 		EnsureCleanState(t, th, ss)
 
-		var syncAttempts int32
+		var syncAttempts atomic.Int32
 		var serverOnline atomic.Bool
 		serverOnline.Store(true)
 
@@ -862,9 +862,9 @@ func TestSharedChannelGlobalUserSyncSelfReferential(t *testing.T) {
 			}
 
 			if r.URL.Path == "/api/v4/remotecluster/msg" {
-				atomic.AddInt32(&syncAttempts, 1)
+				syncAttempts.Add(1)
 				// On second attempt, go offline
-				if atomic.LoadInt32(&syncAttempts) >= 2 {
+				if syncAttempts.Load() >= 2 {
 					serverOnline.Store(false)
 					w.WriteHeader(http.StatusServiceUnavailable)
 					return
@@ -903,7 +903,7 @@ func TestSharedChannelGlobalUserSyncSelfReferential(t *testing.T) {
 
 		// Wait for first sync
 		require.Eventually(t, func() bool {
-			return atomic.LoadInt32(&syncAttempts) >= 1
+			return syncAttempts.Load() >= 1
 		}, 5*time.Second, 100*time.Millisecond)
 
 		// Get cursor after first sync
@@ -926,7 +926,7 @@ func TestSharedChannelGlobalUserSyncSelfReferential(t *testing.T) {
 
 		// Wait for second sync attempt
 		require.Eventually(t, func() bool {
-			return atomic.LoadInt32(&syncAttempts) >= 2
+			return syncAttempts.Load() >= 2
 		}, 5*time.Second, 100*time.Millisecond)
 
 		// Verify cursor was not updated after failed sync

--- a/server/channels/app/shared_channel_membership_sync_self_referential_test.go
+++ b/server/channels/app/shared_channel_membership_sync_self_referential_test.go
@@ -65,12 +65,12 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		// The test ensures that sync messages are sent asynchronously after a minimum delay for both add and remove operations.
 		EnsureCleanState(t, th, ss)
 		// Track sync messages received
-		var syncMessageCount int32
+		var syncMessageCount atomic.Int32
 		var syncHandler *SelfReferentialSyncHandler
 
 		// Create a test HTTP server that acts as the "remote" cluster
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			atomic.AddInt32(&syncMessageCount, 1)
+			syncMessageCount.Add(1)
 			if syncHandler != nil {
 				syncHandler.HandleRequest(w, r)
 			} else {
@@ -144,7 +144,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 
 		// Wait for async sync with more generous timeout (minimum delay is 2 seconds + async task processing)
 		require.Eventually(t, func() bool {
-			count := atomic.LoadInt32(&syncMessageCount)
+			count := syncMessageCount.Load()
 			return count > 0
 		}, 15*time.Second, 200*time.Millisecond, "Should have received at least one sync message via automatic sync")
 
@@ -161,7 +161,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		// Reset sync counter and wait for background tasks to settle
 		var initialCount int32
 		require.Eventually(t, func() bool {
-			initialCount = atomic.LoadInt32(&syncMessageCount)
+			initialCount = syncMessageCount.Load()
 			return !service.HasPendingTasksForTesting()
 		}, 5*time.Second, 100*time.Millisecond, "Background tasks should settle before removal test")
 
@@ -171,7 +171,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 
 		// Wait for removal sync with increased timeout
 		require.Eventually(t, func() bool {
-			count := atomic.LoadInt32(&syncMessageCount)
+			count := syncMessageCount.Load()
 			return count > initialCount
 		}, 20*time.Second, 200*time.Millisecond, "Should have received sync message for user removal")
 
@@ -532,7 +532,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		// 2. No members are synced during failure mode
 		// 3. Once the server recovers, sync completes successfully
 		EnsureCleanState(t, th, ss)
-		var syncAttempts int32
+		var syncAttempts atomic.Int32
 		var failureMode atomic.Bool
 		failureMode.Store(true)
 		var successfulSyncs []string
@@ -541,7 +541,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/api/v4/remotecluster/msg" {
-				atomic.AddInt32(&syncAttempts, 1)
+				syncAttempts.Add(1)
 
 				if failureMode.Load() {
 					w.WriteHeader(http.StatusInternalServerError)
@@ -621,11 +621,11 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 
 		// Wait for first sync attempt with more robust checking
 		require.Eventually(t, func() bool {
-			attempts := atomic.LoadInt32(&syncAttempts)
+			attempts := syncAttempts.Load()
 			return attempts > 0
 		}, 15*time.Second, 100*time.Millisecond, "Should have attempted sync during failure mode")
 
-		initialAttempts := atomic.LoadInt32(&syncAttempts)
+		initialAttempts := syncAttempts.Load()
 		assert.Greater(t, initialAttempts, int32(0), "Should have attempted sync")
 		assert.Empty(t, successfulSyncs, "No successful syncs during failure mode")
 
@@ -641,7 +641,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		}, 15*time.Second, 100*time.Millisecond, "Should have successful sync after recovery")
 
 		// Verify recovery
-		finalAttempts := atomic.LoadInt32(&syncAttempts)
+		finalAttempts := syncAttempts.Load()
 		assert.Greater(t, finalAttempts, initialAttempts, "Should have retried after recovery")
 	})
 	t.Run("Test 5: Manual sync with cursor management", func(t *testing.T) {
@@ -651,9 +651,9 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		// 3. Verifies all operations are properly synced and cursor is updated correctly
 		// 4. Validates that the LastMembersSyncAt cursor advances after each sync operation
 		EnsureCleanState(t, th, ss)
-		var totalSyncMessages int32
-		var addOperations int32
-		var removeOperations int32
+		var totalSyncMessages atomic.Int32
+		var addOperations atomic.Int32
+		var removeOperations atomic.Int32
 		var selfCluster *model.RemoteCluster
 
 		// Create sync handler
@@ -677,9 +677,9 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 						// Count membership changes (now sent via TopicSync)
 						for _, change := range syncMsg.MembershipChanges {
 							if change.IsAdd {
-								atomic.AddInt32(&addOperations, 1)
+								addOperations.Add(1)
 							} else {
-								atomic.AddInt32(&removeOperations, 1)
+								removeOperations.Add(1)
 							}
 						}
 					}
@@ -763,10 +763,10 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 
 		// Wait for initial sync to complete
 		require.Eventually(t, func() bool {
-			return atomic.LoadInt32(&addOperations) >= 10
+			return addOperations.Load() >= 10
 		}, 10*time.Second, 100*time.Millisecond, "Should sync all initial users")
 
-		initialAdds := atomic.LoadInt32(&addOperations)
+		initialAdds := addOperations.Load()
 		assert.GreaterOrEqual(t, initialAdds, int32(10), "Should sync all initial users")
 
 		// Verify cursor was updated after initial sync
@@ -798,14 +798,14 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		}
 
 		// Sync mixed changes
-		previousMessages := atomic.LoadInt32(&totalSyncMessages)
+		previousMessages := totalSyncMessages.Load()
 
 		service.NotifyMembershipChanged(channel.Id, "")
 
 		// Wait for mixed changes sync to complete
 		require.Eventually(t, func() bool {
-			messages := atomic.LoadInt32(&totalSyncMessages)
-			removes := atomic.LoadInt32(&removeOperations)
+			messages := totalSyncMessages.Load()
+			removes := removeOperations.Load()
 			return messages > previousMessages && removes >= 3
 		}, 10*time.Second, 100*time.Millisecond, "Should sync mixed changes")
 
@@ -825,9 +825,9 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		expectedMembers := 10 - 3 + 5 + 1 // initial - removed + added + system admin
 		assert.Equal(t, expectedMembers, len(members), "Should have correct final member count")
 
-		finalMessages := atomic.LoadInt32(&totalSyncMessages)
-		finalAdds := atomic.LoadInt32(&addOperations)
-		finalRemoves := atomic.LoadInt32(&removeOperations)
+		finalMessages := totalSyncMessages.Load()
+		finalAdds := addOperations.Load()
+		finalRemoves := removeOperations.Load()
 
 		assert.Greater(t, finalMessages, int32(0), "Should have sync messages")
 		assert.Greater(t, finalAdds, int32(0), "Should have add operations")
@@ -839,7 +839,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		// 2. Changes from one cluster propagate through our server to other clusters
 		// 3. Removals sync to all clusters
 		EnsureCleanState(t, th, ss)
-		var totalSyncMessages int32
+		var totalSyncMessages atomic.Int32
 		var syncMessagesPerCluster = make(map[string]*int32)
 
 		// Create multiple test HTTP servers to simulate different remote clusters
@@ -983,7 +983,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		// This simulates cluster-2 receiving a membership change and propagating it
 
 		// Reset counters
-		atomic.StoreInt32(&totalSyncMessages, 0)
+		totalSyncMessages.Store(0)
 		for _, countPtr := range syncMessagesPerCluster {
 			atomic.StoreInt32(countPtr, 0)
 		}
@@ -1044,7 +1044,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		// Part 3: Test removal syncing to all clusters
 
 		// Reset counters
-		atomic.StoreInt32(&totalSyncMessages, 0)
+		totalSyncMessages.Store(0)
 		for _, countPtr := range syncMessagesPerCluster {
 			atomic.StoreInt32(countPtr, 0)
 		}
@@ -1081,7 +1081,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		// 2. When the feature flag is enabled, sync messages should be sent as expected
 		// This ensures that the feature can be safely disabled in production without triggering unintended syncs
 		EnsureCleanState(t, th, ss)
-		var syncMessageCount int32
+		var syncMessageCount atomic.Int32
 
 		// Disable feature flag from the beginning to prevent any automatic sync
 		os.Setenv("MM_FEATUREFLAGS_ENABLESHAREDCHANNELMEMBERSYNC", "false")
@@ -1091,7 +1091,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		// Create test HTTP server that counts sync messages
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/api/v4/remotecluster/msg" {
-				atomic.AddInt32(&syncMessageCount, 1)
+				syncMessageCount.Add(1)
 			}
 			writeOKResponse(w)
 		}))
@@ -1151,12 +1151,12 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 			require.Nil(t, appErr)
 		}
 
-		atomic.StoreInt32(&syncMessageCount, 0)
+		syncMessageCount.Store(0)
 		service.NotifyMembershipChanged(channel.Id, "")
 
 		// Verify no sync messages were sent
 		require.Never(t, func() bool {
-			return atomic.LoadInt32(&syncMessageCount) > 0
+			return syncMessageCount.Load() > 0
 		}, 2*time.Second, 100*time.Millisecond, "No sync should occur with feature flag disabled")
 
 		// Test 2: Sync with feature flag enabled
@@ -1164,12 +1164,12 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 			cfg.FeatureFlags.EnableSharedChannelsMemberSync = true
 		})
 
-		atomic.StoreInt32(&syncMessageCount, 0)
+		syncMessageCount.Store(0)
 		service.NotifyMembershipChanged(channel.Id, "")
 
 		// Verify sync messages were sent
 		require.Eventually(t, func() bool {
-			return atomic.LoadInt32(&syncMessageCount) > 0
+			return syncMessageCount.Load() > 0
 		}, 5*time.Second, 100*time.Millisecond, "Sync should occur with feature flag enabled")
 	})
 	t.Run("Test 8: Sync Task After Connection Becomes Available", func(t *testing.T) {
@@ -1287,7 +1287,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		// 5. No partial data is persisted from the failed sync
 		EnsureCleanState(t, th, ss)
 
-		var syncAttempts int32
+		var syncAttempts atomic.Int32
 		var serverOnline atomic.Bool
 		serverOnline.Store(true)
 		var syncHandler *SelfReferentialSyncHandler
@@ -1301,7 +1301,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 			}
 
 			if r.URL.Path == "/api/v4/remotecluster/msg" {
-				currentAttempt := atomic.AddInt32(&syncAttempts, 1)
+				currentAttempt := syncAttempts.Add(1)
 				// On second sync cycle, go offline (allow first full sync to complete)
 				if currentAttempt > 2 {
 					serverOnline.Store(false)
@@ -1377,7 +1377,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 
 		// Wait for first sync with more generous timeout
 		require.Eventually(t, func() bool {
-			return atomic.LoadInt32(&syncAttempts) >= 1
+			return syncAttempts.Load() >= 1
 		}, 15*time.Second, 200*time.Millisecond, "Should complete first sync")
 
 		// Wait for cursor to be updated after first sync
@@ -1405,7 +1405,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 
 		// Wait for second sync attempt with more generous timeout
 		require.Eventually(t, func() bool {
-			return atomic.LoadInt32(&syncAttempts) >= 2
+			return syncAttempts.Load() >= 2
 		}, 20*time.Second, 200*time.Millisecond, "Should attempt second sync")
 
 		// Wait for any cursor updates to complete and verify cursor was not updated
@@ -1435,7 +1435,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 		var mu sync.Mutex
 		var syncHandler *SelfReferentialSyncHandler
 		var testServer *httptest.Server
-		var totalSyncMessages int32
+		var totalSyncMessages atomic.Int32
 
 		// Create users
 		user1 := th.CreateUser(t)
@@ -1506,7 +1506,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 								for _, change := range syncMsg.MembershipChanges {
 									if change.IsAdd {
 										syncedChannelUsers[channelId] = append(syncedChannelUsers[channelId], change.UserId)
-										atomic.AddInt32(&totalSyncMessages, 1)
+										totalSyncMessages.Add(1)
 									}
 								}
 							}
@@ -1560,7 +1560,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 
 		// Ensure the sync handler is ready by waiting for the first message
 		require.Eventually(t, func() bool {
-			return atomic.LoadInt32(&totalSyncMessages) > 0
+			return totalSyncMessages.Load() > 0
 		}, 10*time.Second, 50*time.Millisecond, "Expected at least one sync message to be sent")
 
 		// Calculate expected number of sync messages
@@ -1572,7 +1572,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 
 		// Wait for all sync messages to be processed with detailed debugging
 		require.Eventually(t, func() bool {
-			currentMessages := atomic.LoadInt32(&totalSyncMessages)
+			currentMessages := totalSyncMessages.Load()
 
 			mu.Lock()
 			channelCount := len(syncedChannelUsers)
@@ -1590,7 +1590,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 
 			return currentMessages >= expectedSyncMessages
 		}, 30*time.Second, 200*time.Millisecond,
-			fmt.Sprintf("Expected %d sync messages, but got %d", expectedSyncMessages, atomic.LoadInt32(&totalSyncMessages)))
+			fmt.Sprintf("Expected %d sync messages, but got %d", expectedSyncMessages, totalSyncMessages.Load()))
 
 		// Verify we have complete data for all channels
 		require.Eventually(t, func() bool {
@@ -1674,7 +1674,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 	// 	EnsureCleanState(t, th, ss)
 	// 	var syncMessages []model.SyncMsg
 	// 	var mu sync.Mutex
-	// 	var syncMessageCount int32
+	// 	var syncMessageCount atomic.Int32
 	// 	var selfCluster *model.RemoteCluster
 
 	// 	// Create sync handler
@@ -1683,7 +1683,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 	// 	// Create test HTTP server that tracks sync messages
 	// 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	// 		if r.URL.Path == "/api/v4/remotecluster/msg" {
-	// 			atomic.AddInt32(&syncMessageCount, 1)
+	// 			syncMessageCount.Add(1)
 
 	// 			// Read body once
 	// 			bodyBytes, readErr := io.ReadAll(r.Body)
@@ -1783,7 +1783,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 
 	// 	// Wait for initial sync to complete
 	// 	require.Eventually(t, func() bool {
-	// 		count := atomic.LoadInt32(&syncMessageCount)
+	// 		count := syncMessageCount.Load()
 	// 		return count > 0
 	// 	}, 15*time.Second, 200*time.Millisecond, "Should have initial sync messages")
 
@@ -1830,7 +1830,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 
 	// 	// Phase 5: Conflict resolution sync
 	// 	// Reset message tracking for conflict resolution phase
-	// 	atomic.StoreInt32(&syncMessageCount, 0)
+	// 	syncMessageCount.Store(0)
 	// 	mu.Lock()
 	// 	syncMessages = []model.SyncMsg{}
 	// 	mu.Unlock()
@@ -1840,7 +1840,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 
 	// 	// Wait for conflict resolution sync to complete
 	// 	require.Eventually(t, func() bool {
-	// 		count := atomic.LoadInt32(&syncMessageCount)
+	// 		count := syncMessageCount.Load()
 	// 		return count > 0
 	// 	}, 20*time.Second, 200*time.Millisecond, "Should receive conflict resolution sync messages")
 
@@ -1884,7 +1884,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 	// 	require.Nil(t, appErr)
 
 	// 	// Reset and sync this new user
-	// 	atomic.StoreInt32(&syncMessageCount, 0)
+	// 	syncMessageCount.Store(0)
 	// 	mu.Lock()
 	// 	syncMessages = []model.SyncMsg{}
 	// 	mu.Unlock()
@@ -1909,7 +1909,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 	// 	}, 15*time.Second, 200*time.Millisecond, "New user should be synced correctly after conflict resolution")
 
 	// 	// Phase 9: Verify efficiency - no redundant syncs for existing members
-	// 	atomic.StoreInt32(&syncMessageCount, 0)
+	// 	syncMessageCount.Store(0)
 	// 	mu.Lock()
 	// 	syncMessages = []model.SyncMsg{}
 	// 	mu.Unlock()
@@ -1921,7 +1921,7 @@ func TestSharedChannelMembershipSyncSelfReferential(t *testing.T) {
 	// 	// Wait for sync completion and verify minimal activity
 	// 	// Give time for any sync to complete, then check the final count
 	// 	require.Eventually(t, func() bool {
-	// 		finalCount := atomic.LoadInt32(&syncMessageCount)
+	// 		finalCount := syncMessageCount.Load()
 	// 		// Should have minimal activity since all members are already synced
 	// 		return finalCount <= 1
 	// 	}, 10*time.Second, 200*time.Millisecond, "Should have minimal sync activity for already-synced members")

--- a/server/channels/app/shared_channel_sync_self_referential_utils_test.go
+++ b/server/channels/app/shared_channel_sync_self_referential_utils_test.go
@@ -41,7 +41,7 @@ type SelfReferentialSyncHandler struct {
 	t                *testing.T
 	service          *sharedchannel.Service
 	selfCluster      *model.RemoteCluster
-	syncMessageCount *int32
+	syncMessageCount *atomic.Int32
 	SimulateUnshared bool // When true, always return ErrChannelIsNotShared for sync messages
 
 	// Callbacks for capturing sync data
@@ -52,12 +52,11 @@ type SelfReferentialSyncHandler struct {
 
 // NewSelfReferentialSyncHandler creates a new handler for processing sync messages in tests
 func NewSelfReferentialSyncHandler(t *testing.T, service *sharedchannel.Service, selfCluster *model.RemoteCluster) *SelfReferentialSyncHandler {
-	count := int32(0)
 	return &SelfReferentialSyncHandler{
 		t:                t,
 		service:          service,
 		selfCluster:      selfCluster,
-		syncMessageCount: &count,
+		syncMessageCount: &atomic.Int32{},
 	}
 }
 
@@ -69,7 +68,7 @@ func NewSelfReferentialSyncHandler(t *testing.T, service *sharedchannel.Service,
 func (h *SelfReferentialSyncHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
 	case "/api/v4/remotecluster/msg":
-		currentCall := atomic.AddInt32(h.syncMessageCount, 1)
+		currentCall := h.syncMessageCount.Add(1)
 
 		// Read and process the sync message
 		body, _ := io.ReadAll(r.Body)
@@ -164,7 +163,7 @@ func (h *SelfReferentialSyncHandler) HandleRequest(w http.ResponseWriter, r *htt
 
 // GetSyncMessageCount returns the current count of sync messages received
 func (h *SelfReferentialSyncHandler) GetSyncMessageCount() int32 {
-	return atomic.LoadInt32(h.syncMessageCount)
+	return h.syncMessageCount.Load()
 }
 
 // EnsureCleanState ensures a clean test state by removing all shared channels, remote clusters,

--- a/server/channels/app/user_agent.go
+++ b/server/channels/app/user_agent.go
@@ -133,9 +133,8 @@ func GetDesktopAppVersion(userAgentString string) (version string, ok bool) {
 
 func getBrowserVersion(ua *uasurfer.UserAgent, userAgentString string) string {
 	for _, prefix := range versionPrefixes {
-		if index := strings.Index(userAgentString, prefix); index != -1 {
-			afterPrefix := userAgentString[index+len(prefix):]
-			if fields := strings.Fields(afterPrefix); len(fields) > 0 {
+		if _, after, ok := strings.Cut(userAgentString, prefix); ok {
+			if fields := strings.Fields(after); len(fields) > 0 {
 				// MM-55320: limitStringLength prevents potential DOS caused by filling an unbounded string with junk data
 				return limitStringLength(fields[0], maxUserAgentVersionLength)
 			}

--- a/server/channels/jobs/migrations/worker.go
+++ b/server/channels/jobs/migrations/worker.go
@@ -28,7 +28,7 @@ type Worker struct {
 	jobServer *jobs.JobServer
 	logger    mlog.LoggerIFace
 	store     store.Store
-	closed    int32
+	closed    atomic.Int32
 }
 
 func MakeWorker(jobServer *jobs.JobServer, store store.Store) *Worker {
@@ -48,7 +48,7 @@ func MakeWorker(jobServer *jobs.JobServer, store store.Store) *Worker {
 
 func (worker *Worker) Run() {
 	// Set to open if closed before. We are not bothered about multiple opens.
-	if atomic.CompareAndSwapInt32(&worker.closed, 1, 0) {
+	if worker.closed.CompareAndSwap(1, 0) {
 		worker.stop = make(chan struct{})
 	}
 	worker.logger.Debug("Worker started")
@@ -71,7 +71,7 @@ func (worker *Worker) Run() {
 
 func (worker *Worker) Stop() {
 	// Set to close, and if already closed before, then return.
-	if !atomic.CompareAndSwapInt32(&worker.closed, 0, 1) {
+	if !worker.closed.CompareAndSwap(0, 1) {
 		return
 	}
 	worker.logger.Debug("Worker stopping")

--- a/server/channels/web/webhook_test.go
+++ b/server/channels/web/webhook_test.go
@@ -30,10 +30,11 @@ func TestIncomingWebhook(t *testing.T) {
 
 	url := apiClient.URL + "/hooks/" + hook.Id
 
-	tooLongText := ""
+	var tooLongTextBuilder strings.Builder
 	for range 8200 {
-		tooLongText += "a"
+		tooLongTextBuilder.WriteString("a")
 	}
+	tooLongText := tooLongTextBuilder.String()
 
 	t.Run("WebhookBasics", func(t *testing.T) {
 		payload := "payload={\"text\": \"test text\"}"

--- a/server/enterprise/elasticsearch/elasticsearch/elasticsearch.go
+++ b/server/enterprise/elasticsearch/elasticsearch/elasticsearch.go
@@ -41,7 +41,7 @@ var (
 type ElasticsearchInterfaceImpl struct {
 	client      *elastic.TypedClient
 	mutex       sync.RWMutex
-	ready       int32
+	ready       atomic.Int32
 	version     int
 	fullVersion string
 	plugins     []string
@@ -72,7 +72,7 @@ func (es *ElasticsearchInterfaceImpl) IsEnabled() bool {
 }
 
 func (es *ElasticsearchInterfaceImpl) IsActive() bool {
-	return *es.Platform.Config().ElasticsearchSettings.EnableIndexing && atomic.LoadInt32(&es.ready) == 1
+	return *es.Platform.Config().ElasticsearchSettings.EnableIndexing && es.ready.Load() == 1
 }
 
 func (es *ElasticsearchInterfaceImpl) IsIndexingEnabled() bool {
@@ -124,7 +124,7 @@ func (es *ElasticsearchInterfaceImpl) Start() *model.AppError {
 	es.mutex.Lock()
 	defer es.mutex.Unlock()
 
-	if atomic.LoadInt32(&es.ready) != 0 {
+	if es.ready.Load() != 0 {
 		// Elasticsearch is already started. We don't return an error
 		// because "Test Connection" already re-initializes the client. So this
 		// can be a valid scenario.
@@ -228,7 +228,7 @@ func (es *ElasticsearchInterfaceImpl) Start() *model.AppError {
 		return model.NewAppError("Elasticsearch.start", "ent.elasticsearch.create_template_file_info_if_not_exists.template_create_failed", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError).Wrap(err)
 	}
 
-	atomic.StoreInt32(&es.ready, 1)
+	es.ready.Store(1)
 
 	return nil
 }
@@ -237,7 +237,7 @@ func (es *ElasticsearchInterfaceImpl) Stop() *model.AppError {
 	es.mutex.Lock()
 	defer es.mutex.Unlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.start", "ent.elasticsearch.stop.already_stopped.app_error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -250,7 +250,7 @@ func (es *ElasticsearchInterfaceImpl) Stop() *model.AppError {
 		es.bulkProcessor = nil
 	}
 
-	atomic.StoreInt32(&es.ready, 0)
+	es.ready.Store(0)
 
 	return nil
 }
@@ -271,7 +271,7 @@ func (es *ElasticsearchInterfaceImpl) IndexPost(post *model.Post, teamId string,
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.IndexPost", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -357,7 +357,7 @@ func (es *ElasticsearchInterfaceImpl) SearchPosts(channels model.ChannelList, se
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return []string{}, nil, model.NewAppError("Elasticsearch.SearchPosts", "ent.elasticsearch.search_posts.disabled", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -717,7 +717,7 @@ func (es *ElasticsearchInterfaceImpl) DeletePost(post *model.Post) *model.AppErr
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.DeletePost", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -739,7 +739,7 @@ func (es *ElasticsearchInterfaceImpl) DeleteChannelPosts(rctx request.CTX, chann
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.DeleteChannelPosts", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -775,7 +775,7 @@ func (es *ElasticsearchInterfaceImpl) UpdatePostsChannelTypeByChannelId(rctx req
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.UpdatePostsChannelTypeByChannelId", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -832,7 +832,7 @@ func (es *ElasticsearchInterfaceImpl) BackfillPostsChannelType(rctx request.CTX,
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.BackfillPostsChannelType", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -895,7 +895,7 @@ func (es *ElasticsearchInterfaceImpl) DeleteUserPosts(rctx request.CTX, userID s
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.DeleteUserPosts", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -954,7 +954,7 @@ func (es *ElasticsearchInterfaceImpl) IndexChannel(rctx request.CTX, channel *mo
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.IndexChannel", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -999,7 +999,7 @@ func (es *ElasticsearchInterfaceImpl) SyncBulkIndexChannels(rctx request.CTX, ch
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.SyncBulkIndexChannels", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1038,7 +1038,7 @@ func (es *ElasticsearchInterfaceImpl) SearchChannels(teamId, userID string, term
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return []string{}, model.NewAppError("Elasticsearch.SearchChannels", "ent.elasticsearch.search_channels.disabled", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1141,7 +1141,7 @@ func (es *ElasticsearchInterfaceImpl) DeleteChannel(channel *model.Channel) *mod
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.DeleteChannel", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1172,7 +1172,7 @@ func (es *ElasticsearchInterfaceImpl) IndexUser(rctx request.CTX, user *model.Us
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.IndexUser", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1214,7 +1214,7 @@ func (es *ElasticsearchInterfaceImpl) autocompleteUsers(contextCategory string, 
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return nil, model.NewAppError("Elasticsearch.autocompleteUsers", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1327,7 +1327,7 @@ func (es *ElasticsearchInterfaceImpl) autocompleteUsersNotInChannel(teamId, chan
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return nil, model.NewAppError("Elasticsearch.autocompleteUsersNotInChannel", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1490,7 +1490,7 @@ func (es *ElasticsearchInterfaceImpl) DeleteUser(user *model.User) *model.AppErr
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.DeleteUser", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1536,7 +1536,7 @@ func (es *ElasticsearchInterfaceImpl) TestConfig(rctx request.CTX, cfg *model.Co
 	}
 
 	// Resetting the state.
-	if atomic.CompareAndSwapInt32(&es.ready, 0, 1) {
+	if es.ready.CompareAndSwap(0, 1) {
 		// Re-assign the client.
 		// This is necessary in case elasticsearch was started
 		// after server start.
@@ -1556,7 +1556,7 @@ func (es *ElasticsearchInterfaceImpl) PurgeIndexes(rctx request.CTX) *model.AppE
 		return model.NewAppError("Elasticsearch.PurgeIndexes", "ent.elasticsearch.test_config.license.error", nil, "", http.StatusNotImplemented)
 	}
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.PurgeIndexes", "ent.elasticsearch.generic.disabled", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1606,7 +1606,7 @@ func (es *ElasticsearchInterfaceImpl) PurgeIndexList(rctx request.CTX, indexes [
 		return model.NewAppError("Elasticsearch.PurgeIndexList", "ent.elasticsearch.test_config.license.error", nil, "", http.StatusNotImplemented)
 	}
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.PurgeIndexList", "ent.elasticsearch.generic.disabled", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1669,7 +1669,7 @@ func (es *ElasticsearchInterfaceImpl) DataRetentionDeleteIndexes(rctx request.CT
 		return model.NewAppError("Elasticsearch.DataRetentionDeleteIndexes", "ent.elasticsearch.test_config.license.error", nil, "", http.StatusNotImplemented)
 	}
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.DataRetentionDeleteIndexes", "ent.elasticsearch.generic.disabled", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1698,7 +1698,7 @@ func (es *ElasticsearchInterfaceImpl) IndexFile(file *model.FileInfo, channelId 
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.IndexFile", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1739,7 +1739,7 @@ func (es *ElasticsearchInterfaceImpl) SearchFiles(channels model.ChannelList, se
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return []string{}, model.NewAppError("Elasticsearch.SearchPosts", "ent.elasticsearch.search_files.disabled", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1980,7 +1980,7 @@ func (es *ElasticsearchInterfaceImpl) DeleteFile(fileID string) *model.AppError 
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.DeleteFile", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -2011,7 +2011,7 @@ func (es *ElasticsearchInterfaceImpl) DeleteUserFiles(rctx request.CTX, userID s
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.DeleteFilesBatch", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -2043,7 +2043,7 @@ func (es *ElasticsearchInterfaceImpl) DeletePostFiles(rctx request.CTX, postID s
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.DeleteFilesBatch", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -2074,7 +2074,7 @@ func (es *ElasticsearchInterfaceImpl) DeleteFilesBatch(rctx request.CTX, endTime
 	es.mutex.RLock()
 	defer es.mutex.RUnlock()
 
-	if atomic.LoadInt32(&es.ready) == 0 {
+	if es.ready.Load() == 0 {
 		return model.NewAppError("Elasticsearch.DeleteFilesBatch", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError)
 	}
 

--- a/server/enterprise/elasticsearch/opensearch/opensearch.go
+++ b/server/enterprise/elasticsearch/opensearch/opensearch.go
@@ -43,7 +43,7 @@ var (
 type OpensearchInterfaceImpl struct {
 	client      *opensearchapi.Client
 	mutex       sync.RWMutex
-	ready       int32
+	ready       atomic.Int32
 	version     int
 	fullVersion string
 	plugins     []string
@@ -74,7 +74,7 @@ func (os *OpensearchInterfaceImpl) IsEnabled() bool {
 }
 
 func (os *OpensearchInterfaceImpl) IsActive() bool {
-	return *os.Platform.Config().ElasticsearchSettings.EnableIndexing && atomic.LoadInt32(&os.ready) == 1
+	return *os.Platform.Config().ElasticsearchSettings.EnableIndexing && os.ready.Load() == 1
 }
 
 func (os *OpensearchInterfaceImpl) IsIndexingEnabled() bool {
@@ -126,7 +126,7 @@ func (os *OpensearchInterfaceImpl) Start() *model.AppError {
 	os.mutex.Lock()
 	defer os.mutex.Unlock()
 
-	if atomic.LoadInt32(&os.ready) != 0 {
+	if os.ready.Load() != 0 {
 		// Elasticsearch is already started. We don't return an error
 		// because "Test Connection" already re-initializes the client. So this
 		// can be a valid scenario.
@@ -236,7 +236,7 @@ func (os *OpensearchInterfaceImpl) Start() *model.AppError {
 		return model.NewAppError("Opensearch.start", "ent.elasticsearch.create_template_file_info_if_not_exists.template_create_failed", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
 	}
 
-	atomic.StoreInt32(&os.ready, 1)
+	os.ready.Store(1)
 
 	return nil
 }
@@ -245,7 +245,7 @@ func (os *OpensearchInterfaceImpl) Stop() *model.AppError {
 	os.mutex.Lock()
 	defer os.mutex.Unlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.start", "ent.elasticsearch.stop.already_stopped.app_error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -258,7 +258,7 @@ func (os *OpensearchInterfaceImpl) Stop() *model.AppError {
 	}
 
 	os.client = nil
-	atomic.StoreInt32(&os.ready, 0)
+	os.ready.Store(0)
 
 	return nil
 }
@@ -279,7 +279,7 @@ func (os *OpensearchInterfaceImpl) IndexPost(post *model.Post, teamId string, ch
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.IndexPost", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -373,7 +373,7 @@ func (os *OpensearchInterfaceImpl) SearchPosts(channels model.ChannelList, searc
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return []string{}, nil, model.NewAppError("Opensearch.SearchPosts", "ent.elasticsearch.search_posts.disabled", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -767,7 +767,7 @@ func (os *OpensearchInterfaceImpl) DeletePost(post *model.Post) *model.AppError 
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.DeletePost", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -789,7 +789,7 @@ func (os *OpensearchInterfaceImpl) DeleteChannelPosts(rctx request.CTX, channelI
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.DeleteChannelPosts", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -830,7 +830,7 @@ func (os *OpensearchInterfaceImpl) UpdatePostsChannelTypeByChannelId(rctx reques
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.UpdatePostsChannelTypeByChannelId", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -892,7 +892,7 @@ func (os *OpensearchInterfaceImpl) BackfillPostsChannelType(rctx request.CTX, ch
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.BackfillPostsChannelType", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -963,7 +963,7 @@ func (os *OpensearchInterfaceImpl) DeleteUserPosts(rctx request.CTX, userID stri
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.DeleteUserPosts", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1029,7 +1029,7 @@ func (os *OpensearchInterfaceImpl) IndexChannel(rctx request.CTX, channel *model
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.IndexChannel", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1080,7 +1080,7 @@ func (os *OpensearchInterfaceImpl) SyncBulkIndexChannels(rctx request.CTX, chann
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.SyncBulkIndexChannels", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1119,7 +1119,7 @@ func (os *OpensearchInterfaceImpl) SearchChannels(teamId, userID string, term st
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return []string{}, model.NewAppError("Opensearch.SearchChannels", "ent.elasticsearch.search_channels.disabled", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1226,7 +1226,7 @@ func (os *OpensearchInterfaceImpl) DeleteChannel(channel *model.Channel) *model.
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.DeleteChannel", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1259,7 +1259,7 @@ func (os *OpensearchInterfaceImpl) IndexUser(rctx request.CTX, user *model.User,
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.IndexUser", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1307,7 +1307,7 @@ func (os *OpensearchInterfaceImpl) autocompleteUsers(contextCategory string, cat
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return nil, model.NewAppError("Opensearch.autocompleteUsers", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1426,7 +1426,7 @@ func (os *OpensearchInterfaceImpl) autocompleteUsersNotInChannel(teamId, channel
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return nil, model.NewAppError("Opensearch.autocompleteUsersNotInChannel", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1595,7 +1595,7 @@ func (os *OpensearchInterfaceImpl) DeleteUser(user *model.User) *model.AppError 
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.DeleteUser", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1643,7 +1643,7 @@ func (os *OpensearchInterfaceImpl) TestConfig(rctx request.CTX, cfg *model.Confi
 	}
 
 	// Resetting the state.
-	if atomic.CompareAndSwapInt32(&os.ready, 0, 1) {
+	if os.ready.CompareAndSwap(0, 1) {
 		// Re-assign the client.
 		// This is necessary in case opensearch was started
 		// after server start.
@@ -1663,7 +1663,7 @@ func (os *OpensearchInterfaceImpl) PurgeIndexes(rctx request.CTX) *model.AppErro
 		return model.NewAppError("Opensearch.PurgeIndexes", "ent.elasticsearch.test_config.license.error", nil, "", http.StatusNotImplemented)
 	}
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.PurgeIndexes", "ent.elasticsearch.generic.disabled", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1716,7 +1716,7 @@ func (os *OpensearchInterfaceImpl) PurgeIndexList(rctx request.CTX, indexes []st
 		return model.NewAppError("Opensearch.PurgeIndexList", "ent.elasticsearch.test_config.license.error", nil, "", http.StatusNotImplemented)
 	}
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.PurgeIndexList", "ent.elasticsearch.generic.disabled", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1781,7 +1781,7 @@ func (os *OpensearchInterfaceImpl) DataRetentionDeleteIndexes(rctx request.CTX, 
 		return model.NewAppError("Opensearch.DataRetentionDeleteIndexes", "ent.elasticsearch.test_config.license.error", nil, "", http.StatusNotImplemented)
 	}
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.DataRetentionDeleteIndexes", "ent.elasticsearch.generic.disabled", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1814,7 +1814,7 @@ func (os *OpensearchInterfaceImpl) IndexFile(file *model.FileInfo, channelId str
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.IndexFile", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -1861,7 +1861,7 @@ func (os *OpensearchInterfaceImpl) SearchFiles(channels model.ChannelList, searc
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return []string{}, model.NewAppError("Opensearch.SearchPosts", "ent.elasticsearch.search_files.disabled", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -2108,7 +2108,7 @@ func (os *OpensearchInterfaceImpl) DeleteFile(fileID string) *model.AppError {
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.DeleteFile", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -2141,7 +2141,7 @@ func (os *OpensearchInterfaceImpl) DeleteUserFiles(rctx request.CTX, userID stri
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.DeleteFilesBatch", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -2178,7 +2178,7 @@ func (os *OpensearchInterfaceImpl) DeletePostFiles(rctx request.CTX, postID stri
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.DeleteFilesBatch", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 
@@ -2214,7 +2214,7 @@ func (os *OpensearchInterfaceImpl) DeleteFilesBatch(rctx request.CTX, endTime, l
 	os.mutex.RLock()
 	defer os.mutex.RUnlock()
 
-	if atomic.LoadInt32(&os.ready) == 0 {
+	if os.ready.Load() == 0 {
 		return model.NewAppError("Opensearch.DeleteFilesBatch", "ent.elasticsearch.not_started.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError)
 	}
 

--- a/server/enterprise/metrics/metrics.go
+++ b/server/enterprise/metrics/metrics.go
@@ -2346,12 +2346,12 @@ func extractDBCluster(driver, connectionString string) (string, error) {
 		return "", err
 	}
 
-	clusterEnd := strings.Index(host, ".")
-	if clusterEnd == -1 {
+	cluster, _, found := strings.Cut(host, ".")
+	if !found {
 		return host, nil
 	}
 
-	return host[:clusterEnd], nil
+	return cluster, nil
 }
 
 func extractHost(driver, connectionString string) (string, error) {

--- a/server/platform/services/remotecluster/send_test.go
+++ b/server/platform/services/remotecluster/send_test.go
@@ -37,8 +37,8 @@ func TestBroadcastMsg(t *testing.T) {
 	disablePing = true
 
 	t.Run("No error", func(t *testing.T) {
-		var countCallbacks int32
-		var countWebReq int32
+		var countCallbacks atomic.Int32
+		var countWebReq atomic.Int32
 		merr := merror.New()
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -53,7 +53,7 @@ func TestBroadcastMsg(t *testing.T) {
 				w.Write(b)
 			}()
 
-			atomic.AddInt32(&countWebReq, 1)
+			countWebReq.Add(1)
 
 			var frame model.RemoteClusterFrame
 			jsonErr := json.NewDecoder(r.Body).Decode(&frame)
@@ -102,7 +102,7 @@ func TestBroadcastMsg(t *testing.T) {
 
 		err = service.BroadcastMsg(ctx, msg, func(msg model.RemoteClusterMsg, remote *model.RemoteCluster, resp *Response, err error) {
 			defer wg.Done()
-			atomic.AddInt32(&countCallbacks, 1)
+			countCallbacks.Add(1)
 
 			if err != nil {
 				merr.Append(err)
@@ -127,10 +127,10 @@ func TestBroadcastMsg(t *testing.T) {
 
 		assert.NoError(t, merr.ErrorOrNil())
 
-		assert.Equal(t, int32(NumRemotes), atomic.LoadInt32(&countCallbacks))
-		assert.Equal(t, int32(NumRemotes), atomic.LoadInt32(&countWebReq))
+		assert.Equal(t, int32(NumRemotes), countCallbacks.Load())
+		assert.Equal(t, int32(NumRemotes), countWebReq.Load())
 		t.Logf("%d callbacks counted;  %d web requests counted;  %d expected",
-			atomic.LoadInt32(&countCallbacks), atomic.LoadInt32(&countWebReq), NumRemotes)
+			countCallbacks.Load(), countWebReq.Load(), NumRemotes)
 	})
 
 	t.Run("HTTP error", func(t *testing.T) {
@@ -150,24 +150,24 @@ func TestBroadcastMsg(t *testing.T) {
 		defer service.Shutdown()
 
 		msg := makeRemoteClusterMsg(msgId, NoteContent)
-		var countCallbacks int32
-		var countErrors int32
+		var countCallbacks atomic.Int32
+		var countErrors atomic.Int32
 		wg := &sync.WaitGroup{}
 		wg.Add(NumRemotes)
 
 		err = service.BroadcastMsg(context.Background(), msg, func(msg model.RemoteClusterMsg, remote *model.RemoteCluster, resp *Response, err error) {
 			defer wg.Done()
-			atomic.AddInt32(&countCallbacks, 1)
+			countCallbacks.Add(1)
 			if err != nil {
-				atomic.AddInt32(&countErrors, 1)
+				countErrors.Add(1)
 			}
 		})
 		assert.NoError(t, err)
 
 		wg.Wait()
 
-		assert.Equal(t, int32(NumRemotes), atomic.LoadInt32(&countCallbacks))
-		assert.Equal(t, int32(NumRemotes), atomic.LoadInt32(&countErrors))
+		assert.Equal(t, int32(NumRemotes), countCallbacks.Load())
+		assert.Equal(t, int32(NumRemotes), countErrors.Load())
 	})
 }
 

--- a/server/platform/services/remotecluster/service_test.go
+++ b/server/platform/services/remotecluster/service_test.go
@@ -14,18 +14,18 @@ import (
 )
 
 func TestService_AddTopicListener(t *testing.T) {
-	var count int32
+	var count atomic.Int32
 
 	l1 := func(msg model.RemoteClusterMsg, rc *model.RemoteCluster, resp *Response) error {
-		atomic.AddInt32(&count, 1)
+		count.Add(1)
 		return nil
 	}
 	l2 := func(msg model.RemoteClusterMsg, rc *model.RemoteCluster, resp *Response) error {
-		atomic.AddInt32(&count, 1)
+		count.Add(1)
 		return nil
 	}
 	l3 := func(msg model.RemoteClusterMsg, rc *model.RemoteCluster, resp *Response) error {
-		atomic.AddInt32(&count, 1)
+		count.Add(1)
 		return nil
 	}
 
@@ -47,26 +47,26 @@ func TestService_AddTopicListener(t *testing.T) {
 	msg2 := model.RemoteClusterMsg{Topic: "different"}
 
 	service.ReceiveIncomingMsg(rc, msg1)
-	assert.Equal(t, int32(2), atomic.LoadInt32(&count))
+	assert.Equal(t, int32(2), count.Load())
 
 	service.ReceiveIncomingMsg(rc, msg2)
-	assert.Equal(t, int32(3), atomic.LoadInt32(&count))
+	assert.Equal(t, int32(3), count.Load())
 
 	service.RemoveTopicListener(l1id)
 	service.ReceiveIncomingMsg(rc, msg1)
-	assert.Equal(t, int32(4), atomic.LoadInt32(&count))
+	assert.Equal(t, int32(4), count.Load())
 
 	service.RemoveTopicListener(l2id)
 	service.ReceiveIncomingMsg(rc, msg1)
-	assert.Equal(t, int32(4), atomic.LoadInt32(&count))
+	assert.Equal(t, int32(4), count.Load())
 
 	service.ReceiveIncomingMsg(rc, msg2)
-	assert.Equal(t, int32(5), atomic.LoadInt32(&count))
+	assert.Equal(t, int32(5), count.Load())
 
 	service.RemoveTopicListener(l3id)
 	service.ReceiveIncomingMsg(rc, msg1)
 	service.ReceiveIncomingMsg(rc, msg2)
-	assert.Equal(t, int32(5), atomic.LoadInt32(&count))
+	assert.Equal(t, int32(5), count.Load())
 
 	listeners = service.getTopicListeners("test")
 	assert.Empty(t, listeners)

--- a/server/public/model/push_notification.go
+++ b/server/public/model/push_notification.go
@@ -95,10 +95,8 @@ func (pn *PushNotification) DeepCopy() *PushNotification {
 }
 
 func (pn *PushNotification) SetDeviceIdAndPlatform(deviceId string) {
-	index := strings.Index(deviceId, ":")
-
-	if index > -1 {
-		pn.Platform = deviceId[:index]
-		pn.DeviceId = deviceId[index+1:]
+	if platform, id, ok := strings.Cut(deviceId, ":"); ok {
+		pn.Platform = platform
+		pn.DeviceId = id
 	}
 }


### PR DESCRIPTION
#### Summary

Upgrade golangci-lint from v2.6.0 to v2.11.4 and fix all 27 new `modernize` linter findings:

- **atomic.Int32** (24 fixes): Convert `var x int32` / struct field `x int32` with `atomic.AddInt32`/`LoadInt32`/`StoreInt32`/`CompareAndSwapInt32` to `atomic.Int32` with method calls
- **strings.Cut** (2 fixes): Replace `strings.Index` + manual slicing with `strings.Cut` in `user_agent.go` and `push_notification.go`
- **strings.Builder** (1 fix): Replace `string +=` in a loop with `strings.Builder` in `webhook_test.go`

Enterprise PR: https://github.com/mattermost/enterprise/pull/2108

#### Ticket Link

N/A

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 **Medium**

**Regression Risk:** The changes are semantically-preserving refactorings from atomic function patterns to atomic.Int32 types and from string.Index-based splitting to strings.Cut, all of which are direct 1:1 API equivalences. However, modifications span 15+ files across multiple subsystems (job migrations, remote cluster services, Elasticsearch/OpenSearch implementations, user agent parsing, and webhook handling), creating broader blast radius than a typical utility refactoring.

**QA Recommendation:** Regression risk is low due to semantic equivalence, but targeted smoke testing is recommended for: (1) job migration worker state transitions, (2) shared channel sync message counting and attempt tracking, (3) Elasticsearch/OpenSearch readiness state management, and (4) user agent version extraction and push notification device ID parsing. Existing automated test coverage should suffice, with selective manual verification of these critical synchronization flows.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->