### PR TITLE
E2E: fix Playwright CI sharding by passing PW_SHARD into container

### DIFF
--- a/e2e-tests/.ci/server.run_playwright.sh
+++ b/e2e-tests/.ci/server.run_playwright.sh
@@ -43,7 +43,13 @@ ${MME2E_DC_SERVER} exec -T -u "$MME2E_UID" -- playwright bash -c "for i in {1..3
 
 # Run Playwright test
 # NB: do not exit the script if some testcases fail
-${MME2E_DC_SERVER} exec -i -u "$MME2E_UID" -- playwright bash -c "cd e2e-tests/playwright && npm run test:ci -- ${TEST_FILTER} ${PW_SHARD:-}" | tee ../playwright/logs/playwright.log || true
+# Pass TEST_FILTER and PW_SHARD with `docker compose exec -e` so they are set
+# inside the container. Expanding them only in the host-side bash -c "..." string
+# can leave them empty (then every CI shard runs the full suite and hits the job timeout).
+${MME2E_DC_SERVER} exec -i -T -u "$MME2E_UID" \
+  -e "TEST_FILTER=${TEST_FILTER:-}" \
+  -e "PW_SHARD=${PW_SHARD:-}" \
+  -- playwright bash -lc 'cd e2e-tests/playwright && npm run test:ci -- ${TEST_FILTER:+$TEST_FILTER} ${PW_SHARD:+$PW_SHARD}' | tee ../playwright/logs/playwright.log || true
 
 # Collect run results
 # Documentation on the results.json file: https://playwright.dev/docs/api/class-testcase#test-case-expected-status

--- a/e2e-tests/.ci/server.run_playwright.sh
+++ b/e2e-tests/.ci/server.run_playwright.sh
@@ -49,7 +49,7 @@ ${MME2E_DC_SERVER} exec -T -u "$MME2E_UID" -- playwright bash -c "for i in {1..3
 ${MME2E_DC_SERVER} exec -i -T -u "$MME2E_UID" \
   -e "TEST_FILTER=${TEST_FILTER:-}" \
   -e "PW_SHARD=${PW_SHARD:-}" \
-  -- playwright bash -lc 'cd e2e-tests/playwright && npm run test:ci -- ${TEST_FILTER:+$TEST_FILTER} ${PW_SHARD:+$PW_SHARD}' | tee ../playwright/logs/playwright.log || true
+  -- playwright bash -lc "cd e2e-tests/playwright && npm run test:ci -- \${TEST_FILTER:+\$TEST_FILTER} \${PW_SHARD:+\$PW_SHARD}" | tee ../playwright/logs/playwright.log || true
 
 # Collect run results
 # Documentation on the results.json file: https://playwright.dev/docs/api/class-testcase#test-case-expected-status

--- a/e2e-tests/.ci/server.run_specs.sh
+++ b/e2e-tests/.ci/server.run_specs.sh
@@ -74,7 +74,10 @@ EOF
 
   # Run playwright with specific spec files
   LOGFILE_SUFFIX="${CI_BASE_URL//\//_}_specs"
-  ${MME2E_DC_SERVER} exec -T -u "$MME2E_UID" -- playwright bash -c "cd e2e-tests/playwright && npm run test:ci -- $SPEC_ARGS" | tee "../playwright/logs/${LOGFILE_SUFFIX}_playwright.log" || true
+  ${MME2E_DC_SERVER} exec -T -u "$MME2E_UID" \
+    -e "TEST_FILTER=${TEST_FILTER:-}" \
+    -e "PW_SHARD=${PW_SHARD:-}" \
+    -- playwright bash -lc "cd e2e-tests/playwright && npm run test:ci -- $SPEC_ARGS \${TEST_FILTER:+\$TEST_FILTER} \${PW_SHARD:+\$PW_SHARD}" | tee "../playwright/logs/${LOGFILE_SUFFIX}_playwright.log" || true
 
   # Collect run results (if results.json exists)
   if [ -f ../playwright/results/reporter/results.json ]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In GitHub Actions run [24520424164](https://github.com/mattermost/mattermost/actions/runs/24520424164), all eight `playwright-full / run-tests` matrix jobs hit the 30-minute timeout. That matches **each shard running the full suite** instead of a `--shard=i/8` slice.

## Root cause

`server.run_playwright.sh` invoked:

`docker compose exec ... bash -c "... npm run test:ci -- ${TEST_FILTER} ${PW_SHARD:-}"`

The `TEST_FILTER` / `PW_SHARD` fragments are expanded when the **host** parses that command. If they are empty at that moment, the inner `bash -c` never receives `--shard=…`, so Playwright runs everything on every shard.

## Fix

- Pass `TEST_FILTER` and `PW_SHARD` with `docker compose exec -e` so they are set **inside** the Playwright container.
- Run the inner command with `bash -lc` and append optional filter/shard args using parameter expansion **inside** the container (`\${VAR:+\$VAR}` in the host double-quoted string so the remote shell expands them).
- Apply the same pattern in `server.run_specs.sh` for retest runs (failed specs + shard/filter).

Also add `-T` on the main test `exec` alongside `-i` for consistent non-TTY behavior in CI.

## Follow-up

- ShellCheck SC2016: avoid single quotes around the remote `bash -lc` script; use the escaped double-quote form so CI `make check-shell` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06763417-eebf-4fd9-893e-8865ee8dca77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06763417-eebf-4fd9-893e-8865ee8dca77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

