### PR TITLE
MM-68532: default EnableSearchPublicChannelsWithoutMembership to true for new installations

### DIFF
--- a/server/channels/app/platform/searchengine_test.go
+++ b/server/channels/app/platform/searchengine_test.go
@@ -64,6 +64,12 @@ func setupWatcherTest(t *testing.T) (*searchEngineWatcher, *searchenginemocks.Se
 	engineMock.On("IsHealthy").Return(true).Maybe()
 	engineMock.On("SetHealthy", mock.Anything).Maybe()
 
+	// Disable the backfill so it doesn't fire in watcher-focused tests that
+	// use a mock store without the required methods set up.
+	ps.UpdateConfig(func(cfg *model.Config) {
+		cfg.ElasticsearchSettings.EnableSearchPublicChannelsWithoutMembership = model.NewPointer(false)
+	})
+
 	ps.SearchEngine = searchengine.NewBroker(ps.Config())
 	ps.SearchEngine.ElasticsearchEngine = engineMock
 

--- a/server/channels/app/platform/searchengine_test.go
+++ b/server/channels/app/platform/searchengine_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/public/shared/request"
+	storemocks "github.com/mattermost/mattermost/server/v8/channels/store/storetest/mocks"
 	"github.com/mattermost/mattermost/server/v8/channels/testlib"
 	"github.com/mattermost/mattermost/server/v8/platform/services/searchengine"
 	searchenginemocks "github.com/mattermost/mattermost/server/v8/platform/services/searchengine/mocks"
@@ -64,11 +65,13 @@ func setupWatcherTest(t *testing.T) (*searchEngineWatcher, *searchenginemocks.Se
 	engineMock.On("IsHealthy").Return(true).Maybe()
 	engineMock.On("SetHealthy", mock.Anything).Maybe()
 
-	// Disable the backfill so it doesn't fire in watcher-focused tests that
-	// use a mock store without the required methods set up.
-	ps.UpdateConfig(func(cfg *model.Config) {
-		cfg.ElasticsearchSettings.EnableSearchPublicChannelsWithoutMembership = model.NewPointer(false)
-	})
+	// Make backfillPostsChannelType return immediately by indicating the backfill
+	// is already done. This prevents the goroutine from calling unmocked store
+	// methods in tests that only exercise watcher retry/health logic.
+	systemMock := &storemocks.SystemStore{}
+	systemMock.On("GetByName", model.SystemPostChannelTypeBackfillComplete).
+		Return(&model.System{Name: model.SystemPostChannelTypeBackfillComplete, Value: "true"}, nil).Maybe()
+	ps.Store.(*storemocks.Store).On("System").Return(systemMock).Maybe()
 
 	ps.SearchEngine = searchengine.NewBroker(ps.Config())
 	ps.SearchEngine.ElasticsearchEngine = engineMock

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -3273,7 +3273,7 @@ func (s *ElasticsearchSettings) SetDefaults() {
 	}
 
 	if s.EnableSearchPublicChannelsWithoutMembership == nil {
-		s.EnableSearchPublicChannelsWithoutMembership = NewPointer(false)
+		s.EnableSearchPublicChannelsWithoutMembership = NewPointer(true)
 	}
 }
 

--- a/server/public/model/config_test.go
+++ b/server/public/model/config_test.go
@@ -3001,3 +3001,17 @@ func TestExperimentalSettingsEnableWatermarkDefault(t *testing.T) {
 		require.True(t, *cfg.ExperimentalSettings.EnableWatermark)
 	})
 }
+
+func TestElasticsearchSettingsSetDefaults(t *testing.T) {
+	t.Run("EnableSearchPublicChannelsWithoutMembership defaults to true when nil", func(t *testing.T) {
+		s := ElasticsearchSettings{}
+		s.SetDefaults()
+		require.True(t, *s.EnableSearchPublicChannelsWithoutMembership)
+	})
+
+	t.Run("EnableSearchPublicChannelsWithoutMembership preserves explicit false", func(t *testing.T) {
+		s := ElasticsearchSettings{EnableSearchPublicChannelsWithoutMembership: NewPointer(false)}
+		s.SetDefaults()
+		require.False(t, *s.EnableSearchPublicChannelsWithoutMembership)
+	})
+}


### PR DESCRIPTION
#### Summary

Changes the default value of `EnableSearchPublicChannelsWithoutMembership` from `false` to `true` for new installations. Existing installations with an explicit configuration value are unaffected — the change only applies when the setting has never been set (i.e., `nil` at startup).

This setting only affects Elasticsearch/OpenSearch; database search is not impacted.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-68532

#### Release Note

```release-note
On new installations using Elasticsearch or OpenSearch, search now includes public channels the user isn't a member of by default.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change alters default search behavior for new Elasticsearch/OpenSearch installations only (applies when the setting is nil), minimizing disruption to existing deployments; however, it touches search configuration initialization which could affect search results for new installs and lacks explicit unit tests prior to this PR, posing moderate regression risk.  
**QA Recommendation:** Perform targeted manual QA on new installations using Elasticsearch/OpenSearch to verify public channels appear in search results by default, and regression checks on existing installations with explicit settings to ensure no behavioral changes.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->