### PR TITLE
Bump Boards FIPS version to v9.2.4

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -179,7 +179,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.8.0%2Bc4449ac-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v1.7.2%2B866e2dd-fips
-	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.2%2B4282c63-fips
+	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.4%2B5855fe1-fips
 endif
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)


### PR DESCRIPTION
#### Summary
Bump Boards FIPS version to v9.2.4

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67931

#### Screenshots
--

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This is an isolated Makefile update that only changes the FIPS plugin artifact reference for Boards from v9.2.2 to v9.2.4. No build logic, shared dependencies, or application code is affected—only a pre-built binary artifact version is updated.

**QA Recommendation:** Minimal manual QA required. Verify that FIPS builds complete successfully and that the Boards plugin loads correctly when `FIPS_ENABLED=true` is set during build. Standard smoke testing on Boards plugin functionality is sufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->