### PR TITLE
Updated minimum supported Edge and Chrome versions

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -12486,11 +12486,11 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "Version 144+"
+    "translation": "Version 146+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "Version 144+"
+    "translation": "Version 146+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",


### PR DESCRIPTION
Desktop app v6.2 ESR will include Electron 41.2.0+ which supports Chrome 146+.

```release-note
Updated minimum Edge and Chrome versions to 146+.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** These are isolated i18n string updates with no functional code or behavioral changes. The modifications only update displayed version numbers in unsupported browser error messages from 144+ to 146+, with no impact on any code paths or shared dependencies.

**QA Recommendation:** Minimal manual QA required. Verify that users viewing unsupported browser error messages see the updated version requirement (146+) instead of the previous version (144+). No regression testing needed as this is a static string update with no code logic changes.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->