### PR TITLE
fix(e2e): correct 'occured' -> 'occurred' in channel_scroll_spec assertion comment

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/scroll/channel_scroll_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/scroll/channel_scroll_spec.js
@@ -167,7 +167,7 @@ describe('Scroll', () => {
             });
         });
 
-        // * Verify we are still on the top of the channel and no scrolling occured
+        // * Verify we are still on the top of the channel and no scrolling occurred
         cy.findByText(firstPost).should('exist').and('be.visible');
         cy.findByText(lastPost).should('exist').and('not.be.visible');
     });


### PR DESCRIPTION
A Cypress assertion comment in `e2e-tests/cypress/tests/integration/channels/scroll/channel_scroll_spec.js:170` read `no scrolling occured`. Doc-only change inside a test comment; `node -c` parses cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** No regression risk. The change is a comment-only fix that does not modify any test logic, assertions, selectors, or executable code. There are no code paths affected and no behavioral changes to any system.

**QA Recommendation:** No manual QA needed. This is a documentation fix in a test comment with zero functional impact. Automated test execution will confirm the test still runs correctly.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->