### PR TITLE
Add branch-freshness CI check

### DIFF
--- a/.github/scripts/branch-freshness-check.sh
+++ b/.github/scripts/branch-freshness-check.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 : "${MAX_AGE_DAYS:=7}"
 
 cmp=$(gh api "repos/${REPO}/compare/${BASE_SHA}...${HEAD_SHA}" \
-  --jq '{behind: .behind_by, mb_date: .merge_base_commit.committer.date}')
+  --jq '{behind: .behind_by, mb_date: .merge_base_commit.commit.committer.date}')
 
 commits_behind=$(jq -r '.behind' <<<"$cmp")
 mb_date=$(jq -r '.mb_date' <<<"$cmp")

--- a/.github/scripts/branch-freshness-check.sh
+++ b/.github/scripts/branch-freshness-check.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Compute branch freshness for a single PR (BASE_SHA vs HEAD_SHA in the upstream
+# repo) and emit the result on stdout as a single JSON object. Exits 0 if the
+# branch is within thresholds, 1 if not.
+#
+# Required env:
+#   BASE_SHA            base branch SHA (typically pull_request.base.sha).
+#   HEAD_SHA            PR head SHA (typically pull_request.head.sha).
+#   REPO                "owner/repo".
+#   GH_TOKEN            token for `gh api` (read access is enough).
+#
+# Optional env (thresholds; defaults are the source of truth):
+#   MAX_COMMITS_BEHIND  more commits behind master = fail (default 30).
+#   MAX_AGE_DAYS        merge-base older than this = fail (default 7).
+
+set -euo pipefail
+
+: "${BASE_SHA:?required}"
+: "${HEAD_SHA:?required}"
+: "${REPO:?required}"
+: "${GH_TOKEN:?required}"
+: "${MAX_COMMITS_BEHIND:=30}"
+: "${MAX_AGE_DAYS:=7}"
+
+cmp=$(gh api "repos/${REPO}/compare/${BASE_SHA}...${HEAD_SHA}" \
+  --jq '{behind: .behind_by, mb_date: .merge_base_commit.committer.date}')
+
+commits_behind=$(jq -r '.behind' <<<"$cmp")
+mb_date=$(jq -r '.mb_date' <<<"$cmp")
+mb_ts=$(date -u -d "$mb_date" +%s)
+now_ts=$(date -u +%s)
+age_seconds=$(( now_ts - mb_ts ))
+age_days=$(( age_seconds / 86400 ))
+max_age_seconds=$(( MAX_AGE_DAYS * 86400 ))
+
+conclusion=success
+title="${commits_behind} commits / ${age_days} days behind master"
+if [ "$commits_behind" -gt "$MAX_COMMITS_BEHIND" ] \
+    || [ "$age_seconds" -gt "$max_age_seconds" ]; then
+  conclusion=failure
+  title="Branch too far behind master: ${commits_behind} commits, ${age_days} days"
+fi
+
+summary="Commits behind master: ${commits_behind} (max ${MAX_COMMITS_BEHIND}). Merge-base age: ${age_days} days (max ${MAX_AGE_DAYS})."
+
+printf "%s\n" "$title" >&2
+
+jq -nc \
+  --arg conclusion "$conclusion" \
+  --arg title "$title" \
+  --arg summary "$summary" \
+  --argjson commits_behind "$commits_behind" \
+  --argjson age_days "$age_days" \
+  '{conclusion: $conclusion, title: $title, summary: $summary, commits_behind: $commits_behind, age_days: $age_days}'
+
+if [ "$conclusion" = "failure" ]; then
+  printf "::error::%s. Rebase or merge master into your branch.\n" "$title" >&2
+  exit 1
+fi

--- a/.github/scripts/branch-freshness-recheck.sh
+++ b/.github/scripts/branch-freshness-recheck.sh
@@ -24,14 +24,22 @@ prs_json=$(mktemp)
 trap 'rm -f "$prs_json"' EXIT
 
 gh pr list --repo "$REPO" --base master --state open --limit 1000 \
-  --json number,headRefOid,baseRefOid > "$prs_json"
+  --json number,headRefOid,baseRefOid,headRefName > "$prs_json"
 
-echo "Re-evaluating $(jq length "$prs_json") open PRs."
+# TODO: remove this filter once the check has been validated end-to-end.
+branch_filter="${BRANCH_PREFIX_FILTER:-}"
+
+echo "Re-evaluating $(jq length "$prs_json") open PRs${branch_filter:+ matching prefix '${branch_filter}'}."
 
 jq -c '.[]' "$prs_json" | while read -r pr; do
   number=$(jq -r '.number' <<<"$pr")
   head_sha=$(jq -r '.headRefOid' <<<"$pr")
   base_sha=$(jq -r '.baseRefOid' <<<"$pr")
+  head_ref=$(jq -r '.headRefName' <<<"$pr")
+
+  if [ -n "$branch_filter" ] && [[ "$head_ref" != "${branch_filter}"* ]]; then
+    continue
+  fi
 
   # branch-freshness-check.sh exits 1 when the branch is too far behind, but
   # still prints a JSON result to stdout. Treat empty output as a real error.
@@ -48,10 +56,28 @@ jq -c '.[]' "$prs_json" | while read -r pr; do
 
   printf "PR #%s @ %s -> %s (%s)\n" "$number" "$head_sha" "$conclusion" "$title"
 
-  if ! gh api "repos/${REPO}/check-runs" \
-      --method POST \
+  existing_id=$(gh api "repos/${REPO}/check-runs" \
+      --method GET \
       --field name='branch-freshness' \
       --field head_sha="$head_sha" \
+      --jq '.check_runs[0].id // empty' 2>/dev/null || true)
+
+  if [ -n "$existing_id" ]; then
+    method=PATCH
+    endpoint="repos/${REPO}/check-runs/${existing_id}"
+  else
+    method=POST
+    endpoint="repos/${REPO}/check-runs"
+  fi
+
+  extra_fields=()
+  if [ "$method" = POST ]; then
+    extra_fields=(--field name='branch-freshness' --field head_sha="$head_sha")
+  fi
+
+  if ! gh api "$endpoint" \
+      --method "$method" \
+      "${extra_fields[@]}" \
       --field status='completed' \
       --field conclusion="$conclusion" \
       --field "output[title]=$title" \

--- a/.github/scripts/branch-freshness-recheck.sh
+++ b/.github/scripts/branch-freshness-recheck.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Re-evaluate "branch freshness" for every open PR targeting master and post a
+# Check Run named "branch-freshness" to each PR's head SHA. Designed to run from
+# a scheduled GitHub Actions workflow so the threshold keeps applying after the
+# initial pull_request check has gone green.
+#
+# Required env:
+#   REPO                "owner/repo".
+#   GH_TOKEN            token with checks:write and pull-requests:read.
+#
+# Thresholds (MAX_COMMITS_BEHIND, MAX_AGE_DAYS) are owned by
+# branch-freshness-check.sh; this script just passes them through if set.
+
+set -euo pipefail
+
+: "${REPO:?required}"
+: "${GH_TOKEN:?required}"
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+check="${script_dir}/branch-freshness-check.sh"
+
+prs_json=$(mktemp)
+trap 'rm -f "$prs_json"' EXIT
+
+gh pr list --repo "$REPO" --base master --state open --limit 1000 \
+  --json number,headRefOid,baseRefOid > "$prs_json"
+
+echo "Re-evaluating $(jq length "$prs_json") open PRs."
+
+jq -c '.[]' "$prs_json" | while read -r pr; do
+  number=$(jq -r '.number' <<<"$pr")
+  head_sha=$(jq -r '.headRefOid' <<<"$pr")
+  base_sha=$(jq -r '.baseRefOid' <<<"$pr")
+
+  # branch-freshness-check.sh exits 1 when the branch is too far behind, but
+  # still prints a JSON result to stdout. Treat empty output as a real error.
+  if ! result=$(BASE_SHA="$base_sha" HEAD_SHA="$head_sha" bash "$check"); then
+    if [ -z "$result" ]; then
+      printf "PR #%s: check script errored, skipping.\n" "$number"
+      continue
+    fi
+  fi
+
+  conclusion=$(jq -r '.conclusion' <<<"$result")
+  title=$(jq -r '.title' <<<"$result")
+  summary=$(jq -r '.summary' <<<"$result")
+
+  printf "PR #%s @ %s -> %s (%s)\n" "$number" "$head_sha" "$conclusion" "$title"
+
+  gh api "repos/${REPO}/check-runs" \
+    --method POST \
+    --field name='branch-freshness' \
+    --field head_sha="$head_sha" \
+    --field status='completed' \
+    --field conclusion="$conclusion" \
+    --field "output[title]=$title" \
+    --field "output[summary]=$summary" >/dev/null
+done

--- a/.github/scripts/branch-freshness-recheck.sh
+++ b/.github/scripts/branch-freshness-recheck.sh
@@ -48,12 +48,15 @@ jq -c '.[]' "$prs_json" | while read -r pr; do
 
   printf "PR #%s @ %s -> %s (%s)\n" "$number" "$head_sha" "$conclusion" "$title"
 
-  gh api "repos/${REPO}/check-runs" \
-    --method POST \
-    --field name='branch-freshness' \
-    --field head_sha="$head_sha" \
-    --field status='completed' \
-    --field conclusion="$conclusion" \
-    --field "output[title]=$title" \
-    --field "output[summary]=$summary" >/dev/null
+  if ! gh api "repos/${REPO}/check-runs" \
+      --method POST \
+      --field name='branch-freshness' \
+      --field head_sha="$head_sha" \
+      --field status='completed' \
+      --field conclusion="$conclusion" \
+      --field "output[title]=$title" \
+      --field "output[summary]=$summary" >/dev/null; then
+    printf "PR #%s: failed to update check run, continuing.\n" "$number" >&2
+    continue
+  fi
 done

--- a/.github/workflows/branch-freshness-cron.yml
+++ b/.github/workflows/branch-freshness-cron.yml
@@ -20,6 +20,8 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
+      # TODO: remove once validated end-to-end; limits recheck to test branches only.
+      BRANCH_PREFIX_FILTER: test-branch-freshness
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/branch-freshness-cron.yml
+++ b/.github/workflows/branch-freshness-cron.yml
@@ -1,0 +1,28 @@
+name: Branch Freshness Cron
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: read
+
+jobs:
+  recheck-open-prs:
+    runs-on: ubuntu-22.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Re-evaluate freshness for open PRs targeting master
+        run: bash .github/scripts/branch-freshness-recheck.sh

--- a/.github/workflows/branch-freshness.yml
+++ b/.github/workflows/branch-freshness.yml
@@ -36,7 +36,9 @@ jobs:
 
           merge_base_ts=$(git show -s --format=%ct "$merge_base")
           now_ts=$(date -u +%s)
-          age_days=$(( (now_ts - merge_base_ts) / 86400 ))
+          age_seconds=$(( now_ts - merge_base_ts ))
+          age_days=$(( age_seconds / 86400 ))
+          max_age_seconds=$(( MAX_AGE_DAYS * 86400 ))
 
           echo "Commits behind ${BASE_REF}: ${commits_behind} (max ${MAX_COMMITS_BEHIND})"
           echo "Merge-base age:           ${age_days} days (max ${MAX_AGE_DAYS})"
@@ -46,7 +48,7 @@ jobs:
             echo "::error::Branch is ${commits_behind} commits behind ${BASE_REF} (max ${MAX_COMMITS_BEHIND}). Rebase or merge ${BASE_REF} into your branch."
             fail=1
           fi
-          if [ "$age_days" -gt "$MAX_AGE_DAYS" ]; then
+          if [ "$age_seconds" -gt "$max_age_seconds" ]; then
             echo "::error::Branch's merge-base with ${BASE_REF} is ${age_days} days old (max ${MAX_AGE_DAYS}). Rebase or merge ${BASE_REF} into your branch."
             fail=1
           fi

--- a/.github/workflows/branch-freshness.yml
+++ b/.github/workflows/branch-freshness.yml
@@ -16,40 +16,13 @@ jobs:
   branch-freshness:
     runs-on: ubuntu-22.04
     env:
-      MAX_COMMITS_BEHIND: 30
-      MAX_AGE_DAYS: 7
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
           persist-credentials: false
       - name: Check branch freshness
-        env:
-          BASE_REF: ${{ github.base_ref }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-
-          merge_base=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
-          commits_behind=$(git rev-list --count "$merge_base..$BASE_SHA")
-
-          merge_base_ts=$(git show -s --format=%ct "$merge_base")
-          now_ts=$(date -u +%s)
-          age_seconds=$(( now_ts - merge_base_ts ))
-          age_days=$(( age_seconds / 86400 ))
-          max_age_seconds=$(( MAX_AGE_DAYS * 86400 ))
-
-          echo "Commits behind ${BASE_REF}: ${commits_behind} (max ${MAX_COMMITS_BEHIND})"
-          echo "Merge-base age:           ${age_days} days (max ${MAX_AGE_DAYS})"
-
-          fail=0
-          if [ "$commits_behind" -gt "$MAX_COMMITS_BEHIND" ]; then
-            echo "::error::Branch is ${commits_behind} commits behind ${BASE_REF} (max ${MAX_COMMITS_BEHIND}). Rebase or merge ${BASE_REF} into your branch."
-            fail=1
-          fi
-          if [ "$age_seconds" -gt "$max_age_seconds" ]; then
-            echo "::error::Branch's merge-base with ${BASE_REF} is ${age_days} days old (max ${MAX_AGE_DAYS}). Rebase or merge ${BASE_REF} into your branch."
-            fail=1
-          fi
-          exit $fail
+        run: bash .github/scripts/branch-freshness-check.sh

--- a/.github/workflows/branch-freshness.yml
+++ b/.github/workflows/branch-freshness.yml
@@ -1,0 +1,53 @@
+name: Branch Freshness
+
+on:
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  branch-freshness:
+    runs-on: ubuntu-22.04
+    env:
+      MAX_COMMITS_BEHIND: 30
+      MAX_AGE_DAYS: 7
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check branch freshness
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          merge_base=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
+          commits_behind=$(git rev-list --count "$merge_base..$BASE_SHA")
+
+          merge_base_ts=$(git show -s --format=%ct "$merge_base")
+          now_ts=$(date -u +%s)
+          age_days=$(( (now_ts - merge_base_ts) / 86400 ))
+
+          echo "Commits behind ${BASE_REF}: ${commits_behind} (max ${MAX_COMMITS_BEHIND})"
+          echo "Merge-base age:           ${age_days} days (max ${MAX_AGE_DAYS})"
+
+          fail=0
+          if [ "$commits_behind" -gt "$MAX_COMMITS_BEHIND" ]; then
+            echo "::error::Branch is ${commits_behind} commits behind ${BASE_REF} (max ${MAX_COMMITS_BEHIND}). Rebase or merge ${BASE_REF} into your branch."
+            fail=1
+          fi
+          if [ "$age_days" -gt "$MAX_AGE_DAYS" ]; then
+            echo "::error::Branch's merge-base with ${BASE_REF} is ${age_days} days old (max ${MAX_AGE_DAYS}). Rebase or merge ${BASE_REF} into your branch."
+            fail=1
+          fi
+          exit $fail


### PR DESCRIPTION
#### Summary
Adds a `branch-freshness` GitHub Actions check that fails when a PR's merge-base with `master` is too far behind:

- More than **30 commits** behind `master`, or
- More than **7 days** old (by merge-base committer date).

Two triggers feed the same check:

- **Per-PR** (`.github/workflows/branch-freshness.yml`) — runs on `pull_request` against `master`. Catches drift at PR open / push.
- **Daily cron** (`.github/workflows/branch-freshness-cron.yml`, `0 6 * * *` UTC) — walks every open PR targeting `master` and posts a Check Run named `branch-freshness` to each PR's head SHA via the Checks API. Catches PRs that pass once and then sit stale as `master` advances.

Both triggers share `.github/scripts/branch-freshness-check.sh`, which queries the GitHub compare API for `behind_by` and `merge_base_commit.commit.committer.date`, emits a JSON result on stdout, and exits non-zero on threshold violation. The cron's `branch-freshness-recheck.sh` invokes the per-PR script once per open PR and POSTs the conclusion as a Check Run. Thresholds (`MAX_COMMITS_BEHIND`, `MAX_AGE_DAYS`) live only in the inner script as defaults.

To enforce, add `branch-freshness` as a required status check in `master` branch protection after this lands. Failure mode verified end-to-end in #36315 (test PR 31 commits behind, check fails with `Branch too far behind master: 31 commits, 5 days`).

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
