### PR TITLE
MM-68647: Fix Data Spillage reviewer pill background in dark mode

### DIFF
--- a/webapp/channels/src/components/properties_card_view/propertyValueRenderer/user_property_renderer/selectable_user_property_renderer.scss
+++ b/webapp/channels/src/components/properties_card_view/propertyValueRenderer/user_property_renderer/selectable_user_property_renderer.scss
@@ -8,7 +8,9 @@
             min-height: unset;
             align-items: baseline;
             border: none !important;
+            background: transparent;
             box-shadow: none !important;
+            color: var(--center-channel-color);
 
             .UserMultiSelector__indicators {
                 height: 32px;
@@ -22,6 +24,7 @@
                     display: flex;
                     align-items: center;
                     gap: 8px;
+                    color: var(--center-channel-color);
 
                     i.icon.icon-account-outline {
                         width: 24px;
@@ -35,6 +38,12 @@
                     }
                 }
             }
+
+            .UserMultiSelector__single-value,
+            .UserMultiSelector__input-container,
+            .UserMultiSelector__input {
+                color: var(--center-channel-color);
+            }
         }
     }
 }
@@ -46,6 +55,8 @@
         min-width: 200px;
         max-width: 400px;
         margin-top: 0 !important;
+        background: var(--center-channel-bg);
+        color: var(--center-channel-color);
 
         .UserMultiSelector__control {
             min-height: unset;

--- a/webapp/channels/src/components/properties_card_view/propertyValueRenderer/user_property_renderer/selectable_user_property_renderer.scss
+++ b/webapp/channels/src/components/properties_card_view/propertyValueRenderer/user_property_renderer/selectable_user_property_renderer.scss
@@ -23,8 +23,8 @@
                 .SelectableUserPropertyRenderer_placeholder {
                     display: flex;
                     align-items: center;
-                    gap: 8px;
                     color: var(--center-channel-color);
+                    gap: 8px;
 
                     i.icon.icon-account-outline {
                         width: 24px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

The `SelectableUserPropertyRenderer` used in the Data Spillage report wraps a `react-select` instance with `classNamePrefix="UserMultiSelector"`, so the global theme-aware styles in `_react-select.scss` (which key off the `react-select__*` classes) never matched. As a result the inner control kept `react-select`'s default inline `backgroundColor: hsl(0,0%,100%)`, making the reviewer pill area render as a glaring white bar in dark themes — even though the pill itself uses `--center-channel-color-08` and adapts correctly.

This change makes the control transparent and ensures the value/placeholder/input/menu all use theme-driven CSS variables so the reviewer field blends correctly in both light and dark mode.

QA steps:
1. With Content Flagging enabled and reviewers configured, set Mattermost to a dark theme (e.g. Onyx or Indigo).
2. Flag a post and open the Data Spillage report DM (and "View details" RHS) as a content reviewer.
3. Confirm the Reviewer field's pill (e.g. "paulharrison") sits on the dark card background instead of a white bar — both in the channel-center "short" card and in the RHS "full" card.
4. Switch to a light theme and confirm the field still renders correctly.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-68647

#### Screenshots

End-to-end manual reproduction against a real Mattermost server (with the `MM_LICENSE` Enterprise Advanced license) — Content Flagging enabled, a post flagged by `paulharrison` (also a configured reviewer), Onyx (dark) theme.

**Before** — same server with the `master` SCSS in place: the reviewer pill area renders as a stark white react-select control bar in both the channel-center card and the RHS full report.

![Real Mattermost, Onyx theme — bug reproduced (channel center)](https://cursor.com/artifacts/c/art-9db3ef19-5ce8-409d-861f-075410dca3e5)
![Real Mattermost, Onyx theme — bug reproduced (RHS full report)](https://cursor.com/artifacts/c/art-e031edcc-ef83-4f31-856d-20ce3e85095f)

**After** — same server with this PR's SCSS: the control is transparent and the pill blends with the dark card in both views.

![Real Mattermost, Onyx theme — fixed (channel center)](https://cursor.com/artifacts/c/art-ab455164-fd31-4212-954d-7ee3b87676af)
![Real Mattermost, Onyx theme — fixed (RHS full report)](https://cursor.com/artifacts/c/art-718df3f0-275c-4d83-ab42-8db54c7268c0)

#### Release Note
```release-note
Fixed an issue where the Reviewer field pill on the Data Spillage review card rendered with a white background in dark themes.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-761a1186-ad2e-4cd6-afcc-4fa53a8e754c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-761a1186-ad2e-4cd6-afcc-4fa53a8e754c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is a pure CSS styling update to a single component with no functional modifications. It applies standard Mattermost theme variables (--center-channel-color, --center-channel-bg) to the SelectableUserPropertyRenderer's react-select control, with minimal blast radius and low risk of unintended side effects.

**QA Recommendation:** Manual QA can focus on the Data Spillage review card (both channel-center and RHS views) across light and dark themes. Verify the reviewer pill displays correctly without unexpected visual regressions. Given the isolated, styling-only nature of the change and existing test coverage, automated testing should be sufficient; light manual verification of the specific UI element is recommended.

---

## Release Notes

Fixed an issue where the Reviewer field pill on the Data Spillage review card rendered with a white background in dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->