### PR TITLE
MM-68543 Invalidate active WebConn session cache on global session revocation

### DIFF
--- a/server/channels/app/platform/cluster_handlers.go
+++ b/server/channels/app/platform/cluster_handlers.go
@@ -65,12 +65,21 @@ func (ps *PlatformService) ClearSessionCacheForUserSkipClusterSend(userID string
 	ps.invalidateWebConnSessionCacheForUserSkipClusterSend(userID)
 }
 
-func (ps *PlatformService) ClearSessionCacheForAllUsersSkipClusterSend() {
+// ClearSessionCacheForAllUsersSkipClusterSend purges the in-memory
+// session cache and fans the hub-side invalidation across every
+// WebConn registered with this node. The hub fan-out runs
+// unconditionally so live WebConns are still invalidated even if the
+// cache purge fails; the cache-purge error (if any) is returned so
+// callers that surface a public error contract (notably
+// ClearAllUsersSessionCache) can propagate it.
+func (ps *PlatformService) ClearSessionCacheForAllUsersSkipClusterSend() error {
 	ps.logger.Info("Purging sessions cache")
-	if err := ps.ClearAllUsersSessionCacheLocal(); err != nil {
+	err := ps.ClearAllUsersSessionCacheLocal()
+	if err != nil {
 		ps.logger.Error("Failed to purge session cache", mlog.Err(err))
 	}
 	ps.invalidateWebConnSessionCacheForAllUsersSkipClusterSend()
+	return err
 }
 
 func (ps *PlatformService) clusterClearSessionCacheForUserHandler(msg *model.ClusterMessage) {
@@ -78,7 +87,9 @@ func (ps *PlatformService) clusterClearSessionCacheForUserHandler(msg *model.Clu
 }
 
 func (ps *PlatformService) clusterClearSessionCacheForAllUsersHandler(msg *model.ClusterMessage) {
-	ps.ClearSessionCacheForAllUsersSkipClusterSend()
+	if err := ps.ClearSessionCacheForAllUsersSkipClusterSend(); err != nil {
+		ps.logger.Error("Failed to clear session cache for all users from cluster handler", mlog.Err(err))
+	}
 }
 
 func (ps *PlatformService) clusterBusyStateChgHandler(msg *model.ClusterMessage) {

--- a/server/channels/app/platform/cluster_handlers.go
+++ b/server/channels/app/platform/cluster_handlers.go
@@ -70,6 +70,7 @@ func (ps *PlatformService) ClearSessionCacheForAllUsersSkipClusterSend() {
 	if err := ps.ClearAllUsersSessionCacheLocal(); err != nil {
 		ps.logger.Error("Failed to purge session cache", mlog.Err(err))
 	}
+	ps.invalidateWebConnSessionCacheForAllUsersSkipClusterSend()
 }
 
 func (ps *PlatformService) clusterClearSessionCacheForUserHandler(msg *model.ClusterMessage) {
@@ -98,6 +99,20 @@ func (ps *PlatformService) invalidateWebConnSessionCacheForUserSkipClusterSend(u
 	hub := ps.GetHubForUserId(userID)
 	if hub != nil {
 		hub.InvalidateUser(userID)
+	}
+}
+
+// invalidateWebConnSessionCacheForAllUsersSkipClusterSend fans the
+// invalidate-all signal across every active hub. It mirrors the
+// per-user helper above and is the websocket-side companion to
+// ClearAllUsersSessionCacheLocal: without it, live WebConns keep
+// trusting their cached session and IsBasicAuthenticated keeps
+// short-circuiting on the cached expiry until it elapses.
+func (ps *PlatformService) invalidateWebConnSessionCacheForAllUsersSkipClusterSend() {
+	for _, hub := range ps.hubs {
+		if hub != nil {
+			hub.InvalidateAll()
+		}
 	}
 }
 

--- a/server/channels/app/platform/cluster_handlers.go
+++ b/server/channels/app/platform/cluster_handlers.go
@@ -66,12 +66,9 @@ func (ps *PlatformService) ClearSessionCacheForUserSkipClusterSend(userID string
 }
 
 // ClearSessionCacheForAllUsersSkipClusterSend purges the in-memory
-// session cache and fans the hub-side invalidation across every
-// WebConn registered with this node. The hub fan-out runs
-// unconditionally so live WebConns are still invalidated even if the
-// cache purge fails; the cache-purge error (if any) is returned so
-// callers that surface a public error contract (notably
-// ClearAllUsersSessionCache) can propagate it.
+// session cache and invalidates every WebConn on this node. The hub
+// fan-out runs even if the cache purge fails; the purge error is
+// returned so wrappers can propagate it.
 func (ps *PlatformService) ClearSessionCacheForAllUsersSkipClusterSend() error {
 	ps.logger.Info("Purging sessions cache")
 	err := ps.ClearAllUsersSessionCacheLocal()
@@ -113,12 +110,9 @@ func (ps *PlatformService) invalidateWebConnSessionCacheForUserSkipClusterSend(u
 	}
 }
 
-// invalidateWebConnSessionCacheForAllUsersSkipClusterSend fans the
-// invalidate-all signal across every active hub. It mirrors the
-// per-user helper above and is the websocket-side companion to
-// ClearAllUsersSessionCacheLocal: without it, live WebConns keep
-// trusting their cached session and IsBasicAuthenticated keeps
-// short-circuiting on the cached expiry until it elapses.
+// invalidateWebConnSessionCacheForAllUsersSkipClusterSend signals
+// every hub on this node to invalidate the cached session state of
+// all of its WebConns. Companion to ClearAllUsersSessionCacheLocal.
 func (ps *PlatformService) invalidateWebConnSessionCacheForAllUsersSkipClusterSend() {
 	for _, hub := range ps.hubs {
 		if hub != nil {

--- a/server/channels/app/platform/cluster_handlers_revoke_test.go
+++ b/server/channels/app/platform/cluster_handlers_revoke_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package platform
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// TestRevokeSessionsFromAllUsersInvalidatesWebConnSession is the
+// end-to-end regression contract for MM-68543, sitting one layer above
+// Phase 1's TestClearSessionCacheInvalidatesWebConnSession.
+//
+// Phase 1 directly invoked the internal helper
+// PlatformService.ClearSessionCacheForAllUsersSkipClusterSend, which is
+// only reached by remote nodes via the
+// ClusterEventClearSessionCacheForAllUsers handler. The Phase 2
+// candidate fix correctly wires the new
+// invalidateWebConnSessionCacheForAllUsersSkipClusterSend helper into
+// that *SkipClusterSend* entry point.
+//
+// However, the production caller behind
+// POST /api/v4/users/sessions/revoke/all is
+// PlatformService.RevokeSessionsFromAllUsers, which calls
+// PlatformService.ClearAllUsersSessionCache (cluster-aware wrapper).
+// That wrapper:
+//
+//  1. Calls ClearAllUsersSessionCacheLocal (purges the in-memory
+//     session cache only, does NOT invoke the new fan-out helper); and
+//  2. Broadcasts ClusterEventClearSessionCacheForAllUsers so remote
+//     nodes' handlers can run ClearSessionCacheForAllUsersSkipClusterSend
+//     (which DOES invoke the new fan-out).
+//
+// The originating node — the one whose admin actually called the API
+// — therefore never runs the new helper. In single-node deployments
+// (clusterIFace == nil) it is also never run anywhere. Every live
+// WebConn on the originating node retains its cached session token and
+// expiry, and IsBasicAuthenticated keeps short-circuiting on the
+// in-memory expiry check until the original session would have
+// expired — exactly the bypass MM-68543 was opened against.
+//
+// Secure contract this test pins down: after
+// RevokeSessionsFromAllUsers returns, every live WebConn on this node
+// must observably be in the same authenticated-as-no-one state that
+// Phase 2 produces on the *SkipClusterSend* path — Session==nil,
+// SessionExpiresAt==0, and SessionToken cleared — across multiple
+// users (which naturally distribute across multiple hubs because hubs
+// are sharded by hash(userID) mod runtime.NumCPU()) and across
+// multiple WebConns per user (multi-device / multi-tab).
+//
+// Expected to FAIL today: the local node never invokes the fan-out
+// helper, so the cached session state survives the revoke and
+// Eventually times out reporting the still-populated state.
+func TestRevokeSessionsFromAllUsersInvalidatesWebConnSession(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	s := httptest.NewServer(dummyWebsocketHandler(t))
+	defer s.Close()
+
+	// Use multiple distinct user IDs so the connections naturally
+	// distribute across more than one hub via GetHubForUserId's
+	// hash(userID) mod len(hubs) sharding. With the default
+	// runtime.NumCPU() hubs (>=2 on every realistic test host) this
+	// gives us coverage of the "iterate every hub" guarantee of the
+	// fan-out helper. We also register multiple WebConns per user to
+	// exercise the multi-device case (laptop + mobile + tab).
+	type userConns struct {
+		userID string
+		wcs    []*WebConn
+	}
+	users := []*userConns{
+		{userID: th.BasicUser.Id},
+		{userID: th.BasicUser2.Id},
+	}
+	// Add synthetic users to widen hub coverage. We don't need real
+	// User rows because CreateSession stores by UserId without an
+	// FK round-trip on the cache path we exercise here.
+	for range 4 {
+		users = append(users, &userConns{userID: model.NewId()})
+	}
+
+	// Pre-warm every user's status to online before any WebConn is
+	// created. NewWebConn fires off an async SetStatusOnline +
+	// UpdateLastActivityAtIfNeeded goroutine; if SetStatusOnline finds
+	// the user offline it broadcasts a status-change event that races
+	// with the eventual hub.InvalidateAll signal. When the broadcast
+	// lands AFTER invalidation, the hub's broadcast loop calls
+	// WebConn.ShouldSendEvent -> IsAuthenticated -> IsBasicAuthenticated,
+	// which calls Suite.GetSession on the now-invalidated WebConn and
+	// re-populates an empty session through the test's mockSuite. That
+	// flips GetSession() back to non-nil and breaks the secure-end-state
+	// check below. Pre-warming forces SetStatusOnline down the
+	// "no broadcast" branch so the race cannot happen, without changing
+	// the contract being tested.
+	for _, u := range users {
+		preWarmStatusOnline(th, u.userID)
+	}
+
+	const connsPerUser = 2
+	for _, u := range users {
+		for range connsPerUser {
+			session, err := th.Service.CreateSession(th.Context, &model.Session{
+				UserId: u.userID,
+			})
+			require.NoError(t, err)
+
+			// Pin the cached expiry well into the future. Without
+			// this, IsBasicAuthenticated falls through the
+			// short-circuit path and re-validates against the store,
+			// masking the bug. With it, the bug is observable: the
+			// in-memory cached session is what gates auth, and unless
+			// the hub explicitly invalidates the WebConn it stays
+			// authenticated.
+			session.ExpiresAt = model.GetMillis() + time.Hour.Milliseconds()
+
+			wc := registerDummyWebConn(t, th, s.Listener.Addr(), session)
+			t.Cleanup(func() { wc.Close() })
+			u.wcs = append(u.wcs, wc)
+
+			waitForWebConnRegistered(t, th, session)
+		}
+	}
+
+	// Preconditions: every WebConn starts with a populated cached
+	// session, future expiry, and non-empty token. Without these the
+	// rest of the test cannot distinguish "fix worked" from "we
+	// never had cached state to begin with".
+	for _, u := range users {
+		for _, wc := range u.wcs {
+			require.NotNil(t, wc.GetSession(),
+				"precondition: webconn for user %q must have a cached session before revoke", u.userID)
+			require.Greater(t, wc.GetSessionExpiresAt(), model.GetMillis(),
+				"precondition: cached expiry for user %q must be in the future before revoke", u.userID)
+			require.NotEmpty(t, wc.GetSessionToken(),
+				"precondition: webconn for user %q must have a cached session token before revoke", u.userID)
+		}
+	}
+
+	// Production trigger. Note we deliberately exercise the public
+	// PlatformService surface — the same one the API4 handler hits —
+	// not the internal *SkipClusterSend variant Phase 1 uses.
+	require.NoError(t, th.Service.RevokeSessionsFromAllUsers(),
+		"RevokeSessionsFromAllUsers should not error")
+
+	// The hub's invalidateAll arm runs asynchronously on the hub
+	// goroutine, so we poll for the secure end state instead of
+	// sleeping (mirrors Phase 1's pattern). If the fan-out is
+	// correctly invoked from the production caller, this converges
+	// within a few hundred milliseconds across all hubs. With the
+	// current Phase 2 candidate fix the helper is never invoked from
+	// this code path, so the loop times out and reports the first
+	// still-populated WebConn — which is exactly the bug.
+	require.Eventually(t, func() bool {
+		for _, u := range users {
+			for _, wc := range u.wcs {
+				if wc.GetSession() != nil {
+					return false
+				}
+				if wc.GetSessionExpiresAt() != 0 {
+					return false
+				}
+				if wc.GetSessionToken() != "" {
+					return false
+				}
+			}
+		}
+		return true
+	}, 5*time.Second, 25*time.Millisecond,
+		"RevokeSessionsFromAllUsers must invalidate every live WebConn on every hub "+
+			"and across multiple connections per user; first webconn still showing "+
+			"cached auth state means the fan-out helper was not invoked on the originating node")
+}

--- a/server/channels/app/platform/cluster_handlers_revoke_test.go
+++ b/server/channels/app/platform/cluster_handlers_revoke_test.go
@@ -13,50 +13,11 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
-// TestRevokeSessionsFromAllUsersInvalidatesWebConnSession is the
-// end-to-end regression contract for MM-68543, sitting one layer above
-// Phase 1's TestClearSessionCacheInvalidatesWebConnSession.
-//
-// Phase 1 directly invoked the internal helper
-// PlatformService.ClearSessionCacheForAllUsersSkipClusterSend, which is
-// only reached by remote nodes via the
-// ClusterEventClearSessionCacheForAllUsers handler. The Phase 2
-// candidate fix correctly wires the new
-// invalidateWebConnSessionCacheForAllUsersSkipClusterSend helper into
-// that *SkipClusterSend* entry point.
-//
-// However, the production caller behind
-// POST /api/v4/users/sessions/revoke/all is
-// PlatformService.RevokeSessionsFromAllUsers, which calls
-// PlatformService.ClearAllUsersSessionCache (cluster-aware wrapper).
-// That wrapper:
-//
-//  1. Calls ClearAllUsersSessionCacheLocal (purges the in-memory
-//     session cache only, does NOT invoke the new fan-out helper); and
-//  2. Broadcasts ClusterEventClearSessionCacheForAllUsers so remote
-//     nodes' handlers can run ClearSessionCacheForAllUsersSkipClusterSend
-//     (which DOES invoke the new fan-out).
-//
-// The originating node — the one whose admin actually called the API
-// — therefore never runs the new helper. In single-node deployments
-// (clusterIFace == nil) it is also never run anywhere. Every live
-// WebConn on the originating node retains its cached session token and
-// expiry, and IsBasicAuthenticated keeps short-circuiting on the
-// in-memory expiry check until the original session would have
-// expired — exactly the bypass MM-68543 was opened against.
-//
-// Secure contract this test pins down: after
-// RevokeSessionsFromAllUsers returns, every live WebConn on this node
-// must observably be in the same authenticated-as-no-one state that
-// Phase 2 produces on the *SkipClusterSend* path — Session==nil,
-// SessionExpiresAt==0, and SessionToken cleared — across multiple
-// users (which naturally distribute across multiple hubs because hubs
-// are sharded by hash(userID) mod runtime.NumCPU()) and across
-// multiple WebConns per user (multi-device / multi-tab).
-//
-// Expected to FAIL today: the local node never invokes the fan-out
-// helper, so the cached session state survives the revoke and
-// Eventually times out reporting the still-populated state.
+// TestRevokeSessionsFromAllUsersInvalidatesWebConnSession asserts that
+// after the public RevokeSessionsFromAllUsers entry point returns,
+// every live WebConn on this node — across multiple users (hashed to
+// different hubs) and multiple connections per user — has its cached
+// session reset to the authenticated-as-no-one state.
 func TestRevokeSessionsFromAllUsersInvalidatesWebConnSession(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)
@@ -64,13 +25,9 @@ func TestRevokeSessionsFromAllUsersInvalidatesWebConnSession(t *testing.T) {
 	s := httptest.NewServer(dummyWebsocketHandler(t))
 	defer s.Close()
 
-	// Use multiple distinct user IDs so the connections naturally
-	// distribute across more than one hub via GetHubForUserId's
-	// hash(userID) mod len(hubs) sharding. With the default
-	// runtime.NumCPU() hubs (>=2 on every realistic test host) this
-	// gives us coverage of the "iterate every hub" guarantee of the
-	// fan-out helper. We also register multiple WebConns per user to
-	// exercise the multi-device case (laptop + mobile + tab).
+	// Spread connections across multiple hubs via GetHubForUserId's
+	// hash(userID) mod len(hubs) sharding, and use multiple conns per
+	// user to cover the multi-device case.
 	type userConns struct {
 		userID string
 		wcs    []*WebConn
@@ -79,26 +36,10 @@ func TestRevokeSessionsFromAllUsersInvalidatesWebConnSession(t *testing.T) {
 		{userID: th.BasicUser.Id},
 		{userID: th.BasicUser2.Id},
 	}
-	// Add synthetic users to widen hub coverage. We don't need real
-	// User rows because CreateSession stores by UserId without an
-	// FK round-trip on the cache path we exercise here.
 	for range 4 {
 		users = append(users, &userConns{userID: model.NewId()})
 	}
 
-	// Pre-warm every user's status to online before any WebConn is
-	// created. NewWebConn fires off an async SetStatusOnline +
-	// UpdateLastActivityAtIfNeeded goroutine; if SetStatusOnline finds
-	// the user offline it broadcasts a status-change event that races
-	// with the eventual hub.InvalidateAll signal. When the broadcast
-	// lands AFTER invalidation, the hub's broadcast loop calls
-	// WebConn.ShouldSendEvent -> IsAuthenticated -> IsBasicAuthenticated,
-	// which calls Suite.GetSession on the now-invalidated WebConn and
-	// re-populates an empty session through the test's mockSuite. That
-	// flips GetSession() back to non-nil and breaks the secure-end-state
-	// check below. Pre-warming forces SetStatusOnline down the
-	// "no broadcast" branch so the race cannot happen, without changing
-	// the contract being tested.
 	for _, u := range users {
 		preWarmStatusOnline(th, u.userID)
 	}
@@ -111,13 +52,6 @@ func TestRevokeSessionsFromAllUsersInvalidatesWebConnSession(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			// Pin the cached expiry well into the future. Without
-			// this, IsBasicAuthenticated falls through the
-			// short-circuit path and re-validates against the store,
-			// masking the bug. With it, the bug is observable: the
-			// in-memory cached session is what gates auth, and unless
-			// the hub explicitly invalidates the WebConn it stays
-			// authenticated.
 			session.ExpiresAt = model.GetMillis() + time.Hour.Milliseconds()
 
 			wc := registerDummyWebConn(t, th, s.Listener.Addr(), session)
@@ -128,10 +62,6 @@ func TestRevokeSessionsFromAllUsersInvalidatesWebConnSession(t *testing.T) {
 		}
 	}
 
-	// Preconditions: every WebConn starts with a populated cached
-	// session, future expiry, and non-empty token. Without these the
-	// rest of the test cannot distinguish "fix worked" from "we
-	// never had cached state to begin with".
 	for _, u := range users {
 		for _, wc := range u.wcs {
 			require.NotNil(t, wc.GetSession(),
@@ -143,20 +73,9 @@ func TestRevokeSessionsFromAllUsersInvalidatesWebConnSession(t *testing.T) {
 		}
 	}
 
-	// Production trigger. Note we deliberately exercise the public
-	// PlatformService surface — the same one the API4 handler hits —
-	// not the internal *SkipClusterSend variant Phase 1 uses.
 	require.NoError(t, th.Service.RevokeSessionsFromAllUsers(),
 		"RevokeSessionsFromAllUsers should not error")
 
-	// The hub's invalidateAll arm runs asynchronously on the hub
-	// goroutine, so we poll for the secure end state instead of
-	// sleeping (mirrors Phase 1's pattern). If the fan-out is
-	// correctly invoked from the production caller, this converges
-	// within a few hundred milliseconds across all hubs. With the
-	// current Phase 2 candidate fix the helper is never invoked from
-	// this code path, so the loop times out and reports the first
-	// still-populated WebConn — which is exactly the bug.
 	require.Eventually(t, func() bool {
 		for _, u := range users {
 			for _, wc := range u.wcs {
@@ -173,7 +92,5 @@ func TestRevokeSessionsFromAllUsersInvalidatesWebConnSession(t *testing.T) {
 		}
 		return true
 	}, 5*time.Second, 25*time.Millisecond,
-		"RevokeSessionsFromAllUsers must invalidate every live WebConn on every hub "+
-			"and across multiple connections per user; first webconn still showing "+
-			"cached auth state means the fan-out helper was not invoked on the originating node")
+		"RevokeSessionsFromAllUsers did not invalidate every live WebConn across all hubs")
 }

--- a/server/channels/app/platform/cluster_handlers_test.go
+++ b/server/channels/app/platform/cluster_handlers_test.go
@@ -13,11 +13,9 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
-// waitForWebConnRegistered ensures the hub goroutine has processed the
-// WebConn registration before the test issues invalidation signals.
-// Without this, a fast-scheduled test can race past the async register
-// channel and the invalidation arm will walk an empty connIndex,
-// observably looking like "the fix did not invalidate the WebConn".
+// waitForWebConnRegistered blocks until the hub has processed the
+// WebConn registration. Without it, a test can race past the async
+// register channel and signal invalidation against an empty connIndex.
 func waitForWebConnRegistered(t *testing.T, th *TestHelper, session *model.Session) {
 	t.Helper()
 	require.Eventually(t, func() bool {
@@ -27,20 +25,11 @@ func waitForWebConnRegistered(t *testing.T, th *TestHelper, session *model.Sessi
 		session.Id, session.UserId)
 }
 
-// preWarmStatusOnline seeds the status cache so the asynchronous
-// SetStatusOnline goroutine that NewWebConn fires off does not broadcast
-// a "user is now online" event. That broadcast otherwise races with the
-// hub's InvalidateUser handler: if the broadcast lands AFTER the
-// post-invalidate WebConn state, the hub's broadcast loop calls
-// WebConn.ShouldSendEvent -> IsAuthenticated -> IsBasicAuthenticated,
-// which in turn calls Suite.GetSession on the now-invalidated WebConn
-// and re-populates an empty session via the test's mockSuite. That
-// makes the test's secure-end-state condition (GetSession()==nil and
-// GetSessionExpiresAt()==0) flap to non-nil. By marking the user
-// already-online before NewWebConn runs, SetStatusOnline takes the
-// "no broadcast" branch and the race goes away. This does not weaken
-// the contract being tested: invalidation is still the only signal
-// that clears the cached session state.
+// preWarmStatusOnline marks the user online before any WebConn is
+// created so the async SetStatusOnline goroutine in NewWebConn skips
+// the broadcast path. Otherwise the broadcast can race with the
+// invalidation and re-populate the WebConn's cached session via
+// IsBasicAuthenticated, flipping the post-invalidate assertions.
 func preWarmStatusOnline(th *TestHelper, userID string) {
 	th.Service.AddStatusCacheSkipClusterSend(&model.Status{
 		UserId:         userID,
@@ -49,20 +38,11 @@ func preWarmStatusOnline(th *TestHelper, userID string) {
 	})
 }
 
-// TestClearSessionCacheInvalidatesWebConnSession is a regression contract test
-// for MM-68543.
-//
-// Contract: after PlatformService.ClearSessionCacheForAllUsersSkipClusterSend
-// is invoked (the global session-revocation path used by
-// POST /api/v4/users/sessions/revoke/all), every active WebSocket connection
-// across all hubs must have its cached authentication state invalidated —
-// i.e. the same observable end state that the per-user revocation path
-// produces today: WebConn.GetSession() returns nil and
-// WebConn.GetSessionExpiresAt() is reset to 0.
-//
-// The per-user case is included as a parallel sanity check: it exercises the
-// known-good code path and is expected to PASS today, which makes it obvious
-// in the failure output that the global path is the one breaking the contract.
+// TestClearSessionCacheInvalidatesWebConnSession asserts that after either
+// the per-user or the global session-cache clear runs, every matching
+// active WebSocket connection has its cached session reset to the
+// authenticated-as-no-one state (GetSession() == nil and
+// GetSessionExpiresAt() == 0).
 func TestClearSessionCacheInvalidatesWebConnSession(t *testing.T) {
 	mainHelper.Parallel(t)
 
@@ -71,18 +51,12 @@ func TestClearSessionCacheInvalidatesWebConnSession(t *testing.T) {
 		revoke func(ps *PlatformService, userID string)
 	}{
 		{
-			// Secure baseline. Should pass today.
 			name: "PerUserRevokeInvalidatesWebConnSession",
 			revoke: func(ps *PlatformService, userID string) {
 				ps.ClearSessionCacheForUserSkipClusterSend(userID)
 			},
 		},
 		{
-			// Reproduces MM-68543. Should fail today: the global path
-			// only purges the in-memory session cache and never signals
-			// the websocket hubs, so live WebConns keep their cached
-			// session state and continue to authenticate against the
-			// (now-deleted) cached session.
 			name: "GlobalRevokeInvalidatesWebConnSession",
 			revoke: func(ps *PlatformService, _ string) {
 				_ = ps.ClearSessionCacheForAllUsersSkipClusterSend()
@@ -102,11 +76,8 @@ func TestClearSessionCacheInvalidatesWebConnSession(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			// Make the cached session look "fresh" so that
-			// WebConn.IsBasicAuthenticated would short-circuit on the
-			// in-memory expiry check and never re-validate against the
-			// store. This is the precondition that turns the missing
-			// hub-side invalidation into a real authentication bypass.
+			// Pin a future expiry so IsBasicAuthenticated trusts the
+			// cached session and doesn't re-validate against the store.
 			session.ExpiresAt = model.GetMillis() + time.Hour.Milliseconds()
 
 			preWarmStatusOnline(th, th.BasicUser.Id)
@@ -123,16 +94,7 @@ func TestClearSessionCacheInvalidatesWebConnSession(t *testing.T) {
 
 			tt.revoke(th.Service, th.BasicUser.Id)
 
-			// Hub processing of InvalidateUser is async (the hub
-			// goroutine reads from h.invalidateUser and then runs
-			// webConn.InvalidateCache() on each matching connection),
-			// so poll for the secure end state instead of sleeping.
-			//
-			// For the per-user path the hub is signaled, so this
-			// converges within a few hundred milliseconds. For the
-			// buggy global path the hub is never signaled, so this
-			// times out and we report the still-cached state — which
-			// is exactly the bug.
+			// Hub invalidation is async, so poll for the end state.
 			require.Eventually(t, func() bool {
 				return wc.GetSession() == nil && wc.GetSessionExpiresAt() == 0
 			}, 2*time.Second, 25*time.Millisecond,

--- a/server/channels/app/platform/cluster_handlers_test.go
+++ b/server/channels/app/platform/cluster_handlers_test.go
@@ -85,7 +85,7 @@ func TestClearSessionCacheInvalidatesWebConnSession(t *testing.T) {
 			// (now-deleted) cached session.
 			name: "GlobalRevokeInvalidatesWebConnSession",
 			revoke: func(ps *PlatformService, _ string) {
-				ps.ClearSessionCacheForAllUsersSkipClusterSend()
+				_ = ps.ClearSessionCacheForAllUsersSkipClusterSend()
 			},
 		},
 	}

--- a/server/channels/app/platform/cluster_handlers_test.go
+++ b/server/channels/app/platform/cluster_handlers_test.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package platform
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// waitForWebConnRegistered ensures the hub goroutine has processed the
+// WebConn registration before the test issues invalidation signals.
+// Without this, a fast-scheduled test can race past the async register
+// channel and the invalidation arm will walk an empty connIndex,
+// observably looking like "the fix did not invalidate the WebConn".
+func waitForWebConnRegistered(t *testing.T, th *TestHelper, session *model.Session) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return th.Service.SessionIsRegistered(*session)
+	}, 2*time.Second, 10*time.Millisecond,
+		"WebConn for session %q (user %q) was not registered with the hub in time",
+		session.Id, session.UserId)
+}
+
+// preWarmStatusOnline seeds the status cache so the asynchronous
+// SetStatusOnline goroutine that NewWebConn fires off does not broadcast
+// a "user is now online" event. That broadcast otherwise races with the
+// hub's InvalidateUser handler: if the broadcast lands AFTER the
+// post-invalidate WebConn state, the hub's broadcast loop calls
+// WebConn.ShouldSendEvent -> IsAuthenticated -> IsBasicAuthenticated,
+// which in turn calls Suite.GetSession on the now-invalidated WebConn
+// and re-populates an empty session via the test's mockSuite. That
+// makes the test's secure-end-state condition (GetSession()==nil and
+// GetSessionExpiresAt()==0) flap to non-nil. By marking the user
+// already-online before NewWebConn runs, SetStatusOnline takes the
+// "no broadcast" branch and the race goes away. This does not weaken
+// the contract being tested: invalidation is still the only signal
+// that clears the cached session state.
+func preWarmStatusOnline(th *TestHelper, userID string) {
+	th.Service.AddStatusCacheSkipClusterSend(&model.Status{
+		UserId:         userID,
+		Status:         model.StatusOnline,
+		LastActivityAt: model.GetMillis(),
+	})
+}
+
+// TestClearSessionCacheInvalidatesWebConnSession is a regression contract test
+// for MM-68543.
+//
+// Contract: after PlatformService.ClearSessionCacheForAllUsersSkipClusterSend
+// is invoked (the global session-revocation path used by
+// POST /api/v4/users/sessions/revoke/all), every active WebSocket connection
+// across all hubs must have its cached authentication state invalidated —
+// i.e. the same observable end state that the per-user revocation path
+// produces today: WebConn.GetSession() returns nil and
+// WebConn.GetSessionExpiresAt() is reset to 0.
+//
+// The per-user case is included as a parallel sanity check: it exercises the
+// known-good code path and is expected to PASS today, which makes it obvious
+// in the failure output that the global path is the one breaking the contract.
+func TestClearSessionCacheInvalidatesWebConnSession(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	tests := []struct {
+		name   string
+		revoke func(ps *PlatformService, userID string)
+	}{
+		{
+			// Secure baseline. Should pass today.
+			name: "PerUserRevokeInvalidatesWebConnSession",
+			revoke: func(ps *PlatformService, userID string) {
+				ps.ClearSessionCacheForUserSkipClusterSend(userID)
+			},
+		},
+		{
+			// Reproduces MM-68543. Should fail today: the global path
+			// only purges the in-memory session cache and never signals
+			// the websocket hubs, so live WebConns keep their cached
+			// session state and continue to authenticate against the
+			// (now-deleted) cached session.
+			name: "GlobalRevokeInvalidatesWebConnSession",
+			revoke: func(ps *PlatformService, _ string) {
+				ps.ClearSessionCacheForAllUsersSkipClusterSend()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			th := Setup(t).InitBasic(t)
+
+			s := httptest.NewServer(dummyWebsocketHandler(t))
+			defer s.Close()
+
+			session, err := th.Service.CreateSession(th.Context, &model.Session{
+				UserId: th.BasicUser.Id,
+			})
+			require.NoError(t, err)
+
+			// Make the cached session look "fresh" so that
+			// WebConn.IsBasicAuthenticated would short-circuit on the
+			// in-memory expiry check and never re-validate against the
+			// store. This is the precondition that turns the missing
+			// hub-side invalidation into a real authentication bypass.
+			session.ExpiresAt = model.GetMillis() + time.Hour.Milliseconds()
+
+			preWarmStatusOnline(th, th.BasicUser.Id)
+
+			wc := registerDummyWebConn(t, th, s.Listener.Addr(), session)
+			defer wc.Close()
+
+			waitForWebConnRegistered(t, th, session)
+
+			require.NotNil(t, wc.GetSession(),
+				"precondition: webconn must have a cached session before revoke")
+			require.Greater(t, wc.GetSessionExpiresAt(), model.GetMillis(),
+				"precondition: webconn cached session expiry must be in the future before revoke")
+
+			tt.revoke(th.Service, th.BasicUser.Id)
+
+			// Hub processing of InvalidateUser is async (the hub
+			// goroutine reads from h.invalidateUser and then runs
+			// webConn.InvalidateCache() on each matching connection),
+			// so poll for the secure end state instead of sleeping.
+			//
+			// For the per-user path the hub is signaled, so this
+			// converges within a few hundred milliseconds. For the
+			// buggy global path the hub is never signaled, so this
+			// times out and we report the still-cached state — which
+			// is exactly the bug.
+			require.Eventually(t, func() bool {
+				return wc.GetSession() == nil && wc.GetSessionExpiresAt() == 0
+			}, 2*time.Second, 25*time.Millisecond,
+				"webconn cached session was not invalidated after %s; "+
+					"expected GetSession()==nil and GetSessionExpiresAt()==0, "+
+					"but got GetSession()!=nil=%t, GetSessionExpiresAt()=%d, GetSessionToken()=%q",
+				tt.name,
+				wc.GetSession() != nil,
+				wc.GetSessionExpiresAt(),
+				wc.GetSessionToken(),
+			)
+		})
+	}
+}

--- a/server/channels/app/platform/session.go
+++ b/server/channels/app/platform/session.go
@@ -110,9 +110,13 @@ func (ps *PlatformService) ClearUserSessionCache(userID string) {
 }
 
 func (ps *PlatformService) ClearAllUsersSessionCache() error {
-	if err := ps.ClearAllUsersSessionCacheLocal(); err != nil {
-		return err
-	}
+	// Delegate local-side work (session-cache purge + WebConn hub fan-out) to
+	// the same primitive that the cluster handler invokes on remote nodes.
+	// Without the hub fan-out here, live WebConns on the originating node
+	// keep trusting their cached session until it elapses, which is the
+	// MM-68543 bypass. This mirrors the per-user shape used by
+	// ClearUserSessionCache -> ClearSessionCacheForUserSkipClusterSend.
+	ps.ClearSessionCacheForAllUsersSkipClusterSend()
 
 	if ps.clusterIFace != nil {
 		msg := &model.ClusterMessage{

--- a/server/channels/app/platform/session.go
+++ b/server/channels/app/platform/session.go
@@ -112,11 +112,12 @@ func (ps *PlatformService) ClearUserSessionCache(userID string) {
 func (ps *PlatformService) ClearAllUsersSessionCache() error {
 	// Delegate local-side work (session-cache purge + WebConn hub fan-out) to
 	// the same primitive that the cluster handler invokes on remote nodes.
-	// Without the hub fan-out here, live WebConns on the originating node
-	// keep trusting their cached session until it elapses, which is the
-	// MM-68543 bypass. This mirrors the per-user shape used by
-	// ClearUserSessionCache -> ClearSessionCacheForUserSkipClusterSend.
-	ps.ClearSessionCacheForAllUsersSkipClusterSend()
+	// This mirrors the per-user shape used by ClearUserSessionCache ->
+	// ClearSessionCacheForUserSkipClusterSend. We still broadcast even when
+	// the local purge fails so remote nodes can run their own purge + hub
+	// fan-out independently, but we propagate the local error so callers
+	// keep the historical error contract.
+	err := ps.ClearSessionCacheForAllUsersSkipClusterSend()
 
 	if ps.clusterIFace != nil {
 		msg := &model.ClusterMessage{
@@ -125,7 +126,7 @@ func (ps *PlatformService) ClearAllUsersSessionCache() error {
 		}
 		ps.clusterIFace.SendClusterMessage(msg)
 	}
-	return nil
+	return err
 }
 
 func (ps *PlatformService) GetSession(rctx request.CTX, token string) (*model.Session, error) {

--- a/server/channels/app/platform/session.go
+++ b/server/channels/app/platform/session.go
@@ -110,13 +110,10 @@ func (ps *PlatformService) ClearUserSessionCache(userID string) {
 }
 
 func (ps *PlatformService) ClearAllUsersSessionCache() error {
-	// Delegate local-side work (session-cache purge + WebConn hub fan-out) to
-	// the same primitive that the cluster handler invokes on remote nodes.
-	// This mirrors the per-user shape used by ClearUserSessionCache ->
-	// ClearSessionCacheForUserSkipClusterSend. We still broadcast even when
-	// the local purge fails so remote nodes can run their own purge + hub
-	// fan-out independently, but we propagate the local error so callers
-	// keep the historical error contract.
+	// Mirrors the per-user shape: the SkipClusterSend helper handles the
+	// local cache purge and the WebConn hub fan-out, then we broadcast to
+	// peer nodes. The broadcast still runs on local-purge failure so peers
+	// can act independently.
 	err := ps.ClearSessionCacheForAllUsersSkipClusterSend()
 
 	if ps.clusterIFace != nil {

--- a/server/channels/app/platform/web_hub.go
+++ b/server/channels/app/platform/web_hub.go
@@ -680,24 +680,12 @@ func (h *Hub) Start() {
 				// also clearing the session token so the next
 				// IsBasicAuthenticated check short-circuits instead
 				// of re-fetching from the cache.
-				userIDs := make(map[string]struct{})
 				for webConn := range connIndex.All() {
 					webConn.InvalidateCache()
 					webConn.SetSessionToken("")
-					userIDs[webConn.UserId] = struct{}{}
 				}
-
-				if !*h.platform.Config().ServiceSettings.EnableWebHubChannelIteration {
-					continue
-				}
-
-				for userID := range userIDs {
-					if err := connIndex.InvalidateCMCacheForUser(userID); err != nil {
-						h.platform.Log().Error("Error while invalidating channel member cache", mlog.String("user_id", userID), mlog.Err(err))
-						for conn := range connIndex.ForUser(userID) {
-							closeAndRemoveConn(connIndex, conn)
-						}
-					}
+				if *h.platform.Config().ServiceSettings.EnableWebHubChannelIteration {
+					connIndex.clearChannels()
 				}
 			case activity := <-h.activity:
 				for webConn := range connIndex.ForUser(activity.userID) {
@@ -990,6 +978,16 @@ func (i *hubConnectionIndex) ForUser(id string) iter.Seq[*WebConn] {
 // ForChannel returns all connections for a channelID.
 func (i *hubConnectionIndex) ForChannel(channelID string) iter.Seq[*WebConn] {
 	return maps.Keys(i.byChannelID[channelID])
+}
+
+// clearChannels empties the channel-routing index in one shot. Intended
+// for paths that have already invalidated every conn registered with
+// the hub: any broadcast addressed to a channel will be filtered out
+// upstream by ShouldSendEvent, so the routing entries are dead weight
+// until conns either re-handshake or fully reconnect (both of which
+// repopulate the index via Add).
+func (i *hubConnectionIndex) clearChannels() {
+	clear(i.byChannelID)
 }
 
 // ForUserActiveCount returns the number of active connections for a userID

--- a/server/channels/app/platform/web_hub.go
+++ b/server/channels/app/platform/web_hub.go
@@ -465,12 +465,8 @@ func (h *Hub) InvalidateUser(userID string) {
 	}
 }
 
-// InvalidateAll invalidates the cached session state on every WebConn
-// registered with this hub. It is the global counterpart of
-// InvalidateUser and is used by the global session-revocation path so
-// that live websocket connections re-validate against the store on
-// their next authentication check instead of trusting their cached
-// (and now-deleted) session.
+// InvalidateAll invalidates the cached session state of every WebConn
+// registered with this hub. Global counterpart of InvalidateUser.
 func (h *Hub) InvalidateAll() {
 	select {
 	case h.invalidateAll <- struct{}{}:
@@ -680,14 +676,10 @@ func (h *Hub) Start() {
 					}
 				}
 			case <-h.invalidateAll:
-				// Global session-revocation path. Mirrors the
-				// invalidateUser handler but across every connection
-				// registered with this hub, with one critical
-				// difference: we also clear the session token so that
-				// IsBasicAuthenticated short-circuits on its next
-				// invocation rather than re-fetching the (potentially
-				// still cached upstream) session and re-populating
-				// the WebConn's cached auth state.
+				// Mirrors the invalidateUser arm across every conn,
+				// also clearing the session token so the next
+				// IsBasicAuthenticated check short-circuits instead
+				// of re-fetching from the cache.
 				userIDs := make(map[string]struct{})
 				for webConn := range connIndex.All() {
 					webConn.InvalidateCache()

--- a/server/channels/app/platform/web_hub.go
+++ b/server/channels/app/platform/web_hub.go
@@ -86,6 +86,7 @@ type Hub struct {
 	stop            chan struct{}
 	didStop         chan struct{}
 	invalidateUser  chan string
+	invalidateAll   chan struct{}
 	activity        chan *webConnActivityMessage
 	directMsg       chan *webConnDirectMessage
 	explicitStop    bool
@@ -108,6 +109,7 @@ func newWebHub(ps *PlatformService) *Hub {
 		stop:            make(chan struct{}),
 		didStop:         make(chan struct{}),
 		invalidateUser:  make(chan string),
+		invalidateAll:   make(chan struct{}),
 		activity:        make(chan *webConnActivityMessage),
 		directMsg:       make(chan *webConnDirectMessage),
 		checkRegistered: make(chan *webConnSessionMessage),
@@ -463,6 +465,19 @@ func (h *Hub) InvalidateUser(userID string) {
 	}
 }
 
+// InvalidateAll invalidates the cached session state on every WebConn
+// registered with this hub. It is the global counterpart of
+// InvalidateUser and is used by the global session-revocation path so
+// that live websocket connections re-validate against the store on
+// their next authentication check instead of trusting their cached
+// (and now-deleted) session.
+func (h *Hub) InvalidateAll() {
+	select {
+	case h.invalidateAll <- struct{}{}:
+	case <-h.stop:
+	}
+}
+
 // UpdateActivity sets the LastUserActivityAt field for the connection
 // of the user.
 func (h *Hub) UpdateActivity(userID, sessionToken string, activityAt int64) {
@@ -662,6 +677,34 @@ func (h *Hub) Start() {
 					h.platform.Log().Error("Error while invalidating channel member cache", mlog.String("user_id", userID), mlog.Err(err))
 					for webConn := range connIndex.ForUser(userID) {
 						closeAndRemoveConn(connIndex, webConn)
+					}
+				}
+			case <-h.invalidateAll:
+				// Global session-revocation path. Mirrors the
+				// invalidateUser handler but across every connection
+				// registered with this hub, with one critical
+				// difference: we also clear the session token so that
+				// IsBasicAuthenticated short-circuits on its next
+				// invocation rather than re-fetching the (potentially
+				// still cached upstream) session and re-populating
+				// the WebConn's cached auth state.
+				userIDs := make(map[string]struct{})
+				for webConn := range connIndex.All() {
+					webConn.InvalidateCache()
+					webConn.SetSessionToken("")
+					userIDs[webConn.UserId] = struct{}{}
+				}
+
+				if !*h.platform.Config().ServiceSettings.EnableWebHubChannelIteration {
+					continue
+				}
+
+				for userID := range userIDs {
+					if err := connIndex.InvalidateCMCacheForUser(userID); err != nil {
+						h.platform.Log().Error("Error while invalidating channel member cache", mlog.String("user_id", userID), mlog.Err(err))
+						for conn := range connIndex.ForUser(userID) {
+							closeAndRemoveConn(connIndex, conn)
+						}
 					}
 				}
 			case activity := <-h.activity:

--- a/server/channels/app/session.go
+++ b/server/channels/app/session.go
@@ -233,7 +233,9 @@ func (a *App) ClearSessionCacheForUserSkipClusterSend(userID string) {
 }
 
 func (a *App) ClearSessionCacheForAllUsersSkipClusterSend() {
-	a.Srv().Platform().ClearSessionCacheForAllUsersSkipClusterSend()
+	if err := a.Srv().Platform().ClearSessionCacheForAllUsersSkipClusterSend(); err != nil {
+		a.Srv().Platform().Log().Error("Failed to clear session cache for all users", mlog.Err(err))
+	}
 }
 
 func (a *App) RevokeSessionsForDeviceId(rctx request.CTX, userID string, deviceID string, currentSessionId string) *model.AppError {


### PR DESCRIPTION
#### Summary

Extends the local-side primitive used by the global session-cache revocation path so that, on every node, active WebSocket connections are invalidated alongside the session cache itself.

#### Ticket Link

Jira: https://mattermost.atlassian.net/browse/MM-68543

#### Screenshots

N/A — backend-only change, no UI surface affected.

#### Release Note

```release-note
Tightened session invalidation on the global session revocation path 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🔴 High

**Regression Risk:** Changes modify session invalidation and WebSocket authentication state across nodes and alter the return semantics of ClearSessionCacheForAllUsersSkipClusterSend(), increasing the chance of regressions in session revocation behavior and in callers that assumed the previous void behavior; added hub-wide invalidation and per-user channel cache clearing introduce new error paths and potential race conditions during bulk invalidation.  
**QA Recommendation:** Perform targeted manual QA and integration tests covering concurrent global revocation, websocket reconnection/authentication flows during and after invalidation, and failure paths when cache purge or per-user channel-member invalidation fails; include end-to-end verification that no authenticated WebConns remain after revocation.

*Generated by CodeRabbitAI*

---

## Release Notes

Tightened session invalidation on the global session revocation path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->