### PR TITLE
[MM-68460] Reorder channel banner

### DIFF
--- a/webapp/channels/src/components/channel_view/channel_view.tsx
+++ b/webapp/channels/src/components/channel_view/channel_view.tsx
@@ -219,8 +219,8 @@ export default class ChannelView extends React.PureComponent<Props, State> {
                     id={DropOverlayIdCenterChannel}
                 />
                 <ChannelHeader/>
-                {this.props.isChannelBookmarksEnabled && <ChannelBookmarks channelId={this.props.channelId}/>}
                 <ChannelBanner channelId={this.props.channelId}/>
+                {this.props.isChannelBookmarksEnabled && <ChannelBookmarks channelId={this.props.channelId}/>}
                 <DeferredPostView
                     channelId={this.props.channelId}
                     focusedPostId={this.state.focusedPostId}


### PR DESCRIPTION
#### Summary

This change moves the channel banner above the bookmarks bar.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-68460

#### Release Note

```release-note
NONE
```

#### Screenshot

<img width="1346" height="1048" alt="Screenshot 2026-04-24 at 3 59 41 PM" src="https://github.com/user-attachments/assets/24fef398-86ef-4f4a-8b0b-9517ed6344ce" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This is a pure UI component reordering with no functional changes—ChannelBookmarks is simply moved from after ChannelHeader to after ChannelBanner. No state mutations, conditional logic modifications, prop alterations, or side effects are introduced. The component retains the same condition (`isChannelBookmarksEnabled`) and props (`channelId`).

**QA Recommendation:** Minimal manual QA required. Snapshot tests should validate the render order, and given the isolated nature of this change (single component, no logic changes), focus manual testing on visual layout verification only.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->