### PR TITLE
fix(mmctl): lengthen sampledata passwords to meet FIPS minimum

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -562,7 +562,7 @@ inject-test-data: # add test data to the local instance.
 	@echo You may need to restart the Mattermost server before using the following
 	@echo ========================================================================
 	@echo Login with a system admin account username=sysadmin password=Sys@dmin-sample1
-	@echo Login with a regular account username=user-1 password=SampleUs@r-1
+	@echo Login with a regular account username=user-1 password=SampleUs@r-001
 	@echo ========================================================================
 
 test-mmctl-unit: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)

--- a/server/cmd/mmctl/commands/sampledata_util.go
+++ b/server/cmd/mmctl/commands/sampledata_util.go
@@ -116,19 +116,19 @@ func createUser(idx int, teamMemberships int, channelMemberships int, teamsAndCh
 
 	switch userType {
 	case guestUser:
-		password = fmt.Sprintf("SampleGu@st-%d", idx)
+		password = fmt.Sprintf("SampleGu@st-%03d", idx)
 		email = fmt.Sprintf("guest-%d@sample.mattermost.com", idx)
 		roles = "system_guest"
 		if idx == 0 {
 			username = "guest"
-			password = "SampleGu@st1"
+			password = "SampleGu@st-001"
 			email = "guest@sample.mattermost.com"
 		}
 	case deactivatedUser:
 		password = fmt.Sprintf("SampleDe@ctivated-%d", idx)
 		email = fmt.Sprintf("deactivated-%d@sample.mattermost.com", idx)
 	default:
-		password = fmt.Sprintf("SampleUs@r-%d", idx)
+		password = fmt.Sprintf("SampleUs@r-%03d", idx)
 		email = fmt.Sprintf("user-%d@sample.mattermost.com", idx)
 		if idx == 0 {
 			username = "sysadmin"

--- a/server/cmd/mmctl/commands/sampledata_util_test.go
+++ b/server/cmd/mmctl/commands/sampledata_util_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateUserPasswordLength ensures all generated sampledata passwords meet the
+// FIPS minimum length requirement (14 chars) for every user type and index range.
+func TestCreateUserPasswordLength(t *testing.T) {
+	const minLen = model.PasswordFIPSMinimumLength
+
+	indices := []int{0, 1, 9, 10, 99, 100, 999, 1000}
+	userTypes := []string{guestUser, deactivatedUser, ""}
+
+	for _, userType := range userTypes {
+		for _, idx := range indices {
+			data := createUser(idx, 0, 0, map[string][]string{}, nil, userType)
+			pwd := *data.User.Password
+			require.GreaterOrEqualf(t, len(pwd), minLen,
+				"password %q (userType=%q idx=%d) is shorter than FIPS minimum %d",
+				pwd, userType, idx, minLen)
+		}
+	}
+}


### PR DESCRIPTION
#### Summary

`mmctl sampledata` generated passwords as short as 12 chars (e.g. `SampleUs@r-1`, `SampleGu@st1`). When `PasswordSettings.MinimumLength` is 14 — the default under FIPS builds (`requirefips` tag, enforced in #35905) — these fail server-side validation and the import fails.

Fix: zero-pad the index to 3 digits (`%d` → `%03d`) so every generated password is ≥ 14 chars. Also updates the `inject-test-data` Makefile echo and adds a regression test covering all user types × index edge cases (0, 1, 9, 10, 99, 100, 999, 1000).

QA steps:
1. Build with `requirefips` tag (or set `PasswordSettings.MinimumLength = 14` in config)
2. Run `mmctl sampledata --local`
3. Verify import succeeds and users are created with the new passwords (`SampleUs@r-001`, `SampleGu@st-001`, etc.)

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-68498

#### Screenshots

N/A

#### Release Note
```release-note
Fixed mmctl sampledata generating passwords shorter than the FIPS minimum length of 14 characters.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to the mmctl sampledata utility function (`createUser`) and Makefile echo text. The modification only affects password format during sample data generation (zero-padding user index from `%d` to `%03d`), with no impact on core authentication, user persistence, or production logic. A new regression test comprehensively validates all user types and index edge cases.

**QA Recommendation:** Minimal manual QA required. The comprehensive new unit test (`TestCreateUserPasswordLength`) covers all user type and index combinations, and the change is functionally straightforward (password string formatting). Automated testing validates the fix meets FIPS minimum length requirements. Only smoke-test QA needed: verify `mmctl sampledata --local` succeeds with the new password format under FIPS-enabled builds.

---

**Release Note:**
Fixed mmctl sampledata generating passwords shorter than the FIPS minimum length of 14 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->