### PR TITLE
MM-67095: Hide Workspace Optimization for cloud-licensed workspaces

### DIFF
--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -343,7 +343,10 @@ const AdminDefinition: AdminDefinitionType = {
                     id: 'WorkspaceOptimizationDashboard',
                     component: WorkspaceOptimizationDashboard,
                 },
-                isHidden: it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.REPORTING.SITE_STATISTICS)),
+                isHidden: it.any(
+                    it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.REPORTING.SITE_STATISTICS)),
+                    it.licensedForFeature('Cloud'),
+                ),
                 isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.REPORTING.SITE_STATISTICS)),
             },
             system_analytics: {

--- a/webapp/channels/src/components/admin_console/admin_sidebar/admin_sidebar.test.tsx
+++ b/webapp/channels/src/components/admin_console/admin_sidebar/admin_sidebar.test.tsx
@@ -12,7 +12,7 @@ import AdminSidebar from 'components/admin_console/admin_sidebar/admin_sidebar';
 import type {Props as OriginalProps} from 'components/admin_console/admin_sidebar/admin_sidebar';
 
 import {samplePlugin1} from 'tests/helpers/admin_console_plugin_index_sample_pluings';
-import {renderWithContext, userEvent} from 'tests/react_testing_utils';
+import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
 import {generateIndex} from 'utils/admin_console_index';
 
 jest.mock('utils/utils', () => {
@@ -127,6 +127,18 @@ describe('components/AdminSidebar', () => {
         };
         const {container} = renderWithContext(<AdminSidebar {...props}/>);
         expect(container).toMatchSnapshot();
+    });
+
+    test('should not show Workspace Optimization when Cloud license feature is enabled', () => {
+        const props = {
+            ...defaultProps,
+            license: {
+                IsLicensed: 'true',
+                Cloud: 'true',
+            },
+        };
+        renderWithContext(<AdminSidebar {...props}/>);
+        expect(screen.queryByText('Workspace Optimization')).not.toBeInTheDocument();
     });
 
     test('should match snapshot, no access', () => {


### PR DESCRIPTION
#### Summary

Hide the **Reporting → Workspace Optimization** System Console entry (and route) when the license has the Cloud feature enabled. The dashboard targets self-hosted server optimization and should not appear on Mattermost Cloud workspaces.

**QA:** On a cloud workspace with an admin user, open System Console → Reporting and confirm **Workspace Optimization** is not in the left sidebar. Direct navigation to `/admin_console/reporting/workspace_optimization` should not show the dashboard (route is gated with the rest of the admin definition).

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-67095

#### Screenshots
Cloud license (subscription view available) but workspace optimization screen missing.
<img width="917" height="920" alt="image" src="https://github.com/user-attachments/assets/a87b0aa9-527c-4d45-973b-586e0a32bd35" />
#### Release Note

```release-note
Fixed an issue where the Workspace Optimization page appeared in the System Console on Mattermost Cloud workspaces.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The changes are highly isolated modifications to UI visibility logic in the admin console, following the same conditional pattern already used elsewhere in the codebase (e.g., Billing section). The new condition simply adds another hiding rule (`licensedForFeature('Cloud')`) to the existing permission check, with no side effects on core logic, data integrity, or other system components.

**QA Recommendation:** Minimal manual QA needed beyond automated testing. Verification should focus on the specific cloud scenario: confirm Workspace Optimization is hidden on cloud-licensed workspaces while remaining visible on self-hosted instances with appropriate permissions. The added test case provides good coverage for the cloud use case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->