### PR TITLE
fix(ci): add path filters and concurrency to api workflow

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'api/**'
+      - '.github/workflows/api.yml'
   pull_request:
+    paths:
+      - 'api/**'
+      - '.github/workflows/api.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -12,6 +22,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: ./api


### PR DESCRIPTION
#### Summary

Add `paths` filters to the API workflow so it only runs when `api/` files change, add `concurrency` with `cancel-in-progress` for PR builds, and add `timeout-minutes: 10` to the build job.

The `api.yml` workflow currently triggers on every pull request regardless of which files changed. It builds an npm-based API spec that only depends on files in `api/`, but runs on PRs touching server, webapp, docs, and CI config files.

It also lacks concurrency settings (rapid pushes to a PR branch stack up runs) and has no `timeout-minutes` (defaulting to GitHub's 6-hour max).

The other core CI workflows (`server-ci.yml`, `webapp-ci.yml`, `tools-ci.yml`) already use path-scoped PR triggers and concurrency groups. This workflow was not updated to match.

#### Ticket Link

N/A

#### Release Note

```release-note
NONE
```

---

> [!NOTE]
> Created by [Mendral](https://mendral.com). Tag @mendral-agent with feedback or questions.