### PR TITLE
fix: add explicit permission grant in team members test

### DIFF
--- a/server/channels/api4/team_test.go
+++ b/server/channels/api4/team_test.go
@@ -4828,6 +4828,13 @@ func TestGetTeamMembersForUserRoleDataSanitization(t *testing.T) {
 	})
 
 	t.Run("team admin sees full role data for other user in managed team", func(t *testing.T) {
+		// The API requires PermissionReadOtherUsersTeams (system-level) to view another user's
+		// team memberships. Grant it explicitly — previously this only passed because a concurrent
+		// test leaked this permission into the system_user role.
+		defaultRolePermissions := th.SaveDefaultRolePermissions(t)
+		defer th.RestoreDefaultRolePermissions(t, defaultRolePermissions)
+		th.AddPermissionToRole(t, model.PermissionReadOtherUsersTeams.Id, model.SystemUserRoleId)
+
 		members, _, err := teamAdminClient.GetTeamMembersForUser(context.Background(), th.BasicUser.Id, "")
 		require.NoError(t, err)
 		require.NotEmpty(t, members)

--- a/server/channels/api4/team_test.go
+++ b/server/channels/api4/team_test.go
@@ -4828,9 +4828,6 @@ func TestGetTeamMembersForUserRoleDataSanitization(t *testing.T) {
 	})
 
 	t.Run("team admin sees full role data for other user in managed team", func(t *testing.T) {
-		// The API requires PermissionReadOtherUsersTeams (system-level) to view another user's
-		// team memberships. Grant it explicitly — previously this only passed because a concurrent
-		// test leaked this permission into the system_user role.
 		defaultRolePermissions := th.SaveDefaultRolePermissions(t)
 		defer th.RestoreDefaultRolePermissions(t, defaultRolePermissions)
 		th.AddPermissionToRole(t, model.PermissionReadOtherUsersTeams.Id, model.SystemUserRoleId)


### PR DESCRIPTION
#### Summary
`TestGetTeamMembersForUserRoleDataSanitization` "team admin sees full role data" subtest was relying on a permission side-effect leaked from concurrent tests. 

**Root cause:** The `GetTeamMembersForUser` API requires `PermissionReadOtherUsersTeams` (system-level) to view another user's team memberships. A team admin does not have this permission by default. Under `fullyparallel: true`, a concurrent test (`TestGetTeamMembersRoleDataSanitization`) temporarily adds this permission to `system_user` role, and the team admin subtest accidentally benefits from it. Under sequential execution (binary parameters mode with `fullyparallel: false`), no concurrent test leaks this permission, so the team admin correctly gets 403.

**Fix:** Explicitly grant `ReadOtherUsersTeams` in the subtest setup, matching the pattern used in adjacent subtests. Save/restore default role permissions to avoid leaking.

The test was introduced in #35562 (merged 2026-04-09) and immediately caught by the binary parameters CI job on the next master push.

**How it was caught:** The binary parameters job runs with `fullyparallel: false`, which on master triggers `-race` mode via the server test template (`RACE_MODE="-race"` when `fullyparallel != true`). This means tests run sequentially with the race detector enabled — a combination that eliminates the parallel permission leakage that masked this bug in the normal sharded runs.

**Broken master CI run:** https://github.com/mattermost/mattermost/actions/runs/24210021666
**Failed job (binary params):** https://github.com/mattermost/mattermost/actions/runs/24210021666/job/70676002397
Failed on all 4 attempts (initial + 3 gotestsum reruns), confirming it is deterministic under sequential execution.

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Test-only changes with no production code modifications. The fix improves test isolation by explicitly granting `PermissionReadOtherUsersTeams` instead of relying on a leaked permission state, reducing flakiness without altering any production behavior.

**QA Recommendation:** Minimal manual QA needed beyond automated test validation. If team member permissions are part of existing manual test flows, a quick sanity check that team admins can view team members would suffice.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->