### PR TITLE
Update Agents plugin FIPS version to v2.0.0

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -179,7 +179,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.8.0%2Bc4449ac-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v1.7.2%2B866e2dd-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.0%2B67aa35a-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.4%2B5855fe1-fips
 endif
 


### PR DESCRIPTION
#### Summary
Update Agents plugin FIPS version to v2.0.0

#### Ticket Link
--

#### Screenshots
--

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Minimal. This is a straightforward version bump of a prepackaged plugin artifact in the FIPS build variant only, with no changes to build logic or other plugin entries. The change is isolated to the FIPS-specific configuration line in the Makefile.

**QA Recommendation:** Minimal manual QA required. Verify that the FIPS-enabled build completes successfully and confirm the agents plugin functions normally in FIPS mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->