### PR TITLE
Remove unused property fields index

### DIFF
--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -337,5 +337,5 @@ channels/db/migrations/postgres/000169_create_linked_field_id_index.down.sql
 channels/db/migrations/postgres/000169_create_linked_field_id_index.up.sql
 channels/db/migrations/postgres/000170_add_property_groups_version.down.sql
 channels/db/migrations/postgres/000170_add_property_groups_version.up.sql
-channels/db/migrations/postgres/000171_drop_property_fields_protected_index.up.sql
 channels/db/migrations/postgres/000171_drop_property_fields_protected_index.down.sql
+channels/db/migrations/postgres/000171_drop_property_fields_protected_index.up.sql

--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -337,3 +337,5 @@ channels/db/migrations/postgres/000169_create_linked_field_id_index.down.sql
 channels/db/migrations/postgres/000169_create_linked_field_id_index.up.sql
 channels/db/migrations/postgres/000170_add_property_groups_version.down.sql
 channels/db/migrations/postgres/000170_add_property_groups_version.up.sql
+channels/db/migrations/postgres/000171_drop_property_fields_protected_index.up.sql
+channels/db/migrations/postgres/000171_drop_property_fields_protected_index.down.sql

--- a/server/channels/db/migrations/postgres/000165_add_protected_and_permissions_to_property_fields.down.sql
+++ b/server/channels/db/migrations/postgres/000165_add_protected_and_permissions_to_property_fields.down.sql
@@ -1,5 +1,3 @@
-DROP INDEX IF EXISTS idx_propertyfields_protected;
-
 ALTER TABLE PropertyFields
 DROP COLUMN IF EXISTS PermissionOptions,
 DROP COLUMN IF EXISTS PermissionValues,

--- a/server/channels/db/migrations/postgres/000165_add_protected_and_permissions_to_property_fields.up.sql
+++ b/server/channels/db/migrations/postgres/000165_add_protected_and_permissions_to_property_fields.up.sql
@@ -15,7 +15,3 @@ ADD COLUMN IF NOT EXISTS Protected BOOLEAN NOT NULL DEFAULT FALSE,
 ADD COLUMN IF NOT EXISTS PermissionField permission_level,
 ADD COLUMN IF NOT EXISTS PermissionValues permission_level,
 ADD COLUMN IF NOT EXISTS PermissionOptions permission_level;
-
-CREATE INDEX IF NOT EXISTS idx_propertyfields_protected
-    ON PropertyFields (Protected)
-    WHERE Protected = true;

--- a/server/channels/db/migrations/postgres/000171_drop_property_fields_protected_index.up.sql
+++ b/server/channels/db/migrations/postgres/000171_drop_property_fields_protected_index.up.sql
@@ -1,0 +1,2 @@
+-- morph:nontransactional
+DROP INDEX CONCURRENTLY IF EXISTS idx_propertyfields_protected;


### PR DESCRIPTION
#### Summary
Removes unused protected property fields index

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68524

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Minimal risk as this PR removes only an unused database index on the PropertyFields table. The index was previously created but not referenced in application logic, so its removal should not break any existing behavior. The migration includes proper rollback capability and follows database best practices with concurrent index dropping.

**QA Recommendation:** Manual QA can be skipped. Automated testing of database migrations should be sufficient given that this is a straightforward index removal with no schema structural changes or code logic alterations. Verify that migration executes cleanly in staging environments and that PropertyFields queries continue to execute as expected.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->