### PR TITLE
Bump prepackaged Playbooks plugin to v2.4.5

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -148,7 +148,7 @@ PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.12.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.5.0
 # We need to prepackage both versions of playbooks and install the correct one based on the server license. See MM-60025.
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v1.41.1
-PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.4.4
+PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.4.5
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.3.4
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-agents-v1.4.0


### PR DESCRIPTION
#### Summary

Bumps prepackaged Playbooks plugin version from v2.4.4 to v2.4.5.

#### Ticket Link

N/A

#### Screenshots

N/A

#### Release Note

```release-note
NONE
```