### PR TITLE
docs: fix broken newsletter link in README (#36087)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ See the [LICENSE file](LICENSE.txt) for license rights and limitations.
 - **Blog** - Get the latest updates from the [Mattermost blog](https://mattermost.com/blog/).
 - **Facebook** - Follow [Mattermost on Facebook](https://www.facebook.com/MattermostHQ).
 - **LinkedIn** - Follow [Mattermost on LinkedIn](https://www.linkedin.com/company/mattermost/).
-- **Email** - Subscribe to our [newsletter](https://mattermost.us11.list-manage.com/subscribe?u=6cdba22349ae374e188e7ab8e&id=2add1c8034) (1 or 2 per month).
+- **Email** - Subscribe to our [newsletter](https://mattermost.com/newsletter/) (1 or 2 per month).
 - **Mattermost** - Join the ~contributors channel on [the Mattermost Community Server](https://community.mattermost.com).
 - **IRC** - Join the #matterbridge channel on [Freenode](https://freenode.net/) (thanks to [matterircd](https://github.com/42wim/matterircd)).
 - **YouTube** -  Subscribe to [Mattermost](https://www.youtube.com/@MattermostHQ).


### PR DESCRIPTION
#### Summary
The Mailchimp signup URL in the "Get the latest news" section of the project README returns a 404 ("Page not found") on Mailchimp. Replaced it with the live https://mattermost.com/newsletter/ signup page (verified 200, page title "Sign up for the Mattermost Newsletter").

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/36087

#### Screenshots
N/A — single-line README change.

#### Release Note
```release-note
NONE
```


## Change Impact: 🟢 Low

**Regression Risk:** No regression risk present; this is a documentation-only change updating a URL link in README.md without affecting any application code, dependencies, or critical paths.

**QA Recommendation:** No manual QA required; verify the updated URL displays correctly in the README and resolves to the intended Mattermost Newsletter signup page.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->