### PR TITLE
MM-68339: Fix CI... slugify RemoteCluster.Name in plugin registration

### DIFF
--- a/server/channels/app/remote_cluster.go
+++ b/server/channels/app/remote_cluster.go
@@ -62,9 +62,11 @@ func (a *App) RegisterPluginForSharedChannels(rctx request.CTX, opts model.Regis
 		return rc.RemoteId, nil
 	}
 
-	// New connection.
+	// New connection. Name must satisfy the slug-style regex enforced by
+	// RemoteCluster.IsValid, so derive it from Displayname; the original
+	// human-readable label is preserved on DisplayName.
 	rc = &model.RemoteCluster{
-		Name:        opts.Displayname,
+		Name:        model.CleanRemoteName(opts.Displayname),
 		DisplayName: opts.Displayname,
 		SiteURL:     opts.SiteURL,
 		Token:       model.NewId(),

--- a/server/public/model/remote_cluster.go
+++ b/server/public/model/remote_cluster.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -199,6 +200,35 @@ func IsValidRemoteName(s string) bool {
 		return false
 	}
 	return validRemoteNameChars.MatchString(s)
+}
+
+// CleanRemoteName converts an arbitrary string into a slug compatible with
+// IsValidRemoteName: lowercased, with spaces and other disallowed characters
+// replaced by hyphens. The result is truncated to RemoteNameMaxLength. If
+// the cleaned value is still invalid (e.g. empty input), a new ID is
+// substituted so the caller always receives a valid name.
+func CleanRemoteName(s string) string {
+	s = strings.ToLower(strings.ReplaceAll(s, " ", "-"))
+	s = strings.TrimSpace(s)
+
+	for _, c := range s {
+		char := fmt.Sprintf("%c", c)
+		if !validRemoteNameChars.MatchString(char) {
+			s = strings.ReplaceAll(s, char, "-")
+		}
+	}
+
+	s = strings.Trim(s, "-")
+
+	if len(s) > RemoteNameMaxLength {
+		s = strings.Trim(s[:RemoteNameMaxLength], "-")
+	}
+
+	if !IsValidRemoteName(s) {
+		s = NewId()
+	}
+
+	return s
 }
 
 func (rc *RemoteCluster) PreUpdate() {

--- a/server/public/model/remote_cluster_test.go
+++ b/server/public/model/remote_cluster_test.go
@@ -6,6 +6,7 @@ package model
 import (
 	"crypto/rand"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -255,5 +256,46 @@ func TestRemoteClusterIsPlugin(t *testing.T) {
 	t.Run("plugin_ SiteURL prefix with empty PluginID returns false", func(t *testing.T) {
 		rc := &RemoteCluster{SiteURL: SiteURLPlugin + "com.example.plugin"}
 		assert.False(t, rc.IsPlugin(), "IsPlugin should only check PluginID, not SiteURL prefix")
+	})
+}
+
+func TestCleanRemoteName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "single space", in: "legacy plugin", want: "legacy-plugin"},
+		{name: "multiple spaces", in: "remote 1 plugin", want: "remote-1-plugin"},
+		{name: "uppercase", in: "Plugin A", want: "plugin-a"},
+		{name: "preserves dot, hyphen, underscore", in: "com.example_plugin-1", want: "com.example_plugin-1"},
+		{name: "trims separators", in: "  ---my remote---  ", want: "my-remote"},
+		{name: "punctuation collapses", in: "plugin@home!", want: "plugin-home"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CleanRemoteName(tc.in)
+			assert.Equal(t, tc.want, got)
+			assert.True(t, IsValidRemoteName(got), "CleanRemoteName must produce a valid name")
+		})
+	}
+
+	t.Run("empty input falls back to NewId", func(t *testing.T) {
+		got := CleanRemoteName("")
+		assert.True(t, IsValidRemoteName(got))
+		assert.Len(t, got, 26)
+	})
+
+	t.Run("only invalid characters falls back to NewId", func(t *testing.T) {
+		got := CleanRemoteName("@@@ !!! ???")
+		assert.True(t, IsValidRemoteName(got))
+		assert.Len(t, got, 26)
+	})
+
+	t.Run("over-length input is truncated", func(t *testing.T) {
+		in := strings.Repeat("a", RemoteNameMaxLength+10)
+		got := CleanRemoteName(in)
+		assert.True(t, IsValidRemoteName(got))
+		assert.LessOrEqual(t, len(got), RemoteNameMaxLength)
 	})
 }


### PR DESCRIPTION
#### Summary
Follow-up to #36126. The new `TestRegisterPluginForSharedChannels` tests added in that PR broke master CI: `RegisterPluginForSharedChannels` assigns `opts.Displayname` directly to `RemoteCluster.Name`, which `IsValid` validates against the slug regex `^[a-zA-Z0-9.\-_]+$`. Display names with spaces (e.g. `"legacy plugin"`) fail validation. 

The new tests didn't get assigned to a shard in the PR's final CI run, so the failure only surfaced post-merge.                                                                                                                                                                
                                                                                                                                                                                           
This PR introduces a `CleanRemoteName` helper in `server/public/model` mirroring `CleanTeamName` and `CleanUsername`: lowercase, replace spaces and other disallowed characters with hyphens, trim leading/trailing   separators, truncate to `RemoteNameMaxLength`, and fall back to `NewId()` when the result would be empty.

`RegisterPluginForSharedChannels` now sets `Name: model.CleanRemoteName(opts.Displayname)`; `DisplayName` continues to carry the original human-readable label. As a side benefit, real plugins with display names containing spaces (e.g. `"Matrix Bridge to matrix.org"`) can now register successfully.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68554

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change introduces `CleanRemoteName()` which normalizes display names into slug-compatible names for plugin remotes. While isolated to `RegisterPluginForSharedChannels()`, the transformation could cause name mismatches if existing plugin remotes or external systems rely on specific Name formats or comparisons. The fallback to `NewId()` for empty/invalid inputs introduces non-deterministic behavior in edge cases.

**QA Recommendation:** Verify plugin shared-channel registration and re-registration workflows, especially with display names containing spaces, special characters, and edge cases (very long names, empty strings, only punctuation). Test idempotency of repeated registrations with the same SiteURL. Validate that the Name/DisplayName distinction is preserved correctly in all downstream references and that external integrations using RemoteCluster data are unaffected by the new name transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->