### PR TITLE
Fix command injection in server-test-template workflow

### DIFF
--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -179,33 +179,15 @@ jobs:
             export RACE_MODE="-race"
           fi
 
-          MAKE_ARGS="${{ inputs.test-target }}${RACE_MODE} BUILD_NUMBER=${GITHUB_HEAD_REF}-${GITHUB_RUN_ID}"
-          DOCKER_CMD="make ${MAKE_ARGS}"
+          TEST_TARGET="${{ inputs.test-target }}${RACE_MODE}"
+          BUILD_NUMBER="${GITHUB_HEAD_REF}-${GITHUB_RUN_ID}"
+          DOCKER_CMD="make ${TEST_TARGET}"
 
-          # When sharding is active, use the multi-run wrapper script
+          # When sharding is active, use the multi-run wrapper script.
+          # run-shard-tests.sh detects heavy runs itself and falls back to
+          # light-only mode when shard-heavy-runs.txt is absent or empty.
           if [[ "${{ inputs.shard-total }}" -gt 1 && -f server/shard-te-packages.txt ]]; then
-            SHARD_TE=$(cat server/shard-te-packages.txt)
-            SHARD_EE=$(cat server/shard-ee-packages.txt)
-            HEAVY_RUNS=""
-            if [[ -f server/shard-heavy-runs.txt && -s server/shard-heavy-runs.txt ]]; then
-              HEAVY_RUNS=$(cat server/shard-heavy-runs.txt)
-            fi
-
-            if [[ -z "$HEAVY_RUNS" ]]; then
-              # No heavy packages — single run via Makefile with package filter.
-              # Read packages from files at runtime to avoid interpolating
-              # file-system-derived paths into a generated shell script.
-              cat > server/run-shard-tests.sh <<SHARD_EOF
-          #!/bin/bash
-          exec make ${MAKE_ARGS} \\
-            TE_PACKAGES="\$(cat shard-te-packages.txt)" \\
-            EE_PACKAGES="\$(cat shard-ee-packages.txt)"
-          SHARD_EOF
-            else
-              # Use the multi-run wrapper script
-              cp server/scripts/run-shard-tests.sh server/run-shard-tests.sh
-            fi
-
+            cp server/scripts/run-shard-tests.sh server/run-shard-tests.sh
             chmod +x server/run-shard-tests.sh
             DOCKER_CMD="/mattermost/server/run-shard-tests.sh"
           fi
@@ -220,6 +202,8 @@ jobs:
             --env ENABLE_COVERAGE="${{ inputs.enablecoverage }}" \
             --env FIPS_ENABLED="${{ inputs.fips-enabled }}" \
             --env RACE_MODE \
+            --env TEST_TARGET \
+            --env BUILD_NUMBER \
             -v $PWD:/mattermost \
             -w /mattermost/server \
             $BUILD_IMAGE \


### PR DESCRIPTION
#### Summary

Fixes a command injection vulnerability in `.github/workflows/server-test-template.yml` [reported by DryRun Security](https://github.com/mattermost/mattermost/pull/35999#issuecomment-4245273188) in a cherry-pick, but actually [previously reported](https://github.com/mattermost/mattermost/pull/35739#issuecomment-4136169543) on the original https://github.com/mattermost/mattermost/issues/35739.

The workflow previously generated a shell script via an unquoted heredoc (`<<SHARD_EOF`), embedding `MAKE_ARGS` — which included the user-controlled `GITHUB_HEAD_REF` — directly into the script content. An attacker could craft a branch name containing shell metacharacters (e.g. `feature/foo; touch /tmp/pwned; #`) to execute arbitrary commands in the CI environment during `docker run`.

The fix removes the heredoc and the associated branch in the shard path entirely. `run-shard-tests.sh` already detects whether heavy runs are present and handles the light-only case on its own, so both shard paths now unconditionally copy that single static script. `BUILD_NUMBER` and `TEST_TARGET` are passed as explicit docker env vars rather than being interpolated into generated script content.

#### Ticket Link

<!-- no Jira ticket -->

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to CI workflow infrastructure and delegates to an already-existing, fully-functional `run-shard-tests.sh` script that handles shard detection and test execution. The primary behavioral change—passing `BUILD_NUMBER` and `TEST_TARGET` as Docker environment variables instead of embedding them in the make command—has minimal regression risk since the underlying test logic remains unchanged and these values are read from environment by the test runner.

**QA Recommendation:** Standard smoke test of sharded and non-sharded test runs in CI to confirm environment variables are properly propagated into the container and test reports generate correctly. No manual QA required given this is a security hardening fix with proven existing logic.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->