### PR TITLE
fix: remove duplicate allow-failure input in server test template

### DIFF
--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -22,10 +22,6 @@ on:
         required: false
         type: boolean
         default: false
-      allow-failure:
-        required: false
-        type: boolean
-        default: false
       enablecoverage:
         required: false
         type: boolean


### PR DESCRIPTION
#### Summary
Remove duplicate `allow-failure` input definition in `server-test-template.yml` that was introduced in #35743. The duplicate key causes GitHub Actions to reject the workflow at parse time (0 jobs, immediate failure on master push).

**Why this passed on the PR but failed on master:** GitHub Actions validates reusable workflow inputs more strictly when called from the default branch. On PR branches, the caller and template are both read from the PR ref, and duplicate input keys are silently accepted (YAML spec allows it — last value wins). On master push, the stricter validation rejects the duplicate, causing the entire workflow to fail with 0 jobs spawned.

#### Ticket Link
N/A — CI hotfix

#### Release Note
```release-note
NONE
```