### PR TITLE
Fix modal title line-height regression

### DIFF
--- a/e2e-tests/playwright/specs/functional/channels/mentions/notify_all.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/mentions/notify_all.spec.ts
@@ -38,10 +38,6 @@ test(
         await expect(modalTitle).toContainText('Confirm sending notifications to entire channel');
 
         // * Read the computed line-height of the modal title and assert correct spacing.
-        // The correct value is 28px (set in _modal.scss by MM-56352).
-        // MM-66442 incorrectly bumped this to 44px, causing the over-spaced title shown
-        // in the Rainforest "Target" baseline. The tight "Screen during failure" view
-        // (captured 26 Jan 2026) is the correct desired appearance.
         const lineHeight = await modalTitle.evaluate((el) => {
             return window.getComputedStyle(el).lineHeight;
         });

--- a/e2e-tests/playwright/specs/functional/channels/mentions/notify_all_modal_spacing.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/mentions/notify_all_modal_spacing.spec.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+// NOTIFY_ALL_MEMBERS threshold from webapp constants — modal triggers when member count > 5.
+const NOTIFY_ALL_THRESHOLD = 5;
+
+test(
+    'MM-68128 notify-all confirm modal title has correct line-height',
+    {tag: ['@mentions', '@visual']},
+    async ({pw}) => {
+        const {adminClient, team, user} = await pw.initSetup();
+
+        // # Add enough extra members so the channel member count exceeds the threshold
+        for (let i = 0; i < NOTIFY_ALL_THRESHOLD; i++) {
+            const extraUser = await pw.createNewUserProfile(adminClient, {prefix: 'notify-extra'});
+            await adminClient.addToTeam(team.id, extraUser.id);
+        }
+
+        // # Log in and go to Town Square (all team members are in it by default)
+        const {channelsPage} = await pw.testBrowser.login(user);
+        await channelsPage.goto(team.name, 'town-square');
+        await channelsPage.toBeVisible();
+
+        // # Type a message with @all to trigger the notify-all confirmation modal
+        await channelsPage.centerView.postCreate.writeMessage('@all test');
+
+        // # Click the Send button (without waiting for navigation — the modal will intercept)
+        await channelsPage.centerView.postCreate.sendMessage();
+
+        // # Wait for the confirm modal
+        const confirmModal = channelsPage.page.locator('#confirmModal');
+        await confirmModal.waitFor({state: 'visible'});
+
+        // * Verify the modal has the correct title text
+        const modalTitle = confirmModal.locator('.modal-title');
+        await expect(modalTitle).toContainText('Confirm sending notifications to entire channel');
+
+        // * Read the computed line-height of the modal title and assert correct spacing.
+        // The correct value is 28px (set in _modal.scss by MM-56352).
+        // MM-66442 incorrectly bumped this to 44px, causing the over-spaced title shown
+        // in the Rainforest "Target" baseline. The tight "Screen during failure" view
+        // (captured 26 Jan 2026) is the correct desired appearance.
+        const lineHeight = await modalTitle.evaluate((el) => {
+            return window.getComputedStyle(el).lineHeight;
+        });
+
+        expect(lineHeight, `Modal title line-height should be 28px but got ${lineHeight}`).toBe('28px');
+    },
+);

--- a/webapp/channels/src/sass/components/_modal.scss
+++ b/webapp/channels/src/sass/components/_modal.scss
@@ -317,7 +317,7 @@
                 background: transparent;
                 color: functions.v(center-channel-color);
                 font-size: 22px;
-                line-height: 44px;
+                line-height: 28px;
             }
         }
 
@@ -327,7 +327,7 @@
             color: functions.v(center-channel-color);
             font-size: 22px;
             font-weight: 600;
-            line-height: 44px;
+            line-height: 28px;
             word-break: break-word;
         }
     }


### PR DESCRIPTION
#### Summary
The current inflated value for the modal's line-height causes multi-line modal titles to overflow or be clipped. Restores the original value and adds an e2e test to prevent future regressions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68128

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to modal title styling in a single SCSS file, reverting a previously inflated line-height value to fix a known regression. An e2e test is added that validates the specific line-height change (28px), providing test coverage against future regressions of this issue.

**QA Recommendation:** Manual QA can be minimal given the targeted nature of the fix and e2e test coverage. Focus testing on modal dialogs with multi-line titles across different screen sizes to confirm proper rendering without overflow/clipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->