### PR TITLE
clean up channel store data after TestChannelStore

### DIFF
--- a/server/channels/store/storetest/channel_store.go
+++ b/server/channels/store/storetest/channel_store.go
@@ -43,6 +43,20 @@ type SqlXExecutor interface {
 	Select(dest any, query string, args ...any) error
 }
 
+// cleanupChannelStoreData purges all channel-related data written by TestChannelStore
+// sub-tests. The integrity tests (TestCheck*) do full-table scans and fail if any
+// orphaned rows remain. A blanket purge is safe: no FK constraints are enforced in the
+// schema, and every test suite creates its own data independently.
+func cleanupChannelStoreData(t *testing.T, s SqlStore) {
+	t.Helper()
+	db := s.GetMaster()
+	db.Exec(`DELETE FROM Threads`)
+	db.Exec(`DELETE FROM ChannelMemberHistory`)
+	db.Exec(`DELETE FROM ChannelMembers`)
+	db.Exec(`DELETE FROM Channels`)
+	db.Exec(`DELETE FROM TeamMembers`)
+}
+
 func cleanupChannels(t *testing.T, rctx request.CTX, ss store.Store) {
 	list, err := ss.Channel().GetAllChannels(0, 100000, store.ChannelSearchOpts{IncludeDeleted: true})
 	require.NoError(t, err, "error cleaning all channels", err)
@@ -68,6 +82,7 @@ func channelMemberToJSON(t *testing.T, cm *model.ChannelMember) string {
 
 func TestChannelStore(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
 	createDefaultRoles(ss)
+	t.Cleanup(func() { cleanupChannelStoreData(t, s) })
 
 	t.Run("Save", func(t *testing.T) { testChannelStoreSave(t, rctx, ss) })
 	t.Run("SaveDirectChannel", func(t *testing.T) { testChannelStoreSaveDirectChannel(t, rctx, ss, s) })


### PR DESCRIPTION
#### Summary

`TestChannelStore` sub-tests create channels, members, and team members using fake `TeamId`s and `UserIds` (`model.NewId()` for non-existent rows) and leave them in the database. When integrity tests (`TestCheck*`) run in the same binary afterward, their full-table scans find these orphaned rows and fail.

Normally, this is not an issue given the order in which the full `storetest` package test suite is run, but if the storetest package exceeds the execution threshold introduced with CI sharding, it can end up being split across runners and the integrity tests end up running without some previous test that did the cleanup.

Fix this by having the offending storetest (`TestChannelStore`) clean up its own data:

```go
db.Exec(`DELETE FROM Threads`)
db.Exec(`DELETE FROM ChannelMemberHistory`)
db.Exec(`DELETE FROM ChannelMembers`)
db.Exec(`DELETE FROM Channels`)
db.Exec(`DELETE FROM TeamMembers`)
```

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-68243

#### Release Note

```release-note
NONE
```