### PR TITLE
mmctl: show command help when positional arguments are missing

### DIFF
--- a/server/cmd/mmctl/commands/root.go
+++ b/server/cmd/mmctl/commands/root.go
@@ -62,14 +62,33 @@ func Run(args []string) error {
 		}
 	}()
 
-	err := RootCmd.Execute()
+	cmd, err := RootCmd.ExecuteC()
 	// Flush the printer first before printing any error
 	_ = printer.Flush()
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		if isCobraPositionalArgsError(err) {
+			if cmd != nil {
+				_ = cmd.Help()
+			} else {
+				_ = RootCmd.Help()
+			}
+		} else {
+			_, _ = fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		}
 	}
 
 	return err
+}
+
+// isCobraPositionalArgsError reports errors from cobra's built-in positional
+// validators (ExactArgs, MinimumNArgs, MaximumNArgs, RangeArgs).
+func isCobraPositionalArgsError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, " arg(s), received ") ||
+		strings.Contains(msg, " arg(s), only received ")
 }
 
 func printPanic(x any) {

--- a/server/cmd/mmctl/commands/root_test.go
+++ b/server/cmd/mmctl/commands/root_test.go
@@ -6,6 +6,7 @@ package commands
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -21,6 +22,23 @@ func executeRawCommand(root *cobra.Command, args string) (c *cobra.Command, outp
 	RootCmd.SetArgs(strings.Split(args, " "))
 	c, err = RootCmd.ExecuteC()
 	return c, actual.String(), err
+}
+
+func TestRunShowsHelpOnMissingPositionalArgs(t *testing.T) {
+	out := new(bytes.Buffer)
+	errOut := new(bytes.Buffer)
+	RootCmd.SetOut(out)
+	RootCmd.SetErr(errOut)
+	t.Cleanup(func() {
+		RootCmd.SetOut(os.Stdout)
+		RootCmd.SetErr(os.Stderr)
+	})
+
+	err := Run([]string{"bot", "assign"})
+	assert.Error(t, err)
+	combined := out.String() + errOut.String()
+	assert.Contains(t, combined, "Usage:")
+	assert.NotContains(t, combined, "Error: accepts")
 }
 
 func TestRootRecover(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

When a subcommand is invoked without the required positional arguments, mmctl previously printed only Cobra’s one-line message (for example `accepts 2 arg(s), received 0`) because the root command sets `SilenceUsage: true`. This change detects errors from Cobra’s built-in positional validators (`ExactArgs`, `MinimumNArgs`, `MaximumNArgs`, `RangeArgs`) and prints that command’s help text instead of the generic `Error:` line, while still returning a non-zero exit code.

Added `TestRunShowsHelpOnMissingPositionalArgs` using `bot assign` with no arguments.

#### Ticket Link

N/A

#### Screenshots

N/A

#### Release Note

```release-note
mmctl now prints the command help when required positional arguments are missing, instead of only a short error message.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cfe643d-14e4-4bb3-9f8e-b2073240f42a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cfe643d-14e4-4bb3-9f8e-b2073240f42a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

