### PR TITLE
MM-67982 Only focus mobile search box when search is opened

### DIFF
--- a/e2e-tests/playwright/specs/functional/channels/search/mobile_rhs_focus.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/search/mobile_rhs_focus.spec.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+test.describe('Mobile view RHS auto-focus', () => {
+    // Shrink the window's width to trigger mobile view
+    test.use({viewport: {width: 400, height: 1024}});
+
+    /**
+     * @objective Opening a thread shouldn't focus the search textbox, even briefly
+     */
+    test(
+        'opens thread in mobile view without ever focusing the mobile search input',
+        {tag: '@search'},
+        async ({pw, isMobile}) => {
+            const {user} = await pw.initSetup();
+
+            // # Log in
+            const {channelsPage, page} = await pw.testBrowser.login(user);
+
+            // # Go to a channel
+            await channelsPage.goto();
+            await channelsPage.toBeVisible();
+
+            // # Make a post
+            await channelsPage.centerView.postCreate.postMessage('Root message for mobile thread focus test');
+
+            // # Set up a listener to track if the search box ever gets focus
+            await page.evaluate(() => {
+                (window as any).__sbrSearchBoxFocusCount = 0;
+                document.addEventListener('focusin', (e) => {
+                    if (e.target && 'id' in e.target && e.target.id === 'sbrSearchBox') {
+                        (window as any).__sbrSearchBoxFocusCount += 1;
+                    }
+                });
+            });
+
+            // # Open the thread
+            const lastPost = await channelsPage.getLastPost();
+            await lastPost.openAThread();
+            await channelsPage.sidebarRight.toBeVisible();
+
+            // * Verify that the textbox is automatically focused on non-mobile devices
+            if (!isMobile) {
+                await expect(channelsPage.sidebarRight.postCreate.input).toBeFocused();
+            }
+
+            // * Verify the mobile RHS search input never received focus
+            const searchFocusCount = await page.evaluate(() => (window as any).__sbrSearchBoxFocusCount);
+            expect(searchFocusCount).toBe(0);
+        },
+    );
+
+    /**
+     * @objective Opening the search RHS auto-focuses the search input in the RHS
+     */
+    test('opens search RHS in mobile view and focuses the mobile search input', {tag: '@search'}, async ({pw}) => {
+        const {user} = await pw.initSetup();
+
+        // # Log in as the test user
+        const {channelsPage, page} = await pw.testBrowser.login(user);
+
+        // # Visit a default channel page
+        await channelsPage.goto();
+        await channelsPage.toBeVisible();
+
+        // # Click the mobile channel header search button to open the search RHS
+        await page.locator('#navbar').getByRole('button', {name: 'Search', exact: true}).click();
+        await channelsPage.sidebarRight.toBeVisible();
+
+        // * Verify the mobile RHS search input is focused
+        await expect(page.locator('#sbrSearchBox')).toBeFocused();
+    });
+});

--- a/webapp/channels/src/components/search/index.tsx
+++ b/webapp/channels/src/components/search/index.tsx
@@ -53,6 +53,7 @@ function mapStateToProps(state: GlobalState) {
         isFlaggedPosts: rhsState === RHSStates.FLAG,
         isPinnedPosts: rhsState === RHSStates.PIN,
         isChannelFiles: rhsState === RHSStates.CHANNEL_FILES,
+        isSearch: rhsState === RHSStates.SEARCH,
         isMobileView,
         crossTeamSearchEnabled,
     };

--- a/webapp/channels/src/components/search/search.tsx
+++ b/webapp/channels/src/components/search/search.tsx
@@ -101,6 +101,7 @@ const Search = ({
     isMobileView,
     isPinnedPosts,
     isRhsExpanded,
+    isSearch,
     isSearchingTerm,
     searchTerms = '',
     searchType,
@@ -169,10 +170,10 @@ const Search = ({
     }, [hideSearchBar, currentChannelName]);
 
     useEffect((): void => {
-        if (isMobileView && isSideBarRight) {
+        if (isMobileView && isSideBarRight && isSearch) {
             handleFocus();
         }
-    }, [isMobileView, isSideBarRight]);
+    }, [isMobileView, isSideBarRight, isSearch]);
 
     useEffect((): void => {
         if (!isMobileView) {

--- a/webapp/channels/src/components/search/types.ts
+++ b/webapp/channels/src/components/search/types.ts
@@ -33,6 +33,7 @@ export type StateProps = {
     isFlaggedPosts: boolean;
     isPinnedPosts: boolean;
     isChannelFiles: boolean;
+    isSearch: boolean;
     isMobileView: boolean;
     crossTeamSearchEnabled: boolean;
 }


### PR DESCRIPTION
#### Summary
Currently, we focus the mobile view search box whenever it's mounted. That's fine when you open the search RHS, but it also triggers on RHSes because the search box is visible at the top of most of them.

This changes so that it only happens when you specifically open the search RHS and not a thread.

#### Ticket Link
MM-67982

#### Release Note
```release-note
Changed mobile view search box to only autofocus when the search button is pressed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Minimal. The change adds a gating condition to an existing effect, restricting autofocus to explicit search RHS openings. Since it only adds a constraint rather than altering core behavior, and only affects mobile view search focus, there is low risk of unintended side effects propagating to other components.

**QA Recommendation:** Manual QA is optional. E2E tests provide comprehensive coverage of the new behavior (validating focus on search RHS open and no focus on other RHS opens). Spot-check mobile search behavior on different devices if resource-constrained, but automated coverage is thorough.

---

**Release Notes:**
Changed mobile view search box to only autofocus when the search button is pressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->