### PR TITLE
docs: clarify PR template rules in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,4 +2,8 @@
 
 ## Pull Requests
 
-When creating a pull request, follow `.github/PULL_REQUEST_TEMPLATE.md`.
+When creating a pull request, follow `.github/PULL_REQUEST_TEMPLATE.md` exactly:
+
+- Remove all `<!-- -->` comments.
+- Omit sections that are not applicable (Ticket Link, Screenshots) — do not write N/A, just remove the header.
+- The `#### Release Note` header and its `release-note` fenced code block **must always be present**. Write `NONE` if the change has no API, schema, UI, or breaking changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,4 +6,4 @@ When creating a pull request, follow `.github/PULL_REQUEST_TEMPLATE.md` exactly:
 
 - Remove all `<!-- -->` comments.
 - Omit sections that are not applicable (Ticket Link, Screenshots) — do not write N/A, just remove the header.
-- The `#### Release Note` header and its `release-note` fenced code block **must always be present**. Write `NONE` if the change has no API, schema, UI, or breaking changes.
+- The `#### Release Note` header and its "```release-note" fenced code block **must always be present** (WITHOUT escaping the ``` characters). Write `NONE` if the change has no API, schema, UI, or breaking changes.


### PR DESCRIPTION
#### Summary

Expands the AGENTS.md pull request guidance to make three things explicit that the bare "follow the template" instruction left ambiguous:

- Strip all HTML comments from the body.
- Remove inapplicable section headers entirely rather than writing N/A.
- The `#### Release Note` header and `release-note` fenced block are always required; use `NONE` when no release note applies.

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Minimal — documentation-only changes to AGENTS.md; no code, runtime behavior, APIs, or data paths are affected.  
**QA Recommendation:** No manual QA required; review by maintainers for wording is sufficient.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->