### PR TITLE
Automated cherry pick of #36249

### DIFF
--- a/e2e-tests/playwright/specs/functional/channels/ai/recaps.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/ai/recaps.spec.ts
@@ -229,14 +229,14 @@ test('moves a recap from unread to read when marked read', {tag: '@ai_recaps'}, 
     await unreadRecap.toBeVisible();
     await unreadRecap.clickMarkRead();
 
-    // * Verify the recap disappears from the Unread tab and appears in the Read tab with unread-only actions removed.
+    // * Verify the recap disappears from the Unread tab and appears in the Read tab with the inline Mark read button removed.
     await recapsPage.expectRecapNotVisible(recapTitle);
     await recapsPage.switchToRead();
 
     const readRecap = recapsPage.getRecap(recapTitle);
     await readRecap.toBeVisible();
     await expect(readRecap.markReadButton).not.toBeVisible();
-    await expect(readRecap.menuButton).not.toBeVisible();
+    await expect(readRecap.menuButton).toBeVisible();
 });
 
 /**

--- a/e2e-tests/playwright/specs/functional/channels/ai/recaps.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/ai/recaps.spec.ts
@@ -229,14 +229,14 @@ test('moves a recap from unread to read when marked read', {tag: '@ai_recaps'}, 
     await unreadRecap.toBeVisible();
     await unreadRecap.clickMarkRead();
 
-    // * Verify the recap disappears from the Unread tab and appears in the Read tab with the inline Mark read button removed.
+    // * Verify the recap disappears from the Unread tab and appears in the Read tab with unread-only actions removed.
     await recapsPage.expectRecapNotVisible(recapTitle);
     await recapsPage.switchToRead();
 
     const readRecap = recapsPage.getRecap(recapTitle);
     await readRecap.toBeVisible();
     await expect(readRecap.markReadButton).not.toBeVisible();
-    await expect(readRecap.menuButton).toBeVisible();
+    await expect(readRecap.menuButton).not.toBeVisible();
 });
 
 /**

--- a/server/channels/store/sqlstore/main_test.go
+++ b/server/channels/store/sqlstore/main_test.go
@@ -17,6 +17,12 @@ import (
 var mainHelper *testlib.MainHelper
 
 func TestMain(m *testing.M) {
+	flag.Parse()
+
+	if f := flag.Lookup("test.list"); f != nil && f.Value.String() != "" {
+		os.Exit(m.Run())
+	}
+
 	var parallelism int
 	if f := flag.Lookup("test.parallel"); f != nil {
 		parallelism, _ = strconv.Atoi(f.Value.String())

--- a/server/scripts/shard-split.js
+++ b/server/scripts/shard-split.js
@@ -38,12 +38,11 @@ const { execSync } = require("node:child_process");
 
 const SHARD_INDEX = parseInt(process.env.SHARD_INDEX);
 const SHARD_TOTAL = parseInt(process.env.SHARD_TOTAL);
-// Threshold for test-level splitting (aggregated pass time from timing cache).
-// Keep this above sqlstore: its total time can exceed 5 minutes while remaining
-// far below api4/app, and treating sqlstore as "heavy" breaks CI — discovery
-// runs `go test -list` on the GitHub host where TestMain cannot reach postgres
-// on the docker compose network (only api4 and app should need -list splitting).
-const HEAVY_MS = 400000; // 400s (~6.7 min): packages above this get test-level splitting
+const HEAVY_MS = 600000; // 10 min: packages above this get test-level splitting
+// Only api4 (~38 min) and app (~15 min) exceed this threshold.
+// Packages like sqlstore (~3 min) stay whole to preserve test isolation —
+// their integrity tests scan the entire database and break if split across
+// shards where other tests leave data behind.
 
 if (isNaN(SHARD_INDEX) || isNaN(SHARD_TOTAL) || SHARD_TOTAL < 1) {
   console.error("ERROR: SHARD_INDEX and SHARD_TOTAL must be set");


### PR DESCRIPTION
Cherry pick of #36249 on release-11.7.

/cc  @davidkrauser

```release-note
NONE
```