### PR TITLE
Fix AI toolbar separator visibility

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -181,6 +181,7 @@ const AdvancedTextEditor = ({
     const teammateDisplayName = useSelector((state: GlobalState) => (teammateId ? getDisplayName(state, teammateId) : ''));
     const showDndWarning = useSelector((state: GlobalState) => (teammateId ? getStatusForUserId(state, teammateId) === UserStatuses.DND : false));
     const selectedPostFocussedAt = useSelector((state: GlobalState) => getSelectedPostFocussedAt(state));
+    const aiActionMenuItems = useSelector((state: GlobalState) => state.plugins.components.AIActionMenuItem);
     const {available: aiRewriteEnabled} = useGetAgentsBridgeEnabled();
 
     const canPost = useSelector((state: GlobalState) => {
@@ -317,6 +318,7 @@ const AdvancedTextEditor = ({
         rewriteMenuProps,
         isProcessing: rewriteIsProcessing,
     } = useRewrite(draft, handleDraftChange, textboxRef, focusTextbox, setServerError);
+    const hasAIActionsMenu = (aiActionMenuItems?.length ?? 0) > 0 || (aiRewriteEnabled && Boolean(rewriteMenuProps));
     const isDisabled = Boolean(readOnlyChannel || (!enableSharedChannelsDMs && isDMOrGMRemote) || rewriteIsProcessing);
 
     const [attachmentPreview, fileUploadJSX] = useUploadFiles(
@@ -707,6 +709,10 @@ const AdvancedTextEditor = ({
     }, [handleDraftChange, draft]);
 
     const aiActionsMenu = useMemo(() => {
+        if (!hasAIActionsMenu) {
+            return null;
+        }
+
         return (
             <AIActionsMenu
                 draft={draft}
@@ -718,7 +724,7 @@ const AdvancedTextEditor = ({
                 aiRewriteEnabled={aiRewriteEnabled}
             />
         );
-    }, [draft, getSelectedText, updateText, channelId, location, rewriteMenuProps, aiRewriteEnabled]);
+    }, [draft, getSelectedText, updateText, channelId, location, rewriteMenuProps, aiRewriteEnabled, hasAIActionsMenu]);
 
     const formattingBar = (
         <AutoHeightSwitcher

--- a/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_bar.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_bar.test.tsx
@@ -107,4 +107,26 @@ describe('FormattingBar', () => {
 
         expect(fireEvent.mouseDown(screen.getByLabelText('code'))).toBe(false);
     });
+
+    test('should only render separator before bold when AI actions menu is present', () => {
+        jest.spyOn(Hooks, 'useFormattingBarControls').mockReturnValue({layoutMode: LayoutModes.Wide, ...splitFormattingBarControls('wide')});
+
+        const {container, rerender} = renderWithContext(
+            <FormattingBar
+                {...baseProps}
+                aiActionsMenu={<button type='button'>{'AI Actions'}</button>}
+            />,
+        );
+
+        expect(container.querySelectorAll('[data-testid="formatting-bar-separator"]')).toHaveLength(2);
+
+        rerender(
+            <FormattingBar
+                {...baseProps}
+                aiActionsMenu={null}
+            />,
+        );
+
+        expect(container.querySelectorAll('[data-testid="formatting-bar-separator"]')).toHaveLength(1);
+    });
 });

--- a/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_bar.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_bar.tsx
@@ -17,7 +17,7 @@ import type {ApplyMarkdownOptions, MarkdownMode} from 'utils/markdown/apply_mark
 import FormattingIcon, {IconContainer} from './formatting_icon';
 import {LayoutModes, useFormattingBarControls} from './hooks';
 
-export const Separator = styled.div`
+export const Separator = styled.div.attrs({'data-testid': 'formatting-bar-separator'})`
     display: block;
     position: relative;
     width: 1px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Fixed the advanced text editor formatting bar so the separator before the bold control only renders when the AI actions button is actually present. Added a focused regression test for the separator behavior.

#### Ticket Link
<!--
Fixes: https://github.com/mattermost/mattermost/issues/XXX
Fixes: https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
Not included: local UI verification was blocked because this Cloud image does not have Node/npm tooling, and the workspace rules prohibit starting the dev server from the agent.

#### Release Note
```release-note
Fixed the AI actions toolbar separator showing when no AI actions button was available.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9de5b21-512a-45e0-bc8f-2f7cb7fc52b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9de5b21-512a-45e0-bc8f-2f7cb7fc52b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The changes are isolated to conditional rendering logic in the formatting bar UI, preventing the separator from displaying when the AI actions menu is absent. A targeted regression test was added to verify separator visibility behavior, covering the modified code path with high specificity.

**QA Recommendation:** Minimal manual QA required. Verify that the AI toolbar separator displays correctly when AI actions are available (with AI action menu items or AI rewrite enabled) and is hidden when no AI actions are available. Standard visual regression testing of the advanced text editor's formatting bar is sufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->