### PR TITLE
ci: disable fullyparallel for unsharded weekly Postgres jobs

### DIFF
--- a/.github/workflows/server-ci-weekly.yml
+++ b/.github/workflows/server-ci-weekly.yml
@@ -47,6 +47,10 @@ jobs:
       logsartifact: postgres-binary-server-test-logs
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: false
+      # Unsharded run on a single 8-core runner: fullyparallel=true causes
+      # resource exhaustion (too many server instances, WebSocket hubs, and
+      # DB connections) and crashes the hosted runner. See #35995.
+      fullyparallel: false
 
   test-postgres-normal-fips:
     name: Postgres FIPS
@@ -60,6 +64,8 @@ jobs:
       logsartifact: postgres-server-fips-test-logs
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: true
+      # Unsharded run on a single 8-core runner: see note on test-postgres-binary.
+      fullyparallel: false
 
   test-mmctl-fips:
     name: Run mmctl tests (FIPS)


### PR DESCRIPTION
## Summary

The unsharded `Postgres with binary parameters` and `Postgres FIPS` jobs in the weekly workflow have been failing consistently with `The hosted runner lost communication with the server` at the ~55–60 min mark of `Run Tests` (run [24979137338](https://github.com/mattermost/mattermost/actions/runs/24979137338) on Apr 27, run [25303708374](https://github.com/mattermost/mattermost/actions/runs/25303708374) on May 4).

## Root cause

PR #35995 disabled `fullyparallel` on the unsharded binary-params job to fix the exact failure mode

> With fullyparallel enabled, all ~755 api4 tests run concurrently, causing resource exhaustion (too many server instances, WebSocket hubs, and DB connections). The test binary gets killed after 11 minutes with no individual test failures — just overwhelmed resources.

When PR #36036 moved binary-params + FIPS into `server-ci-weekly.yml`, the `fullyparallel: false` override was dropped, and both unsharded jobs reverted to the template default of `true`. 

The same resource exhaustion is now crashing the runner agent itself (not just the test binary), which is why GitHub reports "lost communication" instead of a normal test failure. `Run Tests` logs never make it to the artifact, so there are no test errors to look at. The 8-core hosted runner can't survive the concurrent server/WS/DB load that one shard previously absorbed.

## Fix

Add `fullyparallel: false` to both unsharded weekly jobs. This is the minimal change and matches the configuration that demonstrably worked pre-move.

##### Release Note
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)