### PR TITLE
Avoid setting an empty value on slash command IconURL

### DIFF
--- a/server/channels/app/command.go
+++ b/server/channels/app/command.go
@@ -672,8 +672,6 @@ func (a *App) HandleCommandResponsePost(rctx request.CTX, command *model.Command
 		} else if response.IconURL != "" {
 			post.AddProp(model.PostPropsOverrideIconURL, response.IconURL)
 			isBotPost = true
-		} else {
-			post.AddProp(model.PostPropsOverrideIconURL, "")
 		}
 	}
 

--- a/server/channels/app/slashcommands/command_test.go
+++ b/server/channels/app/slashcommands/command_test.go
@@ -257,6 +257,7 @@ func TestHandleCommandResponsePost(t *testing.T) {
 	post, err = th.App.HandleCommandResponsePost(th.Context, command, args, resp, builtIn)
 	assert.Nil(t, err)
 	assert.Nil(t, post.GetProp(model.PostPropsOverrideIconURL))
+	assert.NotContains(t, post.GetProps(), model.PostPropsOverrideIconURL)
 
 	resp.IconURL = "Response icon url"
 

--- a/server/channels/app/slashcommands/command_test.go
+++ b/server/channels/app/slashcommands/command_test.go
@@ -250,6 +250,16 @@ func TestHandleCommandResponsePost(t *testing.T) {
 	assert.Equal(t, resp.IconURL, post.GetProp(model.PostPropsOverrideIconURL))
 	assert.Equal(t, "true", post.GetProp(model.PostPropsFromWebhook))
 
+	resp.IconURL = ""
+
+	// When both command and response icon URLs are empty and EnablePostIconOverride is enabled,
+	// override_icon_url must not be set (avoids spurious "prop must be a valid URL" warning).
+	post, err = th.App.HandleCommandResponsePost(th.Context, command, args, resp, builtIn)
+	assert.Nil(t, err)
+	assert.Nil(t, post.GetProp(model.PostPropsOverrideIconURL))
+
+	resp.IconURL = "Response icon url"
+
 	// Test Slack text conversion.
 	resp.Text = "<!channel>"
 


### PR DESCRIPTION
#### Summary
When `EnablePostIconOverride` is enabled and a slash command response is processed, the post-handling code unconditionally fell into an `else` branch and set `override_icon_url` to an empty string whenever neither the command nor the response provided an icon URL. Downstream consumers validate this prop as a URL, so the empty value produced a spurious "prop must be a valid URL" warning.

This change drops the empty-string assignment so the prop is simply omitted when there is no icon URL to set, and adds a regression test asserting `override_icon_url` is `nil` in that case.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68099

#### Release Note
```release-note
* Fixed a spurious "prop must be a valid URL" warning that was logged when handling slash command responses that had no icon URL configured.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to a single function that sets a post property and removes an unconditional empty-string assignment; it does not touch shared utilities, critical auth/data flows, or public APIs, and a regression test was added to cover the modified path.  
**QA Recommendation:** Manual QA can be skipped; the automated regression test validates the intended behavior and risk is minimal.

*Generated by CodeRabbitAI*

---

## Release Notes

Fixed a spurious "prop must be a valid URL" warning logged when handling slash command responses that had no icon URL configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->