### PR TITLE
[MM-68266] Pass through menu props to popout menu item, guard at menu definition to avoid null component blocking keyboard navigation

### DIFF
--- a/webapp/channels/src/components/channel_header_menu/channel_header_menu.tsx
+++ b/webapp/channels/src/components/channel_header_menu/channel_header_menu.tsx
@@ -28,6 +28,7 @@ import {getIsChannelBookmarksEnabled} from 'components/channel_bookmarks/utils';
 import * as Menu from 'components/menu';
 
 import {Constants} from 'utils/constants';
+import {canPopout, isChannelPopoutWindow} from 'utils/popouts/popout_windows';
 
 import type {GlobalState} from 'types/store';
 
@@ -149,7 +150,9 @@ export default function ChannelHeaderMenu({dmUser, gmMembers, isMobile, archived
                 horizontal: 'left',
             }}
         >
-            <MenuItemOpenInNewWindow channel={channel}/>
+            {canPopout() && !isChannelPopoutWindow() && (
+                <MenuItemOpenInNewWindow channel={channel}/>
+            )}
             {isDirect && (
                 <ChannelDirectMenu
                     channel={channel}

--- a/webapp/channels/src/components/channel_header_menu/menu_items/open_in_new_window.test.tsx
+++ b/webapp/channels/src/components/channel_header_menu/menu_items/open_in_new_window.test.tsx
@@ -8,7 +8,7 @@ import type {ChannelType} from '@mattermost/types/channels';
 import {WithTestMenuContext} from 'components/menu/menu_context_test';
 
 import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
-import {isChannelPopoutWindow, popoutChannel} from 'utils/popouts/popout_windows';
+import {canPopout, isChannelPopoutWindow, popoutChannel} from 'utils/popouts/popout_windows';
 import {TestHelper} from 'utils/test_helper';
 
 import MenuItemOpenInNewWindow from './open_in_new_window';
@@ -55,10 +55,25 @@ describe('MenuItemOpenInNewWindow', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         jest.mocked(isChannelPopoutWindow).mockReturnValue(false);
+        jest.mocked(canPopout).mockReturnValue(true);
     });
 
     test('should render nothing when already in a channel popout', () => {
         jest.mocked(isChannelPopoutWindow).mockReturnValue(true);
+        const channel = TestHelper.getChannelMock({type: 'O' as ChannelType, name: 'town-square'});
+
+        const {container} = renderWithContext(
+            <WithTestMenuContext>
+                <MenuItemOpenInNewWindow channel={channel}/>
+            </WithTestMenuContext>,
+            baseState,
+        );
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    test('should render nothing when popout is not available', () => {
+        jest.mocked(canPopout).mockReturnValue(false);
         const channel = TestHelper.getChannelMock({type: 'O' as ChannelType, name: 'town-square'});
 
         const {container} = renderWithContext(

--- a/webapp/channels/src/components/channel_header_menu/menu_items/open_in_new_window.test.tsx
+++ b/webapp/channels/src/components/channel_header_menu/menu_items/open_in_new_window.test.tsx
@@ -8,7 +8,7 @@ import type {ChannelType} from '@mattermost/types/channels';
 import {WithTestMenuContext} from 'components/menu/menu_context_test';
 
 import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
-import {canPopout, isChannelPopoutWindow, popoutChannel} from 'utils/popouts/popout_windows';
+import {popoutChannel} from 'utils/popouts/popout_windows';
 import {TestHelper} from 'utils/test_helper';
 
 import MenuItemOpenInNewWindow from './open_in_new_window';
@@ -54,36 +54,20 @@ describe('MenuItemOpenInNewWindow', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        jest.mocked(isChannelPopoutWindow).mockReturnValue(false);
-        jest.mocked(canPopout).mockReturnValue(true);
     });
 
-    test('should render nothing when already in a channel popout', () => {
-        jest.mocked(isChannelPopoutWindow).mockReturnValue(true);
+    test('should render menu item and separator', () => {
         const channel = TestHelper.getChannelMock({type: 'O' as ChannelType, name: 'town-square'});
 
-        const {container} = renderWithContext(
+        renderWithContext(
             <WithTestMenuContext>
                 <MenuItemOpenInNewWindow channel={channel}/>
             </WithTestMenuContext>,
             baseState,
         );
 
-        expect(container).toBeEmptyDOMElement();
-    });
-
-    test('should render nothing when popout is not available', () => {
-        jest.mocked(canPopout).mockReturnValue(false);
-        const channel = TestHelper.getChannelMock({type: 'O' as ChannelType, name: 'town-square'});
-
-        const {container} = renderWithContext(
-            <WithTestMenuContext>
-                <MenuItemOpenInNewWindow channel={channel}/>
-            </WithTestMenuContext>,
-            baseState,
-        );
-
-        expect(container).toBeEmptyDOMElement();
+        expect(screen.getByText('Open in new window')).toBeInTheDocument();
+        expect(screen.getByRole('separator')).toBeInTheDocument();
     });
 
     test('should call popoutChannel when clicked', async () => {

--- a/webapp/channels/src/components/channel_header_menu/menu_items/open_in_new_window.tsx
+++ b/webapp/channels/src/components/channel_header_menu/menu_items/open_in_new_window.tsx
@@ -13,19 +13,19 @@ import {getUserIdFromChannelName} from 'mattermost-redux/utils/channel_utils';
 
 import {getPopoutChannelTitle} from 'components/channel_popout/channel_popout';
 import * as Menu from 'components/menu';
-import PopoutMenuItem from 'components/popout_menu_item';
+import PopoutMenuItem, {type PopoutMenuItemProps} from 'components/popout_menu_item';
 
 import {getChannelRoutePathAndIdentifier} from 'utils/channel_utils';
 import {Constants} from 'utils/constants';
-import {isChannelPopoutWindow, popoutChannel} from 'utils/popouts/popout_windows';
+import {popoutChannel} from 'utils/popouts/popout_windows';
 
 import type {GlobalState} from 'types/store';
 
-interface Props {
+interface Props extends PopoutMenuItemProps {
     channel: Channel;
 }
 
-const MenuItemOpenInNewWindow = ({channel}: Props) => {
+const MenuItemOpenInNewWindow = ({channel, ...rest}: Props) => {
     const intl = useIntl();
     const team = useSelector(getCurrentTeam);
     const currentUserId = useSelector(getCurrentUserId);
@@ -36,10 +36,6 @@ const MenuItemOpenInNewWindow = ({channel}: Props) => {
         }
         return undefined;
     });
-
-    if (isChannelPopoutWindow()) {
-        return null;
-    }
 
     const handleClick = () => {
         if (!team) {
@@ -55,6 +51,7 @@ const MenuItemOpenInNewWindow = ({channel}: Props) => {
             <PopoutMenuItem
                 id='channelOpenInNewWindow'
                 onClick={handleClick}
+                {...rest}
             />
             <Menu.Separator/>
         </>

--- a/webapp/channels/src/components/popout_menu_item.tsx
+++ b/webapp/channels/src/components/popout_menu_item.tsx
@@ -7,15 +7,13 @@ import {FormattedMessage} from 'react-intl';
 import {DockWindowIcon} from '@mattermost/compass-icons/components';
 
 import * as Menu from 'components/menu';
+import type {Props as MenuItemProps} from 'components/menu/menu_item';
 
 import {canPopout} from 'utils/popouts/popout_windows';
 
-type Props = {
-    onClick: () => void;
-    id?: string;
-};
+export type PopoutMenuItemProps = Omit<MenuItemProps, 'labels' | 'leadingElement'>;
 
-export default function PopoutMenuItem({onClick, id = 'openInNewWindow'}: Props) {
+export default function PopoutMenuItem({onClick, id = 'openInNewWindow', ...rest}: PopoutMenuItemProps) {
     if (!canPopout()) {
         return null;
     }
@@ -31,6 +29,7 @@ export default function PopoutMenuItem({onClick, id = 'openInNewWindow'}: Props)
                 />
             }
             onClick={onClick}
+            {...rest}
         />
     );
 }

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
@@ -108,10 +108,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
           id="channelOpenInNewWindow"
           role="menuitem"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="leading-element"
@@ -449,10 +449,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
           id="channelOpenInNewWindow"
           role="menuitem"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="leading-element"
@@ -790,10 +790,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
           id="channelOpenInNewWindow"
           role="menuitem"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="leading-element"
@@ -1131,10 +1131,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
           id="channelOpenInNewWindow"
           role="menuitem"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="leading-element"
@@ -1404,10 +1404,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
           id="channelOpenInNewWindow"
           role="menuitem"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="leading-element"
@@ -1713,10 +1713,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
           id="channelOpenInNewWindow"
           role="menuitem"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="leading-element"
@@ -2051,10 +2051,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
           id="channelOpenInNewWindow"
           role="menuitem"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="leading-element"
@@ -2392,10 +2392,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
           id="channelOpenInNewWindow"
           role="menuitem"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="leading-element"
@@ -2733,10 +2733,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
           id="channelOpenInNewWindow"
           role="menuitem"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="leading-element"
@@ -3074,10 +3074,10 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         tabindex="-1"
       >
         <li
-          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
+          class="MuiButtonBase-root-JDVeC cxEgXn MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-focusVisible MuiMenuItem-root-dXjcMb iLWjgG MuiMenuItem-root MuiMenuItem-gutters sc-grYavY jmUrfe"
           id="channelOpenInNewWindow"
           role="menuitem"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="leading-element"

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
@@ -270,7 +270,7 @@ describe('components/sidebar/sidebar_channel/sidebar_channel_menu', () => {
 
     test('should not show Open in new window when popout is not available', async () => {
         jest.mocked(canPopout).mockReturnValue(false);
-        jest.mocked(isChannelPopoutWindow).mockReturnValue(true);
+        jest.mocked(isChannelPopoutWindow).mockReturnValue(false);
 
         renderWithContext(
             <SidebarChannelMenu {...baseProps}/>,

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
@@ -9,6 +9,7 @@ import {CategoryTypes} from 'mattermost-redux/constants/channel_categories';
 
 import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
 import Constants from 'utils/constants';
+import {canPopout, isChannelPopoutWindow} from 'utils/popouts/popout_windows';
 import {TestHelper} from 'utils/test_helper';
 
 import SidebarChannelMenu from './sidebar_channel_menu';
@@ -20,6 +21,12 @@ jest.mock('react-intl', () => ({
             return message.defaultMessage;
         },
     }),
+}));
+
+jest.mock('utils/popouts/popout_windows', () => ({
+    ...jest.requireActual('utils/popouts/popout_windows'),
+    canPopout: jest.fn(() => true),
+    isChannelPopoutWindow: jest.fn(() => false),
 }));
 
 describe('components/sidebar/sidebar_channel/sidebar_channel_menu', () => {
@@ -259,5 +266,17 @@ describe('components/sidebar/sidebar_channel/sidebar_channel_menu', () => {
 
         await openMenu();
         expect(document.body).toMatchSnapshot();
+    });
+
+    test('should not show Open in new window when popout is not available', async () => {
+        jest.mocked(canPopout).mockReturnValue(false);
+        jest.mocked(isChannelPopoutWindow).mockReturnValue(true);
+
+        renderWithContext(
+            <SidebarChannelMenu {...baseProps}/>,
+        );
+
+        await openMenu();
+        expect(screen.queryByRole('menuitem', {name: 'Open in new window'})).not.toBeInTheDocument();
     });
 });

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
@@ -22,6 +22,7 @@ import ChannelMoveToSubmenu from 'components/channel_move_to_sub_menu';
 import * as Menu from 'components/menu';
 
 import Constants, {ModalIdentifiers} from 'utils/constants';
+import {canPopout, isChannelPopoutWindow} from 'utils/popouts/popout_windows';
 import {copyToClipboard} from 'utils/utils';
 
 import type {PropsFromRedux, OwnProps} from './index';
@@ -299,7 +300,9 @@ const SidebarChannelMenu = ({
                 onToggle: onMenuToggle,
             }}
         >
-            <MenuItemOpenInNewWindow channel={channel}/>
+            {canPopout() && !isChannelPopoutWindow() && (
+                <MenuItemOpenInNewWindow channel={channel}/>
+            )}
             {markAsReadUnreadMenuItem}
             {favoriteUnfavoriteMenuItem}
             {muteUnmuteChannelMenuItem}


### PR DESCRIPTION
#### Summary
`PopoutMenuItem` didn't forward MUI's a11y props (`autoFocus`, `tabIndex`) to the underlying `Menu.Item`, so keyboard focus was silently dropped when the menu opened. Additionally, when the popout feature was unavailable, `MenuItemOpenInNewWindow` still appeared in the React children tree, causing MUI to waste its auto-focus on a null-rendering component.

This PR makes `PopoutMenuItem` forward all extra props to the `MenuItem` and moves the visibility checks out to the call sites so the component is excluded from MUI's children list entirely when popout is unavailable.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68266

```release-note
Fixed an issue where keyboard navigation didn't work in the channel header and sidebar channel menus.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Changes alter a shared PopoutMenuItem to forward extra Menu props and move visibility checks to callers across channel header and sidebar menus; this is scoped to UI menu rendering and keyboard focus behavior with updated tests, so moderate risk of regressions primarily around menu focus/prop forwarding and component rendering when popout is unavailable.  
**QA Recommendation:** Perform focused manual QA on keyboard navigation (tab/arrow focus and autoFocus behavior) and verify presence/absence of "Open in new window" in channel header and sidebar under both popout-available and popout-unavailable contexts; run menu-related regression smoke tests.

---

## Release Notes

Fixed an issue where keyboard navigation didn't work in the channel header and sidebar channel menus.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->