### PR TITLE
[MM-68538] Wrap incoming query from the CEL -> SQL conversion with parentheses

### DIFF
--- a/e2e-tests/playwright/specs/functional/channels/channel_settings_access_rules/channel_admin_self_inclusion.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/channel_settings_access_rules/channel_admin_self_inclusion.spec.ts
@@ -116,7 +116,9 @@ async function createUserWithProgram(
 }
 
 test.describe('Channel Settings → Access Control', () => {
-    test('MM-68538 channel admin can test access rule for multiselect "has any of" with multiple values', async ({pw}) => {
+    test('MM-68538 channel admin can test access rule for multiselect "has any of" with multiple values', async ({
+        pw,
+    }) => {
         await pw.skipIfNoLicense();
 
         const {adminClient, team} = await pw.initSetup();
@@ -180,10 +182,7 @@ test.describe('Channel Settings → Access Control', () => {
         expect(singleValueResult.requester_matches).toBe(true);
 
         // Two-value rule: the regression.
-        const orResult = await aliceClient.validateExpressionAgainstRequester(
-            twoValueOrExpression,
-            channel.id,
-        );
+        const orResult = await aliceClient.validateExpressionAgainstRequester(twoValueOrExpression, channel.id);
         expect(orResult.requester_matches).toBe(true);
 
         // Reverse sanity check: an OR expression that legitimately excludes

--- a/e2e-tests/playwright/specs/functional/channels/channel_settings_access_rules/channel_admin_self_inclusion.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/channel_settings_access_rules/channel_admin_self_inclusion.spec.ts
@@ -1,0 +1,220 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/**
+ * @objective Channel Settings → Access Control regression test for the
+ * top-level OR self-exclusion bug.
+ * @reference MM-68538
+ */
+
+import {Client4} from '@mattermost/client';
+import type {UserPropertyField} from '@mattermost/types/properties';
+import type {UserProfile} from '@mattermost/types/users';
+
+import {ChannelsPage, expect, newTestPassword, test} from '@mattermost/playwright-lib';
+
+const PROGRAM_OPTIONS = [
+    {name: 'Artemis', color: '#FF8800'},
+    {name: 'Helios', color: '#00AAFF'},
+];
+
+// CEL the table editor emits for `<field> has any of [Artemis, Helios]`.
+// See rowToCEL() in webapp/.../table_editor/table_editor.tsx.
+function buildTwoValueOrExpression(attributeName: string): string {
+    return `("Artemis" in user.attributes.${attributeName} || "Helios" in user.attributes.${attributeName})`;
+}
+
+// CEL for `has any of [Artemis]` (single disjunct, no top-level OR).
+function buildSingleValueExpression(attributeName: string): string {
+    return `"Artemis" in user.attributes.${attributeName}`;
+}
+
+// CEL that excludes alice (sanity check for the assertion direction).
+function buildNonMatchingOrExpression(attributeName: string): string {
+    return `("DoesNotMatch1" in user.attributes.${attributeName} || "DoesNotMatch2" in user.attributes.${attributeName})`;
+}
+
+type ProgramField = {
+    id: string;
+    optionIdByName: Record<string, string>;
+};
+
+// Create a multiselect CPA field directly via the REST API.
+async function ensureProgramMultiselectField(adminClient: Client4, fieldName: string): Promise<ProgramField> {
+    const baseRoute = `${adminClient.getBaseRoute()}/custom_profile_attributes/fields`;
+
+    const created: UserPropertyField = await (adminClient as any).doFetch(baseRoute, {
+        method: 'POST',
+        body: JSON.stringify({
+            name: fieldName,
+            type: 'multiselect',
+            attrs: {
+                managed: 'admin',
+                visibility: 'when_set',
+                options: PROGRAM_OPTIONS,
+            },
+        }),
+    });
+
+    const options: Array<{id: string; name: string}> =
+        ((created as any)?.attrs?.options as Array<{id: string; name: string}>) ?? [];
+    const optionIdByName: Record<string, string> = {};
+    for (const opt of options) {
+        optionIdByName[opt.name] = opt.id;
+    }
+    for (const expected of PROGRAM_OPTIONS) {
+        if (!optionIdByName[expected.name]) {
+            throw new Error(
+                `Multiselect field "${fieldName}" was created without an id for option "${expected.name}"; ` +
+                    `got: ${JSON.stringify(options)}`,
+            );
+        }
+    }
+
+    return {id: created.id, optionIdByName};
+}
+
+async function createUserWithProgram(
+    adminClient: Client4,
+    programField: ProgramField,
+    program: string[],
+    teamId: string,
+    prefix: string,
+): Promise<UserProfile> {
+    const password = newTestPassword();
+    const id = Math.random().toString(36).substring(2, 9);
+    const user = await adminClient.createUser(
+        {
+            email: `${prefix}-${id}@sample.mattermost.com`,
+            username: `${prefix}${id}`,
+            password,
+        } as UserProfile,
+        '',
+        '',
+    );
+    user.password = password;
+
+    // Multiselect values must be sent as option IDs not names.
+    const optionIds = program.map((name) => {
+        const optionId = programField.optionIdByName[name];
+        if (!optionId) {
+            throw new Error(`Program option "${name}" not found in field options`);
+        }
+        return optionId;
+    });
+    await adminClient.updateUserCustomProfileAttributesValues(user.id, {[programField.id]: optionIds});
+
+    // Suppress tutorials/onboarding so UI navigation is stable.
+    await adminClient.savePreferences(user.id, [
+        {user_id: user.id, category: 'tutorial_step', name: user.id, value: '999'},
+        {user_id: user.id, category: 'onboarding_task_list', name: 'onboarding_task_list_show', value: 'false'},
+        {user_id: user.id, category: 'onboarding_task_list', name: 'onboarding_task_list_open', value: 'false'},
+    ]);
+
+    await adminClient.addToTeam(teamId, user.id);
+    return user;
+}
+
+test.describe('Channel Settings → Access Control', () => {
+    test('MM-68538 channel admin can test access rule for multiselect "has any of" with multiple values', async ({pw}) => {
+        await pw.skipIfNoLicense();
+
+        const {adminClient, team} = await pw.initSetup();
+
+        // Enable ABAC + user-managed attributes so the Access Control tab and
+        // the validate_requester endpoint are available.
+        await adminClient.patchConfig({
+            AccessControlSettings: {
+                EnableAttributeBasedAccessControl: true,
+                EnableUserManagedAttributes: true,
+            },
+        });
+
+        // CPA name must be a valid CEL identifier segment; keep alphanumeric + underscore.
+        const programFieldName = `Program_mm68538_${Math.random().toString(36).substring(2, 14)}`;
+        const programField = await ensureProgramMultiselectField(adminClient, programFieldName);
+
+        const singleValueExpression = buildSingleValueExpression(programFieldName);
+        const twoValueOrExpression = buildTwoValueOrExpression(programFieldName);
+        const nonMatchingExpression = buildNonMatchingOrExpression(programFieldName);
+
+        // Several users matching the OR. Without the fix, SearchUsers ordered
+        // by Users.Id ASC would return whichever of the matching users has the
+        // lowest Id, so populating multiple matches makes the assertion robust
+        // regardless of which Id alice ends up with.
+        const alice = await createUserWithProgram(adminClient, programField, ['Artemis'], team.id, 'alice');
+        const bob = await createUserWithProgram(adminClient, programField, ['Helios'], team.id, 'bob');
+        const carol = await createUserWithProgram(adminClient, programField, ['Artemis'], team.id, 'carol');
+
+        // Private channel where alice is the channel admin and the only one
+        // with the manage_channel_access_rules permission. Bob/carol exist
+        // purely to populate the OR-matching candidate set.
+        const channel = await adminClient.createChannel({
+            team_id: team.id,
+            name: `mm68538-${Math.random().toString(36).substring(2, 8)}`,
+            display_name: `MM-68538 ${Math.random().toString(36).substring(2, 6)}`,
+            type: 'P',
+        } as any);
+        await adminClient.addToChannel(alice.id, channel.id);
+        await adminClient.updateChannelMemberSchemeRoles(channel.id, alice.id, true, true);
+
+        // Sanity-check that bob and carol exist on the server (referenced
+        // implicitly via the OR query); silences the unused-var lint without
+        // adding noisy assertions to the test.
+        expect(bob.id).toBeTruthy();
+        expect(carol.id).toBeTruthy();
+
+        // Authenticate alice via the API so we can call the same endpoint the
+        // table editor uses for its self-exclusion check.
+        const {client: aliceClient} = await pw.makeClient(
+            {username: alice.username, password: alice.password!},
+            {useCache: false},
+        );
+
+        // Single-value rule: Used here as a baseline so a future regression that
+        // breaks the channel-admin code path entirely doesn't pass silently.
+        const singleValueResult = await aliceClient.validateExpressionAgainstRequester(
+            singleValueExpression,
+            channel.id,
+        );
+        expect(singleValueResult.requester_matches).toBe(true);
+
+        // Two-value rule: the regression.
+        const orResult = await aliceClient.validateExpressionAgainstRequester(
+            twoValueOrExpression,
+            channel.id,
+        );
+        expect(orResult.requester_matches).toBe(true);
+
+        // Reverse sanity check: an OR expression that legitimately excludes
+        // alice still returns false. Without this assertion a regression that
+        // unconditionally returned true would falsely pass the test.
+        const nonMatchingResult = await aliceClient.validateExpressionAgainstRequester(
+            nonMatchingExpression,
+            channel.id,
+        );
+        expect(nonMatchingResult.requester_matches).toBe(false);
+
+        // UI sanity: alice can actually open Channel Settings → Access
+        // Control. This confirms she has the manage_channel_access_rules
+        // permission via the channel_admin role and that the API assertions
+        // above exercise the same code path the user hits when they click
+        // "Test access rule".
+        const {page} = await pw.testBrowser.login(alice);
+        const channelsPage = new ChannelsPage(page);
+        await channelsPage.goto(team.name, channel.name);
+        await channelsPage.toBeVisible();
+
+        const channelSettings = await channelsPage.openChannelSettings();
+        const accessControlTab = channelSettings.container.getByRole('tab', {name: /Access Control/i});
+        await expect(accessControlTab).toBeVisible({timeout: 10000});
+        await accessControlTab.click();
+
+        // Access Rules editor should render without the self-exclusion
+        // confirmation modal popping up. The modal id is not stable, so we
+        // assert by its title text from channel_settings_access_rules_tab.tsx.
+        await expect(page.getByText('Cannot save access rules')).not.toBeVisible({timeout: 2000});
+
+        await channelSettings.close();
+    });
+});

--- a/e2e-tests/playwright/specs/functional/channels/channel_settings_access_rules/channel_admin_self_inclusion.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/channel_settings_access_rules/channel_admin_self_inclusion.spec.ts
@@ -3,11 +3,12 @@
 
 /**
  * @objective Channel Settings → Access Control regression test for the
- * top-level OR self-exclusion bug.
+ * "Test access rule" results for top-level OR rules.
  * @reference MM-68538
  */
 
 import {Client4} from '@mattermost/client';
+import type {Page} from '@playwright/test';
 import type {UserPropertyField} from '@mattermost/types/properties';
 import type {UserProfile} from '@mattermost/types/users';
 
@@ -24,14 +25,8 @@ function buildTwoValueOrExpression(attributeName: string): string {
     return `("Artemis" in user.attributes.${attributeName} || "Helios" in user.attributes.${attributeName})`;
 }
 
-// CEL for `has any of [Artemis]` (single disjunct, no top-level OR).
-function buildSingleValueExpression(attributeName: string): string {
-    return `"Artemis" in user.attributes.${attributeName}`;
-}
-
-// CEL that excludes alice (sanity check for the assertion direction).
-function buildNonMatchingOrExpression(attributeName: string): string {
-    return `("DoesNotMatch1" in user.attributes.${attributeName} || "DoesNotMatch2" in user.attributes.${attributeName})`;
+function buildAliceExcludingExpression(attributeName: string): string {
+    return `"Helios" in user.attributes.${attributeName}`;
 }
 
 type ProgramField = {
@@ -115,6 +110,51 @@ async function createUserWithProgram(
     return user;
 }
 
+async function createChannelAccessRule(
+    adminClient: Client4,
+    channel: {id: string; display_name: string},
+    expression: string,
+) {
+    await (adminClient as any).doFetch(`${adminClient.getBaseRoute()}/access_control_policies`, {
+        method: 'PUT',
+        body: JSON.stringify({
+            id: channel.id,
+            name: channel.display_name,
+            type: 'channel',
+            active: false,
+            revision: 1,
+            created_at: Date.now(),
+            rules: [{actions: ['membership'], expression}],
+            imports: [],
+        }),
+    });
+}
+
+async function openAccessControlSettings(channelsPage: ChannelsPage) {
+    const channelSettings = await channelsPage.openChannelSettings();
+    const accessControlTab = channelSettings.container.getByRole('tab', {name: /Access Control/i});
+    await expect(accessControlTab).toBeVisible({timeout: 10000});
+    await accessControlTab.click();
+
+    return channelSettings;
+}
+
+async function verifyTestAccessRuleDisabled(page: Page) {
+    await expect(page.getByRole('button', {name: /Test access rule/i})).toBeDisabled({timeout: 10000});
+}
+
+async function testAccessRuleAndVerifyUser(page: Page, username: string) {
+    const testButton = page.getByRole('button', {name: /Test access rule/i});
+    await expect(testButton).toBeEnabled({timeout: 10000});
+    await testButton.click();
+
+    const modal = page.locator('.TestResultsModal').filter({hasText: 'Access Rule Test Results'});
+    await expect(modal).toBeVisible({timeout: 10000});
+
+    await modal.getByRole('textbox', {name: /Search users/i}).fill(username);
+    await expect(modal.getByText(`@${username}`)).toBeVisible({timeout: 10000});
+}
+
 test.describe('Channel Settings → Access Control', () => {
     test('MM-68538 channel admin can test access rule for multiselect "has any of" with multiple values', async ({
         pw,
@@ -124,7 +164,7 @@ test.describe('Channel Settings → Access Control', () => {
         const {adminClient, team} = await pw.initSetup();
 
         // Enable ABAC + user-managed attributes so the Access Control tab and
-        // the validate_requester endpoint are available.
+        // the test access rule flow are available.
         await adminClient.patchConfig({
             AccessControlSettings: {
                 EnableAttributeBasedAccessControl: true,
@@ -136,17 +176,16 @@ test.describe('Channel Settings → Access Control', () => {
         const programFieldName = `Program_mm68538_${Math.random().toString(36).substring(2, 14)}`;
         const programField = await ensureProgramMultiselectField(adminClient, programFieldName);
 
-        const singleValueExpression = buildSingleValueExpression(programFieldName);
+        const aliceExcludingExpression = buildAliceExcludingExpression(programFieldName);
         const twoValueOrExpression = buildTwoValueOrExpression(programFieldName);
-        const nonMatchingExpression = buildNonMatchingOrExpression(programFieldName);
 
         // Several users matching the OR. Without the fix, SearchUsers ordered
         // by Users.Id ASC would return whichever of the matching users has the
         // lowest Id, so populating multiple matches makes the assertion robust
         // regardless of which Id alice ends up with.
         const alice = await createUserWithProgram(adminClient, programField, ['Artemis'], team.id, 'alice');
-        const bob = await createUserWithProgram(adminClient, programField, ['Helios'], team.id, 'bob');
-        const carol = await createUserWithProgram(adminClient, programField, ['Artemis'], team.id, 'carol');
+        await createUserWithProgram(adminClient, programField, ['Helios'], team.id, 'bob');
+        await createUserWithProgram(adminClient, programField, ['Artemis'], team.id, 'carol');
 
         // Private channel where alice is the channel admin and the only one
         // with the manage_channel_access_rules permission. Bob/carol exist
@@ -160,60 +199,24 @@ test.describe('Channel Settings → Access Control', () => {
         await adminClient.addToChannel(alice.id, channel.id);
         await adminClient.updateChannelMemberSchemeRoles(channel.id, alice.id, true, true);
 
-        // Sanity-check that bob and carol exist on the server (referenced
-        // implicitly via the OR query); silences the unused-var lint without
-        // adding noisy assertions to the test.
-        expect(bob.id).toBeTruthy();
-        expect(carol.id).toBeTruthy();
+        await createChannelAccessRule(adminClient, channel, aliceExcludingExpression);
 
-        // Authenticate alice via the API so we can call the same endpoint the
-        // table editor uses for its self-exclusion check.
-        const {client: aliceClient} = await pw.makeClient(
-            {username: alice.username, password: alice.password!},
-            {useCache: false},
-        );
-
-        // Single-value rule: Used here as a baseline so a future regression that
-        // breaks the channel-admin code path entirely doesn't pass silently.
-        const singleValueResult = await aliceClient.validateExpressionAgainstRequester(
-            singleValueExpression,
-            channel.id,
-        );
-        expect(singleValueResult.requester_matches).toBe(true);
-
-        // Two-value rule: the regression.
-        const orResult = await aliceClient.validateExpressionAgainstRequester(twoValueOrExpression, channel.id);
-        expect(orResult.requester_matches).toBe(true);
-
-        // Reverse sanity check: an OR expression that legitimately excludes
-        // alice still returns false. Without this assertion a regression that
-        // unconditionally returned true would falsely pass the test.
-        const nonMatchingResult = await aliceClient.validateExpressionAgainstRequester(
-            nonMatchingExpression,
-            channel.id,
-        );
-        expect(nonMatchingResult.requester_matches).toBe(false);
-
-        // UI sanity: alice can actually open Channel Settings → Access
-        // Control. This confirms she has the manage_channel_access_rules
-        // permission via the channel_admin role and that the API assertions
-        // above exercise the same code path the user hits when they click
-        // "Test access rule".
+        // Alice can open Channel Settings → Access Control as channel admin
+        // and test the existing rule through the same UI users exercise.
         const {page} = await pw.testBrowser.login(alice);
         const channelsPage = new ChannelsPage(page);
         await channelsPage.goto(team.name, channel.name);
         await channelsPage.toBeVisible();
 
-        const channelSettings = await channelsPage.openChannelSettings();
-        const accessControlTab = channelSettings.container.getByRole('tab', {name: /Access Control/i});
-        await expect(accessControlTab).toBeVisible({timeout: 10000});
-        await accessControlTab.click();
+        const excludingRuleSettings = await openAccessControlSettings(channelsPage);
+        await verifyTestAccessRuleDisabled(page);
+        await excludingRuleSettings.close();
 
-        // Access Rules editor should render without the self-exclusion
-        // confirmation modal popping up. The modal id is not stable, so we
-        // assert by its title text from channel_settings_access_rules_tab.tsx.
-        await expect(page.getByText('Cannot save access rules')).not.toBeVisible({timeout: 2000});
+        await createChannelAccessRule(adminClient, channel, twoValueOrExpression);
 
-        await channelSettings.close();
+        const includingRuleSettings = await openAccessControlSettings(channelsPage);
+        await testAccessRuleAndVerifyUser(page, alice.username);
+
+        await includingRuleSettings.close();
     });
 });

--- a/server/channels/store/sqlstore/attributes_store.go
+++ b/server/channels/store/sqlstore/attributes_store.go
@@ -96,8 +96,15 @@ func (s *SqlAttributesStore) SearchUsers(rctx request.CTX, opts model.SubjectSea
 	count := s.getQueryBuilder().Select("COUNT(*)").From("Users").LeftJoin("AttributeView ON Users.Id = AttributeView.TargetID")
 
 	if opts.Query != "" {
-		query = query.Where(sq.Expr(opts.Query, opts.Args...))
-		count = count.Where(sq.Expr(opts.Query, opts.Args...))
+		// Wrap the CEL-derived expression in parentheses so that any top-level
+		// OR (e.g. produced by "has any of [a, b]") does not bind across the
+		// AND-joined WHERE clauses appended below (SubjectID, DeleteAt,
+		// TeamID, ExcludeChannelMembers, Cursor, Term). Without these
+		// parens, "A OR B AND Users.Id = $X" would be parsed as
+		// "A OR (B AND Users.Id = $X)" because AND binds tighter than OR.
+		wrapped := "(" + opts.Query + ")"
+		query = query.Where(sq.Expr(wrapped, opts.Args...))
+		count = count.Where(sq.Expr(wrapped, opts.Args...))
 	}
 
 	argCount := len(opts.Args)

--- a/server/channels/store/storetest/attributes_store.go
+++ b/server/channels/store/storetest/attributes_store.go
@@ -448,4 +448,66 @@ func testAttributesStoreSearchUsersBySubjectID(t *testing.T, rctx request.CTX, s
 		require.Len(t, subjects, 0, "expected 0 users when query doesn't match SubjectID")
 		require.Equal(t, int64(0), count, "expected count 0")
 	})
+
+	// Regression test: a top-level OR in the CEL-derived query (e.g. produced
+	// by "has any of [a, b]") used to bleed past the AND-joined SubjectID
+	// clause because of SQL operator precedence (AND binds tighter than OR).
+	// The expression must be wrapped in parentheses before it is added to
+	// the WHERE clause; otherwise the SubjectID filter is silently bypassed
+	// for the left-hand side of the OR. See ValidateExpressionAgainstRequester
+	// callers (channel-admin "Test access rule" self-exclusion check).
+	t.Run("Search users by SubjectID with top-level OR query does not bypass SubjectID filter", func(t *testing.T) {
+		// users[0] (u1) has property_a = value_a1
+		// users[1] (u2) has property_a = value_a2
+		// users[2] (u3) has property_a = value_a1
+		// The OR query matches all three; SubjectID must restrict the
+		// result to a single user.
+		query := "Attributes ->> '" + testPropertyA + "' = $1::text OR Attributes ->> '" + testPropertyA + "' = $2::text"
+
+		for _, u := range users {
+			subjects, count, err := ss.Attributes().SearchUsers(rctx, model.SubjectSearchOptions{
+				Query:     query,
+				Args:      []any{testPropertyValueA1, testPropertyValueA2},
+				SubjectID: u.Id,
+				Limit:     1,
+			})
+			require.NoError(t, err, "couldn't search users by SubjectID with top-level OR query")
+			require.Len(t, subjects, 1, "expected exactly the requested SubjectID to be returned (subject_id=%s)", u.Id)
+			require.Equal(t, u.Id, subjects[0].Id, "expected SubjectID filter to be honored despite top-level OR (subject_id=%s)", u.Id)
+			require.Equal(t, int64(1), count, "expected count 1 when filtering by SubjectID with top-level OR query (subject_id=%s)", u.Id)
+		}
+	})
+
+	// Regression test: same root cause as the SubjectID test above, but for
+	// the implicit Users.DeleteAt = 0 filter. A top-level OR in the
+	// CEL-derived query must not bleed past the AND-joined DeleteAt clause
+	// and surface soft-deleted users.
+	t.Run("Search users with top-level OR query does not surface soft-deleted users", func(t *testing.T) {
+		// Soft-delete users[0]; revert at end of subtest.
+		u := users[0]
+		originalDeleteAt := u.DeleteAt
+		u.DeleteAt = model.GetMillis()
+		_, err := ss.User().Update(rctx, u, true)
+		require.NoError(t, err, "couldn't soft-delete user")
+		t.Cleanup(func() {
+			u.DeleteAt = originalDeleteAt
+			_, cErr := ss.User().Update(rctx, u, true)
+			require.NoError(t, cErr, "couldn't restore user")
+		})
+
+		// users[0] (soft-deleted) and users[2] both have property_a = value_a1.
+		// users[1] has property_a = value_a2. The OR query matches all three.
+		// AllowInactive defaults to false, so users[0] must be excluded.
+		query := "Attributes ->> '" + testPropertyA + "' = $1::text OR Attributes ->> '" + testPropertyA + "' = $2::text"
+		subjects, count, err := ss.Attributes().SearchUsers(rctx, model.SubjectSearchOptions{
+			Query: query,
+			Args:  []any{testPropertyValueA1, testPropertyValueA2},
+		})
+		require.NoError(t, err, "couldn't search users with top-level OR query")
+		require.Len(t, subjects, 2, "expected 2 active users (soft-deleted users[0] excluded)")
+		require.Equal(t, int64(2), count, "expected count 2 active users")
+		for _, s := range subjects {
+			require.NotEqual(t, u.Id, s.Id, "soft-deleted user must not be surfaced by top-level OR query")
+		}
+	})
 }


### PR DESCRIPTION
#### Summary

`SqlAttributesStore.SearchUsers` injected the CEL-derived expression as a raw `sq.Expr` and let squirrel AND it with the additional clauses (`SubjectID`, `DeleteAt`, `TeamID`, `ExcludeChannelMembers`, `Cursor`, `Term`). Since SQL binds `AND` tighter than `OR`, any expression whose top-level CEL operator was `||` (e.g. `Program has any of [Artemis, Helios]`) caused the AND-joined filters to apply only to the right-hand side of the OR — silently bypassing `Users.Id = $requesterID` and `Users.DeleteAt = 0`.

The most user-visible symptom: a channel admin building a multi-value `has any of` access rule that should match them is told **"You cannot test access rules that would exclude you from the channel"** and the **Test access rule** button is disabled, because `ValidateExpressionAgainstRequester`'s `SubjectID`-scoped lookup returned a different user (the lowest-`Id` user matching the OR's left branch).

Fix: wrap `opts.Query` in parentheses before adding it as a WHERE part. Same pattern `GetChannelMembersToRemove` already follows.

Added two regression tests under `testAttributesStoreSearchUsersBySubjectID` (both verified to fail without the fix):
- `Search users by SubjectID with top-level OR query does not bypass SubjectID filter`
- `Search users with top-level OR query does not surface soft-deleted users`

QA:
1. As a non–system-admin channel admin with a multiselect CPA value of `Artemis`, open Channel Settings → Access Control on a private channel.
2. Add `Program has any of [Artemis, Helios]`.
3. Verify **Test access rule** is enabled and the modal includes you.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-68538


#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change is localized to SQL construction in SearchUsers (wrapping the CEL→SQL expression in parentheses) and is covered by targeted unit and e2e regression tests, but it alters operator precedence which could affect edge-case queries or consumers that relied on the prior (incorrect) semantics; minor untested paths involving complex combined filters or unusual query args could surface regressions.  
**QA Recommendation:** Moderate manual QA recommended: exercise access-control flows and attribute-based searches with multi-value/OR predicates across SubjectID, TeamID, soft-deletes, term search, cursor pagination, and run basic query performance checks.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->