### PR TITLE
docs: update Help Wanted issues link to current monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Receive notifications of critical security updates. The sophistication of online
 ## Get involved
 
 - [Contribute to Mattermost](https://handbook.mattermost.com/contributors/contributors/ways-to-contribute)
-- [Find "Help Wanted" projects](https://github.com/mattermost/mattermost-server/issues?page=1&q=is%3Aissue+is%3Aopen+%22Help+Wanted%22&utf8=%E2%9C%93)
+- [Find "Help Wanted" projects](https://github.com/mattermost/mattermost/issues?q=is%3Aissue+is%3Aopen+label%3A%22Help+Wanted%22)
 - [Join Developer Discussion on a Mattermost server for contributors](https://community.mattermost.com/signup_user_complete/?id=f1924a8db44ff3bb41c96424cdc20676)
 - [Get Help With Mattermost](https://docs.mattermost.com/guides/get-help.html)
 


### PR DESCRIPTION
The "Find Help Wanted projects" link in the Get involved section currently points to https://github.com/mattermost/mattermost-server/issues, which is the old separate server repository. That repo has been consolidated into the mattermost/mattermost monorepo, so the link no longer points to the canonical issue list a new contributor should be browsing.

This PR updates the link to the current monorepo and switches the query from a free-text "Help Wanted" search to the proper label:"Help Wanted" filter, which is more precise. It also drops the legacy utf8=%E2%9C%93 form-submission parameter that GitHub no longer requires.

Before:
https://github.com/mattermost/mattermost-server/issues?page=1&q=is%3Aissue+is%3Aopen+%22Help+Wanted%22&utf8=%E2%9C%93

After:
https://github.com/mattermost/mattermost/issues?q=is%3Aissue+is%3Aopen+label%3A%22Help+Wanted%22

```release-note
NONE
```