### PR TITLE
Skip sqlstore DB setup during go test -list discovery

### DIFF
--- a/e2e-tests/playwright/specs/functional/channels/ai/recaps.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/ai/recaps.spec.ts
@@ -229,14 +229,14 @@ test('moves a recap from unread to read when marked read', {tag: '@ai_recaps'}, 
     await unreadRecap.toBeVisible();
     await unreadRecap.clickMarkRead();
 
-    // * Verify the recap disappears from the Unread tab and appears in the Read tab with unread-only actions removed.
+    // * Verify the recap disappears from the Unread tab and appears in the Read tab with the inline Mark read button removed.
     await recapsPage.expectRecapNotVisible(recapTitle);
     await recapsPage.switchToRead();
 
     const readRecap = recapsPage.getRecap(recapTitle);
     await readRecap.toBeVisible();
     await expect(readRecap.markReadButton).not.toBeVisible();
-    await expect(readRecap.menuButton).not.toBeVisible();
+    await expect(readRecap.menuButton).toBeVisible();
 });
 
 /**

--- a/server/channels/store/sqlstore/main_test.go
+++ b/server/channels/store/sqlstore/main_test.go
@@ -17,6 +17,12 @@ import (
 var mainHelper *testlib.MainHelper
 
 func TestMain(m *testing.M) {
+	flag.Parse()
+
+	if f := flag.Lookup("test.list"); f != nil && f.Value.String() != "" {
+		os.Exit(m.Run())
+	}
+
 	var parallelism int
 	if f := flag.Lookup("test.parallel"); f != nil {
 		parallelism, _ = strconv.Atoi(f.Value.String())

--- a/server/scripts/shard-split.js
+++ b/server/scripts/shard-split.js
@@ -38,12 +38,11 @@ const { execSync } = require("node:child_process");
 
 const SHARD_INDEX = parseInt(process.env.SHARD_INDEX);
 const SHARD_TOTAL = parseInt(process.env.SHARD_TOTAL);
-// Threshold for test-level splitting (aggregated pass time from timing cache).
-// Keep this above sqlstore: its total time can exceed 5 minutes while remaining
-// far below api4/app, and treating sqlstore as "heavy" breaks CI — discovery
-// runs `go test -list` on the GitHub host where TestMain cannot reach postgres
-// on the docker compose network (only api4 and app should need -list splitting).
-const HEAVY_MS = 400000; // 400s (~6.7 min): packages above this get test-level splitting
+const HEAVY_MS = 600000; // 10 min: packages above this get test-level splitting
+// Only api4 (~38 min) and app (~15 min) exceed this threshold.
+// Packages like sqlstore (~3 min) stay whole to preserve test isolation —
+// their integrity tests scan the entire database and break if split across
+// shards where other tests leave data behind.
 
 if (isNaN(SHARD_INDEX) || isNaN(SHARD_TOTAL) || SHARD_TOTAL < 1) {
   console.error("ERROR: SHARD_INDEX and SHARD_TOTAL must be set");


### PR DESCRIPTION
### Overview

The primary fix here is raising `HEAVY_MS` in `shard-split.js` to 10 minutes so the sqlstore package is never classified as a "heavy" package that gets split by test across shards. sqlstore's integrity tests scan the entire database and break when other tests on a sibling shard leave data behind, so the package needs to run whole. #36233 had already bumped the threshold to 6.7 min as a workaround for a related CI break, but left sqlstore close to the line as its timing grows. 10 min gives enough headroom that we don't have to revisit this every time sqlstore adds a few tests, and restores the original rationale comment that was lost in #36233.

While in the area, I also added a `-test.list` bailout to sqlstore's `TestMain`. This isn't strictly necessary now that sqlstore stays out of the heavy bucket, but it fixes a latent issue: #36222 added a bailout in `mainHelper.Main` so `go test -list` skips DB setup on hosts without postgres, but sqlstore calls `sqlstore.InitTest` (which opens postgres and drops tables) *before* `mainHelper.Main` — so the bailout never fired. Adding the same check at the top of `TestMain` means if sqlstore ever does get pulled into heavy-package discovery again, it'll list cleanly.

This fixes an error we're seeing in master C/I runs:
<img width="820" height="297" alt="Screenshot 2026-04-23 at 5 24 13 PM" src="https://github.com/user-attachments/assets/540246fe-d460-476c-983f-4ea2574e9bc0" />

### E2E Test Failure Fix

The `master` branch has a failing E2E test introduced by #35547. The behavior changed, but the test wasn't changed with it. I've included a small change to fix the test: 1d74d62a64e53c1ed6bf9ed2afb4b28f4be4a03c to unblock this PR.

### Release Note

```release-note
NONE
```