### PR TITLE
SEC-10024 E2E Test: GHA triggers for E2E test workflows, adds slash command and label dispatchers

### DIFF
--- a/.github/actions/check-e2e-test-only/action.yml
+++ b/.github/actions/check-e2e-test-only/action.yml
@@ -18,7 +18,7 @@ outputs:
     description: Whether the PR contains only E2E test changes (true/false)
     value: ${{ steps.check.outputs.e2e_test_only }}
   image_tag:
-    description: Docker image tag to use (base branch ref for E2E-only, short SHA for mixed)
+    description: Docker image tag to use (base branch ref for E2E test-only, short SHA for mixed)
     value: ${{ steps.check.outputs.image_tag }}
 
 runs:
@@ -70,7 +70,7 @@ runs:
           gh api "repos/${{ github.repository }}/pulls/${INPUT_PR_NUMBER}/files" --jq '.[].filename' 2>/dev/null || echo "")
 
         if [ -z "$CHANGED_FILES" ]; then
-          echo "::warning::Could not determine changed files, assuming not E2E-only"
+          echo "::warning::Could not determine changed files, assuming not E2E test-only"
           echo "e2e_test_only=false" >> $GITHUB_OUTPUT
           echo "image_tag=${SHORT_SHA}" >> $GITHUB_OUTPUT
           exit 0

--- a/.github/e2e-tests-workflows.md
+++ b/.github/e2e-tests-workflows.md
@@ -6,7 +6,7 @@ Three automated E2E test pipelines cover different stages of the development lif
 
 | Pipeline | Trigger | Editions Tested | Image Source |
 |----------|---------|----------------|--------------|
-| **PR** (`e2e-tests-ci.yml`) | Argo Events on `Enterprise CI/docker-image` status | enterprise | `mattermostdevelopment/**` |
+| **PR** (`e2e-tests-ci.yml`) | `pull_request`, `Enterprise CI/docker-image` status, slash command, label | enterprise | `mattermostdevelopment/**` |
 | **Merge to master/release** (`e2e-tests-on-merge.yml`) | Platform delivery after docker build (`delivery-platform/.github/workflows/mattermost-platform-delivery.yaml`) | enterprise, fips | `mattermostdevelopment/**` |
 | **Release cut** (`e2e-tests-on-release.yml`) | Platform release after docker build (`delivery-platform/.github/workflows/release-mattermost-platform.yml`) | enterprise, fips, team (future) | `mattermost/**` |
 
@@ -22,31 +22,45 @@ All pipelines follow the **smoke-then-full** pattern: smoke tests run first, ful
 ├── e2e-tests-cypress.yml               # Shared wrapper: cypress smoke -> full
 ├── e2e-tests-playwright.yml            # Shared wrapper: playwright smoke -> full
 ├── e2e-tests-cypress-template.yml      # Template: actual cypress test execution
-└── e2e-tests-playwright-template.yml   # Template: actual playwright test execution
+├── e2e-tests-playwright-template.yml   # Template: actual playwright test execution
+├── e2e-tests-check.yml                 # PR lint/typecheck for e2e test files
+├── e2e-tests-verified-label.yml        # Override failed E2E statuses (dispatched by label-dispatch)
+├── e2e-tests-override-status.yml       # Manual override of failed E2E statuses
+├── slash-command-dispatch.yml          # Catch-all dispatcher for PR slash commands
+└── label-dispatch.yml                  # Catch-all dispatcher for PR labels
 ```
 
 ### Call hierarchy
 
 ```
-e2e-tests-ci.yml ─────────────────┐
-e2e-tests-on-merge.yml ───────────┤──► e2e-tests-cypress.yml ──► e2e-tests-cypress-template.yml
-e2e-tests-on-release.yml ─────────┘    e2e-tests-playwright.yml ──► e2e-tests-playwright-template.yml
+slash-command-dispatch.yml ──► e2e-tests-ci.yml ──────────┐
+label-dispatch.yml ──────────► e2e-tests-ci.yml           │
+                               e2e-tests-on-merge.yml ────┤──► e2e-tests-cypress.yml ──► e2e-tests-cypress-template.yml
+                               e2e-tests-on-release.yml ──┘    e2e-tests-playwright.yml ──► e2e-tests-playwright-template.yml
+
+label-dispatch.yml ──────────► e2e-tests-verified-label.yml
+slash-command-dispatch.yml ──► pr-test-analysis-override.yml
 ```
 
 ---
 
 ## Pipeline 1: PR (`e2e-tests-ci.yml`)
 
-Runs E2E tests for every PR commit after the enterprise docker image is built. Fails if the commit is not associated with an open PR.
+Runs E2E tests for PR commits. Uses early decision-making to avoid unnecessary waits.
 
-**Trigger chain:**
+**Trigger paths:**
 ```
-PR commit ─► Enterprise CI builds docker image
-           ─► Argo Events detects "Enterprise CI/docker-image" status
-           ─► dispatches e2e-tests-ci.yml
+PR open/sync/reopen ─► check file changes and image_tag
+  ├─ should_run=false ─► post skip statuses immediately (no wait for Enterprise CI)
+  ├─ image_tag=master/release-* ─► run tests immediately with existing image
+  └─ image_tag=<sha> ─► exit (wait for Enterprise CI)
+
+Enterprise CI builds docker image
+  ─► sets "Enterprise CI/docker-image" commit status to "success"
+  ─► GitHub fires status event ─► run tests with commit-specific image
 ```
 
-For PRs from forks, `body.branches` may be empty so the workflow falls back to `master` for workflow files (trusted code), while `commit_sha` still points to the fork's commit.
+The `pull_request` event checks for E2E test-relevant changes and whether the PR is E2E test-only (can reuse a branch image). The `status` event handles the case where a commit-specific docker image is needed.
 
 **Jobs:** 2 (cypress + playwright), each does smoke -> full
 
@@ -67,18 +81,55 @@ gh workflow run e2e-tests-ci.yml \
 ```
 
 **Manual trigger (GitHub UI):**
-1. Go to **Actions** > **E2E Tests (smoke-then-full)**
+1. Go to **Actions** > **E2E Tests (pull request)**
 2. Click **Run workflow**
 3. Fill in `pr_number` (e.g., `35171`)
 4. Click **Run workflow**
 
 ### On-demand testing
 
-For on-demand E2E testing, the existing triggers still work:
-- **Comment triggers**: `/e2e-test`, `/e2e-test fips`, or with `MM_ENV` parameters
-- **Label trigger**: `E2E/Run`
+On-demand E2E testing can be triggered via slash commands or labels:
 
-These are separate from the automated workflow and can be used for custom test configurations or re-runs.
+| Trigger | Action |
+|---------|--------|
+| `/e2e-test` comment on PR | Dispatches `e2e-tests-ci.yml` via `slash-command-dispatch.yml` |
+| `E2E Tests/run` label on PR | Dispatches `e2e-tests-ci.yml` via `label-dispatch.yml` (label auto-removed) |
+
+Both require write permission to `mattermost/mattermost`.
+
+---
+
+## Slash Command Dispatch (`slash-command-dispatch.yml`)
+
+Single `issue_comment` listener that catches all `/` commands on PRs and dispatches to the appropriate workflow. Reduces skipped checks by consolidating all slash command handling into one workflow.
+
+**Supported commands:**
+
+| Command | Target Workflow |
+|---------|----------------|
+| `/e2e-test` | `e2e-tests-ci.yml` |
+| `/test-analysis-override <reason>` | `pr-test-analysis-override.yml` |
+
+**Permission model (two layers):**
+1. **Job `if` (free, no runner):** `author_association` check filters out external contributors
+2. **API check (first step):** Verifies write permission to `mattermost/mattermost` via `gh api repos/mattermost/mattermost/collaborators/{user}/permission`
+
+Unknown commands are silently ignored (no reaction, no error).
+
+---
+
+## Label Dispatch (`label-dispatch.yml`)
+
+Single `pull_request: [labeled]` listener that catches label events and dispatches to the appropriate workflow. Same consolidation pattern as slash commands.
+
+**Supported labels:**
+
+| Label | Target Workflow |
+|-------|----------------|
+| `E2E Tests/run` | `e2e-tests-ci.yml` (label auto-removed after dispatch) |
+| `E2E Tests/verified` | `e2e-tests-verified-label.yml` |
+
+**Permission model:** Same two-layer check as slash command dispatch — `startsWith` pre-filter in job `if`, then API permission check as first step.
 
 ---
 
@@ -200,6 +251,7 @@ Where `<phase>` is `cypress-smoke`, `cypress-full`, `playwright-smoke`, or `play
 - All passed: `100% passed (<count>), <specs> specs, image_tag:<tag>[ (<aliases>)]`
 - With failures: `<rate>% passed (<passed>/<total>), <failed> failed, <specs> specs, image_tag:<tag>[ (<aliases>)]`
 - Pending: `tests running, image_tag:<tag>[ (<aliases>)]`
+- Skipped: `No E2E test-relevant changes - skipped`
 
 - Pass rate: `100%` if all pass, otherwise one decimal (e.g., `99.5%`)
 - Aliases only present for release cuts
@@ -210,6 +262,7 @@ Where `<phase>` is `cypress-smoke`, `cypress-full`, `playwright-smoke`, or `play
 2. **Full test fails**: Full commit status shows failure with pass rate
 3. **Both pass**: Both smoke and full commit statuses show success
 4. **No PR found** (PR pipeline only): Workflow fails immediately
+5. **No relevant changes** (PR pipeline only): Skip statuses posted immediately
 
 ---
 

--- a/.github/workflows/e2e-tests-check.yml
+++ b/.github/workflows/e2e-tests-check.yml
@@ -50,7 +50,7 @@ jobs:
         working-directory: e2e-tests
         run: make check-shell
 
-      # E2E-only check and trigger
+      # E2E test-only check and trigger
       - name: ci/check-e2e-test-only
         id: check
         uses: ./.github/actions/check-e2e-test-only

--- a/.github/workflows/e2e-tests-ci.yml
+++ b/.github/workflows/e2e-tests-ci.yml
@@ -1,31 +1,39 @@
 ---
 name: E2E Tests (pull request)
 on:
-  # Argo Events Trigger (automated):
-  #   - Triggered by: Enterprise CI/docker-image status check (success)
-  #   - Payload: { ref: "<branch>", inputs: { commit_sha: "<sha>" } }
-  #   - Uses commit-specific docker image
-  #   - Checks for relevant file changes before running tests
+  # Pull Request Trigger (early decision):
+  #   - Runs on every PR open/sync/reopen
+  #   - If no E2E test-relevant file changes: posts skip statuses immediately
+  #   - If E2E test-only changes (image_tag is branch ref): runs tests immediately with existing image
+  #   - If mixed changes (image_tag is commit SHA): exits and waits for status event
   #
-  # Manual Trigger:
-  #   - Enter PR number only - commit SHA is resolved automatically from PR head
-  #   - Uses commit-specific docker image
+  # Status Event Trigger (after Enterprise CI builds docker image):
+  #   - Fires when "Enterprise CI/docker-image" commit status is set to "success"
+  #   - Runs tests with commit-specific docker image
+  #
+  # Manual Trigger (workflow_dispatch):
+  #   - Enter PR number - commit SHA is resolved automatically from PR head
   #   - E2E tests always run (no file change check)
   #
+  pull_request:
+    types: [opened, synchronize, reopened]
+  status:
   workflow_dispatch:
     inputs:
       pr_number:
         description: "PR number to test (for manual triggers)"
         type: string
-        required: false
-      commit_sha:
-        description: "Commit SHA to test (for Argo Events)"
-        type: string
-        required: false
+        required: true
 
 jobs:
   resolve-pr:
     runs-on: ubuntu-24.04
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'status' &&
+       github.event.state == 'success' &&
+       github.event.context == 'Enterprise CI/docker-image')
     outputs:
       PR_NUMBER: "${{ steps.resolve.outputs.PR_NUMBER }}"
       COMMIT_SHA: "${{ steps.resolve.outputs.COMMIT_SHA }}"
@@ -40,17 +48,24 @@ jobs:
         id: resolve
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_EVENT_NUMBER: ${{ github.event.pull_request.number }}
+          PR_EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STATUS_EVENT_SHA: ${{ github.event.sha }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
-          INPUT_COMMIT_SHA: ${{ inputs.commit_sha }}
         run: |
           # Validate inputs
           if [ -n "$INPUT_PR_NUMBER" ] && ! [[ "$INPUT_PR_NUMBER" =~ ^[0-9]+$ ]]; then
             echo "::error::Invalid PR number format. Must be numeric."
             exit 1
           fi
-          if [ -n "$INPUT_COMMIT_SHA" ] && ! [[ "$INPUT_COMMIT_SHA" =~ ^[a-f0-9]{7,40}$ ]]; then
-            echo "::error::Invalid commit SHA format. Must be 7-40 hex characters."
-            exit 1
+
+          # Pull request event: get PR info directly from event context
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "Pull request trigger: PR #${PR_EVENT_NUMBER}, commit ${PR_EVENT_HEAD_SHA}"
+            echo "PR_NUMBER=${PR_EVENT_NUMBER}" >> $GITHUB_OUTPUT
+            echo "COMMIT_SHA=${PR_EVENT_HEAD_SHA}" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
           # Manual trigger: PR number provided, resolve commit SHA from PR head
@@ -69,40 +84,41 @@ jobs:
             exit 0
           fi
 
-          # Argo Events trigger: commit SHA provided, resolve PR number
-          if [ -n "$INPUT_COMMIT_SHA" ]; then
-            echo "Automated trigger: resolving PR number from commit ${INPUT_COMMIT_SHA}"
-            PR_DATA=$(gh api "repos/${{ github.repository }}/commits/${INPUT_COMMIT_SHA}/pulls" \
-              --jq '.[0] // empty' 2>/dev/null || echo "")
-            PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number // empty' 2>/dev/null || echo "")
-            if [ -z "$PR_NUMBER" ]; then
-              echo "::error::No PR found for commit ${INPUT_COMMIT_SHA}. This workflow is for PRs only."
-              exit 1
-            fi
+          # Status event: get commit SHA from event
+          if [ "$EVENT_NAME" != "status" ]; then
+            echo "::error::Unexpected event: ${EVENT_NAME}"
+            exit 1
+          fi
+          COMMIT_SHA="$STATUS_EVENT_SHA"
+          echo "Status event trigger: using commit ${COMMIT_SHA}"
 
-            echo "Found PR #${PR_NUMBER} for commit ${INPUT_COMMIT_SHA}"
-
-            # Skip if PR is already merged to master or a release branch.
-            # The e2e-tests-on-merge workflow handles post-merge E2E tests.
-            PR_MERGED=$(echo "$PR_DATA" | jq -r '.merged_at // empty' 2>/dev/null || echo "")
-            PR_BASE_REF=$(echo "$PR_DATA" | jq -r '.base.ref // empty' 2>/dev/null || echo "")
-            if [ -n "$PR_MERGED" ]; then
-              if [ "$PR_BASE_REF" = "master" ] || [[ "$PR_BASE_REF" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
-                echo "PR #${PR_NUMBER} is already merged to ${PR_BASE_REF}. Skipping - handled by e2e-tests-on-merge workflow."
-                echo "PR_NUMBER=" >> $GITHUB_OUTPUT
-                echo "COMMIT_SHA=" >> $GITHUB_OUTPUT
-                exit 0
-              fi
-            fi
-
-            echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_OUTPUT
-            echo "COMMIT_SHA=${INPUT_COMMIT_SHA}" >> $GITHUB_OUTPUT
-            exit 0
+          # Resolve PR number from commit SHA
+          echo "Resolving PR number from commit ${COMMIT_SHA}"
+          PR_DATA=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/pulls" \
+            --jq '.[0] // empty' 2>/dev/null || echo "")
+          PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number // empty' 2>/dev/null || echo "")
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::No PR found for commit ${COMMIT_SHA}. This workflow is for PRs only."
+            exit 1
           fi
 
-          # Neither provided
-          echo "::error::Either pr_number or commit_sha must be provided"
-          exit 1
+          echo "Found PR #${PR_NUMBER} for commit ${COMMIT_SHA}"
+
+          # Skip if PR is already merged to master or a release branch.
+          # The e2e-tests-on-merge workflow handles post-merge E2E tests.
+          PR_MERGED=$(echo "$PR_DATA" | jq -r '.merged_at // empty' 2>/dev/null || echo "")
+          PR_BASE_REF=$(echo "$PR_DATA" | jq -r '.base.ref // empty' 2>/dev/null || echo "")
+          if [ -n "$PR_MERGED" ]; then
+            if [ "$PR_BASE_REF" = "master" ] || [[ "$PR_BASE_REF" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
+              echo "PR #${PR_NUMBER} is already merged to ${PR_BASE_REF}. Skipping - handled by e2e-tests-on-merge workflow."
+              echo "PR_NUMBER=" >> $GITHUB_OUTPUT
+              echo "COMMIT_SHA=" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+
+          echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_OUTPUT
+          echo "COMMIT_SHA=${COMMIT_SHA}" >> $GITHUB_OUTPUT
 
       - name: ci/check-e2e-test-only
         if: steps.resolve.outputs.PR_NUMBER != ''
@@ -118,9 +134,12 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       should_run: "${{ steps.check.outputs.should_run }}"
+      image_ready: "${{ steps.image-check.outputs.image_ready }}"
+    permissions:
+      pull-requests: write
     steps:
       - name: ci/checkout-repo
-        if: inputs.commit_sha != ''
+        if: github.event_name == 'pull_request' || github.event_name == 'status'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.resolve-pr.outputs.COMMIT_SHA }}
@@ -132,15 +151,16 @@ jobs:
           PR_NUMBER: ${{ needs.resolve-pr.outputs.PR_NUMBER }}
           COMMIT_SHA: ${{ needs.resolve-pr.outputs.COMMIT_SHA }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          # Manual trigger (pr_number provided): always run E2E tests
-          if [ -n "$INPUT_PR_NUMBER" ]; then
+          # Manual trigger (pr_number provided via workflow_dispatch): always run E2E tests
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_PR_NUMBER" ]; then
             echo "Manual trigger detected - skipping file change check"
             echo "should_run=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          # Automated trigger (commit_sha provided): check for relevant file changes
+          # Automated trigger (pull_request or status event): check for relevant file changes
           echo "Automated trigger detected - checking for relevant file changes"
 
           # Get the base branch of the PR
@@ -182,11 +202,58 @@ jobs:
           echo "should_run=${SHOULD_RUN}" >> $GITHUB_OUTPUT
           echo "Should run E2E tests: ${SHOULD_RUN}"
 
+      - name: ci/check-docker-image-ready
+        id: image-check
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT_SHA: ${{ needs.resolve-pr.outputs.COMMIT_SHA }}
+          SERVER_IMAGE_TAG: ${{ needs.resolve-pr.outputs.SERVER_IMAGE_TAG }}
+          PR_NUMBER: ${{ needs.resolve-pr.outputs.PR_NUMBER }}
+        run: |
+          # Branch ref images (master, release-*) are always available
+          if [ "$SERVER_IMAGE_TAG" = "master" ] || [[ "$SERVER_IMAGE_TAG" =~ ^release- ]]; then
+            echo "Image tag is a branch ref (${SERVER_IMAGE_TAG}) - image available"
+            echo "image_ready=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Commit SHA image: check if Enterprise CI has built it
+          STATUS=$(gh api "repos/mattermost/mattermost/commits/${COMMIT_SHA}/statuses" \
+            --jq '[.[] | select(.context == "Enterprise CI/docker-image")] | first | .state // empty' 2>/dev/null || echo "")
+
+          if [ "$STATUS" = "success" ]; then
+            echo "Docker image for ${SERVER_IMAGE_TAG} is ready (Enterprise CI/docker-image: success)"
+            echo "image_ready=true" >> $GITHUB_OUTPUT
+          else
+            echo "Docker image for ${SERVER_IMAGE_TAG} is not ready (Enterprise CI/docker-image: ${STATUS:-not found})"
+            echo "image_ready=false" >> $GITHUB_OUTPUT
+
+            COMMENT="**E2E tests not started** — Docker image \`mattermostdevelopment/mattermost-enterprise-edition:${SERVER_IMAGE_TAG}\` is not yet available."
+            COMMENT="${COMMENT} The \`Enterprise CI/docker-image\` commit status is \`${STATUS:-not found}\`."
+            COMMENT="${COMMENT} Please retry after the image build completes, or wait for the automated \`status\` event trigger."
+            gh pr comment "$PR_NUMBER" --repo "mattermost/mattermost" --body "$COMMENT"
+          fi
+
   e2e-cypress:
     needs:
       - resolve-pr
       - check-changes
-    if: needs.resolve-pr.outputs.PR_NUMBER != ''
+    # Run when:
+    # - status event or workflow_dispatch: always (should_run is passed through to downstream)
+    # - pull_request with should_run=false: immediately post skip statuses
+    # - pull_request with image_tag as branch ref: run tests immediately with existing image
+    # - pull_request with image_tag as commit SHA: skip (wait for status event)
+    # - workflow_dispatch with image not ready: skip (comment posted on PR)
+    if: >-
+      needs.resolve-pr.outputs.PR_NUMBER != '' &&
+      needs.check-changes.outputs.image_ready != 'false' &&
+      (
+        github.event_name != 'pull_request' ||
+        needs.check-changes.outputs.should_run == 'false' ||
+        needs.resolve-pr.outputs.SERVER_IMAGE_TAG == 'master' ||
+        startsWith(needs.resolve-pr.outputs.SERVER_IMAGE_TAG, 'release-')
+      )
     permissions:
       statuses: write
     uses: ./.github/workflows/e2e-tests-cypress.yml
@@ -211,7 +278,16 @@ jobs:
     needs:
       - resolve-pr
       - check-changes
-    if: needs.resolve-pr.outputs.PR_NUMBER != ''
+    # Same gating logic as e2e-cypress (see comment above)
+    if: >-
+      needs.resolve-pr.outputs.PR_NUMBER != '' &&
+      needs.check-changes.outputs.image_ready != 'false' &&
+      (
+        github.event_name != 'pull_request' ||
+        needs.check-changes.outputs.should_run == 'false' ||
+        needs.resolve-pr.outputs.SERVER_IMAGE_TAG == 'master' ||
+        startsWith(needs.resolve-pr.outputs.SERVER_IMAGE_TAG, 'release-')
+      )
     permissions:
       statuses: write
     uses: ./.github/workflows/e2e-tests-playwright.yml

--- a/.github/workflows/e2e-tests-cypress.yml
+++ b/.github/workflows/e2e-tests-cypress.yml
@@ -157,7 +157,7 @@ jobs:
           gh api repos/${{ github.repository }}/statuses/${COMMIT_SHA} \
             -f state=success \
             -f context="${CONTEXT_NAME}" \
-            -f description="No E2E-relevant changes - skipped" \
+            -f description="No E2E test-relevant changes - skipped" \
             -f target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           echo "Posted success for ${CONTEXT_NAME}"
 

--- a/.github/workflows/e2e-tests-playwright.yml
+++ b/.github/workflows/e2e-tests-playwright.yml
@@ -151,7 +151,7 @@ jobs:
           gh api repos/${{ github.repository }}/statuses/${COMMIT_SHA} \
             -f state=success \
             -f context="${CONTEXT_NAME}" \
-            -f description="No E2E-relevant changes - skipped" \
+            -f description="No E2E test-relevant changes - skipped" \
             -f target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           echo "Posted success for ${CONTEXT_NAME}"
 

--- a/.github/workflows/e2e-tests-verified-label.yml
+++ b/.github/workflows/e2e-tests-verified-label.yml
@@ -2,36 +2,37 @@
 name: "E2E Tests/verified"
 
 on:
-  pull_request:
-    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number"
+        type: string
+        required: true
+      commit_sha:
+        description: "PR head commit SHA"
+        type: string
+        required: true
+      sender:
+        description: "GitHub username (optional, defaults to workflow triggering actor)"
+        type: string
+        required: false
+
+permissions:
+  statuses: write
 
 env:
   REPORT_WEBHOOK_URL: ${{ secrets.MM_E2E_REPORT_WEBHOOK_URL }}
+  SENDER: ${{ inputs.sender || github.actor }}
 
 jobs:
   approve-e2e:
-    if: github.event.label.name == 'E2E Tests/verified'
     runs-on: ubuntu-24.04
     steps:
-      - name: ci/check-user-permission
-        id: check-permission
-        env:
-          GH_TOKEN: ${{ github.token }}
-          LABEL_AUTHOR: ${{ github.event.sender.login }}
-        run: |
-          # Check if user has write permission to the repository
-          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${LABEL_AUTHOR}/permission --jq '.permission' 2>/dev/null || echo "none")
-          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" ]]; then
-            echo "User ${LABEL_AUTHOR} doesn't have write permission to the repository (permission: ${PERMISSION})"
-            exit 1
-          fi
-          echo "User ${LABEL_AUTHOR} has ${PERMISSION} permission to the repository"
-
       - name: ci/override-failed-statuses
         id: override
         env:
           GH_TOKEN: ${{ github.token }}
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          COMMIT_SHA: ${{ inputs.commit_sha }}
         run: |
           # Only full tests can be overridden (smoke tests must pass)
           FULL_TEST_CONTEXTS=("e2e-test/playwright-full/enterprise" "e2e-test/cypress-full/enterprise")
@@ -62,12 +63,12 @@ jobs:
               continue
             fi
 
-          # Prefix existing description
-          if [ -n "$CURRENT_DESC" ]; then
-            NEW_MSG="(verified) ${CURRENT_DESC}"
-          else
-            NEW_MSG="(verified)"
-          fi
+            # Prefix existing description
+            if [ -n "$CURRENT_DESC" ]; then
+              NEW_MSG="(verified) ${CURRENT_DESC}"
+            else
+              NEW_MSG="(verified)"
+            fi
 
             echo "  New: $NEW_MSG"
 
@@ -133,10 +134,10 @@ jobs:
         env:
           REPORT_WEBHOOK_URL: ${{ env.REPORT_WEBHOOK_URL }}
           MESSAGE_TEXT: ${{ steps.webhook-message.outputs.message_text }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
-          SENDER: ${{ github.event.sender.login }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ inputs.pr_number }}
+          COMMIT_SHA: ${{ inputs.commit_sha }}
+          SENDER: ${{ env.SENDER }}
         run: |
           PAYLOAD=$(cat <<EOF
           {

--- a/.github/workflows/label-dispatch.yml
+++ b/.github/workflows/label-dispatch.yml
@@ -1,0 +1,74 @@
+---
+name: Label Dispatch
+
+# Supported labels:
+#   E2E Tests/run       → dispatches e2e-tests-ci.yml
+#   E2E Tests/verified  → dispatches e2e-tests-verified-label.yml
+
+on:
+  pull_request:
+    types: [labeled]
+
+# Required to dispatch other workflows via gh workflow run
+permissions:
+  actions: write
+
+env:
+  LABEL_E2E_RUN: "E2E Tests/run"
+  LABEL_E2E_VERIFIED: "E2E Tests/verified"
+
+jobs:
+  dispatch:
+    # Only run for known labels from users with write permission
+    if: >-
+      github.repository == 'mattermost/mattermost' &&
+      startsWith(github.event.label.name, 'E2E Tests/')
+    runs-on: ubuntu-24.04
+    steps:
+      - name: ci/check-user-permission
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          PERMISSION=$(gh api repos/mattermost/mattermost/collaborators/${SENDER}/permission --jq '.permission' 2>/dev/null || echo "none")
+          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" ]]; then
+            echo "::error::User ${SENDER} doesn't have write permission to mattermost/mattermost (permission: ${PERMISSION})"
+            exit 1
+          fi
+          echo "User ${SENDER} has ${PERMISSION} permission"
+
+      - name: ci/dispatch-e2e-run
+        if: github.event.label.name == env.LABEL_E2E_RUN
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh workflow run e2e-tests-ci.yml \
+            --repo "mattermost/mattermost" \
+            --field pr_number="${PR_NUMBER}"
+          echo "Dispatched e2e-tests-ci.yml for PR #${PR_NUMBER}"
+
+      - name: ci/dispatch-e2e-verified
+        if: github.event.label.name == env.LABEL_E2E_VERIFIED
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          gh workflow run e2e-tests-verified-label.yml \
+            --repo "mattermost/mattermost" \
+            --field pr_number="${PR_NUMBER}" \
+            --field commit_sha="${COMMIT_SHA}" \
+            --field sender="${SENDER}"
+          echo "Dispatched e2e-tests-verified-label.yml for PR #${PR_NUMBER}"
+
+      - name: ci/remove-label
+        if: github.event.label.name == env.LABEL_E2E_RUN
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit "$PR_NUMBER" \
+            --repo "mattermost/mattermost" \
+            --remove-label "$LABEL_E2E_RUN" 2>/dev/null || true

--- a/.github/workflows/pr-test-analysis-override.yml
+++ b/.github/workflows/pr-test-analysis-override.yml
@@ -2,12 +2,20 @@
 name: "PR Test Analysis Override"
 
 on:
-  issue_comment:
-    types: [created]
-
-concurrency:
-  group: test-analyzer-${{ github.event.issue.number }}
-  cancel-in-progress: false
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to override"
+        type: string
+        required: true
+      reason:
+        description: "Reason for override"
+        type: string
+        required: true
+      sender:
+        description: "GitHub username (optional, defaults to workflow triggering actor)"
+        type: string
+        required: false
 
 permissions:
   statuses: write
@@ -16,41 +24,20 @@ env:
   VERIFIED_PREFIX: "(override)"
   STATUS_CONTEXT: "Tests/analysis"
   REPORT_WEBHOOK_URL: ${{ secrets.WEBHOOK_URL_TEST_PR_ANALYSIS_HUB }}
+  SENDER: ${{ inputs.sender || github.actor }}
 
 jobs:
-  # When /test-analysis-override <reason> is posted on a PR, post success status
-  # overriding the previous analysis and send a webhook notification.
   verify:
-    if: >-
-      github.repository == 'mattermost/mattermost' &&
-      github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/test-analysis-override') &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-24.04
     steps:
-      - name: ci/extract-reason
-        id: extract
-        env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
-        run: |
-          # Extract reason after the slash command
-          REASON=$(echo "$COMMENT_BODY" | sed 's|^/test-analysis-override\s*||' | head -1 | xargs)
-          if [ -z "$REASON" ]; then
-            echo "No reason provided — a reason is required"
-            echo "Usage: /test-analysis-override <reason>"
-            exit 1
-          fi
-          echo "reason=${REASON}" >> $GITHUB_OUTPUT
-
       - name: ci/resolve-pr-info
         id: pr-info
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           PR_JSON=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefOid --jq '.headRefOid')
           echo "commit_sha=${PR_JSON}" >> $GITHUB_OUTPUT
-          echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
 
       - name: ci/post-override-status
         env:
@@ -85,22 +72,14 @@ jobs:
 
           echo "Verified: ${NEW_DESC}"
 
-      - name: ci/post-ack-reaction
-        env:
-          GH_TOKEN: ${{ github.token }}
-          COMMENT_ID: ${{ github.event.comment.id }}
-        run: |
-          gh api repos/${{ github.repository }}/issues/comments/${COMMENT_ID}/reactions \
-            -f content='+1' 2>/dev/null || true
-
       - name: ci/send-webhook
         if: env.REPORT_WEBHOOK_URL != ''
         env:
-          PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
-          PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.issue.number }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ inputs.pr_number }}
           COMMIT_SHA: ${{ steps.pr-info.outputs.commit_sha }}
-          SENDER: ${{ github.event.comment.user.login }}
-          REASON: ${{ steps.extract.outputs.reason }}
+          SENDER: ${{ env.SENDER }}
+          REASON: ${{ inputs.reason }}
         run: |
           PAYLOAD=$(jq -n \
             --arg sender "$SENDER" \

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -1,0 +1,103 @@
+---
+name: Slash Command Dispatch
+
+# Supported commands:
+#   /e2e-test                          → dispatches e2e-tests-ci.yml
+#   /test-analysis-override <reason>   → dispatches pr-test-analysis-override.yml
+
+on:
+  issue_comment:
+    types: [created]
+
+# Required to dispatch other workflows via gh workflow run
+permissions:
+  actions: write
+
+env:
+  CMD_E2E_TEST: e2e-test
+  CMD_TEST_ANALYSIS_OVERRIDE: test-analysis-override
+
+jobs:
+  dispatch:
+    # Pre-filter: skip runner for non-PR comments, non-slash, or outside contributors.
+    # author_association is a cheap gate; real permission check happens in ci/check-user-permission.
+    if: >-
+      github.repository == 'mattermost/mattermost' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: ci/check-user-permission
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SENDER: ${{ github.event.comment.user.login }}
+        run: |
+          PERMISSION=$(gh api repos/mattermost/mattermost/collaborators/${SENDER}/permission --jq '.permission' 2>/dev/null || echo "none")
+          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" ]]; then
+            echo "::error::User ${SENDER} doesn't have write permission to mattermost/mattermost (permission: ${PERMISSION})"
+            exit 1
+          fi
+          echo "User ${SENDER} has ${PERMISSION} permission"
+
+      - name: ci/parse-command
+        id: parse
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          # Extract command name (first word after /)
+          COMMAND=$(echo "$COMMENT_BODY" | head -1 | awk '{print $1}' | sed 's|^/||')
+          ARGS=$(echo "$COMMENT_BODY" | head -1 | sed 's|^/[^ ]* *||')
+
+          # Match against known commands
+          case "$COMMAND" in
+            "$CMD_E2E_TEST"|"$CMD_TEST_ANALYSIS_OVERRIDE")
+              echo "known=true" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "Unknown command: /${COMMAND} — ignoring"
+              echo "known=false" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+          echo "command=${COMMAND}" >> $GITHUB_OUTPUT
+          echo "args=${ARGS}" >> $GITHUB_OUTPUT
+
+      - name: ci/ack-reaction
+        if: steps.parse.outputs.known == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api repos/mattermost/mattermost/issues/comments/${COMMENT_ID}/reactions \
+            -f content='+1' 2>/dev/null || true
+
+      - name: ci/dispatch-e2e-test
+        if: steps.parse.outputs.command == env.CMD_E2E_TEST
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh workflow run e2e-tests-ci.yml \
+            --repo "mattermost/mattermost" \
+            --field pr_number="${PR_NUMBER}"
+          echo "Dispatched e2e-tests-ci.yml for PR #${PR_NUMBER}"
+
+      - name: ci/dispatch-test-analysis-override
+        if: steps.parse.outputs.command == env.CMD_TEST_ANALYSIS_OVERRIDE
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REASON: ${{ steps.parse.outputs.args }}
+          SENDER: ${{ github.event.comment.user.login }}
+        run: |
+          if [ -z "$REASON" ]; then
+            echo "::error::No reason provided. Usage: /test-analysis-override <reason>"
+            exit 1
+          fi
+          gh workflow run pr-test-analysis-override.yml \
+            --repo "mattermost/mattermost" \
+            --field pr_number="${PR_NUMBER}" \
+            --field reason="${REASON}" \
+            --field sender="${SENDER}"
+          echo "Dispatched pr-test-analysis-override.yml for PR #${PR_NUMBER}"


### PR DESCRIPTION
#### Summary
Related PR - https://github.com/mattermost/delivery-platform/pull/507

Replaces external Argo Events dependency with native GitHub triggers for E2E test workflows, adds slash command and label dispatchers, and consolidates `issue_comment`/`labeled` listeners to reduce skipped checks.

#### E2E Tests CI (`e2e-tests-ci.yml`) — new trigger model

Replaces the Argo Events `workflow_dispatch` trigger with native `pull_request` and `status` events for early decision-making:

| PR file changes | `pull_request` behavior | Waits for Enterprise CI? |
|---|---|---|
| No E2E test-relevant changes | Posts skip statuses (`e2e-test/cypress-full/enterprise`, `e2e-test/playwright-full/enterprise`) immediately | No |
| E2E test-only changes (image_tag = branch ref) | Runs tests immediately with existing `master`/`release-*` image | No |
| Mixed changes (image_tag = commit SHA) | Exits — waits for `Enterprise CI/docker-image` status event | Yes |

- `status` event trigger: fires when `Enterprise CI/docker-image` is set to `success`, runs tests with commit-specific image
- `workflow_dispatch`: manual trigger with `pr_number` only (removed `commit_sha` input). Includes docker image readiness check — if the image isn't built yet, posts a PR comment and skips tests
- Removed Argo Events dependency for PR E2E trigger path

#### Slash Command Dispatcher (`slash-command-dispatch.yml`) — new

Single `issue_comment` listener that catches all `/` commands on PRs and routes to the appropriate workflow via `gh workflow run`:

| Command | Target |
|---|---|
| `/e2e-test` | `e2e-tests-ci.yml` |
| `/test-analysis-override <reason>` | `pr-test-analysis-override.yml` |

- Two-layer permission model: `author_association` pre-filter (free, no runner) + API write-permission check against `mattermost/mattermost`
- Unknown commands silently ignored
- Known commands acknowledged with thumbs-up reaction before dispatch
- Command names defined as `env` variables at the top for visibility

#### Label Dispatcher (`label-dispatch.yml`) — new

Single `pull_request: [labeled]` listener with the same pattern:

| Label | Target |
|---|---|
| `E2E Tests/run` | `e2e-tests-ci.yml` (label auto-removed after dispatch) |
| `E2E Tests/verified` | `e2e-tests-verified-label.yml` |

- Same two-layer permission model as slash command dispatcher
- Label names defined as `env` variables at the top

#### Migrated workflows

- **`pr-test-analysis-override.yml`**: Changed trigger from `issue_comment` to `workflow_dispatch` with inputs (`pr_number`, `reason`, `sender`). `sender` is optional, falls back to `github.actor` for manual UI triggers.
- **`e2e-tests-verified-label.yml`**: Changed trigger from `pull_request: [labeled]` to `workflow_dispatch` with inputs (`pr_number`, `commit_sha`, `sender`). Same `sender` fallback pattern.

Both workflows are now only triggered when dispatched — they no longer fire (and show as skipped) on every comment or label event.

#### Other changes

- Replaced `E2E-relevant` with `E2E test-relevant` and `E2E-only` with `E2E test-only` across all files to avoid confusion with end-to-end encryption
- All API calls and `gh` commands in dispatchers hardcoded to `mattermost/mattermost`
- Updated `.github/e2e-tests-workflows.md` to reflect all changes

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/SEC-10024

#### Release Note
```release-note
NONE
```