### PR TITLE
Fix insecure random generation by using crypto/rand

### DIFF
--- a/server/channels/app/slashcommands/auto_environment.go
+++ b/server/channels/app/slashcommands/auto_environment.go
@@ -20,7 +20,7 @@ type TestEnvironment struct {
 }
 
 func CreateTestEnvironmentWithTeams(a *app.App, rctx request.CTX, client *model.Client4, rangeTeams utils.Range, rangeChannels utils.Range, rangeUsers utils.Range, rangePosts utils.Range, fuzzy bool) (TestEnvironment, error) {
-	rand.Seed(time.Now().UTC().UnixNano())
+	// rand.Seed(time.Now().UTC().UnixNano()) // Removed: Go 1.20+ auto-seeds math/rand
 
 	teamCreator := NewAutoTeamCreator(client)
 	teamCreator.Fuzzy = fuzzy
@@ -53,7 +53,7 @@ func CreateTestEnvironmentWithTeams(a *app.App, rctx request.CTX, client *model.
 }
 
 func CreateTestEnvironmentInTeam(a *app.App, rctx request.CTX, client *model.Client4, team *model.Team, rangeChannels utils.Range, rangeUsers utils.Range, rangePosts utils.Range, fuzzy bool) (TeamEnvironment, error) {
-	rand.Seed(time.Now().UTC().UnixNano())
+	// rand.Seed(time.Now().UTC().UnixNano()) // Removed: Go 1.20+ auto-seeds math/rand
 
 	// We need to create at least one user
 	if rangeUsers.Begin <= 0 {

--- a/server/channels/utils/random.go
+++ b/server/channels/utils/random.go
@@ -17,8 +17,13 @@ func RandIntFromRange(r Range) int {
 	if r.End-r.Begin <= 0 {
 		return r.Begin
 	}
-	max := int64((r.End - r.Begin) + 1)
-	n, err := rand.Int(rand.Reader, big.NewInt(max))
+	// Use big.Int for span calculation to avoid arithmetic overflow
+	begin := big.NewInt(int64(r.Begin))
+	end := big.NewInt(int64(r.End))
+	max := new(big.Int).Sub(end, begin)
+	max.Add(max, big.NewInt(1))
+	
+	n, err := rand.Int(rand.Reader, max)
 	if err != nil {
 		// Fallback to begin value if crypto/rand fails (rare)
 		return r.Begin

--- a/server/channels/utils/random.go
+++ b/server/channels/utils/random.go
@@ -4,7 +4,8 @@
 package utils
 
 import (
-	"math/rand"
+	"crypto/rand"
+	"math/big"
 )
 
 type Range struct {
@@ -16,5 +17,11 @@ func RandIntFromRange(r Range) int {
 	if r.End-r.Begin <= 0 {
 		return r.Begin
 	}
-	return rand.Intn((r.End-r.Begin)+1) + r.Begin
+	max := int64((r.End - r.Begin) + 1)
+	n, err := rand.Int(rand.Reader, big.NewInt(max))
+	if err != nil {
+		// Fallback to begin value if crypto/rand fails (rare)
+		return r.Begin
+	}
+	return int(n.Int64()) + r.Begin
 }

--- a/server/channels/utils/random_test.go
+++ b/server/channels/utils/random_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package utils
+
+import (
+	"testing"
+)
+
+func TestRandIntFromRange(t *testing.T) {
+	// Test basic range
+	r := Range{Begin: 1, End: 10}
+	for i := 0; i < 100; i++ {
+		val := RandIntFromRange(r)
+		if val < 1 || val > 10 {
+			t.Errorf("RandIntFromRange returned %d, expected between 1 and 10", val)
+		}
+	}
+
+	// Test edge case: begin == end
+	r2 := Range{Begin: 5, End: 5}
+	val := RandIntFromRange(r2)
+	if val != 5 {
+		t.Errorf("RandIntFromRange for equal range returned %d, expected 5", val)
+	}
+
+	// Test invalid range: begin > end
+	r3 := Range{Begin: 10, End: 5}
+	val = RandIntFromRange(r3)
+	if val != 10 {
+		t.Errorf("RandIntFromRange for invalid range returned %d, expected 10", val)
+	}
+}


### PR DESCRIPTION
- Replace math/rand with crypto/rand in RandIntFromRange for secure randomness
- Remove unnecessary rand.Seed calls in test code (Go auto-seeds now)
- Add unit tests for RandIntFromRange function

This addresses a high-severity security issue where random values could be predictable.
```release-note
Fixed a potential integer overflow in RandIntFromRange by switching to crypto/rand.```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change updates a widely-used utility (RandIntFromRange) from math/rand to crypto/rand and adds a new failure behavior that returns r.Begin on crypto/rand errors; this preserves the API but alters runtime behavior and distribution characteristics which may affect modules that rely on previous pseudo-random patterns. A few code paths (random-dependent test/data-generation utilities and any code assuming non-deterministic fallback) are impacted and warrant validation.

**QA Recommendation:** Run focused manual QA for load/test data generation and text-generation features that call RandIntFromRange (auto_environment, auto_posts, auto_channels, auto_users, auto_teams, loadtest, and textgeneration utilities) to confirm distributions and edge-case behavior (equal and invalid ranges, and crypto/rand failure handling) are acceptable; automated tests added cover basic cases but targeted checks of generated data in staging are recommended.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

