### PR TITLE
Add system admin API to get user by auth_data and auth_service

### DIFF
--- a/api/v4/source/users.yaml
+++ b/api/v4/source/users.yaml
@@ -1420,6 +1420,49 @@
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+  "/api/v4/users/auth_data/{auth_data}/auth_service/{auth_service}":
+    get:
+      tags:
+        - users
+      summary: Get a user by auth data and auth service
+      description: >
+        Get a user object by providing the external auth data identifier and the
+        auth service (for example, LDAP or SAML). The `auth_data` value must be
+        URL path-encoded. Sensitive information is included for system
+        administrators consistent with other admin user APIs.
+
+        ##### Permissions
+
+        Must be a system admin.
+      operationId: GetUserByAuthData
+      parameters:
+        - name: auth_data
+          in: path
+          description: The user's AuthData from the external identity provider
+          required: true
+          schema:
+            type: string
+        - name: auth_service
+          in: path
+          description: The auth service (e.g. ldap, saml) matching `Users.AuthService`
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: User retrieval successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /api/v4/users/password/reset:
     post:
       tags:

--- a/api/v4/source/users.yaml
+++ b/api/v4/source/users.yaml
@@ -1420,14 +1420,14 @@
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
-  "/api/v4/users/auth_data/{auth_data}/auth_service/{auth_service}":
+  "/api/v4/users/auth_service/{auth_service}/auth_data/{auth_data}":
     get:
       tags:
         - users
       summary: Get a user by auth data and auth service
       description: >
-        Get a user object by providing the external auth data identifier and the
-        auth service (for example, LDAP or SAML). The `auth_data` value must be
+        Get a user object by providing the auth service (for example, LDAP or SAML)
+        and the external auth data identifier. The `auth_data` value must be
         URL path-encoded. Sensitive information is included for system
         administrators consistent with other admin user APIs.
 
@@ -1436,15 +1436,15 @@
         Must be a system admin.
       operationId: GetUserByAuthData
       parameters:
-        - name: auth_data
-          in: path
-          description: The user's AuthData from the external identity provider
-          required: true
-          schema:
-            type: string
         - name: auth_service
           in: path
           description: The auth service (e.g. ldap, saml) matching `Users.AuthService`
+          required: true
+          schema:
+            type: string
+        - name: auth_data
+          in: path
+          description: The user's AuthData from the external identity provider
           required: true
           schema:
             type: string

--- a/server/channels/api4/api.go
+++ b/server/channels/api4/api.go
@@ -24,7 +24,7 @@ type Routes struct {
 	User           *mux.Router // 'api/v4/users/{user_id:[A-Za-z0-9]+}'
 	UserByUsername *mux.Router // 'api/v4/users/username/{username:[A-Za-z0-9\\_\\-\\.]+}'
 	UserByEmail    *mux.Router // 'api/v4/users/email/{email:.+}'
-	UserByAuthData *mux.Router // 'api/v4/users/auth_data/{auth_data:.+}/auth_service/{auth_service:[A-Za-z0-9_\\-.]+}'
+	UserByAuthData *mux.Router // 'api/v4/users/auth_service/{auth_service:[A-Za-z0-9_\\-.]+}/auth_data/{auth_data:.+}'
 
 	Bots *mux.Router // 'api/v4/bots'
 	Bot  *mux.Router // 'api/v4/bots/{bot_user_id:[A-Za-z0-9]+}'
@@ -197,7 +197,7 @@ func Init(srv *app.Server) (*API, error) {
 	api.BaseRoutes.User = api.BaseRoutes.APIRoot.PathPrefix("/users/{user_id:[A-Za-z0-9]+}").Subrouter()
 	api.BaseRoutes.UserByUsername = api.BaseRoutes.Users.PathPrefix("/username/{username:[A-Za-z0-9\\_\\-\\.]+}").Subrouter()
 	api.BaseRoutes.UserByEmail = api.BaseRoutes.Users.PathPrefix("/email/{email:.+}").Subrouter()
-	api.BaseRoutes.UserByAuthData = api.BaseRoutes.Users.PathPrefix("/auth_data/{auth_data:.+}/auth_service/{auth_service:[A-Za-z0-9_\\-.]+}").Subrouter()
+	api.BaseRoutes.UserByAuthData = api.BaseRoutes.Users.PathPrefix("/auth_service/{auth_service:[A-Za-z0-9_\\-.]+}/auth_data/{auth_data:.+}").Subrouter()
 
 	api.BaseRoutes.Bots = api.BaseRoutes.APIRoot.PathPrefix("/bots").Subrouter()
 	api.BaseRoutes.Bot = api.BaseRoutes.APIRoot.PathPrefix("/bots/{bot_user_id:[A-Za-z0-9]+}").Subrouter()
@@ -422,7 +422,7 @@ func InitLocal(srv *app.Server) *API {
 	api.BaseRoutes.User = api.BaseRoutes.Users.PathPrefix("/{user_id:[A-Za-z0-9]+}").Subrouter()
 	api.BaseRoutes.UserByUsername = api.BaseRoutes.Users.PathPrefix("/username/{username:[A-Za-z0-9\\_\\-\\.]+}").Subrouter()
 	api.BaseRoutes.UserByEmail = api.BaseRoutes.Users.PathPrefix("/email/{email:.+}").Subrouter()
-	api.BaseRoutes.UserByAuthData = api.BaseRoutes.Users.PathPrefix("/auth_data/{auth_data:.+}/auth_service/{auth_service:[A-Za-z0-9_\\-.]+}").Subrouter()
+	api.BaseRoutes.UserByAuthData = api.BaseRoutes.Users.PathPrefix("/auth_service/{auth_service:[A-Za-z0-9_\\-.]+}/auth_data/{auth_data:.+}").Subrouter()
 
 	api.BaseRoutes.Bots = api.BaseRoutes.APIRoot.PathPrefix("/bots").Subrouter()
 	api.BaseRoutes.Bot = api.BaseRoutes.APIRoot.PathPrefix("/bots/{bot_user_id:[A-Za-z0-9]+}").Subrouter()

--- a/server/channels/api4/api.go
+++ b/server/channels/api4/api.go
@@ -24,6 +24,7 @@ type Routes struct {
 	User           *mux.Router // 'api/v4/users/{user_id:[A-Za-z0-9]+}'
 	UserByUsername *mux.Router // 'api/v4/users/username/{username:[A-Za-z0-9\\_\\-\\.]+}'
 	UserByEmail    *mux.Router // 'api/v4/users/email/{email:.+}'
+	UserByAuthData *mux.Router // 'api/v4/users/auth_data/{auth_data:.+}/auth_service/{auth_service:[A-Za-z0-9_\\-.]+}'
 
 	Bots *mux.Router // 'api/v4/bots'
 	Bot  *mux.Router // 'api/v4/bots/{bot_user_id:[A-Za-z0-9]+}'
@@ -196,6 +197,7 @@ func Init(srv *app.Server) (*API, error) {
 	api.BaseRoutes.User = api.BaseRoutes.APIRoot.PathPrefix("/users/{user_id:[A-Za-z0-9]+}").Subrouter()
 	api.BaseRoutes.UserByUsername = api.BaseRoutes.Users.PathPrefix("/username/{username:[A-Za-z0-9\\_\\-\\.]+}").Subrouter()
 	api.BaseRoutes.UserByEmail = api.BaseRoutes.Users.PathPrefix("/email/{email:.+}").Subrouter()
+	api.BaseRoutes.UserByAuthData = api.BaseRoutes.Users.PathPrefix("/auth_data/{auth_data:.+}/auth_service/{auth_service:[A-Za-z0-9_\\-.]+}").Subrouter()
 
 	api.BaseRoutes.Bots = api.BaseRoutes.APIRoot.PathPrefix("/bots").Subrouter()
 	api.BaseRoutes.Bot = api.BaseRoutes.APIRoot.PathPrefix("/bots/{bot_user_id:[A-Za-z0-9]+}").Subrouter()
@@ -420,6 +422,7 @@ func InitLocal(srv *app.Server) *API {
 	api.BaseRoutes.User = api.BaseRoutes.Users.PathPrefix("/{user_id:[A-Za-z0-9]+}").Subrouter()
 	api.BaseRoutes.UserByUsername = api.BaseRoutes.Users.PathPrefix("/username/{username:[A-Za-z0-9\\_\\-\\.]+}").Subrouter()
 	api.BaseRoutes.UserByEmail = api.BaseRoutes.Users.PathPrefix("/email/{email:.+}").Subrouter()
+	api.BaseRoutes.UserByAuthData = api.BaseRoutes.Users.PathPrefix("/auth_data/{auth_data:.+}/auth_service/{auth_service:[A-Za-z0-9_\\-.]+}").Subrouter()
 
 	api.BaseRoutes.Bots = api.BaseRoutes.APIRoot.PathPrefix("/bots").Subrouter()
 	api.BaseRoutes.Bot = api.BaseRoutes.APIRoot.PathPrefix("/bots/{bot_user_id:[A-Za-z0-9]+}").Subrouter()

--- a/server/channels/api4/user.go
+++ b/server/channels/api4/user.go
@@ -6,6 +6,7 @@ package api4
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,6 +26,12 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 	"github.com/mattermost/mattermost/server/v8/channels/utils"
 )
+
+// hashAuthDataForAudit returns a short, non-reversible hash for audit records (raw auth_data is never logged).
+func hashAuthDataForAudit(authData string) string {
+	sum := sha256.Sum256([]byte(authData))
+	return hex.EncodeToString(sum[:8])
+}
 
 func (api *API) InitUser() {
 	api.BaseRoutes.Users.Handle("", api.APIHandler(createUser)).Methods(http.MethodPost)
@@ -463,6 +470,15 @@ func getUserByEmail(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func getUserByAuth(c *Context, w http.ResponseWriter, r *http.Request) {
+	auditRec := c.MakeAuditRecord("getUserByAuth", model.AuditStatusFail)
+	if c.Params.AuthService != "" {
+		model.AddEventParameterToAuditRec(auditRec, "auth_service", c.Params.AuthService)
+	}
+	if c.Params.AuthData != "" {
+		model.AddEventParameterToAuditRec(auditRec, "auth_data_hash", hashAuthDataForAudit(c.Params.AuthData))
+	}
+	defer c.LogAuditRec(auditRec)
+
 	if !c.IsSystemAdmin() {
 		c.SetPermissionError(model.PermissionManageSystem)
 		return
@@ -491,6 +507,10 @@ func getUserByAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.SetPermissionError(model.PermissionViewMembers)
 			return
 		}
+		auditRec.AddMeta("outcome", "lookup_failed")
+		if err.Id != "" {
+			auditRec.AddMeta("app_error_id", err.Id)
+		}
 		c.Err = err
 		return
 	}
@@ -507,6 +527,8 @@ func getUserByAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	etag := user.Etag(*c.App.Config().PrivacySettings.ShowFullName, *c.App.Config().PrivacySettings.ShowEmailAddress)
+	auditRec.AddMeta("user_id", user.Id)
+	auditRec.Success()
 
 	if c.HandleEtag(etag, "Get User", w, r) {
 		return

--- a/server/channels/api4/user.go
+++ b/server/channels/api4/user.go
@@ -76,6 +76,7 @@ func (api *API) InitUser() {
 
 	api.BaseRoutes.UserByUsername.Handle("", api.APISessionRequired(getUserByUsername)).Methods(http.MethodGet)
 	api.BaseRoutes.UserByEmail.Handle("", api.APISessionRequired(getUserByEmail)).Methods(http.MethodGet)
+	api.BaseRoutes.UserByAuthData.Handle("", api.APISessionRequired(getUserByAuth)).Methods(http.MethodGet)
 
 	api.BaseRoutes.User.Handle("/sessions", api.APISessionRequired(getSessions)).Methods(http.MethodGet)
 	api.BaseRoutes.User.Handle("/sessions/revoke", api.APISessionRequired(revokeSession)).Methods(http.MethodPost)
@@ -458,6 +459,63 @@ func getUserByEmail(c *Context, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(model.HeaderEtagServer, etag)
 	if err := json.NewEncoder(w).Encode(user); err != nil {
 		c.Logger.Warn("Error while writing response", mlog.Err(err))
+	}
+}
+
+func getUserByAuth(c *Context, w http.ResponseWriter, r *http.Request) {
+	if !c.IsSystemAdmin() {
+		c.SetPermissionError(model.PermissionManageSystem)
+		return
+	}
+	if c.Params.AuthService == "" {
+		c.SetInvalidURLParam("auth_service")
+		return
+	}
+	if c.Params.AuthData == "" {
+		c.SetInvalidURLParam("auth_data")
+		return
+	}
+	if len(c.Params.AuthData) > model.UserAuthDataMaxLength {
+		c.SetInvalidParam("auth_data")
+		return
+	}
+	authData := c.Params.AuthData
+	user, err := c.App.GetUserByAuth(&authData, c.Params.AuthService)
+	if err != nil {
+		restrictions, err2 := c.App.GetViewUsersRestrictions(c.AppContext, c.AppContext.Session().UserId)
+		if err2 != nil {
+			c.Err = err2
+			return
+		}
+		if restrictions != nil {
+			c.SetPermissionError(model.PermissionViewMembers)
+			return
+		}
+		c.Err = err
+		return
+	}
+
+	canSee, err2 := c.App.UserCanSeeOtherUser(c.AppContext, c.AppContext.Session().UserId, user.Id)
+	if err2 != nil {
+		c.Err = err2
+		return
+	}
+
+	if !canSee {
+		c.SetPermissionError(model.PermissionViewMembers)
+		return
+	}
+
+	etag := user.Etag(*c.App.Config().PrivacySettings.ShowFullName, *c.App.Config().PrivacySettings.ShowEmailAddress)
+
+	if c.HandleEtag(etag, "Get User", w, r) {
+		return
+	}
+
+	c.App.SanitizeProfile(user, c.IsSystemAdmin())
+	w.Header().Set(model.HeaderEtagServer, etag)
+	if jerr := json.NewEncoder(w).Encode(user); jerr != nil {
+		c.Logger.Warn("Error while writing response", mlog.Err(jerr))
 	}
 }
 

--- a/server/channels/api4/user_local.go
+++ b/server/channels/api4/user_local.go
@@ -40,6 +40,7 @@ func (api *API) InitUserLocal() {
 
 	api.BaseRoutes.UserByUsername.Handle("", api.APILocal(localGetUserByUsername)).Methods(http.MethodGet)
 	api.BaseRoutes.UserByEmail.Handle("", api.APILocal(localGetUserByEmail)).Methods(http.MethodGet)
+	api.BaseRoutes.UserByAuthData.Handle("", api.APILocal(localGetUserByAuth)).Methods(http.MethodGet)
 
 	api.BaseRoutes.Users.Handle("/tokens/revoke", api.APILocal(revokeUserAccessToken)).Methods(http.MethodPost)
 	api.BaseRoutes.User.Handle("/tokens", api.APILocal(getUserAccessTokensForUser)).Methods(http.MethodGet)
@@ -424,6 +425,39 @@ func localGetUserByEmail(c *Context, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(model.HeaderEtagServer, etag)
 	if err := json.NewEncoder(w).Encode(user); err != nil {
 		c.Logger.Warn("Error while writing response", mlog.Err(err))
+	}
+}
+
+func localGetUserByAuth(c *Context, w http.ResponseWriter, r *http.Request) {
+	if c.Params.AuthService == "" {
+		c.SetInvalidURLParam("auth_service")
+		return
+	}
+	if c.Params.AuthData == "" {
+		c.SetInvalidURLParam("auth_data")
+		return
+	}
+	if len(c.Params.AuthData) > model.UserAuthDataMaxLength {
+		c.SetInvalidParam("auth_data")
+		return
+	}
+	authData := c.Params.AuthData
+	user, err := c.App.GetUserByAuth(&authData, c.Params.AuthService)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	etag := user.Etag(*c.App.Config().PrivacySettings.ShowFullName, *c.App.Config().PrivacySettings.ShowEmailAddress)
+
+	if c.HandleEtag(etag, "Get User", w, r) {
+		return
+	}
+
+	c.App.SanitizeProfile(user, c.IsSystemAdmin())
+	w.Header().Set(model.HeaderEtagServer, etag)
+	if jerr := json.NewEncoder(w).Encode(user); jerr != nil {
+		c.Logger.Warn("Error while writing response", mlog.Err(jerr))
 	}
 }
 

--- a/server/channels/api4/user_local.go
+++ b/server/channels/api4/user_local.go
@@ -429,6 +429,15 @@ func localGetUserByEmail(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func localGetUserByAuth(c *Context, w http.ResponseWriter, r *http.Request) {
+	auditRec := c.MakeAuditRecord("localGetUserByAuth", model.AuditStatusFail)
+	if c.Params.AuthService != "" {
+		model.AddEventParameterToAuditRec(auditRec, "auth_service", c.Params.AuthService)
+	}
+	if c.Params.AuthData != "" {
+		model.AddEventParameterToAuditRec(auditRec, "auth_data_hash", hashAuthDataForAudit(c.Params.AuthData))
+	}
+	defer c.LogAuditRec(auditRec)
+
 	if c.Params.AuthService == "" {
 		c.SetInvalidURLParam("auth_service")
 		return
@@ -444,11 +453,17 @@ func localGetUserByAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	authData := c.Params.AuthData
 	user, err := c.App.GetUserByAuth(&authData, c.Params.AuthService)
 	if err != nil {
+		auditRec.AddMeta("outcome", "lookup_failed")
+		if err.Id != "" {
+			auditRec.AddMeta("app_error_id", err.Id)
+		}
 		c.Err = err
 		return
 	}
 
 	etag := user.Etag(*c.App.Config().PrivacySettings.ShowFullName, *c.App.Config().PrivacySettings.ShowEmailAddress)
+	auditRec.AddMeta("user_id", user.Id)
+	auditRec.Success()
 
 	if c.HandleEtag(etag, "Get User", w, r) {
 		return

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -1509,7 +1509,7 @@ func TestGetUserByAuthData(t *testing.T) {
 
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
 		t.Run("returns user and auth fields for system admin and local", func(t *testing.T) {
-			ruser, _, getErr := client.GetUserByAuthData(context.Background(), authID, model.UserAuthServiceSaml, "")
+			ruser, _, getErr := client.GetUserByAuthData(context.Background(), model.UserAuthServiceSaml, authID, "")
 			require.NoError(t, getErr)
 			require.Equal(t, user.Id, ruser.Id)
 			require.NotNil(t, ruser.AuthData)
@@ -1518,7 +1518,7 @@ func TestGetUserByAuthData(t *testing.T) {
 		})
 
 		t.Run("not found returns error response", func(t *testing.T) {
-			_, resp, notFoundErr := client.GetUserByAuthData(context.Background(), "nope-"+model.NewId(), model.UserAuthServiceSaml, "")
+			_, resp, notFoundErr := client.GetUserByAuthData(context.Background(), model.UserAuthServiceSaml, "nope-"+model.NewId(), "")
 			require.Error(t, notFoundErr)
 			CheckInternalErrorStatus(t, resp)
 		})
@@ -1529,14 +1529,14 @@ func TestGetUserByAuthData(t *testing.T) {
 		// a separate team member to assert the endpoint requires a system admin.
 		_, _, err = th.Client.Login(context.Background(), regularUser.Email, regularUser.Password)
 		require.NoError(t, err)
-		_, resp, err := th.Client.GetUserByAuthData(context.Background(), authID, model.UserAuthServiceSaml, "")
+		_, resp, err := th.Client.GetUserByAuthData(context.Background(), model.UserAuthServiceSaml, authID, "")
 		require.Error(t, err)
 		CheckForbiddenStatus(t, resp)
 	})
 
 	t.Run("rejects auth data over max length", func(t *testing.T) {
 		longData := strings.Repeat("x", model.UserAuthDataMaxLength+1)
-		_, resp, err := th.SystemAdminClient.GetUserByAuthData(context.Background(), longData, model.UserAuthServiceSaml, "")
+		_, resp, err := th.SystemAdminClient.GetUserByAuthData(context.Background(), model.UserAuthServiceSaml, longData, "")
 		require.Error(t, err)
 		CheckBadRequestStatus(t, resp)
 	})

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -1507,8 +1507,8 @@ func TestGetUserByAuthData(t *testing.T) {
 
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
 		t.Run("returns user and auth fields for system admin and local", func(t *testing.T) {
-			ruser, _, err := client.GetUserByAuthData(context.Background(), authID, model.UserAuthServiceSaml, "")
-			require.NoError(t, err)
+			ruser, _, getErr := client.GetUserByAuthData(context.Background(), authID, model.UserAuthServiceSaml, "")
+			require.NoError(t, getErr)
 			require.Equal(t, user.Id, ruser.Id)
 			require.NotNil(t, ruser.AuthData)
 			require.Equal(t, authID, *ruser.AuthData)
@@ -1516,8 +1516,8 @@ func TestGetUserByAuthData(t *testing.T) {
 		})
 
 		t.Run("not found returns error response", func(t *testing.T) {
-			_, resp, err := client.GetUserByAuthData(context.Background(), "nope-"+model.NewId(), model.UserAuthServiceSaml, "")
-			require.Error(t, err)
+			_, resp, notFoundErr := client.GetUserByAuthData(context.Background(), "nope-"+model.NewId(), model.UserAuthServiceSaml, "")
+			require.Error(t, notFoundErr)
 			CheckInternalErrorStatus(t, resp)
 		})
 	})

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -1487,6 +1487,57 @@ func TestGetUserByEmail(t *testing.T) {
 	})
 }
 
+func TestGetUserByAuthData(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t)
+
+	team := th.CreateTeamWithClient(t, th.SystemAdminClient)
+	user := th.CreateUser(t)
+	th.LinkUserToTeam(t, user, team)
+	_, err := th.App.Srv().Store().User().VerifyEmail(user.Id, user.Email)
+	require.NoError(t, err)
+
+	authID := "extid-" + model.NewId()
+	userAuth := &model.UserAuth{
+		AuthData:    model.NewPointer(authID),
+		AuthService: model.UserAuthServiceSaml,
+	}
+	_, _, err = th.SystemAdminClient.UpdateUserAuth(context.Background(), user.Id, userAuth)
+	require.NoError(t, err)
+
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
+		t.Run("returns user and auth fields for system admin and local", func(t *testing.T) {
+			ruser, _, err := client.GetUserByAuthData(context.Background(), authID, model.UserAuthServiceSaml, "")
+			require.NoError(t, err)
+			require.Equal(t, user.Id, ruser.Id)
+			require.NotNil(t, ruser.AuthData)
+			require.Equal(t, authID, *ruser.AuthData)
+			require.Equal(t, model.UserAuthServiceSaml, ruser.AuthService)
+		})
+
+		t.Run("not found returns error response", func(t *testing.T) {
+			_, resp, err := client.GetUserByAuthData(context.Background(), "nope-"+model.NewId(), model.UserAuthServiceSaml, "")
+			require.Error(t, err)
+			CheckInternalErrorStatus(t, resp)
+		})
+	})
+
+	t.Run("rejects non-system admin", func(t *testing.T) {
+		_, _, err = th.Client.Login(context.Background(), user.Email, user.Password)
+		require.NoError(t, err)
+		_, resp, err := th.Client.GetUserByAuthData(context.Background(), authID, model.UserAuthServiceSaml, "")
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("rejects auth data over max length", func(t *testing.T) {
+		longData := strings.Repeat("x", model.UserAuthDataMaxLength+1)
+		_, resp, err := th.SystemAdminClient.GetUserByAuthData(context.Background(), longData, model.UserAuthServiceSaml, "")
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+	})
+}
+
 // This test can flake if two calls to model.NewId can return the same value.
 // Not much can be done about it.
 func TestSearchUsers(t *testing.T) {

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -1492,6 +1492,8 @@ func TestGetUserByAuthData(t *testing.T) {
 	th := Setup(t)
 
 	team := th.CreateTeamWithClient(t, th.SystemAdminClient)
+	regularUser := th.CreateUser(t)
+	th.LinkUserToTeam(t, regularUser, team)
 	user := th.CreateUser(t)
 	th.LinkUserToTeam(t, user, team)
 	_, err := th.App.Srv().Store().User().VerifyEmail(user.Id, user.Email)
@@ -1523,7 +1525,9 @@ func TestGetUserByAuthData(t *testing.T) {
 	})
 
 	t.Run("rejects non-system admin", func(t *testing.T) {
-		_, _, err = th.Client.Login(context.Background(), user.Email, user.Password)
+		// `user` is converted to SAML below and can no longer use password login; use
+		// a separate team member to assert the endpoint requires a system admin.
+		_, _, err = th.Client.Login(context.Background(), regularUser.Email, regularUser.Password)
 		require.NoError(t, err)
 		_, resp, err := th.Client.GetUserByAuthData(context.Background(), authID, model.UserAuthServiceSaml, "")
 		require.Error(t, err)

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -1509,18 +1509,20 @@ func TestGetUserByAuthData(t *testing.T) {
 
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
 		t.Run("returns user and auth fields for system admin and local", func(t *testing.T) {
-			ruser, _, getErr := client.GetUserByAuthData(context.Background(), model.UserAuthServiceSaml, authID, "")
+			ruser, resp, getErr := client.GetUserByAuthData(context.Background(), model.UserAuthServiceSaml, authID, "")
 			require.NoError(t, getErr)
 			require.Equal(t, user.Id, ruser.Id)
 			require.NotNil(t, ruser.AuthData)
 			require.Equal(t, authID, *ruser.AuthData)
 			require.Equal(t, model.UserAuthServiceSaml, ruser.AuthService)
+			ruser, resp, _ = client.GetUserByAuthData(context.Background(), model.UserAuthServiceSaml, authID, resp.Etag)
+			CheckEtag(t, ruser, resp)
 		})
 
-		t.Run("not found returns error response", func(t *testing.T) {
+		t.Run("not found returns not found", func(t *testing.T) {
 			_, resp, notFoundErr := client.GetUserByAuthData(context.Background(), model.UserAuthServiceSaml, "nope-"+model.NewId(), "")
 			require.Error(t, notFoundErr)
-			CheckInternalErrorStatus(t, resp)
+			CheckNotFoundStatus(t, resp)
 		})
 	})
 

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -597,7 +597,7 @@ func (a *App) GetUserByAuth(authData *string, authService string) (*model.User, 
 		case errors.As(err, &invErr):
 			return nil, model.NewAppError("GetUserByAuth", MissingAuthAccountError, nil, "", http.StatusBadRequest).Wrap(err)
 		case errors.As(err, &nfErr):
-			return nil, model.NewAppError("GetUserByAuth", MissingAuthAccountError, nil, "", http.StatusInternalServerError).Wrap(err)
+			return nil, model.NewAppError("GetUserByAuth", MissingAuthAccountError, nil, "", http.StatusNotFound).Wrap(err)
 		default:
 			return nil, model.NewAppError("GetUserByAuth", "app.user.get_by_auth.other.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 		}

--- a/server/channels/web/params.go
+++ b/server/channels/web/params.go
@@ -47,6 +47,8 @@ type Params struct {
 	AppId                              string
 	Email                              string
 	Username                           string
+	AuthData                           string
+	AuthService                        string
 	TeamName                           string
 	ChannelName                        string
 	PreferenceName                     string
@@ -170,6 +172,8 @@ func ParamsFromRequest(r *http.Request) *Params {
 	params.AppId = props["app_id"]
 	params.Email = props["email"]
 	params.Username = props["username"]
+	params.AuthData = props["auth_data"]
+	params.AuthService = props["auth_service"]
 	params.TeamName = strings.ToLower(props["team_name"])
 	params.ChannelName = strings.ToLower(props["channel_name"])
 	params.Category = props["category"]

--- a/server/public/model/client4.go
+++ b/server/public/model/client4.go
@@ -232,8 +232,8 @@ func (c *Client4) userByEmailRoute(email string) clientRoute {
 	return c.usersRoute().Join("email", email)
 }
 
-func (c *Client4) userByAuthDataRoute(authData, authService string) clientRoute {
-	return c.usersRoute().Join("auth_data", authData, "auth_service", authService)
+func (c *Client4) userByAuthDataRoute(authService, authData string) clientRoute {
+	return c.usersRoute().Join("auth_service", authService, "auth_data", authData)
 }
 
 func (c *Client4) botsRoute() clientRoute {
@@ -1181,9 +1181,9 @@ func (c *Client4) GetUserByEmail(ctx context.Context, email, etag string) (*User
 	return DecodeJSONFromResponse[*User](r)
 }
 
-// GetUserByAuthData returns a user by auth_data and auth_service. Callers should URL-encode authData as a path segment.
-func (c *Client4) GetUserByAuthData(ctx context.Context, authData, authService, etag string) (*User, *Response, error) {
-	r, err := c.doAPIGet(ctx, c.userByAuthDataRoute(authData, authService), etag)
+// GetUserByAuthData returns a user by auth_service and auth_data. Callers should URL-encode authData as a path segment.
+func (c *Client4) GetUserByAuthData(ctx context.Context, authService, authData, etag string) (*User, *Response, error) {
+	r, err := c.doAPIGet(ctx, c.userByAuthDataRoute(authService, authData), etag)
 	if err != nil {
 		return nil, BuildResponse(r), err
 	}

--- a/server/public/model/client4.go
+++ b/server/public/model/client4.go
@@ -1181,7 +1181,7 @@ func (c *Client4) GetUserByEmail(ctx context.Context, email, etag string) (*User
 	return DecodeJSONFromResponse[*User](r)
 }
 
-// GetUserByAuthData returns a user by auth_service and auth_data. Callers should URL-encode authData as a path segment.
+// GetUserByAuthData returns a user by auth_service and auth_data. Path segments are escaped by the route builder.
 func (c *Client4) GetUserByAuthData(ctx context.Context, authService, authData, etag string) (*User, *Response, error) {
 	r, err := c.doAPIGet(ctx, c.userByAuthDataRoute(authService, authData), etag)
 	if err != nil {

--- a/server/public/model/client4.go
+++ b/server/public/model/client4.go
@@ -232,6 +232,10 @@ func (c *Client4) userByEmailRoute(email string) clientRoute {
 	return c.usersRoute().Join("email", email)
 }
 
+func (c *Client4) userByAuthDataRoute(authData, authService string) clientRoute {
+	return c.usersRoute().Join("auth_data", authData, "auth_service", authService)
+}
+
 func (c *Client4) botsRoute() clientRoute {
 	return newClientRoute("bots")
 }
@@ -1170,6 +1174,16 @@ func (c *Client4) GetUserByUsername(ctx context.Context, userName, etag string) 
 // GetUserByEmail returns a user based on the provided user email string.
 func (c *Client4) GetUserByEmail(ctx context.Context, email, etag string) (*User, *Response, error) {
 	r, err := c.doAPIGet(ctx, c.userByEmailRoute(email), etag)
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return DecodeJSONFromResponse[*User](r)
+}
+
+// GetUserByAuthData returns a user by auth_data and auth_service. Callers should URL-encode authData as a path segment.
+func (c *Client4) GetUserByAuthData(ctx context.Context, authData, authService, etag string) (*User, *Response, error) {
+	r, err := c.doAPIGet(ctx, c.userByAuthDataRoute(authData, authService), etag)
 	if err != nil {
 		return nil, BuildResponse(r), err
 	}

--- a/tools/mattermost-govet/apiAuditLogs/whitelist.go
+++ b/tools/mattermost-govet/apiAuditLogs/whitelist.go
@@ -121,6 +121,7 @@ var whiteList = map[string]bool{
 	"getUserAccessToken":                   true,
 	"getUserAccessTokens":                  true,
 	"getUserAccessTokensForUser":           true,
+	"getUserByAuth":                        true,
 	"getUserByEmail":                       true,
 	"getUserByUsername":                    true,
 	"getUsers":                             true,

--- a/tools/mattermost-govet/apiAuditLogs/whitelist.go
+++ b/tools/mattermost-govet/apiAuditLogs/whitelist.go
@@ -121,7 +121,6 @@ var whiteList = map[string]bool{
 	"getUserAccessToken":                   true,
 	"getUserAccessTokens":                  true,
 	"getUserAccessTokensForUser":           true,
-	"getUserByAuth":                        true,
 	"getUserByEmail":                       true,
 	"getUserByUsername":                    true,
 	"getUsers":                             true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds `GET /api/v4/users/auth_service/{auth_service}/auth_data/{auth_data}` for **system admin** sessions, using the existing `App.GetUserByAuth` / `UserStore.GetByAuth` path. Response handling follows `getUserByEmail` (ETag, `UserCanSeeOtherUser`, `SanitizeProfile`).

## Changes
- Route + `Params.AuthData` / `Params.AuthService` for mux vars
- `getUserByAuth` (rejects non-admin with `PermissionManageSystem`) and `localGetUserByAuth` for local mode; audit records with `auth_service` and `auth_data_hash` (SHA-256 prefix, no raw `auth_data`)
- `GetUserByAuth` returns **404** for not-found (was 500)
- `Client4.GetUserByAuthData` with path segment escaping via `clientRoute` / `cleanSegment`
- `TestGetUserByAuthData` in api4
- OpenAPI: `GetUserByAuthData` in `api/v4/source/users.yaml` (Vet API / openApiSync)

## Notes
- Integration test could not be run in this environment (no Postgres). `go build` for `server/...` succeeded.

```release-note
Added system admin API GET /api/v4/users/auth_service/{auth_service}/auth_data/{auth_data} to look up a user by external auth data and auth service.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7da7689-9aee-44fe-bfe5-29497375c116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7da7689-9aee-44fe-bfe5-29497375c116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The PR's main behavioral change—mapping `store.ErrNotFound` to HTTP 404 instead of 500 in `GetUserByAuth`—alters the error contract of an existing method and could impact other callers. However, the change is semantically correct (not-found should be 404). Most other changes are additive and isolated to the new feature.

**QA Recommendation:** Standard testing of the new `GetUserByAuthData` endpoint across admin and non-admin scenarios is sufficient given good automated test coverage. Manual QA should focus on verifying the 404 response semantics in `GetUserByAuth` across any other code paths that call this method, and confirming ETag caching behavior works as expected.

---

## Release Notes

Added system admin API `GET /api/v4/users/auth_service/{auth_service}/auth_data/{auth_data}` to look up a user by external auth data and auth service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->