### PR TITLE
[MM-68588] Add notice in System Console when policy has mixed channel…

### DIFF
--- a/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.scss
+++ b/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.scss
@@ -33,4 +33,12 @@
 
         margin-bottom: 16px;
     }
+
+    .AccessControlPolicySettings__mixedChannelsNotice {
+        margin-bottom: 16px;
+
+        h4 {
+            margin-bottom: 0;
+        }
+    }
 }

--- a/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.tsx
@@ -362,6 +362,34 @@ function PolicyDetails({
         );
     };
 
+    // Effective channel mix = (saved - removed) + added. Reused by the
+    // mixed-channel notice below the channel list and by the confirmation
+    // modal so both surfaces stay in sync.
+    const channelTypeCounts = useMemo(() => {
+        let publicCount = 0;
+        let privateCount = 0;
+        for (const [id, type] of Object.entries(savedChannelTypes)) {
+            if (channelChanges.removed[id]) {
+                continue;
+            }
+            if (type === Constants.OPEN_CHANNEL) {
+                publicCount++;
+            } else if (type === Constants.PRIVATE_CHANNEL) {
+                privateCount++;
+            }
+        }
+        for (const ch of Object.values(channelChanges.added)) {
+            if (ch.type === Constants.OPEN_CHANNEL) {
+                publicCount++;
+            } else if (ch.type === Constants.PRIVATE_CHANNEL) {
+                privateCount++;
+            }
+        }
+        return {publicCount, privateCount};
+    }, [savedChannelTypes, channelChanges.removed, channelChanges.added]);
+
+    const hasMixedChannels = channelTypeCounts.publicCount > 0 && channelTypeCounts.privateCount > 0;
+
     return (
         <div className='wrapper--fixed AccessControlPolicySettings'>
             <AdminHeader withBackButton={true}>
@@ -560,6 +588,23 @@ function PolicyDetails({
                                 onPolicyActiveStatusChange={handlePolicyActiveStatusChange}
                                 saving={saving}
                             />
+                            {hasMixedChannels && (
+                                <div className='AccessControlPolicySettings__mixedChannelsNotice'>
+                                    <SectionNotice
+                                        type='warning'
+                                        title={
+                                            <FormattedMessage
+                                                id='admin.access_control.policy.edit_policy.mixed_channels.title'
+                                                defaultMessage='Membership policies affect public and private channels differently'
+                                            />
+                                        }
+                                        text={formatMessage({
+                                            id: 'admin.access_control.policy.edit_policy.mixed_channels.text',
+                                            defaultMessage: 'On private channels, only matching users can join and non-matching members are removed. On public channels, matching users are recommended or auto-added, but the channel stays open to everyone.',
+                                        })}
+                                    />
+                                </div>
+                            )}
                         </Card.Body>
                     </Card>
                     {policyId && (
@@ -621,40 +666,16 @@ function PolicyDetails({
                 />
             )}
 
-            {showConfirmationModal && (() => {
-                // Effective channel mix = (saved - removed) + added. The
-                // confirmation modal messages the user differently for mixed,
-                // private-only, and public-only selections.
-                let publicCount = 0;
-                let privateCount = 0;
-                for (const [id, type] of Object.entries(savedChannelTypes)) {
-                    if (channelChanges.removed[id]) {
-                        continue;
-                    }
-                    if (type === Constants.OPEN_CHANNEL) {
-                        publicCount++;
-                    } else if (type === Constants.PRIVATE_CHANNEL) {
-                        privateCount++;
-                    }
-                }
-                for (const ch of Object.values(channelChanges.added)) {
-                    if (ch.type === Constants.OPEN_CHANNEL) {
-                        publicCount++;
-                    } else if (ch.type === Constants.PRIVATE_CHANNEL) {
-                        privateCount++;
-                    }
-                }
-                return (
-                    <PolicyConfirmationModal
-                        active={autoSyncMembership}
-                        onExited={() => setShowConfirmationModal(false)}
-                        onConfirm={handleSubmit}
-                        channelsAffected={(channelsCount - channelChanges.removedCount) + Object.keys(channelChanges.added).length}
-                        publicChannelsAffected={publicCount}
-                        privateChannelsAffected={privateCount}
-                    />
-                );
-            })()}
+            {showConfirmationModal && (
+                <PolicyConfirmationModal
+                    active={autoSyncMembership}
+                    onExited={() => setShowConfirmationModal(false)}
+                    onConfirm={handleSubmit}
+                    channelsAffected={(channelsCount - channelChanges.removedCount) + Object.keys(channelChanges.added).length}
+                    publicChannelsAffected={channelTypeCounts.publicCount}
+                    privateChannelsAffected={channelTypeCounts.privateCount}
+                />
+            )}
 
             {showDeleteConfirmationModal && (
                 <GenericModal

--- a/webapp/channels/src/components/team_settings/team_access_policies_tab/team_policy_editor.scss
+++ b/webapp/channels/src/components/team_settings/team_access_policies_tab/team_policy_editor.scss
@@ -56,6 +56,14 @@
         margin-bottom: 0;
     }
 
+    &__mixed-channels-notice {
+        margin-top: 16px;
+
+        h4 {
+            margin-bottom: 0;
+        }
+    }
+
     &__section-header {
         display: flex;
         align-items: flex-start;

--- a/webapp/channels/src/components/team_settings/team_access_policies_tab/team_policy_editor.test.tsx
+++ b/webapp/channels/src/components/team_settings/team_access_policies_tab/team_policy_editor.test.tsx
@@ -4,7 +4,10 @@
 import React from 'react';
 import type {ComponentProps} from 'react';
 
+import type {ChannelWithTeamData} from '@mattermost/types/channels';
+
 import {renderWithContext, screen, userEvent, waitFor} from 'tests/react_testing_utils';
+import Constants from 'utils/constants';
 
 import TeamPolicyEditor from './team_policy_editor';
 
@@ -26,6 +29,9 @@ jest.mock('hooks/useChannelAccessControlActions', () => ({
 }));
 
 describe('TeamPolicyEditor', () => {
+    const publicChannel = {id: 'public-channel', team_id: 'team1', name: 'public-channel', display_name: 'Public Channel', type: Constants.OPEN_CHANNEL} as ChannelWithTeamData;
+    const privateChannel = {id: 'private-channel', team_id: 'team1', name: 'private-channel', display_name: 'Private Channel', type: Constants.PRIVATE_CHANNEL} as ChannelWithTeamData;
+
     const defaultProps: ComponentProps<typeof TeamPolicyEditor> = {
         teamId: 'team1',
         accessControlSettings: {
@@ -125,6 +131,91 @@ describe('TeamPolicyEditor', () => {
         );
         await waitFor(() => {
             expect(screen.getByText('Delete policy')).toBeInTheDocument();
+        });
+    });
+
+    test('should show mixed channel notice when existing policy has public and private channels', async () => {
+        const fetchPolicy = jest.fn().mockResolvedValue({
+            data: {id: 'p1', name: 'Existing', rules: [{expression: 'true', actions: ['*']}]},
+        });
+        const searchChannels = jest.fn().mockResolvedValue({data: {total_count: 2, channels: [publicChannel, privateChannel]}});
+
+        renderWithContext(
+            <TeamPolicyEditor
+                {...defaultProps}
+                policyId='p1'
+                actions={{...defaultProps.actions, fetchPolicy, searchChannels}}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Membership policies affect public and private channels differently')).toBeInTheDocument();
+        });
+        expect(screen.getByText(/On private channels, only matching users can join/)).toBeInTheDocument();
+    });
+
+    test('should not show mixed channel notice when policy has only public channels', async () => {
+        const fetchPolicy = jest.fn().mockResolvedValue({
+            data: {id: 'p1', name: 'Existing', rules: [{expression: 'true', actions: ['*']}]},
+        });
+        const searchChannels = jest.fn().mockResolvedValue({data: {total_count: 1, channels: [publicChannel]}});
+
+        renderWithContext(
+            <TeamPolicyEditor
+                {...defaultProps}
+                policyId='p1'
+                actions={{...defaultProps.actions, fetchPolicy, searchChannels}}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(searchChannels).toHaveBeenCalledWith('p1', '', {per_page: 1000});
+        });
+        expect(screen.queryByText('Membership policies affect public and private channels differently')).not.toBeInTheDocument();
+    });
+
+    test('should hide mixed channel notice when pending removals leave only public channels', async () => {
+        const fetchPolicy = jest.fn().mockResolvedValue({
+            data: {id: 'p1', name: 'Existing', rules: [{expression: 'true', actions: ['*']}]},
+        });
+        const searchChannels = jest.fn().mockResolvedValue({data: {total_count: 2, channels: [publicChannel, privateChannel]}});
+
+        renderWithContext(
+            <TeamPolicyEditor
+                {...defaultProps}
+                policyId='p1'
+                actions={{...defaultProps.actions, fetchPolicy, searchChannels}}
+            />,
+            {
+                entities: {
+                    admin: {
+                        channelsForAccessControlPolicy: {
+                            p1: [publicChannel.id, privateChannel.id],
+                        },
+                    },
+                    channels: {
+                        channels: {
+                            [publicChannel.id]: publicChannel,
+                            [privateChannel.id]: privateChannel,
+                        },
+                    },
+                    teams: {
+                        teams: {
+                            team1: {id: 'team1', display_name: 'Test Team', name: 'test-team'},
+                        },
+                    },
+                },
+            },
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Membership policies affect public and private channels differently')).toBeInTheDocument();
+        });
+
+        await userEvent.click(document.getElementById('remove-channel-private-channel')!);
+
+        await waitFor(() => {
+            expect(screen.queryByText('Membership policies affect public and private channels differently')).not.toBeInTheDocument();
         });
     });
 });

--- a/webapp/channels/src/components/team_settings/team_access_policies_tab/team_policy_editor.tsx
+++ b/webapp/channels/src/components/team_settings/team_access_policies_tab/team_policy_editor.tsx
@@ -18,6 +18,7 @@ import {hasUsableAttributes} from 'components/admin_console/access_control/edito
 import TableEditor from 'components/admin_console/access_control/editors/table_editor/table_editor';
 import ChannelList from 'components/admin_console/access_control/policy_details/channel_list';
 import ChannelSelectorModal from 'components/channel_selector_modal';
+import SectionNotice from 'components/section_notice';
 import Input from 'components/widgets/inputs/input/input';
 import type {CustomMessageInputType} from 'components/widgets/inputs/input/input';
 import SaveChangesPanel from 'components/widgets/modals/components/save_changes_panel';
@@ -247,6 +248,7 @@ export default function TeamPolicyEditor({
         const channelsAffected = (channelsCount - channelChanges.removedCount) + Object.keys(channelChanges.added).length;
         return {publicCount, privateCount, channelsAffected};
     }, [savedChannelTypes, channelChanges, channelsCount]);
+    const hasMixedChannels = confirmationChannelCounts.publicCount > 0 && confirmationChannelCounts.privateCount > 0;
 
     const validateForm = useCallback(async () => {
         if (policyName.length === 0) {
@@ -566,6 +568,23 @@ export default function TeamPolicyEditor({
                     hideTeamColumn={true}
                     teamId={teamId}
                 />
+                {hasMixedChannels && (
+                    <div className='TeamPolicyEditor__mixed-channels-notice'>
+                        <SectionNotice
+                            type='warning'
+                            title={
+                                <FormattedMessage
+                                    id='admin.access_control.policy.edit_policy.mixed_channels.title'
+                                    defaultMessage='Membership policies affect public and private channels differently'
+                                />
+                            }
+                            text={formatMessage({
+                                id: 'admin.access_control.policy.edit_policy.mixed_channels.text',
+                                defaultMessage: 'On private channels, only matching users can join and non-matching members are removed. On public channels, matching users are recommended or auto-added, but the channel stays open to everyone.',
+                            })}
+                        />
+                    </div>
+                )}
             </div>
 
             {policyId && (

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -317,6 +317,8 @@
   "admin.access_control.policy.edit_policy.error.name_required": "Please add a name to the policy",
   "admin.access_control.policy.edit_policy.error.unassign_channels": "Error unassigning channels: {error}",
   "admin.access_control.policy.edit_policy.error.update_active_status": "Error updating policy active status: {error}",
+  "admin.access_control.policy.edit_policy.mixed_channels.text": "On private channels, only matching users can join and non-matching members are removed. On public channels, matching users are recommended or auto-added, but the channel stays open to everyone.",
+  "admin.access_control.policy.edit_policy.mixed_channels.title": "Membership policies affect public and private channels differently",
   "admin.access_control.policy.edit_policy.no_channels_available": "There are no channels available to add to this policy.",
   "admin.access_control.policy.edit_policy.no_usable_attributes_tooltip": "Please configure user attributes to use the editor.",
   "admin.access_control.policy.edit_policy.notice.button": "Configure user attributes",


### PR DESCRIPTION
#### Summary
<!--
A brief description of what this pull request does.
-->
When a membership policy in the System Console has both public and private channels assigned, the implications differ by channel type — private channels restrict who is allowed in, while public channels define who is recommended/auto-added. This PR adds an informational notice below the assigned-channels list in the policy editor that appears whenever the effective channel set contains both types, explaining each behavior so admins understand it before saving. The public/private counting that was inlined in the save-confirmation modal was refactored into a single `useMemo` and reused by both surfaces.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-68588

#### Screenshot
<img width="936" height="491" alt="image" src="https://github.com/user-attachments/assets/546d36d3-b35e-482b-a4fe-4a83b94d2740" />


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.
-->
```release-note
NONE
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The refactor consolidates channel-type counting into a shared useMemo and adds a conditional UI notice; this is primarily a UI change with moderate risk because the same counting logic now feeds both the notice and the confirmation modal—if the computation is incorrect it could cause misleading UI or incorrect counts shown in the modal. Existing tests were added for the team policy editor mixed-channel scenarios, but coverage for the admin Console policy_details counting/refactor path is unclear, leaving potential untested code paths.

**QA Recommendation:** Manual verification of the mixed-channel notice and confirmation modal counts in both Team Policy Editor and System Console Policy Editor (including adding/removing channels and saved/removed channel edge cases). Add targeted unit/render tests covering channelTypeCounts (all-public, all-private, mixed, removed/added channels) and SectionNotice conditional rendering to ensure behavior remains consistent across components.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->