### PR TITLE
MM-68373: Stop broadcasting full config over UDP gossip in HA

### DIFF
--- a/enterprise.pin
+++ b/enterprise.pin
@@ -1,3 +1,3 @@
 # Enterprise commit this server branch is tested against.
 # Updated via: make bump-enterprise
-b03e11ccf5dca59cc3ffd2ed8c73604c5a5a48b8
+e194ed660832f04e638212f96b6dc40c729c970e

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9321,6 +9321,10 @@
     "translation": "Error occurred while marshalling JSON request"
   },
   {
+    "id": "ent.cluster.reload_config.error",
+    "translation": "Error occurred while reloading config from the database"
+  },
+  {
     "id": "ent.cluster.save_config.error",
     "translation": "System Console is set to read-only when High Availability is enabled unless ReadOnlyConfig is disabled in the configuration file."
   },

--- a/server/public/model/cluster_message.go
+++ b/server/public/model/cluster_message.go
@@ -63,6 +63,8 @@ const (
 	ClusterGossipEventResponseGetPluginStatuses     = "gossip_response_plugin_statuses"
 	ClusterGossipEventRequestSaveConfig             = "gossip_request_save_config"
 	ClusterGossipEventResponseSaveConfig            = "gossip_response_save_config"
+	ClusterGossipEventRequestReloadConfig           = "gossip_request_reload_config"
+	ClusterGossipEventResponseReloadConfig          = "gossip_response_reload_config"
 	ClusterGossipEventRequestWebConnCount           = "gossip_request_webconn_count"
 	ClusterGossipEventResponseWebConnCount          = "gossip_response_webconn_count"
 	ClusterGossipEventRequestWSQueues               = "gossip_request_ws_queues"

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -104,6 +104,11 @@ type FeatureFlags struct {
 
 	// Enable LIKE-based CJK (Chinese, Japanese, Korean) search for PostgreSQL
 	CJKSearch bool
+
+	// Send a lightweight reload signal to HA peers instead of the full config
+	// payload when saving config to a DB-backed store. Eliminates UDP MTU
+	// failures on large configs (>65 KB).
+	HAConfigReloadSignal bool
 }
 
 func (f *FeatureFlags) SetDefaults() {
@@ -152,6 +157,8 @@ func (f *FeatureFlags) SetDefaults() {
 	f.IntegratedBoards = false
 
 	f.CJKSearch = false
+
+	f.HAConfigReloadSignal = true
 }
 
 // ToMap returns the feature flags as a map[string]string


### PR DESCRIPTION
#### Summary

Adds two new gossip cluster event constants and a feature flag to support a lightweight config-reload signal:
- `ClusterGossipEventRequestReloadConfig = "gossip_request_reload_config"`
- `ClusterGossipEventResponseReloadConfig = "gossip_response_reload_config"`
- `HAConfigReloadSignal` feature flag (default: `true`)

These are used by the enterprise cluster to broadcast a "please reload config from DB" signal instead of sending the full config payload over UDP gossip, avoiding failures when the config exceeds the UDP MTU (~65 KB).

Companion enterprise PR: https://github.com/mattermost/enterprise/pull/2131

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-68373

#### Release Note

```release-note
NONE
```