### PR TITLE
ci: treat HTTP 429 as a warning in check-external-links

### DIFF
--- a/webapp/scripts/check-external-links.mjs
+++ b/webapp/scripts/check-external-links.mjs
@@ -201,6 +201,10 @@ function processResponse(originalUrl, response) {
         return {url: originalUrl, status, redirect: true};
     }
 
+    if (status === 429) {
+        return {url: originalUrl, status, ok: true, rateLimited: true};
+    }
+
     if (response.ok) {
         return {url: originalUrl, status, ok: true};
     }
@@ -235,11 +239,15 @@ async function checkUrls(urls, concurrency = 5, silentProgress = false) {
 
 function printResults(results, urlMap, nonPermalinkUrls) {
     const broken = results.filter((r) => !r.ok);
-    const working = results.filter((r) => r.ok);
+    const rateLimited = results.filter((r) => r.ok && r.rateLimited);
+    const working = results.filter((r) => r.ok && !r.rateLimited);
 
     console.log('\n' + chalk.bold('=== External Link Check Results ===\n'));
 
     console.log(chalk.green(`✓ ${working.length} URLs are accessible`));
+    if (rateLimited.length > 0) {
+        console.log(chalk.yellow(`⚠ ${rateLimited.length} URLs returned 429 (rate limited, skipped)`));
+    }
     if (broken.length > 0) {
         console.log(chalk.red(`✗ ${broken.length} URLs are broken`));
     }
@@ -247,6 +255,19 @@ function printResults(results, urlMap, nonPermalinkUrls) {
         console.log(chalk.yellow(`⚠ ${nonPermalinkUrls.length} URLs are not using permalink format (warning)`));
     }
     console.log();
+
+    if (rateLimited.length > 0) {
+        console.log(chalk.yellow.bold('Rate-limited URLs (warning only):\n'));
+        for (const result of rateLimited) {
+            console.log(chalk.yellow(`  ${result.url}`));
+            console.log(chalk.gray(`    Status: HTTP 429 (Too Many Requests)`));
+            console.log(chalk.gray(`    Found in:`));
+            for (const file of urlMap.get(result.url)) {
+                console.log(chalk.gray(`      - ${file}`));
+            }
+            console.log();
+        }
+    }
 
     if (broken.length > 0) {
         console.log(chalk.red.bold('Broken URLs:\n'));
@@ -284,13 +305,14 @@ function printResults(results, urlMap, nonPermalinkUrls) {
 
 function generateMarkdownSummary(results, urlMap, nonPermalinkUrls) {
     const broken = results.filter((r) => !r.ok);
-    const working = results.filter((r) => r.ok);
+    const rateLimited = results.filter((r) => r.ok && r.rateLimited);
+    const working = results.filter((r) => r.ok && !r.rateLimited);
 
     const lines = [];
 
     lines.push('## External Link Check Results\n');
 
-    if (broken.length === 0 && nonPermalinkUrls.length === 0) {
+    if (broken.length === 0 && nonPermalinkUrls.length === 0 && rateLimited.length === 0) {
         lines.push(`✅ **All ${working.length} mattermost.com URLs are valid and accessible**\n`);
         return lines.join('\n');
     }
@@ -298,6 +320,9 @@ function generateMarkdownSummary(results, urlMap, nonPermalinkUrls) {
     lines.push(`| Status | Count |`);
     lines.push(`|--------|-------|`);
     lines.push(`| ✅ Working | ${working.length} |`);
+    if (rateLimited.length > 0) {
+        lines.push(`| ⚠️ Rate limited / 429 (warning) | ${rateLimited.length} |`);
+    }
     if (broken.length > 0) {
         lines.push(`| ❌ Broken | ${broken.length} |`);
     }
@@ -305,6 +330,19 @@ function generateMarkdownSummary(results, urlMap, nonPermalinkUrls) {
         lines.push(`| ⚠️ Missing /pl/ prefix (warning) | ${nonPermalinkUrls.length} |`);
     }
     lines.push('');
+
+    if (rateLimited.length > 0) {
+        lines.push('### ⚠️ Rate-limited URLs (warning only)\n');
+        lines.push('> These URLs returned HTTP 429 (Too Many Requests) and could not be verified. They are not treated as failures.\n');
+        lines.push('| URL | Files |');
+        lines.push('|-----|-------|');
+
+        for (const result of rateLimited) {
+            const files = urlMap.get(result.url).map((f) => `\`${f}\``).join(', ');
+            lines.push(`| ${result.url} | ${files} |`);
+        }
+        lines.push('');
+    }
 
     if (broken.length > 0) {
         lines.push('### Broken URLs\n');
@@ -380,7 +418,12 @@ async function main() {
     if (jsonOutput) {
         const output = {
             total: results.length,
-            working: results.filter((r) => r.ok).length,
+            working: results.filter((r) => r.ok && !r.rateLimited).length,
+            rateLimited: results.filter((r) => r.rateLimited).map((r) => ({
+                url: r.url,
+                status: r.status,
+                files: urlMap.get(r.url),
+            })),
             broken: results.filter((r) => !r.ok).map((r) => ({
                 url: r.url,
                 status: r.status,


### PR DESCRIPTION
#### Summary

The `check-external-links` CI job was failing when mattermost.com returned HTTP 429 (Too Many Requests) for some URLs during link validation. Since rate limiting is transient and unrelated to code changes in a PR, 429 responses are now treated as warnings rather than failures.

Rate-limited URLs are reported in their own section in both the terminal output and the GitHub Actions step summary, so they remain visible without blocking CI.

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to a single condition in the `processResponse` function that adds HTTP 429 status handling with a `rateLimited` flag. No existing validation logic is removed or modified, and the script's core URL-checking behavior remains unchanged. This is a CI utility script with no dependencies from other modules or shared code.

**QA Recommendation:** Minimal manual QA required. This is an isolated CI infrastructure change that doesn't affect application code. Verify that the workflow runs without regression when encountering 429 responses (should now succeed with warnings instead of failing), and confirm that rate-limited URLs are properly categorized in console and JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->