### PR TITLE
Restore plain-text content for HTML notification emails

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -148,7 +148,7 @@ require (
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/isacikgoz/fuzzy v0.2.0 // indirect
-	github.com/jaytaylor/html2text v0.0.0-20260303211410-1a4bdc82ecec // indirect
+	github.com/jaytaylor/html2text v0.0.0-20260303211410-1a4bdc82ecec
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/klauspost/crc32 v1.3.0 // indirect

--- a/server/platform/shared/mail/mail.go
+++ b/server/platform/shared/mail/mail.go
@@ -13,10 +13,9 @@ import (
 	"net/mail"
 	"net/smtp"
 	"slices"
-	"strings"
 	"time"
 
-	"code.sajari.com/docconv/v2"
+	html2text "github.com/jaytaylor/html2text"
 	"github.com/pkg/errors"
 	gomail "gopkg.in/mail.v2"
 
@@ -290,11 +289,17 @@ func sendMailUsingConfigAdvanced(mail mailData, config *SMTPConfig) error {
 
 const SendGridXSMTPAPIHeader = "X-SMTPAPI"
 
+func convertHTMLToText(htmlMessage string) (string, error) {
+	return html2text.FromString(htmlMessage, html2text.Options{
+		PrettyTables: false,
+	})
+}
+
 func sendMail(c smtpClient, mail mailData, date time.Time, config *SMTPConfig) error {
 	mlog.Info("sending mail", mlog.String("to", mail.smtpTo), mlog.String("subject", mail.subject))
 
 	htmlMessage := mail.htmlBody
-	text, _, err := docconv.ConvertHTML(strings.NewReader(htmlMessage), true)
+	text, err := convertHTMLToText(htmlMessage)
 	if err != nil {
 		mlog.Warn("Unable to convert html body to text", mlog.Err(err))
 		text = ""

--- a/server/platform/shared/mail/mail_test.go
+++ b/server/platform/shared/mail/mail_test.go
@@ -11,6 +11,7 @@ import (
 	"net/mail"
 	"net/smtp"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -202,6 +203,51 @@ func TestSendMailPlainText(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConvertHTMLToText(t *testing.T) {
+	tests := []struct {
+		name             string
+		emailBodyHTML    string
+		expectedBodyText string
+	}{
+		{
+			name:             "Heading",
+			emailBodyHTML:    "<h1>This is a test from autobot</h1><h2>This is a subheading</h2>",
+			expectedBodyText: "***************************\nThis is a test from autobot\n***************************\n\n--------------------\nThis is a subheading\n--------------------",
+		},
+		{
+			name:             "List",
+			emailBodyHTML:    "<ul><li>Item 1</li><li>Item 2</li></ul>",
+			expectedBodyText: "* Item 1\n* Item 2",
+		},
+		{
+			name:             "Inline formatting",
+			emailBodyHTML:    "<p><strong>Strong</strong> and <a href='https://example.com'>link</a>",
+			expectedBodyText: "*Strong* and link ( https://example.com )",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			text, err := convertHTMLToText(test.emailBodyHTML)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedBodyText, text)
+		})
+	}
+}
+
+func TestConvertHTMLToTextMessagesNotificationTemplate(t *testing.T) {
+	templatePath := filepath.Join("..", "..", "..", "templates", "messages_notification.html")
+	templateContents, err := os.ReadFile(templatePath)
+	require.NoError(t, err)
+
+	text, err := convertHTMLToText(string(templateContents))
+	require.NoError(t, err)
+	require.NotEmpty(t, text)
+	require.Contains(t, text, "{{.Props.Title}}")
+	require.Contains(t, text, "{{.Props.Button}}")
+	require.NotContains(t, text, "<table")
 }
 
 func TestSendMailWithEmbeddedFilesUsingConfig(t *testing.T) {


### PR DESCRIPTION
#### Summary
Replaced the shared mail package HTML-to-text conversion with `html2text` so multipart notification emails keep a usable `text/plain` body even for the compiled notification template that currently converts to an empty string with `docconv`.

Added direct regression coverage for both simple HTML snippets and the `messages_notification.html` template.

QA / verification:
- `go test ./platform/shared/mail -run 'TestConvertHTMLToText|TestConvertHTMLToTextMessagesNotificationTemplate' -count=1`

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/35948
Relates https://github.com/mattermost/mattermost/issues/35405

#### Screenshots
NONE

#### Release Note
```release-note
Restored the plain-text body for multipart notification emails so text-only mail clients no longer receive an empty message.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change replaces a shared HTML-to-text converter (docconv → html2text) in the mail package, which is used by 50+ files across the codebase including notification, email, and API modules. While the conversion logic is isolated to the mail package with comprehensive test coverage (7 existing tests plus 2 new regression tests), the previous converter was demonstrably broken (producing empty text for MJML templates), and this swap affects all email/notification sending flows throughout the system.

**QA Recommendation:** Automated test coverage is comprehensive with new regression tests specifically validating the converter output format and template processing. Manual QA should focus on end-to-end notification email testing across key user flows (account signup, password reset, email verification, notification digests) using text-only mail clients to verify plain-text bodies are properly populated and readable. This is recommended given the change affects all user-facing notification emails and the previous behavior was broken.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->