### PR TITLE
Strip debug symbols from production binaries to reduce release size

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -51,6 +51,7 @@ MMCTL_BUILD_DATE = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 MMCTL_GIT_COMMIT = $(shell git rev-parse HEAD)
 MMCTL_GIT_TREE_STATE = $(shell if [ -n "$$(git status --porcelain 2>/dev/null)" ]; then echo "dirty"; else echo "clean"; fi)
 MMCTL_COMMIT_DATE = $(shell TZ=UTC git log -1 --date=format-local:'%Y-%m-%dT%H:%M:%SZ' --format='%cd' 2>/dev/null || echo "dev")
+MMCTL_LDFLAGS += -s -w
 MMCTL_LDFLAGS += -X "$(MMCTL_PKG).buildDate=$(MMCTL_BUILD_DATE)"
 MMCTL_LDFLAGS += -X "$(MMCTL_PKG).gitCommit=$(MMCTL_GIT_COMMIT)"
 MMCTL_LDFLAGS += -X "$(MMCTL_PKG).gitTreeState=$(MMCTL_GIT_TREE_STATE)"
@@ -120,6 +121,11 @@ ifeq ($(FIPS_ENABLED),true)
 endif
 
 DELVE ?= dlv
+# Strip debug symbols and DWARF info from production binaries to reduce size by ~50%.
+# Go panic stack traces still work (they use runtime.pclntab, not DWARF).
+# pprof profiling still works (uses runtime metadata).
+# For delve/core-dump debugging, build locally without these flags.
+LDFLAGS += -s -w
 LDFLAGS += -X "github.com/mattermost/mattermost/server/public/model.BuildNumber=$(BUILD_NUMBER)"
 LDFLAGS += -X "github.com/mattermost/mattermost/server/public/model.BuildDate=$(BUILD_DATE)"
 LDFLAGS += -X "github.com/mattermost/mattermost/server/public/model.BuildHash=$(BUILD_HASH)"

--- a/server/build/release.mk
+++ b/server/build/release.mk
@@ -14,10 +14,10 @@ ifeq ($(FIPS_ENABLED),true)
 	@echo Verifying Build Linux amd64 for FIPS
 	$(GO) version -m $(GOBIN)/$(MM_BIN_NAME) | grep -q "GOEXPERIMENT=systemcrypto" || (echo "ERROR: FIPS mattermost binary missing GOEXPERIMENT=systemcrypto" && exit 1)
 	$(GO) version -m $(GOBIN)/$(MM_BIN_NAME) | grep "\-tags" | grep -q "requirefips" || (echo "ERROR: FIPS mattermost binary missing -tags=requirefips" && exit 1)
-	$(GO) tool nm $(GOBIN)/$(MM_BIN_NAME) | grep -qE "func_go_openssl_OpenSSL_version|_mkcgo_OpenSSL_version" || (echo "ERROR: FIPS mattermost binary missing OpenSSL integration" && exit 1)
+	strings $(GOBIN)/$(MM_BIN_NAME) | grep -qE "go_openssl_OpenSSL_version|mkcgo_OpenSSL_version" || (echo "ERROR: FIPS mattermost binary missing OpenSSL integration" && exit 1)
 	$(GO) version -m $(GOBIN)/$(MMCTL_BIN_NAME) | grep -q "GOEXPERIMENT=systemcrypto" || (echo "ERROR: FIPS mmctl binary missing GOEXPERIMENT=systemcrypto" && exit 1)
 	$(GO) version -m $(GOBIN)/$(MMCTL_BIN_NAME) | grep "\-tags" | grep -q "requirefips" || (echo "ERROR: FIPS mmctl binary missing -tags=requirefips" && exit 1)
-	$(GO) tool nm $(GOBIN)/$(MMCTL_BIN_NAME) | grep -qE "func_go_openssl_OpenSSL_version|_mkcgo_OpenSSL_version" || (echo "ERROR: FIPS mmctl binary missing OpenSSL integration" && exit 1)
+	strings $(GOBIN)/$(MMCTL_BIN_NAME) | grep -qE "go_openssl_OpenSSL_version|mkcgo_OpenSSL_version" || (echo "ERROR: FIPS mmctl binary missing OpenSSL integration" && exit 1)
 endif
 
 build-linux-arm64: setup-go-work
@@ -90,10 +90,10 @@ ifeq ($(FIPS_ENABLED),true)
 	@echo Verifying Build Linux amd64 for FIPS
 	$(GO) version -m $(GOBIN)/mattermost | grep -q "GOEXPERIMENT=systemcrypto" || (echo "ERROR: FIPS mattermost binary missing GOEXPERIMENT=systemcrypto" && exit 1)
 	$(GO) version -m $(GOBIN)/mattermost | grep "\-tags" | grep -q "requirefips" || (echo "ERROR: FIPS mattermost binary missing -tags=requirefips" && exit 1)
-	$(GO) tool nm $(GOBIN)/mattermost | grep -qE "func_go_openssl_OpenSSL_version|_mkcgo_OpenSSL_version" || (echo "ERROR: FIPS mattermost binary missing OpenSSL integration" && exit 1)
+	strings $(GOBIN)/mattermost | grep -qE "go_openssl_OpenSSL_version|mkcgo_OpenSSL_version" || (echo "ERROR: FIPS mattermost binary missing OpenSSL integration" && exit 1)
 	$(GO) version -m $(GOBIN)/mmctl | grep -q "GOEXPERIMENT=systemcrypto" || (echo "ERROR: FIPS mmctl binary missing GOEXPERIMENT=systemcrypto" && exit 1)
 	$(GO) version -m $(GOBIN)/mmctl | grep "\-tags" | grep -q "requirefips" || (echo "ERROR: FIPS mmctl binary missing -tags=requirefips" && exit 1)
-	$(GO) tool nm $(GOBIN)/mmctl | grep -qE "func_go_openssl_OpenSSL_version|_mkcgo_OpenSSL_version" || (echo "ERROR: FIPS mmctl binary missing OpenSSL integration" && exit 1)
+	strings $(GOBIN)/mmctl | grep -qE "go_openssl_OpenSSL_version|mkcgo_OpenSSL_version" || (echo "ERROR: FIPS mmctl binary missing OpenSSL integration" && exit 1)
 endif
 ifeq ($(FIPS_ENABLED),true)
 	@echo Skipping Build Linux arm64 for FIPS


### PR DESCRIPTION
## Summary

Adds `-s -w` linker flags to strip the symbol table (`-s`) and DWARF debug information (`-w`) from the `mattermost` server binary and `mmctl` CLI binary.

## Problem

The current release tarball is **697 MB** (v11.6.0), up from 45 MB in v4.0 — a 16x increase over 8 years. The two Go binaries alone account for **583 MB (59%)** of the expanded package, and they ship with full debug symbols that are unused in production deployments.

## Measured Impact (CI Artifacts)

| | Master ([run 24582434131](https://github.com/mattermost/mattermost/actions/runs/24582434131)) | This PR ([run 24644068965](https://github.com/mattermost/mattermost/actions/runs/24644068965)) | Delta |
|---|---|---|---|
| **server-dist-artifact (compressed)** | 536 MB | 470 MB | **-66 MB (12%)** |
| **Expanded binaries (estimated)** | ~583 MB | ~230 MB | **~-350 MB (60%)** |

The compressed tarball saving is modest (12%) because debug symbols compress very well. The real impact is on:
- **Expanded install footprint** — ~350 MB less disk usage
- **Docker image layers** — stored uncompressed, so the full saving applies
- **Memory-mapped binary pages** — smaller binaries = less resident memory

## What Still Works

- **Panic stack traces** — Go uses `runtime.pclntab` (not DWARF), which is preserved
- **pprof profiling** — uses runtime metadata, unaffected by stripping
- **`runtime.Caller`**, reflect, all runtime introspection — unaffected

## What Changes

- **delve/gdb attach and core dump analysis** require building from source without `-s -w`
- This is standard practice — Kubernetes, Docker, Terraform, Vault, and CockroachDB all ship stripped binaries

## Industry Comparison

| Project | Ships stripped? | Debug symbols |
|---|---|---|
| Kubernetes | ✅ Yes | Separate archive |
| Docker | ✅ Yes | Build from source |
| Terraform | ✅ Yes | Build from source |
| HashiCorp Vault | ✅ Yes | Build from source |
| CockroachDB | ✅ Yes | Separate archive |
| **Mattermost** | ❌ **No** | Bundled (this PR fixes it) |

## Historical Size Growth (linux-amd64 tarball)

```
v4.0  (2017)   45 MB  — baseline
v5.0  (2018)   44 MB  — still lean
v5.6  (2018)   96 MB  — first prepackaged plugins
v6.0  (2021)  251 MB  — monorepo migration
v6.6  (2022)  313 MB  — Boards + Playbooks bundled
v7.9  (2023)  408 MB  — mmctl added to tarball
v8.0  (2023)  416 MB
v9.0  (2023)  418 MB
v10.0 (2024)  553 MB  — Go upgrade + Agents plugin
v11.6 (2026)  697 MB  — current
```

## Future Considerations

If on-prem debugging with `delve` is needed, a separate `mattermost-debugsyms-vX.Y.Z.tar.gz` artifact could be published alongside releases using `objcopy --only-keep-debug`. This can be done as a follow-up if there's demand.

#### Release Note
```release-note
Reduced the size of Mattermost server and mmctl binaries by stripping debug symbols, significantly reducing the overall download and disk footprint.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to build configuration (Makefile and release.mk) with no runtime code modifications. The PR thoroughly validates preserved behavior: panic stack traces, pprof profiling, and reflection continue working because Go runtime metadata (runtime.pclntab) is preserved—only the static symbol table and DWARF debug info are stripped. The FIPS OpenSSL verification logic is updated from `go tool nm` to `strings`, which reliably detects symbols in the runtime metadata, maintaining functional equivalence while accounting for the symbol table removal.

**QA Recommendation:** Minimal manual QA required beyond standard automated testing. Verify: (1) server and mmctl binaries initialize and perform basic operations, (2) panic/error logs contain complete stack traces, (3) FIPS verification passes in CI builds. Existing automated test suites should execute without modification since binary runtime behavior is unchanged.

---

## Release Notes

Reduced the size of Mattermost server and mmctl binaries by stripping debug symbols, significantly reducing the overall download and disk footprint. Panic stack traces and profiling tools continue to work normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->