### PR TITLE
MM-68378: Fix silent bulk failures in OpenSearch/Elasticsearch indexers

### DIFF
--- a/server/enterprise/elasticsearch/common/indexing_job.go
+++ b/server/enterprise/elasticsearch/common/indexing_job.go
@@ -44,7 +44,7 @@ func NewIndexerWorker(name string,
 	licenseFn func() *model.License,
 	createBulkProcessorFn func() error,
 	addItemToBulkProcessorFn func(indexName string, indexOp string, docID string, body io.ReadSeeker) error,
-	closeBulkProcessorFn func() error,
+	closeBulkProcessorFn func() (int64, error),
 ) *IndexerWorker {
 	return &IndexerWorker{
 		name:                   name,
@@ -79,7 +79,7 @@ type IndexerWorker struct {
 	license func() *model.License
 
 	createBulkProcessor    func() error
-	closeBulkProcessor     func() error
+	closeBulkProcessor     func() (int64, error)
 	addItemToBulkProcessor func(indexName, indexOp, docID string, body io.ReadSeeker) error
 }
 
@@ -239,9 +239,27 @@ func (worker *IndexerWorker) DoJob(job *model.Job) {
 
 	err := worker.createBulkProcessor()
 	if err != nil {
-		worker.logger.Error("Worker: Failed to setup bulk processor", mlog.Err(err))
+		logger.Error("Worker: Failed to setup bulk processor", mlog.Err(err))
+		appErr := model.NewAppError("IndexerWorker", "ent.elasticsearch.indexer.do_job.create_bulk_processor.error", nil, "", http.StatusInternalServerError).Wrap(err)
+		if err2 := worker.jobServer.SetJobError(job, appErr); err2 != nil {
+			logger.Error("Worker: Failed to set job error", mlog.Err(err2), mlog.NamedErr("set_error", appErr))
+		}
 		return
 	}
+
+	// closeOnce ensures the bulk processor is flushed and closed exactly once
+	// regardless of which exit path is taken. numFailed is set by the first call
+	// and read by the success path; logging is handled by closeBulkProcessor itself.
+	var (
+		closeOnce sync.Once
+		numFailed int64
+	)
+	doClose := func() {
+		closeOnce.Do(func() {
+			numFailed, _ = worker.closeBulkProcessor()
+		})
+	}
+	defer doClose()
 
 	worker.initEntitiesToIndex(job)
 	progress, err := initProgress(logger, worker.jobServer, job, worker.backend)
@@ -254,14 +272,7 @@ func (worker *IndexerWorker) DoJob(job *model.Job) {
 	cancelWatcherChan := make(chan struct{}, 1)
 	cancelContext = cancelContext.WithContext(cancelCtx)
 	go worker.jobServer.CancellationWatcher(cancelContext, job.Id, cancelWatcherChan)
-
-	defer func() {
-		cancelCancelWatcher()
-		err := worker.closeBulkProcessor()
-		if err != nil {
-			logger.Warn("Error while closing the bulk indexer", mlog.Err(err), mlog.String("job_id", job.Id))
-		}
-	}()
+	defer cancelCancelWatcher()
 
 	for {
 		select {
@@ -321,6 +332,19 @@ func (worker *IndexerWorker) DoJob(job *model.Job) {
 			}
 
 			if progress.IsDone(job) {
+				doClose()
+				if numFailed > 0 {
+					logger.Error("Worker: Indexing job finished with bulk write failures; some documents were not indexed",
+						mlog.Int("num_failed", numFailed),
+						mlog.Int("done_posts_count", progress.DonePostsCount),
+					)
+					appErr := model.NewAppError("IndexerWorker", "ent.elasticsearch.indexer.do_job.bulk_failures.error",
+						map[string]any{"NumFailed": numFailed}, "", http.StatusInternalServerError)
+					if err2 := worker.jobServer.SetJobError(job, appErr); err2 != nil {
+						logger.Error("Worker: Failed to set job error", mlog.Err(err2), mlog.NamedErr("set_error", appErr))
+					}
+					return
+				}
 				if err := worker.jobServer.SetJobSuccess(job); err != nil {
 					logger.Error("Worker: Failed to set success for job", mlog.Err(err))
 					if err2 := worker.jobServer.SetJobError(job, err); err2 != nil {

--- a/server/enterprise/elasticsearch/common/logger.go
+++ b/server/enterprise/elasticsearch/common/logger.go
@@ -69,7 +69,7 @@ func (l *Logger) LogRoundTrip(req *http.Request, res *http.Response, err error, 
 func (l *Logger) RequestBodyEnabled() bool { return l.trace }
 
 // ResponseBodyEnabled makes the client pass response body to logger
-func (l *Logger) ResponseBodyEnabled() bool { return false }
+func (l *Logger) ResponseBodyEnabled() bool { return l.trace }
 
 func NewBulkIndexerLogger(mlogger mlog.LoggerIFace, name string) BulkIndexerDebugLogger {
 	return BulkIndexerDebugLogger{

--- a/server/enterprise/elasticsearch/elasticsearch/indexing_job.go
+++ b/server/enterprise/elasticsearch/elasticsearch/indexing_job.go
@@ -63,10 +63,33 @@ func (esi *ElasticsearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 				Action:     indexOp,
 				DocumentID: docID,
 				Body:       body,
+				OnFailure: func(_ context.Context, item esutil.BulkIndexerItem, resp esutil.BulkIndexerResponseItem, err error) {
+					logger.Error("Bulk indexer: failed to index document",
+						mlog.String("index", item.Index),
+						mlog.String("doc_id", item.DocumentID),
+						mlog.String("action", item.Action),
+						mlog.String("error_type", resp.Error.Type),
+						mlog.String("error_reason", resp.Error.Reason),
+						mlog.Err(err),
+					)
+				},
 			})
 		},
-		// Closing the bulk processor.
-		func() error {
-			return esi.bulkProcessor.Close(context.Background())
+		// Closing the bulk processor and returning the number of failed items.
+		func() (int64, error) {
+			err := esi.bulkProcessor.Close(context.Background())
+			stats := esi.bulkProcessor.Stats()
+			fields := []mlog.Field{
+				mlog.Uint("num_indexed", stats.NumIndexed),
+				mlog.Uint("num_failed", stats.NumFailed),
+				mlog.Uint("num_added", stats.NumAdded),
+				mlog.Uint("num_flushed", stats.NumFlushed),
+			}
+			if err != nil {
+				logger.Warn("Bulk indexer closed with error", append(fields, mlog.Err(err))...)
+			} else {
+				logger.Info("Bulk indexer closed", fields...)
+			}
+			return int64(stats.NumFailed), err
 		})
 }

--- a/server/enterprise/elasticsearch/elasticsearch/indexing_job_test.go
+++ b/server/enterprise/elasticsearch/elasticsearch/indexing_job_test.go
@@ -4,7 +4,10 @@
 package elasticsearch
 
 import (
+	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,6 +58,98 @@ func TestElasticSearchIndexerJobIsEnabled(t *testing.T) {
 
 		assert.Equal(t, result, false)
 	})
+}
+
+// TestElasticsearchIndexerBulkWriteFailures verifies that a reindex job is marked
+// as failed when Elasticsearch rejects bulk writes with per-item errors (e.g. a
+// write block on the index), rather than silently reporting success.
+//
+// Requires a running Elasticsearch instance (skipped otherwise).
+func TestElasticsearchIndexerBulkWriteFailures(t *testing.T) {
+	th := api4.SetupEnterprise(t).InitBasic(t)
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ElasticsearchSettings.EnableIndexing = true
+		*cfg.ElasticsearchSettings.EnableSearching = true
+		*cfg.ElasticsearchSettings.EnableAutocomplete = true
+		*cfg.SqlSettings.DisableDatabaseSearch = true
+	})
+	th.App.Srv().SetLicense(model.NewTestLicense())
+
+	client := createTestClient(t, th.Context, th.App.Config(), th.App.FileBackend())
+	ctx := context.Background()
+
+	// Skip if Elasticsearch is not reachable.
+	_, err := client.Info().Do(ctx)
+	if err != nil {
+		t.Skipf("Elasticsearch not available at %s: %v", *th.App.Config().ElasticsearchSettings.ConnectionURL, err)
+	}
+
+	impl := ElasticsearchIndexerInterfaceImpl{Server: th.App.Srv()}
+	worker := impl.MakeWorker()
+	require.NotNil(t, worker)
+	th.Server.Jobs.RegisterJobType(model.JobTypeElasticsearchPostIndexing, worker, nil)
+
+	go worker.Run()
+	defer worker.Stop()
+
+	// Phase 1: clean reindex so the indices exist.
+	job, appErr := th.App.Srv().Jobs.CreateJob(th.Context, model.JobTypeElasticsearchPostIndexing, map[string]string{})
+	require.Nil(t, appErr)
+	worker.JobChannel() <- *job
+	job = waitForElasticsearchJob(t, th, job.Id, 60*time.Second)
+	require.Equal(t, model.JobStatusSuccess, job.Status, "initial reindex should succeed")
+
+	// Collect the indices that were created (skip internal dot-prefixed ones).
+	indexMap, err := client.Indices.Get("*").Do(ctx)
+	require.NoError(t, err)
+	var indexNames []string
+	for name := range indexMap {
+		if !strings.HasPrefix(name, ".") {
+			indexNames = append(indexNames, name)
+		}
+	}
+	require.NotEmpty(t, indexNames, "initial reindex should have created at least one index")
+
+	// Apply a write block to all Mattermost indices and remove it on cleanup.
+	setWriteBlock := func(blocked bool) {
+		body := `{"index.blocks.write":true}`
+		if !blocked {
+			body = `{"index.blocks.write":false}`
+		}
+		_, putErr := client.Indices.PutSettings().
+			Indices(strings.Join(indexNames, ",")).
+			Raw(strings.NewReader(body)).
+			Do(ctx)
+		require.NoError(t, putErr, "failed to set write block=%v", blocked)
+	}
+	setWriteBlock(true)
+	defer setWriteBlock(false)
+
+	// Phase 2: reindex against write-blocked indices — job must be marked as error.
+	job, appErr = th.App.Srv().Jobs.CreateJob(th.Context, model.JobTypeElasticsearchPostIndexing, map[string]string{})
+	require.Nil(t, appErr)
+	worker.JobChannel() <- *job
+	job = waitForElasticsearchJob(t, th, job.Id, 60*time.Second)
+	assert.Equal(t, model.JobStatusError, job.Status, "reindex against write-blocked indices should fail")
+}
+
+// waitForElasticsearchJob polls the job store until the job reaches a terminal
+// status or the timeout expires.
+func waitForElasticsearchJob(t *testing.T, th *api4.TestHelper, jobID string, timeout time.Duration) *model.Job {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		job, err := th.App.Srv().Store().Job().Get(th.Context, jobID)
+		require.NoError(t, err)
+		switch job.Status {
+		case model.JobStatusSuccess, model.JobStatusError, model.JobStatusCanceled:
+			return job
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("job %s did not reach a terminal status within %s", jobID, timeout)
+	return nil
 }
 
 func TestElasticSearchIndexerPending(t *testing.T) {

--- a/server/enterprise/elasticsearch/opensearch/indexing_job.go
+++ b/server/enterprise/elasticsearch/opensearch/indexing_job.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mattermost/mattermost/server/v8/enterprise/elasticsearch/common"
 
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 	"github.com/opensearch-project/opensearch-go/v4/opensearchutil"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -64,10 +65,38 @@ func (esi *OpensearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 				Action:     indexOp,
 				DocumentID: docID,
 				Body:       body,
+				OnFailure: func(_ context.Context, item opensearchutil.BulkIndexerItem, resp opensearchapi.BulkRespItem, err error) {
+					var errType, errReason string
+					if resp.Error != nil {
+						errType = resp.Error.Type
+						errReason = resp.Error.Reason
+					}
+					logger.Error("Bulk indexer: failed to index document",
+						mlog.String("index", item.Index),
+						mlog.String("doc_id", item.DocumentID),
+						mlog.String("action", item.Action),
+						mlog.String("error_type", errType),
+						mlog.String("error_reason", errReason),
+						mlog.Err(err),
+					)
+				},
 			})
 		},
-		// Closing the bulk processor
-		func() error {
-			return esi.bulkProcessor.Close(context.Background())
+		// Closing the bulk processor and returning the number of failed items.
+		func() (int64, error) {
+			err := esi.bulkProcessor.Close(context.Background())
+			stats := esi.bulkProcessor.Stats()
+			fields := []mlog.Field{
+				mlog.Uint("num_indexed", stats.NumIndexed),
+				mlog.Uint("num_failed", stats.NumFailed),
+				mlog.Uint("num_added", stats.NumAdded),
+				mlog.Uint("num_flushed", stats.NumFlushed),
+			}
+			if err != nil {
+				logger.Warn("Bulk indexer closed with error", append(fields, mlog.Err(err))...)
+			} else {
+				logger.Info("Bulk indexer closed", fields...)
+			}
+			return int64(stats.NumFailed), err
 		})
 }

--- a/server/enterprise/elasticsearch/opensearch/indexing_job_test.go
+++ b/server/enterprise/elasticsearch/opensearch/indexing_job_test.go
@@ -4,8 +4,13 @@
 package opensearch
 
 import (
+	"context"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -55,6 +60,106 @@ func TestOpenSearchIndexerJobIsEnabled(t *testing.T) {
 
 		assert.Equal(t, result, false)
 	})
+}
+
+// TestOpenSearchIndexerBulkWriteFailures verifies that a reindex job is marked as
+// failed when OpenSearch rejects bulk writes with per-item errors (e.g. a write
+// block on the index), rather than silently reporting success.
+//
+// Requires a running OpenSearch instance (skipped otherwise).
+func TestOpenSearchIndexerBulkWriteFailures(t *testing.T) {
+	th := api4.SetupEnterprise(t).InitBasic(t)
+
+	connURL := "http://localhost:9201"
+	if os.Getenv("IS_CI") == "true" {
+		connURL = "http://opensearch:9201"
+	}
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ElasticsearchSettings.ConnectionURL = connURL
+		*cfg.ElasticsearchSettings.Backend = model.ElasticsearchSettingsOSBackend
+		*cfg.ElasticsearchSettings.EnableIndexing = true
+		*cfg.ElasticsearchSettings.EnableSearching = true
+		*cfg.ElasticsearchSettings.EnableAutocomplete = true
+		*cfg.SqlSettings.DisableDatabaseSearch = true
+	})
+	th.App.Srv().SetLicense(model.NewTestLicense())
+
+	client := createTestClient(t, th.Context, th.App.Config(), th.App.FileBackend())
+
+	// Skip if OpenSearch is not reachable.
+	_, err := client.Info(context.Background(), nil)
+	if err != nil {
+		t.Skipf("OpenSearch not available at %s: %v", connURL, err)
+	}
+
+	impl := OpensearchIndexerInterfaceImpl{Server: th.App.Srv()}
+	worker := impl.MakeWorker()
+	require.NotNil(t, worker)
+	th.Server.Jobs.RegisterJobType(model.JobTypeElasticsearchPostIndexing, worker, nil)
+
+	go worker.Run()
+	defer worker.Stop()
+
+	// Phase 1: clean reindex so the indices exist.
+	job, appErr := th.App.Srv().Jobs.CreateJob(th.Context, model.JobTypeElasticsearchPostIndexing, map[string]string{})
+	require.Nil(t, appErr)
+	worker.JobChannel() <- *job
+	job = waitForIndexingJob(t, th, job.Id, 60*time.Second)
+	require.Equal(t, model.JobStatusSuccess, job.Status, "initial reindex should succeed")
+
+	// Collect the indices that were created (skip internal dot-prefixed ones).
+	settingsResp, err := client.Indices.Settings.Get(context.Background(), &opensearchapi.SettingsGetReq{})
+	require.NoError(t, err)
+	var indexNames []string
+	for name := range settingsResp.Indices {
+		if !strings.HasPrefix(name, ".") {
+			indexNames = append(indexNames, name)
+		}
+	}
+	require.NotEmpty(t, indexNames, "initial reindex should have created at least one index")
+
+	// Apply a write block to all Mattermost indices and remove it on cleanup.
+	setWriteBlock := func(blocked bool) {
+		body := `{"index.blocks.write":true}`
+		if !blocked {
+			body = `{"index.blocks.write":false}`
+		}
+		for _, idx := range indexNames {
+			_, putErr := client.Indices.Settings.Put(context.Background(), opensearchapi.SettingsPutReq{
+				Indices: []string{idx},
+				Body:    strings.NewReader(body),
+			})
+			require.NoError(t, putErr, "failed to set write block=%v on index %s", blocked, idx)
+		}
+	}
+	setWriteBlock(true)
+	defer setWriteBlock(false)
+
+	// Phase 2: reindex against write-blocked indices — job must be marked as error.
+	job, appErr = th.App.Srv().Jobs.CreateJob(th.Context, model.JobTypeElasticsearchPostIndexing, map[string]string{})
+	require.Nil(t, appErr)
+	worker.JobChannel() <- *job
+	job = waitForIndexingJob(t, th, job.Id, 60*time.Second)
+	assert.Equal(t, model.JobStatusError, job.Status, "reindex against write-blocked indices should fail")
+}
+
+// waitForIndexingJob polls the job store until the job reaches a terminal status
+// or the timeout expires.
+func waitForIndexingJob(t *testing.T, th *api4.TestHelper, jobID string, timeout time.Duration) *model.Job {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		job, err := th.App.Srv().Store().Job().Get(th.Context, jobID)
+		require.NoError(t, err)
+		switch job.Status {
+		case model.JobStatusSuccess, model.JobStatusError, model.JobStatusCanceled:
+			return job
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("job %s did not reach a terminal status within %s", jobID, timeout)
+	return nil
 }
 
 func TestOpenSearchIndexerPending(t *testing.T) {

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9497,6 +9497,14 @@
     "translation": "Failed to index the user"
   },
   {
+    "id": "ent.elasticsearch.indexer.do_job.bulk_failures.error",
+    "translation": "Indexing job completed but {{.NumFailed}} document(s) were rejected by the search backend and not indexed"
+  },
+  {
+    "id": "ent.elasticsearch.indexer.do_job.create_bulk_processor.error",
+    "translation": "Indexing worker failed to initialise the bulk processor"
+  },
+  {
     "id": "ent.elasticsearch.indexer.do_job.get_oldest_entity.error",
     "translation": "The oldest entity (user, channel or post), could not be retrieved from the database"
   },


### PR DESCRIPTION
#### Summary

During a reindex on Hub, a job reported success while OpenSearch was silently rejecting every document due to a shard cap — no posts were actually indexed. This PR fixes the four root causes:

- **`OnFailure` callback**: each bulk-rejected document is now logged with its index, doc ID, action, error type, and reason
- **`Stats().NumFailed` check**: the bulk processor is closed before the job is marked complete; if `NumFailed > 0` the job fails instead of succeeding
- **`ResponseBodyEnabled`** was hardcoded `false`, suppressing per-item error JSON even with `Trace=all`; it now respects the trace setting
- **`createBulkProcessor` failure** after job claim now sets the job to error instead of silently returning

Integration tests are added for both backends using a write block to simulate bulk rejections and assert the job reaches `error` status. 

When the job fails, we now report on the system console:

<img width="1924" height="312" alt="CleanShot 2026-04-20 at 17 25 53@2x" src="https://github.com/user-attachments/assets/310d96c8-edd1-4208-8ff9-8d38d321a440" />

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-68378

#### Release Note

```release-note
Fixed a bug where OpenSearch/Elasticsearch reindex jobs could report success even when bulk writes were silently rejected by the search backend, causing silent data loss in the search index.
```