### PR TITLE
MM-68352 - update permission policy ff correctly checks in tests

### DIFF
--- a/server/channels/app/file_test.go
+++ b/server/channels/app/file_test.go
@@ -996,7 +996,9 @@ func TestFilterFilesByChannelPermissions(t *testing.T) {
 
 func TestFilterFilesByChannelPermissions_ABAC(t *testing.T) {
 	mainHelper.Parallel(t)
-	th := Setup(t).InitBasic(t)
+	th := SetupConfig(t, func(cfg *model.Config) {
+		cfg.FeatureFlags.PermissionPolicies = true
+	}).InitBasic(t)
 
 	post := th.CreatePost(t, th.BasicChannel)
 

--- a/server/channels/app/web_broadcast_hooks.go
+++ b/server/channels/app/web_broadcast_hooks.go
@@ -204,7 +204,7 @@ func (h *permalinkBroadcastHook) Process(msg *platform.HookedWebSocketEvent, web
 		(len(permalinkPreviewedPost.Post.FileIds) > 0 ||
 			(permalinkPreviewedPost.Post.Metadata != nil && len(permalinkPreviewedPost.Post.Metadata.Files) > 0)) {
 		session := webConn.GetSession()
-		if session != nil && webConn.Platform.Config().FeatureFlags.PermissionPolicies {
+		if session != nil {
 			rctxWithSession := rctx.WithSession(session)
 			if !webConn.Suite.HasPermissionToFileAction(rctxWithSession, webConn.UserId, session.Roles, permalinkPreviewedPost.Post.ChannelId, model.AccessControlPolicyActionDownloadFileAttachment) {
 				postCopy := permalinkPreviewedPost.Post.Clone()

--- a/server/channels/app/web_broadcast_hooks_test.go
+++ b/server/channels/app/web_broadcast_hooks_test.go
@@ -634,9 +634,9 @@ func TestPermalinkBroadcastHook_AbacFileStripping(t *testing.T) {
 
 		gotJSON, _ := msg.Get("post").(string)
 		assert.NotContains(t, gotJSON, fileID, "file ID should be cleared")
-		// RedactedFileCount is 0 because Files was nil (len(nil) == 0).
-		// With JSON omitempty, a zero value is omitted from the output.
-		assert.NotContains(t, gotJSON, `"redacted_file_count"`, "zero redacted count is omitted by omitempty")
+		// RedactedFileCount falls back to len(FileIds) when Metadata.Files is nil,
+		// so the placeholder count is 1 even though Files was already cleared upstream.
+		assert.Contains(t, gotJSON, `"redacted_file_count":1`, "file count falls back to FileIds length")
 	})
 
 	t.Run("no file stripping when embed has no files", func(t *testing.T) {


### PR DESCRIPTION
#### Summary
this PR fixes unit tests to correctly enable the PermissionPolicies feature flag using SetupConfig, also updates TestPermalinkBroadcastHook_AbacFileStripping to assert redacted_file_count:1 when FileIds is non-empty but Metadata.Files is nil, testing/reflecting correctly the fallback to use len(FileIds) so the redacted count for a preview can be handled correctly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68352

#### Screenshots
N/A


#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Changes touch file attachment permission redaction in broadcasts (ABAC). While the feature flag guard remains in the underlying `HasPermissionToFileAction()` function, removing the redundant check at the hook call site relies solely on the permission check to enforce access control. The fallback redaction count behavior using `len(FileIds)` when `Metadata.Files` is nil is now explicitly tested, reducing risk of regressions in that specific code path.

**QA Recommendation:** Manual testing recommended for file attachment redaction in permalink previews, specifically verifying that: (1) files are properly redacted when users lack download permissions with ABAC enabled, (2) the fallback redaction count correctly reflects `len(FileIds)` when `Metadata.Files` is already cleared upstream, and (3) no unintended file exposure occurs with the simplified guard logic. Focus on scenarios where both `FileIds` and `Metadata.Files` have different states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->