### PR TITLE
[release-11.7] ci: resolve enterprise branch from mattermost merge-base time (#36245)

### DIFF
--- a/enterprise.pin
+++ b/enterprise.pin
@@ -1,3 +1,0 @@
-# Enterprise commit this server branch is tested against.
-# Updated via: make bump-enterprise
-3a62315dded33319341ae9bd313d0d68171534ea


### PR DESCRIPTION
#### Summary
Cherry-pick of #36245 to `release-11.7`. Removes the `enterprise.pin` mechanism in favor of the time-based resolution of the enterprise branch already wired into the enterprise CI workflow (companion: mattermost/enterprise#2143).

#### Ticket Link
Cherry-pick of https://github.com/mattermost/mattermost/pull/36245

#### Conflict resolution notes
- `AGENTS.md` does not exist on `release-11.7` (deleted by us / modified by them). Kept it deleted.
- `enterprise.pin` exists on `release-11.7` (modified by us / deleted by them). Accepted the deletion — release branches now resolve enterprise via the new CI logic.
- `server/Makefile`'s `bump-enterprise` target does not exist on `release-11.7`, so the cherry-pick's removal of those lines was a no-op.

#### Release Note
```release-note
NONE
```