### PR TITLE
MM-67782: Fetch group members on popover open to fix empty member list

### DIFF
--- a/webapp/channels/src/components/at_mention/at_mention.test.tsx
+++ b/webapp/channels/src/components/at_mention/at_mention.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import {General} from 'mattermost-redux/constants';
 
-import {render} from 'tests/react_testing_utils';
+import {render, renderWithContext} from 'tests/react_testing_utils';
 import {TestHelper} from 'utils/test_helper';
 
 import AtMention from './at_mention';
@@ -174,7 +174,7 @@ describe('components/AtMention', () => {
     });
 
     test('should match snapshot when mentioning a group that is allowed reference', () => {
-        const {container} = render(
+        const {container} = renderWithContext(
             <AtMention
                 {...baseProps}
                 mentionName='developers'
@@ -214,7 +214,7 @@ describe('components/AtMention', () => {
     });
 
     test('should match snapshot when mentioning a group followed by punctuation', () => {
-        const {container} = render(
+        const {container} = renderWithContext(
             <AtMention
                 {...baseProps}
                 mentionName='developers.'

--- a/webapp/channels/src/components/user_group_popover/user_group_popover_controller.test.tsx
+++ b/webapp/channels/src/components/user_group_popover/user_group_popover_controller.test.tsx
@@ -1,0 +1,105 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import * as userActions from 'mattermost-redux/actions/users';
+
+import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
+import {TestHelper} from 'utils/test_helper';
+
+import {UserGroupPopoverController} from './user_group_popover_controller';
+
+jest.mock('mattermost-redux/actions/users', () => ({
+    ...jest.requireActual('mattermost-redux/actions/users'),
+    getProfilesInGroup: jest.fn(() => () => ({type: 'MOCK_GET_PROFILES_IN_GROUP'})),
+}));
+
+describe('UserGroupPopoverController', () => {
+    const group = TestHelper.getGroupMock({
+        id: 'group1',
+        name: 'test-group',
+        display_name: 'Test Group',
+        member_count: 5,
+    });
+
+    const initialState = {
+        entities: {
+            teams: {
+                currentTeamId: 'team_id1',
+                teams: {
+                    team_id1: {
+                        id: 'team_id1',
+                        name: 'team1',
+                    },
+                },
+            },
+            general: {
+                config: {},
+            },
+            users: {
+                profiles: {},
+                profilesInGroup: {},
+                statuses: {},
+            },
+            preferences: {
+                myPreferences: {},
+            },
+        },
+        views: {
+            modals: {
+                modalState: {},
+            },
+            search: {
+                popoverSearch: '',
+            },
+        },
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should fetch group members when popover opens on click', async () => {
+        renderWithContext(
+            <UserGroupPopoverController
+                group={group}
+                returnFocus={jest.fn()}
+            >
+                <span>{'@test-group'}</span>
+            </UserGroupPopoverController>,
+            initialState as any,
+        );
+
+        await userEvent.click(screen.getByText('@test-group'));
+
+        expect(userActions.getProfilesInGroup).toHaveBeenCalledWith(
+            'group1',
+            0,
+            100,
+            'display_name',
+        );
+    });
+
+    test('should not fetch additional group members when popover closes', async () => {
+        renderWithContext(
+            <UserGroupPopoverController
+                group={group}
+                returnFocus={jest.fn()}
+            >
+                <span>{'@test-group'}</span>
+            </UserGroupPopoverController>,
+            initialState as any,
+        );
+
+        await userEvent.click(screen.getByText('@test-group'));
+
+        const callCountAfterOpen = (userActions.getProfilesInGroup as jest.Mock).mock.calls.length;
+        expect(callCountAfterOpen).toBeGreaterThanOrEqual(1);
+
+        // Close by pressing Escape
+        await userEvent.keyboard('{Escape}');
+
+        expect(userActions.getProfilesInGroup).toHaveBeenCalledTimes(callCountAfterOpen);
+    });
+});

--- a/webapp/channels/src/components/user_group_popover/user_group_popover_controller.tsx
+++ b/webapp/channels/src/components/user_group_popover/user_group_popover_controller.tsx
@@ -16,8 +16,11 @@ import {
 } from '@floating-ui/react';
 import type {ReactNode} from 'react';
 import React, {useCallback, useState} from 'react';
+import {useDispatch} from 'react-redux';
 
 import type {Group} from '@mattermost/types/groups';
+
+import {getProfilesInGroup} from 'mattermost-redux/actions/users';
 
 import {A11yClassNames} from 'utils/constants';
 
@@ -40,10 +43,18 @@ interface Props {
 
 export function UserGroupPopoverController(props: Props) {
     const [isOpen, setOpen] = useState(false);
+    const dispatch = useDispatch();
+
+    const handleOpenChange = useCallback((open: boolean) => {
+        setOpen(open);
+        if (open) {
+            dispatch(getProfilesInGroup(props.group.id, 0, 100, 'display_name'));
+        }
+    }, [dispatch, props.group.id]);
 
     const {refs, floatingStyles, context: floatingContext} = useFloating({
         open: isOpen,
-        onOpenChange: setOpen,
+        onOpenChange: handleOpenChange,
         whileElementsMounted: autoUpdate,
         middleware: [autoPlacement()],
     });


### PR DESCRIPTION
#### Summary

When a user clicks a custom group mention (e.g. `@engineering`) in a message, the popover that appears may fail to load group members. The `GroupMemberList` component relied entirely on `react-window-infinite-loader`'s `InfiniteLoader` to trigger the initial `getProfilesInGroup` API call. This is fragile because it depends on `AutoSizer` reporting correct dimensions on the first render frame, and on `group.member_count` being accurately populated — conditions that can fail on production with larger DOMs and more data.

This fix dispatches `getProfilesInGroup` explicitly when the popover opens (in `UserGroupPopoverController.onOpenChange`), ensuring group members are always fetched regardless of `InfiniteLoader` timing. This mirrors how `ViewUserGroupModal` (the full group modal) already fetches on mount.

**QA Steps:**
1. Create a custom user group with members
2. Post a message mentioning the group (e.g. `@engineering`)
3. Refresh the page
4. Click on the rendered group mention in the message
5. Verify the popover shows the group name, member count, and a list of group members

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-67782

#### Screenshots

N/A — no UI changes, this is a data-fetching fix.

#### Release Note
```release-note
Fixed an issue where clicking a custom user group mention would sometimes fail to load the group members list in the popover.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to a single UI controller component and only adds an explicit dispatch of the existing read-only action getProfilesInGroup on popover open; it doesn't touch shared utilities, authentication, or persistence and has unit tests covering the new behavior. Risk of unintended side effects is low.

**QA Recommendation:** Minimal manual QA: verify the popover reliably loads and displays group members on open (including after refresh) and confirm no duplicate API calls occur on repeated open/close cycles.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->