### PR TITLE
Fix FIPS test panics from Go 1.25.8 OpenSSL key length enforcement

### DIFF
--- a/server/channels/api4/image_test.go
+++ b/server/channels/api4/image_test.go
@@ -45,12 +45,12 @@ func TestGetImage(t *testing.T) {
 
 	t.Run("atmos/camo", func(t *testing.T) {
 		imageURL := "http://foo.bar/baz.gif"
-		proxiedURL := "https://proxy.foo.bar/004afe2ef382eb5f30c4490f793f8a8c5b33d8a2/687474703a2f2f666f6f2e6261722f62617a2e676966"
+		proxiedURL := "https://proxy.foo.bar/83d4d9ac78b76ce425ea67038826df867c62cc5c/687474703a2f2f666f6f2e6261722f62617a2e676966"
 
 		th.App.UpdateConfig(func(cfg *model.Config) {
 			cfg.ImageProxySettings.Enable = model.NewPointer(true)
 			cfg.ImageProxySettings.ImageProxyType = model.NewPointer("atmos/camo")
-			cfg.ImageProxySettings.RemoteImageProxyOptions = model.NewPointer("foo")
+			cfg.ImageProxySettings.RemoteImageProxyOptions = model.NewPointer("7e5f3fab20b94782b43cdb022a66985ef28ba355df2c5d5da3c9a05e4b697bac")
 			cfg.ImageProxySettings.RemoteImageProxyURL = model.NewPointer("https://proxy.foo.bar")
 		})
 

--- a/server/channels/api4/remote_cluster_test.go
+++ b/server/channels/api4/remote_cluster_test.go
@@ -459,7 +459,7 @@ func TestRemoteClusterAcceptinvite(t *testing.T) {
 		SiteURL:  "http://localhost:8065",
 		Token:    "token",
 	}
-	password := "mysupersecret"
+	password := "mysupersecret!"
 	encrypted, err := invite.Encrypt(password)
 	require.NoError(t, err)
 	encoded := base64.URLEncoding.EncodeToString(encrypted)
@@ -530,7 +530,7 @@ func TestRemoteClusterAcceptinvite(t *testing.T) {
 
 func TestGenerateRemoteClusterInvite(t *testing.T) {
 	mainHelper.Parallel(t)
-	password := "mysupersecret"
+	password := "mysupersecret!"
 
 	newRC := &model.RemoteCluster{
 		Name:    "remotecluster",

--- a/server/channels/app/password/hashers/pbkdf2_test.go
+++ b/server/channels/app/password/hashers/pbkdf2_test.go
@@ -58,10 +58,9 @@ func TestPBKDF2CompareHashAndPassword(t *testing.T) {
 		expectedErr error
 	}{
 		{
-
-			"empty password",
-			"",
-			"",
+			"short password",
+			"a",
+			"a",
 			nil,
 		},
 		{

--- a/server/channels/app/post_metadata_test.go
+++ b/server/channels/app/post_metadata_test.go
@@ -1027,7 +1027,7 @@ func TestPreparePostForClientWithImageProxy(t *testing.T) {
 			*cfg.ImageProxySettings.Enable = true
 			*cfg.ImageProxySettings.ImageProxyType = "atmos/camo"
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"
-			*cfg.ImageProxySettings.RemoteImageProxyOptions = "foo"
+			*cfg.ImageProxySettings.RemoteImageProxyOptions = "7e5f3fab20b94782b43cdb022a66985ef28ba355df2c5d5da3c9a05e4b697bac"
 		})
 
 		th.App.ch.imageProxy = imageproxy.MakeImageProxy(th.Server.platform, th.Server.HTTPService(), th.Server.Log())

--- a/server/channels/app/post_test.go
+++ b/server/channels/app/post_test.go
@@ -750,7 +750,7 @@ func TestImageProxy(t *testing.T) {
 		"atmos/camo": {
 			ProxyType:              model.ImageProxyTypeAtmosCamo,
 			ProxyURL:               "https://127.0.0.1",
-			ProxyOptions:           "foo",
+			ProxyOptions:           "7e5f3fab20b94782b43cdb022a66985ef28ba355df2c5d5da3c9a05e4b697bac",
 			ImageURL:               "http://mydomain.com/myimage",
 			ProxiedRemovedImageURL: "http://mydomain.com/myimage",
 			ProxiedImageURL:        "http://mymattermost.com/api/v4/image?url=http%3A%2F%2Fmydomain.com%2Fmyimage",
@@ -758,7 +758,7 @@ func TestImageProxy(t *testing.T) {
 		"atmos/camo_SameSite": {
 			ProxyType:              model.ImageProxyTypeAtmosCamo,
 			ProxyURL:               "https://127.0.0.1",
-			ProxyOptions:           "foo",
+			ProxyOptions:           "7e5f3fab20b94782b43cdb022a66985ef28ba355df2c5d5da3c9a05e4b697bac",
 			ImageURL:               "http://mymattermost.com/myimage",
 			ProxiedRemovedImageURL: "http://mymattermost.com/myimage",
 			ProxiedImageURL:        "http://mymattermost.com/myimage",
@@ -766,7 +766,7 @@ func TestImageProxy(t *testing.T) {
 		"atmos/camo_PathOnly": {
 			ProxyType:              model.ImageProxyTypeAtmosCamo,
 			ProxyURL:               "https://127.0.0.1",
-			ProxyOptions:           "foo",
+			ProxyOptions:           "7e5f3fab20b94782b43cdb022a66985ef28ba355df2c5d5da3c9a05e4b697bac",
 			ImageURL:               "/myimage",
 			ProxiedRemovedImageURL: "http://mymattermost.com/myimage",
 			ProxiedImageURL:        "http://mymattermost.com/myimage",
@@ -774,7 +774,7 @@ func TestImageProxy(t *testing.T) {
 		"atmos/camo_EmptyImageURL": {
 			ProxyType:              model.ImageProxyTypeAtmosCamo,
 			ProxyURL:               "https://127.0.0.1",
-			ProxyOptions:           "foo",
+			ProxyOptions:           "7e5f3fab20b94782b43cdb022a66985ef28ba355df2c5d5da3c9a05e4b697bac",
 			ImageURL:               "",
 			ProxiedRemovedImageURL: "",
 			ProxiedImageURL:        "",
@@ -961,7 +961,7 @@ func TestCreatePost(t *testing.T) {
 			*cfg.ImageProxySettings.Enable = true
 			*cfg.ImageProxySettings.ImageProxyType = "atmos/camo"
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"
-			*cfg.ImageProxySettings.RemoteImageProxyOptions = "foo"
+			*cfg.ImageProxySettings.RemoteImageProxyOptions = "7e5f3fab20b94782b43cdb022a66985ef28ba355df2c5d5da3c9a05e4b697bac"
 		})
 
 		th.App.ch.imageProxy = imageproxy.MakeImageProxy(th.Server.platform, th.Server.HTTPService(), th.Server.Log())
@@ -1384,7 +1384,7 @@ func TestPatchPost(t *testing.T) {
 			*cfg.ImageProxySettings.Enable = true
 			*cfg.ImageProxySettings.ImageProxyType = "atmos/camo"
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"
-			*cfg.ImageProxySettings.RemoteImageProxyOptions = "foo"
+			*cfg.ImageProxySettings.RemoteImageProxyOptions = "7e5f3fab20b94782b43cdb022a66985ef28ba355df2c5d5da3c9a05e4b697bac"
 		})
 
 		th.App.ch.imageProxy = imageproxy.MakeImageProxy(th.Server.platform, th.Server.HTTPService(), th.Server.Log())
@@ -1839,7 +1839,7 @@ func TestUpdatePost(t *testing.T) {
 			*cfg.ImageProxySettings.Enable = true
 			*cfg.ImageProxySettings.ImageProxyType = "atmos/camo"
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"
-			*cfg.ImageProxySettings.RemoteImageProxyOptions = "foo"
+			*cfg.ImageProxySettings.RemoteImageProxyOptions = "7e5f3fab20b94782b43cdb022a66985ef28ba355df2c5d5da3c9a05e4b697bac"
 		})
 
 		th.App.ch.imageProxy = imageproxy.MakeImageProxy(th.Server.platform, th.Server.HTTPService(), th.Server.Log())

--- a/server/public/model/remote_cluster_test.go
+++ b/server/public/model/remote_cluster_test.go
@@ -133,7 +133,7 @@ func TestRemoteClusterInviteEncryption(t *testing.T) {
 		password   string
 		invite     RemoteClusterInvite
 	}{
-		{name: "empty password", badDecrypt: false, password: "", invite: makeInvite("https://example.com:8065")},
+		{name: "short password", badDecrypt: false, password: "fips-minimum-pwd", invite: makeInvite("https://example.com:8065")},
 		{name: "good password", badDecrypt: false, password: "Ultra secret password!", invite: makeInvite("https://example.com:8065")},
 		{name: "bad decrypt", badDecrypt: true, password: "correct horse battery staple", invite: makeInvite("https://example.com:8065")},
 	}
@@ -168,7 +168,7 @@ func TestRemoteClusterInviteBackwardCompatibility(t *testing.T) {
 		Version:        2, // Old version using scrypt
 	}
 
-	password := "test password"
+	password := "test password!!"
 
 	// Encrypt with old method (scrypt)
 	encrypted, err := oldInvite.Encrypt(password)


### PR DESCRIPTION
## Summary
- Go 1.25.8 shipped a stricter `golang-fips/openssl/v2` binding that enforces NIST SP 800-131A minimums: HMAC keys must be ≥ 14 bytes and PBKDF2 rejects empty passwords
- Several tests used non-compliant keys/passwords (`"foo"`, `""`, `"mysupersecret"`, `"test password"`) that now panic or error in FIPS mode
- Updated all affected test values to meet FIPS minimum lengths

## Test plan
- [ ] Postgres (FIPS) CI job passes without panics
- [ ] Non-FIPS test jobs remain unaffected
- [ ] `TestGetImage/atmos/camo` passes with updated HMAC digest
- [ ] `TestRemoteClusterInviteEncryption` passes
- [ ] `TestRemoteClusterInviteBackwardCompatibility` passes
- [ ] `TestPBKDF2CompareHashAndPassword` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** These changes are test-only modifications that update hardcoded test inputs (passwords, proxy option strings) to comply with Go 1.25.8's FIPS enforcement of minimum key lengths (HMAC ≥14 bytes, PBKDF2 non-empty). No production code is modified, and test logic/assertions remain unchanged—the same code paths are exercised with compliant input values. No side effects propagate to unrelated systems.

**QA Recommendation:** Minimal manual QA needed. Automated test coverage should be sufficient since these changes only update test fixture values to meet new compliance constraints. Verify that the Postgres (FIPS) CI job passes without panics (as noted in the test plan) and confirm that non-FIPS tests continue to pass unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->