### PR TITLE
MM-64977: Fix channel switcher row overlap with long channel and team names

### DIFF
--- a/webapp/channels/src/components/suggestion/switch_channel_provider.test.tsx
+++ b/webapp/channels/src/components/suggestion/switch_channel_provider.test.tsx
@@ -1542,9 +1542,12 @@ describe('SwitchChannelSuggestion', () => {
             const primaryColumn = flexRow.querySelector(':scope > .suggestion-list__switch-channel-primary');
             expect(primaryColumn).not.toBeNull();
 
-            const teamNameNode = flexRow.querySelector(':scope > .suggestion-list__team-name');
+            const teamNameNode = flexRow.querySelector('.suggestion-list__team-name');
             expect(teamNameNode).not.toBeNull();
             expect(teamNameNode).toHaveTextContent(longTeam1.display_name);
+
+            // Team name must live outside the primary column so it remains a flex sibling that doesn't shrink with the channel name.
+            expect(primaryColumn!.contains(teamNameNode)).toBe(false);
 
             // Channel name span should live inside the primary column with the truncation class
             const channelNameNode = primaryColumn!.querySelector('.suggestion-list__channel-name-text');
@@ -1573,6 +1576,10 @@ describe('SwitchChannelSuggestion', () => {
             const channelNameTooltip = tooltips.find((node) => node.getAttribute('data-tooltip-title') === longChannel.display_name);
             expect(channelNameTooltip).toBeDefined();
             expect(channelNameTooltip).toHaveAttribute('data-tooltip-disabled', 'true');
+
+            const teamNameTooltip = tooltips.find((node) => node.getAttribute('data-tooltip-title') === longTeam1.display_name);
+            expect(teamNameTooltip).toBeDefined();
+            expect(teamNameTooltip).toHaveAttribute('data-tooltip-disabled', 'true');
         });
 
         test('should enable the channel-name tooltip when the channel name overflows its container', () => {
@@ -1596,6 +1603,10 @@ describe('SwitchChannelSuggestion', () => {
             const channelNameTooltip = tooltips.find((node) => node.getAttribute('data-tooltip-title') === longChannel.display_name);
             expect(channelNameTooltip).toBeDefined();
             expect(channelNameTooltip).toHaveAttribute('data-tooltip-disabled', 'false');
+
+            const teamNameTooltip = tooltips.find((node) => node.getAttribute('data-tooltip-title') === longTeam1.display_name);
+            expect(teamNameTooltip).toBeDefined();
+            expect(teamNameTooltip).toHaveAttribute('data-tooltip-disabled', 'false');
         });
     });
 });

--- a/webapp/channels/src/components/suggestion/switch_channel_provider.test.tsx
+++ b/webapp/channels/src/components/suggestion/switch_channel_provider.test.tsx
@@ -52,6 +52,25 @@ jest.mock('mattermost-redux/actions/channels', () => ({
     })),
 }));
 
+jest.mock('components/with_tooltip', () => {
+    const ReactActual = jest.requireActual('react');
+    const Mock = jest.fn(({children, title, disabled}: {children: React.ReactNode; title: unknown; disabled?: boolean}) => {
+        return ReactActual.createElement(
+            'div',
+            {
+                'data-testid': 'with-tooltip',
+                'data-tooltip-title': typeof title === 'string' ? title : '',
+                'data-tooltip-disabled': String(Boolean(disabled)),
+            },
+            children,
+        );
+    });
+    return {
+        __esModule: true,
+        default: Mock,
+    };
+});
+
 describe('components/SwitchChannelProvider', () => {
     const defaultState = {
         entities: {
@@ -1471,5 +1490,112 @@ describe('SwitchChannelSuggestion', () => {
         expect(screen.queryByLabelText('5 unread notifications')).toBeInTheDocument();
         expect(suggestion).toHaveAccessibleName(channel3.display_name);
         expect(suggestion).toHaveAccessibleDescription(`5 unread notifications ~${channel3.name} Public channel`);
+    });
+
+    describe('layout and tooltip behavior for long names', () => {
+        const longTeam1 = TestHelper.getTeamMock({
+            id: 'team1',
+            display_name: 'A Very Long Team Display Name That Will Likely Overflow Its Slot In The Switcher',
+        });
+        const longTeam2 = TestHelper.getTeamMock({
+            id: 'team2',
+            display_name: 'Another Long Team Two',
+        });
+        const longChannel = TestHelper.getChannelMock({
+            id: 'channel1',
+            team_id: 'team1',
+            name: 'super_long_channel_name',
+            display_name: 'Super Extremely Long Channel Display Name That Should Truncate With An Ellipsis',
+        });
+
+        afterEach(() => {
+            // reset prototype overrides between tests
+            Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {configurable: true, value: 0});
+            Object.defineProperty(HTMLElement.prototype, 'clientWidth', {configurable: true, value: 0});
+        });
+
+        test('should render team name as a sibling of the primary column wrapper inside .suggestion-list__flex when on multiple teams', () => {
+            renderWithContext(
+                <ConnectedSwitchChannelSuggestion
+                    {...baseProps}
+                    term={longChannel.name}
+                    item={{
+                        channel: longChannel,
+                        name: longChannel.name,
+                        deactivated: false,
+                    }}
+                />,
+                getBaseState([longTeam1, longTeam2], [longChannel]),
+            );
+
+            const suggestion = document.getElementById(baseProps.id) as HTMLElement;
+            expect(suggestion).toBeInTheDocument();
+
+            // Both nodes (channel name and team name) are present
+            expect(screen.getByText(longChannel.display_name)).toBeInTheDocument();
+            expect(screen.getByText(longTeam1.display_name)).toBeInTheDocument();
+
+            // The flex row contains the primary column wrapper and the team name as siblings
+            const flexRow = suggestion.querySelector('.suggestion-list__flex') as HTMLElement;
+            expect(flexRow).not.toBeNull();
+
+            const primaryColumn = flexRow.querySelector(':scope > .suggestion-list__switch-channel-primary');
+            expect(primaryColumn).not.toBeNull();
+
+            const teamNameNode = flexRow.querySelector(':scope > .suggestion-list__team-name');
+            expect(teamNameNode).not.toBeNull();
+            expect(teamNameNode).toHaveTextContent(longTeam1.display_name);
+
+            // Channel name span should live inside the primary column with the truncation class
+            const channelNameNode = primaryColumn!.querySelector('.suggestion-list__channel-name-text');
+            expect(channelNameNode).not.toBeNull();
+            expect(channelNameNode).toHaveTextContent(longChannel.display_name);
+        });
+
+        test('should disable the channel-name tooltip when the channel name fits its container', () => {
+            Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {configurable: true, value: 100});
+            Object.defineProperty(HTMLElement.prototype, 'clientWidth', {configurable: true, value: 100});
+
+            renderWithContext(
+                <ConnectedSwitchChannelSuggestion
+                    {...baseProps}
+                    term={longChannel.name}
+                    item={{
+                        channel: longChannel,
+                        name: longChannel.name,
+                        deactivated: false,
+                    }}
+                />,
+                getBaseState([longTeam1, longTeam2], [longChannel]),
+            );
+
+            const tooltips = screen.getAllByTestId('with-tooltip');
+            const channelNameTooltip = tooltips.find((node) => node.getAttribute('data-tooltip-title') === longChannel.display_name);
+            expect(channelNameTooltip).toBeDefined();
+            expect(channelNameTooltip).toHaveAttribute('data-tooltip-disabled', 'true');
+        });
+
+        test('should enable the channel-name tooltip when the channel name overflows its container', () => {
+            Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {configurable: true, value: 500});
+            Object.defineProperty(HTMLElement.prototype, 'clientWidth', {configurable: true, value: 100});
+
+            renderWithContext(
+                <ConnectedSwitchChannelSuggestion
+                    {...baseProps}
+                    term={longChannel.name}
+                    item={{
+                        channel: longChannel,
+                        name: longChannel.name,
+                        deactivated: false,
+                    }}
+                />,
+                getBaseState([longTeam1, longTeam2], [longChannel]),
+            );
+
+            const tooltips = screen.getAllByTestId('with-tooltip');
+            const channelNameTooltip = tooltips.find((node) => node.getAttribute('data-tooltip-title') === longChannel.display_name);
+            expect(channelNameTooltip).toBeDefined();
+            expect(channelNameTooltip).toHaveAttribute('data-tooltip-disabled', 'false');
+        });
     });
 });

--- a/webapp/channels/src/components/suggestion/switch_channel_provider.tsx
+++ b/webapp/channels/src/components/suggestion/switch_channel_provider.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import classNames from 'classnames';
-import React from 'react';
+import React, {useLayoutEffect, useRef, useState} from 'react';
 import {defineMessage, useIntl} from 'react-intl';
 import {connect, useSelector} from 'react-redux';
 
@@ -58,6 +58,7 @@ import ProfilePicture from 'components/profile_picture';
 import SharedChannelIndicator from 'components/shared_channel_indicator';
 import BotTag from 'components/widgets/tag/bot_tag';
 import GuestTag from 'components/widgets/tag/guest_tag';
+import WithTooltip from 'components/with_tooltip';
 
 import {getArchiveIconClassName} from 'utils/channel_utils';
 import {Constants, StoragePrefixes} from 'utils/constants';
@@ -144,6 +145,9 @@ export const SwitchChannelSuggestion = React.forwardRef<HTMLLIElement, Props>(({
     const channelIsArchived = channel.delete_at && channel.delete_at !== 0;
 
     const currentUserId = useSelector(getCurrentUserId);
+
+    const channelNameRef = useRef<HTMLSpanElement>(null);
+    const [isChannelNameTruncated, setIsChannelNameTruncated] = useState(false);
 
     const ids = usePrefixedIds(id, {
         name: null,
@@ -332,6 +336,11 @@ export const SwitchChannelSuggestion = React.forwardRef<HTMLLIElement, Props>(({
 
     Reflect.deleteProperty(otherProps, 'dispatch');
 
+    useLayoutEffect(() => {
+        const el = channelNameRef.current;
+        setIsChannelNameTruncated(Boolean(el && el.scrollWidth > el.clientWidth));
+    }, [name, description, showSlug, isPartOfOnlyOneTeam, team?.display_name, item.unread, channelIsArchived]);
+
     return (
         <SuggestionContainer
             ref={ref}
@@ -344,26 +353,34 @@ export const SwitchChannelSuggestion = React.forwardRef<HTMLLIElement, Props>(({
         >
             {icon}
             <div className='suggestion-list__ellipsis suggestion-list__flex'>
-                <span className='suggestion-list__main'>
-                    <span
-                        id={ids.name}
-                        className={classNames({'suggestion-list__unread': item.unread && !channelIsArchived})}
-                    >
-                        {name}
-                    </span>
-                    {showSlug && description && (
-                        <span
-                            id={ids.description}
-                            className='ml-2 suggestion-list__desc'
+                <div className='suggestion-list__switch-channel-primary'>
+                    <span className='suggestion-list__main'>
+                        <WithTooltip
+                            title={name}
+                            disabled={!isChannelNameTruncated}
                         >
-                            {description}
-                        </span>
-                    )}
-                </span>
-                {customStatus}
-                {sharedIcon}
-                {tag && <span id={ids.tag}>{tag}</span>}
-                {badge}
+                            <span
+                                id={ids.name}
+                                ref={channelNameRef}
+                                className={classNames('suggestion-list__channel-name-text', {'suggestion-list__unread': item.unread && !channelIsArchived})}
+                            >
+                                {name}
+                            </span>
+                        </WithTooltip>
+                        {showSlug && description && (
+                            <span
+                                id={ids.description}
+                                className='ml-2 suggestion-list__desc'
+                            >
+                                {description}
+                            </span>
+                        )}
+                    </span>
+                    {customStatus}
+                    {sharedIcon}
+                    {tag && <span id={ids.tag}>{tag}</span>}
+                    {badge}
+                </div>
                 {!isPartOfOnlyOneTeam && teamName}
             </div>
         </SuggestionContainer>

--- a/webapp/channels/src/components/suggestion/switch_channel_provider.tsx
+++ b/webapp/channels/src/components/suggestion/switch_channel_provider.tsx
@@ -148,6 +148,8 @@ export const SwitchChannelSuggestion = React.forwardRef<HTMLLIElement, Props>(({
 
     const channelNameRef = useRef<HTMLSpanElement>(null);
     const [isChannelNameTruncated, setIsChannelNameTruncated] = useState(false);
+    const teamNameRef = useRef<HTMLSpanElement>(null);
+    const [isTeamNameTruncated, setIsTeamNameTruncated] = useState(false);
 
     const ids = usePrefixedIds(id, {
         name: null,
@@ -324,12 +326,18 @@ export const SwitchChannelSuggestion = React.forwardRef<HTMLLIElement, Props>(({
     let teamName = null;
     if (isRealChannel(channel) && channel.team_id && team) {
         teamName = (
-            <span
-                id={ids.teamName}
-                className='ml-2 suggestion-list__team-name'
+            <WithTooltip
+                title={team.display_name}
+                disabled={!isTeamNameTruncated}
             >
-                {team.display_name}
-            </span>
+                <span
+                    id={ids.teamName}
+                    ref={teamNameRef}
+                    className='ml-2 suggestion-list__team-name'
+                >
+                    {team.display_name}
+                </span>
+            </WithTooltip>
         );
     }
     const showSlug = (isPartOfOnlyOneTeam || channel.type === Constants.DM_CHANNEL) && channel.type !== Constants.THREADS;
@@ -337,8 +345,11 @@ export const SwitchChannelSuggestion = React.forwardRef<HTMLLIElement, Props>(({
     Reflect.deleteProperty(otherProps, 'dispatch');
 
     useLayoutEffect(() => {
-        const el = channelNameRef.current;
-        setIsChannelNameTruncated(Boolean(el && el.scrollWidth > el.clientWidth));
+        const channelEl = channelNameRef.current;
+        setIsChannelNameTruncated(Boolean(channelEl && channelEl.scrollWidth > channelEl.clientWidth));
+
+        const teamEl = teamNameRef.current;
+        setIsTeamNameTruncated(Boolean(teamEl && teamEl.scrollWidth > teamEl.clientWidth));
     }, [name, description, showSlug, isPartOfOnlyOneTeam, team?.display_name, item.unread, channelIsArchived]);
 
     return (

--- a/webapp/channels/src/sass/components/_suggestion-list.scss
+++ b/webapp/channels/src/sass/components/_suggestion-list.scss
@@ -213,10 +213,6 @@
 
     .modal & {
         padding: 8px 3.2rem;
-
-        .suggestion-list__team-name {
-            right: 32px;
-        }
     }
 
     .suggestion-list__ellipsis {
@@ -248,16 +244,52 @@
     .suggestion-list__flex {
         display: flex;
         width: 100%;
+        min-width: 0;
         max-width: 100%;
         align-items: center;
 
+        .suggestion-list__switch-channel-primary {
+            display: flex;
+            overflow: hidden;
+            min-width: 0;
+            flex: 1 1 auto;
+            align-items: center;
+        }
+
         .suggestion-list__main {
+            display: flex;
+            overflow: hidden;
             width: unset;
+            min-width: 0;
+            flex: 1 1 auto;
+            white-space: nowrap;
 
             > span:first-child {
                 overflow: hidden;
                 text-overflow: ellipsis;
             }
+        }
+
+        .suggestion-list__channel-name-text {
+            overflow: hidden;
+            min-width: 0;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .suggestion-list_unread-mentions {
+            flex: 0 0 auto;
+            margin-left: auto;
+        }
+
+        .suggestion-list__team-name {
+            position: static;
+            overflow: hidden;
+            max-width: 40%;
+            flex: 0 0 auto;
+            text-align: right;
+            text-overflow: ellipsis;
+            white-space: nowrap;
         }
 
         .badge {
@@ -356,16 +388,6 @@
                 max-width: 11px;
             }
         }
-    }
-
-    .suggestion-list__team-name {
-        position: absolute;
-        right: 20px;
-        overflow: hidden;
-        max-width: 20%;
-        text-align: right;
-        text-overflow: ellipsis;
-        white-space: nowrap;
     }
 
     .Tag {


### PR DESCRIPTION
#### Summary
In the **Find Channels** modal (Cmd/Ctrl+K), each suggestion row used to render the team-name label as `position: absolute; right: 20px;` and the channel-name column had no `min-width: 0` flex child to absorb shrinking. With both a long channel name **and** a long team name, the channel text overflowed its column and visually overlapped the team label, making both unreadable.

This PR fixes the overflow and adds tooltips when name is truncated for both long Channel Name and Team name.

All new layout rules are scoped under `.suggestion-list__flex` (only used by the switcher row), so other suggestion providers — `SearchChannelSuggestion`, `ChannelMentionSuggestion`, `AtMentionSuggestion` — are unaffected.

##### QA test steps
1. Sign in as a user that is a member of more than one team.
2. Create (or have) a team with a very long display name and a channel with a very long display name in that team.
3. Switch to a different team in the team sidebar (the team-name column in switcher results only appears for channels outside the active team).
4. Open **Find Channels** with **Cmd/Ctrl+K**.
5. Search for the long channel name. Confirm:
   - The channel name on the left truncates with an ellipsis.
   - The team name remains visible on the right.
   - The two text spans no longer overlap.
   - Hovering the channel name shows a tooltip with the full name only when it is truncated.
6. Repeat the search with a short channel name to confirm no tooltip appears and no visual regression.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-64977

#### Screenshots
<img width="722" height="553" alt="Screenshot 2026-04-29 at 8 03 22 PM" src="https://github.com/user-attachments/assets/be3409ac-b76c-4dbb-93ba-8dbcecd486f9" />


#### Release Note
```release-note
Fixed an issue in the Find Channels modal where long channel names could overlap and obscure the team name on the same row.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to the `SwitchChannelSuggestion` component with scoped CSS rules (`.suggestion-list__flex` only used in this provider). No shared utilities, base classes, or widely-imported modules affected. The DOM measurement pattern via `useLayoutEffect` is standard React practice with minimal performance impact on a single span element.

**QA Recommendation:** Focused manual QA is sufficient. Verify the quick switch modal (Cmd/Ctrl+K) and forward post channel select with: (1) long channel names display with ellipsis without overlapping team names, (2) team name visibility when user is on multiple teams, (3) tooltip appears only when channel name truncates, and (4) single-team scenarios remain unaffected. Automated test coverage for layout and tooltip behavior is comprehensive with 3 new tests.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->