### PR TITLE
MM-68173 Add write-permission guard to AllowDownloadLogs toggle

### DIFF
--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -2494,6 +2494,7 @@ const AdminDefinition: AdminDefinitionType = {
                             key: 'SupportSettings.AllowDownloadLogs',
                             label: defineMessage({id: 'admin.support.problemAllowDownloadTitle', defaultMessage: 'Allow Mobile App Log Downloads:'}),
                             help_text: defineMessage({id: 'admin.support.problemAllowDownloadDescription', defaultMessage: 'When enabled, users can download app logs for troubleshooting. If a ‘Report a Problem’ link is shown, logs can be downloaded as part of that flow; if the ‘Report a Problem’ link is hidden, logs remain accessible as a separate option.'}),
+                            isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.SITE.CUSTOMIZATION)),
                         },
                         {
                             type: 'text',

--- a/webapp/channels/src/components/admin_console/admin_definition_allow_download_logs.test.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition_allow_download_logs.test.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import AdminDefinition from './admin_definition';
+import type {AdminDefinitionSetting} from './types';
+
+describe('AdminDefinition - AllowDownloadLogs permission guard', () => {
+    const getCustomizationSettings = () => {
+        const customizationSection = AdminDefinition.site.subsections.customization;
+        const schema = customizationSection?.schema;
+        return (schema && 'settings' in schema && schema.settings) ? schema.settings : [];
+    };
+
+    test('AllowDownloadLogs setting should exist in customization section', () => {
+        const settings = getCustomizationSettings();
+        const setting = settings.find((s: AdminDefinitionSetting) => s.key === 'SupportSettings.AllowDownloadLogs');
+
+        expect(setting).toBeDefined();
+        expect(setting?.type).toBe('bool');
+    });
+
+    test('AllowDownloadLogs setting should have isDisabled write-permission guard', () => {
+        const settings = getCustomizationSettings();
+        const setting = settings.find((s: AdminDefinitionSetting) => s.key === 'SupportSettings.AllowDownloadLogs');
+
+        expect(setting?.isDisabled).toBeDefined();
+        expect(typeof setting?.isDisabled).toBe('function');
+    });
+});


### PR DESCRIPTION
## Summary
- Added the missing `isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.SITE.CUSTOMIZATION))` guard to the `SupportSettings.AllowDownloadLogs` toggle in the admin console Customization section.
- Without this guard, read-only admins could toggle the AllowDownloadLogs setting when they should not have write access.
- Added a test to verify the setting has the `isDisabled` permission guard.

## Ticket Link
https://mattermost.atlassian.net/browse/MM-68173

## Test plan
- [ ] Log in as a read-only admin (no write permission on `RESOURCE_KEYS.SITE.CUSTOMIZATION`)
- [ ] Navigate to Site Configuration > Customization
- [ ] Verify the "Allow Mobile App Log Downloads" toggle is disabled/greyed out
- [ ] Log in as a full admin and verify the toggle remains functional
- [ ] Run `npm test -- --no-coverage src/components/admin_console/admin_definition_allow_download_logs.test.tsx` and verify tests pass