### PR TITLE
MM-68500 - add AttributeValueMasking flag and HasMaskedValues field

### DIFF
--- a/server/public/model/cel.go
+++ b/server/public/model/cel.go
@@ -23,6 +23,8 @@ type Condition struct {
 	ValueType ValueType `json:"value_type"`
 	// Type of the Attribute (e.g., "text", "select", "multiselect").
 	AttributeType string `json:"attribute_type"`
+	// HasMaskedValues is true when non-held values were omitted from this condition.
+	HasMaskedValues bool `json:"has_masked_values,omitempty"`
 }
 
 // VisualExpression represents a series of conditions combined with logical AND.

--- a/server/public/model/cel_test.go
+++ b/server/public/model/cel_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConditionJSON_HasMaskedValuesOmitEmpty(t *testing.T) {
+	t.Run("has_masked_values omitted when false", func(t *testing.T) {
+		condition := Condition{
+			Attribute:     "user.attributes.Program",
+			Operator:      "==",
+			Value:         "Alpha",
+			ValueType:     LiteralValue,
+			AttributeType: "select",
+			HasMaskedValues: false,
+		}
+
+		data, err := json.Marshal(condition)
+		require.NoError(t, err)
+
+		// has_masked_values should NOT appear in JSON when false (omitempty)
+		assert.NotContains(t, string(data), "has_masked_values")
+	})
+
+	t.Run("has_masked_values present when true", func(t *testing.T) {
+		condition := Condition{
+			Attribute:       "user.attributes.Program",
+			Operator:        "in",
+			Value:           []any{"Alpha"},
+			ValueType:       LiteralValue,
+			AttributeType:   "multiselect",
+			HasMaskedValues: true,
+		}
+
+		data, err := json.Marshal(condition)
+		require.NoError(t, err)
+
+		assert.Contains(t, string(data), `"has_masked_values":true`)
+	})
+
+	t.Run("has_masked_values defaults to false on unmarshal when absent", func(t *testing.T) {
+		// Simulate a response from an older server that doesn't include has_masked_values
+		jsonData := `{"attribute":"user.attributes.Team","operator":"==","value":"Engineering","value_type":0,"attribute_type":"select"}`
+
+		var condition Condition
+		err := json.Unmarshal([]byte(jsonData), &condition)
+		require.NoError(t, err)
+
+		assert.Equal(t, "user.attributes.Team", condition.Attribute)
+		assert.Equal(t, "==", condition.Operator)
+		assert.False(t, condition.HasMaskedValues)
+	})
+
+	t.Run("has_masked_values round-trips correctly when true", func(t *testing.T) {
+		original := Condition{
+			Attribute:       "user.attributes.Program",
+			Operator:        "in",
+			Value:           []any{"Alpha", "Bravo"},
+			ValueType:       LiteralValue,
+			AttributeType:   "multiselect",
+			HasMaskedValues: true,
+		}
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded Condition
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+
+		assert.Equal(t, original.Attribute, decoded.Attribute)
+		assert.Equal(t, original.Operator, decoded.Operator)
+		assert.Equal(t, original.AttributeType, decoded.AttributeType)
+		assert.True(t, decoded.HasMaskedValues)
+	})
+}
+
+func TestVisualExpressionJSON(t *testing.T) {
+	t.Run("visual expression with mixed masked and unmasked conditions", func(t *testing.T) {
+		ve := VisualExpression{
+			Conditions: []Condition{
+				{
+					Attribute:       "user.attributes.Program",
+					Operator:        "in",
+					Value:           []any{"Alpha"},
+					ValueType:       LiteralValue,
+					AttributeType:   "multiselect",
+					HasMaskedValues: true,
+				},
+				{
+					Attribute:     "user.attributes.Location",
+					Operator:      "==",
+					Value:         "Building 1",
+					ValueType:     LiteralValue,
+					AttributeType: "select",
+					// HasMaskedValues defaults to false — no masking on this condition
+				},
+			},
+		}
+
+		data, err := json.Marshal(ve)
+		require.NoError(t, err)
+
+		jsonStr := string(data)
+
+		// First condition should have has_masked_values
+		assert.Contains(t, jsonStr, `"has_masked_values":true`)
+
+		var decoded VisualExpression
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+
+		require.Len(t, decoded.Conditions, 2)
+		assert.True(t, decoded.Conditions[0].HasMaskedValues)
+		assert.False(t, decoded.Conditions[1].HasMaskedValues)
+	})
+}

--- a/server/public/model/cel_test.go
+++ b/server/public/model/cel_test.go
@@ -14,11 +14,11 @@ import (
 func TestConditionJSON_HasMaskedValuesOmitEmpty(t *testing.T) {
 	t.Run("has_masked_values omitted when false", func(t *testing.T) {
 		condition := Condition{
-			Attribute:     "user.attributes.Program",
-			Operator:      "==",
-			Value:         "Alpha",
-			ValueType:     LiteralValue,
-			AttributeType: "select",
+			Attribute:       "user.attributes.Program",
+			Operator:        "==",
+			Value:           "Alpha",
+			ValueType:       LiteralValue,
+			AttributeType:   "select",
 			HasMaskedValues: false,
 		}
 

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -69,6 +69,10 @@ type FeatureFlags struct {
 
 	AttributeBasedAccessControl bool
 
+	// Mask non-held attribute values in the policy editor for delegated admins.
+	// Requires AttributeBasedAccessControl.
+	AttributeValueMasking bool
+
 	// Enable permission policies (file upload/download ABAC policies).
 	// Requires AttributeBasedAccessControl to also be enabled.
 	PermissionPolicies bool
@@ -135,6 +139,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.ExperimentalAuditSettingsSystemConsoleUI = true
 	f.CustomProfileAttributes = true
 	f.AttributeBasedAccessControl = true
+	f.AttributeValueMasking = false
 	f.PermissionPolicies = false
 	f.ContentFlagging = true
 	f.InteractiveDialogAppsForm = true

--- a/server/public/model/feature_flags_test.go
+++ b/server/public/model/feature_flags_test.go
@@ -33,6 +33,14 @@ func TestFeatureFlagsToMap(t *testing.T) {
 	}
 }
 
+func TestFeatureFlagsSetDefaults_AttributeValueMasking(t *testing.T) {
+	var flags FeatureFlags
+	flags.SetDefaults()
+
+	require.False(t, flags.AttributeValueMasking, "AttributeValueMasking should default to false")
+	require.Equal(t, "false", flags.ToMap()["AttributeValueMasking"])
+}
+
 func TestFeatureFlagsToMapBool(t *testing.T) {
 	for name, tc := range map[string]struct {
 		Flags            FeatureFlags


### PR DESCRIPTION
#### Summary
This PR introduces the AttributeValueMasking feature flag (off by default) and a HasMaskedValues bool field on the Condition  model, which signals to clients that some values in a policy condition were omitted due to the caller's access level. The flag gates the entire masking feature.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68500


#### Screenshots
N/A


#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Additive, backward-compatible changes limited to public model serialization (new `has_masked_values` with `omitempty`) and a gated feature flag defaulting to false, so existing behavior and clients remain unaffected; tests cover marshal/unmarshal paths. The risk is minimal since no auth, persistence, or core business logic is modified and the feature is opt-in via the flag.

**QA Recommendation:** Minimal manual QA — smoke test policy editor flows with the flag disabled (default) and enable the flag to verify masking visibility in integration/feature tests.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->