### PR TITLE
Add daily CI health check workflow

### DIFF
--- a/.github/workflows/daily-ci-health-check.yml
+++ b/.github/workflows/daily-ci-health-check.yml
@@ -114,8 +114,8 @@ jobs:
       - name: notify/send-mattermost-alert
         uses: mattermost/action-mattermost-notify@b7d118e440bf2749cd18a4a8c88e7092e696257a
         with:
-          MATTERMOST_WEBHOOK_URL: ${{ secrets.MM_CI_HEALTH_WEBHOOK_URL }}
-          MATTERMOST_CHANNEL: ci-health-alerts
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_TEST_DELIVERY_WEBHOOK }}
+          MATTERMOST_CHANNEL: core-developers
           MATTERMOST_USERNAME: CI Health Bot
           MATTERMOST_ICON_URL: https://avatars.githubusercontent.com/in/276366?s=120&u=b2ac433ba55fc41babb3c6079477f5ead172c543&v=4
           TEXT: |


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that runs daily at 8 AM UTC and checks the health of CI on `master`
- Checks the last 2 completed runs for: **Server CI**, **Web App CI**, **E2E Tests (master/release)**, and **Enterprise CI**
- Only sends a Mattermost notification when **both** of the last 2 runs have failed for any workflow, reducing noise from transient failures
- Uses `mattermost/action-mattermost-notify` for notifications 

## Configuration needed
- **`MM_CI_HEALTH_WEBHOOK_URL`** repo secret: Mattermost incoming webhook URL for the target channel
- **`ci-health-alerts`** channel: update the `MATTERMOST_CHANNEL` value if a different channel is preferred
- Existing `UNIFIED_CI_*` vars/secrets are reused for cross-repo API access (Enterprise CI)

## Release Notes
```release-note
NONE
```


Made with [Cursor](https://cursor.com)