### PR TITLE
fix: detect ADFS when IdpDescriptorURL has no trailing slash

### DIFF
--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -432,7 +432,7 @@ func detectSAMLProviderType(idpDescriptorURL string) string {
 		return "Centrify"
 	case strings.Contains(normalizedURL, "/realms/"):
 		return "Keycloak"
-	case strings.Contains(normalizedURL, "/adfs/") || strings.Contains(normalizedURL, "/FederationMetadata/"):
+	case strings.Contains(normalizedURL, "/adfs") || strings.Contains(normalizedURL, "/FederationMetadata/"):
 		return "ADFS"
 	case strings.Contains(normalizedURL, "shibboleth.net") || strings.Contains(normalizedURL, "/idp/shibboleth"):
 		return "Shibboleth"

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -432,7 +432,7 @@ func detectSAMLProviderType(idpDescriptorURL string) string {
 		return "Centrify"
 	case strings.Contains(normalizedURL, "/realms/"):
 		return "Keycloak"
-	case strings.Contains(normalizedURL, "/adfs") || strings.Contains(normalizedURL, "/FederationMetadata/"):
+	case strings.Contains(normalizedURL, "/adfs") || strings.Contains(normalizedURL, "/federationmetadata/"):
 		return "ADFS"
 	case strings.Contains(normalizedURL, "shibboleth.net") || strings.Contains(normalizedURL, "/idp/shibboleth"):
 		return "Shibboleth"

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -783,6 +783,11 @@ func TestDetectSAMLProviderType(t *testing.T) {
 			expectedProvider: "ADFS",
 		},
 		{
+			name:             "ADFS provider with bare /adfs path (no trailing slash)",
+			idpDescriptorURL: "https://adfs.company.com/adfs",
+			expectedProvider: "ADFS",
+		},
+		{
 			name:             "Azure AD provider with login.microsoftonline.com",
 			idpDescriptorURL: "https://login.microsoftonline.com/12345/saml2",
 			expectedProvider: "Azure AD",


### PR DESCRIPTION
#### Summary
`detectSAMLProviderType` was checking for `/adfs/` (with trailing slash), but ADFS `IdpDescriptorURL` values often end with just `/adfs` (no trailing slash), causing the provider type to show as `unknown` in support packets.

Changed the check from `/adfs/` to `/adfs` to match both forms and added a test case covering the bare path.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```