### PR TITLE
MM-68369: add missing TearDown in TestWebConnRejectBinaryFrameUnauthenticated

### DIFF
--- a/server/channels/app/platform/web_conn_test.go
+++ b/server/channels/app/platform/web_conn_test.go
@@ -245,6 +245,7 @@ func TestWebConnDrainDeadQueue(t *testing.T) {
 
 func TestWebConnRejectBinaryFrameUnauthenticated(t *testing.T) {
 	th := Setup(t)
+	defer th.TearDown()
 
 	readPumpDone := make(chan struct{})
 	upgradeErrCh := make(chan error, 1)


### PR DESCRIPTION
#### Summary
Adds a missing `defer th.TearDown()` call to `TestWebConnRejectBinaryFrameUnauthenticated`. Without it, the test leaks a `PlatformService` whose `SqlStore` keeps morph migration connections idle in the pool. When `TestMain` runs `MainHelper.Close`, Postgres refuses the `DROP DATABASE` because those connections are still attached, and the `channels/app/platform` package panics in teardown. This has been breaking the pr-ci Postgres and Postgres with binary parameters jobs on recent `release-10.11` PRs.

On `master` and `release-11.4` and later, `setupTestHelper` registers the shutdown via `tb.Cleanup` automatically, so the same test does not leak there. `release-10.11` still uses the manual `TearDown` pattern, which is why this fix is scoped to this branch.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68369

#### Release Note
```release-note
NONE
```
