### PR TITLE
MM-67974: Add disk space info to Support Packet for local file store

### DIFF
--- a/server/channels/app/platform/disk_darwin.go
+++ b/server/channels/app/platform/disk_darwin.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build darwin
+
+package platform
+
+import (
+	"errors"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+type diskInfo struct {
+	TotalMB        uint64
+	AvailableMB    uint64
+	FilesystemType string
+}
+
+var errDiskInfoTimeout = errors.New("timed out getting disk space info")
+
+func getDiskInfo(path string) (diskInfo, error) {
+	type result struct {
+		info diskInfo
+		err  error
+	}
+
+	ch := make(chan result, 1)
+	go func() {
+		var stat unix.Statfs_t
+		if err := unix.Statfs(path, &stat); err != nil {
+			ch <- result{err: err}
+			return
+		}
+		bsize := uint64(stat.Bsize)
+		fsType := unix.ByteSliceToString(stat.Fstypename[:])
+		ch <- result{info: diskInfo{
+			TotalMB:        stat.Blocks * bsize / (1024 * 1024),
+			AvailableMB:    stat.Bavail * bsize / (1024 * 1024),
+			FilesystemType: fsType,
+		}}
+	}()
+
+	select {
+	case r := <-ch:
+		return r.info, r.err
+	case <-time.After(5 * time.Second):
+		return diskInfo{}, errDiskInfoTimeout
+	}
+}

--- a/server/channels/app/platform/disk_linux.go
+++ b/server/channels/app/platform/disk_linux.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build linux
+
+package platform
+
+import (
+	"errors"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+type diskInfo struct {
+	TotalMB        uint64
+	AvailableMB    uint64
+	FilesystemType string
+}
+
+var errDiskInfoTimeout = errors.New("timed out getting disk space info")
+
+func getDiskInfo(path string) (diskInfo, error) {
+	type result struct {
+		info diskInfo
+		err  error
+	}
+
+	ch := make(chan result, 1)
+	go func() {
+		var stat syscall.Statfs_t
+		if err := syscall.Statfs(path, &stat); err != nil {
+			ch <- result{err: err}
+			return
+		}
+		bsize := uint64(stat.Bsize)
+		ch <- result{info: diskInfo{
+			TotalMB:        stat.Blocks * bsize / (1024 * 1024),
+			AvailableMB:    stat.Bavail * bsize / (1024 * 1024),
+			FilesystemType: fsTypeToString(stat.Type),
+		}}
+	}()
+
+	select {
+	case r := <-ch:
+		return r.info, r.err
+	case <-time.After(5 * time.Second):
+		return diskInfo{}, errDiskInfoTimeout
+	}
+}
+
+func fsTypeToString(fsType int64) string {
+	switch fsType {
+	case unix.EXT4_SUPER_MAGIC:
+		return "ext4"
+	case unix.XFS_SUPER_MAGIC:
+		return "xfs"
+	case unix.NFS_SUPER_MAGIC:
+		return "nfs"
+	case unix.BTRFS_SUPER_MAGIC:
+		return "btrfs"
+	case unix.TMPFS_MAGIC:
+		return "tmpfs"
+	case unix.SMB_SUPER_MAGIC:
+		return "smb"
+	case unix.FUSE_SUPER_MAGIC:
+		return "fuse"
+	case unix.OVERLAYFS_SUPER_MAGIC:
+		return "overlay"
+	default:
+		return "unknown"
+	}
+}

--- a/server/channels/app/platform/disk_other.go
+++ b/server/channels/app/platform/disk_other.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+//go:build !linux && !darwin
+
+package platform
+
+import "errors"
+
+// ErrDiskSpaceUnsupportedPlatform is returned when disk space detection is not supported on the current platform.
+var ErrDiskSpaceUnsupportedPlatform = errors.New("disk space detection not supported on this platform")
+
+type diskInfo struct {
+	TotalMB        uint64
+	AvailableMB    uint64
+	FilesystemType string
+}
+
+func getDiskInfo(_ string) (diskInfo, error) {
+	return diskInfo{}, ErrDiskSpaceUnsupportedPlatform
+}

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -166,6 +166,20 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 		d.FileStore.Error = err.Error()
 	}
 	d.FileStore.Driver = ps.FileBackend().DriverName()
+	if d.FileStore.Driver == model.ImageDriverLocal {
+		dir := model.SafeDereference(ps.Config().FileSettings.Directory)
+		if dir == "" {
+			dir = model.FileSettingsDefaultDirectory
+		}
+		di, diskErr := getDiskInfo(dir)
+		if diskErr != nil {
+			rctx.Logger().Debug("Failed to get disk space info for Support Packet", mlog.Err(diskErr))
+		} else {
+			d.FileStore.TotalMB = di.TotalMB
+			d.FileStore.AvailableMB = di.AvailableMB
+			d.FileStore.FilesystemType = di.FilesystemType
+		}
+	}
 
 	/* Websockets */
 	d.Websocket.Connections = ps.TotalWebsocketConnections()

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -173,7 +173,7 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 		}
 		di, diskErr := getDiskInfo(dir)
 		if diskErr != nil {
-			rErr = multierror.Append(errors.Wrap(err, "error while getting disk space info"))
+			rErr = multierror.Append(errors.Wrap(diskErr, "error while getting disk space info"))
 		} else {
 			d.FileStore.FilesystemType = di.FilesystemType
 			d.FileStore.TotalMB = di.TotalMB

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -173,11 +173,11 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 		}
 		di, diskErr := getDiskInfo(dir)
 		if diskErr != nil {
-			rctx.Logger().Debug("Failed to get disk space info for Support Packet", mlog.Err(diskErr))
+			rErr = multierror.Append(errors.Wrap(err, "error while getting disk space info"))
 		} else {
+			d.FileStore.FilesystemType = di.FilesystemType
 			d.FileStore.TotalMB = di.TotalMB
 			d.FileStore.AvailableMB = di.AvailableMB
-			d.FileStore.FilesystemType = di.FilesystemType
 		}
 	}
 

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -238,13 +238,13 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		assert.Empty(t, d.FileStore.Error)
 		assert.Equal(t, "local", d.FileStore.Driver)
 		if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+			assert.NotEmpty(t, d.FileStore.FilesystemType, "FilesystemType should not be empty on supported platforms")
 			assert.Positive(t, d.FileStore.TotalMB, "TotalMB should be positive on supported platforms")
 			assert.Positive(t, d.FileStore.AvailableMB, "AvailableMB should be positive on supported platforms")
-			assert.NotEmpty(t, d.FileStore.FilesystemType, "FilesystemType should not be empty on supported platforms")
 		} else {
+			assert.Empty(t, d.FileStore.FilesystemType)
 			assert.Zero(t, d.FileStore.TotalMB)
 			assert.Zero(t, d.FileStore.AvailableMB)
-			assert.Empty(t, d.FileStore.FilesystemType)
 		}
 
 		/* Websockets */
@@ -299,9 +299,9 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 
 		assert.Equal(t, "OK", packet.FileStore.Status)
 		assert.Equal(t, "amazons3", packet.FileStore.Driver)
+		assert.Empty(t, packet.FileStore.FilesystemType)
 		assert.Zero(t, packet.FileStore.TotalMB)
 		assert.Zero(t, packet.FileStore.AvailableMB)
-		assert.Empty(t, packet.FileStore.FilesystemType)
 	})
 
 	t.Run("no LDAP info if LDAP sync is disabled", func(t *testing.T) {

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -237,6 +237,15 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		assert.Equal(t, "OK", d.FileStore.Status)
 		assert.Empty(t, d.FileStore.Error)
 		assert.Equal(t, "local", d.FileStore.Driver)
+		if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+			assert.Positive(t, d.FileStore.TotalMB, "TotalMB should be positive on supported platforms")
+			assert.Positive(t, d.FileStore.AvailableMB, "AvailableMB should be positive on supported platforms")
+			assert.NotEmpty(t, d.FileStore.FilesystemType, "FilesystemType should not be empty on supported platforms")
+		} else {
+			assert.Zero(t, d.FileStore.TotalMB)
+			assert.Zero(t, d.FileStore.AvailableMB)
+			assert.Empty(t, d.FileStore.FilesystemType)
+		}
 
 		/* Websockets */
 		assert.Zero(t, d.Websocket.Connections)
@@ -271,6 +280,22 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		assert.Equal(t, "FAIL", packet.FileStore.Status)
 		assert.Equal(t, "all broken", packet.FileStore.Error)
 		assert.Equal(t, "mock", packet.FileStore.Driver)
+	})
+
+	t.Run("s3 driver omits disk space fields", func(t *testing.T) {
+		fb := &fmocks.FileBackend{}
+		err := SetFileStore(fb)(th.Service)
+		require.NoError(t, err)
+		fb.On("DriverName").Return("amazons3")
+		fb.On("TestConnection").Return(nil)
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, "OK", packet.FileStore.Status)
+		assert.Equal(t, "amazons3", packet.FileStore.Driver)
+		assert.Zero(t, packet.FileStore.TotalMB)
+		assert.Zero(t, packet.FileStore.AvailableMB)
+		assert.Empty(t, packet.FileStore.FilesystemType)
 	})
 
 	t.Run("no LDAP info if LDAP sync is disabled", func(t *testing.T) {

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -283,6 +283,12 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 	})
 
 	t.Run("s3 driver omits disk space fields", func(t *testing.T) {
+		orig := th.Service.filestore
+		t.Cleanup(func() {
+			err := SetFileStore(orig)(th.Service)
+			require.NoError(t, err)
+		})
+
 		fb := &fmocks.FileBackend{}
 		err := SetFileStore(fb)(th.Service)
 		require.NoError(t, err)

--- a/server/public/model/support_packet.go
+++ b/server/public/model/support_packet.go
@@ -58,9 +58,12 @@ type SupportPacketDiagnostics struct {
 	} `yaml:"database"`
 
 	FileStore struct {
-		Status string `yaml:"file_status"`
-		Error  string `yaml:"erorr,omitempty"`
-		Driver string `yaml:"file_driver"`
+		Status         string `yaml:"file_status"`
+		Error          string `yaml:"erorr,omitempty"`
+		Driver         string `yaml:"file_driver"`
+		TotalMB        uint64 `yaml:"total_mb,omitempty"`
+		AvailableMB    uint64 `yaml:"available_mb,omitempty"`
+		FilesystemType string `yaml:"filesystem_type,omitempty"`
 	} `yaml:"file_store"`
 
 	Websocket struct {

--- a/server/public/model/support_packet.go
+++ b/server/public/model/support_packet.go
@@ -61,9 +61,9 @@ type SupportPacketDiagnostics struct {
 		Status         string `yaml:"file_status"`
 		Error          string `yaml:"erorr,omitempty"`
 		Driver         string `yaml:"file_driver"`
+		FilesystemType string `yaml:"filesystem_type,omitempty"`
 		TotalMB        uint64 `yaml:"total_mb,omitempty"`
 		AvailableMB    uint64 `yaml:"available_mb,omitempty"`
-		FilesystemType string `yaml:"filesystem_type,omitempty"`
 	} `yaml:"file_store"`
 
 	Websocket struct {


### PR DESCRIPTION
## Summary

```yml
file_store:
  file_status: OK
  file_driver: local
  total_mb: 866560
  available_mb: 571155
  filesystem_type: ext4
```

## AI Summary

- Adds `total_mb`, `available_mb`, and `filesystem_type` fields to the `file_store` section of `diagnostics.yaml` in the Support Packet
- Fields are populated only when `DriverName == "local"`; omitted (zero/empty) for S3 and unsupported platforms (Windows etc.)
- Uses `syscall.Statfs` on Linux and `unix.Statfs` on Darwin, wrapped in a goroutine with a 5-second timeout to guard against stale NFS mounts
- Filesystem type is mapped from magic numbers (Linux) or `Fstypename` (Darwin) — supports ext4, xfs, nfs, btrfs, tmpfs, smb, fuse, overlay


#### Ticket Link

Closes [MM-67974](https://mattermost.atlassian.net/browse/MM-67974)


#### Release Note
```release-note
Added `client.Audit` on `pluginapi.Client` for plugins to emit audit records via the server audit pipeline (server 10.10+).
```



[MM-67974]: https://mattermost.atlassian.net/browse/MM-67974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** Adds new optional fields to a public diagnostics struct and platform-specific filesystem probing that runs in goroutines with timeouts; while changes are mostly isolated to support packet generation, the added public fields change the diagnostics output and untested paths (statfs timeout and disk-error branch) present moderate regression risk.  
**QA Recommendation:** Moderate manual QA—verify support packet YAML still serializes correctly, confirm disk fields populate on Linux/Darwin with local file store and remain empty for S3/unsupported platforms, exercise the statfs timeout and error path to confirm errors are recorded (and the recent error-variable fix behaves correctly).

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->