### PR TITLE
mmctl: allow local bot create

### DIFF
--- a/server/cmd/mmctl/commands/bot.go
+++ b/server/cmd/mmctl/commands/bot.go
@@ -27,7 +27,6 @@ var CreateBotCmd = &cobra.Command{
 	Short:   "Create bot",
 	Long:    "Create bot.",
 	Example: `  bot create testbot`,
-	PreRun:  disableLocalPrecheck,
 	RunE:    withClient(botCreateCmdF),
 	Args:    cobra.ExactArgs(1),
 }

--- a/server/cmd/mmctl/commands/bot_e2e_test.go
+++ b/server/cmd/mmctl/commands/bot_e2e_test.go
@@ -401,7 +401,7 @@ func (s *MmctlE2ETestSuite) TestBotCreateCmdF() {
 	s.th.App.UpdateConfig(func(c *model.Config) { *c.ServiceSettings.EnableBotAccountCreation = true })
 	defer s.th.App.UpdateConfig(func(c *model.Config) { *c.ServiceSettings.EnableBotAccountCreation = createBots })
 
-	s.Run("MM-T3941 Create Bot with an access token", func() {
+	s.Run("Create Bot with an access token without permission", func() {
 		printer.Clean()
 
 		cmd := &cobra.Command{}
@@ -411,10 +411,15 @@ func (s *MmctlE2ETestSuite) TestBotCreateCmdF() {
 		s.Require().Error(err)
 		s.Require().Empty(printer.GetLines())
 		s.Require().Empty(printer.GetErrorLines())
+	})
 
+	s.RunForSystemAdminAndLocal("MM-T3941 Create Bot with an access token", func(c client.Client) {
 		printer.Clean()
 
-		err = botCreateCmdF(s.th.SystemAdminClient, cmd, []string{"testbot"})
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("with-token", true, "")
+
+		err := botCreateCmdF(c, cmd, []string{model.NewUsername()})
 		s.Require().NoError(err)
 		s.Require().Equal(2, len(printer.GetLines()))
 		bot, ok := printer.GetLines()[0].(*model.Bot)

--- a/server/cmd/mmctl/commands/bot_e2e_test.go
+++ b/server/cmd/mmctl/commands/bot_e2e_test.go
@@ -407,8 +407,10 @@ func (s *MmctlE2ETestSuite) TestBotCreateCmdF() {
 		cmd := &cobra.Command{}
 		cmd.Flags().Bool("with-token", true, "")
 
-		err := botCreateCmdF(s.th.Client, cmd, []string{"testbot"})
+		username := model.NewUsername()
+		err := botCreateCmdF(s.th.Client, cmd, []string{username})
 		s.Require().Error(err)
+		s.Require().Contains(err.Error(), "permissions")
 		s.Require().Empty(printer.GetLines())
 		s.Require().Empty(printer.GetErrorLines())
 	})


### PR DESCRIPTION
#### Summary
Enable `mmctl --local bot create` by removing the command-level local-mode precheck. The command already routes through the local client path via `withClient`, and token generation is already covered for system-admin and local clients.

This also expands the bot-create e2e coverage so `bot create --with-token` runs with both system-admin and local-mode clients while preserving the no-permission regression check.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/36353

#### Screenshots
N/A (CLI-only change)

#### Verification
- `git diff --check`
- static assertions that `bot create` no longer registers `disableLocalPrecheck` and e2e coverage includes `RunForSystemAdminAndLocal` for bot create with token

Limit: this worker does not have Go/gofmt installed, so I could not run the mmctl e2e suite locally.

#### Release Note
```release-note
Allowed mmctl local mode to create bot accounts, including bot token generation when requested.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change removes a per-command PreRun gate for local-mode bot creation which affects provisioning/auth flows; risk is moderate because authorization and token generation still use existing local/system-admin client paths and added e2e tests cover the happy and no-permission failure paths. There is a small risk if any untested local client token-generation edge cases remain.

**QA Recommendation:** Perform focused manual QA: verify `mmctl --local bot create` and `--with-token` succeed for local/system-admin contexts, and verify non-privileged attempts fail with appropriate permission errors; exercise the first-run provisioning scenario to ensure no unexpected exposures.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->