### PR TITLE
Fix flaky TestCreatePost upload_file subtests

### DIFF
--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -62,6 +62,67 @@ func isolatedTeamChannelWithTeamScheme(t *testing.T, th *TestHelper) (*model.Cha
 	return ch, scheme
 }
 
+// isolatedNoSchemeChannelWithoutUploadFile creates a fresh channel inside th.BasicTeam (which has no team scheme)
+// and gives th.BasicUser an isolated channel-member role on it that does not grant upload_file. This exercises the
+// no-scheme permission-resolution path (i.e. the configuration the original test in PR #34538 was validating)
+// without mutating the process-shared channel_user role, so the subtest is safe under ENABLE_FULLY_PARALLEL_TESTS.
+//
+// The returned channel has neither a team scheme nor a channel scheme. The user's channel membership is configured
+// with SchemeUser/SchemeAdmin/SchemeGuest all false and ExplicitRoles set to a unique custom role that mirrors
+// channel_user's default permissions minus upload_file. Because no scheme role is injected into the effective
+// role set for that membership, the only way upload_file could be granted is via the higher-scoped team or system
+// roles, and upload_file is PermissionScopeChannel — it is not granted by team_user, team_admin, system_user, etc.
+//
+// Returns the channel and a cleanup function that removes the test role.
+func isolatedNoSchemeChannelWithoutUploadFile(t *testing.T, th *TestHelper) (*model.Channel, func()) {
+	t.Helper()
+
+	ch := th.CreateChannelWithClientAndTeam(t, th.SystemAdminClient, model.ChannelTypeOpen, th.BasicTeam.Id)
+	_, appErr := th.App.AddUserToChannel(th.Context, th.BasicUser, ch, false)
+	require.Nil(t, appErr)
+
+	channelUserRole, appErr := th.App.GetRoleByName(th.Context, model.ChannelUserRoleId)
+	require.Nil(t, appErr)
+	perms := make([]string, 0, len(channelUserRole.Permissions))
+	for _, p := range channelUserRole.Permissions {
+		if p == model.PermissionUploadFile.Id {
+			continue
+		}
+		perms = append(perms, p)
+	}
+
+	roleName := "test_" + model.NewId()
+	role, appErr := th.App.CreateRole(&model.Role{
+		Name:        roleName,
+		DisplayName: roleName,
+		Description: "isolated no-scheme channel-member role for TestCreatePost/TestUpdatePost",
+		Permissions: perms,
+	})
+	require.Nil(t, appErr)
+
+	// Replace the membership's role flags via the store so the built-in channel_user role is not injected.
+	// App.UpdateChannelMemberRoles refuses to leave a member with SchemeUser=false; the store accepts it.
+	member, appErr := th.App.GetChannelMember(th.Context, ch.Id, th.BasicUser.Id)
+	require.Nil(t, appErr)
+	member.SchemeUser = false
+	member.SchemeAdmin = false
+	member.SchemeGuest = false
+	member.ExplicitRoles = roleName
+	_, sErr := th.App.Srv().Store().Channel().UpdateMember(th.Context, member)
+	require.NoError(t, sErr)
+
+	// SessionHasPermissionToChannel reads through the cached GetAllChannelMembersForUser lookup.
+	// Store().Channel().UpdateMember does not invalidate that cache, so do it explicitly.
+	th.App.Srv().Platform().InvalidateChannelCacheForUser(th.BasicUser.Id)
+
+	cleanup := func() {
+		if _, err := th.App.DeleteRole(role.Id); err != nil {
+			t.Logf("failed to delete test role %s: %v", roleName, err)
+		}
+	}
+	return ch, cleanup
+}
+
 func TestCreatePost(t *testing.T) {
 	mainHelper.Parallel(t)
 
@@ -307,7 +368,7 @@ func TestCreatePost(t *testing.T) {
 		assert.Nil(t, rpost)
 	})
 
-	t.Run("should prevent creating post with files when user lacks upload_file permission in target channel", func(t *testing.T) {
+	t.Run("should prevent creating post with files when user lacks upload_file permission in target channel (team scheme)", func(t *testing.T) {
 		th.LoginBasic(t)
 
 		ch, scheme := isolatedTeamChannelWithTeamScheme(t, th)
@@ -322,6 +383,28 @@ func TestCreatePost(t *testing.T) {
 		defer func() {
 			th.AddPermissionToRole(t, model.PermissionUploadFile.Id, scheme.DefaultChannelUserRole)
 		}()
+
+		post := &model.Post{
+			ChannelId: ch.Id,
+			Message:   "Test post with file",
+			FileIds:   model.StringArray{fileId},
+		}
+		rpost, resp, err := client.CreatePost(context.Background(), post)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+		assert.Nil(t, rpost)
+	})
+
+	t.Run("should prevent creating post with files when user lacks upload_file permission in target channel (no scheme)", func(t *testing.T) {
+		th.LoginBasic(t)
+
+		ch, cleanup := isolatedNoSchemeChannelWithoutUploadFile(t, th)
+		defer cleanup()
+
+		fileResp, resp, err := th.SystemAdminClient.UploadFile(context.Background(), []byte("test file data"), ch.Id, "test-file.txt")
+		require.NoError(t, err)
+		CheckCreatedStatus(t, resp)
+		fileId := fileResp.FileInfos[0].Id
 
 		post := &model.Post{
 			ChannelId: ch.Id,
@@ -1763,7 +1846,7 @@ func TestUpdatePost(t *testing.T) {
 		CheckBadRequestStatus(t, resp)
 	})
 
-	t.Run("should prevent updating post with files when user lacks upload_file permission in target channel", func(t *testing.T) {
+	t.Run("should prevent updating post with files when user lacks upload_file permission in target channel (team scheme)", func(t *testing.T) {
 		ch, scheme := isolatedTeamChannelWithTeamScheme(t, th)
 		require.NotEmpty(t, scheme.DefaultChannelUserRole)
 
@@ -1783,6 +1866,34 @@ func TestUpdatePost(t *testing.T) {
 		defer func() {
 			th.AddPermissionToRole(t, model.PermissionUploadFile.Id, scheme.DefaultChannelUserRole)
 		}()
+
+		updatePost := &model.Post{
+			Id:        postWithoutFiles.Id,
+			ChannelId: ch.Id,
+			Message:   "Updated post with file",
+			FileIds:   model.StringArray{fileId},
+		}
+		updatedPost, resp, err := client.UpdatePost(context.Background(), postWithoutFiles.Id, updatePost)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+		assert.Nil(t, updatedPost)
+	})
+
+	t.Run("should prevent updating post with files when user lacks upload_file permission in target channel (no scheme)", func(t *testing.T) {
+		ch, cleanup := isolatedNoSchemeChannelWithoutUploadFile(t, th)
+		defer cleanup()
+
+		postWithoutFiles, _, appErr := th.App.CreatePost(th.Context, &model.Post{
+			UserId:    th.BasicUser.Id,
+			ChannelId: ch.Id,
+			Message:   "Post without files",
+		}, ch, model.CreatePostFlags{SetOnline: true})
+		require.Nil(t, appErr)
+
+		fileResp, resp, err := th.SystemAdminClient.UploadFile(context.Background(), []byte("test file data"), ch.Id, "test-file.txt")
+		require.NoError(t, err)
+		CheckCreatedStatus(t, resp)
+		fileId := fileResp.FileInfos[0].Id
 
 		updatePost := &model.Post{
 			Id:        postWithoutFiles.Id,

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -42,6 +42,26 @@ func enableBurnOnReadFeature(th *TestHelper) {
 	})
 }
 
+// isolatedTeamChannelWithTeamScheme creates a fresh team (with its own team scheme) and a channel on that team.
+// Permission edits target scheme-specific role names so parallel api4 tests do not mutate built-in channel_user,
+// and upload_file is revoked on the team scheme's channel user role so MergeChannelHigherScopedPermissions does not
+// reintroduce it from the higher scope (model.Role.MergeChannelHigherScopedPermissions).
+func isolatedTeamChannelWithTeamScheme(t *testing.T, th *TestHelper) (*model.Channel, *model.Scheme) {
+	t.Helper()
+	require.NoError(t, th.App.SetPhase2PermissionsMigrationStatus(true))
+
+	team := th.CreateTeamWithClient(t, th.SystemAdminClient)
+	th.LinkUserToTeam(t, th.BasicUser, team)
+
+	scheme := th.SetupTeamScheme(t)
+	team.SchemeId = &scheme.Id
+	_, appErr := th.App.UpdateTeamScheme(team)
+	require.Nil(t, appErr)
+
+	ch := th.CreateChannelWithClientAndTeam(t, th.Client, model.ChannelTypeOpen, team.Id)
+	return ch, scheme
+}
+
 func TestCreatePost(t *testing.T) {
 	mainHelper.Parallel(t)
 
@@ -288,18 +308,23 @@ func TestCreatePost(t *testing.T) {
 	})
 
 	t.Run("should prevent creating post with files when user lacks upload_file permission in target channel", func(t *testing.T) {
-		fileResp, resp, err := client.UploadFile(context.Background(), []byte("test file data"), th.BasicChannel.Id, "test-file.txt")
+		th.LoginBasic(t)
+
+		ch, scheme := isolatedTeamChannelWithTeamScheme(t, th)
+		require.NotEmpty(t, scheme.DefaultChannelUserRole)
+
+		fileResp, resp, err := client.UploadFile(context.Background(), []byte("test file data"), ch.Id, "test-file.txt")
 		require.NoError(t, err)
 		CheckCreatedStatus(t, resp)
 		fileId := fileResp.FileInfos[0].Id
 
-		th.RemovePermissionFromRole(t, model.PermissionUploadFile.Id, model.ChannelUserRoleId)
+		th.RemovePermissionFromRole(t, model.PermissionUploadFile.Id, scheme.DefaultChannelUserRole)
 		defer func() {
-			th.AddPermissionToRole(t, model.PermissionUploadFile.Id, model.ChannelUserRoleId)
+			th.AddPermissionToRole(t, model.PermissionUploadFile.Id, scheme.DefaultChannelUserRole)
 		}()
 
 		post := &model.Post{
-			ChannelId: th.BasicChannel.Id,
+			ChannelId: ch.Id,
 			Message:   "Test post with file",
 			FileIds:   model.StringArray{fileId},
 		}
@@ -310,13 +335,17 @@ func TestCreatePost(t *testing.T) {
 	})
 
 	t.Run("should allow creating post with files when user has upload_file permission", func(t *testing.T) {
-		fileResp, resp, err := client.UploadFile(context.Background(), []byte("test file data"), th.BasicChannel.Id, "test-file.txt")
+		th.LoginBasic(t)
+
+		ch, _ := isolatedTeamChannelWithTeamScheme(t, th)
+
+		fileResp, resp, err := client.UploadFile(context.Background(), []byte("test file data"), ch.Id, "test-file.txt")
 		require.NoError(t, err)
 		CheckCreatedStatus(t, resp)
 		fileId := fileResp.FileInfos[0].Id
 
 		post := &model.Post{
-			ChannelId: th.BasicChannel.Id,
+			ChannelId: ch.Id,
 			Message:   "Test post with file",
 			FileIds:   model.StringArray{fileId},
 		}
@@ -1735,26 +1764,29 @@ func TestUpdatePost(t *testing.T) {
 	})
 
 	t.Run("should prevent updating post with files when user lacks upload_file permission in target channel", func(t *testing.T) {
+		ch, scheme := isolatedTeamChannelWithTeamScheme(t, th)
+		require.NotEmpty(t, scheme.DefaultChannelUserRole)
+
 		postWithoutFiles, _, appErr := th.App.CreatePost(th.Context, &model.Post{
 			UserId:    th.BasicUser.Id,
-			ChannelId: channel.Id,
+			ChannelId: ch.Id,
 			Message:   "Post without files",
-		}, channel, model.CreatePostFlags{SetOnline: true})
+		}, ch, model.CreatePostFlags{SetOnline: true})
 		require.Nil(t, appErr)
 
-		fileResp, resp, err := client.UploadFile(context.Background(), []byte("test file data"), channel.Id, "test-file.txt")
+		fileResp, resp, err := client.UploadFile(context.Background(), []byte("test file data"), ch.Id, "test-file.txt")
 		require.NoError(t, err)
 		CheckCreatedStatus(t, resp)
 		fileId := fileResp.FileInfos[0].Id
 
-		th.RemovePermissionFromRole(t, model.PermissionUploadFile.Id, model.ChannelUserRoleId)
+		th.RemovePermissionFromRole(t, model.PermissionUploadFile.Id, scheme.DefaultChannelUserRole)
 		defer func() {
-			th.AddPermissionToRole(t, model.PermissionUploadFile.Id, model.ChannelUserRoleId)
+			th.AddPermissionToRole(t, model.PermissionUploadFile.Id, scheme.DefaultChannelUserRole)
 		}()
 
 		updatePost := &model.Post{
 			Id:        postWithoutFiles.Id,
-			ChannelId: channel.Id,
+			ChannelId: ch.Id,
 			Message:   "Updated post with file",
 			FileIds:   model.StringArray{fileId},
 		}
@@ -1765,21 +1797,23 @@ func TestUpdatePost(t *testing.T) {
 	})
 
 	t.Run("should allow updating post with files when user has upload_file permission", func(t *testing.T) {
+		ch, _ := isolatedTeamChannelWithTeamScheme(t, th)
+
 		postWithoutFiles, _, appErr := th.App.CreatePost(th.Context, &model.Post{
 			UserId:    th.BasicUser.Id,
-			ChannelId: channel.Id,
+			ChannelId: ch.Id,
 			Message:   "Post without files",
-		}, channel, model.CreatePostFlags{SetOnline: true})
+		}, ch, model.CreatePostFlags{SetOnline: true})
 		require.Nil(t, appErr)
 
-		fileResp, resp, err := client.UploadFile(context.Background(), []byte("test file data"), channel.Id, "test-file.txt")
+		fileResp, resp, err := client.UploadFile(context.Background(), []byte("test file data"), ch.Id, "test-file.txt")
 		require.NoError(t, err)
 		CheckCreatedStatus(t, resp)
 		fileId := fileResp.FileInfos[0].Id
 
 		updatePost := &model.Post{
 			Id:        postWithoutFiles.Id,
-			ChannelId: channel.Id,
+			ChannelId: ch.Id,
 			Message:   "Updated post with file",
 			FileIds:   model.StringArray{fileId},
 		}


### PR DESCRIPTION
_(This is a PoC from Cursor Agent responding to a flaky test report https://github.com/mattermost/mattermost/pull/36433#issuecomment-4383268633, used this one as a start one for this PR)_

#### Summary

The tests removed upload_file from the global channel_user role, which races with other parallel api4 tests, and (for channel-scoped schemes) could not actually revoke upload_file because non-moderated permissions merge from the higher-scoped team channel role.

Use an isolated team with its own team scheme, revoke upload_file on that scheme's channel user role, re-login after subtests that clear the client session, and align UpdatePost file-permission cases.

Tests-only change. Verified with ENABLE_FULLY_PARALLEL_TESTS=true go test -run '^TestCreatePost$' -race -count=100 ./channels/api4/...

Test originally introduced in https://github.com/mattermost/mattermost/pull/34538

#### Ticket Link
Fixes the flaky test report from here: https://github.com/mattermost/mattermost/pull/36433#issuecomment-4383268633

#### Release Note

```release-note
NONE
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** No regression risk—this PR contains only test-only changes with no modifications to production code. The new helper functions create isolated test scenarios with proper cleanup, and the changes are designed to eliminate race conditions between parallel tests, improving test reliability rather than introducing new failure modes.

**QA Recommendation:** No manual QA needed. This is a test-only change that improves flakiness under parallel test execution. Automated testing provides full coverage of the new test subtests, which validate existing permission-enforcement behavior without modifying it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->