### PR TITLE
[MM-67949] Harden notification email filename rendering

### DIFF
--- a/server/channels/app/email/notification_email.go
+++ b/server/channels/app/email/notification_email.go
@@ -8,7 +8,6 @@ import (
 	"html"
 	"html/template"
 	"net/url"
-	"path/filepath"
 	"strings"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -33,7 +32,7 @@ func (es *Service) GetMessageForNotification(post *model.Post, teamName, siteUrl
 		return es.prepareNotificationMessageForEmail(post.Message, teamName, siteUrl)
 	}
 
-	// extract the filenames from their paths and determine what type of files are attached
+	// normalize the filenames and determine what type of files are attached
 	infos, err := es.store.FileInfo().GetForPost(post.Id, true, false, true)
 	if err != nil {
 		mlog.Warn("Encountered error when getting files for notification message", mlog.String("post_id", post.Id), mlog.Err(err))
@@ -42,12 +41,11 @@ func (es *Service) GetMessageForNotification(post *model.Post, teamName, siteUrl
 	filenames := make([]string, len(infos))
 	onlyImages := true
 	for i, info := range infos {
-		if escaped, err := url.QueryUnescape(filepath.Base(info.Name)); err != nil {
-			// this should never error since filepath was escaped using url.QueryEscape
-			filenames[i] = escaped
-		} else {
-			filenames[i] = info.Name
+		filename := info.Name
+		if unescaped, err := url.QueryUnescape(filename); err == nil {
+			filename = unescaped
 		}
+		filenames[i] = filename
 
 		onlyImages = onlyImages && info.IsImage()
 	}
@@ -55,9 +53,15 @@ func (es *Service) GetMessageForNotification(post *model.Post, teamName, siteUrl
 	props := map[string]any{"Filenames": strings.Join(filenames, ", ")}
 
 	if onlyImages {
-		return translateFunc("api.post.get_message_for_notification.images_sent", len(filenames), props)
+		return string(i18n.TranslateAsHTML(translateFunc, "api.post.get_message_for_notification.images_sent", map[string]any{
+			"Count":     len(filenames),
+			"Filenames": props["Filenames"],
+		}))
 	}
-	return translateFunc("api.post.get_message_for_notification.files_sent", len(filenames), props)
+	return string(i18n.TranslateAsHTML(translateFunc, "api.post.get_message_for_notification.files_sent", map[string]any{
+		"Count":     len(filenames),
+		"Filenames": props["Filenames"],
+	}))
 }
 
 func ProcessMessageAttachments(post *model.Post, siteURL string) []*EmailMessageAttachment {

--- a/server/channels/app/notification_email_test.go
+++ b/server/channels/app/notification_email_test.go
@@ -6,7 +6,9 @@ package app
 import (
 	"bytes"
 	"fmt"
+	"html"
 	"html/template"
+	"net/url"
 	"regexp"
 	"testing"
 	"time"
@@ -744,6 +746,106 @@ func TestGetNotificationEmailEscapingChars(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotContains(t, body, message)
+}
+
+func TestGetNotificationEmailBodyFullNotificationFileOnlyPostEscapesFilenameHTML(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := SetupWithStoreMock(t)
+
+	recipient := buildTestUser("test-recipient-id", "recipient", "Recipient User", true)
+	dangerousFilename := "<b>owned</b>.txt"
+	post := &model.Post{
+		Id:      "test-post-id",
+		Message: "",
+		FileIds: []string{"test-file-id"},
+	}
+	channel := &model.Channel{
+		Id:          "test-channel-id",
+		Name:        "testchannel",
+		DisplayName: "ChannelName",
+		Type:        model.ChannelTypeOpen,
+	}
+	sender := buildTestUser("test-sender-id", "sender", "sender", true)
+	team := buildTestTeam("test-team-id", "testteam", "testteam")
+
+	storeMock := th.App.Srv().Store().(*mocks.Store)
+	fileInfoStoreMock := mocks.FileInfoStore{}
+	fileInfoStoreMock.On("GetForPost", post.Id, true, false, true).Return([]*model.FileInfo{{
+		Id:        "test-file-id",
+		PostId:    post.Id,
+		Name:      dangerousFilename,
+		Extension: "txt",
+		MimeType:  "text/plain",
+	}}, nil)
+	storeMock.On("FileInfo").Return(&fileInfoStoreMock)
+
+	setupPreferenceMocks(th, recipient.Id, true)
+	th.App.Srv().EmailService.SetStore(storeMock)
+
+	notification := buildTestPostNotification(post, channel, sender)
+	emailNotification := th.App.buildEmailNotification(th.Context, notification, recipient, team)
+	body, err := th.App.getNotificationEmailBodyFromEmailNotification(th.Context, recipient, emailNotification, post, "")
+	require.NoError(t, err)
+
+	require.Contains(t, body, html.EscapeString(dangerousFilename))
+	require.NotContains(t, body, dangerousFilename)
+}
+
+func TestGetNotificationEmailBodyFullNotificationImageOnlyPostNormalizesAndEscapesFilenamesHTML(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := SetupWithStoreMock(t)
+
+	recipient := buildTestUser("test-recipient-id", "recipient", "Recipient User", true)
+	rawDangerousFilename := "<img src=x onerror=alert(1)>.png"
+	encodedDangerousFilename := url.QueryEscape(rawDangerousFilename)
+	secondFilename := "photo & notes.png"
+	post := &model.Post{
+		Id:      "test-post-id",
+		Message: "",
+		FileIds: []string{"test-file-id-1", "test-file-id-2"},
+	}
+	channel := &model.Channel{
+		Id:          "test-channel-id",
+		Name:        "testchannel",
+		DisplayName: "ChannelName",
+		Type:        model.ChannelTypeOpen,
+	}
+	sender := buildTestUser("test-sender-id", "sender", "sender", true)
+	team := buildTestTeam("test-team-id", "testteam", "testteam")
+
+	storeMock := th.App.Srv().Store().(*mocks.Store)
+	fileInfoStoreMock := mocks.FileInfoStore{}
+	fileInfoStoreMock.On("GetForPost", post.Id, true, false, true).Return([]*model.FileInfo{
+		{
+			Id:        "test-file-id-1",
+			PostId:    post.Id,
+			Name:      encodedDangerousFilename,
+			Extension: "png",
+			MimeType:  "image/png",
+		},
+		{
+			Id:        "test-file-id-2",
+			PostId:    post.Id,
+			Name:      secondFilename,
+			Extension: "png",
+			MimeType:  "image/png",
+		},
+	}, nil)
+	storeMock.On("FileInfo").Return(&fileInfoStoreMock)
+
+	setupPreferenceMocks(th, recipient.Id, true)
+	th.App.Srv().EmailService.SetStore(storeMock)
+
+	notification := buildTestPostNotification(post, channel, sender)
+	emailNotification := th.App.buildEmailNotification(th.Context, notification, recipient, team)
+	body, err := th.App.getNotificationEmailBodyFromEmailNotification(th.Context, recipient, emailNotification, post, "")
+	require.NoError(t, err)
+
+	expectedFilenames := fmt.Sprintf("%s, %s", html.EscapeString(rawDangerousFilename), html.EscapeString(secondFilename))
+	require.Contains(t, body, "2 images sent:")
+	require.Contains(t, body, expectedFilenames)
+	require.NotContains(t, body, rawDangerousFilename)
+	require.NotContains(t, body, encodedDangerousFilename)
 }
 
 func TestGetNotificationEmailBodyPublicChannelMention(t *testing.T) {


### PR DESCRIPTION
#### Summary
Harden filename rendering in notification emails and add focused regression coverage for file-only and image-only notification paths.

QA:
- `go test ./channels/app -run 'TestGetNotificationEmailBodyFullNotification(FileOnlyPostEscapesFilenameHTML|ImageOnlyPostNormalizesAndEscapesFilenamesHTML)$'`
- `go test ./channels/app -run TestGetNotificationEmailEscapingChars -count=1`

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-67949

#### Screenshots
No UI changes.

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes modify filename extraction/normalization from `filepath.Base()` to `url.QueryUnescape()` and alter translation output to use `i18n.TranslateAsHTML()` instead of `translateFunc()` directly. While this is a security hardening measure, the behavioral shift in filename processing could affect rendering of existing filenames that contain URL-encoded characters or special characters.

**QA Recommendation:** Focused manual testing recommended on notification email rendering with edge-case filenames (special characters, URL-encoded names, multi-byte characters) to verify backward compatibility. Automated test coverage for file-only and image-only scenarios is comprehensive, but validation of actual email output formatting across different filename patterns would reduce deployment risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->