### PR TITLE
Add override for E2E test on FIPS

### DIFF
--- a/.github/workflows/e2e-tests-override-status.yml
+++ b/.github/workflows/e2e-tests-override-status.yml
@@ -37,7 +37,7 @@ jobs:
           COMMIT_SHA: ${{ steps.pr-info.outputs.head_sha }}
         run: |
           # Only full tests can be overridden (smoke tests must pass)
-          FULL_TEST_CONTEXTS=("e2e-test/playwright-full/enterprise" "e2e-test/cypress-full/enterprise")
+          FULL_TEST_CONTEXTS=("e2e-test/playwright-full/enterprise" "e2e-test/cypress-full/enterprise" "e2e-test/playwright-full/fips" "e2e-test/cypress-full/fips")
 
           for CONTEXT_NAME in "${FULL_TEST_CONTEXTS[@]}"; do
             echo "Checking: $CONTEXT_NAME"

--- a/.github/workflows/e2e-tests-verified-label.yml
+++ b/.github/workflows/e2e-tests-verified-label.yml
@@ -34,7 +34,7 @@ jobs:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Only full tests can be overridden (smoke tests must pass)
-          FULL_TEST_CONTEXTS=("e2e-test/playwright-full/enterprise" "e2e-test/cypress-full/enterprise")
+          FULL_TEST_CONTEXTS=("e2e-test/playwright-full/enterprise" "e2e-test/cypress-full/enterprise" "e2e-test/playwright-full/fips" "e2e-test/cypress-full/fips")
           OVERRIDDEN=""
           WEBHOOK_DATA="[]"
 


### PR DESCRIPTION
#### Summary
- Add override for E2E test on FIPS when "E2E Tests/verified" label is applied

To be cherry-picked to 11.6, 11.5, 11.4

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** These changes are isolated configuration updates to GitHub Actions workflows, extending the list of E2E test contexts eligible for status overrides from 2 (enterprise) to 4 (enterprise + FIPS). The override logic, API interactions, and conditional flow are unchanged—only the set of contexts being processed is expanded, with no impact to application code or core functionality.

**QA Recommendation:** Manual QA is not required. These are configuration-only changes to CI/CD workflows that simply extend proven override logic to additional test contexts. Verification can be limited to confirming FIPS test contexts appear in workflow runs and respond to the override labels as expected.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->