### PR TITLE
Add --creator to mmctl webhook modify-incoming and modify-outgoing

### DIFF
--- a/server/channels/api4/webhook.go
+++ b/server/channels/api4/webhook.go
@@ -167,6 +167,24 @@ func updateIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if updatedHook.UserId == "" {
+		updatedHook.UserId = oldHook.UserId
+	} else if updatedHook.UserId != oldHook.UserId {
+		if !c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), channel.TeamId, model.PermissionManageOthersIncomingWebhooks) {
+			c.LogAudit("fail - inappropriate permissions")
+			c.SetPermissionError(model.PermissionManageOthersIncomingWebhooks)
+			return
+		}
+		if _, appErr := c.App.GetUser(updatedHook.UserId); appErr != nil {
+			c.Err = appErr
+			return
+		}
+		if _, appErr := c.App.GetTeamMember(c.AppContext, channel.TeamId, updatedHook.UserId); appErr != nil {
+			c.Err = appErr
+			return
+		}
+	}
+
 	if !c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), channel.TeamId, model.PermissionBypassIncomingWebhookChannelLock) {
 		updatedHook.ChannelLocked = true
 		updatedHook.ChannelId = channel.Id
@@ -426,7 +444,23 @@ func updateOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updatedHook.CreatorId = c.AppContext.Session().UserId
+	if updatedHook.CreatorId == "" {
+		updatedHook.CreatorId = oldHook.CreatorId
+	} else if updatedHook.CreatorId != oldHook.CreatorId {
+		if !c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), updatedHook.TeamId, model.PermissionManageOthersOutgoingWebhooks) {
+			c.LogAudit("fail - inappropriate permissions")
+			c.SetPermissionError(model.PermissionManageOthersOutgoingWebhooks)
+			return
+		}
+		if _, appErr := c.App.GetUser(updatedHook.CreatorId); appErr != nil {
+			c.Err = appErr
+			return
+		}
+		if _, appErr := c.App.GetTeamMember(c.AppContext, updatedHook.TeamId, updatedHook.CreatorId); appErr != nil {
+			c.Err = appErr
+			return
+		}
+	}
 
 	rhook, err := c.App.UpdateOutgoingWebhook(c.AppContext, oldHook, &updatedHook)
 	if err != nil {

--- a/server/channels/api4/webhook_test.go
+++ b/server/channels/api4/webhook_test.go
@@ -29,6 +29,11 @@ func removeIncomingWebhookPermissions(t *testing.T, th *TestHelper, roleID strin
 	th.RemovePermissionFromRole(t, model.PermissionBypassIncomingWebhookChannelLock.Id, roleID)
 }
 
+func addOutgoingWebhookPermissionsWithOthers(t *testing.T, th *TestHelper, roleID string) {
+	th.AddPermissionToRole(t, model.PermissionManageOwnOutgoingWebhooks.Id, roleID)
+	th.AddPermissionToRole(t, model.PermissionManageOthersOutgoingWebhooks.Id, roleID)
+}
+
 func TestCreateIncomingWebhook(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)
@@ -1070,8 +1075,9 @@ func TestUpdateIncomingHook(t *testing.T) {
 			require.NoError(t, err)
 
 			sameUserHook.UserId = th.BasicUser2.Id
-			_, _, err = th.Client.UpdateIncomingWebhook(context.Background(), sameUserHook)
-			require.NoError(t, err)
+			_, resp, err := th.Client.UpdateIncomingWebhook(context.Background(), sameUserHook)
+			require.Error(t, err)
+			CheckForbiddenStatus(t, resp)
 		})
 
 		t.Run("UpdateHookOfDifferentUser", func(t *testing.T) {
@@ -1505,6 +1511,72 @@ func TestUpdateOutgoingWebhook_BypassTeamPermissions(t *testing.T) {
 
 	hook2 := &model.OutgoingWebhook{Id: rhook.Id, ChannelId: channel.Id}
 	_, resp, err := th.Client.UpdateOutgoingWebhook(context.Background(), hook2)
+	require.Error(t, err)
+	CheckForbiddenStatus(t, resp)
+}
+
+func TestUpdateIncomingWebhookChangeOwner(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableIncomingWebhooks = true })
+
+	defaultRolePermissions := th.SaveDefaultRolePermissions(t)
+	defer func() {
+		th.RestoreDefaultRolePermissions(t, defaultRolePermissions)
+	}()
+	addIncomingWebhookPermissionsWithOthers(t, th, model.TeamUserRoleId)
+
+	th.LoginBasic(t)
+	hook := &model.IncomingWebhook{ChannelId: th.BasicChannel.Id}
+	created, _, err := th.Client.CreateIncomingWebhook(context.Background(), hook)
+	require.NoError(t, err)
+	require.Equal(t, th.BasicUser.Id, created.UserId)
+
+	created.UserId = th.BasicUser2.Id
+	updated, _, err := th.Client.UpdateIncomingWebhook(context.Background(), created)
+	require.NoError(t, err)
+	require.Equal(t, th.BasicUser2.Id, updated.UserId)
+
+	th.RemovePermissionFromRole(t, model.PermissionManageOthersIncomingWebhooks.Id, model.TeamUserRoleId)
+	created.UserId = th.BasicUser.Id
+	_, resp, err := th.Client.UpdateIncomingWebhook(context.Background(), created)
+	require.Error(t, err)
+	CheckForbiddenStatus(t, resp)
+}
+
+func TestUpdateOutgoingWebhookChangeCreator(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOutgoingWebhooks = true })
+
+	defaultRolePermissions := th.SaveDefaultRolePermissions(t)
+	defer func() {
+		th.RestoreDefaultRolePermissions(t, defaultRolePermissions)
+	}()
+	th.AddPermissionToRole(t, model.PermissionManageOwnOutgoingWebhooks.Id, model.TeamUserRoleId)
+	addOutgoingWebhookPermissionsWithOthers(t, th, model.TeamUserRoleId)
+
+	th.LoginBasic(t)
+	ow := &model.OutgoingWebhook{
+		ChannelId:    th.BasicChannel.Id,
+		TeamId:       th.BasicTeam.Id,
+		CallbackURLs: []string{"http://example.com/owner"},
+		TriggerWords: []string{"ownerword"},
+	}
+	created, _, err := th.Client.CreateOutgoingWebhook(context.Background(), ow)
+	require.NoError(t, err)
+	require.Equal(t, th.BasicUser.Id, created.CreatorId)
+
+	created.CreatorId = th.BasicUser2.Id
+	updated, _, err := th.Client.UpdateOutgoingWebhook(context.Background(), created)
+	require.NoError(t, err)
+	require.Equal(t, th.BasicUser2.Id, updated.CreatorId)
+
+	th.RemovePermissionFromRole(t, model.PermissionManageOthersOutgoingWebhooks.Id, model.TeamUserRoleId)
+	created.CreatorId = th.BasicUser.Id
+	_, resp, err := th.Client.UpdateOutgoingWebhook(context.Background(), created)
 	require.Error(t, err)
 	CheckForbiddenStatus(t, resp)
 }

--- a/server/channels/app/webhook.go
+++ b/server/channels/app/webhook.go
@@ -440,7 +440,9 @@ func (a *App) UpdateIncomingWebhook(oldHook, updatedHook *model.IncomingWebhook)
 	}
 
 	updatedHook.Id = oldHook.Id
-	updatedHook.UserId = oldHook.UserId
+	if updatedHook.UserId == "" || updatedHook.UserId == oldHook.UserId {
+		updatedHook.UserId = oldHook.UserId
+	}
 	updatedHook.CreateAt = oldHook.CreateAt
 	updatedHook.UpdateAt = model.GetMillis()
 	updatedHook.TeamId = oldHook.TeamId
@@ -629,7 +631,9 @@ func (a *App) UpdateOutgoingWebhook(rctx request.CTX, oldHook, updatedHook *mode
 		}
 	}
 
-	updatedHook.CreatorId = oldHook.CreatorId
+	if updatedHook.CreatorId == "" {
+		updatedHook.CreatorId = oldHook.CreatorId
+	}
 	updatedHook.CreateAt = oldHook.CreateAt
 	updatedHook.DeleteAt = oldHook.DeleteAt
 	updatedHook.TeamId = oldHook.TeamId

--- a/server/channels/app/webhook_test.go
+++ b/server/channels/app/webhook_test.go
@@ -292,6 +292,60 @@ func TestUpdateIncomingWebhook(t *testing.T) {
 	}
 }
 
+func TestUpdateIncomingWebhookUserIdChange(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableIncomingWebhooks = true })
+
+	hook, appErr := th.App.CreateIncomingWebhookForChannel(th.BasicUser.Id, th.BasicChannel, &model.IncomingWebhook{
+		ChannelId: th.BasicChannel.Id,
+	})
+	require.Nil(t, appErr)
+	defer func() {
+		appErr = th.App.DeleteIncomingWebhook(hook.Id)
+		require.Nil(t, appErr)
+	}()
+
+	updated := *hook
+	updated.UserId = th.BasicUser2.Id
+	updated.DisplayName = hook.DisplayName
+
+	out, appErr := th.App.UpdateIncomingWebhook(hook, &updated)
+	require.Nil(t, appErr)
+	require.Equal(t, th.BasicUser2.Id, out.UserId)
+}
+
+func TestUpdateOutgoingWebhookCreatorIdChange(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOutgoingWebhooks = true })
+
+	ow := &model.OutgoingWebhook{
+		ChannelId:    th.BasicChannel.Id,
+		TeamId:       th.BasicTeam.Id,
+		CallbackURLs: []string{"http://example.com/creator"},
+		TriggerWords: []string{"creatorword"},
+		CreatorId:    th.BasicUser.Id,
+		Username:     th.BasicUser.Username,
+	}
+	hook, appErr := th.App.CreateOutgoingWebhook(ow)
+	require.Nil(t, appErr)
+	defer func() {
+		appErr = th.App.DeleteOutgoingWebhook(hook.Id)
+		require.Nil(t, appErr)
+	}()
+
+	updated := *hook
+	updated.CreatorId = th.BasicUser2.Id
+	updated.Username = th.BasicUser2.Username
+
+	out, appErr := th.App.UpdateOutgoingWebhook(th.Context, hook, &updated)
+	require.Nil(t, appErr)
+	require.Equal(t, th.BasicUser2.Id, out.CreatorId)
+}
+
 func TestCreateWebhookPost(t *testing.T) {
 	mainHelper.Parallel(t)
 	testCluster := &testlib.FakeClusterInterface{}

--- a/server/channels/store/sqlstore/webhook_store.go
+++ b/server/channels/store/sqlstore/webhook_store.go
@@ -101,7 +101,7 @@ func (s SqlWebhookStore) UpdateIncoming(hook *model.IncomingWebhook) (*model.Inc
 	hook.UpdateAt = model.GetMillis()
 
 	_, err := s.GetMaster().NamedExec(`UPDATE IncomingWebhooks SET
-			CreateAt=:CreateAt, UpdateAt=:UpdateAt, DeleteAt=:DeleteAt, ChannelId=:ChannelId, TeamId=:TeamId, DisplayName=:DisplayName,
+			CreateAt=:CreateAt, UpdateAt=:UpdateAt, DeleteAt=:DeleteAt, UserId=:UserId, ChannelId=:ChannelId, TeamId=:TeamId, DisplayName=:DisplayName,
 			Description=:Description, Username=:Username, IconURL=:IconURL, ChannelLocked=:ChannelLocked
 			WHERE Id=:Id`, hook)
 	if err != nil {

--- a/server/cmd/mmctl/commands/webhook.go
+++ b/server/cmd/mmctl/commands/webhook.go
@@ -53,9 +53,9 @@ var CreateIncomingWebhookCmd = &cobra.Command{
 var ModifyIncomingWebhookCmd = &cobra.Command{
 	Use:     "modify-incoming",
 	Short:   "Modify incoming webhook",
-	Long:    "Modify existing incoming webhook by changing its title, description, channel or icon url",
+	Long:    "Modify existing incoming webhook by changing its title, description, channel, icon url, or owner (requires manage others permission on the server)",
 	Args:    cobra.ExactArgs(1),
-	Example: "  webhook modify-incoming [webhookID] --channel [channelID] --display-name [displayName] --description [webhookDescription] --lock-to-channel --icon [iconURL]",
+	Example: "  webhook modify-incoming [webhookID] --channel [channelID] --display-name [displayName] --description [webhookDescription] --lock-to-channel --icon [iconURL] --creator [username]",
 	RunE:    withClient(modifyIncomingWebhookCmdF),
 }
 
@@ -71,9 +71,9 @@ var CreateOutgoingWebhookCmd = &cobra.Command{
 var ModifyOutgoingWebhookCmd = &cobra.Command{
 	Use:     "modify-outgoing",
 	Short:   "Modify outgoing webhook",
-	Long:    "Modify existing outgoing webhook by changing its title, description, channel, icon, url, content-type, and triggers",
+	Long:    "Modify existing outgoing webhook by changing its title, description, channel, icon, url, content-type, triggers, or owner (requires manage others permission on the server)",
 	Args:    cobra.ExactArgs(1),
-	Example: `  webhook modify-outgoing [webhookId] --channel [channelId] --display-name [displayName] --description "New webhook description" --icon http://localhost:8000/my-slash-handler-bot-icon.png --url http://localhost:8000/my-webhook-handler --content-type "application/json" --trigger-word test --trigger-when start`,
+	Example: `  webhook modify-outgoing [webhookId] --channel [channelId] --display-name [displayName] --description "New webhook description" --icon http://localhost:8000/my-slash-handler-bot-icon.png --url http://localhost:8000/my-webhook-handler --content-type "application/json" --trigger-word test --trigger-when start --creator [username]`,
 	RunE:    withClient(modifyOutgoingWebhookCmdF),
 }
 
@@ -223,6 +223,16 @@ func modifyIncomingWebhookCmdF(c client.Client, command *cobra.Command, args []s
 	channelLocked, _ := command.Flags().GetBool("lock-to-channel")
 	updatedHook.ChannelLocked = channelLocked
 
+	if command.Flags().Changed("creator") {
+		creatorArg, _ := command.Flags().GetString("creator")
+		user := getUserFromUserArg(c, creatorArg)
+		if user == nil {
+			return errors.New("Unable to find user '" + creatorArg + "'")
+		}
+		updatedHook.UserId = user.Id
+		updatedHook.Username = user.Username
+	}
+
 	var newHook *model.IncomingWebhook
 	if newHook, _, err = c.UpdateIncomingWebhook(context.TODO(), updatedHook); err != nil {
 		printer.PrintError("Unable to modify incoming webhook")
@@ -371,6 +381,16 @@ func modifyOutgoingWebhookCmdF(c client.Client, command *cobra.Command, args []s
 		updatedHook.CallbackURLs = callbackURLs
 	}
 
+	if command.Flags().Changed("creator") {
+		creatorArg, _ := command.Flags().GetString("creator")
+		user := getUserFromUserArg(c, creatorArg)
+		if user == nil {
+			return errors.New("unable to find user '" + creatorArg + "'")
+		}
+		updatedHook.CreatorId = user.Id
+		updatedHook.Username = user.Username
+	}
+
 	var newHook *model.OutgoingWebhook
 	if newHook, _, err = c.UpdateOutgoingWebhook(context.TODO(), updatedHook); err != nil {
 		printer.PrintError("Unable to modify outgoing webhook")
@@ -441,6 +461,7 @@ func init() {
 	ModifyIncomingWebhookCmd.Flags().String("description", "", "Incoming webhook description")
 	ModifyIncomingWebhookCmd.Flags().String("icon", "", "Icon URL")
 	ModifyIncomingWebhookCmd.Flags().Bool("lock-to-channel", false, "Lock to channel")
+	ModifyIncomingWebhookCmd.Flags().String("creator", "", "Webhook owner's username, email, or user ID (requires manage others incoming webhooks permission)")
 
 	CreateOutgoingWebhookCmd.Flags().String("team", "", "Team name or ID (required)")
 	_ = CreateOutgoingWebhookCmd.MarkFlagRequired("team")
@@ -466,6 +487,7 @@ func init() {
 	ModifyOutgoingWebhookCmd.Flags().String("icon", "", "Icon URL")
 	ModifyOutgoingWebhookCmd.Flags().StringArray("url", []string{}, "Callback URL")
 	ModifyOutgoingWebhookCmd.Flags().String("content-type", "", "Content-type")
+	ModifyOutgoingWebhookCmd.Flags().String("creator", "", "Webhook creator's username, email, or user ID (requires manage others outgoing webhooks permission)")
 
 	WebhookCmd.AddCommand(
 		ListWebhookCmd,

--- a/server/cmd/mmctl/commands/webhook_test.go
+++ b/server/cmd/mmctl/commands/webhook_test.go
@@ -414,6 +414,61 @@ func (s *MmctlUnitTestSuite) TestModifyIncomingWebhookCmd() {
 		s.Len(printer.GetErrorLines(), 1)
 		s.Require().Equal("Unable to modify incoming webhook", printer.GetErrorLines()[0])
 	})
+
+	s.Run("modify incoming webhook with --creator sets user", func() {
+		printer.Clean()
+
+		oldUserID := "oldUserID"
+		newUserID := "newUserID"
+		newUsername := "newOwner"
+		creatorArg := newUsername
+
+		mockIncomingWebhook := model.IncomingWebhook{
+			Id:            incomingWebhookID,
+			ChannelId:     channelID,
+			UserId:        oldUserID,
+			Username:      userName,
+			DisplayName:   displayName,
+			ChannelLocked: false,
+		}
+		expectedForUpdate := mockIncomingWebhook
+		expectedForUpdate.UserId = newUserID
+		expectedForUpdate.Username = newUsername
+
+		updatedIncomingWebhook := expectedForUpdate
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("channel", "", "")
+		cmd.Flags().String("display-name", "", "")
+		cmd.Flags().String("description", "", "")
+		cmd.Flags().String("icon", "", "")
+		cmd.Flags().Bool("lock-to-channel", false, "")
+		cmd.Flags().String("creator", "", "")
+		err := cmd.ParseFlags([]string{"--creator=" + creatorArg})
+		s.Require().NoError(err)
+
+		s.client.
+			EXPECT().
+			GetIncomingWebhook(context.TODO(), incomingWebhookID, "").
+			Return(&mockIncomingWebhook, &model.Response{}, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUserByUsername(context.TODO(), creatorArg, "").
+			Return(&model.User{Id: newUserID, Username: newUsername}, &model.Response{}, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			UpdateIncomingWebhook(context.TODO(), &expectedForUpdate).
+			Return(&updatedIncomingWebhook, &model.Response{}, nil).
+			Times(1)
+
+		err = modifyIncomingWebhookCmdF(s.client, cmd, []string{incomingWebhookID})
+		s.Require().NoError(err)
+		s.Len(printer.GetLines(), 1)
+	})
 }
 
 func (s *MmctlUnitTestSuite) TestCreateOutgoingWebhookCmd() {
@@ -597,6 +652,64 @@ func (s *MmctlUnitTestSuite) TestModifyOutgoingWebhookCmd() {
 		s.Len(printer.GetLines(), 0)
 		s.Len(printer.GetErrorLines(), 1)
 		s.Require().Equal("Unable to modify outgoing webhook", printer.GetErrorLines()[0])
+	})
+
+	s.Run("modify outgoing webhook with --creator sets creator", func() {
+		printer.Clean()
+
+		oldCreator := "oldCreator"
+		newCreator := "newCreator"
+		newUsername := "newOwner"
+		creatorArg := newUsername
+
+		mockOutgoingWebhook := model.OutgoingWebhook{
+			Id:           outgoingWebhookID,
+			CreatorId:    oldCreator,
+			Username:     "oldname",
+			TriggerWords: []string{"t"},
+			CallbackURLs: []string{"http://x"},
+			TriggerWhen:  0,
+		}
+		expectedForUpdate := mockOutgoingWebhook
+		expectedForUpdate.CreatorId = newCreator
+		expectedForUpdate.Username = newUsername
+
+		updatedOutgoingWebhook := expectedForUpdate
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("channel", "", "")
+		cmd.Flags().String("display-name", "", "")
+		cmd.Flags().String("description", "", "")
+		cmd.Flags().StringArray("trigger-word", []string{}, "")
+		cmd.Flags().String("trigger-when", "", "")
+		cmd.Flags().String("icon", "", "")
+		cmd.Flags().StringArray("url", []string{}, "")
+		cmd.Flags().String("content-type", "", "")
+		cmd.Flags().String("creator", "", "")
+		err := cmd.ParseFlags([]string{"--creator=" + creatorArg})
+		s.Require().NoError(err)
+
+		s.client.
+			EXPECT().
+			GetOutgoingWebhook(context.TODO(), outgoingWebhookID).
+			Return(&mockOutgoingWebhook, &model.Response{}, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUserByUsername(context.TODO(), creatorArg, "").
+			Return(&model.User{Id: newCreator, Username: newUsername}, &model.Response{}, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			UpdateOutgoingWebhook(context.TODO(), &expectedForUpdate).
+			Return(&updatedOutgoingWebhook, &model.Response{}, nil).
+			Times(1)
+
+		err = modifyOutgoingWebhookCmdF(s.client, cmd, []string{outgoingWebhookID})
+		s.Require().NoError(err)
+		s.Len(printer.GetLines(), 1)
 	})
 }
 

--- a/server/cmd/mmctl/docs/mmctl_webhook_modify-incoming.rst
+++ b/server/cmd/mmctl/docs/mmctl_webhook_modify-incoming.rst
@@ -9,7 +9,7 @@ Synopsis
 ~~~~~~~~
 
 
-Modify existing incoming webhook by changing its title, description, channel or icon url
+Modify existing incoming webhook by changing its title, description, channel, icon url, or owner (requires manage others permission on the server)
 
 ::
 
@@ -20,7 +20,7 @@ Examples
 
 ::
 
-    webhook modify-incoming [webhookID] --channel [channelID] --display-name [displayName] --description [webhookDescription] --lock-to-channel --icon [iconURL]
+    webhook modify-incoming [webhookID] --channel [channelID] --display-name [displayName] --description [webhookDescription] --lock-to-channel --icon [iconURL] --creator [username]
 
 Options
 ~~~~~~~
@@ -28,6 +28,7 @@ Options
 ::
 
       --channel string        Channel ID
+      --creator string        Webhook owner's username, email, or user ID (requires manage others incoming webhooks permission)
       --description string    Incoming webhook description
       --display-name string   Incoming webhook display name
   -h, --help                  help for modify-incoming

--- a/server/cmd/mmctl/docs/mmctl_webhook_modify-outgoing.rst
+++ b/server/cmd/mmctl/docs/mmctl_webhook_modify-outgoing.rst
@@ -9,7 +9,7 @@ Synopsis
 ~~~~~~~~
 
 
-Modify existing outgoing webhook by changing its title, description, channel, icon, url, content-type, and triggers
+Modify existing outgoing webhook by changing its title, description, channel, icon, url, content-type, triggers, or owner (requires manage others permission on the server)
 
 ::
 
@@ -20,7 +20,7 @@ Examples
 
 ::
 
-    webhook modify-outgoing [webhookId] --channel [channelId] --display-name [displayName] --description "New webhook description" --icon http://localhost:8000/my-slash-handler-bot-icon.png --url http://localhost:8000/my-webhook-handler --content-type "application/json" --trigger-word test --trigger-when start
+    webhook modify-outgoing [webhookId] --channel [channelId] --display-name [displayName] --description "New webhook description" --icon http://localhost:8000/my-slash-handler-bot-icon.png --url http://localhost:8000/my-webhook-handler --content-type "application/json" --trigger-word test --trigger-when start --creator [username]
 
 Options
 ~~~~~~~
@@ -29,6 +29,7 @@ Options
 
       --channel string             Channel name or ID
       --content-type string        Content-type
+      --creator string             Webhook creator's username, email, or user ID (requires manage others outgoing webhooks permission)
       --description string         Outgoing webhook description
       --display-name string        Outgoing webhook display name
   -h, --help                       help for modify-outgoing


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Incoming webhooks:** `IncomingWebhooks.UserId` is now included in the SQL `UPDATE`. `App.UpdateIncomingWebhook` keeps a new `UserId` when it differs from the old hook. The REST handler validates owner changes with `manage_others_incoming_webhooks`, `GetUser`, and team membership.
- **Outgoing webhooks:** Removed the API handler line that always set `CreatorId` to the session user, and stopped the app from overwriting `CreatorId` with the old hook when the payload carries a new creator. Owner changes require `manage_others_outgoing_webhooks`, `GetUser`, and team membership.
- **mmctl:** Added optional `--creator` (username, email, or ID) to `webhook modify-incoming` and `webhook modify-outgoing`, setting `UserId`/`Username` or `CreatorId`/`Username` before update.
- **Tests:** api4 tests for owner transfer and forbidden paths; app layer tests for persisted `UserId`/`CreatorId` changes; mmctl unit tests (build tag `unit`) for `--creator`.
- **Docs:** Updated RST for both modify commands.

## Testing

- `go build` on touched packages
- `go test -tags=unit ./cmd/mmctl/commands/... -run TestMmctlUnitSuite/TestModifyIncomingWebhookCmd|TestMmctlUnitSuite/TestModifyOutgoingWebhookCmd`

api4/app integration tests require Postgres and were not run in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2bfae8ff-8e05-4c0c-aa81-19cb99570eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bfae8ff-8e05-4c0c-aa81-19cb99570eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes modify webhook ownership semantics (CreatorId is no longer forcibly overwritten with session user), which represents a behavioral contract change that could affect integrations relying on the previous behavior. While permission checks are added as guards, the conditional logic for preserving vs. updating UserId/CreatorId in the app layer introduces new code paths that require careful validation.

**QA Recommendation:** Comprehensive manual testing of webhook ownership transfer scenarios is recommended, including: permission enforcement with and without manage-others permissions, team membership validation, edge cases where webhook creator is removed from team, and regression testing of existing webhook update flows that don't specify --creator flag. Integration testing with actual webhook triggers and events is advised.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->