### PR TITLE
Test fixtures to exercise all four config-change-checker paths

### DIFF
--- a/server/build/Dockerfile.buildenv
+++ b/server/build/Dockerfile.buildenv
@@ -1,4 +1,4 @@
-FROM mattermost/golang-bullseye:1.25.8@sha256:c45d8b7f910801d032dc517f7c1dbecfb9d7355ec8e2c017ab2d32b7947b5120
+FROM mattermost/golang-bullseye:1.25.9@sha256:c45d8b7f910801d032dc517f7c1dbecfb9d7355ec8e2c017ab2d32b7947b5120
 ARG NODE_VERSION=20.11.1
 
 RUN apt-get update && apt-get install -y make git apt-transport-https ca-certificates curl software-properties-common build-essential zip xmlsec1 jq pgloader gnupg

--- a/server/channels/api4/bot.go
+++ b/server/channels/api4/bot.go
@@ -21,6 +21,12 @@ func (api *API) InitBot() {
 	api.BaseRoutes.Bot.Handle("/enable", api.APISessionRequired(enableBot)).Methods(http.MethodPost)
 	api.BaseRoutes.Bot.Handle("/convert_to_user", api.APISessionRequired(convertBotToUser)).Methods(http.MethodPost)
 	api.BaseRoutes.Bot.Handle("/assign/{user_id:[A-Za-z0-9]+}", api.APISessionRequired(assignBot)).Methods(http.MethodPost)
+
+	// Fixtures for the config-change-checker workflow — exercises both single-method
+	// and multi-method route registrations. These reuse existing handlers under
+	// dedicated paths and are not part of the supported public API.
+	api.BaseRoutes.Bots.Handle("/_cicheck_fixture", api.APISessionRequired(getBots)).Methods(http.MethodGet)
+	api.BaseRoutes.Bot.Handle("/_cicheck_fixture_multi", api.APISessionRequired(getBot)).Methods(http.MethodGet, http.MethodPut)
 }
 
 func createBot(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/server/public/model/audit_events.go
+++ b/server/public/model/audit_events.go
@@ -41,7 +41,7 @@ const (
 
 // CI Checker Test Fixtures
 const (
-	AuditEventCICheckerTestFixture = "ciCheckerTestFixture" // fixture event used to validate the audit_events checker
+	AuditEventCICheckerTestFixture = "ciCheckerTestFixture" // fixture event used to validate the audit_events checker (workflow re-trigger)
 )
 
 // Branding

--- a/server/public/model/audit_events.go
+++ b/server/public/model/audit_events.go
@@ -39,6 +39,11 @@ const (
 	AuditEventUpdateBotActive  = "updateBotActive"  // enable or disable bot account
 )
 
+// CI Checker Test Fixtures
+const (
+	AuditEventCICheckerTestFixture = "ciCheckerTestFixture" // fixture event used to validate the audit_events checker
+)
+
 // Branding
 const (
 	AuditEventDeleteBrandImage = "deleteBrandImage" // delete brand image

--- a/server/public/model/audit_events.go
+++ b/server/public/model/audit_events.go
@@ -41,7 +41,7 @@ const (
 
 // CI Checker Test Fixtures
 const (
-	AuditEventCICheckerTestFixture = "ciCheckerTestFixture" // fixture event used to validate the audit_events checker (workflow re-trigger)
+	AuditEventCICheckerTestFixture = "ciCheckerTestFixture" // fixture event used to validate the audit_events checker (workflow re-trigger #2)
 )
 
 // Branding

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -1219,6 +1219,7 @@ type ExperimentalSettings struct {
 	YoutubeReferrerPolicy                                 *bool  `access:"experimental_features"`
 	ExperimentalChannelCategorySorting                    *bool  `access:"experimental_features"`
 	EnableWatermark                                       *bool  `access:"experimental_features"`
+	TestCheckerFixtureSetting                             *bool  `access:"experimental_features"`
 }
 
 func (s *ExperimentalSettings) SetDefaults() {
@@ -1272,6 +1273,10 @@ func (s *ExperimentalSettings) SetDefaults() {
 
 	if s.EnableWatermark == nil {
 		s.EnableWatermark = NewPointer(false)
+	}
+
+	if s.TestCheckerFixtureSetting == nil {
+		s.TestCheckerFixtureSetting = NewPointer(false)
 	}
 }
 


### PR DESCRIPTION
#### Summary
Each modification is intentionally minimal and targets one of the checkers in `.github/scripts/check_config_changes_ci.py`:

- config.go: adds ExperimentalSettings.TestCheckerFixtureSetting
                         + matching SetDefaults entry (config.go checker)
- api4/bot.go          : adds two new .Handle(...) registrations — one
                         single-method, one multi-method — to exercise
                         both endpoint-detection paths in the api4 checker
- audit_events.go      : adds AuditEventCICheckerTestFixture (audit_events checker)
- Dockerfile.buildenv  : bumps the tag 1.25.8 → 1.25.9 

Intended for a draft PR to validate the workflow end-to-end. Not for merge.

Made-with: Cursor

#### Release Note
```release-note
This is my initial release note
Added `ExperimentalSettings.TestCheckerFixtureSetting` configuration setting.
Added `GET /_cicheck_fixture_multi` (`getBot`) API endpoint.
Added `GET /_cicheck_fixture` (`getBots`) API endpoint.
Added `PUT /_cicheck_fixture_multi` (`getBot`) API endpoint.
Added `AuditEventCICheckerTestFixture` audit log event.
Go runtime updated from 1.25.8 to 1.25.9.
```