### PR TITLE
Fix Ctrl+Shift+V plain text paste being linkified (#36206)

### DIFF
--- a/webapp/channels/src/utils/paste.test.tsx
+++ b/webapp/channels/src/utils/paste.test.tsx
@@ -239,15 +239,21 @@ jest.mock('utils/exec_commands', () => ({
 }));
 
 describe('pasteHandler', () => {
-    const testCases = [
+    beforeEach(() => {
+        (execCommandInsertText as jest.Mock).mockClear();
+    });
+
+    const githubHtml = '<table class="highlight tab-size js-file-line-container" data-tab-size="8"><tbody><tr><td id="LC1" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">//</span> a javascript codeblock example</span></td></tr><tr><td id="L2" class="blob-num js-line-number" data-line-number="2">&nbsp;</td><td id="LC2" class="blob-code blob-code-inner js-file-line"><span class="pl-k">if</span> (<span class="pl-c1">1</span> <span class="pl-k">&gt;</span> <span class="pl-c1">0</span>) {</td></tr><tr><td id="L3" class="blob-num js-line-number" data-line-number="3">&nbsp;</td><td id="LC3" class="blob-code blob-code-inner js-file-line"><span class="pl-en">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">\'</span>condition is true<span class="pl-pds">\'</span></span>);</td></tr><tr><td id="L4" class="blob-num js-line-number" data-line-number="4">&nbsp;</td><td id="LC4" class="blob-code blob-code-inner js-file-line">}</td></tr></tbody></table>';
+    const githubPlain = "// a javascript codeblock example\nif (1 > 0) {\n  return 'condition is true';\n}";
+
+    // ── Formatted paste (normal Ctrl+V) ──────────────────────────────────────
+    const formattedTestCases = [
         {
             testName: 'should be able to format a pasted markdown table',
             clipboardData: {
                 items: [1],
                 types: ['text/html'],
-                getData: () => {
-                    return '<table><tr><th>test</th><th>test</th></tr><tr><td>test</td><td>test</td></tr></table>';
-                },
+                getData: () => '<table><tr><th>test</th><th>test</th></tr><tr><td>test</td><td>test</td></tr></table>',
             },
             expectedMarkdown: '| test | test |\n| --- | --- |\n| test | test |',
         },
@@ -256,9 +262,7 @@ describe('pasteHandler', () => {
             clipboardData: {
                 items: [1],
                 types: ['text/html'],
-                getData: () => {
-                    return '<table><tr><td>test</td><td>test</td></tr><tr><td>test</td><td>test</td></tr></table>';
-                },
+                getData: () => '<table><tr><td>test</td><td>test</td></tr><tr><td>test</td><td>test</td></tr></table>',
             },
             expectedMarkdown: '| test | test |\n| --- | --- |\n| test | test |\n',
         },
@@ -267,9 +271,7 @@ describe('pasteHandler', () => {
             clipboardData: {
                 items: [1],
                 types: ['text/html'],
-                getData: () => {
-                    return '<a href="https://test.domain">link text</a>';
-                },
+                getData: () => '<a href="https://test.domain">link text</a>',
             },
             expectedMarkdown: '[link text](https://test.domain)',
         },
@@ -278,18 +280,33 @@ describe('pasteHandler', () => {
             clipboardData: {
                 items: [1],
                 types: ['text/plain', 'text/html'],
-                getData: (type: string) => {
-                    if (type === 'text/plain') {
-                        return '// a javascript codeblock example\nif (1 > 0) {\n  return \'condition is true\';\n}';
-                    }
-                    return '<table class="highlight tab-size js-file-line-container" data-tab-size="8"><tbody><tr><td id="LC1" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">//</span> a javascript codeblock example</span></td></tr><tr><td id="L2" class="blob-num js-line-number" data-line-number="2">&nbsp;</td><td id="LC2" class="blob-code blob-code-inner js-file-line"><span class="pl-k">if</span> (<span class="pl-c1">1</span> <span class="pl-k">&gt;</span> <span class="pl-c1">0</span>) {</td></tr><tr><td id="L3" class="blob-num js-line-number" data-line-number="3">&nbsp;</td><td id="LC3" class="blob-code blob-code-inner js-file-line"><span class="pl-en">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">\'</span>condition is true<span class="pl-pds">\'</span></span>);</td></tr><tr><td id="L4" class="blob-num js-line-number" data-line-number="4">&nbsp;</td><td id="LC4" class="blob-code blob-code-inner js-file-line">}</td></tr></tbody></table>';
-                },
+                getData: (type: string) => (type === 'text/plain' ? githubPlain : githubHtml),
             },
             expectedMarkdown: "```\n// a javascript codeblock example\nif (1 > 0) {\n  return 'condition is true';\n}\n```",
         },
-        {
-            testName: 'should paste table as plain text when shift is held',
-            isNonFormattedPaste: true,
+    ];
+
+    for (const tc of formattedTestCases) {
+        it(tc.testName, () => {
+            const event: any = {
+                target: {id: 'reply_textbox', selectionStart: 0, selectionEnd: 0},
+                preventDefault: jest.fn(),
+                clipboardData: tc.clipboardData,
+            };
+
+            pasteHandler(event, Locations.RHS_COMMENT, '', false);
+
+            expect(event.preventDefault).toHaveBeenCalled();
+            expect(execCommandInsertText).toHaveBeenCalledWith(tc.expectedMarkdown);
+        });
+    }
+
+    // ── Non-formatted paste (Ctrl+Shift+V) ───────────────────────────────────
+
+    it('should paste table as plain text when shift is held', () => {
+        const event: any = {
+            target: {id: 'reply_textbox', selectionStart: 0, selectionEnd: 0},
+            preventDefault: jest.fn(),
             clipboardData: {
                 items: [1],
                 types: ['text/plain', 'text/html'],
@@ -300,45 +317,108 @@ describe('pasteHandler', () => {
                     return '<table><tr><th>test</th>\n<th>test</th>\n</tr>\n<tr>\n<td>test</td>\n<td>test</td></tr></table>';
                 },
             },
-            expectedMarkdown: 'test \ttest\ntest \ttest',
-        },
-        {
-            testName: 'should paste github code as plain text when shift is held',
-            isNonFormattedPaste: true,
+        };
+
+        pasteHandler(event, Locations.RHS_COMMENT, '', true);
+
+        // plain text is available — must preventDefault and insert plain text
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(execCommandInsertText).toHaveBeenCalledWith('test \ttest\ntest \ttest');
+    });
+
+    it('should paste github code as plain text when shift is held', () => {
+        const event: any = {
+            target: {id: 'reply_textbox', selectionStart: 0, selectionEnd: 0},
+            preventDefault: jest.fn(),
+            clipboardData: {
+                items: [1],
+                types: ['text/plain', 'text/html'],
+                getData: (type: string) => (type === 'text/plain' ? githubPlain : githubHtml),
+            },
+        };
+
+        pasteHandler(event, Locations.RHS_COMMENT, '', true);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(execCommandInsertText).toHaveBeenCalledWith(githubPlain);
+    });
+
+    it('should paste HTML hyperlink as plain text when Ctrl+Shift+V is used', () => {
+        const event: any = {
+            target: {id: 'reply_textbox', selectionStart: 0, selectionEnd: 0},
+            preventDefault: jest.fn(),
             clipboardData: {
                 items: [1],
                 types: ['text/plain', 'text/html'],
                 getData: (type: string) => {
-                    if (type === 'text/plain') {
-                        return '// a javascript codeblock example\nif (1 > 0) {\n  return \'condition is true\';\n}';
-                    }
-                    return '<table class="highlight tab-size js-file-line-container" data-tab-size="8"><tbody><tr><td id="LC1" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">//</span> a javascript codeblock example</span></td></tr><tr><td id="L2" class="blob-num js-line-number" data-line-number="2">&nbsp;</td><td id="LC2" class="blob-code blob-code-inner js-file-line"><span class="pl-k">if</span> (<span class="pl-c1">1</span> <span class="pl-k">&gt;</span> <span class="pl-c1">0</span>) {</td></tr><tr><td id="L3" class="blob-num js-line-number" data-line-number="3">&nbsp;</td><td id="LC3" class="blob-code blob-code-inner js-file-line"><span class="pl-en">console</span>.<span class="pl-c1">log</span>(<span class="pl-s"><span class="pl-pds">\'</span>condition is true<span class="pl-pds">\'</span></span>);</td></tr><tr><td id="L4" class="blob-num js-line-number" data-line-number="4">&nbsp;</td><td id="LC4" class="blob-code blob-code-inner js-file-line">}</td></tr></tbody></table>';
+                    if (type === 'text/plain') { return 'link text'; }
+                    return '<a href="https://test.domain">link text</a>';
                 },
             },
-            expectedMarkdown: '// a javascript codeblock example\nif (1 > 0) {\n  return \'condition is true\';\n}',
-        },
-    ];
+        };
 
-    for (const tc of testCases) {
-        it(tc.testName, () => {
-            const location = Locations.RHS_COMMENT;
-            const event: any = {
-                target: {
-                    id: 'reply_textbox',
+        pasteHandler(event, Locations.RHS_COMMENT, '', true);
+
+        // Must insert raw plain text, NOT [link text](https://test.domain)
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(execCommandInsertText).toHaveBeenCalledWith('link text');
+    });
+
+    it('should not preventDefault when clipboard has no plain text (HTML-only payload)', () => {
+        // Edge case from CodeRabbit review: if text/plain is empty,
+        // do not swallow the paste — let the browser handle it.
+        const event: any = {
+            target: {id: 'reply_textbox', selectionStart: 0, selectionEnd: 0},
+            preventDefault: jest.fn(),
+            clipboardData: {
+                items: [1],
+                types: ['text/html'],
+                getData: (type: string) => {
+                    if (type === 'text/plain') { return ''; }
+                    return '<a href="https://test.domain">link text</a>';
                 },
-                preventDefault: jest.fn(),
-                clipboardData: tc.clipboardData,
-            };
+            },
+        };
 
-            pasteHandler(event, location, '', tc.isNonFormattedPaste ?? false);
+        pasteHandler(event, Locations.RHS_COMMENT, '', true);
 
-            if (tc.isNonFormattedPaste) {
-                expect(execCommandInsertText).not.toHaveBeenCalled();
-            } else {
-                expect(execCommandInsertText).toHaveBeenCalledWith(tc.expectedMarkdown);
-            }
-        });
-    }
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect(execCommandInsertText).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing for an unknown target', () => {
+        const event: any = {
+            target: {id: 'some_other_input', selectionStart: 0, selectionEnd: 0},
+            preventDefault: jest.fn(),
+            clipboardData: {
+                items: [1],
+                types: ['text/html'],
+                getData: () => '<a href="https://x.com">X</a>',
+            },
+        };
+
+        pasteHandler(event, Locations.CENTER, '', false);
+
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect(execCommandInsertText).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when clipboard contains only plain text with no HTML', () => {
+        const event: any = {
+            target: {id: 'post_textbox', selectionStart: 0, selectionEnd: 0},
+            preventDefault: jest.fn(),
+            clipboardData: {
+                items: [1],
+                types: ['text/plain'],
+                getData: () => 'just some words',
+            },
+        };
+
+        pasteHandler(event, Locations.CENTER, '', false);
+
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect(execCommandInsertText).not.toHaveBeenCalled();
+    });
 });
 
 describe('hasPlainText', () => {

--- a/webapp/channels/src/utils/paste.tsx
+++ b/webapp/channels/src/utils/paste.tsx
@@ -209,15 +209,13 @@ export function pasteHandler(
     // Only intercept when content would be transformed
     const shouldIntercept = htmlTable || hasHTMLLinks || shouldApplyLinkMarkdown;
 
-    // Handle plain-text paste ONLY when we would otherwise modify content
+    
     if (isNonFormattedPaste && shouldIntercept) {
-        event.preventDefault();
-
         const plainText = clipboardData.getData('text/plain');
         if (plainText) {
+            event.preventDefault();
             execCommandInsertText(plainText);
         }
-
         return;
     }
 

--- a/webapp/channels/src/utils/paste.tsx
+++ b/webapp/channels/src/utils/paste.tsx
@@ -176,9 +176,17 @@ export function isKnownTargetForPaste(event: ClipboardEvent, location: string, i
     return isKnownTarget;
 }
 
-export function pasteHandler(event: ClipboardEvent, location: string, message: string, isNonFormattedPaste: boolean, isInEditMode?: boolean) {
+export function pasteHandler(
+    event: ClipboardEvent,
+    location: string,
+    message: string,
+    isNonFormattedPaste: boolean,
+    isInEditMode?: boolean,
+): void {
     const isKnownTarget = isKnownTargetForPaste(event, location, isInEditMode);
-    if (!isKnownTarget || isNonFormattedPaste) {
+
+    // Not our textbox let other handlers deal with it.
+    if (!isKnownTarget) {
         return;
     }
 
@@ -190,28 +198,58 @@ export function pasteHandler(event: ClipboardEvent, location: string, message: s
 
     const {selectionStart, selectionEnd} = target as TextboxElement;
 
-    const hasSelection = !isNil(selectionStart) && !isNil(selectionEnd) && selectionStart < selectionEnd;
-    const hasTextUrl = isTextUrl(clipboardData);
     const hasHTMLLinks = hasHtmlLink(clipboardData);
     const htmlTable = getHtmlTable(clipboardData);
+    const hasSelection = !isNil(selectionStart) && !isNil(selectionEnd) && selectionStart < selectionEnd;
+    const hasTextUrl = isTextUrl(clipboardData);
+
     const shouldApplyLinkMarkdown = hasSelection && hasTextUrl;
     const shouldApplyGithubCodeBlock = htmlTable && isGitHubCodeBlock(htmlTable.className);
 
-    if (!htmlTable && !hasHTMLLinks && !shouldApplyLinkMarkdown) {
+    // Only intercept when content would be transformed
+    const shouldIntercept = htmlTable || hasHTMLLinks || shouldApplyLinkMarkdown;
+
+    // Handle plain-text paste ONLY when we would otherwise modify content
+    if (isNonFormattedPaste && shouldIntercept) {
+        event.preventDefault();
+
+        const plainText = clipboardData.getData('text/plain');
+        if (plainText) {
+            execCommandInsertText(plainText);
+        }
+
+        return;
+    }
+
+    // Nothing special → let browser handle normally
+    if (!shouldIntercept) {
         return;
     }
 
     event.preventDefault();
 
-    // execCommand's insertText' triggers a 'change' event, hence we need not set respective state explicitly.
     if (shouldApplyLinkMarkdown) {
-        const formattedLink = formatMarkdownLinkMessage({selectionStart, selectionEnd, message, clipboardData});
+        const formattedLink = formatMarkdownLinkMessage({
+            selectionStart: selectionStart!,
+            selectionEnd: selectionEnd!,
+            message,
+            clipboardData,
+        });
         execCommandInsertText(formattedLink);
     } else if (shouldApplyGithubCodeBlock) {
-        const {formattedCodeBlock} = formatGithubCodePaste({selectionStart, selectionEnd, message, clipboardData});
+        const {formattedCodeBlock} = formatGithubCodePaste({
+            selectionStart,
+            selectionEnd,
+            message,
+            clipboardData,
+        });
         execCommandInsertText(formattedCodeBlock);
     } else {
-        const {formattedMarkdown} = formatMarkdownMessage(clipboardData, message, selectionStart ?? message.length);
+        const {formattedMarkdown} = formatMarkdownMessage(
+            clipboardData,
+            message,
+            selectionStart ?? message.length,
+        );
         execCommandInsertText(formattedMarkdown);
     }
 }
@@ -246,3 +284,4 @@ export function createFileFromClipboardDataItem(item: DataTransferItem, fileName
 
     return new File([file as Blob], name, {type: file.type});
 }
+

--- a/webapp/channels/src/utils/paste.tsx
+++ b/webapp/channels/src/utils/paste.tsx
@@ -11,10 +11,25 @@ import {DEFAULT_PLACEHOLDER_URL} from 'utils/markdown/apply_markdown';
 import {splitMessageBasedOnCaretPosition, splitMessageBasedOnTextSelection} from 'utils/post_utils';
 import turndownService from 'utils/turndown';
 
+/**
+ * Parses an HTML string and returns the first <table> element found, or null.
+ *
+ * @param html - Raw HTML string to parse.
+ * @returns The first HTMLTableElement in the parsed document, or null if none exists.
+ */
 export function parseHtmlTable(html: string): HTMLTableElement | null {
     return new DOMParser().parseFromString(html, 'text/html').querySelector('table');
 }
 
+/**
+ * Extracts an HTML table element from clipboard data, if present.
+ *
+ * Returns null if the clipboard does not contain 'text/html' or if
+ * the HTML does not include a <table> element.
+ *
+ * @param clipboardData - The DataTransfer object from a paste event.
+ * @returns The first HTMLTableElement found in the clipboard HTML, or null.
+ */
 export function getHtmlTable(clipboardData: DataTransfer): HTMLTableElement | null {
     // Check if clipboard data has html as one of its types
     if (Array.from(clipboardData.types).indexOf('text/html') === -1) {
@@ -35,15 +50,36 @@ export function getHtmlTable(clipboardData: DataTransfer): HTMLTableElement | nu
     return table;
 }
 
+/**
+ * Checks whether the clipboard data contains HTML with at least one hyperlink (<a> tag).
+ *
+ * @param clipboardData - The DataTransfer object from a paste event.
+ * @returns True if the clipboard contains 'text/html' with an anchor tag, false otherwise.
+ */
 export function hasHtmlLink(clipboardData: DataTransfer): boolean {
     return Array.from(clipboardData.types).includes('text/html') && (/<a/i).test(clipboardData.getData('text/html'));
 }
 
+/**
+ * Determines whether a table's CSS class name indicates it is a GitHub code block.
+ *
+ * GitHub code blocks are rendered as HTML tables with class names containing
+ * 'js-', 'blob-', or 'diff-' prefixes.
+ *
+ * @param tableClassName - The className string of the HTML table element.
+ * @returns True if the class name matches a known GitHub code block pattern.
+ */
 export function isGitHubCodeBlock(tableClassName: string): boolean {
     const result = (/\b(js|blob|diff)-./).test(tableClassName);
     return result;
 }
 
+/**
+ * Checks whether the plain text content of the clipboard is a URL.
+ *
+ * @param clipboardData - The DataTransfer object from a paste event.
+ * @returns True if the plain text starts with 'http://' or 'https://'.
+ */
 export function isTextUrl(clipboardData: DataTransfer): boolean {
     const clipboardText = clipboardData.getData('text/plain');
     return clipboardText.startsWith('http://') || clipboardText.startsWith('https://');
@@ -61,6 +97,12 @@ export function hasPlainText(clipboardData: DataTransfer): boolean {
     return false;
 }
 
+/**
+ * Returns true if the given HTML table has no header cells (<th>).
+ *
+ * @param table - The HTMLTableElement to inspect.
+ * @returns True if the table contains zero <th> elements.
+ */
 function isTableWithoutHeaderRow(table: HTMLTableElement): boolean {
     return table.querySelectorAll('th').length === 0;
 }
@@ -160,6 +202,18 @@ export function formatMarkdownLinkMessage({message, clipboardData, selectionStar
     return markdownLink;
 }
 
+/**
+ * Determines whether a paste event is targeting a known Mattermost textbox element.
+ *
+ * Checks the event target's ID against expected textbox IDs based on the
+ * current location (center channel, RHS comment) and whether the user is
+ * in edit mode.
+ *
+ * @param event - The ClipboardEvent fired by the browser.
+ * @param location - The current UI location (e.g. Locations.CENTER, Locations.RHS_COMMENT).
+ * @param isInEditMode - Whether the user is currently editing an existing post.
+ * @returns True if the event target is a recognised Mattermost input element.
+ */
 export function isKnownTargetForPaste(event: ClipboardEvent, location: string, isInEditMode?: boolean): boolean {
     let isKnownTarget = false;
 
@@ -176,6 +230,23 @@ export function isKnownTargetForPaste(event: ClipboardEvent, location: string, i
     return isKnownTarget;
 }
 
+/**
+ * Central paste event handler for Mattermost message inputs.
+ *
+ * Intercepts paste events when the content would be transformed (HTML tables,
+ * HTML hyperlinks, URL-over-selection markdown links). When the user invokes
+ * plain-text paste (Ctrl+Shift+V, isNonFormattedPaste=true) and plain text is
+ * available, the browser default is suppressed and the raw text/plain value is
+ * inserted instead. If no transformation is needed, the event is left for the
+ * browser to handle natively.
+ *
+ * @param event - The ClipboardEvent fired by the browser.
+ * @param location - The current UI location (e.g. Locations.CENTER, Locations.RHS_COMMENT).
+ * @param message - The current draft message string in the input.
+ * @param isNonFormattedPaste - True when the user pressed Ctrl+Shift+V (paste as plain text).
+ * @param isInEditMode - Whether the user is editing an existing post.
+ * @returns void
+ */
 export function pasteHandler(
     event: ClipboardEvent,
     location: string,
@@ -209,7 +280,6 @@ export function pasteHandler(
     // Only intercept when content would be transformed
     const shouldIntercept = htmlTable || hasHTMLLinks || shouldApplyLinkMarkdown;
 
-    
     if (isNonFormattedPaste && shouldIntercept) {
         const plainText = clipboardData.getData('text/plain');
         if (plainText) {
@@ -252,6 +322,17 @@ export function pasteHandler(
     }
 }
 
+/**
+ * Creates a named File object from a DataTransferItem.
+ *
+ * If the item has no file name, a timestamped name is generated using
+ * the provided prefix and the item's MIME type as the extension.
+ * Returns null if the item cannot be converted to a File.
+ *
+ * @param item - The DataTransferItem to convert.
+ * @param fileNamePrefixIfNoName - Prefix used when generating a fallback filename.
+ * @returns A File object, or null if the item has no associated file.
+ */
 export function createFileFromClipboardDataItem(item: DataTransferItem, fileNamePrefixIfNoName: string): File | null {
     const file = item.getAsFile();
 
@@ -282,4 +363,3 @@ export function createFileFromClipboardDataItem(item: DataTransferItem, fileName
 
     return new File([file as Blob], name, {type: file.type});
 }
-


### PR DESCRIPTION
## Summary

Fixes #36206

When a user copies text from a webpage that contains hyperlinks and presses
Ctrl+Shift+V (paste as plain text), Mattermost was still converting those
links into markdown [text](url) format instead of pasting the raw plain text.
This was especially broken in Firefox.

## Root Cause

In `channels/src/utils/paste.tsx`, the `pasteHandler` function had an early
return when `isNonFormattedPaste` was true — but it returned *without* calling
`event.preventDefault()`. This meant:

- The browser (especially Firefox) would still paste its own rich HTML version
- The linkification path could still run due to flag timing issues between the
  keydown event and the paste event firing

## What This PR Does

Refactors `pasteHandler` to introduce a clear `shouldIntercept` flag that
covers all cases where paste content would be transformed (HTML tables, HTML
links, URL-over-selection markdown links).

- If `isNonFormattedPaste` is true AND `shouldIntercept` is true → call
  `event.preventDefault()` and insert `text/plain` from the clipboard directly
  via `execCommandInsertText`. This guarantees plain text is always inserted,
  regardless of browser.
- If `shouldIntercept` is false → let the browser handle the paste natively
- If the target is not a known textbox → exit immediately without touching
  the event

## Steps to Reproduce (from issue)

1. Copy some text from a website that includes a hyperlink
2. In Mattermost, press Ctrl+Shift+V to paste as plain text
3. **Before fix:** link gets converted to `[text](url)` markdown
4. **After fix:** raw plain text is pasted, no linkification

## Affected Browsers

Primarily reported on Firefox, but the fix applies consistently across
all browsers since we now explicitly control what gets inserted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change modifies central paste handling logic (channels/src/utils/paste.tsx), changing when event.preventDefault() is called and introducing a unified shouldIntercept flow; this could impact edge-case clipboard contents, non-text targets, or timing-sensitive browser behaviors and may expose untested branches.  
**QA Recommendation:** Perform manual QA across major browsers (Firefox, Chrome, Safari) and scenarios: Ctrl+Shift+V plain-text paste, Ctrl+V formatted paste, HTML links, HTML tables, GitHub-style code blocks, mixed-content clipboards, edit mode vs new message, and non-textbox paste targets to ensure no regressions.

```release-note
Fixed an issue where Ctrl+Shift+V (paste as plain text) would still
convert hyperlinks into markdown format instead of pasting raw text,
particularly in Firefox.
```

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->