### PR TITLE
[MM-68535] Invalidate channel cache after policy assignment

### DIFF
--- a/server/channels/api4/access_control_test.go
+++ b/server/channels/api4/access_control_test.go
@@ -435,6 +435,15 @@ func TestDeleteAccessControlPolicy(t *testing.T) {
 
 		mockAccessControlService := &mocks.AccessControlServiceInterface{}
 		th.App.Srv().Channels().AccessControl = mockAccessControlService
+		// DeleteAccessControlPolicy resolves the policy first to decide
+		// whether to broadcast a channel access control update; return a
+		// parent policy so the channel-update path is not exercised here.
+		parentPolicy := &model.AccessControlPolicy{
+			ID:      samplePolicyID,
+			Type:    model.AccessControlPolicyTypeParent,
+			Version: model.AccessControlPolicyVersionV0_3,
+		}
+		mockAccessControlService.On("GetPolicy", mock.AnythingOfType("*request.Context"), samplePolicyID).Return(parentPolicy, nil).Times(1)
 		mockAccessControlService.On("DeletePolicy", mock.AnythingOfType("*request.Context"), samplePolicyID).Return(nil).Times(1)
 
 		th.App.UpdateConfig(func(cfg *model.Config) {

--- a/server/channels/app/access_control.go
+++ b/server/channels/app/access_control.go
@@ -17,6 +17,7 @@ import (
 )
 
 const attributeViewRefreshInterval = 30 * time.Second
+const accessControlChildPolicySearchLimit = 1000
 
 func (a *App) GetChannelsForPolicy(rctx request.CTX, policyID string, cursor model.AccessControlPolicyCursor, limit int) ([]*model.ChannelWithTeamData, int64, *model.AppError) {
 	policy, appErr := a.GetAccessControlPolicy(rctx, policyID)
@@ -100,8 +101,11 @@ func (a *App) CreateOrUpdateAccessControlPolicy(rctx request.CTX, policy *model.
 		return nil, appErr
 	}
 
-	if policy.Type == model.AccessControlPolicyTypeChannel {
+	switch policy.Type {
+	case model.AccessControlPolicyTypeChannel:
 		a.publishChannelPolicyEnforcedUpdate(rctx, policy.ID)
+	case model.AccessControlPolicyTypeParent:
+		a.publishChannelPolicyEnforcedForChannelPoliciesWithImport(rctx, policy.ID)
 	}
 
 	return policy, nil
@@ -121,12 +125,19 @@ func (a *App) DeleteAccessControlPolicy(rctx request.CTX, id string) *model.AppE
 		return appErr
 	}
 
+	var affectedChannelIDs []string
+	if policy != nil && policy.Type != model.AccessControlPolicyTypeChannel {
+		affectedChannelIDs = a.channelPolicyIDsWithImport(rctx, id)
+	}
+
 	if appErr := acs.DeletePolicy(rctx, id); appErr != nil {
 		return appErr
 	}
 
 	if policy != nil && policy.Type == model.AccessControlPolicyTypeChannel {
 		a.publishChannelPolicyEnforcedUpdate(rctx, id)
+	} else if policy.Type == model.AccessControlPolicyTypeParent {
+		a.publishChannelPolicyEnforcedUpdatesForChannels(rctx, affectedChannelIDs)
 	}
 
 	return nil
@@ -343,6 +354,14 @@ func (a *App) UpdateAccessControlPoliciesActive(rctx request.CTX, updates []mode
 	if err != nil {
 		return nil, model.NewAppError("UpdateAccessControlPoliciesActive", "app.pap.update_access_control_policies_active.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
+
+	for _, policy := range policies {
+		// only channel policies use the active state
+		if policy.Type == model.AccessControlPolicyTypeChannel {
+			a.publishChannelPolicyEnforcedUpdate(rctx, policy.ID)
+		}
+	}
+
 	return policies, nil
 }
 
@@ -360,6 +379,56 @@ func (a *App) ExpressionToVisualAST(rctx request.CTX, expression string) (*model
 	return visualAST, nil
 }
 
+// publishChannelPolicyEnforcedForChannelPoliciesWithImport broadcasts
+// channel_access_control_updated for every channel-type policy that lists
+// importID in its imports. Call only after the imported policy (parent,
+// permission, etc.) is persisted.
+func (a *App) publishChannelPolicyEnforcedForChannelPoliciesWithImport(rctx request.CTX, importID string) {
+	a.publishChannelPolicyEnforcedUpdatesForChannels(rctx, a.channelPolicyIDsWithImport(rctx, importID))
+}
+
+func (a *App) publishChannelPolicyEnforcedUpdatesForChannels(rctx request.CTX, channelIDs []string) {
+	seen := make(map[string]struct{}, len(channelIDs))
+	for _, channelID := range channelIDs {
+		if channelID == "" {
+			continue
+		}
+		if _, ok := seen[channelID]; ok {
+			continue
+		}
+		seen[channelID] = struct{}{}
+		a.publishChannelPolicyEnforcedUpdate(rctx, channelID)
+	}
+}
+
+func (a *App) channelPolicyIDsWithImport(rctx request.CTX, importID string) []string {
+	channelIDs := []string{}
+	var cursor model.AccessControlPolicyCursor
+	for {
+		children, _, err := a.Srv().Store().AccessControlPolicy().SearchPolicies(rctx, model.AccessControlPolicySearch{
+			Type:     model.AccessControlPolicyTypeChannel,
+			ParentID: importID,
+			Cursor:   cursor,
+			Limit:    accessControlChildPolicySearchLimit,
+		})
+		if err != nil {
+			rctx.Logger().Warn("Failed to list channel policies that import a policy; skipping channel access control fan-out",
+				mlog.String("imported_policy_id", importID),
+				mlog.Err(err),
+			)
+			return channelIDs
+		}
+		for _, child := range children {
+			channelIDs = append(channelIDs, child.ID)
+		}
+		if len(children) < accessControlChildPolicySearchLimit {
+			break
+		}
+		cursor.ID = children[len(children)-1].ID
+	}
+	return channelIDs
+}
+
 // publishChannelPolicyEnforcedUpdate invalidates the channel cache for the
 // given channel ID and broadcasts a channel_access_control_updated websocket
 // event so that connected clients can refresh their view of the channel's
@@ -367,8 +436,7 @@ func (a *App) ExpressionToVisualAST(rctx request.CTX, expression string) (*model
 // attributes used by the policy). A dedicated event is used rather than
 // channel_updated because this is fired on every policy mutation and clients
 // only need to refresh access control state — not run the full
-// channel_updated reducer/router pipeline. It is best-effort: failures to
-// load or marshal the channel are logged but do not affect the caller.
+// channel_updated reducer/router pipeline.
 func (a *App) publishChannelPolicyEnforcedUpdate(rctx request.CTX, channelID string) {
 	a.Srv().Store().Channel().InvalidateChannel(channelID)
 

--- a/server/channels/app/access_control.go
+++ b/server/channels/app/access_control.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"slices"
@@ -99,6 +100,10 @@ func (a *App) CreateOrUpdateAccessControlPolicy(rctx request.CTX, policy *model.
 		return nil, appErr
 	}
 
+	if policy.Type == model.AccessControlPolicyTypeChannel {
+		a.publishChannelPolicyEnforcedUpdate(rctx, policy.ID)
+	}
+
 	return policy, nil
 }
 
@@ -108,9 +113,20 @@ func (a *App) DeleteAccessControlPolicy(rctx request.CTX, id string) *model.AppE
 		return model.NewAppError("DeleteAccessControlPolicy", "app.pap.delete_access_control_policy.app_error", nil, "Policy Administration Point is not initialized", http.StatusNotImplemented)
 	}
 
-	appErr := acs.DeletePolicy(rctx, id)
+	// Resolve the policy first so we know whether to broadcast a channel
+	// access control update after deletion (channel-type policies share the
+	// channel's ID, so we can use the policy ID as the channel ID).
+	policy, appErr := acs.GetPolicy(rctx, id)
 	if appErr != nil {
 		return appErr
+	}
+
+	if appErr := acs.DeletePolicy(rctx, id); appErr != nil {
+		return appErr
+	}
+
+	if policy != nil && policy.Type == model.AccessControlPolicyTypeChannel {
+		a.publishChannelPolicyEnforcedUpdate(rctx, id)
 	}
 
 	return nil
@@ -194,6 +210,7 @@ func (a *App) AssignAccessControlPolicyToChannels(rctx request.CTX, parentID str
 		if appErr != nil {
 			return nil, appErr
 		}
+		a.publishChannelPolicyEnforcedUpdate(rctx, child.ID)
 		policies = append(policies, child)
 	}
 
@@ -239,14 +256,15 @@ func (a *App) UnassignPoliciesFromChannels(rctx request.CTX, policyID string, ch
 			if err := acs.DeletePolicy(rctx, child.ID); err != nil {
 				return model.NewAppError("UnassignPoliciesFromChannels", "app.pap.unassign_access_control_policy_from_channels.app_error", nil, err.Error(), http.StatusInternalServerError)
 			}
-			// invalidate the channel cache
-			a.Srv().Store().Channel().InvalidateChannel(channelID)
+			// invalidate the channel cache and broadcast the policy change
+			a.publishChannelPolicyEnforcedUpdate(rctx, channelID)
 			continue
 		}
 		_, appErr = acs.SavePolicy(rctx, child)
 		if appErr != nil {
 			return model.NewAppError("UnassignPoliciesFromChannels", "app.pap.unassign_access_control_policy_from_channels.app_error", nil, appErr.Error(), http.StatusInternalServerError)
 		}
+		a.publishChannelPolicyEnforcedUpdate(rctx, channelID)
 	}
 
 	return nil
@@ -340,6 +358,41 @@ func (a *App) ExpressionToVisualAST(rctx request.CTX, expression string) (*model
 	}
 
 	return visualAST, nil
+}
+
+// publishChannelPolicyEnforcedUpdate invalidates the channel cache for the
+// given channel ID and broadcasts a channel_access_control_updated websocket
+// event so that connected clients can refresh their view of the channel's
+// access control state (e.g. the policy_enforced flag and the set of
+// attributes used by the policy). A dedicated event is used rather than
+// channel_updated because this is fired on every policy mutation and clients
+// only need to refresh access control state — not run the full
+// channel_updated reducer/router pipeline. It is best-effort: failures to
+// load or marshal the channel are logged but do not affect the caller.
+func (a *App) publishChannelPolicyEnforcedUpdate(rctx request.CTX, channelID string) {
+	a.Srv().Store().Channel().InvalidateChannel(channelID)
+
+	channel, appErr := a.GetChannel(rctx, channelID)
+	if appErr != nil {
+		rctx.Logger().Warn("Failed to load channel after access control policy change",
+			mlog.String("channel_id", channelID),
+			mlog.Err(appErr),
+		)
+		return
+	}
+
+	channelJSON, jsonErr := json.Marshal(channel)
+	if jsonErr != nil {
+		rctx.Logger().Warn("Failed to marshal channel after access control policy change",
+			mlog.String("channel_id", channelID),
+			mlog.Err(jsonErr),
+		)
+		return
+	}
+
+	messageWs := model.NewWebSocketEvent(model.WebsocketEventChannelAccessControlUpdated, "", channel.Id, "", nil, "")
+	messageWs.Add("channel", string(channelJSON))
+	a.Publish(messageWs)
 }
 
 // ValidateChannelEligibilityForAccessControl checks that a channel is eligible for

--- a/server/channels/app/access_control_test.go
+++ b/server/channels/app/access_control_test.go
@@ -606,6 +606,9 @@ func TestUnassignPoliciesFromChannels(t *testing.T) {
 		mockStore.On("Channel").Return(&mockChannelStore)
 		// Expect InvalidateChannel to be called
 		mockChannelStore.On("InvalidateChannel", channelID).Once()
+		// publishChannelPolicyEnforcedUpdate calls Channel().Get(...) to load
+		// the fresh channel (with PolicyEnforced computed) for the WS payload.
+		mockChannelStore.On("Get", channelID, true).Return(&model.Channel{Id: channelID, Type: model.ChannelTypePrivate}, nil).Once()
 
 		mockAccessControl := &mocks.AccessControlServiceInterface{}
 		thMock.App.Srv().ch.AccessControl = mockAccessControl

--- a/server/channels/app/access_control_test.go
+++ b/server/channels/app/access_control_test.go
@@ -105,6 +105,213 @@ func TestCreateOrUpdateAccessControlPolicy(t *testing.T) {
 		require.NotNil(t, result)
 		mockAccessControl.AssertExpectations(t)
 	})
+
+	t.Run("Channel-type policy broadcasts policy enforced update", func(t *testing.T) {
+		thMock := SetupWithStoreMock(t)
+
+		channelID := model.NewId()
+		channelPolicy := &model.AccessControlPolicy{
+			ID:   channelID,
+			Type: model.AccessControlPolicyTypeChannel,
+			Rules: []model.AccessControlPolicyRule{
+				{Actions: []string{model.AccessControlPolicyActionMembership}, Expression: "true"},
+			},
+		}
+
+		mockStore := thMock.App.Srv().Store().(*storemocks.Store)
+		mockChannelStore := storemocks.ChannelStore{}
+		mockStore.On("Channel").Return(&mockChannelStore)
+		// publishChannelPolicyEnforcedUpdate is expected to invalidate the
+		// channel cache and reload the channel for the WS payload.
+		mockChannelStore.On("InvalidateChannel", channelID).Once()
+		mockChannelStore.On("Get", channelID, true).Return(&model.Channel{Id: channelID, Type: model.ChannelTypePrivate}, nil).Once()
+
+		mockAccessControl := &mocks.AccessControlServiceInterface{}
+		thMock.App.Srv().ch.AccessControl = mockAccessControl
+		mockAccessControl.On("SavePolicy", thMock.Context, mock.MatchedBy(func(p *model.AccessControlPolicy) bool {
+			return p.ID == channelID && p.Type == model.AccessControlPolicyTypeChannel
+		})).Return(channelPolicy, nil).Once()
+
+		result, err := thMock.App.CreateOrUpdateAccessControlPolicy(thMock.Context, channelPolicy)
+		require.Nil(t, err)
+		require.NotNil(t, result)
+
+		mockAccessControl.AssertExpectations(t)
+		mockChannelStore.AssertCalled(t, "InvalidateChannel", channelID)
+		mockChannelStore.AssertCalled(t, "Get", channelID, true)
+	})
+
+	t.Run("Parent-type policy does not broadcast channel-only update", func(t *testing.T) {
+		thMock := SetupWithStoreMock(t)
+
+		parentID := model.NewId()
+		parentPolicy := &model.AccessControlPolicy{
+			ID:   parentID,
+			Type: model.AccessControlPolicyTypeParent,
+			Name: "parent-no-broadcast",
+			Rules: []model.AccessControlPolicyRule{
+				{Actions: []string{model.AccessControlPolicyActionMembership}, Expression: "true"},
+			},
+		}
+
+		mockStore := thMock.App.Srv().Store().(*storemocks.Store)
+		mockChannelStore := storemocks.ChannelStore{}
+		mockStore.On("Channel").Return(&mockChannelStore).Maybe()
+
+		// publishChannelPolicyEnforcedForChannelPoliciesWithImport iterates
+		// over child channel policies; with no children there is no fan-out
+		// to channel cache invalidation.
+		mockACPStore := storemocks.AccessControlPolicyStore{}
+		mockStore.On("AccessControlPolicy").Return(&mockACPStore)
+		mockACPStore.On("SearchPolicies", thMock.Context, mock.MatchedBy(func(s model.AccessControlPolicySearch) bool {
+			return s.Type == model.AccessControlPolicyTypeChannel && s.ParentID == parentID
+		})).Return([]*model.AccessControlPolicy{}, int64(0), nil)
+
+		mockAccessControl := &mocks.AccessControlServiceInterface{}
+		thMock.App.Srv().ch.AccessControl = mockAccessControl
+		mockAccessControl.On("SavePolicy", thMock.Context, mock.Anything).Return(parentPolicy, nil).Once()
+
+		result, err := thMock.App.CreateOrUpdateAccessControlPolicy(thMock.Context, parentPolicy)
+		require.Nil(t, err)
+		require.NotNil(t, result)
+
+		mockChannelStore.AssertNotCalled(t, "InvalidateChannel", mock.Anything)
+		mockChannelStore.AssertNotCalled(t, "Get", mock.Anything, mock.Anything)
+	})
+}
+
+func TestDeleteAccessControlPolicy(t *testing.T) {
+	t.Run("Feature not enabled", func(t *testing.T) {
+		th := Setup(t).InitBasic(t)
+		th.App.Srv().ch.AccessControl = nil
+
+		appErr := th.App.DeleteAccessControlPolicy(th.Context, model.NewId())
+		require.NotNil(t, appErr)
+		require.Equal(t, http.StatusNotImplemented, appErr.StatusCode)
+	})
+
+	t.Run("GetPolicy error is propagated", func(t *testing.T) {
+		th := Setup(t).InitBasic(t)
+
+		policyID := model.NewId()
+		mockAccessControl := &mocks.AccessControlServiceInterface{}
+		th.App.Srv().ch.AccessControl = mockAccessControl
+		expectedErr := model.NewAppError("GetPolicy", "app.pap.get_policy.app_error", nil, "boom", http.StatusInternalServerError)
+		mockAccessControl.On("GetPolicy", th.Context, policyID).Return(nil, expectedErr).Once()
+
+		appErr := th.App.DeleteAccessControlPolicy(th.Context, policyID)
+		require.NotNil(t, appErr)
+		require.Equal(t, expectedErr.Id, appErr.Id)
+		mockAccessControl.AssertNotCalled(t, "DeletePolicy", mock.Anything, mock.Anything)
+	})
+
+	t.Run("Channel-type policy invalidates cache and broadcasts update", func(t *testing.T) {
+		thMock := SetupWithStoreMock(t)
+
+		channelID := model.NewId()
+		channelPolicy := &model.AccessControlPolicy{
+			ID:      channelID,
+			Type:    model.AccessControlPolicyTypeChannel,
+			Version: model.AccessControlPolicyVersionV0_3,
+			Rules: []model.AccessControlPolicyRule{
+				{Actions: []string{model.AccessControlPolicyActionMembership}, Expression: "true"},
+			},
+		}
+
+		mockStore := thMock.App.Srv().Store().(*storemocks.Store)
+		mockChannelStore := storemocks.ChannelStore{}
+		mockStore.On("Channel").Return(&mockChannelStore)
+		// publishChannelPolicyEnforcedUpdate must invalidate the channel
+		// cache and reload the channel for the WS payload.
+		mockChannelStore.On("InvalidateChannel", channelID).Once()
+		mockChannelStore.On("Get", channelID, true).Return(&model.Channel{Id: channelID, Type: model.ChannelTypePrivate}, nil).Once()
+
+		// channel-type policies must NOT trigger a parent fan-out search.
+		mockACPStore := storemocks.AccessControlPolicyStore{}
+		mockStore.On("AccessControlPolicy").Return(&mockACPStore).Maybe()
+
+		mockAccessControl := &mocks.AccessControlServiceInterface{}
+		thMock.App.Srv().ch.AccessControl = mockAccessControl
+		mockAccessControl.On("GetPolicy", thMock.Context, channelID).Return(channelPolicy, nil).Once()
+		mockAccessControl.On("DeletePolicy", thMock.Context, channelID).Return(nil).Once()
+
+		appErr := thMock.App.DeleteAccessControlPolicy(thMock.Context, channelID)
+		require.Nil(t, appErr)
+
+		mockAccessControl.AssertExpectations(t)
+		mockChannelStore.AssertCalled(t, "InvalidateChannel", channelID)
+		mockChannelStore.AssertCalled(t, "Get", channelID, true)
+		mockACPStore.AssertNotCalled(t, "SearchPolicies", mock.Anything, mock.Anything)
+	})
+
+	t.Run("Parent-type policy fans out to all child channels", func(t *testing.T) {
+		thMock := SetupWithStoreMock(t)
+
+		parentID := model.NewId()
+		childChannelID := model.NewId()
+
+		parentPolicy := &model.AccessControlPolicy{
+			ID:      parentID,
+			Type:    model.AccessControlPolicyTypeParent,
+			Name:    "parent-broadcast",
+			Version: model.AccessControlPolicyVersionV0_3,
+		}
+
+		mockStore := thMock.App.Srv().Store().(*storemocks.Store)
+		mockChannelStore := storemocks.ChannelStore{}
+		mockStore.On("Channel").Return(&mockChannelStore)
+		// One affected child channel must have its cache invalidated and be reloaded.
+		mockChannelStore.On("InvalidateChannel", childChannelID).Once()
+		mockChannelStore.On("Get", childChannelID, true).Return(&model.Channel{Id: childChannelID, Type: model.ChannelTypePrivate}, nil).Once()
+
+		mockACPStore := storemocks.AccessControlPolicyStore{}
+		mockStore.On("AccessControlPolicy").Return(&mockACPStore)
+		// channelPolicyIDsWithImport (called pre-delete) returns one child.
+		mockACPStore.On("SearchPolicies", thMock.Context, mock.MatchedBy(func(s model.AccessControlPolicySearch) bool {
+			return s.Type == model.AccessControlPolicyTypeChannel && s.ParentID == parentID
+		})).Return([]*model.AccessControlPolicy{{ID: childChannelID, Type: model.AccessControlPolicyTypeChannel}}, int64(1), nil).Once()
+
+		mockAccessControl := &mocks.AccessControlServiceInterface{}
+		thMock.App.Srv().ch.AccessControl = mockAccessControl
+		mockAccessControl.On("GetPolicy", thMock.Context, parentID).Return(parentPolicy, nil).Once()
+		mockAccessControl.On("DeletePolicy", thMock.Context, parentID).Return(nil).Once()
+
+		appErr := thMock.App.DeleteAccessControlPolicy(thMock.Context, parentID)
+		require.Nil(t, appErr)
+
+		mockAccessControl.AssertExpectations(t)
+		mockChannelStore.AssertCalled(t, "InvalidateChannel", childChannelID)
+		mockChannelStore.AssertCalled(t, "Get", childChannelID, true)
+	})
+
+	t.Run("Channel-type policy: DeletePolicy error short-circuits broadcast", func(t *testing.T) {
+		thMock := SetupWithStoreMock(t)
+
+		channelID := model.NewId()
+		channelPolicy := &model.AccessControlPolicy{
+			ID:      channelID,
+			Type:    model.AccessControlPolicyTypeChannel,
+			Version: model.AccessControlPolicyVersionV0_3,
+		}
+
+		mockStore := thMock.App.Srv().Store().(*storemocks.Store)
+		mockChannelStore := storemocks.ChannelStore{}
+		mockStore.On("Channel").Return(&mockChannelStore).Maybe()
+
+		mockAccessControl := &mocks.AccessControlServiceInterface{}
+		thMock.App.Srv().ch.AccessControl = mockAccessControl
+		mockAccessControl.On("GetPolicy", thMock.Context, channelID).Return(channelPolicy, nil).Once()
+		expectedErr := model.NewAppError("DeletePolicy", "app.pap.delete.app_error", nil, "delete failed", http.StatusInternalServerError)
+		mockAccessControl.On("DeletePolicy", thMock.Context, channelID).Return(expectedErr).Once()
+
+		appErr := thMock.App.DeleteAccessControlPolicy(thMock.Context, channelID)
+		require.NotNil(t, appErr)
+		require.Equal(t, expectedErr.Id, appErr.Id)
+
+		// Broadcast must not happen if deletion failed.
+		mockChannelStore.AssertNotCalled(t, "InvalidateChannel", mock.Anything)
+		mockChannelStore.AssertNotCalled(t, "Get", mock.Anything, mock.Anything)
+	})
 }
 
 func TestGetChannelsForPolicy(t *testing.T) {

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -780,8 +780,7 @@ func (a *App) GetUsersNotInAbacChannel(rctx request.CTX, teamID string, channelI
 		return nil, model.NewAppError("GetUsersNotInAbacChannel", "api.user.get_users_not_in_abac_channel.access_control_unavailable.app_error", nil, "", http.StatusInternalServerError)
 	}
 
-	// Use cursor-based pagination for ABAC channels
-	users, _, appErr := acs.QueryUsersForResource(rctx, channelID, "*", model.SubjectSearchOptions{
+	users, _, appErr := acs.QueryUsersForResource(rctx, channelID, model.AccessControlPolicyActionMembership, model.SubjectSearchOptions{
 		TeamID: teamID,
 		Limit:  limit,
 		Cursor: model.SubjectCursor{
@@ -2330,7 +2329,7 @@ func (a *App) SearchUsersNotInChannel(teamID string, channelID string, term stri
 	} else if ok {
 		acs := a.Srv().Channels().AccessControl
 		if acs != nil {
-			users, _, appErr := acs.QueryUsersForResource(rctx, channelID, "*", model.SubjectSearchOptions{
+			users, _, appErr := acs.QueryUsersForResource(rctx, channelID, model.AccessControlPolicyActionMembership, model.SubjectSearchOptions{
 				Term:   term,
 				TeamID: teamID,
 				Limit:  options.Limit,
@@ -2339,7 +2338,7 @@ func (a *App) SearchUsersNotInChannel(teamID string, channelID string, term stri
 				return nil, appErr
 			}
 
-			return users, nil
+			return a.sanitizeProfiles(users, options.IsAdmin), nil
 		}
 	}
 
@@ -2348,11 +2347,7 @@ func (a *App) SearchUsersNotInChannel(teamID string, channelID string, term stri
 		return nil, model.NewAppError("SearchUsersNotInChannel", "app.user.search.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
-	for _, user := range users {
-		a.SanitizeProfile(user, options.IsAdmin)
-	}
-
-	return users, nil
+	return a.sanitizeProfiles(users, options.IsAdmin), nil
 }
 
 func (a *App) SearchUsersInTeam(rctx request.CTX, teamID, term string, options *model.UserSearchOptions) ([]*model.User, *model.AppError) {

--- a/server/channels/app/user_test.go
+++ b/server/channels/app/user_test.go
@@ -996,7 +996,7 @@ func TestGetUsersNotInAbacChannel(t *testing.T) {
 		mockAccessControl.On("QueryUsersForResource",
 			mock.Anything,
 			abacChannel.Id,
-			"*",
+			model.AccessControlPolicyActionMembership,
 			mock.MatchedBy(func(opts model.SubjectSearchOptions) bool {
 				return opts.TeamID == th.BasicTeam.Id &&
 					opts.Limit == 50 &&
@@ -1027,7 +1027,7 @@ func TestGetUsersNotInAbacChannel(t *testing.T) {
 		mockAccessControl.On("QueryUsersForResource",
 			mock.Anything,
 			abacChannel.Id,
-			"*",
+			model.AccessControlPolicyActionMembership,
 			mock.MatchedBy(func(opts model.SubjectSearchOptions) bool {
 				return opts.TeamID == th.BasicTeam.Id &&
 					opts.Limit == 25 &&

--- a/server/public/model/websocket_message.go
+++ b/server/public/model/websocket_message.go
@@ -87,6 +87,7 @@ const (
 	WebsocketEventChannelBookmarkUpdated              WebsocketEventType = "channel_bookmark_updated"
 	WebsocketEventChannelBookmarkDeleted              WebsocketEventType = "channel_bookmark_deleted"
 	WebsocketEventChannelBookmarkSorted               WebsocketEventType = "channel_bookmark_sorted"
+	WebsocketEventChannelAccessControlUpdated         WebsocketEventType = "channel_access_control_updated"
 	WebsocketPresenceIndicator                        WebsocketEventType = "presence"
 	WebsocketPostedNotifyAck                          WebsocketEventType = "posted_notify_ack"
 	WebsocketScheduledPostCreated                     WebsocketEventType = "scheduled_post_created"

--- a/webapp/channels/src/actions/websocket_actions.test.jsx
+++ b/webapp/channels/src/actions/websocket_actions.test.jsx
@@ -5,7 +5,7 @@ import cloneDeep from 'lodash/cloneDeep';
 
 import {WebSocketEvents} from '@mattermost/client';
 
-import {CloudTypes} from 'mattermost-redux/action_types';
+import {ChannelTypes, CloudTypes} from 'mattermost-redux/action_types';
 import {fetchMyCategories} from 'mattermost-redux/actions/channel_categories';
 import {fetchAllMyTeamsChannels} from 'mattermost-redux/actions/channels';
 import {getCustomProfileAttributeFields} from 'mattermost-redux/actions/general';
@@ -25,6 +25,8 @@ import {closeRightHandSide} from 'actions/views/rhs';
 import realConfigureStore from 'store';
 import store from 'stores/redux_store';
 
+import {invalidateAccessControlAttributesCache} from 'components/common/hooks/useAccessControlAttributes';
+
 import mergeObjects from 'packages/mattermost-redux/test/merge_objects';
 import configureStore from 'tests/test_store';
 import {getHistory} from 'utils/browser_history';
@@ -32,6 +34,7 @@ import Constants, {ActionTypes, UserStatuses} from 'utils/constants';
 
 import {
     handleChannelUpdatedEvent,
+    handleChannelAccessControlUpdatedEvent,
     handleEvent,
     handleNewPostEvent,
     handleNewPostEvents,
@@ -114,6 +117,11 @@ jest.mock('actions/views/channel', () => ({
 jest.mock('plugins', () => ({
     ...jest.requireActual('plugins'),
     loadPluginsIfNecessary: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('components/common/hooks/useAccessControlAttributes', () => ({
+    EntityType: {Channel: 'channel'},
+    invalidateAccessControlAttributesCache: jest.fn(),
 }));
 
 let mockState = {
@@ -871,6 +879,47 @@ describe('handleChannelUpdatedEvent', () => {
         testStore.dispatch(handleChannelUpdatedEvent(msg));
 
         expect(getHistory().replace).not.toHaveBeenCalled();
+    });
+});
+
+describe('handleChannelAccessControlUpdatedEvent', () => {
+    beforeEach(() => {
+        invalidateAccessControlAttributesCache.mockClear();
+    });
+
+    test('dispatches RECEIVED_CHANNEL with parsed channel and invalidates attribute cache', () => {
+        const testStore = configureStore({});
+        const channel = {
+            id: 'channel-ac-1',
+            team_id: 'team-1',
+            policy_enforced: true,
+        };
+        const msg = {
+            data: {
+                channel: JSON.stringify(channel),
+            },
+        };
+
+        testStore.dispatch(handleChannelAccessControlUpdatedEvent(msg));
+
+        expect(testStore.getActions()).toEqual([
+            {
+                type: ChannelTypes.RECEIVED_CHANNEL,
+                data: channel,
+            },
+        ]);
+        expect(invalidateAccessControlAttributesCache).toHaveBeenCalledTimes(1);
+        expect(invalidateAccessControlAttributesCache).toHaveBeenCalledWith('channel', 'channel-ac-1');
+    });
+
+    test('returns early when msg.data.channel is missing', () => {
+        const testStore = configureStore({});
+        const msg = {data: {}};
+
+        testStore.dispatch(handleChannelAccessControlUpdatedEvent(msg));
+
+        expect(testStore.getActions()).toEqual([]);
+        expect(invalidateAccessControlAttributesCache).not.toHaveBeenCalled();
     });
 });
 

--- a/webapp/channels/src/actions/websocket_actions.ts
+++ b/webapp/channels/src/actions/websocket_actions.ts
@@ -149,6 +149,7 @@ import {getSelectedChannelId, getSelectedPost} from 'selectors/rhs';
 import {isThreadOpen, isThreadManuallyUnread} from 'selectors/views/threads';
 import store from 'stores/redux_store';
 
+import {EntityType, invalidateAccessControlAttributesCache} from 'components/common/hooks/useAccessControlAttributes';
 import DialogRouter from 'components/dialog_router';
 import InfoToast from 'components/info_toast/info_toast';
 import RemovedFromChannelModal from 'components/removed_from_channel_modal';
@@ -514,6 +515,10 @@ export function handleEvent(msg: WebSocketMessage) {
         dispatch(handleChannelBookmarkSorted(msg));
         break;
 
+    case WebSocketEvents.ChannelAccessControlUpdated:
+        dispatch(handleChannelAccessControlUpdatedEvent(msg));
+        break;
+
     case WebSocketEvents.DirectAdded:
         dispatch(handleDirectAddedEvent(msg));
         break;
@@ -786,6 +791,25 @@ export function handleChannelUpdatedEvent(msg: WebSocketMessages.ChannelUpdated)
             }
             getHistory().replace(channelPath);
         }
+    };
+}
+
+export function handleChannelAccessControlUpdatedEvent(msg: WebSocketMessages.ChannelAccessControlUpdated): ThunkActionFunc<void> {
+    return (doDispatch) => {
+        if (!msg.data.channel) {
+            return;
+        }
+
+        const channel = JSON.parse(msg.data.channel) as Channel;
+
+        // Refresh the channel record so consumers see the latest
+        // policy_enforced flag (and any other access-control-derived fields).
+        doDispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: channel});
+
+        // Drop any cached access control attributes for this channel so
+        // consumers (e.g. the channel invite modal banner) refetch the
+        // latest attribute set after a policy change.
+        invalidateAccessControlAttributesCache(EntityType.Channel, channel.id);
     };
 }
 

--- a/webapp/channels/src/components/common/hooks/useAccessControlAttributes.test.tsx
+++ b/webapp/channels/src/components/common/hooks/useAccessControlAttributes.test.tsx
@@ -205,7 +205,7 @@ describe('useAccessControlAttributes', () => {
 
     test('invalidateAccessControlAttributesCache forces a refresh on next read', async () => {
         // Prime the cache with a first fetch.
-        const {result: result1} = renderHook(() => useAccessControlAttributes(EntityType.Channel, 'channel-1', true), {wrapper});
+        const {result: result1, unmount} = renderHook(() => useAccessControlAttributes(EntityType.Channel, 'channel-1', true), {wrapper});
 
         await act(async () => {
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -214,6 +214,11 @@ describe('useAccessControlAttributes', () => {
             {name: 'department', values: ['engineering', 'marketing']},
             {name: 'location', values: ['remote']},
         ]);
+
+        // Unmount the first hook so its listener subscription doesn't trigger
+        // an extra fetch when we invalidate below — this test specifically
+        // verifies that the *next* mount sees fresh data after invalidation.
+        unmount();
 
         const getChannelAccessControlAttributes = require('mattermost-redux/actions/channels').getChannelAccessControlAttributes;
         getChannelAccessControlAttributes.mockClear();
@@ -228,5 +233,61 @@ describe('useAccessControlAttributes', () => {
 
         expect(getChannelAccessControlAttributes).toHaveBeenCalledWith('channel-1');
         expect(result2.current.structuredAttributes).toEqual(result1.current.structuredAttributes);
+    });
+
+    test('should re-fetch when the cache is invalidated for the entity', async () => {
+        renderHook(() => useAccessControlAttributes(EntityType.Channel, 'channel-1', true), {wrapper});
+
+        // Wait for the initial fetch to complete and prime the cache
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        const getChannelAccessControlAttributes = require('mattermost-redux/actions/channels').getChannelAccessControlAttributes;
+        getChannelAccessControlAttributes.mockClear();
+
+        await act(async () => {
+            invalidateAccessControlAttributesCache(EntityType.Channel, 'channel-1');
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        expect(getChannelAccessControlAttributes).toHaveBeenCalledWith('channel-1');
+    });
+
+    test('should not re-fetch when the cache is invalidated for a different entity', async () => {
+        renderHook(() => useAccessControlAttributes(EntityType.Channel, 'channel-1', true), {wrapper});
+
+        // Wait for the initial fetch to complete and prime the cache
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        const getChannelAccessControlAttributes = require('mattermost-redux/actions/channels').getChannelAccessControlAttributes;
+        getChannelAccessControlAttributes.mockClear();
+
+        await act(async () => {
+            invalidateAccessControlAttributesCache(EntityType.Channel, 'channel-2');
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        expect(getChannelAccessControlAttributes).not.toHaveBeenCalled();
+    });
+
+    test('should re-fetch all mounted hooks when cache is fully cleared', async () => {
+        renderHook(() => useAccessControlAttributes(EntityType.Channel, 'channel-1', true), {wrapper});
+
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        const getChannelAccessControlAttributes = require('mattermost-redux/actions/channels').getChannelAccessControlAttributes;
+        getChannelAccessControlAttributes.mockClear();
+
+        await act(async () => {
+            invalidateAccessControlAttributesCache();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        expect(getChannelAccessControlAttributes).toHaveBeenCalledWith('channel-1');
     });
 });

--- a/webapp/channels/src/components/common/hooks/useAccessControlAttributes.test.tsx
+++ b/webapp/channels/src/components/common/hooks/useAccessControlAttributes.test.tsx
@@ -92,6 +92,28 @@ describe('useAccessControlAttributes', () => {
         expect(result.current.loading).toBe(false);
     });
 
+    test('clears attribute state when hasAccessControl becomes false after data was loaded', async () => {
+        const {result, rerender, unmount} = renderHook(
+            ({hasAC}: {hasAC: boolean}) => useAccessControlAttributes(EntityType.Channel, 'channel-1', hasAC),
+            {initialProps: {hasAC: true}, wrapper},
+        );
+
+        await waitFor(() => {
+            expect(result.current.attributeTags).toEqual(['engineering', 'marketing', 'remote']);
+        });
+
+        rerender({hasAC: false});
+        await act(async () => {
+            await result.current.fetchAttributes();
+        });
+
+        expect(result.current.attributeTags).toEqual([]);
+        expect(result.current.structuredAttributes).toEqual([]);
+
+        unmount();
+        invalidateAccessControlAttributesCache(EntityType.Channel, 'channel-1');
+    });
+
     test('should fetch and process attributes successfully', async () => {
         const {result} = renderHook(() => useAccessControlAttributes(EntityType.Channel, 'channel-1', true), {wrapper});
 

--- a/webapp/channels/src/components/common/hooks/useAccessControlAttributes.ts
+++ b/webapp/channels/src/components/common/hooks/useAccessControlAttributes.ts
@@ -73,14 +73,36 @@ function processAttributeData(data: Record<string, string[]> | undefined | null)
     return {attributeTags, structuredAttributes};
 }
 
+// Listeners that mounted hook instances register to be notified when the
+// module-level cache is invalidated for an entity they care about. Used to
+// trigger a re-fetch in response to server-side policy changes that arrive
+// out-of-band of the hook's normal dependency-driven refresh.
+type InvalidationListener = (entityType: EntityType | undefined, entityId: string | undefined) => void;
+const invalidationListeners = new Set<InvalidationListener>();
+
 /**
- * Invalidates the cached attributes for a single entity. Components that
- * mutate the underlying access policy should call this to ensure the next
- * read fetches fresh data instead of serving up to CACHE_TTL milliseconds of
- * stale state.
+ * Invalidates cached access control attributes for an entity. When both
+ * entityType and entityId are provided, only that entity's cache entry is
+ * dropped; when omitted, the entire module-level cache is cleared. After
+ * dropping the cache entry/entries, all mounted instances of
+ * useAccessControlAttributes that match the invalidated entity (or all of
+ * them, when called without arguments) will immediately re-fetch so that
+ * consumers (e.g. the channel invite modal banner) pick up the new attribute
+ * set without waiting for the cache TTL to expire.
  */
-export function invalidateAccessControlAttributesCache(entityType: EntityType, entityId: string): void {
-    delete attributesCache[`${entityType}:${entityId}`];
+export function invalidateAccessControlAttributesCache(
+    entityType?: EntityType,
+    entityId?: string,
+): void {
+    if (!entityType || !entityId) {
+        for (const key of Object.keys(attributesCache)) {
+            delete attributesCache[key];
+        }
+    } else {
+        delete attributesCache[`${entityType}:${entityId}`];
+    }
+
+    invalidationListeners.forEach((listener) => listener(entityType, entityId));
 }
 
 /**
@@ -159,6 +181,24 @@ export const useAccessControlAttributes = (
     useEffect(() => {
         fetchAttributes();
     }, [fetchAttributes]);
+
+    // Re-fetch when the cache is invalidated for this entity (e.g. when a
+    // policy change is broadcast over the websocket). Without this, the
+    // hook's input dependencies may not change even though the underlying
+    // attribute set on the server did.
+    useEffect(() => {
+        const listener: InvalidationListener = (invalidatedType, invalidatedId) => {
+            const matchesEntity = !invalidatedType || !invalidatedId ||
+                (invalidatedType === entityType && invalidatedId === entityId);
+            if (matchesEntity) {
+                fetchAttributes(true);
+            }
+        };
+        invalidationListeners.add(listener);
+        return () => {
+            invalidationListeners.delete(listener);
+        };
+    }, [entityType, entityId, fetchAttributes]);
 
     return {
         attributeTags,

--- a/webapp/channels/src/components/common/hooks/useAccessControlAttributes.ts
+++ b/webapp/channels/src/components/common/hooks/useAccessControlAttributes.ts
@@ -131,6 +131,8 @@ export const useAccessControlAttributes = (
 
     const fetchAttributes = useCallback(async (forceRefresh = false) => {
         if (!entityId || !hasAccessControl) {
+            setAttributeTags([]);
+            setStructuredAttributes([]);
             return;
         }
 

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
@@ -30,10 +30,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
     </button>
   </div>
   <div
-    aria-hidden="true"
-    id="root-portal"
-  />
-  <div
     class="MuiModal-root-jIscme ljbrzK MuiPopover-root-kLIimo MuiPopover-root a11y__popup menu_menuStyled MuiModal-root"
     role="presentation"
   >
@@ -297,10 +293,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
 <body
   style="padding-right: 1024px; overflow: hidden;"
 >
-  <div
-    aria-hidden="true"
-    id="root-portal"
-  />
   <div
     aria-hidden="true"
   >
@@ -592,10 +584,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
 >
   <div
     aria-hidden="true"
-    id="root-portal"
-  />
-  <div
-    aria-hidden="true"
   >
     <button
       aria-controls="SidebarChannelMenu-MenuList-channel_id"
@@ -885,10 +873,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
 >
   <div
     aria-hidden="true"
-    id="root-portal"
-  />
-  <div
-    aria-hidden="true"
   >
     <button
       aria-controls="SidebarChannelMenu-MenuList-channel_id"
@@ -1108,10 +1092,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
 <body
   style="padding-right: 1024px; overflow: hidden;"
 >
-  <div
-    aria-hidden="true"
-    id="root-portal"
-  />
   <div
     aria-hidden="true"
   >
@@ -1369,10 +1349,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
 <body
   style="padding-right: 1024px; overflow: hidden;"
 >
-  <div
-    aria-hidden="true"
-    id="root-portal"
-  />
   <div
     aria-hidden="true"
   >
@@ -1659,10 +1635,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
 <body
   style="padding-right: 1024px; overflow: hidden;"
 >
-  <div
-    aria-hidden="true"
-    id="root-portal"
-  />
   <div
     aria-hidden="true"
   >
@@ -1954,10 +1926,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
 >
   <div
     aria-hidden="true"
-    id="root-portal"
-  />
-  <div
-    aria-hidden="true"
   >
     <button
       aria-controls="SidebarChannelMenu-MenuList-channel_id"
@@ -2247,10 +2215,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
 >
   <div
     aria-hidden="true"
-    id="root-portal"
-  />
-  <div
-    aria-hidden="true"
   >
     <button
       aria-controls="SidebarChannelMenu-MenuList-channel_id"
@@ -2538,10 +2502,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
 <body
   style="padding-right: 1024px; overflow: hidden;"
 >
-  <div
-    aria-hidden="true"
-    id="root-portal"
-  />
   <div
     aria-hidden="true"
   >

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
@@ -29,6 +29,13 @@ jest.mock('utils/popouts/popout_windows', () => ({
     isChannelPopoutWindow: jest.fn(() => false),
 }));
 
+// Avoid Floating UI tooltip portals in #root-portal — they mount inconsistently under jsdom
+// and make full-document snapshots flaky (tooltip DOM vs. empty portal).
+jest.mock('components/with_tooltip', () => ({
+    __esModule: true,
+    default: ({children}: {children: React.ReactNode}) => <>{children}</>,
+}));
+
 describe('components/sidebar/sidebar_channel/sidebar_channel_menu', () => {
     const testChannel = TestHelper.getChannelMock();
     const testCategory = TestHelper.getCategoryMock();

--- a/webapp/platform/client/src/websocket_events.ts
+++ b/webapp/platform/client/src/websocket_events.ts
@@ -80,6 +80,7 @@ export const enum WebSocketEvents {
     ChannelBookmarkUpdated = 'channel_bookmark_updated',
     ChannelBookmarkDeleted = 'channel_bookmark_deleted',
     ChannelBookmarkSorted = 'channel_bookmark_sorted',
+    ChannelAccessControlUpdated = 'channel_access_control_updated',
     PresenceIndicator = 'presence',
     PostedNotifyAck = 'posted_notify_ack', // This isn't currently used by the web app
     ScheduledPostCreated = 'scheduled_post_created',

--- a/webapp/platform/client/src/websocket_message.ts
+++ b/webapp/platform/client/src/websocket_message.ts
@@ -47,6 +47,8 @@ export type WebSocketMessage = (
     Messages.ChannelBookmarkDeleted |
     Messages.ChannelBookmarkSorted |
 
+    Messages.ChannelAccessControlUpdated |
+
     Messages.Team |
     Messages.UpdateTeamScheme |
     Messages.UserAddedToTeam |

--- a/webapp/platform/client/src/websocket_messages.ts
+++ b/webapp/platform/client/src/websocket_messages.ts
@@ -261,6 +261,12 @@ export type ChannelBookmarkSorted = BaseWebSocketMessage<WebSocketEvents.Channel
     bookmarks: JsonEncodedValue<ChannelBookmarkWithFileInfo[]>;
 }>;
 
+// Channel access control messages
+
+export type ChannelAccessControlUpdated = BaseWebSocketMessage<WebSocketEvents.ChannelAccessControlUpdated, {
+    channel: JsonEncodedValue<Channel>;
+}>;
+
 // Team and team member messages
 
 export type Team =


### PR DESCRIPTION

#### Summary
We should invalidate the cache so that whenever a policy is applied to a channel we should render channel is policy enforced without requiring a refresh.

Also narrows down user search for policy enforced channels by explicitly querying `membership` action.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-68535

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Changes span server and webapp layers—adding websocket broadcasts, publish/fan-out paths, client cache invalidation, and tightening user-search action filtering—so regressions could occur if broadcasts, cache invalidation, or membership-query behavior fail; while many tests were added/updated, several backend publish branches and cross-layer interactions still carry moderate risk.  
**QA Recommendation:** Perform targeted manual QA across policy lifecycles (create/update/delete/assign/unassign) for both channel-type and parent-type policies to verify websocket delivery, channel cache invalidation, and membership-search behavior; exercise SpinWick and add/extend unit tests for any uncovered publish/invalidation branches where feasible.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->