### PR TITLE
MM-68526: Harden remote cluster patch response

### DIFF
--- a/server/channels/api4/remote_cluster.go
+++ b/server/channels/api4/remote_cluster.go
@@ -660,10 +660,10 @@ func patchRemoteCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	updatedRC.Sanitize()
+
 	auditRec.Success()
 	auditRec.AddEventResultState(updatedRC)
-
-	updatedRC.Sanitize()
 
 	if err := json.NewEncoder(w).Encode(updatedRC); err != nil {
 		c.Logger.Warn("Error while writing response", mlog.Err(err))

--- a/server/channels/api4/remote_cluster.go
+++ b/server/channels/api4/remote_cluster.go
@@ -663,6 +663,8 @@ func patchRemoteCluster(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.Success()
 	auditRec.AddEventResultState(updatedRC)
 
+	updatedRC.Sanitize()
+
 	if err := json.NewEncoder(w).Encode(updatedRC); err != nil {
 		c.Logger.Warn("Error while writing response", mlog.Err(err))
 	}

--- a/server/channels/api4/remote_cluster_test.go
+++ b/server/channels/api4/remote_cluster_test.go
@@ -545,9 +545,10 @@ func TestGenerateRemoteClusterInvite(t *testing.T) {
 func TestGetRemoteCluster(t *testing.T) {
 	mainHelper.Parallel(t)
 	newRC := &model.RemoteCluster{
-		Name:    "remotecluster",
-		SiteURL: "http://example.com",
-		Token:   model.NewId(),
+		Name:        "remotecluster",
+		SiteURL:     "http://example.com",
+		Token:       model.NewId(),
+		RemoteToken: model.NewId(),
 	}
 
 	t.Run("Should not work if the remote cluster service is not enabled", func(t *testing.T) {
@@ -596,6 +597,7 @@ func TestGetRemoteCluster(t *testing.T) {
 		require.Equal(t, rc.RemoteId, fetchedRC.RemoteId)
 		require.Equal(t, th.BasicTeam.Id, fetchedRC.DefaultTeamId)
 		require.Empty(t, fetchedRC.Token)
+		require.Empty(t, fetchedRC.RemoteToken)
 	})
 }
 
@@ -646,6 +648,7 @@ func TestPatchRemoteCluster(t *testing.T) {
 		DisplayName: "initialvalue",
 		SiteURL:     "http://example.com",
 		Token:       model.NewId(),
+		RemoteToken: model.NewId(),
 	}
 
 	rcp := &model.RemoteClusterPatch{DisplayName: model.NewPointer("different value")}
@@ -699,6 +702,8 @@ func TestPatchRemoteCluster(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "patched!", patchedRC.DisplayName)
 		require.Equal(t, newTeamId, patchedRC.DefaultTeamId)
+		require.Empty(t, patchedRC.Token)
+		require.Empty(t, patchedRC.RemoteToken)
 	})
 }
 


### PR DESCRIPTION
#### Summary
Hardened the remote cluster patch response handling and added focused regression coverage for sanitized remote cluster API responses.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-68526

#### Screenshots
N/A. No UI changes.

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change is a small, localized hardening that only adds sanitization of the patched RemoteCluster prior to auditing and JSON encoding; it does not alter control flow, persistence, or shared utilities, and tests were extended to cover the sanitized fields. Risk of regressions is minimal and confined to the PATCH remote cluster endpoint response formatting.

**QA Recommendation:** Minimal manual QA — a quick smoke test of the PATCH remote cluster endpoint to confirm responses remain functional is sufficient given the added automated tests verifying Token and RemoteToken are sanitized.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->