### PR TITLE
Add prepackaged version of github plugin v2.7. (#35968)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -153,7 +153,7 @@ TEMPLATES_DIR=templates
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
 PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.4
-PLUGIN_PACKAGES += mattermost-plugin-github-v2.5.0
+PLUGIN_PACKAGES += mattermost-plugin-github-v2.7.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.12.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.5.1
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.8.0


### PR DESCRIPTION
## Summary
Cherry-pick of #35968 (e2e7aed) onto release-11.4

Bumps the prepackaged GitHub plugin version from v2.5.0 to v2.7.0.

## Release Note
```release-note
Bump github plugin version to latest v2.7.0
```

Made with [Cursor](https://cursor.com)