### PR TITLE
Server: Update docs impact prompt

### DIFF
--- a/.github/workflows/docs-impact-review.yml
+++ b/.github/workflows/docs-impact-review.yml
@@ -84,7 +84,7 @@ jobs:
             - `webapp/channels/src/components/` — UI components → end-user guide if user-facing
             - `webapp/channels/src/i18n/` — Internationalization strings → new user-facing strings suggest new features
             - `webapp/platform/` — Platform-level webapp code
-            - `server/Makefile` - changes to plugin version pins starting at line ~155 (major or minor version bumps) indicate plugin releases that may require documentation updates in the integrations or deployment guide
+            - `server/Makefile` - changes to plugin version pins starting at line ~155 may indicate plugin releases that require documentation updates in the integrations or deployment guide
             </monorepo_paths>
  
             <docs_directories>
@@ -122,7 +122,7 @@ jobs:
             Builds integrations, plugins, bots, and custom tools on top of Mattermost.
             - **Reads:** `integrations-guide/`, API reference (`api/v4/source/`)
             - **Cares about:** REST API endpoints, request/response schemas, webhook payloads, WebSocket events, plugin APIs, bot account behavior, OAuth/authentication flows
-            - **Impact signals:** changes to `api4/` handlers, `api/v4/source/` specs, `model/websocket_message.go`, plugin interfaces, major/minor plugin version bumps in `server/Makefile`
+            - **Impact signals:** changes to `api4/` handlers, `api/v4/source/` specs, `model/websocket_message.go`, plugin interfaces
  
             ### Security / Compliance Officer
             Evaluates and enforces security and regulatory requirements.
@@ -143,7 +143,7 @@ jobs:
               - Feature flag changes (new or modified flags in `feature_flags.go` — treat separately from configuration settings; feature flags are not the same as config settings)
               - Audit event changes (new or modified audit event types in `audit_events.go`)
               - Support packet changes (new or modified fields in `support_packet.go`)
-              - Plugin version changes (major or minor version bumps in `server/Makefile` starting around line 155)
+              - Plugin version changes (version bumps in `server/Makefile` starting around line 155)
               - Database schema changes (new migrations)
               - WebSocket event changes
               - CLI command changes
@@ -165,10 +165,19 @@ jobs:
  
             **Important distinctions to apply during analysis:**
  
+            - **The guiding principle for skipping documentation:** docs are **not** needed when the PR does not introduce or change a user/admin capability, documented setting, workflow, UI string, troubleshooting signal, or supported behavior claim. When in doubt, ask: "Would a system administrator, end user, developer, or compliance officer need to read or update any documentation to understand or work with this change?" If no, classify as "No Documentation Changes Needed."
+ 
+            - **Common no-docs-needed patterns** (classify these as "No Documentation Changes Needed" and keep the response brief):
+              - Prepackaged plugin version bumps where no user/admin workflow, configuration option, or observable capability changes — regardless of whether the version bump is major, minor, or patch
+              - Internal performance improvements or implementation-only refactors with no externally observable behavioral change
+              - Developer-facing renames, internal API restructuring, or code organization changes that do not affect product documentation, supported workflows, or any capability visible to admins or end users
+              - Changes where existing documentation already accurately covers the behavior generically and no update is needed to remain accurate
+ 
+            - Plugin version bumps in `server/Makefile`: flag only when the plugin update introduces or changes a user/admin workflow, configuration, UI element, or observable capability. A bump that is purely a prepackaged update with no such change does not require documentation regardless of version magnitude.
+ 
             - Feature flags (`feature_flags.go`) are **not** configuration settings. Do not conflate them. Config settings belong in the admin configuration reference.
-            - Plugin version bumps in `server/Makefile`: only major or minor version changes (e.g. `1.2.x` → `1.3.0` or `2.0.0`) warrant documentation review; patch-only bumps (e.g. `1.2.3` → `1.2.4`) generally do not.
-            - Purely internal security hardening of existing endpoints is generally **not** documentation-worthy.
-            - However, if hardening introduces an externally observable contract change (e.g., new required headers, auth prerequisites, or request constraints), flag it for documentation as an API behavior change without disclosing vulnerability details.
+ 
+            - Purely internal security hardening of existing endpoints is generally **not** documentation-worthy. However, if hardening introduces an externally observable contract change (e.g., new required headers, auth prerequisites, or request constraints), flag it for documentation as an API behavior change without disclosing vulnerability details.
  
             ## Output
  
@@ -205,7 +214,7 @@ jobs:
             ## Rules
  
             - Name exact RST file paths in `./docs/source/` when you find relevant documentation.
-            - Classify as "No Documentation Changes Needed" and keep the response brief when the PR only modifies test files, internal utilities, internal refactors with no behavioral change, CI/build configuration, or purely internal security hardening with no externally observable behavior/contract changes.
+            - Classify as "No Documentation Changes Needed" and keep the response brief when the PR only modifies test files, internal utilities, internal refactors with no behavioral change, CI/build configuration, purely internal security hardening with no externally observable behavior/contract changes, internal performance improvements, implementation-only changes, developer-facing renames with no product impact, or prepackaged plugin version bumps with no user/admin capability or workflow change.
             - When uncertain whether a change needs documentation, recommend a review rather than staying silent.
             - Keep analysis focused and actionable so developers can act on recommendations directly.
             - This is a READ-ONLY analysis except for writing the output file. Never modify source code, push branches, or create PRs.


### PR DESCRIPTION
Updated the server docs impact prompt based on feedback from John.


```release-note
NONE
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This change updates the AI prompt and categorization rules within a GitHub Actions workflow file with no production code implications. The modifications only affect how documentation impact is assessed on future PRs and do not touch any shared utilities, production logic, or critical paths.

**QA Recommendation:** Manual QA of the workflow can be skipped. The changes simply clarify and broaden the criteria for determining when documentation is not needed (removing "major/minor" constraints on plugin version bumps, explicitly including internal performance improvements and implementation-only changes). The workflow itself can be validated through normal PR testing on subsequent pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->