### PR TITLE
Automated cherry pick of #36264

### DIFF
--- a/server/enterprise/elasticsearch/elasticsearch/indexing_job.go
+++ b/server/enterprise/elasticsearch/elasticsearch/indexing_job.go
@@ -6,6 +6,8 @@ package elasticsearch
 import (
 	"context"
 	"io"
+	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/mattermost/mattermost/server/v8/enterprise/elasticsearch/common"
@@ -34,6 +36,8 @@ func (esi *ElasticsearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 		logger.Error("Worker: Failed to Create Client", mlog.Err(appErr))
 		return nil
 	}
+
+	var realFailed atomic.Int64
 
 	return common.NewIndexerWorker(workerName, model.ElasticsearchSettingsESBackend,
 		esi.Server.Jobs,
@@ -64,14 +68,26 @@ func (esi *ElasticsearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 				DocumentID: docID,
 				Body:       body,
 				OnFailure: func(_ context.Context, item esutil.BulkIndexerItem, resp esutil.BulkIndexerResponseItem, err error) {
-					logger.Error("Bulk indexer: failed to index document",
+					if item.Action == "delete" && resp.Status == http.StatusNotFound {
+						return
+					}
+					realFailed.Add(1)
+					fields := []mlog.Field{
 						mlog.String("index", item.Index),
 						mlog.String("doc_id", item.DocumentID),
 						mlog.String("action", item.Action),
-						mlog.String("error_type", resp.Error.Type),
-						mlog.String("error_reason", resp.Error.Reason),
-						mlog.Err(err),
-					)
+						mlog.Int("status", resp.Status),
+					}
+					if resp.Error.Type != "" || resp.Error.Reason != "" {
+						fields = append(fields,
+							mlog.String("error_type", resp.Error.Type),
+							mlog.String("error_reason", resp.Error.Reason),
+						)
+					}
+					if err != nil {
+						fields = append(fields, mlog.Err(err))
+					}
+					logger.Warn("Bulk indexer: failed to index document", fields...)
 				},
 			})
 		},
@@ -81,7 +97,8 @@ func (esi *ElasticsearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 			stats := esi.bulkProcessor.Stats()
 			fields := []mlog.Field{
 				mlog.Uint("num_indexed", stats.NumIndexed),
-				mlog.Uint("num_failed", stats.NumFailed),
+				mlog.Int("num_failed", realFailed.Load()),
+				mlog.Uint("stats_num_failed", stats.NumFailed),
 				mlog.Uint("num_added", stats.NumAdded),
 				mlog.Uint("num_flushed", stats.NumFlushed),
 			}
@@ -90,6 +107,6 @@ func (esi *ElasticsearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 			} else {
 				logger.Info("Bulk indexer closed", fields...)
 			}
-			return int64(stats.NumFailed), err
+			return realFailed.Load(), err
 		})
 }

--- a/server/enterprise/elasticsearch/elasticsearch/indexing_job_test.go
+++ b/server/enterprise/elasticsearch/elasticsearch/indexing_job_test.go
@@ -60,6 +60,50 @@ func TestElasticSearchIndexerJobIsEnabled(t *testing.T) {
 	})
 }
 
+// TestElasticsearchDeleteNonExistentDocument verifies that bulk deletes returning
+// 404 (document not found) do not cause the indexing job to fail. A soft-deleted
+// post that was never indexed is used so the delete operation is guaranteed to 404.
+//
+// Requires a running Elasticsearch instance (skipped otherwise).
+func TestElasticsearchDeleteNonExistentDocument(t *testing.T) {
+	th := api4.SetupEnterprise(t).InitBasic(t)
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ElasticsearchSettings.EnableIndexing = true
+		*cfg.ElasticsearchSettings.EnableSearching = true
+		*cfg.ElasticsearchSettings.EnableAutocomplete = true
+		*cfg.SqlSettings.DisableDatabaseSearch = true
+	})
+	th.App.Srv().SetLicense(model.NewTestLicense())
+
+	client := createTestClient(t, th.Context, th.App.Config(), th.App.FileBackend())
+	ctx := context.Background()
+
+	_, err := client.Info().Do(ctx)
+	if err != nil {
+		t.Skipf("Elasticsearch not available at %s: %v", *th.App.Config().ElasticsearchSettings.ConnectionURL, err)
+	}
+
+	// Soft-delete a post so the job issues a bulk delete for it. Since the index
+	// is empty (no prior reindex), the document doesn't exist and ES returns 404.
+	_, appErr := th.App.DeletePost(th.Context, th.BasicPost.Id, th.BasicUser.Id)
+	require.Nil(t, appErr)
+
+	impl := ElasticsearchIndexerInterfaceImpl{Server: th.App.Srv()}
+	worker := impl.MakeWorker()
+	require.NotNil(t, worker)
+	th.Server.Jobs.RegisterJobType(model.JobTypeElasticsearchPostIndexing, worker, nil)
+
+	go worker.Run()
+	defer worker.Stop()
+
+	job, appErr := th.App.Srv().Jobs.CreateJob(th.Context, model.JobTypeElasticsearchPostIndexing, map[string]string{})
+	require.Nil(t, appErr)
+	worker.JobChannel() <- *job
+	job = waitForElasticsearchJob(t, th, job.Id, 60*time.Second)
+	assert.Equal(t, model.JobStatusSuccess, job.Status, "reindex with 404 deletes should succeed")
+}
+
 // TestElasticsearchIndexerBulkWriteFailures verifies that a reindex job is marked
 // as failed when Elasticsearch rejects bulk writes with per-item errors (e.g. a
 // write block on the index), rather than silently reporting success.

--- a/server/enterprise/elasticsearch/opensearch/indexing_job.go
+++ b/server/enterprise/elasticsearch/opensearch/indexing_job.go
@@ -6,6 +6,8 @@ package opensearch
 import (
 	"context"
 	"io"
+	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/mattermost/mattermost/server/v8/enterprise/elasticsearch/common"
@@ -35,6 +37,8 @@ func (esi *OpensearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 		logger.Error("Worker: Failed to Create Client", mlog.Err(appErr))
 		return nil
 	}
+
+	var realFailed atomic.Int64
 
 	return common.NewIndexerWorker(workerName, model.ElasticsearchSettingsOSBackend,
 		esi.Server.Jobs,
@@ -66,19 +70,26 @@ func (esi *OpensearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 				DocumentID: docID,
 				Body:       body,
 				OnFailure: func(_ context.Context, item opensearchutil.BulkIndexerItem, resp opensearchapi.BulkRespItem, err error) {
-					var errType, errReason string
-					if resp.Error != nil {
-						errType = resp.Error.Type
-						errReason = resp.Error.Reason
+					if item.Action == "delete" && resp.Status == http.StatusNotFound {
+						return
 					}
-					logger.Error("Bulk indexer: failed to index document",
+					realFailed.Add(1)
+					fields := []mlog.Field{
 						mlog.String("index", item.Index),
 						mlog.String("doc_id", item.DocumentID),
 						mlog.String("action", item.Action),
-						mlog.String("error_type", errType),
-						mlog.String("error_reason", errReason),
-						mlog.Err(err),
-					)
+						mlog.Int("status", resp.Status),
+					}
+					if resp.Error != nil {
+						fields = append(fields,
+							mlog.String("error_type", resp.Error.Type),
+							mlog.String("error_reason", resp.Error.Reason),
+						)
+					}
+					if err != nil {
+						fields = append(fields, mlog.Err(err))
+					}
+					logger.Warn("Bulk indexer: failed to index document", fields...)
 				},
 			})
 		},
@@ -88,7 +99,8 @@ func (esi *OpensearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 			stats := esi.bulkProcessor.Stats()
 			fields := []mlog.Field{
 				mlog.Uint("num_indexed", stats.NumIndexed),
-				mlog.Uint("num_failed", stats.NumFailed),
+				mlog.Int("num_failed", realFailed.Load()),
+				mlog.Uint("stats_num_failed", stats.NumFailed),
 				mlog.Uint("num_added", stats.NumAdded),
 				mlog.Uint("num_flushed", stats.NumFlushed),
 			}
@@ -97,6 +109,6 @@ func (esi *OpensearchIndexerInterfaceImpl) MakeWorker() model.Worker {
 			} else {
 				logger.Info("Bulk indexer closed", fields...)
 			}
-			return int64(stats.NumFailed), err
+			return realFailed.Load(), err
 		})
 }

--- a/server/enterprise/elasticsearch/opensearch/indexing_job_test.go
+++ b/server/enterprise/elasticsearch/opensearch/indexing_job_test.go
@@ -62,6 +62,56 @@ func TestOpenSearchIndexerJobIsEnabled(t *testing.T) {
 	})
 }
 
+// TestOpenSearchDeleteNonExistentDocument verifies that bulk deletes returning 404
+// (document not found) do not cause the indexing job to fail. A soft-deleted post
+// that was never indexed is used so the delete operation is guaranteed to 404.
+//
+// Requires a running OpenSearch instance (skipped otherwise).
+func TestOpenSearchDeleteNonExistentDocument(t *testing.T) {
+	th := api4.SetupEnterprise(t).InitBasic(t)
+
+	connURL := "http://localhost:9201"
+	if os.Getenv("IS_CI") == "true" {
+		connURL = "http://opensearch:9201"
+	}
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ElasticsearchSettings.ConnectionURL = connURL
+		*cfg.ElasticsearchSettings.Backend = model.ElasticsearchSettingsOSBackend
+		*cfg.ElasticsearchSettings.EnableIndexing = true
+		*cfg.ElasticsearchSettings.EnableSearching = true
+		*cfg.ElasticsearchSettings.EnableAutocomplete = true
+		*cfg.SqlSettings.DisableDatabaseSearch = true
+	})
+	th.App.Srv().SetLicense(model.NewTestLicense())
+
+	client := createTestClient(t, th.Context, th.App.Config(), th.App.FileBackend())
+
+	_, err := client.Info(context.Background(), nil)
+	if err != nil {
+		t.Skipf("OpenSearch not available at %s: %v", connURL, err)
+	}
+
+	// Soft-delete a post so the job issues a bulk delete for it. Since the index
+	// is empty (no prior reindex), the document doesn't exist and OS returns 404.
+	_, appErr := th.App.DeletePost(th.Context, th.BasicPost.Id, th.BasicUser.Id)
+	require.Nil(t, appErr)
+
+	impl := OpensearchIndexerInterfaceImpl{Server: th.App.Srv()}
+	worker := impl.MakeWorker()
+	require.NotNil(t, worker)
+	th.Server.Jobs.RegisterJobType(model.JobTypeElasticsearchPostIndexing, worker, nil)
+
+	go worker.Run()
+	defer worker.Stop()
+
+	job, appErr := th.App.Srv().Jobs.CreateJob(th.Context, model.JobTypeElasticsearchPostIndexing, map[string]string{})
+	require.Nil(t, appErr)
+	worker.JobChannel() <- *job
+	job = waitForIndexingJob(t, th, job.Id, 60*time.Second)
+	assert.Equal(t, model.JobStatusSuccess, job.Status, "reindex with 404 deletes should succeed")
+}
+
 // TestOpenSearchIndexerBulkWriteFailures verifies that a reindex job is marked as
 // failed when OpenSearch rejects bulk writes with per-item errors (e.g. a write
 // block on the index), rather than silently reporting success.


### PR DESCRIPTION
Cherry pick of #36264 on release-11.7.

/cc  @lieut-data

```release-note
NONE
```