### PR TITLE
ci: fix cypress statuses perms

### DIFF
--- a/.github/workflows/e2e-tests-ci.yml
+++ b/.github/workflows/e2e-tests-ci.yml
@@ -25,6 +25,7 @@ on:
 
 permissions:
   contents: read
+  statuses: write
 
 jobs:
   resolve-pr:

--- a/.github/workflows/e2e-tests-cypress-template.yml
+++ b/.github/workflows/e2e-tests-cypress-template.yml
@@ -104,12 +104,20 @@ on:
       CWS_EXTRA_HTTP_HEADERS:
         required: false
 
+# Callers must grant at least these scopes on the job that uses this workflow
+permissions:
+  contents: read
+  statuses: write
+
 env:
   SERVER_IMAGE: "${{ inputs.server_image_repo }}/${{ inputs.server_edition == 'fips' && 'mattermost-enterprise-fips-edition' || inputs.server_edition == 'team' && 'mattermost-team-edition' || 'mattermost-enterprise-edition' }}:${{ inputs.server_image_tag }}"
 
 jobs:
   update-initial-status:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      statuses: write
     steps:
       - name: ci/set-initial-status
         uses: mattermost/actions/delivery/update-commit-status@f324ac89b05cc3511cb06e60642ac2fb829f0a63
@@ -612,6 +620,9 @@ jobs:
 
   update-success-status:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      statuses: write
     if: always() && needs.report.result == 'success' && needs.calculate-results.result == 'success'
     needs:
       - generate-test-cycle
@@ -631,6 +642,9 @@ jobs:
 
   update-failure-status:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      statuses: write
     if: always() && (needs.report.result != 'success' || needs.calculate-results.result != 'success')
     needs:
       - generate-test-cycle

--- a/.github/workflows/e2e-tests-cypress.yml
+++ b/.github/workflows/e2e-tests-cypress.yml
@@ -64,6 +64,7 @@ on:
 
 permissions:
   contents: read
+  statuses: write
 
 jobs:
   generate-build-variables:
@@ -149,6 +150,7 @@ jobs:
     if: inputs.should_run == 'false'
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
       statuses: write
     steps:
       - name: ci/post-skip-status
@@ -168,6 +170,9 @@ jobs:
     needs:
       - generate-build-variables
     if: inputs.should_run != 'false'
+    permissions:
+      contents: read
+      statuses: write
     uses: ./.github/workflows/e2e-tests-cypress-template.yml
     with:
       test_type: full

--- a/.github/workflows/e2e-tests-playwright.yml
+++ b/.github/workflows/e2e-tests-playwright.yml
@@ -58,6 +58,7 @@ on:
 
 permissions:
   contents: read
+  statuses: write
 
 jobs:
   generate-build-variables:


### PR DESCRIPTION
#### Summary
Error: Action failed with error: HttpError: Resource not accessible by integration https://github.com/mattermost/mattermost/pull/36178

#### Ticket Link
https://github.com/mattermost/mattermost/pull/36178

#### Release Note

Examples:

```release-note
NONE
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** This is an isolated GitHub Actions permission change limited to CI workflow files to allow posting commit statuses; it does not modify application code or shared libraries, so regression risk is minimal.  
**QA Recommendation:** No manual QA required beyond verifying the next CI run posts statuses correctly.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->