### PR TITLE
docs: remove double space in README YouTube link

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ See the [LICENSE file](LICENSE.txt) for license rights and limitations.
 - **Email** - Subscribe to our [newsletter](https://mattermost.us11.list-manage.com/subscribe?u=6cdba22349ae374e188e7ab8e&id=2add1c8034) (1 or 2 per month).
 - **Mattermost** - Join the ~contributors channel on [the Mattermost Community Server](https://community.mattermost.com).
 - **IRC** - Join the #matterbridge channel on [Freenode](https://freenode.net/) (thanks to [matterircd](https://github.com/42wim/matterircd)).
-- **YouTube** -  Subscribe to [Mattermost](https://www.youtube.com/@MattermostHQ).
+- **YouTube** - Subscribe to [Mattermost](https://www.youtube.com/@MattermostHQ).
 
 ## Contributing
 


### PR DESCRIPTION
The "Get the latest news" list in the README uses a single space between the bullet hyphen and the link description on every line except YouTube, which has a double space. This PR removes the extra space for consistency with the rest of the list.
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** No regression risk exists as this is a documentation-only formatting change that does not modify any code, functionality, or system behavior. The change is completely isolated to a single README.md file entry.

**QA Recommendation:** Manual QA is not required. This is a purely cosmetic documentation change with zero impact on application functionality.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->