### PR TITLE
[MM-68393] Tighten protected role patch authorization

### DIFF
--- a/server/channels/api4/role.go
+++ b/server/channels/api4/role.go
@@ -151,9 +151,9 @@ func patchRole(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.AddEventPriorState(oldRole)
 	auditRec.AddEventObjectType("role")
 
-	// manage_system permission is required to patch system_admin
+	// manage_system permission is required to patch system_admin and other protected system roles.
 	requiredPermission := model.PermissionSysconsoleWriteUserManagementPermissions
-	specialProtectedSystemRoles := append(model.NewSystemRoleIDs, model.SystemAdminRoleId)
+	specialProtectedSystemRoles := append(append([]string{}, model.NewSystemRoleIDs...), model.SystemAdminRoleId, model.SystemUserRoleId, model.SystemGuestRoleId)
 	for _, roleID := range specialProtectedSystemRoles {
 		if oldRole.Name == roleID {
 			requiredPermission = model.PermissionManageSystem

--- a/server/channels/api4/role_test.go
+++ b/server/channels/api4/role_test.go
@@ -335,11 +335,11 @@ func TestPatchRole(t *testing.T) {
 
 		th.LoginSystemManager(t)
 
-		_, resp, err := th.SystemManagerClient.PatchRole(context.Background(), systemUserRole.Id, &model.RolePatch{
+		_, systemUserResp, err := th.SystemManagerClient.PatchRole(context.Background(), systemUserRole.Id, &model.RolePatch{
 			Permissions: &patchedPermissions,
 		})
 		if assert.Error(t, err, "system_manager must not be able to patch system_user") {
-			CheckForbiddenStatus(t, resp)
+			CheckForbiddenStatus(t, systemUserResp)
 		}
 
 		systemUserRole, appErr = th.App.GetRoleByName(th.Context, model.SystemUserRoleId)
@@ -367,11 +367,11 @@ func TestPatchRole(t *testing.T) {
 
 		th.LoginSystemManager(t)
 
-		_, resp, err := th.SystemManagerClient.PatchRole(context.Background(), systemGuestRole.Id, &model.RolePatch{
+		_, systemGuestResp, err := th.SystemManagerClient.PatchRole(context.Background(), systemGuestRole.Id, &model.RolePatch{
 			Permissions: &patchedPermissions,
 		})
 		if assert.Error(t, err, "system_manager must not be able to patch system_guest") {
-			CheckForbiddenStatus(t, resp)
+			CheckForbiddenStatus(t, systemGuestResp)
 		}
 
 		systemGuestRole, appErr = th.App.GetRoleByName(th.Context, model.SystemGuestRoleId)

--- a/server/channels/api4/role_test.go
+++ b/server/channels/api4/role_test.go
@@ -323,6 +323,63 @@ func TestPatchRole(t *testing.T) {
 		Permissions: &[]string{"create_direct_channel", "manage_incoming_webhooks", "manage_outgoing_webhooks"},
 	}
 
+	t.Run("system manager cannot patch system_user", func(t *testing.T) {
+		systemUserRole, appErr := th.App.GetRoleByName(th.Context, model.SystemUserRoleId)
+		require.Nil(t, appErr)
+
+		originalPermissions := append([]string{}, systemUserRole.Permissions...)
+		require.NotContains(t, originalPermissions, model.PermissionEditOtherUsers.Id)
+
+		patchedPermissions := append([]string{}, originalPermissions...)
+		patchedPermissions = append(patchedPermissions, model.PermissionEditOtherUsers.Id)
+
+		th.LoginSystemManager(t)
+
+		_, resp, err := th.SystemManagerClient.PatchRole(context.Background(), systemUserRole.Id, &model.RolePatch{
+			Permissions: &patchedPermissions,
+		})
+		if assert.Error(t, err, "system_manager must not be able to patch system_user") {
+			CheckForbiddenStatus(t, resp)
+		}
+
+		systemUserRole, appErr = th.App.GetRoleByName(th.Context, model.SystemUserRoleId)
+		require.Nil(t, appErr)
+		assert.ElementsMatch(t, originalPermissions, systemUserRole.Permissions)
+		assert.NotContains(t, systemUserRole.Permissions, model.PermissionEditOtherUsers.Id, "system_manager must not be able to inject privileged permissions into system_user")
+	})
+
+	t.Run("system manager cannot patch system_guest", func(t *testing.T) {
+		license := model.NewTestLicense()
+		license.Features.GuestAccountsPermissions = model.NewPointer(true)
+		th.App.Srv().SetLicense(license)
+		t.Cleanup(func() {
+			th.App.Srv().SetLicense(nil)
+		})
+
+		systemGuestRole, appErr := th.App.GetRoleByName(th.Context, model.SystemGuestRoleId)
+		require.Nil(t, appErr)
+
+		originalPermissions := append([]string{}, systemGuestRole.Permissions...)
+		require.NotContains(t, originalPermissions, model.PermissionEditOtherUsers.Id)
+
+		patchedPermissions := append([]string{}, originalPermissions...)
+		patchedPermissions = append(patchedPermissions, model.PermissionEditOtherUsers.Id)
+
+		th.LoginSystemManager(t)
+
+		_, resp, err := th.SystemManagerClient.PatchRole(context.Background(), systemGuestRole.Id, &model.RolePatch{
+			Permissions: &patchedPermissions,
+		})
+		if assert.Error(t, err, "system_manager must not be able to patch system_guest") {
+			CheckForbiddenStatus(t, resp)
+		}
+
+		systemGuestRole, appErr = th.App.GetRoleByName(th.Context, model.SystemGuestRoleId)
+		require.Nil(t, appErr)
+		assert.ElementsMatch(t, originalPermissions, systemGuestRole.Permissions)
+		assert.NotContains(t, systemGuestRole.Permissions, model.PermissionEditOtherUsers.Id, "system_manager must not be able to inject privileged permissions into system_guest")
+	})
+
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
 		received, _, err := client.PatchRole(context.Background(), role.Id, patch)
 		require.NoError(t, err)


### PR DESCRIPTION
#### Summary
Tighten role patch authorization for protected default system roles.
Added focused API coverage for restricted patch paths on protected system roles.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-68393

#### Screenshots
No UI changes.

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Tightens authorization for role patching (now requiring PermissionManageSystem for protected system_user/system_guest roles and blacklisting privileged user-management permissions), which is confined to the role patching and authorization logic but impacts a critical access-control boundary and could break workflows where lower-privileged managers previously modified those roles. Automated tests were added for the restricted paths, but indirect side effects on code relying on prior role mutation behavior (including feature-flagged guest flows) present moderate risk.  
**QA Recommendation:** Run focused manual QA: verify system managers receive HTTP 403 when patching SystemUserRoleId/SystemGuestRoleId or adding blacklisted permissions, confirm only users with PermissionManageSystem can apply such changes, ensure failed attempts leave role permissions unchanged, and test guest-related flows with GuestAccountsPermissions enabled/disabled.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->