### PR TITLE
fix(ci): update checkout action to v6.0.2 in check-external-links job

### DIFF
--- a/.github/workflows/webapp-ci.yml
+++ b/.github/workflows/webapp-ci.yml
@@ -54,7 +54,7 @@ jobs:
         working-directory: webapp
     steps:
       - name: ci/checkout-repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
       - name: ci/check-external-links


### PR DESCRIPTION
#### Summary

Update the `check-external-links` job in `webapp-ci.yml` to use `actions/checkout@v6.0.2` (SHA `de0fac2e`), matching every other job across all 34 workflow files. Currently pinned to `v4.2.2` (SHA `11bd7190`).

#### Ticket Link

N/A

#### Release Note

```release-note
NONE
```

---

> [!NOTE]
> Created by [Mendral](https://mendral.com). Tag @mendral-agent with feedback or questions.