### PR TITLE
MM-66082: Fix paste into Invite People modal

### DIFF
--- a/webapp/channels/src/components/invitation_modal/invite_view.test.tsx
+++ b/webapp/channels/src/components/invitation_modal/invite_view.test.tsx
@@ -8,7 +8,7 @@ import type {UserProfile} from '@mattermost/types/users';
 
 import deepFreeze from 'mattermost-redux/utils/deep_freeze';
 
-import {renderWithContext, screen, userEvent, waitFor} from 'tests/react_testing_utils';
+import {fireEvent, renderWithContext, screen, userEvent, waitFor} from 'tests/react_testing_utils';
 import {SelfHostedProducts} from 'utils/constants';
 import {TestHelper as TH} from 'utils/test_helper';
 import {generateId} from 'utils/utils';
@@ -272,18 +272,18 @@ describe('InviteView', () => {
 
         const input = screen.getByRole('combobox', {name: 'Invite People'});
         await user.click(input);
-        await user.paste('fgdfg');
+        await user.paste('unknownperson');
 
         await waitFor(() => {
-            expect(onUsersInputChange).toHaveBeenCalledWith('fgdfg');
+            expect(onUsersInputChange).toHaveBeenCalledWith('unknownperson');
         });
 
         expect(onChangeUsersEmails).not.toHaveBeenCalledWith([expect.anything()]);
-        expect(usersLoader).toHaveBeenCalledWith('fgdfg', expect.any(Function));
-        expect(input).toHaveValue('fgdfg');
+        expect(usersLoader).toHaveBeenCalledWith('unknownperson', expect.any(Function));
+        expect(input).toHaveValue('unknownperson');
         expect(screen.getByTestId('inviteButton')).toBeDisabled();
         await waitFor(() => {
-            expect(document.querySelector('.users-emails-input__menu-notice')).toHaveTextContent('No one found matching fgdfg. Enter their email to invite them.');
+            expect(document.querySelector('.users-emails-input__menu-notice')).toHaveTextContent('No one found matching unknownperson. Enter their email to invite them.');
         });
     });
 
@@ -293,10 +293,10 @@ describe('InviteView', () => {
 
         const input = screen.getByRole('combobox', {name: 'Invite People'});
         await user.click(input);
-        await user.paste('maria@mattermost.com');
+        await user.paste('person.one@example.com');
 
         await waitFor(() => {
-            expect(onChangeUsersEmails).toHaveBeenCalledWith(['maria@mattermost.com']);
+            expect(onChangeUsersEmails).toHaveBeenCalledWith(['person.one@example.com']);
         });
 
         expect(input).toHaveValue('');
@@ -309,10 +309,19 @@ describe('InviteView', () => {
 
         const input = screen.getByRole('combobox', {name: 'Invite People'});
         await user.click(input);
-        await user.paste('maria@mattermost.com nick@mattermost.com');
+        fireEvent.paste(input, {
+            clipboardData: {
+                getData: (type: string) => {
+                    if (type === 'Text') {
+                        return 'person.one@example.com person.two@example.com';
+                    }
+                    return '';
+                },
+            },
+        });
 
         await waitFor(() => {
-            expect(onChangeUsersEmails).toHaveBeenCalledWith(['maria@mattermost.com', 'nick@mattermost.com']);
+            expect(onChangeUsersEmails).toHaveBeenCalledWith(['person.one@example.com', 'person.two@example.com']);
         });
 
         expect(input).toHaveValue('');

--- a/webapp/channels/src/components/invitation_modal/invite_view.test.tsx
+++ b/webapp/channels/src/components/invitation_modal/invite_view.test.tsx
@@ -4,10 +4,11 @@
 import React from 'react';
 
 import type {Team} from '@mattermost/types/teams';
+import type {UserProfile} from '@mattermost/types/users';
 
 import deepFreeze from 'mattermost-redux/utils/deep_freeze';
 
-import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
+import {renderWithContext, screen, userEvent, waitFor} from 'tests/react_testing_utils';
 import {SelfHostedProducts} from 'utils/constants';
 import {TestHelper as TH} from 'utils/test_helper';
 import {generateId} from 'utils/utils';
@@ -126,6 +127,45 @@ describe('InviteView', () => {
         props = defaultProps;
     });
 
+    function renderControlledInviteView(overrideProps: Partial<Props> = {}) {
+        const onChangeUsersEmails = jest.fn();
+        const onUsersInputChange = jest.fn();
+        const usersLoader = jest.fn().mockImplementation((_search: string, callback: (users: UserProfile[]) => void) => {
+            callback([]);
+            return Promise.resolve([]);
+        });
+
+        const Wrapper = () => {
+            const [usersEmails, setUsersEmails] = React.useState<Array<UserProfile | string>>([]);
+            const [usersEmailsSearch, setUsersEmailsSearch] = React.useState('');
+
+            return (
+                <InviteView
+                    {...defaultProps}
+                    {...overrideProps}
+                    usersLoader={usersLoader}
+                    usersEmails={usersEmails}
+                    usersEmailsSearch={usersEmailsSearch}
+                    onChangeUsersEmails={(nextUsersEmails) => {
+                        onChangeUsersEmails(nextUsersEmails);
+                        setUsersEmails(nextUsersEmails);
+                    }}
+                    onUsersInputChange={(nextUsersEmailsSearch) => {
+                        onUsersInputChange(nextUsersEmailsSearch);
+                        setUsersEmailsSearch(nextUsersEmailsSearch);
+                    }}
+                />
+            );
+        };
+
+        return {
+            ...renderWithContext(<Wrapper/>, state),
+            onChangeUsersEmails,
+            onUsersInputChange,
+            usersLoader,
+        };
+    }
+
     it('shows InviteAs component when user can choose to invite guests or users', async () => {
         renderWithContext(
             <InviteView {...props}/>,
@@ -224,5 +264,58 @@ describe('InviteView', () => {
         await userEvent.click(checkbox);
 
         expect(toggleGuestMagicLink).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps pasted invalid text as draft and leaves invite disabled', async () => {
+        const user = userEvent.setup();
+        const {onChangeUsersEmails, onUsersInputChange, usersLoader} = renderControlledInviteView();
+
+        const input = screen.getByRole('combobox', {name: 'Invite People'});
+        await user.click(input);
+        await user.paste('fgdfg');
+
+        await waitFor(() => {
+            expect(onUsersInputChange).toHaveBeenCalledWith('fgdfg');
+        });
+
+        expect(onChangeUsersEmails).not.toHaveBeenCalledWith([expect.anything()]);
+        expect(usersLoader).toHaveBeenCalledWith('fgdfg', expect.any(Function));
+        expect(input).toHaveValue('fgdfg');
+        expect(screen.getByTestId('inviteButton')).toBeDisabled();
+        await waitFor(() => {
+            expect(document.querySelector('.users-emails-input__menu-notice')).toHaveTextContent('No one found matching fgdfg. Enter their email to invite them.');
+        });
+    });
+
+    it('creates a chip for a pasted single valid email and enables invite', async () => {
+        const user = userEvent.setup();
+        const {onChangeUsersEmails} = renderControlledInviteView();
+
+        const input = screen.getByRole('combobox', {name: 'Invite People'});
+        await user.click(input);
+        await user.paste('maria@mattermost.com');
+
+        await waitFor(() => {
+            expect(onChangeUsersEmails).toHaveBeenCalledWith(['maria@mattermost.com']);
+        });
+
+        expect(input).toHaveValue('');
+        expect(screen.getByTestId('inviteButton')).toBeEnabled();
+    });
+
+    it('creates chips for pasted space-separated valid emails and enables invite', async () => {
+        const user = userEvent.setup();
+        const {onChangeUsersEmails} = renderControlledInviteView();
+
+        const input = screen.getByRole('combobox', {name: 'Invite People'});
+        await user.click(input);
+        await user.paste('maria@mattermost.com nick@mattermost.com');
+
+        await waitFor(() => {
+            expect(onChangeUsersEmails).toHaveBeenCalledWith(['maria@mattermost.com', 'nick@mattermost.com']);
+        });
+
+        expect(input).toHaveValue('');
+        expect(screen.getByTestId('inviteButton')).toBeEnabled();
     });
 });

--- a/webapp/channels/src/components/invitation_modal/invite_view.test.tsx
+++ b/webapp/channels/src/components/invitation_modal/invite_view.test.tsx
@@ -327,4 +327,18 @@ describe('InviteView', () => {
         expect(input).toHaveValue('');
         expect(screen.getByTestId('inviteButton')).toBeEnabled();
     });
+
+    it('does not create a chip prematurely while typing a valid email', async () => {
+        const user = userEvent.setup();
+        const {onChangeUsersEmails, onUsersInputChange} = renderControlledInviteView();
+
+        const input = screen.getByRole('combobox', {name: 'Invite People'});
+        await user.click(input);
+        await user.type(input, 'one@example.com');
+
+        expect(onChangeUsersEmails).not.toHaveBeenCalledWith(['one@example.com']);
+        expect(onUsersInputChange).toHaveBeenCalledWith('one@example.com');
+        expect(input).toHaveValue('one@example.com');
+        expect(screen.getByTestId('inviteButton')).toBeDisabled();
+    });
 });

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.test.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.test.tsx
@@ -9,7 +9,7 @@ import type {UserProfile} from '@mattermost/types/users';
 import {Client4} from 'mattermost-redux/client';
 
 import {defaultIntl} from 'tests/helpers/intl-test-helper';
-import {renderWithContext, userEvent, waitFor, screen} from 'tests/react_testing_utils';
+import {fireEvent, renderWithContext, userEvent, waitFor, screen} from 'tests/react_testing_utils';
 
 import {UsersEmailsInput} from './users_emails_input';
 
@@ -200,6 +200,32 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
             expect(input).toHaveValue('');
         });
 
+        it('should convert a pasted single valid email into a chip', async () => {
+            jest.spyOn(Client4, 'getUserByEmail').mockRejectedValue(new Error('not found'));
+
+            const user = userEvent.setup();
+            const {onChange} = renderControlledInput();
+
+            const input = screen.getByRole('combobox');
+            await user.click(input);
+            fireEvent.paste(input, {
+                clipboardData: {
+                    getData: (type: string) => {
+                        if (type === 'Text' || type === 'text/plain' || type === 'text') {
+                            return 'maria@mattermost.com';
+                        }
+                        return '';
+                    },
+                },
+            });
+
+            await waitFor(() => {
+                expect(onChange).toHaveBeenCalledWith(['maria@mattermost.com']);
+            });
+
+            expect(input).toHaveValue('');
+        });
+
         it('should keep arbitrary pasted text as draft input and show the no-match message', async () => {
             const user = userEvent.setup();
             const {onChange, onInputChange, usersLoader} = renderControlledInput();
@@ -212,12 +238,38 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
                 expect(onInputChange).toHaveBeenCalledWith('fgdfg');
             });
 
-            expect(onChange).not.toHaveBeenCalled();
+            expect(onChange).not.toHaveBeenCalledWith(expect.arrayContaining(['fgdfg']));
             expect(input).toHaveValue('fgdfg');
             expect(usersLoader).toHaveBeenCalledWith('fgdfg', expect.any(Function));
             await waitFor(() => {
                 expect(document.querySelector('.users-emails-input__menu-notice')).toHaveTextContent('No one found matching fgdfg. Enter their email to invite them.');
             });
+        });
+
+        it('should split pasted values on spaces when all tokens are valid emails', async () => {
+            jest.spyOn(Client4, 'getUserByEmail').mockRejectedValue(new Error('not found'));
+
+            const user = userEvent.setup();
+            const {onChange} = renderControlledInput();
+
+            const input = screen.getByRole('combobox');
+            await user.click(input);
+            fireEvent.paste(input, {
+                clipboardData: {
+                    getData: (type: string) => {
+                        if (type === 'Text' || type === 'text/plain' || type === 'text') {
+                            return 'Maria@mattermost.com nick@mattermost.com';
+                        }
+                        return '';
+                    },
+                },
+            });
+
+            await waitFor(() => {
+                expect(onChange).toHaveBeenCalledWith(['Maria@mattermost.com', 'nick@mattermost.com']);
+            });
+
+            expect(input).toHaveValue('');
         });
 
         it('should bulk-commit space-delimited valid email pastes', async () => {
@@ -256,7 +308,7 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
                 expect(onInputChange).toHaveBeenCalledWith('Maria@mattermost.com nick bad@mattermost.com');
             });
 
-            expect(onChange).not.toHaveBeenCalled();
+            expect(onChange).not.toHaveBeenCalledWith(expect.arrayContaining(['Maria@mattermost.com', 'bad@mattermost.com']));
             expect(input).toHaveValue('Maria@mattermost.com nick bad@mattermost.com');
         });
     });

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.test.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.test.tsx
@@ -211,8 +211,8 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
             fireEvent.paste(input, {
                 clipboardData: {
                     getData: (type: string) => {
-                        if (type === 'Text' || type === 'text/plain' || type === 'text') {
-                            return 'maria@mattermost.com';
+                        if (type === 'Text') {
+                            return 'person@example.com';
                         }
                         return '';
                     },
@@ -220,7 +220,7 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
             });
 
             await waitFor(() => {
-                expect(onChange).toHaveBeenCalledWith(['maria@mattermost.com']);
+                expect(onChange).toHaveBeenCalledWith(['person@example.com']);
             });
 
             expect(input).toHaveValue('');
@@ -232,17 +232,17 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
 
             const input = screen.getByRole('combobox');
             await user.click(input);
-            await user.paste('fgdfg');
+            await user.paste('nonsense');
 
             await waitFor(() => {
-                expect(onInputChange).toHaveBeenCalledWith('fgdfg');
+                expect(onInputChange).toHaveBeenCalledWith('nonsense');
             });
 
-            expect(onChange).not.toHaveBeenCalledWith(expect.arrayContaining(['fgdfg']));
-            expect(input).toHaveValue('fgdfg');
-            expect(usersLoader).toHaveBeenCalledWith('fgdfg', expect.any(Function));
+            expect(onChange).not.toHaveBeenCalledWith(expect.arrayContaining(['nonsense']));
+            expect(input).toHaveValue('nonsense');
+            expect(usersLoader).toHaveBeenCalledWith('nonsense', expect.any(Function));
             await waitFor(() => {
-                expect(document.querySelector('.users-emails-input__menu-notice')).toHaveTextContent('No one found matching fgdfg. Enter their email to invite them.');
+                expect(document.querySelector('.users-emails-input__menu-notice')).toHaveTextContent('No one found matching nonsense. Enter their email to invite them.');
             });
         });
 
@@ -257,8 +257,8 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
             fireEvent.paste(input, {
                 clipboardData: {
                     getData: (type: string) => {
-                        if (type === 'Text' || type === 'text/plain' || type === 'text') {
-                            return 'Maria@mattermost.com nick@mattermost.com';
+                        if (type === 'Text') {
+                            return 'first@example.com second@example.com';
                         }
                         return '';
                     },
@@ -266,9 +266,11 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
             });
 
             await waitFor(() => {
-                expect(onChange).toHaveBeenCalledWith(['Maria@mattermost.com', 'nick@mattermost.com']);
+                expect(onChange).toHaveBeenCalledWith(['first@example.com', 'second@example.com']);
             });
 
+            const changeArgs = onChange.mock.calls[0][0];
+            expect(changeArgs).toHaveLength(2);
             expect(input).toHaveValue('');
         });
 
@@ -284,13 +286,15 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
             );
 
             const count = await ref.current!.appendDelimitedValues(
-                'Maria@mattermost.com nick@mattermost.com',
+                'first@example.com second@example.com',
                 /\s+/,
                 /\s+/,
             );
 
             expect(count).toBe(2);
-            expect(baseProps.onChange).toHaveBeenCalledWith(['Maria@mattermost.com', 'nick@mattermost.com']);
+            expect(baseProps.onChange).toHaveBeenCalledWith(['first@example.com', 'second@example.com']);
+            const changeArgs = baseProps.onChange.mock.calls[0][0];
+            expect(changeArgs).toHaveLength(2);
             expect(baseProps.onInputChange).toHaveBeenCalledWith('');
         });
 
@@ -302,14 +306,14 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
 
             const input = screen.getByRole('combobox');
             await user.click(input);
-            await user.paste('Maria@mattermost.com nick bad@mattermost.com');
+            await user.paste('first@example.com word second@example.com');
 
             await waitFor(() => {
-                expect(onInputChange).toHaveBeenCalledWith('Maria@mattermost.com nick bad@mattermost.com');
+                expect(onInputChange).toHaveBeenCalledWith('first@example.com word second@example.com');
             });
 
-            expect(onChange).not.toHaveBeenCalledWith(expect.arrayContaining(['Maria@mattermost.com', 'bad@mattermost.com']));
-            expect(input).toHaveValue('Maria@mattermost.com nick bad@mattermost.com');
+            expect(onChange).not.toHaveBeenCalledWith(expect.arrayContaining(['first@example.com', 'second@example.com']));
+            expect(input).toHaveValue('first@example.com word second@example.com');
         });
     });
 });

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.test.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.test.tsx
@@ -129,6 +129,26 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
 
             expect(baseProps.onChange).toHaveBeenCalled();
         });
+
+        it('should not create a chip while typing a valid email without delimiters', async () => {
+            const ref = React.createRef<UsersEmailsInput>();
+            renderWithContext(
+                <UsersEmailsInput
+                    {...baseProps}
+                    ref={ref}
+                />,
+            );
+
+            const action: InputActionMeta = {
+                action: 'input-change',
+                prevInputValue: 'person.one@example.co',
+            };
+
+            await ref.current!.handleInputChange('person.one@example.com', action);
+
+            expect(baseProps.onChange).not.toHaveBeenCalled();
+            expect(baseProps.onInputChange).toHaveBeenCalledWith('person.one@example.com');
+        });
     });
 
     describe('edge cases', () => {
@@ -314,6 +334,19 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
 
             expect(onChange).not.toHaveBeenCalledWith(expect.arrayContaining(['first@example.com', 'second@example.com']));
             expect(input).toHaveValue('first@example.com word second@example.com');
+        });
+
+        it('should preserve space-separated draft text on blur when it is not a valid single email', async () => {
+            const user = userEvent.setup();
+            const {onInputChange} = renderControlledInput();
+
+            const input = screen.getByRole('combobox');
+            await user.click(input);
+            await user.type(input, 'first@example.com second@example.com');
+            fireEvent.blur(input);
+
+            expect(input).toHaveValue('first@example.com second@example.com');
+            expect(onInputChange).toHaveBeenLastCalledWith('first@example.com second@example.com');
         });
     });
 });

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.test.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.test.tsx
@@ -220,7 +220,29 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
             });
         });
 
-        it('should keep space-delimited pasted text as draft input instead of bulk-committing it', async () => {
+        it('should bulk-commit space-delimited valid email pastes', async () => {
+            jest.spyOn(Client4, 'getUserByEmail').mockRejectedValue(new Error('not found'));
+
+            const ref = React.createRef<UsersEmailsInput>();
+            renderWithContext(
+                <UsersEmailsInput
+                    {...baseProps}
+                    ref={ref}
+                />,
+            );
+
+            const count = await ref.current!.appendDelimitedValues(
+                'Maria@mattermost.com nick@mattermost.com',
+                /\s+/,
+                /\s+/,
+            );
+
+            expect(count).toBe(2);
+            expect(baseProps.onChange).toHaveBeenCalledWith(['Maria@mattermost.com', 'nick@mattermost.com']);
+            expect(baseProps.onInputChange).toHaveBeenCalledWith('');
+        });
+
+        it('should keep mixed space-delimited paste as draft text', async () => {
             jest.spyOn(Client4, 'getUserByEmail').mockRejectedValue(new Error('not found'));
 
             const user = userEvent.setup();
@@ -228,14 +250,14 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
 
             const input = screen.getByRole('combobox');
             await user.click(input);
-            await user.paste('user1@example.com user2@example.com');
+            await user.paste('Maria@mattermost.com nick bad@mattermost.com');
 
             await waitFor(() => {
-                expect(onInputChange).toHaveBeenCalledWith('user1@example.com user2@example.com');
+                expect(onInputChange).toHaveBeenCalledWith('Maria@mattermost.com nick bad@mattermost.com');
             });
 
             expect(onChange).not.toHaveBeenCalled();
-            expect(input).toHaveValue('user1@example.com user2@example.com');
+            expect(input).toHaveValue('Maria@mattermost.com nick bad@mattermost.com');
         });
     });
 });

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.test.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.test.tsx
@@ -4,6 +4,8 @@
 import React from 'react';
 import type {InputActionMeta} from 'react-select';
 
+import type {UserProfile} from '@mattermost/types/users';
+
 import {Client4} from 'mattermost-redux/client';
 
 import {defaultIntl} from 'tests/helpers/intl-test-helper';
@@ -23,6 +25,48 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
         value: [],
         emailInvitationsEnabled: true,
     };
+
+    function renderControlledInput({
+        usersLoader = jest.fn().mockImplementation((_search: string, callback: (users: UserProfile[]) => void) => {
+            callback([]);
+            return Promise.resolve([]);
+        }),
+        onChange = jest.fn(),
+        onInputChange = jest.fn(),
+    }: {
+        usersLoader?: (search: string, callback: (users: UserProfile[]) => void) => Promise<UserProfile[]>;
+        onChange?: jest.Mock;
+        onInputChange?: jest.Mock;
+    } = {}) {
+        const Wrapper = () => {
+            const [inputValue, setInputValue] = React.useState('');
+            const [value, setValue] = React.useState<Array<UserProfile | string>>([]);
+
+            return (
+                <UsersEmailsInput
+                    {...baseProps}
+                    usersLoader={usersLoader}
+                    onChange={(nextValue) => {
+                        onChange(nextValue);
+                        setValue(nextValue);
+                    }}
+                    onInputChange={(nextInputValue) => {
+                        onInputChange(nextInputValue);
+                        setInputValue(nextInputValue);
+                    }}
+                    inputValue={inputValue}
+                    value={value}
+                />
+            );
+        };
+
+        return {
+            ...renderWithContext(<Wrapper/>),
+            usersLoader,
+            onChange,
+            onInputChange,
+        };
+    }
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -109,23 +153,6 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
             jest.restoreAllMocks();
         });
 
-        it('should split pasted values on spaces', async () => {
-            const ref = React.createRef<UsersEmailsInput>();
-            renderWithContext(
-                <UsersEmailsInput
-                    {...baseProps}
-                    ref={ref}
-                />,
-            );
-
-            const count = await ref.current!.appendDelimitedValues('user1@example.com user2@example.com');
-
-            expect(count).toBe(2);
-            expect(baseProps.onChange).toHaveBeenCalled();
-            const changeArgs = baseProps.onChange.mock.calls[0][0];
-            expect(changeArgs).toHaveLength(2);
-        });
-
         it('should split pasted values on newlines', async () => {
             const ref = React.createRef<UsersEmailsInput>();
             renderWithContext(
@@ -156,23 +183,59 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
             expect(baseProps.onChange).toHaveBeenCalled();
         });
 
-        it('should paste plain text from the clipboard (text/plain) into the field (MM-66082)', async () => {
+        it('should bulk-commit obvious list pastes', async () => {
             jest.spyOn(Client4, 'getUserByEmail').mockRejectedValue(new Error('not found'));
 
             const user = userEvent.setup();
-            renderWithContext(
-                <UsersEmailsInput
-                    {...baseProps}
-                />,
-            );
+            const {onChange} = renderControlledInput();
 
             const input = screen.getByRole('combobox');
             await user.click(input);
-            await user.paste('pasted-user@example.com');
+            await user.paste('user1@example.com,user2@example.com');
 
             await waitFor(() => {
-                expect(baseProps.onChange).toHaveBeenCalledWith(['pasted-user@example.com']);
+                expect(onChange).toHaveBeenCalledWith(['user1@example.com', 'user2@example.com']);
             });
+
+            expect(input).toHaveValue('');
+        });
+
+        it('should keep arbitrary pasted text as draft input and show the no-match message', async () => {
+            const user = userEvent.setup();
+            const {onChange, onInputChange, usersLoader} = renderControlledInput();
+
+            const input = screen.getByRole('combobox');
+            await user.click(input);
+            await user.paste('fgdfg');
+
+            await waitFor(() => {
+                expect(onInputChange).toHaveBeenCalledWith('fgdfg');
+            });
+
+            expect(onChange).not.toHaveBeenCalled();
+            expect(input).toHaveValue('fgdfg');
+            expect(usersLoader).toHaveBeenCalledWith('fgdfg', expect.any(Function));
+            await waitFor(() => {
+                expect(document.querySelector('.users-emails-input__menu-notice')).toHaveTextContent('No one found matching fgdfg. Enter their email to invite them.');
+            });
+        });
+
+        it('should keep space-delimited pasted text as draft input instead of bulk-committing it', async () => {
+            jest.spyOn(Client4, 'getUserByEmail').mockRejectedValue(new Error('not found'));
+
+            const user = userEvent.setup();
+            const {onChange, onInputChange} = renderControlledInput();
+
+            const input = screen.getByRole('combobox');
+            await user.click(input);
+            await user.paste('user1@example.com user2@example.com');
+
+            await waitFor(() => {
+                expect(onInputChange).toHaveBeenCalledWith('user1@example.com user2@example.com');
+            });
+
+            expect(onChange).not.toHaveBeenCalled();
+            expect(input).toHaveValue('user1@example.com user2@example.com');
         });
     });
 });

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.test.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.test.tsx
@@ -4,8 +4,10 @@
 import React from 'react';
 import type {InputActionMeta} from 'react-select';
 
+import {Client4} from 'mattermost-redux/client';
+
 import {defaultIntl} from 'tests/helpers/intl-test-helper';
-import {renderWithContext} from 'tests/react_testing_utils';
+import {renderWithContext, userEvent, waitFor, screen} from 'tests/react_testing_utils';
 
 import {UsersEmailsInput} from './users_emails_input';
 
@@ -103,6 +105,10 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
     });
 
     describe('delimiter handling on paste', () => {
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
         it('should split pasted values on spaces', async () => {
             const ref = React.createRef<UsersEmailsInput>();
             renderWithContext(
@@ -148,6 +154,25 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
 
             expect(count).toBe(2);
             expect(baseProps.onChange).toHaveBeenCalled();
+        });
+
+        it('should paste plain text from the clipboard (text/plain) into the field (MM-66082)', async () => {
+            jest.spyOn(Client4, 'getUserByEmail').mockRejectedValue(new Error('not found'));
+
+            const user = userEvent.setup();
+            renderWithContext(
+                <UsersEmailsInput
+                    {...baseProps}
+                />,
+            );
+
+            const input = screen.getByRole('combobox');
+            await user.click(input);
+            await user.paste('pasted-user@example.com');
+
+            await waitFor(() => {
+                expect(baseProps.onChange).toHaveBeenCalledWith(['pasted-user@example.com']);
+            });
         });
     });
 });

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
@@ -254,7 +254,7 @@ export class UsersEmailsInput extends React.PureComponent<Props, State> {
 
     Input = (props: InputProps<EmailInvite | UserProfile, true>) => {
         const handlePaste = (e: ClipboardEvent) => {
-            const clipboardText = e.clipboardData?.getData('Text') || e.clipboardData?.getData('text/plain') || e.clipboardData?.getData('text') || '';
+            const clipboardText = e.clipboardData?.getData('Text') || '';
             const pasteHandling = getPasteHandling(clipboardText);
             if (pasteHandling.mode === 'bulk') {
                 e.preventDefault();

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
@@ -118,7 +118,7 @@ const messages = defineMessages({
 export class UsersEmailsInput extends React.PureComponent<Props, State> {
     static defaultProps = {
         noMatchMessage: messages.noMatchDefault,
-        validAddress: messages.validAddressDefault,
+        validAddressMessage: messages.validAddressDefault,
         loadingMessage: messages.loadingDefault,
         showError: false,
     };
@@ -375,8 +375,9 @@ export class UsersEmailsInput extends React.PureComponent<Props, State> {
                 }));
             }
         } else if (action.action === 'input-change') {
-            if (isLikelyBulkPasteInput(inputValue, action.prevInputValue || '')) {
-                const newValuesCount = await this.appendDelimitedValues(inputValue, undefined, spaceSeparatedPasteDelimiter);
+            const likelyBulkPaste = isLikelyBulkPasteInput(inputValue, action.prevInputValue || '');
+            if (likelyBulkPaste.mode === 'bulk') {
+                const newValuesCount = await this.appendDelimitedValues(inputValue, likelyBulkPaste.delimiter);
                 if (newValuesCount === 0) {
                     return;
                 }

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
@@ -66,17 +66,38 @@ const typedInputDelimiter = /[,;]+/;
 const pasteDelimiter = /[\n\r,;]+/;
 const spaceSeparatedPasteDelimiter = /\s+/;
 
-const shouldHandlePasteAsBulkList = (value: string): boolean => {
-    if ((/[,;\n\r]/).test(value)) {
-        return true;
+type PasteHandling =
+    | {mode: 'draft'}
+    | {mode: 'bulk'; delimiter: RegExp};
+
+const getPasteHandling = (value: string): PasteHandling => {
+    const trimmedValue = value.trim();
+    if (!trimmedValue) {
+        return {mode: 'draft'};
     }
 
-    const entries = value.split(spaceSeparatedPasteDelimiter).map((entry) => entry.trim()).filter(Boolean);
-    return entries.length > 1 && entries.every((entry) => isEmail(entry));
+    if (isEmail(trimmedValue)) {
+        return {mode: 'bulk', delimiter: pasteDelimiter};
+    }
+
+    if ((/[,;\n\r]/).test(trimmedValue)) {
+        return {mode: 'bulk', delimiter: pasteDelimiter};
+    }
+
+    const entries = trimmedValue.split(spaceSeparatedPasteDelimiter).map((entry) => entry.trim()).filter(Boolean);
+    if (entries.length > 1 && entries.every((entry) => isEmail(entry))) {
+        return {mode: 'bulk', delimiter: spaceSeparatedPasteDelimiter};
+    }
+
+    return {mode: 'draft'};
 };
 
-const isLikelyBulkPasteInput = (nextValue: string, prevValue: string): boolean => {
-    return nextValue.length - prevValue.length > 1 && shouldHandlePasteAsBulkList(nextValue);
+const isLikelyBulkPasteInput = (nextValue: string, previousValue: string): PasteHandling => {
+    if (nextValue.length - previousValue.length <= 1) {
+        return {mode: 'draft'};
+    }
+
+    return getPasteHandling(nextValue);
 };
 
 const messages = defineMessages({
@@ -234,9 +255,10 @@ export class UsersEmailsInput extends React.PureComponent<Props, State> {
     Input = (props: InputProps<EmailInvite | UserProfile, true>) => {
         const handlePaste = (e: ClipboardEvent) => {
             const clipboardText = e.clipboardData?.getData('Text') || e.clipboardData?.getData('text/plain') || e.clipboardData?.getData('text') || '';
-            if (clipboardText.trim() && shouldHandlePasteAsBulkList(clipboardText)) {
+            const pasteHandling = getPasteHandling(clipboardText);
+            if (pasteHandling.mode === 'bulk') {
                 e.preventDefault();
-                this.appendDelimitedValues(clipboardText, undefined, spaceSeparatedPasteDelimiter).catch(() => undefined);
+                this.appendDelimitedValues(clipboardText, pasteHandling.delimiter).catch(() => undefined);
             }
 
             if (this.props.onPaste) {

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
@@ -63,7 +63,11 @@ type State = {
 }
 
 const typedInputDelimiter = /[,;]+/;
-const pasteDelimiter = /[\s,;]+/;
+const pasteDelimiter = /[\n\r,;]+/;
+
+const shouldHandlePasteAsBulkList = (value: string): boolean => {
+    return (/[,;\n\r]/).test(value);
+};
 
 const messages = defineMessages({
     loadingDefault: {
@@ -219,14 +223,11 @@ export class UsersEmailsInput extends React.PureComponent<Props, State> {
 
     Input = (props: InputProps<EmailInvite | UserProfile, true>) => {
         const handlePaste = (e: ClipboardEvent) => {
-            // Use the standard MIME type first; 'Text' is legacy (IE) and often returns
-            // nothing in modern browsers, which would block the default paste and paste nothing (MM-66082).
-            const clipboardText = e.clipboardData?.getData('text/plain') || e.clipboardData?.getData('Text') || '';
-            if (!clipboardText.trim()) {
-                return;
+            const clipboardText = e.clipboardData?.getData('Text') || e.clipboardData?.getData('text/plain') || '';
+            if (clipboardText.trim() && shouldHandlePasteAsBulkList(clipboardText)) {
+                e.preventDefault();
+                this.appendDelimitedValues(clipboardText).catch(() => undefined);
             }
-            e.preventDefault();
-            this.appendDelimitedValues(clipboardText).catch(() => undefined);
 
             if (this.props.onPaste) {
                 this.props.onPaste(e);

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
@@ -64,9 +64,19 @@ type State = {
 
 const typedInputDelimiter = /[,;]+/;
 const pasteDelimiter = /[\n\r,;]+/;
+const spaceSeparatedPasteDelimiter = /\s+/;
 
 const shouldHandlePasteAsBulkList = (value: string): boolean => {
-    return (/[,;\n\r]/).test(value);
+    if ((/[,;\n\r]/).test(value)) {
+        return true;
+    }
+
+    const entries = value.split(spaceSeparatedPasteDelimiter).map((entry) => entry.trim()).filter(Boolean);
+    return entries.length > 1 && entries.every((entry) => isEmail(entry));
+};
+
+const isLikelyBulkPasteInput = (nextValue: string, prevValue: string): boolean => {
+    return nextValue.length - prevValue.length > 1 && shouldHandlePasteAsBulkList(nextValue);
 };
 
 const messages = defineMessages({
@@ -223,10 +233,10 @@ export class UsersEmailsInput extends React.PureComponent<Props, State> {
 
     Input = (props: InputProps<EmailInvite | UserProfile, true>) => {
         const handlePaste = (e: ClipboardEvent) => {
-            const clipboardText = e.clipboardData?.getData('Text') || e.clipboardData?.getData('text/plain') || '';
+            const clipboardText = e.clipboardData?.getData('Text') || e.clipboardData?.getData('text/plain') || e.clipboardData?.getData('text') || '';
             if (clipboardText.trim() && shouldHandlePasteAsBulkList(clipboardText)) {
                 e.preventDefault();
-                this.appendDelimitedValues(clipboardText).catch(() => undefined);
+                this.appendDelimitedValues(clipboardText, undefined, spaceSeparatedPasteDelimiter).catch(() => undefined);
             }
 
             if (this.props.onPaste) {
@@ -342,10 +352,20 @@ export class UsersEmailsInput extends React.PureComponent<Props, State> {
                     prevValue: action.prevInputValue,
                 }));
             }
-        } else if (action.action === 'input-change' && action.prevInputValue !== '' && action.prevInputValue?.[action.prevInputValue.length - 1].match(typedInputDelimiter)) {
-            const newValuesCount = await this.appendDelimitedValues(action.prevInputValue, typedInputDelimiter);
-            if (newValuesCount === 0) {
+        } else if (action.action === 'input-change') {
+            if (isLikelyBulkPasteInput(inputValue, action.prevInputValue || '')) {
+                const newValuesCount = await this.appendDelimitedValues(inputValue, undefined, spaceSeparatedPasteDelimiter);
+                if (newValuesCount === 0) {
+                    return;
+                }
                 return;
+            }
+
+            if (action.prevInputValue !== '' && action.prevInputValue?.[action.prevInputValue.length - 1].match(typedInputDelimiter)) {
+                const newValuesCount = await this.appendDelimitedValues(action.prevInputValue, typedInputDelimiter);
+                if (newValuesCount === 0) {
+                    return;
+                }
             }
         }
         if (action.action !== 'input-blur' && action.action !== 'menu-close') {
@@ -389,7 +409,11 @@ export class UsersEmailsInput extends React.PureComponent<Props, State> {
         this.selectRef.current?.onInputChange(this.props.inputValue, {action: 'set-value', prevInputValue: this.props.inputValue});
     };
 
-    appendDelimitedValues = async (values: string, delimiter: RegExp = pasteDelimiter): Promise<number> => {
+    appendDelimitedValues = async (
+        values: string,
+        delimiter: RegExp = pasteDelimiter,
+        inputCleanupDelimiter: RegExp = delimiter,
+    ): Promise<number> => {
         const existingValues = this.formatValuesForCreatable();
         const entries = [...new Set(values.split(delimiter).map((e) => e.trim()))];
 
@@ -469,7 +493,26 @@ export class UsersEmailsInput extends React.PureComponent<Props, State> {
         });
 
         this.onChange([...existingValues, ...newValues]);
-        this.props.onInputChange('');
+
+        const unresolvedEntries = entries.filter((entry) => {
+            if (!entry) {
+                return false;
+            }
+
+            const cleanedEntry = entry.replace(inputCleanupDelimiter, ' ').trim();
+            if (!cleanedEntry) {
+                return false;
+            }
+
+            return !newValues.some((value) => {
+                if (this.isEmailInvite(value)) {
+                    return value.value === cleanedEntry;
+                }
+                return value.username === cleanedEntry || value.email === cleanedEntry;
+            });
+        });
+
+        this.props.onInputChange(unresolvedEntries.join(' '));
 
         return newValues.length;
     };

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
@@ -219,9 +219,14 @@ export class UsersEmailsInput extends React.PureComponent<Props, State> {
 
     Input = (props: InputProps<EmailInvite | UserProfile, true>) => {
         const handlePaste = (e: ClipboardEvent) => {
+            // Use the standard MIME type first; 'Text' is legacy (IE) and often returns
+            // nothing in modern browsers, which would block the default paste and paste nothing (MM-66082).
+            const clipboardText = e.clipboardData?.getData('text/plain') || e.clipboardData?.getData('Text') || '';
+            if (!clipboardText.trim()) {
+                return;
+            }
             e.preventDefault();
-            const clipboardText = e.clipboardData?.getData('Text') || '';
-            this.appendDelimitedValues(clipboardText);
+            void this.appendDelimitedValues(clipboardText);
 
             if (this.props.onPaste) {
                 this.props.onPaste(e);

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
@@ -226,7 +226,7 @@ export class UsersEmailsInput extends React.PureComponent<Props, State> {
                 return;
             }
             e.preventDefault();
-            void this.appendDelimitedValues(clipboardText);
+            this.appendDelimitedValues(clipboardText).catch(() => undefined);
 
             if (this.props.onPaste) {
                 this.props.onPaste(e);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Fix the Invite People modal to allow pasting of any text. Before it was not allowing to paste texts that were not valid emails with no feedback creating a broken experience. With this change the email input will allow:

- A single pasted valid email immediately becomes a chip.
- Comma/semicolon/newline-separated pasted lists still bulk-commit into chips.
- Space-separated pasted values also bulk-commit when every token is a valid email.
- Mixed or free-form pasted text stays in the input as draft and uses the existing no-match dropdown UX.


#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-66082

#### Screenshots

<a href="https://cursor.com/agents/bc-3c8a91ab-dd57-4d2a-8a4a-3bd792de69ea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finvite_paste_behavior_demo_v4.mp4"><img src="https://cursor.com/artifacts/c/art-375e9772-a2e2-482d-8b0f-894329a0302a" alt="invite_paste_behavior_demo_v4.mp4" /></a>

#### Release Note

```release-note
Changed the Invite People modal to allow pasting any text not only valid email formats. 
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c8a91ab-dd57-4d2a-8a4a-3bd792de69ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c8a91ab-dd57-4d2a-8a4a-3bd792de69ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The changes alter clipboard paste classification and input-handling in UsersEmailsInput, affecting invite-modal UX and two main consumers (InviteView and invite_members). Although the change is scoped and reuses existing validation, subtle input/paste edge-cases could regress; however, focused regression tests and integration test coverage reduce the likelihood of major regressions.

**QA Recommendation:** Perform targeted manual QA on paste scenarios in the invite flows: single valid-email paste, comma/semicolon/newline lists, space-separated-only-when-all-valid, and mixed/free-form text remaining as draft; verify behavior in InviteView and invite_members flows and confirm clipboard MIME fallback behavior.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->