### PR TITLE
[MM-67867] Update Playbooks plugin to v2.8.1

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -178,7 +178,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # download the package from to work. This will no longer be needed when we unify
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
-	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.8.1%2Bc5f1e85-fips
+	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.8.0%2Bc4449ac-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.0%2B67aa35a-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.4%2B5855fe1-fips
 endif

--- a/server/Makefile
+++ b/server/Makefile
@@ -162,7 +162,7 @@ PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.4
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.7.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.12.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.6.0
-PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.8.0
+PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.8.1
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.2
@@ -178,7 +178,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # download the package from to work. This will no longer be needed when we unify
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
-	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.8.0%2Bc4449ac-fips
+	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.8.1%2Bc5f1e85-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.0%2B67aa35a-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.4%2B5855fe1-fips
 endif


### PR DESCRIPTION
#### Summary

Updates the prepackaged Playbooks plugin from v2.8.0 to v2.8.1 for regular builds, and updates the FIPS prepackaged artifact to the matching v2.8.1 FIPS release.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-67867

#### Screenshots

N/A

#### Release Note

```release-note
Updated prepackaged Playbooks plugin to v2.8.1.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change is a single Makefile bump of the prepackaged Playbooks plugin from v2.8.0 to v2.8.1, affecting only build artifact selection; risk of breaking runtime behavior is minimal, though the FIPS override still references the older v2.8.0 FIPS artifact which could cause packaging inconsistencies if FIPS builds are used.  
**QA Recommendation:** Manual QA can be minimal—perform smoke tests on built artifacts to confirm the Playbooks plugin v2.8.1 is bundled correctly (and verify FIPS build artifacts if FIPS-enabled releases are produced).

*Generated by CodeRabbitAI*

---

## Release Notes

Updated prepackaged Playbooks plugin to v2.8.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->