### PR TITLE
docs: document enterprise.pin workflow in root AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 **After the enterprise pull request is merged:** update the pin to the enterprise repository HEAD by running:
 
-```
+```bash
 cd server && make bump-enterprise
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## enterprise.pin
+
+`enterprise.pin` records the enterprise commit SHA that this server branch is tested against. It keeps server and enterprise branches in sync across CI and local development.
+
+**During development of an enterprise feature:** manually set `enterprise.pin` to the HEAD commit of your corresponding enterprise feature branch. This ensures CI tests this server branch against the correct enterprise code.
+
+**After the enterprise pull request is merged:** update the pin to the enterprise repository HEAD by running:
+
+```
+cd server && make bump-enterprise
+```
+
+This requires the enterprise directory to be present (configured via `BUILD_ENTERPRISE_DIR`). Commit the updated `enterprise.pin` as part of your server pull request.


### PR DESCRIPTION
#### Summary

Adds a root-level `AGENTS.md` documenting how to manage `enterprise.pin`:
- During development of an enterprise feature, pin to the HEAD of your corresponding enterprise feature branch.
- After the enterprise PR merges, update the pin by running `cd server && make bump-enterprise`.

#### Ticket Link

N/A

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** None — documentation-only change (adds AGENTS.md) with no code modifications, so it cannot affect runtime behavior or introduce regressions.  
**QA Recommendation:** No manual QA required — standard documentation review is sufficient.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->