### PR TITLE
Fix invite modal input text clipping and modal width overflow

### DIFF
--- a/webapp/channels/src/components/invitation_modal/invitation_modal.scss
+++ b/webapp/channels/src/components/invitation_modal/invitation_modal.scss
@@ -14,6 +14,12 @@
         transform: translate(-50%, -50%) !important;
 
     }
+
+    .modal-content {
+        max-width: 100%;
+        overflow: hidden;
+    }
+
     &__header {
         padding-left: 0 !important;
     }

--- a/webapp/channels/src/components/invitation_modal/invitation_modal.scss
+++ b/webapp/channels/src/components/invitation_modal/invitation_modal.scss
@@ -16,8 +16,8 @@
     }
 
     .modal-content {
-        max-width: 100%;
         overflow: hidden;
+        max-width: 100%;
     }
 
     &__header {

--- a/webapp/channels/src/components/preparing_workspace/__snapshots__/invite_members.test.tsx.snap
+++ b/webapp/channels/src/components/preparing_workspace/__snapshots__/invite_members.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`InviteMembers component should match snapshot when it is cloud 1`] = `
               class="users-emails-input__control users-emails-input__control--is-focused users-emails-input__control--menu-is-open css-t3ipsp-control"
             >
               <div
-                class="users-emails-input__value-container users-emails-input__value-container--is-multi css-hlgwow"
+                class="users-emails-input__value-container users-emails-input__value-container--is-multi css-7rvhdx"
               >
                 <div
                   class="users-emails-input__placeholder css-10imb99-placeholder"
@@ -155,7 +155,7 @@ exports[`InviteMembers component should match snapshot when it is cloud 1`] = `
                   Enter email addresses
                 </div>
                 <div
-                  class="users-emails-input__input-container css-11wvis5"
+                  class="users-emails-input__input-container css-18awvv8"
                   data-value=""
                 >
                   <input

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.scss
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.scss
@@ -75,19 +75,18 @@
 
         .users-emails-input__input {
             border-bottom: 1px dotted red;
-
-            >div {
-                width: 1px;
-            }
         }
     }
 
     .users-emails-input__value-container {
+        min-width: 0;
+        max-width: 100%;
         padding-left: 0;
         margin-left: 2px;
     }
 
     .users-emails-input__input-container {
+        max-width: 100%;
         padding-left: 8px;
         margin-left: 2px;
     }
@@ -112,6 +111,7 @@
     }
 
     .users-emails-input__menu {
+        max-width: 100%;
         margin-top: 0;
         background: var(--center-channel-bg);
         box-shadow: 0 0 0 0 hsla(0, 0%, 0%, 0.1), 0 4px 11px hsla(0, 0%, 0%, 0.1);
@@ -124,24 +124,29 @@
 
     .users-emails-input__menu-notice {
         display: flex;
-        height: 60px;
+        min-height: 60px;
         align-items: center;
         justify-content: center;
         padding: 12px;
         border-radius: 4px 4px 0 0;
+        overflow-wrap: anywhere;
+        word-break: break-word;
     }
 
     .users-emails-input__option {
         display: flex;
-        height: 60px;
+        min-height: 60px;
         align-items: center;
         padding: 12px;
         cursor: pointer;
         gap: 8px;
 
         &--no-matches {
+            height: auto;
             color: rgba(var(--center-channel-color-rgb), 0.75);
+            overflow-wrap: anywhere;
             text-align: center;
+            word-break: break-word;
 
             span {
                 width: 100%;

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.scss
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.scss
@@ -86,6 +86,7 @@
     }
 
     .users-emails-input__input-container {
+        min-width: 0;
         max-width: 100%;
         padding-left: 8px;
         margin-left: 2px;

--- a/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
+++ b/webapp/channels/src/components/widgets/inputs/users_emails_input.tsx
@@ -511,17 +511,15 @@ export class UsersEmailsInput extends React.PureComponent<Props, State> {
             input: (css) => ({
                 ...css,
 
-                display: 'flex',
-                flex: '1 1 auto',
-
-                '> div': {
-                    width: '100%',
-                },
+                gridTemplateColumns: '0 minmax(0, 1fr)',
 
                 input: {
-                    width: '100% !important',
                     textAlign: 'left',
                 },
+            }),
+            valueContainer: (css) => ({
+                ...css,
+                gridTemplateColumns: 'minmax(0, 1fr)',
             }),
         } satisfies StylesConfig<UserProfile | EmailInvite, true >;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Fixes two layout issues in the "Invite people" modal when long text is typed:

1. **Modal expanding past its 600px width**: The react-select dropdown menu and the modal-content were growing beyond the modal-dialog boundary.
2. **Input text not using full available width**: Text was clipped at ~60% of the input width due to react-select v5's auto-sizing grid mechanism conflicting with legacy CSS overrides.

**Root cause**: react-select v5 auto-sizes input using CSS grid columns driven by a `data-value` attribute on a pseudo-element. The old `display: flex` and `width: 1px` / `width: 100%` CSS overrides fought with this grid-based sizing, causing the grid to auto-expand past the container boundary. The `modal-content` element had no width constraint, so it grew along with the react-select control.

**Fix approach (3 files)**:

`invitation_modal.scss` -- Constrain `.modal-content` to not overflow the 600px dialog:
- `max-width: 100%` and `overflow: hidden`

`users_emails_input.tsx` -- Override react-select inline styles:
- `input.gridTemplateColumns: '0 minmax(0, 1fr)'` -- sizer column is 0, input column fills available space without expanding
- `valueContainer.gridTemplateColumns: 'minmax(0, 1fr)'` -- prevents value-container grid from auto-sizing beyond container
- Remove old `display: flex`, `width: 100%` overrides that conflicted with react-select v5's inline-grid

`users_emails_input.scss` -- Fix SCSS rules:
- Remove legacy `> div { width: 1px }` that clipped text
- Add `min-width: 0` / `max-width: 100%` on value-container and input-container
- Constrain dropdown menu to `max-width: 100%`
- Add `overflow-wrap: anywhere` / `word-break: break-word` on no-match text
- Use `min-height` instead of fixed `height` on option rows for wrapped text

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-68461

#### Screenshots

**Text fills full input width (scrolled to beginning):**
![Input text fills full width](https://cursor.com/artifacts/c/art-3c6bf70f-f63a-44d8-bf48-5caf7993640f)

**Multi-select chips still work correctly:**
![Multi-select chips working](https://cursor.com/artifacts/c/art-6518a849-43ee-488c-97bd-7eed1a60452b)

#### Release Note
```release-note
Fixed invite modal text input clipping and modal width overflow when typing long text in the "To" field.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ecb97f1d-5761-4a38-b54c-24c505ea3f5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecb97f1d-5761-4a38-b54c-24c505ea3f5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to styling in the invitation modal and the UsersEmailsInput react-select overrides; no application logic, state management, or data persistence was modified, so functional regression risk is minimal. There is a minor risk of visual regressions in other places using the same react-select styles if shared selectors are relied upon.

**QA Recommendation:** Minimal manual QA: visually verify the invite modal with long input text, ensure multi-select chips render/remove correctly, confirm dropdown menu and modal content do not overflow the dialog, and spot-check other places that reuse the same input component for visual regressions.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->