### PR TITLE
MM-67913: fix white flash on product navigation by centralizing app__body ownership

### DIFF
--- a/webapp/channels/src/components/channel_layout/channel_controller.test.tsx
+++ b/webapp/channels/src/components/channel_layout/channel_controller.test.tsx
@@ -91,17 +91,17 @@ describe('ChannelController', () => {
 });
 
 describe('components/channel_layout/ChannelController', () => {
-    test('Should have app__body and channel-view classes by default', () => {
-        expect(getClassnamesForBody('')).toEqual(['app__body', 'channel-view']);
+    test('Should have channel-view class by default', () => {
+        expect(getClassnamesForBody('')).toEqual(['channel-view']);
     });
 
     test('Should have os--windows class on body for windows 32 or windows 64', () => {
-        expect(getClassnamesForBody('Win32')).toEqual(['app__body', 'channel-view', 'os--windows']);
-        expect(getClassnamesForBody('Win64')).toEqual(['app__body', 'channel-view', 'os--windows']);
+        expect(getClassnamesForBody('Win32')).toEqual(['channel-view', 'os--windows']);
+        expect(getClassnamesForBody('Win64')).toEqual(['channel-view', 'os--windows']);
     });
 
     test('Should have os--mac class on body for MacIntel or MacPPC', () => {
-        expect(getClassnamesForBody('MacIntel')).toEqual(['app__body', 'channel-view', 'os--mac']);
-        expect(getClassnamesForBody('MacPPC')).toEqual(['app__body', 'channel-view', 'os--mac']);
+        expect(getClassnamesForBody('MacIntel')).toEqual(['channel-view', 'os--mac']);
+        expect(getClassnamesForBody('MacPPC')).toEqual(['channel-view', 'os--mac']);
     });
 });

--- a/webapp/channels/src/components/channel_layout/channel_controller.tsx
+++ b/webapp/channels/src/components/channel_layout/channel_controller.tsx
@@ -27,7 +27,10 @@ const ProductNoticesModal = makeAsyncComponent('ProductNoticesModal', lazy(() =>
 const ResetStatusModal = makeAsyncComponent('ResetStatusModal', lazy(() => import('components/reset_status_modal')));
 const MobileSidebarRight = makeAsyncComponent('MobileSidebarRight', lazy(() => import('components/mobile_sidebar_right')));
 
-const BODY_CLASS_FOR_CHANNEL = ['app__body', 'channel-view'];
+// Note: `app__body` is intentionally NOT included here. It is owned by `WithUserTheme` so it remains present
+// across product navigation (Channels ↔ Playbooks/Boards) and does not briefly disappear during the React
+// effect gap, which previously caused a white flash in the global header and LHS (MM-67913).
+const BODY_CLASS_FOR_CHANNEL = ['channel-view'];
 
 type Props = {
     shouldRenderCenterChannel: boolean;

--- a/webapp/channels/src/components/channel_layout/channel_controller.tsx
+++ b/webapp/channels/src/components/channel_layout/channel_controller.tsx
@@ -27,9 +27,6 @@ const ProductNoticesModal = makeAsyncComponent('ProductNoticesModal', lazy(() =>
 const ResetStatusModal = makeAsyncComponent('ResetStatusModal', lazy(() => import('components/reset_status_modal')));
 const MobileSidebarRight = makeAsyncComponent('MobileSidebarRight', lazy(() => import('components/mobile_sidebar_right')));
 
-// Note: `app__body` is intentionally NOT included here. It is owned by `WithUserTheme` so it remains present
-// across product navigation (Channels ↔ Playbooks/Boards) and does not briefly disappear during the React
-// effect gap, which previously caused a white flash in the global header and LHS (MM-67913).
 const BODY_CLASS_FOR_CHANNEL = ['channel-view'];
 
 type Props = {

--- a/webapp/channels/src/components/theme_provider/theme_context.test.tsx
+++ b/webapp/channels/src/components/theme_provider/theme_context.test.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {render, renderHook} from 'tests/react_testing_utils';
+
+import {useAppBodyClass, WithUserTheme} from './theme_context';
+
+describe('useAppBodyClass', () => {
+    afterEach(() => {
+        document.body.classList.remove('app__body');
+    });
+
+    it('adds app__body to the document body while mounted', () => {
+        const {unmount} = renderHook(() => useAppBodyClass());
+
+        expect(document.body.classList.contains('app__body')).toBe(true);
+
+        unmount();
+
+        expect(document.body.classList.contains('app__body')).toBe(false);
+    });
+});
+
+describe('WithUserTheme', () => {
+    afterEach(() => {
+        document.body.classList.remove('app__body');
+    });
+
+    it('adds app__body to the document body while mounted', () => {
+        const {unmount} = render(
+            <WithUserTheme>
+                <div>{'Themed content'}</div>
+            </WithUserTheme>,
+        );
+
+        expect(document.body.classList.contains('app__body')).toBe(true);
+
+        unmount();
+
+        expect(document.body.classList.contains('app__body')).toBe(false);
+    });
+});

--- a/webapp/channels/src/components/theme_provider/theme_context.ts
+++ b/webapp/channels/src/components/theme_provider/theme_context.ts
@@ -26,14 +26,10 @@ export function useUserTheme() {
 
 /**
  * useAppBodyClass manages the `app__body` class on the document body for as long as the calling component
- * remains mounted. Centralizing this here (rather than in individual product routes like ChannelController or
- * product plugins like Playbooks/Boards) ensures the class stays present across product navigation, avoiding
- * a white flash during the React effect gap when the new product's tree mounts asynchronously (MM-67913).
- *
- * Product plugins should NOT add or remove `app__body` themselves; this hook is the single owner of that
- * class while the user is in the logged-in portion of the app.
+ * remains mounted. That class is required for much of our CSS to apply the user's theme, so it should be used
+ * wherever those should be used.
  */
-function useAppBodyClass() {
+export function useAppBodyClass() {
     useEffect(() => {
         document.body.classList.add('app__body');
 
@@ -46,7 +42,7 @@ function useAppBodyClass() {
 /**
  * WithUserTheme makes it so that the app will apply the user's theme instead of the default one for as long as it
  * remains mounted. It's used to wrap multiple routes in the Root component instead of having each of them call
- * useUserTheme separately. It also owns the `app__body` document body class for the same reason.
+ * useUserTheme separately.
  */
 export function WithUserTheme({children}: {children: React.ReactNode}) {
     useUserTheme();

--- a/webapp/channels/src/components/theme_provider/theme_context.ts
+++ b/webapp/channels/src/components/theme_provider/theme_context.ts
@@ -25,12 +25,32 @@ export function useUserTheme() {
 }
 
 /**
+ * useAppBodyClass manages the `app__body` class on the document body for as long as the calling component
+ * remains mounted. Centralizing this here (rather than in individual product routes like ChannelController or
+ * product plugins like Playbooks/Boards) ensures the class stays present across product navigation, avoiding
+ * a white flash during the React effect gap when the new product's tree mounts asynchronously (MM-67913).
+ *
+ * Product plugins should NOT add or remove `app__body` themselves; this hook is the single owner of that
+ * class while the user is in the logged-in portion of the app.
+ */
+function useAppBodyClass() {
+    useEffect(() => {
+        document.body.classList.add('app__body');
+
+        return () => {
+            document.body.classList.remove('app__body');
+        };
+    }, []);
+}
+
+/**
  * WithUserTheme makes it so that the app will apply the user's theme instead of the default one for as long as it
  * remains mounted. It's used to wrap multiple routes in the Root component instead of having each of them call
- * useUserTheme separately.
+ * useUserTheme separately. It also owns the `app__body` document body class for the same reason.
  */
 export function WithUserTheme({children}: {children: React.ReactNode}) {
     useUserTheme();
+    useAppBodyClass();
 
     return children;
 }

--- a/webapp/channels/src/components/theme_provider/theme_context.ts
+++ b/webapp/channels/src/components/theme_provider/theme_context.ts
@@ -20,10 +20,6 @@ export function useUserTheme() {
 
         return () => {
             context.stopUsingUserTheme();
-        };
-    }, [context]);
-}
-
 /**
  * useAppBodyClass manages the `app__body` class on the document body for as long as the calling component
  * remains mounted. That class is required for much of our CSS to apply the user's theme, so it should be used

--- a/webapp/channels/src/components/theme_provider/theme_context.ts
+++ b/webapp/channels/src/components/theme_provider/theme_context.ts
@@ -20,6 +20,10 @@ export function useUserTheme() {
 
         return () => {
             context.stopUsingUserTheme();
+        };
+    }, [context]);
+}
+
 /**
  * useAppBodyClass manages the `app__body` class on the document body for as long as the calling component
  * remains mounted. That class is required for much of our CSS to apply the user's theme, so it should be used


### PR DESCRIPTION
#### Summary
Fixes a UI glitch where a momentary white flash appears on the screen when switching products — particularly Playbooks → Channels and Boards → Channels. Originally reported on Desktop but reproducible everywhere.

**Root cause** (proven with runtime instrumentation on Desktop):
The `app__body` class on `document.body` was managed independently by `ChannelController` (core) and each product plugin (Playbooks, Boards). When switching products, the outgoing component's `useEffect` cleanup ran `document.body.classList.remove('app__body')` *before* the incoming component's `useEffect` re-applied it. Because `ChannelController` sits several levels deep in the tree (`Root → Switch → LoggedIn → TeamController → Switch → ChannelController`, some lazy) the gap between cleanup and the re-add could be ~170ms — approximately 10 browser paint frames. During that window, `body.app__body { background-color: var(--sidebar-header-bg) }` no longer applied, and the fallback `body { background: $bg--gray }` was visible through the transparent `GlobalHeader` and any transient gaps in the tree → white flash.

**Fix**:
Centralize `app__body` ownership in a single component that stays mounted across product navigation. `WithUserTheme` wraps both the products Switch and the `/:team` route in `root.tsx`, so it's the correct level. Introduces a tiny `useAppBodyClass` hook that adds `app__body` on mount and removes it on unmount.

- `theme_provider/theme_context.ts`: new `useAppBodyClass` hook; `WithUserTheme` now calls it alongside `useUserTheme`.
- `channel_layout/channel_controller.tsx`: `BODY_CLASS_FOR_CHANNEL` no longer includes `app__body`; only `channel-view` + OS classes remain.
- `channel_layout/channel_controller.test.tsx`: assertions updated to match.

Product plugins (Playbooks and Boards) should stop managing `app__body` themselves since the host webapp now owns it. Companion PRs land in their respective repos:
- Playbooks: https://github.com/mattermost/mattermost-plugin-playbooks (PR opened shortly, will be linked back here)
- Boards: https://github.com/mattermost/mattermost-plugin-boards (PR opened shortly, will be linked back here)

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-67913

#### Screenshots
Flash is brief and hard to capture in a still; it's most observable on Desktop after a Playbooks → Channels or Boards → Channels switch. Runtime logging confirmed the fix: post-fix the body keeps `app__body` throughout navigation; pre-fix showed ~170ms without it.

#### Release Note
```release-note
Fixed a white flash that appeared in the global header and left sidebar when switching between products (Playbooks/Boards) and Channels.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** Centralizing app__body ownership reduces the race that caused visual flashes but changes where the body class is managed and relies on companion PRs in product plugins; if plugins or other components continue to mutate app__body, visual regressions may still occur. Tests cover the new hook and ChannelController change, but cross-repo coordination and potential untested consumers of app__body present residual risk.

**QA Recommendation:** Perform targeted manual QA of product navigation flows (Playbooks ↔ Channels, Boards ↔ Channels) to confirm no white flash and verify app__body persists during navigation; ensure companion plugin PRs are merged and validated.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->