### PR TITLE
MM-68378: Fix empty error fields and spurious failures for OS/ES bulk deletes

### DIFF
--- a/server/enterprise/elasticsearch/elasticsearch/indexing_job.go
+++ b/server/enterprise/elasticsearch/elasticsearch/indexing_job.go
@@ -64,14 +64,22 @@ func (esi *ElasticsearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 				DocumentID: docID,
 				Body:       body,
 				OnFailure: func(_ context.Context, item esutil.BulkIndexerItem, resp esutil.BulkIndexerResponseItem, err error) {
-					logger.Error("Bulk indexer: failed to index document",
+					fields := []mlog.Field{
 						mlog.String("index", item.Index),
 						mlog.String("doc_id", item.DocumentID),
 						mlog.String("action", item.Action),
-						mlog.String("error_type", resp.Error.Type),
-						mlog.String("error_reason", resp.Error.Reason),
-						mlog.Err(err),
-					)
+						mlog.Int("status", resp.Status),
+					}
+					if resp.Error.Type != "" || resp.Error.Reason != "" {
+						fields = append(fields,
+							mlog.String("error_type", resp.Error.Type),
+							mlog.String("error_reason", resp.Error.Reason),
+						)
+					}
+					if err != nil {
+						fields = append(fields, mlog.Err(err))
+					}
+					logger.Warn("Bulk indexer: failed to index document", fields...)
 				},
 			})
 		},

--- a/server/enterprise/elasticsearch/elasticsearch/indexing_job.go
+++ b/server/enterprise/elasticsearch/elasticsearch/indexing_job.go
@@ -6,6 +6,8 @@ package elasticsearch
 import (
 	"context"
 	"io"
+	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/mattermost/mattermost/server/v8/enterprise/elasticsearch/common"
@@ -34,6 +36,8 @@ func (esi *ElasticsearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 		logger.Error("Worker: Failed to Create Client", mlog.Err(appErr))
 		return nil
 	}
+
+	var realFailed atomic.Int64
 
 	return common.NewIndexerWorker(workerName, model.ElasticsearchSettingsESBackend,
 		esi.Server.Jobs,
@@ -64,6 +68,10 @@ func (esi *ElasticsearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 				DocumentID: docID,
 				Body:       body,
 				OnFailure: func(_ context.Context, item esutil.BulkIndexerItem, resp esutil.BulkIndexerResponseItem, err error) {
+					if item.Action == "delete" && resp.Status == http.StatusNotFound {
+						return
+					}
+					realFailed.Add(1)
 					fields := []mlog.Field{
 						mlog.String("index", item.Index),
 						mlog.String("doc_id", item.DocumentID),
@@ -89,7 +97,8 @@ func (esi *ElasticsearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 			stats := esi.bulkProcessor.Stats()
 			fields := []mlog.Field{
 				mlog.Uint("num_indexed", stats.NumIndexed),
-				mlog.Uint("num_failed", stats.NumFailed),
+				mlog.Int("num_failed", realFailed.Load()),
+				mlog.Uint("stats_num_failed", stats.NumFailed),
 				mlog.Uint("num_added", stats.NumAdded),
 				mlog.Uint("num_flushed", stats.NumFlushed),
 			}
@@ -98,6 +107,6 @@ func (esi *ElasticsearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 			} else {
 				logger.Info("Bulk indexer closed", fields...)
 			}
-			return int64(stats.NumFailed), err
+			return realFailed.Load(), err
 		})
 }

--- a/server/enterprise/elasticsearch/elasticsearch/indexing_job_test.go
+++ b/server/enterprise/elasticsearch/elasticsearch/indexing_job_test.go
@@ -60,6 +60,50 @@ func TestElasticSearchIndexerJobIsEnabled(t *testing.T) {
 	})
 }
 
+// TestElasticsearchDeleteNonExistentDocument verifies that bulk deletes returning
+// 404 (document not found) do not cause the indexing job to fail. A soft-deleted
+// post that was never indexed is used so the delete operation is guaranteed to 404.
+//
+// Requires a running Elasticsearch instance (skipped otherwise).
+func TestElasticsearchDeleteNonExistentDocument(t *testing.T) {
+	th := api4.SetupEnterprise(t).InitBasic(t)
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ElasticsearchSettings.EnableIndexing = true
+		*cfg.ElasticsearchSettings.EnableSearching = true
+		*cfg.ElasticsearchSettings.EnableAutocomplete = true
+		*cfg.SqlSettings.DisableDatabaseSearch = true
+	})
+	th.App.Srv().SetLicense(model.NewTestLicense())
+
+	client := createTestClient(t, th.Context, th.App.Config(), th.App.FileBackend())
+	ctx := context.Background()
+
+	_, err := client.Info().Do(ctx)
+	if err != nil {
+		t.Skipf("Elasticsearch not available at %s: %v", *th.App.Config().ElasticsearchSettings.ConnectionURL, err)
+	}
+
+	// Soft-delete a post so the job issues a bulk delete for it. Since the index
+	// is empty (no prior reindex), the document doesn't exist and ES returns 404.
+	_, appErr := th.App.DeletePost(th.Context, th.BasicPost.Id, th.BasicUser.Id)
+	require.Nil(t, appErr)
+
+	impl := ElasticsearchIndexerInterfaceImpl{Server: th.App.Srv()}
+	worker := impl.MakeWorker()
+	require.NotNil(t, worker)
+	th.Server.Jobs.RegisterJobType(model.JobTypeElasticsearchPostIndexing, worker, nil)
+
+	go worker.Run()
+	defer worker.Stop()
+
+	job, appErr := th.App.Srv().Jobs.CreateJob(th.Context, model.JobTypeElasticsearchPostIndexing, map[string]string{})
+	require.Nil(t, appErr)
+	worker.JobChannel() <- *job
+	job = waitForElasticsearchJob(t, th, job.Id, 60*time.Second)
+	assert.Equal(t, model.JobStatusSuccess, job.Status, "reindex with 404 deletes should succeed")
+}
+
 // TestElasticsearchIndexerBulkWriteFailures verifies that a reindex job is marked
 // as failed when Elasticsearch rejects bulk writes with per-item errors (e.g. a
 // write block on the index), rather than silently reporting success.

--- a/server/enterprise/elasticsearch/opensearch/indexing_job.go
+++ b/server/enterprise/elasticsearch/opensearch/indexing_job.go
@@ -66,19 +66,22 @@ func (esi *OpensearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 				DocumentID: docID,
 				Body:       body,
 				OnFailure: func(_ context.Context, item opensearchutil.BulkIndexerItem, resp opensearchapi.BulkRespItem, err error) {
-					var errType, errReason string
-					if resp.Error != nil {
-						errType = resp.Error.Type
-						errReason = resp.Error.Reason
-					}
-					logger.Error("Bulk indexer: failed to index document",
+					fields := []mlog.Field{
 						mlog.String("index", item.Index),
 						mlog.String("doc_id", item.DocumentID),
 						mlog.String("action", item.Action),
-						mlog.String("error_type", errType),
-						mlog.String("error_reason", errReason),
-						mlog.Err(err),
-					)
+						mlog.Int("status", resp.Status),
+					}
+					if resp.Error != nil {
+						fields = append(fields,
+							mlog.String("error_type", resp.Error.Type),
+							mlog.String("error_reason", resp.Error.Reason),
+						)
+					}
+					if err != nil {
+						fields = append(fields, mlog.Err(err))
+					}
+					logger.Warn("Bulk indexer: failed to index document", fields...)
 				},
 			})
 		},

--- a/server/enterprise/elasticsearch/opensearch/indexing_job.go
+++ b/server/enterprise/elasticsearch/opensearch/indexing_job.go
@@ -6,6 +6,8 @@ package opensearch
 import (
 	"context"
 	"io"
+	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/mattermost/mattermost/server/v8/enterprise/elasticsearch/common"
@@ -35,6 +37,8 @@ func (esi *OpensearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 		logger.Error("Worker: Failed to Create Client", mlog.Err(appErr))
 		return nil
 	}
+
+	var realFailed atomic.Int64
 
 	return common.NewIndexerWorker(workerName, model.ElasticsearchSettingsOSBackend,
 		esi.Server.Jobs,
@@ -66,6 +70,10 @@ func (esi *OpensearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 				DocumentID: docID,
 				Body:       body,
 				OnFailure: func(_ context.Context, item opensearchutil.BulkIndexerItem, resp opensearchapi.BulkRespItem, err error) {
+					if item.Action == "delete" && resp.Status == http.StatusNotFound {
+						return
+					}
+					realFailed.Add(1)
 					fields := []mlog.Field{
 						mlog.String("index", item.Index),
 						mlog.String("doc_id", item.DocumentID),
@@ -91,7 +99,8 @@ func (esi *OpensearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 			stats := esi.bulkProcessor.Stats()
 			fields := []mlog.Field{
 				mlog.Uint("num_indexed", stats.NumIndexed),
-				mlog.Uint("num_failed", stats.NumFailed),
+				mlog.Int("num_failed", realFailed.Load()),
+				mlog.Uint("stats_num_failed", stats.NumFailed),
 				mlog.Uint("num_added", stats.NumAdded),
 				mlog.Uint("num_flushed", stats.NumFlushed),
 			}
@@ -100,6 +109,6 @@ func (esi *OpensearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 			} else {
 				logger.Info("Bulk indexer closed", fields...)
 			}
-			return int64(stats.NumFailed), err
+			return realFailed.Load(), err
 		})
 }

--- a/server/enterprise/elasticsearch/opensearch/indexing_job_test.go
+++ b/server/enterprise/elasticsearch/opensearch/indexing_job_test.go
@@ -62,6 +62,56 @@ func TestOpenSearchIndexerJobIsEnabled(t *testing.T) {
 	})
 }
 
+// TestOpenSearchDeleteNonExistentDocument verifies that bulk deletes returning 404
+// (document not found) do not cause the indexing job to fail. A soft-deleted post
+// that was never indexed is used so the delete operation is guaranteed to 404.
+//
+// Requires a running OpenSearch instance (skipped otherwise).
+func TestOpenSearchDeleteNonExistentDocument(t *testing.T) {
+	th := api4.SetupEnterprise(t).InitBasic(t)
+
+	connURL := "http://localhost:9201"
+	if os.Getenv("IS_CI") == "true" {
+		connURL = "http://opensearch:9201"
+	}
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ElasticsearchSettings.ConnectionURL = connURL
+		*cfg.ElasticsearchSettings.Backend = model.ElasticsearchSettingsOSBackend
+		*cfg.ElasticsearchSettings.EnableIndexing = true
+		*cfg.ElasticsearchSettings.EnableSearching = true
+		*cfg.ElasticsearchSettings.EnableAutocomplete = true
+		*cfg.SqlSettings.DisableDatabaseSearch = true
+	})
+	th.App.Srv().SetLicense(model.NewTestLicense())
+
+	client := createTestClient(t, th.Context, th.App.Config(), th.App.FileBackend())
+
+	_, err := client.Info(context.Background(), nil)
+	if err != nil {
+		t.Skipf("OpenSearch not available at %s: %v", connURL, err)
+	}
+
+	// Soft-delete a post so the job issues a bulk delete for it. Since the index
+	// is empty (no prior reindex), the document doesn't exist and OS returns 404.
+	_, appErr := th.App.DeletePost(th.Context, th.BasicPost.Id, th.BasicUser.Id)
+	require.Nil(t, appErr)
+
+	impl := OpensearchIndexerInterfaceImpl{Server: th.App.Srv()}
+	worker := impl.MakeWorker()
+	require.NotNil(t, worker)
+	th.Server.Jobs.RegisterJobType(model.JobTypeElasticsearchPostIndexing, worker, nil)
+
+	go worker.Run()
+	defer worker.Stop()
+
+	job, appErr := th.App.Srv().Jobs.CreateJob(th.Context, model.JobTypeElasticsearchPostIndexing, map[string]string{})
+	require.Nil(t, appErr)
+	worker.JobChannel() <- *job
+	job = waitForIndexingJob(t, th, job.Id, 60*time.Second)
+	assert.Equal(t, model.JobStatusSuccess, job.Status, "reindex with 404 deletes should succeed")
+}
+
 // TestOpenSearchIndexerBulkWriteFailures verifies that a reindex job is marked as
 // failed when OpenSearch rejects bulk writes with per-item errors (e.g. a write
 // block on the index), rather than silently reporting success.


### PR DESCRIPTION
#### Summary

Follow-up to #36189, which fixed silent bulk indexing failures. Three issues observed after deployment:

1. **Empty error fields** — `OnFailure` can be called with `resp.Error == nil` and `err == nil` when OpenSearch/Elasticsearch rejects a document by HTTP status alone (e.g. 429, 403). The previous code only logged `error_type`/`error_reason` (both empty) and `err` (nil). Now `status` is always logged, and the error detail fields are only appended when present.

2. **Per-item log level** — Per-item `OnFailure` callbacks were logged at `Error`. Since the job-level aggregate is already logged as `Error` (with `num_failed` count) before the job is set to error state, the per-item logs are demoted to `Warn`.

3. **Spurious job failures on delete** — A bulk `delete` for a document that was never indexed returns HTTP 404, which the SDK counts as a failure (`status > 201`). This caused reindex jobs to be marked as error when any soft-deleted post had never been indexed. A `realFailed` atomic counter now tracks only genuine failures; 404 deletes are silently skipped. The close log reports both `num_failed` (from `realFailed`) and `stats_num_failed` (raw SDK count) for reference.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-68495

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes modify the failure counting logic used to determine job completion status (success vs. error). A new `realFailed` atomic counter replaces direct use of `stats.NumFailed`, and 404 responses on delete operations are now skipped rather than counted as failures. This behavioral change directly affects whether indexing jobs are marked as succeeded or failed, which is a critical path decision point. However, the change is narrowly scoped to only Elasticsearch/OpenSearch indexing jobs, and comprehensive integration tests validate the new 404-skip behavior.

**QA Recommendation:** Standard regression testing recommended for bulk indexing workflows with both Elasticsearch and OpenSearch backends, particularly scenarios involving document deletions and failure recovery. The new integration tests provide good coverage of the 404-delete scenario, but manual testing of end-to-end indexing job workflows and job status reporting would be beneficial to validate no edge cases are impacted by the failure counting change.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->