### PR TITLE
E2E/Test: Only run against FIPS build for versions v11+

### DIFF
--- a/.github/workflows/e2e-tests-on-merge.yml
+++ b/.github/workflows/e2e-tests-on-merge.yml
@@ -22,6 +22,7 @@ jobs:
     outputs:
       report_type: "${{ steps.vars.outputs.report_type }}"
       ref_branch: "${{ steps.vars.outputs.ref_branch }}"
+      fips_supported: "${{ steps.vars.outputs.fips_supported }}"
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -37,11 +38,18 @@ jobs:
           # Strip refs/heads/ prefix if present
           BRANCH="${BRANCH#refs/heads/}"
 
-          # Validate branch is master or release-X.Y
+          # Validate branch is master or release-X.Y, and decide whether FIPS is supported.
+          # FIPS builds were introduced in release-11.0; skip FIPS tests for older branches.
           if [[ "$BRANCH" == "master" ]]; then
             echo "report_type=MASTER" >> $GITHUB_OUTPUT
-          elif [[ "$BRANCH" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
+            echo "fips_supported=true" >> $GITHUB_OUTPUT
+          elif [[ "$BRANCH" =~ ^release-([0-9]+)\.[0-9]+$ ]]; then
             echo "report_type=RELEASE" >> $GITHUB_OUTPUT
+            if [[ "${BASH_REMATCH[1]}" -ge 11 ]]; then
+              echo "fips_supported=true" >> $GITHUB_OUTPUT
+            else
+              echo "fips_supported=false" >> $GITHUB_OUTPUT
+            fi
           else
             echo "::error::Branch ${BRANCH} must be 'master' or 'release-X.Y' format."
             exit 1
@@ -92,8 +100,10 @@ jobs:
       REPORT_WEBHOOK_URL: "${{ secrets.MM_E2E_REPORT_WEBHOOK_URL }}"
 
   # Enterprise FIPS Edition
+  # FIPS builds were introduced in release-11.0; skip for older branches.
   e2e-cypress-fips:
     needs: generate-build-variables
+    if: needs.generate-build-variables.outputs.fips_supported == 'true'
     uses: ./.github/workflows/e2e-tests-cypress.yml
     with:
       commit_sha: ${{ inputs.commit_sha }}
@@ -114,6 +124,7 @@ jobs:
 
   e2e-playwright-fips:
     needs: generate-build-variables
+    if: needs.generate-build-variables.outputs.fips_supported == 'true'
     uses: ./.github/workflows/e2e-tests-playwright.yml
     with:
       commit_sha: ${{ inputs.commit_sha }}

--- a/.github/workflows/e2e-tests-on-release.yml
+++ b/.github/workflows/e2e-tests-on-release.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       ref_branch: "${{ steps.check.outputs.ref_branch }}"
+      fips_supported: "${{ steps.check.outputs.fips_supported }}"
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -40,12 +41,19 @@ jobs:
           # Strip refs/heads/ prefix if present
           BRANCH="${BRANCH#refs/heads/}"
 
-          if ! [[ "$BRANCH" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
+          # FIPS builds were introduced in release-11.0; skip FIPS tests for older branches.
+          if ! [[ "$BRANCH" =~ ^release-([0-9]+)\.[0-9]+$ ]]; then
             echo "::error::Branch ${BRANCH} must be 'release-X.Y' format."
             exit 1
           elif ! git merge-base --is-ancestor "$COMMIT_SHA" HEAD; then
             echo "::error::Commit ${COMMIT_SHA} is not on branch ${BRANCH}."
             exit 1
+          fi
+
+          if [[ "${BASH_REMATCH[1]}" -ge 11 ]]; then
+            echo "fips_supported=true" >> $GITHUB_OUTPUT
+          else
+            echo "fips_supported=false" >> $GITHUB_OUTPUT
           fi
 
           echo "ref_branch=${BRANCH}" >> $GITHUB_OUTPUT
@@ -91,8 +99,10 @@ jobs:
       REPORT_WEBHOOK_URL: "${{ secrets.MM_E2E_REPORT_WEBHOOK_URL }}"
 
   # Enterprise FIPS Edition
+  # FIPS builds were introduced in release-11.0; skip for older branches.
   e2e-cypress-fips:
     needs: validate
+    if: needs.validate.outputs.fips_supported == 'true'
     uses: ./.github/workflows/e2e-tests-cypress.yml
     with:
       commit_sha: ${{ inputs.commit_sha }}
@@ -115,6 +125,7 @@ jobs:
 
   e2e-playwright-fips:
     needs: validate
+    if: needs.validate.outputs.fips_supported == 'true'
     uses: ./.github/workflows/e2e-tests-playwright.yml
     with:
       commit_sha: ${{ inputs.commit_sha }}


### PR DESCRIPTION
#### Summary
Only run against FIPS build for versions v11+

Note: no need to cherry-pick to release-10.11 since these workflows are run with master branch.
cc @amyblais 

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** No risk to application functionality. Changes only affect CI/CD test scheduling by adding version-based conditional logic that skips FIPS tests for pre-v11 release branches, with no impact on runtime code paths or shared dependencies.

**QA Recommendation:** No manual QA needed. These are workflow-only changes affecting test execution scheduling, not application behavior. Automated verification of workflow logic (testing both conditional branches) would be sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->