### PR TITLE
Quick fixes for docs label automation

### DIFF
--- a/.github/workflows/docs-impact-review.yml
+++ b/.github/workflows/docs-impact-review.yml
@@ -1,7 +1,11 @@
 name: Documentation Impact Review
+ 
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - master
+      - main
  
 concurrency:
   group: ${{ format('docs-impact-{0}', github.event.pull_request.number) }}
@@ -15,7 +19,7 @@ permissions:
  
 jobs:
   docs-impact-review:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && !startsWith(github.event.pull_request.user.login, 'unified-ci-app')
     runs-on: ubuntu-24.04
     env:
       HAS_ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}

--- a/.github/workflows/docs-impact-review.yml
+++ b/.github/workflows/docs-impact-review.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
-      - main
  
 concurrency:
   group: ${{ format('docs-impact-{0}', github.event.pull_request.number) }}


### PR DESCRIPTION
Fixes the following issues:
- Don't run the ci check on release branches. Only run it on master/main branch.
- Skip analyzing docs impact for PRs opened by ``unified-ci-app`` bot.

Will add the same fixes to mobile/desktop after this PR is merged.


```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Changes are limited to a GitHub Actions workflow YAML (trigger branch filter and a job-level author check) and do not modify application code, shared libraries, or runtime behavior; risk of breaking production behavior is minimal. The only potential for misconfiguration is the workflow not running on intended branches or for certain bot users if the condition or branch list is incorrect.

**QA Recommendation:** No manual QA required beyond verifying the workflow YAML parses correctly and observing the workflow runs as expected on master and not on release branches or PRs opened by the `unified-ci-app` bot.

Release note: NONE

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->