### PR TITLE
MM-68622: start inter-cluster services before plugin activation

### DIFF
--- a/server/channels/app/remote_cluster_test.go
+++ b/server/channels/app/remote_cluster_test.go
@@ -4,11 +4,13 @@
 package app
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/v8/channels/testlib"
 )
 
 func setupRemoteCluster(tb testing.TB) *TestHelper {
@@ -16,6 +18,57 @@ func setupRemoteCluster(tb testing.TB) *TestHelper {
 		*cfg.ConnectedWorkspacesSettings.EnableRemoteClusterService = true
 		*cfg.ConnectedWorkspacesSettings.EnableSharedChannels = true
 	})
+}
+
+// TestSharedChannelServicesAvailableBeforePluginActivation guards the fix for
+// MM-68622. Plugins that call shared channels APIs from OnActivate previously
+// failed with "Shared Channels Service is disabled" because
+// startInterClusterServices ran after Channels().Start() initialized plugins.
+// Server.Start now starts the inter-cluster services first, so the services
+// must be available by the time plugin initialization begins.
+func TestSharedChannelServicesAvailableBeforePluginActivation(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := setupRemoteCluster(t).InitBasic(t)
+
+	require.NotNil(t, th.Server.GetRemoteClusterService(),
+		"remote cluster service must be initialized after Server.Start")
+	require.NotNil(t, th.Server.GetSharedChannelSyncService(),
+		"shared channel sync service must be initialized after Server.Start")
+
+	// Order check: scs.resume() logs "Shared Channel Service active" from
+	// scs.Start(), and initPlugins logs "Starting up plugins" from
+	// Channels().Start(). The first must precede the second, otherwise plugin
+	// OnActivate would observe a nil service.
+	require.NoError(t, th.TestLogger.Flush())
+	entries := testlib.ParseLogEntries(t, strings.NewReader(th.LogBuffer.String()))
+
+	scsActiveIdx, pluginInitIdx := -1, -1
+	for i, e := range entries {
+		if scsActiveIdx == -1 && e.Msg == "Shared Channel Service active" {
+			scsActiveIdx = i
+		}
+		if pluginInitIdx == -1 && e.Msg == "Starting up plugins" {
+			pluginInitIdx = i
+		}
+	}
+	require.NotEqual(t, -1, scsActiveIdx,
+		"expected log message 'Shared Channel Service active' from scs.resume()")
+	require.NotEqual(t, -1, pluginInitIdx,
+		"expected log message 'Starting up plugins' from initPlugins")
+	require.Less(t, scsActiveIdx, pluginInitIdx,
+		"shared channel service must activate before plugin initialization (MM-68622)")
+
+	// Plugin entry path: this is the App-layer call a plugin would make from
+	// OnActivate. Before MM-68622 it would return "Shared Channels Service is
+	// disabled" because GetSharedChannelSyncService() was still nil.
+	pluginID := "com.test.startup-" + model.NewId()
+	_, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+		Displayname: "startup test plugin",
+		PluginID:    pluginID,
+		CreatorID:   th.BasicUser.Id,
+	})
+	require.NoError(t, err,
+		"RegisterPluginForSharedChannels must succeed when shared channels is enabled")
 }
 
 func TestAddRemoteCluster(t *testing.T) {

--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -856,6 +856,12 @@ func stripPort(hostport string) string {
 }
 
 func (s *Server) Start() error {
+	// Start inter-cluster services first so shared channels APIs are
+	// available when plugins activate during channels startup.
+	if err := s.startInterClusterServices(s.License()); err != nil {
+		mlog.Error("Error starting inter-cluster services", mlog.Err(err))
+	}
+
 	// Start channels.
 	// This needs to happen before because channels is dependent on the HTTP server.
 	if err := s.Channels().Start(); err != nil {
@@ -1111,10 +1117,6 @@ func (s *Server) Start() error {
 		if err := s.startLocalModeServer(); err != nil {
 			mlog.Fatal(err.Error())
 		}
-	}
-
-	if err := s.startInterClusterServices(s.License()); err != nil {
-		mlog.Error("Error starting inter-cluster services", mlog.Err(err))
 	}
 
 	return nil


### PR DESCRIPTION
#### Summary
Moves `startInterClusterServices` from the end of `Server.Start()` to the beginning, before `Channels().Start()` initializes plugins. Plugins that call shared channels APIs (`ShareChannel`, `InviteRemoteToChannel`, `UninviteRemoteFromChannel`, `UnshareChannel`, `UpdateSharedChannel`, `CheckCanInviteToSharedChannel`) during `OnActivate` no longer fail with "Shared Channels Service is disabled."

`RegisterPluginForSharedChannels` already worked because it writes directly to the database, but every other shared channels API requires the service to be non-nil. This change makes the rest work the same way. 

#### Side-effect analysis

**Plugin API gating.** `getSharedChannelsService` in `channels/app/shared_channel.go:32` only requires the service to be non-nil. The plugin-facing wrappers all pass `ensureIsActive=false`, so
`Active()` is bypassed. Once `SetSharedChannelService` runs, calls succeed on both leader and follower nodes.

**Multi-node leader timing.** The enterprise cluster impl in `enterprise/cluster/cluster.go:70` initializes `currentLeader=""`, so `IsLeader()` returns false before `StartInterNodeCommunication` runs. The immediate `onClusterLeaderChange` in `scs.Start` at `platform/services/sharedchannel/service.go:151` therefore takes the pause path, which is a no-op since the service was never active. When `memberlist.Create` fires `NotifyJoin` for the local node, `addPotentialLeader` runs and `InvokeClusterLeaderChangedListeners` drives the registered listener to `resume()` the sync loop on the elected leader. End state matches the prior ordering.

**Single-node.** `IsLeader()` returns true unconditionally per `channels/app/platform/cluster.go:33`, so `SharedChannelSyncHandler` is active during plugin `OnActivate`. Events emitted by plugins during activation (posts to shared channels, DM creation) now flow through sync where they were previously dropped. This is intended correctness, not a regression.

**Transport and handlers.** api4 remote-cluster routes are registered before `Server.Start`, so HTTP handlers exist when `rcs.Start` runs early. `rcs` and `scs` do not send cluster-broadcast messages during `Start`; they only register topic listeners on the rcs transport, which is independent of cluster gossip. `registerClusterHandlers` ordering is unaffected.

**Config.** `scs` reads only `ConnectedWorkspacesSettings` and the License at construction, both stable from the initial config load. `ReloadConfig` at `server.go:912` has no bearing on inter-cluster service init.

Errors from `startInterClusterServices` remain logged and non-fatal, matching prior behavior.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68622

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** The change reorders inter-cluster service startup earlier in Server.Start(), which is localized but affects plugin activation timing and inter-node sync behavior; risk of regressions is moderate due to timing-sensitive code paths and limited existing test coverage around multi-node leader timing.  
**QA Recommendation:** Add integration tests covering plugin OnActivate calls to shared channels APIs in single-node and clustered setups, and run targeted manual QA for cluster startup/leader election timing and plugin lifecycle interactions.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->