### PR TITLE
Disable morph logging in NewTestPool

### DIFF
--- a/server/channels/store/sqlstore/testpool.go
+++ b/server/channels/store/sqlstore/testpool.go
@@ -38,7 +38,7 @@ func NewTestPool(logger mlog.LoggerIFace, driverName string, poolSize int) (*Tes
 			settings := storetest.MakeSqlSettings(driverName)
 			sqlStore, err := New(*settings, logger, nil, WithFeatureFlags(func() *model.FeatureFlags {
 				return &model.FeatureFlags{CJKSearch: true}
-			}))
+			}), DisableMorphLogging())
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
#### Summary

In a recent [tranche of flaky tests](https://github.com/mattermost/mattermost/actions/runs/25058902870/job/73407100475), the retries alone spammed the logs with morph migration details to the point that GitHub truncated the output and required using raw logs:

<img width="2238" height="684" alt="CleanShot 2026-04-28 at 13 35 49@2x" src="https://github.com/user-attachments/assets/b3e7cde7-5256-4827-965a-7487eb170d1e" />

Avoid this by disabling morph logs for the `NewTestPool` construct. We had originally kept this for the store since it might have made sense to log the migrations, but it has yet to prove useful. 

 Note that migration failures will still be surfaced: only the per-step progress chatter is suppressed.

#### Ticket Link

NONE

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This is a test-only logging configuration change with no impact on migration logic or behavior. The `DisableMorphLogging()` option is already established and widely used in other test files (testlib/helper.go, layer_test.go, searchlayer/layer_test.go), and migration failures are explicitly preserved—only debug output is suppressed.

**QA Recommendation:** Manual QA can be skipped. The change is a logging control flag affecting only test infrastructure with minimal risk; automated test coverage is already comprehensive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->