### PR TITLE
Update Agents plugin FIPS version to v2.0.2

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -179,7 +179,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.8.0%2Bc4449ac-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.0%2B67aa35a-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.2%2B3b1ec24-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.4%2B5855fe1-fips
 endif
 


### PR DESCRIPTION
#### Summary
Update Agents plugin FIPS version to v2.0.2.

The FIPS build is produced from the [`CLD-9438-build-agents-fips-complaint` branch](https://github.com/mattermost/mattermost-plugin-agents/pull/372) of `mattermost-plugin-agents`, signed and uploaded via the [`Sign Plugin PR Artifacts` workflow](https://github.com/mattermost/delivery-platform/actions/runs/25312943710).

Source commit on the agents repo: [`3b1ec24`](https://github.com/mattermost/mattermost-plugin-agents/commit/3b1ec2433b3dacd8402519b9759717a60166884e) (merge of tag `v2.0.2` plus a bump of the FIPS build image to Go 1.26.2 to match `go.mod`).

The signed FIPS bundle is reachable at [https://plugins.releases.mattermost.com/release/mattermost-plugin-agents-v2.0.2%2B3b1ec24-fips-linux-amd64.tar.gz](https://plugins.releases.mattermost.com/release/mattermost-plugin-agents-v2.0.2%2B3b1ec24-fips-linux-amd64.tar.gz).

This needs to be cherry-picked to `release-11.7` once merged.

#### Ticket Link
--

#### Screenshots
--

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This is an isolated build configuration update changing a single plugin artifact version reference in the FIPS-enabled build path. No application code, runtime logic, or shared utilities are modified, minimizing regression risk.

**QA Recommendation:** Manual QA is minimal. Verify that FIPS builds generate correctly with the new plugin version and that non-FIPS builds remain unaffected. Basic smoke testing of the agents plugin in FIPS-enabled deployments is recommended.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->