### PR TITLE
Fix web app run script crashing

### DIFF
--- a/webapp/platform/shared/package.json
+++ b/webapp/platform/shared/package.json
@@ -104,7 +104,7 @@
     "check:stylelint": "stylelint \"**/*.{css,scss}\"",
     "check-types": "tsc -b",
     "fix": "eslint --ext .js,.jsx,.tsx,.ts ./src --quiet --fix && stylelint \"**/*.{css,scss}\" --fix",
-    "run": "parcel watch",
+    "run": "parcel watch --watch-dir .",
     "test": "jest",
     "test-ci": "jest --ci --forceExit --detectOpenHandles --maxWorkers=100% --logHeapUsage",
     "clean": "rm -rf dist node_modules *.tsbuildinfo .parcel-cache"


### PR DESCRIPTION
#### Summary
`npm run run` sometimes crashes on first launch because the shared package's Parcel instance watches the whole web app folder by default instead of just the shared package files. During that first launch, enough stuff is built that causes the Parcel instance to give a warning about missing file system events which then causes `concurrently` to error out.

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This change is isolated to a single npm development script for the shared package and does not affect any production code, shared utilities, base classes, or runtime behavior. The modification constrains Parcel's file watching to the current directory, preventing file system events from propagating to unrelated parts of the build system.

**QA Recommendation:** Minimal manual QA required. Verify that `npm run run` in the shared package launches without crashing on first execution and that the Parcel watch task starts successfully.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->