### PR TITLE
MM-68149: Upgrade mattermost-server-build images to Go 1.26.2

### DIFF
--- a/server/build/Dockerfile.buildenv
+++ b/server/build/Dockerfile.buildenv
@@ -1,4 +1,4 @@
-FROM mattermost/golang-bullseye:1.25.9@sha256:eb35cc5421737a4a85c7000aa85ed153a26b979d573b961c28f013d47726d4ed
+FROM mattermost/golang-bullseye:1.26.2@sha256:fc2cc64f035c74f14b0e5921971bcda4b6dbd281430d3cbfb0bf539ebb1bacd5
 ARG NODE_VERSION=20.11.1
 
 RUN apt-get update && apt-get install -y make git apt-transport-https ca-certificates curl software-properties-common build-essential zip xmlsec1 jq pgloader gnupg

--- a/server/build/Dockerfile.buildenv-fips
+++ b/server/build/Dockerfile.buildenv-fips
@@ -1,4 +1,4 @@
-FROM cgr.dev/mattermost.com/go-msft-fips:1.25.9-dev@sha256:e85eab899d8700962a60ad05b887de5fc8463a879b38d5d2c30b0d1384446189
+FROM cgr.dev/mattermost.com/go-msft-fips:1.26.2-dev@sha256:cdd5bd448fcf61654893846572f006aff7349aa21027de590fc2bd020f8126f1
 ARG NODE_VERSION=20.11.1
 
 RUN apk add curl ca-certificates mailcap unrtf wv poppler-utils tzdata gpg xmlsec


### PR DESCRIPTION
#### Summary
Updates `Dockerfile.buildenv` and `Dockerfile.buildenv-fips` to use the Go 1.26.2 build images. Once merged, `build-server-image.yml` will publish the updated `mattermost-server-build` and `mattermost-server-build-fips` containers.

This is a prerequisite for the Go 1.26.2 toolchain upgrade (https://github.com/mattermost/mattermost/pull/36418).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68149

#### Screenshots

#### Release Note
```release-note
NONE
```