### PR TITLE
Revert "[release-10.11] Add prepackaged version of github plugin v2.7.0"

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -143,7 +143,7 @@ TEMPLATES_DIR=templates
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
 PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.4
-PLUGIN_PACKAGES += mattermost-plugin-github-v2.7.0
+PLUGIN_PACKAGES += mattermost-plugin-github-v2.5.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.12.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.5.0
 # We need to prepackage both versions of playbooks and install the correct one based on the server license. See MM-60025.


### PR DESCRIPTION
Reverts mattermost/mattermost#35973

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Minimal. This change reverts the GitHub plugin from v2.7.0 back to v2.5.0 by modifying a single line in the Makefile's `PLUGIN_PACKAGES` configuration variable. The system was previously stable with v2.5.0, and this is a straightforward reversion with no code logic changes, no shared utilities affected, and no untested code paths.

**QA Recommendation:** Minimal. Verify that the build process completes successfully and confirm that the prepackaged plugin tarball/signature uses GitHub plugin v2.5.0. Since this is a reversion to a previously stable version of a third-party plugin, manual QA beyond build verification is not required.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->