### PR TITLE
MM-68156: Fix space key clearing input in invite modal

### DIFF
--- a/webapp/channels/src/components/preparing_workspace/__snapshots__/invite_members.test.tsx.snap
+++ b/webapp/channels/src/components/preparing_workspace/__snapshots__/invite_members.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`InviteMembers component should match snapshot when it is cloud 1`] = `
           class="PreparingWorkspaceDescription"
         >
           <span>
-            Collaboration is tough by yourself. Invite a few team members. Separate each email address with a space or comma.
+            Collaboration is tough by yourself. Invite a few team members. Separate each email address with a comma or semicolon.
           </span>
         </p>
         <div

--- a/webapp/channels/src/components/preparing_workspace/invite_members.tsx
+++ b/webapp/channels/src/components/preparing_workspace/invite_members.tsx
@@ -166,7 +166,7 @@ const InviteMembers = (props: Props) => {
                 <Description>
                     <FormattedMessage
                         id={'onboarding_wizard.invite_members.description'}
-                        defaultMessage='Collaboration is tough by yourself. Invite a few team members. Separate each email address with a space or comma.'
+                        defaultMessage='Collaboration is tough by yourself. Invite a few team members. Separate each email address with a comma or semicolon.'
                     />
                 </Description>
                 <PageBody>

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.test.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.test.tsx
@@ -1,0 +1,131 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import type {InputActionMeta} from 'react-select';
+
+import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
+
+import UsersEmailsInputWrapper from './users_emails_input';
+import type {UsersEmailsInput} from './users_emails_input';
+
+describe('components/widgets/inputs/UsersEmailsInput', () => {
+    const baseProps = {
+        placeholder: 'Search and add people',
+        ariaLabel: 'Search and add people',
+        usersLoader: jest.fn().mockReturnValue(Promise.resolve([])),
+        onChange: jest.fn(),
+        onInputChange: jest.fn(),
+        inputValue: '',
+        value: [],
+        emailInvitationsEnabled: true,
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('delimiter handling on typed input', () => {
+        it('should NOT treat space as a delimiter when typing', async () => {
+            const wrapper = shallowWithIntl(
+                <UsersEmailsInputWrapper {...baseProps}/>,
+            );
+            const instance = wrapper.instance() as UsersEmailsInput;
+
+            const action: InputActionMeta = {
+                action: 'input-change',
+                prevInputValue: 'john ',
+            };
+
+            await instance.handleInputChange('john s', action);
+
+            expect(baseProps.onInputChange).toHaveBeenCalledWith('john s');
+        });
+
+        it('should treat comma as a delimiter when typing', async () => {
+            const wrapper = shallowWithIntl(
+                <UsersEmailsInputWrapper {...baseProps}/>,
+            );
+            const instance = wrapper.instance() as UsersEmailsInput;
+
+            const action: InputActionMeta = {
+                action: 'input-change',
+                prevInputValue: 'user@example.com,',
+            };
+
+            await instance.handleInputChange('', action);
+
+            expect(baseProps.onChange).toHaveBeenCalled();
+        });
+
+        it('should treat semicolon as a delimiter when typing', async () => {
+            const wrapper = shallowWithIntl(
+                <UsersEmailsInputWrapper {...baseProps}/>,
+            );
+            const instance = wrapper.instance() as UsersEmailsInput;
+
+            const action: InputActionMeta = {
+                action: 'input-change',
+                prevInputValue: 'user@example.com;',
+            };
+
+            await instance.handleInputChange('', action);
+
+            expect(baseProps.onChange).toHaveBeenCalled();
+        });
+    });
+
+    describe('edge cases', () => {
+        it('should handle comma-then-space pattern without losing email', async () => {
+            const wrapper = shallowWithIntl(
+                <UsersEmailsInputWrapper {...baseProps}/>,
+            );
+            const instance = wrapper.instance() as UsersEmailsInput;
+
+            const count = await instance.appendDelimitedValues('user@example.com, ', /[,;]+/);
+
+            expect(count).toBe(1);
+            expect(baseProps.onChange).toHaveBeenCalled();
+        });
+    });
+
+    describe('delimiter handling on paste', () => {
+        it('should split pasted values on spaces', async () => {
+            const wrapper = shallowWithIntl(
+                <UsersEmailsInputWrapper {...baseProps}/>,
+            );
+            const instance = wrapper.instance() as UsersEmailsInput;
+
+            const count = await instance.appendDelimitedValues('user1@example.com user2@example.com');
+
+            expect(count).toBe(2);
+            expect(baseProps.onChange).toHaveBeenCalled();
+            const changeArgs = baseProps.onChange.mock.calls[0][0];
+            expect(changeArgs).toHaveLength(2);
+        });
+
+        it('should split pasted values on newlines', async () => {
+            const wrapper = shallowWithIntl(
+                <UsersEmailsInputWrapper {...baseProps}/>,
+            );
+            const instance = wrapper.instance() as UsersEmailsInput;
+
+            const count = await instance.appendDelimitedValues('user1@example.com\nuser2@example.com');
+
+            expect(count).toBe(2);
+            expect(baseProps.onChange).toHaveBeenCalled();
+        });
+
+        it('should split pasted values on commas', async () => {
+            const wrapper = shallowWithIntl(
+                <UsersEmailsInputWrapper {...baseProps}/>,
+            );
+            const instance = wrapper.instance() as UsersEmailsInput;
+
+            const count = await instance.appendDelimitedValues('user1@example.com,user2@example.com');
+
+            expect(count).toBe(2);
+            expect(baseProps.onChange).toHaveBeenCalled();
+        });
+    });
+});

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
@@ -63,7 +63,8 @@ type State = {
     prevValue: string;
 }
 
-const multipleValuesDelimiter = /[\s,;]+/;
+const typedInputDelimiter = /[,;]+/;
+const pasteDelimiter = /[\s,;]+/;
 
 const messages = defineMessages({
     loadingDefault: {
@@ -336,8 +337,8 @@ export class UsersEmailsInput extends React.PureComponent<Props, State> {
                     prevValue: action.prevInputValue,
                 }));
             }
-        } else if (action.action === 'input-change' && action.prevInputValue !== '' && action.prevInputValue?.[action.prevInputValue.length - 1].match(multipleValuesDelimiter)) {
-            const newValuesCount = await this.appendDelimitedValues(action.prevInputValue);
+        } else if (action.action === 'input-change' && action.prevInputValue !== '' && action.prevInputValue?.[action.prevInputValue.length - 1].match(typedInputDelimiter)) {
+            const newValuesCount = await this.appendDelimitedValues(action.prevInputValue, typedInputDelimiter);
             if (newValuesCount === 0) {
                 return;
             }
@@ -390,9 +391,9 @@ export class UsersEmailsInput extends React.PureComponent<Props, State> {
         }
     };
 
-    appendDelimitedValues = async (values: string): Promise<number> => {
+    appendDelimitedValues = async (values: string, delimiter: RegExp = pasteDelimiter): Promise<number> => {
         const existingValues = this.formatValuesForCreatable();
-        const entries = [...new Set(values.split(multipleValuesDelimiter))];
+        const entries = [...new Set(values.split(delimiter).map((e) => e.trim()))];
 
         if (entries.length === 0) {
             return 0;

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -5428,7 +5428,7 @@
   "onboarding_wizard.invite_members.copied_link": "Link Copied",
   "onboarding_wizard.invite_members.copy_link": "Copy Link",
   "onboarding_wizard.invite_members.copy_link_input": "team invite link",
-  "onboarding_wizard.invite_members.description": "Collaboration is tough by yourself. Invite a few team members. Separate each email address with a space or comma.",
+  "onboarding_wizard.invite_members.description": "Collaboration is tough by yourself. Invite a few team members. Separate each email address with a comma or semicolon.",
   "onboarding_wizard.invite_members.description_link": "Collaboration is tough by yourself. Invite a few team members using the invitation link below.",
   "onboarding_wizard.invite_members.next": "Send invites",
   "onboarding_wizard.invite_members.next_link": "Finish setup",


### PR DESCRIPTION
## Summary

Fixes https://mattermost.atlassian.net/browse/MM-68156

- The invite modal's `UsersEmailsInput` component used a single delimiter regex (`/[\s,;]+/`) that treated whitespace (including space) as a token separator. Typing a space (e.g., between a first and last name) triggered the delimiter logic, splitting and clearing the input field.
- Split the delimiter into two: `typedInputDelimiter` (`/[,;]+/`) for interactive typing and `pasteDelimiter` (`/[\s,;]+/`) for paste operations where whitespace-separated values are expected. Added `.trim()` to split entries to correctly handle the `email, email` (comma+space) typing pattern.
- Updated the onboarding invite description text from "space or comma" to "comma or semicolon" to reflect the new delimiter behavior.

## Test plan

- [x] Type a first name, press space, type a last name — input is preserved (not cleared)
- [x] Type `user@example.com,` — comma triggers delimiter processing
- [x] Type `user@example.com;` — semicolon triggers delimiter processing
- [x] Paste `user1@example.com user2@example.com` — both emails are parsed
- [x] Paste `user1@example.com,user2@example.com` — both emails are parsed
- [x] Paste newline-separated emails — all emails are parsed
- [x] Type `user@example.com, ` then continue typing — first email is not lost (trim handles trailing space)
- [x] 7 new unit tests added covering typed input, paste, and edge cases
- [x] All 83 existing tests across 12 related suites pass
- [x] ESLint clean, no new TypeScript errors