### PR TITLE
[MM-68351] Fix nil pointer panic in mmctl websocket command on connection failure

### DIFF
--- a/server/cmd/mmctl/commands/websockets.go
+++ b/server/cmd/mmctl/commands/websockets.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -33,6 +34,10 @@ func websocketCmdF(cmd *cobra.Command, args []string) error {
 
 	c.Listen()
 	fmt.Fprintln(os.Stderr, "Press CTRL+C to exit")
+	return processWebSocketEvents(c)
+}
+
+func processWebSocketEvents(c *model.WebSocketClient) error {
 	for event := range c.EventChannel {
 		if event == nil {
 			continue

--- a/server/cmd/mmctl/commands/websockets.go
+++ b/server/cmd/mmctl/commands/websockets.go
@@ -33,8 +33,10 @@ func websocketCmdF(cmd *cobra.Command, args []string) error {
 
 	c.Listen()
 	fmt.Fprintln(os.Stderr, "Press CTRL+C to exit")
-	for {
-		event := <-c.EventChannel
+	for event := range c.EventChannel {
+		if event == nil {
+			continue
+		}
 		data, err := event.ToJSON()
 		if err != nil {
 			fmt.Println(err.Error())
@@ -42,4 +44,8 @@ func websocketCmdF(cmd *cobra.Command, args []string) error {
 			fmt.Println(string(data))
 		}
 	}
+	if c.ListenError != nil {
+		return errors.New(c.ListenError.Error())
+	}
+	return nil
 }

--- a/server/cmd/mmctl/commands/websockets_test.go
+++ b/server/cmd/mmctl/commands/websockets_test.go
@@ -22,6 +22,16 @@ func TestProcessWebSocketEvents(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("non-nil event is processed and returns nil", func(t *testing.T) {
+		ch := make(chan *model.WebSocketEvent, 1)
+		ch <- model.NewWebSocketEvent(model.WebsocketEventPosted, "", "", "", nil, "")
+		close(ch)
+
+		c := &model.WebSocketClient{EventChannel: ch}
+		err := processWebSocketEvents(c)
+		require.NoError(t, err)
+	})
+
 	t.Run("ListenError is surfaced after channel closes", func(t *testing.T) {
 		ch := make(chan *model.WebSocketEvent)
 		close(ch)

--- a/server/cmd/mmctl/commands/websockets_test.go
+++ b/server/cmd/mmctl/commands/websockets_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package commands
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessWebSocketEvents(t *testing.T) {
+	t.Run("nil event in channel does not panic and returns nil", func(t *testing.T) {
+		ch := make(chan *model.WebSocketEvent, 1)
+		ch <- nil
+		close(ch)
+
+		c := &model.WebSocketClient{EventChannel: ch}
+		err := processWebSocketEvents(c)
+		require.NoError(t, err)
+	})
+
+	t.Run("ListenError is surfaced after channel closes", func(t *testing.T) {
+		ch := make(chan *model.WebSocketEvent)
+		close(ch)
+
+		appErr := model.NewAppError("Listen", "model.websocket_client.connect_fail.app_error", nil, "connection refused", http.StatusInternalServerError)
+		c := &model.WebSocketClient{
+			EventChannel: ch,
+			ListenError:  appErr,
+		}
+		err := processWebSocketEvents(c)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), appErr.Error())
+	})
+}


### PR DESCRIPTION
#### Summary

The `mmctl websocket` command panicked with a nil pointer dereference when the WebSocket connection failed immediately on startup.

`WebSocketClient.Listen()` defers `close(wsc.EventChannel)` when its goroutine exits. If the connection fails right away, the channel is closed before the command loop reads from it. Reading from a closed channel with a bare `<-ch` returns the zero value (`nil` for `*WebSocketEvent`), and calling `.ToJSON()` on a nil receiver caused the panic.

Two issues fixed:
- Switch to `range c.EventChannel` so the loop exits cleanly when the channel closes, with a nil guard for safety
- Surface `c.ListenError` after the loop so connection errors are shown to the user instead of being silently swallowed

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-68351

#### Release Note

```release-note
Fixed a panic in the mmctl websocket command when the WebSocket connection failed on startup.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to the mmctl websocket command's event loop and error handling; tests cover nil-event and ListenError paths, minimizing regression risk. No shared/core systems, authentication, or persistence are affected.

**QA Recommendation:** Minimal manual QA — smoke test the mmctl websocket command to confirm normal event output and that connection failures return a clear error instead of panicking.

*Generated by CodeRabbitAI*

---

## Release Notes

Fixed a panic in the mmctl websocket command when the WebSocket connection failed on startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->