### PR TITLE
test(app): GetJobsByTypeAndData empty data and cross-type policy_id

### DIFF
--- a/server/channels/app/job_test.go
+++ b/server/channels/app/job_test.go
@@ -659,6 +659,12 @@ func TestGetJobsByTypeAndData(t *testing.T) {
 			CreateAt: 1002,
 			Data:     map[string]string{"policy_id": otherPolicyID},
 		},
+		{
+			Id:       model.NewId(),
+			Type:     model.JobTypeDataRetention,
+			CreateAt: 1003,
+			Data:     map[string]string{"policy_id": policyID},
+		},
 	}
 
 	for _, job := range jobs {
@@ -680,6 +686,10 @@ func TestGetJobsByTypeAndData(t *testing.T) {
 			receivedIDs[i] = j.Id
 		}
 		require.ElementsMatch(t, []string{jobs[0].Id, jobs[1].Id, jobs[2].Id}, receivedIDs)
+		for _, j := range received {
+			assert.Equal(t, model.JobTypeAccessControlSync, j.Type,
+				"other job types sharing policy_id must not appear in access control sync results")
+		}
 	})
 
 	t.Run("filters by data key-value, excludes other policies", func(t *testing.T) {
@@ -695,6 +705,19 @@ func TestGetJobsByTypeAndData(t *testing.T) {
 			map[string]string{"policy_id": model.NewId()})
 		require.Nil(t, appErr)
 		require.Empty(t, received)
+	})
+
+	t.Run("empty data map returns all jobs of that type only", func(t *testing.T) {
+		received, appErr := th.App.GetJobsByTypeAndData(th.Context, model.JobTypeAccessControlSync,
+			map[string]string{})
+		require.Nil(t, appErr)
+		require.Len(t, received, 4)
+		receivedIDs := make([]string, len(received))
+		for i, j := range received {
+			receivedIDs[i] = j.Id
+			assert.Equal(t, model.JobTypeAccessControlSync, j.Type)
+		}
+		require.ElementsMatch(t, []string{jobs[0].Id, jobs[1].Id, jobs[2].Id, jobs[3].Id}, receivedIDs)
 	})
 }
 

--- a/server/channels/app/job_test.go
+++ b/server/channels/app/job_test.go
@@ -631,37 +631,41 @@ func TestGetJobsByTypeAndData(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t)
 
+	// Unique synthetic types avoid collisions with jobs seeded elsewhere (same pattern as TestGetJobByType).
+	targetJobType := model.NewId()
+	otherJobType := model.NewId()
+
 	policyID := model.NewId()
 	otherPolicyID := model.NewId()
 
 	jobs := []*model.Job{
 		{
 			Id:       model.NewId(),
-			Type:     model.JobTypeAccessControlSync,
+			Type:     targetJobType,
 			CreateAt: 1000,
 			Data:     map[string]string{"policy_id": policyID},
 		},
 		{
 			Id:       model.NewId(),
-			Type:     model.JobTypeAccessControlSync,
+			Type:     targetJobType,
 			CreateAt: 999,
 			Data:     map[string]string{"policy_id": policyID},
 		},
 		{
 			Id:       model.NewId(),
-			Type:     model.JobTypeAccessControlSync,
+			Type:     targetJobType,
 			CreateAt: 1001,
 			Data:     map[string]string{"policy_id": policyID},
 		},
 		{
 			Id:       model.NewId(),
-			Type:     model.JobTypeAccessControlSync,
+			Type:     targetJobType,
 			CreateAt: 1002,
 			Data:     map[string]string{"policy_id": otherPolicyID},
 		},
 		{
 			Id:       model.NewId(),
-			Type:     model.JobTypeDataRetention,
+			Type:     otherJobType,
 			CreateAt: 1003,
 			Data:     map[string]string{"policy_id": policyID},
 		},
@@ -677,23 +681,20 @@ func TestGetJobsByTypeAndData(t *testing.T) {
 	}
 
 	t.Run("returns all matching jobs for policy", func(t *testing.T) {
-		received, appErr := th.App.GetJobsByTypeAndData(th.Context, model.JobTypeAccessControlSync,
+		received, appErr := th.App.GetJobsByTypeAndData(th.Context, targetJobType,
 			map[string]string{"policy_id": policyID})
 		require.Nil(t, appErr)
 		require.Len(t, received, 3)
 		receivedIDs := make([]string, len(received))
 		for i, j := range received {
 			receivedIDs[i] = j.Id
+			assert.Equal(t, targetJobType, j.Type)
 		}
 		require.ElementsMatch(t, []string{jobs[0].Id, jobs[1].Id, jobs[2].Id}, receivedIDs)
-		for _, j := range received {
-			assert.Equal(t, model.JobTypeAccessControlSync, j.Type,
-				"other job types sharing policy_id must not appear in access control sync results")
-		}
 	})
 
 	t.Run("filters by data key-value, excludes other policies", func(t *testing.T) {
-		received, appErr := th.App.GetJobsByTypeAndData(th.Context, model.JobTypeAccessControlSync,
+		received, appErr := th.App.GetJobsByTypeAndData(th.Context, targetJobType,
 			map[string]string{"policy_id": otherPolicyID})
 		require.Nil(t, appErr)
 		require.Len(t, received, 1)
@@ -701,21 +702,21 @@ func TestGetJobsByTypeAndData(t *testing.T) {
 	})
 
 	t.Run("returns empty when no jobs match data filter", func(t *testing.T) {
-		received, appErr := th.App.GetJobsByTypeAndData(th.Context, model.JobTypeAccessControlSync,
+		received, appErr := th.App.GetJobsByTypeAndData(th.Context, targetJobType,
 			map[string]string{"policy_id": model.NewId()})
 		require.Nil(t, appErr)
 		require.Empty(t, received)
 	})
 
 	t.Run("empty data map returns all jobs of that type only", func(t *testing.T) {
-		received, appErr := th.App.GetJobsByTypeAndData(th.Context, model.JobTypeAccessControlSync,
+		received, appErr := th.App.GetJobsByTypeAndData(th.Context, targetJobType,
 			map[string]string{})
 		require.Nil(t, appErr)
 		require.Len(t, received, 4)
 		receivedIDs := make([]string, len(received))
 		for i, j := range received {
 			receivedIDs[i] = j.Id
-			assert.Equal(t, model.JobTypeAccessControlSync, j.Type)
+			assert.Equal(t, targetJobType, j.Type)
 		}
 		require.ElementsMatch(t, []string{jobs[0].Id, jobs[1].Id, jobs[2].Id, jobs[3].Id}, receivedIDs)
 	})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Extends `TestGetJobsByTypeAndData` to cover empty `data` (no JSON predicates; type filter only) and cross-type isolation when another job shares the same `policy_id`.

Uses **unique synthetic `Type` values** (`model.NewId()`) for the fixture and queries, matching `TestGetJobByType`, so parallel runs and any seeded jobs cannot collide with fixed constants like `JobTypeAccessControlSync`.

#### Ticket Link

N/A (test coverage only)

#### Screenshots

N/A

#### Release Note

```release-note
NONE
```