### PR TITLE
Lower default test console log level from stdlog to debug

### DIFF
--- a/server/channels/api4/apitestlib.go
+++ b/server/channels/api4/apitestlib.go
@@ -106,7 +106,7 @@ func setupTestHelper(tb testing.TB, dbStore store.Store, sqlSettings *model.SqlS
 	// Check for environment variable override for console log level (useful for debugging tests)
 	consoleLevel := os.Getenv("MM_LOGSETTINGS_CONSOLELEVEL")
 	if consoleLevel == "" {
-		consoleLevel = mlog.LvlStdLog.Name
+		consoleLevel = mlog.LvlDebug.Name
 	}
 	*memoryConfig.LogSettings.ConsoleLevel = consoleLevel
 	// Use a subdirectory within the logging root (from MM_LOG_PATH or default)

--- a/server/channels/api4/apitestlib_test.go
+++ b/server/channels/api4/apitestlib_test.go
@@ -60,7 +60,7 @@ func TestEnvironmentVariableHandling(t *testing.T) {
 		customConsoleLevel := *config2.LogSettings.ConsoleLevel
 
 		// Verify our manual implementation works
-		assert.Equal(t, mlog.LvlStdLog.Name, defaultConsoleLevel, "Default should be stdlog")
+		assert.Equal(t, mlog.LvlDebug.Name, defaultConsoleLevel, "Default should be debug")
 		assert.Equal(t, "DEBUG", customConsoleLevel, "Environment variable should be respected")
 		assert.NotEqual(t, defaultConsoleLevel, customConsoleLevel, "Values should be different")
 	})

--- a/server/channels/app/helper_test.go
+++ b/server/channels/app/helper_test.go
@@ -77,7 +77,7 @@ func setupTestHelper(dbStore store.Store, sqlStore *sqlstore.SqlStore, sqlSettin
 	// Check for environment variable override for console log level (useful for debugging tests)
 	consoleLevel := os.Getenv("MM_LOGSETTINGS_CONSOLELEVEL")
 	if consoleLevel == "" {
-		consoleLevel = mlog.LvlStdLog.Name
+		consoleLevel = mlog.LvlDebug.Name
 	}
 	*memoryConfig.LogSettings.ConsoleLevel = consoleLevel
 


### PR DESCRIPTION
<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
The default console log level in both integration test helpers was `stdlog` (ID=10). Because the level filter uses `level.ID <= threshold.ID`, all standard levels with a lower ID — including `trace` (ID=6) — passed through. Any log emitted via `MlvlNotificationTrace = []Level{LvlTrace, LvlNotificationTrace}` fired on `LvlTrace` and was written to stdout, producing a flood of lines like these on most tests:

```
{"level":"trace","msg":"Successfully fetched all profiles","sender_id":"abc123","post_id":"xyz789"}
{"level":"trace","msg":"Finished processing mentions","sender_id":"abc123","post_id":"xyz789"}
{"level":"trace","msg":"Begin sending email notifications","type":"email","sender_id":"abc123","post_id":"xyz789"}
{"level":"trace","msg":"Finished sending email notifications","type":"email","sender_id":"abc123","post_id":"xyz789"}
{"level":"trace","msg":"Begin sending push notifications","type":"push","sender_id":"abc123","post_id":"xyz789"}
{"level":"trace","msg":"Notification will be sent","status":"preparing"}
{"level":"trace","msg":"Finished sending push notifications","type":"push","sender_id":"abc123","post_id":"xyz789"}
{"level":"trace","msg":"Begin sending websocket notifications","type":"websocket","sender_id":"abc123","post_id":"xyz789"}
{"level":"trace","msg":"Finish sending websocket notifications","type":"websocket","sender_id":"abc123","post_id":"xyz789"}
```

This changes the default console level from `stdlog` to `debug` in `apitestlib.go` and `app/helper_test.go`. `MM_LOGSETTINGS_CONSOLELEVEL` still overrides for local debugging.

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to test helper initialization, reducing console log output verbosity without affecting production code. The log level override via `MM_LOGSETTINGS_CONSOLELEVEL` remains functional for debugging, and the modification is backwards compatible with existing test infrastructure.

**QA Recommendation:** Run the test suite to verify no unexpected regressions in test execution. Manual QA can be skipped as this is a test-only configuration change that reduces log spam without altering functional behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->