### PR TITLE
Require sysadmin permission to create templates

### DIFF
--- a/server/channels/api4/properties.go
+++ b/server/channels/api4/properties.go
@@ -96,23 +96,27 @@ func createPropertyField(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	// Set permissions based on admin status.
 	// Permissions are not accepted from the request body; they're set by the server.
+	// Templates default to sysadmin since they define the schema linked fields inherit.
 	isAdmin := c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageSystem)
-	memberLevel := model.PermissionLevelMember
+	defaultLevel := model.PermissionLevelMember
+	if field.ObjectType == model.PropertyFieldObjectTypeTemplate {
+		defaultLevel = model.PermissionLevelSysadmin
+	}
 	if !isAdmin {
-		// Non-admin: force all permissions to member level
-		field.PermissionField = &memberLevel
-		field.PermissionValues = &memberLevel
-		field.PermissionOptions = &memberLevel
+		// Non-admin: force all permissions to the default level
+		field.PermissionField = &defaultLevel
+		field.PermissionValues = &defaultLevel
+		field.PermissionOptions = &defaultLevel
 	} else {
-		// Admin with nil fields: set defaults to member level
+		// Admin with nil fields: set defaults
 		if field.PermissionField == nil {
-			field.PermissionField = &memberLevel
+			field.PermissionField = &defaultLevel
 		}
 		if field.PermissionValues == nil {
-			field.PermissionValues = &memberLevel
+			field.PermissionValues = &defaultLevel
 		}
 		if field.PermissionOptions == nil {
-			field.PermissionOptions = &memberLevel
+			field.PermissionOptions = &defaultLevel
 		}
 	}
 

--- a/server/channels/api4/properties.go
+++ b/server/channels/api4/properties.go
@@ -60,6 +60,13 @@ func createPropertyField(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Template creation is always sysadmin-only, regardless of target_type.
+	if field.ObjectType == model.PropertyFieldObjectTypeTemplate &&
+		!c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageSystem) {
+		c.SetPermissionError(model.PermissionManageSystem)
+		return
+	}
+
 	// Check scope access for creation based on target_type
 	switch field.TargetType {
 	case "channel":


### PR DESCRIPTION
This change requires sysadmin permission to create templates. Additionally, templates define the schema that linked fields inherit, so their permission levels now default to sysadmin rather than member.

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** This change introduces a new authorization requirement for template field creation, requiring `PermissionManageSystem` (sysadmin). Any existing workflows or scripts attempting to create template fields as non-sysadmin users will now be rejected. However, comprehensive tests in `TestLinkedProperties` validate the new behavior and the change is isolated to template field creation.

**QA Recommendation:** Manual QA should focus on validating that non-sysadmin users cannot create template fields and that sysadmin-created templates properly inherit the new `PermissionLevelSysadmin` defaults. Test the linked properties workflows to ensure template-to-linked-field schema inheritance works as expected. Verify rollback scenarios where existing non-sysadmin template creation attempts are appropriately rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->