### PR TITLE
Generate instead of hard-coding test passwords, enforce new minimum for FIPS, shard CI, fix FIPS builds

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.calculate.outputs.GO_VERSION }}
+      gomod-changed: ${{ steps.changed-files.outputs.any_changed }}
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,6 +40,12 @@ jobs:
         id: calculate
         working-directory: server/
         run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
+      - name: Check for go.mod changes
+        id: changed-files
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        with:
+          files: |
+            **/go.mod
   check-mocks:
     name: Check mocks
     needs: go
@@ -225,89 +232,42 @@ jobs:
     name: Merge Postgres Test Results
     needs: test-postgres-normal
     if: always()
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Download all shard artifacts
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
-        with:
-          pattern: postgres-server-test-logs-shard-*
-          path: shards
-
-      - name: Setup Node for junit-report-merger
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: 20
-
-      - name: Merge JUnit reports
-        run: |
-          npx junit-report-merger@7.0.0 merged-report.xml "shards/*/report.xml"
-
-      # Prepare files with expected names for the report workflow
-      - name: Prepare merged artifact
-        run: |
-          mkdir -p merged
-          cp merged-report.xml merged/report.xml
-          # Find the first shard artifact that has test-name and pr-number
-          for dir in shards/postgres-server-test-logs-shard-*/; do
-            if [[ -f "${dir}test-name" ]]; then
-              cp "${dir}test-name" merged/test-name
-              cp "${dir}pr-number" merged/pr-number
-              break
-            fi
-          done
-
-      # Upload merged artifact with the name the report workflow expects
-      - name: Upload merged test logs
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: postgres-server-test-logs
-          path: merged/
-
-      # Save merged timing data for future shard balancing.
-      # Includes both JUnit XML (package-level) and gotestsum.json (per-test).
-      - name: Prepare timing cache
-        id: timing-prep
-        run: |
-          mkdir -p server
-          # Only save timing cache if we have real data (merged report > 1KB).
-          # Failed runs produce tiny/empty files that would overwrite good data.
-          if [[ -f merged-report.xml && $(stat -c%s merged-report.xml) -gt 1024 ]]; then
-            cp merged-report.xml server/prev-report.xml
-            # Merge gotestsum.json (JSONL) from all shards for per-test timing
-            cat shards/*/gotestsum.json > server/prev-gotestsum.json 2>/dev/null || true
-            echo "has_timing=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Skipping timing cache — merged report too small or missing"
-            echo "has_timing=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Save test timing cache
-        # Only save timing on the default branch. PR branches restore from
-        # master via restore-keys prefix match. Timing data is stable day-to-day
-        # so this eliminates cache misses on first PR runs.
-        if: steps.timing-prep.outputs.has_timing == 'true' && github.ref_name == github.event.repository.default_branch
-        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          path: |
-            server/prev-report.xml
-            server/prev-gotestsum.json
-          key: server-test-timing-master-${{ github.run_id }}
+    uses: ./.github/workflows/server-test-merge-template.yml
+    with:
+      artifact-pattern: postgres-server-test-logs-shard-*
+      artifact-name: postgres-server-test-logs
+      save-timing-cache: true
 
   test-postgres-normal-fips:
-    # FIPS compile check already runs in enterprise CI for PRs.
-    # Only run full FIPS tests on pushes to the default branch.
-    if: github.event_name == 'push'
-    name: Postgres (FIPS)
+    # Always run on pushes to master/release branches.
+    # For PRs, run when the branch name contains "fips" or any go.mod was changed.
+    if: github.event_name == 'push' || contains(github.head_ref, 'fips') || needs.go.outputs.gomod-changed == 'true'
+    name: Postgres FIPS (shard ${{ matrix.shard }})
     needs: go
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     uses: ./.github/workflows/server-test-template.yml
     secrets: inherit
     with:
-      name: Postgres
+      name: "Postgres FIPS (shard ${{ matrix.shard }})"
       datasource: postgres://mmuser:mostest-fips-test@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
       drivername: postgres
-      logsartifact: postgres-server-test-logs
+      logsartifact: "postgres-fips-server-test-logs-shard-${{ matrix.shard }}"
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: true
+      shard-index: ${{ matrix.shard }}
+      shard-total: 4
+  merge-postgres-fips-test-results:
+    name: Merge Postgres FIPS Test Results
+    needs: test-postgres-normal-fips
+    if: always()
+    uses: ./.github/workflows/server-test-merge-template.yml
+    with:
+      artifact-pattern: postgres-fips-server-test-logs-shard-*
+      artifact-name: postgres-server-test-logs-fips
+
   test-coverage:
     name: Generate Test Coverage
     # Disabled: Running out of memory and causing spurious failures.

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -14,6 +14,7 @@ on:
       - "server/**"
       - ".github/workflows/server-ci.yml"
       - ".github/workflows/server-test-template.yml"
+      - ".github/workflows/server-test-merge-template.yml"
       - ".github/workflows/mmctl-test-template.yml"
       - "!server/build/Dockerfile.buildenv"
       - "!server/build/Dockerfile.buildenv-fips"
@@ -262,7 +263,7 @@ jobs:
   merge-postgres-fips-test-results:
     name: Merge Postgres FIPS Test Results
     needs: test-postgres-normal-fips
-    if: always()
+    if: needs.test-postgres-normal-fips.result != 'skipped'
     uses: ./.github/workflows/server-test-merge-template.yml
     with:
       artifact-pattern: postgres-fips-server-test-logs-shard-*

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -255,7 +255,7 @@ jobs:
       name: "Postgres FIPS (shard ${{ matrix.shard }})"
       datasource: postgres://mmuser:mostest-fips-test@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
       drivername: postgres
-      logsartifact: "postgres-fips-server-test-logs-shard-${{ matrix.shard }}"
+      logsartifact: "postgres-server-fips-test-logs-shard-${{ matrix.shard }}"
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: true
       shard-index: ${{ matrix.shard }}
@@ -266,8 +266,8 @@ jobs:
     if: needs.test-postgres-normal-fips.result != 'skipped'
     uses: ./.github/workflows/server-test-merge-template.yml
     with:
-      artifact-pattern: postgres-fips-server-test-logs-shard-*
-      artifact-name: postgres-server-test-logs-fips
+      artifact-pattern: postgres-server-fips-test-logs-shard-*
+      artifact-name: postgres-server-fips-test-logs
 
   test-coverage:
     name: Generate Test Coverage

--- a/.github/workflows/server-test-merge-template.yml
+++ b/.github/workflows/server-test-merge-template.yml
@@ -1,0 +1,89 @@
+name: Server Test Merge Template
+
+on:
+  workflow_call:
+    inputs:
+      artifact-pattern:
+        description: "Glob pattern to download shard artifacts"
+        required: true
+        type: string
+      artifact-name:
+        description: "Name for the merged output artifact"
+        required: true
+        type: string
+      save-timing-cache:
+        description: "Whether to save timing cache for future shard balancing"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  merge:
+    name: Merge
+    if: always()
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download all shard artifacts
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          pattern: ${{ inputs.artifact-pattern }}
+          path: shards
+
+      - name: Merge JUnit reports
+        run: |
+          python3 -c "
+          import glob, sys
+          from xml.etree import ElementTree as ET
+
+          root = ET.Element('testsuites')
+          for path in sorted(glob.glob('shards/*/report.xml')):
+              tree = ET.parse(path)
+              r = tree.getroot()
+              if r.tag == 'testsuites':
+                  root.extend(r)
+              else:
+                  root.append(r)
+
+          ET.ElementTree(root).write('merged-report.xml', xml_declaration=True, encoding='UTF-8')
+          "
+
+      - name: Prepare merged artifact
+        run: |
+          mkdir -p merged
+          cp merged-report.xml merged/report.xml
+          for dir in shards/*/; do
+            if [[ -f "${dir}test-name" ]]; then
+              cp "${dir}test-name" merged/test-name
+              cp "${dir}pr-number" merged/pr-number
+              break
+            fi
+          done
+
+      - name: Upload merged test logs
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: merged/
+
+      - name: Prepare timing cache
+        if: inputs.save-timing-cache
+        id: timing-prep
+        run: |
+          mkdir -p server
+          if [[ -f merged-report.xml && $(stat -c%s merged-report.xml) -gt 1024 ]]; then
+            cp merged-report.xml server/prev-report.xml
+            cat shards/*/gotestsum.json > server/prev-gotestsum.json 2>/dev/null || true
+            echo "has_timing=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Skipping timing cache — merged report too small or missing"
+            echo "has_timing=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Save test timing cache
+        if: inputs.save-timing-cache && steps.timing-prep.outputs.has_timing == 'true' && github.ref_name == github.event.repository.default_branch
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            server/prev-report.xml
+            server/prev-gotestsum.json
+          key: server-test-timing-master-${{ github.run_id }}

--- a/server/channels/api4/apitestlib.go
+++ b/server/channels/api4/apitestlib.go
@@ -203,7 +203,6 @@ func setupTestHelper(tb testing.TB, dbStore store.Store, sqlSettings *model.SqlS
 		*cfg.TeamSettings.EnableOpenServer = true
 
 		// Disable strict password requirements for test
-		*cfg.PasswordSettings.MinimumLength = 5
 		*cfg.PasswordSettings.Lowercase = false
 		*cfg.PasswordSettings.Uppercase = false
 		*cfg.PasswordSettings.Symbol = false
@@ -472,37 +471,42 @@ func (th *TestHelper) InitLogin(tb testing.TB) *TestHelper {
 	th.waitForConnectivity(tb)
 
 	th.SystemAdminUser = th.CreateUser(tb)
+	systemAdminPassword := th.SystemAdminUser.Password
 	_, appErr := th.App.UpdateUserRoles(th.Context, th.SystemAdminUser.Id, model.SystemUserRoleId+" "+model.SystemAdminRoleId, false)
 	require.Nil(tb, appErr)
 	th.SystemAdminUser, appErr = th.App.GetUser(th.SystemAdminUser.Id)
 	require.Nil(tb, appErr)
 
 	th.SystemManagerUser = th.CreateUser(tb)
+	systemManagerPassword := th.SystemManagerUser.Password
 	_, appErr = th.App.UpdateUserRoles(th.Context, th.SystemManagerUser.Id, model.SystemUserRoleId+" "+model.SystemManagerRoleId, false)
 	require.Nil(tb, appErr)
 	th.SystemManagerUser, appErr = th.App.GetUser(th.SystemManagerUser.Id)
 	require.Nil(tb, appErr)
 
 	th.TeamAdminUser = th.CreateUser(tb)
+	teamAdminPassword := th.TeamAdminUser.Password
 	_, appErr = th.App.UpdateUserRoles(th.Context, th.TeamAdminUser.Id, model.SystemUserRoleId, false)
 	require.Nil(tb, appErr)
 	th.TeamAdminUser, appErr = th.App.GetUser(th.TeamAdminUser.Id)
 	require.Nil(tb, appErr)
 
 	th.BasicUser = th.CreateUser(tb)
+	basicUserPassword := th.BasicUser.Password
 	th.BasicUser, appErr = th.App.GetUser(th.BasicUser.Id)
 	require.Nil(tb, appErr)
 
 	th.BasicUser2 = th.CreateUser(tb)
+	basicUser2Password := th.BasicUser2.Password
 	th.BasicUser2, appErr = th.App.GetUser(th.BasicUser2.Id)
 	require.Nil(tb, appErr)
 
-	// restore non hashed password for login
-	th.SystemAdminUser.Password = "Pa$$word11"
-	th.TeamAdminUser.Password = "Pa$$word11"
-	th.BasicUser.Password = "Pa$$word11"
-	th.BasicUser2.Password = "Pa$$word11"
-	th.SystemManagerUser.Password = "Pa$$word11"
+	// restore non-hashed password for login
+	th.SystemAdminUser.Password = systemAdminPassword
+	th.SystemManagerUser.Password = systemManagerPassword
+	th.TeamAdminUser.Password = teamAdminPassword
+	th.BasicUser.Password = basicUserPassword
+	th.BasicUser2.Password = basicUser2Password
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -694,13 +698,13 @@ func (th *TestHelper) CreateUserWithClient(tb testing.TB, client *model.Client4)
 		Nickname:  "nn_" + id,
 		FirstName: "f_" + id,
 		LastName:  "l_" + id,
-		Password:  "Pa$$word11",
+		Password:  model.NewTestPassword(),
 	}
 
 	ruser, _, err := client.CreateUser(context.Background(), user)
 	require.NoError(tb, err)
 
-	ruser.Password = "Pa$$word11"
+	ruser.Password = user.Password
 	_, err = th.App.Srv().Store().User().VerifyEmail(ruser.Id, ruser.Email)
 	if err != nil {
 		return nil
@@ -730,11 +734,12 @@ func (th *TestHelper) CreateGuestAndClient(tb testing.TB) (*model.User, *model.C
 	id := model.NewId()
 
 	// create a guest user and add it to the basic team and public/private channels
+	password := model.NewTestPassword()
 	guest, cgErr := th.App.CreateGuest(th.Context, &model.User{
 		Email:         "test_guest" + id + "@sample.com",
 		Username:      "guest_" + id,
 		Nickname:      "guest_" + id,
-		Password:      "Password1",
+		Password:      password,
 		EmailVerified: true,
 	})
 	require.Nil(tb, cgErr)
@@ -746,7 +751,7 @@ func (th *TestHelper) CreateGuestAndClient(tb testing.TB) (*model.User, *model.C
 
 	// create a client and login the guest
 	guestClient := th.CreateClient()
-	_, _, err := guestClient.Login(context.Background(), guest.Email, "Password1")
+	_, _, err := guestClient.Login(context.Background(), guest.Email, password)
 	require.NoError(tb, err)
 
 	return guest, guestClient

--- a/server/channels/api4/apitestlib.go
+++ b/server/channels/api4/apitestlib.go
@@ -202,12 +202,6 @@ func setupTestHelper(tb testing.TB, dbStore store.Store, sqlSettings *model.SqlS
 
 		*cfg.TeamSettings.EnableOpenServer = true
 
-		// Disable strict password requirements for test
-		*cfg.PasswordSettings.Lowercase = false
-		*cfg.PasswordSettings.Uppercase = false
-		*cfg.PasswordSettings.Symbol = false
-		*cfg.PasswordSettings.Number = false
-
 		*cfg.ServiceSettings.ListenAddress = "localhost:0"
 	})
 

--- a/server/channels/api4/apitestlib.go
+++ b/server/channels/api4/apitestlib.go
@@ -748,6 +748,7 @@ func (th *TestHelper) CreateGuestAndClient(tb testing.TB) (*model.User, *model.C
 	_, _, err := guestClient.Login(context.Background(), guest.Email, password)
 	require.NoError(tb, err)
 
+	guest.Password = password
 	return guest, guestClient
 }
 

--- a/server/channels/api4/bot_test.go
+++ b/server/channels/api4/bot_test.go
@@ -1519,7 +1519,7 @@ func TestConvertBotToUser(t *testing.T) {
 	require.Error(t, err)
 	CheckBadRequestStatus(t, resp)
 
-	user, resp, err := th.Client.ConvertBotToUser(context.Background(), bot.UserId, &model.UserPatch{Password: model.NewPointer("password")}, false)
+	user, resp, err := th.Client.ConvertBotToUser(context.Background(), bot.UserId, &model.UserPatch{Password: model.NewPointer(model.NewTestPassword())}, false)
 	require.Error(t, err)
 	CheckForbiddenStatus(t, resp)
 	require.Nil(t, user)
@@ -1538,7 +1538,7 @@ func TestConvertBotToUser(t *testing.T) {
 		CheckBadRequestStatus(t, resp)
 		require.Nil(t, user)
 
-		user, _, err = client.ConvertBotToUser(context.Background(), bot.UserId, &model.UserPatch{Password: model.NewPointer("password")}, false)
+		user, _, err = client.ConvertBotToUser(context.Background(), bot.UserId, &model.UserPatch{Password: model.NewPointer(model.NewTestPassword())}, false)
 		require.NoError(t, err)
 		require.NotNil(t, user)
 		require.Equal(t, bot.UserId, user.Id)
@@ -1555,7 +1555,7 @@ func TestConvertBotToUser(t *testing.T) {
 		require.NoError(t, err)
 		CheckCreatedStatus(t, resp)
 
-		user, _, err = client.ConvertBotToUser(context.Background(), bot.UserId, &model.UserPatch{Password: model.NewPointer("password")}, true)
+		user, _, err = client.ConvertBotToUser(context.Background(), bot.UserId, &model.UserPatch{Password: model.NewPointer(model.NewTestPassword())}, true)
 		require.NoError(t, err)
 		require.NotNil(t, user)
 		require.Equal(t, bot.UserId, user.Id)

--- a/server/channels/api4/channel_bookmark_test.go
+++ b/server/channels/api4/channel_bookmark_test.go
@@ -612,7 +612,7 @@ func TestEditChannelBookmark(t *testing.T) {
 
 		// create a client for basic user 2
 		client2 := th.CreateClient()
-		_, _, lErr := client2.Login(context.Background(), th.BasicUser2.Username, "Pa$$word11")
+		_, _, lErr := client2.Login(context.Background(), th.BasicUser2.Username, th.BasicUser2.Password)
 		require.NoError(t, lErr)
 
 		ucb, resp, err := client2.UpdateChannelBookmark(context.Background(), cb.ChannelId, cb.Id, patch)
@@ -1013,7 +1013,7 @@ func TestUpdateChannelBookmarkSortOrder(t *testing.T) {
 
 		// create a client for basic user 2
 		client2 := th.CreateClient()
-		_, _, lErr := client2.Login(context.Background(), th.BasicUser2.Username, "Pa$$word11")
+		_, _, lErr := client2.Login(context.Background(), th.BasicUser2.Username, th.BasicUser2.Password)
 		require.NoError(t, lErr)
 
 		bookmarks, resp, err := client2.UpdateChannelBookmarkSortOrder(context.Background(), th.BasicChannel.Id, cb.Id, 0)
@@ -1387,7 +1387,7 @@ func TestDeleteChannelBookmark(t *testing.T) {
 
 		// create a client for basic user 2
 		client2 := th.CreateClient()
-		_, _, lErr := client2.Login(context.Background(), th.BasicUser2.Username, "Pa$$word11")
+		_, _, lErr := client2.Login(context.Background(), th.BasicUser2.Username, th.BasicUser2.Password)
 		require.NoError(t, lErr)
 
 		dbm, resp, err := client2.DeleteChannelBookmark(context.Background(), th.BasicChannel.Id, cb.Id)

--- a/server/channels/api4/channel_category_test.go
+++ b/server/channels/api4/channel_category_test.go
@@ -107,10 +107,11 @@ func TestCreateCategoryForTeamForUser(t *testing.T) {
 
 	t.Run("should return error when user tries to create a category for a team they're not a member of", func(t *testing.T) {
 		// Create a user
+		password := model.NewTestPassword()
 		user, appErr := th.App.CreateUser(th.Context, &model.User{
 			Email:    th.GenerateTestEmail(),
 			Username: "user_" + model.NewId(),
-			Password: "password",
+			Password: password,
 		})
 		require.Nil(t, appErr)
 
@@ -127,7 +128,7 @@ func TestCreateCategoryForTeamForUser(t *testing.T) {
 
 		// Create a client and log in
 		client := th.CreateClient()
-		_, _, err := client.Login(context.Background(), user.Email, "password")
+		_, _, err := client.Login(context.Background(), user.Email, password)
 		require.NoError(t, err)
 
 		// Now remove the user from the team
@@ -494,10 +495,11 @@ func TestUpdateCategoryForTeamForUser(t *testing.T) {
 
 	t.Run("should return error when user tries to update a category for a team they're not a member of", func(t *testing.T) {
 		// Create a user
+		password := model.NewTestPassword()
 		user, appErr := th.App.CreateUser(th.Context, &model.User{
 			Email:    th.GenerateTestEmail(),
 			Username: "user_" + model.NewId(),
-			Password: "password",
+			Password: password,
 		})
 		require.Nil(t, appErr)
 
@@ -514,7 +516,7 @@ func TestUpdateCategoryForTeamForUser(t *testing.T) {
 
 		// Create a client and log in
 		client := th.CreateClient()
-		_, _, err := client.Login(context.Background(), user.Email, "password")
+		_, _, err := client.Login(context.Background(), user.Email, password)
 		require.NoError(t, err)
 
 		// Get categories to have valid category IDs
@@ -643,10 +645,11 @@ func TestUpdateCategoriesForTeamForUser(t *testing.T) {
 
 	t.Run("should return error when user tries to update categories for a team they're not a member of", func(t *testing.T) {
 		// Create a user
+		password := model.NewTestPassword()
 		user, appErr := th.App.CreateUser(th.Context, &model.User{
 			Email:    th.GenerateTestEmail(),
 			Username: "user_" + model.NewId(),
-			Password: "password",
+			Password: password,
 		})
 		require.Nil(t, appErr)
 
@@ -663,7 +666,7 @@ func TestUpdateCategoriesForTeamForUser(t *testing.T) {
 
 		// Create a client and log in
 		client := th.CreateClient()
-		_, _, err := client.Login(context.Background(), user.Email, "password")
+		_, _, err := client.Login(context.Background(), user.Email, password)
 		require.NoError(t, err)
 
 		// Get categories to have valid category IDs
@@ -711,15 +714,16 @@ func TestGetCategoriesForTeamForUser(t *testing.T) {
 
 	t.Run("should return error when user doesn't have permission", func(t *testing.T) {
 		// Create a new user that's not on the team
+		password := model.NewTestPassword()
 		user, appErr := th.App.CreateUser(th.Context, &model.User{
 			Email:    th.GenerateTestEmail(),
 			Username: "user_" + model.NewId(),
-			Password: "password",
+			Password: password,
 		})
 		require.Nil(t, appErr)
 
 		client := th.CreateClient()
-		_, _, err := client.Login(context.Background(), user.Email, "password")
+		_, _, err := client.Login(context.Background(), user.Email, password)
 		require.NoError(t, err)
 
 		// Attempt to get categories for the basic user
@@ -730,10 +734,11 @@ func TestGetCategoriesForTeamForUser(t *testing.T) {
 
 	t.Run("should return error for a team the user is not a member of", func(t *testing.T) {
 		// Create a new user and team
+		password := model.NewTestPassword()
 		user, appErr := th.App.CreateUser(th.Context, &model.User{
 			Email:    th.GenerateTestEmail(),
 			Username: "user_" + model.NewId(),
-			Password: "password",
+			Password: password,
 		})
 		require.Nil(t, appErr)
 
@@ -747,7 +752,7 @@ func TestGetCategoriesForTeamForUser(t *testing.T) {
 
 		// Log in as the new user
 		client := th.CreateClient()
-		_, _, err := client.Login(context.Background(), user.Email, "password")
+		_, _, err := client.Login(context.Background(), user.Email, password)
 		require.NoError(t, err)
 
 		// Attempt to get categories for a team the user is not a member of
@@ -797,15 +802,16 @@ func TestGetCategoryOrderForTeamForUser(t *testing.T) {
 
 	t.Run("should return error when user doesn't have permission", func(t *testing.T) {
 		// Create a new user that's not on the team
+		password := model.NewTestPassword()
 		user, appErr := th.App.CreateUser(th.Context, &model.User{
 			Email:    th.GenerateTestEmail(),
 			Username: "user_" + model.NewId(),
-			Password: "password",
+			Password: password,
 		})
 		require.Nil(t, appErr)
 
 		client := th.CreateClient()
-		_, _, err := client.Login(context.Background(), user.Email, "password")
+		_, _, err := client.Login(context.Background(), user.Email, password)
 		require.NoError(t, err)
 
 		// Attempt to get order for the basic user
@@ -835,10 +841,11 @@ func TestGetCategoryOrderForTeamForUser(t *testing.T) {
 
 	t.Run("should return error when user tries to get category order for a team they're not a member of", func(t *testing.T) {
 		// Create a user
+		password := model.NewTestPassword()
 		user, appErr := th.App.CreateUser(th.Context, &model.User{
 			Email:    th.GenerateTestEmail(),
 			Username: "user_" + model.NewId(),
-			Password: "password",
+			Password: password,
 		})
 		require.Nil(t, appErr)
 
@@ -855,7 +862,7 @@ func TestGetCategoryOrderForTeamForUser(t *testing.T) {
 
 		// Create a client and log in
 		client := th.CreateClient()
-		_, _, err := client.Login(context.Background(), user.Email, "password")
+		_, _, err := client.Login(context.Background(), user.Email, password)
 		require.NoError(t, err)
 
 		// Verify the user can access categories initially
@@ -904,15 +911,16 @@ func TestUpdateCategoryOrderForTeamForUser(t *testing.T) {
 
 	t.Run("should return error when user doesn't have permission", func(t *testing.T) {
 		// Create a new user that's not on the team
+		password := model.NewTestPassword()
 		user, appErr := th.App.CreateUser(th.Context, &model.User{
 			Email:    th.GenerateTestEmail(),
 			Username: "user_" + model.NewId(),
-			Password: "password",
+			Password: password,
 		})
 		require.Nil(t, appErr)
 
 		client := th.CreateClient()
-		_, _, err := client.Login(context.Background(), user.Email, "password")
+		_, _, err := client.Login(context.Background(), user.Email, password)
 		require.NoError(t, err)
 
 		// Get categories for basic user to try to update
@@ -992,10 +1000,11 @@ func TestUpdateCategoryOrderForTeamForUser(t *testing.T) {
 
 	t.Run("should return error when user tries to update category order for a team they're not a member of", func(t *testing.T) {
 		// Create a user
+		password := model.NewTestPassword()
 		user, appErr := th.App.CreateUser(th.Context, &model.User{
 			Email:    th.GenerateTestEmail(),
 			Username: "user_" + model.NewId(),
-			Password: "password",
+			Password: password,
 		})
 		require.Nil(t, appErr)
 
@@ -1012,7 +1021,7 @@ func TestUpdateCategoryOrderForTeamForUser(t *testing.T) {
 
 		// Create a client and log in
 		client := th.CreateClient()
-		_, _, err := client.Login(context.Background(), user.Email, "password")
+		_, _, err := client.Login(context.Background(), user.Email, password)
 		require.NoError(t, err)
 
 		// Get categories to have a valid order
@@ -1055,15 +1064,16 @@ func TestGetCategoryForTeamForUser(t *testing.T) {
 
 	t.Run("should return error when user doesn't have permission", func(t *testing.T) {
 		// Create a new user that's not on the team
+		password := model.NewTestPassword()
 		user, appErr := th.App.CreateUser(th.Context, &model.User{
 			Email:    th.GenerateTestEmail(),
 			Username: "user_" + model.NewId(),
-			Password: "password",
+			Password: password,
 		})
 		require.Nil(t, appErr)
 
 		client := th.CreateClient()
-		_, _, err := client.Login(context.Background(), user.Email, "password")
+		_, _, err := client.Login(context.Background(), user.Email, password)
 		require.NoError(t, err)
 
 		// Get categories for basic user to get a valid category ID
@@ -1130,10 +1140,11 @@ func TestGetCategoryForTeamForUser(t *testing.T) {
 
 	t.Run("should return error when user tries to get category for a team they're not a member of", func(t *testing.T) {
 		// Create a user
+		password := model.NewTestPassword()
 		user, appErr := th.App.CreateUser(th.Context, &model.User{
 			Email:    th.GenerateTestEmail(),
 			Username: "user_" + model.NewId(),
-			Password: "password",
+			Password: password,
 		})
 		require.Nil(t, appErr)
 
@@ -1150,7 +1161,7 @@ func TestGetCategoryForTeamForUser(t *testing.T) {
 
 		// Create a client and log in
 		client := th.CreateClient()
-		_, _, err := client.Login(context.Background(), user.Email, "password")
+		_, _, err := client.Login(context.Background(), user.Email, password)
 		require.NoError(t, err)
 
 		// Get categories to have valid category IDs
@@ -1470,15 +1481,16 @@ func TestDeleteCategoryForTeamForUser(t *testing.T) {
 
 	t.Run("should return error when user doesn't have permission", func(t *testing.T) {
 		// Create a new user that's not on the team
+		password := model.NewTestPassword()
 		user, appErr := th.App.CreateUser(th.Context, &model.User{
 			Email:    th.GenerateTestEmail(),
 			Username: "user_" + model.NewId(),
-			Password: "password",
+			Password: password,
 		})
 		require.Nil(t, appErr)
 
 		client := th.CreateClient()
-		_, _, err := client.Login(context.Background(), user.Email, "password")
+		_, _, err := client.Login(context.Background(), user.Email, password)
 		require.NoError(t, err)
 
 		// Get categories for basic user to get a valid category ID
@@ -1551,10 +1563,11 @@ func TestDeleteCategoryForTeamForUser(t *testing.T) {
 
 	t.Run("should return error when user tries to delete a category for a team they're not a member of", func(t *testing.T) {
 		// Create a user
+		password := model.NewTestPassword()
 		user, appErr := th.App.CreateUser(th.Context, &model.User{
 			Email:    th.GenerateTestEmail(),
 			Username: "user_" + model.NewId(),
-			Password: "password",
+			Password: password,
 		})
 		require.Nil(t, appErr)
 
@@ -1571,7 +1584,7 @@ func TestDeleteCategoryForTeamForUser(t *testing.T) {
 
 		// Create a client and log in
 		client := th.CreateClient()
-		_, _, err := client.Login(context.Background(), user.Email, "password")
+		_, _, err := client.Login(context.Background(), user.Email, password)
 		require.NoError(t, err)
 
 		// Create a custom category
@@ -1598,7 +1611,7 @@ func TestDeleteCategoryForTeamForUser(t *testing.T) {
 }
 
 func setupUserForSubtest(t *testing.T, th *TestHelper) (*model.User, *model.Client4) {
-	password := "password"
+	password := model.NewTestPassword()
 	user, appErr := th.App.CreateUser(th.Context, &model.User{
 		Email:    th.GenerateTestEmail(),
 		Username: "user_" + model.NewId(),

--- a/server/channels/api4/channel_test.go
+++ b/server/channels/api4/channel_test.go
@@ -1830,17 +1830,18 @@ func TestCreateDirectChannelAsGuest(t *testing.T) {
 	th.App.Srv().SetLicense(model.NewTestLicense())
 
 	id := model.NewId()
+	guestPassword := model.NewTestPassword()
 	guest := &model.User{
 		Email:         "success+" + id + "@simulator.amazonses.com",
 		Username:      "un_" + id,
 		Nickname:      "nn_" + id,
-		Password:      "Password1",
+		Password:      guestPassword,
 		EmailVerified: true,
 	}
 	guest, appErr := th.App.CreateGuest(th.Context, guest)
 	require.Nil(t, appErr)
 
-	_, _, err := client.Login(context.Background(), guest.Username, "Password1")
+	_, _, err := client.Login(context.Background(), guest.Username, guestPassword)
 	require.NoError(t, err)
 
 	t.Run("Try to created DM with not visible user", func(t *testing.T) {
@@ -1968,17 +1969,18 @@ func TestCreateGroupChannelAsGuest(t *testing.T) {
 	th.App.Srv().SetLicense(model.NewTestLicense())
 
 	id := model.NewId()
+	guestPassword := model.NewTestPassword()
 	guest := &model.User{
 		Email:         "success+" + id + "@simulator.amazonses.com",
 		Username:      "un_" + id,
 		Nickname:      "nn_" + id,
-		Password:      "Password1",
+		Password:      guestPassword,
 		EmailVerified: true,
 	}
 	guest, appErr := th.App.CreateGuest(th.Context, guest)
 	require.Nil(t, appErr)
 
-	_, _, err := client.Login(context.Background(), guest.Username, "Password1")
+	_, _, err := client.Login(context.Background(), guest.Username, guestPassword)
 	require.NoError(t, err)
 
 	var resp *model.Response
@@ -2413,18 +2415,19 @@ func TestGetPublicChannelsByIdsForTeam(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.GuestAccountsSettings.AllowEmailAccounts = true })
 
 		id := model.NewId()
+		guestPassword := model.NewTestPassword()
 		guest := &model.User{
 			Email:         "success+" + id + "@simulator.amazonses.com",
 			Username:      "un_" + id,
 			Nickname:      "nn_" + id,
-			Password:      "Password1",
+			Password:      guestPassword,
 			EmailVerified: true,
 		}
 		guest, appErr := th.App.CreateGuest(th.Context, guest)
 		require.Nil(t, appErr)
 
 		guestClient := th.CreateClient()
-		_, _, err := guestClient.Login(context.Background(), guest.Username, "Password1")
+		_, _, err := guestClient.Login(context.Background(), guest.Username, guestPassword)
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			_, lErr := guestClient.Logout(context.Background())
@@ -4410,7 +4413,7 @@ func TestUpdateChannelMemberSchemeRoles(t *testing.T) {
 		Nickname:      "nn_" + id,
 		FirstName:     "f_" + id,
 		LastName:      "l_" + id,
-		Password:      "Pa$$word11",
+		Password:      model.NewTestPassword(),
 		EmailVerified: true,
 	}
 	guest, appError := th.App.CreateGuest(th.Context, guest)
@@ -5628,11 +5631,12 @@ func TestAutocompleteChannelsForSearchGuestUsers(t *testing.T) {
 	th.App.Srv().SetLicense(model.NewTestLicense())
 
 	id := model.NewId()
+	guestPassword := model.NewTestPassword()
 	guest := &model.User{
 		Email:         "success+" + id + "@simulator.amazonses.com",
 		Username:      "un_" + id,
 		Nickname:      "nn_" + id,
-		Password:      "Password1",
+		Password:      guestPassword,
 		EmailVerified: true,
 	}
 	guest, appErr := th.App.CreateGuest(th.Context, guest)
@@ -5682,7 +5686,7 @@ func TestAutocompleteChannelsForSearchGuestUsers(t *testing.T) {
 	gc2, _, err := th.SystemAdminClient.CreateGroupChannel(context.Background(), []string{th.BasicUser.Id, th.BasicUser2.Id, u1.Id})
 	require.NoError(t, err)
 
-	_, _, err = th.Client.Login(context.Background(), guest.Username, "Password1")
+	_, _, err = th.Client.Login(context.Background(), guest.Username, guestPassword)
 	require.NoError(t, err)
 
 	for _, tc := range []struct {

--- a/server/channels/api4/file_test.go
+++ b/server/channels/api4/file_test.go
@@ -867,7 +867,7 @@ func TestGetFile(t *testing.T) {
 		CheckOKStatus(t, response)
 
 		reviewerClient := th.CreateClient()
-		_, response, err = reviewerClient.Login(context.Background(), reviewer.Email, "Pa$$word11")
+		_, response, err = reviewerClient.Login(context.Background(), reviewer.Email, reviewer.Password)
 		require.NoError(t, err)
 		CheckOKStatus(t, response)
 

--- a/server/channels/api4/image_test.go
+++ b/server/channels/api4/image_test.go
@@ -45,12 +45,12 @@ func TestGetImage(t *testing.T) {
 
 	t.Run("atmos/camo", func(t *testing.T) {
 		imageURL := "http://foo.bar/baz.gif"
-		proxiedURL := "https://proxy.foo.bar/004afe2ef382eb5f30c4490f793f8a8c5b33d8a2/687474703a2f2f666f6f2e6261722f62617a2e676966"
+		proxiedURL := "https://proxy.foo.bar/83d4d9ac78b76ce425ea67038826df867c62cc5c/687474703a2f2f666f6f2e6261722f62617a2e676966"
 
 		th.App.UpdateConfig(func(cfg *model.Config) {
 			cfg.ImageProxySettings.Enable = model.NewPointer(true)
 			cfg.ImageProxySettings.ImageProxyType = model.NewPointer("atmos/camo")
-			cfg.ImageProxySettings.RemoteImageProxyOptions = model.NewPointer("foo")
+			cfg.ImageProxySettings.RemoteImageProxyOptions = model.NewPointer("7e5f3fab20b94782b43cdb022a66985ef28ba355df2c5d5da3c9a05e4b697bac")
 			cfg.ImageProxySettings.RemoteImageProxyURL = model.NewPointer("https://proxy.foo.bar")
 		})
 

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -1213,7 +1213,7 @@ func TestCreatePostPublic(t *testing.T) {
 
 	post := &model.Post{ChannelId: th.BasicChannel.Id, Message: "#hashtag a" + model.NewId() + "a"}
 
-	user := model.User{Email: th.GenerateTestEmail(), Nickname: "Joram Wilander", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemUserRoleId}
+	user := model.User{Email: th.GenerateTestEmail(), Nickname: "Joram Wilander", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemUserRoleId}
 
 	ruser, _, err := client.CreateUser(context.Background(), &user)
 	require.NoError(t, err)
@@ -1271,7 +1271,7 @@ func TestCreatePostAll(t *testing.T) {
 
 	post := &model.Post{ChannelId: th.BasicChannel.Id, Message: "#hashtag a" + model.NewId() + "a"}
 
-	user := model.User{Email: th.GenerateTestEmail(), Nickname: "Joram Wilander", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemUserRoleId}
+	user := model.User{Email: th.GenerateTestEmail(), Nickname: "Joram Wilander", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemUserRoleId}
 
 	directChannel, _ := th.App.GetOrCreateDirectChannel(th.Context, th.BasicUser.Id, th.BasicUser2.Id)
 

--- a/server/channels/api4/properties_test.go
+++ b/server/channels/api4/properties_test.go
@@ -2265,7 +2265,7 @@ func TestGetPropertyValuesChannelTargetAccess(t *testing.T) {
 	// Create a non-member user
 	nonMember := th.CreateUser(t)
 	nonMemberClient := th.CreateClient()
-	_, _, err := nonMemberClient.Login(context.Background(), nonMember.Email, "Pa$$word11")
+	_, _, err := nonMemberClient.Login(context.Background(), nonMember.Email, nonMember.Password)
 	require.NoError(t, err)
 
 	t.Run("public channel - member can read", func(t *testing.T) {
@@ -2374,7 +2374,7 @@ func TestPatchPropertyValuesChannelTargetAccess(t *testing.T) {
 	// Create a non-member user
 	nonMember := th.CreateUser(t)
 	nonMemberClient := th.CreateClient()
-	_, _, err := nonMemberClient.Login(context.Background(), nonMember.Email, "Pa$$word11")
+	_, _, err := nonMemberClient.Login(context.Background(), nonMember.Email, nonMember.Password)
 	require.NoError(t, err)
 
 	t.Run("public channel - member with manage permission can write", func(t *testing.T) {

--- a/server/channels/api4/remote_cluster_test.go
+++ b/server/channels/api4/remote_cluster_test.go
@@ -107,7 +107,7 @@ func TestCreateRemoteClusterWithSecureConnectionManagerRole(t *testing.T) {
 			Name:          "test-from-scm",
 			DefaultTeamId: th.BasicTeam.Id,
 		},
-		Password: "mysupersecret",
+		Password: model.NewTestPassword(),
 	}
 
 	t.Run("regular user should be denied", func(t *testing.T) {
@@ -144,7 +144,7 @@ func TestCreateRemoteClusterDeniedForSharedChannelManagerRole(t *testing.T) {
 				Name:          "test-from-scm",
 				DefaultTeamId: th.BasicTeam.Id,
 			},
-			Password: "mysupersecret",
+			Password: model.NewTestPassword(),
 		}
 		_, resp, err := scmClient.CreateRemoteCluster(context.Background(), rcPayload)
 		CheckForbiddenStatus(t, resp)
@@ -328,7 +328,7 @@ func TestCreateRemoteCluster(t *testing.T) {
 			DefaultTeamId: model.NewId(),
 			Token:         model.NewId(),
 		},
-		Password: "mysupersecret",
+		Password: model.NewTestPassword(),
 	}
 
 	t.Run("Should not work if the remote cluster service is not enabled", func(t *testing.T) {
@@ -436,7 +436,7 @@ func TestRemoteClusterAcceptinvite(t *testing.T) {
 	rcAcceptInvite := &model.RemoteClusterAcceptInvite{
 		Name:          "remotecluster",
 		Invite:        "myinvitecode",
-		Password:      "mysupersecret",
+		Password:      model.NewTestPassword(),
 		DefaultTeamId: "",
 	}
 
@@ -459,8 +459,7 @@ func TestRemoteClusterAcceptinvite(t *testing.T) {
 		SiteURL:  "http://localhost:8065",
 		Token:    "token",
 	}
-	password := "mysupersecret"
-	encrypted, err := invite.Encrypt(password)
+	encrypted, err := invite.Encrypt(rcAcceptInvite.Password)
 	require.NoError(t, err)
 	encoded := base64.URLEncoding.EncodeToString(encrypted)
 	rcAcceptInvite.Invite = encoded
@@ -530,7 +529,7 @@ func TestRemoteClusterAcceptinvite(t *testing.T) {
 
 func TestGenerateRemoteClusterInvite(t *testing.T) {
 	mainHelper.Parallel(t)
-	password := "mysupersecret"
+	password := model.NewTestPassword()
 
 	newRC := &model.RemoteCluster{
 		Name:    "remotecluster",

--- a/server/channels/api4/shared_channel_metadata_test.go
+++ b/server/channels/api4/shared_channel_metadata_test.go
@@ -455,7 +455,7 @@ func TestSharedChannelPostMetadataSync(t *testing.T) {
 		remoteUserFromClusterB := &model.User{
 			Email:         "remote-user-b@example.com",
 			Username:      "remoteuserb" + model.NewId()[:4],
-			Password:      "password123",
+			Password:      model.NewTestPassword(),
 			EmailVerified: true,
 			RemoteId:      &clusterB.RemoteId,
 		}

--- a/server/channels/api4/team_test.go
+++ b/server/channels/api4/team_test.go
@@ -3055,15 +3055,16 @@ func TestAddTeamMembersDomainConstrained(t *testing.T) {
 	require.NoError(t, err)
 
 	// create two users on allowed domains
+	password := model.NewTestPassword()
 	user1, _, err := client.CreateUser(context.Background(), &model.User{
 		Email:    "user@domain1.com",
-		Password: "Pa$$word11",
+		Password: password,
 		Username: GenerateTestUsername(),
 	})
 	require.NoError(t, err)
 	user2, _, err := client.CreateUser(context.Background(), &model.User{
 		Email:    "user@domain2.com",
-		Password: "Pa$$word11",
+		Password: password,
 		Username: GenerateTestUsername(),
 	})
 	require.NoError(t, err)
@@ -3552,7 +3553,7 @@ func TestUpdateTeamMemberSchemeRoles(t *testing.T) {
 		Nickname:      "nn_" + id,
 		FirstName:     "f_" + id,
 		LastName:      "l_" + id,
-		Password:      "Pa$$word11",
+		Password:      model.NewTestPassword(),
 		EmailVerified: true,
 	}
 	guest, appError := th.App.CreateGuest(th.Context, guest)

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -44,7 +44,7 @@ func TestCreateUser(t *testing.T) {
 		Id:       model.NewId(),
 		Email:    th.GenerateTestEmail(),
 		Nickname: "Corey Hulen",
-		Password: "hello1",
+		Password: model.NewTestPassword(),
 		Username: GenerateTestUsername(),
 	}
 	_, resp, err := th.Client.CreateUser(context.Background(), &user)
@@ -54,7 +54,7 @@ func TestCreateUser(t *testing.T) {
 	user = model.User{
 		Email:          th.GenerateTestEmail(),
 		Nickname:       "Corey Hulen",
-		Password:       "hello1",
+		Password:       model.NewTestPassword(),
 		Username:       GenerateTestUsername(),
 		Roles:          model.SystemAdminRoleId + " " + model.SystemUserRoleId,
 		EmailVerified:  true,
@@ -88,7 +88,7 @@ func TestCreateUser(t *testing.T) {
 
 	ruser.Id = ""
 	ruser.Username = GenerateTestUsername()
-	ruser.Password = "passwd1"
+	ruser.Password = model.NewTestPassword()
 	_, resp, err = th.Client.CreateUser(context.Background(), ruser)
 	CheckErrorID(t, err, "app.user.save.email_exists.app_error")
 	CheckBadRequestStatus(t, resp)
@@ -113,7 +113,7 @@ func TestCreateUser(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.EnableUserCreation = false })
 
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
-		user2 := &model.User{Email: th.GenerateTestEmail(), Password: "Password1", Username: GenerateTestUsername(), EmailVerified: true}
+		user2 := &model.User{Email: th.GenerateTestEmail(), Password: model.NewTestPassword(), Username: GenerateTestUsername(), EmailVerified: true}
 		ruser2, _, err2 := client.CreateUser(context.Background(), user2)
 		require.NoError(t, err2)
 		// Creating a user as sysadmin should verify the user with the EmailVerified flag.
@@ -126,13 +126,13 @@ func TestCreateUser(t *testing.T) {
 
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
 		email := th.GenerateTestEmail()
-		user2 := &model.User{Email: email, Password: "Password1", Username: GenerateTestUsername(), EmailVerified: true}
+		user2 := &model.User{Email: email, Password: model.NewTestPassword(), Username: GenerateTestUsername(), EmailVerified: true}
 		_, _, err = client.CreateUser(context.Background(), user2)
 		require.NoError(t, err)
 		_, appErr := th.App.GetUserByUsername(user2.Username)
 		require.Nil(t, appErr)
 
-		user3 := &model.User{Email: fmt.Sprintf(" %s  ", email), Password: "Password1", Username: GenerateTestUsername(), EmailVerified: true}
+		user3 := &model.User{Email: fmt.Sprintf(" %s  ", email), Password: model.NewTestPassword(), Username: GenerateTestUsername(), EmailVerified: true}
 		_, resp, err = client.CreateUser(context.Background(), user3)
 		require.Error(t, err)
 		CheckBadRequestStatus(t, resp)
@@ -146,7 +146,7 @@ func TestCreateUser(t *testing.T) {
 			Id:            model.NewId(),
 			RemoteId:      model.NewPointer(model.NewId()),
 			Email:         email,
-			Password:      "Password1",
+			Password:      model.NewTestPassword(),
 			Username:      GenerateTestUsername(),
 			EmailVerified: true,
 		}
@@ -174,7 +174,7 @@ func TestCreateUserPasswordValidation(t *testing.T) {
 
 	ruser := model.User{
 		Nickname:      "Corey Hulen",
-		Password:      "hello1",
+		Password:      model.NewTestPassword(),
 		Roles:         model.SystemAdminRoleId + " " + model.SystemUserRoleId,
 		EmailVerified: true,
 	}
@@ -185,9 +185,9 @@ func TestCreateUserPasswordValidation(t *testing.T) {
 		ExpectedError string
 	}{
 		"Short": {
-			Password: strings.Repeat("x", 5),
+			Password: strings.Repeat("x", model.PasswordFIPSMinimumLength),
 			Settings: &model.PasswordSettings{
-				MinimumLength: model.NewPointer(5),
+				MinimumLength: model.NewPointer(model.PasswordFIPSMinimumLength),
 				Lowercase:     model.NewPointer(false),
 				Uppercase:     model.NewPointer(false),
 				Number:        model.NewPointer(false),
@@ -206,7 +206,7 @@ func TestCreateUserPasswordValidation(t *testing.T) {
 		"TooShort": {
 			Password: strings.Repeat("x", 2),
 			Settings: &model.PasswordSettings{
-				MinimumLength: model.NewPointer(5),
+				MinimumLength: model.NewPointer(model.PasswordFIPSMinimumLength),
 				Lowercase:     model.NewPointer(false),
 				Uppercase:     model.NewPointer(false),
 				Number:        model.NewPointer(false),
@@ -275,7 +275,7 @@ func TestCreateUserPasswordValidation(t *testing.T) {
 			ExpectedError: "model.user.is_valid.pwd_uppercase_number_symbol.app_error",
 		},
 		"Everything": {
-			Password: "asdASD!@#123",
+			Password: "asdASDasd!@#123",
 			Settings: &model.PasswordSettings{
 				Lowercase: model.NewPointer(true),
 				Uppercase: model.NewPointer(true),
@@ -313,10 +313,9 @@ func TestCreateUserAudit(t *testing.T) {
 	th := SetupWithServerOptions(t, options)
 
 	email := th.GenerateTestEmail()
-	password := "this_is_the_password"
 	user := model.User{
 		Email:    email,
-		Password: password,
+		Password: model.NewTestPassword(),
 		Username: GenerateTestUsername(),
 	}
 	_, resp, err := th.Client.CreateUser(context.Background(), &user)
@@ -334,7 +333,7 @@ func TestCreateUserAudit(t *testing.T) {
 	require.NotEmpty(t, data)
 
 	require.Contains(t, string(data), email)
-	require.NotContains(t, string(data), password)
+	require.NotContains(t, string(data), user.Password)
 }
 
 func TestUserLoginAudit(t *testing.T) {
@@ -497,7 +496,7 @@ func TestCreateUserInputFilter(t *testing.T) {
 		})
 
 		th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
-			user := &model.User{Email: "foobar+testdomainrestriction@mattermost.com", Password: "Password1", Username: GenerateTestUsername()}
+			user := &model.User{Email: "foobar+testdomainrestriction@mattermost.com", Password: model.NewTestPassword(), Username: GenerateTestUsername()}
 			u, _, err := client.CreateUser(context.Background(), user) // we need the returned created user to use its Id for deletion.
 			require.NoError(t, err)
 			_, err = client.PermanentDeleteUser(context.Background(), u.Id)
@@ -505,7 +504,7 @@ func TestCreateUserInputFilter(t *testing.T) {
 		}, "ValidUser")
 
 		th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
-			user := &model.User{Email: "foobar+testdomainrestriction@mattermost.org", Password: "Password1", Username: GenerateTestUsername()}
+			user := &model.User{Email: "foobar+testdomainrestriction@mattermost.org", Password: model.NewTestPassword(), Username: GenerateTestUsername()}
 			_, resp, err := client.CreateUser(context.Background(), user)
 			require.Error(t, err)
 			CheckBadRequestStatus(t, resp)
@@ -539,7 +538,7 @@ func TestCreateUserInputFilter(t *testing.T) {
 		})
 
 		th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
-			user := &model.User{Email: "foobar+testdomainrestriction@mattermost.org", Password: "Password1", Username: GenerateTestUsername(), AuthService: "ldap"}
+			user := &model.User{Email: "foobar+testdomainrestriction@mattermost.org", Password: model.NewTestPassword(), Username: GenerateTestUsername(), AuthService: "ldap"}
 			_, resp, err := th.Client.CreateUser(context.Background(), user)
 			require.Error(t, err)
 			CheckBadRequestStatus(t, resp)
@@ -556,7 +555,7 @@ func TestCreateUserInputFilter(t *testing.T) {
 
 		th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
 			emailAddr := "foobar+testinvalidrole@mattermost.com"
-			user := &model.User{Email: emailAddr, Password: "Password1", Username: GenerateTestUsername(), Roles: "system_user system_admin"}
+			user := &model.User{Email: emailAddr, Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: "system_user system_admin"}
 			_, _, err := client.CreateUser(context.Background(), user)
 			require.NoError(t, err)
 			ruser, appErr := th.App.GetUserByEmail(emailAddr)
@@ -572,7 +571,7 @@ func TestCreateUserInputFilter(t *testing.T) {
 			*cfg.TeamSettings.EnableOpenServer = true
 			*cfg.TeamSettings.EnableUserCreation = true
 		})
-		user := &model.User{Id: "AAAAAAAAAAAAAAAAAAAAAAAAAA", Email: "foobar+testinvalidid@mattermost.com", Password: "Password1", Username: GenerateTestUsername(), Roles: "system_user system_admin"}
+		user := &model.User{Id: "AAAAAAAAAAAAAAAAAAAAAAAAAA", Email: "foobar+testinvalidid@mattermost.com", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: "system_user system_admin"}
 		_, resp, err := client.CreateUser(context.Background(), user)
 		require.Error(t, err)
 		CheckBadRequestStatus(t, resp)
@@ -584,7 +583,7 @@ func TestCreateUserWithToken(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 
 	t.Run("CreateWithTokenHappyPath", func(t *testing.T) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 		token := model.NewToken(
 			model.TokenTypeTeamInvitation,
 			model.MapToJSON(map[string]string{"teamId": th.BasicTeam.Id, "email": user.Email}),
@@ -610,7 +609,7 @@ func TestCreateUserWithToken(t *testing.T) {
 	})
 
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 		token := model.NewToken(
 			model.TokenTypeTeamInvitation,
 			model.MapToJSON(map[string]string{"teamId": th.BasicTeam.Id, "email": user.Email}),
@@ -636,7 +635,7 @@ func TestCreateUserWithToken(t *testing.T) {
 	}, "CreateWithTokenHappyPath")
 
 	t.Run("NoToken", func(t *testing.T) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 		token := model.NewToken(
 			model.TokenTypeTeamInvitation,
 			model.MapToJSON(map[string]string{"teamId": th.BasicTeam.Id, "email": user.Email}),
@@ -653,7 +652,7 @@ func TestCreateUserWithToken(t *testing.T) {
 	})
 
 	t.Run("TokenExpired", func(t *testing.T) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 		timeNow := time.Now()
 		past49Hours := timeNow.Add(-49*time.Hour).UnixNano() / int64(time.Millisecond)
 		token := model.NewToken(
@@ -674,7 +673,7 @@ func TestCreateUserWithToken(t *testing.T) {
 	})
 
 	t.Run("WrongToken", func(t *testing.T) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 
 		_, resp, err := th.Client.CreateUserWithToken(context.Background(), &user, "wrong")
 		require.Error(t, err)
@@ -688,7 +687,7 @@ func TestCreateUserWithToken(t *testing.T) {
 			th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableUserCreation = enableUserCreation })
 		}()
 
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 
 		token := model.NewToken(
 			model.TokenTypeTeamInvitation,
@@ -711,7 +710,7 @@ func TestCreateUserWithToken(t *testing.T) {
 		enableUserCreation := th.App.Config().TeamSettings.EnableUserCreation
 		defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableUserCreation = enableUserCreation })
 
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 
 		token := model.NewToken(
 			model.TokenTypeTeamInvitation,
@@ -732,7 +731,7 @@ func TestCreateUserWithToken(t *testing.T) {
 	}, "EnableUserCreationDisable")
 
 	t.Run("EnableOpenServerDisable", func(t *testing.T) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 
 		token := model.NewToken(
 			model.TokenTypeTeamInvitation,
@@ -761,7 +760,7 @@ func TestCreateUserWithToken(t *testing.T) {
 	})
 
 	t.Run("Validate inviter user has permissions on channels he is inviting", func(t *testing.T) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemUserRoleId}
 		channelIdWithoutPermissions := th.BasicPrivateChannel2.Id
 		channelIds := th.BasicChannel.Id + " " + channelIdWithoutPermissions
 		token := model.NewToken(
@@ -800,7 +799,7 @@ func TestCreateUserWithToken(t *testing.T) {
 	})
 
 	t.Run("Validate inviterUser permissions on channels he is inviting, when inviting guests", func(t *testing.T) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Guest User", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Guest User", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemUserRoleId}
 		channelIdWithoutPermissions := th.BasicPrivateChannel2.Id
 		channelIds := th.BasicChannel.Id + " " + channelIdWithoutPermissions
 		token := model.NewToken(
@@ -849,7 +848,7 @@ func TestCreateUserWebSocketEvent(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.GuestAccountsSettings.AllowEmailAccounts = true })
 
 		id := model.NewId()
-		guestPassword := "Pa$$word11"
+		guestPassword := model.NewTestPassword()
 		guest := &model.User{
 			Email:         "success+" + id + "@simulator.amazonses.com",
 			Username:      "un_" + id,
@@ -875,7 +874,7 @@ func TestCreateUserWebSocketEvent(t *testing.T) {
 		guestWSClient := th.CreateConnectedWebSocketClientWithClient(t, guestClient)
 		userWSClient := th.CreateConnectedWebSocketClient(t)
 
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 
 		inviteId := th.BasicTeam.InviteId
 
@@ -913,7 +912,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 
 	t.Run("CreateWithInviteIdHappyPath", func(t *testing.T) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 
 		inviteId := th.BasicTeam.InviteId
 
@@ -928,7 +927,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 		CheckUserSanitization(t, ruser)
 	})
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 
 		inviteId := th.BasicTeam.InviteId
 
@@ -944,7 +943,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	}, "CreateWithInviteIdHappyPath")
 
 	t.Run("GroupConstrainedTeam", func(t *testing.T) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 
 		th.BasicTeam.GroupConstrained = model.NewPointer(true)
 		team, appErr := th.App.UpdateTeam(th.BasicTeam)
@@ -963,7 +962,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	})
 
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 
 		th.BasicTeam.GroupConstrained = model.NewPointer(true)
 		team, appErr := th.App.UpdateTeam(th.BasicTeam)
@@ -982,7 +981,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	}, "GroupConstrainedTeam")
 
 	t.Run("WrongInviteId", func(t *testing.T) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 
 		inviteId := model.NewId()
 
@@ -993,7 +992,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	})
 
 	t.Run("NoInviteId", func(t *testing.T) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 
 		_, _, err := th.Client.CreateUserWithInviteId(context.Background(), &user, "")
 		require.Error(t, err)
@@ -1001,7 +1000,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	})
 
 	t.Run("ExpiredInviteId", func(t *testing.T) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 
 		inviteId := th.BasicTeam.InviteId
 
@@ -1015,7 +1014,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	})
 
 	t.Run("EnableUserCreationDisable", func(t *testing.T) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 
 		enableUserCreation := th.App.Config().TeamSettings.EnableUserCreation
 		defer func() {
@@ -1032,7 +1031,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 		CheckErrorID(t, err, "api.user.create_user.signup_email_disabled.app_error")
 	})
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 
 		enableUserCreation := th.App.Config().TeamSettings.EnableUserCreation
 		defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableUserCreation = enableUserCreation })
@@ -1047,7 +1046,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	}, "EnableUserCreationDisable")
 
 	t.Run("EnableOpenServerDisable", func(t *testing.T) {
-		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 
 		enableOpenServer := th.App.Config().TeamSettings.EnableOpenServer
 		defer func() {
@@ -1368,7 +1367,7 @@ func TestGetUserByEmail(t *testing.T) {
 	userWithSlash, _, err := th.SystemAdminClient.CreateUser(context.Background(), &model.User{
 		Email:    "email/with/slashes@example.com",
 		Username: GenerateTestUsername(),
-		Password: "Pa$$word11",
+		Password: model.NewTestPassword(),
 	})
 	require.NoError(t, err)
 
@@ -2387,7 +2386,7 @@ func TestPatchUser(t *testing.T) {
 	})
 
 	patch := &model.UserPatch{}
-	patch.Password = model.NewPointer("testpassword")
+	patch.Password = model.NewPointer(model.NewTestPassword())
 	patch.Nickname = model.NewPointer("Joram Wilander")
 	patch.FirstName = model.NewPointer("Joram")
 	patch.LastName = model.NewPointer("Wilander")
@@ -2536,7 +2535,7 @@ func TestUserUnicodeNames(t *testing.T) {
 			FirstName: "Andrew\u202e",
 			LastName:  "\ufeffWiggin",
 			Nickname:  "Ender\u2028 Wiggin",
-			Password:  "hello1",
+			Password:  model.NewTestPassword(),
 			Username:  "\ufeffwiggin77",
 			Roles:     model.SystemAdminRoleId + " " + model.SystemUserRoleId,
 		}
@@ -2633,7 +2632,7 @@ func TestUpdateUserAuth(t *testing.T) {
 	_, err = th.App.Srv().Store().User().VerifyEmail(user2.Id, user2.Email)
 	require.NoError(t, err)
 
-	_, _, err = th.SystemAdminClient.Login(context.Background(), user2.Email, "Pa$$word11")
+	_, _, err = th.SystemAdminClient.Login(context.Background(), user2.Email, user2.Password)
 	require.NoError(t, err)
 
 	userAuth.AuthData = user.AuthData
@@ -2972,7 +2971,7 @@ func TestUpdateUserActive(t *testing.T) {
 			Email:         "success+" + id + "@simulator.amazonses.com",
 			Username:      "un_" + id,
 			Nickname:      "nn_" + id,
-			Password:      "Password1",
+			Password:      model.NewTestPassword(),
 			EmailVerified: true,
 		}
 		user, err := th.App.CreateGuest(th.Context, guest)
@@ -2999,7 +2998,7 @@ func TestUpdateUserActive(t *testing.T) {
 			Email:         "success+" + id + "@simulator.amazonses.com",
 			Username:      "un_" + id,
 			Nickname:      "nn_" + id,
-			Password:      "Password1",
+			Password:      model.NewTestPassword(),
 			EmailVerified: true,
 		}
 		user, appErr := th.App.CreateGuest(th.Context, guest)
@@ -3021,7 +3020,7 @@ func TestUpdateUserActive(t *testing.T) {
 		ldapUser := &model.User{
 			Email:         "ldapuser@mattermost-customer.com",
 			Username:      "ldapuser",
-			Password:      "Password123",
+			Password:      model.NewTestPassword(),
 			AuthService:   model.UserAuthServiceLdap,
 			EmailVerified: true,
 		}
@@ -3206,7 +3205,7 @@ func TestGetUsersWithoutTeam(t *testing.T) {
 	user, _, err := th.Client.CreateUser(context.Background(), &model.User{
 		Username: "a000000000" + model.NewId(),
 		Email:    "success+" + model.NewId() + "@simulator.amazonses.com",
-		Password: "Password1",
+		Password: model.NewTestPassword(),
 	})
 	require.NoError(t, err)
 	th.LinkUserToTeam(t, user, th.BasicTeam)
@@ -3218,7 +3217,7 @@ func TestGetUsersWithoutTeam(t *testing.T) {
 	user2, _, err := th.Client.CreateUser(context.Background(), &model.User{
 		Username: "a000000001" + model.NewId(),
 		Email:    "success+" + model.NewId() + "@simulator.amazonses.com",
-		Password: "Password1",
+		Password: model.NewTestPassword(),
 	})
 	require.NoError(t, err)
 	defer func() {
@@ -3728,7 +3727,7 @@ func TestUpdateUserPassword(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)
 
-	password := "newpassword1"
+	password := model.NewTestPassword()
 	_, err := th.Client.UpdateUserPassword(context.Background(), th.BasicUser.Id, th.BasicUser.Password, password)
 	require.NoError(t, err)
 
@@ -3736,7 +3735,8 @@ func TestUpdateUserPassword(t *testing.T) {
 	require.Error(t, err)
 	CheckBadRequestStatus(t, resp)
 
-	resp, err = th.Client.UpdateUserPassword(context.Background(), th.BasicUser.Id, password, "junk")
+	newInvalidPassword := "junk"
+	resp, err = th.Client.UpdateUserPassword(context.Background(), th.BasicUser.Id, password, newInvalidPassword)
 	require.Error(t, err)
 	CheckBadRequestStatus(t, resp)
 
@@ -3748,7 +3748,7 @@ func TestUpdateUserPassword(t *testing.T) {
 	require.Error(t, err)
 	CheckBadRequestStatus(t, resp)
 
-	resp, err = th.Client.UpdateUserPassword(context.Background(), th.BasicUser.Id, "junk", password)
+	resp, err = th.Client.UpdateUserPassword(context.Background(), th.BasicUser.Id, model.NewTestPassword(), password)
 	require.Error(t, err)
 	CheckBadRequestStatus(t, resp)
 
@@ -3772,20 +3772,22 @@ func TestUpdateUserPassword(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.MaximumLoginAttempts = 2 })
 
 	// Fail twice
-	resp, err = th.Client.UpdateUserPassword(context.Background(), th.BasicUser.Id, "badpwd", "newpwd")
+	badPassword := model.NewTestPassword()
+	newPassword := model.NewTestPassword()
+	resp, err = th.Client.UpdateUserPassword(context.Background(), th.BasicUser.Id, badPassword, newPassword)
 	require.Error(t, err)
 	CheckBadRequestStatus(t, resp)
-	resp, err = th.Client.UpdateUserPassword(context.Background(), th.BasicUser.Id, "badpwd", "newpwd")
+	resp, err = th.Client.UpdateUserPassword(context.Background(), th.BasicUser.Id, badPassword, newPassword)
 	require.Error(t, err)
 	CheckBadRequestStatus(t, resp)
 
 	// Should fail because account is locked out
-	resp, err = th.Client.UpdateUserPassword(context.Background(), th.BasicUser.Id, th.BasicUser.Password, "newpwd")
+	resp, err = th.Client.UpdateUserPassword(context.Background(), th.BasicUser.Id, th.BasicUser.Password, newPassword)
 	CheckErrorID(t, err, "api.user.check_user_login_attempts.too_many.app_error")
 	CheckUnauthorizedStatus(t, resp)
 
 	// System admin can update another user's password
-	adminSetPassword := "pwdsetbyadmin"
+	adminSetPassword := model.NewTestPassword()
 	_, err = th.SystemAdminClient.UpdateUserPassword(context.Background(), th.BasicUser.Id, "", adminSetPassword)
 	require.NoError(t, err)
 
@@ -4239,7 +4241,7 @@ func TestVerifyUserEmail(t *testing.T) {
 	th := Setup(t)
 
 	email := th.GenerateTestEmail()
-	user := model.User{Email: email, Nickname: "Darth Vader", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
+	user := model.User{Email: email, Nickname: "Darth Vader", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId}
 
 	ruser, _, _ := th.Client.CreateUser(context.Background(), &user)
 
@@ -4424,24 +4426,26 @@ func TestLogin(t *testing.T) {
 		botUser, _, err := th.SystemAdminClient.GetUser(context.Background(), bot.UserId, "")
 		require.NoError(t, err)
 
-		_, err = th.SystemAdminClient.UpdateUserPassword(context.Background(), bot.UserId, "", "password")
+		botPassword := model.NewTestPassword()
+		_, err = th.SystemAdminClient.UpdateUserPassword(context.Background(), bot.UserId, "", botPassword)
 		require.NoError(t, err)
 
-		_, _, err = th.Client.Login(context.Background(), botUser.Email, "password")
+		_, _, err = th.Client.Login(context.Background(), botUser.Email, botPassword)
 		CheckErrorID(t, err, "api.user.login.bot_login_forbidden.app_error")
 	})
 
 	t.Run("remote user login rejected", func(t *testing.T) {
 		email := th.GenerateTestEmail()
-		user := model.User{Email: email, Nickname: "Darth Vader", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId, RemoteId: model.NewPointer("remote-id")}
+		remoteUserPassword := model.NewTestPassword()
+		user := model.User{Email: email, Nickname: "Darth Vader", Password: remoteUserPassword, Username: GenerateTestUsername(), Roles: model.SystemAdminRoleId + " " + model.SystemUserRoleId, RemoteId: model.NewPointer("remote-id")}
 		ruser, appErr := th.App.CreateUser(th.Context, &user)
 		require.Nil(t, appErr)
 
 		// remote user cannot reset password
-		_, err := th.SystemAdminClient.UpdateUserPassword(context.Background(), ruser.Id, "", "password")
+		_, err := th.SystemAdminClient.UpdateUserPassword(context.Background(), ruser.Id, "", model.NewTestPassword())
 		require.Error(t, err)
 
-		_, _, err = th.Client.Login(context.Background(), ruser.Email, "hello1")
+		_, _, err = th.Client.Login(context.Background(), ruser.Email, remoteUserPassword)
 		CheckErrorID(t, err, "api.user.login.remote_users.login.error")
 	})
 
@@ -4757,7 +4761,7 @@ func TestSwitchAccount(t *testing.T) {
 				CurrentService: model.UserAuthServiceGitlab,
 				NewService:     model.UserAuthServiceEmail,
 				Email:          th.BasicUser.Email,
-				NewPassword:    "NewPassword123!",
+				NewPassword:    model.NewTestPassword(),
 			}
 
 			_, resp, err := th.Client.SwitchAccountType(context.Background(), sr)
@@ -6119,6 +6123,7 @@ func TestGetUsersByStatus(t *testing.T) {
 	}, false)
 	require.Nil(t, appErr, "failed to create channel")
 
+	userPassword := model.NewTestPassword()
 	createUserWithStatus := func(username string, status string) *model.User {
 		id := model.NewId()
 
@@ -6126,7 +6131,7 @@ func TestGetUsersByStatus(t *testing.T) {
 			Email:    "success+" + id + "@simulator.amazonses.com",
 			Username: "un_" + username + "_" + id,
 			Nickname: "nn_" + id,
-			Password: "Password1",
+			Password: userPassword,
 		})
 		require.Nil(t, err, "failed to create user")
 
@@ -6153,7 +6158,7 @@ func TestGetUsersByStatus(t *testing.T) {
 	dndUser2 := createUserWithStatus("dnd2", model.StatusDnd)
 
 	client := th.CreateClient()
-	_, _, err := client.Login(context.Background(), onlineUser2.Username, "Password1")
+	_, _, err := client.Login(context.Background(), onlineUser2.Username, userPassword)
 	require.NoError(t, err)
 
 	t.Run("sorting by status then alphabetical", func(t *testing.T) {
@@ -6252,12 +6257,14 @@ func TestLoginErrorMessage(t *testing.T) {
 	_, err := th.Client.Logout(context.Background())
 	require.NoError(t, err)
 
+	wrongPassword := model.NewTestPassword()
+
 	// Email and Username enabled
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.EmailSettings.EnableSignInWithEmail = true
 		*cfg.EmailSettings.EnableSignInWithUsername = true
 	})
-	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, "wrong")
+	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, wrongPassword)
 	CheckErrorID(t, err, "api.user.login.invalid_credentials_email_username")
 
 	// Email enabled
@@ -6265,7 +6272,7 @@ func TestLoginErrorMessage(t *testing.T) {
 		*cfg.EmailSettings.EnableSignInWithEmail = true
 		*cfg.EmailSettings.EnableSignInWithUsername = false
 	})
-	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, "wrong")
+	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, wrongPassword)
 	CheckErrorID(t, err, "api.user.login.invalid_credentials_email")
 
 	// Username enabled
@@ -6273,7 +6280,7 @@ func TestLoginErrorMessage(t *testing.T) {
 		*cfg.EmailSettings.EnableSignInWithEmail = false
 		*cfg.EmailSettings.EnableSignInWithUsername = true
 	})
-	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, "wrong")
+	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, wrongPassword)
 	CheckErrorID(t, err, "api.user.login.invalid_credentials_username")
 
 	// SAML/SSO enabled
@@ -6297,7 +6304,7 @@ func TestLoginErrorMessage(t *testing.T) {
 		*cfg.SamlSettings.PositionAttribute = ""
 		*cfg.SamlSettings.LocaleAttribute = ""
 	})
-	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, "wrong")
+	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, wrongPassword)
 	CheckErrorID(t, err, "api.user.login.invalid_credentials_sso")
 }
 
@@ -6312,15 +6319,16 @@ func TestLoginLockout(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.MaximumLoginAttempts = 3 })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableMultifactorAuthentication = true })
 
-	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, "wrong")
+	wrongPassword := model.NewTestPassword()
+	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, wrongPassword)
 	CheckErrorID(t, err, "api.user.login.invalid_credentials_email_username")
-	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, "wrong")
+	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, wrongPassword)
 	CheckErrorID(t, err, "api.user.login.invalid_credentials_email_username")
-	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, "wrong")
+	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, wrongPassword)
 	CheckErrorID(t, err, "api.user.login.invalid_credentials_email_username")
-	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, "wrong")
+	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, wrongPassword)
 	CheckErrorID(t, err, "api.user.check_user_login_attempts.too_many.app_error")
-	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, "wrong")
+	_, _, err = th.Client.Login(context.Background(), th.BasicUser.Email, wrongPassword)
 	CheckErrorID(t, err, "api.user.check_user_login_attempts.too_many.app_error")
 
 	// Check if lock is active
@@ -6488,8 +6496,9 @@ func TestVerifyUserEmailWithoutToken(t *testing.T) {
 
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
 		email := th.GenerateTestEmail()
-		user := model.User{Email: email, Nickname: "Darth Vader", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemUserRoleId}
-		ruser, _, _ := th.Client.CreateUser(context.Background(), &user)
+		user := model.User{Email: email, Nickname: "Darth Vader", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemUserRoleId}
+		ruser, _, err := th.Client.CreateUser(context.Background(), &user)
+		require.NoError(t, err)
 
 		vuser, _, err := client.VerifyUserEmailWithoutToken(context.Background(), ruser.Id)
 		require.NoError(t, err)
@@ -6502,8 +6511,9 @@ func TestVerifyUserEmailWithoutToken(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableMultifactorAuthentication = true })
 
 		email := th.GenerateTestEmail()
-		user := model.User{Email: email, Nickname: "Test User", Password: "password123", Username: GenerateTestUsername(), Roles: model.SystemUserRoleId}
-		ruser, _, _ := th.Client.CreateUser(context.Background(), &user)
+		user := model.User{Email: email, Nickname: "Test User", Password: model.NewTestPassword(), Username: GenerateTestUsername(), Roles: model.SystemUserRoleId}
+		ruser, _, err := th.Client.CreateUser(context.Background(), &user)
+		require.NoError(t, err)
 
 		// Set some NotifyProps to ensure we have data to verify is preserved
 		ruser.NotifyProps = map[string]string{
@@ -6518,7 +6528,7 @@ func TestVerifyUserEmailWithoutToken(t *testing.T) {
 		// Set up MFA secret for the user
 		secret, appErr := th.App.GenerateMfaSecret(ruser.Id)
 		require.Nil(t, appErr)
-		err := th.Server.Store().User().UpdateMfaSecret(ruser.Id, secret.Secret)
+		err = th.Server.Store().User().UpdateMfaSecret(ruser.Id, secret.Secret)
 		require.NoError(t, err)
 
 		// Verify the user has a password hash and MFA secret in the database
@@ -6758,7 +6768,7 @@ func TestConvertUserToBot(t *testing.T) {
 	require.Nil(t, bot)
 
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
-		user := model.User{Email: th.GenerateTestEmail(), Username: GenerateTestUsername(), Password: "password"}
+		user := model.User{Email: th.GenerateTestEmail(), Username: GenerateTestUsername(), Password: model.NewTestPassword()}
 
 		ruser, resp, err := client.CreateUser(context.Background(), &user)
 		require.NoError(t, err)
@@ -6860,7 +6870,7 @@ func TestUpdatePassword(t *testing.T) {
 	th := Setup(t)
 
 	t.Run("Forbidden when request performed by system user on a system admin", func(t *testing.T) {
-		res, err := th.Client.UpdatePassword(context.Background(), th.SystemAdminUser.Id, "Pa$$word11", "foobar")
+		res, err := th.Client.UpdatePassword(context.Background(), th.SystemAdminUser.Id, th.SystemAdminUser.Password, model.NewTestPassword())
 		require.Error(t, err)
 		CheckForbiddenStatus(t, res)
 	})
@@ -6869,16 +6879,16 @@ func TestUpdatePassword(t *testing.T) {
 		th.AddPermissionToRole(t, model.PermissionSysconsoleWriteUserManagementUsers.Id, model.SystemUserRoleId)
 		defer th.RemovePermissionFromRole(t, model.PermissionSysconsoleWriteUserManagementUsers.Id, model.SystemUserRoleId)
 
-		res, _ := th.Client.UpdatePassword(context.Background(), th.TeamAdminUser.Id, "Pa$$word11", "foobar")
+		res, _ := th.Client.UpdatePassword(context.Background(), th.TeamAdminUser.Id, th.TeamAdminUser.Password, model.NewTestPassword())
 		CheckOKStatus(t, res)
 
-		res, err := th.Client.UpdatePassword(context.Background(), th.SystemAdminUser.Id, "Pa$$word11", "foobar")
+		res, err := th.Client.UpdatePassword(context.Background(), th.SystemAdminUser.Id, th.SystemAdminUser.Password, model.NewTestPassword())
 		require.Error(t, err)
 		CheckForbiddenStatus(t, res)
 	})
 
 	t.Run("OK when request performed by system admin, even if requested user is system admin", func(t *testing.T) {
-		res, _ := th.SystemAdminClient.UpdatePassword(context.Background(), th.SystemAdminUser.Id, "Pa$$word11", "foobar")
+		res, _ := th.SystemAdminClient.UpdatePassword(context.Background(), th.SystemAdminUser.Id, th.SystemAdminUser.Password, model.NewTestPassword())
 		CheckOKStatus(t, res)
 	})
 }
@@ -6896,7 +6906,7 @@ func TestUpdatePasswordAudit(t *testing.T) {
 	options := []app.Option{app.WithLicense(model.NewTestLicense("advanced_logging"))}
 	th := SetupWithServerOptions(t, options)
 
-	password := "this_is_the_password"
+	password := model.NewTestPassword()
 	th.LoginBasic(t)
 	resp, err := th.Client.UpdatePassword(context.Background(), th.BasicUser.Id, th.BasicUser.Password, password)
 	require.NoError(t, err)
@@ -8390,7 +8400,7 @@ func TestGetUsersWithInvalidEmails(t *testing.T) {
 	user := model.User{
 		Email:    "ben@invalid.mattermost.com",
 		Nickname: "Ben Cooke",
-		Password: "hello1",
+		Password: model.NewTestPassword(),
 		Username: GenerateTestUsername(),
 		Roles:    model.SystemAdminRoleId + " " + model.SystemUserRoleId,
 	}
@@ -9308,6 +9318,7 @@ func TestResetPasswordFailedAttempts(t *testing.T) {
 	th.SetupLdapConfig()
 
 	th.App.Srv().SetLicense(model.NewTestLicense("ldap"))
+	wrongPassword := model.NewTestPassword()
 
 	t.Run("Reset password failed attempts for regular user", func(t *testing.T) {
 		client := th.CreateClient()
@@ -9319,7 +9330,7 @@ func TestResetPasswordFailedAttempts(t *testing.T) {
 		user := th.CreateUser(t)
 
 		for i := 0; i < *maxAttempts; i++ {
-			_, _, err := client.Login(context.Background(), user.Email, "wrongpassword")
+			_, _, err := client.Login(context.Background(), user.Email, wrongPassword)
 			require.Error(t, err)
 		}
 
@@ -9398,7 +9409,7 @@ func TestResetPasswordFailedAttempts(t *testing.T) {
 		user := th.CreateUser(t)
 
 		for i := 0; i < *maxAttempts; i++ {
-			_, _, err := client.Login(context.Background(), user.Email, "wrongpassword")
+			_, _, err := client.Login(context.Background(), user.Email, wrongPassword)
 			require.Error(t, err)
 		}
 
@@ -9430,7 +9441,7 @@ func TestResetPasswordFailedAttempts(t *testing.T) {
 		user := th.CreateUser(t)
 
 		for i := 0; i < *maxAttempts; i++ {
-			_, _, err := client.Login(context.Background(), user.Email, "wrongpassword")
+			_, _, err := client.Login(context.Background(), user.Email, wrongPassword)
 			require.Error(t, err)
 		}
 
@@ -9466,7 +9477,7 @@ func TestResetPasswordFailedAttempts(t *testing.T) {
 		require.Nil(t, appErr)
 
 		for i := 0; i < *maxAttempts; i++ {
-			_, _, err := client.Login(context.Background(), sysadmin.Email, "wrongpassword")
+			_, _, err := client.Login(context.Background(), sysadmin.Email, wrongPassword)
 			require.Error(t, err)
 		}
 
@@ -9498,7 +9509,7 @@ func TestResetPasswordFailedAttempts(t *testing.T) {
 		require.Nil(t, appErr)
 
 		for i := 0; i < *maxAttempts; i++ {
-			_, _, err := client.Login(context.Background(), sysadmin.Email, "wrongpassword")
+			_, _, err := client.Login(context.Background(), sysadmin.Email, wrongPassword)
 			require.Error(t, err)
 		}
 

--- a/server/channels/api4/websocket_test.go
+++ b/server/channels/api4/websocket_test.go
@@ -286,14 +286,14 @@ func TestWebSocketStatuses(t *testing.T) {
 	team := model.Team{DisplayName: "Name", Name: "z-z-" + model.NewRandomTeamName() + "a", Email: "test@nowhere.com", Type: model.TeamOpen}
 	rteam, _, _ := client.CreateTeam(context.Background(), &team)
 
-	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
+	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: model.NewTestPassword()}
 	ruser, _, err := client.CreateUser(context.Background(), &user)
 	require.NoError(t, err)
 	th.LinkUserToTeam(t, ruser, rteam)
 	_, err = th.App.Srv().Store().User().VerifyEmail(ruser.Id, ruser.Email)
 	require.NoError(t, err)
 
-	user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
+	user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: model.NewTestPassword()}
 	ruser2, _, err := client.CreateUser(context.Background(), &user2)
 	require.NoError(t, err)
 	th.LinkUserToTeam(t, ruser2, rteam)
@@ -587,7 +587,7 @@ func TestWebSocketMFAEnforcement(t *testing.T) {
 
 		// Login user (this should work for initial authentication)
 		client := th.CreateClient()
-		_, _, err := client.Login(context.Background(), user.Email, "Pa$$word11")
+		_, _, err := client.Login(context.Background(), user.Email, user.Password)
 		require.NoError(t, err)
 
 		// Create WebSocket client - initial connection succeeds, but subsequent API requests require completed MFA
@@ -633,7 +633,7 @@ func TestWebSocketMFAEnforcement(t *testing.T) {
 		user := &model.User{
 			Email:    th.GenerateTestEmail(),
 			Username: model.NewUsername(),
-			Password: "password123",
+			Password: model.NewTestPassword(),
 		}
 		ruser, _, err := th.Client.CreateUser(context.Background(), user)
 		require.NoError(t, err)

--- a/server/channels/app/authentication_test.go
+++ b/server/channels/app/authentication_test.go
@@ -76,7 +76,7 @@ func TestCheckPasswordAndAllCriteria(t *testing.T) {
 		*cfg.ServiceSettings.EnableMultifactorAuthentication = true
 	})
 
-	password := "newpassword1"
+	password := model.NewTestPassword()
 	appErr := th.App.UpdatePassword(th.Context, th.BasicUser, password)
 	require.Nil(t, appErr)
 
@@ -107,7 +107,7 @@ func TestCheckPasswordAndAllCriteria(t *testing.T) {
 		}{
 			{
 				name:          "should not breach max. login attempts when password is wrong",
-				password:      "wrong password",
+				password:      model.NewTestPassword(),
 				expectedErrID: "api.user.check_user_password.invalid.app_error",
 			},
 			{
@@ -186,6 +186,9 @@ func TestCheckLdapUserPasswordAndAllCriteria(t *testing.T) {
 	require.Nil(t, appErr)
 	user.AuthData = &authData
 
+	validPassword := model.NewTestPassword()
+	wrongPassword := model.NewTestPassword()
+
 	testCases := []struct {
 		name          string
 		password      string
@@ -194,26 +197,26 @@ func TestCheckLdapUserPasswordAndAllCriteria(t *testing.T) {
 	}{
 		{
 			name:          "valid password",
-			password:      "password",
+			password:      validPassword,
 			expectedErrID: "",
 			mockDoLogin: func() {
-				mockLdap.Mock.On("DoLogin", th.Context, authData, "password").Return(user, nil)
+				mockLdap.Mock.On("DoLogin", th.Context, authData, validPassword).Return(user, nil)
 			},
 		},
 		{
 			name:          "invalid password",
-			password:      "wrongpassword",
+			password:      wrongPassword,
 			expectedErrID: "api.user.check_user_password.invalid.app_error",
 			mockDoLogin: func() {
-				mockLdap.Mock.On("DoLogin", th.Context, authData, "wrongpassword").Return(nil, &model.AppError{Id: "ent.ldap.do_login.invalid_password.app_error"})
+				mockLdap.Mock.On("DoLogin", th.Context, authData, wrongPassword).Return(nil, &model.AppError{Id: "ent.ldap.do_login.invalid_password.app_error"})
 			},
 		},
 		{
 			name:          "too many login attempts",
-			password:      "wrongpassword",
+			password:      wrongPassword,
 			expectedErrID: "api.user.check_user_login_attempts.too_many_ldap.app_error",
 			mockDoLogin: func() {
-				mockLdap.Mock.On("DoLogin", th.Context, authData, "wrongpassword").Return(nil, &model.AppError{Id: "ent.ldap.do_login.invalid_password.app_error"}).Once()
+				mockLdap.Mock.On("DoLogin", th.Context, authData, wrongPassword).Return(nil, &model.AppError{Id: "ent.ldap.do_login.invalid_password.app_error"}).Once()
 			},
 		},
 	}
@@ -231,7 +234,7 @@ func TestCheckLdapUserPasswordAndAllCriteria(t *testing.T) {
 			// Simulate failed login attempts if necessary
 			if tc.expectedErrID == "api.user.check_user_login_attempts.too_many_ldap.app_error" {
 				for range maxFailedLoginAttempts - 1 {
-					_, appErr = th.App.checkLdapUserPasswordAndAllCriteria(th.Context, ldapUser, "wrongpassword", "")
+					_, appErr = th.App.checkLdapUserPasswordAndAllCriteria(th.Context, ldapUser, wrongPassword, "")
 					require.NotNil(t, appErr)
 					require.Equal(t, "ent.ldap.do_login.invalid_password.app_error", appErr.Id)
 				}
@@ -291,6 +294,9 @@ func TestCheckLdapUserPasswordConcurrency(t *testing.T) {
 	require.Nil(t, appErr)
 	user.AuthData = &authData
 
+	wrongPassword := model.NewTestPassword()
+	validPassword := model.NewTestPassword()
+
 	t.Run("validate concurrent failed attempts to bypass checks", func(t *testing.T) {
 		testCases := []struct {
 			name                 string
@@ -301,14 +307,14 @@ func TestCheckLdapUserPasswordConcurrency(t *testing.T) {
 		}{
 			{
 				name:                 "should not breach max. login attempts when password is wrong",
-				password:             "wrong password",
+				password:             wrongPassword,
 				mfaToken:             "",
 				doLoginExpectedErrID: "ent.ldap.do_login.invalid_password.app_error",
 				expectedErrID:        "ent.ldap.do_login.invalid_password.app_error",
 			},
 			{
 				name:                 "should not breach max. login attempts when MFA is wrong",
-				password:             "password",
+				password:             validPassword,
 				mfaToken:             "123456",
 				doLoginExpectedErrID: "",
 				expectedErrID:        "api.user.check_user_mfa.bad_code.app_error",
@@ -368,7 +374,7 @@ func TestCheckLdapUserPasswordConcurrency(t *testing.T) {
 func TestCheckUserPassword(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 
-	pwd := "testPassword123$"
+	pwd := model.NewTestPassword()
 	pwdBcryptBytes, err := bcrypt.GenerateFromPassword([]byte(pwd), 10)
 	require.NoError(t, err)
 	pwdBcrypt := string(pwdBcryptBytes)
@@ -404,10 +410,12 @@ func TestCheckUserPassword(t *testing.T) {
 		require.Nil(t, err)
 	})
 
+	wrongPassword := model.NewTestPassword()
+
 	t.Run("invalid password", func(t *testing.T) {
 		user := createUserWithHash(pwdPBKDF2)
 
-		err := th.App.checkUserPassword(user, "wrongpassword", false)
+		err := th.App.checkUserPassword(user, wrongPassword, false)
 		require.NotNil(t, err)
 		require.Equal(t, "api.user.check_user_password.invalid.app_error", err.Id)
 
@@ -437,7 +445,7 @@ func TestCheckUserPassword(t *testing.T) {
 	t.Run("password migration fails with invalid password", func(t *testing.T) {
 		user := createUserWithHash(pwdBcrypt)
 
-		err := th.App.checkUserPassword(user, "wrongpassword", false)
+		err := th.App.checkUserPassword(user, wrongPassword, false)
 		require.NotNil(t, err)
 		require.Equal(t, "api.user.check_user_password.invalid.app_error", err.Id)
 
@@ -500,7 +508,7 @@ func TestCheckUserPassword(t *testing.T) {
 func TestMigratePassword(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 
-	pwd := "testPassword123$"
+	pwd := model.NewTestPassword()
 	pwdBcryptBytes, err := bcrypt.GenerateFromPassword([]byte(pwd), 10)
 	require.NoError(t, err)
 	pwdBcrypt := string(pwdBcryptBytes)

--- a/server/channels/app/bot_test.go
+++ b/server/channels/app/bot_test.go
@@ -718,7 +718,7 @@ func TestNotifySysadminsBotOwnerDisabled(t *testing.T) {
 	sysadmin1 := model.User{
 		Email:    "sys1@example.com",
 		Nickname: "nn_sysadmin1",
-		Password: "hello1",
+		Password: model.NewTestPassword(),
 		Username: "un_sysadmin1",
 		Roles:    model.SystemAdminRoleId + " " + model.SystemUserRoleId,
 	}
@@ -730,7 +730,7 @@ func TestNotifySysadminsBotOwnerDisabled(t *testing.T) {
 	sysadmin2 := model.User{
 		Email:    "sys2@example.com",
 		Nickname: "nn_sysadmin2",
-		Password: "hello1",
+		Password: model.NewTestPassword(),
 		Username: "un_sysadmin2",
 		Roles:    model.SystemAdminRoleId + " " + model.SystemUserRoleId,
 	}
@@ -744,7 +744,7 @@ func TestNotifySysadminsBotOwnerDisabled(t *testing.T) {
 		Email:    "user1@example.com",
 		Username: "user1_disabled",
 		Nickname: "user1",
-		Password: "Password1",
+		Password: model.NewTestPassword(),
 	})
 	require.Nil(t, err, "failed to create user")
 
@@ -753,7 +753,7 @@ func TestNotifySysadminsBotOwnerDisabled(t *testing.T) {
 		Email:    "user2@example.com",
 		Username: "user2_disabled",
 		Nickname: "user2",
-		Password: "Password1",
+		Password: model.NewTestPassword(),
 	})
 	require.Nil(t, err, "failed to create user")
 
@@ -902,7 +902,7 @@ func TestConvertUserToBot(t *testing.T) {
 		oauthUser := &model.User{
 			Email:         "oauth_user@example.com",
 			Username:      "oauth_user",
-			Password:      "password",
+			Password:      model.NewTestPassword(),
 			EmailVerified: true,
 		}
 

--- a/server/channels/app/channel_test.go
+++ b/server/channels/app/channel_test.go
@@ -1404,7 +1404,7 @@ func TestGetChannelMembersTimezones(t *testing.T) {
 	_, appErr = th.App.UpdateUser(th.Context, user2, false)
 	require.Nil(t, appErr)
 
-	user3 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+	user3 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 	ruser, appErr := th.App.CreateUser(th.Context, &user3)
 	require.Nil(t, appErr)
 
@@ -1418,7 +1418,7 @@ func TestGetChannelMembersTimezones(t *testing.T) {
 	_, appErr = th.App.UpdateUser(th.Context, ruser, false)
 	require.Nil(t, appErr)
 
-	user4 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+	user4 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 	ruser, _ = th.App.CreateUser(th.Context, &user4)
 	_, appErr = th.App.AddUserToChannel(th.Context, ruser, th.BasicChannel, false)
 	require.NotNil(t, appErr, "user should not be able to join the channel without being in the team.")
@@ -1561,7 +1561,7 @@ func TestUpdateChannelMemberRolesChangingGuest(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 
 	t.Run("from guest to user", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateGuest(th.Context, &user)
 
 		_, _, appErr := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1575,7 +1575,7 @@ func TestUpdateChannelMemberRolesChangingGuest(t *testing.T) {
 	})
 
 	t.Run("from user to guest", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, appErr := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1589,7 +1589,7 @@ func TestUpdateChannelMemberRolesChangingGuest(t *testing.T) {
 	})
 
 	t.Run("from user to admin", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, appErr := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1603,7 +1603,7 @@ func TestUpdateChannelMemberRolesChangingGuest(t *testing.T) {
 	})
 
 	t.Run("from guest to guest plus custom", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateGuest(th.Context, &user)
 
 		_, _, appErr := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1620,7 +1620,7 @@ func TestUpdateChannelMemberRolesChangingGuest(t *testing.T) {
 	})
 
 	t.Run("a guest cant have user role", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateGuest(th.Context, &user)
 
 		_, _, appErr := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1639,7 +1639,7 @@ func TestUpdateChannelMemberRolesRequireUser(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 
 	t.Run("empty roles string requires user or guest scheme role", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, appErr := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1659,7 +1659,7 @@ func TestUpdateChannelMemberRolesRequireUser(t *testing.T) {
 	})
 
 	t.Run("admin role requires user or guest scheme role", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, appErr := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1674,7 +1674,7 @@ func TestUpdateChannelMemberRolesRequireUser(t *testing.T) {
 	})
 
 	t.Run("valid user and admin roles update succeeds", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, appErr := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1691,7 +1691,7 @@ func TestUpdateChannelMemberRolesRequireUser(t *testing.T) {
 	})
 
 	t.Run("removing admin role while keeping user role succeeds", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, appErr := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1984,7 +1984,7 @@ func TestAddUserToChannel(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)
 
-	user1 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+	user1 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 	ruser1, _ := th.App.CreateUser(th.Context, &user1)
 	defer func() {
 		appErr := th.App.PermanentDeleteUser(th.Context, &user1)
@@ -2024,7 +2024,7 @@ func TestAddUserToChannel(t *testing.T) {
 	require.Nil(t, appErr)
 	require.False(t, cm1.SchemeAdmin)
 
-	user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+	user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 	ruser2, _ := th.App.CreateUser(th.Context, &user2)
 	defer func() {
 		appErr = th.App.PermanentDeleteUser(th.Context, &user2)
@@ -2078,7 +2078,7 @@ func TestRemoveUserFromChannel(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)
 
-	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 	ruser, _ := th.App.CreateUser(th.Context, &user)
 	defer func() {
 		appErr := th.App.PermanentDeleteUser(th.Context, ruser)

--- a/server/channels/app/email/helper_test.go
+++ b/server/channels/app/email/helper_test.go
@@ -89,7 +89,10 @@ func setupTestHelper(s store.Store, tb testing.TB) *TestHelper {
 	*config.RateLimitSettings.Enable = false
 	*config.TeamSettings.EnableOpenServer = true
 	// Disable strict password requirements for test
-	*config.PasswordSettings.MinimumLength = 5
+	*config.PasswordSettings.MinimumLength = model.PasswordMinimumLength
+	if model.FIPSEnabled {
+		*config.PasswordSettings.MinimumLength = model.PasswordFIPSMinimumLength
+	}
 	*config.PasswordSettings.Lowercase = false
 	*config.PasswordSettings.Uppercase = false
 	*config.PasswordSettings.Symbol = false

--- a/server/channels/app/email/helper_test.go
+++ b/server/channels/app/email/helper_test.go
@@ -247,7 +247,7 @@ func (th *TestHelper) CreateUserOrGuest(tb testing.TB, guest bool) *model.User {
 		Email:         "success+" + id + "@simulator.amazonses.com",
 		Username:      "un_" + id,
 		Nickname:      "nn_" + id,
-		Password:      "Password1",
+		Password:      model.NewTestPassword(),
 		EmailVerified: true,
 	}
 

--- a/server/channels/app/email/helper_test.go
+++ b/server/channels/app/email/helper_test.go
@@ -88,15 +88,6 @@ func setupTestHelper(s store.Store, tb testing.TB) *TestHelper {
 	*config.TeamSettings.MaxUsersPerTeam = 50
 	*config.RateLimitSettings.Enable = false
 	*config.TeamSettings.EnableOpenServer = true
-	// Disable strict password requirements for test
-	*config.PasswordSettings.MinimumLength = model.PasswordMinimumLength
-	if model.FIPSEnabled {
-		*config.PasswordSettings.MinimumLength = model.PasswordFIPSMinimumLength
-	}
-	*config.PasswordSettings.Lowercase = false
-	*config.PasswordSettings.Uppercase = false
-	*config.PasswordSettings.Symbol = false
-	*config.PasswordSettings.Number = false
 	_, _, err = configStore.Set(config)
 	require.NoError(tb, err)
 

--- a/server/channels/app/helper_test.go
+++ b/server/channels/app/helper_test.go
@@ -168,18 +168,6 @@ func setupTestHelper(dbStore store.Store, sqlStore *sqlstore.SqlStore, sqlSettin
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.EnableOpenServer = true })
 
-	// Disable strict password requirements for test
-	th.App.UpdateConfig(func(cfg *model.Config) {
-		*cfg.PasswordSettings.MinimumLength = model.PasswordMinimumLength
-		if model.FIPSEnabled {
-			*cfg.PasswordSettings.MinimumLength = model.PasswordFIPSMinimumLength
-		}
-		*cfg.PasswordSettings.Lowercase = false
-		*cfg.PasswordSettings.Uppercase = false
-		*cfg.PasswordSettings.Symbol = false
-		*cfg.PasswordSettings.Number = false
-	})
-
 	tb.Cleanup(func() {
 		if th.IncludeCacheLayer {
 			// Clean all the caches

--- a/server/channels/app/helper_test.go
+++ b/server/channels/app/helper_test.go
@@ -381,7 +381,7 @@ func (th *TestHelper) CreateUserOrGuest(tb testing.TB, guest bool) *model.User {
 		Email:         "success+" + id + "@simulator.amazonses.com",
 		Username:      "un_" + id,
 		Nickname:      "nn_" + id,
-		Password:      "Password1",
+		Password:      model.NewTestPassword(),
 		EmailVerified: true,
 	}
 

--- a/server/channels/app/helper_test.go
+++ b/server/channels/app/helper_test.go
@@ -170,7 +170,10 @@ func setupTestHelper(dbStore store.Store, sqlStore *sqlstore.SqlStore, sqlSettin
 
 	// Disable strict password requirements for test
 	th.App.UpdateConfig(func(cfg *model.Config) {
-		*cfg.PasswordSettings.MinimumLength = 5
+		*cfg.PasswordSettings.MinimumLength = model.PasswordMinimumLength
+		if model.FIPSEnabled {
+			*cfg.PasswordSettings.MinimumLength = model.PasswordFIPSMinimumLength
+		}
 		*cfg.PasswordSettings.Lowercase = false
 		*cfg.PasswordSettings.Uppercase = false
 		*cfg.PasswordSettings.Symbol = false

--- a/server/channels/app/import_functions_test.go
+++ b/server/channels/app/import_functions_test.go
@@ -946,7 +946,7 @@ func TestImportImportUser(t *testing.T) {
 		assert.Equal(t, userCount, userCountCurrent, "Unexpected number of users")
 
 		// Check Password and AuthData together.
-		data.Password = model.NewPointer("PasswordTest")
+		data.Password = model.NewPointer(model.NewTestPassword())
 		appErr = th.App.importUser(th.Context, &data, false)
 		require.NotNil(t, appErr, "Should have failed to import invalid user.")
 

--- a/server/channels/app/notification_email_test.go
+++ b/server/channels/app/notification_email_test.go
@@ -762,7 +762,7 @@ func TestGetNotificationEmailBodyPublicChannelMention(t *testing.T) {
 		Email:         "success+" + id + "@simulator.amazonses.com",
 		Username:      "un_" + id,
 		Nickname:      "nn_" + id,
-		Password:      "Password1",
+		Password:      model.NewTestPassword(),
 		EmailVerified: true,
 		Locale:        "en",
 	}
@@ -879,7 +879,7 @@ func TestGetNotificationEmailBodyPrivateChannelMention(t *testing.T) {
 		Email:         "success+" + id + "@simulator.amazonses.com",
 		Username:      "un_" + id,
 		Nickname:      "nn_" + id,
-		Password:      "Password1",
+		Password:      model.NewTestPassword(),
 		EmailVerified: true,
 		Locale:        "en",
 	}

--- a/server/channels/app/notification_push_test.go
+++ b/server/channels/app/notification_push_test.go
@@ -1748,7 +1748,7 @@ func BenchmarkPushNotificationThroughput(b *testing.B) {
 			Email:         "success+" + id + "@simulator.amazonses.com",
 			Username:      "un_" + id,
 			Nickname:      "nn_" + id,
-			Password:      "Password1",
+			Password:      model.NewTestPassword(),
 			EmailVerified: true,
 		}
 		sess1 := &model.Session{

--- a/server/channels/app/password/hashers/fips.go
+++ b/server/channels/app/password/hashers/fips.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build requirefips
+
+package hashers
+
+import "github.com/mattermost/mattermost/server/public/model"
+
+// fipsMinKeyLength is the minimum PBKDF2 key length enforced by the OpenSSL 3.x
+// FIPS provider (NIST SP 800-132: PBKDF password must be at least 14 bytes).
+const fipsMinKeyLength = model.PasswordFIPSMinimumLength

--- a/server/channels/app/password/hashers/fips_default.go
+++ b/server/channels/app/password/hashers/fips_default.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build !requirefips
+
+package hashers
+
+// fipsMinKeyLength is 0 in non-FIPS builds, meaning no minimum is enforced.
+const fipsMinKeyLength = 0

--- a/server/channels/app/password/hashers/hashers_dev_test.go
+++ b/server/channels/app/password/hashers/hashers_dev_test.go
@@ -16,7 +16,7 @@ func TestSetTestHasher(t *testing.T) {
 	SetTestHasher(nil)
 
 	// Hash should work with nil testHasher (uses latestHasher)
-	hash1, err := Hash("password")
+	hash1, err := Hash("T3stP@ssw0rd!xYz")
 	require.NoError(t, err)
 	require.NotEmpty(t, hash1)
 
@@ -26,7 +26,7 @@ func TestSetTestHasher(t *testing.T) {
 	defer SetTestHasher(nil)
 
 	// Hash should now use the fast test hasher
-	hash2, err := Hash("password")
+	hash2, err := Hash("T3stP@ssw0rd!xYz")
 	require.NoError(t, err)
 	require.NotEmpty(t, hash2)
 
@@ -37,8 +37,8 @@ func TestSetTestHasher(t *testing.T) {
 	// Verify the password can be verified against the hash
 	hasher, phc, err := GetHasherFromPHCString(hash2)
 	require.NoError(t, err)
-	require.NoError(t, hasher.CompareHashAndPassword(phc, "password"))
-	require.Error(t, hasher.CompareHashAndPassword(phc, "wrongpassword"))
+	require.NoError(t, hasher.CompareHashAndPassword(phc, "T3stP@ssw0rd!xYz"))
+	require.Error(t, hasher.CompareHashAndPassword(phc, "Wr0ngP@ssw0rd!!"))
 }
 
 func TestFastTestHasher(t *testing.T) {
@@ -51,14 +51,15 @@ func TestFastTestHasher(t *testing.T) {
 	require.Equal(t, fastTestHasherWorkFactor, pbkdf2Hasher.workFactor)
 
 	// Test that it produces valid hashes
-	hash, err := hasher.Hash("testpassword")
+	testPassword := "T3stP@ssw0rd!xYz"
+	hash, err := hasher.Hash(testPassword)
 	require.NoError(t, err)
 	require.Contains(t, hash, ",w=1000,")
 
 	// Verify the hash can be validated
 	parsedHasher, phc, err := GetHasherFromPHCString(hash)
 	require.NoError(t, err)
-	require.NoError(t, parsedHasher.CompareHashAndPassword(phc, "testpassword"))
+	require.NoError(t, parsedHasher.CompareHashAndPassword(phc, testPassword))
 }
 
 func TestGetLatestHasher(t *testing.T) {

--- a/server/channels/app/password/hashers/pbkdf2.go
+++ b/server/channels/app/password/hashers/pbkdf2.go
@@ -199,6 +199,14 @@ func (p PBKDF2) CompareHashAndPassword(hash phcparser.PHC, password string) erro
 		return ErrPasswordTooLong
 	}
 
+	// Under FIPS, the OpenSSL PBKDF2 implementation requires keys of at least
+	// fipsMinKeyLength bytes. A password shorter than this can never match a
+	// stored hash, so return ErrMismatchedHashAndPassword directly rather than
+	// letting PBKDF2 fail with a generic crypto error.
+	if fipsMinKeyLength > 0 && len(password) < fipsMinKeyLength {
+		return ErrMismatchedHashAndPassword
+	}
+
 	// Validate parameters
 	if !p.IsPHCValid(hash) {
 		return fmt.Errorf("the stored password does not comply with the PBKDF2 parser's PHC serialization")

--- a/server/channels/app/password/hashers/pbkdf2_test.go
+++ b/server/channels/app/password/hashers/pbkdf2_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/v8/channels/app/password/phcparser"
 	"github.com/stretchr/testify/require"
 )
@@ -56,31 +57,32 @@ func TestPBKDF2CompareHashAndPassword(t *testing.T) {
 		storedPwd   string
 		inputPwd    string
 		expectedErr error
+		skipFIPS    bool
 	}{
 		{
-
-			"empty password",
-			"",
-			"",
-			nil,
+			testName:    "empty password",
+			storedPwd:   "",
+			inputPwd:    "",
+			expectedErr: nil,
+			skipFIPS:    true,
 		},
 		{
-			"same password",
-			"one password",
-			"one password",
-			nil,
+			testName:    "same password",
+			storedPwd:   "one password!!!",
+			inputPwd:    "one password!!!",
+			expectedErr: nil,
 		},
 		{
-			"different password",
-			"one password",
-			"another password",
-			ErrMismatchedHashAndPassword,
+			testName:    "different password",
+			storedPwd:   "one password!!!",
+			inputPwd:    "another password",
+			expectedErr: ErrMismatchedHashAndPassword,
 		},
 		{
-			"password too long",
-			"stored password",
-			string(passwordTooLong),
-			ErrPasswordTooLong,
+			testName:    "password too long",
+			storedPwd:   "stored password",
+			inputPwd:    string(passwordTooLong),
+			expectedErr: ErrPasswordTooLong,
 		},
 	}
 
@@ -88,6 +90,9 @@ func TestPBKDF2CompareHashAndPassword(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
+			if tc.skipFIPS && model.FIPSEnabled {
+				t.Skip("skipping under FIPS: PBKDF2 requires keys >= 14 bytes")
+			}
 			storedPHCStr, err := hasher.Hash(tc.storedPwd)
 			require.NoError(t, err)
 

--- a/server/channels/app/platform/helper_test.go
+++ b/server/channels/app/platform/helper_test.go
@@ -203,18 +203,6 @@ func setupTestHelper(dbStore store.Store, dbSettings *model.SqlSettings, enterpr
 		*cfg.TeamSettings.EnableOpenServer = true
 	})
 
-	// Disable strict password requirements for test
-	th.Service.UpdateConfig(func(cfg *model.Config) {
-		*cfg.PasswordSettings.MinimumLength = model.PasswordMinimumLength
-		if model.FIPSEnabled {
-			*cfg.PasswordSettings.MinimumLength = model.PasswordFIPSMinimumLength
-		}
-		*cfg.PasswordSettings.Lowercase = false
-		*cfg.PasswordSettings.Uppercase = false
-		*cfg.PasswordSettings.Symbol = false
-		*cfg.PasswordSettings.Number = false
-	})
-
 	if enterprise {
 		th.Service.SetLicense(model.NewTestLicense())
 	} else {

--- a/server/channels/app/platform/helper_test.go
+++ b/server/channels/app/platform/helper_test.go
@@ -268,7 +268,7 @@ func (th *TestHelper) CreateUserOrGuest(tb testing.TB, guest bool) *model.User {
 		Email:         "success+" + id + "@simulator.amazonses.com",
 		Username:      "un_" + id,
 		Nickname:      "nn_" + id,
-		Password:      "Password1",
+		Password:      model.NewTestPassword(),
 		EmailVerified: true,
 		Roles:         model.SystemUserRoleId,
 	}
@@ -286,7 +286,7 @@ func (th *TestHelper) CreateAdmin(tb testing.TB) *model.User {
 		Email:         "success+" + id + "@simulator.amazonses.com",
 		Username:      "un_" + id,
 		Nickname:      "nn_" + id,
-		Password:      "Password1",
+		Password:      model.NewTestPassword(),
 		EmailVerified: true,
 		Roles:         model.SystemAdminRoleId + " " + model.SystemUserRoleId,
 	}

--- a/server/channels/app/platform/helper_test.go
+++ b/server/channels/app/platform/helper_test.go
@@ -205,7 +205,10 @@ func setupTestHelper(dbStore store.Store, dbSettings *model.SqlSettings, enterpr
 
 	// Disable strict password requirements for test
 	th.Service.UpdateConfig(func(cfg *model.Config) {
-		*cfg.PasswordSettings.MinimumLength = 5
+		*cfg.PasswordSettings.MinimumLength = model.PasswordMinimumLength
+		if model.FIPSEnabled {
+			*cfg.PasswordSettings.MinimumLength = model.PasswordFIPSMinimumLength
+		}
 		*cfg.PasswordSettings.Lowercase = false
 		*cfg.PasswordSettings.Uppercase = false
 		*cfg.PasswordSettings.Symbol = false

--- a/server/channels/app/plugin_api_test.go
+++ b/server/channels/app/plugin_api_test.go
@@ -219,7 +219,7 @@ func TestPluginAPIGetUserPreferences(t *testing.T) {
 
 	user1, err := th.App.CreateUser(th.Context, &model.User{
 		Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
-		Password: "password",
+		Password: model.NewTestPassword(),
 		Username: "user1" + model.NewId(),
 	})
 	require.Nil(t, err)
@@ -253,7 +253,7 @@ func TestPluginAPIDeleteUserPreferences(t *testing.T) {
 
 	user1, err := th.App.CreateUser(th.Context, &model.User{
 		Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
-		Password: "password",
+		Password: model.NewTestPassword(),
 		Username: "user1" + model.NewId(),
 	})
 	require.Nil(t, err)
@@ -274,7 +274,7 @@ func TestPluginAPIDeleteUserPreferences(t *testing.T) {
 
 	user2, err := th.App.CreateUser(th.Context, &model.User{
 		Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
-		Password: "password",
+		Password: model.NewTestPassword(),
 		Username: "user2" + model.NewId(),
 	})
 	require.Nil(t, err)
@@ -315,7 +315,7 @@ func TestPluginAPIUpdateUserPreferences(t *testing.T) {
 
 	user1, err := th.App.CreateUser(th.Context, &model.User{
 		Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
-		Password: "password",
+		Password: model.NewTestPassword(),
 		Username: "user1" + model.NewId(),
 	})
 	require.Nil(t, err)
@@ -367,7 +367,7 @@ func TestPluginAPIGetUsers(t *testing.T) {
 
 	user1, err := th.App.CreateUser(th.Context, &model.User{
 		Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
-		Password: "password",
+		Password: model.NewTestPassword(),
 		Username: "user1" + model.NewId(),
 	})
 	require.Nil(t, err)
@@ -378,7 +378,7 @@ func TestPluginAPIGetUsers(t *testing.T) {
 
 	user2, err := th.App.CreateUser(th.Context, &model.User{
 		Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
-		Password: "password",
+		Password: model.NewTestPassword(),
 		Username: "user2" + model.NewId(),
 	})
 	require.Nil(t, err)
@@ -389,7 +389,7 @@ func TestPluginAPIGetUsers(t *testing.T) {
 
 	user3, err := th.App.CreateUser(th.Context, &model.User{
 		Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
-		Password: "password",
+		Password: model.NewTestPassword(),
 		Username: "user3" + model.NewId(),
 	})
 	require.Nil(t, err)
@@ -400,7 +400,7 @@ func TestPluginAPIGetUsers(t *testing.T) {
 
 	user4, err := th.App.CreateUser(th.Context, &model.User{
 		Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
-		Password: "password",
+		Password: model.NewTestPassword(),
 		Username: "user4" + model.NewId(),
 	})
 	require.Nil(t, err)
@@ -467,7 +467,7 @@ func TestPluginAPIGetUsersByIds(t *testing.T) {
 
 	user1, err := th.App.CreateUser(th.Context, &model.User{
 		Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
-		Password: "password",
+		Password: model.NewTestPassword(),
 		Username: "user1" + model.NewId(),
 	})
 	require.Nil(t, err)
@@ -478,7 +478,7 @@ func TestPluginAPIGetUsersByIds(t *testing.T) {
 
 	user2, err := th.App.CreateUser(th.Context, &model.User{
 		Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
-		Password: "password",
+		Password: model.NewTestPassword(),
 		Username: "user2" + model.NewId(),
 	})
 	require.Nil(t, err)
@@ -489,7 +489,7 @@ func TestPluginAPIGetUsersByIds(t *testing.T) {
 
 	user3, err := th.App.CreateUser(th.Context, &model.User{
 		Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
-		Password: "password",
+		Password: model.NewTestPassword(),
 		Username: "user3" + model.NewId(),
 	})
 	require.Nil(t, err)
@@ -535,7 +535,7 @@ func TestPluginAPIGetUsersInTeam(t *testing.T) {
 
 	user1, err := th.App.CreateUser(th.Context, &model.User{
 		Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
-		Password: "password",
+		Password: model.NewTestPassword(),
 		Username: "user1" + model.NewId(),
 	})
 	require.Nil(t, err)
@@ -546,7 +546,7 @@ func TestPluginAPIGetUsersInTeam(t *testing.T) {
 
 	user2, err := th.App.CreateUser(th.Context, &model.User{
 		Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
-		Password: "password",
+		Password: model.NewTestPassword(),
 		Username: "user2" + model.NewId(),
 	})
 	require.Nil(t, err)
@@ -557,7 +557,7 @@ func TestPluginAPIGetUsersInTeam(t *testing.T) {
 
 	user3, err := th.App.CreateUser(th.Context, &model.User{
 		Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
-		Password: "password",
+		Password: model.NewTestPassword(),
 		Username: "user3" + model.NewId(),
 	})
 	require.Nil(t, err)
@@ -568,7 +568,7 @@ func TestPluginAPIGetUsersInTeam(t *testing.T) {
 
 	user4, err := th.App.CreateUser(th.Context, &model.User{
 		Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
-		Password: "password",
+		Password: model.NewTestPassword(),
 		Username: "user4" + model.NewId(),
 	})
 	require.Nil(t, err)
@@ -662,7 +662,7 @@ func TestPluginAPIUserCustomStatus(t *testing.T) {
 	user1, err := th.App.CreateUser(th.Context, &model.User{
 		Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
 		Username: "user_" + model.NewId(),
-		Password: "password",
+		Password: model.NewTestPassword(),
 	})
 	require.Nil(t, err)
 	defer func() {
@@ -2242,7 +2242,7 @@ func TestAPIMetrics(t *testing.T) {
 			Email:       model.NewId() + "success+test@example.com",
 			Nickname:    "Darth Vader1",
 			Username:    "vader" + model.NewId(),
-			Password:    "passwd1",
+			Password:    model.NewTestPassword(),
 			AuthService: "",
 		}
 		_, appErr := th.App.CreateUser(th.Context, user1)

--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -718,7 +718,7 @@ func TestUserWillLogIn_Blocked(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)
 
-	err := th.App.UpdatePassword(th.Context, th.BasicUser, "hunter2")
+	err := th.App.UpdatePassword(th.Context, th.BasicUser, model.NewTestPassword())
 	assert.Nil(t, err, "Error updating user password: %s", err)
 	tearDown, _, _ := SetAppEnvironmentWithPlugins(t,
 		[]string{
@@ -757,7 +757,7 @@ func TestUserWillLogInIn_Passed(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)
 
-	err := th.App.UpdatePassword(th.Context, th.BasicUser, "hunter2")
+	err := th.App.UpdatePassword(th.Context, th.BasicUser, model.NewTestPassword())
 
 	assert.Nil(t, err, "Error updating user password: %s", err)
 
@@ -799,7 +799,7 @@ func TestUserHasLoggedIn(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)
 
-	err := th.App.UpdatePassword(th.Context, th.BasicUser, "hunter2")
+	err := th.App.UpdatePassword(th.Context, th.BasicUser, model.NewTestPassword())
 
 	assert.Nil(t, err, "Error updating user password: %s", err)
 
@@ -876,7 +876,7 @@ func TestUserHasBeenDeactivated(t *testing.T) {
 		Email:    "success+test@example.com",
 		Nickname: "testnickname",
 		Username: "testusername",
-		Password: "testpassword",
+		Password: model.NewTestPassword(),
 	}
 
 	_, err := th.App.CreateUser(th.Context, user)
@@ -925,7 +925,7 @@ func TestUserHasBeenCreated(t *testing.T) {
 		Email:    "success+test@example.com",
 		Nickname: "testnickname",
 		Username: "testusername",
-		Password: "testpassword",
+		Password: model.NewTestPassword(),
 	}
 	_, err := th.App.CreateUser(th.Context, user)
 	require.Nil(t, err)
@@ -1113,7 +1113,7 @@ func TestActiveHooks(t *testing.T) {
 			Email:    "success+test@example.com",
 			Nickname: "testnickname",
 			Username: "testusername",
-			Password: "testpassword",
+			Password: model.NewTestPassword(),
 		}
 		_, appErr := th.App.CreateUser(th.Context, user1)
 		require.Nil(t, appErr)
@@ -1218,7 +1218,7 @@ func TestHookMetrics(t *testing.T) {
 			Email:       "success+test@example.com",
 			Nickname:    "testnickname",
 			Username:    "testusername",
-			Password:    "testpassword",
+			Password:    model.NewTestPassword(),
 			AuthService: "",
 		}
 		_, appErr := th.App.CreateUser(th.Context, user1)

--- a/server/channels/app/post_metadata_test.go
+++ b/server/channels/app/post_metadata_test.go
@@ -1027,7 +1027,7 @@ func TestPreparePostForClientWithImageProxy(t *testing.T) {
 			*cfg.ImageProxySettings.Enable = true
 			*cfg.ImageProxySettings.ImageProxyType = "atmos/camo"
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"
-			*cfg.ImageProxySettings.RemoteImageProxyOptions = "foo"
+			*cfg.ImageProxySettings.RemoteImageProxyOptions = model.NewTestPassword()
 		})
 
 		th.App.ch.imageProxy = imageproxy.MakeImageProxy(th.Server.platform, th.Server.HTTPService(), th.Server.Log())

--- a/server/channels/app/post_test.go
+++ b/server/channels/app/post_test.go
@@ -750,7 +750,7 @@ func TestImageProxy(t *testing.T) {
 		"atmos/camo": {
 			ProxyType:              model.ImageProxyTypeAtmosCamo,
 			ProxyURL:               "https://127.0.0.1",
-			ProxyOptions:           "foo",
+			ProxyOptions:           "test-hmac-key-fips",
 			ImageURL:               "http://mydomain.com/myimage",
 			ProxiedRemovedImageURL: "http://mydomain.com/myimage",
 			ProxiedImageURL:        "http://mymattermost.com/api/v4/image?url=http%3A%2F%2Fmydomain.com%2Fmyimage",
@@ -758,7 +758,7 @@ func TestImageProxy(t *testing.T) {
 		"atmos/camo_SameSite": {
 			ProxyType:              model.ImageProxyTypeAtmosCamo,
 			ProxyURL:               "https://127.0.0.1",
-			ProxyOptions:           "foo",
+			ProxyOptions:           "test-hmac-key-fips",
 			ImageURL:               "http://mymattermost.com/myimage",
 			ProxiedRemovedImageURL: "http://mymattermost.com/myimage",
 			ProxiedImageURL:        "http://mymattermost.com/myimage",
@@ -766,7 +766,7 @@ func TestImageProxy(t *testing.T) {
 		"atmos/camo_PathOnly": {
 			ProxyType:              model.ImageProxyTypeAtmosCamo,
 			ProxyURL:               "https://127.0.0.1",
-			ProxyOptions:           "foo",
+			ProxyOptions:           "test-hmac-key-fips",
 			ImageURL:               "/myimage",
 			ProxiedRemovedImageURL: "http://mymattermost.com/myimage",
 			ProxiedImageURL:        "http://mymattermost.com/myimage",
@@ -774,7 +774,7 @@ func TestImageProxy(t *testing.T) {
 		"atmos/camo_EmptyImageURL": {
 			ProxyType:              model.ImageProxyTypeAtmosCamo,
 			ProxyURL:               "https://127.0.0.1",
-			ProxyOptions:           "foo",
+			ProxyOptions:           "test-hmac-key-fips",
 			ImageURL:               "",
 			ProxiedRemovedImageURL: "",
 			ProxiedImageURL:        "",
@@ -961,8 +961,9 @@ func TestCreatePost(t *testing.T) {
 			*cfg.ImageProxySettings.Enable = true
 			*cfg.ImageProxySettings.ImageProxyType = "atmos/camo"
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"
-			*cfg.ImageProxySettings.RemoteImageProxyOptions = "foo"
+			*cfg.ImageProxySettings.RemoteImageProxyOptions = "test-hmac-key-fips"
 		})
+		require.True(t, *th.App.Config().ImageProxySettings.Enable, "UpdateConfig must have applied the image proxy settings")
 
 		th.App.ch.imageProxy = imageproxy.MakeImageProxy(th.Server.platform, th.Server.HTTPService(), th.Server.Log())
 
@@ -1448,8 +1449,9 @@ func TestPatchPost(t *testing.T) {
 			*cfg.ImageProxySettings.Enable = true
 			*cfg.ImageProxySettings.ImageProxyType = "atmos/camo"
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"
-			*cfg.ImageProxySettings.RemoteImageProxyOptions = "foo"
+			*cfg.ImageProxySettings.RemoteImageProxyOptions = "test-hmac-key-fips"
 		})
+		require.True(t, *th.App.Config().ImageProxySettings.Enable, "UpdateConfig must have applied the image proxy settings")
 
 		th.App.ch.imageProxy = imageproxy.MakeImageProxy(th.Server.platform, th.Server.HTTPService(), th.Server.Log())
 
@@ -1903,8 +1905,9 @@ func TestUpdatePost(t *testing.T) {
 			*cfg.ImageProxySettings.Enable = true
 			*cfg.ImageProxySettings.ImageProxyType = "atmos/camo"
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"
-			*cfg.ImageProxySettings.RemoteImageProxyOptions = "foo"
+			*cfg.ImageProxySettings.RemoteImageProxyOptions = "test-hmac-key-fips"
 		})
+		require.True(t, *th.App.Config().ImageProxySettings.Enable, "UpdateConfig must have applied the image proxy settings")
 
 		th.App.ch.imageProxy = imageproxy.MakeImageProxy(th.Server.platform, th.Server.HTTPService(), th.Server.Log())
 
@@ -3150,7 +3153,7 @@ func TestFillInPostProps(t *testing.T) {
 			Email:         "success+" + id + "@simulator.amazonses.com",
 			Username:      "un_" + id,
 			Nickname:      "nn_" + id,
-			Password:      "Password1",
+			Password:      model.NewTestPassword(),
 			EmailVerified: true,
 		}
 		guest, err := th.App.CreateGuest(th.Context, guest)
@@ -3184,7 +3187,7 @@ func TestFillInPostProps(t *testing.T) {
 			Email:         "success+" + id + "@simulator.amazonses.com",
 			Username:      "un_" + id,
 			Nickname:      "nn_" + id,
-			Password:      "Password1",
+			Password:      model.NewTestPassword(),
 			EmailVerified: true,
 		}
 		guest, err := th.App.CreateGuest(th.Context, guest)

--- a/server/channels/app/post_test.go
+++ b/server/channels/app/post_test.go
@@ -739,6 +739,8 @@ func TestImageProxy(t *testing.T) {
 
 	th.App.ch.imageProxy = imageproxy.MakeImageProxy(th.Server.platform, th.Server.HTTPService(), th.Server.Log())
 
+	testHMACKey := model.NewTestPassword()
+
 	for name, tc := range map[string]struct {
 		ProxyType              string
 		ProxyURL               string
@@ -750,7 +752,7 @@ func TestImageProxy(t *testing.T) {
 		"atmos/camo": {
 			ProxyType:              model.ImageProxyTypeAtmosCamo,
 			ProxyURL:               "https://127.0.0.1",
-			ProxyOptions:           "test-hmac-key-fips",
+			ProxyOptions:           testHMACKey,
 			ImageURL:               "http://mydomain.com/myimage",
 			ProxiedRemovedImageURL: "http://mydomain.com/myimage",
 			ProxiedImageURL:        "http://mymattermost.com/api/v4/image?url=http%3A%2F%2Fmydomain.com%2Fmyimage",
@@ -758,7 +760,7 @@ func TestImageProxy(t *testing.T) {
 		"atmos/camo_SameSite": {
 			ProxyType:              model.ImageProxyTypeAtmosCamo,
 			ProxyURL:               "https://127.0.0.1",
-			ProxyOptions:           "test-hmac-key-fips",
+			ProxyOptions:           testHMACKey,
 			ImageURL:               "http://mymattermost.com/myimage",
 			ProxiedRemovedImageURL: "http://mymattermost.com/myimage",
 			ProxiedImageURL:        "http://mymattermost.com/myimage",
@@ -766,7 +768,7 @@ func TestImageProxy(t *testing.T) {
 		"atmos/camo_PathOnly": {
 			ProxyType:              model.ImageProxyTypeAtmosCamo,
 			ProxyURL:               "https://127.0.0.1",
-			ProxyOptions:           "test-hmac-key-fips",
+			ProxyOptions:           testHMACKey,
 			ImageURL:               "/myimage",
 			ProxiedRemovedImageURL: "http://mymattermost.com/myimage",
 			ProxiedImageURL:        "http://mymattermost.com/myimage",
@@ -774,7 +776,7 @@ func TestImageProxy(t *testing.T) {
 		"atmos/camo_EmptyImageURL": {
 			ProxyType:              model.ImageProxyTypeAtmosCamo,
 			ProxyURL:               "https://127.0.0.1",
-			ProxyOptions:           "test-hmac-key-fips",
+			ProxyOptions:           testHMACKey,
 			ImageURL:               "",
 			ProxiedRemovedImageURL: "",
 			ProxiedImageURL:        "",
@@ -961,9 +963,8 @@ func TestCreatePost(t *testing.T) {
 			*cfg.ImageProxySettings.Enable = true
 			*cfg.ImageProxySettings.ImageProxyType = "atmos/camo"
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"
-			*cfg.ImageProxySettings.RemoteImageProxyOptions = "test-hmac-key-fips"
+			*cfg.ImageProxySettings.RemoteImageProxyOptions = model.NewTestPassword()
 		})
-		require.True(t, *th.App.Config().ImageProxySettings.Enable, "UpdateConfig must have applied the image proxy settings")
 
 		th.App.ch.imageProxy = imageproxy.MakeImageProxy(th.Server.platform, th.Server.HTTPService(), th.Server.Log())
 
@@ -1449,9 +1450,8 @@ func TestPatchPost(t *testing.T) {
 			*cfg.ImageProxySettings.Enable = true
 			*cfg.ImageProxySettings.ImageProxyType = "atmos/camo"
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"
-			*cfg.ImageProxySettings.RemoteImageProxyOptions = "test-hmac-key-fips"
+			*cfg.ImageProxySettings.RemoteImageProxyOptions = model.NewTestPassword()
 		})
-		require.True(t, *th.App.Config().ImageProxySettings.Enable, "UpdateConfig must have applied the image proxy settings")
 
 		th.App.ch.imageProxy = imageproxy.MakeImageProxy(th.Server.platform, th.Server.HTTPService(), th.Server.Log())
 
@@ -1905,9 +1905,8 @@ func TestUpdatePost(t *testing.T) {
 			*cfg.ImageProxySettings.Enable = true
 			*cfg.ImageProxySettings.ImageProxyType = "atmos/camo"
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"
-			*cfg.ImageProxySettings.RemoteImageProxyOptions = "test-hmac-key-fips"
+			*cfg.ImageProxySettings.RemoteImageProxyOptions = model.NewTestPassword()
 		})
-		require.True(t, *th.App.Config().ImageProxySettings.Enable, "UpdateConfig must have applied the image proxy settings")
 
 		th.App.ch.imageProxy = imageproxy.MakeImageProxy(th.Server.platform, th.Server.HTTPService(), th.Server.Log())
 

--- a/server/channels/app/properties/helper_test.go
+++ b/server/channels/app/properties/helper_test.go
@@ -120,7 +120,7 @@ func (th *TestHelper) CreateUser(tb testing.TB) *model.User {
 		Email:         "success+" + id + "@simulator.amazonses.com",
 		Username:      "un_" + id,
 		Nickname:      "nn_" + id,
-		Password:      "Password1",
+		Password:      model.NewTestPassword(),
 		EmailVerified: true,
 	}
 	user, err := th.dbStore.User().Save(th.Context, user)

--- a/server/channels/app/shared_channel_global_user_sync_self_referential_test.go
+++ b/server/channels/app/shared_channel_global_user_sync_self_referential_test.go
@@ -1192,7 +1192,7 @@ func TestSharedChannelGlobalUserSyncSelfReferential(t *testing.T) {
 		syncedUserOnB := &model.User{
 			Email:    model.NewId() + "@example.com",
 			Username: originalUser.Username + "_" + clusterB.Name, // Munged username
-			Password: "password",
+			Password: model.NewTestPassword(),
 			RemoteId: &clusterB.RemoteId, // This would be A's cluster ID on the actual B server
 			UpdateAt: model.GetMillis(),
 		}

--- a/server/channels/app/slashcommands/auto_constants.go
+++ b/server/channels/app/slashcommands/auto_constants.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	UserPassword         = "Usr@MMTest123"
+	UserPassword         = "Usr@MMTest12345"
 	ChannelType          = model.ChannelTypeOpen
 	BTestTeamDisplayName = "TestTeam"
 	BTestTeamName        = "z-z-testdomaina"
@@ -17,7 +17,7 @@ const (
 	BTestTeamType        = model.TeamOpen
 	BTestUserName        = "Mr. Testing Tester"
 	BTestUserEmail       = "success+ttester@simulator.amazonses.com"
-	BTestUserPassword    = "passwd"
+	BTestUserPassword    = "Passwd+Us3r1234"
 )
 
 var (

--- a/server/channels/app/slashcommands/helper_test.go
+++ b/server/channels/app/slashcommands/helper_test.go
@@ -249,7 +249,7 @@ func (th *TestHelper) createUserOrGuest(tb testing.TB, guest bool) *model.User {
 		Email:         "success+" + id + "@simulator.amazonses.com",
 		Username:      "un_" + id,
 		Nickname:      "nn_" + id,
-		Password:      "Password1",
+		Password:      model.NewTestPassword(),
 		EmailVerified: true,
 	}
 

--- a/server/channels/app/slashcommands/helper_test.go
+++ b/server/channels/app/slashcommands/helper_test.go
@@ -131,7 +131,10 @@ func setupTestHelper(dbStore store.Store, enterprise bool, includeCacheLayer boo
 
 	// Disable strict password requirements for test
 	th.App.UpdateConfig(func(cfg *model.Config) {
-		*cfg.PasswordSettings.MinimumLength = 5
+		*cfg.PasswordSettings.MinimumLength = model.PasswordMinimumLength
+		if model.FIPSEnabled {
+			*cfg.PasswordSettings.MinimumLength = model.PasswordFIPSMinimumLength
+		}
 		*cfg.PasswordSettings.Lowercase = false
 		*cfg.PasswordSettings.Uppercase = false
 		*cfg.PasswordSettings.Symbol = false

--- a/server/channels/app/slashcommands/helper_test.go
+++ b/server/channels/app/slashcommands/helper_test.go
@@ -129,18 +129,6 @@ func setupTestHelper(dbStore store.Store, enterprise bool, includeCacheLayer boo
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.EnableOpenServer = true })
 
-	// Disable strict password requirements for test
-	th.App.UpdateConfig(func(cfg *model.Config) {
-		*cfg.PasswordSettings.MinimumLength = model.PasswordMinimumLength
-		if model.FIPSEnabled {
-			*cfg.PasswordSettings.MinimumLength = model.PasswordFIPSMinimumLength
-		}
-		*cfg.PasswordSettings.Lowercase = false
-		*cfg.PasswordSettings.Uppercase = false
-		*cfg.PasswordSettings.Symbol = false
-		*cfg.PasswordSettings.Number = false
-	})
-
 	tb.Cleanup(func() {
 		if th.IncludeCacheLayer {
 			// Clean all the caches

--- a/server/channels/app/team_test.go
+++ b/server/channels/app/team_test.go
@@ -84,7 +84,7 @@ func TestAddUserToTeam(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 
 	t.Run("add user", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 		defer func() {
 			appErr := th.App.PermanentDeleteUser(th.Context, &user)
@@ -100,7 +100,7 @@ func TestAddUserToTeam(t *testing.T) {
 		_, err := th.App.UpdateTeam(th.BasicTeam)
 		require.Nil(t, err, "Should update the team")
 
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 		defer func() {
 			appErr := th.App.PermanentDeleteUser(th.Context, &user)
@@ -116,7 +116,7 @@ func TestAddUserToTeam(t *testing.T) {
 		_, err := th.App.UpdateTeam(th.BasicTeam)
 		require.Nil(t, err, "Should update the team")
 
-		user := model.User{Email: strings.ToLower(model.NewId()) + "test@invalid.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "test@invalid.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, err := th.App.CreateUser(th.Context, &user)
 		require.Nil(t, err, "Error creating user: %s", err)
 		defer func() {
@@ -156,7 +156,7 @@ func TestAddUserToTeam(t *testing.T) {
 		_, err := th.App.UpdateTeam(th.BasicTeam)
 		require.Nil(t, err, "Should update the team")
 
-		user := model.User{Email: strings.ToLower(model.NewId()) + "test@invalid.example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "test@invalid.example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 		defer func() {
 			appErr := th.App.PermanentDeleteUser(th.Context, &user)
@@ -173,13 +173,13 @@ func TestAddUserToTeam(t *testing.T) {
 		_, err := th.App.UpdateTeam(th.BasicTeam)
 		require.Nil(t, err, "Should update the team")
 
-		user1 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@foo.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user1 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@foo.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser1, _ := th.App.CreateUser(th.Context, &user1)
 
-		user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@bar.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@bar.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser2, _ := th.App.CreateUser(th.Context, &user2)
 
-		user3 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@invalid.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user3 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@invalid.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser3, _ := th.App.CreateUser(th.Context, &user3)
 
 		defer func() {
@@ -226,7 +226,7 @@ func TestAddUserToTeamByToken(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)
 
-	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 	ruser, _ := th.App.CreateUser(th.Context, &user)
 	rguest := th.CreateGuest(t)
 
@@ -445,7 +445,7 @@ func TestAddUserToTeamByToken(t *testing.T) {
 			_, _ = th.App.UpdateTeam(th.BasicTeam)
 		}()
 
-		user := model.User{Email: strings.ToLower(model.NewId()) + "test@invalid.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "test@invalid.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 		defer func() {
 			appErr := th.App.PermanentDeleteUser(th.Context, &user)
@@ -572,7 +572,7 @@ func TestAddUserToTeamByTeamId(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 
 	t.Run("add user", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		err := th.App.AddUserToTeamByTeamId(th.Context, th.BasicTeam.Id, ruser)
@@ -588,7 +588,7 @@ func TestAddUserToTeamByTeamId(t *testing.T) {
 			_, _ = th.App.UpdateTeam(th.BasicTeam)
 		}()
 
-		user := model.User{Email: strings.ToLower(model.NewId()) + "test@invalid.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "test@invalid.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 		defer func() {
 			appErr := th.App.PermanentDeleteUser(th.Context, &user)
@@ -1027,7 +1027,7 @@ func TestJoinUserToTeam(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.MaxUsersPerTeam = &one })
 
 	t.Run("new join", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 		defer func() {
 			appErr := th.App.PermanentDeleteUser(th.Context, &user)
@@ -1039,9 +1039,9 @@ func TestJoinUserToTeam(t *testing.T) {
 	})
 
 	t.Run("new join with limit problem", func(t *testing.T) {
-		user1 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user1 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser1, _ := th.App.CreateUser(th.Context, &user1)
-		user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser2, _ := th.App.CreateUser(th.Context, &user2)
 
 		defer func() {
@@ -1061,10 +1061,10 @@ func TestJoinUserToTeam(t *testing.T) {
 	})
 
 	t.Run("re-join after leaving with limit problem", func(t *testing.T) {
-		user1 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user1 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser1, _ := th.App.CreateUser(th.Context, &user1)
 
-		user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser2, _ := th.App.CreateUser(th.Context, &user2)
 
 		defer func() {
@@ -1088,7 +1088,7 @@ func TestJoinUserToTeam(t *testing.T) {
 	})
 
 	t.Run("new join with correct scheme_admin value from group syncable", func(t *testing.T) {
-		user1 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user1 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser1, _ := th.App.CreateUser(th.Context, &user1)
 		defer func() {
 			appErr := th.App.PermanentDeleteUser(th.Context, &user1)
@@ -1115,7 +1115,7 @@ func TestJoinUserToTeam(t *testing.T) {
 		require.Nil(t, appErr)
 		require.False(t, tm1.SchemeAdmin)
 
-		user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser2, _ := th.App.CreateUser(th.Context, &user2)
 		defer func() {
 			appErr = th.App.PermanentDeleteUser(th.Context, &user2)
@@ -1287,7 +1287,7 @@ func TestGetTeamMembers(t *testing.T) {
 		user := model.User{
 			Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
 			Username: fmt.Sprintf("user%v", i),
-			Password: "passwd1",
+			Password: model.NewTestPassword(),
 			DeleteAt: int64(rand.Intn(2)),
 		}
 		ruser, err := th.App.CreateUser(th.Context, &user)
@@ -1455,7 +1455,7 @@ func TestUpdateTeamMemberRolesChangingGuest(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 
 	t.Run("from guest to user", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateGuest(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1466,7 +1466,7 @@ func TestUpdateTeamMemberRolesChangingGuest(t *testing.T) {
 	})
 
 	t.Run("from user to guest", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1477,7 +1477,7 @@ func TestUpdateTeamMemberRolesChangingGuest(t *testing.T) {
 	})
 
 	t.Run("from user to admin", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1488,7 +1488,7 @@ func TestUpdateTeamMemberRolesChangingGuest(t *testing.T) {
 	})
 
 	t.Run("from guest to guest plus custom", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateGuest(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1502,7 +1502,7 @@ func TestUpdateTeamMemberRolesChangingGuest(t *testing.T) {
 	})
 
 	t.Run("a guest cant have user role", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateGuest(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1518,7 +1518,7 @@ func TestUpdateTeamMemberRolesRequireUser(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 
 	t.Run("empty roles string requires user or guest scheme role", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1535,7 +1535,7 @@ func TestUpdateTeamMemberRolesRequireUser(t *testing.T) {
 	})
 
 	t.Run("admin role requires user or guest scheme role", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1547,7 +1547,7 @@ func TestUpdateTeamMemberRolesRequireUser(t *testing.T) {
 	})
 
 	t.Run("valid user and admin roles update succeeds", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1561,7 +1561,7 @@ func TestUpdateTeamMemberRolesRequireUser(t *testing.T) {
 	})
 
 	t.Run("removing admin role while keeping user role succeeds", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1577,7 +1577,7 @@ func TestUpdateTeamMemberRolesRequireUser(t *testing.T) {
 	})
 
 	t.Run("team_post_all alone should fail", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1589,7 +1589,7 @@ func TestUpdateTeamMemberRolesRequireUser(t *testing.T) {
 	})
 
 	t.Run("team_post_all_public alone should fail", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1601,7 +1601,7 @@ func TestUpdateTeamMemberRolesRequireUser(t *testing.T) {
 	})
 
 	t.Run("system_post_all alone should fail", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1613,7 +1613,7 @@ func TestUpdateTeamMemberRolesRequireUser(t *testing.T) {
 	})
 
 	t.Run("system_user_manager alone should fail", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1625,7 +1625,7 @@ func TestUpdateTeamMemberRolesRequireUser(t *testing.T) {
 	})
 
 	t.Run("multiple non-scheme-managed roles without user scheme should fail", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1637,7 +1637,7 @@ func TestUpdateTeamMemberRolesRequireUser(t *testing.T) {
 	})
 
 	t.Run("team_post_all with team_user should succeed", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1650,7 +1650,7 @@ func TestUpdateTeamMemberRolesRequireUser(t *testing.T) {
 	})
 
 	t.Run("team_post_all_public with team_user should succeed", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1663,7 +1663,7 @@ func TestUpdateTeamMemberRolesRequireUser(t *testing.T) {
 	})
 
 	t.Run("multiple explicit roles with team_user should succeed", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
@@ -1677,7 +1677,7 @@ func TestUpdateTeamMemberRolesRequireUser(t *testing.T) {
 	})
 
 	t.Run("explicit role with admin should succeed", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser, _ := th.App.CreateUser(th.Context, &user)
 
 		_, _, err := th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")

--- a/server/channels/app/teams/helper_test.go
+++ b/server/channels/app/teams/helper_test.go
@@ -62,7 +62,10 @@ func setupTestHelper(s store.Store, includeCacheLayer bool, tb testing.TB) *Test
 	*config.RateLimitSettings.Enable = false
 	*config.TeamSettings.EnableOpenServer = true
 	// Disable strict password requirements for test
-	*config.PasswordSettings.MinimumLength = 5
+	*config.PasswordSettings.MinimumLength = model.PasswordMinimumLength
+	if model.FIPSEnabled {
+		*config.PasswordSettings.MinimumLength = model.PasswordFIPSMinimumLength
+	}
 	*config.PasswordSettings.Lowercase = false
 	*config.PasswordSettings.Uppercase = false
 	*config.PasswordSettings.Symbol = false

--- a/server/channels/app/teams/helper_test.go
+++ b/server/channels/app/teams/helper_test.go
@@ -61,15 +61,6 @@ func setupTestHelper(s store.Store, includeCacheLayer bool, tb testing.TB) *Test
 	*config.TeamSettings.MaxUsersPerTeam = 50
 	*config.RateLimitSettings.Enable = false
 	*config.TeamSettings.EnableOpenServer = true
-	// Disable strict password requirements for test
-	*config.PasswordSettings.MinimumLength = model.PasswordMinimumLength
-	if model.FIPSEnabled {
-		*config.PasswordSettings.MinimumLength = model.PasswordFIPSMinimumLength
-	}
-	*config.PasswordSettings.Lowercase = false
-	*config.PasswordSettings.Uppercase = false
-	*config.PasswordSettings.Symbol = false
-	*config.PasswordSettings.Number = false
 	_, _, err = configStore.Set(config)
 	require.NoError(tb, err)
 

--- a/server/channels/app/teams/teams_test.go
+++ b/server/channels/app/teams/teams_test.go
@@ -93,7 +93,7 @@ func TestJoinUserToTeam(t *testing.T) {
 	th.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.MaxUsersPerTeam = &one })
 
 	t.Run("new join", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser := th.CreateUser(&user)
 		defer th.DeleteUser(&user)
 
@@ -103,7 +103,7 @@ func TestJoinUserToTeam(t *testing.T) {
 	})
 
 	t.Run("join when you are a member", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser := th.CreateUser(&user)
 		defer th.DeleteUser(&user)
 
@@ -116,7 +116,7 @@ func TestJoinUserToTeam(t *testing.T) {
 	})
 
 	t.Run("re-join after leaving", func(t *testing.T) {
-		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser := th.CreateUser(&user)
 		defer th.DeleteUser(&user)
 
@@ -131,9 +131,9 @@ func TestJoinUserToTeam(t *testing.T) {
 	})
 
 	t.Run("new join with limit problem", func(t *testing.T) {
-		user1 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user1 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser1 := th.CreateUser(&user1)
-		user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser2 := th.CreateUser(&user2)
 
 		defer th.DeleteUser(&user1)
@@ -147,10 +147,10 @@ func TestJoinUserToTeam(t *testing.T) {
 	})
 
 	t.Run("re-join after leaving with limit problem", func(t *testing.T) {
-		user1 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user1 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser1 := th.CreateUser(&user1)
 
-		user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser2 := th.CreateUser(&user2)
 
 		defer th.DeleteUser(&user1)

--- a/server/channels/app/user_limits_test.go
+++ b/server/channels/app/user_limits_test.go
@@ -280,7 +280,7 @@ func TestCreateUserOrGuestSeatCountEnforcement(t *testing.T) {
 		user := &model.User{
 			Email:         "TestCreateUserOrGuest@example.com",
 			Username:      "username_123",
-			Password:      "Password1",
+			Password:      model.NewTestPassword(),
 			EmailVerified: true,
 		}
 
@@ -311,7 +311,7 @@ func TestCreateUserOrGuestSeatCountEnforcement(t *testing.T) {
 		user := &model.User{
 			Email:         "TestSeatCount@example.com",
 			Username:      "seat_test_user",
-			Password:      "Password1",
+			Password:      model.NewTestPassword(),
 			EmailVerified: true,
 		}
 
@@ -349,7 +349,7 @@ func TestCreateUserOrGuestSeatCountEnforcement(t *testing.T) {
 		user := &model.User{
 			Email:         "TestSeatCount@example.com",
 			Username:      "seat_test_user",
-			Password:      "Password1",
+			Password:      model.NewTestPassword(),
 			EmailVerified: true,
 		}
 
@@ -377,7 +377,7 @@ func TestCreateUserOrGuestSeatCountEnforcement(t *testing.T) {
 		user := &model.User{
 			Email:         "TestSeatCount@example.com",
 			Username:      "seat_test_user",
-			Password:      "Password1",
+			Password:      model.NewTestPassword(),
 			EmailVerified: true,
 		}
 
@@ -396,7 +396,7 @@ func TestCreateUserOrGuestSeatCountEnforcement(t *testing.T) {
 		user := &model.User{
 			Email:         "TestSeatCount@example.com",
 			Username:      "seat_test_user",
-			Password:      "Password1",
+			Password:      model.NewTestPassword(),
 			EmailVerified: true,
 		}
 
@@ -418,7 +418,7 @@ func TestCreateUserOrGuestSeatCountEnforcement(t *testing.T) {
 		user := &model.User{
 			Email:         "TestSeatCount@example.com",
 			Username:      "seat_test_user",
-			Password:      "Password1",
+			Password:      model.NewTestPassword(),
 			EmailVerified: true,
 		}
 
@@ -449,7 +449,7 @@ func TestCreateUserOrGuestSeatCountEnforcement(t *testing.T) {
 		user := &model.User{
 			Email:         "TestSeatCountGuest@example.com",
 			Username:      "seat_test_guest",
-			Password:      "Password1",
+			Password:      model.NewTestPassword(),
 			EmailVerified: true,
 		}
 
@@ -474,7 +474,7 @@ func TestCreateUserOrGuestSeatCountEnforcement(t *testing.T) {
 		user := &model.User{
 			Email:         "TestSeatCountGuest@example.com",
 			Username:      "seat_test_guest",
-			Password:      "Password1",
+			Password:      model.NewTestPassword(),
 			EmailVerified: true,
 		}
 

--- a/server/channels/app/user_test.go
+++ b/server/channels/app/user_test.go
@@ -350,7 +350,7 @@ func TestCreateUser(t *testing.T) {
 			Email:         "success+" + id + "@simulator.amazonses.com",
 			Username:      *group.Name,
 			Nickname:      "nn_" + id,
-			Password:      "Password1",
+			Password:      model.NewTestPassword(),
 			EmailVerified: true,
 		}
 
@@ -394,7 +394,7 @@ func TestCreateUser(t *testing.T) {
 			Email:       model.NewId() + "success+test@example.com",
 			Nickname:    "Darth Vader",
 			Username:    "vader" + model.NewId(),
-			Password:    "passwd12345",
+			Password:    model.NewTestPassword(),
 			AuthService: "",
 		}
 		_, err := th.App.CreateUser(th.Context, user)
@@ -828,7 +828,7 @@ func TestGetUsersByStatus(t *testing.T) {
 			Email:    "success+" + id + "@simulator.amazonses.com",
 			Username: "un_" + username + "_" + id,
 			Nickname: "nn_" + id,
-			Password: "Password1",
+			Password: model.NewTestPassword(),
 		})
 		require.Nil(t, err, "failed to create user: %v", err)
 
@@ -1060,7 +1060,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)
 
-	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 
 	t.Run("should create a user", func(t *testing.T) {
 		u, err := th.App.CreateUserWithInviteId(th.Context, &user, th.BasicTeam.InviteId, "")
@@ -1091,7 +1091,7 @@ func TestCreateUserWithToken(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)
 
-	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 
 	t.Run("invalid token", func(t *testing.T) {
 		_, err := th.App.CreateUserWithToken(th.Context, &user, &model.Token{Token: "123"})
@@ -1155,7 +1155,7 @@ func TestCreateUserWithToken(t *testing.T) {
 
 	t.Run("valid regular user request", func(t *testing.T) {
 		invitationEmail := strings.ToLower(model.NewId()) + "other-email@test.com"
-		u := model.User{Email: invitationEmail, Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		u := model.User{Email: invitationEmail, Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		token := model.NewToken(
 			model.TokenTypeTeamInvitation,
 			model.MapToJSON(map[string]string{"teamId": th.BasicTeam.Id, "email": invitationEmail}),
@@ -1182,7 +1182,7 @@ func TestCreateUserWithToken(t *testing.T) {
 		)
 
 		require.NoError(t, th.App.Srv().Store().Token().Save(token))
-		guest := model.User{Email: invitationEmail, Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+		guest := model.User{Email: invitationEmail, Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		newGuest, err := th.App.CreateUserWithToken(th.Context, &guest, token)
 		require.Nil(t, err, "Should add user to the team. err=%v", err)
 
@@ -1221,7 +1221,7 @@ func TestCreateUserWithToken(t *testing.T) {
 			Email:       forbiddenInvitationEmail,
 			Nickname:    "Darth Vader",
 			Username:    "vader" + model.NewId(),
-			Password:    "passwd1",
+			Password:    model.NewTestPassword(),
 			AuthService: "",
 		}
 		newGuest, err := th.App.CreateUserWithToken(th.Context, &guest, forbiddenDomainToken)
@@ -1267,7 +1267,7 @@ func TestCreateUserWithToken(t *testing.T) {
 			Email:       invitationEmail,
 			Nickname:    "Darth Vader",
 			Username:    "vader" + model.NewId(),
-			Password:    "passwd1",
+			Password:    model.NewTestPassword(),
 			AuthService: "",
 		}
 		newGuest, err := th.App.CreateUserWithToken(th.Context, &guest, token)
@@ -1302,7 +1302,7 @@ func TestCreateUserWithToken(t *testing.T) {
 		)
 		require.NoError(t, th.App.Srv().Store().Token().Save(token))
 
-		guest := model.User{Email: invitationEmail, Nickname: "Magic Link Guest", Username: "magiclinkguest" + model.NewId(), Password: "passwd1", AuthService: ""}
+		guest := model.User{Email: invitationEmail, Nickname: "Magic Link Guest", Username: "magiclinkguest" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		newGuest, err := th.App.CreateUserWithToken(th.Context, &guest, token)
 		require.Nil(t, err, "Should create guest user successfully")
 		require.True(t, newGuest.IsGuest())
@@ -1351,7 +1351,7 @@ func TestCreateUserWithToken(t *testing.T) {
 		)
 		require.NoError(t, th.App.Srv().Store().Token().Save(token))
 
-		guest := model.User{Email: invitationEmail, Nickname: "Magic Link Guest", Username: "magiclinkguest" + model.NewId(), Password: "passwd1", AuthService: ""}
+		guest := model.User{Email: invitationEmail, Nickname: "Magic Link Guest", Username: "magiclinkguest" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		newGuest, err := th.App.CreateUserWithToken(th.Context, &guest, token)
 		require.Nil(t, err)
 
@@ -1385,7 +1385,7 @@ func TestCreateUserWithToken(t *testing.T) {
 		)
 		require.NoError(t, th.App.Srv().Store().Token().Save(token))
 
-		regularUser := model.User{Email: invitationEmail, Nickname: "Regular User", Username: "regular" + model.NewId(), Password: "passwd1", AuthService: ""}
+		regularUser := model.User{Email: invitationEmail, Nickname: "Regular User", Username: "regular" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		newUser, err := th.App.CreateUserWithToken(th.Context, &regularUser, token)
 		require.Nil(t, err)
 		require.False(t, newUser.IsGuest())
@@ -1516,7 +1516,7 @@ func TestPasswordRecovery(t *testing.T) {
 		assert.Equal(t, th.BasicUser.Id, tokenData.UserID)
 		assert.Equal(t, th.BasicUser.Email, tokenData.Email)
 
-		err = th.App.ResetPasswordFromToken(th.Context, token.Token, "abcdefgh")
+		err = th.App.ResetPasswordFromToken(th.Context, token.Token, model.NewTestPassword())
 		assert.Nil(t, err)
 	})
 
@@ -1532,7 +1532,7 @@ func TestPasswordRecovery(t *testing.T) {
 		_, err = th.App.UpdateUser(th.Context, th.BasicUser, false)
 		assert.Nil(t, err)
 
-		err = th.App.ResetPasswordFromToken(th.Context, token.Token, "abcdefgh")
+		err = th.App.ResetPasswordFromToken(th.Context, token.Token, model.NewTestPassword())
 		assert.NotNil(t, err)
 	})
 
@@ -1540,7 +1540,7 @@ func TestPasswordRecovery(t *testing.T) {
 		token, err := th.App.CreatePasswordRecoveryToken(th.Context, th.BasicUser.Id, th.BasicUser.Email)
 		assert.Nil(t, err)
 
-		err = th.App.resetPasswordFromToken(th.Context, token.Token, "abcdefgh", model.GetMillis())
+		err = th.App.resetPasswordFromToken(th.Context, token.Token, model.NewTestPassword(), model.GetMillis())
 		assert.Nil(t, err)
 	})
 
@@ -1548,7 +1548,7 @@ func TestPasswordRecovery(t *testing.T) {
 		token, err := th.App.CreatePasswordRecoveryToken(th.Context, th.BasicUser.Id, th.BasicUser.Email)
 		assert.Nil(t, err)
 
-		err = th.App.resetPasswordFromToken(th.Context, token.Token, "abcdefgh", model.GetMillisForTime(time.Now().Add(25*time.Hour)))
+		err = th.App.resetPasswordFromToken(th.Context, token.Token, model.NewTestPassword(), model.GetMillisForTime(time.Now().Add(25*time.Hour)))
 		assert.NotNil(t, err)
 	})
 }
@@ -1615,7 +1615,7 @@ func TestPasswordChangeSessionTermination(t *testing.T) {
 		th.Context.Session().UserId = th.BasicUser2.Id
 		th.Context.Session().Id = session.Id
 
-		err = th.App.UpdatePassword(th.Context, th.BasicUser2, "Password2")
+		err = th.App.UpdatePassword(th.Context, th.BasicUser2, model.NewTestPassword())
 		require.Nil(t, err)
 
 		session, err = th.App.GetSession(session.Token)
@@ -1627,7 +1627,7 @@ func TestPasswordChangeSessionTermination(t *testing.T) {
 		require.Nil(t, session2)
 
 		// Cleanup
-		err = th.App.UpdatePassword(th.Context, th.BasicUser2, "Password1")
+		err = th.App.UpdatePassword(th.Context, th.BasicUser2, model.NewTestPassword())
 		require.Nil(t, err)
 		th.Context.Session().UserId = ""
 		th.Context.Session().Id = ""
@@ -1653,7 +1653,7 @@ func TestPasswordChangeSessionTermination(t *testing.T) {
 		th.Context.Session().UserId = th.BasicUser2.Id
 		th.Context.Session().Id = session.Id
 
-		err = th.App.UpdatePassword(th.Context, th.BasicUser2, "Password2")
+		err = th.App.UpdatePassword(th.Context, th.BasicUser2, model.NewTestPassword())
 		require.Nil(t, err)
 
 		session, err = th.App.GetSession(session.Token)
@@ -1665,7 +1665,7 @@ func TestPasswordChangeSessionTermination(t *testing.T) {
 		require.False(t, session2.IsExpired())
 
 		// Cleanup
-		err = th.App.UpdatePassword(th.Context, th.BasicUser2, "Password1")
+		err = th.App.UpdatePassword(th.Context, th.BasicUser2, model.NewTestPassword())
 		require.Nil(t, err)
 		th.Context.Session().UserId = ""
 		th.Context.Session().Id = ""
@@ -1688,7 +1688,7 @@ func TestPasswordChangeSessionTermination(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		err = th.App.UpdatePassword(th.Context, th.BasicUser2, "Password2")
+		err = th.App.UpdatePassword(th.Context, th.BasicUser2, model.NewTestPassword())
 		require.Nil(t, err)
 
 		session, err = th.App.GetSession(session.Token)
@@ -1700,7 +1700,7 @@ func TestPasswordChangeSessionTermination(t *testing.T) {
 		require.Nil(t, session2)
 
 		// Cleanup
-		err = th.App.UpdatePassword(th.Context, th.BasicUser2, "Password1")
+		err = th.App.UpdatePassword(th.Context, th.BasicUser2, model.NewTestPassword())
 		require.Nil(t, err)
 	})
 
@@ -1721,7 +1721,7 @@ func TestPasswordChangeSessionTermination(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		err = th.App.UpdatePassword(th.Context, th.BasicUser2, "Password2")
+		err = th.App.UpdatePassword(th.Context, th.BasicUser2, model.NewTestPassword())
 		require.Nil(t, err)
 
 		session, err = th.App.GetSession(session.Token)
@@ -1733,7 +1733,7 @@ func TestPasswordChangeSessionTermination(t *testing.T) {
 		require.False(t, session2.IsExpired())
 
 		// Cleanup
-		err = th.App.UpdatePassword(th.Context, th.BasicUser2, "Password1")
+		err = th.App.UpdatePassword(th.Context, th.BasicUser2, model.NewTestPassword())
 		require.Nil(t, err)
 	})
 }

--- a/server/channels/app/users/helper_test.go
+++ b/server/channels/app/users/helper_test.go
@@ -129,7 +129,7 @@ func (th *TestHelper) CreateUserOrGuest(tb testing.TB, guest bool) *model.User {
 		Email:         "success+" + id + "@simulator.amazonses.com",
 		Username:      "un_" + id,
 		Nickname:      "nn_" + id,
-		Password:      "Password1",
+		Password:      model.NewTestPassword(),
 		EmailVerified: true,
 	}
 

--- a/server/channels/app/users/helper_test.go
+++ b/server/channels/app/users/helper_test.go
@@ -59,15 +59,6 @@ func setupTestHelper(s store.Store, _ bool, tb testing.TB) *TestHelper {
 	*config.TeamSettings.MaxUsersPerTeam = 50
 	*config.RateLimitSettings.Enable = false
 	*config.TeamSettings.EnableOpenServer = true
-	// Disable strict password requirements for test
-	*config.PasswordSettings.MinimumLength = model.PasswordMinimumLength
-	if model.FIPSEnabled {
-		*config.PasswordSettings.MinimumLength = model.PasswordFIPSMinimumLength
-	}
-	*config.PasswordSettings.Lowercase = false
-	*config.PasswordSettings.Uppercase = false
-	*config.PasswordSettings.Symbol = false
-	*config.PasswordSettings.Number = false
 	_, _, err = configStore.Set(config)
 	require.NoError(tb, err)
 

--- a/server/channels/app/users/helper_test.go
+++ b/server/channels/app/users/helper_test.go
@@ -60,7 +60,10 @@ func setupTestHelper(s store.Store, _ bool, tb testing.TB) *TestHelper {
 	*config.RateLimitSettings.Enable = false
 	*config.TeamSettings.EnableOpenServer = true
 	// Disable strict password requirements for test
-	*config.PasswordSettings.MinimumLength = 5
+	*config.PasswordSettings.MinimumLength = model.PasswordMinimumLength
+	if model.FIPSEnabled {
+		*config.PasswordSettings.MinimumLength = model.PasswordFIPSMinimumLength
+	}
 	*config.PasswordSettings.Lowercase = false
 	*config.PasswordSettings.Uppercase = false
 	*config.PasswordSettings.Symbol = false

--- a/server/channels/app/users/password_test.go
+++ b/server/channels/app/users/password_test.go
@@ -20,9 +20,9 @@ func TestIsPasswordValidWithSettings(t *testing.T) {
 		ExpectedError string
 	}{
 		"Short": {
-			Password: strings.Repeat("x", 3),
+			Password: strings.Repeat("x", model.PasswordFIPSMinimumLength),
 			Settings: &model.PasswordSettings{
-				MinimumLength: model.NewPointer(3),
+				MinimumLength: model.NewPointer(model.PasswordFIPSMinimumLength),
 				Lowercase:     model.NewPointer(false),
 				Uppercase:     model.NewPointer(false),
 				Number:        model.NewPointer(false),
@@ -41,7 +41,7 @@ func TestIsPasswordValidWithSettings(t *testing.T) {
 		"TooShort": {
 			Password: strings.Repeat("x", 2),
 			Settings: &model.PasswordSettings{
-				MinimumLength: model.NewPointer(3),
+				MinimumLength: model.NewPointer(model.PasswordFIPSMinimumLength),
 				Lowercase:     model.NewPointer(false),
 				Uppercase:     model.NewPointer(false),
 				Number:        model.NewPointer(false),
@@ -110,7 +110,7 @@ func TestIsPasswordValidWithSettings(t *testing.T) {
 			ExpectedError: "model.user.is_valid.pwd_uppercase_number_symbol.app_error",
 		},
 		"Everything": {
-			Password: "asdASD!@#123",
+			Password: "asdASDasd!@#123",
 			Settings: &model.PasswordSettings{
 				Lowercase: model.NewPointer(true),
 				Uppercase: model.NewPointer(true),

--- a/server/channels/jobs/helper_test.go
+++ b/server/channels/jobs/helper_test.go
@@ -225,7 +225,7 @@ func (th *TestHelper) CreateUserOrGuest(tb testing.TB, guest bool) *model.User {
 		Email:         "success+" + id + "@simulator.amazonses.com",
 		Username:      "un_" + id,
 		Nickname:      "nn_" + id,
-		Password:      "Password1",
+		Password:      model.NewTestPassword(),
 		EmailVerified: true,
 	}
 

--- a/server/channels/store/searchtest/helper.go
+++ b/server/channels/store/searchtest/helper.go
@@ -165,7 +165,7 @@ func (th *SearchTestHelper) makeEmail() string {
 func (th *SearchTestHelper) createUser(username, nickname, firstName, lastName string) (*model.User, error) {
 	return th.Store.User().Save(th.Context, &model.User{
 		Username:  username,
-		Password:  username,
+		Password:  model.NewTestPassword(),
 		Nickname:  nickname,
 		FirstName: firstName,
 		LastName:  lastName,
@@ -176,7 +176,7 @@ func (th *SearchTestHelper) createUser(username, nickname, firstName, lastName s
 func (th *SearchTestHelper) createGuest(username, nickname, firstName, lastName string) (*model.User, error) {
 	return th.Store.User().Save(th.Context, &model.User{
 		Username:  username,
-		Password:  username,
+		Password:  model.NewTestPassword(),
 		Nickname:  nickname,
 		FirstName: firstName,
 		LastName:  lastName,

--- a/server/channels/store/storetest/user_store.go
+++ b/server/channels/store/storetest/user_store.go
@@ -2372,7 +2372,7 @@ func testUserStoreUpdatePassword(t *testing.T, rctx request.CTX, ss store.Store)
 	_, err = hashers.Hash(strings.Repeat("1234567890", 8))
 	require.ErrorIs(t, err, hashers.ErrPasswordTooLong)
 
-	hashedPassword, err := hashers.Hash("newpwd")
+	hashedPassword, err := hashers.Hash(model.NewTestPassword())
 	require.NoError(t, err)
 
 	err = ss.User().UpdatePassword(u1.Id, hashedPassword)
@@ -5296,7 +5296,7 @@ func testUserStoreGetTeamGroupUsers(t *testing.T, rctx request.CTX, ss store.Sto
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 		})
 		require.NoError(t, userErr)
 		require.NotNil(t, user)
@@ -5417,7 +5417,7 @@ func testUserStoreGetChannelGroupUsers(t *testing.T, rctx request.CTX, ss store.
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 		})
 		require.NoError(t, userErr)
 		require.NotNil(t, user)
@@ -5528,7 +5528,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_user",
 		})
 		require.NoError(t, err)
@@ -5574,7 +5574,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_user system_admin",
 		})
 		require.NoError(t, err)
@@ -5619,7 +5619,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_guest",
 		})
 		require.NoError(t, err)
@@ -5640,7 +5640,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_guest",
 		})
 		require.NoError(t, err)
@@ -5670,7 +5670,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_guest",
 		})
 		require.NoError(t, err)
@@ -5715,7 +5715,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_guest custom_role",
 		})
 		require.NoError(t, err)
@@ -5760,7 +5760,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_guest",
 		})
 		require.NoError(t, err)
@@ -5788,7 +5788,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_guest",
 		})
 		require.NoError(t, err)
@@ -5843,7 +5843,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_guest",
 		})
 		require.NoError(t, err)
@@ -5887,7 +5887,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_user system_admin",
 		})
 		require.NoError(t, err)
@@ -5930,7 +5930,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_user",
 		})
 		require.NoError(t, err)
@@ -5949,7 +5949,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_user",
 		})
 		require.NoError(t, err)
@@ -5977,7 +5977,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_user",
 		})
 		require.NoError(t, err)
@@ -6020,7 +6020,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_user custom_role",
 		})
 		require.NoError(t, err)
@@ -6063,7 +6063,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_user",
 		})
 		require.NoError(t, err)
@@ -6091,7 +6091,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 			Nickname:  "nn_" + id,
 			FirstName: "f_" + id,
 			LastName:  "l_" + id,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_user",
 		})
 		require.NoError(t, err)
@@ -6144,7 +6144,7 @@ func testDeactivateGuests(t *testing.T, rctx request.CTX, ss store.Store) {
 			Nickname:  "nn_" + guest1Random,
 			FirstName: "f_" + guest1Random,
 			LastName:  "l_" + guest1Random,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_guest",
 		})
 		require.NoError(t, err)
@@ -6157,7 +6157,7 @@ func testDeactivateGuests(t *testing.T, rctx request.CTX, ss store.Store) {
 			Nickname:  "nn_" + guest2Random,
 			FirstName: "f_" + guest2Random,
 			LastName:  "l_" + guest2Random,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_guest",
 		})
 		require.NoError(t, err)
@@ -6170,7 +6170,7 @@ func testDeactivateGuests(t *testing.T, rctx request.CTX, ss store.Store) {
 			Nickname:  "nn_" + guest3Random,
 			FirstName: "f_" + guest3Random,
 			LastName:  "l_" + guest3Random,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_guest",
 			DeleteAt:  10,
 		})
@@ -6184,7 +6184,7 @@ func testDeactivateGuests(t *testing.T, rctx request.CTX, ss store.Store) {
 			Nickname:  "nn_" + regularUserRandom,
 			FirstName: "f_" + regularUserRandom,
 			LastName:  "l_" + regularUserRandom,
-			Password:  "Password1",
+			Password:  model.NewTestPassword(),
 			Roles:     "system_user",
 		})
 		require.NoError(t, err)

--- a/server/channels/web/web_test.go
+++ b/server/channels/web/web_test.go
@@ -115,18 +115,6 @@ func setupTestHelper(tb testing.TB, includeCacheLayer bool, options []app.Option
 	require.NoError(tb, err)
 	a.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ListenAddress = prevListenAddress })
 
-	// Disable strict password requirements for test
-	a.UpdateConfig(func(cfg *model.Config) {
-		*cfg.PasswordSettings.MinimumLength = model.PasswordMinimumLength
-		if model.FIPSEnabled {
-			*cfg.PasswordSettings.MinimumLength = model.PasswordFIPSMinimumLength
-		}
-		*cfg.PasswordSettings.Lowercase = false
-		*cfg.PasswordSettings.Uppercase = false
-		*cfg.PasswordSettings.Symbol = false
-		*cfg.PasswordSettings.Number = false
-	})
-
 	web := New(s)
 	URL = fmt.Sprintf("http://localhost:%v", s.ListenAddr.Port)
 	apiClient = model.NewAPIv4Client(URL)

--- a/server/channels/web/web_test.go
+++ b/server/channels/web/web_test.go
@@ -172,10 +172,10 @@ func (th *TestHelper) InitBasic(tb testing.TB) *TestHelper {
 	tb.Helper()
 
 	var appErr *model.AppError
-	th.SystemAdminUser, appErr = th.App.CreateUser(th.Context, &model.User{Email: model.NewId() + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1", EmailVerified: true, Roles: model.SystemAdminRoleId})
+	th.SystemAdminUser, appErr = th.App.CreateUser(th.Context, &model.User{Email: model.NewId() + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: model.NewTestPassword(), EmailVerified: true, Roles: model.SystemAdminRoleId})
 	require.Nil(tb, appErr)
 
-	th.BasicUser, appErr = th.App.CreateUser(th.Context, &model.User{Email: model.NewId() + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1", EmailVerified: true, Roles: model.SystemUserRoleId})
+	th.BasicUser, appErr = th.App.CreateUser(th.Context, &model.User{Email: model.NewId() + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: model.NewTestPassword(), EmailVerified: true, Roles: model.SystemUserRoleId})
 	require.Nil(tb, appErr)
 
 	th.BasicTeam, appErr = th.App.CreateTeam(th.Context, &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: th.BasicUser.Email, Type: model.TeamOpen})

--- a/server/channels/web/web_test.go
+++ b/server/channels/web/web_test.go
@@ -117,7 +117,10 @@ func setupTestHelper(tb testing.TB, includeCacheLayer bool, options []app.Option
 
 	// Disable strict password requirements for test
 	a.UpdateConfig(func(cfg *model.Config) {
-		*cfg.PasswordSettings.MinimumLength = 5
+		*cfg.PasswordSettings.MinimumLength = model.PasswordMinimumLength
+		if model.FIPSEnabled {
+			*cfg.PasswordSettings.MinimumLength = model.PasswordFIPSMinimumLength
+		}
 		*cfg.PasswordSettings.Lowercase = false
 		*cfg.PasswordSettings.Uppercase = false
 		*cfg.PasswordSettings.Symbol = false

--- a/server/cmd/mattermost/commands/cmdtestlib.go
+++ b/server/cmd/mattermost/commands/cmdtestlib.go
@@ -95,7 +95,10 @@ func (h *testHelper) SetConfig(config *model.Config) {
 	}
 
 	// Disable strict password requirements for test
-	*config.PasswordSettings.MinimumLength = 5
+	*config.PasswordSettings.MinimumLength = model.PasswordMinimumLength
+	if model.FIPSEnabled {
+		*config.PasswordSettings.MinimumLength = model.PasswordFIPSMinimumLength
+	}
 	*config.PasswordSettings.Lowercase = false
 	*config.PasswordSettings.Uppercase = false
 	*config.PasswordSettings.Symbol = false

--- a/server/cmd/mattermost/commands/cmdtestlib.go
+++ b/server/cmd/mattermost/commands/cmdtestlib.go
@@ -94,16 +94,6 @@ func (h *testHelper) SetConfig(config *model.Config) {
 		config.SqlSettings = *mainHelper.GetSQLSettings()
 	}
 
-	// Disable strict password requirements for test
-	*config.PasswordSettings.MinimumLength = model.PasswordMinimumLength
-	if model.FIPSEnabled {
-		*config.PasswordSettings.MinimumLength = model.PasswordFIPSMinimumLength
-	}
-	*config.PasswordSettings.Lowercase = false
-	*config.PasswordSettings.Uppercase = false
-	*config.PasswordSettings.Symbol = false
-	*config.PasswordSettings.Number = false
-
 	h.config = config
 
 	buf, err := json.Marshal(config)

--- a/server/cmd/mmctl/commands/user_e2e_test.go
+++ b/server/cmd/mmctl/commands/user_e2e_test.go
@@ -218,7 +218,7 @@ func (s *MmctlE2ETestSuite) TestListUserCmd() {
 	for range 10 {
 		userData := model.User{
 			Username: "fakeuser" + model.NewRandomString(10),
-			Password: "Pa$$word11",
+			Password: model.NewTestPassword(),
 			Email:    s.th.GenerateTestEmail(),
 		}
 		usr, err := s.th.App.CreateUser(s.th.Context, &userData)
@@ -231,7 +231,7 @@ func (s *MmctlE2ETestSuite) TestListUserCmd() {
 	for range 2 {
 		userData := model.User{
 			Username: "fakeuser" + model.NewRandomString(10),
-			Password: "Pa$$word11",
+			Password: model.NewTestPassword(),
 			Email:    s.th.GenerateTestEmail(),
 			DeleteAt: model.GetMillis(),
 		}
@@ -297,7 +297,7 @@ func (s *MmctlE2ETestSuite) TestListUserCmd() {
 	for range 10 {
 		userData := model.User{
 			Username: "teamuser" + model.NewRandomString(10),
-			Password: "Pa$$word11",
+			Password: model.NewTestPassword(),
 			Email:    s.th.GenerateTestEmail(),
 		}
 		usr, err := s.th.App.CreateUser(s.th.Context, &userData)
@@ -330,7 +330,7 @@ func (s *MmctlE2ETestSuite) TestListUserCmd() {
 	for range 10 {
 		userData := model.User{
 			Username: "inactiveteamuser" + model.NewRandomString(10),
-			Password: "Pa$$word11",
+			Password: model.NewTestPassword(),
 			Email:    s.th.GenerateTestEmail(),
 			DeleteAt: model.GetMillis(),
 		}
@@ -971,7 +971,7 @@ func (s *MmctlE2ETestSuite) TestDeleteAllUserCmd() {
 		for range 10 {
 			userData := model.User{
 				Username: "fakeuser" + model.NewRandomString(10),
-				Password: "Pa$$word11",
+				Password: model.NewTestPassword(),
 				Email:    s.th.GenerateTestEmail(),
 			}
 			_, err := s.th.App.CreateUser(s.th.Context, &userData)

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10433,6 +10433,10 @@
     "translation": "Invalid RemoteImageProxyOptions for atmos/camo. Must be set to your shared key."
   },
   {
+    "id": "model.config.is_valid.atmos_camo_image_proxy_options_length.app_error",
+    "translation": "Invalid RemoteImageProxyOptions for atmos/camo: HMAC key must be at least {{.MinLength}} bytes for FIPS compliance."
+  },
+  {
     "id": "model.config.is_valid.atmos_camo_image_proxy_url.app_error",
     "translation": "Invalid RemoteImageProxyURL for atmos/camo. Must be set to your shared key."
   },

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -45,8 +45,9 @@ const (
 	MinioSecretKey = "miniosecretkey"
 	MinioBucket    = "mattermost-test"
 
-	PasswordMaximumLength = 72
-	PasswordMinimumLength = 5
+	PasswordMaximumLength     = 72
+	PasswordMinimumLength     = 5
+	PasswordFIPSMinimumLength = 14
 
 	ServiceGitlab = "gitlab"
 
@@ -1734,7 +1735,11 @@ type PasswordSettings struct {
 
 func (s *PasswordSettings) SetDefaults() {
 	if s.MinimumLength == nil {
-		s.MinimumLength = NewPointer(8)
+		if FIPSEnabled {
+			s.MinimumLength = NewPointer(PasswordFIPSMinimumLength)
+		} else {
+			s.MinimumLength = NewPointer(8)
+		}
 	}
 
 	if s.Lowercase == nil {
@@ -4197,8 +4202,12 @@ func (o *Config) IsValid() *AppError {
 		}
 	}
 
-	if *o.PasswordSettings.MinimumLength < PasswordMinimumLength || *o.PasswordSettings.MinimumLength > PasswordMaximumLength {
-		return NewAppError("Config.IsValid", "model.config.is_valid.password_length.app_error", map[string]any{"MinLength": PasswordMinimumLength, "MaxLength": PasswordMaximumLength}, "", http.StatusBadRequest)
+	minPasswordLength := PasswordMinimumLength
+	if FIPSEnabled && PasswordFIPSMinimumLength > minPasswordLength {
+		minPasswordLength = PasswordFIPSMinimumLength
+	}
+	if *o.PasswordSettings.MinimumLength < minPasswordLength || *o.PasswordSettings.MinimumLength > PasswordMaximumLength {
+		return NewAppError("Config.IsValid", "model.config.is_valid.password_length.app_error", map[string]any{"MinLength": minPasswordLength, "MaxLength": PasswordMaximumLength}, "", http.StatusBadRequest)
 	}
 
 	if appErr := o.RateLimitSettings.isValid(); appErr != nil {
@@ -4965,6 +4974,12 @@ func (s *ImageProxySettings) isValid() *AppError {
 
 			if *s.RemoteImageProxyOptions == "" {
 				return NewAppError("Config.IsValid", "model.config.is_valid.atmos_camo_image_proxy_options.app_error", nil, "", http.StatusBadRequest)
+			}
+
+			// RemoteImageProxyOptions is used as the HMAC key for URL signing,
+			// so it is subject to the same FIPS minimum key length as passwords.
+			if FIPSEnabled && len(*s.RemoteImageProxyOptions) < PasswordFIPSMinimumLength {
+				return NewAppError("Config.IsValid", "model.config.is_valid.atmos_camo_image_proxy_options_length.app_error", map[string]any{"MinLength": PasswordFIPSMinimumLength}, "", http.StatusBadRequest)
 			}
 		default:
 			return NewAppError("Config.IsValid", "model.config.is_valid.image_proxy_type.app_error", nil, "", http.StatusBadRequest)

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -4203,7 +4203,7 @@ func (o *Config) IsValid() *AppError {
 	}
 
 	minPasswordLength := PasswordMinimumLength
-	if FIPSEnabled && PasswordFIPSMinimumLength > minPasswordLength {
+	if FIPSEnabled {
 		minPasswordLength = PasswordFIPSMinimumLength
 	}
 	if *o.PasswordSettings.MinimumLength < minPasswordLength || *o.PasswordSettings.MinimumLength > PasswordMaximumLength {

--- a/server/public/model/config_test.go
+++ b/server/public/model/config_test.go
@@ -1014,7 +1014,7 @@ func TestImageProxySettingsIsValid(t *testing.T) {
 			Enable:                  true,
 			ImageProxyType:          ImageProxyTypeAtmosCamo,
 			RemoteImageProxyURL:     "someurl",
-			RemoteImageProxyOptions: "someoptions",
+			RemoteImageProxyOptions: "7e5f3fab20b94782b43cdb022a66985ef28ba355df2c5d5da3c9a05e4b697bac",
 			ExpectError:             false,
 		},
 		{
@@ -1032,6 +1032,14 @@ func TestImageProxySettingsIsValid(t *testing.T) {
 			RemoteImageProxyURL:     "someurl",
 			RemoteImageProxyOptions: "",
 			ExpectError:             true,
+		},
+		{
+			Name:                    "atmos/camo, short options under FIPS",
+			Enable:                  true,
+			ImageProxyType:          ImageProxyTypeAtmosCamo,
+			RemoteImageProxyURL:     "someurl",
+			RemoteImageProxyOptions: "foo",
+			ExpectError:             FIPSEnabled,
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {

--- a/server/public/model/config_test.go
+++ b/server/public/model/config_test.go
@@ -974,6 +974,8 @@ func TestImageProxySettingsSetDefaults(t *testing.T) {
 }
 
 func TestImageProxySettingsIsValid(t *testing.T) {
+	testHMACKey := NewTestPassword()
+
 	for _, test := range []struct {
 		Name                    string
 		Enable                  bool
@@ -1014,7 +1016,7 @@ func TestImageProxySettingsIsValid(t *testing.T) {
 			Enable:                  true,
 			ImageProxyType:          ImageProxyTypeAtmosCamo,
 			RemoteImageProxyURL:     "someurl",
-			RemoteImageProxyOptions: "7e5f3fab20b94782b43cdb022a66985ef28ba355df2c5d5da3c9a05e4b697bac",
+			RemoteImageProxyOptions: testHMACKey,
 			ExpectError:             false,
 		},
 		{

--- a/server/public/model/fips.go
+++ b/server/public/model/fips.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build requirefips
+
+package model
+
+const FIPSEnabled = true

--- a/server/public/model/fips_default.go
+++ b/server/public/model/fips_default.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build !requirefips
+
+package model
+
+const FIPSEnabled = false

--- a/server/public/model/remote_cluster_test.go
+++ b/server/public/model/remote_cluster_test.go
@@ -132,29 +132,35 @@ func TestRemoteClusterInviteEncryption(t *testing.T) {
 		badDecrypt bool
 		password   string
 		invite     RemoteClusterInvite
+		skipFIPS   bool
 	}{
-		{name: "empty password", badDecrypt: false, password: "", invite: makeInvite("https://example.com:8065")},
+		{name: "empty password", badDecrypt: false, password: "", invite: makeInvite("https://example.com:8065"), skipFIPS: true},
 		{name: "good password", badDecrypt: false, password: "Ultra secret password!", invite: makeInvite("https://example.com:8065")},
 		{name: "bad decrypt", badDecrypt: true, password: "correct horse battery staple", invite: makeInvite("https://example.com:8065")},
 	}
 
 	for _, tt := range testData {
-		encrypted, err := tt.invite.Encrypt(tt.password)
-		require.NoError(t, err)
-
-		invite := RemoteClusterInvite{}
-		if tt.badDecrypt {
-			buf := make([]byte, len(encrypted))
-			_, err = io.ReadFull(rand.Reader, buf)
-			assert.NoError(t, err)
-
-			err = invite.Decrypt(buf, tt.password)
-			require.Error(t, err)
-		} else {
-			err = invite.Decrypt(encrypted, tt.password)
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.skipFIPS && FIPSEnabled {
+				t.Skip("skipping under FIPS: encryption requires keys >= 14 bytes")
+			}
+			encrypted, err := tt.invite.Encrypt(tt.password)
 			require.NoError(t, err)
-			assert.Equal(t, tt.invite, invite)
-		}
+
+			invite := RemoteClusterInvite{}
+			if tt.badDecrypt {
+				buf := make([]byte, len(encrypted))
+				_, err = io.ReadFull(rand.Reader, buf)
+				assert.NoError(t, err)
+
+				err = invite.Decrypt(buf, tt.password)
+				require.Error(t, err)
+			} else {
+				err = invite.Decrypt(encrypted, tt.password)
+				require.NoError(t, err)
+				assert.Equal(t, tt.invite, invite)
+			}
+		})
 	}
 }
 
@@ -168,7 +174,7 @@ func TestRemoteClusterInviteBackwardCompatibility(t *testing.T) {
 		Version:        2, // Old version using scrypt
 	}
 
-	password := "test password"
+	password := NewTestPassword()
 
 	// Encrypt with old method (scrypt)
 	encrypted, err := oldInvite.Encrypt(password)

--- a/server/public/model/utils.go
+++ b/server/public/model/utils.go
@@ -411,12 +411,12 @@ func NewRandomString(length int) string {
 // The passwords are not cryptographically random. Use only in tests.
 func NewTestPassword() string {
 	const (
-		lowers   = "abcdefghijklmnopqrstuvwxyz"
-		uppers   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-		digits   = "0123456789"
+		lowers   = LowercaseLetters
+		uppers   = UppercaseLetters
+		digits   = NUMBERS
 		specials = "!%^&*(),."
 		all      = lowers + uppers + digits + specials
-		minLen   = 14
+		minLen   = PasswordFIPSMinimumLength
 	)
 
 	// Read all randomness in one call for performance.

--- a/server/public/model/utils.go
+++ b/server/public/model/utils.go
@@ -406,6 +406,44 @@ func NewRandomString(length int) string {
 	return encoding.EncodeToString(data)[:length]
 }
 
+// NewTestPassword generates a password that meets complexity requirements
+// (uppercase, lowercase, number, special character) with a minimum length of 14.
+// The passwords are not cryptographically random. Use only in tests.
+func NewTestPassword() string {
+	const (
+		lowers   = "abcdefghijklmnopqrstuvwxyz"
+		uppers   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+		digits   = "0123456789"
+		specials = "!%^&*(),."
+		all      = lowers + uppers + digits + specials
+		minLen   = 14
+	)
+
+	// Read all randomness in one call for performance.
+	// We need minLen bytes for character selection + minLen bytes for shuffle indices.
+	entropy := make([]byte, 2*minLen)
+	if _, err := rand.Read(entropy); err != nil {
+		panic(err)
+	}
+
+	pw := make([]byte, minLen)
+	pw[0] = uppers[int(entropy[0])%len(uppers)]
+	pw[1] = lowers[int(entropy[1])%len(lowers)]
+	pw[2] = digits[int(entropy[2])%len(digits)]
+	pw[3] = specials[int(entropy[3])%len(specials)]
+	for i := 4; i < minLen; i++ {
+		pw[i] = all[int(entropy[i])%len(all)]
+	}
+
+	// Shuffle to avoid predictable prefix using remaining entropy.
+	for i := len(pw) - 1; i > 0; i-- {
+		j := int(entropy[minLen+i]) % (i + 1)
+		pw[i], pw[j] = pw[j], pw[i]
+	}
+
+	return string(pw)
+}
+
 // GetMillis is a convenience method to get milliseconds since epoch.
 func GetMillis() int64 {
 	return GetMillisForTime(time.Now())

--- a/server/public/model/utils_test.go
+++ b/server/public/model/utils_test.go
@@ -33,6 +33,12 @@ func TestRandomString(t *testing.T) {
 	}
 }
 
+func BenchmarkNewTestPassword(b *testing.B) {
+	for range b.N {
+		NewTestPassword()
+	}
+}
+
 func TestGetMillisForTime(t *testing.T) {
 	thisTimeMillis := int64(1471219200000)
 	thisTime := time.Date(2016, time.August, 15, 0, 0, 0, 0, time.UTC)

--- a/tools/sharedchannel-test/main.go
+++ b/tools/sharedchannel-test/main.go
@@ -41,7 +41,7 @@ func main() {
 	flag.StringVar(&cfg.ServerDir, "server-dir", "", "Path to server directory (for managed mode)")
 	flag.BoolVar(&cfg.Manage, "manage", true, "Manage server lifecycle (build/start/stop)")
 	flag.StringVar(&cfg.AdminUser, "admin-user", "admin", "Admin username to create")
-	flag.StringVar(&cfg.AdminPass, "admin-pass", "Admin1234!", "Admin password")
+	flag.StringVar(&cfg.AdminPass, "admin-pass", "Admin1234567890", "Admin password")
 	flag.Parse()
 
 	if cfg.LicensePath == "" {

--- a/tools/sharedchannel-test/runner.go
+++ b/tools/sharedchannel-test/runner.go
@@ -135,7 +135,7 @@ func (tr *TestRunner) provision(ctx context.Context) error {
 
 	// Create a single remote cluster connection for all tests
 	tr.logger.Info("Setting up remote cluster connection...")
-	invitePassword := "TestInvite123!"
+	invitePassword := model.NewTestPassword()
 	invite, _, err := tr.clientA.CreateRemoteCluster(ctx, &model.RemoteClusterWithPassword{
 		RemoteCluster: &model.RemoteCluster{
 			Name:          "server-b-" + tr.suffix,
@@ -245,7 +245,7 @@ func (tr *TestRunner) createTestUser(ctx context.Context, username string) (stri
 	user, _, err := tr.clientA.CreateUser(ctx, &model.User{
 		Username: uniqueName,
 		Email:    uniqueName + "@test.local",
-		Password: "TestPass123!",
+		Password: model.NewTestPassword(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("create user %s: %w", username, err)


### PR DESCRIPTION
#### Summary

Fix FIPS test failures caused by OpenSSL rejecting short HMAC keys in PBKDF2.

- Add `model.NewTestPassword()` to generate 14+ character passwords meeting complexity requirements, replacing hardcoded short test passwords (`hello1`, `passwd1`, etc.) across the test suite
- Enforce a minimum password length of 14 under FIPS builds (`requirefips` build tag), since PBKDF2 uses the password as the HMAC key internally
- Return `ErrMismatchedHashAndPassword` for too-short passwords in PBKDF2 instead of a cryptic OpenSSL error
- Validate atmos/camo HMAC key length under FIPS and lengthen test keys
- Shard FIPS test suite across 4 CI runners and extract a reusable merge template workflow

**Not changed:**
- `ldap_e2e_test.go` passwords that must match LDAP test data fixtures
- `user_test.go` password paired with a pre-computed bcrypt hash
- `hashers_dev_test.go` hardcoded password to avoid an import cycle with `model`
- Password validation tests with intentionally short/invalid passwords

#### Ticket Link

N/A

#### Screenshots

N/A

#### Release Note
```release-note
FIPS builds require a minimum of 14 characters for passwords, atmos/camo proxy configuration, and shared channel secrets. Shorter passwords for existing users will no longer be valid and require a password reset. Non-FIPS builds are unaffected.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🔴 High

**Regression Risk:** Changes touch core authentication/password handling (PBKDF2 CompareHashAndPassword, global password validation, new FIPS minimum) and widely-used test helpers/config; behavior differs under FIPS builds and may break legacy short-password or HMAC-key paths. The modifications affect many modules and CI flows, increasing the chance of regressions in authentication, image-proxy validation, and CI artifact handling.

**QA Recommendation:** Require thorough manual QA for both FIPS and non-FIPS builds focusing on: end-to-end signup/login/password-reset paths (edge-case lengths), PBKDF2 hash/compare behavior for short and max-length passwords, atmos/camo HMAC key validation, backward-compatibility checks for existing users, and validation of sharded FIPS CI runs and artifact merging.

*Generated by CodeRabbitAI*

---

## Release Note

FIPS builds now enforce a minimum password length of 14 characters and require atmos/camo image-proxy HMAC keys (and shared channel secrets) to meet the same minimum; existing FIPS deployments with shorter passwords or keys will require user password resets. Non-FIPS builds are unaffected. Test suite and CI were updated to shard and better validate FIPS runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->