### PR TITLE
Add OAuth/OpenID provider diagnostics to support packet

### DIFF
--- a/server/channels/app/platform/enterprise.go
+++ b/server/channels/app/platform/enterprise.go
@@ -26,6 +26,12 @@ func RegisterLdapDiagnosticInterface(f func(*PlatformService) einterfaces.LdapDi
 	ldapDiagnosticInterface = f
 }
 
+var samlDiagnosticInterface func(*PlatformService) einterfaces.SamlDiagnosticInterface
+
+func RegisterSamlDiagnosticInterface(f func(*PlatformService) einterfaces.SamlDiagnosticInterface) {
+	samlDiagnosticInterface = f
+}
+
 var licenseInterface func(*PlatformService) einterfaces.LicenseInterface
 
 func RegisterLicenseInterface(f func(*PlatformService) einterfaces.LicenseInterface) {

--- a/server/channels/app/platform/enterprise.go
+++ b/server/channels/app/platform/enterprise.go
@@ -26,10 +26,10 @@ func RegisterLdapDiagnosticInterface(f func(*PlatformService) einterfaces.LdapDi
 	ldapDiagnosticInterface = f
 }
 
-var samlDiagnosticInterface func(*PlatformService) einterfaces.SamlDiagnosticInterface
+var supportPacketDiagnosticInterface func(*PlatformService) einterfaces.SupportPacketDiagnosticInterface
 
-func RegisterSamlDiagnosticInterface(f func(*PlatformService) einterfaces.SamlDiagnosticInterface) {
-	samlDiagnosticInterface = f
+func RegisterSupportPacketDiagnosticsInterface(f func(*PlatformService) einterfaces.SupportPacketDiagnosticInterface) {
+	supportPacketDiagnosticInterface = f
 }
 
 var licenseInterface func(*PlatformService) einterfaces.LicenseInterface

--- a/server/channels/app/platform/service.go
+++ b/server/channels/app/platform/service.go
@@ -96,8 +96,8 @@ type PlatformService struct {
 
 	esWatcher *searchEngineWatcher
 
-	ldapDiagnostic einterfaces.LdapDiagnosticInterface
-	samlDiagnostic einterfaces.SamlDiagnosticInterface
+	ldapDiagnostic          einterfaces.LdapDiagnosticInterface
+	supportPacketDiagnostic einterfaces.SupportPacketDiagnosticInterface
 
 	Jobs *jobs.JobServer
 
@@ -534,8 +534,8 @@ func (ps *PlatformService) initEnterprise() {
 	if ldapDiagnosticInterface != nil {
 		ps.ldapDiagnostic = ldapDiagnosticInterface(ps)
 	}
-	if samlDiagnosticInterface != nil {
-		ps.samlDiagnostic = samlDiagnosticInterface(ps)
+	if supportPacketDiagnosticInterface != nil {
+		ps.supportPacketDiagnostic = supportPacketDiagnosticInterface(ps)
 	}
 
 	if licenseInterface != nil {
@@ -671,8 +671,8 @@ func (ps *PlatformService) LdapDiagnostic() einterfaces.LdapDiagnosticInterface 
 	return ps.ldapDiagnostic
 }
 
-func (ps *PlatformService) SamlDiagnostic() einterfaces.SamlDiagnosticInterface {
-	return ps.samlDiagnostic
+func (ps *PlatformService) SupportPacketDiagnostic() einterfaces.SupportPacketDiagnosticInterface {
+	return ps.supportPacketDiagnostic
 }
 
 // DatabaseTypeAndSchemaVersion returns the database type and current version of the schema

--- a/server/channels/app/platform/service.go
+++ b/server/channels/app/platform/service.go
@@ -97,6 +97,7 @@ type PlatformService struct {
 	esWatcher *searchEngineWatcher
 
 	ldapDiagnostic einterfaces.LdapDiagnosticInterface
+	samlDiagnostic einterfaces.SamlDiagnosticInterface
 
 	Jobs *jobs.JobServer
 
@@ -533,6 +534,9 @@ func (ps *PlatformService) initEnterprise() {
 	if ldapDiagnosticInterface != nil {
 		ps.ldapDiagnostic = ldapDiagnosticInterface(ps)
 	}
+	if samlDiagnosticInterface != nil {
+		ps.samlDiagnostic = samlDiagnosticInterface(ps)
+	}
 
 	if licenseInterface != nil {
 		ps.licenseManager = licenseInterface(ps)
@@ -665,6 +669,10 @@ func (ps *PlatformService) ExportFileBackend() filestore.FileBackend {
 
 func (ps *PlatformService) LdapDiagnostic() einterfaces.LdapDiagnosticInterface {
 	return ps.ldapDiagnostic
+}
+
+func (ps *PlatformService) SamlDiagnostic() einterfaces.SamlDiagnosticInterface {
+	return ps.samlDiagnostic
 }
 
 // DatabaseTypeAndSchemaVersion returns the database type and current version of the schema

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/utils"
+	"github.com/mattermost/mattermost/server/v8/einterfaces"
 	"github.com/mattermost/mattermost/server/v8/platform/shared/mail"
 )
 
@@ -238,7 +239,7 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 
 	/* SAML */
 	if idpDescriptorURL := model.SafeDereference(ps.Config().SamlSettings.IdpDescriptorURL); idpDescriptorURL != "" {
-		d.SAML.ProviderType = detectSAMLProviderType(idpDescriptorURL)
+		d.SAML.ProviderType = ps.GetSupportPacketSAMLProviderType(idpDescriptorURL)
 	}
 
 	/* Elastic Search */
@@ -459,6 +460,17 @@ func testOIDCDiscoveryEndpoint(ctx context.Context, discoveryEndpoint string) er
 	}
 
 	return nil
+}
+
+func getSAMLProviderTypeForSupportPacket(rctx request.CTX, samlDiagnostic einterfaces.SamlDiagnosticInterface, idpDescriptorURL string) string {
+	if samlDiagnostic != nil {
+		return samlDiagnostic.DetectProviderType(rctx, idpDescriptorURL)
+	}
+	return detectSAMLProviderType(idpDescriptorURL)
+}
+
+func (ps *PlatformService) GetSupportPacketSAMLProviderType(idpDescriptorURL string) string {
+	return getSAMLProviderTypeForSupportPacket(request.EmptyContext(ps.Log()), ps.SamlDiagnostic(), idpDescriptorURL)
 }
 
 func (ps *PlatformService) getSanitizedConfigFile(rctx request.CTX) (*model.FileData, error) {

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -362,9 +362,7 @@ func testPushProxyConnection(ctx context.Context, serverURL string) error {
 }
 
 func getOAuthProviderStatusForTokenEndpoint(ctx context.Context, enabled bool, tokenEndpoint string) model.OAuthProviderStatus {
-	providerStatus := model.OAuthProviderStatus{
-		Enabled: enabled,
-	}
+	providerStatus := model.OAuthProviderStatus{}
 	if !enabled {
 		providerStatus.Status = model.StatusDisabled
 		return providerStatus
@@ -381,15 +379,13 @@ func getOAuthProviderStatusForTokenEndpoint(ctx context.Context, enabled bool, t
 }
 
 func getOpenIDProviderStatus(ctx context.Context, enabled bool, discoveryEndpoint string) model.OAuthProviderStatus {
-	providerStatus := model.OAuthProviderStatus{
-		Enabled: enabled,
-	}
+	providerStatus := model.OAuthProviderStatus{}
 	if !enabled {
 		providerStatus.Status = model.StatusDisabled
 		return providerStatus
 	}
 
-	issuer, err := testOIDCDiscoveryEndpoint(ctx, discoveryEndpoint)
+	err := testOIDCDiscoveryEndpoint(ctx, discoveryEndpoint)
 	if err != nil {
 		providerStatus.Status = model.StatusFail
 		providerStatus.Error = err.Error()
@@ -397,7 +393,6 @@ func getOpenIDProviderStatus(ctx context.Context, enabled bool, discoveryEndpoin
 	}
 
 	providerStatus.Status = model.StatusOk
-	providerStatus.DiscoveredIssuer = issuer
 	return providerStatus
 }
 
@@ -433,9 +428,9 @@ func testTokenEndpointHostConnection(ctx context.Context, tokenEndpoint string) 
 	return conn.Close()
 }
 
-func testOIDCDiscoveryEndpoint(ctx context.Context, discoveryEndpoint string) (string, error) {
+func testOIDCDiscoveryEndpoint(ctx context.Context, discoveryEndpoint string) error {
 	if discoveryEndpoint == "" {
-		return "", fmt.Errorf("discovery endpoint is empty")
+		return fmt.Errorf("discovery endpoint is empty")
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
@@ -443,27 +438,27 @@ func testOIDCDiscoveryEndpoint(ctx context.Context, discoveryEndpoint string) (s
 
 	req, err := http.NewRequestWithContext(timeoutCtx, http.MethodGet, discoveryEndpoint, nil)
 	if err != nil {
-		return "", err
+		return err
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", err
+		return err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= http.StatusBadRequest {
-		return "", fmt.Errorf("openid discovery endpoint returned unexpected status %d", resp.StatusCode)
+		return fmt.Errorf("openid discovery endpoint returned unexpected status %d", resp.StatusCode)
 	}
 
 	var document oidcDiscoveryDocument
 	if err := json.NewDecoder(resp.Body).Decode(&document); err != nil {
-		return "", fmt.Errorf("failed to decode OpenID Connect discovery document: %w", err)
+		return fmt.Errorf("failed to decode OpenID Connect discovery document: %w", err)
 	}
 	if document.Issuer == "" {
-		return "", fmt.Errorf("OpenID Connect discovery document is missing issuer")
+		return fmt.Errorf("OpenID Connect discovery document is missing issuer")
 	}
 
-	return document.Issuer, nil
+	return nil
 }
 
 func (ps *PlatformService) getSanitizedConfigFile(rctx request.CTX) (*model.FileData, error) {

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -31,6 +32,10 @@ const (
 	envVarInstallType = "MM_INSTALL_TYPE"
 	unknownDataPoint  = "unknown"
 )
+
+type oidcDiscoveryDocument struct {
+	Issuer string `json:"issuer"`
+}
 
 func (ps *PlatformService) GenerateSupportPacket(rctx request.CTX, options *model.SupportPacketOptions) ([]model.FileData, error) {
 	functions := map[string]func(request.CTX) (*model.FileData, error){
@@ -299,6 +304,28 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 		d.Notifications.Push.Status = model.StatusDisabled
 	}
 
+	/* OAuth Providers */
+	d.OAuthProviders.GitLab = getOAuthProviderStatusForTokenEndpoint(
+		rctx.Context(),
+		model.SafeDereference(ps.Config().GitLabSettings.Enable),
+		model.SafeDereference(ps.Config().GitLabSettings.TokenEndpoint),
+	)
+	d.OAuthProviders.Google = getOAuthProviderStatusForTokenEndpoint(
+		rctx.Context(),
+		model.SafeDereference(ps.Config().GoogleSettings.Enable),
+		model.SafeDereference(ps.Config().GoogleSettings.TokenEndpoint),
+	)
+	d.OAuthProviders.Office365 = getOAuthProviderStatusForTokenEndpoint(
+		rctx.Context(),
+		model.SafeDereference(ps.Config().Office365Settings.Enable),
+		model.SafeDereference(ps.Config().Office365Settings.TokenEndpoint),
+	)
+	d.OAuthProviders.OpenID = getOpenIDProviderStatus(
+		rctx.Context(),
+		model.SafeDereference(ps.Config().OpenIdSettings.Enable),
+		model.SafeDereference(ps.Config().OpenIdSettings.DiscoveryEndpoint),
+	)
+
 	b, err := yaml.Marshal(&d)
 	if err != nil {
 		rErr = multierror.Append(errors.Wrap(err, "failed to marshal Support Packet into yaml"))
@@ -332,6 +359,111 @@ func testPushProxyConnection(ctx context.Context, serverURL string) error {
 		return fmt.Errorf("push proxy returned unexpected status %d", resp.StatusCode)
 	}
 	return nil
+}
+
+func getOAuthProviderStatusForTokenEndpoint(ctx context.Context, enabled bool, tokenEndpoint string) model.OAuthProviderStatus {
+	providerStatus := model.OAuthProviderStatus{
+		Enabled: enabled,
+	}
+	if !enabled {
+		providerStatus.Status = model.StatusDisabled
+		return providerStatus
+	}
+
+	if err := testTokenEndpointHostConnection(ctx, tokenEndpoint); err != nil {
+		providerStatus.Status = model.StatusFail
+		providerStatus.Error = err.Error()
+		return providerStatus
+	}
+
+	providerStatus.Status = model.StatusOk
+	return providerStatus
+}
+
+func getOpenIDProviderStatus(ctx context.Context, enabled bool, discoveryEndpoint string) model.OAuthProviderStatus {
+	providerStatus := model.OAuthProviderStatus{
+		Enabled: enabled,
+	}
+	if !enabled {
+		providerStatus.Status = model.StatusDisabled
+		return providerStatus
+	}
+
+	issuer, err := testOIDCDiscoveryEndpoint(ctx, discoveryEndpoint)
+	if err != nil {
+		providerStatus.Status = model.StatusFail
+		providerStatus.Error = err.Error()
+		return providerStatus
+	}
+
+	providerStatus.Status = model.StatusOk
+	providerStatus.DiscoveredIssuer = issuer
+	return providerStatus
+}
+
+func testTokenEndpointHostConnection(ctx context.Context, tokenEndpoint string) error {
+	parsedTokenEndpoint, err := url.Parse(tokenEndpoint)
+	if err != nil {
+		return fmt.Errorf("failed to parse token endpoint: %w", err)
+	}
+	if parsedTokenEndpoint.Hostname() == "" {
+		return fmt.Errorf("token endpoint %q does not include a valid host", tokenEndpoint)
+	}
+
+	port := parsedTokenEndpoint.Port()
+	if port == "" {
+		switch parsedTokenEndpoint.Scheme {
+		case "https":
+			port = "443"
+		case "http":
+			port = "80"
+		default:
+			return fmt.Errorf("token endpoint %q does not include a supported scheme", tokenEndpoint)
+		}
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	dialer := net.Dialer{}
+	conn, err := dialer.DialContext(timeoutCtx, "tcp", net.JoinHostPort(parsedTokenEndpoint.Hostname(), port))
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}
+
+func testOIDCDiscoveryEndpoint(ctx context.Context, discoveryEndpoint string) (string, error) {
+	if discoveryEndpoint == "" {
+		return "", fmt.Errorf("discovery endpoint is empty")
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(timeoutCtx, http.MethodGet, discoveryEndpoint, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return "", fmt.Errorf("openid discovery endpoint returned unexpected status %d", resp.StatusCode)
+	}
+
+	var document oidcDiscoveryDocument
+	if err := json.NewDecoder(resp.Body).Decode(&document); err != nil {
+		return "", fmt.Errorf("failed to decode OpenID Connect discovery document: %w", err)
+	}
+	if document.Issuer == "" {
+		return "", fmt.Errorf("OpenID Connect discovery document is missing issuer")
+	}
+
+	return document.Issuer, nil
 }
 
 func (ps *PlatformService) getSanitizedConfigFile(rctx request.CTX) (*model.FileData, error) {

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -239,7 +239,7 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 
 	/* SAML */
 	if idpDescriptorURL := model.SafeDereference(ps.Config().SamlSettings.IdpDescriptorURL); idpDescriptorURL != "" {
-		d.SAML.ProviderType = ps.GetSupportPacketSAMLProviderType(idpDescriptorURL)
+		d.SAML.ProviderType = detectSAMLProviderType(idpDescriptorURL)
 	}
 
 	/* Elastic Search */
@@ -306,26 +306,7 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 	}
 
 	/* OAuth Providers */
-	d.OAuthProviders.GitLab = getOAuthProviderStatusForTokenEndpoint(
-		rctx.Context(),
-		model.SafeDereference(ps.Config().GitLabSettings.Enable),
-		model.SafeDereference(ps.Config().GitLabSettings.TokenEndpoint),
-	)
-	d.OAuthProviders.Google = getOAuthProviderStatusForTokenEndpoint(
-		rctx.Context(),
-		model.SafeDereference(ps.Config().GoogleSettings.Enable),
-		model.SafeDereference(ps.Config().GoogleSettings.TokenEndpoint),
-	)
-	d.OAuthProviders.Office365 = getOAuthProviderStatusForTokenEndpoint(
-		rctx.Context(),
-		model.SafeDereference(ps.Config().Office365Settings.Enable),
-		model.SafeDereference(ps.Config().Office365Settings.TokenEndpoint),
-	)
-	d.OAuthProviders.OpenID = getOpenIDProviderStatus(
-		rctx.Context(),
-		model.SafeDereference(ps.Config().OpenIdSettings.Enable),
-		model.SafeDereference(ps.Config().OpenIdSettings.DiscoveryEndpoint),
-	)
+	d.OAuthProviders = ps.GetOAuthProvidersDiagnosticsForSupportPacket(rctx.Context())
 
 	b, err := yaml.Marshal(&d)
 	if err != nil {
@@ -462,15 +443,37 @@ func testOIDCDiscoveryEndpoint(ctx context.Context, discoveryEndpoint string) er
 	return nil
 }
 
-func getSAMLProviderTypeForSupportPacket(rctx request.CTX, samlDiagnostic einterfaces.SamlDiagnosticInterface, idpDescriptorURL string) string {
-	if samlDiagnostic != nil {
-		return samlDiagnostic.DetectProviderType(rctx, idpDescriptorURL)
+func getOAuthProvidersDiagnosticsForSupportPacket(ctx context.Context, oauthDiagnostic einterfaces.SupportPacketDiagnosticInterface, cfg *model.Config) model.OAuthProviders {
+	if oauthDiagnostic != nil {
+		return oauthDiagnostic.GetOAuthProvidersStatus(request.EmptyContext(mlog.CreateConsoleLogger()).WithContext(ctx), cfg)
 	}
-	return detectSAMLProviderType(idpDescriptorURL)
+
+	return model.OAuthProviders{
+		GitLab: getOAuthProviderStatusForTokenEndpoint(
+			ctx,
+			model.SafeDereference(cfg.GitLabSettings.Enable),
+			model.SafeDereference(cfg.GitLabSettings.TokenEndpoint),
+		),
+		Google: getOAuthProviderStatusForTokenEndpoint(
+			ctx,
+			model.SafeDereference(cfg.GoogleSettings.Enable),
+			model.SafeDereference(cfg.GoogleSettings.TokenEndpoint),
+		),
+		Office365: getOAuthProviderStatusForTokenEndpoint(
+			ctx,
+			model.SafeDereference(cfg.Office365Settings.Enable),
+			model.SafeDereference(cfg.Office365Settings.TokenEndpoint),
+		),
+		OpenID: getOpenIDProviderStatus(
+			ctx,
+			model.SafeDereference(cfg.OpenIdSettings.Enable),
+			model.SafeDereference(cfg.OpenIdSettings.DiscoveryEndpoint),
+		),
+	}
 }
 
-func (ps *PlatformService) GetSupportPacketSAMLProviderType(idpDescriptorURL string) string {
-	return getSAMLProviderTypeForSupportPacket(request.EmptyContext(ps.Log()), ps.SamlDiagnostic(), idpDescriptorURL)
+func (ps *PlatformService) GetOAuthProvidersDiagnosticsForSupportPacket(ctx context.Context) model.OAuthProviders {
+	return getOAuthProvidersDiagnosticsForSupportPacket(ctx, ps.SupportPacketDiagnostic(), ps.Config())
 }
 
 func (ps *PlatformService) getSanitizedConfigFile(rctx request.CTX) (*model.FileData, error) {

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -33,14 +33,6 @@ import (
 	fmocks "github.com/mattermost/mattermost/server/v8/platform/shared/filestore/mocks"
 )
 
-type samlDiagnosticStub struct {
-	providerType string
-}
-
-func (s *samlDiagnosticStub) DetectProviderType(_ request.CTX, _ string) string {
-	return s.providerType
-}
-
 func TestGenerateSupportPacket(t *testing.T) {
 	mainHelper.Parallel(t)
 
@@ -1069,22 +1061,53 @@ func TestGetOpenIDProviderStatus(t *testing.T) {
 	})
 }
 
-func TestGetSAMLProviderTypeForSupportPacket(t *testing.T) {
-	t.Run("falls back to local detection when enterprise hook is unavailable", func(t *testing.T) {
-		providerType := getSAMLProviderTypeForSupportPacket(
-			request.EmptyContext(mlog.CreateConsoleLogger()),
+type oauthDiagnosticStub struct {
+	status model.OAuthProviders
+}
+
+func (o *oauthDiagnosticStub) GetOAuthProvidersStatus(_ request.CTX, _ *model.Config) model.OAuthProviders {
+	return o.status
+}
+
+func TestGetOAuthProvidersDiagnosticsForSupportPacket(t *testing.T) {
+	t.Run("falls back to local token endpoint probe when enterprise hook is unavailable", func(t *testing.T) {
+		tokenEndpointServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer tokenEndpointServer.Close()
+
+		cfg := &model.Config{}
+		cfg.SetDefaults()
+		cfg.GitLabSettings.Enable = model.NewPointer(true)
+		cfg.GitLabSettings.TokenEndpoint = model.NewPointer(tokenEndpointServer.URL + "/oauth/token")
+		cfg.GoogleSettings.Enable = model.NewPointer(false)
+		cfg.Office365Settings.Enable = model.NewPointer(false)
+		cfg.OpenIdSettings.Enable = model.NewPointer(false)
+
+		status := getOAuthProvidersDiagnosticsForSupportPacket(
+			t.Context(),
 			nil,
-			"https://company.okta.com/app/mattermost/saml",
+			cfg,
 		)
-		assert.Equal(t, "Okta", providerType)
+		assert.Equal(t, model.StatusOk, status.GitLab.Status)
+		assert.Equal(t, model.StatusDisabled, status.Google.Status)
+		assert.Equal(t, model.StatusDisabled, status.Office365.Status)
+		assert.Equal(t, model.StatusDisabled, status.OpenID.Status)
 	})
 
 	t.Run("uses enterprise hook when available", func(t *testing.T) {
-		providerType := getSAMLProviderTypeForSupportPacket(
-			request.EmptyContext(mlog.CreateConsoleLogger()),
-			&samlDiagnosticStub{providerType: "EE Provider"},
-			"https://saml.example.com/metadata",
+		expected := model.OAuthProviders{
+			GitLab: model.OAuthProviderStatus{Status: model.StatusOk},
+			Google: model.OAuthProviderStatus{Status: model.StatusFail, Error: "google down"},
+		}
+		cfg := &model.Config{}
+		cfg.SetDefaults()
+
+		status := getOAuthProvidersDiagnosticsForSupportPacket(
+			t.Context(),
+			&oauthDiagnosticStub{status: expected},
+			cfg,
 		)
-		assert.Equal(t, "EE Provider", providerType)
+		assert.Equal(t, expected, status)
 	})
 }

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -710,14 +710,9 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		packet := getDiagnostics(t)
 
 		assert.Equal(t, model.StatusDisabled, packet.OAuthProviders.GitLab.Status)
-		assert.False(t, packet.OAuthProviders.GitLab.Enabled)
 		assert.Equal(t, model.StatusDisabled, packet.OAuthProviders.Google.Status)
-		assert.False(t, packet.OAuthProviders.Google.Enabled)
 		assert.Equal(t, model.StatusDisabled, packet.OAuthProviders.Office365.Status)
-		assert.False(t, packet.OAuthProviders.Office365.Enabled)
 		assert.Equal(t, model.StatusDisabled, packet.OAuthProviders.OpenID.Status)
-		assert.False(t, packet.OAuthProviders.OpenID.Enabled)
-		assert.Empty(t, packet.OAuthProviders.OpenID.DiscoveredIssuer)
 	})
 
 	t.Run("oauth token endpoint providers reachable", func(t *testing.T) {
@@ -746,13 +741,10 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		packet := getDiagnostics(t)
 
 		assert.Equal(t, model.StatusOk, packet.OAuthProviders.GitLab.Status)
-		assert.True(t, packet.OAuthProviders.GitLab.Enabled)
 		assert.Empty(t, packet.OAuthProviders.GitLab.Error)
 		assert.Equal(t, model.StatusOk, packet.OAuthProviders.Google.Status)
-		assert.True(t, packet.OAuthProviders.Google.Enabled)
 		assert.Empty(t, packet.OAuthProviders.Google.Error)
 		assert.Equal(t, model.StatusOk, packet.OAuthProviders.Office365.Status)
-		assert.True(t, packet.OAuthProviders.Office365.Enabled)
 		assert.Empty(t, packet.OAuthProviders.Office365.Error)
 	})
 
@@ -776,13 +768,10 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		packet := getDiagnostics(t)
 
 		assert.Equal(t, model.StatusFail, packet.OAuthProviders.GitLab.Status)
-		assert.True(t, packet.OAuthProviders.GitLab.Enabled)
 		assert.NotEmpty(t, packet.OAuthProviders.GitLab.Error)
 		assert.Equal(t, model.StatusFail, packet.OAuthProviders.Google.Status)
-		assert.True(t, packet.OAuthProviders.Google.Enabled)
 		assert.NotEmpty(t, packet.OAuthProviders.Google.Error)
 		assert.Equal(t, model.StatusFail, packet.OAuthProviders.Office365.Status)
-		assert.True(t, packet.OAuthProviders.Office365.Enabled)
 		assert.NotEmpty(t, packet.OAuthProviders.Office365.Error)
 	})
 
@@ -810,8 +799,6 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		packet := getDiagnostics(t)
 
 		assert.Equal(t, model.StatusOk, packet.OAuthProviders.OpenID.Status)
-		assert.True(t, packet.OAuthProviders.OpenID.Enabled)
-		assert.Equal(t, "https://idp.example.com", packet.OAuthProviders.OpenID.DiscoveredIssuer)
 		assert.Empty(t, packet.OAuthProviders.OpenID.Error)
 	})
 
@@ -838,8 +825,6 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		packet := getDiagnostics(t)
 
 		assert.Equal(t, model.StatusFail, packet.OAuthProviders.OpenID.Status)
-		assert.True(t, packet.OAuthProviders.OpenID.Enabled)
-		assert.Empty(t, packet.OAuthProviders.OpenID.DiscoveredIssuer)
 		assert.Contains(t, packet.OAuthProviders.OpenID.Error, "missing issuer")
 	})
 }
@@ -1019,7 +1004,6 @@ func TestDetectSAMLProviderType(t *testing.T) {
 func TestGetOAuthProviderStatusForTokenEndpoint(t *testing.T) {
 	t.Run("disabled provider", func(t *testing.T) {
 		status := getOAuthProviderStatusForTokenEndpoint(t.Context(), false, "")
-		assert.False(t, status.Enabled)
 		assert.Equal(t, model.StatusDisabled, status.Status)
 		assert.Empty(t, status.Error)
 	})
@@ -1031,14 +1015,12 @@ func TestGetOAuthProviderStatusForTokenEndpoint(t *testing.T) {
 		defer tokenEndpointServer.Close()
 
 		status := getOAuthProviderStatusForTokenEndpoint(t.Context(), true, tokenEndpointServer.URL+"/oauth/token")
-		assert.True(t, status.Enabled)
 		assert.Equal(t, model.StatusOk, status.Status)
 		assert.Empty(t, status.Error)
 	})
 
 	t.Run("unreachable token endpoint host", func(t *testing.T) {
 		status := getOAuthProviderStatusForTokenEndpoint(t.Context(), true, "http://localhost:1/oauth/token")
-		assert.True(t, status.Enabled)
 		assert.Equal(t, model.StatusFail, status.Status)
 		assert.NotEmpty(t, status.Error)
 	})
@@ -1047,10 +1029,8 @@ func TestGetOAuthProviderStatusForTokenEndpoint(t *testing.T) {
 func TestGetOpenIDProviderStatus(t *testing.T) {
 	t.Run("disabled provider", func(t *testing.T) {
 		status := getOpenIDProviderStatus(t.Context(), false, "")
-		assert.False(t, status.Enabled)
 		assert.Equal(t, model.StatusDisabled, status.Status)
 		assert.Empty(t, status.Error)
-		assert.Empty(t, status.DiscoveredIssuer)
 	})
 
 	t.Run("reachable discovery endpoint with issuer", func(t *testing.T) {
@@ -1062,9 +1042,7 @@ func TestGetOpenIDProviderStatus(t *testing.T) {
 		defer discoveryEndpointServer.Close()
 
 		status := getOpenIDProviderStatus(t.Context(), true, discoveryEndpointServer.URL+"/.well-known/openid-configuration")
-		assert.True(t, status.Enabled)
 		assert.Equal(t, model.StatusOk, status.Status)
-		assert.Equal(t, "https://idp.example.com", status.DiscoveredIssuer)
 		assert.Empty(t, status.Error)
 	})
 
@@ -1077,9 +1055,7 @@ func TestGetOpenIDProviderStatus(t *testing.T) {
 		defer discoveryEndpointServer.Close()
 
 		status := getOpenIDProviderStatus(t.Context(), true, discoveryEndpointServer.URL+"/.well-known/openid-configuration")
-		assert.True(t, status.Enabled)
 		assert.Equal(t, model.StatusFail, status.Status)
 		assert.Contains(t, status.Error, "missing issuer")
-		assert.Empty(t, status.DiscoveredIssuer)
 	})
 }

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -1015,3 +1015,71 @@ func TestDetectSAMLProviderType(t *testing.T) {
 		})
 	}
 }
+
+func TestGetOAuthProviderStatusForTokenEndpoint(t *testing.T) {
+	t.Run("disabled provider", func(t *testing.T) {
+		status := getOAuthProviderStatusForTokenEndpoint(t.Context(), false, "")
+		assert.False(t, status.Enabled)
+		assert.Equal(t, model.StatusDisabled, status.Status)
+		assert.Empty(t, status.Error)
+	})
+
+	t.Run("reachable token endpoint host", func(t *testing.T) {
+		tokenEndpointServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer tokenEndpointServer.Close()
+
+		status := getOAuthProviderStatusForTokenEndpoint(t.Context(), true, tokenEndpointServer.URL+"/oauth/token")
+		assert.True(t, status.Enabled)
+		assert.Equal(t, model.StatusOk, status.Status)
+		assert.Empty(t, status.Error)
+	})
+
+	t.Run("unreachable token endpoint host", func(t *testing.T) {
+		status := getOAuthProviderStatusForTokenEndpoint(t.Context(), true, "http://localhost:1/oauth/token")
+		assert.True(t, status.Enabled)
+		assert.Equal(t, model.StatusFail, status.Status)
+		assert.NotEmpty(t, status.Error)
+	})
+}
+
+func TestGetOpenIDProviderStatus(t *testing.T) {
+	t.Run("disabled provider", func(t *testing.T) {
+		status := getOpenIDProviderStatus(t.Context(), false, "")
+		assert.False(t, status.Enabled)
+		assert.Equal(t, model.StatusDisabled, status.Status)
+		assert.Empty(t, status.Error)
+		assert.Empty(t, status.DiscoveredIssuer)
+	})
+
+	t.Run("reachable discovery endpoint with issuer", func(t *testing.T) {
+		discoveryEndpointServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, writeErr := w.Write([]byte(`{"issuer":"https://idp.example.com"}`))
+			require.NoError(t, writeErr)
+		}))
+		defer discoveryEndpointServer.Close()
+
+		status := getOpenIDProviderStatus(t.Context(), true, discoveryEndpointServer.URL+"/.well-known/openid-configuration")
+		assert.True(t, status.Enabled)
+		assert.Equal(t, model.StatusOk, status.Status)
+		assert.Equal(t, "https://idp.example.com", status.DiscoveredIssuer)
+		assert.Empty(t, status.Error)
+	})
+
+	t.Run("discovery endpoint missing issuer", func(t *testing.T) {
+		discoveryEndpointServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, writeErr := w.Write([]byte(`{}`))
+			require.NoError(t, writeErr)
+		}))
+		defer discoveryEndpointServer.Close()
+
+		status := getOpenIDProviderStatus(t.Context(), true, discoveryEndpointServer.URL+"/.well-known/openid-configuration")
+		assert.True(t, status.Enabled)
+		assert.Equal(t, model.StatusFail, status.Status)
+		assert.Contains(t, status.Error, "missing issuer")
+		assert.Empty(t, status.DiscoveredIssuer)
+	})
+}

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -698,6 +698,150 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		assert.Equal(t, model.StatusFail, packet.Notifications.Email.Status)
 		assert.NotEmpty(t, packet.Notifications.Email.Error)
 	})
+
+	t.Run("oauth providers disabled", func(t *testing.T) {
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.GitLabSettings.Enable = model.NewPointer(false)
+			cfg.GoogleSettings.Enable = model.NewPointer(false)
+			cfg.Office365Settings.Enable = model.NewPointer(false)
+			cfg.OpenIdSettings.Enable = model.NewPointer(false)
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusDisabled, packet.OAuthProviders.GitLab.Status)
+		assert.False(t, packet.OAuthProviders.GitLab.Enabled)
+		assert.Equal(t, model.StatusDisabled, packet.OAuthProviders.Google.Status)
+		assert.False(t, packet.OAuthProviders.Google.Enabled)
+		assert.Equal(t, model.StatusDisabled, packet.OAuthProviders.Office365.Status)
+		assert.False(t, packet.OAuthProviders.Office365.Enabled)
+		assert.Equal(t, model.StatusDisabled, packet.OAuthProviders.OpenID.Status)
+		assert.False(t, packet.OAuthProviders.OpenID.Enabled)
+		assert.Empty(t, packet.OAuthProviders.OpenID.DiscoveredIssuer)
+	})
+
+	t.Run("oauth token endpoint providers reachable", func(t *testing.T) {
+		tokenEndpointServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer tokenEndpointServer.Close()
+
+		tokenEndpoint := tokenEndpointServer.URL + "/oauth/token"
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.GitLabSettings.Enable = model.NewPointer(true)
+			cfg.GitLabSettings.TokenEndpoint = model.NewPointer(tokenEndpoint)
+			cfg.GoogleSettings.Enable = model.NewPointer(true)
+			cfg.GoogleSettings.TokenEndpoint = model.NewPointer(tokenEndpoint)
+			cfg.Office365Settings.Enable = model.NewPointer(true)
+			cfg.Office365Settings.TokenEndpoint = model.NewPointer(tokenEndpoint)
+		})
+		t.Cleanup(func() {
+			th.Service.UpdateConfig(func(cfg *model.Config) {
+				cfg.GitLabSettings.Enable = model.NewPointer(false)
+				cfg.GoogleSettings.Enable = model.NewPointer(false)
+				cfg.Office365Settings.Enable = model.NewPointer(false)
+			})
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusOk, packet.OAuthProviders.GitLab.Status)
+		assert.True(t, packet.OAuthProviders.GitLab.Enabled)
+		assert.Empty(t, packet.OAuthProviders.GitLab.Error)
+		assert.Equal(t, model.StatusOk, packet.OAuthProviders.Google.Status)
+		assert.True(t, packet.OAuthProviders.Google.Enabled)
+		assert.Empty(t, packet.OAuthProviders.Google.Error)
+		assert.Equal(t, model.StatusOk, packet.OAuthProviders.Office365.Status)
+		assert.True(t, packet.OAuthProviders.Office365.Enabled)
+		assert.Empty(t, packet.OAuthProviders.Office365.Error)
+	})
+
+	t.Run("oauth token endpoint providers unreachable", func(t *testing.T) {
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.GitLabSettings.Enable = model.NewPointer(true)
+			cfg.GitLabSettings.TokenEndpoint = model.NewPointer("http://localhost:1/oauth/token")
+			cfg.GoogleSettings.Enable = model.NewPointer(true)
+			cfg.GoogleSettings.TokenEndpoint = model.NewPointer("http://localhost:1/oauth/token")
+			cfg.Office365Settings.Enable = model.NewPointer(true)
+			cfg.Office365Settings.TokenEndpoint = model.NewPointer("http://localhost:1/oauth/token")
+		})
+		t.Cleanup(func() {
+			th.Service.UpdateConfig(func(cfg *model.Config) {
+				cfg.GitLabSettings.Enable = model.NewPointer(false)
+				cfg.GoogleSettings.Enable = model.NewPointer(false)
+				cfg.Office365Settings.Enable = model.NewPointer(false)
+			})
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusFail, packet.OAuthProviders.GitLab.Status)
+		assert.True(t, packet.OAuthProviders.GitLab.Enabled)
+		assert.NotEmpty(t, packet.OAuthProviders.GitLab.Error)
+		assert.Equal(t, model.StatusFail, packet.OAuthProviders.Google.Status)
+		assert.True(t, packet.OAuthProviders.Google.Enabled)
+		assert.NotEmpty(t, packet.OAuthProviders.Google.Error)
+		assert.Equal(t, model.StatusFail, packet.OAuthProviders.Office365.Status)
+		assert.True(t, packet.OAuthProviders.Office365.Enabled)
+		assert.NotEmpty(t, packet.OAuthProviders.Office365.Error)
+	})
+
+	t.Run("openid provider reachable with discovery issuer", func(t *testing.T) {
+		discoveryEndpointServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/.well-known/openid-configuration", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			_, writeErr := w.Write([]byte(`{"issuer":"https://idp.example.com"}`))
+			require.NoError(t, writeErr)
+		}))
+		defer discoveryEndpointServer.Close()
+
+		discoveryEndpoint := discoveryEndpointServer.URL + "/.well-known/openid-configuration"
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.OpenIdSettings.Enable = model.NewPointer(true)
+			cfg.OpenIdSettings.DiscoveryEndpoint = model.NewPointer(discoveryEndpoint)
+		})
+		t.Cleanup(func() {
+			th.Service.UpdateConfig(func(cfg *model.Config) {
+				cfg.OpenIdSettings.Enable = model.NewPointer(false)
+				cfg.OpenIdSettings.DiscoveryEndpoint = model.NewPointer("")
+			})
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusOk, packet.OAuthProviders.OpenID.Status)
+		assert.True(t, packet.OAuthProviders.OpenID.Enabled)
+		assert.Equal(t, "https://idp.example.com", packet.OAuthProviders.OpenID.DiscoveredIssuer)
+		assert.Empty(t, packet.OAuthProviders.OpenID.Error)
+	})
+
+	t.Run("openid provider discovery endpoint failure", func(t *testing.T) {
+		discoveryEndpointServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, writeErr := w.Write([]byte(`{}`))
+			require.NoError(t, writeErr)
+		}))
+		defer discoveryEndpointServer.Close()
+
+		discoveryEndpoint := discoveryEndpointServer.URL + "/.well-known/openid-configuration"
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.OpenIdSettings.Enable = model.NewPointer(true)
+			cfg.OpenIdSettings.DiscoveryEndpoint = model.NewPointer(discoveryEndpoint)
+		})
+		t.Cleanup(func() {
+			th.Service.UpdateConfig(func(cfg *model.Config) {
+				cfg.OpenIdSettings.Enable = model.NewPointer(false)
+				cfg.OpenIdSettings.DiscoveryEndpoint = model.NewPointer("")
+			})
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusFail, packet.OAuthProviders.OpenID.Status)
+		assert.True(t, packet.OAuthProviders.OpenID.Enabled)
+		assert.Empty(t, packet.OAuthProviders.OpenID.DiscoveredIssuer)
+		assert.Contains(t, packet.OAuthProviders.OpenID.Error, "missing issuer")
+	})
 }
 
 func TestGetSanitizedConfigFile(t *testing.T) {

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -25,12 +25,21 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/testlib"
 	"github.com/mattermost/mattermost/server/v8/config"
 	emocks "github.com/mattermost/mattermost/server/v8/einterfaces/mocks"
 	semocks "github.com/mattermost/mattermost/server/v8/platform/services/searchengine/mocks"
 	fmocks "github.com/mattermost/mattermost/server/v8/platform/shared/filestore/mocks"
 )
+
+type samlDiagnosticStub struct {
+	providerType string
+}
+
+func (s *samlDiagnosticStub) DetectProviderType(_ request.CTX, _ string) string {
+	return s.providerType
+}
 
 func TestGenerateSupportPacket(t *testing.T) {
 	mainHelper.Parallel(t)
@@ -1057,5 +1066,25 @@ func TestGetOpenIDProviderStatus(t *testing.T) {
 		status := getOpenIDProviderStatus(t.Context(), true, discoveryEndpointServer.URL+"/.well-known/openid-configuration")
 		assert.Equal(t, model.StatusFail, status.Status)
 		assert.Contains(t, status.Error, "missing issuer")
+	})
+}
+
+func TestGetSAMLProviderTypeForSupportPacket(t *testing.T) {
+	t.Run("falls back to local detection when enterprise hook is unavailable", func(t *testing.T) {
+		providerType := getSAMLProviderTypeForSupportPacket(
+			request.EmptyContext(mlog.CreateConsoleLogger()),
+			nil,
+			"https://company.okta.com/app/mattermost/saml",
+		)
+		assert.Equal(t, "Okta", providerType)
+	})
+
+	t.Run("uses enterprise hook when available", func(t *testing.T) {
+		providerType := getSAMLProviderTypeForSupportPacket(
+			request.EmptyContext(mlog.CreateConsoleLogger()),
+			&samlDiagnosticStub{providerType: "EE Provider"},
+			"https://saml.example.com/metadata",
+		)
+		assert.Equal(t, "EE Provider", providerType)
 	})
 }

--- a/server/einterfaces/saml.go
+++ b/server/einterfaces/saml.go
@@ -16,3 +16,7 @@ type SamlInterface interface {
 	GetMetadata(rctx request.CTX) (string, *model.AppError)
 	CheckProviderAttributes(rctx request.CTX, SS *model.SamlSettings, ouser *model.User, patch *model.UserPatch) string
 }
+
+type SamlDiagnosticInterface interface {
+	DetectProviderType(rctx request.CTX, idpDescriptorURL string) string
+}

--- a/server/einterfaces/saml.go
+++ b/server/einterfaces/saml.go
@@ -16,7 +16,3 @@ type SamlInterface interface {
 	GetMetadata(rctx request.CTX) (string, *model.AppError)
 	CheckProviderAttributes(rctx request.CTX, SS *model.SamlSettings, ouser *model.User, patch *model.UserPatch) string
 }
-
-type SamlDiagnosticInterface interface {
-	DetectProviderType(rctx request.CTX, idpDescriptorURL string) string
-}

--- a/server/einterfaces/support_packet.go
+++ b/server/einterfaces/support_packet.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package einterfaces
+
+import (
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+)
+
+type SupportPacketDiagnosticInterface interface {
+	GetOAuthProvidersStatus(rctx request.CTX, cfg *model.Config) model.OAuthProviders
+}

--- a/server/public/model/support_packet.go
+++ b/server/public/model/support_packet.go
@@ -104,6 +104,22 @@ type SupportPacketDiagnostics struct {
 		ServerPlugins []string `yaml:"server_plugins,omitempty"`
 		Error         string   `yaml:"error,omitempty"`
 	} `yaml:"elastic"`
+
+	OAuthProviders OAuthProviders `yaml:"oauth_providers,omitempty"`
+}
+
+type OAuthProviderStatus struct {
+	Enabled          bool   `yaml:"enabled"`
+	Status           string `yaml:"status,omitempty"`
+	Error            string `yaml:"error,omitempty"`
+	DiscoveredIssuer string `yaml:"discovered_issuer,omitempty"`
+}
+
+type OAuthProviders struct {
+	GitLab    OAuthProviderStatus `yaml:"gitlab,omitempty"`
+	Google    OAuthProviderStatus `yaml:"google,omitempty"`
+	Office365 OAuthProviderStatus `yaml:"office365,omitempty"`
+	OpenID    OAuthProviderStatus `yaml:"openid,omitempty"`
 }
 
 type SupportPacketStats struct {

--- a/server/public/model/support_packet.go
+++ b/server/public/model/support_packet.go
@@ -109,10 +109,8 @@ type SupportPacketDiagnostics struct {
 }
 
 type OAuthProviderStatus struct {
-	Enabled          bool   `yaml:"enabled"`
-	Status           string `yaml:"status,omitempty"`
-	Error            string `yaml:"error,omitempty"`
-	DiscoveredIssuer string `yaml:"discovered_issuer,omitempty"`
+	Status string `yaml:"status,omitempty"`
+	Error  string `yaml:"error,omitempty"`
 }
 
 type OAuthProviders struct {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Adds OAuth/OpenID provider diagnostics to support packet `diagnostics.yaml` by reporting per-provider status and connectivity errors based on endpoint reachability checks. Routes OAuth support-packet diagnostics through a new enterprise extension interface when available, with team-edition fallback to existing local probes.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-68577

#### Screenshots
N/A (non-UI change)

#### Release Note
```release-note
Added OAuth/OpenID provider diagnostics to support packets, including provider status and connectivity errors. Added an enterprise hook for support-packet OAuth diagnostics with fallback behavior.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1003feb0-ee4a-4447-a32a-458cba9dd2dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1003feb0-ee4a-4447-a32a-458cba9dd2dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

