### PR TITLE
MM-68332: honour query timeout in sqlstore

### DIFF
--- a/server/channels/store/sqlstore/attributes_store.go
+++ b/server/channels/store/sqlstore/attributes_store.go
@@ -66,7 +66,7 @@ func (s *SqlAttributesStore) GetSubject(rctx request.CTX, ID, groupID string) (*
 		return nil, errors.Wrap(err, "failed to build query for subject")
 	}
 
-	row := s.GetReplica().QueryRowxContext(rctx.Context(), q, args...)
+	row := s.GetReplica().QueryRowContext(rctx.Context(), q, args...)
 	if err := row.Err(); err != nil {
 		return nil, errors.Wrap(err, "failed to get subject")
 	}

--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -2202,7 +2202,7 @@ func (s SqlChannelStore) GetMemberForPost(postId string, userId string) (*model.
 	return dbMember.ToModel(), nil
 }
 
-func (s SqlChannelStore) GetAllChannelMembersForUser(rctx request.CTX, userId string, allowFromCache bool, includeDeleted bool) (_ map[string]string, err error) {
+func (s SqlChannelStore) GetAllChannelMembersForUser(rctx request.CTX, userId string, allowFromCache bool, includeDeleted bool) (map[string]string, error) {
 	query := s.getQueryBuilder().
 		Select(`
 				ChannelMembers.ChannelId, ChannelMembers.Roles, ChannelMembers.SchemeGuest,
@@ -2228,24 +2228,17 @@ func (s SqlChannelStore) GetAllChannelMembersForUser(rctx request.CTX, userId st
 		return nil, errors.Wrap(err, "channel_tosql")
 	}
 
-	rows, err := s.SqlStore.DBXFromContext(rctx.Context()).Query(queryString, args...)
-	if err != nil {
+	var members []allChannelMember
+	if err = s.SqlStore.DBXFromContext(rctx.Context()).SelectCtx(rctx.Context(), &members, queryString, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to find ChannelMembers, TeamScheme and ChannelScheme data")
 	}
-	defer deferClose(rows, &err)
 
-	scanner := func(rows *sql.Rows) (string, string, error) {
-		var cm allChannelMember
-		err = rows.Scan(
-			&cm.ChannelId, &cm.Roles, &cm.SchemeGuest, &cm.SchemeUser,
-			&cm.SchemeAdmin, &cm.TeamSchemeDefaultGuestRole, &cm.TeamSchemeDefaultUserRole,
-			&cm.TeamSchemeDefaultAdminRole, &cm.ChannelSchemeDefaultGuestRole,
-			&cm.ChannelSchemeDefaultUserRole, &cm.ChannelSchemeDefaultAdminRole,
-		)
+	result := make(map[string]string, len(members))
+	for _, cm := range members {
 		k, v := cm.Process()
-		return k, v, errors.Wrap(err, "unable to scan columns")
+		result[k] = v
 	}
-	return scanRowsIntoMap(rows, scanner, nil)
+	return result, nil
 }
 
 func (s SqlChannelStore) GetChannelsMemberCount(channelIDs []string) (_ map[string]int64, err error) {
@@ -2264,26 +2257,22 @@ func (s SqlChannelStore) GetChannelsMemberCount(channelIDs []string) (_ map[stri
 		return nil, errors.Wrap(err, "channels_member_count_tosql")
 	}
 
-	rows, err := s.GetReplica().Query(queryString, args...)
-	if err != nil {
+	var counts []struct {
+		ChannelId string
+		Count     int64
+	}
+	if err = s.GetReplica().Select(&counts, queryString, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to fetch member counts")
 	}
-	defer rows.Close()
 
-	// Initialize default values map
-	defaults := make(map[string]int64, len(channelIDs))
+	result := make(map[string]int64, len(channelIDs))
 	for _, channelID := range channelIDs {
-		defaults[channelID] = 0
+		result[channelID] = 0
 	}
-
-	scanner := func(rows *sql.Rows) (string, int64, error) {
-		var channelID string
-		var count int64
-		err := rows.Scan(&channelID, &count)
-		return channelID, count, errors.Wrap(err, "failed to scan row")
+	for _, row := range counts {
+		result[row.ChannelId] = row.Count
 	}
-
-	return scanRowsIntoMap(rows, scanner, defaults)
+	return result, nil
 }
 
 func (s SqlChannelStore) InvalidateCacheForChannelMembersNotifyProps(channelId string) {
@@ -2917,20 +2906,19 @@ func (s SqlChannelStore) AnalyticsCountAll(teamId string) (map[model.ChannelType
 		return nil, errors.Wrap(err, "AnalyticsCountAll_ToSql")
 	}
 
-	rows, err := s.GetReplica().Query(sqlStr, args...)
-	if err != nil {
+	var counts []struct {
+		Type  model.ChannelType
+		Count int64
+	}
+	if err := s.GetReplica().Select(&counts, sqlStr, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to count Channels by type")
 	}
-	defer rows.Close()
 
-	scanner := func(rows *sql.Rows) (model.ChannelType, int64, error) {
-		var channelType model.ChannelType
-		var count int64
-		err := rows.Scan(&channelType, &count)
-		return channelType, count, errors.Wrap(err, "unable to scan row")
+	result := make(map[model.ChannelType]int64, len(counts))
+	for _, row := range counts {
+		result[row.Type] = row.Count
 	}
-
-	return scanRowsIntoMap(rows, scanner, nil)
+	return result, nil
 }
 
 func (s SqlChannelStore) GetMembersForUser(teamID string, userID string) (model.ChannelMembers, error) {

--- a/server/channels/store/sqlstore/migrate.go
+++ b/server/channels/store/sqlstore/migrate.go
@@ -110,7 +110,7 @@ func (ss *SqlStore) initMorph(dryRun, enableLogging bool) (*morph.Morph, error) 
 		return nil, err
 	}
 
-	driver, err := ps.WithInstance(ss.GetMaster().DB.DB)
+	driver, err := ps.WithInstance(ss.GetMaster().DB())
 	if err != nil {
 		return nil, err
 	}

--- a/server/channels/store/sqlstore/plugin_store.go
+++ b/server/channels/store/sqlstore/plugin_store.go
@@ -217,7 +217,7 @@ func (ps SqlPluginStore) Get(pluginId, key string) (*model.PluginKeyValue, error
 		return nil, errors.Wrap(err, "plugin_tosql")
 	}
 
-	row := ps.GetReplica().QueryRowx(queryString, args...)
+	row := ps.GetReplica().QueryRow(queryString, args...)
 	var kv model.PluginKeyValue
 	if err := row.Scan(&kv.PluginId, &kv.Key, &kv.Value, &kv.ExpireAt); err != nil {
 		if err == sql.ErrNoRows {

--- a/server/channels/store/sqlstore/plugin_store.go
+++ b/server/channels/store/sqlstore/plugin_store.go
@@ -4,7 +4,6 @@
 package sqlstore
 
 import (
-	"database/sql"
 	"fmt"
 
 	sq "github.com/mattermost/squirrel"
@@ -212,21 +211,25 @@ func (ps SqlPluginStore) Get(pluginId, key string) (*model.PluginKeyValue, error
 		Where(sq.Eq{"PluginId": pluginId}).
 		Where(sq.Eq{"PKey": key}).
 		Where(sq.Or{sq.Eq{"ExpireAt": 0}, sq.Gt{"ExpireAt": currentTime}})
-	queryString, args, err := query.ToSql()
-	if err != nil {
-		return nil, errors.Wrap(err, "plugin_tosql")
+	type pluginKVRow struct {
+		PluginId string `db:"pluginid"`
+		Key      string `db:"pkey"`
+		Value    []byte `db:"pvalue"`
+		ExpireAt int64  `db:"expireat"`
 	}
-
-	row := ps.GetReplica().QueryRow(queryString, args...)
-	var kv model.PluginKeyValue
-	if err := row.Scan(&kv.PluginId, &kv.Key, &kv.Value, &kv.ExpireAt); err != nil {
-		if err == sql.ErrNoRows {
-			return nil, store.NewErrNotFound("PluginKeyValue", fmt.Sprintf("pluginId=%s, key=%s", pluginId, key))
-		}
+	var rows []pluginKVRow
+	if err := ps.GetReplica().SelectBuilder(&rows, query); err != nil {
 		return nil, errors.Wrapf(err, "failed to get PluginKeyValue with pluginId=%s and key=%s", pluginId, key)
 	}
-
-	return &kv, nil
+	if len(rows) == 0 {
+		return nil, store.NewErrNotFound("PluginKeyValue", fmt.Sprintf("pluginId=%s, key=%s", pluginId, key))
+	}
+	return &model.PluginKeyValue{
+		PluginId: rows[0].PluginId,
+		Key:      rows[0].Key,
+		Value:    rows[0].Value,
+		ExpireAt: rows[0].ExpireAt,
+	}, nil
 }
 
 func (ps SqlPluginStore) Delete(pluginId, key string) error {

--- a/server/channels/store/sqlstore/property_field_store.go
+++ b/server/channels/store/sqlstore/property_field_store.go
@@ -493,7 +493,7 @@ func (s *SqlPropertyFieldStore) checkSystemLevelConflict(field *model.PropertyFi
 	args = append(args, channelArgs...)
 
 	var conflictLevel model.PropertyFieldTargetLevel
-	if err := s.GetMaster().DB.Get(&conflictLevel, s.GetMaster().DB.Rebind(query), args...); err != nil {
+	if err := s.GetMaster().Get(&conflictLevel, query, args...); err != nil {
 		return "", errors.Wrap(err, "property_field_check_conflict_system")
 	}
 
@@ -547,7 +547,7 @@ func (s *SqlPropertyFieldStore) checkTeamLevelConflict(field *model.PropertyFiel
 	args = append(args, channelArgs...)
 
 	var conflictLevel model.PropertyFieldTargetLevel
-	if err := s.GetMaster().DB.Get(&conflictLevel, s.GetMaster().DB.Rebind(query), args...); err != nil {
+	if err := s.GetMaster().Get(&conflictLevel, query, args...); err != nil {
 		return "", errors.Wrap(err, "property_field_check_conflict_team")
 	}
 
@@ -591,7 +591,7 @@ func (s *SqlPropertyFieldStore) checkChannelLevelConflict(field *model.PropertyF
 	args = append(args, teamArgs...)
 
 	var conflictLevel model.PropertyFieldTargetLevel
-	if err := s.GetMaster().DB.Get(&conflictLevel, s.GetMaster().DB.Rebind(query), args...); err != nil {
+	if err := s.GetMaster().Get(&conflictLevel, query, args...); err != nil {
 		return "", errors.Wrap(err, "property_field_check_conflict_channel")
 	}
 

--- a/server/channels/store/sqlstore/retention_policy_store.go
+++ b/server/channels/store/sqlstore/retention_policy_store.go
@@ -807,50 +807,37 @@ func (s *SqlRetentionPolicyStore) GetChannelPoliciesCountForUser(userID string) 
 	return count, nil
 }
 
-func scanRetentionIdsForDeletion(rows *sql.Rows) ([]*model.RetentionIdsForDeletion, error) {
-	idsForDeletion := []*model.RetentionIdsForDeletion{}
-	for rows.Next() {
-		var row model.RetentionIdsForDeletion
-		if err := rows.Scan(
-			&row.Id, &row.TableName, pq.Array(&row.Ids),
-		); err != nil {
-			return nil, errors.Wrap(err, "unable to scan columns")
-		}
-
-		idsForDeletion = append(idsForDeletion, &row)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, errors.Wrap(err, "error while iterating over rows")
-	}
-	return idsForDeletion, nil
-}
-
 func (s *SqlRetentionPolicyStore) GetIdsForDeletionByTableName(tableName string, limit int) ([]*model.RetentionIdsForDeletion, error) {
+	type retentionIdsForDeletionRow struct {
+		Id        string
+		TableName string
+		Ids       pq.StringArray
+	}
+
 	query := s.getQueryBuilder().
 		Select("Id", "TableName", "Ids").
 		From("RetentionIdsForDeletion").
-		Where(
-			sq.Eq{"TableName": tableName},
-		).
+		Where(sq.Eq{"TableName": tableName}).
 		Limit(uint64(limit))
 
-	queryString, args, err := query.ToSql()
-	if err != nil {
-		return nil, errors.Wrap(err, "get_ids_for_deletion_tosql")
-	}
-
-	rows, err := s.GetReplica().DB.Query(queryString, args...)
-	if err != nil {
+	var dbRows []retentionIdsForDeletionRow
+	if err := s.GetReplica().SelectBuilder(&dbRows, query); err != nil {
 		return nil, errors.Wrap(err, "failed to get ids for deletion")
 	}
-	defer rows.Close()
 
-	idsForDeletion, err := scanRetentionIdsForDeletion(rows)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to scan ids for deletion")
+	result := make([]*model.RetentionIdsForDeletion, len(dbRows))
+	for i, row := range dbRows {
+		ids := []string(row.Ids)
+		if ids == nil {
+			ids = []string{}
+		}
+		result[i] = &model.RetentionIdsForDeletion{
+			Id:        row.Id,
+			TableName: row.TableName,
+			Ids:       ids,
+		}
 	}
-
-	return idsForDeletion, nil
+	return result, nil
 }
 
 func insertRetentionIdsForDeletion(txn *sqlxTxWrapper, row *model.RetentionIdsForDeletion, s *SqlStore) error {
@@ -1023,23 +1010,9 @@ func genericRetentionPoliciesDeletion(
 		primaryKeysStr := "(" + strings.Join(r.PrimaryKeys, ",") + ")"
 
 		query = fmt.Sprintf("DELETE FROM %s WHERE %s IN (%s) RETURNING %s.%s", r.Table, primaryKeysStr, query, r.Table, r.PrimaryKeys[0])
-		var rows *sql.Rows
-		rows, err = txn.Query(query, args...)
-		if err != nil {
+		var ids []string
+		if err = txn.Select(&ids, query, args...); err != nil {
 			return 0, errors.Wrap(err, "failed to delete "+r.Table)
-		}
-
-		defer rows.Close()
-		ids := []string{}
-		for rows.Next() {
-			var id string
-			if err = rows.Scan(&id); err != nil {
-				return 0, errors.Wrap(err, "unable to scan from rows")
-			}
-			ids = append(ids, id)
-		}
-		if err = rows.Err(); err != nil {
-			return 0, errors.Wrap(err, "failed while iterating over rows")
 		}
 		rowsAffected = int64(len(ids))
 

--- a/server/channels/store/sqlstore/role_store.go
+++ b/server/channels/store/sqlstore/role_store.go
@@ -222,28 +222,15 @@ func (s *SqlRoleStore) GetByNames(names []string) ([]*model.Role, error) {
 		return nil, errors.Wrap(err, "role_tosql")
 	}
 
-	rows, err := s.GetReplica().DB.Query(queryString, args...)
-	if err != nil {
+	var dbRoles []Role
+	if err := s.GetReplica().Select(&dbRoles, queryString, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to find Roles")
 	}
 
-	roles := []*model.Role{}
-	defer rows.Close()
-	for rows.Next() {
-		var role Role
-		err = rows.Scan(
-			&role.Id, &role.Name, &role.DisplayName, &role.Description,
-			&role.CreateAt, &role.UpdateAt, &role.DeleteAt, &role.Permissions,
-			&role.SchemeManaged, &role.BuiltIn, &role.SchemeId)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to scan values")
-		}
-		roles = append(roles, role.ToModel())
+	roles := make([]*model.Role, len(dbRoles))
+	for i := range dbRoles {
+		roles[i] = dbRoles[i].ToModel()
 	}
-	if err = rows.Err(); err != nil {
-		return nil, errors.Wrap(err, "unable to iterate over rows")
-	}
-
 	return roles, nil
 }
 

--- a/server/channels/store/sqlstore/schema_dump.go
+++ b/server/channels/store/sqlstore/schema_dump.go
@@ -88,7 +88,10 @@ func (ss *SqlStore) getDatabaseCollation() (string, error) {
 		return "", errors.Wrap(err, "failed to build database collation query")
 	}
 
-	err = ss.GetMaster().DB.QueryRow(sqlString, args...).Scan(&dbCollation)
+	ctx, cancel := ss.analyticsContext()
+	defer cancel()
+
+	err = ss.GetMaster().QueryRowContext(ctx, sqlString, args...).Scan(&dbCollation)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get database collation")
 	}
@@ -112,7 +115,10 @@ func (ss *SqlStore) getDatabaseEncoding() (string, error) {
 		return "", errors.Wrap(err, "failed to build database encoding query")
 	}
 
-	err = ss.GetMaster().DB.QueryRow(sqlString, args...).Scan(&dbEncoding)
+	ctx, cancel := ss.analyticsContext()
+	defer cancel()
+
+	err = ss.GetMaster().QueryRowContext(ctx, sqlString, args...).Scan(&dbEncoding)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get database encoding")
 	}
@@ -142,7 +148,10 @@ func (ss *SqlStore) getTableOptions() (map[string]map[string]string, error) {
 		return nil, errors.Wrap(err, "failed to build table options query")
 	}
 
-	optionsRows, err := ss.GetMaster().DB.Query(optionsSql, optionsArgs...)
+	ctx, cancel := ss.analyticsContext()
+	defer cancel()
+
+	optionsRows, err := ss.GetMaster().QueryContext(ctx, optionsSql, optionsArgs...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to query table options")
 	}
@@ -204,7 +213,10 @@ func (ss *SqlStore) getTableSchemaInformation() (map[string]*model.DatabaseTable
 		return nil, nil, errors.Wrap(err, "failed to build schema information query")
 	}
 
-	rows, err := ss.GetMaster().DB.Query(schemaSql, schemaArgs...)
+	ctx, cancel := ss.analyticsContext()
+	defer cancel()
+
+	rows, err := ss.GetMaster().QueryContext(ctx, schemaSql, schemaArgs...)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to query schema information")
 	}
@@ -275,7 +287,10 @@ func (ss *SqlStore) getTableIndexes() (map[string][]model.DatabaseIndex, error) 
 		return nil, errors.Wrap(err, "failed to build index query")
 	}
 
-	rows, err := ss.GetMaster().DB.Query(indexSql, indexArgs...)
+	ctx, cancel := ss.analyticsContext()
+	defer cancel()
+
+	rows, err := ss.GetMaster().QueryContext(ctx, indexSql, indexArgs...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to query index information")
 	}

--- a/server/channels/store/sqlstore/sqlx_wrapper.go
+++ b/server/channels/store/sqlstore/sqlx_wrapper.go
@@ -55,9 +55,7 @@ type sqlxExecutor interface {
 	Exec(query string, args ...any) (sql.Result, error)
 	ExecBuilder(builder Builder) (sql.Result, error)
 	ExecRaw(query string, args ...any) (sql.Result, error)
-	NamedQuery(query string, arg any) (*sqlx.Rows, error)
-	QueryRowX(query string, args ...any) *sqlx.Row
-	QueryX(query string, args ...any) (*sqlx.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
 	Select(dest any, query string, args ...any) error
 	SelectBuilder(dest any, builder Builder) error
 }
@@ -68,7 +66,7 @@ type sqlxExecutor interface {
 var namedParamRegex = regexp.MustCompile(`:\w+`)
 
 type sqlxDBWrapper struct {
-	*sqlx.DB
+	db           *sqlx.DB
 	queryTimeout time.Duration
 	trace        bool
 	isOnline     *atomic.Bool
@@ -76,7 +74,7 @@ type sqlxDBWrapper struct {
 
 func newSqlxDBWrapper(db *sqlx.DB, timeout time.Duration, trace bool) *sqlxDBWrapper {
 	w := &sqlxDBWrapper{
-		DB:           db,
+		db:           db,
 		queryTimeout: timeout,
 		trace:        trace,
 		isOnline:     &atomic.Bool{},
@@ -85,12 +83,36 @@ func newSqlxDBWrapper(db *sqlx.DB, timeout time.Duration, trace bool) *sqlxDBWra
 	return w
 }
 
+// DB returns the underlying *sql.DB, for use by infrastructure code (morph, metrics)
+// that requires the standard library handle directly.
+func (w *sqlxDBWrapper) DB() *sql.DB {
+	return w.db.DB
+}
+
+// Sqlx returns the underlying *sqlx.DB, for use by infrastructure code that
+// requires the sqlx handle directly (e.g. the config store in tests).
+func (w *sqlxDBWrapper) Sqlx() *sqlx.DB {
+	return w.db
+}
+
 func (w *sqlxDBWrapper) Stats() sql.DBStats {
-	return w.DB.Stats()
+	return w.db.Stats()
+}
+
+func (w *sqlxDBWrapper) Close() error {
+	return w.db.Close()
+}
+
+func (w *sqlxDBWrapper) SetConnMaxLifetime(d time.Duration) {
+	w.db.SetConnMaxLifetime(d)
+}
+
+func (w *sqlxDBWrapper) Rebind(query string) string {
+	return w.db.Rebind(query)
 }
 
 func (w *sqlxDBWrapper) Beginx() (*sqlxTxWrapper, error) {
-	tx, err := w.DB.Beginx()
+	tx, err := w.db.Beginx()
 	if err != nil {
 		return nil, w.checkErr(err)
 	}
@@ -99,7 +121,7 @@ func (w *sqlxDBWrapper) Beginx() (*sqlxTxWrapper, error) {
 }
 
 func (w *sqlxDBWrapper) BeginXWithIsolation(opts *sql.TxOptions) (*sqlxTxWrapper, error) {
-	tx, err := w.DB.BeginTxx(context.Background(), opts)
+	tx, err := w.db.BeginTxx(context.Background(), opts)
 	if err != nil {
 		return nil, w.checkErr(err)
 	}
@@ -108,7 +130,7 @@ func (w *sqlxDBWrapper) BeginXWithIsolation(opts *sql.TxOptions) (*sqlxTxWrapper
 }
 
 func (w *sqlxDBWrapper) Get(dest any, query string, args ...any) error {
-	query = w.DB.Rebind(query)
+	query = w.db.Rebind(query)
 	ctx, cancel := context.WithTimeout(context.Background(), w.queryTimeout)
 	defer cancel()
 
@@ -118,7 +140,7 @@ func (w *sqlxDBWrapper) Get(dest any, query string, args ...any) error {
 		}(time.Now())
 	}
 
-	return w.checkErr(w.DB.GetContext(ctx, dest, query, args...))
+	return w.checkErr(w.db.GetContext(ctx, dest, query, args...))
 }
 
 func (w *sqlxDBWrapper) GetBuilder(dest any, builder Builder) error {
@@ -141,11 +163,11 @@ func (w *sqlxDBWrapper) NamedExec(query string, arg any) (sql.Result, error) {
 		}(time.Now())
 	}
 
-	return w.checkErrWithResult(w.DB.NamedExecContext(ctx, query, arg))
+	return w.checkErrWithResult(w.db.NamedExecContext(ctx, query, arg))
 }
 
 func (w *sqlxDBWrapper) Exec(query string, args ...any) (sql.Result, error) {
-	query = w.DB.Rebind(query)
+	query = w.db.Rebind(query)
 
 	return w.ExecRaw(query, args...)
 }
@@ -160,7 +182,7 @@ func (w *sqlxDBWrapper) ExecBuilder(builder Builder) (sql.Result, error) {
 }
 
 func (w *sqlxDBWrapper) ExecNoTimeout(query string, args ...any) (sql.Result, error) {
-	query = w.DB.Rebind(query)
+	query = w.db.Rebind(query)
 
 	if w.trace {
 		defer func(then time.Time) {
@@ -168,7 +190,7 @@ func (w *sqlxDBWrapper) ExecNoTimeout(query string, args ...any) (sql.Result, er
 		}(time.Now())
 	}
 
-	return w.checkErrWithResult(w.DB.ExecContext(context.Background(), query, args...))
+	return w.checkErrWithResult(w.db.ExecContext(context.Background(), query, args...))
 }
 
 // ExecRaw is like Exec but without any rebinding of params. You need to pass
@@ -183,49 +205,13 @@ func (w *sqlxDBWrapper) ExecRaw(query string, args ...any) (sql.Result, error) {
 		}(time.Now())
 	}
 
-	return w.checkErrWithResult(w.DB.ExecContext(ctx, query, args...))
+	return w.checkErrWithResult(w.db.ExecContext(ctx, query, args...))
 }
 
-func (w *sqlxDBWrapper) NamedQuery(query string, arg any) (*sqlx.Rows, error) {
-	query = namedParamRegex.ReplaceAllStringFunc(query, strings.ToLower)
-	ctx, cancel := context.WithTimeout(context.Background(), w.queryTimeout)
-	defer cancel()
-
-	if w.trace {
-		defer func(then time.Time) {
-			printArgs(query, time.Since(then), arg)
-		}(time.Now())
-	}
-
-	return w.checkErrWithRows(w.DB.NamedQueryContext(ctx, query, arg))
-}
-
-func (w *sqlxDBWrapper) QueryRowX(query string, args ...any) *sqlx.Row {
-	query = w.DB.Rebind(query)
-	ctx, cancel := context.WithTimeout(context.Background(), w.queryTimeout)
-	defer cancel()
-
-	if w.trace {
-		defer func(then time.Time) {
-			printArgs(query, time.Since(then), args)
-		}(time.Now())
-	}
-
-	return w.DB.QueryRowxContext(ctx, query, args...)
-}
-
-func (w *sqlxDBWrapper) QueryX(query string, args ...any) (*sqlx.Rows, error) {
-	query = w.DB.Rebind(query)
-	ctx, cancel := context.WithTimeout(context.Background(), w.queryTimeout)
-	defer cancel()
-
-	if w.trace {
-		defer func(then time.Time) {
-			printArgs(query, time.Since(then), args)
-		}(time.Now())
-	}
-
-	return w.checkErrWithRows(w.DB.QueryxContext(ctx, query, args...))
+// ExecContext forwards to the underlying DB with the caller-supplied context.
+// The caller is responsible for applying an appropriate timeout.
+func (w *sqlxDBWrapper) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return w.db.ExecContext(ctx, query, args...)
 }
 
 func (w *sqlxDBWrapper) Select(dest any, query string, args ...any) error {
@@ -233,7 +219,7 @@ func (w *sqlxDBWrapper) Select(dest any, query string, args ...any) error {
 }
 
 func (w *sqlxDBWrapper) SelectCtx(ctx context.Context, dest any, query string, args ...any) error {
-	query = w.DB.Rebind(query)
+	query = w.db.Rebind(query)
 	ctx, cancel := context.WithTimeout(ctx, w.queryTimeout)
 	defer cancel()
 
@@ -243,7 +229,33 @@ func (w *sqlxDBWrapper) SelectCtx(ctx context.Context, dest any, query string, a
 		}(time.Now())
 	}
 
-	return w.checkErr(w.DB.SelectContext(ctx, dest, query, args...))
+	return w.checkErr(w.db.SelectContext(ctx, dest, query, args...))
+}
+
+func (w *sqlxDBWrapper) QueryRow(query string, args ...any) *sql.Row {
+	query = w.db.Rebind(query)
+	ctx, cancel := context.WithTimeout(context.Background(), w.queryTimeout)
+	defer cancel()
+
+	if w.trace {
+		defer func(then time.Time) {
+			printArgs(query, time.Since(then), args)
+		}(time.Now())
+	}
+
+	return w.db.QueryRowContext(ctx, query, args...)
+}
+
+// QueryRowContext forwards to the underlying DB with the caller-supplied context.
+// The caller is responsible for applying an appropriate timeout.
+func (w *sqlxDBWrapper) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return w.db.QueryRowContext(ctx, query, args...)
+}
+
+// QueryContext forwards to the underlying DB with the caller-supplied context.
+// The caller is responsible for applying an appropriate timeout.
+func (w *sqlxDBWrapper) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return w.db.QueryContext(ctx, query, args...)
 }
 
 func (w *sqlxDBWrapper) SelectBuilder(dest any, builder Builder) error {
@@ -260,7 +272,7 @@ func (w *sqlxDBWrapper) SelectBuilderCtx(ctx context.Context, dest any, builder 
 }
 
 type sqlxTxWrapper struct {
-	*sqlx.Tx
+	tx           *sqlx.Tx
 	queryTimeout time.Duration
 	trace        bool
 	dbw          *sqlxDBWrapper
@@ -268,15 +280,23 @@ type sqlxTxWrapper struct {
 
 func newSqlxTxWrapper(tx *sqlx.Tx, timeout time.Duration, trace bool, dbw *sqlxDBWrapper) *sqlxTxWrapper {
 	return &sqlxTxWrapper{
-		Tx:           tx,
+		tx:           tx,
 		queryTimeout: timeout,
 		trace:        trace,
 		dbw:          dbw,
 	}
 }
 
+func (w *sqlxTxWrapper) Commit() error {
+	return w.tx.Commit()
+}
+
+func (w *sqlxTxWrapper) Rollback() error {
+	return w.tx.Rollback()
+}
+
 func (w *sqlxTxWrapper) Get(dest any, query string, args ...any) error {
-	query = w.Tx.Rebind(query)
+	query = w.tx.Rebind(query)
 	ctx, cancel := context.WithTimeout(context.Background(), w.queryTimeout)
 	defer cancel()
 
@@ -286,7 +306,7 @@ func (w *sqlxTxWrapper) Get(dest any, query string, args ...any) error {
 		}(time.Now())
 	}
 
-	return w.dbw.checkErr(w.Tx.GetContext(ctx, dest, query, args...))
+	return w.dbw.checkErr(w.tx.GetContext(ctx, dest, query, args...))
 }
 
 func (w *sqlxTxWrapper) GetBuilder(dest any, builder Builder) error {
@@ -299,13 +319,13 @@ func (w *sqlxTxWrapper) GetBuilder(dest any, builder Builder) error {
 }
 
 func (w *sqlxTxWrapper) Exec(query string, args ...any) (sql.Result, error) {
-	query = w.Tx.Rebind(query)
+	query = w.tx.Rebind(query)
 
 	return w.dbw.checkErrWithResult(w.ExecRaw(query, args...))
 }
 
 func (w *sqlxTxWrapper) ExecNoTimeout(query string, args ...any) (sql.Result, error) {
-	query = w.Tx.Rebind(query)
+	query = w.tx.Rebind(query)
 
 	if w.trace {
 		defer func(then time.Time) {
@@ -313,7 +333,7 @@ func (w *sqlxTxWrapper) ExecNoTimeout(query string, args ...any) (sql.Result, er
 		}(time.Now())
 	}
 
-	return w.dbw.checkErrWithResult(w.Tx.ExecContext(context.Background(), query, args...))
+	return w.dbw.checkErrWithResult(w.tx.ExecContext(context.Background(), query, args...))
 }
 
 func (w *sqlxTxWrapper) ExecBuilder(builder Builder) (sql.Result, error) {
@@ -337,7 +357,7 @@ func (w *sqlxTxWrapper) ExecRaw(query string, args ...any) (sql.Result, error) {
 		}(time.Now())
 	}
 
-	return w.dbw.checkErrWithResult(w.Tx.ExecContext(ctx, query, args...))
+	return w.dbw.checkErrWithResult(w.tx.ExecContext(ctx, query, args...))
 }
 
 func (w *sqlxTxWrapper) NamedExec(query string, arg any) (sql.Result, error) {
@@ -351,81 +371,11 @@ func (w *sqlxTxWrapper) NamedExec(query string, arg any) (sql.Result, error) {
 		}(time.Now())
 	}
 
-	return w.dbw.checkErrWithResult(w.Tx.NamedExecContext(ctx, query, arg))
-}
-
-func (w *sqlxTxWrapper) NamedQuery(query string, arg any) (*sqlx.Rows, error) {
-	query = namedParamRegex.ReplaceAllStringFunc(query, strings.ToLower)
-	ctx, cancel := context.WithTimeout(context.Background(), w.queryTimeout)
-	defer cancel()
-
-	if w.trace {
-		defer func(then time.Time) {
-			printArgs(query, time.Since(then), arg)
-		}(time.Now())
-	}
-
-	// There is no tx.NamedQueryContext support in the sqlx API. (https://github.com/jmoiron/sqlx/issues/447)
-	// So we need to implement this ourselves.
-	type result struct {
-		rows *sqlx.Rows
-		err  error
-	}
-
-	// Need to add a buffer of 1 to prevent goroutine leak.
-	resChan := make(chan *result, 1)
-	go func() {
-		rows, err := w.Tx.NamedQuery(query, arg)
-		resChan <- &result{
-			rows: rows,
-			err:  err,
-		}
-	}()
-
-	// staticcheck fails to check that res gets re-assigned later.
-	res := &result{} //nolint:staticcheck
-	select {
-	case res = <-resChan:
-	case <-ctx.Done():
-		res = &result{
-			rows: nil,
-			err:  ctx.Err(),
-		}
-	}
-
-	return res.rows, w.dbw.checkErr(res.err)
-}
-
-func (w *sqlxTxWrapper) QueryRowX(query string, args ...any) *sqlx.Row {
-	query = w.Tx.Rebind(query)
-	ctx, cancel := context.WithTimeout(context.Background(), w.queryTimeout)
-	defer cancel()
-
-	if w.trace {
-		defer func(then time.Time) {
-			printArgs(query, time.Since(then), args)
-		}(time.Now())
-	}
-
-	return w.Tx.QueryRowxContext(ctx, query, args...)
-}
-
-func (w *sqlxTxWrapper) QueryX(query string, args ...any) (*sqlx.Rows, error) {
-	query = w.Tx.Rebind(query)
-	ctx, cancel := context.WithTimeout(context.Background(), w.queryTimeout)
-	defer cancel()
-
-	if w.trace {
-		defer func(then time.Time) {
-			printArgs(query, time.Since(then), args)
-		}(time.Now())
-	}
-
-	return w.dbw.checkErrWithRows(w.Tx.QueryxContext(ctx, query, args...))
+	return w.dbw.checkErrWithResult(w.tx.NamedExecContext(ctx, query, arg))
 }
 
 func (w *sqlxTxWrapper) Select(dest any, query string, args ...any) error {
-	query = w.Tx.Rebind(query)
+	query = w.tx.Rebind(query)
 	ctx, cancel := context.WithTimeout(context.Background(), w.queryTimeout)
 	defer cancel()
 
@@ -435,7 +385,21 @@ func (w *sqlxTxWrapper) Select(dest any, query string, args ...any) error {
 		}(time.Now())
 	}
 
-	return w.dbw.checkErr(w.Tx.SelectContext(ctx, dest, query, args...))
+	return w.dbw.checkErr(w.tx.SelectContext(ctx, dest, query, args...))
+}
+
+func (w *sqlxTxWrapper) QueryRow(query string, args ...any) *sql.Row {
+	query = w.tx.Rebind(query)
+	ctx, cancel := context.WithTimeout(context.Background(), w.queryTimeout)
+	defer cancel()
+
+	if w.trace {
+		defer func(then time.Time) {
+			printArgs(query, time.Since(then), args)
+		}(time.Now())
+	}
+
+	return w.tx.QueryRowContext(ctx, query, args...)
 }
 
 func (w *sqlxTxWrapper) SelectBuilder(dest any, builder Builder) error {
@@ -468,10 +432,6 @@ func printArgs(query string, dur time.Duration, args ...any) {
 }
 
 func (w *sqlxDBWrapper) checkErrWithResult(res sql.Result, err error) (sql.Result, error) {
-	return res, w.checkErr(err)
-}
-
-func (w *sqlxDBWrapper) checkErrWithRows(res *sqlx.Rows, err error) (*sqlx.Rows, error) {
 	return res, w.checkErr(err)
 }
 

--- a/server/channels/store/sqlstore/sqlx_wrapper.go
+++ b/server/channels/store/sqlstore/sqlx_wrapper.go
@@ -55,7 +55,6 @@ type sqlxExecutor interface {
 	Exec(query string, args ...any) (sql.Result, error)
 	ExecBuilder(builder Builder) (sql.Result, error)
 	ExecRaw(query string, args ...any) (sql.Result, error)
-	QueryRow(query string, args ...any) *sql.Row
 	Select(dest any, query string, args ...any) error
 	SelectBuilder(dest any, builder Builder) error
 }
@@ -232,20 +231,6 @@ func (w *sqlxDBWrapper) SelectCtx(ctx context.Context, dest any, query string, a
 	return w.checkErr(w.db.SelectContext(ctx, dest, query, args...))
 }
 
-func (w *sqlxDBWrapper) QueryRow(query string, args ...any) *sql.Row {
-	query = w.db.Rebind(query)
-	ctx, cancel := context.WithTimeout(context.Background(), w.queryTimeout)
-	defer cancel()
-
-	if w.trace {
-		defer func(then time.Time) {
-			printArgs(query, time.Since(then), args)
-		}(time.Now())
-	}
-
-	return w.db.QueryRowContext(ctx, query, args...)
-}
-
 // QueryRowContext forwards to the underlying DB with the caller-supplied context.
 // The caller is responsible for applying an appropriate timeout.
 func (w *sqlxDBWrapper) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
@@ -386,20 +371,6 @@ func (w *sqlxTxWrapper) Select(dest any, query string, args ...any) error {
 	}
 
 	return w.dbw.checkErr(w.tx.SelectContext(ctx, dest, query, args...))
-}
-
-func (w *sqlxTxWrapper) QueryRow(query string, args ...any) *sql.Row {
-	query = w.tx.Rebind(query)
-	ctx, cancel := context.WithTimeout(context.Background(), w.queryTimeout)
-	defer cancel()
-
-	if w.trace {
-		defer func(then time.Time) {
-			printArgs(query, time.Since(then), args)
-		}(time.Now())
-	}
-
-	return w.tx.QueryRowContext(ctx, query, args...)
 }
 
 func (w *sqlxTxWrapper) SelectBuilder(dest any, builder Builder) error {

--- a/server/channels/store/sqlstore/sqlx_wrapper_test.go
+++ b/server/channels/store/sqlstore/sqlx_wrapper_test.go
@@ -17,41 +17,6 @@ import (
 )
 
 func TestSqlX(t *testing.T) {
-	t.Run("NamedQuery", func(t *testing.T) {
-		testDrivers := []string{
-			model.DatabaseDriverPostgres,
-		}
-
-		for _, driver := range testDrivers {
-			settings, err := makeSqlSettings(driver)
-			if err != nil {
-				continue
-			}
-			*settings.QueryTimeout = 1
-			store := &SqlStore{
-				rrCounter:   0,
-				srCounter:   0,
-				settings:    settings,
-				logger:      mlog.CreateConsoleTestLogger(t),
-				quitMonitor: make(chan struct{}),
-				wgMonitor:   &sync.WaitGroup{},
-			}
-
-			require.NoError(t, store.initConnection())
-
-			defer store.Close()
-
-			tx, err := store.GetMaster().Beginx()
-			require.NoError(t, err)
-
-			query := `SELECT pg_sleep(:timeout);`
-			arg := struct{ Timeout int }{Timeout: 2}
-			_, err = tx.NamedQuery(query, arg)
-			require.Equal(t, context.DeadlineExceeded, err)
-			require.NoError(t, tx.Commit())
-		}
-	})
-
 	t.Run("NamedParse", func(t *testing.T) {
 		queries := []struct {
 			in  string

--- a/server/channels/store/sqlstore/store.go
+++ b/server/channels/store/sqlstore/store.go
@@ -324,7 +324,7 @@ func (ss *SqlStore) initConnection() error {
 		time.Duration(*ss.settings.QueryTimeout)*time.Second,
 		*ss.settings.Trace)
 	if ss.metrics != nil {
-		ss.metrics.RegisterDBCollector(ss.masterX.DB.DB, "master")
+		ss.metrics.RegisterDBCollector(ss.masterX.DB(), "master")
 	}
 
 	if len(ss.settings.DataSourceReplicas) > 0 {
@@ -436,7 +436,7 @@ func (ss *SqlStore) SetMasterX(db *sql.DB) {
 }
 
 func (ss *SqlStore) GetInternalMasterDB() *sql.DB {
-	return ss.GetMaster().DB.DB
+	return ss.GetMaster().DB()
 }
 
 func (ss *SqlStore) GetSearchReplicaX() *sqlxDBWrapper {
@@ -500,8 +500,8 @@ func (ss *SqlStore) monitorReplicas() {
 					mlog.Warn("Failed to setup connection. Skipping..", mlog.String("db", name), mlog.Err(err))
 					return
 				}
-				if ss.metrics != nil && r.Load() != nil && r.Load().DB != nil {
-					ss.metrics.UnregisterDBCollector(r.Load().DB.DB, name)
+				if ss.metrics != nil && r.Load() != nil {
+					ss.metrics.UnregisterDBCollector(r.Load().DB(), name)
 				}
 				ss.setDB(r, handle, name)
 			}
@@ -521,17 +521,17 @@ func (ss *SqlStore) setDB(replica *atomic.Pointer[sqlxDBWrapper], handle *sql.DB
 		time.Duration(*ss.settings.QueryTimeout)*time.Second,
 		*ss.settings.Trace))
 	if ss.metrics != nil {
-		ss.metrics.RegisterDBCollector(replica.Load().DB.DB, name)
+		ss.metrics.RegisterDBCollector(replica.Load().DB(), name)
 	}
 }
 
 func (ss *SqlStore) GetInternalReplicaDB() *sql.DB {
 	if len(ss.settings.DataSourceReplicas) == 0 || ss.lockedToMaster || !ss.hasLicense() {
-		return ss.GetMaster().DB.DB
+		return ss.GetMaster().DB()
 	}
 
 	rrNum := atomic.AddInt64(&ss.rrCounter, 1) % int64(len(ss.ReplicaXs))
-	return ss.ReplicaXs[rrNum].Load().DB.DB
+	return ss.ReplicaXs[rrNum].Load().DB()
 }
 
 func (ss *SqlStore) TotalMasterDbConnections() int {

--- a/server/channels/store/sqlstore/user_store.go
+++ b/server/channels/store/sqlstore/user_store.go
@@ -574,7 +574,7 @@ func (us SqlUserStore) Get(ctx context.Context, id string) (*model.User, error) 
 	if err != nil {
 		return nil, errors.Wrap(err, "users_get_tosql")
 	}
-	row := us.SqlStore.DBXFromContext(ctx).QueryRow(queryString, args...)
+	row := us.SqlStore.DBXFromContext(ctx).QueryRowContext(ctx, queryString, args...)
 
 	var user model.User
 	var props, notifyProps, timezone []byte
@@ -927,47 +927,16 @@ func (us SqlUserStore) GetAllProfilesInChannel(ctx context.Context, channelID st
 		Where("Users.DeleteAt = 0").
 		OrderBy("Users.Username ASC")
 
-	queryString, args, err := query.ToSql()
-	if err != nil {
-		return nil, errors.Wrap(err, "get_all_profiles_in_channel_tosql")
-	}
-
-	users := []*model.User{}
-	rows, err := us.SqlStore.DBXFromContext(ctx).Query(queryString, args...)
-	if err != nil {
+	var users []*model.User
+	if err := us.SqlStore.DBXFromContext(ctx).SelectBuilder(&users, query); err != nil {
 		return nil, errors.Wrap(err, "failed to find Users")
 	}
 
-	defer rows.Close()
-	for rows.Next() {
-		var user model.User
-		var props, notifyProps, timezone []byte
-		if err = rows.Scan(&user.Id, &user.CreateAt, &user.UpdateAt, &user.DeleteAt, &user.Username, &user.Password, &user.AuthData, &user.AuthService, &user.Email, &user.EmailVerified, &user.Nickname, &user.FirstName, &user.LastName, &user.Position, &user.Roles, &user.AllowMarketing, &props, &notifyProps, &user.LastPasswordUpdate, &user.LastPictureUpdate, &user.FailedAttempts, &user.Locale, &timezone, &user.MfaActive, &user.MfaSecret, &user.MfaUsedTimestamps, &user.RemoteId, &user.LastLogin, &user.IsBot, &user.BotDescription, &user.BotLastIconUpdate); err != nil {
-			return nil, errors.Wrap(err, "failed to scan values from rows into User entity")
-		}
-		if err = json.Unmarshal(props, &user.Props); err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal user props")
-		}
-		if err = json.Unmarshal(notifyProps, &user.NotifyProps); err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal user notify props")
-		}
-		if err = json.Unmarshal(timezone, &user.Timezone); err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal user timezone")
-		}
-		users = append(users, &user)
-	}
-	err = rows.Err()
-	if err != nil {
-		return nil, errors.Wrap(err, "error while iterating over rows")
-	}
-
-	userMap := make(map[string]*model.User)
-
+	userMap := make(map[string]*model.User, len(users))
 	for _, u := range users {
 		u.Sanitize(map[string]bool{})
 		userMap[u.Id] = u
 	}
-
 	return userMap, nil
 }
 

--- a/server/channels/store/sqlstore/utils.go
+++ b/server/channels/store/sqlstore/utils.go
@@ -7,7 +7,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io"
 	"maps"
 	"net/url"
 	"strconv"
@@ -93,11 +92,6 @@ func finalizeTransactionX(transaction *sqlxTxWrapper, perr *error) {
 	if err := transaction.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
 		*perr = merror.Append(*perr, err)
 	}
-}
-
-func deferClose(c io.Closer, perr *error) {
-	err := c.Close()
-	*perr = merror.Append(*perr, err)
 }
 
 // removeNonAlphaNumericUnquotedTerms removes all unquoted words that only contain

--- a/server/channels/store/sqlstore/utils_test.go
+++ b/server/channels/store/sqlstore/utils_test.go
@@ -209,7 +209,7 @@ func TestScanRowsIntoMap(t *testing.T) {
 			require.NoError(t, err)
 
 			// Query the data
-			rows, err := sqlStore.GetMaster().Query(`SELECT id, value FROM MapTest ORDER BY id`)
+			rows, err := sqlStore.GetMaster().QueryContext(t.Context(), `SELECT id, value FROM MapTest ORDER BY id`)
 			require.NoError(t, err)
 			defer rows.Close()
 
@@ -248,7 +248,7 @@ func TestScanRowsIntoMap(t *testing.T) {
 			require.NoError(t, err)
 
 			// Query the data
-			rows, err := sqlStore.GetMaster().Query(`SELECT id, value FROM MapTestDefaults`)
+			rows, err := sqlStore.GetMaster().QueryContext(t.Context(), `SELECT id, value FROM MapTestDefaults`)
 			require.NoError(t, err)
 			defer rows.Close()
 
@@ -288,7 +288,7 @@ func TestScanRowsIntoMap(t *testing.T) {
 			require.NoError(t, err)
 
 			// Query the empty table
-			rows, err := sqlStore.GetMaster().Query(`SELECT id, value FROM MapTestEmpty`)
+			rows, err := sqlStore.GetMaster().QueryContext(t.Context(), `SELECT id, value FROM MapTestEmpty`)
 			require.NoError(t, err)
 			defer rows.Close()
 

--- a/server/channels/store/storetest/channel_store.go
+++ b/server/channels/store/storetest/channel_store.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -37,9 +36,7 @@ type SqlXExecutor interface {
 	NamedExec(query string, arg any) (sql.Result, error)
 	Exec(query string, args ...any) (sql.Result, error)
 	ExecRaw(query string, args ...any) (sql.Result, error)
-	NamedQuery(query string, arg any) (*sqlx.Rows, error)
-	QueryRowX(query string, args ...any) *sqlx.Row
-	QueryX(query string, args ...any) (*sqlx.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
 	Select(dest any, query string, args ...any) error
 }
 
@@ -112,6 +109,8 @@ func TestChannelStore(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore
 	t.Run("RemoveMember", func(t *testing.T) { testChannelRemoveMember(t, rctx, ss) })
 	t.Run("RemoveMembers", func(t *testing.T) { testChannelRemoveMembers(t, rctx, ss) })
 	t.Run("ChannelDeleteMemberStore", func(t *testing.T) { testChannelDeleteMemberStore(t, rctx, ss) })
+	t.Run("GetAllChannelMembersForUser", func(t *testing.T) { testChannelStoreGetAllChannelMembersForUser(t, rctx, ss) })
+	t.Run("GetChannelsMemberCount", func(t *testing.T) { testChannelStoreGetChannelsMemberCount(t, rctx, ss) })
 	t.Run("GetChannels", func(t *testing.T) { testChannelStoreGetChannels(t, rctx, ss) })
 	t.Run("GetChannelsByUser", func(t *testing.T) { testChannelStoreGetChannelsByUser(t, rctx, ss) })
 	t.Run("GetAllChannels", func(t *testing.T) { testChannelStoreGetAllChannels(t, rctx, ss, s) })
@@ -3723,6 +3722,125 @@ func testChannelDeleteMemberStore(t *testing.T, rctx request.CTX, ss store.Store
 	count, nErr = ss.Channel().GetMemberCount(o1.ChannelId, false)
 	require.NoError(t, nErr)
 	require.EqualValues(t, 0, count, "should have removed all members")
+}
+
+func testChannelStoreGetAllChannelMembersForUser(t *testing.T, rctx request.CTX, ss store.Store) {
+	userId := model.NewId()
+
+	channel, nErr := ss.Channel().Save(rctx, &model.Channel{
+		TeamId:      model.NewId(),
+		DisplayName: "Channel",
+		Name:        NewTestID(),
+		Type:        model.ChannelTypeOpen,
+	}, -1)
+	require.NoError(t, nErr)
+
+	_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{
+		ChannelId:   channel.Id,
+		UserId:      userId,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+		SchemeUser:  true,
+	})
+	require.NoError(t, nErr)
+
+	t.Run("map value contains channel_user role for plain member", func(t *testing.T) {
+		result, err := ss.Channel().GetAllChannelMembersForUser(rctx, userId, false, false)
+		require.NoError(t, err)
+		roles, ok := result[channel.Id]
+		require.True(t, ok, "channel should be present in result")
+		assert.Contains(t, roles, model.ChannelUserRoleId)
+	})
+
+	t.Run("channel scheme default user role appears in map value", func(t *testing.T) {
+		scheme, nErr := ss.Scheme().Save(&model.Scheme{
+			Name:        model.NewId(),
+			DisplayName: model.NewId(),
+			Scope:       model.SchemeScopeChannel,
+		})
+		require.NoError(t, nErr)
+		defer func() { _, err := ss.Scheme().Delete(scheme.Id); require.NoError(t, err) }()
+
+		schemChannel, nErr := ss.Channel().Save(rctx, &model.Channel{
+			TeamId:      model.NewId(),
+			DisplayName: "Schemed Channel",
+			Name:        NewTestID(),
+			Type:        model.ChannelTypeOpen,
+			SchemeId:    &scheme.Id,
+		}, -1)
+		require.NoError(t, nErr)
+
+		_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{
+			ChannelId:   schemChannel.Id,
+			UserId:      userId,
+			NotifyProps: model.GetDefaultChannelNotifyProps(),
+			SchemeUser:  true,
+		})
+		require.NoError(t, nErr)
+
+		result, err := ss.Channel().GetAllChannelMembersForUser(rctx, userId, false, false)
+		require.NoError(t, err)
+		roles, ok := result[schemChannel.Id]
+		require.True(t, ok, "schemed channel should be present in result")
+		assert.Contains(t, roles, scheme.DefaultChannelUserRole)
+		assert.NotContains(t, roles, model.ChannelUserRoleId)
+	})
+}
+
+func testChannelStoreGetChannelsMemberCount(t *testing.T, rctx request.CTX, ss store.Store) {
+	teamID := model.NewId()
+
+	ch1, nErr := ss.Channel().Save(rctx, &model.Channel{
+		TeamId:      teamID,
+		DisplayName: "Channel 1",
+		Name:        NewTestID(),
+		Type:        model.ChannelTypeOpen,
+	}, -1)
+	require.NoError(t, nErr)
+
+	ch2, nErr := ss.Channel().Save(rctx, &model.Channel{
+		TeamId:      teamID,
+		DisplayName: "Channel 2",
+		Name:        NewTestID(),
+		Type:        model.ChannelTypeOpen,
+	}, -1)
+	require.NoError(t, nErr)
+
+	for i := range 3 {
+		u, err := ss.User().Save(rctx, &model.User{
+			Email:    MakeEmail(),
+			Username: model.NewId(),
+		})
+		require.NoError(t, err)
+		_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{
+			ChannelId:   ch1.Id,
+			UserId:      u.Id,
+			NotifyProps: model.GetDefaultChannelNotifyProps(),
+		})
+		require.NoError(t, nErr)
+		if i < 2 {
+			_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{
+				ChannelId:   ch2.Id,
+				UserId:      u.Id,
+				NotifyProps: model.GetDefaultChannelNotifyProps(),
+			})
+			require.NoError(t, nErr)
+		}
+	}
+
+	t.Run("counts per channel are correct", func(t *testing.T) {
+		counts, err := ss.Channel().GetChannelsMemberCount([]string{ch1.Id, ch2.Id})
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), counts[ch1.Id])
+		assert.Equal(t, int64(2), counts[ch2.Id])
+	})
+
+	t.Run("unknown channel ID defaults to zero", func(t *testing.T) {
+		unknown := model.NewId()
+		counts, err := ss.Channel().GetChannelsMemberCount([]string{ch1.Id, unknown})
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), counts[ch1.Id])
+		assert.Equal(t, int64(0), counts[unknown])
+	})
 }
 
 func testChannelStoreGetChannels(t *testing.T, rctx request.CTX, ss store.Store) {

--- a/server/channels/store/storetest/channel_store.go
+++ b/server/channels/store/storetest/channel_store.go
@@ -36,7 +36,6 @@ type SqlXExecutor interface {
 	NamedExec(query string, arg any) (sql.Result, error)
 	Exec(query string, args ...any) (sql.Result, error)
 	ExecRaw(query string, args ...any) (sql.Result, error)
-	QueryRow(query string, args ...any) *sql.Row
 	Select(dest any, query string, args ...any) error
 }
 

--- a/server/channels/store/storetest/retention_policy_store.go
+++ b/server/channels/store/storetest/retention_policy_store.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -15,6 +17,7 @@ import (
 )
 
 func TestRetentionPolicyStore(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
+	t.Run("GetIdsForDeletionByTableName", func(t *testing.T) { testRetentionPolicyStoreGetIdsForDeletionByTableName(t, ss, s) })
 	t.Run("Save", func(t *testing.T) { testRetentionPolicyStoreSave(t, rctx, ss, s) })
 	t.Run("Patch", func(t *testing.T) { testRetentionPolicyStorePatch(t, rctx, ss, s) })
 	t.Run("Get", func(t *testing.T) { testRetentionPolicyStoreGet(t, rctx, ss, s) })
@@ -177,6 +180,80 @@ func restoreRetentionPolicy(t *testing.T, ss store.Store, policy *model.Retentio
 	_, err := ss.RetentionPolicy().Patch(policy)
 	require.NoError(t, err)
 	checkRetentionPolicyLikeThisExists(t, ss, policy)
+}
+
+func testRetentionPolicyStoreGetIdsForDeletionByTableName(t *testing.T, ss store.Store, s SqlStore) {
+	ph := s.GetQueryPlaceholder()
+
+	insertRow := func(t *testing.T, tableName string, ids []string) string {
+		t.Helper()
+		id := model.NewId()
+		q, err := ph.ReplacePlaceholders(`INSERT INTO RetentionIdsForDeletion (Id, TableName, Ids) VALUES (?, ?, ?)`)
+		require.NoError(t, err)
+		_, err = s.GetMaster().Exec(q, id, tableName, pq.Array(ids))
+		require.NoError(t, err)
+		return id
+	}
+
+	cleanup := func() {
+		_, err := s.GetMaster().Exec("DELETE FROM RetentionIdsForDeletion")
+		require.NoError(t, err)
+	}
+	defer cleanup()
+
+	t.Run("Ids array is scanned correctly", func(t *testing.T) {
+		defer cleanup()
+		ids := []string{model.NewId(), model.NewId(), model.NewId()}
+		insertedId := insertRow(t, "Posts", ids)
+
+		rows, err := ss.RetentionPolicy().GetIdsForDeletionByTableName("Posts", 100)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, insertedId, rows[0].Id)
+		assert.Equal(t, "Posts", rows[0].TableName)
+		assert.ElementsMatch(t, ids, rows[0].Ids)
+	})
+
+	t.Run("filters by TableName", func(t *testing.T) {
+		defer cleanup()
+		insertRow(t, "Posts", []string{model.NewId()})
+		insertRow(t, "Posts", []string{model.NewId()})
+		insertRow(t, "FileInfo", []string{model.NewId()})
+
+		rows, err := ss.RetentionPolicy().GetIdsForDeletionByTableName("Posts", 100)
+		require.NoError(t, err)
+		assert.Len(t, rows, 2)
+
+		rows, err = ss.RetentionPolicy().GetIdsForDeletionByTableName("FileInfo", 100)
+		require.NoError(t, err)
+		assert.Len(t, rows, 1)
+	})
+
+	t.Run("respects limit", func(t *testing.T) {
+		defer cleanup()
+		for range 5 {
+			insertRow(t, "Posts", []string{model.NewId()})
+		}
+
+		rows, err := ss.RetentionPolicy().GetIdsForDeletionByTableName("Posts", 3)
+		require.NoError(t, err)
+		assert.Len(t, rows, 3)
+	})
+
+	t.Run("NULL Ids column maps to empty slice", func(t *testing.T) {
+		defer cleanup()
+		id := model.NewId()
+		q, err := ph.ReplacePlaceholders(`INSERT INTO RetentionIdsForDeletion (Id, TableName, Ids) VALUES (?, ?, NULL)`)
+		require.NoError(t, err)
+		_, err = s.GetMaster().Exec(q, id, "Posts")
+		require.NoError(t, err)
+
+		rows, err := ss.RetentionPolicy().GetIdsForDeletionByTableName("Posts", 100)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.NotNil(t, rows[0].Ids)
+		assert.Empty(t, rows[0].Ids)
+	})
 }
 
 func testRetentionPolicyStoreSave(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {

--- a/server/channels/store/storetest/user_store.go
+++ b/server/channels/store/storetest/user_store.go
@@ -1542,6 +1542,43 @@ func testUserStoreGetAllProfilesInChannel(t *testing.T, rctx request.CTX, ss sto
 		}, profiles)
 	})
 
+	t.Run("Props, NotifyProps and Timezone are scanned correctly", func(t *testing.T) {
+		u4, err := ss.User().Save(rctx, &model.User{
+			Email:    MakeEmail(),
+			Username: "u4" + model.NewId(),
+			Props: model.StringMap{
+				"custom_key": "custom_value",
+			},
+			NotifyProps: model.StringMap{
+				model.EmailNotifyProp: model.UserNotifyAll,
+			},
+			Timezone: model.StringMap{
+				"automaticTimezone":    "America/New_York",
+				"manualTimezone":       "",
+				"useAutomaticTimezone": "true",
+			},
+		})
+		require.NoError(t, err)
+		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u4.Id)) }()
+
+		_, nErr := ss.Channel().SaveMember(rctx, &model.ChannelMember{
+			ChannelId:   c1.Id,
+			UserId:      u4.Id,
+			NotifyProps: model.GetDefaultChannelNotifyProps(),
+		})
+		require.NoError(t, nErr)
+
+		profiles, err := ss.User().GetAllProfilesInChannel(t.Context(), c1.Id, false)
+		require.NoError(t, err)
+		require.Contains(t, profiles, u4.Id)
+
+		got := profiles[u4.Id]
+		assert.Equal(t, "custom_value", got.Props["custom_key"])
+		assert.Equal(t, model.UserNotifyAll, got.NotifyProps[model.EmailNotifyProp])
+		assert.Equal(t, "America/New_York", got.Timezone["automaticTimezone"])
+		assert.Equal(t, "true", got.Timezone["useAutomaticTimezone"])
+	})
+
 	ss.User().InvalidateProfilesInChannelCacheByUser(u1.Id)
 	ss.User().InvalidateProfilesInChannelCache(c2.Id)
 }

--- a/server/config/database_test.go
+++ b/server/config/database_test.go
@@ -35,7 +35,7 @@ func setupConfigDatabase(t *testing.T, cfg *model.Config, files map[string][]byt
 
 	ds := &DatabaseStore{
 		driverName:     *mainHelper.GetSQLSettings().DriverName,
-		db:             mainHelper.GetSQLStore().GetMaster().DB,
+		db:             mainHelper.GetSQLStore().GetMaster().Sqlx(),
 		dataSourceName: *mainHelper.Settings.DataSource,
 	}
 


### PR DESCRIPTION
#### Summary

Address some shortcomings with the `sqlxDBWrapper`:
* Clients using `Query()` wouldn't automatically apply the configured `queryTimeout`
* `NamedQuery`, while unused, was effectively broken: it would immediately `cancel` on return before the caller had time to consume the a timeout on returning the 

...

Store methods that called SQL-executing functions directly on the embedded `*sqlx.DB`/`*sqlx.Tx` fields bypassed the per-query timeout entirely. This PR wires every call site through the `sqlxDBWrapper`/`sqlxTxWrapper` so the configured `QueryTimeout` (and `AnalyticsQueryTimeout` for schema introspection) is always applied.

**Commit by commit:**

1. **use AnalyticsQueryTimeout for schema dump queries** — `GetSchemaDefinition` queries system catalogs that can be slow on large databases. Wire them to `analyticsContext()` (300 s) via the promoted `QueryContext`/`QueryRowContext` methods instead of running with no timeout at all.

2. **sqlxwrapper helper methods** — Add `QueryRow`, `QueryRowContext`, `QueryContext`, and `ExecContext` as explicit methods. Remove `NamedQuery` (unsafe: returns `*sqlx.Rows` with a deferred-cancel context that fires before the caller can iterate rows) and `Queryx` (same issue). Drop the `sqlxWrapper` govet analyser — with the embedded fields now private the type system handles enforcement.

3. **use sqlxwrapper consistently** — Migrate every remaining call site:
   - `property_field_store`: `.DB.Get()` → `Get()`
   - `role_store`: `.DB.Query()` → `SelectBuilder` (removes manual `rows.Next()` loop)
   - `retention_policy_store`: `.DB.Query()` → `SelectCtx`; `DELETE RETURNING` → `txn.Select`; `GetIdsForDeletionByTableName` → `SelectBuilder` with inline `pq.StringArray` scan struct
   - `channel_store`: `GetChannelsMemberCount` and `AnalyticsCountAll` → `Select()`; `GetAllChannelMembersForUser` → `SelectCtx`
   - `user_store`: `GetAllProfilesInChannel` → `SelectBuilder` (`StringMap` implements `sql.Scanner` so sqlx handles JSON columns automatically)
   - `schema_dump`: `GetIdsForDeletionByTableName` already covered; remaining `QueryContext` callers supply function-scoped timeout contexts

4. **hide embedded fields** — Change `*sqlx.DB` and `*sqlx.Tx` from embedded to private named fields (`db`, `tx`). Methods that would bypass timeout enforcement simply don't exist on the wrapper type. Infrastructure accessors (`DB()`, `Sqlx()`, `Close()`, etc.) are exposed explicitly.

Adds targeted test coverage for each migrated function, including a `NULL Ids` column case for `retentionIdsForDeletionRow`.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-68332

#### Release Note

```release-note
NONE
```