### PR TITLE
[MM-68577] Add OAuth2/OpenID Connect provider status to support packet

### DIFF
--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -386,7 +386,9 @@ func probeOAuthTokenEndpoint(ctx context.Context, tokenURL string) error {
 	if err != nil {
 		return err
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
+	// Drain the body so the underlying TCP connection can be reused.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
 	return nil
 }
 

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -357,7 +357,7 @@ func probeOIDCDiscovery(ctx context.Context, discoveryURL string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer drainAndCloseBody(resp.Body)
 	if resp.StatusCode >= http.StatusBadRequest {
 		return fmt.Errorf("discovery endpoint returned unexpected status %d", resp.StatusCode)
 	}
@@ -386,10 +386,17 @@ func probeOAuthTokenEndpoint(ctx context.Context, tokenURL string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
-	// Drain the body so the underlying TCP connection can be reused.
-	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+	defer drainAndCloseBody(resp.Body)
 	return nil
+}
+
+// drainAndCloseBody fully reads and discards an HTTP response body (up to 1 MiB
+// to bound a misbehaving server) and closes it. Draining before closing allows
+// net/http to return the underlying TCP connection to the idle pool for
+// keep-alive reuse on subsequent requests.
+func drainAndCloseBody(body io.ReadCloser) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(body, 1<<20))
+	_ = body.Close()
 }
 
 // TODO: move this into its own push proxy package once one exists (see also pushNotificationClient in server.go)
@@ -408,7 +415,7 @@ func testPushProxyConnection(ctx context.Context, serverURL string) error {
 	if err != nil {
 		return err
 	}
-	resp.Body.Close()
+	defer drainAndCloseBody(resp.Body)
 	if resp.StatusCode >= http.StatusBadRequest {
 		return fmt.Errorf("push proxy returned unexpected status %d", resp.StatusCode)
 	}

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -361,6 +361,7 @@ func probeOIDCDiscovery(ctx context.Context, discoveryURL string) error {
 	if resp.StatusCode >= http.StatusBadRequest {
 		return fmt.Errorf("discovery endpoint returned unexpected status %d", resp.StatusCode)
 	}
+	// Cap the discovery document at 1 MiB; real OIDC discovery responses are a few KiB.
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return errors.Wrap(err, "failed to read discovery response")

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -286,6 +287,12 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 		d.Notifications.Email.Status = model.StatusDisabled
 	}
 
+	/* OAuth2 / OpenID Connect Providers */
+	d.OAuthProviders.GitLab = probeOAuthProvider(rctx.Context(), &ps.Config().GitLabSettings)
+	d.OAuthProviders.Google = probeOAuthProvider(rctx.Context(), &ps.Config().GoogleSettings)
+	d.OAuthProviders.Office365 = probeOAuthProvider(rctx.Context(), ps.Config().Office365Settings.SSOSettings())
+	d.OAuthProviders.OpenID = probeOAuthProvider(rctx.Context(), &ps.Config().OpenIdSettings)
+
 	/* Push Notifications */
 	if model.SafeDereference(ps.Config().EmailSettings.SendPushNotifications) {
 		pushServerURL := model.SafeDereference(ps.Config().EmailSettings.PushNotificationServer)
@@ -309,6 +316,78 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 		Body:     b,
 	}
 	return fileData, rErr.ErrorOrNil()
+}
+
+// probeOAuthProvider checks connectivity for an OAuth2/OpenID Connect provider.
+// If the provider has a DiscoveryEndpoint configured, it issues an HTTP GET to
+// that URL and verifies the response is a valid OIDC discovery document.
+// Otherwise it probes the TokenEndpoint host: any HTTP response (including
+// 4xx/5xx) is treated as reachable, since token endpoints typically reject GETs.
+func probeOAuthProvider(ctx context.Context, sso *model.SSOSettings) model.OAuthProviderStatus {
+	if !model.SafeDereference(sso.Enable) {
+		return model.OAuthProviderStatus{Status: model.StatusDisabled}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	if discoveryEndpoint := model.SafeDereference(sso.DiscoveryEndpoint); discoveryEndpoint != "" {
+		if err := probeOIDCDiscovery(ctx, discoveryEndpoint); err != nil {
+			return model.OAuthProviderStatus{Status: model.StatusFail, Error: err.Error()}
+		}
+		return model.OAuthProviderStatus{Status: model.StatusOk}
+	}
+
+	if tokenEndpoint := model.SafeDereference(sso.TokenEndpoint); tokenEndpoint != "" {
+		if err := probeOAuthTokenEndpoint(ctx, tokenEndpoint); err != nil {
+			return model.OAuthProviderStatus{Status: model.StatusFail, Error: err.Error()}
+		}
+		return model.OAuthProviderStatus{Status: model.StatusOk}
+	}
+
+	return model.OAuthProviderStatus{Status: model.StatusFail, Error: "no discovery or token endpoint configured"}
+}
+
+func probeOIDCDiscovery(ctx context.Context, discoveryURL string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("discovery endpoint returned unexpected status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return errors.Wrap(err, "failed to read discovery response")
+	}
+	var doc struct {
+		Issuer string `json:"issuer"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return errors.Wrap(err, "discovery endpoint did not return valid JSON")
+	}
+	if doc.Issuer == "" {
+		return fmt.Errorf("discovery endpoint response missing required 'issuer' field")
+	}
+	return nil
+}
+
+func probeOAuthTokenEndpoint(ctx context.Context, tokenURL string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
 }
 
 // TODO: move this into its own push proxy package once one exists (see also pushNotificationClient in server.go)

--- a/server/channels/app/platform/support_packet_test.go
+++ b/server/channels/app/platform/support_packet_test.go
@@ -273,6 +273,12 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 		assert.Equal(t, model.StatusDisabled, d.ElasticSearch.Status)
 		assert.Empty(t, d.ElasticSearch.ServerVersion)
 		assert.Empty(t, d.ElasticSearch.ServerPlugins)
+
+		/* OAuth Providers (all disabled by default) */
+		assert.Equal(t, model.StatusDisabled, d.OAuthProviders.GitLab.Status)
+		assert.Equal(t, model.StatusDisabled, d.OAuthProviders.Google.Status)
+		assert.Equal(t, model.StatusDisabled, d.OAuthProviders.Office365.Status)
+		assert.Equal(t, model.StatusDisabled, d.OAuthProviders.OpenID.Status)
 	})
 
 	t.Run("filestore fails", func(t *testing.T) {
@@ -697,6 +703,171 @@ func TestGetSupportPacketDiagnostics(t *testing.T) {
 
 		assert.Equal(t, model.StatusFail, packet.Notifications.Email.Status)
 		assert.NotEmpty(t, packet.Notifications.Email.Error)
+	})
+
+	t.Run("OpenID disabled", func(t *testing.T) {
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.OpenIdSettings.Enable = model.NewPointer(false)
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusDisabled, packet.OAuthProviders.OpenID.Status)
+		assert.Empty(t, packet.OAuthProviders.OpenID.Error)
+	})
+
+	t.Run("OpenID reachable via discovery endpoint", func(t *testing.T) {
+		idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/.well-known/openid-configuration", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"issuer":"https://idp.example.com","authorization_endpoint":"https://idp.example.com/auth"}`))
+		}))
+		defer idp.Close()
+
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.OpenIdSettings.Enable = model.NewPointer(true)
+			cfg.OpenIdSettings.DiscoveryEndpoint = model.NewPointer(idp.URL + "/.well-known/openid-configuration")
+		})
+		t.Cleanup(func() {
+			th.Service.UpdateConfig(func(cfg *model.Config) {
+				cfg.OpenIdSettings.Enable = model.NewPointer(false)
+				cfg.OpenIdSettings.DiscoveryEndpoint = model.NewPointer("")
+			})
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusOk, packet.OAuthProviders.OpenID.Status)
+		assert.Empty(t, packet.OAuthProviders.OpenID.Error)
+	})
+
+	t.Run("OpenID discovery endpoint returns invalid JSON", func(t *testing.T) {
+		idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`not-json`))
+		}))
+		defer idp.Close()
+
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.OpenIdSettings.Enable = model.NewPointer(true)
+			cfg.OpenIdSettings.DiscoveryEndpoint = model.NewPointer(idp.URL + "/.well-known/openid-configuration")
+		})
+		t.Cleanup(func() {
+			th.Service.UpdateConfig(func(cfg *model.Config) {
+				cfg.OpenIdSettings.Enable = model.NewPointer(false)
+				cfg.OpenIdSettings.DiscoveryEndpoint = model.NewPointer("")
+			})
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusFail, packet.OAuthProviders.OpenID.Status)
+		assert.Contains(t, packet.OAuthProviders.OpenID.Error, "valid JSON")
+	})
+
+	t.Run("OpenID discovery endpoint missing issuer field", func(t *testing.T) {
+		idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"authorization_endpoint":"https://idp.example.com/auth"}`))
+		}))
+		defer idp.Close()
+
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.OpenIdSettings.Enable = model.NewPointer(true)
+			cfg.OpenIdSettings.DiscoveryEndpoint = model.NewPointer(idp.URL + "/.well-known/openid-configuration")
+		})
+		t.Cleanup(func() {
+			th.Service.UpdateConfig(func(cfg *model.Config) {
+				cfg.OpenIdSettings.Enable = model.NewPointer(false)
+				cfg.OpenIdSettings.DiscoveryEndpoint = model.NewPointer("")
+			})
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusFail, packet.OAuthProviders.OpenID.Status)
+		assert.Contains(t, packet.OAuthProviders.OpenID.Error, "issuer")
+	})
+
+	t.Run("OpenID discovery endpoint unreachable", func(t *testing.T) {
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.OpenIdSettings.Enable = model.NewPointer(true)
+			cfg.OpenIdSettings.DiscoveryEndpoint = model.NewPointer("http://127.0.0.1:1/.well-known/openid-configuration")
+		})
+		t.Cleanup(func() {
+			th.Service.UpdateConfig(func(cfg *model.Config) {
+				cfg.OpenIdSettings.Enable = model.NewPointer(false)
+				cfg.OpenIdSettings.DiscoveryEndpoint = model.NewPointer("")
+			})
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusFail, packet.OAuthProviders.OpenID.Status)
+		assert.NotEmpty(t, packet.OAuthProviders.OpenID.Error)
+	})
+
+	t.Run("GitLab enabled with reachable token endpoint", func(t *testing.T) {
+		// GitLab has no DiscoveryEndpoint by default, so we fall through to the
+		// TokenEndpoint host probe. Token endpoints reject GETs, so any HTTP
+		// response (including 4xx/5xx) is treated as reachable.
+		idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}))
+		defer idp.Close()
+
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.GitLabSettings.Enable = model.NewPointer(true)
+			cfg.GitLabSettings.DiscoveryEndpoint = model.NewPointer("")
+			cfg.GitLabSettings.TokenEndpoint = model.NewPointer(idp.URL + "/oauth/token")
+		})
+		t.Cleanup(func() {
+			th.Service.UpdateConfig(func(cfg *model.Config) {
+				cfg.GitLabSettings.Enable = model.NewPointer(false)
+				cfg.GitLabSettings.TokenEndpoint = model.NewPointer("")
+			})
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusOk, packet.OAuthProviders.GitLab.Status)
+		assert.Empty(t, packet.OAuthProviders.GitLab.Error)
+	})
+
+	t.Run("GitLab enabled with unreachable token endpoint", func(t *testing.T) {
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.GitLabSettings.Enable = model.NewPointer(true)
+			cfg.GitLabSettings.DiscoveryEndpoint = model.NewPointer("")
+			cfg.GitLabSettings.TokenEndpoint = model.NewPointer("http://127.0.0.1:1/oauth/token")
+		})
+		t.Cleanup(func() {
+			th.Service.UpdateConfig(func(cfg *model.Config) {
+				cfg.GitLabSettings.Enable = model.NewPointer(false)
+				cfg.GitLabSettings.TokenEndpoint = model.NewPointer("")
+			})
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusFail, packet.OAuthProviders.GitLab.Status)
+		assert.NotEmpty(t, packet.OAuthProviders.GitLab.Error)
+	})
+
+	t.Run("GitLab enabled with no endpoints configured", func(t *testing.T) {
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			cfg.GitLabSettings.Enable = model.NewPointer(true)
+			cfg.GitLabSettings.DiscoveryEndpoint = model.NewPointer("")
+			cfg.GitLabSettings.TokenEndpoint = model.NewPointer("")
+		})
+		t.Cleanup(func() {
+			th.Service.UpdateConfig(func(cfg *model.Config) {
+				cfg.GitLabSettings.Enable = model.NewPointer(false)
+			})
+		})
+
+		packet := getDiagnostics(t)
+
+		assert.Equal(t, model.StatusFail, packet.OAuthProviders.GitLab.Status)
+		assert.Contains(t, packet.OAuthProviders.GitLab.Error, "no discovery or token endpoint")
 	})
 }
 

--- a/server/public/model/support_packet.go
+++ b/server/public/model/support_packet.go
@@ -104,6 +104,22 @@ type SupportPacketDiagnostics struct {
 		ServerPlugins []string `yaml:"server_plugins,omitempty"`
 		Error         string   `yaml:"error,omitempty"`
 	} `yaml:"elastic"`
+
+	OAuthProviders OAuthProviders `yaml:"oauth_providers,omitempty"`
+}
+
+// OAuthProviderStatus reports the connectivity status of a single OAuth2/OpenID Connect provider.
+type OAuthProviderStatus struct {
+	Status string `yaml:"status,omitempty"` // ok / fail / disabled
+	Error  string `yaml:"error,omitempty"`
+}
+
+// OAuthProviders aggregates the connectivity status for the configured OAuth2/OpenID Connect providers.
+type OAuthProviders struct {
+	GitLab    OAuthProviderStatus `yaml:"gitlab,omitempty"`
+	Google    OAuthProviderStatus `yaml:"google,omitempty"`
+	Office365 OAuthProviderStatus `yaml:"office365,omitempty"`
+	OpenID    OAuthProviderStatus `yaml:"openid,omitempty"`
 }
 
 type SupportPacketStats struct {


### PR DESCRIPTION
#### Summary
Adds GitLab, Google, Office365, and OpenID Connect provider connectivity to the support packet diagnostics, following the existing SMTP/push proxy pattern in `channels/app/platform/support_packet.go`.

For each provider:
- **Disabled** → `status: disabled`.
- **Enabled with `DiscoveryEndpoint`** → HTTP GET the discovery URL and verify a valid OIDC discovery document is returned (JSON with an `issuer` field).
- **Enabled without `DiscoveryEndpoint` (GitLab/Google/Office365)** → probe the `TokenEndpoint` host. Token endpoints reject GETs, so any HTTP response is treated as reachable; only network-level failures mark the provider as `fail`.

No secrets are read or transmitted — only public endpoint URLs are probed. New types `OAuthProviderStatus` and `OAuthProviders` are added to `public/model/support_packet.go`.

The OAuth/OpenID flows live in the open-source repo (not enterprise), so all changes are in `mattermost/mattermost`. No enterprise repo changes are needed; unlike LDAP/Elasticsearch, there is no enterprise-only logic the diagnostic needs to call into.

QA:
- Generate a support packet with all four providers disabled → all four entries show `status: disabled`.
- Configure a reachable OpenID `DiscoveryEndpoint` → `openid.status: ok`.
- Point `OpenIdSettings.DiscoveryEndpoint` at an unreachable host or a URL returning non-JSON / missing `issuer` → `status: fail` with a descriptive error.
- Enable GitLab with a reachable `TokenEndpoint` (any HTTP response) → `gitlab.status: ok`; point it at `http://127.0.0.1:1` → `status: fail`.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-68577

#### Release Note
```release-note
Added OAuth2/OpenID Connect provider connectivity status (GitLab, Google, Office365, OpenID) to the support packet diagnostics.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** Additive diagnostics and a new exported struct field limit scope, but changes add network probing logic and touch public model types used by support-packet generation—introducing a moderate chance of regressions in diagnostics generation or consumers of the diagnostics payload.  
**QA Recommendation:** Moderate manual QA recommended — validate support packet generation with providers enabled/disabled and test reachable/unreachable discovery and token endpoints; automated tests cover OpenID paths but verify integration behavior in representative environments.

*Generated by CodeRabbitAI*

---

## Release Notes

Added OAuth2/OpenID Connect provider connectivity status (GitLab, Google, Office365, OpenID) to the support packet diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->