### PR TITLE
Fix FIPS test failures caused by short hardcoded passwords

### DIFF
--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -3973,6 +3973,7 @@ func TestResetPassword(t *testing.T) {
 		return tokenErr == nil
 	}, 10*time.Second, 500*time.Millisecond, "Recovery token not found (%s)", recoveryTokenString)
 
+	newPwd := model.NewTestPassword()
 	resp, err := th.Client.ResetPassword(context.Background(), recoveryToken.Token, "")
 	require.Error(t, err)
 	CheckBadRequestStatus(t, resp)
@@ -3989,16 +3990,16 @@ func TestResetPassword(t *testing.T) {
 	for range model.TokenSize {
 		code.WriteString("a")
 	}
-	resp, err = th.Client.ResetPassword(context.Background(), code.String(), "newpasswd")
+	resp, err = th.Client.ResetPassword(context.Background(), code.String(), newPwd)
 	require.Error(t, err)
 	CheckBadRequestStatus(t, resp)
-	_, err = th.Client.ResetPassword(context.Background(), recoveryToken.Token, "newpasswd")
+	_, err = th.Client.ResetPassword(context.Background(), recoveryToken.Token, newPwd)
 	require.NoError(t, err)
-	_, _, err = th.Client.Login(context.Background(), user.Email, "newpasswd")
+	_, _, err = th.Client.Login(context.Background(), user.Email, newPwd)
 	require.NoError(t, err)
 	_, err = th.Client.Logout(context.Background())
 	require.NoError(t, err)
-	resp, err = th.Client.ResetPassword(context.Background(), recoveryToken.Token, "newpasswd")
+	resp, err = th.Client.ResetPassword(context.Background(), recoveryToken.Token, newPwd)
 	require.Error(t, err)
 	CheckBadRequestStatus(t, resp)
 	authData := model.NewId()
@@ -4028,7 +4029,7 @@ func TestResetPasswordAuditDoesNotLeakToken(t *testing.T) {
 		_ = th.App.Srv().Store().Token().Delete(token.Token)
 	}()
 
-	_, err = th.Client.ResetPassword(context.Background(), token.Token, "newPassword1!")
+	_, err = th.Client.ResetPassword(context.Background(), token.Token, model.NewTestPassword())
 	require.NoError(t, err)
 
 	audits, appErr := th.App.GetAudits(request.EmptyContext(th.TestLogger), "", 100)

--- a/server/channels/app/shared_channel_test.go
+++ b/server/channels/app/shared_channel_test.go
@@ -1334,7 +1334,7 @@ func TestPluginAPIReceiveSharedChannelAttachmentSyncMsg(t *testing.T) {
 		remoteUser := &model.User{
 			Email:    model.NewId() + "@remote.test",
 			Username: "remote-attach-" + model.NewId()[:8],
-			Password: "Password1!",
+			Password: model.NewTestPassword(),
 			RemoteId: model.NewPointer(rc.RemoteId),
 		}
 		remoteUser, appErr := th.App.CreateUser(th.Context, remoteUser)
@@ -1409,7 +1409,7 @@ func TestPluginAPIReceiveSharedChannelProfileImageSyncMsg(t *testing.T) {
 		remoteUser := &model.User{
 			Email:    model.NewId() + "@remote.test",
 			Username: "remote-img-" + model.NewId()[:8],
-			Password: "Password1!",
+			Password: model.NewTestPassword(),
 			RemoteId: model.NewPointer(rc.RemoteId),
 		}
 		remoteUser, appErr := th.App.CreateUser(th.Context, remoteUser)


### PR DESCRIPTION
#### Summary
Three test functions were failing in FIPS builds because they used hardcoded passwords shorter than the 14-character FIPS minimum enforced by `model.NewTestPassword()`:

- `TestResetPassword` — `"newpasswd"` (9 chars), missed when #35905 updated the test suite
- `TestResetPasswordAuditDoesNotLeakToken` — `"newPassword1!"` (13 chars), introduced after #35905 in #35911
- `TestPluginAPIReceiveSharedChannelAttachmentSyncMsg` / `TestPluginAPIReceiveSharedChannelProfileImageSyncMsg` — `"Password1!"` (10 chars), introduced after #35905 in #35962

Replaces all offending literals with `model.NewTestPassword()`.

#### Ticket Link
<!-- none -->

#### Screenshots
<!-- none -->

#### Release Note
```release-note
NONE
```