### PR TITLE
Cherry-pick MM-68269 Set Bulk channel membership endpoint into 11.5

### DIFF
--- a/api/v4/source/channels.yaml
+++ b/api/v4/source/channels.yaml
@@ -1356,6 +1356,191 @@
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+    put:
+      tags:
+        - channels
+      summary: Set channel members
+      description: |
+        Set the complete membership list for a channel, with optional channel admin designation.
+        The server compares the provided list against the current membership and adds or removes
+        users as needed. Users already in the channel are left untouched (no-op).
+
+        When `channel_admins` is provided, a role reconciliation phase runs after membership
+        changes: listed users are promoted to channel admin, all other members are demoted.
+        When `channel_admins` is omitted (null), existing admin roles are preserved.
+
+        Results are streamed back as NDJSON (`application/x-ndjson`), one line per batch. Each line
+        is a JSON object with `added`, `removed`, `promoted`, `demoted`, and `errors` arrays for
+        that batch.
+
+        Removals are processed before additions, then role changes. Private channels cannot be
+        emptied entirely. DM/GM and group-constrained channels are rejected.
+
+        #### Example: membership only
+
+        Request (using `batch_size=2` and `batch_delay_ms=200`):
+
+        ```bash
+        curl -X PUT \
+          'https://mattermost.example.com/api/v4/channels/channel123/members?batch_size=2&batch_delay_ms=200' \
+          -H 'Authorization: Bearer <token>' \
+          -H 'Content-Type: application/json' \
+          -d '{"members": ["user_id_1", "user_id_2", "user_id_3", "user_id_4"]}'
+        ```
+
+        Streamed NDJSON response (one JSON object per line, one line per batch):
+
+        ```text
+        {"added":[],"removed":["user_id_5","user_id_6"],"errors":[]}
+        {"added":["user_id_3","user_id_4"],"removed":[],"errors":[]}
+        {"added":[],"removed":[],"errors":[{"user_id":"user_id_7","id":"api.channel.add_members.user_denied","error":"user is not a member of the team"}]}
+        ```
+
+        In this example, `user_id_1` and `user_id_2` were already members (no-op), `user_id_5` and
+        `user_id_6` were removed, `user_id_3` and `user_id_4` were added, and `user_id_7` could not
+        be added because the user is not on the team.
+
+        #### Example: membership with admin roles
+
+        ```bash
+        curl -X PUT \
+          'https://mattermost.example.com/api/v4/channels/channel123/members' \
+          -H 'Authorization: Bearer <token>' \
+          -H 'Content-Type: application/json' \
+          -d '{"members": ["user_id_1", "user_id_2", "user_id_3"], "channel_admins": ["user_id_1"]}'
+        ```
+
+        Response:
+
+        ```text
+        {"added":["user_id_3"],"removed":["user_id_4"]}
+        {"promoted":["user_id_1"],"demoted":["user_id_2"]}
+        ```
+
+        In this example, `user_id_1` was promoted to channel admin and `user_id_2` was demoted.
+        When `channel_admins` is omitted, existing admin roles are preserved.
+
+        __Minimum server version__: 11.7
+        ##### Permissions
+        Must have `manage_system` permission (system admin only).
+      operationId: SetChannelMembers
+      parameters:
+        - name: channel_id
+          in: path
+          description: Channel GUID
+          required: true
+          schema:
+            type: string
+        - name: batch_size
+          in: query
+          description: Number of add/remove operations per batch.
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+            maximum: 1000
+        - name: batch_delay_ms
+          in: query
+          description: Milliseconds to pause between batches, giving the server time to process
+            websocket events and plugin hooks.
+          schema:
+            type: integer
+            default: 500
+            minimum: 0
+            maximum: 10000
+      requestBody:
+        description: JSON object specifying the complete desired membership and
+          optional channel admin designations. Request body is limited to 12 MB.
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - members
+              properties:
+                members:
+                  type: array
+                  items:
+                    type: string
+                  description: User IDs for the desired channel membership. The
+                    final membership is the union of `members` and `channel_admins`.
+                channel_admins:
+                  type: array
+                  nullable: true
+                  items:
+                    type: string
+                  description: User IDs that should have the channel admin role.
+                    Users listed here are automatically included in the desired
+                    membership (they do not need to also appear in `members`).
+                    When null or omitted, existing admin roles are preserved for
+                    members who remain in the channel. When present (including
+                    empty array), admin roles are set declaratively.
+        required: true
+      responses:
+        "200":
+          description: |
+            Streamed NDJSON response. Each line is a JSON object representing one batch of results.
+
+            If the operation is interrupted (e.g. context cancellation), a final NDJSON line
+            with an `error` field is emitted so the client can distinguish partial from full
+            success: `{"error":"The set channel members operation was cancelled."}`
+          content:
+            application/x-ndjson:
+              schema:
+                oneOf:
+                  - type: object
+                    description: A batch of results from the set channel members operation.
+                    properties:
+                      added:
+                        type: array
+                        items:
+                          type: string
+                        description: User IDs successfully added to the channel in this batch.
+                      removed:
+                        type: array
+                        items:
+                          type: string
+                        description: User IDs successfully removed from the channel in this batch.
+                      promoted:
+                        type: array
+                        items:
+                          type: string
+                        description: User IDs promoted to channel admin in this batch.
+                      demoted:
+                        type: array
+                        items:
+                          type: string
+                        description: User IDs demoted from channel admin in this batch.
+                      errors:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            user_id:
+                              type: string
+                              description: The user ID that failed.
+                            id:
+                              type: string
+                              description: Machine-readable error identifier (i18n key).
+                            error:
+                              type: string
+                              description: Human-readable description of the failure.
+                        description: Per-user failures (not on team, deleted user, cannot remove
+                          from default channel, plugin rejection).
+                  - type: object
+                    description: Terminal error line emitted when the operation is interrupted.
+                    required:
+                      - error
+                    properties:
+                      error:
+                        type: string
+                        description: Human-readable description of the interruption.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   "/api/v4/channels/{channel_id}/members/ids":
     post:
       tags:

--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -72,6 +72,7 @@ func (api *API) InitChannel() {
 	api.BaseRoutes.ChannelMembers.Handle("", api.APISessionRequired(getChannelMembers)).Methods(http.MethodGet)
 	api.BaseRoutes.ChannelMembers.Handle("/ids", api.APISessionRequired(getChannelMembersByIds)).Methods(http.MethodPost)
 	api.BaseRoutes.ChannelMembers.Handle("", api.APISessionRequired(addChannelMember)).Methods(http.MethodPost)
+	api.BaseRoutes.ChannelMembers.Handle("", api.APISessionRequired(setChannelMembers)).Methods(http.MethodPut)
 	api.BaseRoutes.ChannelMembersForUser.Handle("", api.APISessionRequired(getChannelMembersForTeamForUser)).Methods(http.MethodGet)
 	api.BaseRoutes.ChannelMember.Handle("", api.APISessionRequired(getChannelMember)).Methods(http.MethodGet)
 	api.BaseRoutes.ChannelMember.Handle("", api.APISessionRequired(removeChannelMember)).Methods(http.MethodDelete)
@@ -2165,6 +2166,185 @@ func addChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.Logger.Warn("Error while writing response", mlog.Err(err))
 		}
 	}
+}
+
+const (
+	setChannelMembersDefaultBatchSize    = 100
+	setChannelMembersMinBatchSize        = 1
+	setChannelMembersMaxBatchSize        = 1000
+	setChannelMembersDefaultBatchDelayMs = 500
+	setChannelMembersMinBatchDelayMs     = 0
+	setChannelMembersMaxBatchDelayMs     = 10000
+	setChannelMembersMaxBodySize         = 12 * 1024 * 1024 // 12 MB
+)
+
+func setChannelMembers(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.RequireChannelId()
+	if c.Err != nil {
+		return
+	}
+
+	// Require system admin
+	if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageSystem) {
+		c.SetPermissionError(model.PermissionManageSystem)
+		return
+	}
+
+	// Parse query params
+	batchSize := setChannelMembersDefaultBatchSize
+	if v := r.URL.Query().Get("batch_size"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < setChannelMembersMinBatchSize || n > setChannelMembersMaxBatchSize {
+			c.SetInvalidURLParam("batch_size")
+			return
+		}
+		batchSize = n
+	}
+
+	batchDelayMs := setChannelMembersDefaultBatchDelayMs
+	if v := r.URL.Query().Get("batch_delay_ms"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < setChannelMembersMinBatchDelayMs || n > setChannelMembersMaxBatchDelayMs {
+			c.SetInvalidURLParam("batch_delay_ms")
+			return
+		}
+		batchDelayMs = n
+	}
+
+	// Cap request body size
+	r.Body = http.MaxBytesReader(w, r.Body, setChannelMembersMaxBodySize)
+
+	// Decode request body
+	var req model.SetChannelMembersRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		c.SetInvalidParamWithErr("body", err)
+		return
+	}
+	if req.Members == nil {
+		c.SetInvalidParam("members")
+		return
+	}
+
+	// Validate and deduplicate member IDs. The desired membership is the
+	// union of Members and ChannelAdmins (admins are implicitly members).
+	seen := make(map[string]struct{}, len(req.Members))
+	deduped := make([]string, 0, len(req.Members))
+	for _, id := range req.Members {
+		if !model.IsValidId(id) {
+			c.SetInvalidParam("members")
+			return
+		}
+		if _, exists := seen[id]; !exists {
+			seen[id] = struct{}{}
+			deduped = append(deduped, id)
+		}
+	}
+
+	// Build admin set and merge admin IDs into the desired membership list.
+	var adminSet map[string]struct{}
+	if req.ChannelAdmins != nil {
+		adminSet = make(map[string]struct{}, len(*req.ChannelAdmins))
+		for _, id := range *req.ChannelAdmins {
+			if !model.IsValidId(id) {
+				c.SetInvalidParam("channel_admins")
+				return
+			}
+			adminSet[id] = struct{}{}
+			if _, exists := seen[id]; !exists {
+				seen[id] = struct{}{}
+				deduped = append(deduped, id)
+			}
+		}
+	}
+	desiredUserIDs := deduped
+
+	channel, appErr := c.App.GetChannel(c.AppContext, c.Params.ChannelId)
+	if appErr != nil {
+		c.Err = appErr
+		return
+	}
+
+	// Reject DM/GM channels
+	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
+		c.Err = model.NewAppError("setChannelMembers", "api.channel.set_members.type.app_error", nil, "", http.StatusBadRequest)
+		return
+	}
+
+	// Reject group-constrained channels
+	if channel.IsGroupConstrained() {
+		c.Err = model.NewAppError("setChannelMembers", "api.channel.set_members.group_constrained.app_error", nil, "", http.StatusBadRequest)
+		return
+	}
+
+	// Reject policy-enforced (ABAC) channels
+	if channel.PolicyEnforced {
+		c.Err = model.NewAppError("setChannelMembers", "api.channel.set_members.policy_enforced.app_error", nil, "", http.StatusBadRequest)
+		return
+	}
+
+	auditRec := c.MakeAuditRecord(model.AuditEventSetChannelMembers, model.AuditStatusFail)
+	defer c.LogAuditRec(auditRec)
+	model.AddEventParameterToAuditRec(auditRec, "channel_id", c.Params.ChannelId)
+	model.AddEventParameterToAuditRec(auditRec, "desired_user_count", len(desiredUserIDs))
+	model.AddEventParameterToAuditRec(auditRec, "channel_admin_count", len(adminSet))
+	model.AddEventParameterToAuditRec(auditRec, "batch_size", batchSize)
+	model.AddEventParameterToAuditRec(auditRec, "batch_delay_ms", batchDelayMs)
+
+	enc := json.NewEncoder(w)
+	flusher, _ := w.(http.Flusher)
+	streamingStarted := false
+	var totalAdded, totalRemoved, totalErrors int
+
+	appErr = c.App.SetChannelMembers(c.AppContext, channel, desiredUserIDs, adminSet, c.AppContext.Session().UserId, batchSize, batchDelayMs, func(result *model.SetChannelMembersResponse) {
+		if !streamingStarted {
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			streamingStarted = true
+		}
+		if result.Added == nil {
+			result.Added = []string{}
+		}
+		if result.Removed == nil {
+			result.Removed = []string{}
+		}
+		if result.Errors == nil {
+			result.Errors = []model.SetChannelMembersError{}
+		}
+		totalAdded += len(result.Added)
+		totalRemoved += len(result.Removed)
+		totalErrors += len(result.Errors)
+		if err := enc.Encode(result); err != nil {
+			c.Logger.Warn("Error while writing response", mlog.Err(err))
+		}
+		if flusher != nil {
+			flusher.Flush()
+		}
+	})
+
+	model.AddEventParameterToAuditRec(auditRec, "total_added", totalAdded)
+	model.AddEventParameterToAuditRec(auditRec, "total_removed", totalRemoved)
+	model.AddEventParameterToAuditRec(auditRec, "total_errors", totalErrors)
+
+	if appErr != nil {
+		if streamingStarted {
+			// Response is already committed (NDJSON lines written), so we cannot
+			// set c.Err — the framework would try to write a JSON error into the
+			// NDJSON stream. Emit a final error line so the client can detect
+			// the incomplete operation.
+			errLine := map[string]string{"error": appErr.Error()}
+			if err := enc.Encode(errLine); err != nil {
+				c.Logger.Warn("Error writing terminal error to NDJSON stream", mlog.Err(err))
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+			c.Logger.Warn("SetChannelMembers terminated with error", mlog.Err(appErr))
+		} else {
+			c.Err = appErr
+		}
+		return
+	}
+
+	auditRec.Success()
 }
 
 func removeChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/server/channels/api4/channel_test.go
+++ b/server/channels/api4/channel_test.go
@@ -6796,3 +6796,479 @@ func TestChannelMemberSanitization(t *testing.T) {
 		assert.Equal(t, channel.Id, returnedMember.ChannelId, "ChannelId should be preserved")
 	})
 }
+
+func TestSetChannelMembers(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+	ctx := context.Background()
+
+	t.Run("basic reconcile", func(t *testing.T) {
+		channel := th.CreatePublicChannel(t)
+		user2 := th.BasicUser2
+
+		// Add user2 to channel first
+		_, _, err := th.SystemAdminClient.AddChannelMember(ctx, channel.Id, user2.Id)
+		require.NoError(t, err)
+
+		// Create a new user on the team
+		user3 := th.CreateUserWithClient(t, th.SystemAdminClient)
+		th.LinkUserToTeam(t, user3, th.BasicTeam)
+
+		// Set members to [BasicUser, user3] — user2 should be removed, user3 added
+		results, resp, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id, &model.SetChannelMembersRequest{Members: []string{th.BasicUser.Id, user3.Id}}, 0, 0)
+		require.NoError(t, err)
+		assert.Equal(t, "application/x-ndjson", resp.Header.Get("Content-Type"))
+
+		// Collect all results
+		var allAdded, allRemoved []string
+		var allErrors []model.SetChannelMembersError
+		for _, r := range results {
+			allAdded = append(allAdded, r.Added...)
+			allRemoved = append(allRemoved, r.Removed...)
+			allErrors = append(allErrors, r.Errors...)
+		}
+		assert.Contains(t, allRemoved, user2.Id)
+		assert.Contains(t, allAdded, user3.Id)
+		assert.NotContains(t, allAdded, th.BasicUser.Id, "existing member should not be re-added")
+		assert.NotContains(t, allRemoved, th.BasicUser.Id, "existing member should not be removed")
+		assert.Empty(t, allErrors, "should have no errors")
+
+		// Verify final channel membership matches what was requested
+		members, _, err := th.SystemAdminClient.GetChannelMembers(ctx, channel.Id, 0, 100, "")
+		require.NoError(t, err)
+		memberIDs := make(map[string]bool)
+		for _, m := range members {
+			memberIDs[m.UserId] = true
+		}
+		assert.Len(t, members, 2, "channel should have exactly 2 members")
+		assert.True(t, memberIDs[th.BasicUser.Id], "BasicUser should be a member")
+		assert.True(t, memberIDs[user3.Id], "user3 should be a member")
+		assert.False(t, memberIDs[user2.Id], "user2 should not be a member")
+	})
+
+	t.Run("idempotent", func(t *testing.T) {
+		channel := th.CreatePublicChannel(t)
+		user2 := th.BasicUser2
+
+		// First call performs a real mutation — add user2
+		results1, _, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id, &model.SetChannelMembersRequest{Members: []string{th.BasicUser.Id, user2.Id}}, 0, 0)
+		require.NoError(t, err)
+		var firstAdded []string
+		for _, r := range results1 {
+			firstAdded = append(firstAdded, r.Added...)
+		}
+		assert.Contains(t, firstAdded, user2.Id, "first call should add user2")
+
+		// Second call with same list — should be all no-ops
+		results2, _, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id, &model.SetChannelMembersRequest{Members: []string{th.BasicUser.Id, user2.Id}}, 0, 0)
+		require.NoError(t, err)
+		for _, r := range results2 {
+			assert.Empty(t, r.Added)
+			assert.Empty(t, r.Removed)
+			assert.Empty(t, r.Errors)
+		}
+
+		// Verify membership unchanged
+		members, _, err := th.SystemAdminClient.GetChannelMembers(ctx, channel.Id, 0, 100, "")
+		require.NoError(t, err)
+		assert.Len(t, members, 2)
+	})
+
+	t.Run("empty list removes all removable members", func(t *testing.T) {
+		channel := th.CreatePublicChannel(t)
+
+		// Set to empty list
+		results, _, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id, &model.SetChannelMembersRequest{Members: []string{}}, 0, 0)
+		require.NoError(t, err)
+
+		var allRemoved []string
+		for _, r := range results {
+			allRemoved = append(allRemoved, r.Removed...)
+		}
+		assert.Contains(t, allRemoved, th.BasicUser.Id)
+
+		// Verify channel has no members
+		members, _, err := th.SystemAdminClient.GetChannelMembers(ctx, channel.Id, 0, 100, "")
+		require.NoError(t, err)
+		assert.Empty(t, members)
+	})
+
+	t.Run("empty private channel rejected", func(t *testing.T) {
+		privateChannel := th.CreatePrivateChannel(t)
+		_, resp, err := th.SystemAdminClient.SetChannelMembers(ctx, privateChannel.Id, &model.SetChannelMembersRequest{Members: []string{}}, 0, 0)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+
+		// Verify members are unchanged
+		members, _, err := th.SystemAdminClient.GetChannelMembers(ctx, privateChannel.Id, 0, 100, "")
+		require.NoError(t, err)
+		assert.NotEmpty(t, members, "private channel should still have members")
+	})
+
+	t.Run("private channel can be orphaned when all desired users are invalid", func(t *testing.T) {
+		// Known limitation: if the desired list is non-empty but all users are
+		// invalid (e.g. not on the team), removals succeed first and then all
+		// adds fail, leaving the private channel empty. The sysadmin can recover
+		// by adding members back via the API.
+		privateChannel := th.CreatePrivateChannel(t)
+
+		// Create a user NOT on the team
+		otherUser := th.CreateUserWithClient(t, th.SystemAdminClient)
+
+		results, _, err := th.SystemAdminClient.SetChannelMembers(ctx, privateChannel.Id, &model.SetChannelMembersRequest{Members: []string{otherUser.Id}}, 0, 0)
+		require.NoError(t, err)
+
+		// The add should have failed
+		var allErrors []model.SetChannelMembersError
+		for _, r := range results {
+			allErrors = append(allErrors, r.Errors...)
+		}
+		assert.NotEmpty(t, allErrors, "invalid user should appear in errors")
+
+		// The channel is now empty — this is the known limitation
+		members, _, err := th.SystemAdminClient.GetChannelMembers(ctx, privateChannel.Id, 0, 100, "")
+		require.NoError(t, err)
+		assert.Empty(t, members, "private channel is orphaned (known limitation)")
+	})
+
+	t.Run("non-sysadmin returns 403", func(t *testing.T) {
+		channel := th.CreatePublicChannel(t)
+		_, resp, err := th.Client.SetChannelMembers(ctx, channel.Id, &model.SetChannelMembersRequest{Members: []string{th.BasicUser.Id}}, 0, 0)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("DM channel rejected", func(t *testing.T) {
+		dmChannel := th.CreateDmChannel(t, th.BasicUser2)
+		_, resp, err := th.SystemAdminClient.SetChannelMembers(ctx, dmChannel.Id, &model.SetChannelMembersRequest{Members: []string{th.BasicUser.Id}}, 0, 0)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+	})
+
+	t.Run("GM channel rejected", func(t *testing.T) {
+		user3 := th.CreateUserWithClient(t, th.SystemAdminClient)
+		th.LinkUserToTeam(t, user3, th.BasicTeam)
+		gmChannel, _, err := th.SystemAdminClient.CreateGroupChannel(ctx, []string{th.BasicUser.Id, th.BasicUser2.Id, user3.Id})
+		require.NoError(t, err)
+
+		_, resp, err := th.SystemAdminClient.SetChannelMembers(ctx, gmChannel.Id, &model.SetChannelMembersRequest{Members: []string{th.BasicUser.Id}}, 0, 0)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+	})
+
+	t.Run("group-constrained channel rejected", func(t *testing.T) {
+		channel := th.CreatePublicChannel(t)
+		channel.GroupConstrained = model.NewPointer(true)
+		_, appErr := th.App.UpdateChannel(th.Context, channel)
+		require.Nil(t, appErr)
+
+		_, resp, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id, &model.SetChannelMembersRequest{Members: []string{th.BasicUser.Id}}, 0, 0)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+	})
+
+	t.Run("policy-enforced channel rejected", func(t *testing.T) {
+		channel := th.CreatePublicChannel(t)
+
+		// Create an access control policy to make the channel policy-enforced
+		policy := &model.AccessControlPolicy{
+			Type:    model.AccessControlPolicyTypeChannel,
+			ID:      channel.Id,
+			Name:    "Test Policy",
+			Version: model.AccessControlPolicyVersionV0_2,
+			Rules: []model.AccessControlPolicyRule{
+				{
+					Actions:    []string{"view"},
+					Expression: "user.attributes.team == \"test\"",
+				},
+			},
+		}
+		_, storeErr := th.App.Srv().Store().AccessControlPolicy().Save(th.Context, policy)
+		require.NoError(t, storeErr)
+
+		_, resp, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id, &model.SetChannelMembersRequest{Members: []string{th.BasicUser.Id}}, 0, 0)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+	})
+
+	t.Run("town-square non-guests cannot be removed", func(t *testing.T) {
+		// Find town-square
+		townSquare, appErr := th.App.GetChannelByName(th.Context, model.DefaultChannelName, th.BasicTeam.Id, false)
+		require.Nil(t, appErr)
+
+		// Set to empty list, non-guest members cannot be removed and should appear in errors
+		results, _, err := th.SystemAdminClient.SetChannelMembers(ctx, townSquare.Id, &model.SetChannelMembersRequest{Members: []string{}}, 0, 0)
+		require.NoError(t, err)
+
+		var allErrors []model.SetChannelMembersError
+		for _, r := range results {
+			allErrors = append(allErrors, r.Errors...)
+		}
+		assert.NotEmpty(t, allErrors, "non-guest members should appear in errors")
+
+		// Verify members are still in town-square (removal was blocked)
+		members, _, err := th.SystemAdminClient.GetChannelMembers(ctx, townSquare.Id, 0, 100, "")
+		require.NoError(t, err)
+		assert.NotEmpty(t, members, "town-square should still have members")
+	})
+
+	t.Run("user not on team appears in errors", func(t *testing.T) {
+		channel := th.CreatePublicChannel(t)
+
+		// Create a user NOT on the team
+		otherUser := th.CreateUserWithClient(t, th.SystemAdminClient)
+
+		results, _, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id, &model.SetChannelMembersRequest{Members: []string{th.BasicUser.Id, otherUser.Id}}, 0, 0)
+		require.NoError(t, err)
+
+		var allErrors []model.SetChannelMembersError
+		for _, r := range results {
+			allErrors = append(allErrors, r.Errors...)
+		}
+		found := false
+		for _, e := range allErrors {
+			if e.UserID == otherUser.Id {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "user not on team should appear in errors")
+	})
+
+	t.Run("null members rejected", func(t *testing.T) {
+		channel := th.CreatePublicChannel(t)
+		// nil Members field serializes as JSON null for the members array
+		_, resp, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id, &model.SetChannelMembersRequest{}, 0, 0)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+	})
+
+	t.Run("invalid batch_size rejected", func(t *testing.T) {
+		channel := th.CreatePublicChannel(t)
+
+		// batch_size out of range (too large)
+		_, resp, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id, &model.SetChannelMembersRequest{Members: []string{th.BasicUser.Id}}, 9999, 0)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+	})
+
+	t.Run("invalid batch_delay_ms rejected", func(t *testing.T) {
+		channel := th.CreatePublicChannel(t)
+
+		// batch_delay_ms out of range (above max 10000)
+		_, resp, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id, &model.SetChannelMembersRequest{Members: []string{th.BasicUser.Id}}, 0, 99999)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+	})
+
+	t.Run("batching with large list", func(t *testing.T) {
+		channel := th.CreatePublicChannel(t)
+
+		// Create 5 users and add them to the team
+		var userIDs []string
+		userIDs = append(userIDs, th.BasicUser.Id)
+		for range 5 {
+			u := th.CreateUserWithClient(t, th.SystemAdminClient)
+			th.LinkUserToTeam(t, u, th.BasicTeam)
+			userIDs = append(userIDs, u.Id)
+		}
+
+		// Use batch_size=2 to force multiple batches
+		results, _, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id, &model.SetChannelMembersRequest{Members: userIDs}, 2, 0)
+		require.NoError(t, err)
+
+		// BasicUser is already a member, so 5 to add in batches of 2 = 3 batches
+		assert.Len(t, results, 3, "should have exactly 3 batches for 5 adds with batch_size=2")
+
+		var allAdded []string
+		for _, r := range results {
+			assert.LessOrEqual(t, len(r.Added), 2, "each batch should have at most 2 additions")
+			allAdded = append(allAdded, r.Added...)
+		}
+		assert.Len(t, allAdded, 5, "should have added 5 users total")
+
+		// Verify final membership matches the requested list
+		members, _, err := th.SystemAdminClient.GetChannelMembers(ctx, channel.Id, 0, 100, "")
+		require.NoError(t, err)
+		memberIDs := make(map[string]bool)
+		for _, m := range members {
+			memberIDs[m.UserId] = true
+		}
+		for _, id := range userIDs {
+			assert.True(t, memberIDs[id], "user %s should be a member", id)
+		}
+		assert.Len(t, members, len(userIDs), "channel should have exactly the requested members")
+	})
+
+	t.Run("channel_admins sets admin roles", func(t *testing.T) {
+		channel := th.CreatePublicChannel(t)
+		user2 := th.BasicUser2
+		user3 := th.CreateUserWithClient(t, th.SystemAdminClient)
+		th.LinkUserToTeam(t, user3, th.BasicTeam)
+
+		// BasicUser is already channel admin (as creator). Promote user2 instead.
+		adminIDs := []string{th.BasicUser.Id, user2.Id}
+		results, _, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id,
+			&model.SetChannelMembersRequest{
+				Members:       []string{th.BasicUser.Id, user2.Id, user3.Id},
+				ChannelAdmins: &adminIDs,
+			}, 0, 0)
+		require.NoError(t, err)
+
+		var allPromoted []string
+		for _, r := range results {
+			allPromoted = append(allPromoted, r.Promoted...)
+		}
+		assert.Contains(t, allPromoted, user2.Id, "user2 should be promoted to admin")
+
+		// Verify SchemeAdmin is set for both admins
+		member, _, err := th.SystemAdminClient.GetChannelMember(ctx, channel.Id, th.BasicUser.Id, "")
+		require.NoError(t, err)
+		assert.True(t, member.SchemeAdmin, "BasicUser should be channel admin")
+
+		member2, _, err := th.SystemAdminClient.GetChannelMember(ctx, channel.Id, user2.Id, "")
+		require.NoError(t, err)
+		assert.True(t, member2.SchemeAdmin, "user2 should be channel admin")
+
+		// user3 should not be admin
+		member3, _, err := th.SystemAdminClient.GetChannelMember(ctx, channel.Id, user3.Id, "")
+		require.NoError(t, err)
+		assert.False(t, member3.SchemeAdmin, "user3 should not be channel admin")
+	})
+
+	t.Run("channel_admins omitted preserves existing admins", func(t *testing.T) {
+		channel := th.CreatePublicChannel(t)
+
+		// First, set BasicUser as admin
+		adminIDs := []string{th.BasicUser.Id}
+		_, _, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id,
+			&model.SetChannelMembersRequest{
+				Members:       []string{th.BasicUser.Id},
+				ChannelAdmins: &adminIDs,
+			}, 0, 0)
+		require.NoError(t, err)
+
+		// Verify admin is set
+		member, _, err := th.SystemAdminClient.GetChannelMember(ctx, channel.Id, th.BasicUser.Id, "")
+		require.NoError(t, err)
+		require.True(t, member.SchemeAdmin)
+
+		// Now call again without channel_admins (nil). Admin role should be preserved.
+		user2 := th.BasicUser2
+		_, _, err = th.SystemAdminClient.SetChannelMembers(ctx, channel.Id,
+			&model.SetChannelMembersRequest{
+				Members: []string{th.BasicUser.Id, user2.Id},
+			}, 0, 0)
+		require.NoError(t, err)
+
+		member, _, err = th.SystemAdminClient.GetChannelMember(ctx, channel.Id, th.BasicUser.Id, "")
+		require.NoError(t, err)
+		assert.True(t, member.SchemeAdmin, "admin role should be preserved when channel_admins is omitted")
+	})
+
+	t.Run("channel_admins demotes existing admins", func(t *testing.T) {
+		channel := th.CreatePublicChannel(t)
+		user2 := th.BasicUser2
+
+		// Set both users as members with BasicUser as admin
+		adminIDs := []string{th.BasicUser.Id}
+		_, _, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id,
+			&model.SetChannelMembersRequest{
+				Members:       []string{th.BasicUser.Id, user2.Id},
+				ChannelAdmins: &adminIDs,
+			}, 0, 0)
+		require.NoError(t, err)
+
+		// Verify BasicUser is admin
+		member, _, err := th.SystemAdminClient.GetChannelMember(ctx, channel.Id, th.BasicUser.Id, "")
+		require.NoError(t, err)
+		require.True(t, member.SchemeAdmin)
+
+		// Now set user2 as admin instead, demoting BasicUser
+		newAdminIDs := []string{user2.Id}
+		results, _, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id,
+			&model.SetChannelMembersRequest{
+				Members:       []string{th.BasicUser.Id, user2.Id},
+				ChannelAdmins: &newAdminIDs,
+			}, 0, 0)
+		require.NoError(t, err)
+
+		var allPromoted, allDemoted []string
+		for _, r := range results {
+			allPromoted = append(allPromoted, r.Promoted...)
+			allDemoted = append(allDemoted, r.Demoted...)
+		}
+		assert.Contains(t, allPromoted, user2.Id, "user2 should be promoted")
+		assert.Contains(t, allDemoted, th.BasicUser.Id, "BasicUser should be demoted")
+
+		member, _, err = th.SystemAdminClient.GetChannelMember(ctx, channel.Id, th.BasicUser.Id, "")
+		require.NoError(t, err)
+		assert.False(t, member.SchemeAdmin, "BasicUser should no longer be admin")
+
+		member2, _, err := th.SystemAdminClient.GetChannelMember(ctx, channel.Id, user2.Id, "")
+		require.NoError(t, err)
+		assert.True(t, member2.SchemeAdmin, "user2 should be admin")
+	})
+
+	t.Run("channel_admins adds user only in admins list as member and admin", func(t *testing.T) {
+		channel := th.CreatePublicChannel(t)
+		user2 := th.BasicUser2
+
+		// user2 is only in channel_admins, not in members. Should be added and made admin.
+		adminIDs := []string{user2.Id}
+		results, _, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id,
+			&model.SetChannelMembersRequest{
+				Members:       []string{th.BasicUser.Id},
+				ChannelAdmins: &adminIDs,
+			}, 0, 0)
+		require.NoError(t, err)
+
+		var allAdded, allPromoted []string
+		for _, r := range results {
+			allAdded = append(allAdded, r.Added...)
+			allPromoted = append(allPromoted, r.Promoted...)
+		}
+		assert.Contains(t, allAdded, user2.Id, "user2 should be added as member")
+		assert.Contains(t, allPromoted, user2.Id, "user2 should be promoted to admin")
+
+		member, _, err := th.SystemAdminClient.GetChannelMember(ctx, channel.Id, user2.Id, "")
+		require.NoError(t, err)
+		assert.True(t, member.SchemeAdmin, "user2 should be channel admin")
+	})
+
+	t.Run("empty channel_admins clears all admin roles", func(t *testing.T) {
+		channel := th.CreatePublicChannel(t)
+
+		// First, set BasicUser as admin
+		adminIDs := []string{th.BasicUser.Id}
+		_, _, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id,
+			&model.SetChannelMembersRequest{
+				Members:       []string{th.BasicUser.Id},
+				ChannelAdmins: &adminIDs,
+			}, 0, 0)
+		require.NoError(t, err)
+
+		member, _, err := th.SystemAdminClient.GetChannelMember(ctx, channel.Id, th.BasicUser.Id, "")
+		require.NoError(t, err)
+		require.True(t, member.SchemeAdmin)
+
+		// Set channel_admins to empty slice, should demote everyone
+		emptyAdmins := []string{}
+		results, _, err := th.SystemAdminClient.SetChannelMembers(ctx, channel.Id,
+			&model.SetChannelMembersRequest{
+				Members:       []string{th.BasicUser.Id},
+				ChannelAdmins: &emptyAdmins,
+			}, 0, 0)
+		require.NoError(t, err)
+
+		var allDemoted []string
+		for _, r := range results {
+			allDemoted = append(allDemoted, r.Demoted...)
+		}
+		assert.Contains(t, allDemoted, th.BasicUser.Id, "BasicUser should be demoted")
+
+		member, _, err = th.SystemAdminClient.GetChannelMember(ctx, channel.Id, th.BasicUser.Id, "")
+		require.NoError(t, err)
+		assert.False(t, member.SchemeAdmin, "BasicUser should no longer be admin")
+	})
+}

--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/mattermost/mattermost/server/v8/channels/utils"
 	"github.com/mattermost/mattermost/server/v8/platform/services/sharedchannel"
@@ -4137,4 +4138,215 @@ func (a *App) addChannelToDefaultCategory(rctx request.CTX, userID string, chann
 			}
 		}
 	}
+}
+
+// SetChannelMembers reconciles the membership of a channel to match the desired list of user IDs.
+// Users already in the channel are left untouched (no-op). Users not in the desired list are removed.
+// Users in the desired list but not in the channel are added.
+//
+// When adminSet is non-nil, channel admin roles are set declaratively: users in adminSet become
+// channel admins, all other members lose the admin role. When adminSet is nil, existing admin
+// roles are preserved for members who remain in the channel.
+//
+// Operations are processed in batches with a configurable delay between batches.
+// The onBatch callback is invoked after each batch with the results for that batch.
+func (a *App) SetChannelMembers(rctx request.CTX, channel *model.Channel, desiredUserIDs []string, adminSet map[string]struct{}, requestorUserID string, batchSize int, batchDelayMs int, onBatch func(*model.SetChannelMembersResponse)) *model.AppError {
+	currentIDs, err := a.Srv().Store().Channel().GetAllChannelMemberIdsByChannelId(channel.Id)
+	if err != nil {
+		return model.NewAppError("SetChannelMembers", "app.channel.set_members.get_current.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+
+	currentSet := make(map[string]struct{}, len(currentIDs))
+	for _, id := range currentIDs {
+		currentSet[id] = struct{}{}
+	}
+	desiredSet := make(map[string]struct{}, len(desiredUserIDs))
+	for _, id := range desiredUserIDs {
+		desiredSet[id] = struct{}{}
+	}
+
+	var toAdd, toRemove []string
+	for id := range desiredSet {
+		if _, exists := currentSet[id]; !exists {
+			toAdd = append(toAdd, id)
+		}
+	}
+	for id := range currentSet {
+		if _, exists := desiredSet[id]; !exists {
+			toRemove = append(toRemove, id)
+		}
+	}
+
+	// Prevent emptying private channels, they become orphaned since non-admins can't rejoin.
+	if channel.Type == model.ChannelTypePrivate && len(desiredUserIDs) == 0 {
+		return model.NewAppError("SetChannelMembers", "app.channel.set_members.empty_private.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	if len(toAdd) == 0 && len(toRemove) == 0 && adminSet == nil {
+		onBatch(&model.SetChannelMembersResponse{})
+		return nil
+	}
+
+	if batchSize <= 0 {
+		batchSize = 1
+	}
+
+	batchDelay := time.Duration(batchDelayMs) * time.Millisecond
+
+	// Process removals first
+	for i := 0; i < len(toRemove); i += batchSize {
+		end := min(i+batchSize, len(toRemove))
+		batch := toRemove[i:end]
+
+		result := &model.SetChannelMembersResponse{}
+		for _, userID := range batch {
+			if appErr := a.removeUserFromChannel(rctx, userID, requestorUserID, channel); appErr != nil {
+				result.Errors = append(result.Errors, model.SetChannelMembersError{
+					UserID: userID,
+					ID:     appErr.Id,
+					Error:  appErr.Error(),
+				})
+			} else {
+				result.Removed = append(result.Removed, userID)
+			}
+		}
+		onBatch(result)
+
+		if end < len(toRemove) {
+			select {
+			case <-rctx.Context().Done():
+				return model.NewAppError("SetChannelMembers", "app.channel.set_members.context_cancelled.app_error", nil, "", http.StatusInternalServerError).Wrap(rctx.Context().Err())
+			case <-time.After(batchDelay):
+			}
+		}
+	}
+
+	// Check context between removal and addition phases
+	if rctx.Context().Err() != nil {
+		return model.NewAppError("SetChannelMembers", "app.channel.set_members.context_cancelled.app_error", nil, "", http.StatusInternalServerError).Wrap(rctx.Context().Err())
+	}
+
+	// Process additions
+	for i := 0; i < len(toAdd); i += batchSize {
+		end := min(i+batchSize, len(toAdd))
+		batch := toAdd[i:end]
+
+		result := &model.SetChannelMembersResponse{}
+		for _, userID := range batch {
+			if _, appErr := a.AddChannelMember(rctx, userID, channel, ChannelMemberOpts{UserRequestorID: requestorUserID}); appErr != nil {
+				result.Errors = append(result.Errors, model.SetChannelMembersError{
+					UserID: userID,
+					ID:     appErr.Id,
+					Error:  appErr.Error(),
+				})
+			} else {
+				result.Added = append(result.Added, userID)
+			}
+		}
+		onBatch(result)
+
+		if end < len(toAdd) {
+			select {
+			case <-rctx.Context().Done():
+				return model.NewAppError("SetChannelMembers", "app.channel.set_members.context_cancelled.app_error", nil, "", http.StatusInternalServerError).Wrap(rctx.Context().Err())
+			case <-time.After(batchDelay):
+			}
+		}
+	}
+
+	// Reconcile channel admin roles when adminSet is provided.
+	if adminSet != nil {
+		if rctx.Context().Err() != nil {
+			return model.NewAppError("SetChannelMembers", "app.channel.set_members.context_cancelled.app_error", nil, "", http.StatusInternalServerError).Wrap(rctx.Context().Err())
+		}
+
+		// Build the list of members whose admin status needs to change.
+		// We need the current SchemeAdmin state for all remaining members.
+		members, storeErr := a.Srv().Store().Channel().GetMembers(model.ChannelMembersGetOptions{ChannelID: channel.Id, Offset: 0, Limit: 100000})
+		if storeErr != nil {
+			return model.NewAppError("SetChannelMembers", "app.channel.set_members.get_members.app_error", nil, "", http.StatusInternalServerError).Wrap(storeErr)
+		}
+
+		var toPromote, toDemote []string
+		for _, m := range members {
+			_, wantAdmin := adminSet[m.UserId]
+			if wantAdmin && !m.SchemeAdmin {
+				toPromote = append(toPromote, m.UserId)
+			} else if !wantAdmin && m.SchemeAdmin {
+				toDemote = append(toDemote, m.UserId)
+			}
+		}
+
+		// Process role changes in batches
+		for i := 0; i < len(toPromote); i += batchSize {
+			end := min(i+batchSize, len(toPromote))
+			batch := toPromote[i:end]
+
+			result := &model.SetChannelMembersResponse{}
+			for _, userID := range batch {
+				if _, appErr := a.UpdateChannelMemberSchemeRoles(rctx, channel.Id, userID, false, true, true); appErr != nil {
+					result.Errors = append(result.Errors, model.SetChannelMembersError{
+						UserID: userID,
+						ID:     appErr.Id,
+						Error:  appErr.Error(),
+					})
+				} else {
+					result.Promoted = append(result.Promoted, userID)
+				}
+			}
+			onBatch(result)
+
+			if end < len(toPromote) {
+				select {
+				case <-rctx.Context().Done():
+					return model.NewAppError("SetChannelMembers", "app.channel.set_members.context_cancelled.app_error", nil, "", http.StatusInternalServerError).Wrap(rctx.Context().Err())
+				case <-time.After(batchDelay):
+				}
+			}
+		}
+
+		if len(toDemote) > 0 && rctx.Context().Err() != nil {
+			return model.NewAppError("SetChannelMembers", "app.channel.set_members.context_cancelled.app_error", nil, "", http.StatusInternalServerError).Wrap(rctx.Context().Err())
+		}
+
+		for i := 0; i < len(toDemote); i += batchSize {
+			end := min(i+batchSize, len(toDemote))
+			batch := toDemote[i:end]
+
+			result := &model.SetChannelMembersResponse{}
+			for _, userID := range batch {
+				if _, appErr := a.UpdateChannelMemberSchemeRoles(rctx, channel.Id, userID, false, true, false); appErr != nil {
+					result.Errors = append(result.Errors, model.SetChannelMembersError{
+						UserID: userID,
+						ID:     appErr.Id,
+						Error:  appErr.Error(),
+					})
+				} else {
+					result.Demoted = append(result.Demoted, userID)
+				}
+			}
+			onBatch(result)
+
+			if end < len(toDemote) {
+				select {
+				case <-rctx.Context().Done():
+					return model.NewAppError("SetChannelMembers", "app.channel.set_members.context_cancelled.app_error", nil, "", http.StatusInternalServerError).Wrap(rctx.Context().Err())
+				case <-time.After(batchDelay):
+				}
+			}
+		}
+	}
+
+	// Warn if a private channel was left with no members (known limitation)
+	if channel.Type == model.ChannelTypePrivate {
+		remainingIDs, err := a.Srv().Store().Channel().GetAllChannelMemberIdsByChannelId(channel.Id)
+		if err == nil && len(remainingIDs) == 0 {
+			rctx.Logger().Error("SetChannelMembers left private channel with no members",
+				mlog.String("channel_id", channel.Id),
+				mlog.String("requestor_user_id", requestorUserID),
+			)
+		}
+	}
+
+	return nil
 }

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -576,6 +576,18 @@
     "translation": "{{.Username}} unarchived the channel."
   },
   {
+    "id": "api.channel.set_members.group_constrained.app_error",
+    "translation": "Cannot set members on a group-constrained channel."
+  },
+  {
+    "id": "api.channel.set_members.policy_enforced.app_error",
+    "translation": "Cannot set members on a policy-enforced channel."
+  },
+  {
+    "id": "api.channel.set_members.type.app_error",
+    "translation": "Cannot set members on this channel type."
+  },
+  {
     "id": "api.channel.update_channel.banner_info.channel_type.not_allowed",
     "translation": "Channel banner can only be configured on Public and Private channels."
   },
@@ -5325,6 +5337,22 @@
   {
     "id": "app.channel.search_group_channels.app_error",
     "translation": "Unable to get the group channels for the given user and term."
+  },
+  {
+    "id": "app.channel.set_members.context_cancelled.app_error",
+    "translation": "The set channel members operation was cancelled."
+  },
+  {
+    "id": "app.channel.set_members.empty_private.app_error",
+    "translation": "Cannot remove all members from a private channel."
+  },
+  {
+    "id": "app.channel.set_members.get_current.app_error",
+    "translation": "Unable to get current channel members."
+  },
+  {
+    "id": "app.channel.set_members.get_members.app_error",
+    "translation": "Unable to get channel members for role reconciliation."
   },
   {
     "id": "app.channel.sidebar_categories.app_error",

--- a/server/public/model/audit_events.go
+++ b/server/public/model/audit_events.go
@@ -78,6 +78,7 @@ const (
 	AuditEventPatchChannelModerations            = "patchChannelModerations"            // update channel moderation settings
 	AuditEventRemoveChannelMember                = "removeChannelMember"                // remove member from channel
 	AuditEventRestoreChannel                     = "restoreChannel"                     // restore previously deleted channel
+	AuditEventSetChannelMembers                  = "setChannelMembers"                  // bulk set (replace) channel memberships
 	AuditEventUpdateChannel                      = "updateChannel"                      // update channel properties
 	AuditEventUpdateChannelMemberNotifyProps     = "updateChannelMemberNotifyProps"     // update notification preferences
 	AuditEventUpdateChannelMemberAutotranslation = "updateChannelMemberAutotranslation" // update autotranslation setting

--- a/server/public/model/channel_member.go
+++ b/server/public/model/channel_member.go
@@ -254,3 +254,44 @@ type ChannelMemberIdentifier struct {
 	ChannelId string `json:"channel_id"`
 	UserId    string `json:"user_id"`
 }
+
+// SetChannelMembersRequest is the request body for the bulk set channel members endpoint.
+type SetChannelMembersRequest struct {
+	// Members is the complete desired membership list. Users in this list
+	// (and in ChannelAdmins) will be the final set of channel members.
+	Members []string `json:"members"`
+	// ChannelAdmins is an optional list of user IDs that should have the
+	// channel admin role. Users in this list are automatically included in
+	// the desired membership (they do not need to also appear in Members).
+	// When nil, existing admin roles are preserved for members who remain
+	// in the channel. When non-nil (including empty slice), admin roles
+	// are set declaratively: listed users become admins, all others lose
+	// the admin role.
+	ChannelAdmins *[]string `json:"channel_admins"`
+}
+
+// SetChannelMembersResponse is one batch of results from a bulk set channel members operation.
+// Multiple responses may be streamed as NDJSON lines.
+type SetChannelMembersResponse struct {
+	Added    []string                 `json:"added"`
+	Removed  []string                 `json:"removed"`
+	Promoted []string                 `json:"promoted,omitempty"`
+	Demoted  []string                 `json:"demoted,omitempty"`
+	Errors   []SetChannelMembersError `json:"errors,omitempty"`
+}
+
+func (o *SetChannelMembersResponse) Auditable() map[string]any {
+	return map[string]any{
+		"added":    o.Added,
+		"removed":  o.Removed,
+		"promoted": o.Promoted,
+		"demoted":  o.Demoted,
+		"errors":   o.Errors,
+	}
+}
+
+type SetChannelMembersError struct {
+	UserID string `json:"user_id"`
+	ID     string `json:"id"`
+	Error  string `json:"error"`
+}

--- a/server/public/model/client4.go
+++ b/server/public/model/client4.go
@@ -3294,6 +3294,49 @@ func (c *Client4) AddChannelMembers(ctx context.Context, channelId, postRootId s
 	return DecodeJSONFromResponse[[]*ChannelMember](r)
 }
 
+// SetChannelMembers performs a bulk set (replace) of channel memberships. It accepts the complete
+// desired membership list and reconciles it against the current state. Results are streamed back
+// as NDJSON, one line per batch. The batchSize and batchDelayMs parameters control the processing
+// rate; pass 0 to use server defaults.
+func (c *Client4) SetChannelMembers(ctx context.Context, channelId string, req *SetChannelMembersRequest, batchSize, batchDelayMs int) ([]*SetChannelMembersResponse, *Response, error) {
+	route := c.channelMembersRoute(channelId)
+	routePath, err := route.String()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if batchSize > 0 || batchDelayMs > 0 {
+		params := url.Values{}
+		if batchSize > 0 {
+			params.Set("batch_size", strconv.Itoa(batchSize))
+		}
+		if batchDelayMs > 0 {
+			params.Set("batch_delay_ms", strconv.Itoa(batchDelayMs))
+		}
+		routePath = fmt.Sprintf("%s?%s", routePath, params.Encode())
+	}
+
+	r, err := c.DoAPIPutJSON(ctx, routePath, req)
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+
+	var results []*SetChannelMembersResponse
+	dec := json.NewDecoder(r.Body)
+	for {
+		var result SetChannelMembersResponse
+		if err := dec.Decode(&result); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return results, BuildResponse(r), err
+		}
+		results = append(results, &result)
+	}
+	return results, BuildResponse(r), nil
+}
+
 // AddChannelMemberWithRootId adds user to channel and return a channel member. Post add to channel message has the postRootId.
 func (c *Client4) AddChannelMemberWithRootId(ctx context.Context, channelId, userId, postRootId string) (*ChannelMember, *Response, error) {
 	requestBody := map[string]string{"user_id": userId, "post_root_id": postRootId}


### PR DESCRIPTION
#### Summary
Cherry-picks https://github.com/mattermost/mattermost/pull/36031 into release-11.5

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68269

#### Release Note
```release-note
Added a new API endpoint `PUT /api/v4/channels/{channel_id}/members` that sets the complete membership of a channel in a single call. The endpoint accepts a JSON object with `members` (desired user IDs) and an optional `channel_admins` (user IDs to designate as channel admins). The server computes the diff against current membership, adds or removes users as needed, and reconciles admin roles. When `channel_admins` is omitted, existing admin roles are preserved. Results are streamed back as NDJSON for progress tracking. Requires system admin permissions.
```
