### PR TITLE
MM-68356 - ensure files are stripped when session is nil for fail-secure handling

### DIFF
--- a/server/channels/app/web_broadcast_hooks.go
+++ b/server/channels/app/web_broadcast_hooks.go
@@ -199,29 +199,32 @@ func (h *permalinkBroadcastHook) Process(msg *platform.HookedWebSocketEvent, web
 
 	// Strip files from the referenced post for recipients denied download access.
 	// Clone to avoid mutating the shared hook arg across concurrent recipients.
+	// Fail-secure: if the session is nil we cannot evaluate permissions, so strip files.
 	embedData := permalinkPreviewedPost
 	if permalinkPreviewedPost.Post != nil &&
 		(len(permalinkPreviewedPost.Post.FileIds) > 0 ||
 			(permalinkPreviewedPost.Post.Metadata != nil && len(permalinkPreviewedPost.Post.Metadata.Files) > 0)) {
 		session := webConn.GetSession()
+		stripFiles := true
 		if session != nil {
 			rctxWithSession := rctx.WithSession(session)
-			if !webConn.Suite.HasPermissionToFileAction(rctxWithSession, webConn.UserId, session.Roles, permalinkPreviewedPost.Post.ChannelId, model.AccessControlPolicyActionDownloadFileAttachment) {
-				postCopy := permalinkPreviewedPost.Post.Clone()
-				if postCopy.Metadata == nil {
-					postCopy.Metadata = &model.PostMetadata{}
-				}
-				actualCount := len(postCopy.Metadata.Files)
-				if actualCount == 0 {
-					actualCount = len(postCopy.FileIds)
-				}
-				postCopy.Metadata.RedactedFileCount = actualCount
-				postCopy.Metadata.Files = nil
-				postCopy.FileIds = model.StringArray{}
-				previewCopy := *permalinkPreviewedPost
-				previewCopy.Post = postCopy
-				embedData = &previewCopy
+			stripFiles = !webConn.Suite.HasPermissionToFileAction(rctxWithSession, webConn.UserId, session.Roles, permalinkPreviewedPost.Post.ChannelId, model.AccessControlPolicyActionDownloadFileAttachment)
+		}
+		if stripFiles {
+			postCopy := permalinkPreviewedPost.Post.Clone()
+			if postCopy.Metadata == nil {
+				postCopy.Metadata = &model.PostMetadata{}
 			}
+			actualCount := len(postCopy.Metadata.Files)
+			if actualCount == 0 {
+				actualCount = len(postCopy.FileIds)
+			}
+			postCopy.Metadata.RedactedFileCount = actualCount
+			postCopy.Metadata.Files = nil
+			postCopy.FileIds = model.StringArray{}
+			previewCopy := *permalinkPreviewedPost
+			previewCopy.Post = postCopy
+			embedData = &previewCopy
 		}
 	}
 
@@ -431,15 +434,13 @@ func (h *abacFilesBroadcastHook) Process(msg *platform.HookedWebSocketEvent, web
 	}
 
 	// The ABAC evaluator resolves role from rctx.Session(), not Subject.Role.
+	// Fail-secure: if the session is nil we cannot evaluate permissions, so strip files.
 	session := webConn.GetSession()
-	if session == nil {
-		return nil
-	}
-
-	rctx := request.EmptyContext(webConn.Platform.Log()).WithSession(session)
-
-	if webConn.Suite.HasPermissionToFileAction(rctx, webConn.UserId, session.Roles, channelID, model.AccessControlPolicyActionDownloadFileAttachment) {
-		return nil
+	if session != nil {
+		rctx := request.EmptyContext(webConn.Platform.Log()).WithSession(session)
+		if webConn.Suite.HasPermissionToFileAction(rctx, webConn.UserId, session.Roles, channelID, model.AccessControlPolicyActionDownloadFileAttachment) {
+			return nil
+		}
 	}
 
 	post, postErr := getPostFromMessage(msg)

--- a/server/channels/app/web_broadcast_hooks_test.go
+++ b/server/channels/app/web_broadcast_hooks_test.go
@@ -803,11 +803,11 @@ func TestAbacFilesBroadcastHook_Process(t *testing.T) {
 		assert.Empty(t, gotPost.FileIds)
 	})
 
-	t.Run("nil session: pass-through, no stripping", func(t *testing.T) {
+	t.Run("nil session: fail-secure, files stripped", func(t *testing.T) {
 		_, postJSON := makePostWithFiles(t, 2)
 		msg := makeMessage(channelID, postJSON)
 
-		// WebConn with no session set
+		// WebConn with no session set — cannot evaluate permissions, must strip files
 		wc := &platform.WebConn{
 			UserId:   userID,
 			Platform: &platform.PlatformService{},
@@ -818,9 +818,9 @@ func TestAbacFilesBroadcastHook_Process(t *testing.T) {
 		require.NoError(t, err)
 
 		gotPost := extractPost(t, msg)
-		assert.Len(t, gotPost.Metadata.Files, 2)
-		assert.Len(t, gotPost.FileIds, 2)
-		assert.Equal(t, 0, gotPost.Metadata.RedactedFileCount)
+		assert.Empty(t, gotPost.Metadata.Files)
+		assert.Empty(t, gotPost.FileIds)
+		assert.Equal(t, 2, gotPost.Metadata.RedactedFileCount)
 	})
 
 	t.Run("missing channel_id arg: returns error", func(t *testing.T) {

--- a/server/channels/app/web_broadcast_hooks_test.go
+++ b/server/channels/app/web_broadcast_hooks_test.go
@@ -660,6 +660,43 @@ func TestPermalinkBroadcastHook_AbacFileStripping(t *testing.T) {
 		gotJSON, _ := msg.Get("post").(string)
 		assert.NotContains(t, gotJSON, `"redacted_file_count"`, "no redaction metadata should be present")
 	})
+
+	t.Run("nil session: fail-secure, files stripped from permalink preview", func(t *testing.T) {
+		postJSON := makeOuterPostJSON(t)
+		msg := makeMessage(postJSON)
+
+		// WebConn with no session — cannot evaluate permissions, must strip files.
+		mockSuite := &platform_mocks.SuiteIFace{}
+		mockSuite.On("HasPermissionToReadChannel", mock.Anything, userID, previewChannel).Return(true, true)
+		mockSuite.On("MakeAuditRecord", mock.Anything, mock.Anything, mock.Anything).Return(&model.AuditRecord{})
+		mockSuite.On("LogAuditRec", mock.Anything, mock.Anything, mock.Anything).Return()
+		wc := &platform.WebConn{
+			UserId:   userID,
+			Platform: &platform.PlatformService{},
+			Suite:    mockSuite,
+		}
+		// Do NOT call wc.SetSession — session remains nil
+
+		fileID := model.NewId()
+		previewPost := makeRefPost(
+			model.StringArray{fileID},
+			[]*model.FileInfo{{Id: fileID, Name: "doc.pdf", Extension: "pdf"}},
+		)
+
+		err := hook.Process(msg, wc, map[string]any{
+			"preview_channel":          previewChannel,
+			"permalink_previewed_post": previewPost,
+			"preview_prop":             previewPost.PostID,
+		})
+		require.NoError(t, err)
+
+		gotPost := extractPost(t, msg)
+		require.Len(t, gotPost.Metadata.Embeds, 1)
+
+		gotJSON, _ := msg.Get("post").(string)
+		assert.NotContains(t, gotJSON, fileID, "file ID should be stripped when session is nil")
+		assert.Contains(t, gotJSON, `"redacted_file_count":1`, "redacted count should be set when session is nil")
+	})
 }
 
 func TestAbacFilesBroadcastHook_Process(t *testing.T) {


### PR DESCRIPTION
#### Summary
Adds fail-secure handling for WebSocket broadcast hooks when delivering posts with file attachments under permission      policies, connections without an active session now consistently apply the same redaction logic as authenticated connections, ensuring uniform behavior across all delivery paths

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68356

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Changes modify WebSocket broadcast hooks to enforce fail-secure file redaction for nil sessions, altering behavior for unauthenticated/expired-session delivery paths; this is a behavioral contract change limited to broadcast hooks and covered by updated tests, but touches auth/permission evaluation which could affect edge cases. There is a small gap in test coverage originally noted for the permalink hook but a follow-up test commit was added to address it, reducing but not eliminating residual risk.

**QA Recommendation:** Moderate manual QA recommended: validate file delivery for authenticated sessions, verify nil/expired-session connections have files stripped and RedactedFileCount set, and exercise session expiration/reconnection edge cases.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->