### PR TITLE
Mm 68353 show placeholder for redacted files in preview

### DIFF
--- a/e2e-tests/playwright/specs/functional/system_console/abac/file_access/file_permissions.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/file_access/file_permissions.spec.ts
@@ -473,9 +473,15 @@ test.describe('ABAC Permission Policies - BOR and Permalink', () => {
         await deniedChannelsPage.goto(team.name, channelName);
         await deniedChannelsPage.toBeVisible();
 
-        // * The permalink preview embeds the referenced post — file must be redacted.
-        // Both the standalone post and the embedded preview should show the placeholder.
+        // * The standalone original post shows the placeholder (files redacted at top level)
         await expect(deniedPage.getByTestId('redactedFilesPlaceholder').first()).toBeVisible({timeout: 15000});
+
+        // * The embedded permalink preview (.post-preview) must ALSO show the placeholder —
+        // this specifically validates that the fix strips files from the embedded post
+        // and sets RedactedFileCount, causing the placeholder to render inside the embed.
+        const permalinkEmbed = deniedPage.locator('.post-preview');
+        await expect(permalinkEmbed).toBeVisible({timeout: 15000});
+        await expect(permalinkEmbed.getByTestId('redactedFilesPlaceholder')).toBeVisible({timeout: 10000});
 
         // * No file attachment card anywhere in the channel view
         await expect(deniedPage.locator('[data-testid="fileAttachmentList"]')).not.toBeVisible();

--- a/webapp/channels/src/components/post_view/post_message_preview/index.ts
+++ b/webapp/channels/src/components/post_view/post_message_preview/index.ts
@@ -9,7 +9,7 @@ import type {PostPreviewMetadata} from '@mattermost/types/posts';
 
 import {General} from 'mattermost-redux/constants';
 import {isMyChannelAutotranslated, makeGetChannel} from 'mattermost-redux/selectors/entities/channels';
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getConfig, isPermissionPoliciesEnabled} from 'mattermost-redux/selectors/entities/general';
 import {getPost, isPostPriorityEnabled} from 'mattermost-redux/selectors/entities/posts';
 import {get} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
@@ -64,6 +64,7 @@ function makeMapStateToProps() {
             compactDisplay: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.MESSAGE_DISPLAY, Preferences.MESSAGE_DISPLAY_DEFAULT) === Preferences.MESSAGE_DISPLAY_COMPACT,
             isPostPriorityEnabled: isPostPriorityEnabled(state),
             isChannelAutotranslated: isMyChannelAutotranslated(state, previewPost?.channel_id),
+            permissionPoliciesEnabled: isPermissionPoliciesEnabled(state),
         };
     };
 }

--- a/webapp/channels/src/components/post_view/post_message_preview/post_message_preview.test.tsx
+++ b/webapp/channels/src/components/post_view/post_message_preview/post_message_preview.test.tsx
@@ -204,6 +204,68 @@ describe('PostMessagePreview', () => {
         expect(container).toMatchSnapshot();
     });
 
+    describe('redacted files placeholder', () => {
+        test('should render placeholder when permissionPoliciesEnabled and redacted_file_count > 0', () => {
+            const postPreview = {
+                ...previewPost,
+                metadata: {
+                    redacted_file_count: 2,
+                },
+            } as Post;
+
+            const props = {
+                ...baseProps,
+                previewPost: postPreview,
+                permissionPoliciesEnabled: true,
+            };
+
+            const {getByTestId, queryByTestId} = renderWithContext(<PostMessagePreview {...props}/>, baseState);
+
+            expect(getByTestId('redactedFilesPlaceholder')).toBeInTheDocument();
+            expect(queryByTestId('fileAttachmentList')).not.toBeInTheDocument();
+        });
+
+        test('should not render placeholder when permissionPoliciesEnabled is false even if redacted_file_count > 0', () => {
+            const postPreview = {
+                ...previewPost,
+                file_ids: ['file_1'],
+                metadata: {
+                    redacted_file_count: 1,
+                },
+            } as Post;
+
+            const props = {
+                ...baseProps,
+                previewPost: postPreview,
+                permissionPoliciesEnabled: false,
+            };
+
+            const {queryByTestId} = renderWithContext(<PostMessagePreview {...props}/>, baseState);
+
+            expect(queryByTestId('redactedFilesPlaceholder')).not.toBeInTheDocument();
+        });
+
+        test('should render regular file list when permissionPoliciesEnabled is true but redacted_file_count is 0', () => {
+            const postPreview = {
+                ...previewPost,
+                file_ids: ['file_1'],
+                metadata: {
+                    redacted_file_count: 0,
+                },
+            } as Post;
+
+            const props = {
+                ...baseProps,
+                previewPost: postPreview,
+                permissionPoliciesEnabled: true,
+            };
+
+            const {queryByTestId} = renderWithContext(<PostMessagePreview {...props}/>, baseState);
+
+            expect(queryByTestId('redactedFilesPlaceholder')).not.toBeInTheDocument();
+        });
+    });
+
     describe('nested previews', () => {
         const files = {
             file_ids: [

--- a/webapp/channels/src/components/post_view/post_message_preview/post_message_preview.tsx
+++ b/webapp/channels/src/components/post_view/post_message_preview/post_message_preview.tsx
@@ -17,6 +17,7 @@ import PriorityLabel from 'components/post_priority/post_priority_label';
 import AiGeneratedIndicator from 'components/post_view/ai_generated_indicator/ai_generated_indicator';
 import PostAttachmentOpenGraph from 'components/post_view/post_attachment_opengraph';
 import PostMessageView from 'components/post_view/post_message_view';
+import RedactedFilesPlaceholder from 'components/post_view/redacted_files_placeholder';
 import Timestamp from 'components/timestamp';
 import UserProfileComponent from 'components/user_profile';
 
@@ -42,6 +43,7 @@ export type Props = OwnProps & {
     handleFileDropdownOpened?: (open: boolean) => void;
     overrideGenerateFileDownloadUrl?: (fileId: string) => string;
     disableActions?: boolean;
+    permissionPoliciesEnabled?: boolean;
     actions: {
         toggleEmbedVisibility: (id: string) => void;
     };
@@ -63,7 +65,15 @@ const PostMessagePreview = (props: Props) => {
 
     let fileAttachmentPreview = null;
 
-    if (((previewPost.file_ids && previewPost.file_ids.length > 0) || (previewPost.filenames && previewPost.filenames.length > 0))) {
+    const redactedFileCount = previewPost.metadata?.redacted_file_count ?? 0;
+    if (props.permissionPoliciesEnabled && redactedFileCount > 0) {
+        fileAttachmentPreview = (
+            <RedactedFilesPlaceholder
+                count={redactedFileCount}
+                compactDisplay={compactDisplay}
+            />
+        );
+    } else if ((previewPost.file_ids && previewPost.file_ids.length > 0) || (previewPost.filenames && previewPost.filenames.length > 0)) {
         fileAttachmentPreview = (
             <FileAttachmentListContainer
                 post={previewPost}


### PR DESCRIPTION
#### Summary
This PR updates the preview logic to display the redacter files placeholder whenever the download permission policy is present and the recipient lacks that permission.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68353

#### Screenshots
Before:
<img width="1708" height="872" alt="Screenshot 2026-04-16 at 17 41 13" src="https://github.com/user-attachments/assets/4f12c932-8376-4a26-b928-0333cc7c8a67" />


After:
<img width="1712" height="869" alt="Screenshot 2026-04-16 at 17 41 54" src="https://github.com/user-attachments/assets/b3c801a8-dd36-4105-b486-79defffa770b" />


#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change introduces conditional rendering logic in the PostMessagePreview component, which is used across multiple UI surfaces (post body additional content, modals, properties card renderer). While the new logic is additive and backward compatible (new prop is optional, defaults to existing behavior when false/undefined), the modification affects file attachment rendering—a frequently accessed user-facing feature. Existing behavior is preserved when `permissionPoliciesEnabled` is false or redacted file count is 0.

**QA Recommendation:** Verify the placeholder renders correctly in post previews when permission policies are enabled with redacted files across different contexts (embedded previews, direct messages, properties card). Test that the existing file attachment list still renders when policies are disabled or when there are no redacted files. Automated test coverage is comprehensive (3 dedicated test cases), but manual QA should focus on visual rendering and behavior consistency across the component's usage contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->