### PR TITLE
[MM-67867][MM-67931] Prepackage Playbooks v2.8.1 (TE and FIPS) (cherry-pick #36361, #36391)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -158,7 +158,7 @@ PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.4
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.7.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.12.1
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.5.1
-PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.8.0
+PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.8.1
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-agents-v1.7.2
@@ -174,7 +174,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # download the package from to work. This will no longer be needed when we unify
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
-	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.8.0%2Bc4449ac-fips
+	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.8.1%2Bac0a223-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v1.7.2%2B866e2dd-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.4%2B5855fe1-fips
 endif


### PR DESCRIPTION
#### Summary

Cherry-pick of [#36361](https://github.com/mattermost/mattermost/pull/36361) and [#36391](https://github.com/mattermost/mattermost/pull/36391) to `release-11.5`.

- Bump prepackaged Playbooks plugin to v2.8.1 for non-FIPS builds.
- Bump prepackaged FIPS Playbooks artifact to v2.8.1+ac0a223-fips.

#### Ticket Link

- https://mattermost.atlassian.net/browse/MM-67867
- https://mattermost.atlassian.net/browse/MM-67931

#### Screenshots

N/A

#### Release Note

```release-note
Updated prepackaged Playbooks plugin to v2.8.1 (TE and FIPS).
```