### PR TITLE
Update Agents plugin FIPS version to v2.0.3

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -179,7 +179,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.8.1%2Bac0a223-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.2%2B3b1ec24-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.3%2Bcab391a-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.4%2B5855fe1-fips
 endif
 


### PR DESCRIPTION
#### Summary
Update Agents plugin FIPS version to v2.0.3.

The FIPS build is produced from the [`CLD-9438-build-agents-fips-complaint` branch](https://github.com/mattermost/mattermost-plugin-agents/pull/372) of `mattermost-plugin-agents`, signed and uploaded via the [`Sign Plugin PR Artifacts` workflow](https://github.com/mattermost/delivery-platform/actions/runs/25374711497).

Source commit on the agents repo: [`cab391a`](https://github.com/mattermost/mattermost-plugin-agents/commit/cab391a21a738f8b18f17b7d8674e0a15da0a617) (merge of tag `v2.0.3`).

The signed FIPS bundle is reachable at [https://plugins.releases.mattermost.com/release/mattermost-plugin-agents-v2.0.3%2Bcab391a-fips-linux-amd64.tar.gz](https://plugins.releases.mattermost.com/release/mattermost-plugin-agents-v2.0.3%2Bcab391a-fips-linux-amd64.tar.gz).

This needs to be cherry-picked to `release-11.7` once merged.

#### Ticket Link
--

#### Screenshots
--

#### Release Note
```release-note
NONE
```