### PR TITLE
MM-67982 Don't autofocus mobile view search box

### DIFF
--- a/webapp/channels/src/components/search/search.tsx
+++ b/webapp/channels/src/components/search/search.tsx
@@ -169,12 +169,6 @@ const Search = ({
     }, [hideSearchBar, currentChannelName]);
 
     useEffect((): void => {
-        if (isMobileView && isSideBarRight) {
-            handleFocus();
-        }
-    }, [isMobileView, isSideBarRight]);
-
-    useEffect((): void => {
         if (!isMobileView) {
             setVisibleSearchHintOptions(determineVisibleSearchHintOptions(searchTerms, searchType));
         }


### PR DESCRIPTION
#### Summary
Autofocusing this textbox causes the keyboard to pop up on mobile. This causes a UX issue when the search box takes focus when tapping on a thread to open it in the RHS instead of tapping on the search box. Differentiating between those two cases is hard, so I think it would be better to revert this

For reference, this was added in https://github.com/mattermost/mattermost/pull/30041, but it wasn't the main focus of that PR.

#### Ticket Link
MM-67982

#### Release Note
```release-note
Stopped automatically focusing the search box in mobile web view
```
