### PR TITLE
docs: import server/AGENTS.md from platform/AGENTS.md to ensure eager loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,8 @@
 # AGENTS.md
 
+# Explicitly import subdirectory instruction files that must always be in context.
+@server/AGENTS.md
+
 ## Pull Requests
 
 When creating a pull request, follow `.github/PULL_REQUEST_TEMPLATE.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-# Explicitly import subdirectory instruction files that must always be in context.
+Explicitly import subdirectory instruction files that must always be in context:
 @server/AGENTS.md
 
 ## Pull Requests


### PR DESCRIPTION
#### Summary
Claude Code (and similar agents) load subdirectory instruction files lazily — only when a file in that directory is read. This means `server/AGENTS.md` may never be loaded if an agent acts on `server/` without first reading a file there (e.g. running `make` directly).

This PR adds an explicit `@server/AGENTS.md` import to `platform/AGENTS.md` so the server-level rules (notably: never run `go mod tidy`, always use `make modules-tidy`) are guaranteed to be in context from the start of any session.

#### Ticket Link

#### Screenshots

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Extremely low. This is a documentation-only change that adds an explicit import directive to ensure server-level AI agent instructions are eagerly loaded. No code logic is modified, no dependencies are changed, and the modification only enhances instruction context availability without altering existing behavior.

**QA Recommendation:** No manual QA required. This change affects AI agent instruction files used for context loading and does not involve production code, user-facing features, or system behavior that would require testing.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->