### PR TITLE
Raise shard-split HEAVY_MS above sqlstore timing

### DIFF
--- a/server/scripts/shard-split.js
+++ b/server/scripts/shard-split.js
@@ -38,11 +38,12 @@ const { execSync } = require("node:child_process");
 
 const SHARD_INDEX = parseInt(process.env.SHARD_INDEX);
 const SHARD_TOTAL = parseInt(process.env.SHARD_TOTAL);
-const HEAVY_MS = 300000; // 5 min: packages above this get test-level splitting
-// Only api4 (~38 min) and app (~15 min) exceed this threshold.
-// Packages like sqlstore (~3 min) stay whole to preserve test isolation —
-// their integrity tests scan the entire database and break if split across
-// shards where other tests leave data behind.
+// Threshold for test-level splitting (aggregated pass time from timing cache).
+// Keep this above sqlstore: its total time can exceed 5 minutes while remaining
+// far below api4/app, and treating sqlstore as "heavy" breaks CI — discovery
+// runs `go test -list` on the GitHub host where TestMain cannot reach postgres
+// on the docker compose network (only api4 and app should need -list splitting).
+const HEAVY_MS = 400000; // 400s (~6.7 min): packages above this get test-level splitting
 
 if (isNaN(SHARD_INDEX) || isNaN(SHARD_TOTAL) || SHARD_TOTAL < 1) {
   console.error("ERROR: SHARD_INDEX and SHARD_TOTAL must be set");


### PR DESCRIPTION
#### Summary

Raises `HEAVY_MS` in `server/scripts/shard-split.js` from 5 minutes to ~6.7 minutes so **sqlstore** is no longer classified as a heavy package.

When sqlstore crossed the 5-minute aggregate timing threshold, CI ran `go test -list` for it on the GitHub Actions **host** during shard discovery. **sqlstore** `TestMain` expects Postgres on the docker compose network, so discovery failed and all Postgres shards errored.

**api4** and **app** remain well above the new threshold and still use test-level splitting.

Split out from https://github.com/mattermost/mattermost/pull/36232 (MM-68457 audit work).

#### Ticket Link

N/A — CI infrastructure fix (unblocks sharded server tests).

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)