### PR TITLE
Simplify PULL_REQUEST_TEMPLATE.md and document it in AGENTS.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,59 +1,30 @@
-<!-- Thank you for contributing a pull request! Here are a few tips to help you:
-
-1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
-2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
-3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
--->
+<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->
 
 #### Summary
-<!--
-A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
--->
+<!-- What does this PR do? Include QA steps if not covered in the ticket. -->
 
 #### Ticket Link
 <!--
-If applicable, please include both or either of the following links:
-
-Fixes https://github.com/mattermost/mattermost/issues/XXX
-Jira https://mattermost.atlassian.net/browse/MM-XXX
+Fixes: https://github.com/mattermost/mattermost/issues/XXX
+Fixes: https://mattermost.atlassian.net/browse/MM-XXX
 -->
 
 #### Screenshots
-<!--
-If the PR includes UI changes, include screenshots/GIFs.
-
-For an easier comparison of UI changes a table (template below) can be used.
-
-|  before  |  after  |
-|----|----|
-| <insert before screenshot here> | <insert after screenshot here> |
-
--->
+<!-- Include screenshots or GIFs for UI changes. -->
 
 #### Release Note
 <!--
-Add a release note for each of the following conditions:
+Write a release note if this PR includes any of:
+* API or config changes.
+* Schema migrations (added/dropped tables or columns, index changes, column type changes).
+* User-visible behavior changes (UI, CLI, websocket).
+* Deprecations, breaking changes, or compatibility notes.
 
-* Config changes (additions, deletions, updates).
-* API additions—new endpoint, new response fields, or newly accepted request parameters.
-* Database changes (any).
-* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
-* Websocket additions or changes.
-* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
-* New features and improvements, including behavioral changes, UI changes, and CLI changes.
-* Bug fixes and fixes of previous known issues.
-* Deprecation warnings, breaking changes, or compatibility notes.
+The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.
 
-If no release notes are required, write NONE. Use past-tense. Newlines are stripped.
-
-Examples:
-
-```
-Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
-```
-
-```
-Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
+Example:
+```release-note
+Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
 ```
 
 ```release-note

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,7 @@ cd server && make bump-enterprise
 ```
 
 This requires the enterprise directory to be present (configured via `BUILD_ENTERPRISE_DIR`). Commit the updated `enterprise.pin` as part of your server pull request.
+
+## Pull Requests
+
+When creating a pull request, follow `.github/PULL_REQUEST_TEMPLATE.md`.


### PR DESCRIPTION
#### Summary

I'm frustrated by Claude always forgetting to add a release note, despite often reading the pull request template:

<img width="1792" height="570" alt="CleanShot 2026-04-23 at 11 26 38@2x" src="https://github.com/user-attachments/assets/82f552b9-abcc-4976-9a75-8a31ca77e42f" />

So first I've explicitly called out `.github/PULL_REQUEST_TEMPLATE.md` in AGENTS.md. Then I'm trimming this file to focus on the details, and make the example release notes include the block-type.

Note that I've also trimmed a bunch of the header content. While this is valuable for community PRs, in practice it's a lot of noise for the vast majority of PRs, and I think we can raise this manually in community PRs going forward instead.

Open to discussion! (It worked for this PR ;P)

#### Ticket Link

N/A

#### Screenshots

N/A

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** These changes affect only static documentation and template files with zero code logic modifications. No shared utilities, dependencies, or system behaviors are impacted.

**QA Recommendation:** No manual QA needed. Changes are purely documentation/template guidance that do not affect system functionality or behavior.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->