### PR TITLE
Update interdependency between packages to 11.8.0

### DIFF
--- a/webapp/channels/src/components/recaps_link/recaps_link.tsx
+++ b/webapp/channels/src/components/recaps_link/recaps_link.tsx
@@ -8,6 +8,7 @@ import {shallowEqual, useSelector} from 'react-redux';
 import {Link, useLocation, matchPath, useRouteMatch} from 'react-router-dom';
 
 import {AlertOutlineIcon, CreationOutlineIcon} from '@mattermost/compass-icons/components';
+import {WithTooltip} from '@mattermost/shared/components/tooltip';
 
 import {getUnreadFinishedRecapsBadge} from 'mattermost-redux/selectors/entities/recaps';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
@@ -15,7 +16,6 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import useGetFeatureFlagValue from 'components/common/hooks/useGetFeatureFlagValue';
 import ChannelMentionBadge from 'components/sidebar/sidebar_channel/channel_mention_badge';
-import WithTooltip from 'components/with_tooltip';
 
 import './recaps_link.scss';
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -25746,7 +25746,7 @@
       "peerDependencies": {
         "@babel/runtime-corejs3": "^7.17.8",
         "@mattermost/compass-icons": "0.1.53",
-        "@mattermost/shared": "11.7.0",
+        "@mattermost/shared": "11.8.0",
         "classnames": "^2.3.1",
         "lodash": "^4.17.21",
         "react-intl": "*",

--- a/webapp/platform/components/package.json
+++ b/webapp/platform/components/package.json
@@ -41,7 +41,7 @@
   "peerDependencies": {
     "@babel/runtime-corejs3": "^7.17.8",
     "@mattermost/compass-icons": "0.1.53",
-    "@mattermost/shared": "11.7.0",
+    "@mattermost/shared": "11.8.0",
     "classnames": "^2.3.1",
     "lodash": "^4.17.21",
     "react-intl": "*",


### PR DESCRIPTION
#### Summary
I merged https://github.com/mattermost/mattermost/pull/36191 without merging the latest master this morning, so I got caught by the version update.

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Changes are limited to a peer dependency version bump (@mattermost/shared 11.7.0 → 11.8.0) and a refactor of a tooltip import to the shared module; no behavioral or public API changes detected, and affected code paths are isolated. Risk of regressions is low provided dependency resolution succeeds.

**QA Recommendation:** Minimal manual QA — run dependency install and existing automated tests; spot-check the Recaps sidebar tooltip/indicator in QA smoke tests.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->