### PR TITLE
fix: retry image preview loads after mini preview fallback

### DIFF
--- a/webapp/channels/src/components/size_aware_image.test.tsx
+++ b/webapp/channels/src/components/size_aware_image.test.tsx
@@ -98,25 +98,71 @@ describe('components/SizeAwareImage', () => {
 
     test('should retry loading the image when mini preview is shown', () => {
         jest.useFakeTimers();
-        const props = {
-            ...baseProps,
-            onImageLoadFail: jest.fn(),
-            fileInfo: TestHelper.getFileInfoMock({
-                ...baseProps.fileInfo,
-                mime_type: 'image/png',
-                mini_preview: 'mini_preview',
-            }),
-        };
+        try {
+            const props = {
+                ...baseProps,
+                onImageLoadFail: jest.fn(),
+                fileInfo: TestHelper.getFileInfoMock({
+                    ...baseProps.fileInfo,
+                    mime_type: 'image/png',
+                    mini_preview: 'mini_preview',
+                }),
+            };
 
-        const {container} = renderWithContext(<SizeAwareImage {...props}/>, state);
+            const {container} = renderWithContext(<SizeAwareImage {...props}/>, state);
 
-        simulateImageError(container.querySelector('.file-preview__button img')!);
-        act(() => {
-            jest.runOnlyPendingTimers();
-        });
+            simulateImageError(container.querySelector('.file-preview__button img')!);
+            act(() => {
+                jest.runOnlyPendingTimers();
+            });
 
-        expect(container.querySelector('.file-preview__button img')?.getAttribute('src')).toEqual(`${props.src}?retry=1`);
-        jest.useRealTimers();
+            expect(container.querySelector('.file-preview__button img')?.getAttribute('src')).toEqual(`${props.src}?retry=1`);
+            expect(props.onImageLoadFail).not.toHaveBeenCalled();
+
+            for (let retry = 2; retry <= 3; retry++) {
+                simulateImageError(container.querySelector('.file-preview__button img')!);
+                act(() => {
+                    jest.runOnlyPendingTimers();
+                });
+
+                expect(container.querySelector('.file-preview__button img')?.getAttribute('src')).toEqual(`${props.src}?retry=${retry}`);
+                expect(props.onImageLoadFail).not.toHaveBeenCalled();
+            }
+
+            simulateImageError(container.querySelector('.file-preview__button img')!);
+
+            expect(props.onImageLoadFail).toHaveBeenCalledTimes(1);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('should not retry loading rejected files', () => {
+        jest.useFakeTimers();
+        try {
+            const props = {
+                ...baseProps,
+                isFileRejected: true,
+                onImageLoadFail: jest.fn(),
+                fileInfo: TestHelper.getFileInfoMock({
+                    ...baseProps.fileInfo,
+                    mime_type: 'image/png',
+                    mini_preview: 'mini_preview',
+                }),
+            };
+
+            const {container} = renderWithContext(<SizeAwareImage {...props}/>, state);
+
+            simulateImageError(container.querySelector('.file-preview__button img')!);
+            act(() => {
+                jest.runOnlyPendingTimers();
+            });
+
+            expect(container.querySelector('.file-preview__button img')?.getAttribute('src')).toEqual(props.src);
+            expect(props.onImageLoadFail).toHaveBeenCalledTimes(1);
+        } finally {
+            jest.useRealTimers();
+        }
     });
 
     test('should have display set to initial in loaded state', () => {

--- a/webapp/channels/src/components/size_aware_image.test.tsx
+++ b/webapp/channels/src/components/size_aware_image.test.tsx
@@ -96,6 +96,29 @@ describe('components/SizeAwareImage', () => {
         expect(miniPreviewImg?.getAttribute('src')).toEqual('data:mime_type;base64,mini_preview');
     });
 
+    test('should retry loading the image when mini preview is shown', () => {
+        jest.useFakeTimers();
+        const props = {
+            ...baseProps,
+            onImageLoadFail: jest.fn(),
+            fileInfo: TestHelper.getFileInfoMock({
+                ...baseProps.fileInfo,
+                mime_type: 'image/png',
+                mini_preview: 'mini_preview',
+            }),
+        };
+
+        const {container} = renderWithContext(<SizeAwareImage {...props}/>, state);
+
+        simulateImageError(container.querySelector('.file-preview__button img')!);
+        act(() => {
+            jest.runOnlyPendingTimers();
+        });
+
+        expect(container.querySelector('.file-preview__button img')?.getAttribute('src')).toEqual(`${props.src}?retry=1`);
+        jest.useRealTimers();
+    });
+
     test('should have display set to initial in loaded state', () => {
         const {container} = renderWithContext(<SizeAwareImage {...baseProps}/>, state);
 

--- a/webapp/channels/src/components/size_aware_image.tsx
+++ b/webapp/channels/src/components/size_aware_image.tsx
@@ -118,6 +118,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
     public heightTimeout = 0;
     public mounted = false;
     public timeout: NodeJS.Timeout | null = null;
+    public imageRetryTimeout: NodeJS.Timeout | null = null;
 
     constructor(props: Props) {
         super(props);
@@ -143,6 +144,10 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
 
     componentWillUnmount() {
         this.mounted = false;
+        if (this.imageRetryTimeout) {
+            clearTimeout(this.imageRetryTimeout);
+            this.imageRetryTimeout = null;
+        }
     }
 
     dimensionsAvailable = (dimensions?: Partial<PostImage>) => {
@@ -172,14 +177,17 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
 
     handleError = () => {
         if (this.mounted) {
-            if (this.props.onImageLoadFail) {
-                this.props.onImageLoadFail();
-            }
+            const shouldRetry = !this.props.isFileRejected && getFileMiniPreviewUrl(this.props.fileInfo) && this.state.imageRetry < MAX_IMAGE_LOAD_RETRIES;
+
             this.setState({error: true});
 
-            if (getFileMiniPreviewUrl(this.props.fileInfo) && this.state.imageRetry < MAX_IMAGE_LOAD_RETRIES) {
+            if (shouldRetry) {
                 const imageRetry = this.state.imageRetry + 1;
-                setTimeout(() => {
+                if (this.imageRetryTimeout) {
+                    clearTimeout(this.imageRetryTimeout);
+                }
+                this.imageRetryTimeout = setTimeout(() => {
+                    this.imageRetryTimeout = null;
                     if (this.mounted) {
                         this.setState({
                             error: false,
@@ -187,6 +195,11 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
                         });
                     }
                 }, IMAGE_LOAD_RETRY_DELAY);
+                return;
+            }
+
+            if (this.props.onImageLoadFail) {
+                this.props.onImageLoadFail();
             }
         }
     };

--- a/webapp/channels/src/components/size_aware_image.tsx
+++ b/webapp/channels/src/components/size_aware_image.tsx
@@ -25,6 +25,8 @@ import {copyToClipboard, getFileType} from 'utils/utils';
 const MIN_IMAGE_SIZE = 48;
 const MIN_IMAGE_SIZE_FOR_INTERNAL_BUTTONS = 100;
 const MAX_IMAGE_HEIGHT = 350;
+const MAX_IMAGE_LOAD_RETRIES = 3;
+const IMAGE_LOAD_RETRY_DELAY = 1000;
 
 export type Props = WrappedComponentProps & {
 
@@ -107,6 +109,7 @@ type State = {
     linkCopyInProgress: boolean;
     error: boolean;
     imageWidth: number;
+    imageRetry: number;
 }
 
 // SizeAwareImage is a component used for rendering images where the dimensions of the image are important for
@@ -128,6 +131,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
             linkCopyInProgress: false,
             error: false,
             imageWidth: 0,
+            imageRetry: 0,
         };
 
         this.heightTimeout = 0;
@@ -172,6 +176,18 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
                 this.props.onImageLoadFail();
             }
             this.setState({error: true});
+
+            if (getFileMiniPreviewUrl(this.props.fileInfo) && this.state.imageRetry < MAX_IMAGE_LOAD_RETRIES) {
+                const imageRetry = this.state.imageRetry + 1;
+                setTimeout(() => {
+                    if (this.mounted) {
+                        this.setState({
+                            error: false,
+                            imageRetry,
+                        });
+                    }
+                }, IMAGE_LOAD_RETRY_DELAY);
+            }
         }
     };
 
@@ -235,6 +251,9 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
             };
         }
 
+        const separator = src.includes('?') ? '&' : '?';
+        const imageSrc = this.state.imageRetry ? `${src}${separator}retry=${this.state.imageRetry}` : src;
+
         const image = (
             <img
                 {...props}
@@ -246,7 +265,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
                     this.props.className +
                     (this.props.handleSmallImageContainer &&
                         this.state.isSmallImage ? ' small-image--inside-container' : '')}
-                src={src}
+                src={imageSrc}
                 onError={this.handleError}
                 onLoad={this.handleLoad}
                 style={conditionalSVGStyleAttribute}


### PR DESCRIPTION
#### Summary
Retry mini-preview-backed image loads after a transient full preview image failure so the post does not stay stuck on the blurred mini preview until the component remounts.

<img width="589" height="443" alt="image" src="https://github.com/user-attachments/assets/64bca67b-aba1-4df9-a901-138882a0ff4d" />


Added a regression test covering the first failed image load updating the hidden image request URL.

QA steps:
1. Post an image that includes a mini preview.
2. Fail the first `/api/v4/files/<id>/preview` request in the browser devtools network panel or a proxy.
3. Verify the full preview retries and loads without switching channels or remounting the post.

#### Ticket Link
N/A

#### Screenshots
N/A

#### Release Note
```release-note
Fixed an issue where image previews could remain stuck on the blurred mini preview after a transient preview load failure.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change adds stateful retry timing to a UI image component's error path; while retries are bounded and covered by new tests, the timing and URL-manipulation logic could produce edge cases across consumers that render the same component. No core auth/data flows are affected and successful load paths are unchanged.

**QA Recommendation:** Full manual QA recommended for the retry scenario in all places the component is used (posts, attachments, single image view, markdown), verifying retries succeed after transient failures and that unmounting or rapid navigation doesn't cause leaks or stuck mini-previews.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->