### PR TITLE
MM-68204: Use multi-level logging for shared channel and remote cluster service errors

### DIFF
--- a/server/platform/services/remotecluster/ping.go
+++ b/server/platform/services/remotecluster/ping.go
@@ -18,7 +18,7 @@ func (rcs *Service) PingNow(rc *model.RemoteCluster) {
 	online := rc.IsOnline()
 
 	if err := rcs.pingRemote(rc); err != nil {
-		rcs.server.Log().Log(mlog.LvlRemoteClusterServiceWarn, "Remote cluster ping failed",
+		rcs.server.Log().LogM(mlog.MlvlRemoteClusterServiceWarn, "Remote cluster ping failed",
 			mlog.String("remote", rc.DisplayName),
 			mlog.String("remoteId", rc.RemoteId),
 			mlog.String("pluginId", rc.PluginID),
@@ -39,7 +39,7 @@ func (rcs *Service) pingAllNow(filter model.RemoteClusterQueryFilter) {
 	// get all remotes, including any previously offline.
 	remotes, err := rcs.server.GetStore().RemoteCluster().GetAll(0, 999999, filter)
 	if err != nil {
-		rcs.server.Log().Log(mlog.LvlRemoteClusterServiceError, "Ping all remote clusters failed (could not get list of remotes)", mlog.Err(err))
+		rcs.server.Log().LogM(mlog.MlvlRemoteClusterServiceError, "Ping all remote clusters failed (could not get list of remotes)", mlog.Err(err))
 		return
 	}
 
@@ -135,7 +135,7 @@ func (rcs *Service) pingRemote(rc *model.RemoteCluster) error {
 	}
 
 	if err := rcs.server.GetStore().RemoteCluster().SetLastPingAt(rc.RemoteId); err != nil {
-		rcs.server.Log().Log(mlog.LvlRemoteClusterServiceError, "Failed to update LastPingAt for remote cluster",
+		rcs.server.Log().LogM(mlog.MlvlRemoteClusterServiceWarn, "Failed to update LastPingAt for remote cluster",
 			mlog.String("remote", rc.DisplayName),
 			mlog.String("remoteId", rc.RemoteId),
 			mlog.Err(err),

--- a/server/platform/services/remotecluster/ping.go
+++ b/server/platform/services/remotecluster/ping.go
@@ -135,7 +135,7 @@ func (rcs *Service) pingRemote(rc *model.RemoteCluster) error {
 	}
 
 	if err := rcs.server.GetStore().RemoteCluster().SetLastPingAt(rc.RemoteId); err != nil {
-		rcs.server.Log().LogM(mlog.MlvlRemoteClusterServiceWarn, "Failed to update LastPingAt for remote cluster",
+		rcs.server.Log().LogM(mlog.MlvlRemoteClusterServiceError, "Failed to update LastPingAt for remote cluster",
 			mlog.String("remote", rc.DisplayName),
 			mlog.String("remoteId", rc.RemoteId),
 			mlog.Err(err),

--- a/server/platform/services/remotecluster/recv.go
+++ b/server/platform/services/remotecluster/recv.go
@@ -32,7 +32,7 @@ func (rcs *Service) ReceiveIncomingMsg(rc *model.RemoteCluster, msg model.Remote
 
 	for _, l := range listeners {
 		if err := callback(l, msg, &rcSanitized, &response); err != nil {
-			rcs.server.Log().Log(mlog.LvlRemoteClusterServiceError, "Error from remote cluster message listener",
+			rcs.server.Log().LogM(mlog.MlvlRemoteClusterServiceError, "Error from remote cluster message listener",
 				mlog.String("msgId", msg.Id), mlog.String("topic", msg.Topic), mlog.String("remote", rc.DisplayName), mlog.Err(err))
 
 			response.Status = ResponseStatusFail

--- a/server/platform/services/remotecluster/sendfile.go
+++ b/server/platform/services/remotecluster/sendfile.go
@@ -59,7 +59,7 @@ func (rcs *Service) sendFile(task sendFileTask) {
 	var response Response
 
 	if err != nil {
-		rcs.server.Log().Log(mlog.LvlRemoteClusterServiceError, "Remote Cluster send file failed",
+		rcs.server.Log().LogM(mlog.MlvlRemoteClusterServiceError, "Remote Cluster send file failed",
 			mlog.String("remote", task.rc.DisplayName),
 			mlog.String("uploadId", task.us.Id),
 			mlog.Err(err),

--- a/server/platform/services/remotecluster/sendmsg.go
+++ b/server/platform/services/remotecluster/sendmsg.go
@@ -99,7 +99,7 @@ func (rcs *Service) sendMsg(task sendMsgTask) {
 
 	u, err := url.Parse(task.rc.SiteURL)
 	if err != nil {
-		rcs.server.Log().Log(mlog.LvlRemoteClusterServiceError, "Invalid siteURL while sending message to remote",
+		rcs.server.Log().LogM(mlog.MlvlRemoteClusterServiceError, "Invalid siteURL while sending message to remote",
 			mlog.String("remote", task.rc.DisplayName),
 			mlog.String("msgId", task.msg.Id),
 			mlog.Err(err),
@@ -112,7 +112,7 @@ func (rcs *Service) sendMsg(task sendMsgTask) {
 	respJSON, err := rcs.sendFrameToRemote(SendTimeout, task.rc, frame, u.String())
 
 	if err != nil {
-		rcs.server.Log().Log(mlog.LvlRemoteClusterServiceError, "Remote Cluster send message failed",
+		rcs.server.Log().LogM(mlog.MlvlRemoteClusterServiceError, "Remote Cluster send message failed",
 			mlog.String("remote", task.rc.DisplayName),
 			mlog.String("msgId", task.msg.Id),
 			mlog.Err(err),

--- a/server/platform/services/remotecluster/sendprofileImage.go
+++ b/server/platform/services/remotecluster/sendprofileImage.go
@@ -57,7 +57,7 @@ func (rcs *Service) sendProfileImage(task sendProfileImageTask) {
 	var response Response
 
 	if err != nil {
-		rcs.server.Log().Log(mlog.LvlRemoteClusterServiceError, "Remote Cluster send profile image failed",
+		rcs.server.Log().LogM(mlog.MlvlRemoteClusterServiceWarn, "Remote Cluster send profile image failed",
 			mlog.String("remote", task.rc.DisplayName),
 			mlog.String("UserId", task.userID),
 			mlog.Err(err),

--- a/server/platform/services/sharedchannel/attachment.go
+++ b/server/platform/services/sharedchannel/attachment.go
@@ -22,7 +22,7 @@ func (scs *Service) shouldSyncAttachment(fi *model.FileInfo, rc *model.RemoteClu
 	sca, err := scs.server.GetStore().SharedChannel().GetAttachment(fi.Id, rc.RemoteId)
 	if err != nil {
 		if _, ok := err.(errNotFound); !ok {
-			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "error fetching shared channel attachment",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "error fetching shared channel attachment",
 				mlog.String("file_id", fi.Id),
 				mlog.String("remote_id", rc.RemoteId),
 				mlog.Err(err),

--- a/server/platform/services/sharedchannel/attachment.go
+++ b/server/platform/services/sharedchannel/attachment.go
@@ -22,7 +22,7 @@ func (scs *Service) shouldSyncAttachment(fi *model.FileInfo, rc *model.RemoteClu
 	sca, err := scs.server.GetStore().SharedChannel().GetAttachment(fi.Id, rc.RemoteId)
 	if err != nil {
 		if _, ok := err.(errNotFound); !ok {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "error fetching shared channel attachment",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "error fetching shared channel attachment",
 				mlog.String("file_id", fi.Id),
 				mlog.String("remote_id", rc.RemoteId),
 				mlog.Err(err),
@@ -105,7 +105,7 @@ func (scs *Service) sendAttachmentForRemote(fi *model.FileInfo, post *model.Post
 		}
 
 		if !resp.IsSuccess() {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "send file failed",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "send file failed",
 				mlog.String("remote", rc.DisplayName),
 				mlog.String("uploadId", usResp.Id),
 				mlog.String("err", resp.Err),
@@ -116,7 +116,7 @@ func (scs *Service) sendAttachmentForRemote(fi *model.FileInfo, post *model.Post
 		// response payload should be a model.FileInfo.
 		var fi model.FileInfo
 		if err2 := json.Unmarshal(resp.Payload, &fi); err2 != nil {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "invalid file info response after send file",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "invalid file info response after send file",
 				mlog.String("remote", rc.DisplayName),
 				mlog.String("uploadId", usResp.Id),
 				mlog.Err(err2),
@@ -126,7 +126,7 @@ func (scs *Service) sendAttachmentForRemote(fi *model.FileInfo, post *model.Post
 
 		// save file attachment record in SharedChannelAttachments table
 		if err2 := scs.saveSharedAttachment(&fi, rc); err2 != nil {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "error saving SharedChannelAttachment",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "error saving SharedChannelAttachment",
 				mlog.String("remote", rc.DisplayName),
 				mlog.String("uploadId", usResp.Id),
 				mlog.Err(err2),

--- a/server/platform/services/sharedchannel/channelinvite.go
+++ b/server/platform/services/sharedchannel/channelinvite.go
@@ -267,7 +267,7 @@ func (scs *Service) onReceiveChannelInvite(msg model.RemoteClusterMsg, rc *model
 			// unless the remote is compromised AND has knowledge of the local user ids.
 			// Another possibility would be an actual user ID collision between two servers, where the likelihood is
 			// infinitesimally small
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Channel invite failed - channel created/fetched with wrong id",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Channel invite failed - channel created/fetched with wrong id",
 				mlog.String("remote", rc.DisplayName),
 				mlog.String("channel_id", invite.ChannelId),
 				mlog.String("channel_type", invite.Type),
@@ -475,7 +475,7 @@ func (scs *Service) createDirectChannel(invite channelInviteMsg, rc *model.Remot
 	// ensure remote user is allowed to DM the local user
 	canSee, appErr := scs.app.UserCanSeeOtherUser(request.EmptyContext(scs.server.Log()), userRemote.Id, userLocal.Id)
 	if appErr != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "cannot check user visibility for DM creation",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "cannot check user visibility for DM creation",
 			mlog.String("user_remote", userRemote.Id),
 			mlog.String("user_local", userLocal.Id),
 			mlog.String("channel_id", invite.ChannelId),

--- a/server/platform/services/sharedchannel/membership.go
+++ b/server/platform/services/sharedchannel/membership.go
@@ -46,7 +46,7 @@ func (scs *Service) ForceMembershipSyncForRemote(rc *model.RemoteCluster) {
 	}
 	scrs, err := scs.server.GetStore().SharedChannel().GetRemotes(0, 999999, opts)
 	if err != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to fetch shared channel remotes for membership sync",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Failed to fetch shared channel remotes for membership sync",
 			mlog.String("remote", rc.DisplayName),
 			mlog.String("remoteId", rc.RemoteId),
 			mlog.Err(err),

--- a/server/platform/services/sharedchannel/membership_recv.go
+++ b/server/platform/services/sharedchannel/membership_recv.go
@@ -54,7 +54,7 @@ func (scs *Service) onReceiveMembershipChanges(syncMsg *model.SyncMsg, rc *model
 
 	for _, change := range syncMsg.MembershipChanges {
 		if change.ChannelId != syncMsg.ChannelId {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "ChannelId mismatch in membership change",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "ChannelId mismatch in membership change",
 				mlog.String("expected", syncMsg.ChannelId),
 				mlog.String("got", change.ChannelId),
 				mlog.String("remote_id", rc.RemoteId),
@@ -82,7 +82,7 @@ func (scs *Service) onReceiveMembershipChanges(syncMsg *model.SyncMsg, rc *model
 		}
 
 		if processErr != nil {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to process membership change",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Failed to process membership change",
 				mlog.String("user_id", change.UserId),
 				mlog.String("channel_id", change.ChannelId),
 				mlog.String("remote_id", rc.RemoteId),
@@ -95,7 +95,7 @@ func (scs *Service) onReceiveMembershipChanges(syncMsg *model.SyncMsg, rc *model
 	}
 
 	if failCount > 0 {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceWarn, "Some membership changes failed",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Some membership changes failed",
 			mlog.String("channel_id", syncMsg.ChannelId),
 			mlog.Int("total", len(syncMsg.MembershipChanges)),
 			mlog.Int("failed", failCount),
@@ -156,7 +156,7 @@ func (scs *Service) processMemberRemove(change *model.MembershipChangeMsg, rc *m
 	// Get channel so we can use app layer methods properly
 	channel, err := scs.server.GetStore().Channel().Get(change.ChannelId, true)
 	if err != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceWarn, "Cannot find channel for member removal",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Cannot find channel for member removal",
 			mlog.String("channel_id", change.ChannelId),
 			mlog.String("user_id", change.UserId),
 			mlog.Err(err),

--- a/server/platform/services/sharedchannel/permalink.go
+++ b/server/platform/services/sharedchannel/permalink.go
@@ -40,11 +40,11 @@ func (scs *Service) processPermalinkToRemote(p *model.Post) string {
 		}
 		postList, err := scs.server.GetStore().Post().Get(rctx, postID, opts, "", map[string]bool{})
 		if err != nil {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceWarn, "Unable to get post during replacing permalinks", mlog.Err(err))
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Unable to get post during replacing permalinks", mlog.Err(err))
 			return msg
 		}
 		if len(postList.Order) == 0 {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceWarn, "No post found for permalink", mlog.String("postID", postID))
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "No post found for permalink", mlog.String("postID", postID))
 			return msg
 		}
 
@@ -70,7 +70,7 @@ func (scs *Service) processPermalinkFromRemote(p *model.Post, team *model.Team) 
 		// Extract host name
 		parsed, err := url.Parse(remoteLink)
 		if err != nil {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceWarn, "Unable to parse the remote link during replacing permalinks", mlog.Err(err))
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Unable to parse the remote link during replacing permalinks", mlog.Err(err))
 			return remoteLink
 		}
 

--- a/server/platform/services/sharedchannel/service.go
+++ b/server/platform/services/sharedchannel/service.go
@@ -289,7 +289,7 @@ func (scs *Service) notifyClientsForSharedChannelConverted(channel *model.Channe
 	messageWs := model.NewWebSocketEvent(model.WebsocketEventChannelUpdated, "", channel.Id, "", nil, "")
 	channelJSON, err := json.Marshal(channel)
 	if err != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceWarn, "Cannot marshal channel to notify clients",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Cannot marshal channel to notify clients",
 			mlog.String("channel_id", channel.Id),
 			mlog.Err(err),
 		)
@@ -319,8 +319,8 @@ func (scs *Service) postUnshareNotification(channelID string, creatorID string, 
 	_, _, appErr := scs.app.CreatePost(request.EmptyContext(logger), post, channel, model.CreatePostFlags{})
 
 	if appErr != nil {
-		scs.server.Log().Log(
-			mlog.LvlSharedChannelServiceError,
+		scs.server.Log().LogM(
+			mlog.MlvlSharedChannelServiceWarn,
 			"Error creating unshare notification post",
 			mlog.String("channel_id", channelID),
 			mlog.String("remote_id", rc.RemoteId),

--- a/server/platform/services/sharedchannel/service_api.go
+++ b/server/platform/services/sharedchannel/service_api.go
@@ -284,7 +284,7 @@ func (scs *Service) updateMembershipSyncCursor(channelID string, remoteID string
 	// Get the remote record
 	scr, err := scs.server.GetStore().SharedChannel().GetRemoteByIds(channelID, remoteID)
 	if err != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to get shared channel remote for cursor update",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Failed to get shared channel remote for cursor update",
 			mlog.String("channel_id", channelID),
 			mlog.String("remote_id", remoteID),
 			mlog.Int("timestamp", int(newTimestamp)),
@@ -294,7 +294,7 @@ func (scs *Service) updateMembershipSyncCursor(channelID string, remoteID string
 	}
 
 	if scr == nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Shared channel remote not found for cursor update",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Shared channel remote not found for cursor update",
 			mlog.String("channel_id", channelID),
 			mlog.String("remote_id", remoteID),
 		)
@@ -304,7 +304,7 @@ func (scs *Service) updateMembershipSyncCursor(channelID string, remoteID string
 	// Update the cursor - the store will handle ensuring it only moves forward
 	err = scs.server.GetStore().SharedChannel().UpdateRemoteMembershipCursor(scr.Id, newTimestamp)
 	if err != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to update membership cursor",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Failed to update membership cursor",
 			mlog.String("channel_id", channelID),
 			mlog.String("remote_id", remoteID),
 			mlog.String("remote_record_id", scr.Id),

--- a/server/platform/services/sharedchannel/sync_recv.go
+++ b/server/platform/services/sharedchannel/sync_recv.go
@@ -219,7 +219,7 @@ func (scs *Service) processSyncMessage(rctx request.CTX, syncMsg *model.SyncMsg,
 	// add/remove reactions
 	for _, reaction := range syncMsg.Reactions {
 		if _, err := scs.upsertSyncReaction(reaction, targetChannel, rc); err != nil {
-			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Error upserting sync reaction",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Error upserting sync reaction",
 				mlog.String("remote", rc.Name),
 				mlog.String("user_id", reaction.UserId),
 				mlog.String("post_id", reaction.PostId),
@@ -245,7 +245,7 @@ func (scs *Service) processSyncMessage(rctx request.CTX, syncMsg *model.SyncMsg,
 	// add/remove acknowledgements
 	for _, acknowledgement := range syncMsg.Acknowledgements {
 		if _, err := scs.upsertSyncAcknowledgement(acknowledgement, targetChannel, rc); err != nil {
-			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Error upserting sync acknowledgement",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Error upserting sync acknowledgement",
 				mlog.String("remote", rc.Name),
 				mlog.String("user_id", acknowledgement.UserId),
 				mlog.String("post_id", acknowledgement.PostId),
@@ -595,7 +595,7 @@ func (scs *Service) syncRemotePriorityMetadata(rctx request.CTX, post *model.Pos
 	// Save the new priority - this will replace any existing priority for the post
 	savedPriority, priorityErr := scs.server.GetStore().PostPriority().Save(newPriority)
 	if priorityErr != nil {
-		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Error saving post priority from remote",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Error saving post priority from remote",
 			mlog.String("post_id", post.Id),
 			mlog.String("channel_id", post.ChannelId),
 			mlog.Err(priorityErr),

--- a/server/platform/services/sharedchannel/sync_recv.go
+++ b/server/platform/services/sharedchannel/sync_recv.go
@@ -147,7 +147,7 @@ func (scs *Service) processSyncMessage(rctx request.CTX, syncMsg *model.SyncMsg,
 	// add/update users before posts
 	for _, user := range syncMsg.Users {
 		if userSaved, err := scs.upsertSyncUser(rctx, user, targetChannel, rc); err != nil {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Error upserting sync user",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Error upserting sync user",
 				mlog.String("remote", rc.Name),
 				mlog.String("channel_id", syncMsg.ChannelId),
 				mlog.String("user_id", user.Id),
@@ -171,7 +171,7 @@ func (scs *Service) processSyncMessage(rctx request.CTX, syncMsg *model.SyncMsg,
 		}
 
 		if syncMsg.ChannelId != post.ChannelId {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "ChannelId mismatch",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "ChannelId mismatch",
 				mlog.String("remote", rc.Name),
 				mlog.String("sm.ChannelId", syncMsg.ChannelId),
 				mlog.String("sm.Post.ChannelId", post.ChannelId),
@@ -185,7 +185,7 @@ func (scs *Service) processSyncMessage(rctx request.CTX, syncMsg *model.SyncMsg,
 			var err2 error
 			team, err2 = scs.server.GetStore().Channel().GetTeamForChannel(syncMsg.ChannelId)
 			if err2 != nil {
-				scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Error getting Team for Channel",
+				scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Error getting Team for Channel",
 					mlog.String("ChannelId", post.ChannelId),
 					mlog.String("PostId", post.Id),
 					mlog.String("remote", rc.Name),
@@ -205,7 +205,7 @@ func (scs *Service) processSyncMessage(rctx request.CTX, syncMsg *model.SyncMsg,
 		rpost, err := scs.upsertSyncPost(post, targetChannel, rc, syncMsg.MentionTransforms)
 		if err != nil {
 			syncResp.PostErrors = append(syncResp.PostErrors, post.Id)
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Error upserting sync post",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Error upserting sync post",
 				mlog.String("post_id", post.Id),
 				mlog.String("channel_id", post.ChannelId),
 				mlog.String("remote", rc.Name),
@@ -219,7 +219,7 @@ func (scs *Service) processSyncMessage(rctx request.CTX, syncMsg *model.SyncMsg,
 	// add/remove reactions
 	for _, reaction := range syncMsg.Reactions {
 		if _, err := scs.upsertSyncReaction(reaction, targetChannel, rc); err != nil {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Error upserting sync reaction",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Error upserting sync reaction",
 				mlog.String("remote", rc.Name),
 				mlog.String("user_id", reaction.UserId),
 				mlog.String("post_id", reaction.PostId),
@@ -245,7 +245,7 @@ func (scs *Service) processSyncMessage(rctx request.CTX, syncMsg *model.SyncMsg,
 	// add/remove acknowledgements
 	for _, acknowledgement := range syncMsg.Acknowledgements {
 		if _, err := scs.upsertSyncAcknowledgement(acknowledgement, targetChannel, rc); err != nil {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Error upserting sync acknowledgement",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Error upserting sync acknowledgement",
 				mlog.String("remote", rc.Name),
 				mlog.String("user_id", acknowledgement.UserId),
 				mlog.String("post_id", acknowledgement.PostId),
@@ -269,7 +269,7 @@ func (scs *Service) processSyncMessage(rctx request.CTX, syncMsg *model.SyncMsg,
 
 	for _, status := range syncMsg.Statuses {
 		if err := scs.upsertSyncUserStatus(rctx, status, rc); err != nil {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Error upserting sync user status",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Error upserting sync user status",
 				mlog.String("remote", rc.Name),
 				mlog.String("user_id", status.UserId),
 				mlog.Err(err))
@@ -280,7 +280,7 @@ func (scs *Service) processSyncMessage(rctx request.CTX, syncMsg *model.SyncMsg,
 	// Process membership changes after users have been synced
 	if hasMembershipChanges && membershipSyncEnabled {
 		if err := scs.onReceiveMembershipChanges(syncMsg, rc, response); err != nil {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Error processing membership changes",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Error processing membership changes",
 				mlog.String("remote", rc.Name),
 				mlog.String("channel_id", syncMsg.ChannelId),
 				mlog.Int("change_count", len(syncMsg.MembershipChanges)),
@@ -325,7 +325,7 @@ func (scs *Service) upsertSyncUser(rctx request.CTX, user *model.User, channel *
 	} else {
 		// existing user. Make sure user belongs to the remote that issued the update
 		if euser.GetRemoteID() != rc.RemoteId {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "RemoteID mismatch sync'ing user",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "RemoteID mismatch sync'ing user",
 				mlog.String("remote", rc.Name),
 				mlog.String("user_id", user.Id),
 				mlog.String("existing_user_remote_id", euser.GetRemoteID()),
@@ -403,7 +403,7 @@ func (scs *Service) insertSyncUser(rctx request.CTX, user *model.User, _ *model.
 			}
 			if field == "email" || field == "username" {
 				// username or email collision; try again with different suffix
-				scs.server.Log().Log(mlog.LvlSharedChannelServiceWarn, "Collision inserting sync user",
+				scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Collision inserting sync user",
 					mlog.String("field", field),
 					mlog.String("username", user.Username),
 					mlog.String("email", user.Email),
@@ -457,7 +457,7 @@ func (scs *Service) updateSyncUser(rctx request.CTX, patch *model.UserPatch, use
 			}
 			if field == "email" || field == "username" {
 				// username or email collision; try again with different suffix
-				scs.server.Log().Log(mlog.LvlSharedChannelServiceWarn, "Collision updating sync user",
+				scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Collision updating sync user",
 					mlog.String("field", field),
 					mlog.String("username", user.Username),
 					mlog.String("email", user.Email),
@@ -595,7 +595,7 @@ func (scs *Service) syncRemotePriorityMetadata(rctx request.CTX, post *model.Pos
 	// Save the new priority - this will replace any existing priority for the post
 	savedPriority, priorityErr := scs.server.GetStore().PostPriority().Save(newPriority)
 	if priorityErr != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Error saving post priority from remote",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Error saving post priority from remote",
 			mlog.String("post_id", post.Id),
 			mlog.String("channel_id", post.ChannelId),
 			mlog.Err(priorityErr),
@@ -621,14 +621,14 @@ func (scs *Service) syncRemoteAcknowledgementsMetadata(rctx request.CTX, post *m
 	// Get existing acknowledgements and delete them using batch operation
 	existingAcks, appErrGet := scs.app.GetAcknowledgementsForPost(post.Id)
 	if appErrGet != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Error getting existing acknowledgements for remote sync",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Error getting existing acknowledgements for remote sync",
 			mlog.String("post_id", post.Id),
 			mlog.Err(appErrGet),
 		)
 	} else if len(existingAcks) > 0 {
 		// Use batch delete for better performance
 		if nErr := scs.server.GetStore().PostAcknowledgement().BatchDelete(existingAcks); nErr != nil {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Error batch deleting acknowledgements for remote sync",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Error batch deleting acknowledgements for remote sync",
 				mlog.String("post_id", post.Id),
 				mlog.Int("count", len(existingAcks)),
 				mlog.Err(nErr),
@@ -649,7 +649,7 @@ func (scs *Service) syncRemoteAcknowledgementsMetadata(rctx request.CTX, post *m
 		var appErrAck *model.AppError
 		savedAcks, appErrAck = scs.app.SaveAcknowledgementsForPost(rctx, post.Id, userIDs)
 		if appErrAck != nil {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Error syncing remote post acknowledgements",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Error syncing remote post acknowledgements",
 				mlog.String("post_id", post.Id),
 				mlog.Int("count", len(userIDs)),
 				mlog.Err(appErrAck),
@@ -773,7 +773,7 @@ func (scs *Service) upsertSyncUserStatus(rctx request.CTX, status *model.Status,
 	}
 
 	if user.GetRemoteID() != rc.RemoteId {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "RemoteID mismatch sync'ing user status",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "RemoteID mismatch sync'ing user status",
 			mlog.String("remote", rc.Name),
 			mlog.String("user_id", status.UserId),
 			mlog.String("user_remote_id", user.GetRemoteID()),

--- a/server/platform/services/sharedchannel/sync_send.go
+++ b/server/platform/services/sharedchannel/sync_send.go
@@ -87,7 +87,7 @@ func (scs *Service) NotifyUserProfileChanged(userID string) {
 
 	scusers, err := scs.server.GetStore().SharedChannel().GetUsersForUser(userID)
 	if err != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to fetch shared channel users",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Failed to fetch shared channel users",
 			mlog.String("userID", userID),
 			mlog.Err(err),
 		)
@@ -126,7 +126,7 @@ func (scs *Service) NotifyUserStatusChanged(status *model.Status) {
 	}
 
 	if status.UserId == "" {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Received invalid status for sync",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Received invalid status for sync",
 			mlog.String("userID", status.UserId),
 		)
 		return
@@ -134,7 +134,7 @@ func (scs *Service) NotifyUserStatusChanged(status *model.Status) {
 
 	scusers, err := scs.server.GetStore().SharedChannel().GetUsersForUser(status.UserId)
 	if err != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to fetch shared channel users",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Failed to fetch shared channel users",
 			mlog.String("userID", status.UserId),
 			mlog.Err(err),
 		)
@@ -178,7 +178,7 @@ func (scs *Service) SendPendingInvitesForRemote(rc *model.RemoteCluster) {
 	}
 	scrs, err := scs.server.GetStore().SharedChannel().GetRemotes(0, 999999, opts)
 	if err != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to fetch shared channel remotes for pending invites",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Failed to fetch shared channel remotes for pending invites",
 			mlog.String("remote", rc.DisplayName),
 			mlog.String("remoteId", rc.RemoteId),
 			mlog.Err(err),
@@ -189,7 +189,7 @@ func (scs *Service) SendPendingInvitesForRemote(rc *model.RemoteCluster) {
 	for _, scr := range scrs {
 		channel, err := scs.server.GetStore().Channel().Get(scr.ChannelId, true)
 		if err != nil {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to fetch channel for pending invite",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Failed to fetch channel for pending invite",
 				mlog.String("remote_id", scr.RemoteId),
 				mlog.String("channel_id", scr.ChannelId),
 				mlog.String("sharedchannelremote_id", scr.Id),
@@ -199,7 +199,7 @@ func (scs *Service) SendPendingInvitesForRemote(rc *model.RemoteCluster) {
 		}
 
 		if err := scs.SendChannelInvite(channel, scr.CreatorId, rc); err != nil {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to send pending invite",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Failed to send pending invite",
 				mlog.String("remote_id", scr.RemoteId),
 				mlog.String("channel_id", scr.ChannelId),
 				mlog.String("sharedchannelremote_id", scr.Id),
@@ -229,7 +229,7 @@ func (scs *Service) ForceSyncForRemote(rc *model.RemoteCluster) {
 	}
 	scrs, err := scs.server.GetStore().SharedChannel().GetRemotes(0, 999999, opts)
 	if err != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to fetch shared channel remotes",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Failed to fetch shared channel remotes",
 			mlog.String("remote", rc.DisplayName),
 			mlog.String("remoteId", rc.RemoteId),
 			mlog.Err(err),
@@ -462,7 +462,7 @@ func (scs *Service) handlePostError(postId string, task syncTask, rc *model.Remo
 		if task.incRetry() {
 			scs.addTask(task)
 		} else {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "error syncing post",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "error syncing post",
 				mlog.String("remote", rc.DisplayName),
 				mlog.String("post_id", postId),
 			)
@@ -473,7 +473,7 @@ func (scs *Service) handlePostError(postId string, task syncTask, rc *model.Remo
 	// this post failed as part of a group of posts. Retry as an individual post.
 	post, err := scs.server.GetStore().Post().GetSingle(request.EmptyContext(scs.server.Log()), postId, true)
 	if err != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "error fetching post for sync retry",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "error fetching post for sync retry",
 			mlog.String("remote", rc.DisplayName),
 			mlog.String("post_id", postId),
 			mlog.Err(err),
@@ -496,7 +496,7 @@ func (scs *Service) handleStatusError(userId string, task syncTask, rc *model.Re
 		if task.incRetry() {
 			scs.addTask(task)
 		} else {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "error syncing status",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "error syncing status",
 				mlog.String("remote", rc.DisplayName),
 				mlog.String("user_id", userId),
 			)
@@ -507,7 +507,7 @@ func (scs *Service) handleStatusError(userId string, task syncTask, rc *model.Re
 	// this status failed as part of a group of statuses. Retry as an individual status.
 	status, err := scs.server.GetStore().Status().Get(userId)
 	if err != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "error fetching status for sync retry",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "error fetching status for sync retry",
 			mlog.String("remote", rc.DisplayName),
 			mlog.String("user_id", userId),
 			mlog.Err(err),
@@ -553,7 +553,7 @@ func (scs *Service) notifyRemoteOffline(posts []*model.Post, rc *model.RemoteClu
 
 func (scs *Service) updateCursorForRemote(scrId string, rc *model.RemoteCluster, cursor model.GetPostsSinceForSyncCursor) {
 	if err := scs.server.GetStore().SharedChannel().UpdateRemoteCursor(scrId, cursor); err != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "error updating cursor for shared channel remote",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "error updating cursor for shared channel remote",
 			mlog.String("remote", rc.DisplayName),
 			mlog.Err(err),
 		)
@@ -604,7 +604,7 @@ func (scs *Service) shouldUserSync(user *model.User, channelID string, rc *model
 			ChannelId: channelID,
 		}
 		if _, err = scs.server.GetStore().SharedChannel().SaveUser(scu); err != nil {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Error adding user to shared channel users",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Error adding user to shared channel users",
 				mlog.String("user_id", user.Id),
 				mlog.String("channel_id", channelID),
 				mlog.String("remote_id", rc.RemoteId),
@@ -643,7 +643,7 @@ func (scs *Service) syncProfileImage(user *model.User, channelID string, rc *mod
 			return
 		}
 
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Error synchronizing users profile image",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Error synchronizing users profile image",
 			mlog.String("user_id", user.Id),
 			mlog.String("channel_id", channelID),
 			mlog.String("remote_id", rc.RemoteId),
@@ -654,7 +654,7 @@ func (scs *Service) syncProfileImage(user *model.User, channelID string, rc *mod
 
 func (scs *Service) sendProfileImageToPlugin(user *model.User, channelID string, rc *model.RemoteCluster) {
 	if err := scs.app.OnSharedChannelsProfileImageSyncMsg(user, rc); err != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Error synchronizing users profile image for plugin",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Error synchronizing users profile image for plugin",
 			mlog.String("user_id", user.Id),
 			mlog.String("channel_id", channelID),
 			mlog.String("remote_id", rc.RemoteId),
@@ -673,7 +673,7 @@ func (scs *Service) recordProfileImageSuccess(userID, channelID, remoteID string
 
 	// update LastSyncAt for user in SharedChannelUsers table
 	if err := scs.server.GetStore().SharedChannel().UpdateUserLastSyncAt(userID, channelID, remoteID); err != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Error updating users LastSyncTime after profile image update",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Error updating users LastSyncTime after profile image update",
 			mlog.String("user_id", userID),
 			mlog.String("channel_id", channelID),
 			mlog.String("remote_id", remoteID),

--- a/server/platform/services/sharedchannel/sync_send_remote.go
+++ b/server/platform/services/sharedchannel/sync_send_remote.go
@@ -418,7 +418,7 @@ func (scs *Service) fetchMembershipsForSync(sd *syncData) error {
 		if state.isAdd {
 			user, userErr := scs.server.GetStore().User().Get(context.Background(), userID)
 			if userErr != nil {
-				scs.server.Log().Log(mlog.LvlSharedChannelServiceWarn, "Failed to get user for membership sync",
+				scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Failed to get user for membership sync",
 					mlog.String("user_id", userID),
 					mlog.String("channel_id", sd.task.channelID),
 					mlog.Err(userErr),
@@ -483,7 +483,7 @@ func (scs *Service) sendMembershipSyncData(sd *syncData) error {
 
 	return scs.sendSyncMsgToRemote(msg, sd.rc, func(syncResp model.SyncResponse, errResp error) {
 		if len(syncResp.MembershipErrors) != 0 {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Response indicates error for membership(s) sync",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Response indicates error for membership(s) sync",
 				mlog.String("channel_id", sd.task.channelID),
 				mlog.String("remote_id", sd.rc.RemoteId),
 				mlog.Array("membership_errors", syncResp.MembershipErrors),
@@ -493,7 +493,7 @@ func (scs *Service) sendMembershipSyncData(sd *syncData) error {
 		// Update the membership cursor on success
 		if errResp == nil && sd.resultNextMembershipCursor > 0 {
 			if err := scs.updateMembershipSyncCursor(sd.task.channelID, sd.rc.RemoteId, sd.resultNextMembershipCursor); err != nil {
-				scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to update membership sync cursor",
+				scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Failed to update membership sync cursor",
 					mlog.String("channel_id", sd.task.channelID),
 					mlog.String("remote_id", sd.rc.RemoteId),
 					mlog.Err(err),
@@ -826,7 +826,7 @@ func (scs *Service) sendUserSyncData(sd *syncData) error {
 
 		for _, userID := range syncResp.UsersSyncd {
 			if err := scs.server.GetStore().SharedChannel().UpdateUserLastSyncAt(userID, sd.task.channelID, sd.rc.RemoteId); err != nil {
-				scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Cannot update shared channel user LastSyncAt",
+				scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Cannot update shared channel user LastSyncAt",
 					mlog.String("user_id", userID),
 					mlog.String("channel_id", sd.task.channelID),
 					mlog.String("remote_id", sd.rc.RemoteId),
@@ -835,7 +835,7 @@ func (scs *Service) sendUserSyncData(sd *syncData) error {
 			}
 		}
 		if len(syncResp.UserErrors) != 0 {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Response indicates error for user(s) sync",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Response indicates error for user(s) sync",
 				mlog.String("channel_id", sd.task.channelID),
 				mlog.String("remote_id", sd.rc.RemoteId),
 				mlog.Array("users", syncResp.UserErrors),
@@ -849,7 +849,7 @@ func (scs *Service) sendUserSyncData(sd *syncData) error {
 func (scs *Service) sendAttachmentSyncData(sd *syncData) {
 	for _, a := range sd.attachments {
 		if err := scs.sendAttachmentForRemote(a.fi, a.post, sd.rc); err != nil {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Cannot sync post attachment",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Cannot sync post attachment",
 				mlog.String("post_id", a.post.Id),
 				mlog.String("channel_id", sd.task.channelID),
 				mlog.String("remote_id", sd.rc.RemoteId),
@@ -875,7 +875,7 @@ func (scs *Service) sendPostSyncData(sd *syncData) error {
 
 	return scs.sendSyncMsgToRemote(msg, sd.rc, func(syncResp model.SyncResponse, errResp error) {
 		if len(syncResp.PostErrors) != 0 {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Response indicates error for post(s) sync",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Response indicates error for post(s) sync",
 				mlog.String("channel_id", sd.task.channelID),
 				mlog.String("remote_id", sd.rc.RemoteId),
 				mlog.Array("posts", syncResp.PostErrors),
@@ -903,7 +903,7 @@ func (scs *Service) sendReactionSyncData(sd *syncData) error {
 
 	return scs.sendSyncMsgToRemote(msg, sd.rc, func(syncResp model.SyncResponse, errResp error) {
 		if len(syncResp.ReactionErrors) != 0 {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Response indicates error for reactions(s) sync",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Response indicates error for reactions(s) sync",
 				mlog.String("channel_id", sd.task.channelID),
 				mlog.String("remote_id", sd.rc.RemoteId),
 				mlog.Array("reaction_posts", syncResp.ReactionErrors),
@@ -926,7 +926,7 @@ func (scs *Service) sendAcknowledgementSyncData(sd *syncData) error {
 
 	return scs.sendSyncMsgToRemote(msg, sd.rc, func(syncResp model.SyncResponse, errResp error) {
 		if len(syncResp.AcknowledgementErrors) != 0 {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Response indicates error for acknowledgement(s) sync",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Response indicates error for acknowledgement(s) sync",
 				mlog.String("channel_id", sd.task.channelID),
 				mlog.String("remote_id", sd.rc.RemoteId),
 				mlog.Array("acknowledgement_posts", syncResp.AcknowledgementErrors),
@@ -942,7 +942,7 @@ func (scs *Service) sendStatusSyncData(sd *syncData) error {
 
 	return scs.sendSyncMsgToRemote(msg, sd.rc, func(syncResp model.SyncResponse, errResp error) {
 		if len(syncResp.StatusErrors) != 0 {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Response indicates error from status(es) sync",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Response indicates error from status(es) sync",
 				mlog.String("remote_id", sd.rc.RemoteId),
 				mlog.Array("user_ids", syncResp.StatusErrors),
 			)
@@ -1032,7 +1032,7 @@ func (scs *Service) syncAllUsers(rc *model.RemoteCluster) error {
 
 	// Send the collected users to remote
 	if err := scs.sendUserSyncData(sd); err != nil {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Error sending user batch during sync",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Error sending user batch during sync",
 			mlog.String("remote_id", rc.RemoteId),
 			mlog.Err(err),
 		)
@@ -1082,7 +1082,7 @@ func (scs *Service) collectUsersForGlobalSync(rc *model.RemoteCluster, batchSize
 	for {
 		batch, err := scs.server.GetStore().User().GetAllProfiles(options)
 		if err != nil {
-			scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Error fetching users for global sync",
+			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Error fetching users for global sync",
 				mlog.String("remote_id", rc.RemoteId),
 				mlog.Err(err),
 			)
@@ -1139,7 +1139,7 @@ func (scs *Service) updateGlobalSyncCursor(rc *model.RemoteCluster, newTimestamp
 	if err := scs.server.GetStore().RemoteCluster().UpdateLastGlobalUserSyncAt(rc.RemoteId, newTimestamp); err == nil {
 		rc.LastGlobalUserSyncAt = newTimestamp
 	} else {
-		scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Failed to update global user sync cursor",
+		scs.server.Log().LogM(mlog.MlvlSharedChannelServiceError, "Failed to update global user sync cursor",
 			mlog.String("remote_id", rc.RemoteId),
 			mlog.Err(err),
 		)
@@ -1200,7 +1200,7 @@ func (scs *Service) sendSyncMsgToRemote(msg *model.SyncMsg, rc *model.RemoteClus
 		if errResp == nil {
 			if rcResp != nil && len(rcResp.Payload) > 0 {
 				if err2 := json.Unmarshal(rcResp.Payload, &syncResp); err2 != nil {
-					scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Invalid sync msg response from remote cluster",
+					scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Invalid sync msg response from remote cluster",
 						mlog.String("remote", rc.Name),
 						mlog.String("channel_id", msg.ChannelId),
 						mlog.Err(err2),
@@ -1213,7 +1213,7 @@ func (scs *Service) sendSyncMsgToRemote(msg *model.SyncMsg, rc *model.RemoteClus
 				}
 			} else {
 				// No error but response is nil or empty
-				scs.server.Log().Log(mlog.LvlSharedChannelServiceError, "Empty or nil response payload from remote cluster",
+				scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Empty or nil response payload from remote cluster",
 					mlog.String("remote", rc.Name),
 					mlog.String("channel_id", msg.ChannelId),
 				)
@@ -1259,7 +1259,7 @@ func (scs *Service) handleChannelNotSharedError(msg *model.SyncMsg, rc *model.Re
 	// Get the SharedChannelRemote record for this channel and remote
 	scr, getErr := scs.server.GetStore().SharedChannel().GetRemoteByIds(msg.ChannelId, rc.RemoteId)
 	if getErr != nil {
-		logger.Log(mlog.LvlSharedChannelServiceError, "Failed to get shared channel remote",
+		logger.LogM(mlog.MlvlSharedChannelServiceError, "Failed to get shared channel remote",
 			mlog.String("remote", rc.Name),
 			mlog.String("channel_id", msg.ChannelId),
 			mlog.Err(getErr),
@@ -1270,7 +1270,7 @@ func (scs *Service) handleChannelNotSharedError(msg *model.SyncMsg, rc *model.Re
 	// Get channel details for posting the system message
 	channel, channelErr := scs.server.GetStore().Channel().Get(msg.ChannelId, true)
 	if channelErr != nil {
-		logger.Log(mlog.LvlSharedChannelServiceError, "Failed to get channel details",
+		logger.LogM(mlog.MlvlSharedChannelServiceError, "Failed to get channel details",
 			mlog.String("remote", rc.Name),
 			mlog.String("channel_id", msg.ChannelId),
 			mlog.Err(channelErr),
@@ -1282,7 +1282,7 @@ func (scs *Service) handleChannelNotSharedError(msg *model.SyncMsg, rc *model.Re
 	scs.postUnshareNotification(msg.ChannelId, scr.CreatorId, channel, rc)
 
 	if err := scs.UninviteRemoteFromChannel(msg.ChannelId, rc.RemoteId); err != nil {
-		logger.Log(mlog.LvlSharedChannelServiceError, "Failed to uninvite remote from shared channel", mlog.Err(err))
+		logger.LogM(mlog.MlvlSharedChannelServiceError, "Failed to uninvite remote from shared channel", mlog.Err(err))
 		return
 	}
 }

--- a/server/public/shared/mlog/levels.go
+++ b/server/public/shared/mlog/levels.go
@@ -117,6 +117,12 @@ var (
 
 // Combinations for LogM (log multi).
 var (
+	MlvlRemoteClusterServiceError = []Level{LvlError, LvlRemoteClusterServiceError}
+	MlvlRemoteClusterServiceWarn  = []Level{LvlWarn, LvlRemoteClusterServiceWarn}
+
+	MlvlSharedChannelServiceError = []Level{LvlError, LvlSharedChannelServiceError}
+	MlvlSharedChannelServiceWarn  = []Level{LvlWarn, LvlSharedChannelServiceWarn}
+
 	MlvlLDAPError = []Level{LvlError, LvlLDAPError}
 	MlvlLDAPWarn  = []Level{LvlWarn, LvlLDAPWarn}
 	MlvlLDAPInfo  = []Level{LvlInfo, LvlLDAPInfo}


### PR DESCRIPTION
#### Summary
Previously the log levels LvlRemoteClusterServiceError and LvlSharedChannelServiceError require these levels to be configured for output. The levels exist so that admins can choose to output these errors into files or streams dedicated to shared channels related logs. However, the errors are hidden by default as these levels are not output to the main log by default.

This PR ensure these errors output to main log with default config, while preserving the ability to isolate them into their own file.

- Added multi-level combos (`MlvlRemoteClusterServiceError`, `MlvlSharedChannelServiceWarn`, etc.) following the existing LDAP/Notification pattern, and switched all 58 call sites from `Log()` to `LogM()` so each line is attributed to both the standard level (error/warn) and the service-specific level.

- Each instance was reviewed: actionable errors (DB failures, security/integrity issues, config errors, exhausted retries on critical data) remain at error level; non-actionable issues (transient network failures, remote-side reported errors with retry logic, non-critical data like profile images, reactions, acknowledgements, status) were downgraded to warn.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68204

#### Release Note
```release-note
Shared Channels related errors now appear in main log file by default.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The changes are primarily logging-only and do not modify control flow or data paths, so functional breakage is unlikely; however, adding new multi-level log mappings and downgrading some errors to warnings across ~58 call sites could reduce visibility for misclassified actionable failures.  
**QA Recommendation:** Run targeted log-visibility tests (unit/integration and a small set of representative failure scenarios in staging) to confirm critical failures remain logged at error level and that main-log filtering behaves as expected.

*Generated by CodeRabbitAI*

---

## Release Notes

Shared Channels related errors now appear in main log file by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->