### PR TITLE
feat(test analysis): using reusable workflow

### DIFF
--- a/.github/workflows/pr-test-analysis-override.yml
+++ b/.github/workflows/pr-test-analysis-override.yml
@@ -21,11 +21,12 @@ jobs:
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/test-analysis-override') &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-    uses: mattermost/mattermost-test-automation-toolkit/.github/workflows/pr-test-analysis-override.yml@12f2893ede3e83a569b4a17d7ba837c49270bc00
+    # Pin to a commit SHA once the reusable workflow is stable. Using @main during initial rollout.
+    uses: mattermost/mattermost-test-automation-toolkit/.github/workflows/pr-test-analysis-override.yml@main
     with:
       pr_number: ${{ github.event.issue.number }}
       target_repo: mattermost/mattermost
-      reason: ${{ github.event.comment.body }}
+      comment_body: ${{ github.event.comment.body }}
       comment_id: ${{ github.event.comment.id }}
       sender: ${{ github.event.comment.user.login }}
     secrets:

--- a/.github/workflows/pr-test-analysis.yml
+++ b/.github/workflows/pr-test-analysis.yml
@@ -36,7 +36,8 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.draft == false &&
        github.event.pull_request.head.repo.full_name == 'mattermost/mattermost')
-    uses: mattermost/mattermost-test-automation-toolkit/.github/workflows/pr-test-analysis.yml@12f2893ede3e83a569b4a17d7ba837c49270bc00
+    # Pin to a commit SHA once the reusable workflow is stable. Using @main during initial rollout.
+    uses: mattermost/mattermost-test-automation-toolkit/.github/workflows/pr-test-analysis.yml@main
     with:
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
       target_repo: mattermost/mattermost


### PR DESCRIPTION
#### Summary
PR Test analysis using reusable workflow - https://github.com/mattermost/mattermost-test-automation-toolkit/pull/1

TODO: Commit hash to be updated once the linked PR is merged - `mattermost/mattermost-test-automation-toolkit/.github/workflows/pr-test-analysis.yml@12f2893ede3e83a569b4a17d7ba837c49270bc00`

#### Ticket Link
https://mattermost.atlassian.net/browse/SEC-9968

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Delegating CI behavior to an external reusable workflow introduces dependency risk on the mattermost-test-automation-toolkit (currently referenced by @main during rollout), so differences or outages in that toolkit could alter or break PR analysis, statuses, comments, and webhook notifications; changes only affect CI workflow logic (no runtime application code).  
**QA Recommendation:** Run manual verification on a non-critical PR (and update the reusable-workflow reference to a pinned commit after the toolkit PR is merged) to confirm parity with the previous inline implementation and that statuses, comments, and webhook notifications behave as expected.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->