### PR TITLE
Removing Beta Label From Hungarian Language

### DIFF
--- a/webapp/channels/src/i18n/i18n.jsx
+++ b/webapp/channels/src/i18n/i18n.jsx
@@ -49,7 +49,7 @@ export const languages = {
     },
     hu: {
         value: 'hu',
-        name: 'Magyar (Beta)',
+        name: 'Magyar (Alpha)',
         order: 6,
         url: langFiles.hu,
     },


### PR DESCRIPTION
#### Summary
Moving Hungarian language from Beta to Alpha as Hungarian has fallen below the 79% quality threshold for over three months.

#### Release Note
```release-note
Downgrading Hungarian translations from Beta to Alpha.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This is a pure string literal update with zero functional impact. No code logic, conditionals, or business logic is affected, eliminating any regression risk to existing behavior.

**QA Recommendation:** Skip manual QA. This cosmetic text update requires only a visual verification that the Hungarian language now displays as "Magyar (Alpha)" instead of "Magyar (Beta)" in the UI language selector.

---

**Release Note:** Downgrading Hungarian translations from Beta to Alpha.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->