### PR TITLE
fix: tolerate concurrent update conflicts in content flagging migration

### DIFF
--- a/server/channels/app/migrations.go
+++ b/server/channels/app/migrations.go
@@ -750,7 +750,14 @@ func (s *Server) doSetupContentFlaggingProperties() error {
 
 	if len(propertiesToUpdate) > 0 {
 		if _, _, err := s.propertyService.UpdatePropertyFields(nil, group.ID, propertiesToUpdate); err != nil {
-			return fmt.Errorf("failed to update content flagging property fields: %w", err)
+			// Another server may have won the race and updated these fields
+			// concurrently (e.g. parallel tests sharing a database pool).
+			// Both servers write the same expected values, so tolerate the
+			// conflict but propagate any other error.
+			var conflictErr *store.ErrConflict
+			if !errors.As(err, &conflictErr) {
+				return fmt.Errorf("failed to update content flagging property fields: %w", err)
+			}
 		}
 	}
 

--- a/server/channels/app/migrations_test.go
+++ b/server/channels/app/migrations_test.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -55,6 +56,45 @@ func TestDoSetupContentFlaggingProperties(t *testing.T) {
 		data, sysErr := th.Store.System().GetByName(contentFlaggingSetupDoneKey)
 		require.NoError(t, sysErr)
 		require.Equal(t, "v5", data.Value)
+	})
+
+	t.Run("concurrent runs tolerate update conflicts", func(t *testing.T) {
+		// Reproduce the CI failure: two server instances both read the same
+		// UpdateAt timestamps for the existing fields, then race to update them.
+		// The store's optimistic concurrency control means only one wins; the
+		// other must tolerate ErrConflict rather than crashing fatally.
+		th := Setup(t)
+
+		// Fields are already created by Setup. Clear the done key so both
+		// goroutines enter the migration body and take the update path.
+		_, err := th.Store.System().PermanentDeleteByName(contentFlaggingSetupDoneKey)
+		require.NoError(t, err)
+
+		const runners = 5
+		errs := make([]error, runners)
+		var wg sync.WaitGroup
+		wg.Add(runners)
+		for i := range runners {
+			go func() {
+				defer wg.Done()
+				errs[i] = th.Server.doSetupContentFlaggingProperties()
+			}()
+		}
+		wg.Wait()
+
+		for i, err := range errs {
+			require.NoError(t, err, "runner %d must not fail on concurrent update", i)
+		}
+
+		group, appErr := th.App.GetPropertyGroup(th.Context, model.ContentFlaggingGroupName)
+		require.Nil(t, appErr)
+		propertyFields, appErr := th.App.SearchPropertyFields(th.Context, group.ID, model.PropertyFieldSearchOpts{PerPage: 100})
+		require.Nil(t, appErr)
+		require.Len(t, propertyFields, 11)
+
+		data, sysErr := th.Store.System().GetByName(contentFlaggingSetupDoneKey)
+		require.NoError(t, sysErr)
+		require.Equal(t, contentFlaggingMigrationVersion, data.Value)
 	})
 }
 


### PR DESCRIPTION
#### Summary

Seen in a [CI run](https://github.com/mattermost/mattermost/actions/runs/25337515282/job/74418484353?pr=36404#step:10:6698):

<img width="2688" height="564" alt="CleanShot 2026-05-05 at 11 11 24@2x" src="https://github.com/user-attachments/assets/f4929cd7-7cb8-485e-bfcd-2a301e8da951" />


To fix this, we tolerate the `ErrConflict` on the update path in the same way the create path does.

#### Release Note

```release-note
NONE
```