### PR TITLE
Fix inviting deactivated users by email

### DIFF
--- a/server/channels/api4/team_local.go
+++ b/server/channels/api4/team_local.go
@@ -145,7 +145,18 @@ func localInviteUsersToTeam(c *Context, w http.ResponseWriter, r *http.Request) 
 				invite.Error = model.NewAppError("localInviteUsersToTeam", "api.team.invite_members.invalid_email.app_error", map[string]any{"Addresses": email}, "", http.StatusBadRequest)
 				errList = append(errList, model.EmailInviteWithErrorToString(invite))
 			} else {
-				goodEmails = append(goodEmails, email)
+				user, appErr := c.App.GetUserByEmail(email)
+				if appErr != nil && appErr.StatusCode != http.StatusNotFound {
+					c.Err = model.NewAppError("localInviteUsersToTeam", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(appErr)
+					return
+				}
+
+				if user != nil && user.DeleteAt != 0 {
+					invite.Error = model.NewAppError("localInviteUsersToTeam", "api.team.invite_members.deactivated_email.app_error", map[string]any{"Addresses": email}, "", http.StatusBadRequest)
+					errList = append(errList, model.EmailInviteWithErrorToString(invite))
+				} else {
+					goodEmails = append(goodEmails, email)
+				}
 			}
 			invitesWithErrors = append(invitesWithErrors, invite)
 		}
@@ -184,15 +195,32 @@ func localInviteUsersToTeam(c *Context, w http.ResponseWriter, r *http.Request) 
 		}
 	} else {
 		var invalidEmailList []string
+		var deactivatedEmailList []string
 
 		for _, email := range emailList {
 			if !isEmailAddressAllowed(email, allowedDomains) {
 				invalidEmailList = append(invalidEmailList, email)
+				continue
+			}
+
+			user, appErr := c.App.GetUserByEmail(email)
+			if appErr != nil && appErr.StatusCode != http.StatusNotFound {
+				c.Err = model.NewAppError("localInviteUsersToTeam", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(appErr)
+				return
+			}
+
+			if user != nil && user.DeleteAt != 0 {
+				deactivatedEmailList = append(deactivatedEmailList, email)
 			}
 		}
 		if len(invalidEmailList) > 0 {
 			s := strings.Join(invalidEmailList, ", ")
 			c.Err = model.NewAppError("localInviteUsersToTeam", "api.team.invite_members.invalid_email.app_error", map[string]any{"Addresses": s}, "", http.StatusBadRequest)
+			return
+		}
+		if len(deactivatedEmailList) > 0 {
+			s := strings.Join(deactivatedEmailList, ", ")
+			c.Err = model.NewAppError("localInviteUsersToTeam", "api.team.invite_members.deactivated_email.app_error", map[string]any{"Addresses": s}, "", http.StatusBadRequest)
 			return
 		}
 		err := c.App.Srv().EmailService.SendInviteEmails(c.AppContext, team, "Administrator", "mmctl "+model.NewId(), emailList, *c.App.Config().ServiceSettings.SiteURL, nil, false, true, false)

--- a/server/channels/api4/team_test.go
+++ b/server/channels/api4/team_test.go
@@ -4080,8 +4080,13 @@ func TestInviteUsersToTeam(t *testing.T) {
 	}, "rate limits")
 
 	th.TestForAllClients(t, func(t *testing.T, client *model.Client4) {
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictCreationToDomains = "" })
+		th.BasicTeam.AllowedDomains = ""
+		_, appErr := th.App.UpdateTeam(th.BasicTeam)
+		require.Nil(t, appErr)
+
 		deactivatedUser := th.CreateUser(t)
-		_, appErr := th.App.UpdateActive(th.Context, deactivatedUser, false)
+		_, appErr = th.App.UpdateActive(th.Context, deactivatedUser, false)
 		require.Nil(t, appErr)
 
 		invitesWithErrors, _, err := client.InviteUsersToTeamGracefully(context.Background(), th.BasicTeam.Id, []string{deactivatedUser.Email, user1})

--- a/server/channels/api4/team_test.go
+++ b/server/channels/api4/team_test.go
@@ -4078,6 +4078,25 @@ func TestInviteUsersToTeam(t *testing.T) {
 		CheckRequestEntityTooLargeStatus(t, resp)
 		CheckErrorID(t, err, "app.email.rate_limit_exceeded.app_error")
 	}, "rate limits")
+
+	th.TestForAllClients(t, func(t *testing.T, client *model.Client4) {
+		deactivatedUser := th.CreateUser(t)
+		_, appErr := th.App.UpdateActive(th.Context, deactivatedUser, false)
+		require.Nil(t, appErr)
+
+		invitesWithErrors, _, err := client.InviteUsersToTeamGracefully(context.Background(), th.BasicTeam.Id, []string{deactivatedUser.Email, user1})
+		require.NoError(t, err)
+		require.Len(t, invitesWithErrors, 2)
+		require.Equal(t, deactivatedUser.Email, invitesWithErrors[0].Email)
+		require.NotNil(t, invitesWithErrors[0].Error)
+		require.Equal(t, "api.team.invite_members.deactivated_email.app_error", invitesWithErrors[0].Error.Id)
+		require.Equal(t, user1, invitesWithErrors[1].Email)
+		require.Nil(t, invitesWithErrors[1].Error)
+
+		_, err = client.InviteUsersToTeam(context.Background(), th.BasicTeam.Id, []string{deactivatedUser.Email})
+		require.Error(t, err)
+		CheckErrorID(t, err, "api.team.invite_members.deactivated_email.app_error")
+	}, "deactivated users")
 }
 
 func TestInviteGuestsToTeam(t *testing.T) {

--- a/server/channels/app/team.go
+++ b/server/channels/app/team.go
@@ -1415,6 +1415,20 @@ func (a *App) prepareInviteNewUsersToTeam(teamID, senderId string, channelIds []
 	return user, team, channels, nil
 }
 
+func (a *App) getExistingInviteUserByEmail(email string) (*model.User, *model.AppError) {
+	user, err := a.ch.srv.userService.GetUserByEmail(email)
+	if err != nil {
+		var nfErr *store.ErrNotFound
+		if errors.As(err, &nfErr) {
+			return nil, nil
+		}
+
+		return nil, model.NewAppError("getExistingInviteUserByEmail", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+
+	return user, nil
+}
+
 func (a *App) InviteNewUsersToTeamGracefully(rctx request.CTX, memberInvite *model.MemberInvite, teamID, senderId string, reminderInterval string) ([]*model.EmailInviteWithError, *model.AppError) {
 	if !*a.Config().ServiceSettings.EnableEmailInvitations {
 		return nil, model.NewAppError("InviteNewUsersToTeam", "api.team.invite_members.disabled.app_error", nil, "", http.StatusNotImplemented)
@@ -1441,7 +1455,16 @@ func (a *App) InviteNewUsersToTeamGracefully(rctx request.CTX, memberInvite *mod
 		if !teams.IsEmailAddressAllowed(email, allowedDomains) {
 			invite.Error = model.NewAppError("InviteNewUsersToTeam", "api.team.invite_members.invalid_email.app_error", map[string]any{"Addresses": email}, "", http.StatusBadRequest)
 		} else {
-			goodEmails = append(goodEmails, email)
+			existingUser, appErr := a.getExistingInviteUserByEmail(email)
+			if appErr != nil {
+				return nil, appErr
+			}
+
+			if existingUser != nil && existingUser.DeleteAt != 0 {
+				invite.Error = model.NewAppError("InviteNewUsersToTeam", "api.team.invite_members.deactivated_email.app_error", map[string]any{"Addresses": email}, "", http.StatusBadRequest)
+			} else {
+				goodEmails = append(goodEmails, email)
+			}
 		}
 		inviteListWithErrors = append(inviteListWithErrors, invite)
 	}
@@ -1635,16 +1658,32 @@ func (a *App) InviteNewUsersToTeam(rctx request.CTX, emailList []string, teamID,
 
 	allowedDomains := a.ch.srv.teamService.GetAllowedDomains(user, team)
 	var invalidEmailList []string
+	var deactivatedEmailList []string
 
 	for _, email := range emailList {
 		if !teams.IsEmailAddressAllowed(email, allowedDomains) {
 			invalidEmailList = append(invalidEmailList, email)
+			continue
+		}
+
+		existingUser, appErr := a.getExistingInviteUserByEmail(email)
+		if appErr != nil {
+			return appErr
+		}
+
+		if existingUser != nil && existingUser.DeleteAt != 0 {
+			deactivatedEmailList = append(deactivatedEmailList, email)
 		}
 	}
 
 	if len(invalidEmailList) > 0 {
 		s := strings.Join(invalidEmailList, ", ")
 		return model.NewAppError("InviteNewUsersToTeam", "api.team.invite_members.invalid_email.app_error", map[string]any{"Addresses": s}, "", http.StatusBadRequest)
+	}
+
+	if len(deactivatedEmailList) > 0 {
+		s := strings.Join(deactivatedEmailList, ", ")
+		return model.NewAppError("InviteNewUsersToTeam", "api.team.invite_members.deactivated_email.app_error", map[string]any{"Addresses": s}, "", http.StatusBadRequest)
 	}
 
 	nameFormat := *a.Config().TeamSettings.TeammateNameDisplay

--- a/server/channels/app/team_test.go
+++ b/server/channels/app/team_test.go
@@ -1895,6 +1895,55 @@ func TestInviteNewUsersToTeamGracefully(t *testing.T) {
 		require.Len(t, res, 1)
 		require.Nil(t, res[0].Error)
 	})
+
+	t.Run("it should reject deactivated users and only invite the remaining emails", func(t *testing.T) {
+		deactivatedUser := th.CreateUser(t)
+		_, appErr := th.App.UpdateActive(th.Context, deactivatedUser, false)
+		require.Nil(t, appErr)
+
+		emailServiceMock := emailmocks.ServiceInterface{}
+		memberInvite := &model.MemberInvite{
+			Emails: []string{deactivatedUser.Email, "idontexist@mattermost.com"},
+		}
+		emailServiceMock.On("SendInviteEmails",
+			mock.Anything,
+			mock.AnythingOfType("*model.Team"),
+			mock.AnythingOfType("string"),
+			mock.AnythingOfType("string"),
+			[]string{"idontexist@mattermost.com"},
+			"",
+			mock.Anything,
+			true,
+			false,
+			false,
+		).Once().Return(nil)
+		emailServiceMock.On("Stop").Once().Return()
+		th.App.Srv().EmailService = &emailServiceMock
+
+		res, err := th.App.InviteNewUsersToTeamGracefully(th.Context, memberInvite, th.BasicTeam.Id, th.BasicUser.Id, "")
+		require.Nil(t, err)
+		require.Len(t, res, 2)
+		require.Equal(t, deactivatedUser.Email, res[0].Email)
+		require.NotNil(t, res[0].Error)
+		require.Equal(t, "api.team.invite_members.deactivated_email.app_error", res[0].Error.Id)
+		require.Equal(t, "idontexist@mattermost.com", res[1].Email)
+		require.Nil(t, res[1].Error)
+	})
+
+	t.Run("it should return an error for deactivated users before sending emails", func(t *testing.T) {
+		deactivatedUser := th.CreateUser(t)
+		_, appErr := th.App.UpdateActive(th.Context, deactivatedUser, false)
+		require.Nil(t, appErr)
+
+		emailServiceMock := emailmocks.ServiceInterface{}
+		emailServiceMock.On("Stop").Once().Return()
+		th.App.Srv().EmailService = &emailServiceMock
+
+		err := th.App.InviteNewUsersToTeam(th.Context, []string{deactivatedUser.Email}, th.BasicTeam.Id, th.BasicUser.Id)
+		require.NotNil(t, err)
+		require.Equal(t, "api.team.invite_members.deactivated_email.app_error", err.Id)
+		emailServiceMock.AssertNotCalled(t, "SendInviteEmails", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
 }
 
 func TestInviteGuestsToChannelsGracefully(t *testing.T) {

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -3631,6 +3631,10 @@
     "translation": "Your license does not support guest accounts"
   },
   {
+    "id": "api.team.invite_members.deactivated_email.app_error",
+    "translation": "The following email addresses belong to deactivated accounts: {{.Addresses}}."
+  },
+  {
     "id": "api.team.invite_members.disabled.app_error",
     "translation": "Email invitations are disabled."
   },


### PR DESCRIPTION
#### Summary
Return an error when an invite email belongs to a deactivated account, and avoid sending invitation emails for those addresses.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/27095
Jira https://mattermost.atlassian.net/browse/MM-57390

#### Test Plan
- Added app-layer tests for graceful and non-graceful invite handling with deactivated users
- Added API test coverage for the deactivated-user invite response
- Fixed the API test setup so domain restrictions do not mask the deactivated-user path

#### Release Note
```release-note
Fixed an issue where deactivated users could still be invited to a team by email.
