### PR TITLE
ci: collect coverage inline on Postgres job, remove duplicate Coverage job

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -215,6 +215,7 @@ jobs:
       drivername: postgres
       # Each shard gets a unique artifact name so they don't collide
       logsartifact: "postgres-server-test-logs-shard-${{ matrix.shard }}"
+      enablecoverage: ${{ github.event_name != 'pull_request' || !startsWith(github.event.pull_request.base.ref, 'release-') }}
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: false
       shard-index: ${{ matrix.shard }}
@@ -275,29 +276,6 @@ jobs:
       artifact-pattern: postgres-server-fips-test-logs-shard-*
       artifact-name: postgres-server-fips-test-logs
 
-  test-coverage:
-    name: "Coverage (shard ${{ matrix.shard }})"
-    if: ${{ github.event_name != 'pull_request' || !startsWith(github.event.pull_request.base.ref, 'release-') }}
-    needs: go
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [0, 1, 2, 3]
-    uses: ./.github/workflows/server-test-template.yml
-    secrets: inherit
-    with:
-      name: "Coverage (shard ${{ matrix.shard }})"
-      datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
-      drivername: postgres
-      logsartifact: "coverage-server-test-logs-shard-${{ matrix.shard }}"
-      fullyparallel: true
-      allow-failure: true
-      enablecoverage: true
-      go-version: ${{ needs.go.outputs.version }}
-      fips-enabled: false
-      # runner: ubuntu-22.04 # Coverage is non-blocking (allow-failure), no need for 8-core
-      shard-index: ${{ matrix.shard }}
-      shard-total: 4
   test-mmctl:
     name: Run mmctl tests
     needs: go


### PR DESCRIPTION
#### Summary
Now that coverage collection is stable, we can enable it directly on the `Postgres` job under the same conditions that previously gated the `Coverage` job (i.e. skip on PRs targeting `release-*` branches), eliminating 4x 8-core runner hours per PR. (Each shard still uploads its `cover.out` to Codecov independently; Codecov merges them by commit as before.)

This should halve our compute costs on each pull request.

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This is a CI workflow optimization with zero impact on test execution or coverage collection logic. The actual test commands and coverage mechanisms remain unchanged—only the job orchestration is consolidated. The coverage condition (skip on release-* branch PRs) is preserved and applied inline rather than in a separate job.

**QA Recommendation:** No manual QA required. Automated test coverage is unaffected by this workflow restructuring, and coverage collection continues with identical logic and conditions.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->