### PR TITLE
[MM-68655] Surface RPC errors from plugin hooks

### DIFF
--- a/server/channels/app/channels.go
+++ b/server/channels/app/channels.go
@@ -333,7 +333,7 @@ func (ch *Channels) RunMultiHook(hookRunnerFunc func(hooks plugin.Hooks, manifes
 // invoked; (b) iteration completed and every closure invocation returned nil. Callers that need
 // fail-closed semantics on case (a) must check `ch.GetPluginsEnvironment() != nil` at the call site
 // before invoking — the right policy when plugins are disabled by config is caller-specific.
-func (ch *Channels) RunMultiHookWithRPCErr(hookRunnerFunc func(hooks plugin.HooksRPCErr, manifest *model.Manifest) (bool, error), hookId int) error {
+func (ch *Channels) RunMultiHookWithRPCErr(hookRunnerFunc func(hooks plugin.HooksWithRPCErr, manifest *model.Manifest) (bool, error), hookId int) error {
 	if env := ch.GetPluginsEnvironment(); env != nil {
 		return env.RunMultiPluginHookWithRPCErr(hookRunnerFunc, hookId)
 	}

--- a/server/channels/app/channels.go
+++ b/server/channels/app/channels.go
@@ -327,6 +327,19 @@ func (ch *Channels) RunMultiHook(hookRunnerFunc func(hooks plugin.Hooks, manifes
 	}
 }
 
+// RunMultiHookWithRPCErr dispatches a hook closure across active plugins, surfacing RPC transport
+// errors. Returns nil in two cases that callers must distinguish themselves: (a) the plugin
+// environment is unavailable (plugins disabled, or not yet initialized), so the closure was never
+// invoked; (b) iteration completed and every closure invocation returned nil. Callers that need
+// fail-closed semantics on case (a) must check `ch.GetPluginsEnvironment() != nil` at the call site
+// before invoking — the right policy when plugins are disabled by config is caller-specific.
+func (ch *Channels) RunMultiHookWithRPCErr(hookRunnerFunc func(hooks plugin.HooksRPCErr, manifest *model.Manifest) (bool, error), hookId int) error {
+	if env := ch.GetPluginsEnvironment(); env != nil {
+		return env.RunMultiPluginHookWithRPCErr(hookRunnerFunc, hookId)
+	}
+	return nil
+}
+
 func (ch *Channels) HooksForPlugin(id string) (plugin.Hooks, error) {
 	env := ch.GetPluginsEnvironment()
 	if env == nil {

--- a/server/go.mod
+++ b/server/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
+	github.com/prometheus/common v0.67.5
 	github.com/redis/rueidis v1.0.73
 	github.com/reflog/dateconstraints v0.2.1
 	github.com/rs/cors v1.11.1
@@ -181,7 +182,6 @@ require (
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/redis/go-redis/v9 v9.18.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -358,8 +358,6 @@ github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
-github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728 h1:QwWKgMY28TAXaDl+ExRDqGQltzXqN/xypdKP86niVn8=
-github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728/go.mod h1:1fEHWurg7pvf5SG6XNE5Q8UZmOwex51Mkx3SLhrW5B4=
 github.com/levigross/exp-html v0.0.0-20120902181939-8df60c69a8f5 h1:W7p+m/AECTL3s/YR5RpQ4hz5SjNeKzZBl1q36ws12s0=
 github.com/levigross/exp-html v0.0.0-20120902181939-8df60c69a8f5/go.mod h1:QMe2wuKJ0o7zIVE8AqiT8rd8epmm6WDIZ2wyuBqYPzM=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -47,7 +47,7 @@ func (g *hooksRPCClient) OnDeactivateWithRPCErr() (error, error) {
 		_err = g.client.Call("Plugin.OnDeactivate", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_OnDeactivateReturns{}
 			g.log.Debug("RPC call OnDeactivate to plugin failed.", mlog.Err(_err))
 		}
@@ -99,7 +99,7 @@ func (g *hooksRPCClient) OnConfigurationChangeWithRPCErr() (error, error) {
 		_err = g.client.Call("Plugin.OnConfigurationChange", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_OnConfigurationChangeReturns{}
 			g.log.Debug("RPC call OnConfigurationChange to plugin failed.", mlog.Err(_err))
 		}
@@ -154,7 +154,7 @@ func (g *hooksRPCClient) ExecuteCommandWithRPCErr(c *Context, args *model.Comman
 		_err = g.client.Call("Plugin.ExecuteCommand", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_ExecuteCommandReturns{}
 			g.log.Debug("RPC call ExecuteCommand to plugin failed.", mlog.Err(_err))
 		}
@@ -206,7 +206,7 @@ func (g *hooksRPCClient) UserHasBeenCreatedWithRPCErr(c *Context, user *model.Us
 		_err = g.client.Call("Plugin.UserHasBeenCreated", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_UserHasBeenCreatedReturns{}
 			g.log.Debug("RPC call UserHasBeenCreated to plugin failed.", mlog.Err(_err))
 		}
@@ -259,7 +259,7 @@ func (g *hooksRPCClient) UserWillLogInWithRPCErr(c *Context, user *model.User) (
 		_err = g.client.Call("Plugin.UserWillLogIn", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_UserWillLogInReturns{}
 			g.log.Debug("RPC call UserWillLogIn to plugin failed.", mlog.Err(_err))
 		}
@@ -311,7 +311,7 @@ func (g *hooksRPCClient) UserHasLoggedInWithRPCErr(c *Context, user *model.User)
 		_err = g.client.Call("Plugin.UserHasLoggedIn", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_UserHasLoggedInReturns{}
 			g.log.Debug("RPC call UserHasLoggedIn to plugin failed.", mlog.Err(_err))
 		}
@@ -363,7 +363,7 @@ func (g *hooksRPCClient) MessageHasBeenPostedWithRPCErr(c *Context, post *model.
 		_err = g.client.Call("Plugin.MessageHasBeenPosted", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_MessageHasBeenPostedReturns{}
 			g.log.Debug("RPC call MessageHasBeenPosted to plugin failed.", mlog.Err(_err))
 		}
@@ -416,7 +416,7 @@ func (g *hooksRPCClient) MessageHasBeenUpdatedWithRPCErr(c *Context, newPost, ol
 		_err = g.client.Call("Plugin.MessageHasBeenUpdated", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_MessageHasBeenUpdatedReturns{}
 			g.log.Debug("RPC call MessageHasBeenUpdated to plugin failed.", mlog.Err(_err))
 		}
@@ -468,7 +468,7 @@ func (g *hooksRPCClient) MessageHasBeenDeletedWithRPCErr(c *Context, post *model
 		_err = g.client.Call("Plugin.MessageHasBeenDeleted", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_MessageHasBeenDeletedReturns{}
 			g.log.Debug("RPC call MessageHasBeenDeleted to plugin failed.", mlog.Err(_err))
 		}
@@ -520,7 +520,7 @@ func (g *hooksRPCClient) ChannelHasBeenCreatedWithRPCErr(c *Context, channel *mo
 		_err = g.client.Call("Plugin.ChannelHasBeenCreated", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_ChannelHasBeenCreatedReturns{}
 			g.log.Debug("RPC call ChannelHasBeenCreated to plugin failed.", mlog.Err(_err))
 		}
@@ -573,7 +573,7 @@ func (g *hooksRPCClient) ChannelWillBeArchivedWithRPCErr(c *Context, channel *mo
 		_err = g.client.Call("Plugin.ChannelWillBeArchived", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_ChannelWillBeArchivedReturns{}
 			g.log.Debug("RPC call ChannelWillBeArchived to plugin failed.", mlog.Err(_err))
 		}
@@ -626,7 +626,7 @@ func (g *hooksRPCClient) UserHasJoinedChannelWithRPCErr(c *Context, channelMembe
 		_err = g.client.Call("Plugin.UserHasJoinedChannel", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_UserHasJoinedChannelReturns{}
 			g.log.Debug("RPC call UserHasJoinedChannel to plugin failed.", mlog.Err(_err))
 		}
@@ -679,7 +679,7 @@ func (g *hooksRPCClient) UserHasLeftChannelWithRPCErr(c *Context, channelMember 
 		_err = g.client.Call("Plugin.UserHasLeftChannel", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_UserHasLeftChannelReturns{}
 			g.log.Debug("RPC call UserHasLeftChannel to plugin failed.", mlog.Err(_err))
 		}
@@ -732,7 +732,7 @@ func (g *hooksRPCClient) UserHasJoinedTeamWithRPCErr(c *Context, teamMember *mod
 		_err = g.client.Call("Plugin.UserHasJoinedTeam", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_UserHasJoinedTeamReturns{}
 			g.log.Debug("RPC call UserHasJoinedTeam to plugin failed.", mlog.Err(_err))
 		}
@@ -785,7 +785,7 @@ func (g *hooksRPCClient) UserHasLeftTeamWithRPCErr(c *Context, teamMember *model
 		_err = g.client.Call("Plugin.UserHasLeftTeam", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_UserHasLeftTeamReturns{}
 			g.log.Debug("RPC call UserHasLeftTeam to plugin failed.", mlog.Err(_err))
 		}
@@ -840,7 +840,7 @@ func (g *hooksRPCClient) FileWillBeDownloadedWithRPCErr(c *Context, fileInfo *mo
 		_err = g.client.Call("Plugin.FileWillBeDownloaded", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_FileWillBeDownloadedReturns{}
 			g.log.Debug("RPC call FileWillBeDownloaded to plugin failed.", mlog.Err(_err))
 		}
@@ -892,7 +892,7 @@ func (g *hooksRPCClient) ReactionHasBeenAddedWithRPCErr(c *Context, reaction *mo
 		_err = g.client.Call("Plugin.ReactionHasBeenAdded", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_ReactionHasBeenAddedReturns{}
 			g.log.Debug("RPC call ReactionHasBeenAdded to plugin failed.", mlog.Err(_err))
 		}
@@ -944,7 +944,7 @@ func (g *hooksRPCClient) ReactionHasBeenRemovedWithRPCErr(c *Context, reaction *
 		_err = g.client.Call("Plugin.ReactionHasBeenRemoved", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_ReactionHasBeenRemovedReturns{}
 			g.log.Debug("RPC call ReactionHasBeenRemoved to plugin failed.", mlog.Err(_err))
 		}
@@ -996,7 +996,7 @@ func (g *hooksRPCClient) OnPluginClusterEventWithRPCErr(c *Context, ev model.Plu
 		_err = g.client.Call("Plugin.OnPluginClusterEvent", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_OnPluginClusterEventReturns{}
 			g.log.Debug("RPC call OnPluginClusterEvent to plugin failed.", mlog.Err(_err))
 		}
@@ -1048,7 +1048,7 @@ func (g *hooksRPCClient) OnWebSocketConnectWithRPCErr(webConnID, userID string) 
 		_err = g.client.Call("Plugin.OnWebSocketConnect", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_OnWebSocketConnectReturns{}
 			g.log.Debug("RPC call OnWebSocketConnect to plugin failed.", mlog.Err(_err))
 		}
@@ -1100,7 +1100,7 @@ func (g *hooksRPCClient) OnWebSocketDisconnectWithRPCErr(webConnID, userID strin
 		_err = g.client.Call("Plugin.OnWebSocketDisconnect", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_OnWebSocketDisconnectReturns{}
 			g.log.Debug("RPC call OnWebSocketDisconnect to plugin failed.", mlog.Err(_err))
 		}
@@ -1153,7 +1153,7 @@ func (g *hooksRPCClient) WebSocketMessageHasBeenPostedWithRPCErr(webConnID, user
 		_err = g.client.Call("Plugin.WebSocketMessageHasBeenPosted", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_WebSocketMessageHasBeenPostedReturns{}
 			g.log.Debug("RPC call WebSocketMessageHasBeenPosted to plugin failed.", mlog.Err(_err))
 		}
@@ -1207,7 +1207,7 @@ func (g *hooksRPCClient) RunDataRetentionWithRPCErr(nowTime, batchSize int64) (i
 		_err = g.client.Call("Plugin.RunDataRetention", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_RunDataRetentionReturns{}
 			g.log.Debug("RPC call RunDataRetention to plugin failed.", mlog.Err(_err))
 		}
@@ -1261,7 +1261,7 @@ func (g *hooksRPCClient) OnInstallWithRPCErr(c *Context, event model.OnInstallEv
 		_err = g.client.Call("Plugin.OnInstall", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_OnInstallReturns{}
 			g.log.Debug("RPC call OnInstall to plugin failed.", mlog.Err(_err))
 		}
@@ -1312,7 +1312,7 @@ func (g *hooksRPCClient) OnSendDailyTelemetryWithRPCErr() error {
 		_err = g.client.Call("Plugin.OnSendDailyTelemetry", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_OnSendDailyTelemetryReturns{}
 			g.log.Debug("RPC call OnSendDailyTelemetry to plugin failed.", mlog.Err(_err))
 		}
@@ -1363,7 +1363,7 @@ func (g *hooksRPCClient) OnCloudLimitsUpdatedWithRPCErr(limits *model.ProductLim
 		_err = g.client.Call("Plugin.OnCloudLimitsUpdated", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_OnCloudLimitsUpdatedReturns{}
 			g.log.Debug("RPC call OnCloudLimitsUpdated to plugin failed.", mlog.Err(_err))
 		}
@@ -1416,7 +1416,7 @@ func (g *hooksRPCClient) ConfigurationWillBeSavedWithRPCErr(newCfg *model.Config
 		_err = g.client.Call("Plugin.ConfigurationWillBeSaved", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_ConfigurationWillBeSavedReturns{}
 			g.log.Debug("RPC call ConfigurationWillBeSaved to plugin failed.", mlog.Err(_err))
 		}
@@ -1470,7 +1470,7 @@ func (g *hooksRPCClient) EmailNotificationWillBeSentWithRPCErr(emailNotification
 		_err = g.client.Call("Plugin.EmailNotificationWillBeSent", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_EmailNotificationWillBeSentReturns{}
 			g.log.Debug("RPC call EmailNotificationWillBeSent to plugin failed.", mlog.Err(_err))
 		}
@@ -1524,7 +1524,7 @@ func (g *hooksRPCClient) NotificationWillBePushedWithRPCErr(pushNotification *mo
 		_err = g.client.Call("Plugin.NotificationWillBePushed", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_NotificationWillBePushedReturns{}
 			g.log.Debug("RPC call NotificationWillBePushed to plugin failed.", mlog.Err(_err))
 		}
@@ -1576,7 +1576,7 @@ func (g *hooksRPCClient) UserHasBeenDeactivatedWithRPCErr(c *Context, user *mode
 		_err = g.client.Call("Plugin.UserHasBeenDeactivated", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_UserHasBeenDeactivatedReturns{}
 			g.log.Debug("RPC call UserHasBeenDeactivated to plugin failed.", mlog.Err(_err))
 		}
@@ -1630,7 +1630,7 @@ func (g *hooksRPCClient) OnSharedChannelsSyncMsgWithRPCErr(msg *model.SyncMsg, r
 		_err = g.client.Call("Plugin.OnSharedChannelsSyncMsg", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_OnSharedChannelsSyncMsgReturns{}
 			g.log.Debug("RPC call OnSharedChannelsSyncMsg to plugin failed.", mlog.Err(_err))
 		}
@@ -1683,7 +1683,7 @@ func (g *hooksRPCClient) OnSharedChannelsPingWithRPCErr(rc *model.RemoteCluster)
 		_err = g.client.Call("Plugin.OnSharedChannelsPing", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_OnSharedChannelsPingReturns{}
 			g.log.Debug("RPC call OnSharedChannelsPing to plugin failed.", mlog.Err(_err))
 		}
@@ -1735,7 +1735,7 @@ func (g *hooksRPCClient) PreferencesHaveChangedWithRPCErr(c *Context, preference
 		_err = g.client.Call("Plugin.PreferencesHaveChanged", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_PreferencesHaveChangedReturns{}
 			g.log.Debug("RPC call PreferencesHaveChanged to plugin failed.", mlog.Err(_err))
 		}
@@ -1789,7 +1789,7 @@ func (g *hooksRPCClient) OnSharedChannelsAttachmentSyncMsgWithRPCErr(fi *model.F
 		_err = g.client.Call("Plugin.OnSharedChannelsAttachmentSyncMsg", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_OnSharedChannelsAttachmentSyncMsgReturns{}
 			g.log.Debug("RPC call OnSharedChannelsAttachmentSyncMsg to plugin failed.", mlog.Err(_err))
 		}
@@ -1843,7 +1843,7 @@ func (g *hooksRPCClient) OnSharedChannelsProfileImageSyncMsgWithRPCErr(user *mod
 		_err = g.client.Call("Plugin.OnSharedChannelsProfileImageSyncMsg", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_OnSharedChannelsProfileImageSyncMsgReturns{}
 			g.log.Debug("RPC call OnSharedChannelsProfileImageSyncMsg to plugin failed.", mlog.Err(_err))
 		}
@@ -1897,7 +1897,7 @@ func (g *hooksRPCClient) GenerateSupportDataWithRPCErr(c *Context) ([]*model.Fil
 		_err = g.client.Call("Plugin.GenerateSupportData", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_GenerateSupportDataReturns{}
 			g.log.Debug("RPC call GenerateSupportData to plugin failed.", mlog.Err(_err))
 		}
@@ -1952,7 +1952,7 @@ func (g *hooksRPCClient) OnSAMLLoginWithRPCErr(c *Context, user *model.User, ass
 		_err = g.client.Call("Plugin.OnSAMLLogin", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &Z_OnSAMLLoginReturns{}
 			g.log.Debug("RPC call OnSAMLLogin to plugin failed.", mlog.Err(_err))
 		}
@@ -1972,7 +1972,7 @@ func (s *hooksRPCServer) OnSAMLLogin(args *Z_OnSAMLLoginArgs, returns *Z_OnSAMLL
 	return nil
 }
 
-// HooksRPCErr is implemented by hooksRPCClient. It provides a WithRPCErr variant for every
+// HooksWithRPCErr is implemented by hooksRPCClient. It provides a WithRPCErr variant for every
 // generated hook. The last error return is always the RPC transport error — if non-nil, the
 // plugin's other return values are zero. For hooks whose base signature already returns error,
 // the tuple is (originalReturns..., rpcErr) where the final slot is always transport.
@@ -1981,8 +1981,8 @@ func (s *hooksRPCServer) OnSAMLLogin(args *Z_OnSAMLLoginArgs, returns *Z_OnSAMLL
 // indistinguishable from a successful invocation that returned zeros. Callers MUST gate on
 // supervisor.Implements(<HookID>) (or use Environment.RunMultiPluginHookWithRPCErr, which gates
 // by the iteration's hook ID — note that any *WithRPCErr method called on the closure's
-// HooksRPCErr is independently subject to its own implemented-gate).
-type HooksRPCErr interface {
+// HooksWithRPCErr is independently subject to its own implemented-gate).
+type HooksWithRPCErr interface {
 	OnDeactivateWithRPCErr() (error, error)
 
 	OnConfigurationChangeWithRPCErr() (error, error)

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -46,6 +46,9 @@ func (g *hooksRPCClient) OnDeactivateWithRPCErr() (error, error) {
 	if g.implemented[OnDeactivateID] {
 		_err = g.client.Call("Plugin.OnDeactivate", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_OnDeactivateReturns{}
 			g.log.Debug("RPC call OnDeactivate to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -95,6 +98,9 @@ func (g *hooksRPCClient) OnConfigurationChangeWithRPCErr() (error, error) {
 	if g.implemented[OnConfigurationChangeID] {
 		_err = g.client.Call("Plugin.OnConfigurationChange", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_OnConfigurationChangeReturns{}
 			g.log.Debug("RPC call OnConfigurationChange to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -147,6 +153,9 @@ func (g *hooksRPCClient) ExecuteCommandWithRPCErr(c *Context, args *model.Comman
 	if g.implemented[ExecuteCommandID] {
 		_err = g.client.Call("Plugin.ExecuteCommand", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_ExecuteCommandReturns{}
 			g.log.Debug("RPC call ExecuteCommand to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -196,6 +205,9 @@ func (g *hooksRPCClient) UserHasBeenCreatedWithRPCErr(c *Context, user *model.Us
 	if g.implemented[UserHasBeenCreatedID] {
 		_err = g.client.Call("Plugin.UserHasBeenCreated", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_UserHasBeenCreatedReturns{}
 			g.log.Debug("RPC call UserHasBeenCreated to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -246,6 +258,9 @@ func (g *hooksRPCClient) UserWillLogInWithRPCErr(c *Context, user *model.User) (
 	if g.implemented[UserWillLogInID] {
 		_err = g.client.Call("Plugin.UserWillLogIn", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_UserWillLogInReturns{}
 			g.log.Debug("RPC call UserWillLogIn to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -295,6 +310,9 @@ func (g *hooksRPCClient) UserHasLoggedInWithRPCErr(c *Context, user *model.User)
 	if g.implemented[UserHasLoggedInID] {
 		_err = g.client.Call("Plugin.UserHasLoggedIn", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_UserHasLoggedInReturns{}
 			g.log.Debug("RPC call UserHasLoggedIn to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -344,6 +362,9 @@ func (g *hooksRPCClient) MessageHasBeenPostedWithRPCErr(c *Context, post *model.
 	if g.implemented[MessageHasBeenPostedID] {
 		_err = g.client.Call("Plugin.MessageHasBeenPosted", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_MessageHasBeenPostedReturns{}
 			g.log.Debug("RPC call MessageHasBeenPosted to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -394,6 +415,9 @@ func (g *hooksRPCClient) MessageHasBeenUpdatedWithRPCErr(c *Context, newPost, ol
 	if g.implemented[MessageHasBeenUpdatedID] {
 		_err = g.client.Call("Plugin.MessageHasBeenUpdated", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_MessageHasBeenUpdatedReturns{}
 			g.log.Debug("RPC call MessageHasBeenUpdated to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -443,6 +467,9 @@ func (g *hooksRPCClient) MessageHasBeenDeletedWithRPCErr(c *Context, post *model
 	if g.implemented[MessageHasBeenDeletedID] {
 		_err = g.client.Call("Plugin.MessageHasBeenDeleted", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_MessageHasBeenDeletedReturns{}
 			g.log.Debug("RPC call MessageHasBeenDeleted to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -492,6 +519,9 @@ func (g *hooksRPCClient) ChannelHasBeenCreatedWithRPCErr(c *Context, channel *mo
 	if g.implemented[ChannelHasBeenCreatedID] {
 		_err = g.client.Call("Plugin.ChannelHasBeenCreated", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_ChannelHasBeenCreatedReturns{}
 			g.log.Debug("RPC call ChannelHasBeenCreated to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -542,6 +572,9 @@ func (g *hooksRPCClient) ChannelWillBeArchivedWithRPCErr(c *Context, channel *mo
 	if g.implemented[ChannelWillBeArchivedID] {
 		_err = g.client.Call("Plugin.ChannelWillBeArchived", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_ChannelWillBeArchivedReturns{}
 			g.log.Debug("RPC call ChannelWillBeArchived to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -592,6 +625,9 @@ func (g *hooksRPCClient) UserHasJoinedChannelWithRPCErr(c *Context, channelMembe
 	if g.implemented[UserHasJoinedChannelID] {
 		_err = g.client.Call("Plugin.UserHasJoinedChannel", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_UserHasJoinedChannelReturns{}
 			g.log.Debug("RPC call UserHasJoinedChannel to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -642,6 +678,9 @@ func (g *hooksRPCClient) UserHasLeftChannelWithRPCErr(c *Context, channelMember 
 	if g.implemented[UserHasLeftChannelID] {
 		_err = g.client.Call("Plugin.UserHasLeftChannel", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_UserHasLeftChannelReturns{}
 			g.log.Debug("RPC call UserHasLeftChannel to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -692,6 +731,9 @@ func (g *hooksRPCClient) UserHasJoinedTeamWithRPCErr(c *Context, teamMember *mod
 	if g.implemented[UserHasJoinedTeamID] {
 		_err = g.client.Call("Plugin.UserHasJoinedTeam", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_UserHasJoinedTeamReturns{}
 			g.log.Debug("RPC call UserHasJoinedTeam to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -742,6 +784,9 @@ func (g *hooksRPCClient) UserHasLeftTeamWithRPCErr(c *Context, teamMember *model
 	if g.implemented[UserHasLeftTeamID] {
 		_err = g.client.Call("Plugin.UserHasLeftTeam", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_UserHasLeftTeamReturns{}
 			g.log.Debug("RPC call UserHasLeftTeam to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -794,6 +839,9 @@ func (g *hooksRPCClient) FileWillBeDownloadedWithRPCErr(c *Context, fileInfo *mo
 	if g.implemented[FileWillBeDownloadedID] {
 		_err = g.client.Call("Plugin.FileWillBeDownloaded", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_FileWillBeDownloadedReturns{}
 			g.log.Debug("RPC call FileWillBeDownloaded to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -843,6 +891,9 @@ func (g *hooksRPCClient) ReactionHasBeenAddedWithRPCErr(c *Context, reaction *mo
 	if g.implemented[ReactionHasBeenAddedID] {
 		_err = g.client.Call("Plugin.ReactionHasBeenAdded", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_ReactionHasBeenAddedReturns{}
 			g.log.Debug("RPC call ReactionHasBeenAdded to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -892,6 +943,9 @@ func (g *hooksRPCClient) ReactionHasBeenRemovedWithRPCErr(c *Context, reaction *
 	if g.implemented[ReactionHasBeenRemovedID] {
 		_err = g.client.Call("Plugin.ReactionHasBeenRemoved", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_ReactionHasBeenRemovedReturns{}
 			g.log.Debug("RPC call ReactionHasBeenRemoved to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -941,6 +995,9 @@ func (g *hooksRPCClient) OnPluginClusterEventWithRPCErr(c *Context, ev model.Plu
 	if g.implemented[OnPluginClusterEventID] {
 		_err = g.client.Call("Plugin.OnPluginClusterEvent", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_OnPluginClusterEventReturns{}
 			g.log.Debug("RPC call OnPluginClusterEvent to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -990,6 +1047,9 @@ func (g *hooksRPCClient) OnWebSocketConnectWithRPCErr(webConnID, userID string) 
 	if g.implemented[OnWebSocketConnectID] {
 		_err = g.client.Call("Plugin.OnWebSocketConnect", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_OnWebSocketConnectReturns{}
 			g.log.Debug("RPC call OnWebSocketConnect to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -1039,6 +1099,9 @@ func (g *hooksRPCClient) OnWebSocketDisconnectWithRPCErr(webConnID, userID strin
 	if g.implemented[OnWebSocketDisconnectID] {
 		_err = g.client.Call("Plugin.OnWebSocketDisconnect", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_OnWebSocketDisconnectReturns{}
 			g.log.Debug("RPC call OnWebSocketDisconnect to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -1089,6 +1152,9 @@ func (g *hooksRPCClient) WebSocketMessageHasBeenPostedWithRPCErr(webConnID, user
 	if g.implemented[WebSocketMessageHasBeenPostedID] {
 		_err = g.client.Call("Plugin.WebSocketMessageHasBeenPosted", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_WebSocketMessageHasBeenPostedReturns{}
 			g.log.Debug("RPC call WebSocketMessageHasBeenPosted to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -1140,6 +1206,9 @@ func (g *hooksRPCClient) RunDataRetentionWithRPCErr(nowTime, batchSize int64) (i
 	if g.implemented[RunDataRetentionID] {
 		_err = g.client.Call("Plugin.RunDataRetention", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_RunDataRetentionReturns{}
 			g.log.Debug("RPC call RunDataRetention to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -1191,6 +1260,9 @@ func (g *hooksRPCClient) OnInstallWithRPCErr(c *Context, event model.OnInstallEv
 	if g.implemented[OnInstallID] {
 		_err = g.client.Call("Plugin.OnInstall", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_OnInstallReturns{}
 			g.log.Debug("RPC call OnInstall to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -1239,6 +1311,9 @@ func (g *hooksRPCClient) OnSendDailyTelemetryWithRPCErr() error {
 	if g.implemented[OnSendDailyTelemetryID] {
 		_err = g.client.Call("Plugin.OnSendDailyTelemetry", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_OnSendDailyTelemetryReturns{}
 			g.log.Debug("RPC call OnSendDailyTelemetry to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -1287,6 +1362,9 @@ func (g *hooksRPCClient) OnCloudLimitsUpdatedWithRPCErr(limits *model.ProductLim
 	if g.implemented[OnCloudLimitsUpdatedID] {
 		_err = g.client.Call("Plugin.OnCloudLimitsUpdated", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_OnCloudLimitsUpdatedReturns{}
 			g.log.Debug("RPC call OnCloudLimitsUpdated to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -1337,6 +1415,9 @@ func (g *hooksRPCClient) ConfigurationWillBeSavedWithRPCErr(newCfg *model.Config
 	if g.implemented[ConfigurationWillBeSavedID] {
 		_err = g.client.Call("Plugin.ConfigurationWillBeSaved", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_ConfigurationWillBeSavedReturns{}
 			g.log.Debug("RPC call ConfigurationWillBeSaved to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -1388,6 +1469,9 @@ func (g *hooksRPCClient) EmailNotificationWillBeSentWithRPCErr(emailNotification
 	if g.implemented[EmailNotificationWillBeSentID] {
 		_err = g.client.Call("Plugin.EmailNotificationWillBeSent", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_EmailNotificationWillBeSentReturns{}
 			g.log.Debug("RPC call EmailNotificationWillBeSent to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -1439,6 +1523,9 @@ func (g *hooksRPCClient) NotificationWillBePushedWithRPCErr(pushNotification *mo
 	if g.implemented[NotificationWillBePushedID] {
 		_err = g.client.Call("Plugin.NotificationWillBePushed", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_NotificationWillBePushedReturns{}
 			g.log.Debug("RPC call NotificationWillBePushed to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -1488,6 +1575,9 @@ func (g *hooksRPCClient) UserHasBeenDeactivatedWithRPCErr(c *Context, user *mode
 	if g.implemented[UserHasBeenDeactivatedID] {
 		_err = g.client.Call("Plugin.UserHasBeenDeactivated", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_UserHasBeenDeactivatedReturns{}
 			g.log.Debug("RPC call UserHasBeenDeactivated to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -1539,6 +1629,9 @@ func (g *hooksRPCClient) OnSharedChannelsSyncMsgWithRPCErr(msg *model.SyncMsg, r
 	if g.implemented[OnSharedChannelsSyncMsgID] {
 		_err = g.client.Call("Plugin.OnSharedChannelsSyncMsg", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_OnSharedChannelsSyncMsgReturns{}
 			g.log.Debug("RPC call OnSharedChannelsSyncMsg to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -1589,6 +1682,9 @@ func (g *hooksRPCClient) OnSharedChannelsPingWithRPCErr(rc *model.RemoteCluster)
 	if g.implemented[OnSharedChannelsPingID] {
 		_err = g.client.Call("Plugin.OnSharedChannelsPing", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_OnSharedChannelsPingReturns{}
 			g.log.Debug("RPC call OnSharedChannelsPing to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -1638,6 +1734,9 @@ func (g *hooksRPCClient) PreferencesHaveChangedWithRPCErr(c *Context, preference
 	if g.implemented[PreferencesHaveChangedID] {
 		_err = g.client.Call("Plugin.PreferencesHaveChanged", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_PreferencesHaveChangedReturns{}
 			g.log.Debug("RPC call PreferencesHaveChanged to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -1689,6 +1788,9 @@ func (g *hooksRPCClient) OnSharedChannelsAttachmentSyncMsgWithRPCErr(fi *model.F
 	if g.implemented[OnSharedChannelsAttachmentSyncMsgID] {
 		_err = g.client.Call("Plugin.OnSharedChannelsAttachmentSyncMsg", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_OnSharedChannelsAttachmentSyncMsgReturns{}
 			g.log.Debug("RPC call OnSharedChannelsAttachmentSyncMsg to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -1740,6 +1842,9 @@ func (g *hooksRPCClient) OnSharedChannelsProfileImageSyncMsgWithRPCErr(user *mod
 	if g.implemented[OnSharedChannelsProfileImageSyncMsgID] {
 		_err = g.client.Call("Plugin.OnSharedChannelsProfileImageSyncMsg", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_OnSharedChannelsProfileImageSyncMsgReturns{}
 			g.log.Debug("RPC call OnSharedChannelsProfileImageSyncMsg to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -1791,6 +1896,9 @@ func (g *hooksRPCClient) GenerateSupportDataWithRPCErr(c *Context) ([]*model.Fil
 	if g.implemented[GenerateSupportDataID] {
 		_err = g.client.Call("Plugin.GenerateSupportData", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_GenerateSupportDataReturns{}
 			g.log.Debug("RPC call GenerateSupportData to plugin failed.", mlog.Err(_err))
 		}
 	}
@@ -1843,6 +1951,9 @@ func (g *hooksRPCClient) OnSAMLLoginWithRPCErr(c *Context, user *model.User, ass
 	if g.implemented[OnSAMLLoginID] {
 		_err = g.client.Call("Plugin.OnSAMLLogin", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &Z_OnSAMLLoginReturns{}
 			g.log.Debug("RPC call OnSAMLLogin to plugin failed.", mlog.Err(_err))
 		}
 	}

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -1972,10 +1972,10 @@ func (s *hooksRPCServer) OnSAMLLogin(args *Z_OnSAMLLoginArgs, returns *Z_OnSAMLL
 	return nil
 }
 
-// HooksWithRPCErr is implemented by hooksRPCClient. It provides a WithRPCErr variant for every
-// generated hook. The last error return is always the RPC transport error — if non-nil, the
-// plugin's other return values are zero. For hooks whose base signature already returns error,
-// the tuple is (originalReturns..., rpcErr) where the final slot is always transport.
+// HooksWithRPCErr provides a WithRPCErr variant for every generated hook. The last error return
+// is always the RPC transport error — if non-nil, the plugin's other return values are zero. For
+// hooks whose base signature already returns error, the tuple is (originalReturns..., rpcErr)
+// where the final slot is always transport.
 //
 // If the plugin does not implement the hook, the companion returns zero values and a nil error —
 // indistinguishable from a successful invocation that returned zeros. Callers MUST gate on

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -37,6 +37,21 @@ func (g *hooksRPCClient) OnDeactivate() error {
 	return _returns.A
 }
 
+// OnDeactivateWithRPCErr returns the same values as OnDeactivate, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) OnDeactivateWithRPCErr() (error, error) {
+	_args := &Z_OnDeactivateArgs{}
+	_returns := &Z_OnDeactivateReturns{}
+	var _err error
+	if g.implemented[OnDeactivateID] {
+		_err = g.client.Call("Plugin.OnDeactivate", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call OnDeactivate to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _err
+}
+
 func (s *hooksRPCServer) OnDeactivate(args *Z_OnDeactivateArgs, returns *Z_OnDeactivateReturns) error {
 	if hook, ok := s.impl.(interface {
 		OnDeactivate() error
@@ -69,6 +84,21 @@ func (g *hooksRPCClient) OnConfigurationChange() error {
 		}
 	}
 	return _returns.A
+}
+
+// OnConfigurationChangeWithRPCErr returns the same values as OnConfigurationChange, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) OnConfigurationChangeWithRPCErr() (error, error) {
+	_args := &Z_OnConfigurationChangeArgs{}
+	_returns := &Z_OnConfigurationChangeReturns{}
+	var _err error
+	if g.implemented[OnConfigurationChangeID] {
+		_err = g.client.Call("Plugin.OnConfigurationChange", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call OnConfigurationChange to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _err
 }
 
 func (s *hooksRPCServer) OnConfigurationChange(args *Z_OnConfigurationChangeArgs, returns *Z_OnConfigurationChangeReturns) error {
@@ -108,6 +138,21 @@ func (g *hooksRPCClient) ExecuteCommand(c *Context, args *model.CommandArgs) (*m
 	return _returns.A, _returns.B
 }
 
+// ExecuteCommandWithRPCErr returns the same values as ExecuteCommand, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) ExecuteCommandWithRPCErr(c *Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError, error) {
+	_args := &Z_ExecuteCommandArgs{c, args}
+	_returns := &Z_ExecuteCommandReturns{}
+	var _err error
+	if g.implemented[ExecuteCommandID] {
+		_err = g.client.Call("Plugin.ExecuteCommand", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call ExecuteCommand to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _returns.B, _err
+}
+
 func (s *hooksRPCServer) ExecuteCommand(args *Z_ExecuteCommandArgs, returns *Z_ExecuteCommandReturns) error {
 	if hook, ok := s.impl.(interface {
 		ExecuteCommand(c *Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError)
@@ -140,6 +185,21 @@ func (g *hooksRPCClient) UserHasBeenCreated(c *Context, user *model.User) {
 		}
 	}
 
+}
+
+// UserHasBeenCreatedWithRPCErr returns the same values as UserHasBeenCreated, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) UserHasBeenCreatedWithRPCErr(c *Context, user *model.User) error {
+	_args := &Z_UserHasBeenCreatedArgs{c, user}
+	_returns := &Z_UserHasBeenCreatedReturns{}
+	var _err error
+	if g.implemented[UserHasBeenCreatedID] {
+		_err = g.client.Call("Plugin.UserHasBeenCreated", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call UserHasBeenCreated to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
 }
 
 func (s *hooksRPCServer) UserHasBeenCreated(args *Z_UserHasBeenCreatedArgs, returns *Z_UserHasBeenCreatedReturns) error {
@@ -177,6 +237,21 @@ func (g *hooksRPCClient) UserWillLogIn(c *Context, user *model.User) string {
 	return _returns.A
 }
 
+// UserWillLogInWithRPCErr returns the same values as UserWillLogIn, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) UserWillLogInWithRPCErr(c *Context, user *model.User) (string, error) {
+	_args := &Z_UserWillLogInArgs{c, user}
+	_returns := &Z_UserWillLogInReturns{}
+	var _err error
+	if g.implemented[UserWillLogInID] {
+		_err = g.client.Call("Plugin.UserWillLogIn", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call UserWillLogIn to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _err
+}
+
 func (s *hooksRPCServer) UserWillLogIn(args *Z_UserWillLogInArgs, returns *Z_UserWillLogInReturns) error {
 	if hook, ok := s.impl.(interface {
 		UserWillLogIn(c *Context, user *model.User) string
@@ -211,6 +286,21 @@ func (g *hooksRPCClient) UserHasLoggedIn(c *Context, user *model.User) {
 
 }
 
+// UserHasLoggedInWithRPCErr returns the same values as UserHasLoggedIn, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) UserHasLoggedInWithRPCErr(c *Context, user *model.User) error {
+	_args := &Z_UserHasLoggedInArgs{c, user}
+	_returns := &Z_UserHasLoggedInReturns{}
+	var _err error
+	if g.implemented[UserHasLoggedInID] {
+		_err = g.client.Call("Plugin.UserHasLoggedIn", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call UserHasLoggedIn to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
+}
+
 func (s *hooksRPCServer) UserHasLoggedIn(args *Z_UserHasLoggedInArgs, returns *Z_UserHasLoggedInReturns) error {
 	if hook, ok := s.impl.(interface {
 		UserHasLoggedIn(c *Context, user *model.User)
@@ -243,6 +333,21 @@ func (g *hooksRPCClient) MessageHasBeenPosted(c *Context, post *model.Post) {
 		}
 	}
 
+}
+
+// MessageHasBeenPostedWithRPCErr returns the same values as MessageHasBeenPosted, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) MessageHasBeenPostedWithRPCErr(c *Context, post *model.Post) error {
+	_args := &Z_MessageHasBeenPostedArgs{c, post}
+	_returns := &Z_MessageHasBeenPostedReturns{}
+	var _err error
+	if g.implemented[MessageHasBeenPostedID] {
+		_err = g.client.Call("Plugin.MessageHasBeenPosted", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call MessageHasBeenPosted to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
 }
 
 func (s *hooksRPCServer) MessageHasBeenPosted(args *Z_MessageHasBeenPostedArgs, returns *Z_MessageHasBeenPostedReturns) error {
@@ -280,6 +385,21 @@ func (g *hooksRPCClient) MessageHasBeenUpdated(c *Context, newPost, oldPost *mod
 
 }
 
+// MessageHasBeenUpdatedWithRPCErr returns the same values as MessageHasBeenUpdated, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) MessageHasBeenUpdatedWithRPCErr(c *Context, newPost, oldPost *model.Post) error {
+	_args := &Z_MessageHasBeenUpdatedArgs{c, newPost, oldPost}
+	_returns := &Z_MessageHasBeenUpdatedReturns{}
+	var _err error
+	if g.implemented[MessageHasBeenUpdatedID] {
+		_err = g.client.Call("Plugin.MessageHasBeenUpdated", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call MessageHasBeenUpdated to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
+}
+
 func (s *hooksRPCServer) MessageHasBeenUpdated(args *Z_MessageHasBeenUpdatedArgs, returns *Z_MessageHasBeenUpdatedReturns) error {
 	if hook, ok := s.impl.(interface {
 		MessageHasBeenUpdated(c *Context, newPost, oldPost *model.Post)
@@ -314,6 +434,21 @@ func (g *hooksRPCClient) MessageHasBeenDeleted(c *Context, post *model.Post) {
 
 }
 
+// MessageHasBeenDeletedWithRPCErr returns the same values as MessageHasBeenDeleted, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) MessageHasBeenDeletedWithRPCErr(c *Context, post *model.Post) error {
+	_args := &Z_MessageHasBeenDeletedArgs{c, post}
+	_returns := &Z_MessageHasBeenDeletedReturns{}
+	var _err error
+	if g.implemented[MessageHasBeenDeletedID] {
+		_err = g.client.Call("Plugin.MessageHasBeenDeleted", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call MessageHasBeenDeleted to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
+}
+
 func (s *hooksRPCServer) MessageHasBeenDeleted(args *Z_MessageHasBeenDeletedArgs, returns *Z_MessageHasBeenDeletedReturns) error {
 	if hook, ok := s.impl.(interface {
 		MessageHasBeenDeleted(c *Context, post *model.Post)
@@ -346,6 +481,21 @@ func (g *hooksRPCClient) ChannelHasBeenCreated(c *Context, channel *model.Channe
 		}
 	}
 
+}
+
+// ChannelHasBeenCreatedWithRPCErr returns the same values as ChannelHasBeenCreated, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) ChannelHasBeenCreatedWithRPCErr(c *Context, channel *model.Channel) error {
+	_args := &Z_ChannelHasBeenCreatedArgs{c, channel}
+	_returns := &Z_ChannelHasBeenCreatedReturns{}
+	var _err error
+	if g.implemented[ChannelHasBeenCreatedID] {
+		_err = g.client.Call("Plugin.ChannelHasBeenCreated", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call ChannelHasBeenCreated to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
 }
 
 func (s *hooksRPCServer) ChannelHasBeenCreated(args *Z_ChannelHasBeenCreatedArgs, returns *Z_ChannelHasBeenCreatedReturns) error {
@@ -383,6 +533,21 @@ func (g *hooksRPCClient) ChannelWillBeArchived(c *Context, channel *model.Channe
 	return _returns.A
 }
 
+// ChannelWillBeArchivedWithRPCErr returns the same values as ChannelWillBeArchived, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) ChannelWillBeArchivedWithRPCErr(c *Context, channel *model.Channel) (string, error) {
+	_args := &Z_ChannelWillBeArchivedArgs{c, channel}
+	_returns := &Z_ChannelWillBeArchivedReturns{}
+	var _err error
+	if g.implemented[ChannelWillBeArchivedID] {
+		_err = g.client.Call("Plugin.ChannelWillBeArchived", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call ChannelWillBeArchived to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _err
+}
+
 func (s *hooksRPCServer) ChannelWillBeArchived(args *Z_ChannelWillBeArchivedArgs, returns *Z_ChannelWillBeArchivedReturns) error {
 	if hook, ok := s.impl.(interface {
 		ChannelWillBeArchived(c *Context, channel *model.Channel) string
@@ -416,6 +581,21 @@ func (g *hooksRPCClient) UserHasJoinedChannel(c *Context, channelMember *model.C
 		}
 	}
 
+}
+
+// UserHasJoinedChannelWithRPCErr returns the same values as UserHasJoinedChannel, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) UserHasJoinedChannelWithRPCErr(c *Context, channelMember *model.ChannelMember, actor *model.User) error {
+	_args := &Z_UserHasJoinedChannelArgs{c, channelMember, actor}
+	_returns := &Z_UserHasJoinedChannelReturns{}
+	var _err error
+	if g.implemented[UserHasJoinedChannelID] {
+		_err = g.client.Call("Plugin.UserHasJoinedChannel", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call UserHasJoinedChannel to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
 }
 
 func (s *hooksRPCServer) UserHasJoinedChannel(args *Z_UserHasJoinedChannelArgs, returns *Z_UserHasJoinedChannelReturns) error {
@@ -453,6 +633,21 @@ func (g *hooksRPCClient) UserHasLeftChannel(c *Context, channelMember *model.Cha
 
 }
 
+// UserHasLeftChannelWithRPCErr returns the same values as UserHasLeftChannel, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) UserHasLeftChannelWithRPCErr(c *Context, channelMember *model.ChannelMember, actor *model.User) error {
+	_args := &Z_UserHasLeftChannelArgs{c, channelMember, actor}
+	_returns := &Z_UserHasLeftChannelReturns{}
+	var _err error
+	if g.implemented[UserHasLeftChannelID] {
+		_err = g.client.Call("Plugin.UserHasLeftChannel", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call UserHasLeftChannel to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
+}
+
 func (s *hooksRPCServer) UserHasLeftChannel(args *Z_UserHasLeftChannelArgs, returns *Z_UserHasLeftChannelReturns) error {
 	if hook, ok := s.impl.(interface {
 		UserHasLeftChannel(c *Context, channelMember *model.ChannelMember, actor *model.User)
@@ -488,6 +683,21 @@ func (g *hooksRPCClient) UserHasJoinedTeam(c *Context, teamMember *model.TeamMem
 
 }
 
+// UserHasJoinedTeamWithRPCErr returns the same values as UserHasJoinedTeam, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) UserHasJoinedTeamWithRPCErr(c *Context, teamMember *model.TeamMember, actor *model.User) error {
+	_args := &Z_UserHasJoinedTeamArgs{c, teamMember, actor}
+	_returns := &Z_UserHasJoinedTeamReturns{}
+	var _err error
+	if g.implemented[UserHasJoinedTeamID] {
+		_err = g.client.Call("Plugin.UserHasJoinedTeam", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call UserHasJoinedTeam to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
+}
+
 func (s *hooksRPCServer) UserHasJoinedTeam(args *Z_UserHasJoinedTeamArgs, returns *Z_UserHasJoinedTeamReturns) error {
 	if hook, ok := s.impl.(interface {
 		UserHasJoinedTeam(c *Context, teamMember *model.TeamMember, actor *model.User)
@@ -521,6 +731,21 @@ func (g *hooksRPCClient) UserHasLeftTeam(c *Context, teamMember *model.TeamMembe
 		}
 	}
 
+}
+
+// UserHasLeftTeamWithRPCErr returns the same values as UserHasLeftTeam, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) UserHasLeftTeamWithRPCErr(c *Context, teamMember *model.TeamMember, actor *model.User) error {
+	_args := &Z_UserHasLeftTeamArgs{c, teamMember, actor}
+	_returns := &Z_UserHasLeftTeamReturns{}
+	var _err error
+	if g.implemented[UserHasLeftTeamID] {
+		_err = g.client.Call("Plugin.UserHasLeftTeam", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call UserHasLeftTeam to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
 }
 
 func (s *hooksRPCServer) UserHasLeftTeam(args *Z_UserHasLeftTeamArgs, returns *Z_UserHasLeftTeamReturns) error {
@@ -560,6 +785,21 @@ func (g *hooksRPCClient) FileWillBeDownloaded(c *Context, fileInfo *model.FileIn
 	return _returns.A
 }
 
+// FileWillBeDownloadedWithRPCErr returns the same values as FileWillBeDownloaded, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) FileWillBeDownloadedWithRPCErr(c *Context, fileInfo *model.FileInfo, userID string, downloadType model.FileDownloadType) (string, error) {
+	_args := &Z_FileWillBeDownloadedArgs{c, fileInfo, userID, downloadType}
+	_returns := &Z_FileWillBeDownloadedReturns{}
+	var _err error
+	if g.implemented[FileWillBeDownloadedID] {
+		_err = g.client.Call("Plugin.FileWillBeDownloaded", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call FileWillBeDownloaded to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _err
+}
+
 func (s *hooksRPCServer) FileWillBeDownloaded(args *Z_FileWillBeDownloadedArgs, returns *Z_FileWillBeDownloadedReturns) error {
 	if hook, ok := s.impl.(interface {
 		FileWillBeDownloaded(c *Context, fileInfo *model.FileInfo, userID string, downloadType model.FileDownloadType) string
@@ -592,6 +832,21 @@ func (g *hooksRPCClient) ReactionHasBeenAdded(c *Context, reaction *model.Reacti
 		}
 	}
 
+}
+
+// ReactionHasBeenAddedWithRPCErr returns the same values as ReactionHasBeenAdded, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) ReactionHasBeenAddedWithRPCErr(c *Context, reaction *model.Reaction) error {
+	_args := &Z_ReactionHasBeenAddedArgs{c, reaction}
+	_returns := &Z_ReactionHasBeenAddedReturns{}
+	var _err error
+	if g.implemented[ReactionHasBeenAddedID] {
+		_err = g.client.Call("Plugin.ReactionHasBeenAdded", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call ReactionHasBeenAdded to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
 }
 
 func (s *hooksRPCServer) ReactionHasBeenAdded(args *Z_ReactionHasBeenAddedArgs, returns *Z_ReactionHasBeenAddedReturns) error {
@@ -628,6 +883,21 @@ func (g *hooksRPCClient) ReactionHasBeenRemoved(c *Context, reaction *model.Reac
 
 }
 
+// ReactionHasBeenRemovedWithRPCErr returns the same values as ReactionHasBeenRemoved, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) ReactionHasBeenRemovedWithRPCErr(c *Context, reaction *model.Reaction) error {
+	_args := &Z_ReactionHasBeenRemovedArgs{c, reaction}
+	_returns := &Z_ReactionHasBeenRemovedReturns{}
+	var _err error
+	if g.implemented[ReactionHasBeenRemovedID] {
+		_err = g.client.Call("Plugin.ReactionHasBeenRemoved", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call ReactionHasBeenRemoved to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
+}
+
 func (s *hooksRPCServer) ReactionHasBeenRemoved(args *Z_ReactionHasBeenRemovedArgs, returns *Z_ReactionHasBeenRemovedReturns) error {
 	if hook, ok := s.impl.(interface {
 		ReactionHasBeenRemoved(c *Context, reaction *model.Reaction)
@@ -660,6 +930,21 @@ func (g *hooksRPCClient) OnPluginClusterEvent(c *Context, ev model.PluginCluster
 		}
 	}
 
+}
+
+// OnPluginClusterEventWithRPCErr returns the same values as OnPluginClusterEvent, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) OnPluginClusterEventWithRPCErr(c *Context, ev model.PluginClusterEvent) error {
+	_args := &Z_OnPluginClusterEventArgs{c, ev}
+	_returns := &Z_OnPluginClusterEventReturns{}
+	var _err error
+	if g.implemented[OnPluginClusterEventID] {
+		_err = g.client.Call("Plugin.OnPluginClusterEvent", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call OnPluginClusterEvent to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
 }
 
 func (s *hooksRPCServer) OnPluginClusterEvent(args *Z_OnPluginClusterEventArgs, returns *Z_OnPluginClusterEventReturns) error {
@@ -696,6 +981,21 @@ func (g *hooksRPCClient) OnWebSocketConnect(webConnID, userID string) {
 
 }
 
+// OnWebSocketConnectWithRPCErr returns the same values as OnWebSocketConnect, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) OnWebSocketConnectWithRPCErr(webConnID, userID string) error {
+	_args := &Z_OnWebSocketConnectArgs{webConnID, userID}
+	_returns := &Z_OnWebSocketConnectReturns{}
+	var _err error
+	if g.implemented[OnWebSocketConnectID] {
+		_err = g.client.Call("Plugin.OnWebSocketConnect", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call OnWebSocketConnect to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
+}
+
 func (s *hooksRPCServer) OnWebSocketConnect(args *Z_OnWebSocketConnectArgs, returns *Z_OnWebSocketConnectReturns) error {
 	if hook, ok := s.impl.(interface {
 		OnWebSocketConnect(webConnID, userID string)
@@ -728,6 +1028,21 @@ func (g *hooksRPCClient) OnWebSocketDisconnect(webConnID, userID string) {
 		}
 	}
 
+}
+
+// OnWebSocketDisconnectWithRPCErr returns the same values as OnWebSocketDisconnect, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) OnWebSocketDisconnectWithRPCErr(webConnID, userID string) error {
+	_args := &Z_OnWebSocketDisconnectArgs{webConnID, userID}
+	_returns := &Z_OnWebSocketDisconnectReturns{}
+	var _err error
+	if g.implemented[OnWebSocketDisconnectID] {
+		_err = g.client.Call("Plugin.OnWebSocketDisconnect", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call OnWebSocketDisconnect to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
 }
 
 func (s *hooksRPCServer) OnWebSocketDisconnect(args *Z_OnWebSocketDisconnectArgs, returns *Z_OnWebSocketDisconnectReturns) error {
@@ -763,6 +1078,21 @@ func (g *hooksRPCClient) WebSocketMessageHasBeenPosted(webConnID, userID string,
 		}
 	}
 
+}
+
+// WebSocketMessageHasBeenPostedWithRPCErr returns the same values as WebSocketMessageHasBeenPosted, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) WebSocketMessageHasBeenPostedWithRPCErr(webConnID, userID string, req *model.WebSocketRequest) error {
+	_args := &Z_WebSocketMessageHasBeenPostedArgs{webConnID, userID, req}
+	_returns := &Z_WebSocketMessageHasBeenPostedReturns{}
+	var _err error
+	if g.implemented[WebSocketMessageHasBeenPostedID] {
+		_err = g.client.Call("Plugin.WebSocketMessageHasBeenPosted", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call WebSocketMessageHasBeenPosted to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
 }
 
 func (s *hooksRPCServer) WebSocketMessageHasBeenPosted(args *Z_WebSocketMessageHasBeenPostedArgs, returns *Z_WebSocketMessageHasBeenPostedReturns) error {
@@ -801,6 +1131,21 @@ func (g *hooksRPCClient) RunDataRetention(nowTime, batchSize int64) (int64, erro
 	return _returns.A, _returns.B
 }
 
+// RunDataRetentionWithRPCErr returns the same values as RunDataRetention, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) RunDataRetentionWithRPCErr(nowTime, batchSize int64) (int64, error, error) {
+	_args := &Z_RunDataRetentionArgs{nowTime, batchSize}
+	_returns := &Z_RunDataRetentionReturns{}
+	var _err error
+	if g.implemented[RunDataRetentionID] {
+		_err = g.client.Call("Plugin.RunDataRetention", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call RunDataRetention to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _returns.B, _err
+}
+
 func (s *hooksRPCServer) RunDataRetention(args *Z_RunDataRetentionArgs, returns *Z_RunDataRetentionReturns) error {
 	if hook, ok := s.impl.(interface {
 		RunDataRetention(nowTime, batchSize int64) (int64, error)
@@ -837,6 +1182,21 @@ func (g *hooksRPCClient) OnInstall(c *Context, event model.OnInstallEvent) error
 	return _returns.A
 }
 
+// OnInstallWithRPCErr returns the same values as OnInstall, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) OnInstallWithRPCErr(c *Context, event model.OnInstallEvent) (error, error) {
+	_args := &Z_OnInstallArgs{c, event}
+	_returns := &Z_OnInstallReturns{}
+	var _err error
+	if g.implemented[OnInstallID] {
+		_err = g.client.Call("Plugin.OnInstall", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call OnInstall to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _err
+}
+
 func (s *hooksRPCServer) OnInstall(args *Z_OnInstallArgs, returns *Z_OnInstallReturns) error {
 	if hook, ok := s.impl.(interface {
 		OnInstall(c *Context, event model.OnInstallEvent) error
@@ -868,6 +1228,21 @@ func (g *hooksRPCClient) OnSendDailyTelemetry() {
 		}
 	}
 
+}
+
+// OnSendDailyTelemetryWithRPCErr returns the same values as OnSendDailyTelemetry, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) OnSendDailyTelemetryWithRPCErr() error {
+	_args := &Z_OnSendDailyTelemetryArgs{}
+	_returns := &Z_OnSendDailyTelemetryReturns{}
+	var _err error
+	if g.implemented[OnSendDailyTelemetryID] {
+		_err = g.client.Call("Plugin.OnSendDailyTelemetry", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call OnSendDailyTelemetry to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
 }
 
 func (s *hooksRPCServer) OnSendDailyTelemetry(args *Z_OnSendDailyTelemetryArgs, returns *Z_OnSendDailyTelemetryReturns) error {
@@ -903,6 +1278,21 @@ func (g *hooksRPCClient) OnCloudLimitsUpdated(limits *model.ProductLimits) {
 
 }
 
+// OnCloudLimitsUpdatedWithRPCErr returns the same values as OnCloudLimitsUpdated, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) OnCloudLimitsUpdatedWithRPCErr(limits *model.ProductLimits) error {
+	_args := &Z_OnCloudLimitsUpdatedArgs{limits}
+	_returns := &Z_OnCloudLimitsUpdatedReturns{}
+	var _err error
+	if g.implemented[OnCloudLimitsUpdatedID] {
+		_err = g.client.Call("Plugin.OnCloudLimitsUpdated", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call OnCloudLimitsUpdated to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
+}
+
 func (s *hooksRPCServer) OnCloudLimitsUpdated(args *Z_OnCloudLimitsUpdatedArgs, returns *Z_OnCloudLimitsUpdatedReturns) error {
 	if hook, ok := s.impl.(interface {
 		OnCloudLimitsUpdated(limits *model.ProductLimits)
@@ -936,6 +1326,21 @@ func (g *hooksRPCClient) ConfigurationWillBeSaved(newCfg *model.Config) (*model.
 		}
 	}
 	return _returns.A, _returns.B
+}
+
+// ConfigurationWillBeSavedWithRPCErr returns the same values as ConfigurationWillBeSaved, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) ConfigurationWillBeSavedWithRPCErr(newCfg *model.Config) (*model.Config, error, error) {
+	_args := &Z_ConfigurationWillBeSavedArgs{newCfg}
+	_returns := &Z_ConfigurationWillBeSavedReturns{}
+	var _err error
+	if g.implemented[ConfigurationWillBeSavedID] {
+		_err = g.client.Call("Plugin.ConfigurationWillBeSaved", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call ConfigurationWillBeSaved to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _returns.B, _err
 }
 
 func (s *hooksRPCServer) ConfigurationWillBeSaved(args *Z_ConfigurationWillBeSavedArgs, returns *Z_ConfigurationWillBeSavedReturns) error {
@@ -974,6 +1379,21 @@ func (g *hooksRPCClient) EmailNotificationWillBeSent(emailNotification *model.Em
 	return _returns.A, _returns.B
 }
 
+// EmailNotificationWillBeSentWithRPCErr returns the same values as EmailNotificationWillBeSent, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) EmailNotificationWillBeSentWithRPCErr(emailNotification *model.EmailNotification) (*model.EmailNotificationContent, string, error) {
+	_args := &Z_EmailNotificationWillBeSentArgs{emailNotification}
+	_returns := &Z_EmailNotificationWillBeSentReturns{}
+	var _err error
+	if g.implemented[EmailNotificationWillBeSentID] {
+		_err = g.client.Call("Plugin.EmailNotificationWillBeSent", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call EmailNotificationWillBeSent to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _returns.B, _err
+}
+
 func (s *hooksRPCServer) EmailNotificationWillBeSent(args *Z_EmailNotificationWillBeSentArgs, returns *Z_EmailNotificationWillBeSentReturns) error {
 	if hook, ok := s.impl.(interface {
 		EmailNotificationWillBeSent(emailNotification *model.EmailNotification) (*model.EmailNotificationContent, string)
@@ -1010,6 +1430,21 @@ func (g *hooksRPCClient) NotificationWillBePushed(pushNotification *model.PushNo
 	return _returns.A, _returns.B
 }
 
+// NotificationWillBePushedWithRPCErr returns the same values as NotificationWillBePushed, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) NotificationWillBePushedWithRPCErr(pushNotification *model.PushNotification, userID string) (*model.PushNotification, string, error) {
+	_args := &Z_NotificationWillBePushedArgs{pushNotification, userID}
+	_returns := &Z_NotificationWillBePushedReturns{}
+	var _err error
+	if g.implemented[NotificationWillBePushedID] {
+		_err = g.client.Call("Plugin.NotificationWillBePushed", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call NotificationWillBePushed to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _returns.B, _err
+}
+
 func (s *hooksRPCServer) NotificationWillBePushed(args *Z_NotificationWillBePushedArgs, returns *Z_NotificationWillBePushedReturns) error {
 	if hook, ok := s.impl.(interface {
 		NotificationWillBePushed(pushNotification *model.PushNotification, userID string) (*model.PushNotification, string)
@@ -1042,6 +1477,21 @@ func (g *hooksRPCClient) UserHasBeenDeactivated(c *Context, user *model.User) {
 		}
 	}
 
+}
+
+// UserHasBeenDeactivatedWithRPCErr returns the same values as UserHasBeenDeactivated, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) UserHasBeenDeactivatedWithRPCErr(c *Context, user *model.User) error {
+	_args := &Z_UserHasBeenDeactivatedArgs{c, user}
+	_returns := &Z_UserHasBeenDeactivatedReturns{}
+	var _err error
+	if g.implemented[UserHasBeenDeactivatedID] {
+		_err = g.client.Call("Plugin.UserHasBeenDeactivated", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call UserHasBeenDeactivated to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
 }
 
 func (s *hooksRPCServer) UserHasBeenDeactivated(args *Z_UserHasBeenDeactivatedArgs, returns *Z_UserHasBeenDeactivatedReturns) error {
@@ -1080,6 +1530,21 @@ func (g *hooksRPCClient) OnSharedChannelsSyncMsg(msg *model.SyncMsg, rc *model.R
 	return _returns.A, _returns.B
 }
 
+// OnSharedChannelsSyncMsgWithRPCErr returns the same values as OnSharedChannelsSyncMsg, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) OnSharedChannelsSyncMsgWithRPCErr(msg *model.SyncMsg, rc *model.RemoteCluster) (model.SyncResponse, error, error) {
+	_args := &Z_OnSharedChannelsSyncMsgArgs{msg, rc}
+	_returns := &Z_OnSharedChannelsSyncMsgReturns{}
+	var _err error
+	if g.implemented[OnSharedChannelsSyncMsgID] {
+		_err = g.client.Call("Plugin.OnSharedChannelsSyncMsg", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call OnSharedChannelsSyncMsg to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _returns.B, _err
+}
+
 func (s *hooksRPCServer) OnSharedChannelsSyncMsg(args *Z_OnSharedChannelsSyncMsgArgs, returns *Z_OnSharedChannelsSyncMsgReturns) error {
 	if hook, ok := s.impl.(interface {
 		OnSharedChannelsSyncMsg(msg *model.SyncMsg, rc *model.RemoteCluster) (model.SyncResponse, error)
@@ -1115,6 +1580,21 @@ func (g *hooksRPCClient) OnSharedChannelsPing(rc *model.RemoteCluster) bool {
 	return _returns.A
 }
 
+// OnSharedChannelsPingWithRPCErr returns the same values as OnSharedChannelsPing, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) OnSharedChannelsPingWithRPCErr(rc *model.RemoteCluster) (bool, error) {
+	_args := &Z_OnSharedChannelsPingArgs{rc}
+	_returns := &Z_OnSharedChannelsPingReturns{}
+	var _err error
+	if g.implemented[OnSharedChannelsPingID] {
+		_err = g.client.Call("Plugin.OnSharedChannelsPing", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call OnSharedChannelsPing to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _err
+}
+
 func (s *hooksRPCServer) OnSharedChannelsPing(args *Z_OnSharedChannelsPingArgs, returns *Z_OnSharedChannelsPingReturns) error {
 	if hook, ok := s.impl.(interface {
 		OnSharedChannelsPing(rc *model.RemoteCluster) bool
@@ -1147,6 +1627,21 @@ func (g *hooksRPCClient) PreferencesHaveChanged(c *Context, preferences []model.
 		}
 	}
 
+}
+
+// PreferencesHaveChangedWithRPCErr returns the same values as PreferencesHaveChanged, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) PreferencesHaveChangedWithRPCErr(c *Context, preferences []model.Preference) error {
+	_args := &Z_PreferencesHaveChangedArgs{c, preferences}
+	_returns := &Z_PreferencesHaveChangedReturns{}
+	var _err error
+	if g.implemented[PreferencesHaveChangedID] {
+		_err = g.client.Call("Plugin.PreferencesHaveChanged", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call PreferencesHaveChanged to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _err
 }
 
 func (s *hooksRPCServer) PreferencesHaveChanged(args *Z_PreferencesHaveChangedArgs, returns *Z_PreferencesHaveChangedReturns) error {
@@ -1185,6 +1680,21 @@ func (g *hooksRPCClient) OnSharedChannelsAttachmentSyncMsg(fi *model.FileInfo, p
 	return _returns.A
 }
 
+// OnSharedChannelsAttachmentSyncMsgWithRPCErr returns the same values as OnSharedChannelsAttachmentSyncMsg, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) OnSharedChannelsAttachmentSyncMsgWithRPCErr(fi *model.FileInfo, post *model.Post, rc *model.RemoteCluster) (error, error) {
+	_args := &Z_OnSharedChannelsAttachmentSyncMsgArgs{fi, post, rc}
+	_returns := &Z_OnSharedChannelsAttachmentSyncMsgReturns{}
+	var _err error
+	if g.implemented[OnSharedChannelsAttachmentSyncMsgID] {
+		_err = g.client.Call("Plugin.OnSharedChannelsAttachmentSyncMsg", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call OnSharedChannelsAttachmentSyncMsg to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _err
+}
+
 func (s *hooksRPCServer) OnSharedChannelsAttachmentSyncMsg(args *Z_OnSharedChannelsAttachmentSyncMsgArgs, returns *Z_OnSharedChannelsAttachmentSyncMsgReturns) error {
 	if hook, ok := s.impl.(interface {
 		OnSharedChannelsAttachmentSyncMsg(fi *model.FileInfo, post *model.Post, rc *model.RemoteCluster) error
@@ -1221,6 +1731,21 @@ func (g *hooksRPCClient) OnSharedChannelsProfileImageSyncMsg(user *model.User, r
 	return _returns.A
 }
 
+// OnSharedChannelsProfileImageSyncMsgWithRPCErr returns the same values as OnSharedChannelsProfileImageSyncMsg, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) OnSharedChannelsProfileImageSyncMsgWithRPCErr(user *model.User, rc *model.RemoteCluster) (error, error) {
+	_args := &Z_OnSharedChannelsProfileImageSyncMsgArgs{user, rc}
+	_returns := &Z_OnSharedChannelsProfileImageSyncMsgReturns{}
+	var _err error
+	if g.implemented[OnSharedChannelsProfileImageSyncMsgID] {
+		_err = g.client.Call("Plugin.OnSharedChannelsProfileImageSyncMsg", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call OnSharedChannelsProfileImageSyncMsg to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _err
+}
+
 func (s *hooksRPCServer) OnSharedChannelsProfileImageSyncMsg(args *Z_OnSharedChannelsProfileImageSyncMsgArgs, returns *Z_OnSharedChannelsProfileImageSyncMsgReturns) error {
 	if hook, ok := s.impl.(interface {
 		OnSharedChannelsProfileImageSyncMsg(user *model.User, rc *model.RemoteCluster) error
@@ -1255,6 +1780,21 @@ func (g *hooksRPCClient) GenerateSupportData(c *Context) ([]*model.FileData, err
 		}
 	}
 	return _returns.A, _returns.B
+}
+
+// GenerateSupportDataWithRPCErr returns the same values as GenerateSupportData, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) GenerateSupportDataWithRPCErr(c *Context) ([]*model.FileData, error, error) {
+	_args := &Z_GenerateSupportDataArgs{c}
+	_returns := &Z_GenerateSupportDataReturns{}
+	var _err error
+	if g.implemented[GenerateSupportDataID] {
+		_err = g.client.Call("Plugin.GenerateSupportData", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call GenerateSupportData to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _returns.B, _err
 }
 
 func (s *hooksRPCServer) GenerateSupportData(args *Z_GenerateSupportDataArgs, returns *Z_GenerateSupportDataReturns) error {
@@ -1294,6 +1834,21 @@ func (g *hooksRPCClient) OnSAMLLogin(c *Context, user *model.User, assertion *sa
 	return _returns.A
 }
 
+// OnSAMLLoginWithRPCErr returns the same values as OnSAMLLogin, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) OnSAMLLoginWithRPCErr(c *Context, user *model.User, assertion *saml2.AssertionInfo) (error, error) {
+	_args := &Z_OnSAMLLoginArgs{c, user, assertion}
+	_returns := &Z_OnSAMLLoginReturns{}
+	var _err error
+	if g.implemented[OnSAMLLoginID] {
+		_err = g.client.Call("Plugin.OnSAMLLogin", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call OnSAMLLogin to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _err
+}
+
 func (s *hooksRPCServer) OnSAMLLogin(args *Z_OnSAMLLoginArgs, returns *Z_OnSAMLLoginReturns) error {
 	if hook, ok := s.impl.(interface {
 		OnSAMLLogin(c *Context, user *model.User, assertion *saml2.AssertionInfo) error
@@ -1304,6 +1859,92 @@ func (s *hooksRPCServer) OnSAMLLogin(args *Z_OnSAMLLoginArgs, returns *Z_OnSAMLL
 		return encodableError(fmt.Errorf("Hook OnSAMLLogin called but not implemented."))
 	}
 	return nil
+}
+
+// HooksRPCErr is implemented by hooksRPCClient. It provides a WithRPCErr variant for every
+// generated hook. The last error return is always the RPC transport error — if non-nil, the
+// plugin's other return values are zero. For hooks whose base signature already returns error,
+// the tuple is (originalReturns..., rpcErr) where the final slot is always transport.
+//
+// If the plugin does not implement the hook, the companion returns zero values and a nil error —
+// indistinguishable from a successful invocation that returned zeros. Callers MUST gate on
+// supervisor.Implements(<HookID>) (or use Environment.RunMultiPluginHookWithRPCErr, which gates
+// by the iteration's hook ID — note that any *WithRPCErr method called on the closure's
+// HooksRPCErr is independently subject to its own implemented-gate).
+type HooksRPCErr interface {
+	OnDeactivateWithRPCErr() (error, error)
+
+	OnConfigurationChangeWithRPCErr() (error, error)
+
+	ExecuteCommandWithRPCErr(c *Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError, error)
+
+	UserHasBeenCreatedWithRPCErr(c *Context, user *model.User) error
+
+	UserWillLogInWithRPCErr(c *Context, user *model.User) (string, error)
+
+	UserHasLoggedInWithRPCErr(c *Context, user *model.User) error
+
+	MessageHasBeenPostedWithRPCErr(c *Context, post *model.Post) error
+
+	MessageHasBeenUpdatedWithRPCErr(c *Context, newPost, oldPost *model.Post) error
+
+	MessageHasBeenDeletedWithRPCErr(c *Context, post *model.Post) error
+
+	ChannelHasBeenCreatedWithRPCErr(c *Context, channel *model.Channel) error
+
+	ChannelWillBeArchivedWithRPCErr(c *Context, channel *model.Channel) (string, error)
+
+	UserHasJoinedChannelWithRPCErr(c *Context, channelMember *model.ChannelMember, actor *model.User) error
+
+	UserHasLeftChannelWithRPCErr(c *Context, channelMember *model.ChannelMember, actor *model.User) error
+
+	UserHasJoinedTeamWithRPCErr(c *Context, teamMember *model.TeamMember, actor *model.User) error
+
+	UserHasLeftTeamWithRPCErr(c *Context, teamMember *model.TeamMember, actor *model.User) error
+
+	FileWillBeDownloadedWithRPCErr(c *Context, fileInfo *model.FileInfo, userID string, downloadType model.FileDownloadType) (string, error)
+
+	ReactionHasBeenAddedWithRPCErr(c *Context, reaction *model.Reaction) error
+
+	ReactionHasBeenRemovedWithRPCErr(c *Context, reaction *model.Reaction) error
+
+	OnPluginClusterEventWithRPCErr(c *Context, ev model.PluginClusterEvent) error
+
+	OnWebSocketConnectWithRPCErr(webConnID, userID string) error
+
+	OnWebSocketDisconnectWithRPCErr(webConnID, userID string) error
+
+	WebSocketMessageHasBeenPostedWithRPCErr(webConnID, userID string, req *model.WebSocketRequest) error
+
+	RunDataRetentionWithRPCErr(nowTime, batchSize int64) (int64, error, error)
+
+	OnInstallWithRPCErr(c *Context, event model.OnInstallEvent) (error, error)
+
+	OnSendDailyTelemetryWithRPCErr() error
+
+	OnCloudLimitsUpdatedWithRPCErr(limits *model.ProductLimits) error
+
+	ConfigurationWillBeSavedWithRPCErr(newCfg *model.Config) (*model.Config, error, error)
+
+	EmailNotificationWillBeSentWithRPCErr(emailNotification *model.EmailNotification) (*model.EmailNotificationContent, string, error)
+
+	NotificationWillBePushedWithRPCErr(pushNotification *model.PushNotification, userID string) (*model.PushNotification, string, error)
+
+	UserHasBeenDeactivatedWithRPCErr(c *Context, user *model.User) error
+
+	OnSharedChannelsSyncMsgWithRPCErr(msg *model.SyncMsg, rc *model.RemoteCluster) (model.SyncResponse, error, error)
+
+	OnSharedChannelsPingWithRPCErr(rc *model.RemoteCluster) (bool, error)
+
+	PreferencesHaveChangedWithRPCErr(c *Context, preferences []model.Preference) error
+
+	OnSharedChannelsAttachmentSyncMsgWithRPCErr(fi *model.FileInfo, post *model.Post, rc *model.RemoteCluster) (error, error)
+
+	OnSharedChannelsProfileImageSyncMsgWithRPCErr(user *model.User, rc *model.RemoteCluster) (error, error)
+
+	GenerateSupportDataWithRPCErr(c *Context) ([]*model.FileData, error, error)
+
+	OnSAMLLoginWithRPCErr(c *Context, user *model.User, assertion *saml2.AssertionInfo) (error, error)
 }
 
 type Z_RegisterCommandArgs struct {

--- a/server/public/plugin/environment.go
+++ b/server/public/plugin/environment.go
@@ -627,9 +627,9 @@ func (env *Environment) RunMultiPluginHook(hookRunnerFunc func(hooks Hooks, mani
 }
 
 // RunMultiPluginHookWithRPCErr is like RunMultiPluginHook but surfaces RPC transport errors. The
-// closure receives a HooksRPCErr so it can call *WithRPCErr variants. Iteration stops on the first
+// closure receives a HooksWithRPCErr so it can call *WithRPCErr variants. Iteration stops on the first
 // non-nil error returned by the closure.
-func (env *Environment) RunMultiPluginHookWithRPCErr(hookRunnerFunc func(hooks HooksRPCErr, manifest *model.Manifest) (bool, error), hookId int) error {
+func (env *Environment) RunMultiPluginHookWithRPCErr(hookRunnerFunc func(hooks HooksWithRPCErr, manifest *model.Manifest) (bool, error), hookId int) error {
 	startTime := time.Now()
 	var retErr error
 
@@ -640,9 +640,9 @@ func (env *Environment) RunMultiPluginHookWithRPCErr(hookRunnerFunc func(hooks H
 			return true
 		}
 
-		hooks, ok := rp.supervisor.Hooks().(HooksRPCErr)
+		hooks, ok := rp.supervisor.Hooks().(HooksWithRPCErr)
 		if !ok {
-			retErr = fmt.Errorf("plugin %s hooks do not implement HooksRPCErr", rp.BundleInfo.Manifest.Id)
+			retErr = fmt.Errorf("plugin %s hooks do not implement HooksWithRPCErr", rp.BundleInfo.Manifest.Id)
 			return false
 		}
 

--- a/server/public/plugin/environment.go
+++ b/server/public/plugin/environment.go
@@ -626,6 +626,48 @@ func (env *Environment) RunMultiPluginHook(hookRunnerFunc func(hooks Hooks, mani
 	}
 }
 
+// RunMultiPluginHookWithRPCErr is like RunMultiPluginHook but surfaces RPC transport errors. The
+// closure receives a HooksRPCErr so it can call *WithRPCErr variants. Iteration stops on the first
+// non-nil error returned by the closure.
+func (env *Environment) RunMultiPluginHookWithRPCErr(hookRunnerFunc func(hooks HooksRPCErr, manifest *model.Manifest) (bool, error), hookId int) error {
+	startTime := time.Now()
+	var retErr error
+
+	env.registeredPlugins.Range(func(key, value any) bool {
+		rp := value.(registeredPlugin)
+
+		if rp.supervisor == nil || !rp.supervisor.Implements(hookId) || !env.IsActive(rp.BundleInfo.Manifest.Id) {
+			return true
+		}
+
+		hooks, ok := rp.supervisor.Hooks().(HooksRPCErr)
+		if !ok {
+			retErr = fmt.Errorf("plugin %s hooks do not implement HooksRPCErr", rp.BundleInfo.Manifest.Id)
+			return false
+		}
+
+		hookStartTime := time.Now()
+		cont, err := hookRunnerFunc(hooks, rp.BundleInfo.Manifest)
+
+		if env.metrics != nil {
+			elapsedTime := float64(time.Since(hookStartTime)) / float64(time.Second)
+			env.metrics.ObservePluginMultiHookIterationDuration(rp.BundleInfo.Manifest.Id, elapsedTime)
+		}
+
+		if err != nil {
+			retErr = err
+			return false
+		}
+		return cont
+	})
+
+	if env.metrics != nil {
+		elapsedTime := float64(time.Since(startTime)) / float64(time.Second)
+		env.metrics.ObservePluginMultiHookDuration(elapsedTime)
+	}
+	return retErr
+}
+
 // PerformHealthCheck uses the active plugin's supervisor to verify if the plugin has crashed.
 func (env *Environment) PerformHealthCheck(id string) error {
 	p, ok := env.registeredPlugins.Load(id)

--- a/server/public/plugin/environment.go
+++ b/server/public/plugin/environment.go
@@ -640,14 +640,8 @@ func (env *Environment) RunMultiPluginHookWithRPCErr(hookRunnerFunc func(hooks H
 			return true
 		}
 
-		hooks, ok := rp.supervisor.Hooks().(HooksWithRPCErr)
-		if !ok {
-			retErr = fmt.Errorf("plugin %s hooks do not implement HooksWithRPCErr", rp.BundleInfo.Manifest.Id)
-			return false
-		}
-
 		hookStartTime := time.Now()
-		cont, err := hookRunnerFunc(hooks, rp.BundleInfo.Manifest)
+		cont, err := hookRunnerFunc(rp.supervisor.HooksWithRPCErr(), rp.BundleInfo.Manifest)
 
 		if env.metrics != nil {
 			elapsedTime := float64(time.Since(hookStartTime)) / float64(time.Second)

--- a/server/public/plugin/environment_with_rpcerr_test.go
+++ b/server/public/plugin/environment_with_rpcerr_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package plugin
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin/utils"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+)
+
+// Both the wire-level client and the metrics-wrapping layer returned by
+// supervisor.Hooks() must implement HooksRPCErr — RunMultiPluginHookWithRPCErr's
+// type assertion targets the latter.
+var (
+	_ HooksRPCErr = (*hooksRPCClient)(nil)
+	_ HooksRPCErr = (*hooksTimerLayer)(nil)
+)
+
+func TestRunMultiPluginHookWithRPCErr(t *testing.T) {
+	pluginDir, err := os.MkdirTemp("", "mm-rpcerr-plugin")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(pluginDir) })
+	webappPluginDir, err := os.MkdirTemp("", "mm-rpcerr-webapp")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(webappPluginDir) })
+
+	pluginID1 := "test-rpc-err-plugin"
+	pluginID2 := "test-rpc-err-plugin-2"
+	require.NoError(t, os.MkdirAll(filepath.Join(pluginDir, pluginID1), 0700))
+	require.NoError(t, os.MkdirAll(filepath.Join(pluginDir, pluginID2), 0700))
+	backend1 := filepath.Join(pluginDir, pluginID1, "backend.exe")
+	backend2 := filepath.Join(pluginDir, pluginID2, "backend.exe")
+
+	utils.CompileGo(t, `
+		package main
+
+		import (
+			"github.com/mattermost/mattermost/server/public/model"
+			"github.com/mattermost/mattermost/server/public/plugin"
+		)
+
+		type MyPlugin struct {
+			plugin.MattermostPlugin
+		}
+
+		func (p *MyPlugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {}
+
+		func main() {
+			plugin.ClientMain(&MyPlugin{})
+		}
+	`, backend1)
+	copyExecutable(t, backend1, backend2)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(pluginDir, pluginID1, "plugin.json"),
+		[]byte(`{"id":"`+pluginID1+`","server":{"executable":"backend.exe"}}`),
+		0600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(pluginDir, pluginID2, "plugin.json"),
+		[]byte(`{"id":"`+pluginID2+`","server":{"executable":"backend.exe"}}`),
+		0600,
+	))
+
+	logger := mlog.CreateConsoleTestLogger(t)
+	apiImpl := func(*model.Manifest) API { return nil }
+	env, err := NewEnvironment(apiImpl, nil, pluginDir, webappPluginDir, logger, nil)
+	require.NoError(t, err)
+	t.Cleanup(env.Shutdown)
+
+	_, _, err = env.Activate(pluginID1)
+	require.NoError(t, err)
+	require.True(t, env.IsActive(pluginID1))
+	_, _, err = env.Activate(pluginID2)
+	require.NoError(t, err)
+	require.True(t, env.IsActive(pluginID2))
+
+	t.Run("both plugins healthy - closure invoked once per plugin", func(t *testing.T) {
+		seen := map[string]int{}
+		runErr := env.RunMultiPluginHookWithRPCErr(func(hooks HooksRPCErr, manifest *model.Manifest) (bool, error) {
+			seen[manifest.Id]++
+			require.NoError(t, hooks.MessageHasBeenPostedWithRPCErr(&Context{}, &model.Post{}))
+			return true, nil
+		}, MessageHasBeenPostedID)
+		require.NoError(t, runErr)
+		require.Equal(t, map[string]int{pluginID1: 1, pluginID2: 1}, seen)
+	})
+
+	t.Run("closure error propagates and stops iteration", func(t *testing.T) {
+		sentinel := errors.New("from closure")
+		var calls int
+		runErr := env.RunMultiPluginHookWithRPCErr(func(_ HooksRPCErr, _ *model.Manifest) (bool, error) {
+			calls++
+			return true, sentinel
+		}, MessageHasBeenPostedID)
+		require.ErrorIs(t, runErr, sentinel)
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("hook id not implemented - closure never invoked", func(t *testing.T) {
+		var calls int
+		runErr := env.RunMultiPluginHookWithRPCErr(func(_ HooksRPCErr, _ *model.Manifest) (bool, error) {
+			calls++
+			return true, nil
+		}, MessageHasBeenUpdatedID)
+		require.NoError(t, runErr)
+		require.Equal(t, 0, calls)
+	})
+
+	t.Run("rpc transport error surfaces after plugin process dies", func(t *testing.T) {
+		rp, ok := env.registeredPlugins.Load(pluginID1)
+		require.True(t, ok)
+		sup := rp.(registeredPlugin).supervisor
+		require.NotNil(t, sup)
+		sup.client.Kill()
+
+		// Give the rpc client a moment to notice the dead connection.
+		require.Eventually(t, func() bool {
+			var rpcErr error
+			_ = env.RunMultiPluginHookWithRPCErr(func(hooks HooksRPCErr, manifest *model.Manifest) (bool, error) {
+				if manifest.Id != pluginID1 {
+					return true, nil
+				}
+				rpcErr = hooks.MessageHasBeenPostedWithRPCErr(&Context{}, &model.Post{})
+				return true, nil
+			}, MessageHasBeenPostedID)
+			return rpcErr != nil
+		}, 2*time.Second, 50*time.Millisecond)
+	})
+}
+
+func copyExecutable(t *testing.T, src, dst string) {
+	t.Helper()
+	in, err := os.Open(src)
+	require.NoError(t, err)
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0700)
+	require.NoError(t, err)
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	require.NoError(t, err)
+}

--- a/server/public/plugin/environment_with_rpcerr_test.go
+++ b/server/public/plugin/environment_with_rpcerr_test.go
@@ -19,11 +19,11 @@ import (
 )
 
 // Both the wire-level client and the metrics-wrapping layer returned by
-// supervisor.Hooks() must implement HooksRPCErr — RunMultiPluginHookWithRPCErr's
+// supervisor.Hooks() must implement HooksWithRPCErr — RunMultiPluginHookWithRPCErr's
 // type assertion targets the latter.
 var (
-	_ HooksRPCErr = (*hooksRPCClient)(nil)
-	_ HooksRPCErr = (*hooksTimerLayer)(nil)
+	_ HooksWithRPCErr = (*hooksRPCClient)(nil)
+	_ HooksWithRPCErr = (*hooksTimerLayer)(nil)
 )
 
 func TestRunMultiPluginHookWithRPCErr(t *testing.T) {
@@ -87,7 +87,7 @@ func TestRunMultiPluginHookWithRPCErr(t *testing.T) {
 
 	t.Run("both plugins healthy - closure invoked once per plugin", func(t *testing.T) {
 		seen := map[string]int{}
-		runErr := env.RunMultiPluginHookWithRPCErr(func(hooks HooksRPCErr, manifest *model.Manifest) (bool, error) {
+		runErr := env.RunMultiPluginHookWithRPCErr(func(hooks HooksWithRPCErr, manifest *model.Manifest) (bool, error) {
 			seen[manifest.Id]++
 			require.NoError(t, hooks.MessageHasBeenPostedWithRPCErr(&Context{}, &model.Post{}))
 			return true, nil
@@ -99,7 +99,7 @@ func TestRunMultiPluginHookWithRPCErr(t *testing.T) {
 	t.Run("closure error propagates and stops iteration", func(t *testing.T) {
 		sentinel := errors.New("from closure")
 		var calls int
-		runErr := env.RunMultiPluginHookWithRPCErr(func(_ HooksRPCErr, _ *model.Manifest) (bool, error) {
+		runErr := env.RunMultiPluginHookWithRPCErr(func(_ HooksWithRPCErr, _ *model.Manifest) (bool, error) {
 			calls++
 			return true, sentinel
 		}, MessageHasBeenPostedID)
@@ -109,7 +109,7 @@ func TestRunMultiPluginHookWithRPCErr(t *testing.T) {
 
 	t.Run("hook id not implemented - closure never invoked", func(t *testing.T) {
 		var calls int
-		runErr := env.RunMultiPluginHookWithRPCErr(func(_ HooksRPCErr, _ *model.Manifest) (bool, error) {
+		runErr := env.RunMultiPluginHookWithRPCErr(func(_ HooksWithRPCErr, _ *model.Manifest) (bool, error) {
 			calls++
 			return true, nil
 		}, MessageHasBeenUpdatedID)
@@ -127,7 +127,7 @@ func TestRunMultiPluginHookWithRPCErr(t *testing.T) {
 		// Give the rpc client a moment to notice the dead connection.
 		require.Eventually(t, func() bool {
 			var rpcErr error
-			_ = env.RunMultiPluginHookWithRPCErr(func(hooks HooksRPCErr, manifest *model.Manifest) (bool, error) {
+			_ = env.RunMultiPluginHookWithRPCErr(func(hooks HooksWithRPCErr, manifest *model.Manifest) (bool, error) {
 				if manifest.Id != pluginID1 {
 					return true, nil
 				}

--- a/server/public/plugin/hooks_timer_layer_generated.go
+++ b/server/public/plugin/hooks_timer_layer_generated.go
@@ -18,7 +18,7 @@ import (
 type hooksTimerLayer struct {
 	pluginID   string
 	hooksImpl  Hooks
-	rpcErrImpl HooksRPCErr
+	rpcErrImpl HooksWithRPCErr
 	metrics    metricsInterface
 }
 

--- a/server/public/plugin/hooks_timer_layer_generated.go
+++ b/server/public/plugin/hooks_timer_layer_generated.go
@@ -16,10 +16,10 @@ import (
 )
 
 type hooksTimerLayer struct {
-	pluginID   string
-	hooksImpl  Hooks
-	rpcErrImpl HooksWithRPCErr
-	metrics    metricsInterface
+	pluginID            string
+	hooksImpl           Hooks
+	hooksWithRPCErrImpl HooksWithRPCErr
+	metrics             metricsInterface
 }
 
 func (hooks *hooksTimerLayer) recordTime(startTime timePkg.Time, name string, success bool) {
@@ -338,259 +338,259 @@ func (hooks *hooksTimerLayer) OnSAMLLogin(c *Context, user *model.User, assertio
 
 func (hooks *hooksTimerLayer) OnDeactivateWithRPCErr() (error, error) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.OnDeactivateWithRPCErr()
+	_returnsA, _returnsRPCErr := hooks.hooksWithRPCErrImpl.OnDeactivateWithRPCErr()
 	hooks.recordTime(startTime, "OnDeactivateWithRPCErr", _returnsRPCErr == nil && _returnsA == nil)
 	return _returnsA, _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) OnConfigurationChangeWithRPCErr() (error, error) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.OnConfigurationChangeWithRPCErr()
+	_returnsA, _returnsRPCErr := hooks.hooksWithRPCErrImpl.OnConfigurationChangeWithRPCErr()
 	hooks.recordTime(startTime, "OnConfigurationChangeWithRPCErr", _returnsRPCErr == nil && _returnsA == nil)
 	return _returnsA, _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) ExecuteCommandWithRPCErr(c *Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError, error) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsB, _returnsRPCErr := hooks.rpcErrImpl.ExecuteCommandWithRPCErr(c, args)
+	_returnsA, _returnsB, _returnsRPCErr := hooks.hooksWithRPCErrImpl.ExecuteCommandWithRPCErr(c, args)
 	hooks.recordTime(startTime, "ExecuteCommandWithRPCErr", _returnsRPCErr == nil && _returnsB == nil)
 	return _returnsA, _returnsB, _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) UserHasBeenCreatedWithRPCErr(c *Context, user *model.User) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.UserHasBeenCreatedWithRPCErr(c, user)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.UserHasBeenCreatedWithRPCErr(c, user)
 	hooks.recordTime(startTime, "UserHasBeenCreatedWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) UserWillLogInWithRPCErr(c *Context, user *model.User) (string, error) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.UserWillLogInWithRPCErr(c, user)
+	_returnsA, _returnsRPCErr := hooks.hooksWithRPCErrImpl.UserWillLogInWithRPCErr(c, user)
 	hooks.recordTime(startTime, "UserWillLogInWithRPCErr", _returnsRPCErr == nil)
 	return _returnsA, _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) UserHasLoggedInWithRPCErr(c *Context, user *model.User) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.UserHasLoggedInWithRPCErr(c, user)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.UserHasLoggedInWithRPCErr(c, user)
 	hooks.recordTime(startTime, "UserHasLoggedInWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) MessageHasBeenPostedWithRPCErr(c *Context, post *model.Post) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.MessageHasBeenPostedWithRPCErr(c, post)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.MessageHasBeenPostedWithRPCErr(c, post)
 	hooks.recordTime(startTime, "MessageHasBeenPostedWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) MessageHasBeenUpdatedWithRPCErr(c *Context, newPost, oldPost *model.Post) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.MessageHasBeenUpdatedWithRPCErr(c, newPost, oldPost)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.MessageHasBeenUpdatedWithRPCErr(c, newPost, oldPost)
 	hooks.recordTime(startTime, "MessageHasBeenUpdatedWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) MessageHasBeenDeletedWithRPCErr(c *Context, post *model.Post) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.MessageHasBeenDeletedWithRPCErr(c, post)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.MessageHasBeenDeletedWithRPCErr(c, post)
 	hooks.recordTime(startTime, "MessageHasBeenDeletedWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) ChannelHasBeenCreatedWithRPCErr(c *Context, channel *model.Channel) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.ChannelHasBeenCreatedWithRPCErr(c, channel)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.ChannelHasBeenCreatedWithRPCErr(c, channel)
 	hooks.recordTime(startTime, "ChannelHasBeenCreatedWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) ChannelWillBeArchivedWithRPCErr(c *Context, channel *model.Channel) (string, error) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.ChannelWillBeArchivedWithRPCErr(c, channel)
+	_returnsA, _returnsRPCErr := hooks.hooksWithRPCErrImpl.ChannelWillBeArchivedWithRPCErr(c, channel)
 	hooks.recordTime(startTime, "ChannelWillBeArchivedWithRPCErr", _returnsRPCErr == nil)
 	return _returnsA, _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) UserHasJoinedChannelWithRPCErr(c *Context, channelMember *model.ChannelMember, actor *model.User) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.UserHasJoinedChannelWithRPCErr(c, channelMember, actor)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.UserHasJoinedChannelWithRPCErr(c, channelMember, actor)
 	hooks.recordTime(startTime, "UserHasJoinedChannelWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) UserHasLeftChannelWithRPCErr(c *Context, channelMember *model.ChannelMember, actor *model.User) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.UserHasLeftChannelWithRPCErr(c, channelMember, actor)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.UserHasLeftChannelWithRPCErr(c, channelMember, actor)
 	hooks.recordTime(startTime, "UserHasLeftChannelWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) UserHasJoinedTeamWithRPCErr(c *Context, teamMember *model.TeamMember, actor *model.User) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.UserHasJoinedTeamWithRPCErr(c, teamMember, actor)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.UserHasJoinedTeamWithRPCErr(c, teamMember, actor)
 	hooks.recordTime(startTime, "UserHasJoinedTeamWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) UserHasLeftTeamWithRPCErr(c *Context, teamMember *model.TeamMember, actor *model.User) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.UserHasLeftTeamWithRPCErr(c, teamMember, actor)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.UserHasLeftTeamWithRPCErr(c, teamMember, actor)
 	hooks.recordTime(startTime, "UserHasLeftTeamWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) FileWillBeDownloadedWithRPCErr(c *Context, fileInfo *model.FileInfo, userID string, downloadType model.FileDownloadType) (string, error) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.FileWillBeDownloadedWithRPCErr(c, fileInfo, userID, downloadType)
+	_returnsA, _returnsRPCErr := hooks.hooksWithRPCErrImpl.FileWillBeDownloadedWithRPCErr(c, fileInfo, userID, downloadType)
 	hooks.recordTime(startTime, "FileWillBeDownloadedWithRPCErr", _returnsRPCErr == nil)
 	return _returnsA, _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) ReactionHasBeenAddedWithRPCErr(c *Context, reaction *model.Reaction) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.ReactionHasBeenAddedWithRPCErr(c, reaction)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.ReactionHasBeenAddedWithRPCErr(c, reaction)
 	hooks.recordTime(startTime, "ReactionHasBeenAddedWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) ReactionHasBeenRemovedWithRPCErr(c *Context, reaction *model.Reaction) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.ReactionHasBeenRemovedWithRPCErr(c, reaction)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.ReactionHasBeenRemovedWithRPCErr(c, reaction)
 	hooks.recordTime(startTime, "ReactionHasBeenRemovedWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) OnPluginClusterEventWithRPCErr(c *Context, ev model.PluginClusterEvent) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.OnPluginClusterEventWithRPCErr(c, ev)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.OnPluginClusterEventWithRPCErr(c, ev)
 	hooks.recordTime(startTime, "OnPluginClusterEventWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) OnWebSocketConnectWithRPCErr(webConnID, userID string) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.OnWebSocketConnectWithRPCErr(webConnID, userID)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.OnWebSocketConnectWithRPCErr(webConnID, userID)
 	hooks.recordTime(startTime, "OnWebSocketConnectWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) OnWebSocketDisconnectWithRPCErr(webConnID, userID string) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.OnWebSocketDisconnectWithRPCErr(webConnID, userID)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.OnWebSocketDisconnectWithRPCErr(webConnID, userID)
 	hooks.recordTime(startTime, "OnWebSocketDisconnectWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) WebSocketMessageHasBeenPostedWithRPCErr(webConnID, userID string, req *model.WebSocketRequest) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.WebSocketMessageHasBeenPostedWithRPCErr(webConnID, userID, req)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.WebSocketMessageHasBeenPostedWithRPCErr(webConnID, userID, req)
 	hooks.recordTime(startTime, "WebSocketMessageHasBeenPostedWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) RunDataRetentionWithRPCErr(nowTime, batchSize int64) (int64, error, error) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsB, _returnsRPCErr := hooks.rpcErrImpl.RunDataRetentionWithRPCErr(nowTime, batchSize)
+	_returnsA, _returnsB, _returnsRPCErr := hooks.hooksWithRPCErrImpl.RunDataRetentionWithRPCErr(nowTime, batchSize)
 	hooks.recordTime(startTime, "RunDataRetentionWithRPCErr", _returnsRPCErr == nil && _returnsB == nil)
 	return _returnsA, _returnsB, _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) OnInstallWithRPCErr(c *Context, event model.OnInstallEvent) (error, error) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.OnInstallWithRPCErr(c, event)
+	_returnsA, _returnsRPCErr := hooks.hooksWithRPCErrImpl.OnInstallWithRPCErr(c, event)
 	hooks.recordTime(startTime, "OnInstallWithRPCErr", _returnsRPCErr == nil && _returnsA == nil)
 	return _returnsA, _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) OnSendDailyTelemetryWithRPCErr() error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.OnSendDailyTelemetryWithRPCErr()
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.OnSendDailyTelemetryWithRPCErr()
 	hooks.recordTime(startTime, "OnSendDailyTelemetryWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) OnCloudLimitsUpdatedWithRPCErr(limits *model.ProductLimits) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.OnCloudLimitsUpdatedWithRPCErr(limits)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.OnCloudLimitsUpdatedWithRPCErr(limits)
 	hooks.recordTime(startTime, "OnCloudLimitsUpdatedWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) ConfigurationWillBeSavedWithRPCErr(newCfg *model.Config) (*model.Config, error, error) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsB, _returnsRPCErr := hooks.rpcErrImpl.ConfigurationWillBeSavedWithRPCErr(newCfg)
+	_returnsA, _returnsB, _returnsRPCErr := hooks.hooksWithRPCErrImpl.ConfigurationWillBeSavedWithRPCErr(newCfg)
 	hooks.recordTime(startTime, "ConfigurationWillBeSavedWithRPCErr", _returnsRPCErr == nil && _returnsB == nil)
 	return _returnsA, _returnsB, _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) EmailNotificationWillBeSentWithRPCErr(emailNotification *model.EmailNotification) (*model.EmailNotificationContent, string, error) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsB, _returnsRPCErr := hooks.rpcErrImpl.EmailNotificationWillBeSentWithRPCErr(emailNotification)
+	_returnsA, _returnsB, _returnsRPCErr := hooks.hooksWithRPCErrImpl.EmailNotificationWillBeSentWithRPCErr(emailNotification)
 	hooks.recordTime(startTime, "EmailNotificationWillBeSentWithRPCErr", _returnsRPCErr == nil)
 	return _returnsA, _returnsB, _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) NotificationWillBePushedWithRPCErr(pushNotification *model.PushNotification, userID string) (*model.PushNotification, string, error) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsB, _returnsRPCErr := hooks.rpcErrImpl.NotificationWillBePushedWithRPCErr(pushNotification, userID)
+	_returnsA, _returnsB, _returnsRPCErr := hooks.hooksWithRPCErrImpl.NotificationWillBePushedWithRPCErr(pushNotification, userID)
 	hooks.recordTime(startTime, "NotificationWillBePushedWithRPCErr", _returnsRPCErr == nil)
 	return _returnsA, _returnsB, _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) UserHasBeenDeactivatedWithRPCErr(c *Context, user *model.User) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.UserHasBeenDeactivatedWithRPCErr(c, user)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.UserHasBeenDeactivatedWithRPCErr(c, user)
 	hooks.recordTime(startTime, "UserHasBeenDeactivatedWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) OnSharedChannelsSyncMsgWithRPCErr(msg *model.SyncMsg, rc *model.RemoteCluster) (model.SyncResponse, error, error) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsB, _returnsRPCErr := hooks.rpcErrImpl.OnSharedChannelsSyncMsgWithRPCErr(msg, rc)
+	_returnsA, _returnsB, _returnsRPCErr := hooks.hooksWithRPCErrImpl.OnSharedChannelsSyncMsgWithRPCErr(msg, rc)
 	hooks.recordTime(startTime, "OnSharedChannelsSyncMsgWithRPCErr", _returnsRPCErr == nil && _returnsB == nil)
 	return _returnsA, _returnsB, _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) OnSharedChannelsPingWithRPCErr(rc *model.RemoteCluster) (bool, error) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.OnSharedChannelsPingWithRPCErr(rc)
+	_returnsA, _returnsRPCErr := hooks.hooksWithRPCErrImpl.OnSharedChannelsPingWithRPCErr(rc)
 	hooks.recordTime(startTime, "OnSharedChannelsPingWithRPCErr", _returnsRPCErr == nil)
 	return _returnsA, _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) PreferencesHaveChangedWithRPCErr(c *Context, preferences []model.Preference) error {
 	startTime := timePkg.Now()
-	_returnsRPCErr := hooks.rpcErrImpl.PreferencesHaveChangedWithRPCErr(c, preferences)
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.PreferencesHaveChangedWithRPCErr(c, preferences)
 	hooks.recordTime(startTime, "PreferencesHaveChangedWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) OnSharedChannelsAttachmentSyncMsgWithRPCErr(fi *model.FileInfo, post *model.Post, rc *model.RemoteCluster) (error, error) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.OnSharedChannelsAttachmentSyncMsgWithRPCErr(fi, post, rc)
+	_returnsA, _returnsRPCErr := hooks.hooksWithRPCErrImpl.OnSharedChannelsAttachmentSyncMsgWithRPCErr(fi, post, rc)
 	hooks.recordTime(startTime, "OnSharedChannelsAttachmentSyncMsgWithRPCErr", _returnsRPCErr == nil && _returnsA == nil)
 	return _returnsA, _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) OnSharedChannelsProfileImageSyncMsgWithRPCErr(user *model.User, rc *model.RemoteCluster) (error, error) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.OnSharedChannelsProfileImageSyncMsgWithRPCErr(user, rc)
+	_returnsA, _returnsRPCErr := hooks.hooksWithRPCErrImpl.OnSharedChannelsProfileImageSyncMsgWithRPCErr(user, rc)
 	hooks.recordTime(startTime, "OnSharedChannelsProfileImageSyncMsgWithRPCErr", _returnsRPCErr == nil && _returnsA == nil)
 	return _returnsA, _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) GenerateSupportDataWithRPCErr(c *Context) ([]*model.FileData, error, error) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsB, _returnsRPCErr := hooks.rpcErrImpl.GenerateSupportDataWithRPCErr(c)
+	_returnsA, _returnsB, _returnsRPCErr := hooks.hooksWithRPCErrImpl.GenerateSupportDataWithRPCErr(c)
 	hooks.recordTime(startTime, "GenerateSupportDataWithRPCErr", _returnsRPCErr == nil && _returnsB == nil)
 	return _returnsA, _returnsB, _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) OnSAMLLoginWithRPCErr(c *Context, user *model.User, assertion *saml2.AssertionInfo) (error, error) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.OnSAMLLoginWithRPCErr(c, user, assertion)
+	_returnsA, _returnsRPCErr := hooks.hooksWithRPCErrImpl.OnSAMLLoginWithRPCErr(c, user, assertion)
 	hooks.recordTime(startTime, "OnSAMLLoginWithRPCErr", _returnsRPCErr == nil && _returnsA == nil)
 	return _returnsA, _returnsRPCErr
 }

--- a/server/public/plugin/hooks_timer_layer_generated.go
+++ b/server/public/plugin/hooks_timer_layer_generated.go
@@ -16,9 +16,10 @@ import (
 )
 
 type hooksTimerLayer struct {
-	pluginID  string
-	hooksImpl Hooks
-	metrics   metricsInterface
+	pluginID   string
+	hooksImpl  Hooks
+	rpcErrImpl HooksRPCErr
+	metrics    metricsInterface
 }
 
 func (hooks *hooksTimerLayer) recordTime(startTime timePkg.Time, name string, success bool) {
@@ -333,4 +334,263 @@ func (hooks *hooksTimerLayer) OnSAMLLogin(c *Context, user *model.User, assertio
 	_returnsA := hooks.hooksImpl.OnSAMLLogin(c, user, assertion)
 	hooks.recordTime(startTime, "OnSAMLLogin", _returnsA == nil)
 	return _returnsA
+}
+
+func (hooks *hooksTimerLayer) OnDeactivateWithRPCErr() (error, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.OnDeactivateWithRPCErr()
+	hooks.recordTime(startTime, "OnDeactivateWithRPCErr", _returnsRPCErr == nil && _returnsA == nil)
+	return _returnsA, _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) OnConfigurationChangeWithRPCErr() (error, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.OnConfigurationChangeWithRPCErr()
+	hooks.recordTime(startTime, "OnConfigurationChangeWithRPCErr", _returnsRPCErr == nil && _returnsA == nil)
+	return _returnsA, _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) ExecuteCommandWithRPCErr(c *Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB, _returnsRPCErr := hooks.rpcErrImpl.ExecuteCommandWithRPCErr(c, args)
+	hooks.recordTime(startTime, "ExecuteCommandWithRPCErr", _returnsRPCErr == nil && _returnsB == nil)
+	return _returnsA, _returnsB, _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) UserHasBeenCreatedWithRPCErr(c *Context, user *model.User) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.UserHasBeenCreatedWithRPCErr(c, user)
+	hooks.recordTime(startTime, "UserHasBeenCreatedWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) UserWillLogInWithRPCErr(c *Context, user *model.User) (string, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.UserWillLogInWithRPCErr(c, user)
+	hooks.recordTime(startTime, "UserWillLogInWithRPCErr", _returnsRPCErr == nil)
+	return _returnsA, _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) UserHasLoggedInWithRPCErr(c *Context, user *model.User) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.UserHasLoggedInWithRPCErr(c, user)
+	hooks.recordTime(startTime, "UserHasLoggedInWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) MessageHasBeenPostedWithRPCErr(c *Context, post *model.Post) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.MessageHasBeenPostedWithRPCErr(c, post)
+	hooks.recordTime(startTime, "MessageHasBeenPostedWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) MessageHasBeenUpdatedWithRPCErr(c *Context, newPost, oldPost *model.Post) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.MessageHasBeenUpdatedWithRPCErr(c, newPost, oldPost)
+	hooks.recordTime(startTime, "MessageHasBeenUpdatedWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) MessageHasBeenDeletedWithRPCErr(c *Context, post *model.Post) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.MessageHasBeenDeletedWithRPCErr(c, post)
+	hooks.recordTime(startTime, "MessageHasBeenDeletedWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) ChannelHasBeenCreatedWithRPCErr(c *Context, channel *model.Channel) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.ChannelHasBeenCreatedWithRPCErr(c, channel)
+	hooks.recordTime(startTime, "ChannelHasBeenCreatedWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) ChannelWillBeArchivedWithRPCErr(c *Context, channel *model.Channel) (string, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.ChannelWillBeArchivedWithRPCErr(c, channel)
+	hooks.recordTime(startTime, "ChannelWillBeArchivedWithRPCErr", _returnsRPCErr == nil)
+	return _returnsA, _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) UserHasJoinedChannelWithRPCErr(c *Context, channelMember *model.ChannelMember, actor *model.User) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.UserHasJoinedChannelWithRPCErr(c, channelMember, actor)
+	hooks.recordTime(startTime, "UserHasJoinedChannelWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) UserHasLeftChannelWithRPCErr(c *Context, channelMember *model.ChannelMember, actor *model.User) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.UserHasLeftChannelWithRPCErr(c, channelMember, actor)
+	hooks.recordTime(startTime, "UserHasLeftChannelWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) UserHasJoinedTeamWithRPCErr(c *Context, teamMember *model.TeamMember, actor *model.User) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.UserHasJoinedTeamWithRPCErr(c, teamMember, actor)
+	hooks.recordTime(startTime, "UserHasJoinedTeamWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) UserHasLeftTeamWithRPCErr(c *Context, teamMember *model.TeamMember, actor *model.User) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.UserHasLeftTeamWithRPCErr(c, teamMember, actor)
+	hooks.recordTime(startTime, "UserHasLeftTeamWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) FileWillBeDownloadedWithRPCErr(c *Context, fileInfo *model.FileInfo, userID string, downloadType model.FileDownloadType) (string, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.FileWillBeDownloadedWithRPCErr(c, fileInfo, userID, downloadType)
+	hooks.recordTime(startTime, "FileWillBeDownloadedWithRPCErr", _returnsRPCErr == nil)
+	return _returnsA, _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) ReactionHasBeenAddedWithRPCErr(c *Context, reaction *model.Reaction) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.ReactionHasBeenAddedWithRPCErr(c, reaction)
+	hooks.recordTime(startTime, "ReactionHasBeenAddedWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) ReactionHasBeenRemovedWithRPCErr(c *Context, reaction *model.Reaction) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.ReactionHasBeenRemovedWithRPCErr(c, reaction)
+	hooks.recordTime(startTime, "ReactionHasBeenRemovedWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) OnPluginClusterEventWithRPCErr(c *Context, ev model.PluginClusterEvent) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.OnPluginClusterEventWithRPCErr(c, ev)
+	hooks.recordTime(startTime, "OnPluginClusterEventWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) OnWebSocketConnectWithRPCErr(webConnID, userID string) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.OnWebSocketConnectWithRPCErr(webConnID, userID)
+	hooks.recordTime(startTime, "OnWebSocketConnectWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) OnWebSocketDisconnectWithRPCErr(webConnID, userID string) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.OnWebSocketDisconnectWithRPCErr(webConnID, userID)
+	hooks.recordTime(startTime, "OnWebSocketDisconnectWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) WebSocketMessageHasBeenPostedWithRPCErr(webConnID, userID string, req *model.WebSocketRequest) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.WebSocketMessageHasBeenPostedWithRPCErr(webConnID, userID, req)
+	hooks.recordTime(startTime, "WebSocketMessageHasBeenPostedWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) RunDataRetentionWithRPCErr(nowTime, batchSize int64) (int64, error, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB, _returnsRPCErr := hooks.rpcErrImpl.RunDataRetentionWithRPCErr(nowTime, batchSize)
+	hooks.recordTime(startTime, "RunDataRetentionWithRPCErr", _returnsRPCErr == nil && _returnsB == nil)
+	return _returnsA, _returnsB, _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) OnInstallWithRPCErr(c *Context, event model.OnInstallEvent) (error, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.OnInstallWithRPCErr(c, event)
+	hooks.recordTime(startTime, "OnInstallWithRPCErr", _returnsRPCErr == nil && _returnsA == nil)
+	return _returnsA, _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) OnSendDailyTelemetryWithRPCErr() error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.OnSendDailyTelemetryWithRPCErr()
+	hooks.recordTime(startTime, "OnSendDailyTelemetryWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) OnCloudLimitsUpdatedWithRPCErr(limits *model.ProductLimits) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.OnCloudLimitsUpdatedWithRPCErr(limits)
+	hooks.recordTime(startTime, "OnCloudLimitsUpdatedWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) ConfigurationWillBeSavedWithRPCErr(newCfg *model.Config) (*model.Config, error, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB, _returnsRPCErr := hooks.rpcErrImpl.ConfigurationWillBeSavedWithRPCErr(newCfg)
+	hooks.recordTime(startTime, "ConfigurationWillBeSavedWithRPCErr", _returnsRPCErr == nil && _returnsB == nil)
+	return _returnsA, _returnsB, _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) EmailNotificationWillBeSentWithRPCErr(emailNotification *model.EmailNotification) (*model.EmailNotificationContent, string, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB, _returnsRPCErr := hooks.rpcErrImpl.EmailNotificationWillBeSentWithRPCErr(emailNotification)
+	hooks.recordTime(startTime, "EmailNotificationWillBeSentWithRPCErr", _returnsRPCErr == nil)
+	return _returnsA, _returnsB, _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) NotificationWillBePushedWithRPCErr(pushNotification *model.PushNotification, userID string) (*model.PushNotification, string, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB, _returnsRPCErr := hooks.rpcErrImpl.NotificationWillBePushedWithRPCErr(pushNotification, userID)
+	hooks.recordTime(startTime, "NotificationWillBePushedWithRPCErr", _returnsRPCErr == nil)
+	return _returnsA, _returnsB, _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) UserHasBeenDeactivatedWithRPCErr(c *Context, user *model.User) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.UserHasBeenDeactivatedWithRPCErr(c, user)
+	hooks.recordTime(startTime, "UserHasBeenDeactivatedWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) OnSharedChannelsSyncMsgWithRPCErr(msg *model.SyncMsg, rc *model.RemoteCluster) (model.SyncResponse, error, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB, _returnsRPCErr := hooks.rpcErrImpl.OnSharedChannelsSyncMsgWithRPCErr(msg, rc)
+	hooks.recordTime(startTime, "OnSharedChannelsSyncMsgWithRPCErr", _returnsRPCErr == nil && _returnsB == nil)
+	return _returnsA, _returnsB, _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) OnSharedChannelsPingWithRPCErr(rc *model.RemoteCluster) (bool, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.OnSharedChannelsPingWithRPCErr(rc)
+	hooks.recordTime(startTime, "OnSharedChannelsPingWithRPCErr", _returnsRPCErr == nil)
+	return _returnsA, _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) PreferencesHaveChangedWithRPCErr(c *Context, preferences []model.Preference) error {
+	startTime := timePkg.Now()
+	_returnsRPCErr := hooks.rpcErrImpl.PreferencesHaveChangedWithRPCErr(c, preferences)
+	hooks.recordTime(startTime, "PreferencesHaveChangedWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) OnSharedChannelsAttachmentSyncMsgWithRPCErr(fi *model.FileInfo, post *model.Post, rc *model.RemoteCluster) (error, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.OnSharedChannelsAttachmentSyncMsgWithRPCErr(fi, post, rc)
+	hooks.recordTime(startTime, "OnSharedChannelsAttachmentSyncMsgWithRPCErr", _returnsRPCErr == nil && _returnsA == nil)
+	return _returnsA, _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) OnSharedChannelsProfileImageSyncMsgWithRPCErr(user *model.User, rc *model.RemoteCluster) (error, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.OnSharedChannelsProfileImageSyncMsgWithRPCErr(user, rc)
+	hooks.recordTime(startTime, "OnSharedChannelsProfileImageSyncMsgWithRPCErr", _returnsRPCErr == nil && _returnsA == nil)
+	return _returnsA, _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) GenerateSupportDataWithRPCErr(c *Context) ([]*model.FileData, error, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB, _returnsRPCErr := hooks.rpcErrImpl.GenerateSupportDataWithRPCErr(c)
+	hooks.recordTime(startTime, "GenerateSupportDataWithRPCErr", _returnsRPCErr == nil && _returnsB == nil)
+	return _returnsA, _returnsB, _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) OnSAMLLoginWithRPCErr(c *Context, user *model.User, assertion *saml2.AssertionInfo) (error, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsRPCErr := hooks.rpcErrImpl.OnSAMLLoginWithRPCErr(c, user, assertion)
+	hooks.recordTime(startTime, "OnSAMLLoginWithRPCErr", _returnsRPCErr == nil && _returnsA == nil)
+	return _returnsA, _returnsRPCErr
 }

--- a/server/public/plugin/interface_generator/main.go
+++ b/server/public/plugin/interface_generator/main.go
@@ -390,6 +390,9 @@ func (g *hooksRPCClient) {{.Name}}WithRPCErr{{funcStyle .Params}} {{funcStyleApp
 	if g.implemented[{{.Name}}ID] {
 		_err = g.client.Call("Plugin.{{.Name}}", _args, _returns)
 		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksRPCErr contract).
+			_returns = &{{.Name | obscure}}Returns{}
 			g.log.Debug("RPC call {{.Name}} to plugin failed.", mlog.Err(_err))
 		}
 	}

--- a/server/public/plugin/interface_generator/main.go
+++ b/server/public/plugin/interface_generator/main.go
@@ -80,6 +80,16 @@ func FieldListToFuncList(fieldList *ast.FieldList, fileset *token.FileSet) strin
 	return "(" + strings.Join(result, ", ") + ")"
 }
 
+// FieldListToFuncListAppendErr renders the return signature with an extra trailing
+// `error` (the RPC transport error). Used to emit *WithRPCErr companion signatures.
+func FieldListToFuncListAppendErr(fieldList *ast.FieldList, fileset *token.FileSet) string {
+	if fieldList == nil || len(fieldList.List) == 0 {
+		return "error"
+	}
+	base := FieldListToFuncList(fieldList, fileset)
+	return "(" + base[1:len(base)-1] + ", error)"
+}
+
 func FieldListToNames(fieldList *ast.FieldList, variadicForm bool) string {
 	result := []string{}
 	if fieldList == nil || len(fieldList.List) == 0 {
@@ -165,6 +175,17 @@ func FieldListDestruct(structPrefix string, fieldList *ast.FieldList, fileset *t
 	return strings.Join(result, ", ")
 }
 
+// FieldListDestructAppendErr is FieldListDestruct with an extra trailing `<prefix>RPCErr`
+// variable name appended — used to bind the transport error in *WithRPCErr templates.
+func FieldListDestructAppendErr(structPrefix string, fieldList *ast.FieldList, fileset *token.FileSet) string {
+	base := FieldListDestruct(structPrefix, fieldList, fileset)
+	rpcErr := structPrefix + "RPCErr"
+	if base == "" {
+		return rpcErr
+	}
+	return base + ", " + rpcErr
+}
+
 func FieldListToRecordSuccess(structPrefix string, fieldList *ast.FieldList) string {
 	if fieldList == nil || len(fieldList.List) == 0 {
 		return "true"
@@ -185,6 +206,19 @@ func FieldListToRecordSuccess(structPrefix string, fieldList *ast.FieldList) str
 		return "true"
 	}
 	return fmt.Sprintf("%s == nil", result)
+}
+
+// FieldListToRecordSuccessWithRPCErr renders the success-flag expression for a *WithRPCErr
+// timer-layer call. It combines the RPC transport check with the base hook's app-error check
+// (if any), so the metric counts a call as successful only when both the transport and the
+// plugin's application-level return signal success.
+func FieldListToRecordSuccessWithRPCErr(structPrefix string, fieldList *ast.FieldList) string {
+	rpcErr := structPrefix + "RPCErr == nil"
+	base := FieldListToRecordSuccess(structPrefix, fieldList)
+	if base == "true" {
+		return rpcErr
+	}
+	return rpcErr + " && " + base
 }
 
 func FieldListToStructList(fieldList *ast.FieldList, fileset *token.FileSet) string {
@@ -347,6 +381,21 @@ func (g *hooksRPCClient) {{.Name}}{{funcStyle .Params}} {{funcStyle .Return}} {
 	{{ if .Return }} return {{destruct "_returns." .Return}} {{ end }}
 }
 
+// {{.Name}}WithRPCErr returns the same values as {{.Name}}, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) {{.Name}}WithRPCErr{{funcStyle .Params}} {{funcStyleAppendErr .Return}} {
+	_args := &{{.Name | obscure}}Args{ {{valuesOnly .Params}} }
+	_returns := &{{.Name | obscure}}Returns{}
+	var _err error
+	if g.implemented[{{.Name}}ID] {
+		_err = g.client.Call("Plugin.{{.Name}}", _args, _returns)
+		if _err != nil {
+			g.log.Debug("RPC call {{.Name}} to plugin failed.", mlog.Err(_err))
+		}
+	}
+	{{ if .Return }} return {{destruct "_returns." .Return}}, _err {{ else }} return _err {{ end }}
+}
+
 func (s *hooksRPCServer) {{.Name}}(args *{{.Name | obscure}}Args, returns *{{.Name | obscure}}Returns) error {
 	if hook, ok := s.impl.(interface {
 		{{.Name}}{{funcStyle .Params}} {{funcStyle .Return}}
@@ -359,6 +408,22 @@ func (s *hooksRPCServer) {{.Name}}(args *{{.Name | obscure}}Args, returns *{{.Na
 	return nil
 }
 {{end}}
+
+// HooksRPCErr is implemented by hooksRPCClient. It provides a WithRPCErr variant for every
+// generated hook. The last error return is always the RPC transport error — if non-nil, the
+// plugin's other return values are zero. For hooks whose base signature already returns error,
+// the tuple is (originalReturns..., rpcErr) where the final slot is always transport.
+//
+// If the plugin does not implement the hook, the companion returns zero values and a nil error —
+// indistinguishable from a successful invocation that returned zeros. Callers MUST gate on
+// supervisor.Implements(<HookID>) (or use Environment.RunMultiPluginHookWithRPCErr, which gates
+// by the iteration's hook ID — note that any *WithRPCErr method called on the closure's
+// HooksRPCErr is independently subject to its own implemented-gate).
+type HooksRPCErr interface {
+	{{range .HooksMethods}}
+	{{.Name}}WithRPCErr{{funcStyle .Params}} {{funcStyleAppendErr .Return}}
+	{{end}}
+}
 
 {{range .APIMethods}}
 
@@ -452,9 +517,10 @@ import (
 )
 
 type hooksTimerLayer struct {
-	pluginID  string
-	hooksImpl Hooks
-	metrics   metricsInterface
+	pluginID   string
+	hooksImpl  Hooks
+	rpcErrImpl HooksRPCErr
+	metrics    metricsInterface
 }
 
 func (hooks *hooksTimerLayer) recordTime(startTime timePkg.Time, name string, success bool) {
@@ -474,6 +540,17 @@ func (hooks *hooksTimerLayer) {{.Name}}{{funcStyle .Params}} {{funcStyle .Return
 }
 
 {{end}}
+
+{{range .HooksMethodsRPCErr}}
+
+func (hooks *hooksTimerLayer) {{.Name}}WithRPCErr{{funcStyle .Params}} {{funcStyleAppendErr .Return}} {
+	startTime := timePkg.Now()
+	{{destructAppendErr "_returns" .Return}} := hooks.rpcErrImpl.{{.Name}}WithRPCErr({{valuesOnly .Params}})
+	hooks.recordTime(startTime, "{{.Name}}WithRPCErr", {{ shouldRecordSuccessWithRPCErr "_returns" .Return }})
+	return {{destructAppendErr "_returns" .Return}}
+}
+
+{{end}}
 `
 
 type MethodParams struct {
@@ -483,15 +560,17 @@ type MethodParams struct {
 }
 
 type HooksTemplateParams struct {
-	HooksMethods []MethodParams
-	APIMethods   []MethodParams
+	HooksMethods       []MethodParams
+	HooksMethodsRPCErr []MethodParams
+	APIMethods         []MethodParams
 }
 
 func generateHooksGlue(info *PluginInterfaceInfo) {
 	templateFunctions := map[string]any{
-		"funcStyle":   func(fields *ast.FieldList) string { return FieldListToFuncList(fields, info.FileSet) },
-		"structStyle": func(fields *ast.FieldList) string { return FieldListToStructList(fields, info.FileSet) },
-		"valuesOnly":  func(fields *ast.FieldList) string { return FieldListToNames(fields, false) },
+		"funcStyle":          func(fields *ast.FieldList) string { return FieldListToFuncList(fields, info.FileSet) },
+		"funcStyleAppendErr": func(fields *ast.FieldList) string { return FieldListToFuncListAppendErr(fields, info.FileSet) },
+		"structStyle":        func(fields *ast.FieldList) string { return FieldListToStructList(fields, info.FileSet) },
+		"valuesOnly":         func(fields *ast.FieldList) string { return FieldListToNames(fields, false) },
 		"encodeErrors": func(structPrefix string, fields *ast.FieldList) string {
 			return FieldListToEncodedErrors(structPrefix, fields, info.FileSet)
 		},
@@ -544,25 +623,40 @@ func generateHooksGlue(info *PluginInterfaceInfo) {
 
 func generatePluginTimerLayer(info *PluginInterfaceInfo) {
 	templateFunctions := map[string]any{
-		"funcStyle":   func(fields *ast.FieldList) string { return FieldListToFuncList(fields, info.FileSet) },
-		"structStyle": func(fields *ast.FieldList) string { return FieldListToStructList(fields, info.FileSet) },
-		"valuesOnly":  func(fields *ast.FieldList) string { return FieldListToNames(fields, true) },
+		"funcStyle":          func(fields *ast.FieldList) string { return FieldListToFuncList(fields, info.FileSet) },
+		"funcStyleAppendErr": func(fields *ast.FieldList) string { return FieldListToFuncListAppendErr(fields, info.FileSet) },
+		"structStyle":        func(fields *ast.FieldList) string { return FieldListToStructList(fields, info.FileSet) },
+		"valuesOnly":         func(fields *ast.FieldList) string { return FieldListToNames(fields, true) },
 		"destruct": func(structPrefix string, fields *ast.FieldList) string {
 			return FieldListDestruct(structPrefix, fields, info.FileSet)
+		},
+		"destructAppendErr": func(structPrefix string, fields *ast.FieldList) string {
+			return FieldListDestructAppendErr(structPrefix, fields, info.FileSet)
 		},
 		"shouldRecordSuccess": func(structPrefix string, fields *ast.FieldList) string {
 			return FieldListToRecordSuccess(structPrefix, fields)
 		},
+		"shouldRecordSuccessWithRPCErr": func(structPrefix string, fields *ast.FieldList) string {
+			return FieldListToRecordSuccessWithRPCErr(structPrefix, fields)
+		},
 	}
 
-	// Prepare template params
+	// Prepare template params. The timer layer wraps the full Hooks interface, so
+	// HooksMethods includes excluded hooks too. *WithRPCErr companions only exist
+	// for non-excluded hooks (see HooksRPCErr in client_rpc_generated.go), so the
+	// excluded subset is filtered into HooksMethodsRPCErr for that loop.
+	excluded := func(name string) bool { return slices.Contains(excludedPluginHooks, name) }
 	templateParams := HooksTemplateParams{}
 	for _, hook := range info.Hooks {
-		templateParams.HooksMethods = append(templateParams.HooksMethods, MethodParams{
+		mp := MethodParams{
 			Name:   hook.FuncName,
 			Params: hook.Args,
 			Return: hook.Results,
-		})
+		}
+		templateParams.HooksMethods = append(templateParams.HooksMethods, mp)
+		if !excluded(hook.FuncName) {
+			templateParams.HooksMethodsRPCErr = append(templateParams.HooksMethodsRPCErr, mp)
+		}
 	}
 	for _, api := range info.API {
 		templateParams.APIMethods = append(templateParams.APIMethods, MethodParams{

--- a/server/public/plugin/interface_generator/main.go
+++ b/server/public/plugin/interface_generator/main.go
@@ -522,7 +522,7 @@ import (
 type hooksTimerLayer struct {
 	pluginID   string
 	hooksImpl  Hooks
-	rpcErrImpl HooksWithRPCErr
+	hooksWithRPCErrImpl HooksWithRPCErr
 	metrics    metricsInterface
 }
 
@@ -548,7 +548,7 @@ func (hooks *hooksTimerLayer) {{.Name}}{{funcStyle .Params}} {{funcStyle .Return
 
 func (hooks *hooksTimerLayer) {{.Name}}WithRPCErr{{funcStyle .Params}} {{funcStyleAppendErr .Return}} {
 	startTime := timePkg.Now()
-	{{destructAppendErr "_returns" .Return}} := hooks.rpcErrImpl.{{.Name}}WithRPCErr({{valuesOnly .Params}})
+	{{destructAppendErr "_returns" .Return}} := hooks.hooksWithRPCErrImpl.{{.Name}}WithRPCErr({{valuesOnly .Params}})
 	hooks.recordTime(startTime, "{{.Name}}WithRPCErr", {{ shouldRecordSuccessWithRPCErr "_returns" .Return }})
 	return {{destructAppendErr "_returns" .Return}}
 }

--- a/server/public/plugin/interface_generator/main.go
+++ b/server/public/plugin/interface_generator/main.go
@@ -412,10 +412,10 @@ func (s *hooksRPCServer) {{.Name}}(args *{{.Name | obscure}}Args, returns *{{.Na
 }
 {{end}}
 
-// HooksWithRPCErr is implemented by hooksRPCClient. It provides a WithRPCErr variant for every
-// generated hook. The last error return is always the RPC transport error — if non-nil, the
-// plugin's other return values are zero. For hooks whose base signature already returns error,
-// the tuple is (originalReturns..., rpcErr) where the final slot is always transport.
+// HooksWithRPCErr provides a WithRPCErr variant for every generated hook. The last error return
+// is always the RPC transport error — if non-nil, the plugin's other return values are zero. For
+// hooks whose base signature already returns error, the tuple is (originalReturns..., rpcErr)
+// where the final slot is always transport.
 //
 // If the plugin does not implement the hook, the companion returns zero values and a nil error —
 // indistinguishable from a successful invocation that returned zeros. Callers MUST gate on

--- a/server/public/plugin/interface_generator/main.go
+++ b/server/public/plugin/interface_generator/main.go
@@ -391,7 +391,7 @@ func (g *hooksRPCClient) {{.Name}}WithRPCErr{{funcStyle .Params}} {{funcStyleApp
 		_err = g.client.Call("Plugin.{{.Name}}", _args, _returns)
 		if _err != nil {
 			// Reset _returns so partial gob decoding can't leak non-zero
-			// values past a transport failure (HooksRPCErr contract).
+			// values past a transport failure (HooksWithRPCErr contract).
 			_returns = &{{.Name | obscure}}Returns{}
 			g.log.Debug("RPC call {{.Name}} to plugin failed.", mlog.Err(_err))
 		}
@@ -412,7 +412,7 @@ func (s *hooksRPCServer) {{.Name}}(args *{{.Name | obscure}}Args, returns *{{.Na
 }
 {{end}}
 
-// HooksRPCErr is implemented by hooksRPCClient. It provides a WithRPCErr variant for every
+// HooksWithRPCErr is implemented by hooksRPCClient. It provides a WithRPCErr variant for every
 // generated hook. The last error return is always the RPC transport error — if non-nil, the
 // plugin's other return values are zero. For hooks whose base signature already returns error,
 // the tuple is (originalReturns..., rpcErr) where the final slot is always transport.
@@ -421,8 +421,8 @@ func (s *hooksRPCServer) {{.Name}}(args *{{.Name | obscure}}Args, returns *{{.Na
 // indistinguishable from a successful invocation that returned zeros. Callers MUST gate on
 // supervisor.Implements(<HookID>) (or use Environment.RunMultiPluginHookWithRPCErr, which gates
 // by the iteration's hook ID — note that any *WithRPCErr method called on the closure's
-// HooksRPCErr is independently subject to its own implemented-gate).
-type HooksRPCErr interface {
+// HooksWithRPCErr is independently subject to its own implemented-gate).
+type HooksWithRPCErr interface {
 	{{range .HooksMethods}}
 	{{.Name}}WithRPCErr{{funcStyle .Params}} {{funcStyleAppendErr .Return}}
 	{{end}}
@@ -522,7 +522,7 @@ import (
 type hooksTimerLayer struct {
 	pluginID   string
 	hooksImpl  Hooks
-	rpcErrImpl HooksRPCErr
+	rpcErrImpl HooksWithRPCErr
 	metrics    metricsInterface
 }
 
@@ -646,7 +646,7 @@ func generatePluginTimerLayer(info *PluginInterfaceInfo) {
 
 	// Prepare template params. The timer layer wraps the full Hooks interface, so
 	// HooksMethods includes excluded hooks too. *WithRPCErr companions only exist
-	// for non-excluded hooks (see HooksRPCErr in client_rpc_generated.go), so the
+	// for non-excluded hooks (see HooksWithRPCErr in client_rpc_generated.go), so the
 	// excluded subset is filtered into HooksMethodsRPCErr for that loop.
 	excluded := func(name string) bool { return slices.Contains(excludedPluginHooks, name) }
 	templateParams := HooksTemplateParams{}

--- a/server/public/plugin/supervisor.go
+++ b/server/public/plugin/supervisor.go
@@ -27,7 +27,7 @@ type supervisor struct {
 	pluginID     string
 	appDriver    AppDriver
 	client       *plugin.Client
-	hooks        Hooks
+	hooks        *hooksTimerLayer
 	implemented  [TotalHooksID]bool
 	hooksClient  *hooksRPCClient
 	isReattached bool
@@ -193,6 +193,12 @@ func (sup *supervisor) Shutdown() {
 }
 
 func (sup *supervisor) Hooks() Hooks {
+	sup.lock.RLock()
+	defer sup.lock.RUnlock()
+	return sup.hooks
+}
+
+func (sup *supervisor) HooksWithRPCErr() HooksWithRPCErr {
 	sup.lock.RLock()
 	defer sup.lock.RUnlock()
 	return sup.hooks

--- a/server/public/plugin/supervisor.go
+++ b/server/public/plugin/supervisor.go
@@ -146,7 +146,7 @@ func newSupervisor(pluginInfo *model.BundleInfo, apiImpl API, driver AppDriver, 
 		sup.hooksClient = c
 	}
 
-	sup.hooks = &hooksTimerLayer{pluginInfo.Manifest.Id, raw.(Hooks), raw.(HooksRPCErr), metrics}
+	sup.hooks = &hooksTimerLayer{pluginInfo.Manifest.Id, raw.(Hooks), raw.(HooksWithRPCErr), metrics}
 
 	impl, err := sup.hooks.Implemented()
 	if err != nil {

--- a/server/public/plugin/supervisor.go
+++ b/server/public/plugin/supervisor.go
@@ -146,7 +146,7 @@ func newSupervisor(pluginInfo *model.BundleInfo, apiImpl API, driver AppDriver, 
 		sup.hooksClient = c
 	}
 
-	sup.hooks = &hooksTimerLayer{pluginInfo.Manifest.Id, raw.(Hooks), metrics}
+	sup.hooks = &hooksTimerLayer{pluginInfo.Manifest.Id, raw.(Hooks), raw.(HooksRPCErr), metrics}
 
 	impl, err := sup.hooks.Implemented()
 	if err != nil {


### PR DESCRIPTION
#### Summary
Adds an optional `*WithRPCErr` companion for every plugin hook, returning an extra trailing `error` so callers can tell a real plugin response from a transport failure.

Today, `ChannelWillBeUpdated` returns `(nil, "")` when the plugin doesn't need to modify the channel — and the *same* `(nil, "")` if the plugin crashed or RPC failed mid-call. Callers can't distinguish "approved" from "transport broke." With `ChannelWillBeUpdatedWithRPCErr` they get `(nil, "", err)` — the trailing slot is always the RPC transport error, so the caller can fail closed on a crash and accept the no-op only when the plugin really returned it.

Server-side plumbing only. The `Hooks` interface, all existing call sites, and plugin authors are unchanged. Lays groundwork for an upcoming fail-closed dispatch path (for the Message-Based Encryption tech preview plugin -- but can be used by anyone who needs this kind of information).

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-68655

#### Tips to Review
- **Why `HooksRPCErr` is split from `Hooks`** — `Hooks` is the public plugin-author godoc surface ("methods a plugin may implement"). Appending ~37 internal companion methods would mislead authors into thinking they should implement them (`Implemented()` reflection ignores them by design). The runtime type assertion in `environment.go` is structurally unreachable thanks to a compile-time `_ HooksRPCErr = (*hooksTimerLayer)(nil)` check.
- **Why `RunMultiHookWithRPCErr` returns `nil` for missing plugin env** rather than a sentinel — `GetPluginsEnvironment()` returns nil both when plugins are disabled by config (operator intent) and when the env hasn't initialized. A fail-closed sentinel would conflate them and deny every guarded user action whenever plugins are disabled — wrong policy. Callers needing fail-closed-on-no-env guard at the call site (documented on the method).
- **Why the companion logs at Debug, not Error** — future fail-closed callers will log RPC failures at Error with full context (user/channel/operation). Companion-level Error would double-count in Sentry during plugin restarts. Base (non-WithRPCErr) hooks still log at Error for callers that swallow the failure.
- **Why the timer-layer `*WithRPCErr` success metric combines transport + app error** — parity with the base hook metric (`appErr == nil`); transport-only would silently label app-level failures as "success."

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Additive companion methods and generator changes reduce breaking risk, but the changes touch foundational plugin RPC generation, timer-layer metrics, supervisor accessors, and cross-cutting dispatch paths—introducing integration complexity and potential for subtle regressions in plugin hook dispatch and telemetry.  
**QA Recommendation:** Run focused manual QA on plugin hook flows (message/user/channel lifecycle hooks) including plugin process crash and RPC-failure scenarios; exercise timer/metrics and supervisor hook accessors in integration tests in addition to existing unit tests.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->