### PR TITLE
Pull Agents plugin OpenAPI into API docs

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -12,6 +12,8 @@ v4/html/index.html
 node_modules
 playbooks/*.yaml
 !playbooks/tags.yaml
+agents/*.yaml
+!agents/tags.yaml
 
 # IDEs
 .idea/

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,18 +1,19 @@
 ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
-.PHONY: build build-v4 clean playbooks
+.PHONY: build build-v4 clean playbooks agents
 
 V4_YAML = $(ROOT)/v4/html/static/mattermost-openapi-v4.yaml
 
 V4_SRC = $(ROOT)/v4/source
 PLAYBOOKS_SRC = $(ROOT)/playbooks
+AGENTS_SRC = $(ROOT)/agents
 
 build: build-v4
 
-build-v4: node_modules playbooks
+build-v4: node_modules playbooks agents
 	@echo Building mattermost openapi yaml for v4
 
-	@if [ -r $(PLAYBOOKS_SRC)/merged-tags.yaml ]; then cat $(PLAYBOOKS_SRC)/merged-tags.yaml > $(V4_YAML); else cat $(V4_SRC)/introduction.yaml > $(V4_YAML); fi
+	@if [ -r $(AGENTS_SRC)/merged-tags.yaml ]; then cat $(AGENTS_SRC)/merged-tags.yaml > $(V4_YAML); elif [ -r $(PLAYBOOKS_SRC)/merged-tags.yaml ]; then cat $(PLAYBOOKS_SRC)/merged-tags.yaml > $(V4_YAML); else cat $(V4_SRC)/introduction.yaml > $(V4_YAML); fi
 	@cat $(V4_SRC)/users.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/status.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/teams.yaml >> $(V4_YAML)
@@ -68,7 +69,8 @@ build-v4: node_modules playbooks
 	@cat $(V4_SRC)/agents.yaml >> $(V4_YAML)
 	@cat $(V4_SRC)/properties.yaml >> $(V4_YAML)
 	@if [ -r $(PLAYBOOKS_SRC)/paths.yaml ]; then cat $(PLAYBOOKS_SRC)/paths.yaml >> $(V4_YAML); fi
-	@if [ -r $(PLAYBOOKS_SRC)/merged-definitions.yaml ]; then cat $(PLAYBOOKS_SRC)/merged-definitions.yaml >> $(V4_YAML); else cat $(V4_SRC)/definitions.yaml >> $(V4_YAML); fi
+	@if [ -r $(AGENTS_SRC)/paths.yaml ]; then cat $(AGENTS_SRC)/paths.yaml >> $(V4_YAML); fi
+	@if [ -r $(AGENTS_SRC)/merged-definitions.yaml ]; then cat $(AGENTS_SRC)/merged-definitions.yaml >> $(V4_YAML); elif [ -r $(PLAYBOOKS_SRC)/merged-definitions.yaml ]; then cat $(PLAYBOOKS_SRC)/merged-definitions.yaml >> $(V4_YAML); else cat $(V4_SRC)/definitions.yaml >> $(V4_YAML); fi
 	@echo Extracting code samples
 	cd server && go run . $(V4_YAML)
 
@@ -96,3 +98,9 @@ playbooks:
 	cd playbooks && node extract.js
 	cd playbooks && node merge-definitions.js $(V4_SRC)/definitions.yaml
 	cd playbooks && node merge-tags.js $(V4_SRC)/introduction.yaml
+
+agents:
+	@echo Fetching Agents OpenAPI spec
+	cd agents && node extract.js
+	cd agents && node merge-definitions.js $(PLAYBOOKS_SRC)/merged-definitions.yaml $(V4_SRC)/definitions.yaml
+	cd agents && node merge-tags.js $(PLAYBOOKS_SRC)/merged-tags.yaml $(V4_SRC)/introduction.yaml

--- a/api/README.md
+++ b/api/README.md
@@ -11,7 +11,7 @@ All documentation is available under the terms of a [Creative Commons License](h
 We're accepting pull requests! See something that could be documented better or is missing documentation? Make a PR and we'll gladly accept it.
 
 All the documentation is written in YAML and found in the [v4/source](v4/source) directories. APIv4 documentation is in the [v4 directory](v4).
-APIs for [Playbooks](https://github.com/mattermost/mattermost-plugin-playbooks) are retrieved from GitHub at build time and integrated into the final YAML file.
+APIs for [Playbooks](https://github.com/mattermost/mattermost-plugin-playbooks) and the [Agents plugin](https://github.com/mattermost/mattermost-plugin-agents) are retrieved from GitHub at build time and integrated into the final YAML file.
 
 * When adding a new route, please add it to the correct file. For example, a channel route will go in [channels.yaml](v4/source/channels.yaml).
 * To add a new tag, please do so in [introduction.yaml](v4/source/introduction.yaml)

--- a/api/agents/extract.js
+++ b/api/agents/extract.js
@@ -1,0 +1,59 @@
+'use strict';
+const YAML = require('yaml');
+const fs = require('fs');
+const fetch = require('sync-fetch');
+
+const defaultSpecURL = 'https://raw.githubusercontent.com/mattermost/mattermost-plugin-agents/master/api/openapi.yaml';
+
+class Extractor {
+    constructor() {}
+
+    writeFile(filename, data, indent = 0) {
+        let stringified = YAML.stringify(data, { lineWidth: 0 });
+        if (indent > 0) {
+            stringified = stringified.replace(/^(.*)$/mg, '$1'.padStart(2 + indent)) + '\n';
+        }
+        fs.writeFileSync(filename, stringified);
+        console.log('wrote file ' + filename);
+    }
+
+    readSpec(source) {
+        if (source.startsWith('http://') || source.startsWith('https://')) {
+            console.log('fetching Agents OpenAPI spec from ' + source);
+            return fetch(source).text();
+        }
+
+        console.log('reading Agents OpenAPI spec from ' + source);
+        return fs.readFileSync(source).toString();
+    }
+
+    run() {
+        const rawSpec = this.readSpec(process.env.AGENTS_OPENAPI_SPEC || defaultSpecURL);
+        const parsed = YAML.parse(rawSpec);
+
+        if ('paths' in parsed) {
+            this.writeFile('paths.yaml', parsed.paths, 2);
+        }
+
+        if ('components' in parsed) {
+            const components = parsed.components;
+            if ('schemas' in components) {
+                this.writeFile('schemas.yaml', components.schemas);
+            }
+            if ('responses' in components) {
+                this.writeFile('responses.yaml', components.responses);
+            }
+            if ('securitySchemes' in components) {
+                this.writeFile('securitySchemes.yaml', components.securitySchemes);
+            }
+            if ('parameters' in components) {
+                this.writeFile('parameters.yaml', components.parameters);
+            }
+            if ('requestBodies' in components) {
+                this.writeFile('requestBodies.yaml', components.requestBodies);
+            }
+        }
+    }
+}
+
+new Extractor().run();

--- a/api/agents/merge-definitions.js
+++ b/api/agents/merge-definitions.js
@@ -1,0 +1,54 @@
+'use strict';
+const YAML = require('yaml');
+const fs = require('fs');
+
+class MergeDefinitions {
+    constructor() {}
+
+    writeFile(filename, data) {
+        fs.writeFileSync(filename, YAML.stringify(data, { lineWidth: 0 }).trimEnd());
+        console.log('wrote file ' + filename);
+    }
+
+    readFile(filename) {
+        const rawYaml = fs.readFileSync(filename);
+        console.log('read file ' + filename);
+        return YAML.parse(rawYaml.toString());
+    }
+
+    firstReadable(filenames) {
+        for (const filename of filenames) {
+            if (filename && fs.existsSync(filename)) {
+                return filename;
+            }
+        }
+        throw new Error('no readable input definitions file found');
+    }
+
+    mergeSection(target, section, filename) {
+        if (!fs.existsSync(filename)) {
+            return;
+        }
+        const data = this.readFile(filename);
+        target.components[section] = Object.assign(target.components[section] || {}, data || {});
+    }
+
+    run(args) {
+        const input = this.firstReadable(args.slice(2));
+        const parsed = this.readFile(input);
+
+        if (!parsed.components) {
+            parsed.components = {};
+        }
+
+        this.mergeSection(parsed, 'schemas', 'schemas.yaml');
+        this.mergeSection(parsed, 'responses', 'responses.yaml');
+        this.mergeSection(parsed, 'securitySchemes', 'securitySchemes.yaml');
+        this.mergeSection(parsed, 'parameters', 'parameters.yaml');
+        this.mergeSection(parsed, 'requestBodies', 'requestBodies.yaml');
+
+        this.writeFile('merged-definitions.yaml', parsed);
+    }
+}
+
+new MergeDefinitions().run(process.argv);

--- a/api/agents/merge-tags.js
+++ b/api/agents/merge-tags.js
@@ -1,0 +1,42 @@
+'use strict';
+const YAML = require('yaml');
+const fs = require('fs');
+
+class MergeTags {
+    constructor() {}
+
+    readFile(filename) {
+        const rawYaml = fs.readFileSync(filename);
+        console.log('read file ' + filename);
+        return YAML.parse(rawYaml.toString());
+    }
+
+    firstReadable(filenames) {
+        for (const filename of filenames) {
+            if (filename && fs.existsSync(filename)) {
+                return filename;
+            }
+        }
+        throw new Error('no readable input introduction file found');
+    }
+
+    run(args) {
+        const input = this.firstReadable(args.slice(2));
+        const parsed = this.readFile(input);
+        const tags = this.readFile('tags.yaml');
+
+        if ('tags' in parsed) {
+            parsed.tags.push(...tags.tags);
+        }
+        if ('x-tagGroups' in parsed) {
+            parsed['x-tagGroups'].push(...tags['x-tagGroups']);
+        }
+
+        const yamlString = YAML.stringify(parsed, { lineWidth: 0 }).
+            replace(/^paths:.*null.*$/mg, 'paths: ');
+        fs.writeFileSync('merged-tags.yaml', yamlString);
+        console.log('wrote file merged-tags.yaml');
+    }
+}
+
+new MergeTags().run(process.argv);

--- a/api/agents/tags.yaml
+++ b/api/agents/tags.yaml
@@ -1,0 +1,32 @@
+---
+tags:
+  - name: AgentsPluginAgents
+    description: User-created AI agents
+  - name: AgentsPluginBridge
+    description: Inter-plugin LLM bridge endpoints
+  - name: AgentsPluginChannels
+    description: Channel analysis endpoints
+  - name: AgentsPluginConversations
+    description: Conversation history endpoints
+  - name: AgentsPluginCustomPrompts
+    description: Custom prompt endpoints
+  - name: AgentsPluginMCP
+    description: Model Context Protocol endpoints
+  - name: AgentsPluginAdmin
+    description: System administrator endpoints
+  - name: AgentsPluginPosts
+    description: Post action endpoints
+  - name: AgentsPluginSearch
+    description: Semantic search endpoints
+x-tagGroups:
+  - name: Agents plugin
+    tags:
+      - AgentsPluginAgents
+      - AgentsPluginBridge
+      - AgentsPluginChannels
+      - AgentsPluginConversations
+      - AgentsPluginCustomPrompts
+      - AgentsPluginMCP
+      - AgentsPluginAdmin
+      - AgentsPluginPosts
+      - AgentsPluginSearch


### PR DESCRIPTION
#### Summary
Adds an Agents plugin OpenAPI ingestion pipeline alongside the existing Playbooks pipeline in `api/Makefile`.

The new `api/agents` helpers fetch the Agents plugin spec, extract paths and components, chain definition/tag merging after Playbooks, and append `/plugins/mattermost-ai/...` routes into the generated Mattermost OpenAPI output while preserving existing `/api/v4/agents` docs.

Validation:
- `AGENTS_OPENAPI_SPEC=/Users/nickmisasi/.cursor/worktrees/mattermost-plugin-agents-IDEA-006-cross-plugin-mcp/qga6/api/openapi.yaml make build-v4`
- Confirmed generated output includes `/api/v4/agents`, `/plugins/playbooks/...`, and `/plugins/mattermost-ai/...` paths.

#### Ticket Link

N/A

#### Screenshots

N/A

#### Release Note
```release-note
Added Agents plugin API documentation to the generated Mattermost OpenAPI reference.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The PR adds a new `agents` target as a hard dependency to the build-v4 pipeline with minimal error handling in the extraction scripts. If the AGENTS_OPENAPI_SPEC environment variable is unset or unreachable, or if the OpenAPI spec is malformed, the entire build fails with no graceful fallback. No automated tests exist for the API documentation generation pipeline, and the cascading merge logic (agents > playbooks > base definitions) increases complexity.

**QA Recommendation:** Verify that the build succeeds when AGENTS_OPENAPI_SPEC is not set (confirm it falls back to the default URL gracefully). Test that the generated OpenAPI spec is valid YAML and contains all expected sections (paths, schemas, responses, etc.). Validate that existing /api/v4 documentation paths remain intact and correctly merged. Confirm the build fails with a clear error message if the OpenAPI spec fetch/parse fails.

**Release Note:**
Added Agents plugin API documentation to the generated Mattermost OpenAPI reference.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->